### PR TITLE
core/vdbe: add peephole optimizer for bytecode programs

### DIFF
--- a/cli/tests/vdbe_trace.rs
+++ b/cli/tests/vdbe_trace.rs
@@ -28,8 +28,7 @@ fn vdbe_trace_on_traces_literal_select() {
         "7",
         "\
 VDBE Trace:
-0     Init               0     2     0                    0   Start at 2
-2     Goto               0     1     0                    0
+0     Init               0     1     0                    0   Start at 1
 1     Halt               0     0     0                    0
 VDBE Trace:
 0     Init               0     3     0                    0   Start at 3
@@ -48,8 +47,7 @@ fn vdbe_trace_on_traces_computed_expression() {
         "7",
         "\
 VDBE Trace:
-0     Init               0     2     0                    0   Start at 2
-2     Goto               0     1     0                    0
+0     Init               0     1     0                    0   Start at 1
 1     Halt               0     0     0                    0
 VDBE Trace:
 0     Init               0     3     0                    0   Start at 3

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -40,7 +40,7 @@ impl TableRefIdCounter {
 }
 
 use super::{
-    affinity::Affinity, BranchOffset, CursorID, Insn, InsnReference, PrepareContext,
+    affinity::Affinity, peephole, BranchOffset, CursorID, Insn, InsnReference, PrepareContext,
     PreparedProgram, Program,
 };
 use crate::translate::plan::BitSet;
@@ -1802,6 +1802,13 @@ impl ProgramBuilder {
         sql: &str,
     ) -> crate::Result<PreparedProgram> {
         self.resolve_labels()?;
+
+        // EXPLAIN QUERY PLAN programs are made of Insn::Explain rows that
+        // carry raw instruction indices, which deleting instructions would
+        // invalidate; they are also never executed for performance.
+        if !matches!(self.query_mode, QueryMode::ExplainQueryPlan) && peephole::enabled() {
+            peephole::optimize_program(&mut self.insns, &mut self.comments);
+        }
 
         self.parameters.list.dedup();
 

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1312,227 +1312,29 @@ impl ProgramBuilder {
     /// It ensures that all labels are resolved correctly and updates the target program counter (PC)
     /// of each instruction that references a label.
     pub fn resolve_labels(&mut self) -> crate::Result<()> {
-        let resolve = |pc: &mut BranchOffset, insn_name: &str| -> crate::Result<()> {
-            if let BranchOffset::Label(label) = pc {
-                let Some(Some(anchor)) = self.label_to_resolved_offset.get(*label as usize) else {
-                    crate::bail_corrupt_error!(
-                        "Reference to undefined or unresolved label in {insn_name}: {label}"
-                    );
-                };
-                *pc = BranchOffset::Offset(anchor + 1);
-            }
-            Ok(())
-        };
+        let label_to_resolved_offset = &self.label_to_resolved_offset;
+        // The visitor callback cannot early-return, so remember the first
+        // unresolved label and report it after the scan.
+        let mut unresolved: Option<(u32, &'static str)> = None;
         for (insn, _) in self.insns.iter_mut() {
-            match insn {
-                Insn::Init { target_pc } => {
-                    resolve(target_pc, "Init")?;
+            let insn_name = insn.name();
+            insn.for_each_branch_offset(|pc| {
+                if let BranchOffset::Label(label) = pc {
+                    match label_to_resolved_offset.get(*label as usize) {
+                        Some(Some(anchor)) => *pc = BranchOffset::Offset(anchor + 1),
+                        _ => {
+                            if unresolved.is_none() {
+                                unresolved = Some((*label, insn_name));
+                            }
+                        }
+                    }
                 }
-                Insn::Eq {
-                    lhs: _lhs,
-                    rhs: _rhs,
-                    target_pc,
-                    ..
-                } => {
-                    resolve(target_pc, "Eq")?;
-                }
-                Insn::Ne {
-                    lhs: _lhs,
-                    rhs: _rhs,
-                    target_pc,
-                    ..
-                } => {
-                    resolve(target_pc, "Ne")?;
-                }
-                Insn::Lt {
-                    lhs: _lhs,
-                    rhs: _rhs,
-                    target_pc,
-                    ..
-                } => {
-                    resolve(target_pc, "Lt")?;
-                }
-                Insn::Le {
-                    lhs: _lhs,
-                    rhs: _rhs,
-                    target_pc,
-                    ..
-                } => {
-                    resolve(target_pc, "Le")?;
-                }
-                Insn::Gt {
-                    lhs: _lhs,
-                    rhs: _rhs,
-                    target_pc,
-                    ..
-                } => {
-                    resolve(target_pc, "Gt")?;
-                }
-                Insn::Ge {
-                    lhs: _lhs,
-                    rhs: _rhs,
-                    target_pc,
-                    ..
-                } => {
-                    resolve(target_pc, "Ge")?;
-                }
-                Insn::If {
-                    reg: _reg,
-                    target_pc,
-                    jump_if_null: _,
-                } => {
-                    resolve(target_pc, "If")?;
-                }
-                Insn::IfNot {
-                    reg: _reg,
-                    target_pc,
-                    jump_if_null: _,
-                } => {
-                    resolve(target_pc, "IfNot")?;
-                }
-                Insn::Rewind { pc_if_empty, .. } => {
-                    resolve(pc_if_empty, "Rewind")?;
-                }
-                Insn::Last { pc_if_empty, .. } => {
-                    resolve(pc_if_empty, "Last")?;
-                }
-                Insn::Goto { target_pc } => {
-                    resolve(target_pc, "Goto")?;
-                }
-                Insn::DecrJumpZero {
-                    reg: _reg,
-                    target_pc,
-                } => {
-                    resolve(target_pc, "DecrJumpZero")?;
-                }
-                Insn::SorterNext {
-                    cursor_id: _cursor_id,
-                    pc_if_next,
-                } => {
-                    resolve(pc_if_next, "SorterNext")?;
-                }
-                Insn::SorterSort { pc_if_empty, .. } => {
-                    resolve(pc_if_empty, "SorterSort")?;
-                }
-                Insn::SorterCompare {
-                    pc_when_nonequal: target_pc,
-                    ..
-                } => {
-                    resolve(target_pc, "SorterCompare")?;
-                }
-                Insn::NotNull {
-                    reg: _reg,
-                    target_pc,
-                } => {
-                    resolve(target_pc, "NotNull")?;
-                }
-                Insn::ColumnHasField { target_pc, .. } => {
-                    resolve(target_pc, "ColumnHasField")?;
-                }
-                Insn::IfPos { target_pc, .. } => {
-                    resolve(target_pc, "IfPos")?;
-                }
-                Insn::Next { pc_if_next, .. } => {
-                    resolve(pc_if_next, "Next")?;
-                }
-                Insn::Once {
-                    target_pc_when_reentered,
-                    ..
-                } => {
-                    resolve(target_pc_when_reentered, "Once")?;
-                }
-                Insn::Prev { pc_if_prev, .. } => {
-                    resolve(pc_if_prev, "Prev")?;
-                }
-                Insn::InitCoroutine {
-                    yield_reg: _,
-                    jump_on_definition,
-                    start_offset,
-                } => {
-                    resolve(jump_on_definition, "InitCoroutine")?;
-                    resolve(start_offset, "InitCoroutine")?;
-                }
-                Insn::NotExists {
-                    cursor: _,
-                    rowid_reg: _,
-                    target_pc,
-                } => {
-                    resolve(target_pc, "NotExists")?;
-                }
-                Insn::MustBeInt {
-                    target_pc: Some(target_pc),
-                    ..
-                } => {
-                    resolve(target_pc, "MustBeInt")?;
-                }
-                Insn::Yield {
-                    yield_reg: _,
-                    end_offset,
-                    subtype_clear_start_reg: _,
-                    subtype_clear_count: _,
-                } => {
-                    resolve(end_offset, "Yield")?;
-                }
-                Insn::SeekRowid { target_pc, .. } => {
-                    resolve(target_pc, "SeekRowid")?;
-                }
-                Insn::Gosub { target_pc, .. } => {
-                    resolve(target_pc, "Gosub")?;
-                }
-                Insn::Jump {
-                    target_pc_eq,
-                    target_pc_lt,
-                    target_pc_gt,
-                } => {
-                    resolve(target_pc_eq, "Jump")?;
-                    resolve(target_pc_lt, "Jump")?;
-                    resolve(target_pc_gt, "Jump")?;
-                }
-                Insn::SeekGE { target_pc, .. } => resolve(target_pc, "SeekGE")?,
-                Insn::SeekGT { target_pc, .. } => resolve(target_pc, "SeekGT")?,
-                Insn::SeekLE { target_pc, .. } => resolve(target_pc, "SeekLE")?,
-                Insn::SeekLT { target_pc, .. } => resolve(target_pc, "SeekLT")?,
-                Insn::IdxGE { target_pc, .. } => resolve(target_pc, "IdxGE")?,
-                Insn::IdxLE { target_pc, .. } => resolve(target_pc, "IdxLE")?,
-                Insn::IdxGT { target_pc, .. } => resolve(target_pc, "IdxGT")?,
-                Insn::IdxLT { target_pc, .. } => resolve(target_pc, "IdxLT")?,
-                Insn::IndexMethodQuery { pc_if_empty, .. } => {
-                    resolve(pc_if_empty, "IndexMethodQuery")?;
-                }
-                Insn::IsNull { reg: _, target_pc } => resolve(target_pc, "IsNull")?,
-                Insn::VNext { pc_if_next, .. } => resolve(pc_if_next, "VNext")?,
-                Insn::VFilter { pc_if_empty, .. } => resolve(pc_if_empty, "VFilter")?,
-                Insn::RowSetRead { pc_if_empty, .. } => resolve(pc_if_empty, "RowSetRead")?,
-                Insn::RowSetTest { pc_if_found, .. } => resolve(pc_if_found, "RowSetTest")?,
-                Insn::NoConflict { target_pc, .. } => resolve(target_pc, "NoConflict")?,
-                Insn::Found { target_pc, .. } => resolve(target_pc, "Found")?,
-                Insn::NotFound { target_pc, .. } => resolve(target_pc, "NotFound")?,
-                Insn::FkIfZero { target_pc, .. } => resolve(target_pc, "FkIfZero")?,
-                Insn::Filter { target_pc, .. } => resolve(target_pc, "Filter")?,
-                Insn::HashProbe { target_pc, .. } => resolve(target_pc, "HashProbe")?,
-                Insn::HashNext { target_pc, .. } => resolve(target_pc, "HashNext")?,
-                Insn::HashDistinct { data } => resolve(&mut data.target_pc, "HashDistinct")?,
-                Insn::HashScanUnmatched { target_pc, .. } => {
-                    resolve(target_pc, "HashScanUnmatched")?
-                }
-                Insn::HashNextUnmatched { target_pc, .. } => {
-                    resolve(target_pc, "HashNextUnmatched")?
-                }
-                Insn::HashGraceInit { target_pc, .. } => resolve(target_pc, "HashGraceInit")?,
-                Insn::HashGraceLoadPartition { target_pc, .. } => {
-                    resolve(target_pc, "HashGraceLoadPartition")?
-                }
-                Insn::HashGraceNextProbe { target_pc, .. } => {
-                    resolve(target_pc, "HashGraceNextProbe")?
-                }
-                Insn::HashGraceAdvancePartition { target_pc, .. } => {
-                    resolve(target_pc, "HashGraceAdvancePartition")?
-                }
-                Insn::Program {
-                    ignore_jump_target, ..
-                } => resolve(ignore_jump_target, "Program")?,
-                _ => {}
-            }
+            });
+        }
+        if let Some((label, insn_name)) = unresolved {
+            crate::bail_corrupt_error!(
+                "Reference to undefined or unresolved label in {insn_name}: {label}"
+            );
         }
         self.label_to_resolved_offset.clear();
         Ok(())

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -102,6 +102,13 @@ impl CmpInsFlags {
         self.has(CmpInsFlags::JUMP_IF_NULL)
     }
 
+    /// Copy of these flags with the JUMP_IF_NULL bit flipped. Used when the
+    /// peephole pass inverts a comparison: the inverse must make the opposite
+    /// jump decision when an operand is NULL.
+    pub fn with_jump_if_null_flipped(&self) -> Self {
+        Self(self.0 ^ CmpInsFlags::JUMP_IF_NULL)
+    }
+
     pub fn has_nulleq(&self) -> bool {
         self.has(CmpInsFlags::NULL_EQ)
     }

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -21,7 +21,7 @@ use crate::{
     PreparedProgram, Value,
 };
 use strum::EnumCount;
-use strum_macros::{EnumDiscriminants, FromRepr, VariantArray};
+use strum_macros::{EnumDiscriminants, FromRepr, IntoStaticStr, VariantArray};
 use turso_macros::Description;
 use turso_parser::ast::{ResolveType, SortOrder};
 
@@ -284,7 +284,7 @@ pub struct HashDistinctData {
 #[repr(u8)]
 #[derive(Description, Debug, Clone, EnumDiscriminants)]
 #[strum_discriminants(vis(pub(crate)))]
-#[strum_discriminants(derive(VariantArray, EnumCount, FromRepr))]
+#[strum_discriminants(derive(VariantArray, EnumCount, FromRepr, IntoStaticStr))]
 #[strum_discriminants(name(InsnVariants))]
 pub enum Insn {
     /// Initialize the program state and jump to the given PC.
@@ -2304,6 +2304,258 @@ impl Insn {
                 Subprogram::Pending(_) => false,
             },
             _ => true,
+        }
+    }
+
+    /// Short opcode name, e.g. "Goto".
+    pub(crate) fn name(&self) -> &'static str {
+        InsnVariants::from(self).into()
+    }
+
+    /// Visit every branch-offset operand of this instruction.
+    ///
+    /// This is the single source of truth for which fields of which opcodes
+    /// hold jump targets. Label resolution and the peephole pass both use it
+    /// to find, chase and remap targets, so a new opcode with a jump target
+    /// only needs to be added here. The match is exhaustive on purpose:
+    /// adding a variant forces the author to classify it.
+    pub(crate) fn for_each_branch_offset(&mut self, mut f: impl FnMut(&mut BranchOffset)) {
+        match self {
+            Insn::Init { target_pc, .. } => f(target_pc),
+            Insn::Jump {
+                target_pc_lt,
+                target_pc_eq,
+                target_pc_gt,
+                ..
+            } => {
+                f(target_pc_lt);
+                f(target_pc_eq);
+                f(target_pc_gt);
+            }
+            Insn::IfPos { target_pc, .. } => f(target_pc),
+            Insn::NotNull { target_pc, .. } => f(target_pc),
+            Insn::Eq { target_pc, .. } => f(target_pc),
+            Insn::Filter { target_pc, .. } => f(target_pc),
+            Insn::Ne { target_pc, .. } => f(target_pc),
+            Insn::Lt { target_pc, .. } => f(target_pc),
+            Insn::Le { target_pc, .. } => f(target_pc),
+            Insn::Gt { target_pc, .. } => f(target_pc),
+            Insn::Ge { target_pc, .. } => f(target_pc),
+            Insn::If { target_pc, .. } => f(target_pc),
+            Insn::IfNot { target_pc, .. } => f(target_pc),
+            Insn::VFilter { pc_if_empty, .. } => f(pc_if_empty),
+            Insn::VNext { pc_if_next, .. } => f(pc_if_next),
+            Insn::Rewind { pc_if_empty, .. } => f(pc_if_empty),
+            Insn::Last { pc_if_empty, .. } => f(pc_if_empty),
+            Insn::ColumnHasField { target_pc, .. } => f(target_pc),
+            Insn::Next { pc_if_next, .. } => f(pc_if_next),
+            Insn::Prev { pc_if_prev, .. } => f(pc_if_prev),
+            Insn::Goto { target_pc, .. } => f(target_pc),
+            Insn::Gosub { target_pc, .. } => f(target_pc),
+            Insn::Program {
+                ignore_jump_target, ..
+            } => f(ignore_jump_target),
+            Insn::SeekRowid { target_pc, .. } => f(target_pc),
+            Insn::SeekGE { target_pc, .. } => f(target_pc),
+            Insn::SeekGT { target_pc, .. } => f(target_pc),
+            Insn::SeekLE { target_pc, .. } => f(target_pc),
+            Insn::SeekLT { target_pc, .. } => f(target_pc),
+            Insn::IdxGE { target_pc, .. } => f(target_pc),
+            Insn::IdxGT { target_pc, .. } => f(target_pc),
+            Insn::IdxLE { target_pc, .. } => f(target_pc),
+            Insn::IdxLT { target_pc, .. } => f(target_pc),
+            Insn::DecrJumpZero { target_pc, .. } => f(target_pc),
+            Insn::SorterCompare {
+                pc_when_nonequal, ..
+            } => f(pc_when_nonequal),
+            Insn::SorterSort { pc_if_empty, .. } => f(pc_if_empty),
+            Insn::SorterNext { pc_if_next, .. } => f(pc_if_next),
+            Insn::RowSetRead { pc_if_empty, .. } => f(pc_if_empty),
+            Insn::RowSetTest { pc_if_found, .. } => f(pc_if_found),
+            Insn::InitCoroutine {
+                jump_on_definition,
+                start_offset,
+                ..
+            } => {
+                f(jump_on_definition);
+                f(start_offset);
+            }
+            Insn::Yield { end_offset, .. } => f(end_offset),
+            Insn::MustBeInt { target_pc, .. } => {
+                if let Some(pc) = target_pc.as_mut() {
+                    f(pc);
+                }
+            }
+            Insn::NoConflict { target_pc, .. } => f(target_pc),
+            Insn::NotExists { target_pc, .. } => f(target_pc),
+            Insn::IndexMethodQuery { pc_if_empty, .. } => f(pc_if_empty),
+            Insn::IsNull { target_pc, .. } => f(target_pc),
+            Insn::Once {
+                target_pc_when_reentered,
+                ..
+            } => f(target_pc_when_reentered),
+            Insn::Found { target_pc, .. } => f(target_pc),
+            Insn::NotFound { target_pc, .. } => f(target_pc),
+            Insn::IfNeg { target_pc, .. } => f(target_pc),
+            Insn::SequenceTest { target_pc, .. } => f(target_pc),
+            Insn::FkIfZero { target_pc, .. } => f(target_pc),
+            Insn::HashDistinct { data } => f(&mut data.target_pc),
+            Insn::HashProbe { target_pc, .. } => f(target_pc),
+            Insn::HashNext { target_pc, .. } => f(target_pc),
+            Insn::HashScanUnmatched { target_pc, .. } => f(target_pc),
+            Insn::HashNextUnmatched { target_pc, .. } => f(target_pc),
+            Insn::HashGraceInit { target_pc, .. } => f(target_pc),
+            Insn::HashGraceLoadPartition { target_pc, .. } => f(target_pc),
+            Insn::HashGraceNextProbe { target_pc, .. } => f(target_pc),
+            Insn::HashGraceAdvancePartition { target_pc, .. } => f(target_pc),
+            // Opcodes with no branch-offset operands.
+            Insn::Null { .. }
+            | Insn::BeginSubrtn { .. }
+            | Insn::NullRow { .. }
+            | Insn::Add { .. }
+            | Insn::Subtract { .. }
+            | Insn::Multiply { .. }
+            | Insn::MemMax { .. }
+            | Insn::Divide { .. }
+            | Insn::Compare { .. }
+            | Insn::BitAnd { .. }
+            | Insn::BitOr { .. }
+            | Insn::BitNot { .. }
+            | Insn::Checkpoint { .. }
+            | Insn::Remainder { .. }
+            | Insn::Move { .. }
+            | Insn::FilterAdd { .. }
+            | Insn::OpenRead { .. }
+            | Insn::VOpen { .. }
+            | Insn::VCreate { .. }
+            | Insn::VColumn { .. }
+            | Insn::VUpdate { .. }
+            | Insn::VDestroy { .. }
+            | Insn::VBegin { .. }
+            | Insn::VRename { .. }
+            | Insn::OpenPseudo { .. }
+            | Insn::Column { .. }
+            | Insn::TypeCheck { .. }
+            | Insn::ArrayEncode { .. }
+            | Insn::ArrayDecode { .. }
+            | Insn::ArrayElement { .. }
+            | Insn::ArrayLength { .. }
+            | Insn::MakeArray { .. }
+            | Insn::MakeArrayDynamic { .. }
+            | Insn::StructField { .. }
+            | Insn::UnionPack { .. }
+            | Insn::UnionTag { .. }
+            | Insn::UnionExtract { .. }
+            | Insn::RegCopyOffset { .. }
+            | Insn::BlobRead { .. }
+            | Insn::BlobWrite { .. }
+            | Insn::BlobLen { .. }
+            | Insn::ArrayConcat { .. }
+            | Insn::ArraySetElement { .. }
+            | Insn::ArraySlice { .. }
+            | Insn::MakeRecord { .. }
+            | Insn::ResultRow { .. }
+            | Insn::Halt { .. }
+            | Insn::HaltIfNull { .. }
+            | Insn::Transaction { .. }
+            | Insn::AutoCommit { .. }
+            | Insn::Savepoint { .. }
+            | Insn::Return { .. }
+            | Insn::ResetCount
+            | Insn::Integer { .. }
+            | Insn::Real { .. }
+            | Insn::RealAffinity { .. }
+            | Insn::String8 { .. }
+            | Insn::Blob { .. }
+            | Insn::RowData { .. }
+            | Insn::RowId { .. }
+            | Insn::IdxRowId { .. }
+            | Insn::SeekEnd { .. }
+            | Insn::DeferredSeek { .. }
+            | Insn::IdxInsert { .. }
+            | Insn::AggStep { .. }
+            | Insn::AggInverse { .. }
+            | Insn::AggFinal { .. }
+            | Insn::AggValue { .. }
+            | Insn::SorterOpen { .. }
+            | Insn::SorterInsert { .. }
+            | Insn::SorterData { .. }
+            | Insn::RowSetAdd { .. }
+            | Insn::Function { .. }
+            | Insn::Cast { .. }
+            | Insn::EndCoroutine { .. }
+            | Insn::Insert { .. }
+            | Insn::Int64 { .. }
+            | Insn::Delete { .. }
+            | Insn::IdxDelete { .. }
+            | Insn::NewRowid { .. }
+            | Insn::SoftNull { .. }
+            | Insn::OffsetLimit { .. }
+            | Insn::OpenWrite { .. }
+            | Insn::Copy { .. }
+            | Insn::CreateBtree { .. }
+            | Insn::IndexMethodCreate { .. }
+            | Insn::IndexMethodDestroy { .. }
+            | Insn::IndexMethodOptimize { .. }
+            | Insn::ClearBtree { .. }
+            | Insn::Destroy { .. }
+            | Insn::ResetSorter { .. }
+            | Insn::DropTable { .. }
+            | Insn::DropView { .. }
+            | Insn::DropIndex { .. }
+            | Insn::DropTrigger { .. }
+            | Insn::DropType { .. }
+            | Insn::AddSequence { .. }
+            | Insn::DropSequence { .. }
+            | Insn::SequenceBeginInnerTx { .. }
+            | Insn::SequenceCommitInnerTx { .. }
+            | Insn::SequenceComputeNext { .. }
+            | Insn::SetSequenceCurrval { .. }
+            | Insn::SequenceTrackAllocation { .. }
+            | Insn::SequenceRegisterAllocation { .. }
+            | Insn::AddType { .. }
+            | Insn::Close { .. }
+            | Insn::ParseSchema { .. }
+            | Insn::PopulateMaterializedViews { .. }
+            | Insn::ShiftRight { .. }
+            | Insn::ShiftLeft { .. }
+            | Insn::AddImm { .. }
+            | Insn::Variable { .. }
+            | Insn::ZeroOrNull { .. }
+            | Insn::Not { .. }
+            | Insn::IsTrue { .. }
+            | Insn::Concat { .. }
+            | Insn::And { .. }
+            | Insn::Or { .. }
+            | Insn::Noop
+            | Insn::PageCount { .. }
+            | Insn::ReadCookie { .. }
+            | Insn::SetCookie { .. }
+            | Insn::OpenEphemeral { .. }
+            | Insn::OpenAutoindex { .. }
+            | Insn::OpenDup { .. }
+            | Insn::Affinity { .. }
+            | Insn::Count { .. }
+            | Insn::IntegrityCk { .. }
+            | Insn::RenameTable { .. }
+            | Insn::DropColumn { .. }
+            | Insn::AddColumn { .. }
+            | Insn::AlterColumn { .. }
+            | Insn::MaxPgcnt { .. }
+            | Insn::JournalMode { .. }
+            | Insn::Sequence { .. }
+            | Insn::Explain { .. }
+            | Insn::FkCounter { .. }
+            | Insn::FkCheck { .. }
+            | Insn::HashBuild { .. }
+            | Insn::HashBuildFinalize { .. }
+            | Insn::HashClose { .. }
+            | Insn::HashClear { .. }
+            | Insn::HashMarkMatched { .. }
+            | Insn::HashResetMatched { .. }
+            | Insn::VacuumInto { .. }
+            | Insn::Vacuum { .. }
+            | Insn::InitCdcVersion { .. } => {}
         }
     }
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -33,6 +33,9 @@ pub mod explain;
 pub mod hash_table;
 pub mod insn;
 pub mod metrics;
+pub mod peephole;
+#[cfg(test)]
+mod peephole_tests;
 pub mod rowset;
 pub mod sorter;
 #[cfg(test)]

--- a/core/vdbe/peephole.rs
+++ b/core/vdbe/peephole.rs
@@ -107,26 +107,23 @@ impl PassStats {
     }
 
     fn add_to_global(&self) {
+        // Most programs leave most counters at zero; skip those RMWs.
+        fn add(counter: &AtomicU64, value: u64) {
+            if value != 0 {
+                counter.fetch_add(value, Ordering::Relaxed);
+            }
+        }
         let c = &COUNTERS;
         c.programs.fetch_add(1, Ordering::Relaxed);
-        c.jumps_threaded
-            .fetch_add(self.jumps_threaded, Ordering::Relaxed);
-        c.gotos_replaced_with_halt
-            .fetch_add(self.gotos_replaced_with_halt, Ordering::Relaxed);
-        c.branches_inverted
-            .fetch_add(self.branches_inverted, Ordering::Relaxed);
-        c.copies_merged
-            .fetch_add(self.copies_merged, Ordering::Relaxed);
-        c.affinities_folded
-            .fetch_add(self.affinities_folded, Ordering::Relaxed);
-        c.jumps_to_next_deleted
-            .fetch_add(self.jumps_to_next_deleted, Ordering::Relaxed);
-        c.unreachable_deleted
-            .fetch_add(self.unreachable_deleted, Ordering::Relaxed);
-        c.cmp_deletes_skipped
-            .fetch_add(self.cmp_deletes_skipped, Ordering::Relaxed);
-        c.affinity_folds_skipped
-            .fetch_add(self.affinity_folds_skipped, Ordering::Relaxed);
+        add(&c.jumps_threaded, self.jumps_threaded);
+        add(&c.gotos_replaced_with_halt, self.gotos_replaced_with_halt);
+        add(&c.branches_inverted, self.branches_inverted);
+        add(&c.copies_merged, self.copies_merged);
+        add(&c.affinities_folded, self.affinities_folded);
+        add(&c.jumps_to_next_deleted, self.jumps_to_next_deleted);
+        add(&c.unreachable_deleted, self.unreachable_deleted);
+        add(&c.cmp_deletes_skipped, self.cmp_deletes_skipped);
+        add(&c.affinity_folds_skipped, self.affinity_folds_skipped);
     }
 }
 
@@ -201,6 +198,33 @@ extern "C" fn dump_stats_at_exit() {
 ///
 /// `comments` maps instruction indices to EXPLAIN comments; entries move with
 /// their instruction and entries for deleted instructions are dropped.
+/// Reusable per-thread buffers. The pass runs on every prepare, often on
+/// programs a handful of instructions long, where fresh allocations would
+/// dominate its cost.
+#[derive(Default)]
+struct Scratch {
+    /// Which instructions are still alive.
+    live: Vec<bool>,
+    /// Which instructions some branch operand points at.
+    targets: Vec<bool>,
+    /// Rule 1's "was a Goto" set, reused as the sweep's "reached" set.
+    aux: Vec<bool>,
+    /// Rule 1's chain resolution state per instruction.
+    state: Vec<u8>,
+    /// Rule 1's final chain destinations, reused as compaction's old-to-new map.
+    u32_a: Vec<u32>,
+    /// The sweep's next-live-instruction table.
+    u32_b: Vec<u32>,
+    /// Rule 1's current chain of Gotos.
+    chain: Vec<u32>,
+    /// The sweep's worklist.
+    worklist: Vec<u32>,
+}
+
+thread_local! {
+    static SCRATCH: std::cell::RefCell<Scratch> = std::cell::RefCell::new(Scratch::default());
+}
+
 pub(crate) fn optimize_program(
     insns: &mut Vec<(Insn, usize)>,
     comments: &mut Vec<(InsnReference, &'static str)>,
@@ -210,19 +234,55 @@ pub(crate) fn optimize_program(
         return;
     }
     maybe_register_stats_dump();
+    SCRATCH.with(|cell| match cell.try_borrow_mut() {
+        Ok(mut scratch) => run_pass(insns, comments, &mut scratch),
+        // Defensive: if a prepare ever nests inside another prepare on this
+        // thread, fall back to fresh buffers instead of sharing.
+        Err(_) => run_pass(insns, comments, &mut Scratch::default()),
+    });
+}
 
+fn run_pass(
+    insns: &mut Vec<(Insn, usize)>,
+    comments: &mut Vec<(InsnReference, &'static str)>,
+    scratch: &mut Scratch,
+) {
+    let n = insns.len();
     let mut stats = PassStats::default();
-    let mut live = vec![true; n];
-    // Scratch buffer for "is instruction i the target of any branch operand".
-    let mut targets = vec![false; n];
+    scratch.live.clear();
+    scratch.live.resize(n, true);
 
-    thread_jumps(insns, &mut stats);
-    invert_branches_over_gotos(insns, &mut live, &mut targets, &mut stats);
-    merge_adjacent_copies(insns, &mut live, &mut targets, &mut stats);
-    fold_affinity_into_make_record(insns, &mut live, &mut targets, &mut stats);
-    delete_jumps_to_next(insns, &mut live, &mut targets, &mut stats);
-    sweep_unreachable(insns, &mut live, &mut stats);
-    compact(insns, comments, &live);
+    // Threading also fills `scratch.targets` (which instructions some branch
+    // operand points at) in its operand walk: collected after retargeting and
+    // before anything is marked dead, so every operand (including those of
+    // instructions that later die) is included. The only rule that changes a
+    // target afterwards is the inversion, and the destination it retargets to
+    // is the dead Goto's destination, which that Goto's own operand already
+    // put in the set. Staleness is therefore always conservative: it can only
+    // block a rewrite.
+    let present = thread_jumps(insns, scratch, &mut stats);
+
+    let (live, targets) = (&mut scratch.live, &mut scratch.targets);
+    if present.any_goto {
+        // The inversion needs a Goto right after the conditional.
+        invert_branches_over_gotos(insns, live, targets, &mut stats);
+    }
+    if present.any_copy {
+        merge_adjacent_copies(insns, live, targets, &mut stats);
+    }
+    if present.any_affinity {
+        fold_affinity_into_make_record(insns, live, targets, &mut stats);
+    }
+    delete_jumps_to_next(insns, live, targets, &mut stats);
+    let dead_before_sweep = stats.branches_inverted
+        + stats.copies_merged
+        + stats.affinities_folded
+        + stats.jumps_to_next_deleted
+        > 0;
+    sweep_unreachable(insns, scratch, dead_before_sweep, &mut stats);
+    if dead_before_sweep || stats.unreachable_deleted > 0 {
+        compact(insns, comments, scratch);
+    }
 
     #[cfg(debug_assertions)]
     verify_all_branches_resolved(insns);
@@ -259,12 +319,27 @@ fn resolved_target(off: &BranchOffset, n: usize) -> Option<u32> {
 /// Afterwards, any `Goto` that (now) points directly at a plain `Halt` is
 /// replaced by a copy of that `Halt`: jumping to a `Halt` and executing it is
 /// identical to executing it in place, since `Goto` has no other effect.
-fn thread_jumps(insns: &mut [(Insn, usize)], stats: &mut PassStats) {
+/// Which opcodes the program contains at all, so `run_pass` can skip rules
+/// that cannot fire. Collected during rule 1's scans, which touch every
+/// instruction anyway.
+struct RulePresence {
+    any_goto: bool,
+    any_copy: bool,
+    any_affinity: bool,
+}
+
+fn thread_jumps(
+    insns: &mut [(Insn, usize)],
+    scratch: &mut Scratch,
+    stats: &mut PassStats,
+) -> RulePresence {
     let n = insns.len();
-    let is_goto: Vec<bool> = insns
-        .iter()
-        .map(|(insn, _)| matches!(insn, Insn::Goto { .. }))
-        .collect();
+    // was_goto[i]: instruction i was a Goto when chains were resolved. Kept
+    // separately from a live `matches!` check so that replacing a Goto with a
+    // Halt below does not stop later operands from threading through it.
+    let was_goto = &mut scratch.aux;
+    was_goto.clear();
+    was_goto.resize(n, false);
 
     // For each Goto index: the ultimate non-Goto destination of its chain, or
     // its own index when the chain hits a cycle or an unresolved operand
@@ -272,11 +347,34 @@ fn thread_jumps(insns: &mut [(Insn, usize)], stats: &mut PassStats) {
     const UNVISITED: u8 = 0;
     const IN_PROGRESS: u8 = 1;
     const DONE: u8 = 2;
-    let mut final_target: Vec<u32> = (0..n as u32).collect();
-    let mut state = vec![UNVISITED; n];
-    let mut chain: Vec<u32> = Vec::new();
+    let final_target = &mut scratch.u32_a;
+    final_target.clear();
+    final_target.extend(0..n as u32);
+    let state = &mut scratch.state;
+    state.clear();
+    state.resize(n, UNVISITED);
+    let chain = &mut scratch.chain;
+    let mut present = RulePresence {
+        any_goto: false,
+        any_copy: false,
+        any_affinity: false,
+    };
     for i in 0..n {
-        if !is_goto[i] || state[i] != UNVISITED {
+        match &insns[i].0 {
+            Insn::Copy { .. } => {
+                present.any_copy = true;
+                continue;
+            }
+            Insn::Affinity { .. } => {
+                present.any_affinity = true;
+                continue;
+            }
+            Insn::Goto { .. } => {}
+            _ => continue,
+        }
+        was_goto[i] = true;
+        present.any_goto = true;
+        if state[i] != UNVISITED {
             continue;
         }
         chain.clear();
@@ -286,12 +384,12 @@ fn thread_jumps(insns: &mut [(Insn, usize)], stats: &mut PassStats) {
             state[cur as usize] = IN_PROGRESS;
             chain.push(cur);
             let Insn::Goto { target_pc } = &insns[cur as usize].0 else {
-                unreachable!("is_goto guarantees a Goto");
+                unreachable!("checked above");
             };
             let Some(t) = resolved_target(target_pc, n) else {
                 break None;
             };
-            if !is_goto[t as usize] {
+            if !matches!(insns[t as usize].0, Insn::Goto { .. }) {
                 break Some(t);
             }
             match state[t as usize] {
@@ -303,64 +401,78 @@ fn thread_jumps(insns: &mut [(Insn, usize)], stats: &mut PassStats) {
                 _ => cur = t,
             }
         };
-        for &g in &chain {
+        for &g in chain.iter() {
             state[g as usize] = DONE;
             if let Some(d) = final_dst {
                 final_target[g as usize] = d;
             }
         }
     }
-
     // Retarget every operand that lands on a Goto with a known final
-    // destination. This includes the Gotos' own targets, so after this loop
-    // every Goto in a chain points directly at the chain's destination.
-    for (insn, _) in insns.iter_mut() {
-        insn.for_each_branch_offset(|off| {
+    // destination, and record the (post-rewrite) target set for the rules
+    // below in the same walk. Retargeting includes the Gotos' own operands,
+    // so every Goto in a chain ends up pointing directly at the chain's
+    // destination — which is why a Goto whose destination is a plain Halt can
+    // become a copy of that Halt in the same walk: its own operand was just
+    // rewritten, and operands of later instructions thread through
+    // `was_goto`/`final_target` rather than re-inspecting the replaced
+    // instruction.
+    let targets = &mut scratch.targets;
+    targets.clear();
+    targets.resize(n, false);
+    let threading = present.any_goto;
+    for i in 0..n {
+        if was_goto[i] {
+            // A Goto has exactly one operand. Thread it, and if the final
+            // destination is a plain Halt, become a copy of that Halt: the
+            // operand disappears with the replacement, so it must not be
+            // recorded as a target (that would keep an otherwise-unreachable
+            // Halt alive). The chain destination is never itself a Goto
+            // (cycles keep final_target[i] == i and are skipped by the
+            // d != i check), so a Halt seen here is a real Halt, not a copy
+            // this loop created.
+            let Insn::Goto { target_pc } = &mut insns[i].0 else {
+                unreachable!("was_goto is only set on Gotos and nothing replaced this one yet");
+            };
+            let Some(t) = resolved_target(target_pc, n) else {
+                continue;
+            };
+            let d = if threading && was_goto[t as usize] {
+                let d = final_target[t as usize];
+                if d != t {
+                    *target_pc = BranchOffset::Offset(d);
+                    stats.jumps_threaded += 1;
+                }
+                d
+            } else {
+                t
+            };
+            if d as usize != i && matches!(insns[d as usize].0, Insn::Halt { .. }) {
+                let halt = insns[d as usize].0.clone();
+                insns[i].0 = halt;
+                stats.gotos_replaced_with_halt += 1;
+            } else {
+                targets[d as usize] = true;
+            }
+            continue;
+        }
+        insns[i].0.for_each_branch_offset(|off| {
             let Some(t) = resolved_target(off, n) else {
                 return;
             };
-            if is_goto[t as usize] {
+            if threading && was_goto[t as usize] {
                 let d = final_target[t as usize];
                 if d != t {
                     *off = BranchOffset::Offset(d);
                     stats.jumps_threaded += 1;
+                    targets[d as usize] = true;
+                    return;
                 }
             }
+            targets[t as usize] = true;
         });
     }
-
-    // Replace `Goto -> Halt` with a copy of the Halt.
-    for i in 0..n {
-        if !is_goto[i] {
-            continue;
-        }
-        let Insn::Goto { target_pc } = &insns[i].0 else {
-            unreachable!("is_goto guarantees a Goto");
-        };
-        let Some(t) = resolved_target(target_pc, n) else {
-            continue;
-        };
-        if t as usize != i && matches!(insns[t as usize].0, Insn::Halt { .. }) {
-            let halt = insns[t as usize].0.clone();
-            insns[i].0 = halt;
-            stats.gotos_replaced_with_halt += 1;
-        }
-    }
-}
-
-/// Fill `targets[i] = true` for every instruction `i` that some branch operand
-/// points at. Operands of instructions already marked dead are included on
-/// purpose: that is conservative (it only ever blocks a rewrite).
-fn collect_jump_targets(insns: &mut [(Insn, usize)], targets: &mut [bool]) {
-    targets.fill(false);
-    let n = insns.len();
-    for (insn, _) in insns.iter_mut() {
-        insn.for_each_branch_offset(|off| {
-            if let Some(t) = resolved_target(off, n) {
-                targets[t as usize] = true;
-            }
-        });
-    }
+    present
 }
 
 /// The conditional opcodes rule 2 knows how to invert, paired up.
@@ -519,7 +631,6 @@ fn invert_branches_over_gotos(
     if n < 3 {
         return;
     }
-    collect_jump_targets(insns, targets);
     for i in 0..n - 2 {
         if !live[i] || !live[i + 1] || targets[i + 1] {
             continue;
@@ -559,7 +670,6 @@ fn merge_adjacent_copies(
     stats: &mut PassStats,
 ) {
     let n = insns.len();
-    collect_jump_targets(insns, targets);
     let mut i = 0;
     while i < n {
         if !live[i] {
@@ -654,7 +764,6 @@ fn fold_affinity_into_make_record(
         (from..live.len()).find(|&j| live[j])
     }
     let n = insns.len();
-    collect_jump_targets(insns, targets);
     for i in 0..n {
         if !live[i] {
             continue;
@@ -756,7 +865,6 @@ fn delete_jumps_to_next(
     stats: &mut PassStats,
 ) {
     let n = insns.len();
-    collect_jump_targets(insns, targets);
     for i in 0..n {
         if !live[i] || targets[i] {
             continue;
@@ -826,26 +934,47 @@ fn delete_jumps_to_next(
 
 /// Rule 6: delete instructions no path from instruction 0 reaches.
 ///
-/// Successors of a live instruction:
+/// Worklist reachability over the live instructions. Successors of a live
+/// instruction:
 /// - `Goto`, `Jump`, `Halt`: their branch targets only (none for `Halt`).
 /// - everything else: every branch target plus the next live instruction.
 ///   That covers `Gosub` and `Yield`, whose "return points" (index + 1) are
 ///   entered dynamically through an address stored in a register, and stays
 ///   conservative for opcodes like `Init` that never actually fall through.
-fn sweep_unreachable(insns: &mut [(Insn, usize)], live: &mut [bool], stats: &mut PassStats) {
+///
+/// A cheaper single forward scan (reachable = jump target or fall-through)
+/// was tried here and rejected: window-function programs carry whole dead
+/// regions with internal loops, and any scheme that trusts the static target
+/// set keeps a dead cycle alive because its members point at each other.
+/// Only real reachability from instruction 0 removes them.
+fn sweep_unreachable(
+    insns: &mut [(Insn, usize)],
+    scratch: &mut Scratch,
+    any_dead: bool,
+    stats: &mut PassStats,
+) {
     let n = insns.len();
-    // next_live[i] = smallest live index strictly greater than i.
-    let mut next_live = vec![u32::MAX; n];
-    let mut nl = u32::MAX;
-    for i in (0..n).rev() {
-        next_live[i] = nl;
-        if live[i] {
-            nl = i as u32;
+    let live = &mut scratch.live;
+    // next_live[i] = smallest live index strictly greater than i. When
+    // nothing is dead yet that is just i + 1, so skip building the table.
+    let next_live = &mut scratch.u32_b;
+    next_live.clear();
+    if any_dead {
+        next_live.resize(n, u32::MAX);
+        let mut nl = u32::MAX;
+        for i in (0..n).rev() {
+            next_live[i] = nl;
+            if live[i] {
+                nl = i as u32;
+            }
         }
     }
 
-    let mut reached = vec![false; n];
-    let mut worklist: Vec<u32> = Vec::with_capacity(16);
+    let reached = &mut scratch.aux;
+    reached.clear();
+    reached.resize(n, false);
+    let worklist = &mut scratch.worklist;
+    worklist.clear();
     // Instruction 0 may itself have been marked dead by an earlier rule; the
     // walk still starts there because its fall-through successor is the next
     // live instruction, which is where execution starts after compaction.
@@ -868,7 +997,13 @@ fn sweep_unreachable(insns: &mut [(Insn, usize)], live: &mut [bool], stats: &mut
             }
         });
         if falls_through {
-            let next = next_live[i];
+            let next = if any_dead {
+                next_live[i]
+            } else if i + 1 < n {
+                i as u32 + 1
+            } else {
+                u32::MAX
+            };
             if next != u32::MAX && !reached[next as usize] {
                 worklist.push(next);
             }
@@ -889,10 +1024,13 @@ fn sweep_unreachable(insns: &mut [(Insn, usize)], live: &mut [bool], stats: &mut
 fn compact(
     insns: &mut Vec<(Insn, usize)>,
     comments: &mut Vec<(InsnReference, &'static str)>,
-    live: &[bool],
+    scratch: &mut Scratch,
 ) {
     let n = insns.len();
-    let mut old_to_new = vec![u32::MAX; n];
+    let live = &scratch.live;
+    let old_to_new = &mut scratch.u32_a;
+    old_to_new.clear();
+    old_to_new.resize(n, u32::MAX);
     let mut new_index = 0u32;
     for i in 0..n {
         if live[i] {
@@ -1062,9 +1200,9 @@ mod tests {
         assert_eq!(actual_fmt, expected_fmt);
     }
 
-    fn run_whole_pass(
-        insns: Vec<Insn>,
-    ) -> (Vec<(Insn, usize)>, Vec<(InsnReference, &'static str)>) {
+    type PassOutput = (Vec<(Insn, usize)>, Vec<(InsnReference, &'static str)>);
+
+    fn run_whole_pass(insns: Vec<Insn>) -> PassOutput {
         let mut insns = prog(insns);
         let mut comments = Vec::new();
         optimize_program(&mut insns, &mut comments);
@@ -1083,7 +1221,7 @@ mod tests {
             integer(7, 0),        // 4
         ]);
         let mut stats = PassStats::default();
-        thread_jumps(&mut insns, &mut stats);
+        thread_jumps(&mut insns, &mut Scratch::default(), &mut stats);
         assert_program(
             &insns,
             &[
@@ -1103,7 +1241,7 @@ mod tests {
     fn threading_leaves_a_goto_to_itself_alone() {
         let mut insns = prog(vec![if_insn(0, 1, false), goto(1), halt()]);
         let mut stats = PassStats::default();
-        thread_jumps(&mut insns, &mut stats);
+        thread_jumps(&mut insns, &mut Scratch::default(), &mut stats);
         assert_program(&insns, &[if_insn(0, 1, false), goto(1), halt()]);
         assert_eq!(stats.jumps_threaded, 0);
     }
@@ -1112,7 +1250,7 @@ mod tests {
     fn threading_leaves_a_two_goto_cycle_alone() {
         let mut insns = prog(vec![if_insn(0, 1, false), goto(2), goto(1), halt()]);
         let mut stats = PassStats::default();
-        thread_jumps(&mut insns, &mut stats);
+        thread_jumps(&mut insns, &mut Scratch::default(), &mut stats);
         assert_program(&insns, &[if_insn(0, 1, false), goto(2), goto(1), halt()]);
     }
 
@@ -1124,7 +1262,7 @@ mod tests {
             halt_err(19, "constraint"), // 2
         ]);
         let mut stats = PassStats::default();
-        thread_jumps(&mut insns, &mut stats);
+        thread_jumps(&mut insns, &mut Scratch::default(), &mut stats);
         assert_program(
             &insns,
             &[
@@ -1140,9 +1278,23 @@ mod tests {
     fn conditional_branch_to_halt_is_not_replaced() {
         let mut insns = prog(vec![if_insn(0, 2, false), integer(1, 0), halt()]);
         let mut stats = PassStats::default();
-        thread_jumps(&mut insns, &mut stats);
+        thread_jumps(&mut insns, &mut Scratch::default(), &mut stats);
         assert_program(&insns, &[if_insn(0, 2, false), integer(1, 0), halt()]);
         assert_eq!(stats.gotos_replaced_with_halt, 0);
+    }
+
+    /// Populate `targets` the way `run_pass` does before the rules run.
+    fn collect_targets_for_test(insns: &mut [(Insn, usize)]) -> Vec<bool> {
+        let n = insns.len();
+        let mut targets = vec![false; n];
+        for (insn, _) in insns.iter_mut() {
+            insn.for_each_branch_offset(|off| {
+                if let Some(t) = resolved_target(off, n) {
+                    targets[t as usize] = true;
+                }
+            });
+        }
+        targets
     }
 
     // ---------------- rule 2: branch-over-goto inversion ----------------
@@ -1150,7 +1302,7 @@ mod tests {
     fn run_inversion(insns: &mut [(Insn, usize)]) -> (Vec<bool>, PassStats) {
         let n = insns.len();
         let mut live = vec![true; n];
-        let mut targets = vec![false; n];
+        let mut targets = collect_targets_for_test(insns);
         let mut stats = PassStats::default();
         invert_branches_over_gotos(insns, &mut live, &mut targets, &mut stats);
         (live, stats)
@@ -1283,7 +1435,7 @@ mod tests {
     fn run_copy_merge(insns: &mut [(Insn, usize)]) -> (Vec<bool>, PassStats) {
         let n = insns.len();
         let mut live = vec![true; n];
-        let mut targets = vec![false; n];
+        let mut targets = collect_targets_for_test(insns);
         let mut stats = PassStats::default();
         merge_adjacent_copies(insns, &mut live, &mut targets, &mut stats);
         (live, stats)
@@ -1348,7 +1500,7 @@ mod tests {
     fn run_affinity_fold(insns: &mut [(Insn, usize)]) -> (Vec<bool>, PassStats) {
         let n = insns.len();
         let mut live = vec![true; n];
-        let mut targets = vec![false; n];
+        let mut targets = collect_targets_for_test(insns);
         let mut stats = PassStats::default();
         fold_affinity_into_make_record(insns, &mut live, &mut targets, &mut stats);
         (live, stats)
@@ -1445,7 +1597,7 @@ mod tests {
     fn run_delete_jump_to_next(insns: &mut [(Insn, usize)]) -> (Vec<bool>, PassStats) {
         let n = insns.len();
         let mut live = vec![true; n];
-        let mut targets = vec![false; n];
+        let mut targets = collect_targets_for_test(insns);
         let mut stats = PassStats::default();
         delete_jumps_to_next(insns, &mut live, &mut targets, &mut stats);
         (live, stats)
@@ -1539,10 +1691,12 @@ mod tests {
 
     fn run_sweep(insns: &mut [(Insn, usize)]) -> (Vec<bool>, PassStats) {
         let n = insns.len();
-        let mut live = vec![true; n];
+        let mut scratch = Scratch::default();
+        scratch.live.resize(n, true);
+        scratch.targets = collect_targets_for_test(insns);
         let mut stats = PassStats::default();
-        sweep_unreachable(insns, &mut live, &mut stats);
-        (live, stats)
+        sweep_unreachable(insns, &mut scratch, false, &mut stats);
+        (scratch.live, stats)
     }
 
     #[test]
@@ -1625,13 +1779,83 @@ mod tests {
         let mut insns = prog(insns);
         let mut comments: Vec<(InsnReference, &'static str)> =
             vec![(0, "jump"), (1, "dead"), (2, "stop")];
-        let live = vec![true, false, true];
-        compact(&mut insns, &mut comments, &live);
+        let mut scratch = Scratch {
+            live: vec![true, false, true],
+            ..Scratch::default()
+        };
+        compact(&mut insns, &mut comments, &mut scratch);
         assert_program(&insns, &[goto(1), halt()]);
         assert_eq!(comments, vec![(0, "jump"), (1, "stop")]);
     }
 
     // ---------------- whole pass ----------------
+
+    /// Not a correctness test: measures the pass by itself, back to back with
+    /// the clone cost, so the numbers hold up even on machines whose speed
+    /// drifts between runs. Run with:
+    /// `cargo test --release -p turso_core --lib time_the_pass -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual timing harness"]
+    fn time_the_pass_manually() {
+        use std::time::Instant;
+        let build = || {
+            vec![
+                Insn::Init { target_pc: off(4) },
+                integer(1, 0),
+                goto(3),
+                Insn::ResultRow {
+                    start_reg: 0,
+                    count: 1,
+                },
+                halt(),
+                Insn::Transaction {
+                    db: 0,
+                    tx_mode: crate::translate::emitter::TransactionMode::Read,
+                    schema_cookie: 0,
+                },
+                goto(1),
+            ]
+        };
+        let build_noop = || {
+            vec![
+                Insn::Init { target_pc: off(3) },
+                Insn::ResultRow {
+                    start_reg: 0,
+                    count: 1,
+                },
+                halt(),
+                Insn::Transaction {
+                    db: 0,
+                    tx_mode: crate::translate::emitter::TransactionMode::Read,
+                    schema_cookie: 0,
+                },
+                goto(1),
+            ]
+        };
+        let iters = 1_000_000u32;
+        let mut sink = 0usize;
+        let time = |f: &dyn Fn() -> Vec<Insn>, run: bool, sink: &mut usize| {
+            let t0 = Instant::now();
+            for _ in 0..iters {
+                let mut p = prog(f());
+                if run {
+                    let mut c = Vec::new();
+                    optimize_program(&mut p, &mut c);
+                }
+                *sink += p.len();
+            }
+            t0.elapsed() / iters
+        };
+        let clone_rw = time(&build, false, &mut sink);
+        let full_rw = time(&build, true, &mut sink);
+        let clone_no = time(&build_noop, false, &mut sink);
+        let full_no = time(&build_noop, true, &mut sink);
+        eprintln!(
+            "rewriting: pass {:?}/iter; no-op: pass {:?}/iter (sink {sink})",
+            full_rw - clone_rw,
+            full_no - clone_no,
+        );
+    }
 
     #[test]
     fn single_row_insert_epilogue_collapses() {

--- a/core/vdbe/peephole.rs
+++ b/core/vdbe/peephole.rs
@@ -1,0 +1,1727 @@
+//! Peephole optimizer for finished bytecode programs.
+//!
+//! [`optimize_program`] runs on every prepared program right after label
+//! resolution ([`super::builder::ProgramBuilder::resolve_labels`]), so every
+//! branch operand is already a concrete [`BranchOffset::Offset`]. It applies a
+//! fixed list of rewrite rules, marks instructions dead, and then compacts the
+//! instruction list once, remapping every branch operand through the shared
+//! [`Insn::for_each_branch_offset`] visitor.
+//!
+//! The rules, in order:
+//! 1. Jump threading: retarget every branch operand that lands on a `Goto` to
+//!    that `Goto`'s final destination. A `Goto` whose final destination is a
+//!    plain `Halt` becomes a copy of that `Halt`.
+//! 2. Branch-over-Goto inversion: `If x -> +2; Goto L` becomes `IfNot x -> L`.
+//! 3. Copy merge: adjacent `Copy`s over contiguous register ranges become one
+//!    `Copy` with a larger `extra_amount`.
+//! 4. Affinity fold: a standalone `Affinity` directly before a `MakeRecord`
+//!    over the same register range moves its affinity string onto the
+//!    `MakeRecord`.
+//! 5. Delete jumps to the next instruction.
+//! 6. Delete instructions that no path from instruction 0 can reach.
+//!
+//! Set `TURSO_PEEPHOLE=0` in the environment to disable the pass (read once
+//! per process). Set `TURSO_PEEPHOLE_STATS=1` to print cumulative rule-hit
+//! counters when the process exits (unix only).
+//!
+//! The pass never runs for `EXPLAIN QUERY PLAN` programs: those consist of
+//! `Insn::Explain` rows that carry raw instruction indices which compaction
+//! would invalidate, and they are never executed for performance.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::turso_debug_assert;
+use crate::vdbe::affinity::Affinity;
+use crate::vdbe::insn::Insn;
+use crate::vdbe::{BranchOffset, InsnReference};
+
+/// Process-wide rule-hit counters.
+///
+/// These use `std::sync::atomic` directly (not `crate::sync`) because they are
+/// diagnostic-only and must be const-initializable in a static, which the
+/// shuttle atomics are not.
+#[derive(Debug)]
+pub struct PeepholeCounters {
+    /// Programs the pass ran on.
+    pub programs: AtomicU64,
+    /// Branch operands retargeted through one or more `Goto`s (rule 1).
+    pub jumps_threaded: AtomicU64,
+    /// `Goto`s replaced by a copy of the `Halt` they jump to (rule 1).
+    pub gotos_replaced_with_halt: AtomicU64,
+    /// Conditional branches inverted over a following `Goto` (rule 2).
+    pub branches_inverted: AtomicU64,
+    /// `Copy` instructions merged into a preceding `Copy` (rule 3).
+    pub copies_merged: AtomicU64,
+    /// `Affinity` instructions folded into a following `MakeRecord` (rule 4).
+    pub affinities_folded: AtomicU64,
+    /// Jumps to the next instruction deleted (rule 5).
+    pub jumps_to_next_deleted: AtomicU64,
+    /// Unreachable instructions deleted (rule 6).
+    pub unreachable_deleted: AtomicU64,
+    /// Comparison jumps to the next instruction kept because deleting them
+    /// would also delete their affinity conversion of the operand registers
+    /// (rule 5 safety skip).
+    pub cmp_deletes_skipped: AtomicU64,
+    /// Affinity/MakeRecord pairs left alone because an instruction between
+    /// them could observe the register range, or one of the instructions is a
+    /// jump target (rule 4 safety skip).
+    pub affinity_folds_skipped: AtomicU64,
+}
+
+pub static COUNTERS: PeepholeCounters = PeepholeCounters {
+    programs: AtomicU64::new(0),
+    jumps_threaded: AtomicU64::new(0),
+    gotos_replaced_with_halt: AtomicU64::new(0),
+    branches_inverted: AtomicU64::new(0),
+    copies_merged: AtomicU64::new(0),
+    affinities_folded: AtomicU64::new(0),
+    jumps_to_next_deleted: AtomicU64::new(0),
+    unreachable_deleted: AtomicU64::new(0),
+    cmp_deletes_skipped: AtomicU64::new(0),
+    affinity_folds_skipped: AtomicU64::new(0),
+};
+
+/// Per-run counters, folded into [`COUNTERS`] once per program.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PassStats {
+    pub jumps_threaded: u64,
+    pub gotos_replaced_with_halt: u64,
+    pub branches_inverted: u64,
+    pub copies_merged: u64,
+    pub affinities_folded: u64,
+    pub jumps_to_next_deleted: u64,
+    pub unreachable_deleted: u64,
+    pub cmp_deletes_skipped: u64,
+    pub affinity_folds_skipped: u64,
+}
+
+impl PassStats {
+    fn total_rewrites(&self) -> u64 {
+        self.jumps_threaded
+            + self.gotos_replaced_with_halt
+            + self.branches_inverted
+            + self.copies_merged
+            + self.affinities_folded
+            + self.jumps_to_next_deleted
+            + self.unreachable_deleted
+    }
+
+    fn add_to_global(&self) {
+        let c = &COUNTERS;
+        c.programs.fetch_add(1, Ordering::Relaxed);
+        c.jumps_threaded
+            .fetch_add(self.jumps_threaded, Ordering::Relaxed);
+        c.gotos_replaced_with_halt
+            .fetch_add(self.gotos_replaced_with_halt, Ordering::Relaxed);
+        c.branches_inverted
+            .fetch_add(self.branches_inverted, Ordering::Relaxed);
+        c.copies_merged
+            .fetch_add(self.copies_merged, Ordering::Relaxed);
+        c.affinities_folded
+            .fetch_add(self.affinities_folded, Ordering::Relaxed);
+        c.jumps_to_next_deleted
+            .fetch_add(self.jumps_to_next_deleted, Ordering::Relaxed);
+        c.unreachable_deleted
+            .fetch_add(self.unreachable_deleted, Ordering::Relaxed);
+        c.cmp_deletes_skipped
+            .fetch_add(self.cmp_deletes_skipped, Ordering::Relaxed);
+        c.affinity_folds_skipped
+            .fetch_add(self.affinity_folds_skipped, Ordering::Relaxed);
+    }
+}
+
+/// Whether the pass runs at all. `TURSO_PEEPHOLE=0` (or `false`/`off`)
+/// disables it; read once per process.
+static ENABLED_FROM_ENV: std::sync::LazyLock<bool> =
+    std::sync::LazyLock::new(|| match std::env::var("TURSO_PEEPHOLE") {
+        Ok(v) => !(v == "0" || v.eq_ignore_ascii_case("false") || v.eq_ignore_ascii_case("off")),
+        Err(_) => true,
+    });
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only override so one process can prepare the same statement with
+    /// the pass on and off and compare the bytecode.
+    static ENABLED_OVERRIDE: std::cell::Cell<Option<bool>> = const { std::cell::Cell::new(None) };
+}
+
+pub(crate) fn enabled() -> bool {
+    #[cfg(test)]
+    if let Some(v) = ENABLED_OVERRIDE.with(|c| c.get()) {
+        return v;
+    }
+    *ENABLED_FROM_ENV
+}
+
+/// Force the pass on or off for statements prepared on this thread;
+/// `None` restores the environment default.
+#[cfg(test)]
+pub(crate) fn set_enabled_for_current_thread(enabled: Option<bool>) {
+    ENABLED_OVERRIDE.with(|c| c.set(enabled));
+}
+
+/// Print cumulative counters when the process exits, if
+/// `TURSO_PEEPHOLE_STATS=1` is set. Unix only (uses libc::atexit).
+fn maybe_register_stats_dump() {
+    #[cfg(unix)]
+    {
+        static STATS_ENABLED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
+            std::env::var("TURSO_PEEPHOLE_STATS").is_ok_and(|v| v == "1")
+        });
+        static REGISTER: std::sync::Once = std::sync::Once::new();
+        if *STATS_ENABLED {
+            REGISTER.call_once(|| unsafe {
+                libc::atexit(dump_stats_at_exit);
+            });
+        }
+    }
+}
+
+#[cfg(unix)]
+extern "C" fn dump_stats_at_exit() {
+    let c = &COUNTERS;
+    eprintln!(
+        "peephole stats: programs={} jumps_threaded={} gotos_replaced_with_halt={} \
+         branches_inverted={} copies_merged={} affinities_folded={} jumps_to_next_deleted={} \
+         unreachable_deleted={} cmp_deletes_skipped={} affinity_folds_skipped={}",
+        c.programs.load(Ordering::Relaxed),
+        c.jumps_threaded.load(Ordering::Relaxed),
+        c.gotos_replaced_with_halt.load(Ordering::Relaxed),
+        c.branches_inverted.load(Ordering::Relaxed),
+        c.copies_merged.load(Ordering::Relaxed),
+        c.affinities_folded.load(Ordering::Relaxed),
+        c.jumps_to_next_deleted.load(Ordering::Relaxed),
+        c.unreachable_deleted.load(Ordering::Relaxed),
+        c.cmp_deletes_skipped.load(Ordering::Relaxed),
+        c.affinity_folds_skipped.load(Ordering::Relaxed),
+    );
+}
+
+/// Run the peephole pass on a finished, label-resolved instruction list.
+///
+/// `comments` maps instruction indices to EXPLAIN comments; entries move with
+/// their instruction and entries for deleted instructions are dropped.
+pub(crate) fn optimize_program(
+    insns: &mut Vec<(Insn, usize)>,
+    comments: &mut Vec<(InsnReference, &'static str)>,
+) {
+    let n = insns.len();
+    if n == 0 {
+        return;
+    }
+    maybe_register_stats_dump();
+
+    let mut stats = PassStats::default();
+    let mut live = vec![true; n];
+    // Scratch buffer for "is instruction i the target of any branch operand".
+    let mut targets = vec![false; n];
+
+    thread_jumps(insns, &mut stats);
+    invert_branches_over_gotos(insns, &mut live, &mut targets, &mut stats);
+    merge_adjacent_copies(insns, &mut live, &mut targets, &mut stats);
+    fold_affinity_into_make_record(insns, &mut live, &mut targets, &mut stats);
+    delete_jumps_to_next(insns, &mut live, &mut targets, &mut stats);
+    sweep_unreachable(insns, &mut live, &mut stats);
+    compact(insns, comments, &live);
+
+    #[cfg(debug_assertions)]
+    verify_all_branches_resolved(insns);
+
+    if stats.total_rewrites() > 0 {
+        tracing::debug!(
+            insns_before = n,
+            insns_after = insns.len(),
+            ?stats,
+            "peephole pass rewrote program"
+        );
+    }
+    stats.add_to_global();
+}
+
+/// Return the branch target of a resolved operand, or `None` when the operand
+/// is (unexpectedly) still a label or placeholder or out of bounds. Rules skip
+/// such operands rather than corrupt them; the final debug verification
+/// flags them.
+fn resolved_target(off: &BranchOffset, n: usize) -> Option<u32> {
+    match off {
+        BranchOffset::Offset(t) if (*t as usize) < n => Some(*t),
+        _ => None,
+    }
+}
+
+/// Rule 1: jump threading.
+///
+/// For every branch operand pointing at a `Goto`, retarget it to the end of
+/// the `Goto` chain. Chains are resolved once per `Goto` (linear total time)
+/// with a cycle guard: any chain that reaches a `Goto` already on the current
+/// chain (including a `Goto` to itself) is left alone.
+///
+/// Afterwards, any `Goto` that (now) points directly at a plain `Halt` is
+/// replaced by a copy of that `Halt`: jumping to a `Halt` and executing it is
+/// identical to executing it in place, since `Goto` has no other effect.
+fn thread_jumps(insns: &mut [(Insn, usize)], stats: &mut PassStats) {
+    let n = insns.len();
+    let is_goto: Vec<bool> = insns
+        .iter()
+        .map(|(insn, _)| matches!(insn, Insn::Goto { .. }))
+        .collect();
+
+    // For each Goto index: the ultimate non-Goto destination of its chain, or
+    // its own index when the chain hits a cycle or an unresolved operand
+    // (meaning: leave every operand that points here unchanged).
+    const UNVISITED: u8 = 0;
+    const IN_PROGRESS: u8 = 1;
+    const DONE: u8 = 2;
+    let mut final_target: Vec<u32> = (0..n as u32).collect();
+    let mut state = vec![UNVISITED; n];
+    let mut chain: Vec<u32> = Vec::new();
+    for i in 0..n {
+        if !is_goto[i] || state[i] != UNVISITED {
+            continue;
+        }
+        chain.clear();
+        let mut cur = i as u32;
+        let final_dst = loop {
+            // Invariant: `cur` is an unvisited Goto.
+            state[cur as usize] = IN_PROGRESS;
+            chain.push(cur);
+            let Insn::Goto { target_pc } = &insns[cur as usize].0 else {
+                unreachable!("is_goto guarantees a Goto");
+            };
+            let Some(t) = resolved_target(target_pc, n) else {
+                break None;
+            };
+            if !is_goto[t as usize] {
+                break Some(t);
+            }
+            match state[t as usize] {
+                // A previously resolved chain: reuse its result. When that
+                // chain was left alone (cycle), final_target[t] == t, which
+                // correctly threads this chain up to the cycle entrance.
+                DONE => break Some(final_target[t as usize]),
+                IN_PROGRESS => break None, // cycle through the current chain
+                _ => cur = t,
+            }
+        };
+        for &g in &chain {
+            state[g as usize] = DONE;
+            if let Some(d) = final_dst {
+                final_target[g as usize] = d;
+            }
+        }
+    }
+
+    // Retarget every operand that lands on a Goto with a known final
+    // destination. This includes the Gotos' own targets, so after this loop
+    // every Goto in a chain points directly at the chain's destination.
+    for (insn, _) in insns.iter_mut() {
+        insn.for_each_branch_offset(|off| {
+            let Some(t) = resolved_target(off, n) else {
+                return;
+            };
+            if is_goto[t as usize] {
+                let d = final_target[t as usize];
+                if d != t {
+                    *off = BranchOffset::Offset(d);
+                    stats.jumps_threaded += 1;
+                }
+            }
+        });
+    }
+
+    // Replace `Goto -> Halt` with a copy of the Halt.
+    for i in 0..n {
+        if !is_goto[i] {
+            continue;
+        }
+        let Insn::Goto { target_pc } = &insns[i].0 else {
+            unreachable!("is_goto guarantees a Goto");
+        };
+        let Some(t) = resolved_target(target_pc, n) else {
+            continue;
+        };
+        if t as usize != i && matches!(insns[t as usize].0, Insn::Halt { .. }) {
+            let halt = insns[t as usize].0.clone();
+            insns[i].0 = halt;
+            stats.gotos_replaced_with_halt += 1;
+        }
+    }
+}
+
+/// Fill `targets[i] = true` for every instruction `i` that some branch operand
+/// points at. Operands of instructions already marked dead are included on
+/// purpose: that is conservative (it only ever blocks a rewrite).
+fn collect_jump_targets(insns: &mut [(Insn, usize)], targets: &mut [bool]) {
+    targets.fill(false);
+    let n = insns.len();
+    for (insn, _) in insns.iter_mut() {
+        insn.for_each_branch_offset(|off| {
+            if let Some(t) = resolved_target(off, n) {
+                targets[t as usize] = true;
+            }
+        });
+    }
+}
+
+/// The conditional opcodes rule 2 knows how to invert, paired up.
+/// `NotExists`/`Found`/`NotFound`/`DecrJumpZero` and friends are deliberately
+/// not invertible: their "jump" and "fall through" sides have different side
+/// effects (cursor positioning, register decrements).
+fn inverted_condition(insn: &Insn, new_target: BranchOffset) -> Option<Insn> {
+    // For If/IfNot, `jump_if_null` decides whether a NULL register jumps; the
+    // inverse must make the opposite decision for NULL, so the flag flips.
+    //
+    // For the comparisons, `CmpInsFlags::JUMP_IF_NULL` flips for the same
+    // reason. `NULL_EQ` stays: it only affects Eq/Ne, and with it set, Eq
+    // jumps iff `lhs == rhs` and Ne jumps iff `lhs != rhs` even when operands
+    // are NULL (op_comparison consults NULL_EQ before JUMP_IF_NULL), so Eq
+    // and Ne remain exact complements. Affinity and collation stay unchanged:
+    // both sides of the comparison run the exact same conversion code, so an
+    // inverted opcode applies the same register conversions the original did.
+    match insn {
+        Insn::If {
+            reg,
+            target_pc: _,
+            jump_if_null,
+        } => Some(Insn::IfNot {
+            reg: *reg,
+            target_pc: new_target,
+            jump_if_null: !*jump_if_null,
+        }),
+        Insn::IfNot {
+            reg,
+            target_pc: _,
+            jump_if_null,
+        } => Some(Insn::If {
+            reg: *reg,
+            target_pc: new_target,
+            jump_if_null: !*jump_if_null,
+        }),
+        Insn::IsNull { reg, target_pc: _ } => Some(Insn::NotNull {
+            reg: *reg,
+            target_pc: new_target,
+        }),
+        Insn::NotNull { reg, target_pc: _ } => Some(Insn::IsNull {
+            reg: *reg,
+            target_pc: new_target,
+        }),
+        Insn::Eq {
+            lhs,
+            rhs,
+            target_pc: _,
+            flags,
+            collation,
+        } => Some(Insn::Ne {
+            lhs: *lhs,
+            rhs: *rhs,
+            target_pc: new_target,
+            flags: flags.with_jump_if_null_flipped(),
+            collation: *collation,
+        }),
+        Insn::Ne {
+            lhs,
+            rhs,
+            target_pc: _,
+            flags,
+            collation,
+        } => Some(Insn::Eq {
+            lhs: *lhs,
+            rhs: *rhs,
+            target_pc: new_target,
+            flags: flags.with_jump_if_null_flipped(),
+            collation: *collation,
+        }),
+        Insn::Lt {
+            lhs,
+            rhs,
+            target_pc: _,
+            flags,
+            collation,
+        } => Some(Insn::Ge {
+            lhs: *lhs,
+            rhs: *rhs,
+            target_pc: new_target,
+            flags: flags.with_jump_if_null_flipped(),
+            collation: *collation,
+        }),
+        Insn::Ge {
+            lhs,
+            rhs,
+            target_pc: _,
+            flags,
+            collation,
+        } => Some(Insn::Lt {
+            lhs: *lhs,
+            rhs: *rhs,
+            target_pc: new_target,
+            flags: flags.with_jump_if_null_flipped(),
+            collation: *collation,
+        }),
+        Insn::Le {
+            lhs,
+            rhs,
+            target_pc: _,
+            flags,
+            collation,
+        } => Some(Insn::Gt {
+            lhs: *lhs,
+            rhs: *rhs,
+            target_pc: new_target,
+            flags: flags.with_jump_if_null_flipped(),
+            collation: *collation,
+        }),
+        Insn::Gt {
+            lhs,
+            rhs,
+            target_pc: _,
+            flags,
+            collation,
+        } => Some(Insn::Le {
+            lhs: *lhs,
+            rhs: *rhs,
+            target_pc: new_target,
+            flags: flags.with_jump_if_null_flipped(),
+            collation: *collation,
+        }),
+        _ => None,
+    }
+}
+
+/// The single branch target of an invertible conditional.
+fn invertible_condition_target(insn: &Insn) -> Option<&BranchOffset> {
+    match insn {
+        Insn::If { target_pc, .. }
+        | Insn::IfNot { target_pc, .. }
+        | Insn::IsNull { target_pc, .. }
+        | Insn::NotNull { target_pc, .. }
+        | Insn::Eq { target_pc, .. }
+        | Insn::Ne { target_pc, .. }
+        | Insn::Lt { target_pc, .. }
+        | Insn::Le { target_pc, .. }
+        | Insn::Gt { target_pc, .. }
+        | Insn::Ge { target_pc, .. } => Some(target_pc),
+        _ => None,
+    }
+}
+
+/// Rule 2: invert a conditional branch that only skips over a `Goto`.
+///
+/// `cond -> +2; Goto L` becomes `inverted-cond -> L` and the `Goto` dies.
+/// The `Goto` must not be a jump target (anything that jumps to it must keep
+/// finding it), which also excludes a `Goto` to itself.
+fn invert_branches_over_gotos(
+    insns: &mut [(Insn, usize)],
+    live: &mut [bool],
+    targets: &mut [bool],
+    stats: &mut PassStats,
+) {
+    let n = insns.len();
+    if n < 3 {
+        return;
+    }
+    collect_jump_targets(insns, targets);
+    for i in 0..n - 2 {
+        if !live[i] || !live[i + 1] || targets[i + 1] {
+            continue;
+        }
+        let Some(cond_target) = invertible_condition_target(&insns[i].0) else {
+            continue;
+        };
+        if resolved_target(cond_target, n) != Some(i as u32 + 2) {
+            continue;
+        }
+        let Insn::Goto { target_pc } = &insns[i + 1].0 else {
+            continue;
+        };
+        let Some(goto_dst) = resolved_target(target_pc, n) else {
+            continue;
+        };
+        let Some(inverted) = inverted_condition(&insns[i].0, BranchOffset::Offset(goto_dst)) else {
+            continue;
+        };
+        insns[i].0 = inverted;
+        live[i + 1] = false;
+        stats.branches_inverted += 1;
+    }
+}
+
+/// Rule 3: merge adjacent `Copy`s over contiguous register ranges.
+///
+/// `op_copy` copies element by element from the lowest register up, so running
+/// one merged `Copy { extra_amount: a + b + 1 }` performs exactly the same
+/// register operations in exactly the same order as the two originals, even
+/// when source and destination ranges overlap. A merged-away `Copy` must not
+/// be a jump target: whoever jumps there expects the tail of the run only.
+fn merge_adjacent_copies(
+    insns: &mut [(Insn, usize)],
+    live: &mut [bool],
+    targets: &mut [bool],
+    stats: &mut PassStats,
+) {
+    let n = insns.len();
+    collect_jump_targets(insns, targets);
+    let mut i = 0;
+    while i < n {
+        if !live[i] {
+            i += 1;
+            continue;
+        }
+        let Insn::Copy {
+            src_reg,
+            dst_reg,
+            extra_amount,
+        } = insns[i].0
+        else {
+            i += 1;
+            continue;
+        };
+        let mut merged_extra = extra_amount;
+        let mut j = i + 1;
+        while j < n && live[j] && !targets[j] {
+            let Insn::Copy {
+                src_reg: next_src,
+                dst_reg: next_dst,
+                extra_amount: next_extra,
+            } = insns[j].0
+            else {
+                break;
+            };
+            if next_src != src_reg + merged_extra + 1 || next_dst != dst_reg + merged_extra + 1 {
+                break;
+            }
+            merged_extra += next_extra + 1;
+            live[j] = false;
+            stats.copies_merged += 1;
+            j += 1;
+        }
+        if merged_extra != extra_amount {
+            let Insn::Copy { extra_amount, .. } = &mut insns[i].0 else {
+                unreachable!("checked above");
+            };
+            *extra_amount = merged_extra;
+        }
+        i = j;
+    }
+}
+
+/// Registers an instruction reads or writes, for the rule 4 gap check.
+/// Returns `None` for any opcode we have not proven safe: rule 4 then skips.
+/// Every whitelisted opcode has no branch operands (it cannot jump away
+/// between the `Affinity` and the `MakeRecord`) and cannot suspend.
+fn known_register_footprint(insn: &Insn) -> Option<std::ops::RangeInclusive<usize>> {
+    match insn {
+        // Writes rowid_reg; prev_largest_reg is documented unused but treated
+        // as read to stay conservative. The two are always adjacent-or-equal
+        // in emitted code, but compute the enclosing range to be safe.
+        Insn::NewRowid {
+            rowid_reg,
+            prev_largest_reg,
+            ..
+        } => Some(*rowid_reg.min(prev_largest_reg)..=*rowid_reg.max(prev_largest_reg)),
+        Insn::Integer { dest, .. }
+        | Insn::Real { dest, .. }
+        | Insn::String8 { dest, .. }
+        | Insn::Blob { dest, .. } => Some(*dest..=*dest),
+        Insn::Null { dest, dest_end } => Some(*dest..=dest_end.unwrap_or(*dest)),
+        _ => None,
+    }
+}
+
+/// Rule 4: fold `Affinity` into a directly following `MakeRecord`.
+///
+/// `op_make_record` with `affinity_str` applies affinities to the source
+/// registers in place with the exact same `apply_affinity_char` loop that
+/// `op_affinity` uses, so folding preserves both the built record and the
+/// register mutations. The fold only moves the *time* of the conversion past
+/// the instructions in between, so those instructions (at most one) must not
+/// read or write the register range, must not be able to jump away, and
+/// nothing may jump into the window past the `Affinity`.
+///
+/// This fires rarely in practice, and the skips are all correct: UPDATE's
+/// main-record path already sets `MakeRecord.affinity_str` (its preceding
+/// standalone `Affinity` applies the same conversions twice, which this rule
+/// must not touch since folding needs an empty `affinity_str`), index records
+/// cover one more register than their `Affinity` (the appended rowid must not
+/// be converted), and INSERT applies affinities several instructions before
+/// its `MakeRecord` with constraint checks in between.
+fn fold_affinity_into_make_record(
+    insns: &mut [(Insn, usize)],
+    live: &mut [bool],
+    targets: &mut [bool],
+    stats: &mut PassStats,
+) {
+    fn next_live(live: &[bool], from: usize) -> Option<usize> {
+        (from..live.len()).find(|&j| live[j])
+    }
+    let n = insns.len();
+    collect_jump_targets(insns, targets);
+    for i in 0..n {
+        if !live[i] {
+            continue;
+        }
+        let Insn::Affinity {
+            start_reg, count, ..
+        } = &insns[i].0
+        else {
+            continue;
+        };
+        let (aff_start, aff_count) = (*start_reg, count.get());
+
+        // Locate the shape: MakeRecord directly after the Affinity, or after
+        // exactly one instruction in between.
+        let Some(j) = next_live(live, i + 1) else {
+            continue;
+        };
+        let (mr, gap) = if matches!(insns[j].0, Insn::MakeRecord { .. }) {
+            (j, None)
+        } else {
+            let Some(k) = next_live(live, j + 1) else {
+                continue;
+            };
+            if !matches!(insns[k].0, Insn::MakeRecord { .. }) {
+                continue;
+            }
+            (k, Some(j))
+        };
+        let Insn::MakeRecord {
+            start_reg: mr_start,
+            count: mr_count,
+            affinity_str,
+            ..
+        } = &insns[mr].0
+        else {
+            unreachable!("checked above");
+        };
+        if *mr_start as usize != aff_start
+            || *mr_count as usize != aff_count
+            || affinity_str.is_some()
+        {
+            continue;
+        }
+
+        // The shape matches; now the safety checks. Deleting a jump target
+        // would leave branches pointing at a removed instruction, and a
+        // branch that jumps straight to the MakeRecord skips the Affinity
+        // today but would suddenly get the conversions after the fold.
+        if targets[i] || targets[mr] {
+            stats.affinity_folds_skipped += 1;
+            continue;
+        }
+        // The instruction in between must not read or write the register
+        // range (it would observe values before/after conversion), must not
+        // be able to branch away (the whitelist only contains straight-line
+        // opcodes), and must not be a jump target.
+        if let Some(gap) = gap {
+            let safe = match known_register_footprint(&insns[gap].0) {
+                Some(range) if !targets[gap] => {
+                    *range.end() < aff_start || *range.start() >= aff_start + aff_count
+                }
+                _ => false,
+            };
+            if !safe {
+                stats.affinity_folds_skipped += 1;
+                continue;
+            }
+        }
+
+        let Insn::Affinity { affinities, .. } = &mut insns[i].0 else {
+            unreachable!("checked above");
+        };
+        let affinities = std::mem::take(affinities);
+        let Insn::MakeRecord { affinity_str, .. } = &mut insns[mr].0 else {
+            unreachable!("checked above");
+        };
+        *affinity_str = Some(affinities);
+        live[i] = false;
+        stats.affinities_folded += 1;
+    }
+}
+
+/// Rule 5: delete branches whose only destination is the next instruction.
+///
+/// Jumping to `i + 1` and falling through to `i + 1` are the same thing, so
+/// the branch only matters through its side effects:
+/// - `Goto`, `If`, `IfNot`, `IsNull`, `NotNull` have none (`op_if`/`op_if_not`
+///   only read the register; `op_is_null`/`op_not_null` only inspect it).
+/// - `Eq`/`Ne`/`Lt`/`Le`/`Gt`/`Ge` write affinity-converted operands back to
+///   the registers unless their affinity is BLOB (none), and a custom
+///   collation lookup can fail at runtime; such instances are kept.
+///
+/// The deleted instruction must not be a jump target, since branches pointing
+/// at a deleted instruction cannot be remapped.
+fn delete_jumps_to_next(
+    insns: &mut [(Insn, usize)],
+    live: &mut [bool],
+    targets: &mut [bool],
+    stats: &mut PassStats,
+) {
+    let n = insns.len();
+    collect_jump_targets(insns, targets);
+    for i in 0..n {
+        if !live[i] || targets[i] {
+            continue;
+        }
+        let next = i as u32 + 1;
+        let deletable = match &insns[i].0 {
+            Insn::Goto { target_pc } => resolved_target(target_pc, n) == Some(next),
+            Insn::If { target_pc, .. }
+            | Insn::IfNot { target_pc, .. }
+            | Insn::IsNull { target_pc, .. }
+            | Insn::NotNull { target_pc, .. } => resolved_target(target_pc, n) == Some(next),
+            Insn::Eq {
+                target_pc,
+                flags,
+                collation,
+                ..
+            }
+            | Insn::Ne {
+                target_pc,
+                flags,
+                collation,
+                ..
+            }
+            | Insn::Lt {
+                target_pc,
+                flags,
+                collation,
+                ..
+            }
+            | Insn::Le {
+                target_pc,
+                flags,
+                collation,
+                ..
+            }
+            | Insn::Gt {
+                target_pc,
+                flags,
+                collation,
+                ..
+            }
+            | Insn::Ge {
+                target_pc,
+                flags,
+                collation,
+                ..
+            } => {
+                if resolved_target(target_pc, n) != Some(next) {
+                    false
+                } else if flags.get_affinity() == Affinity::Blob
+                    && !collation.is_some_and(|c| c.is_custom())
+                {
+                    true
+                } else {
+                    stats.cmp_deletes_skipped += 1;
+                    false
+                }
+            }
+            _ => false,
+        };
+        if deletable {
+            live[i] = false;
+            stats.jumps_to_next_deleted += 1;
+        }
+    }
+}
+
+/// Rule 6: delete instructions no path from instruction 0 reaches.
+///
+/// Successors of a live instruction:
+/// - `Goto`, `Jump`, `Halt`: their branch targets only (none for `Halt`).
+/// - everything else: every branch target plus the next live instruction.
+///   That covers `Gosub` and `Yield`, whose "return points" (index + 1) are
+///   entered dynamically through an address stored in a register, and stays
+///   conservative for opcodes like `Init` that never actually fall through.
+fn sweep_unreachable(insns: &mut [(Insn, usize)], live: &mut [bool], stats: &mut PassStats) {
+    let n = insns.len();
+    // next_live[i] = smallest live index strictly greater than i.
+    let mut next_live = vec![u32::MAX; n];
+    let mut nl = u32::MAX;
+    for i in (0..n).rev() {
+        next_live[i] = nl;
+        if live[i] {
+            nl = i as u32;
+        }
+    }
+
+    let mut reached = vec![false; n];
+    let mut worklist: Vec<u32> = Vec::with_capacity(16);
+    // Instruction 0 may itself have been marked dead by an earlier rule; the
+    // walk still starts there because its fall-through successor is the next
+    // live instruction, which is where execution starts after compaction.
+    worklist.push(0);
+    while let Some(i) = worklist.pop() {
+        let i = i as usize;
+        if reached[i] {
+            continue;
+        }
+        reached[i] = true;
+        let falls_through = !matches!(
+            insns[i].0,
+            Insn::Goto { .. } | Insn::Jump { .. } | Insn::Halt { .. }
+        );
+        insns[i].0.for_each_branch_offset(|off| {
+            if let Some(t) = resolved_target(off, n) {
+                if !reached[t as usize] {
+                    worklist.push(t);
+                }
+            }
+        });
+        if falls_through {
+            let next = next_live[i];
+            if next != u32::MAX && !reached[next as usize] {
+                worklist.push(next);
+            }
+        }
+    }
+
+    for i in 0..n {
+        if live[i] && !reached[i] {
+            live[i] = false;
+            stats.unreachable_deleted += 1;
+        }
+    }
+}
+
+/// Drop dead instructions and remap every branch operand of the survivors.
+/// EXPLAIN comments move with their instruction; comments on dead
+/// instructions are dropped.
+fn compact(
+    insns: &mut Vec<(Insn, usize)>,
+    comments: &mut Vec<(InsnReference, &'static str)>,
+    live: &[bool],
+) {
+    let n = insns.len();
+    let mut old_to_new = vec![u32::MAX; n];
+    let mut new_index = 0u32;
+    for i in 0..n {
+        if live[i] {
+            old_to_new[i] = new_index;
+            new_index += 1;
+        }
+    }
+    if new_index as usize == n {
+        return;
+    }
+
+    let mut i = 0;
+    insns.retain(|_| {
+        let keep = live[i];
+        i += 1;
+        keep
+    });
+    for (insn, _) in insns.iter_mut() {
+        insn.for_each_branch_offset(|off| {
+            let Some(t) = resolved_target(off, n) else {
+                return;
+            };
+            let new_t = old_to_new[t as usize];
+            // A live branch pointing at a deleted instruction means one of
+            // the rules above violated its precondition.
+            turso_debug_assert!(
+                new_t != u32::MAX,
+                "live branch operand points at a deleted instruction"
+            );
+            if new_t != u32::MAX {
+                *off = BranchOffset::Offset(new_t);
+            }
+        });
+    }
+    comments.retain_mut(|(offset, _)| {
+        let new_offset = old_to_new[*offset as usize];
+        if new_offset == u32::MAX {
+            false
+        } else {
+            *offset = new_offset;
+            true
+        }
+    });
+}
+
+/// Debug check: after the pass every branch operand must be a resolved,
+/// in-bounds offset.
+#[cfg(debug_assertions)]
+fn verify_all_branches_resolved(insns: &mut [(Insn, usize)]) {
+    let n = insns.len();
+    for (insn, _) in insns.iter_mut() {
+        insn.for_each_branch_offset(|off| {
+            turso_debug_assert!(
+                matches!(off, BranchOffset::Offset(t) if (*t as usize) < n),
+                "peephole pass left an unresolved or out-of-bounds branch operand"
+            );
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::translate::collate::CollationSeq;
+    use crate::vdbe::insn::CmpInsFlags;
+    use std::num::NonZeroUsize;
+
+    fn off(t: u32) -> BranchOffset {
+        BranchOffset::Offset(t)
+    }
+
+    fn goto(t: u32) -> Insn {
+        Insn::Goto { target_pc: off(t) }
+    }
+
+    fn halt() -> Insn {
+        Insn::Halt {
+            err_code: 0,
+            description: String::new(),
+            on_error: None,
+            description_reg: None,
+        }
+    }
+
+    fn halt_err(err_code: usize, description: &str) -> Insn {
+        Insn::Halt {
+            err_code,
+            description: description.to_string(),
+            on_error: None,
+            description_reg: None,
+        }
+    }
+
+    fn integer(value: i64, dest: usize) -> Insn {
+        Insn::Integer { value, dest }
+    }
+
+    fn if_insn(reg: usize, t: u32, jump_if_null: bool) -> Insn {
+        Insn::If {
+            reg,
+            target_pc: off(t),
+            jump_if_null,
+        }
+    }
+
+    fn not_null(reg: usize, t: u32) -> Insn {
+        Insn::NotNull {
+            reg,
+            target_pc: off(t),
+        }
+    }
+
+    fn is_null(reg: usize, t: u32) -> Insn {
+        Insn::IsNull {
+            reg,
+            target_pc: off(t),
+        }
+    }
+
+    fn eq(lhs: usize, rhs: usize, t: u32, flags: CmpInsFlags) -> Insn {
+        Insn::Eq {
+            lhs,
+            rhs,
+            target_pc: off(t),
+            flags,
+            collation: None,
+        }
+    }
+
+    fn copy(src_reg: usize, dst_reg: usize, extra_amount: usize) -> Insn {
+        Insn::Copy {
+            src_reg,
+            dst_reg,
+            extra_amount,
+        }
+    }
+
+    fn affinity(start_reg: usize, count: usize, affinities: &str) -> Insn {
+        Insn::Affinity {
+            start_reg,
+            count: NonZeroUsize::new(count).unwrap(),
+            affinities: affinities.to_string(),
+        }
+    }
+
+    fn make_record(start_reg: u32, count: u32, dest_reg: u32) -> Insn {
+        Insn::MakeRecord {
+            start_reg,
+            count,
+            dest_reg,
+            index_name: None,
+            affinity_str: None,
+        }
+    }
+
+    fn prog(insns: Vec<Insn>) -> Vec<(Insn, usize)> {
+        insns
+            .into_iter()
+            .enumerate()
+            .map(|(original_index, insn)| (insn, original_index))
+            .collect()
+    }
+
+    fn assert_program(actual: &[(Insn, usize)], expected: &[Insn]) {
+        let actual_fmt: Vec<String> = actual.iter().map(|(insn, _)| format!("{insn:?}")).collect();
+        let expected_fmt: Vec<String> = expected.iter().map(|insn| format!("{insn:?}")).collect();
+        assert_eq!(actual_fmt, expected_fmt);
+    }
+
+    fn run_whole_pass(
+        insns: Vec<Insn>,
+    ) -> (Vec<(Insn, usize)>, Vec<(InsnReference, &'static str)>) {
+        let mut insns = prog(insns);
+        let mut comments = Vec::new();
+        optimize_program(&mut insns, &mut comments);
+        (insns, comments)
+    }
+
+    // ---------------- rule 1: jump threading ----------------
+
+    #[test]
+    fn threading_retargets_through_a_goto_chain() {
+        let mut insns = prog(vec![
+            if_insn(0, 2, false), // 0: points at a Goto
+            halt(),               // 1
+            goto(3),              // 2: -> another Goto
+            goto(4),              // 3: -> Integer
+            integer(7, 0),        // 4
+        ]);
+        let mut stats = PassStats::default();
+        thread_jumps(&mut insns, &mut stats);
+        assert_program(
+            &insns,
+            &[
+                if_insn(0, 4, false),
+                halt(),
+                goto(4),
+                goto(4),
+                integer(7, 0),
+            ],
+        );
+        // Retargeted: the If operand and the first Goto's own operand. The
+        // second Goto already pointed at the final destination.
+        assert_eq!(stats.jumps_threaded, 2);
+    }
+
+    #[test]
+    fn threading_leaves_a_goto_to_itself_alone() {
+        let mut insns = prog(vec![if_insn(0, 1, false), goto(1), halt()]);
+        let mut stats = PassStats::default();
+        thread_jumps(&mut insns, &mut stats);
+        assert_program(&insns, &[if_insn(0, 1, false), goto(1), halt()]);
+        assert_eq!(stats.jumps_threaded, 0);
+    }
+
+    #[test]
+    fn threading_leaves_a_two_goto_cycle_alone() {
+        let mut insns = prog(vec![if_insn(0, 1, false), goto(2), goto(1), halt()]);
+        let mut stats = PassStats::default();
+        thread_jumps(&mut insns, &mut stats);
+        assert_program(&insns, &[if_insn(0, 1, false), goto(2), goto(1), halt()]);
+    }
+
+    #[test]
+    fn goto_to_halt_becomes_that_halt() {
+        let mut insns = prog(vec![
+            goto(2),                    // 0: jumps straight at a Halt
+            integer(1, 0),              // 1
+            halt_err(19, "constraint"), // 2
+        ]);
+        let mut stats = PassStats::default();
+        thread_jumps(&mut insns, &mut stats);
+        assert_program(
+            &insns,
+            &[
+                halt_err(19, "constraint"), // clone carries all fields
+                integer(1, 0),
+                halt_err(19, "constraint"),
+            ],
+        );
+        assert_eq!(stats.gotos_replaced_with_halt, 1);
+    }
+
+    #[test]
+    fn conditional_branch_to_halt_is_not_replaced() {
+        let mut insns = prog(vec![if_insn(0, 2, false), integer(1, 0), halt()]);
+        let mut stats = PassStats::default();
+        thread_jumps(&mut insns, &mut stats);
+        assert_program(&insns, &[if_insn(0, 2, false), integer(1, 0), halt()]);
+        assert_eq!(stats.gotos_replaced_with_halt, 0);
+    }
+
+    // ---------------- rule 2: branch-over-goto inversion ----------------
+
+    fn run_inversion(insns: &mut [(Insn, usize)]) -> (Vec<bool>, PassStats) {
+        let n = insns.len();
+        let mut live = vec![true; n];
+        let mut targets = vec![false; n];
+        let mut stats = PassStats::default();
+        invert_branches_over_gotos(insns, &mut live, &mut targets, &mut stats);
+        (live, stats)
+    }
+
+    #[test]
+    fn if_over_goto_becomes_ifnot_with_flipped_null_flag() {
+        let mut insns = prog(vec![
+            if_insn(0, 2, false), // 0: skips over the Goto
+            goto(4),              // 1: the loop exit
+            integer(1, 0),        // 2
+            halt(),               // 3
+            halt(),               // 4
+        ]);
+        let (live, stats) = run_inversion(&mut insns);
+        assert_program(
+            &insns,
+            &[
+                Insn::IfNot {
+                    reg: 0,
+                    target_pc: off(4),
+                    jump_if_null: true,
+                },
+                goto(4), // marked dead, removed later by compaction
+                integer(1, 0),
+                halt(),
+                halt(),
+            ],
+        );
+        assert!(!live[1]);
+        assert_eq!(stats.branches_inverted, 1);
+    }
+
+    #[test]
+    fn not_null_over_goto_becomes_is_null() {
+        let mut insns = prog(vec![
+            not_null(3, 2), // the INSERT explicit-rowid shape
+            goto(4),
+            integer(1, 0),
+            halt(),
+            halt(),
+        ]);
+        let (live, stats) = run_inversion(&mut insns);
+        assert_program(
+            &insns,
+            &[is_null(3, 4), goto(4), integer(1, 0), halt(), halt()],
+        );
+        assert!(!live[1]);
+        assert_eq!(stats.branches_inverted, 1);
+    }
+
+    #[test]
+    fn eq_over_goto_becomes_ne_and_flips_jump_if_null() {
+        let flags = CmpInsFlags::default().jump_if_null();
+        let mut insns = prog(vec![
+            eq(0, 1, 2, flags),
+            goto(4),
+            integer(1, 0),
+            halt(),
+            halt(),
+        ]);
+        let (_, stats) = run_inversion(&mut insns);
+        let Insn::Ne {
+            target_pc, flags, ..
+        } = &insns[0].0
+        else {
+            panic!("Eq must invert to Ne, got {:?}", insns[0].0);
+        };
+        assert_eq!(*target_pc, off(4));
+        // Original jumped on NULL; the inverse must not.
+        assert!(!flags.has_jump_if_null());
+        assert_eq!(stats.branches_inverted, 1);
+    }
+
+    #[test]
+    fn eq_inversion_keeps_null_eq_and_sets_jump_if_null() {
+        let flags = CmpInsFlags::default().null_eq();
+        let mut insns = prog(vec![
+            eq(0, 1, 2, flags),
+            goto(4),
+            integer(1, 0),
+            halt(),
+            halt(),
+        ]);
+        run_inversion(&mut insns);
+        let Insn::Ne { flags, .. } = &insns[0].0 else {
+            panic!("Eq must invert to Ne, got {:?}", insns[0].0);
+        };
+        assert!(flags.has_nulleq());
+        assert!(flags.has_jump_if_null());
+    }
+
+    #[test]
+    fn inversion_blocked_when_goto_is_a_jump_target() {
+        let mut insns = prog(vec![
+            if_insn(0, 2, false), // would invert...
+            goto(5),              // ...but something jumps here
+            integer(1, 0),
+            not_null(1, 1), // jumps to the Goto
+            halt(),
+            halt(),
+        ]);
+        let (live, stats) = run_inversion(&mut insns);
+        assert!(live[1]);
+        assert_eq!(stats.branches_inverted, 0);
+        assert!(matches!(insns[0].0, Insn::If { .. }));
+    }
+
+    #[test]
+    fn non_invertible_conditional_is_left_alone() {
+        let mut insns = prog(vec![
+            Insn::Found {
+                cursor_id: 0,
+                target_pc: off(2),
+                record_reg: 0,
+                num_regs: 1,
+            },
+            goto(4),
+            integer(1, 0),
+            halt(),
+            halt(),
+        ]);
+        let (live, stats) = run_inversion(&mut insns);
+        assert!(live[1]);
+        assert_eq!(stats.branches_inverted, 0);
+    }
+
+    // ---------------- rule 3: copy merge ----------------
+
+    fn run_copy_merge(insns: &mut [(Insn, usize)]) -> (Vec<bool>, PassStats) {
+        let n = insns.len();
+        let mut live = vec![true; n];
+        let mut targets = vec![false; n];
+        let mut stats = PassStats::default();
+        merge_adjacent_copies(insns, &mut live, &mut targets, &mut stats);
+        (live, stats)
+    }
+
+    #[test]
+    fn adjacent_parallel_copies_merge_into_a_range_copy() {
+        let mut insns = prog(vec![copy(1, 10, 0), copy(2, 11, 0), copy(3, 12, 0), halt()]);
+        let (live, stats) = run_copy_merge(&mut insns);
+        let Insn::Copy { extra_amount, .. } = insns[0].0 else {
+            panic!("first Copy must survive");
+        };
+        assert_eq!(extra_amount, 2);
+        assert!(live[0] && !live[1] && !live[2]);
+        assert_eq!(stats.copies_merged, 2);
+    }
+
+    #[test]
+    fn copies_with_ranges_merge_too() {
+        // extra_amount on the first copy already spans two registers.
+        let mut insns = prog(vec![copy(1, 10, 1), copy(3, 12, 0), halt()]);
+        let (live, stats) = run_copy_merge(&mut insns);
+        let Insn::Copy { extra_amount, .. } = insns[0].0 else {
+            panic!("first Copy must survive");
+        };
+        assert_eq!(extra_amount, 2);
+        assert!(!live[1]);
+        assert_eq!(stats.copies_merged, 1);
+    }
+
+    #[test]
+    fn copy_merge_blocked_when_second_copy_is_a_jump_target() {
+        let mut insns = prog(vec![
+            copy(1, 10, 0),
+            copy(2, 11, 0), // jump target: must stay addressable
+            goto(1),
+            halt(),
+        ]);
+        let (live, stats) = run_copy_merge(&mut insns);
+        let Insn::Copy { extra_amount, .. } = insns[0].0 else {
+            panic!();
+        };
+        assert_eq!(extra_amount, 0);
+        assert!(live[1]);
+        assert_eq!(stats.copies_merged, 0);
+    }
+
+    #[test]
+    fn non_contiguous_copies_do_not_merge() {
+        let mut insns = prog(vec![copy(1, 10, 0), copy(3, 11, 0), halt()]);
+        let (live, stats) = run_copy_merge(&mut insns);
+        assert!(live[1]);
+        assert_eq!(stats.copies_merged, 0);
+        let Insn::Copy { extra_amount, .. } = insns[0].0 else {
+            panic!();
+        };
+        assert_eq!(extra_amount, 0);
+    }
+
+    // ---------------- rule 4: affinity fold ----------------
+
+    fn run_affinity_fold(insns: &mut [(Insn, usize)]) -> (Vec<bool>, PassStats) {
+        let n = insns.len();
+        let mut live = vec![true; n];
+        let mut targets = vec![false; n];
+        let mut stats = PassStats::default();
+        fold_affinity_into_make_record(insns, &mut live, &mut targets, &mut stats);
+        (live, stats)
+    }
+
+    #[test]
+    fn affinity_folds_into_adjacent_make_record() {
+        let mut insns = prog(vec![affinity(5, 2, "BC"), make_record(5, 2, 9), halt()]);
+        let (live, stats) = run_affinity_fold(&mut insns);
+        assert!(!live[0]);
+        let Insn::MakeRecord { affinity_str, .. } = &insns[1].0 else {
+            panic!();
+        };
+        assert_eq!(affinity_str.as_deref(), Some("BC"));
+        assert_eq!(stats.affinities_folded, 1);
+    }
+
+    #[test]
+    fn affinity_folds_across_new_rowid_outside_the_range() {
+        let mut insns = prog(vec![
+            affinity(5, 2, "DD"),
+            Insn::NewRowid {
+                cursor: 0,
+                rowid_reg: 3,
+                prev_largest_reg: 0,
+            },
+            make_record(5, 2, 9),
+            halt(),
+        ]);
+        let (live, stats) = run_affinity_fold(&mut insns);
+        assert!(!live[0]);
+        let Insn::MakeRecord { affinity_str, .. } = &insns[2].0 else {
+            panic!();
+        };
+        assert_eq!(affinity_str.as_deref(), Some("DD"));
+        assert_eq!(stats.affinities_folded, 1);
+    }
+
+    #[test]
+    fn affinity_fold_blocked_when_gap_insn_writes_into_the_range() {
+        let mut insns = prog(vec![
+            affinity(5, 2, "DD"),
+            integer(0, 6), // overwrites a register the affinity already converted
+            make_record(5, 2, 9),
+            halt(),
+        ]);
+        let (live, stats) = run_affinity_fold(&mut insns);
+        assert!(live[0]);
+        assert_eq!(stats.affinities_folded, 0);
+        assert_eq!(stats.affinity_folds_skipped, 1);
+    }
+
+    #[test]
+    fn affinity_fold_blocked_when_make_record_is_a_jump_target() {
+        let mut insns = prog(vec![
+            affinity(5, 2, "DD"),
+            make_record(5, 2, 9), // jumped to directly: skips the Affinity today
+            goto(1),
+            halt(),
+        ]);
+        let (live, stats) = run_affinity_fold(&mut insns);
+        assert!(live[0]);
+        assert_eq!(stats.affinities_folded, 0);
+        assert_eq!(stats.affinity_folds_skipped, 1);
+    }
+
+    #[test]
+    fn affinity_fold_blocked_on_range_mismatch() {
+        let mut insns = prog(vec![affinity(5, 2, "DD"), make_record(5, 3, 9), halt()]);
+        let (live, stats) = run_affinity_fold(&mut insns);
+        assert!(live[0]);
+        assert_eq!(stats.affinities_folded, 0);
+    }
+
+    #[test]
+    fn affinity_fold_blocked_when_make_record_already_has_affinities() {
+        let mut insns = prog(vec![
+            affinity(5, 2, "DD"),
+            Insn::MakeRecord {
+                start_reg: 5,
+                count: 2,
+                dest_reg: 9,
+                index_name: None,
+                affinity_str: Some("BB".to_string()),
+            },
+            halt(),
+        ]);
+        let (live, _) = run_affinity_fold(&mut insns);
+        assert!(live[0]);
+    }
+
+    // ---------------- rule 5: delete jump-to-next ----------------
+
+    fn run_delete_jump_to_next(insns: &mut [(Insn, usize)]) -> (Vec<bool>, PassStats) {
+        let n = insns.len();
+        let mut live = vec![true; n];
+        let mut targets = vec![false; n];
+        let mut stats = PassStats::default();
+        delete_jumps_to_next(insns, &mut live, &mut targets, &mut stats);
+        (live, stats)
+    }
+
+    #[test]
+    fn goto_to_next_instruction_is_deleted() {
+        let mut insns = prog(vec![integer(1, 0), goto(2), halt()]);
+        let (live, stats) = run_delete_jump_to_next(&mut insns);
+        assert!(!live[1]);
+        assert_eq!(stats.jumps_to_next_deleted, 1);
+    }
+
+    #[test]
+    fn pure_conditional_to_next_instruction_is_deleted() {
+        let mut insns = prog(vec![integer(1, 0), is_null(0, 2), halt()]);
+        let (live, stats) = run_delete_jump_to_next(&mut insns);
+        assert!(!live[1]);
+        assert_eq!(stats.jumps_to_next_deleted, 1);
+    }
+
+    #[test]
+    fn comparison_without_affinity_to_next_instruction_is_deleted() {
+        let mut insns = prog(vec![
+            integer(1, 0),
+            eq(0, 1, 2, CmpInsFlags::default()),
+            halt(),
+        ]);
+        let (live, stats) = run_delete_jump_to_next(&mut insns);
+        assert!(!live[1]);
+        assert_eq!(stats.jumps_to_next_deleted, 1);
+        assert_eq!(stats.cmp_deletes_skipped, 0);
+    }
+
+    #[test]
+    fn comparison_with_affinity_to_next_is_kept_for_its_register_writes() {
+        // Eq with TEXT affinity converts its operand registers in place;
+        // deleting it would skip those conversions.
+        let flags = CmpInsFlags::default().with_affinity(crate::vdbe::affinity::Affinity::Text);
+        let mut insns = prog(vec![eq(0, 1, 1, flags), halt()]);
+        let (live, stats) = run_delete_jump_to_next(&mut insns);
+        assert!(live[0]);
+        assert_eq!(stats.jumps_to_next_deleted, 0);
+        assert_eq!(stats.cmp_deletes_skipped, 1);
+    }
+
+    #[test]
+    fn comparison_with_custom_collation_to_next_is_kept() {
+        let mut insns = prog(vec![
+            Insn::Eq {
+                lhs: 0,
+                rhs: 1,
+                target_pc: off(1),
+                flags: CmpInsFlags::default(),
+                collation: Some(CollationSeq::custom("mycoll")),
+            },
+            halt(),
+        ]);
+        let (live, stats) = run_delete_jump_to_next(&mut insns);
+        assert!(live[0]);
+        assert_eq!(stats.cmp_deletes_skipped, 1);
+    }
+
+    #[test]
+    fn goto_to_next_that_is_a_jump_target_is_kept() {
+        let mut insns = prog(vec![
+            integer(1, 0),
+            goto(2), // goto-to-next, but the If below jumps here
+            if_insn(0, 1, false),
+            halt(),
+        ]);
+        let (live, stats) = run_delete_jump_to_next(&mut insns);
+        assert!(live[1]);
+        assert_eq!(stats.jumps_to_next_deleted, 0);
+    }
+
+    #[test]
+    fn decr_jump_zero_to_next_is_kept_for_its_decrement() {
+        let mut insns = prog(vec![
+            Insn::DecrJumpZero {
+                reg: 0,
+                target_pc: off(1),
+            },
+            halt(),
+        ]);
+        let (live, _) = run_delete_jump_to_next(&mut insns);
+        assert!(live[0]);
+    }
+
+    // ---------------- rule 6: unreachable sweep ----------------
+
+    fn run_sweep(insns: &mut [(Insn, usize)]) -> (Vec<bool>, PassStats) {
+        let n = insns.len();
+        let mut live = vec![true; n];
+        let mut stats = PassStats::default();
+        sweep_unreachable(insns, &mut live, &mut stats);
+        (live, stats)
+    }
+
+    #[test]
+    fn code_after_a_goto_with_no_way_in_is_swept() {
+        let mut insns = prog(vec![
+            goto(3),       // 0
+            integer(1, 0), // 1: the abort-subroutine shape nothing calls
+            Insn::Return {
+                return_reg: 0,
+                can_fallthrough: false,
+            }, // 2
+            halt(),        // 3
+        ]);
+        let (live, stats) = run_sweep(&mut insns);
+        assert!(live[0] && !live[1] && !live[2] && live[3]);
+        assert_eq!(stats.unreachable_deleted, 2);
+    }
+
+    #[test]
+    fn gosub_keeps_its_return_point_alive() {
+        let mut insns = prog(vec![
+            Insn::Gosub {
+                target_pc: off(3),
+                return_reg: 0,
+            }, // 0: calls the subroutine
+            integer(1, 0), // 1: the dynamic return point
+            halt(),        // 2
+            Insn::Return {
+                return_reg: 0,
+                can_fallthrough: false,
+            }, // 3: subroutine body
+        ]);
+        let (live, stats) = run_sweep(&mut insns);
+        assert!(live.iter().all(|l| *l), "all live, got {live:?}");
+        assert_eq!(stats.unreachable_deleted, 0);
+    }
+
+    #[test]
+    fn yield_keeps_its_resume_point_alive() {
+        let mut insns = prog(vec![
+            Insn::Yield {
+                yield_reg: 0,
+                end_offset: off(2),
+                subtype_clear_start_reg: 0,
+                subtype_clear_count: 0,
+            }, // 0
+            integer(1, 0), // 1: resumed dynamically after the coroutine yields back
+            halt(),        // 2
+        ]);
+        let (live, _) = run_sweep(&mut insns);
+        assert!(live.iter().all(|l| *l), "all live, got {live:?}");
+    }
+
+    #[test]
+    fn jump_successors_are_its_three_targets_only() {
+        let mut insns = prog(vec![
+            Insn::Jump {
+                target_pc_lt: off(2),
+                target_pc_eq: off(3),
+                target_pc_gt: off(4),
+            }, // 0
+            integer(1, 0), // 1: not a successor of Jump
+            halt(),        // 2
+            halt(),        // 3
+            halt(),        // 4
+        ]);
+        let (live, _) = run_sweep(&mut insns);
+        assert!(live[0] && !live[1] && live[2] && live[3] && live[4]);
+    }
+
+    // ---------------- compaction ----------------
+
+    #[test]
+    fn compaction_remaps_branches_and_moves_comments() {
+        let insns = vec![
+            goto(2),       // 0: jump-to-next after deleting 1? No: points at 2
+            integer(1, 0), // 1: unreachable
+            halt(),        // 2
+        ];
+        let mut insns = prog(insns);
+        let mut comments: Vec<(InsnReference, &'static str)> =
+            vec![(0, "jump"), (1, "dead"), (2, "stop")];
+        let live = vec![true, false, true];
+        compact(&mut insns, &mut comments, &live);
+        assert_program(&insns, &[goto(1), halt()]);
+        assert_eq!(comments, vec![(0, "jump"), (1, "stop")]);
+    }
+
+    // ---------------- whole pass ----------------
+
+    #[test]
+    fn single_row_insert_epilogue_collapses() {
+        // The shape a single-row INSERT ends with: payload, `Goto +1; Goto +1;
+        // Halt`, then the transaction prologue that jumps back to the payload.
+        let (insns, _) = run_whole_pass(vec![
+            Insn::Init { target_pc: off(5) }, // 0
+            integer(1, 0),                    // 1: stands in for the Insert
+            goto(3),                          // 2: goto to next
+            goto(4),                          // 3: goto to next
+            halt(),                           // 4
+            Insn::Transaction {
+                db: 0,
+                tx_mode: crate::translate::emitter::TransactionMode::Write,
+                schema_cookie: 0,
+            }, // 5
+            goto(1),                          // 6: back edge to the payload
+        ]);
+        // Both `Goto +1`s thread to the Halt and become Halts themselves; the
+        // second one and the original Halt then have no way in and get swept.
+        assert_program(
+            &insns,
+            &[
+                Insn::Init { target_pc: off(3) },
+                integer(1, 0),
+                halt(),
+                Insn::Transaction {
+                    db: 0,
+                    tx_mode: crate::translate::emitter::TransactionMode::Write,
+                    schema_cookie: 0,
+                },
+                goto(1),
+            ],
+        );
+    }
+
+    #[test]
+    fn whole_pass_threads_conditional_through_exit_trampoline() {
+        // An If that exits the statement through a `Goto -> Halt` trampoline:
+        // the If must end up jumping straight at the Halt and the trampoline
+        // must be swept.
+        let (insns, _) = run_whole_pass(vec![
+            Insn::Init { target_pc: off(5) }, // 0
+            if_insn(0, 4, false),             // 1: exit early via the trampoline
+            integer(1, 0),                    // 2
+            halt(),                           // 3
+            goto(3),                          // 4: exit trampoline
+            Insn::Transaction {
+                db: 0,
+                tx_mode: crate::translate::emitter::TransactionMode::Read,
+                schema_cookie: 0,
+            }, // 5
+            goto(1),                          // 6
+        ]);
+        assert_program(
+            &insns,
+            &[
+                Insn::Init { target_pc: off(4) },
+                if_insn(0, 3, false),
+                integer(1, 0),
+                halt(),
+                Insn::Transaction {
+                    db: 0,
+                    tx_mode: crate::translate::emitter::TransactionMode::Read,
+                    schema_cookie: 0,
+                },
+                goto(1),
+            ],
+        );
+    }
+
+    #[test]
+    fn whole_pass_leaves_an_already_tight_program_alone() {
+        let build = || {
+            vec![
+                Insn::Init { target_pc: off(3) },
+                Insn::ResultRow {
+                    start_reg: 0,
+                    count: 1,
+                },
+                halt(),
+                Insn::Transaction {
+                    db: 0,
+                    tx_mode: crate::translate::emitter::TransactionMode::Read,
+                    schema_cookie: 0,
+                },
+                goto(1),
+            ]
+        };
+        let (insns, _) = run_whole_pass(build());
+        assert_program(&insns, &build());
+    }
+}

--- a/core/vdbe/peephole_tests.rs
+++ b/core/vdbe/peephole_tests.rs
@@ -1,0 +1,298 @@
+//! End-to-end tests for the peephole pass: prepare real SQL, compare the
+//! EXPLAIN bytecode with the pass on and off, and check that results stay
+//! identical. The on/off switch is the same escape hatch `TURSO_PEEPHOLE=0`
+//! uses, applied through a thread-local override so both variants can be
+//! prepared in one process.
+
+use std::sync::Arc;
+
+use crate::vdbe::builder::{ProgramBuilder, ProgramBuilderOpts, QueryMode};
+use crate::vdbe::insn::{CmpInsFlags, Insn};
+use crate::vdbe::peephole;
+use crate::{Connection, Database, MemoryIO, SqliteDialect, Statement, Value, IO};
+
+fn fresh_db() -> Arc<Connection> {
+    let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+    db.connect().unwrap()
+}
+
+fn exec(conn: &Arc<Connection>, sql: &str) {
+    conn.execute(sql).unwrap();
+}
+
+fn rows(conn: &Arc<Connection>, sql: &str) -> Vec<Vec<Value>> {
+    let mut stmt = conn.prepare(sql).unwrap();
+    stmt.run_collect_rows().unwrap()
+}
+
+/// Run `f` with the peephole pass forced on or off for this thread.
+fn with_pass<T>(enabled: bool, f: impl FnOnce() -> T) -> T {
+    struct Restore;
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            peephole::set_enabled_for_current_thread(None);
+        }
+    }
+    let _restore = Restore;
+    peephole::set_enabled_for_current_thread(Some(enabled));
+    f()
+}
+
+#[derive(Debug, Clone)]
+struct ExplainRow {
+    addr: i64,
+    opcode: String,
+    p1: i64,
+    p2: i64,
+    p3: i64,
+}
+
+fn explain(conn: &Arc<Connection>, sql: &str) -> Vec<ExplainRow> {
+    rows(conn, &format!("EXPLAIN {sql}"))
+        .into_iter()
+        .map(|row| {
+            let int = |v: &Value| -> i64 {
+                match v {
+                    Value::Numeric(crate::Numeric::Integer(i)) => *i,
+                    other => panic!("expected integer, got {other:?}"),
+                }
+            };
+            ExplainRow {
+                addr: int(&row[0]),
+                opcode: row[1].to_text().unwrap().to_string(),
+                p1: int(&row[2]),
+                p2: int(&row[3]),
+                p3: int(&row[4]),
+            }
+        })
+        .collect()
+}
+
+fn opcode_count(program: &[ExplainRow], opcode: &str) -> usize {
+    program.iter().filter(|r| r.opcode == opcode).count()
+}
+
+/// `Goto` whose target is the very next instruction.
+fn has_goto_to_next(program: &[ExplainRow]) -> bool {
+    program
+        .iter()
+        .any(|r| r.opcode == "Goto" && r.p2 == r.addr + 1)
+}
+
+#[test]
+fn single_row_insert_epilogue_collapses_in_real_bytecode() {
+    let conn = fresh_db();
+    exec(
+        &conn,
+        "CREATE TABLE t(id INTEGER PRIMARY KEY, x TEXT, y INT)",
+    );
+    let sql = "INSERT INTO t(id, x, y) VALUES (1, 'a', 2)";
+    let off = with_pass(false, || explain(&conn, sql));
+    let on = with_pass(true, || explain(&conn, sql));
+
+    // Unoptimized: the statement body ends `Insert; Goto +1; Goto +1; Halt`.
+    let insert_off = off.iter().position(|r| r.opcode == "Insert").unwrap();
+    assert_eq!(off[insert_off + 1].opcode, "Goto");
+    assert_eq!(off[insert_off + 1].p2, off[insert_off + 1].addr + 1);
+    assert_eq!(off[insert_off + 2].opcode, "Goto");
+    assert_eq!(off[insert_off + 2].p2, off[insert_off + 2].addr + 1);
+    assert_eq!(off[insert_off + 3].opcode, "Halt");
+
+    // Optimized: the Insert is followed directly by the Halt.
+    let insert_on = on.iter().position(|r| r.opcode == "Insert").unwrap();
+    assert_eq!(on[insert_on + 1].opcode, "Halt");
+    assert!(!has_goto_to_next(&on));
+    assert!(on.len() < off.len());
+}
+
+#[test]
+fn insert_with_explicit_rowid_inverts_not_null_over_goto() {
+    let conn = fresh_db();
+    exec(&conn, "CREATE TABLE t(id INTEGER PRIMARY KEY, x TEXT)");
+    let sql = "INSERT INTO t(id, x) VALUES (5, 'a')";
+    let off = with_pass(false, || explain(&conn, sql));
+    let on = with_pass(true, || explain(&conn, sql));
+
+    // Unoptimized: `NotNull -> +2; Goto` guards the explicit-rowid path.
+    let not_null_off = off.iter().position(|r| r.opcode == "NotNull").unwrap();
+    assert_eq!(off[not_null_off].p2, off[not_null_off].addr + 2);
+    assert_eq!(off[not_null_off + 1].opcode, "Goto");
+
+    // Optimized: the pair became one IsNull that jumps where the Goto went,
+    // which is the NewRowid path for the id-is-NULL case.
+    assert_eq!(opcode_count(&on, "NotNull"), 0);
+    let is_null_on = on.iter().position(|r| r.opcode == "IsNull").unwrap();
+    let is_null_target = on[is_null_on].p2;
+    let target_row = on.iter().find(|r| r.addr == is_null_target).unwrap();
+    assert_eq!(target_row.opcode, "NewRowid");
+
+    // Both variants insert their row: one with the inverted bytecode, one
+    // with the original.
+    with_pass(true, || {
+        exec(&conn, sql);
+    });
+    with_pass(false, || {
+        exec(&conn, "INSERT INTO t(id, x) VALUES (6, 'b')");
+    });
+    let count = rows(&conn, "SELECT count(*) FROM t");
+    assert!(
+        matches!(count[0][0], Value::Numeric(crate::Numeric::Integer(2))),
+        "expected both inserts to land, got {count:?}"
+    );
+}
+
+#[test]
+fn group_by_loses_dead_abort_subroutine_and_merges_copies() {
+    let conn = fresh_db();
+    exec(&conn, "CREATE TABLE g(a INT, b TEXT)");
+    let sql = "SELECT b, count(*) FROM g GROUP BY b";
+    let off = with_pass(false, || explain(&conn, sql));
+    let on = with_pass(true, || explain(&conn, sql));
+
+    // The abort subroutine (`Integer 1 -> abort flag; Return`) is emitted but
+    // nothing Gosubs it: one Return disappears with it.
+    assert_eq!(
+        opcode_count(&on, "Return"),
+        opcode_count(&off, "Return") - 1
+    );
+
+    // The two adjacent result Copies merge into one ranged Copy.
+    assert_eq!(opcode_count(&on, "Copy"), opcode_count(&off, "Copy") - 1);
+    let merged_copy = on.iter().find(|r| r.opcode == "Copy").unwrap();
+    assert_eq!(merged_copy.p3, 1, "merged Copy must span two registers");
+
+    assert!(on.len() < off.len());
+}
+
+#[test]
+fn results_stay_identical_for_null_heavy_comparisons() {
+    let queries = [
+        "SELECT a = b FROM t ORDER BY 1",
+        "SELECT a, b FROM t WHERE a = b",
+        "SELECT a, b FROM t WHERE a <> b",
+        "SELECT a, b FROM t WHERE a < b OR s = 'z'",
+        "SELECT CASE WHEN a = b THEN 'eq' WHEN a < b THEN 'lt' ELSE 'other' END FROM t",
+        "SELECT count(*) FROM t WHERE NOT (a = b)",
+        "SELECT s, count(*) FROM t GROUP BY s HAVING count(*) >= 1 ORDER BY s",
+        "SELECT a IS b FROM t ORDER BY 1",
+    ];
+    let run_all = |enabled: bool| -> Vec<Vec<Vec<Value>>> {
+        with_pass(enabled, || {
+            let conn = fresh_db();
+            exec(&conn, "CREATE TABLE t(a INT, b INT, s TEXT)");
+            exec(
+                &conn,
+                "INSERT INTO t VALUES (1, 1, 'x'), (2, 3, 'y'), (NULL, 1, 'z'), \
+                 (4, NULL, 'w'), (NULL, NULL, 'v')",
+            );
+            queries.iter().map(|q| rows(&conn, q)).collect()
+        })
+    };
+    let off = run_all(false);
+    let on = run_all(true);
+    for ((off_rows, on_rows), query) in off.iter().zip(on.iter()).zip(queries.iter()) {
+        assert_eq!(
+            format!("{off_rows:?}"),
+            format!("{on_rows:?}"),
+            "results changed with the peephole pass for: {query}"
+        );
+    }
+}
+
+/// Build `Eq(jump_if_null) -> +2; Goto L` by hand, run it on NULL input with
+/// the pass on and off, and also run the *wrong* inversion (Ne with the flag
+/// unchanged) to show the flag flip is what keeps NULL semantics intact.
+#[test]
+fn eq_inversion_preserves_jump_if_null_semantics_at_runtime() {
+    // r_out = 111 when the Eq branch is taken, 222 when not.
+    fn build_and_run(conn: &Arc<Connection>, wrong_inversion: bool) -> i64 {
+        let mut b = ProgramBuilder::new(QueryMode::Normal, None, ProgramBuilderOpts::new(0, 16, 8));
+        b.prologue();
+        let r_lhs = b.alloc_register();
+        let r_rhs = b.alloc_register();
+        let r_out = b.alloc_register();
+        b.emit_insn(Insn::Null {
+            dest: r_lhs,
+            dest_end: None,
+        });
+        b.emit_insn(Insn::Integer {
+            value: 7,
+            dest: r_rhs,
+        });
+        let taken = b.allocate_label();
+        let not_taken = b.allocate_label();
+        let done = b.allocate_label();
+        if wrong_inversion {
+            // What rule 2 would produce if it forgot to flip JUMP_IF_NULL:
+            // jumps to `not_taken` on NULL, unlike the original program.
+            b.emit_insn(Insn::Ne {
+                lhs: r_lhs,
+                rhs: r_rhs,
+                target_pc: not_taken,
+                flags: CmpInsFlags::default().jump_if_null(),
+                collation: None,
+            });
+        } else {
+            // Jumps on NULL because of jump_if_null.
+            b.emit_insn(Insn::Eq {
+                lhs: r_lhs,
+                rhs: r_rhs,
+                target_pc: taken,
+                flags: CmpInsFlags::default().jump_if_null(),
+                collation: None,
+            });
+            b.emit_insn(Insn::Goto {
+                target_pc: not_taken,
+            });
+        }
+        b.preassign_label_to_next_insn(taken);
+        b.emit_insn(Insn::Integer {
+            value: 111,
+            dest: r_out,
+        });
+        b.emit_insn(Insn::Goto { target_pc: done });
+        b.preassign_label_to_next_insn(not_taken);
+        b.emit_insn(Insn::Integer {
+            value: 222,
+            dest: r_out,
+        });
+        b.preassign_label_to_next_insn(done);
+        b.emit_result_row(r_out, 1);
+        conn.with_schema_mut(|schema| b.epilogue(schema)).unwrap();
+        let program = b.build(conn.clone(), false, "peephole nulltest").unwrap();
+        let mut stmt = Statement::new(program, conn.get_pager(), QueryMode::Normal, 0);
+        let result = stmt.run_collect_rows().unwrap();
+        match &result[0][0] {
+            Value::Numeric(crate::Numeric::Integer(i)) => *i,
+            other => panic!("expected integer, got {other:?}"),
+        }
+    }
+
+    let conn = fresh_db();
+    // NULL = 7 with jump_if_null jumps: the branch is taken.
+    let off = with_pass(false, || build_and_run(&conn, false));
+    assert_eq!(off, 111);
+    // The pass inverts the Eq into `Ne(!jump_if_null) -> not_taken`; NULL
+    // must still take the original branch.
+    let on = with_pass(true, || build_and_run(&conn, false));
+    assert_eq!(on, 111);
+    // Without the flag flip the NULL case flips to the wrong branch: this is
+    // the bug the flip prevents.
+    let wrong = with_pass(false, || build_and_run(&conn, true));
+    assert_eq!(wrong, 222);
+}
+
+/// The escape hatch really changes what gets prepared: with the pass off the
+/// epilogue keeps its `Goto +1`s, with it on they are gone.
+#[test]
+fn escape_hatch_toggles_the_pass() {
+    let conn = fresh_db();
+    exec(&conn, "CREATE TABLE t(a INT)");
+    let sql = "INSERT INTO t VALUES (1)";
+    let off = with_pass(false, || explain(&conn, sql));
+    let on = with_pass(true, || explain(&conn, sql));
+    assert!(has_goto_to_next(&off));
+    assert!(!has_goto_to_next(&on));
+    assert!(on.len() < off.len());
+}

--- a/core/vdbe/peephole_tests.rs
+++ b/core/vdbe/peephole_tests.rs
@@ -43,7 +43,6 @@ fn with_pass<T>(enabled: bool, f: impl FnOnce() -> T) -> T {
 struct ExplainRow {
     addr: i64,
     opcode: String,
-    p1: i64,
     p2: i64,
     p3: i64,
 }
@@ -61,7 +60,6 @@ fn explain(conn: &Arc<Connection>, sql: &str) -> Vec<ExplainRow> {
             ExplainRow {
                 addr: int(&row[0]),
                 opcode: row[1].to_text().unwrap().to_string(),
-                p1: int(&row[2]),
                 p2: int(&row[3]),
                 p3: int(&row[4]),
             }
@@ -295,4 +293,64 @@ fn escape_hatch_toggles_the_pass() {
     assert!(has_goto_to_next(&off));
     assert!(!has_goto_to_next(&on));
     assert!(on.len() < off.len());
+}
+
+/// Not a correctness test: measures real prepare cost with the pass on and
+/// off in alternating blocks within one process, so machine speed drift
+/// cancels out. Run with:
+/// `cargo test --release -p turso_core --lib prepare_overhead -- --ignored --nocapture`
+#[test]
+#[ignore = "manual timing harness"]
+fn prepare_overhead_manually() {
+    use std::time::Instant;
+    let conn = fresh_db();
+    exec(
+        &conn,
+        "CREATE TABLE users(id INTEGER PRIMARY KEY, first_name TEXT, last_name TEXT, \
+         state TEXT, city TEXT, age INT, email TEXT, phone_number TEXT, zipcode TEXT)",
+    );
+    let queries = [
+        ("SELECT 1", 20_000u32),
+        ("SELECT * FROM users LIMIT 1", 10_000),
+        (
+            "SELECT first_name, count(1) FROM users GROUP BY first_name \
+             HAVING count(1) > 1 ORDER BY count(1) LIMIT 1",
+            5_000,
+        ),
+        ("INSERT INTO users(id, first_name) VALUES (1, 'a')", 10_000),
+    ];
+    for (sql, iters) in queries {
+        let measure = |enabled: bool| {
+            with_pass(enabled, || {
+                let t0 = Instant::now();
+                for _ in 0..iters {
+                    let stmt = conn.prepare(sql).unwrap();
+                    std::hint::black_box(&stmt);
+                }
+                t0.elapsed()
+            })
+        };
+        // Warm up, then alternate off/on blocks and use the sums.
+        measure(false);
+        measure(true);
+        let (mut off_total, mut on_total) = (Vec::new(), Vec::new());
+        for _ in 0..6 {
+            off_total.push(measure(false));
+            on_total.push(measure(true));
+        }
+        off_total.sort();
+        on_total.sort();
+        // Median block per side.
+        let off = off_total[off_total.len() / 2] / iters;
+        let on = on_total[on_total.len() / 2] / iters;
+        let delta = on.as_nanos() as i128 - off.as_nanos() as i128;
+        eprintln!(
+            "prepare {:60} off {:>8.3?} on {:>8.3?} delta {:>6}ns ({:+.1}%)",
+            &sql[..sql.len().min(60)],
+            off,
+            on,
+            delta,
+            delta as f64 * 100.0 / off.as_nanos() as f64,
+        );
+    }
 }

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__aggregation-with-join.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__aggregation-with-join.snap
@@ -30,84 +30,81 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4                p5  comment
-   0          Init               0  78   0                     0  Start at 78
-   1          SorterOpen         0   1   0  k(1,-B)            0  cursor=0
-   2          Null               0  11  13                     0  r[11..13]=NULL
-   3          SorterOpen         1   4   0  k(1,-B)            0  cursor=1
-   4          Integer            0   8   0                     0  r[8]=0; clear group by abort flag
-   5          Null               0   9   0                     0  r[9]=NULL; initialize group by comparison registers to NULL
-   6          Gosub             19  65   0                     0  ; go to clear accumulator subroutine
-   7          OpenRead           3   6   0  k(4,B,B,B,B)       0  table=products, root=6, iDb=0
-   8          OpenRead           4   7   0  k(6,B,B,B,B,B,B)   0  table=orders, root=7, iDb=0
-   9          OpenRead           5   9   0  k(2,B)             0  index=idx_orders_product, root=9, iDb=0
-  10          Rewind             3  29   0                     0  Rewind table products
-  11            Integer          0  20   0                     0  r[20]=0
-  12            RowId            3  21   0                     0  r[21]=products.rowid
-  13            SeekGE           5  24  21                     0  key=[21..21]
-  14              IdxGT          5  24  21                     0  key=[21..21]
-  15              DeferredSeek   5   4   0                     0
-  16              Integer        1  20   0                     0  r[20]=1
-  17              Column         3   2  15                     0  r[15]=products.category
-  18              IdxRowId       5  16   0                     0  r[16]=cursor 5 for index idx_orders_product.rowid
-  19              Column         4   5  17                     0  r[17]=orders.total_amount
-  20              Column         4   4  18                     0  r[18]=orders.quantity
-  21              MakeRecord    15   4  14                     0  r[14]=mkrec(r[15..18])
-  22              SorterInsert   1  14   0  0                  0  key=r[14]
-  23            Next             5  14   0                     0
-  24            IfPos           20  28   0                     0  r[20]>0 -> r[20]-=0, goto 28
-  25            NullRow          4   0   0                     0  Set cursor 4 to a (pseudo) NULL row
-  26            NullRow          5   0   0                     0  Set cursor 5 to a (pseudo) NULL row
-  27            Goto             0  16   0                     0
-  28          Next               3  11   0                     0
-  29          OpenPseudo         2  14   4                     0  4 columns in r[14]
-  30          SorterSort         1  49   0                     0
-  31            SorterData       1  14   2                     0  r[14]=data
-  32            Column           2   0  22                     0  r[22]=pseudo.column 0
-  33            Compare          9  22   1  k(1, Binary)       0  r[9..9]==r[22..22]
-  34            Jump            35  39  35                     0  ; start new group if comparison is not equal
-  35            Gosub            6  53   0                     0  ; check if ended group had data, and output if so
-  36            Move            22   9   1                     0  r[9..9]=r[22..22]
-  37            IfPos            8  68   0                     0  r[8]>0 -> r[8]-=0, goto 68; check abort flag
-  38            Gosub           19  65   0                     0  ; goto clear accumulator subroutine
-  39            Column           2   1  23                     0  r[23]=pseudo.column 1
-  40            Column           2   2  24                     0  r[24]=pseudo.column 2
-  41            Column           2   3  25                     0  r[25]=pseudo.column 3
-  42            AggStep          0  23  11  count              0  accum=r[11] step(r[23])
-  43            AggStep          0  24  12  sum                0  accum=r[12] step(r[24])
-  44            AggStep          0  25  13  avg                0  accum=r[13] step(r[25])
-  45            If               7  47   0                     0  if r[7] goto 47; don't emit group columns if continuing existing group
-  46            Column           2   0  10                     0  r[10]=pseudo.column 0
-  47            Integer          1   7   0                     0  r[7]=1; indicate data in accumulator
-  48          SorterNext         1  31   0                     0
-  49          Gosub              6  53   0                     0  ; emit row for final group
-  50          Goto               0  68   0                     0  ; group by finished
-  51          Integer            1   8   0                     0  r[8]=1
-  52        Return               6   0   0                     0
-  53        IfPos                7  55   0                     0  r[7]>0 -> r[7]-=0, goto 55; output group by row subroutine start
-  54      Return                 6   0   0                     0
-  55      AggFinal               0  11   0  count              0  accum=r[11]
-  56      AggFinal               0  12   0  sum                0  accum=r[12]
-  57      AggFinal               0  13   0  avg                0  accum=r[13]
-  58      Copy                  12  26   0                     0  r[26]=r[12]
-  59      Copy                  10  27   0                     0  r[27]=r[10]
-  60      Copy                  11  28   0                     0  r[28]=r[11]
-  61      Copy                  13  29   0                     0  r[29]=r[13]
-  62      MakeRecord            26   4   5                     0  r[5]=mkrec(r[26..29])
-  63      SorterInsert           0   5   0  0                  0  key=r[5]
-  64    Return                   6   0   0                     0
-  65    Null                     0  10  13                     0  r[10..13]=NULL; clear accumulator subroutine start
-  66    Integer                  0   7   0                     0  r[7]=0
-  67  Return                    19   0   0                     0
-  68  OpenPseudo                 6   5   4                     0  4 columns in r[5]
-  69  SorterSort                 0  77   0                     0
-  70    SorterData               0   5   6                     0  r[5]=data
-  71    Column                   6   1   1                     0  r[1]=pseudo.column 1
-  72    Column                   6   2   2                     0  r[2]=pseudo.column 2
-  73    Column                   6   0   3                     0  r[3]=pseudo.column 0
-  74    Column                   6   3   4                     0  r[4]=pseudo.column 3
-  75    ResultRow                1   4   0                     0  output=r[1..4]
-  76  SorterNext                 0  70   0                     0
-  77  Halt                       0   0   0                     0
-  78  Transaction                0   1   8                     0  iDb=0 tx_mode=Read
-  79  Goto                       0   1   0                     0
+addr  opcode                  p1  p2  p3  p4                p5  comment
+   0        Init               0  75   0                     0  Start at 75
+   1        SorterOpen         0   1   0  k(1,-B)            0  cursor=0
+   2        Null               0  11  13                     0  r[11..13]=NULL
+   3        SorterOpen         1   4   0  k(1,-B)            0  cursor=1
+   4        Integer            0   8   0                     0  r[8]=0; clear group by abort flag
+   5        Null               0   9   0                     0  r[9]=NULL; initialize group by comparison registers to NULL
+   6        Gosub             19  62   0                     0  ; go to clear accumulator subroutine
+   7        OpenRead           3   6   0  k(4,B,B,B,B)       0  table=products, root=6, iDb=0
+   8        OpenRead           4   7   0  k(6,B,B,B,B,B,B)   0  table=orders, root=7, iDb=0
+   9        OpenRead           5   9   0  k(2,B)             0  index=idx_orders_product, root=9, iDb=0
+  10        Rewind             3  29   0                     0  Rewind table products
+  11          Integer          0  20   0                     0  r[20]=0
+  12          RowId            3  21   0                     0  r[21]=products.rowid
+  13          SeekGE           5  24  21                     0  key=[21..21]
+  14            IdxGT          5  24  21                     0  key=[21..21]
+  15            DeferredSeek   5   4   0                     0
+  16            Integer        1  20   0                     0  r[20]=1
+  17            Column         3   2  15                     0  r[15]=products.category
+  18            IdxRowId       5  16   0                     0  r[16]=cursor 5 for index idx_orders_product.rowid
+  19            Column         4   5  17                     0  r[17]=orders.total_amount
+  20            Column         4   4  18                     0  r[18]=orders.quantity
+  21            MakeRecord    15   4  14                     0  r[14]=mkrec(r[15..18])
+  22            SorterInsert   1  14   0  0                  0  key=r[14]
+  23          Next             5  14   0                     0
+  24          IfPos           20  28   0                     0  r[20]>0 -> r[20]-=0, goto 28
+  25          NullRow          4   0   0                     0  Set cursor 4 to a (pseudo) NULL row
+  26          NullRow          5   0   0                     0  Set cursor 5 to a (pseudo) NULL row
+  27          Goto             0  16   0                     0
+  28        Next               3  11   0                     0
+  29        OpenPseudo         2  14   4                     0  4 columns in r[14]
+  30        SorterSort         1  49   0                     0
+  31          SorterData       1  14   2                     0  r[14]=data
+  32          Column           2   0  22                     0  r[22]=pseudo.column 0
+  33          Compare          9  22   1  k(1, Binary)       0  r[9..9]==r[22..22]
+  34          Jump            35  39  35                     0  ; start new group if comparison is not equal
+  35          Gosub            6  51   0                     0  ; check if ended group had data, and output if so
+  36          Move            22   9   1                     0  r[9..9]=r[22..22]
+  37          IfPos            8  65   0                     0  r[8]>0 -> r[8]-=0, goto 65; check abort flag
+  38          Gosub           19  62   0                     0  ; goto clear accumulator subroutine
+  39          Column           2   1  23                     0  r[23]=pseudo.column 1
+  40          Column           2   2  24                     0  r[24]=pseudo.column 2
+  41          Column           2   3  25                     0  r[25]=pseudo.column 3
+  42          AggStep          0  23  11  count              0  accum=r[11] step(r[23])
+  43          AggStep          0  24  12  sum                0  accum=r[12] step(r[24])
+  44          AggStep          0  25  13  avg                0  accum=r[13] step(r[25])
+  45          If               7  47   0                     0  if r[7] goto 47; don't emit group columns if continuing existing group
+  46          Column           2   0  10                     0  r[10]=pseudo.column 0
+  47          Integer          1   7   0                     0  r[7]=1; indicate data in accumulator
+  48        SorterNext         1  31   0                     0
+  49        Gosub              6  51   0                     0  ; emit row for final group
+  50        Goto               0  65   0                     0  ; group by finished
+  51        IfPos              7  53   0                     0  r[7]>0 -> r[7]-=0, goto 53; output group by row subroutine start
+  52      Return               6   0   0                     0
+  53      AggFinal             0  11   0  count              0  accum=r[11]
+  54      AggFinal             0  12   0  sum                0  accum=r[12]
+  55      AggFinal             0  13   0  avg                0  accum=r[13]
+  56      Copy                12  26   0                     0  r[26]=r[12]
+  57      Copy                10  27   1                     0  r[27]=r[10]
+  58      Copy                13  29   0                     0  r[29]=r[13]
+  59      MakeRecord          26   4   5                     0  r[5]=mkrec(r[26..29])
+  60      SorterInsert         0   5   0  0                  0  key=r[5]
+  61    Return                 6   0   0                     0
+  62    Null                   0  10  13                     0  r[10..13]=NULL; clear accumulator subroutine start
+  63    Integer                0   7   0                     0  r[7]=0
+  64  Return                  19   0   0                     0
+  65  OpenPseudo               6   5   4                     0  4 columns in r[5]
+  66  SorterSort               0  74   0                     0
+  67    SorterData             0   5   6                     0  r[5]=data
+  68    Column                 6   1   1                     0  r[1]=pseudo.column 1
+  69    Column                 6   2   2                     0  r[2]=pseudo.column 2
+  70    Column                 6   0   3                     0  r[3]=pseudo.column 0
+  71    Column                 6   3   4                     0  r[4]=pseudo.column 3
+  72    ResultRow              1   4   0                     0  output=r[1..4]
+  73  SorterNext               0  67   0                     0
+  74  Halt                     0   0   0                     0
+  75  Transaction              0   1   8                     0  iDb=0 tx_mode=Read
+  76  Goto                     0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-distinct.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-distinct.snap
@@ -26,63 +26,61 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                          p1  p2  p3  p4                  p5  comment
-   0          Init                     0  57   0                       0  Start at 57
-   1          SorterOpen               0   1   0  k(1,-B)              0  cursor=0
-   2          Null                     0  10  11                       0  r[10..11]=NULL
-   3          Integer                  0   7   0                       0  r[7]=0; clear group by abort flag
-   4          Null                     0   8   0                       0  r[8]=NULL; initialize group by comparison registers to NULL
-   5          Gosub                   16  43   0                       0  ; go to clear accumulator subroutine
-   6          HashClear       1073741824   0   0                       0
-   7          HashClear       1073741825   0   0                       0
-   8          OpenRead                 1   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
-   9          OpenRead                 2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
-  10          Rewind                   2  29   0                       0  Rewind index idx_sales_category
-  11            DeferredSeek           2   1   0                       0
-  12            Column                 2   0  13                       0  r[13]=idx_sales_category.category
-  13            Column                 1   6  14                       0  r[14]=sales.salesperson_id
-  14            Column                 1   2  15                       0  r[15]=sales.region
-  15            Compare                8  13   1  k(1, Binary)         0  r[8..8]==r[13..13]
-  16            Jump                  17  21  17                       0  ; start new group if comparison is not equal
-  17            Gosub                  5  33   0                       0  ; check if ended group had data, and output if so
-  18            Move                  13   8   1                       0  r[8..8]=r[13..13]
-  19            IfPos                  7  48   0                       0  r[7]>0 -> r[7]-=0, goto 48; check abort flag
-  20            Gosub                 16  43   0                       0  ; goto clear accumulator subroutine
-  21            HashDistinct  1073741824  14   1  jmp=23               0
-  22            AggStep                0  14  10  count                0  accum=r[10] step(r[14])
-  23            HashDistinct  1073741825  15   1  jmp=25               0
-  24            AggStep                0  15  11  count                0  accum=r[11] step(r[15])
-  25            If                     6  27   0                       0  if r[6] goto 27; don't emit group columns if continuing existing group
-  26            Column                 2   0   9                       0  r[9]=idx_sales_category.category
-  27            Integer                1   6   0                       0  r[6]=1; indicate data in accumulator
-  28          Next                     2  11   0                       0
-  29          Gosub                    5  33   0                       0  ; emit row for final group
-  30          Goto                     0  48   0                       0  ; group by finished
-  31          Integer                  1   7   0                       0  r[7]=1
-  32        Return                     5   0   0                       0
-  33        IfPos                      6  35   0                       0  r[6]>0 -> r[6]-=0, goto 35; output group by row subroutine start
-  34      Return                       5   0   0                       0
-  35      AggFinal                     0  10   0  count                0  accum=r[10]
-  36      AggFinal                     0  11   0  count                0  accum=r[11]
-  37      Copy                        10  17   0                       0  r[17]=r[10]
-  38      Copy                         9  18   0                       0  r[18]=r[9]
-  39      Copy                        11  19   0                       0  r[19]=r[11]
-  40      MakeRecord                  17   3   4                       0  r[4]=mkrec(r[17..19])
-  41      SorterInsert                 0   4   0  0                    0  key=r[4]
-  42    Return                         5   0   0                       0
-  43    Null                           0   9  11                       0  r[9..11]=NULL; clear accumulator subroutine start
-  44    HashClear             1073741824   0   0                       0
-  45    HashClear             1073741825   0   0                       0
-  46    Integer                        0   6   0                       0  r[6]=0
-  47  Return                          16   0   0                       0
-  48  OpenPseudo                       3   4   3                       0  3 columns in r[4]
-  49  SorterSort                       0  56   0                       0
-  50    SorterData                     0   4   3                       0  r[4]=data
-  51    Column                         3   1   1                       0  r[1]=pseudo.column 1
-  52    Column                         3   0   2                       0  r[2]=pseudo.column 0
-  53    Column                         3   2   3                       0  r[3]=pseudo.column 2
-  54    ResultRow                      1   3   0                       0  output=r[1..3]
-  55  SorterNext                       0  50   0                       0
-  56  Halt                             0   0   0                       0
-  57  Transaction                      0   1   8                       0  iDb=0 tx_mode=Read
-  58  Goto                             0   1   0                       0
+addr  opcode                        p1  p2  p3  p4                  p5  comment
+   0        Init                     0  55   0                       0  Start at 55
+   1        SorterOpen               0   1   0  k(1,-B)              0  cursor=0
+   2        Null                     0  10  11                       0  r[10..11]=NULL
+   3        Integer                  0   7   0                       0  r[7]=0; clear group by abort flag
+   4        Null                     0   8   0                       0  r[8]=NULL; initialize group by comparison registers to NULL
+   5        Gosub                   16  41   0                       0  ; go to clear accumulator subroutine
+   6        HashClear       1073741824   0   0                       0
+   7        HashClear       1073741825   0   0                       0
+   8        OpenRead                 1   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
+   9        OpenRead                 2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
+  10        Rewind                   2  29   0                       0  Rewind index idx_sales_category
+  11          DeferredSeek           2   1   0                       0
+  12          Column                 2   0  13                       0  r[13]=idx_sales_category.category
+  13          Column                 1   6  14                       0  r[14]=sales.salesperson_id
+  14          Column                 1   2  15                       0  r[15]=sales.region
+  15          Compare                8  13   1  k(1, Binary)         0  r[8..8]==r[13..13]
+  16          Jump                  17  21  17                       0  ; start new group if comparison is not equal
+  17          Gosub                  5  31   0                       0  ; check if ended group had data, and output if so
+  18          Move                  13   8   1                       0  r[8..8]=r[13..13]
+  19          IfPos                  7  46   0                       0  r[7]>0 -> r[7]-=0, goto 46; check abort flag
+  20          Gosub                 16  41   0                       0  ; goto clear accumulator subroutine
+  21          HashDistinct  1073741824  14   1  jmp=23               0
+  22          AggStep                0  14  10  count                0  accum=r[10] step(r[14])
+  23          HashDistinct  1073741825  15   1  jmp=25               0
+  24          AggStep                0  15  11  count                0  accum=r[11] step(r[15])
+  25          If                     6  27   0                       0  if r[6] goto 27; don't emit group columns if continuing existing group
+  26          Column                 2   0   9                       0  r[9]=idx_sales_category.category
+  27          Integer                1   6   0                       0  r[6]=1; indicate data in accumulator
+  28        Next                     2  11   0                       0
+  29        Gosub                    5  31   0                       0  ; emit row for final group
+  30        Goto                     0  46   0                       0  ; group by finished
+  31        IfPos                    6  33   0                       0  r[6]>0 -> r[6]-=0, goto 33; output group by row subroutine start
+  32      Return                     5   0   0                       0
+  33      AggFinal                   0  10   0  count                0  accum=r[10]
+  34      AggFinal                   0  11   0  count                0  accum=r[11]
+  35      Copy                      10  17   0                       0  r[17]=r[10]
+  36      Copy                       9  18   0                       0  r[18]=r[9]
+  37      Copy                      11  19   0                       0  r[19]=r[11]
+  38      MakeRecord                17   3   4                       0  r[4]=mkrec(r[17..19])
+  39      SorterInsert               0   4   0  0                    0  key=r[4]
+  40    Return                       5   0   0                       0
+  41    Null                         0   9  11                       0  r[9..11]=NULL; clear accumulator subroutine start
+  42    HashClear           1073741824   0   0                       0
+  43    HashClear           1073741825   0   0                       0
+  44    Integer                      0   6   0                       0  r[6]=0
+  45  Return                        16   0   0                       0
+  46  OpenPseudo                     3   4   3                       0  3 columns in r[4]
+  47  SorterSort                     0  54   0                       0
+  48    SorterData                   0   4   3                       0  r[4]=data
+  49    Column                       3   1   1                       0  r[1]=pseudo.column 1
+  50    Column                       3   0   2                       0  r[2]=pseudo.column 0
+  51    Column                       3   2   3                       0  r[3]=pseudo.column 2
+  52    ResultRow                    1   3   0                       0  output=r[1..3]
+  53  SorterNext                     0  48   0                       0
+  54  Halt                           0   0   0                       0
+  55  Transaction                    0   1   8                       0  iDb=0 tx_mode=Read
+  56  Goto                           0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__distinct-count-with-join.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__distinct-count-with-join.snap
@@ -31,74 +31,72 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                          p1  p2  p3  p4                p5  comment
-   0          Init                     0  68   0                     0  Start at 68
-   1          SorterOpen               0   1   0  k(1,-B)            0  cursor=0
-   2          Null                     0  10  11                     0  r[10..11]=NULL
-   3          SorterOpen               1   3   0  k(1,-B)            0  cursor=1
-   4          Integer                  0   7   0                     0  r[7]=0; clear group by abort flag
-   5          Null                     0   8   0                     0  r[8]=NULL; initialize group by comparison registers to NULL
-   6          Gosub                   16  54   0                     0  ; go to clear accumulator subroutine
-   7          HashClear       1073741824   0   0                     0
-   8          HashClear       1073741825   0   0                     0
-   9          OpenRead                 3   6   0  k(4,B,B,B,B)       0  table=products, root=6, iDb=0
-  10          OpenRead                 4   7   0  k(6,B,B,B,B,B,B)   0  table=orders, root=7, iDb=0
-  11          Rewind                   4  20   0                     0  Rewind table orders
-  12            Column                 4   2  17                     0  r[17]=orders.product_id
-  13            SeekRowid              3  17  19                     0  if (r[17]!=cursor 3 for table products.rowid) goto 19
-  14            Column                 3   2  13                     0  r[13]=products.category
-  15            Column                 4   1  14                     0  r[14]=orders.customer_id
-  16            RowId                  4  15   0                     0  r[15]=orders.rowid
-  17            MakeRecord            13   3  12                     0  r[12]=mkrec(r[13..15])
-  18            SorterInsert           1  12   0  0                  0  key=r[12]
-  19          Next                     4  12   0                     0
-  20          OpenPseudo               2  12   3                     0  3 columns in r[12]
-  21          SorterSort               1  40   0                     0
-  22            SorterData             1  12   2                     0  r[12]=data
-  23            Column                 2   0  18                     0  r[18]=pseudo.column 0
-  24            Compare                8  18   1  k(1, Binary)       0  r[8..8]==r[18..18]
-  25            Jump                  26  30  26                     0  ; start new group if comparison is not equal
-  26            Gosub                  5  44   0                     0  ; check if ended group had data, and output if so
-  27            Move                  18   8   1                     0  r[8..8]=r[18..18]
-  28            IfPos                  7  59   0                     0  r[7]>0 -> r[7]-=0, goto 59; check abort flag
-  29            Gosub                 16  54   0                     0  ; goto clear accumulator subroutine
-  30            Column                 2   1  19                     0  r[19]=pseudo.column 1
-  31            Column                 2   2  20                     0  r[20]=pseudo.column 2
-  32            HashDistinct  1073741824  19   1  jmp=34             0
-  33            AggStep                0  19  10  count              0  accum=r[10] step(r[19])
-  34            HashDistinct  1073741825  20   1  jmp=36             0
-  35            AggStep                0  20  11  count              0  accum=r[11] step(r[20])
-  36            If                     6  38   0                     0  if r[6] goto 38; don't emit group columns if continuing existing group
-  37            Column                 2   0   9                     0  r[9]=pseudo.column 0
-  38            Integer                1   6   0                     0  r[6]=1; indicate data in accumulator
-  39          SorterNext               1  22   0                     0
-  40          Gosub                    5  44   0                     0  ; emit row for final group
-  41          Goto                     0  59   0                     0  ; group by finished
-  42          Integer                  1   7   0                     0  r[7]=1
-  43        Return                     5   0   0                     0
-  44        IfPos                      6  46   0                     0  r[6]>0 -> r[6]-=0, goto 46; output group by row subroutine start
-  45      Return                       5   0   0                     0
-  46      AggFinal                     0  10   0  count              0  accum=r[10]
-  47      AggFinal                     0  11   0  count              0  accum=r[11]
-  48      Copy                        10  21   0                     0  r[21]=r[10]
-  49      Copy                         9  22   0                     0  r[22]=r[9]
-  50      Copy                        11  23   0                     0  r[23]=r[11]
-  51      MakeRecord                  21   3   4                     0  r[4]=mkrec(r[21..23])
-  52      SorterInsert                 0   4   0  0                  0  key=r[4]
-  53    Return                         5   0   0                     0
-  54    Null                           0   9  11                     0  r[9..11]=NULL; clear accumulator subroutine start
-  55    HashClear             1073741824   0   0                     0
-  56    HashClear             1073741825   0   0                     0
-  57    Integer                        0   6   0                     0  r[6]=0
-  58  Return                          16   0   0                     0
-  59  OpenPseudo                       5   4   3                     0  3 columns in r[4]
-  60  SorterSort                       0  67   0                     0
-  61    SorterData                     0   4   5                     0  r[4]=data
-  62    Column                         5   1   1                     0  r[1]=pseudo.column 1
-  63    Column                         5   0   2                     0  r[2]=pseudo.column 0
-  64    Column                         5   2   3                     0  r[3]=pseudo.column 2
-  65    ResultRow                      1   3   0                     0  output=r[1..3]
-  66  SorterNext                       0  61   0                     0
-  67  Halt                             0   0   0                     0
-  68  Transaction                      0   1   8                     0  iDb=0 tx_mode=Read
-  69  Goto                             0   1   0                     0
+addr  opcode                        p1  p2  p3  p4                p5  comment
+   0        Init                     0  66   0                     0  Start at 66
+   1        SorterOpen               0   1   0  k(1,-B)            0  cursor=0
+   2        Null                     0  10  11                     0  r[10..11]=NULL
+   3        SorterOpen               1   3   0  k(1,-B)            0  cursor=1
+   4        Integer                  0   7   0                     0  r[7]=0; clear group by abort flag
+   5        Null                     0   8   0                     0  r[8]=NULL; initialize group by comparison registers to NULL
+   6        Gosub                   16  52   0                     0  ; go to clear accumulator subroutine
+   7        HashClear       1073741824   0   0                     0
+   8        HashClear       1073741825   0   0                     0
+   9        OpenRead                 3   6   0  k(4,B,B,B,B)       0  table=products, root=6, iDb=0
+  10        OpenRead                 4   7   0  k(6,B,B,B,B,B,B)   0  table=orders, root=7, iDb=0
+  11        Rewind                   4  20   0                     0  Rewind table orders
+  12          Column                 4   2  17                     0  r[17]=orders.product_id
+  13          SeekRowid              3  17  19                     0  if (r[17]!=cursor 3 for table products.rowid) goto 19
+  14          Column                 3   2  13                     0  r[13]=products.category
+  15          Column                 4   1  14                     0  r[14]=orders.customer_id
+  16          RowId                  4  15   0                     0  r[15]=orders.rowid
+  17          MakeRecord            13   3  12                     0  r[12]=mkrec(r[13..15])
+  18          SorterInsert           1  12   0  0                  0  key=r[12]
+  19        Next                     4  12   0                     0
+  20        OpenPseudo               2  12   3                     0  3 columns in r[12]
+  21        SorterSort               1  40   0                     0
+  22          SorterData             1  12   2                     0  r[12]=data
+  23          Column                 2   0  18                     0  r[18]=pseudo.column 0
+  24          Compare                8  18   1  k(1, Binary)       0  r[8..8]==r[18..18]
+  25          Jump                  26  30  26                     0  ; start new group if comparison is not equal
+  26          Gosub                  5  42   0                     0  ; check if ended group had data, and output if so
+  27          Move                  18   8   1                     0  r[8..8]=r[18..18]
+  28          IfPos                  7  57   0                     0  r[7]>0 -> r[7]-=0, goto 57; check abort flag
+  29          Gosub                 16  52   0                     0  ; goto clear accumulator subroutine
+  30          Column                 2   1  19                     0  r[19]=pseudo.column 1
+  31          Column                 2   2  20                     0  r[20]=pseudo.column 2
+  32          HashDistinct  1073741824  19   1  jmp=34             0
+  33          AggStep                0  19  10  count              0  accum=r[10] step(r[19])
+  34          HashDistinct  1073741825  20   1  jmp=36             0
+  35          AggStep                0  20  11  count              0  accum=r[11] step(r[20])
+  36          If                     6  38   0                     0  if r[6] goto 38; don't emit group columns if continuing existing group
+  37          Column                 2   0   9                     0  r[9]=pseudo.column 0
+  38          Integer                1   6   0                     0  r[6]=1; indicate data in accumulator
+  39        SorterNext               1  22   0                     0
+  40        Gosub                    5  42   0                     0  ; emit row for final group
+  41        Goto                     0  57   0                     0  ; group by finished
+  42        IfPos                    6  44   0                     0  r[6]>0 -> r[6]-=0, goto 44; output group by row subroutine start
+  43      Return                     5   0   0                     0
+  44      AggFinal                   0  10   0  count              0  accum=r[10]
+  45      AggFinal                   0  11   0  count              0  accum=r[11]
+  46      Copy                      10  21   0                     0  r[21]=r[10]
+  47      Copy                       9  22   0                     0  r[22]=r[9]
+  48      Copy                      11  23   0                     0  r[23]=r[11]
+  49      MakeRecord                21   3   4                     0  r[4]=mkrec(r[21..23])
+  50      SorterInsert               0   4   0  0                  0  key=r[4]
+  51    Return                       5   0   0                     0
+  52    Null                         0   9  11                     0  r[9..11]=NULL; clear accumulator subroutine start
+  53    HashClear           1073741824   0   0                     0
+  54    HashClear           1073741825   0   0                     0
+  55    Integer                      0   6   0                     0  r[6]=0
+  56  Return                        16   0   0                     0
+  57  OpenPseudo                     5   4   3                     0  3 columns in r[4]
+  58  SorterSort                     0  65   0                     0
+  59    SorterData                   0   4   5                     0  r[4]=data
+  60    Column                       5   1   1                     0  r[1]=pseudo.column 1
+  61    Column                       5   0   2                     0  r[2]=pseudo.column 0
+  62    Column                       5   2   3                     0  r[3]=pseudo.column 2
+  63    ResultRow                    1   3   0                     0  output=r[1..3]
+  64  SorterNext                     0  59   0                     0
+  65  Halt                           0   0   0                     0
+  66  Transaction                    0   1   8                     0  iDb=0 tx_mode=Read
+  67  Goto                           0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__group-by-with-having.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__group-by-with-having.snap
@@ -26,60 +26,58 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                     p1  p2  p3  p4                  p5  comment
-   0          Init                0  54   0                       0  Start at 54
-   1          SorterOpen          0   1   0  k(1,-B)              0  cursor=0
-   2          Null                0  10  11                       0  r[10..11]=NULL
-   3          Integer             0   7   0                       0  r[7]=0; clear group by abort flag
-   4          Null                0   8   0                       0  r[8]=NULL; initialize group by comparison registers to NULL
-   5          Gosub              16  42   0                       0  ; go to clear accumulator subroutine
-   6          OpenRead            1   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
-   7          OpenRead            2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
-   8          Rewind              2  25   0                       0  Rewind index idx_sales_category
-   9            DeferredSeek      2   1   0                       0
-  10            Column            2   0  13                       0  r[13]=idx_sales_category.category
-  11            Column            1   4  14                       0  r[14]=sales.amount
-  12            Column            1   4  15                       0  r[15]=sales.amount
-  13            Compare           8  13   1  k(1, Binary)         0  r[8..8]==r[13..13]
-  14            Jump             15  19  15                       0  ; start new group if comparison is not equal
-  15            Gosub             5  29   0                       0  ; check if ended group had data, and output if so
-  16            Move             13   8   1                       0  r[8..8]=r[13..13]
-  17            IfPos             7  45   0                       0  r[7]>0 -> r[7]-=0, goto 45; check abort flag
-  18            Gosub            16  42   0                       0  ; goto clear accumulator subroutine
-  19            AggStep           0  14  10  sum                  0  accum=r[10] step(r[14])
-  20            AggStep           0  15  11  avg                  0  accum=r[11] step(r[15])
-  21            If                6  23   0                       0  if r[6] goto 23; don't emit group columns if continuing existing group
-  22            Column            2   0   9                       0  r[9]=idx_sales_category.category
-  23            Integer           1   6   0                       0  r[6]=1; indicate data in accumulator
-  24          Next                2   9   0                       0
-  25          Gosub               5  29   0                       0  ; emit row for final group
-  26          Goto                0  45   0                       0  ; group by finished
-  27          Integer             1   7   0                       0  r[7]=1
-  28        Return                5   0   0                       0
-  29        IfPos                 6  31   0                       0  r[6]>0 -> r[6]-=0, goto 31; output group by row subroutine start
-  30      Return                  5   0   0                       0
-  31      AggFinal                0  10   0  sum                  0  accum=r[10]
-  32      AggFinal                0  11   0  avg                  0  accum=r[11]
-  33      Copy                   10  18   0                       0  r[18]=r[10]
-  34      Integer             10000  19   0                       0  r[19]=10000
-  35      Le                     18  19  30                       0  if r[18]<=r[19] goto 30
-  36      Copy                   10  20   0                       0  r[20]=r[10]
-  37      Copy                    9  21   0                       0  r[21]=r[9]
-  38      Copy                   11  22   0                       0  r[22]=r[11]
-  39      MakeRecord             20   3   4                       0  r[4]=mkrec(r[20..22])
-  40      SorterInsert            0   4   0  0                    0  key=r[4]
-  41    Return                    5   0   0                       0
-  42    Null                      0   9  11                       0  r[9..11]=NULL; clear accumulator subroutine start
-  43    Integer                   0   6   0                       0  r[6]=0
-  44  Return                     16   0   0                       0
-  45  OpenPseudo                  3   4   3                       0  3 columns in r[4]
-  46  SorterSort                  0  53   0                       0
-  47    SorterData                0   4   3                       0  r[4]=data
-  48    Column                    3   1   1                       0  r[1]=pseudo.column 1
-  49    Column                    3   0   2                       0  r[2]=pseudo.column 0
-  50    Column                    3   2   3                       0  r[3]=pseudo.column 2
-  51    ResultRow                 1   3   0                       0  output=r[1..3]
-  52  SorterNext                  0  47   0                       0
-  53  Halt                        0   0   0                       0
-  54  Transaction                 0   1   8                       0  iDb=0 tx_mode=Read
-  55  Goto                        0   1   0                       0
+addr  opcode                   p1  p2  p3  p4                  p5  comment
+   0        Init                0  52   0                       0  Start at 52
+   1        SorterOpen          0   1   0  k(1,-B)              0  cursor=0
+   2        Null                0  10  11                       0  r[10..11]=NULL
+   3        Integer             0   7   0                       0  r[7]=0; clear group by abort flag
+   4        Null                0   8   0                       0  r[8]=NULL; initialize group by comparison registers to NULL
+   5        Gosub              16  40   0                       0  ; go to clear accumulator subroutine
+   6        OpenRead            1   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
+   7        OpenRead            2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
+   8        Rewind              2  25   0                       0  Rewind index idx_sales_category
+   9          DeferredSeek      2   1   0                       0
+  10          Column            2   0  13                       0  r[13]=idx_sales_category.category
+  11          Column            1   4  14                       0  r[14]=sales.amount
+  12          Column            1   4  15                       0  r[15]=sales.amount
+  13          Compare           8  13   1  k(1, Binary)         0  r[8..8]==r[13..13]
+  14          Jump             15  19  15                       0  ; start new group if comparison is not equal
+  15          Gosub             5  27   0                       0  ; check if ended group had data, and output if so
+  16          Move             13   8   1                       0  r[8..8]=r[13..13]
+  17          IfPos             7  43   0                       0  r[7]>0 -> r[7]-=0, goto 43; check abort flag
+  18          Gosub            16  40   0                       0  ; goto clear accumulator subroutine
+  19          AggStep           0  14  10  sum                  0  accum=r[10] step(r[14])
+  20          AggStep           0  15  11  avg                  0  accum=r[11] step(r[15])
+  21          If                6  23   0                       0  if r[6] goto 23; don't emit group columns if continuing existing group
+  22          Column            2   0   9                       0  r[9]=idx_sales_category.category
+  23          Integer           1   6   0                       0  r[6]=1; indicate data in accumulator
+  24        Next                2   9   0                       0
+  25        Gosub               5  27   0                       0  ; emit row for final group
+  26        Goto                0  43   0                       0  ; group by finished
+  27        IfPos               6  29   0                       0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
+  28      Return                5   0   0                       0
+  29      AggFinal              0  10   0  sum                  0  accum=r[10]
+  30      AggFinal              0  11   0  avg                  0  accum=r[11]
+  31      Copy                 10  18   0                       0  r[18]=r[10]
+  32      Integer           10000  19   0                       0  r[19]=10000
+  33      Le                   18  19  28                       0  if r[18]<=r[19] goto 28
+  34      Copy                 10  20   0                       0  r[20]=r[10]
+  35      Copy                  9  21   0                       0  r[21]=r[9]
+  36      Copy                 11  22   0                       0  r[22]=r[11]
+  37      MakeRecord           20   3   4                       0  r[4]=mkrec(r[20..22])
+  38      SorterInsert          0   4   0  0                    0  key=r[4]
+  39    Return                  5   0   0                       0
+  40    Null                    0   9  11                       0  r[9..11]=NULL; clear accumulator subroutine start
+  41    Integer                 0   6   0                       0  r[6]=0
+  42  Return                   16   0   0                       0
+  43  OpenPseudo                3   4   3                       0  3 columns in r[4]
+  44  SorterSort                0  51   0                       0
+  45    SorterData              0   4   3                       0  r[4]=data
+  46    Column                  3   1   1                       0  r[1]=pseudo.column 1
+  47    Column                  3   0   2                       0  r[2]=pseudo.column 0
+  48    Column                  3   2   3                       0  r[3]=pseudo.column 2
+  49    ResultRow               1   3   0                       0  output=r[1..3]
+  50  SorterNext                0  45   0                       0
+  51  Halt                      0   0   0                       0
+  52  Transaction               0   1   8                       0  iDb=0 tx_mode=Read
+  53  Goto                      0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
@@ -23,47 +23,43 @@ QUERY PLAN
 `--SCAN sales USING INDEX idx_sales_category
 
 BYTECODE
-addr  opcode                  p1  p2  p3  p4                  p5  comment
-   0          Init             0  41   0                       0  Start at 41
-   1          Null             0   9  10                       0  r[9..10]=NULL
-   2          Integer          0   6   0                       0  r[6]=0; clear group by abort flag
-   3          Null             0   7   0                       0  r[7]=NULL; initialize group by comparison registers to NULL
-   4          Gosub           15  37   0                       0  ; go to clear accumulator subroutine
-   5          OpenRead         0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
-   6          OpenRead         1   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
-   7          Rewind           1  24   0                       0  Rewind index idx_sales_category
-   8            DeferredSeek   1   0   0                       0
-   9            Column         1   0  12                       0  r[12]=idx_sales_category.category
-  10            Column         0   4  13                       0  r[13]=sales.amount
-  11            Column         0   4  14                       0  r[14]=sales.amount
-  12            Compare        7  12   1  k(1, Binary)         0  r[7..7]==r[12..12]
-  13            Jump          14  18  14                       0  ; start new group if comparison is not equal
-  14            Gosub          4  28   0                       0  ; check if ended group had data, and output if so
-  15            Move          12   7   1                       0  r[7..7]=r[12..12]
-  16            IfPos          6  40   0                       0  r[6]>0 -> r[6]-=0, goto 40; check abort flag
-  17            Gosub         15  37   0                       0  ; goto clear accumulator subroutine
-  18            AggStep        0  13   9  min(Binary)          0  accum=r[9] step(r[13])
-  19            AggStep        0  14  10  max(Binary)          0  accum=r[10] step(r[14])
-  20            If             5  22   0                       0  if r[5] goto 22; don't emit group columns if continuing existing group
-  21            Column         1   0   8                       0  r[8]=idx_sales_category.category
-  22            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
-  23          Next             1   8   0                       0
-  24          Gosub            4  28   0                       0  ; emit row for final group
-  25          Goto             0  40   0                       0  ; group by finished
-  26          Integer          1   6   0                       0  r[6]=1
-  27        Return             4   0   0                       0
-  28        IfPos              5  30   0                       0  r[5]>0 -> r[5]-=0, goto 30; output group by row subroutine start
-  29      Return               4   0   0                       0
-  30      AggFinal             0   9   0  min                  0  accum=r[9]
-  31      AggFinal             0  10   0  max                  0  accum=r[10]
-  32      Copy                 8   1   0                       0  r[1]=r[8]
-  33      Copy                 9   2   0                       0  r[2]=r[9]
-  34      Copy                10   3   0                       0  r[3]=r[10]
-  35      ResultRow            1   3   0                       0  output=r[1..3]
-  36    Return                 4   0   0                       0
-  37    Null                   0   8  10                       0  r[8..10]=NULL; clear accumulator subroutine start
-  38    Integer                0   5   0                       0  r[5]=0
-  39  Return                  15   0   0                       0
-  40  Halt                     0   0   0                       0
-  41  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
-  42  Goto                     0   1   0                       0
+addr  opcode                p1  p2  p3  p4                  p5  comment
+   0        Init             0  37   0                       0  Start at 37
+   1        Null             0   9  10                       0  r[9..10]=NULL
+   2        Integer          0   6   0                       0  r[6]=0; clear group by abort flag
+   3        Null             0   7   0                       0  r[7]=NULL; initialize group by comparison registers to NULL
+   4        Gosub           15  33   0                       0  ; go to clear accumulator subroutine
+   5        OpenRead         0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
+   6        OpenRead         1   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
+   7        Rewind           1  24   0                       0  Rewind index idx_sales_category
+   8          DeferredSeek   1   0   0                       0
+   9          Column         1   0  12                       0  r[12]=idx_sales_category.category
+  10          Column         0   4  13                       0  r[13]=sales.amount
+  11          Column         0   4  14                       0  r[14]=sales.amount
+  12          Compare        7  12   1  k(1, Binary)         0  r[7..7]==r[12..12]
+  13          Jump          14  18  14                       0  ; start new group if comparison is not equal
+  14          Gosub          4  26   0                       0  ; check if ended group had data, and output if so
+  15          Move          12   7   1                       0  r[7..7]=r[12..12]
+  16          IfPos          6  36   0                       0  r[6]>0 -> r[6]-=0, goto 36; check abort flag
+  17          Gosub         15  33   0                       0  ; goto clear accumulator subroutine
+  18          AggStep        0  13   9  min(Binary)          0  accum=r[9] step(r[13])
+  19          AggStep        0  14  10  max(Binary)          0  accum=r[10] step(r[14])
+  20          If             5  22   0                       0  if r[5] goto 22; don't emit group columns if continuing existing group
+  21          Column         1   0   8                       0  r[8]=idx_sales_category.category
+  22          Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
+  23        Next             1   8   0                       0
+  24        Gosub            4  26   0                       0  ; emit row for final group
+  25        Halt             0   0   0                       0  ; group by finished
+  26        IfPos            5  28   0                       0  r[5]>0 -> r[5]-=0, goto 28; output group by row subroutine start
+  27      Return             4   0   0                       0
+  28      AggFinal           0   9   0  min                  0  accum=r[9]
+  29      AggFinal           0  10   0  max                  0  accum=r[10]
+  30      Copy               8   1   2                       0  r[1]=r[8]
+  31      ResultRow          1   3   0                       0  output=r[1..3]
+  32    Return               4   0   0                       0
+  33    Null                 0   8  10                       0  r[8..10]=NULL; clear accumulator subroutine start
+  34    Integer              0   5   0                       0  r[5]=0
+  35  Return                15   0   0                       0
+  36  Halt                   0   0   0                       0
+  37  Transaction            0   1   8                       0  iDb=0 tx_mode=Read
+  38  Goto                   0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-with-index.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-with-index.snap
@@ -19,7 +19,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4           p5  comment
-   0  Init          0  15   0                0  Start at 15
+   0  Init          0  14   0                0  Start at 14
    1  Null          0   3   4                0  r[3..4]=NULL
    2  OpenRead      0   3   0  k(2,B)        0  index=idx_sales_amount, root=3, iDb=0
    3  Rewind        0   9   0                0  Rewind index idx_sales_amount
@@ -30,9 +30,8 @@ addr  opcode       p1  p2  p3  p4           p5  comment
    8  Next          0   4   0                0
    9  AggFinal      0   3   0  min           0  accum=r[3]
   10  AggFinal      0   4   0  max           0  accum=r[4]
-  11  Copy          3   1   0                0  r[1]=r[3]
-  12  Copy          4   2   0                0  r[2]=r[4]
-  13  ResultRow     1   2   0                0  output=r[1..2]
-  14  Halt          0   0   0                0
-  15  Transaction   0   1   8                0  iDb=0 tx_mode=Read
-  16  Goto          0   1   0                0
+  11  Copy          3   1   1                0  r[1]=r[3]
+  12  ResultRow     1   2   0                0  output=r[1..2]
+  13  Halt          0   0   0                0
+  14  Transaction   0   1   8                0  iDb=0 tx_mode=Read
+  15  Goto          0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__multi-column-group-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__multi-column-group-by.snap
@@ -26,50 +26,45 @@ QUERY PLAN
 `--SCAN sales USING INDEX idx_sales_category_region
 
 BYTECODE
-addr  opcode                  p1  p2  p3  p4                    p5  comment
-   0          Init             0  43   0                         0  Start at 43
-   1          Null             0  12  13                         0  r[12..13]=NULL
-   2          Integer          0   7   0                         0  r[7]=0; clear group by abort flag
-   3          Null             0   8   9                         0  r[8..9]=NULL; initialize group by comparison registers to NULL
-   4          Gosub           18  39   0                         0  ; go to clear accumulator subroutine
-   5          OpenRead         0   2   0  k(7,B,B,B,B,B,B,B)     0  table=sales, root=2, iDb=0
-   6          OpenRead         1   5   0  k(3,B,B)               0  index=idx_sales_category_region, root=5, iDb=0
-   7          Rewind           1  25   0                         0  Rewind index idx_sales_category_region
-   8            DeferredSeek   1   0   0                         0
-   9            Column         1   0  15                         0  r[15]=idx_sales_category_region.category
-  10            Column         1   1  16                         0  r[16]=idx_sales_category_region.region
-  11            Column         0   4  17                         0  r[17]=sales.amount
-  12            Compare        8  15   2  k(2, Binary, Binary)   0  r[8..9]==r[15..16]
-  13            Jump          14  18  14                         0  ; start new group if comparison is not equal
-  14            Gosub          5  29   0                         0  ; check if ended group had data, and output if so
-  15            Move          15   8   2                         0  r[8..9]=r[15..16]
-  16            IfPos          7  42   0                         0  r[7]>0 -> r[7]-=0, goto 42; check abort flag
-  17            Gosub         18  39   0                         0  ; goto clear accumulator subroutine
-  18            AggStep        0  17  12  sum                    0  accum=r[12] step(r[17])
-  19            AggStep        0  19  13  count                  0  accum=r[13] step(r[19])
-  20            If             6  23   0                         0  if r[6] goto 23; don't emit group columns if continuing existing group
-  21            Column         1   0  10                         0  r[10]=idx_sales_category_region.category
-  22            Column         1   1  11                         0  r[11]=idx_sales_category_region.region
-  23            Integer        1   6   0                         0  r[6]=1; indicate data in accumulator
-  24          Next             1   8   0                         0
-  25          Gosub            5  29   0                         0  ; emit row for final group
-  26          Goto             0  42   0                         0  ; group by finished
-  27          Integer          1   7   0                         0  r[7]=1
-  28        Return             5   0   0                         0
-  29        IfPos              6  31   0                         0  r[6]>0 -> r[6]-=0, goto 31; output group by row subroutine start
-  30      Return               5   0   0                         0
-  31      AggFinal             0  12   0  sum                    0  accum=r[12]
-  32      AggFinal             0  13   0  count                  0  accum=r[13]
-  33      Copy                10   1   0                         0  r[1]=r[10]
-  34      Copy                11   2   0                         0  r[2]=r[11]
-  35      Copy                12   3   0                         0  r[3]=r[12]
-  36      Copy                13   4   0                         0  r[4]=r[13]
-  37      ResultRow            1   4   0                         0  output=r[1..4]
-  38    Return                 5   0   0                         0
-  39    Null                   0  10  13                         0  r[10..13]=NULL; clear accumulator subroutine start
-  40    Integer                0   6   0                         0  r[6]=0
-  41  Return                  18   0   0                         0
-  42  Halt                     0   0   0                         0
-  43  Transaction              0   1   8                         0  iDb=0 tx_mode=Read
-  44  Integer                  1  19   0                         0  r[19]=1
-  45  Goto                     0   1   0                         0
+addr  opcode                p1  p2  p3  p4                    p5  comment
+   0        Init             0  38   0                         0  Start at 38
+   1        Null             0  12  13                         0  r[12..13]=NULL
+   2        Integer          0   7   0                         0  r[7]=0; clear group by abort flag
+   3        Null             0   8   9                         0  r[8..9]=NULL; initialize group by comparison registers to NULL
+   4        Gosub           18  34   0                         0  ; go to clear accumulator subroutine
+   5        OpenRead         0   2   0  k(7,B,B,B,B,B,B,B)     0  table=sales, root=2, iDb=0
+   6        OpenRead         1   5   0  k(3,B,B)               0  index=idx_sales_category_region, root=5, iDb=0
+   7        Rewind           1  25   0                         0  Rewind index idx_sales_category_region
+   8          DeferredSeek   1   0   0                         0
+   9          Column         1   0  15                         0  r[15]=idx_sales_category_region.category
+  10          Column         1   1  16                         0  r[16]=idx_sales_category_region.region
+  11          Column         0   4  17                         0  r[17]=sales.amount
+  12          Compare        8  15   2  k(2, Binary, Binary)   0  r[8..9]==r[15..16]
+  13          Jump          14  18  14                         0  ; start new group if comparison is not equal
+  14          Gosub          5  27   0                         0  ; check if ended group had data, and output if so
+  15          Move          15   8   2                         0  r[8..9]=r[15..16]
+  16          IfPos          7  37   0                         0  r[7]>0 -> r[7]-=0, goto 37; check abort flag
+  17          Gosub         18  34   0                         0  ; goto clear accumulator subroutine
+  18          AggStep        0  17  12  sum                    0  accum=r[12] step(r[17])
+  19          AggStep        0  19  13  count                  0  accum=r[13] step(r[19])
+  20          If             6  23   0                         0  if r[6] goto 23; don't emit group columns if continuing existing group
+  21          Column         1   0  10                         0  r[10]=idx_sales_category_region.category
+  22          Column         1   1  11                         0  r[11]=idx_sales_category_region.region
+  23          Integer        1   6   0                         0  r[6]=1; indicate data in accumulator
+  24        Next             1   8   0                         0
+  25        Gosub            5  27   0                         0  ; emit row for final group
+  26        Halt             0   0   0                         0  ; group by finished
+  27        IfPos            6  29   0                         0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
+  28      Return             5   0   0                         0
+  29      AggFinal           0  12   0  sum                    0  accum=r[12]
+  30      AggFinal           0  13   0  count                  0  accum=r[13]
+  31      Copy              10   1   3                         0  r[1]=r[10]
+  32      ResultRow          1   4   0                         0  output=r[1..4]
+  33    Return               5   0   0                         0
+  34    Null                 0  10  13                         0  r[10..13]=NULL; clear accumulator subroutine start
+  35    Integer              0   6   0                         0  r[6]=0
+  36  Return                18   0   0                         0
+  37  Halt                   0   0   0                         0
+  38  Transaction            0   1   8                         0  iDb=0 tx_mode=Read
+  39  Integer                1  19   0                         0  r[19]=1
+  40  Goto                   0   1   0                         0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__multiple-aggregates.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__multiple-aggregates.snap
@@ -27,72 +27,67 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                  p1  p2  p3  p4                  p5  comment
-   0          Init             0  65   0                       0  Start at 65
-   1          SorterOpen       0   1   0  k(1,-B)              0  cursor=0
-   2          Null             0  13  17                       0  r[13..17]=NULL
-   3          Integer          0  10   0                       0  r[10]=0; clear group by abort flag
-   4          Null             0  11   0                       0  r[11]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           24  50   0                       0  ; go to clear accumulator subroutine
-   6          OpenRead         1   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
-   7          OpenRead         2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
-   8          Rewind           2  30   0                       0  Rewind index idx_sales_category
-   9            DeferredSeek   2   1   0                       0
-  10            Column         2   0  19                       0  r[19]=idx_sales_category.category
-  11            Column         1   4  20                       0  r[20]=sales.amount
-  12            Column         1   4  21                       0  r[21]=sales.amount
-  13            Column         1   5  22                       0  r[22]=sales.quantity
-  14            Column         1   5  23                       0  r[23]=sales.quantity
-  15            Compare       11  19   1  k(1, Binary)         0  r[11..11]==r[19..19]
-  16            Jump          17  21  17                       0  ; start new group if comparison is not equal
-  17            Gosub          8  34   0                       0  ; check if ended group had data, and output if so
-  18            Move          19  11   1                       0  r[11..11]=r[19..19]
-  19            IfPos         10  53   0                       0  r[10]>0 -> r[10]-=0, goto 53; check abort flag
-  20            Gosub         24  50   0                       0  ; goto clear accumulator subroutine
-  21            AggStep        0  25  13  count                0  accum=r[13] step(r[25])
-  22            AggStep        0  20  14  sum                  0  accum=r[14] step(r[20])
-  23            AggStep        0  21  15  avg                  0  accum=r[15] step(r[21])
-  24            AggStep        0  22  16  sum                  0  accum=r[16] step(r[22])
-  25            AggStep        0  23  17  avg                  0  accum=r[17] step(r[23])
-  26            If             9  28   0                       0  if r[9] goto 28; don't emit group columns if continuing existing group
-  27            Column         2   0  12                       0  r[12]=idx_sales_category.category
-  28            Integer        1   9   0                       0  r[9]=1; indicate data in accumulator
-  29          Next             2   9   0                       0
-  30          Gosub            8  34   0                       0  ; emit row for final group
-  31          Goto             0  53   0                       0  ; group by finished
-  32          Integer          1  10   0                       0  r[10]=1
-  33        Return             8   0   0                       0
-  34        IfPos              9  36   0                       0  r[9]>0 -> r[9]-=0, goto 36; output group by row subroutine start
-  35      Return               8   0   0                       0
-  36      AggFinal             0  13   0  count                0  accum=r[13]
-  37      AggFinal             0  14   0  sum                  0  accum=r[14]
-  38      AggFinal             0  15   0  avg                  0  accum=r[15]
-  39      AggFinal             0  16   0  sum                  0  accum=r[16]
-  40      AggFinal             0  17   0  avg                  0  accum=r[17]
-  41      Copy                14  26   0                       0  r[26]=r[14]
-  42      Copy                12  27   0                       0  r[27]=r[12]
-  43      Copy                13  28   0                       0  r[28]=r[13]
-  44      Copy                15  29   0                       0  r[29]=r[15]
-  45      Copy                16  30   0                       0  r[30]=r[16]
-  46      Copy                17  31   0                       0  r[31]=r[17]
-  47      MakeRecord          26   6   7                       0  r[7]=mkrec(r[26..31])
-  48      SorterInsert         0   7   0  0                    0  key=r[7]
-  49    Return                 8   0   0                       0
-  50    Null                   0  12  17                       0  r[12..17]=NULL; clear accumulator subroutine start
-  51    Integer                0   9   0                       0  r[9]=0
-  52  Return                  24   0   0                       0
-  53  OpenPseudo               3   7   6                       0  6 columns in r[7]
-  54  SorterSort               0  64   0                       0
-  55    SorterData             0   7   3                       0  r[7]=data
-  56    Column                 3   1   1                       0  r[1]=pseudo.column 1
-  57    Column                 3   2   2                       0  r[2]=pseudo.column 2
-  58    Column                 3   0   3                       0  r[3]=pseudo.column 0
-  59    Column                 3   3   4                       0  r[4]=pseudo.column 3
-  60    Column                 3   4   5                       0  r[5]=pseudo.column 4
-  61    Column                 3   5   6                       0  r[6]=pseudo.column 5
-  62    ResultRow              1   6   0                       0  output=r[1..6]
-  63  SorterNext               0  55   0                       0
-  64  Halt                     0   0   0                       0
-  65  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
-  66  Integer                  1  25   0                       0  r[25]=1
-  67  Goto                     0   1   0                       0
+addr  opcode                p1  p2  p3  p4                  p5  comment
+   0        Init             0  60   0                       0  Start at 60
+   1        SorterOpen       0   1   0  k(1,-B)              0  cursor=0
+   2        Null             0  13  17                       0  r[13..17]=NULL
+   3        Integer          0  10   0                       0  r[10]=0; clear group by abort flag
+   4        Null             0  11   0                       0  r[11]=NULL; initialize group by comparison registers to NULL
+   5        Gosub           24  45   0                       0  ; go to clear accumulator subroutine
+   6        OpenRead         1   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
+   7        OpenRead         2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
+   8        Rewind           2  30   0                       0  Rewind index idx_sales_category
+   9          DeferredSeek   2   1   0                       0
+  10          Column         2   0  19                       0  r[19]=idx_sales_category.category
+  11          Column         1   4  20                       0  r[20]=sales.amount
+  12          Column         1   4  21                       0  r[21]=sales.amount
+  13          Column         1   5  22                       0  r[22]=sales.quantity
+  14          Column         1   5  23                       0  r[23]=sales.quantity
+  15          Compare       11  19   1  k(1, Binary)         0  r[11..11]==r[19..19]
+  16          Jump          17  21  17                       0  ; start new group if comparison is not equal
+  17          Gosub          8  32   0                       0  ; check if ended group had data, and output if so
+  18          Move          19  11   1                       0  r[11..11]=r[19..19]
+  19          IfPos         10  48   0                       0  r[10]>0 -> r[10]-=0, goto 48; check abort flag
+  20          Gosub         24  45   0                       0  ; goto clear accumulator subroutine
+  21          AggStep        0  25  13  count                0  accum=r[13] step(r[25])
+  22          AggStep        0  20  14  sum                  0  accum=r[14] step(r[20])
+  23          AggStep        0  21  15  avg                  0  accum=r[15] step(r[21])
+  24          AggStep        0  22  16  sum                  0  accum=r[16] step(r[22])
+  25          AggStep        0  23  17  avg                  0  accum=r[17] step(r[23])
+  26          If             9  28   0                       0  if r[9] goto 28; don't emit group columns if continuing existing group
+  27          Column         2   0  12                       0  r[12]=idx_sales_category.category
+  28          Integer        1   9   0                       0  r[9]=1; indicate data in accumulator
+  29        Next             2   9   0                       0
+  30        Gosub            8  32   0                       0  ; emit row for final group
+  31        Goto             0  48   0                       0  ; group by finished
+  32        IfPos            9  34   0                       0  r[9]>0 -> r[9]-=0, goto 34; output group by row subroutine start
+  33      Return             8   0   0                       0
+  34      AggFinal           0  13   0  count                0  accum=r[13]
+  35      AggFinal           0  14   0  sum                  0  accum=r[14]
+  36      AggFinal           0  15   0  avg                  0  accum=r[15]
+  37      AggFinal           0  16   0  sum                  0  accum=r[16]
+  38      AggFinal           0  17   0  avg                  0  accum=r[17]
+  39      Copy              14  26   0                       0  r[26]=r[14]
+  40      Copy              12  27   1                       0  r[27]=r[12]
+  41      Copy              15  29   2                       0  r[29]=r[15]
+  42      MakeRecord        26   6   7                       0  r[7]=mkrec(r[26..31])
+  43      SorterInsert       0   7   0  0                    0  key=r[7]
+  44    Return               8   0   0                       0
+  45    Null                 0  12  17                       0  r[12..17]=NULL; clear accumulator subroutine start
+  46    Integer              0   9   0                       0  r[9]=0
+  47  Return                24   0   0                       0
+  48  OpenPseudo             3   7   6                       0  6 columns in r[7]
+  49  SorterSort             0  59   0                       0
+  50    SorterData           0   7   3                       0  r[7]=data
+  51    Column               3   1   1                       0  r[1]=pseudo.column 1
+  52    Column               3   2   2                       0  r[2]=pseudo.column 2
+  53    Column               3   0   3                       0  r[3]=pseudo.column 0
+  54    Column               3   3   4                       0  r[4]=pseudo.column 3
+  55    Column               3   4   5                       0  r[5]=pseudo.column 4
+  56    Column               3   5   6                       0  r[6]=pseudo.column 5
+  57    ResultRow            1   6   0                       0  output=r[1..6]
+  58  SorterNext             0  50   0                       0
+  59  Halt                   0   0   0                       0
+  60  Transaction            0   1   8                       0  iDb=0 tx_mode=Read
+  61  Integer                1  25   0                       0  r[25]=1
+  62  Goto                   0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
@@ -28,62 +28,57 @@ QUERY PLAN
    `--SCAN sales USING INDEX idx_sales_category
 
 BYTECODE
-addr  opcode                  p1  p2  p3  p4                  p5  comment
-   0          Init             0  56   0                       0  Start at 56
-   1          InitCoroutine    1  38   2                       0
-   2          Null             0   9   0                       0  r[9]=NULL
-   3          Integer          0   6   0                       0  r[6]=0; clear group by abort flag
-   4          Null             0   7   0                       0  r[7]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           13  34   0                       0  ; go to clear accumulator subroutine
-   6          OpenRead         0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
-   7          OpenRead         1   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
-   8          Rewind           1  23   0                       0  Rewind index idx_sales_category
-   9            DeferredSeek   1   0   0                       0
-  10            Column         1   0  11                       0  r[11]=idx_sales_category.category
-  11            Column         0   4  12                       0  r[12]=sales.amount
-  12            Compare        7  11   1  k(1, Binary)         0  r[7..7]==r[11..11]
-  13            Jump          14  18  14                       0  ; start new group if comparison is not equal
-  14            Gosub          4  27   0                       0  ; check if ended group had data, and output if so
-  15            Move          11   7   1                       0  r[7..7]=r[11..11]
-  16            IfPos          6  37   0                       0  r[6]>0 -> r[6]-=0, goto 37; check abort flag
-  17            Gosub         13  34   0                       0  ; goto clear accumulator subroutine
-  18            AggStep        0  12   9  sum                  0  accum=r[9] step(r[12])
-  19            If             5  21   0                       0  if r[5] goto 21; don't emit group columns if continuing existing group
-  20            Column         1   0   8                       0  r[8]=idx_sales_category.category
-  21            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
-  22          Next             1   9   0                       0
-  23          Gosub            4  27   0                       0  ; emit row for final group
-  24          Goto             0  37   0                       0  ; group by finished
-  25          Integer          1   6   0                       0  r[6]=1
-  26        Return             4   0   0                       0
-  27        IfPos              5  29   0                       0  r[5]>0 -> r[5]-=0, goto 29; output group by row subroutine start
-  28      Return               4   0   0                       0
-  29      AggFinal             0   9   0  sum                  0  accum=r[9]
-  30      Copy                 8   2   0                       0  r[2]=r[8]
-  31      Copy                 9   3   0                       0  r[3]=r[9]
-  32      Yield                1   0   0                       0
-  33    Return                 4   0   0                       0
-  34    Null                   0   8   9                       0  r[8..9]=NULL; clear accumulator subroutine start
-  35    Integer                0   5   0                       0  r[5]=0
-  36  Return                  13   0   0                       0
-  37  EndCoroutine             1   0   0                       0
-  38  Null                     0  17  19                       0  r[17..19]=NULL
-  39  InitCoroutine            1   0   2                       0
-  40    Yield                  1  48   0                       0
-  41    Copy                   3  20   0                       0  r[20]=r[3]
-  42    AggStep                0  20  17  avg                  0  accum=r[17] step(r[20])
-  43    Copy                   3  21   0                       0  r[21]=r[3]
-  44    AggStep                0  21  18  max(Binary)          0  accum=r[18] step(r[21])
-  45    Copy                   3  22   0                       0  r[22]=r[3]
-  46    AggStep                0  22  19  min(Binary)          0  accum=r[19] step(r[22])
-  47  Goto                     0  40   0                       0
-  48  AggFinal                 0  17   0  avg                  0  accum=r[17]
-  49  AggFinal                 0  18   0  max                  0  accum=r[18]
-  50  AggFinal                 0  19   0  min                  0  accum=r[19]
-  51  Copy                    17  14   0                       0  r[14]=r[17]
-  52  Copy                    18  15   0                       0  r[15]=r[18]
-  53  Copy                    19  16   0                       0  r[16]=r[19]
-  54  ResultRow               14   3   0                       0  output=r[14..16]
-  55  Halt                     0   0   0                       0
-  56  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
-  57  Goto                     0   1   0                       0
+addr  opcode                p1  p2  p3  p4                  p5  comment
+   0        Init             0  51   0                       0  Start at 51
+   1        InitCoroutine    1  35   2                       0
+   2        Null             0   9   0                       0  r[9]=NULL
+   3        Integer          0   6   0                       0  r[6]=0; clear group by abort flag
+   4        Null             0   7   0                       0  r[7]=NULL; initialize group by comparison registers to NULL
+   5        Gosub           13  31   0                       0  ; go to clear accumulator subroutine
+   6        OpenRead         0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
+   7        OpenRead         1   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
+   8        Rewind           1  23   0                       0  Rewind index idx_sales_category
+   9          DeferredSeek   1   0   0                       0
+  10          Column         1   0  11                       0  r[11]=idx_sales_category.category
+  11          Column         0   4  12                       0  r[12]=sales.amount
+  12          Compare        7  11   1  k(1, Binary)         0  r[7..7]==r[11..11]
+  13          Jump          14  18  14                       0  ; start new group if comparison is not equal
+  14          Gosub          4  25   0                       0  ; check if ended group had data, and output if so
+  15          Move          11   7   1                       0  r[7..7]=r[11..11]
+  16          IfPos          6  34   0                       0  r[6]>0 -> r[6]-=0, goto 34; check abort flag
+  17          Gosub         13  31   0                       0  ; goto clear accumulator subroutine
+  18          AggStep        0  12   9  sum                  0  accum=r[9] step(r[12])
+  19          If             5  21   0                       0  if r[5] goto 21; don't emit group columns if continuing existing group
+  20          Column         1   0   8                       0  r[8]=idx_sales_category.category
+  21          Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
+  22        Next             1   9   0                       0
+  23        Gosub            4  25   0                       0  ; emit row for final group
+  24        Goto             0  34   0                       0  ; group by finished
+  25        IfPos            5  27   0                       0  r[5]>0 -> r[5]-=0, goto 27; output group by row subroutine start
+  26      Return             4   0   0                       0
+  27      AggFinal           0   9   0  sum                  0  accum=r[9]
+  28      Copy               8   2   1                       0  r[2]=r[8]
+  29      Yield              1   0   0                       0
+  30    Return               4   0   0                       0
+  31    Null                 0   8   9                       0  r[8..9]=NULL; clear accumulator subroutine start
+  32    Integer              0   5   0                       0  r[5]=0
+  33  Return                13   0   0                       0
+  34  EndCoroutine           1   0   0                       0
+  35  Null                   0  17  19                       0  r[17..19]=NULL
+  36  InitCoroutine          1   0   2                       0
+  37    Yield                1  45   0                       0
+  38    Copy                 3  20   0                       0  r[20]=r[3]
+  39    AggStep              0  20  17  avg                  0  accum=r[17] step(r[20])
+  40    Copy                 3  21   0                       0  r[21]=r[3]
+  41    AggStep              0  21  18  max(Binary)          0  accum=r[18] step(r[21])
+  42    Copy                 3  22   0                       0  r[22]=r[3]
+  43    AggStep              0  22  19  min(Binary)          0  accum=r[19] step(r[22])
+  44  Goto                   0  37   0                       0
+  45  AggFinal               0  17   0  avg                  0  accum=r[17]
+  46  AggFinal               0  18   0  max                  0  accum=r[18]
+  47  AggFinal               0  19   0  min                  0  accum=r[19]
+  48  Copy                  17  14   2                       0  r[14]=r[17]
+  49  ResultRow             14   3   0                       0  output=r[14..16]
+  50  Halt                   0   0   0                       0
+  51  Transaction            0   1   8                       0  iDb=0 tx_mode=Read
+  52  Goto                   0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-group-by-single-column.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-group-by-single-column.snap
@@ -23,52 +23,50 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                  p1  p2  p3  p4                  p5  comment
-   0          Init             0  46   0                       0  Start at 46
-   1          SorterOpen       0   1   0  k(1,-B)              0  cursor=0
-   2          Null             0   9   0                       0  r[9]=NULL
-   3          Integer          0   6   0                       0  r[6]=0; clear group by abort flag
-   4          Null             0   7   0                       0  r[7]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           13  35   0                       0  ; go to clear accumulator subroutine
-   6          OpenRead         1   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
-   7          OpenRead         2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
-   8          Rewind           2  23   0                       0  Rewind index idx_sales_category
-   9            DeferredSeek   2   1   0                       0
-  10            Column         2   0  11                       0  r[11]=idx_sales_category.category
-  11            Column         1   4  12                       0  r[12]=sales.amount
-  12            Compare        7  11   1  k(1, Binary)         0  r[7..7]==r[11..11]
-  13            Jump          14  18  14                       0  ; start new group if comparison is not equal
-  14            Gosub          4  27   0                       0  ; check if ended group had data, and output if so
-  15            Move          11   7   1                       0  r[7..7]=r[11..11]
-  16            IfPos          6  38   0                       0  r[6]>0 -> r[6]-=0, goto 38; check abort flag
-  17            Gosub         13  35   0                       0  ; goto clear accumulator subroutine
-  18            AggStep        0  12   9  sum                  0  accum=r[9] step(r[12])
-  19            If             5  21   0                       0  if r[5] goto 21; don't emit group columns if continuing existing group
-  20            Column         2   0   8                       0  r[8]=idx_sales_category.category
-  21            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
-  22          Next             2   9   0                       0
-  23          Gosub            4  27   0                       0  ; emit row for final group
-  24          Goto             0  38   0                       0  ; group by finished
-  25          Integer          1   6   0                       0  r[6]=1
-  26        Return             4   0   0                       0
-  27        IfPos              5  29   0                       0  r[5]>0 -> r[5]-=0, goto 29; output group by row subroutine start
-  28      Return               4   0   0                       0
-  29      AggFinal             0   9   0  sum                  0  accum=r[9]
-  30      Copy                 9  14   0                       0  r[14]=r[9]
-  31      Copy                 8  15   0                       0  r[15]=r[8]
-  32      MakeRecord          14   2   3                       0  r[3]=mkrec(r[14..15])
-  33      SorterInsert         0   3   0  0                    0  key=r[3]
-  34    Return                 4   0   0                       0
-  35    Null                   0   8   9                       0  r[8..9]=NULL; clear accumulator subroutine start
-  36    Integer                0   5   0                       0  r[5]=0
-  37  Return                  13   0   0                       0
-  38  OpenPseudo               3   3   2                       0  2 columns in r[3]
-  39  SorterSort               0  45   0                       0
-  40    SorterData             0   3   3                       0  r[3]=data
-  41    Column                 3   1   1                       0  r[1]=pseudo.column 1
-  42    Column                 3   0   2                       0  r[2]=pseudo.column 0
-  43    ResultRow              1   2   0                       0  output=r[1..2]
-  44  SorterNext               0  40   0                       0
-  45  Halt                     0   0   0                       0
-  46  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
-  47  Goto                     0   1   0                       0
+addr  opcode                p1  p2  p3  p4                  p5  comment
+   0        Init             0  44   0                       0  Start at 44
+   1        SorterOpen       0   1   0  k(1,-B)              0  cursor=0
+   2        Null             0   9   0                       0  r[9]=NULL
+   3        Integer          0   6   0                       0  r[6]=0; clear group by abort flag
+   4        Null             0   7   0                       0  r[7]=NULL; initialize group by comparison registers to NULL
+   5        Gosub           13  33   0                       0  ; go to clear accumulator subroutine
+   6        OpenRead         1   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
+   7        OpenRead         2   4   0  k(2,B)               0  index=idx_sales_category, root=4, iDb=0
+   8        Rewind           2  23   0                       0  Rewind index idx_sales_category
+   9          DeferredSeek   2   1   0                       0
+  10          Column         2   0  11                       0  r[11]=idx_sales_category.category
+  11          Column         1   4  12                       0  r[12]=sales.amount
+  12          Compare        7  11   1  k(1, Binary)         0  r[7..7]==r[11..11]
+  13          Jump          14  18  14                       0  ; start new group if comparison is not equal
+  14          Gosub          4  25   0                       0  ; check if ended group had data, and output if so
+  15          Move          11   7   1                       0  r[7..7]=r[11..11]
+  16          IfPos          6  36   0                       0  r[6]>0 -> r[6]-=0, goto 36; check abort flag
+  17          Gosub         13  33   0                       0  ; goto clear accumulator subroutine
+  18          AggStep        0  12   9  sum                  0  accum=r[9] step(r[12])
+  19          If             5  21   0                       0  if r[5] goto 21; don't emit group columns if continuing existing group
+  20          Column         2   0   8                       0  r[8]=idx_sales_category.category
+  21          Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
+  22        Next             2   9   0                       0
+  23        Gosub            4  25   0                       0  ; emit row for final group
+  24        Goto             0  36   0                       0  ; group by finished
+  25        IfPos            5  27   0                       0  r[5]>0 -> r[5]-=0, goto 27; output group by row subroutine start
+  26      Return             4   0   0                       0
+  27      AggFinal           0   9   0  sum                  0  accum=r[9]
+  28      Copy               9  14   0                       0  r[14]=r[9]
+  29      Copy               8  15   0                       0  r[15]=r[8]
+  30      MakeRecord        14   2   3                       0  r[3]=mkrec(r[14..15])
+  31      SorterInsert       0   3   0  0                    0  key=r[3]
+  32    Return               4   0   0                       0
+  33    Null                 0   8   9                       0  r[8..9]=NULL; clear accumulator subroutine start
+  34    Integer              0   5   0                       0  r[5]=0
+  35  Return                13   0   0                       0
+  36  OpenPseudo             3   3   2                       0  2 columns in r[3]
+  37  SorterSort             0  43   0                       0
+  38    SorterData           0   3   3                       0  r[3]=data
+  39    Column               3   1   1                       0  r[1]=pseudo.column 1
+  40    Column               3   0   2                       0  r[2]=pseudo.column 0
+  41    ResultRow            1   2   0                       0  output=r[1..2]
+  42  SorterNext             0  38   0                       0
+  43  Halt                   0   0   0                       0
+  44  Transaction            0   1   8                       0  iDb=0 tx_mode=Read
+  45  Goto                   0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__whole-table-aggregates.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__whole-table-aggregates.snap
@@ -23,7 +23,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4                  p5  comment
-   0  Init          0  30   0                       0  Start at 30
+   0  Init          0  25   0                       0  Start at 25
    1  Null          0   7  12                       0  r[7..12]=NULL
    2  OpenRead      0   2   0  k(7,B,B,B,B,B,B,B)   0  table=sales, root=2, iDb=0
    3  Rewind        0  16   0                       0  Rewind table sales
@@ -45,14 +45,9 @@ addr  opcode       p1  p2  p3  p4                  p5  comment
   19  AggFinal      0  10   0  min                  0  accum=r[10]
   20  AggFinal      0  11   0  max                  0  accum=r[11]
   21  AggFinal      0  12   0  sum                  0  accum=r[12]
-  22  Copy          7   1   0                       0  r[1]=r[7]
-  23  Copy          8   2   0                       0  r[2]=r[8]
-  24  Copy          9   3   0                       0  r[3]=r[9]
-  25  Copy         10   4   0                       0  r[4]=r[10]
-  26  Copy         11   5   0                       0  r[5]=r[11]
-  27  Copy         12   6   0                       0  r[6]=r[12]
-  28  ResultRow     1   6   0                       0  output=r[1..6]
-  29  Halt          0   0   0                       0
-  30  Transaction   0   1   8                       0  iDb=0 tx_mode=Read
-  31  Integer       1  13   0                       0  r[13]=1
-  32  Goto          0   1   0                       0
+  22  Copy          7   1   5                       0  r[1]=r[7]
+  23  ResultRow     1   6   0                       0  output=r[1..6]
+  24  Halt          0   0   0                       0
+  25  Transaction   0   1   8                       0  iDb=0 tx_mode=Read
+  26  Integer       1  13   0                       0  r[13]=1
+  27  Goto          0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__aggregate-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__aggregate-after-analyze.snap
@@ -17,55 +17,51 @@ QUERY PLAN
 `--USE SORTER FOR GROUP BY
 
 BYTECODE
-addr  opcode                  p1  p2  p3  p4                p5  comment
-   0          Init             0  48   0                     0  Start at 48
-   1          Null             0   9  10                     0  r[9..10]=NULL
-   2          SorterOpen       0   2   0  k(1,B)             0  cursor=0
-   3          Integer          0   6   0                     0  r[6]=0; clear group by abort flag
-   4          Null             0   7   0                     0  r[7]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           14  44   0                     0  ; go to clear accumulator subroutine
-   6          OpenRead         2   2   0  k(6,B,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   7          Rewind           2  14   0                     0  Rewind table products
-   8            Column         2   3  12                     0  r[12]=products.category
-   9            Column         2   4  13                     0  r[13]=products.price
-  10            RealAffinity  13   0   0                     0
-  11            MakeRecord    12   2  11                     0  r[11]=mkrec(r[12..13])
-  12            SorterInsert   0  11   0  0                  0  key=r[11]
-  13          Next             2   8   0                     0
-  14          OpenPseudo       1  11   2                     0  2 columns in r[11]
-  15          SorterSort       0  31   0                     0
-  16            SorterData     0  11   1                     0  r[11]=data
-  17            Column         1   0  15                     0  r[15]=pseudo.column 0
-  18            Compare        7  15   1  k(1, Binary)       0  r[7..7]==r[15..15]
-  19            Jump          20  24  20                     0  ; start new group if comparison is not equal
-  20            Gosub          4  35   0                     0  ; check if ended group had data, and output if so
-  21            Move          15   7   1                     0  r[7..7]=r[15..15]
-  22            IfPos          6  47   0                     0  r[6]>0 -> r[6]-=0, goto 47; check abort flag
-  23            Gosub         14  44   0                     0  ; goto clear accumulator subroutine
-  24            Column         1   1  16                     0  r[16]=pseudo.column 1
-  25            AggStep        0  17   9  count              0  accum=r[9] step(r[17])
-  26            AggStep        0  16  10  avg                0  accum=r[10] step(r[16])
-  27            If             5  29   0                     0  if r[5] goto 29; don't emit group columns if continuing existing group
-  28            Column         1   0   8                     0  r[8]=pseudo.column 0
-  29            Integer        1   5   0                     0  r[5]=1; indicate data in accumulator
-  30          SorterNext       0  16   0                     0
-  31          Gosub            4  35   0                     0  ; emit row for final group
-  32          Goto             0  47   0                     0  ; group by finished
-  33          Integer          1   6   0                     0  r[6]=1
-  34        Return             4   0   0                     0
-  35        IfPos              5  37   0                     0  r[5]>0 -> r[5]-=0, goto 37; output group by row subroutine start
-  36      Return               4   0   0                     0
-  37      AggFinal             0   9   0  count              0  accum=r[9]
-  38      AggFinal             0  10   0  avg                0  accum=r[10]
-  39      Copy                 8   1   0                     0  r[1]=r[8]
-  40      Copy                 9   2   0                     0  r[2]=r[9]
-  41      Copy                10   3   0                     0  r[3]=r[10]
-  42      ResultRow            1   3   0                     0  output=r[1..3]
-  43    Return                 4   0   0                     0
-  44    Null                   0   8  10                     0  r[8..10]=NULL; clear accumulator subroutine start
-  45    Integer                0   5   0                     0  r[5]=0
-  46  Return                  14   0   0                     0
-  47  Halt                     0   0   0                     0
-  48  Transaction              0   1   5                     0  iDb=0 tx_mode=Read
-  49  Integer                  1  17   0                     0  r[17]=1
-  50  Goto                     0   1   0                     0
+addr  opcode                p1  p2  p3  p4                p5  comment
+   0        Init             0  44   0                     0  Start at 44
+   1        Null             0   9  10                     0  r[9..10]=NULL
+   2        SorterOpen       0   2   0  k(1,B)             0  cursor=0
+   3        Integer          0   6   0                     0  r[6]=0; clear group by abort flag
+   4        Null             0   7   0                     0  r[7]=NULL; initialize group by comparison registers to NULL
+   5        Gosub           14  40   0                     0  ; go to clear accumulator subroutine
+   6        OpenRead         2   2   0  k(6,B,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   7        Rewind           2  14   0                     0  Rewind table products
+   8          Column         2   3  12                     0  r[12]=products.category
+   9          Column         2   4  13                     0  r[13]=products.price
+  10          RealAffinity  13   0   0                     0
+  11          MakeRecord    12   2  11                     0  r[11]=mkrec(r[12..13])
+  12          SorterInsert   0  11   0  0                  0  key=r[11]
+  13        Next             2   8   0                     0
+  14        OpenPseudo       1  11   2                     0  2 columns in r[11]
+  15        SorterSort       0  31   0                     0
+  16          SorterData     0  11   1                     0  r[11]=data
+  17          Column         1   0  15                     0  r[15]=pseudo.column 0
+  18          Compare        7  15   1  k(1, Binary)       0  r[7..7]==r[15..15]
+  19          Jump          20  24  20                     0  ; start new group if comparison is not equal
+  20          Gosub          4  33   0                     0  ; check if ended group had data, and output if so
+  21          Move          15   7   1                     0  r[7..7]=r[15..15]
+  22          IfPos          6  43   0                     0  r[6]>0 -> r[6]-=0, goto 43; check abort flag
+  23          Gosub         14  40   0                     0  ; goto clear accumulator subroutine
+  24          Column         1   1  16                     0  r[16]=pseudo.column 1
+  25          AggStep        0  17   9  count              0  accum=r[9] step(r[17])
+  26          AggStep        0  16  10  avg                0  accum=r[10] step(r[16])
+  27          If             5  29   0                     0  if r[5] goto 29; don't emit group columns if continuing existing group
+  28          Column         1   0   8                     0  r[8]=pseudo.column 0
+  29          Integer        1   5   0                     0  r[5]=1; indicate data in accumulator
+  30        SorterNext       0  16   0                     0
+  31        Gosub            4  33   0                     0  ; emit row for final group
+  32        Halt             0   0   0                     0  ; group by finished
+  33        IfPos            5  35   0                     0  r[5]>0 -> r[5]-=0, goto 35; output group by row subroutine start
+  34      Return             4   0   0                     0
+  35      AggFinal           0   9   0  count              0  accum=r[9]
+  36      AggFinal           0  10   0  avg                0  accum=r[10]
+  37      Copy               8   1   2                     0  r[1]=r[8]
+  38      ResultRow          1   3   0                     0  output=r[1..3]
+  39    Return               4   0   0                     0
+  40    Null                 0   8  10                     0  r[8..10]=NULL; clear accumulator subroutine start
+  41    Integer              0   5   0                     0  r[5]=0
+  42  Return                14   0   0                     0
+  43  Halt                   0   0   0                     0
+  44  Transaction            0   1   5                     0  iDb=0 tx_mode=Read
+  45  Integer                1  17   0                     0  r[17]=1
+  46  Goto                   0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-aggregate-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-aggregate-after-analyze.snap
@@ -20,64 +20,61 @@ QUERY PLAN
 `--SEARCH p USING INDEX ephemeral_purchases_t2 (customer_id=?)
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4            p5  comment
-   0          Init               0  57   0                 0  Start at 57
-   1          Null               0  10  11                 0  r[10..11]=NULL
-   2          Integer            0   6   0                 0  r[6]=0; clear group by abort flag
-   3          Null               0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
-   4          Gosub             16  53   0                 0  ; go to clear accumulator subroutine
-   5          OpenRead           0   2   0  k(2,B,B)       0  table=customers, root=2, iDb=0
-   6          OpenRead           1   3   0  k(3,B,B,B)     0  table=purchases, root=3, iDb=0
-   7          Rewind             0  40   0                 0  Rewind table customers
-   8            Once            18   0   0                 0  goto 18
-   9            OpenAutoindex    2   0   0                 0  cursor=2
-  10            Rewind           1  11   0                 0  Rewind table purchases
-  11              Column         1   1  17                 0  r[17]=purchases.customer_id
-  12              Column         1   2  18                 0  r[18]=purchases.amount
-  13              RowId          1  19   0                 0  r[19]=purchases.rowid
-  14              MakeRecord    17   3  20                 0  r[20]=mkrec(r[17..19]); for ephemeral_purchases_t2
-  15              FilterAdd      2  17   1                 0  bloom_filter_add(r[17..18])
-  16              IdxInsert      2  20  17                 0  key=r[20]
-  17            Next             1  11   0                 0
-  18            RowId            0  21   0                 0  r[21]=customers.rowid
-  19            Filter           2  39  21                 1  if !bloom_filter(r[21..22]) goto 39
-  20            SeekGE           2  39  21                 0  key=[21..21]
-  21              IdxGT          2  39  21                 0  key=[21..21]
-  22              DeferredSeek   2   1   0                 0
-  23              RowId          0  13   0                 0  r[13]=customers.rowid
-  24              Column         0   1  14                 0  r[14]=customers.name
-  25              Column         2   1  15                 0  r[15]=ephemeral(ephemeral_purchases_t2).amount
-  26              RealAffinity  15   0   0                 0
-  27              Compare        7  13   1  k(1, Binary)   0  r[7..7]==r[13..13]
-  28              Jump          29  33  29                 0  ; start new group if comparison is not equal
-  29              Gosub          4  44   0                 0  ; check if ended group had data, and output if so
-  30              Move          13   7   1                 0  r[7..7]=r[13..13]
-  31              IfPos          6  56   0                 0  r[6]>0 -> r[6]-=0, goto 56; check abort flag
-  32              Gosub         16  53   0                 0  ; goto clear accumulator subroutine
-  33              AggStep        0  22  10  count          0  accum=r[10] step(r[22])
-  34              AggStep        0  15  11  sum            0  accum=r[11] step(r[15])
-  35              If             5  37   0                 0  if r[5] goto 37; don't emit group columns if continuing existing group
-  36              Column         0   1   8                 0  r[8]=customers.name
-  37              Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
-  38            Next             2  21   0                 0
-  39          Next               0   8   0                 0
-  40          Gosub              4  44   0                 0  ; emit row for final group
-  41          Goto               0  56   0                 0  ; group by finished
-  42          Integer            1   6   0                 0  r[6]=1
-  43        Return               4   0   0                 0
-  44        IfPos                5  46   0                 0  r[5]>0 -> r[5]-=0, goto 46; output group by row subroutine start
-  45      Return                 4   0   0                 0
-  46      AggFinal               0  10   0  count          0  accum=r[10]
-  47      AggFinal               0  11   0  sum            0  accum=r[11]
-  48      Copy                   8   1   0                 0  r[1]=r[8]
-  49      Copy                  10   2   0                 0  r[2]=r[10]
-  50      Copy                  11   3   0                 0  r[3]=r[11]
-  51      ResultRow              1   3   0                 0  output=r[1..3]
-  52    Return                   4   0   0                 0
-  53    Null                     0   8  11                 0  r[8..11]=NULL; clear accumulator subroutine start
-  54    Integer                  0   5   0                 0  r[5]=0
-  55  Return                    16   0   0                 0
-  56  Halt                       0   0   0                 0
-  57  Transaction                0   1   4                 0  iDb=0 tx_mode=Read
-  58  Integer                    1  22   0                 0  r[22]=1
-  59  Goto                       0   1   0                 0
+addr  opcode                  p1  p2  p3  p4            p5  comment
+   0        Init               0  54   0                 0  Start at 54
+   1        Null               0  10  11                 0  r[10..11]=NULL
+   2        Integer            0   6   0                 0  r[6]=0; clear group by abort flag
+   3        Null               0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
+   4        Gosub             16  50   0                 0  ; go to clear accumulator subroutine
+   5        OpenRead           0   2   0  k(2,B,B)       0  table=customers, root=2, iDb=0
+   6        OpenRead           1   3   0  k(3,B,B,B)     0  table=purchases, root=3, iDb=0
+   7        Rewind             0  40   0                 0  Rewind table customers
+   8          Once            18   0   0                 0  goto 18
+   9          OpenAutoindex    2   0   0                 0  cursor=2
+  10          Rewind           1  11   0                 0  Rewind table purchases
+  11            Column         1   1  17                 0  r[17]=purchases.customer_id
+  12            Column         1   2  18                 0  r[18]=purchases.amount
+  13            RowId          1  19   0                 0  r[19]=purchases.rowid
+  14            MakeRecord    17   3  20                 0  r[20]=mkrec(r[17..19]); for ephemeral_purchases_t2
+  15            FilterAdd      2  17   1                 0  bloom_filter_add(r[17..18])
+  16            IdxInsert      2  20  17                 0  key=r[20]
+  17          Next             1  11   0                 0
+  18          RowId            0  21   0                 0  r[21]=customers.rowid
+  19          Filter           2  39  21                 1  if !bloom_filter(r[21..22]) goto 39
+  20          SeekGE           2  39  21                 0  key=[21..21]
+  21            IdxGT          2  39  21                 0  key=[21..21]
+  22            DeferredSeek   2   1   0                 0
+  23            RowId          0  13   0                 0  r[13]=customers.rowid
+  24            Column         0   1  14                 0  r[14]=customers.name
+  25            Column         2   1  15                 0  r[15]=ephemeral(ephemeral_purchases_t2).amount
+  26            RealAffinity  15   0   0                 0
+  27            Compare        7  13   1  k(1, Binary)   0  r[7..7]==r[13..13]
+  28            Jump          29  33  29                 0  ; start new group if comparison is not equal
+  29            Gosub          4  42   0                 0  ; check if ended group had data, and output if so
+  30            Move          13   7   1                 0  r[7..7]=r[13..13]
+  31            IfPos          6  53   0                 0  r[6]>0 -> r[6]-=0, goto 53; check abort flag
+  32            Gosub         16  50   0                 0  ; goto clear accumulator subroutine
+  33            AggStep        0  22  10  count          0  accum=r[10] step(r[22])
+  34            AggStep        0  15  11  sum            0  accum=r[11] step(r[15])
+  35            If             5  37   0                 0  if r[5] goto 37; don't emit group columns if continuing existing group
+  36            Column         0   1   8                 0  r[8]=customers.name
+  37            Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
+  38          Next             2  21   0                 0
+  39        Next               0   8   0                 0
+  40        Gosub              4  42   0                 0  ; emit row for final group
+  41        Halt               0   0   0                 0  ; group by finished
+  42        IfPos              5  44   0                 0  r[5]>0 -> r[5]-=0, goto 44; output group by row subroutine start
+  43      Return               4   0   0                 0
+  44      AggFinal             0  10   0  count          0  accum=r[10]
+  45      AggFinal             0  11   0  sum            0  accum=r[11]
+  46      Copy                 8   1   0                 0  r[1]=r[8]
+  47      Copy                10   2   1                 0  r[2]=r[10]
+  48      ResultRow            1   3   0                 0  output=r[1..3]
+  49    Return                 4   0   0                 0
+  50    Null                   0   8  11                 0  r[8..11]=NULL; clear accumulator subroutine start
+  51    Integer                0   5   0                 0  r[5]=0
+  52  Return                  16   0   0                 0
+  53  Halt                     0   0   0                 0
+  54  Transaction              0   1   4                 0  iDb=0 tx_mode=Read
+  55  Integer                  1  22   0                 0  r[22]=1
+  56  Goto                     0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-bytecode.snap
@@ -13,19 +13,18 @@ QUERY PLAN
 `--SCAN products USING COVERING INDEX idx_products_price
 
 BYTECODE
-addr  opcode          p1  p2  p3  p4           p5  comment
-   0  Init             0  13   0                0  Start at 13
-   1  Null             0   2   0                0  r[2]=NULL
-   2  OpenRead         0   5   0  k(2,B)        0  index=idx_products_price, root=5, iDb=0
-   3  Last             0   9   0                0
-   4    Column         0   0   3                0  r[3]=idx_products_price.price
-   5    RealAffinity   3   0   0                0
-   6    AggStep        0   3   2  max(Binary)   0  accum=r[2] step(r[3])
-   7    Goto           0   9   0                0
-   8  Prev             0   4   0                0
-   9  AggFinal         0   2   0  max           0  accum=r[2]
-  10  Copy             2   1   0                0  r[1]=r[2]
-  11  ResultRow        1   1   0                0  output=r[1]
-  12  Halt             0   0   0                0
-  13  Transaction      0   1  14                0  iDb=0 tx_mode=Read
-  14  Goto             0   1   0                0
+addr  opcode        p1  p2  p3  p4           p5  comment
+   0  Init           0  12   0                0  Start at 12
+   1  Null           0   2   0                0  r[2]=NULL
+   2  OpenRead       0   5   0  k(2,B)        0  index=idx_products_price, root=5, iDb=0
+   3  Last           0   8   0                0
+   4  Column         0   0   3                0  r[3]=idx_products_price.price
+   5  RealAffinity   3   0   0                0
+   6  AggStep        0   3   2  max(Binary)   0  accum=r[2] step(r[3])
+   7  Goto           0   8   0                0
+   8  AggFinal       0   2   0  max           0  accum=r[2]
+   9  Copy           2   1   0                0  r[1]=r[2]
+  10  ResultRow      1   1   0                0  output=r[1]
+  11  Halt           0   0   0                0
+  12  Transaction    0   1  14                0  iDb=0 tx_mode=Read
+  13  Goto           0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-no-where-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-no-where-bytecode.snap
@@ -20,7 +20,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4           p5  comment
-   0  Init             0  21   0                0  Start at 21
+   0  Init             0  20   0                0  Start at 20
    1  OpenEphemeral    0   1   0                0  cursor=0 is_table=true
    2  OpenRead         1   5   0  k(2,B)        0  index=idx_products_price, root=5, iDb=0
    3  Rewind           1  10   0                0  Rewind index idx_products_price
@@ -31,15 +31,14 @@ addr  opcode          p1  p2  p3  p4           p5  comment
    8    Insert         0   3   4                4  intkey=r[4] data=r[3]
    9  Next             1   4   0                0
   10  Null             0   6   0                0  r[6]=NULL
-  11  Last             0  17   0                0
-  12    Column         0   0   1                0  r[1]=ephemeral().price
-  13    Copy           1   7   0                0  r[7]=r[1]
-  14    AggStep        0   7   6  max(Binary)   0  accum=r[6] step(r[7])
-  15    Goto           0  17   0                0
-  16  Prev             0  12   0                0
-  17  AggFinal         0   6   0  max           0  accum=r[6]
-  18  Copy             6   5   0                0  r[5]=r[6]
-  19  ResultRow        5   1   0                0  output=r[5]
-  20  Halt             0   0   0                0
-  21  Transaction      0   1  14                0  iDb=0 tx_mode=Read
-  22  Goto             0   1   0                0
+  11  Last             0  16   0                0
+  12  Column           0   0   1                0  r[1]=ephemeral().price
+  13  Copy             1   7   0                0  r[7]=r[1]
+  14  AggStep          0   7   6  max(Binary)   0  accum=r[6] step(r[7])
+  15  Goto             0  16   0                0
+  16  AggFinal         0   6   0  max           0  accum=r[6]
+  17  Copy             6   5   0                0  r[5]=r[6]
+  18  ResultRow        5   1   0                0  output=r[5]
+  19  Halt             0   0   0                0
+  20  Transaction      0   1  14                0  iDb=0 tx_mode=Read
+  21  Goto             0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__max-with-equality-prefix-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__max-with-equality-prefix-bytecode.snap
@@ -14,19 +14,18 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4           p5  comment
-   0  Init          0  14   0                0  Start at 14
+   0  Init          0  13   0                0  Start at 13
    1  Null          0   2   0                0  r[2]=NULL
    2  OpenRead      0   3   0  k(3,B,B)      0  index=idx_measurements_category_value, root=3, iDb=0
    3  String8       0   3   0  a             0  r[3]='a'
-   4  SeekLE        0  10   3                0  key=[3..3]
-   5    IdxLT       0  10   3                0  key=[3..3]
-   6    Column      0   1   4                0  r[4]=idx_measurements_category_value.value
-   7    AggStep     0   4   2  max(Binary)   0  accum=r[2] step(r[4])
-   8    Goto        0  10   0                0
-   9  Prev          0   5   0                0
-  10  AggFinal      0   2   0  max           0  accum=r[2]
-  11  Copy          2   1   0                0  r[1]=r[2]
-  12  ResultRow     1   1   0                0  output=r[1]
-  13  Halt          0   0   0                0
-  14  Transaction   0   1   2                0  iDb=0 tx_mode=Read
-  15  Goto          0   1   0                0
+   4  SeekLE        0   9   3                0  key=[3..3]
+   5  IdxLT         0   9   3                0  key=[3..3]
+   6  Column        0   1   4                0  r[4]=idx_measurements_category_value.value
+   7  AggStep       0   4   2  max(Binary)   0  accum=r[2] step(r[4])
+   8  Goto          0   9   0                0
+   9  AggFinal      0   2   0  max           0  accum=r[2]
+  10  Copy          2   1   0                0  r[1]=r[2]
+  11  ResultRow     1   1   0                0  output=r[1]
+  12  Halt          0   0   0                0
+  13  Transaction   0   1   2                0  iDb=0 tx_mode=Read
+  14  Goto          0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-correlated-max-materialized-cte-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-correlated-max-materialized-cte-bytecode.snap
@@ -27,56 +27,55 @@ QUERY PLAN
    `--SEARCH p2 USING INDEX ephemeral_subquery_t7 (price<?)
 
 BYTECODE
-addr  opcode               p1  p2  p3  p4           p5  comment
-   0    Init                0  49   0                0  Start at 49
-   1    OpenEphemeral       0   1   0                0  cursor=0 is_table=true
-   2    OpenRead            1   2   0  k(2,B)        0  table=products, root=2, iDb=0
-   3    Rewind              1  10   0                0  Rewind table products
-   4      Column            1   0   3                0  r[3]=products.price
-   5      RealAffinity      3   0   0                0
-   6      MakeRecord        3   1   4                0  r[4]=mkrec(r[3..3]); for
-   7      NewRowid          0   5   0                0  r[5]=rowid
-   8      Insert            0   4   5                4  intkey=r[5] data=r[4]
-   9    Next                1   4   0                0
-  10    Rewind              0  48   0                0  Rewind  ephemeral()
-  11      Column            0   0   2                0  r[2]=ephemeral().price
-  12      Copy              2   8   0                0  r[8]=r[2]
-  13      Ge                8   9  47  Binary        0  if r[8]>=r[9] goto 47
-  14      BeginSubrtn      10   0   0                0  r[10]=NULL
-  15      Null              0   1   0                0  r[1]=NULL
-  16      OpenDup           2   0   0                0  new_cursor=2, original_cursor=0
-  17      Null              0  13   0                0  r[13]=NULL
-  18      Integer           1  14   0                0  r[14]=1; LIMIT counter
-  19      IfNot            14  41   0                0  if !r[14] goto 41
-  20      Once             28   0   0                0  goto 28
-  21      OpenAutoindex     3   0   0                0  cursor=3
-  22      Rewind            2  23   0                0  Rewind  ephemeral()
-  23        Column          2   0  15                0  r[15]=ephemeral().price
-  24        RowId           2  16   0                0  r[16]=ephemeral().rowid
-  25        MakeRecord     15   2  17                0  r[17]=mkrec(r[15..16]); for ephemeral_subquery_t7
-  26        IdxInsert       3  17  15                0  key=r[17]
-  27      Next              2  23   0                0
-  28      Copy              2  18   0                0  r[18]=r[2]
-  29      IsNull           18  41   0                0  if (r[18]==NULL) goto 41
-  30      Affinity         18   1   0                0  r[18..19] = C
-  31      SeekLT            3  41  18                0  key=[18..18]
-  32        Null            0  18   0                0  r[18]=NULL
-  33        IdxLE           3  41  18                0  key=[18..18]
-  34        DeferredSeek    3   2   0                0
-  35        Column          2   0  11                0  r[11]=ephemeral().price
-  36        Column          3   0  19                0  r[19]=ephemeral(ephemeral_subquery_t7).price
-  37        RealAffinity   19   0   0                0
-  38        AggStep         0  19  13  max(Binary)   0  accum=r[13] step(r[19])
-  39        Goto            0  41   0                0
-  40      Prev              3  32   0                0
-  41      AggFinal          0  13   0  max           0  accum=r[13]
-  42      Copy             13  12   0                0  r[12]=r[13]
-  43      Copy             12   1   0                0  r[1]=r[12]
-  44    Return             10   0   1                0
-  45    Copy                1   6   0                0  r[6]=r[1]
-  46    ResultRow           6   1   0                0  output=r[6]
-  47  Next                  0  11   0                0
-  48  Halt                  0   0   0                0
-  49  Transaction           0   1   1                0  iDb=0 tx_mode=Read
-  50  Integer             100   9   0                0  r[9]=100
-  51  Goto                  0   1   0                0
+addr  opcode              p1  p2  p3  p4           p5  comment
+   0    Init               0  48   0                0  Start at 48
+   1    OpenEphemeral      0   1   0                0  cursor=0 is_table=true
+   2    OpenRead           1   2   0  k(2,B)        0  table=products, root=2, iDb=0
+   3    Rewind             1  10   0                0  Rewind table products
+   4      Column           1   0   3                0  r[3]=products.price
+   5      RealAffinity     3   0   0                0
+   6      MakeRecord       3   1   4                0  r[4]=mkrec(r[3..3]); for
+   7      NewRowid         0   5   0                0  r[5]=rowid
+   8      Insert           0   4   5                4  intkey=r[5] data=r[4]
+   9    Next               1   4   0                0
+  10    Rewind             0  47   0                0  Rewind  ephemeral()
+  11      Column           0   0   2                0  r[2]=ephemeral().price
+  12      Copy             2   8   0                0  r[8]=r[2]
+  13      Ge               8   9  46  Binary        0  if r[8]>=r[9] goto 46
+  14      BeginSubrtn     10   0   0                0  r[10]=NULL
+  15      Null             0   1   0                0  r[1]=NULL
+  16      OpenDup          2   0   0                0  new_cursor=2, original_cursor=0
+  17      Null             0  13   0                0  r[13]=NULL
+  18      Integer          1  14   0                0  r[14]=1; LIMIT counter
+  19      IfNot           14  40   0                0  if !r[14] goto 40
+  20      Once            28   0   0                0  goto 28
+  21      OpenAutoindex    3   0   0                0  cursor=3
+  22      Rewind           2  23   0                0  Rewind  ephemeral()
+  23        Column         2   0  15                0  r[15]=ephemeral().price
+  24        RowId          2  16   0                0  r[16]=ephemeral().rowid
+  25        MakeRecord    15   2  17                0  r[17]=mkrec(r[15..16]); for ephemeral_subquery_t7
+  26        IdxInsert      3  17  15                0  key=r[17]
+  27      Next             2  23   0                0
+  28      Copy             2  18   0                0  r[18]=r[2]
+  29      IsNull          18  40   0                0  if (r[18]==NULL) goto 40
+  30      Affinity        18   1   0                0  r[18..19] = C
+  31      SeekLT           3  40  18                0  key=[18..18]
+  32      Null             0  18   0                0  r[18]=NULL
+  33      IdxLE            3  40  18                0  key=[18..18]
+  34      DeferredSeek     3   2   0                0
+  35      Column           2   0  11                0  r[11]=ephemeral().price
+  36      Column           3   0  19                0  r[19]=ephemeral(ephemeral_subquery_t7).price
+  37      RealAffinity    19   0   0                0
+  38      AggStep          0  19  13  max(Binary)   0  accum=r[13] step(r[19])
+  39      Goto             0  40   0                0
+  40      AggFinal         0  13   0  max           0  accum=r[13]
+  41      Copy            13  12   0                0  r[12]=r[13]
+  42      Copy            12   1   0                0  r[1]=r[12]
+  43    Return            10   0   1                0
+  44    Copy               1   6   0                0  r[6]=r[1]
+  45    ResultRow          6   1   0                0  output=r[6]
+  46  Next                 0  11   0                0
+  47  Halt                 0   0   0                0
+  48  Transaction          0   1   1                0  iDb=0 tx_mode=Read
+  49  Integer            100   9   0                0  r[9]=100
+  50  Goto                 0   1   0                0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-full-outer.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-full-outer.snap
@@ -20,7 +20,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode               p1  p2  p3  p4                                        p5  comment
-   0    Init                0  72   0                                             0  Start at 72
+   0    Init                0  71   0                                             0  Start at 71
    1    OpenRead            0   2   0  k(3,B,B,B)                                 0  table=h_orders, root=2, iDb=0
    2    OpenRead            1   3   0  k(4,B,B,B,B)                               0  table=h_items, root=3, iDb=0
    3    Integer             0   5   0                                             0  r[5]=0
@@ -35,62 +35,61 @@ addr  opcode               p1  p2  p3  p4                                       
   12    Next                2   7   0                                             0
   13    HashBuildFinalize   1   0   0                                             0
   14    HashResetMatched    1   0   0                                             0
-  15    Rewind              1  40   0                                             0  Rewind table h_items
+  15    Rewind              1  39   0                                             0  Rewind table h_items
   16      Column            1   1   9                                             0  r[9]=h_items.order_name
   17      Affinity          9   1   0                                             0  r[9..10] = A
   18      Integer           0   5   0                                             0  r[5]=0
   19      RowId             1  12   0                                             0  r[12]=h_items.rowid
   20      Integer           0  13   0                                             0  r[13]=0
-  21      HashProbe         1   9   1  r[14]=35 payload=r[10]..r[11]              0
+  21      HashProbe         1   9   1  r[14]=34 payload=r[10]..r[11]              0
   22      HashMarkMatched   1   0   0                                             0
   23      Integer           1   5   0                                             0  r[5]=1
   24      Gosub            15  26   0                                             0
-  25      Goto              0  32   0                                             0
-  26      Copy             10   1   0                                             0  r[1]=r[10]
-  27      Copy             11   2   0                                             0  r[2]=r[11]
-  28      RowId             1   3   0                                             0  r[3]=h_items.rowid
-  29      Column            1   2   4                                             0  r[4]=h_items.product
-  30      ResultRow         1   4   0                                             0  output=r[1..4]
-  31    Return             15   0   0                                             0
-  32    IfPos              13  54   0                                             0  r[13]>0 -> r[13]-=0, goto 54
-  33    HashNext            1  14  35   payload=r[10]..r[11]                      0
-  34    Goto                0  22   0                                             0
-  35    IfPos               5  39   0                                             0  r[5]>0 -> r[5]-=0, goto 39
-  36    NullRow             0   0   0                                             0  Set cursor 0 to a (pseudo) NULL row
-  37    Null                0  10  11                                             0  r[10..11]=NULL
-  38    Gosub              15  26   0                                             0
-  39  Next                  1  16   0                                             0
-  40  NullRow               1   0   0                                             0  Set cursor 1 to a (pseudo) NULL row
-  41  HashScanUnmatched     1  14  46                                             0  hash_table_id=1 payload=r[10]..r[11]
-  42  SeekRowid             0  14  46                                             0  if (r[14]!=cursor 0 for table h_orders.rowid) goto 46
-  43  Gosub                15  26   0                                             0
-  44  HashNextUnmatched     1  14  46                                             0  hash_table_id=1 payload=r[10]..r[11]
-  45  Goto                  0  42   0                                             0
-  46  HashGraceInit         1   0  70                                             0  hash_table_id=1
-  47  Integer               1  13   0                                             0  r[13]=1
-  48  HashGraceLoadPart     1   0  69                                             0  hash_table_id=1
-  49  Integer               0   5   0                                             0  r[5]=0
-  50  HashGraceNextProbe    1   9  61                                             0  hash_table_id=1 keys=r[9]..r[9] probe_rowid_dest=r[12]
-  51  SeekRowid             1  12  49                                             0  if (r[12]!=cursor 1 for table h_items.rowid) goto 49
-  52  HashProbe             1   9   1  r[14]=56 payload=r[10]..r[11]              0
-  53  Goto                  0  22   0                                             0
-  54  HashNext              1  14  56   payload=r[10]..r[11]                      0
-  55  Goto                  0  22   0                                             0
-  56  IfPos                 5  49   0                                             0  r[5]>0 -> r[5]-=0, goto 49
-  57  NullRow               0   0   0                                             0  Set cursor 0 to a (pseudo) NULL row
-  58  Null                  0  10  11                                             0  r[10..11]=NULL
-  59  Gosub                15  26   0                                             0
-  60  Goto                  0  49   0                                             0
-  61  NullRow               1   0   0                                             0  Set cursor 1 to a (pseudo) NULL row
-  62  HashScanUnmatched     1  14  67                                             0  hash_table_id=1 payload=r[10]..r[11]
-  63  SeekRowid             0  14  67                                             0  if (r[14]!=cursor 0 for table h_orders.rowid) goto 67
-  64  Gosub                15  26   0                                             0
-  65  HashNextUnmatched     1  14  67                                             0  hash_table_id=1 payload=r[10]..r[11]
-  66  Goto                  0  63   0                                             0
-  67  HashGraceAdvPart      1   0  69                                             0  hash_table_id=1
-  68  Goto                  0  48   0                                             0
-  69  Integer               0  13   0                                             0  r[13]=0
-  70  HashClose             1   0   0                                             0
-  71  Halt                  0   0   0                                             0
-  72  Transaction           0   1   3                                             0  iDb=0 tx_mode=Read
-  73  Goto                  0   1   0                                             0
+  25      Goto              0  31   0                                             0
+  26      Copy             10   1   1                                             0  r[1]=r[10]
+  27      RowId             1   3   0                                             0  r[3]=h_items.rowid
+  28      Column            1   2   4                                             0  r[4]=h_items.product
+  29      ResultRow         1   4   0                                             0  output=r[1..4]
+  30    Return             15   0   0                                             0
+  31    IfPos              13  53   0                                             0  r[13]>0 -> r[13]-=0, goto 53
+  32    HashNext            1  14  34   payload=r[10]..r[11]                      0
+  33    Goto                0  22   0                                             0
+  34    IfPos               5  38   0                                             0  r[5]>0 -> r[5]-=0, goto 38
+  35    NullRow             0   0   0                                             0  Set cursor 0 to a (pseudo) NULL row
+  36    Null                0  10  11                                             0  r[10..11]=NULL
+  37    Gosub              15  26   0                                             0
+  38  Next                  1  16   0                                             0
+  39  NullRow               1   0   0                                             0  Set cursor 1 to a (pseudo) NULL row
+  40  HashScanUnmatched     1  14  45                                             0  hash_table_id=1 payload=r[10]..r[11]
+  41  SeekRowid             0  14  45                                             0  if (r[14]!=cursor 0 for table h_orders.rowid) goto 45
+  42  Gosub                15  26   0                                             0
+  43  HashNextUnmatched     1  14  45                                             0  hash_table_id=1 payload=r[10]..r[11]
+  44  Goto                  0  41   0                                             0
+  45  HashGraceInit         1   0  69                                             0  hash_table_id=1
+  46  Integer               1  13   0                                             0  r[13]=1
+  47  HashGraceLoadPart     1   0  68                                             0  hash_table_id=1
+  48  Integer               0   5   0                                             0  r[5]=0
+  49  HashGraceNextProbe    1   9  60                                             0  hash_table_id=1 keys=r[9]..r[9] probe_rowid_dest=r[12]
+  50  SeekRowid             1  12  48                                             0  if (r[12]!=cursor 1 for table h_items.rowid) goto 48
+  51  HashProbe             1   9   1  r[14]=55 payload=r[10]..r[11]              0
+  52  Goto                  0  22   0                                             0
+  53  HashNext              1  14  55   payload=r[10]..r[11]                      0
+  54  Goto                  0  22   0                                             0
+  55  IfPos                 5  48   0                                             0  r[5]>0 -> r[5]-=0, goto 48
+  56  NullRow               0   0   0                                             0  Set cursor 0 to a (pseudo) NULL row
+  57  Null                  0  10  11                                             0  r[10..11]=NULL
+  58  Gosub                15  26   0                                             0
+  59  Goto                  0  48   0                                             0
+  60  NullRow               1   0   0                                             0  Set cursor 1 to a (pseudo) NULL row
+  61  HashScanUnmatched     1  14  66                                             0  hash_table_id=1 payload=r[10]..r[11]
+  62  SeekRowid             0  14  66                                             0  if (r[14]!=cursor 0 for table h_orders.rowid) goto 66
+  63  Gosub                15  26   0                                             0
+  64  HashNextUnmatched     1  14  66                                             0  hash_table_id=1 payload=r[10]..r[11]
+  65  Goto                  0  62   0                                             0
+  66  HashGraceAdvPart      1   0  68                                             0  hash_table_id=1
+  67  Goto                  0  47   0                                             0
+  68  Integer               0  13   0                                             0  r[13]=0
+  69  HashClose             1   0   0                                             0
+  70  Halt                  0   0   0                                             0
+  71  Transaction           0   1   3                                             0  iDb=0 tx_mode=Read
+  72  Goto                  0   1   0                                             0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-inner-basic.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-inner-basic.snap
@@ -20,7 +20,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode              p1  p2  p3  p4                                        p5  comment
-   0  Init                 0  42   0                                             0  Start at 42
+   0  Init                 0  41   0                                             0  Start at 41
    1  OpenRead             0   2   0  k(3,B,B,B)                                 0  table=h_orders, root=2, iDb=0
    2  OpenRead             1   3   0  k(4,B,B,B,B)                               0  table=h_items, root=3, iDb=0
    3  Once                13   0   0                                             0  goto 13
@@ -33,34 +33,33 @@ addr  opcode              p1  p2  p3  p4                                        
   10    HashBuild          2   5   1  r=[1] budget=67108864 payload=r[6]..r[7]   0
   11  Next                 2   6   0                                             0
   12  HashBuildFinalize    1   0   0                                             0
-  13  Rewind               1  28   0                                             0  Rewind table h_items
+  13  Rewind               1  27   0                                             0  Rewind table h_items
   14    Column             1   1   8                                             0  r[8]=h_items.order_name
   15    Affinity           8   1   0                                             0  r[8..9] = A
   16    RowId              1  11   0                                             0  r[11]=h_items.rowid
   17    Integer            0  12   0                                             0  r[12]=0
-  18    HashProbe          1   8   1  r[13]=27 payload=r[9]..r[10]               0
-  19    Copy               9   1   0                                             0  r[1]=r[9]
-  20    Copy              10   2   0                                             0  r[2]=r[10]
-  21    Column             1   2   3                                             0  r[3]=h_items.product
-  22    Column             1   3   4                                             0  r[4]=h_items.quantity
-  23    ResultRow          1   4   0                                             0  output=r[1..4]
-  24    IfPos             12  35   0                                             0  r[12]>0 -> r[12]-=0, goto 35
-  25    HashNext           1  13  27   payload=r[9]..r[10]                       0
-  26    Goto               0  19   0                                             0
-  27  Next                 1  14   0                                             0
-  28  HashGraceInit        1   0  40                                             0  hash_table_id=1
-  29  Integer              1  12   0                                             0  r[12]=1
-  30  HashGraceLoadPart    1   0  39                                             0  hash_table_id=1
-  31  HashGraceNextProbe   1   8  37                                             0  hash_table_id=1 keys=r[8]..r[8] probe_rowid_dest=r[11]
-  32  SeekRowid            1  11  31                                             0  if (r[11]!=cursor 1 for table h_items.rowid) goto 31
-  33  HashProbe            1   8   1  r[13]=31 payload=r[9]..r[10]               0
-  34  Goto                 0  19   0                                             0
-  35  HashNext             1  13  31   payload=r[9]..r[10]                       0
-  36  Goto                 0  19   0                                             0
-  37  HashGraceAdvPart     1   0  39                                             0  hash_table_id=1
-  38  Goto                 0  30   0                                             0
-  39  Integer              0  12   0                                             0  r[12]=0
-  40  HashClose            1   0   0                                             0
-  41  Halt                 0   0   0                                             0
-  42  Transaction          0   1   3                                             0  iDb=0 tx_mode=Read
-  43  Goto                 0   1   0                                             0
+  18    HashProbe          1   8   1  r[13]=26 payload=r[9]..r[10]               0
+  19    Copy               9   1   1                                             0  r[1]=r[9]
+  20    Column             1   2   3                                             0  r[3]=h_items.product
+  21    Column             1   3   4                                             0  r[4]=h_items.quantity
+  22    ResultRow          1   4   0                                             0  output=r[1..4]
+  23    IfPos             12  34   0                                             0  r[12]>0 -> r[12]-=0, goto 34
+  24    HashNext           1  13  26   payload=r[9]..r[10]                       0
+  25    Goto               0  19   0                                             0
+  26  Next                 1  14   0                                             0
+  27  HashGraceInit        1   0  39                                             0  hash_table_id=1
+  28  Integer              1  12   0                                             0  r[12]=1
+  29  HashGraceLoadPart    1   0  38                                             0  hash_table_id=1
+  30  HashGraceNextProbe   1   8  36                                             0  hash_table_id=1 keys=r[8]..r[8] probe_rowid_dest=r[11]
+  31  SeekRowid            1  11  30                                             0  if (r[11]!=cursor 1 for table h_items.rowid) goto 30
+  32  HashProbe            1   8   1  r[13]=30 payload=r[9]..r[10]               0
+  33  Goto                 0  19   0                                             0
+  34  HashNext             1  13  30   payload=r[9]..r[10]                       0
+  35  Goto                 0  19   0                                             0
+  36  HashGraceAdvPart     1   0  38                                             0  hash_table_id=1
+  37  Goto                 0  29   0                                             0
+  38  Integer              0  12   0                                             0  r[12]=0
+  39  HashClose            1   0   0                                             0
+  40  Halt                 0   0   0                                             0
+  41  Transaction          0   1   3                                             0  iDb=0 tx_mode=Read
+  42  Goto                 0   1   0                                             0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-left-outer-agg.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-left-outer-agg.snap
@@ -22,99 +22,96 @@ QUERY PLAN
 `--USE SORTER FOR GROUP BY
 
 BYTECODE
-addr  opcode                       p1  p2  p3  p4                                          p5  comment
-   0            Init                0  93   0                                               0  Start at 93
-   1            Null                0   8   0                                               0  r[8]=NULL
-   2            SorterOpen          0   2   0  k(1,B)                                       0  cursor=0
-   3            Integer             0   5   0                                               0  r[5]=0; clear group by abort flag
-   4            Null                0   6   0                                               0  r[6]=NULL; initialize group by comparison registers to NULL
-   5            Gosub              12  89   0                                               0  ; go to clear accumulator subroutine
-   6            OpenRead            2   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
-   7            OpenRead            3   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
-   8            Integer             0  13   0                                               0  r[13]=0
-   9            Once               18   0   0                                               0  goto 18
-  10            OpenRead            4   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
-  11            Rewind              4  17   0                                               0  Rewind table h_orders
-  12              Column            4   1  14                                               0  r[14]=h_orders.customer_name
-  13              Affinity         14   1   0                                               0  r[14..15] = A
-  14              Column            4   1  15                                               0  r[15]=h_orders.customer_name
-  15              HashBuild         4  14   1  r=[1] budget=67108864 payload=r[15]..r[15]   0
-  16            Next                4  12   0                                               0
-  17            HashBuildFinalize   1   0   0                                               0
-  18            HashResetMatched    1   0   0                                               0
-  19            Rewind              3  37   0                                               0  Rewind table h_items
-  20              Column            3   1  16                                               0  r[16]=h_items.order_name
-  21              Affinity         16   1   0                                               0  r[16..17] = A
-  22              RowId             3  18   0                                               0  r[18]=h_items.rowid
-  23              Integer           0  19   0                                               0  r[19]=0
-  24              HashProbe         1  16   1  r[20]=36 payload=r[17]..r[17]                0
-  25              HashMarkMatched   1   0   0                                               0
-  26              Gosub            21  28   0                                               0
-  27              Goto              0  33   0                                               0
-  28              Copy             17  10   0                                               0  r[10]=r[17]
-  29              RowId             3  11   0                                               0  r[11]=h_items.rowid
-  30              MakeRecord       10   2   9                                               0  r[9]=mkrec(r[10..11])
-  31              SorterInsert      0   9   0  0                                            0  key=r[9]
-  32            Return             21   0   0                                               0
-  33            IfPos              19  50   0                                               0  r[19]>0 -> r[19]-=0, goto 50
-  34            HashNext            1  20  36   payload=r[17]..r[17]                        0
-  35            Goto                0  25   0                                               0
-  36          Next                  3  20   0                                               0
-  37          NullRow               3   0   0                                               0  Set cursor 3 to a (pseudo) NULL row
-  38          HashScanUnmatched     1  20  43                                               0  hash_table_id=1 payload=r[17]..r[17]
-  39          SeekRowid             2  20  43                                               0  if (r[20]!=cursor 2 for table h_orders.rowid) goto 43
-  40          Gosub                21  28   0                                               0
-  41          HashNextUnmatched     1  20  43                                               0  hash_table_id=1 payload=r[17]..r[17]
-  42          Goto                  0  39   0                                               0
-  43          HashGraceInit         1   0  61                                               0  hash_table_id=1
-  44          Integer               1  19   0                                               0  r[19]=1
-  45          HashGraceLoadPart     1   0  60                                               0  hash_table_id=1
-  46          HashGraceNextProbe    1  16  52                                               0  hash_table_id=1 keys=r[16]..r[16] probe_rowid_dest=r[18]
-  47          SeekRowid             3  18  46                                               0  if (r[18]!=cursor 3 for table h_items.rowid) goto 46
-  48          HashProbe             1  16   1  r[20]=46 payload=r[17]..r[17]                0
-  49          Goto                  0  25   0                                               0
-  50          HashNext              1  20  46   payload=r[17]..r[17]                        0
-  51          Goto                  0  25   0                                               0
-  52          NullRow               3   0   0                                               0  Set cursor 3 to a (pseudo) NULL row
-  53          HashScanUnmatched     1  20  58                                               0  hash_table_id=1 payload=r[17]..r[17]
-  54          SeekRowid             2  20  58                                               0  if (r[20]!=cursor 2 for table h_orders.rowid) goto 58
-  55          Gosub                21  28   0                                               0
-  56          HashNextUnmatched     1  20  58                                               0  hash_table_id=1 payload=r[17]..r[17]
-  57          Goto                  0  54   0                                               0
-  58          HashGraceAdvPart      1   0  60                                               0  hash_table_id=1
-  59          Goto                  0  45   0                                               0
-  60          Integer               0  19   0                                               0  r[19]=0
-  61          HashClose             1   0   0                                               0
-  62          OpenPseudo            1   9   2                                               0  2 columns in r[9]
-  63          SorterSort            0  78   0                                               0
-  64            SorterData          0   9   1                                               0  r[9]=data
-  65            Column              1   0  22                                               0  r[22]=pseudo.column 0
-  66            Compare             6  22   1  k(1, Binary)                                 0  r[6..6]==r[22..22]
-  67            Jump               68  72  68                                               0  ; start new group if comparison is not equal
-  68            Gosub               3  82   0                                               0  ; check if ended group had data, and output if so
-  69            Move               22   6   1                                               0  r[6..6]=r[22..22]
-  70            IfPos               5  92   0                                               0  r[5]>0 -> r[5]-=0, goto 92; check abort flag
-  71            Gosub              12  89   0                                               0  ; goto clear accumulator subroutine
-  72            Column              1   1  23                                               0  r[23]=pseudo.column 1
-  73            AggStep             0  23   8  count                                        0  accum=r[8] step(r[23])
-  74            If                  4  76   0                                               0  if r[4] goto 76; don't emit group columns if continuing existing group
-  75            Column              1   0   7                                               0  r[7]=pseudo.column 0
-  76            Integer             1   4   0                                               0  r[4]=1; indicate data in accumulator
-  77          SorterNext            0  64   0                                               0
-  78          Gosub                 3  82   0                                               0  ; emit row for final group
-  79          Goto                  0  92   0                                               0  ; group by finished
-  80          Integer               1   5   0                                               0  r[5]=1
-  81        Return                  3   0   0                                               0
-  82        IfPos                   4  84   0                                               0  r[4]>0 -> r[4]-=0, goto 84; output group by row subroutine start
-  83      Return                    3   0   0                                               0
-  84      AggFinal                  0   8   0  count                                        0  accum=r[8]
-  85      Copy                      7   1   0                                               0  r[1]=r[7]
-  86      Copy                      8   2   0                                               0  r[2]=r[8]
-  87      ResultRow                 1   2   0                                               0  output=r[1..2]
-  88    Return                      3   0   0                                               0
-  89    Null                        0   7   8                                               0  r[7..8]=NULL; clear accumulator subroutine start
-  90    Integer                     0   4   0                                               0  r[4]=0
-  91  Return                       12   0   0                                               0
-  92  Halt                          0   0   0                                               0
-  93  Transaction                   0   1   3                                               0  iDb=0 tx_mode=Read
-  94  Goto                          0   1   0                                               0
+addr  opcode                     p1  p2  p3  p4                                          p5  comment
+   0          Init                0  90   0                                               0  Start at 90
+   1          Null                0   8   0                                               0  r[8]=NULL
+   2          SorterOpen          0   2   0  k(1,B)                                       0  cursor=0
+   3          Integer             0   5   0                                               0  r[5]=0; clear group by abort flag
+   4          Null                0   6   0                                               0  r[6]=NULL; initialize group by comparison registers to NULL
+   5          Gosub              12  86   0                                               0  ; go to clear accumulator subroutine
+   6          OpenRead            2   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
+   7          OpenRead            3   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
+   8          Integer             0  13   0                                               0  r[13]=0
+   9          Once               18   0   0                                               0  goto 18
+  10          OpenRead            4   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
+  11          Rewind              4  17   0                                               0  Rewind table h_orders
+  12            Column            4   1  14                                               0  r[14]=h_orders.customer_name
+  13            Affinity         14   1   0                                               0  r[14..15] = A
+  14            Column            4   1  15                                               0  r[15]=h_orders.customer_name
+  15            HashBuild         4  14   1  r=[1] budget=67108864 payload=r[15]..r[15]   0
+  16          Next                4  12   0                                               0
+  17          HashBuildFinalize   1   0   0                                               0
+  18          HashResetMatched    1   0   0                                               0
+  19          Rewind              3  37   0                                               0  Rewind table h_items
+  20            Column            3   1  16                                               0  r[16]=h_items.order_name
+  21            Affinity         16   1   0                                               0  r[16..17] = A
+  22            RowId             3  18   0                                               0  r[18]=h_items.rowid
+  23            Integer           0  19   0                                               0  r[19]=0
+  24            HashProbe         1  16   1  r[20]=36 payload=r[17]..r[17]                0
+  25            HashMarkMatched   1   0   0                                               0
+  26            Gosub            21  28   0                                               0
+  27            Goto              0  33   0                                               0
+  28            Copy             17  10   0                                               0  r[10]=r[17]
+  29            RowId             3  11   0                                               0  r[11]=h_items.rowid
+  30            MakeRecord       10   2   9                                               0  r[9]=mkrec(r[10..11])
+  31            SorterInsert      0   9   0  0                                            0  key=r[9]
+  32          Return             21   0   0                                               0
+  33          IfPos              19  50   0                                               0  r[19]>0 -> r[19]-=0, goto 50
+  34          HashNext            1  20  36   payload=r[17]..r[17]                        0
+  35          Goto                0  25   0                                               0
+  36        Next                  3  20   0                                               0
+  37        NullRow               3   0   0                                               0  Set cursor 3 to a (pseudo) NULL row
+  38        HashScanUnmatched     1  20  43                                               0  hash_table_id=1 payload=r[17]..r[17]
+  39        SeekRowid             2  20  43                                               0  if (r[20]!=cursor 2 for table h_orders.rowid) goto 43
+  40        Gosub                21  28   0                                               0
+  41        HashNextUnmatched     1  20  43                                               0  hash_table_id=1 payload=r[17]..r[17]
+  42        Goto                  0  39   0                                               0
+  43        HashGraceInit         1   0  61                                               0  hash_table_id=1
+  44        Integer               1  19   0                                               0  r[19]=1
+  45        HashGraceLoadPart     1   0  60                                               0  hash_table_id=1
+  46        HashGraceNextProbe    1  16  52                                               0  hash_table_id=1 keys=r[16]..r[16] probe_rowid_dest=r[18]
+  47        SeekRowid             3  18  46                                               0  if (r[18]!=cursor 3 for table h_items.rowid) goto 46
+  48        HashProbe             1  16   1  r[20]=46 payload=r[17]..r[17]                0
+  49        Goto                  0  25   0                                               0
+  50        HashNext              1  20  46   payload=r[17]..r[17]                        0
+  51        Goto                  0  25   0                                               0
+  52        NullRow               3   0   0                                               0  Set cursor 3 to a (pseudo) NULL row
+  53        HashScanUnmatched     1  20  58                                               0  hash_table_id=1 payload=r[17]..r[17]
+  54        SeekRowid             2  20  58                                               0  if (r[20]!=cursor 2 for table h_orders.rowid) goto 58
+  55        Gosub                21  28   0                                               0
+  56        HashNextUnmatched     1  20  58                                               0  hash_table_id=1 payload=r[17]..r[17]
+  57        Goto                  0  54   0                                               0
+  58        HashGraceAdvPart      1   0  60                                               0  hash_table_id=1
+  59        Goto                  0  45   0                                               0
+  60        Integer               0  19   0                                               0  r[19]=0
+  61        HashClose             1   0   0                                               0
+  62        OpenPseudo            1   9   2                                               0  2 columns in r[9]
+  63        SorterSort            0  78   0                                               0
+  64          SorterData          0   9   1                                               0  r[9]=data
+  65          Column              1   0  22                                               0  r[22]=pseudo.column 0
+  66          Compare             6  22   1  k(1, Binary)                                 0  r[6..6]==r[22..22]
+  67          Jump               68  72  68                                               0  ; start new group if comparison is not equal
+  68          Gosub               3  80   0                                               0  ; check if ended group had data, and output if so
+  69          Move               22   6   1                                               0  r[6..6]=r[22..22]
+  70          IfPos               5  89   0                                               0  r[5]>0 -> r[5]-=0, goto 89; check abort flag
+  71          Gosub              12  86   0                                               0  ; goto clear accumulator subroutine
+  72          Column              1   1  23                                               0  r[23]=pseudo.column 1
+  73          AggStep             0  23   8  count                                        0  accum=r[8] step(r[23])
+  74          If                  4  76   0                                               0  if r[4] goto 76; don't emit group columns if continuing existing group
+  75          Column              1   0   7                                               0  r[7]=pseudo.column 0
+  76          Integer             1   4   0                                               0  r[4]=1; indicate data in accumulator
+  77        SorterNext            0  64   0                                               0
+  78        Gosub                 3  80   0                                               0  ; emit row for final group
+  79        Halt                  0   0   0                                               0  ; group by finished
+  80        IfPos                 4  82   0                                               0  r[4]>0 -> r[4]-=0, goto 82; output group by row subroutine start
+  81      Return                  3   0   0                                               0
+  82      AggFinal                0   8   0  count                                        0  accum=r[8]
+  83      Copy                    7   1   1                                               0  r[1]=r[7]
+  84      ResultRow               1   2   0                                               0  output=r[1..2]
+  85    Return                    3   0   0                                               0
+  86    Null                      0   7   8                                               0  r[7..8]=NULL; clear accumulator subroutine start
+  87    Integer                   0   4   0                                               0  r[4]=0
+  88  Return                     12   0   0                                               0
+  89  Halt                        0   0   0                                               0
+  90  Transaction                 0   1   3                                               0  iDb=0 tx_mode=Read
+  91  Goto                        0   1   0                                               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-left-outer.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-left-outer.snap
@@ -20,7 +20,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode               p1  p2  p3  p4                                        p5  comment
-   0    Init                0  59   0                                             0  Start at 59
+   0    Init                0  58   0                                             0  Start at 58
    1    OpenRead            0   2   0  k(3,B,B,B)                                 0  table=h_orders, root=2, iDb=0
    2    OpenRead            1   3   0  k(4,B,B,B,B)                               0  table=h_items, root=3, iDb=0
    3    Integer             0   4   0                                             0  r[4]=0
@@ -35,49 +35,48 @@ addr  opcode               p1  p2  p3  p4                                       
   12    Next                2   7   0                                             0
   13    HashBuildFinalize   1   0   0                                             0
   14    HashResetMatched    1   0   0                                             0
-  15    Rewind              1  33   0                                             0  Rewind table h_items
+  15    Rewind              1  32   0                                             0  Rewind table h_items
   16      Column            1   1   8                                             0  r[8]=h_items.order_name
   17      Affinity          8   1   0                                             0  r[8..9] = A
   18      RowId             1  11   0                                             0  r[11]=h_items.rowid
   19      Integer           0  12   0                                             0  r[12]=0
-  20      HashProbe         1   8   1  r[13]=32 payload=r[9]..r[10]               0
+  20      HashProbe         1   8   1  r[13]=31 payload=r[9]..r[10]               0
   21      HashMarkMatched   1   0   0                                             0
   22      Gosub            14  24   0                                             0
-  23      Goto              0  29   0                                             0
-  24      Copy              9   1   0                                             0  r[1]=r[9]
-  25      Copy             10   2   0                                             0  r[2]=r[10]
-  26      Column            1   2   3                                             0  r[3]=h_items.product
-  27      ResultRow         1   3   0                                             0  output=r[1..3]
-  28    Return             14   0   0                                             0
-  29    IfPos              12  46   0                                             0  r[12]>0 -> r[12]-=0, goto 46
-  30    HashNext            1  13  32   payload=r[9]..r[10]                       0
-  31    Goto                0  21   0                                             0
-  32  Next                  1  16   0                                             0
-  33  NullRow               1   0   0                                             0  Set cursor 1 to a (pseudo) NULL row
-  34  HashScanUnmatched     1  13  39                                             0  hash_table_id=1 payload=r[9]..r[10]
-  35  SeekRowid             0  13  39                                             0  if (r[13]!=cursor 0 for table h_orders.rowid) goto 39
-  36  Gosub                14  24   0                                             0
-  37  HashNextUnmatched     1  13  39                                             0  hash_table_id=1 payload=r[9]..r[10]
-  38  Goto                  0  35   0                                             0
-  39  HashGraceInit         1   0  57                                             0  hash_table_id=1
-  40  Integer               1  12   0                                             0  r[12]=1
-  41  HashGraceLoadPart     1   0  56                                             0  hash_table_id=1
-  42  HashGraceNextProbe    1   8  48                                             0  hash_table_id=1 keys=r[8]..r[8] probe_rowid_dest=r[11]
-  43  SeekRowid             1  11  42                                             0  if (r[11]!=cursor 1 for table h_items.rowid) goto 42
-  44  HashProbe             1   8   1  r[13]=42 payload=r[9]..r[10]               0
-  45  Goto                  0  21   0                                             0
-  46  HashNext              1  13  42   payload=r[9]..r[10]                       0
-  47  Goto                  0  21   0                                             0
-  48  NullRow               1   0   0                                             0  Set cursor 1 to a (pseudo) NULL row
-  49  HashScanUnmatched     1  13  54                                             0  hash_table_id=1 payload=r[9]..r[10]
-  50  SeekRowid             0  13  54                                             0  if (r[13]!=cursor 0 for table h_orders.rowid) goto 54
-  51  Gosub                14  24   0                                             0
-  52  HashNextUnmatched     1  13  54                                             0  hash_table_id=1 payload=r[9]..r[10]
-  53  Goto                  0  50   0                                             0
-  54  HashGraceAdvPart      1   0  56                                             0  hash_table_id=1
-  55  Goto                  0  41   0                                             0
-  56  Integer               0  12   0                                             0  r[12]=0
-  57  HashClose             1   0   0                                             0
-  58  Halt                  0   0   0                                             0
-  59  Transaction           0   1   3                                             0  iDb=0 tx_mode=Read
-  60  Goto                  0   1   0                                             0
+  23      Goto              0  28   0                                             0
+  24      Copy              9   1   1                                             0  r[1]=r[9]
+  25      Column            1   2   3                                             0  r[3]=h_items.product
+  26      ResultRow         1   3   0                                             0  output=r[1..3]
+  27    Return             14   0   0                                             0
+  28    IfPos              12  45   0                                             0  r[12]>0 -> r[12]-=0, goto 45
+  29    HashNext            1  13  31   payload=r[9]..r[10]                       0
+  30    Goto                0  21   0                                             0
+  31  Next                  1  16   0                                             0
+  32  NullRow               1   0   0                                             0  Set cursor 1 to a (pseudo) NULL row
+  33  HashScanUnmatched     1  13  38                                             0  hash_table_id=1 payload=r[9]..r[10]
+  34  SeekRowid             0  13  38                                             0  if (r[13]!=cursor 0 for table h_orders.rowid) goto 38
+  35  Gosub                14  24   0                                             0
+  36  HashNextUnmatched     1  13  38                                             0  hash_table_id=1 payload=r[9]..r[10]
+  37  Goto                  0  34   0                                             0
+  38  HashGraceInit         1   0  56                                             0  hash_table_id=1
+  39  Integer               1  12   0                                             0  r[12]=1
+  40  HashGraceLoadPart     1   0  55                                             0  hash_table_id=1
+  41  HashGraceNextProbe    1   8  47                                             0  hash_table_id=1 keys=r[8]..r[8] probe_rowid_dest=r[11]
+  42  SeekRowid             1  11  41                                             0  if (r[11]!=cursor 1 for table h_items.rowid) goto 41
+  43  HashProbe             1   8   1  r[13]=41 payload=r[9]..r[10]               0
+  44  Goto                  0  21   0                                             0
+  45  HashNext              1  13  41   payload=r[9]..r[10]                       0
+  46  Goto                  0  21   0                                             0
+  47  NullRow               1   0   0                                             0  Set cursor 1 to a (pseudo) NULL row
+  48  HashScanUnmatched     1  13  53                                             0  hash_table_id=1 payload=r[9]..r[10]
+  49  SeekRowid             0  13  53                                             0  if (r[13]!=cursor 0 for table h_orders.rowid) goto 53
+  50  Gosub                14  24   0                                             0
+  51  HashNextUnmatched     1  13  53                                             0  hash_table_id=1 payload=r[9]..r[10]
+  52  Goto                  0  49   0                                             0
+  53  HashGraceAdvPart      1   0  55                                             0  hash_table_id=1
+  54  Goto                  0  40   0                                             0
+  55  Integer               0  12   0                                             0  r[12]=0
+  56  HashClose             1   0   0                                             0
+  57  Halt                  0   0   0                                             0
+  58  Transaction           0   1   3                                             0  iDb=0 tx_mode=Read
+  59  Goto                  0   1   0                                             0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-three-table.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-three-table.snap
@@ -26,7 +26,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode              p1  p2  p3  p4                                          p5  comment
-   0  Init                 0  95   0                                               0  Start at 95
+   0  Init                 0  94   0                                               0  Start at 94
    1  OpenEphemeral        0   1   0                                               0  cursor=0 is_table=true
    2  OpenRead             1   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
    3  OpenRead             2   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
@@ -40,86 +40,85 @@ addr  opcode              p1  p2  p3  p4                                        
   11    HashBuild          3   8   1  r=[2] budget=67108864 payload=r[9]..r[10]    0
   12  Next                 3   7   0                                               0
   13  HashBuildFinalize    2   0   0                                               0
-  14  Rewind               1  37   0                                               0  Rewind table h_orders
+  14  Rewind               1  36   0                                               0  Rewind table h_orders
   15    Column             1   1  11                                               0  r[11]=h_orders.customer_name
   16    Affinity          11   1   0                                               0  r[11..12] = A
   17    RowId              1  14   0                                               0  r[14]=h_orders.rowid
   18    Integer            0  15   0                                               0  r[15]=0
-  19    HashProbe          2  11   1  r[16]=36 payload=r[12]..r[13]                0
+  19    HashProbe          2  11   1  r[16]=35 payload=r[12]..r[13]                0
   20    Column             1   1  18                                               0  r[18]=h_orders.customer_name
   21    Copy              12  19   0                                               0  r[19]=r[12]
-  22    Ne                18  19  33  Binary                                       0  if r[18]!=r[19] goto 33
+  22    Ne                18  19  32  Binary                                       0  if r[18]!=r[19] goto 32
   23    Column             1   1   1                                               0  r[1]=h_orders.customer_name
   24    RowId              1   2   0                                               0  r[2]=h_orders.rowid
   25    Column             1   1   3                                               0  r[3]=h_orders.customer_name
   26    RowId              1   4   0                                               0  r[4]=h_orders.rowid
-  27    Copy              12   5   0                                               0  r[5]=r[12]
-  28    Copy              13   6   0                                               0  r[6]=r[13]
-  29    Copy              16   7   0                                               0  r[7]=r[16]
-  30    MakeRecord         1   7  20                                               0  r[20]=mkrec(r[1..7]); for hash_build_input_t4
-  31    NewRowid           0  21   0                                               0  r[21]=rowid
-  32    Insert             0  20  21  hash_build_input_t4                          4  intkey=r[21] data=r[20]
-  33    IfPos             15  44   0                                               0  r[15]>0 -> r[15]-=0, goto 44
-  34    HashNext           2  16  36   payload=r[12]..r[13]                        0
-  35    Goto               0  20   0                                               0
-  36  Next                 1  15   0                                               0
-  37  HashGraceInit        2   0  49                                               0  hash_table_id=2
-  38  Integer              1  15   0                                               0  r[15]=1
-  39  HashGraceLoadPart    2   0  48                                               0  hash_table_id=2
-  40  HashGraceNextProbe   2  11  46                                               0  hash_table_id=2 keys=r[11]..r[11] probe_rowid_dest=r[14]
-  41  SeekRowid            1  14  40                                               0  if (r[14]!=cursor 1 for table h_orders.rowid) goto 40
-  42  HashProbe            2  11   1  r[16]=40 payload=r[12]..r[13]                0
-  43  Goto                 0  20   0                                               0
-  44  HashNext             2  16  40   payload=r[12]..r[13]                        0
-  45  Goto                 0  20   0                                               0
-  46  HashGraceAdvPart     2   0  48                                               0  hash_table_id=2
-  47  Goto                 0  39   0                                               0
-  48  Integer              0  15   0                                               0  r[15]=0
-  49  OpenRead             1   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
-  50  OpenRead             2   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
-  51  OpenRead             4   4   0  k(3,B,B,B)                                   0  table=h_returns, root=4, iDb=0
-  52  Once                66   0   0                                               0  goto 66
-  53  Rewind               0  65   0                                               0  Rewind  ephemeral(hash_build_input_t4)
-  54    Column             0   0  25                                               0  r[25]=ephemeral(hash_build_input_t4).key_0
-  55    Affinity          25   1   0                                               0  r[25..26] = A
-  56    Column             0   1  26                                               0  r[26]=ephemeral(hash_build_input_t4).payload_0
-  57    Column             0   2  27                                               0  r[27]=ephemeral(hash_build_input_t4).payload_1
-  58    Column             0   3  28                                               0  r[28]=ephemeral(hash_build_input_t4).payload_2
-  59    Column             0   4  29                                               0  r[29]=ephemeral(hash_build_input_t4).payload_3
-  60    Column             0   5  30                                               0  r[30]=ephemeral(hash_build_input_t4).payload_4
-  61    Column             0   6  31                                               0  r[31]=ephemeral(hash_build_input_t4).payload_5
-  62    HashBuild          0  25   1  r=[1] budget=67108864 payload=r[26]..r[31]   0
-  63    FilterAdd          0  25   1                                               0  bloom_filter_add(r[25..26])
-  64  Next                 0  54   0                                               0
-  65  HashBuildFinalize    1   0   0                                               0
-  66  Rewind               4  81   0                                               0  Rewind table h_returns
-  67    Column             4   1  32                                               0  r[32]=h_returns.order_name
-  68    Affinity          32   1   0                                               0  r[32..33] = A
-  69    Filter             0  80  32                                               1  if !bloom_filter(r[32..33]) goto 80
-  70    RowId              4  39   0                                               0  r[39]=h_returns.rowid
-  71    Integer            0  40   0                                               0  r[40]=0
-  72    HashProbe          1  32   1  r[41]=80 payload=r[33]..r[38]                0
-  73    Copy              33  22   0                                               0  r[22]=r[33]
-  74    Copy              37  23   0                                               0  r[23]=r[37]
-  75    Column             4   2  24                                               0  r[24]=h_returns.reason
-  76    ResultRow         22   3   0                                               0  output=r[22..24]
-  77    IfPos             40  88   0                                               0  r[40]>0 -> r[40]-=0, goto 88
-  78    HashNext           1  41  80   payload=r[33]..r[38]                        0
-  79    Goto               0  73   0                                               0
-  80  Next                 4  67   0                                               0
-  81  HashGraceInit        1   0  93                                               0  hash_table_id=1
-  82  Integer              1  40   0                                               0  r[40]=1
-  83  HashGraceLoadPart    1   0  92                                               0  hash_table_id=1
-  84  HashGraceNextProbe   1  32  90                                               0  hash_table_id=1 keys=r[32]..r[32] probe_rowid_dest=r[39]
-  85  SeekRowid            4  39  84                                               0  if (r[39]!=cursor 4 for table h_returns.rowid) goto 84
-  86  HashProbe            1  32   1  r[41]=84 payload=r[33]..r[38]                0
-  87  Goto                 0  73   0                                               0
-  88  HashNext             1  41  84   payload=r[33]..r[38]                        0
-  89  Goto                 0  73   0                                               0
-  90  HashGraceAdvPart     1   0  92                                               0  hash_table_id=1
-  91  Goto                 0  83   0                                               0
-  92  Integer              0  40   0                                               0  r[40]=0
-  93  HashClose            1   0   0                                               0
-  94  Halt                 0   0   0                                               0
-  95  Transaction          0   1   3                                               0  iDb=0 tx_mode=Read
-  96  Goto                 0   1   0                                               0
+  27    Copy              12   5   1                                               0  r[5]=r[12]
+  28    Copy              16   7   0                                               0  r[7]=r[16]
+  29    MakeRecord         1   7  20                                               0  r[20]=mkrec(r[1..7]); for hash_build_input_t4
+  30    NewRowid           0  21   0                                               0  r[21]=rowid
+  31    Insert             0  20  21  hash_build_input_t4                          4  intkey=r[21] data=r[20]
+  32    IfPos             15  43   0                                               0  r[15]>0 -> r[15]-=0, goto 43
+  33    HashNext           2  16  35   payload=r[12]..r[13]                        0
+  34    Goto               0  20   0                                               0
+  35  Next                 1  15   0                                               0
+  36  HashGraceInit        2   0  48                                               0  hash_table_id=2
+  37  Integer              1  15   0                                               0  r[15]=1
+  38  HashGraceLoadPart    2   0  47                                               0  hash_table_id=2
+  39  HashGraceNextProbe   2  11  45                                               0  hash_table_id=2 keys=r[11]..r[11] probe_rowid_dest=r[14]
+  40  SeekRowid            1  14  39                                               0  if (r[14]!=cursor 1 for table h_orders.rowid) goto 39
+  41  HashProbe            2  11   1  r[16]=39 payload=r[12]..r[13]                0
+  42  Goto                 0  20   0                                               0
+  43  HashNext             2  16  39   payload=r[12]..r[13]                        0
+  44  Goto                 0  20   0                                               0
+  45  HashGraceAdvPart     2   0  47                                               0  hash_table_id=2
+  46  Goto                 0  38   0                                               0
+  47  Integer              0  15   0                                               0  r[15]=0
+  48  OpenRead             1   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
+  49  OpenRead             2   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
+  50  OpenRead             4   4   0  k(3,B,B,B)                                   0  table=h_returns, root=4, iDb=0
+  51  Once                65   0   0                                               0  goto 65
+  52  Rewind               0  64   0                                               0  Rewind  ephemeral(hash_build_input_t4)
+  53    Column             0   0  25                                               0  r[25]=ephemeral(hash_build_input_t4).key_0
+  54    Affinity          25   1   0                                               0  r[25..26] = A
+  55    Column             0   1  26                                               0  r[26]=ephemeral(hash_build_input_t4).payload_0
+  56    Column             0   2  27                                               0  r[27]=ephemeral(hash_build_input_t4).payload_1
+  57    Column             0   3  28                                               0  r[28]=ephemeral(hash_build_input_t4).payload_2
+  58    Column             0   4  29                                               0  r[29]=ephemeral(hash_build_input_t4).payload_3
+  59    Column             0   5  30                                               0  r[30]=ephemeral(hash_build_input_t4).payload_4
+  60    Column             0   6  31                                               0  r[31]=ephemeral(hash_build_input_t4).payload_5
+  61    HashBuild          0  25   1  r=[1] budget=67108864 payload=r[26]..r[31]   0
+  62    FilterAdd          0  25   1                                               0  bloom_filter_add(r[25..26])
+  63  Next                 0  53   0                                               0
+  64  HashBuildFinalize    1   0   0                                               0
+  65  Rewind               4  80   0                                               0  Rewind table h_returns
+  66    Column             4   1  32                                               0  r[32]=h_returns.order_name
+  67    Affinity          32   1   0                                               0  r[32..33] = A
+  68    Filter             0  79  32                                               1  if !bloom_filter(r[32..33]) goto 79
+  69    RowId              4  39   0                                               0  r[39]=h_returns.rowid
+  70    Integer            0  40   0                                               0  r[40]=0
+  71    HashProbe          1  32   1  r[41]=79 payload=r[33]..r[38]                0
+  72    Copy              33  22   0                                               0  r[22]=r[33]
+  73    Copy              37  23   0                                               0  r[23]=r[37]
+  74    Column             4   2  24                                               0  r[24]=h_returns.reason
+  75    ResultRow         22   3   0                                               0  output=r[22..24]
+  76    IfPos             40  87   0                                               0  r[40]>0 -> r[40]-=0, goto 87
+  77    HashNext           1  41  79   payload=r[33]..r[38]                        0
+  78    Goto               0  72   0                                               0
+  79  Next                 4  66   0                                               0
+  80  HashGraceInit        1   0  92                                               0  hash_table_id=1
+  81  Integer              1  40   0                                               0  r[40]=1
+  82  HashGraceLoadPart    1   0  91                                               0  hash_table_id=1
+  83  HashGraceNextProbe   1  32  89                                               0  hash_table_id=1 keys=r[32]..r[32] probe_rowid_dest=r[39]
+  84  SeekRowid            4  39  83                                               0  if (r[39]!=cursor 4 for table h_returns.rowid) goto 83
+  85  HashProbe            1  32   1  r[41]=83 payload=r[33]..r[38]                0
+  86  Goto                 0  72   0                                               0
+  87  HashNext             1  41  83   payload=r[33]..r[38]                        0
+  88  Goto                 0  72   0                                               0
+  89  HashGraceAdvPart     1   0  91                                               0  hash_table_id=1
+  90  Goto                 0  82   0                                               0
+  91  Integer              0  40   0                                               0  r[40]=0
+  92  HashClose            1   0   0                                               0
+  93  Halt                 0   0   0                                               0
+  94  Transaction          0   1   3                                               0  iDb=0 tx_mode=Read
+  95  Goto                 0   1   0                                               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-with-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__hash-join-with-aggregation.snap
@@ -21,85 +21,81 @@ QUERY PLAN
 `--USE SORTER FOR GROUP BY
 
 BYTECODE
-addr  opcode                      p1  p2  p3  p4                                          p5  comment
-   0          Init                 0  78   0                                               0  Start at 78
-   1          Null                 0   9  10                                               0  r[9..10]=NULL
-   2          SorterOpen           0   2   0  k(1,B)                                       0  cursor=0
-   3          Integer              0   6   0                                               0  r[6]=0; clear group by abort flag
-   4          Null                 0   7   0                                               0  r[7]=NULL; initialize group by comparison registers to NULL
-   5          Gosub               14  74   0                                               0  ; go to clear accumulator subroutine
-   6          OpenRead             2   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
-   7          OpenRead             3   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
-   8          Once                17   0   0                                               0  goto 17
-   9          OpenRead             4   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
-  10          Rewind               4  16   0                                               0  Rewind table h_orders
-  11            Column             4   1  15                                               0  r[15]=h_orders.customer_name
-  12            Affinity          15   1   0                                               0  r[15..16] = A
-  13            Column             4   1  16                                               0  r[16]=h_orders.customer_name
-  14            HashBuild          4  15   1  r=[1] budget=67108864 payload=r[16]..r[16]   0
-  15          Next                 4  11   0                                               0
-  16          HashBuildFinalize    1   0   0                                               0
-  17          Rewind               3  31   0                                               0  Rewind table h_items
-  18            Column             3   1  17                                               0  r[17]=h_items.order_name
-  19            Affinity          17   1   0                                               0  r[17..18] = A
-  20            RowId              3  19   0                                               0  r[19]=h_items.rowid
-  21            Integer            0  20   0                                               0  r[20]=0
-  22            HashProbe          1  17   1  r[21]=30 payload=r[18]..r[18]                0
-  23            Copy              18  12   0                                               0  r[12]=r[18]
-  24            Column             3   3  13                                               0  r[13]=h_items.quantity
-  25            MakeRecord        12   2  11                                               0  r[11]=mkrec(r[12..13])
-  26            SorterInsert       0  11   0  0                                            0  key=r[11]
-  27            IfPos             20  38   0                                               0  r[20]>0 -> r[20]-=0, goto 38
-  28            HashNext           1  21  30   payload=r[18]..r[18]                        0
-  29            Goto               0  23   0                                               0
-  30          Next                 3  18   0                                               0
-  31          HashGraceInit        1   0  43                                               0  hash_table_id=1
-  32          Integer              1  20   0                                               0  r[20]=1
-  33          HashGraceLoadPart    1   0  42                                               0  hash_table_id=1
-  34          HashGraceNextProbe   1  17  40                                               0  hash_table_id=1 keys=r[17]..r[17] probe_rowid_dest=r[19]
-  35          SeekRowid            3  19  34                                               0  if (r[19]!=cursor 3 for table h_items.rowid) goto 34
-  36          HashProbe            1  17   1  r[21]=34 payload=r[18]..r[18]                0
-  37          Goto                 0  23   0                                               0
-  38          HashNext             1  21  34   payload=r[18]..r[18]                        0
-  39          Goto                 0  23   0                                               0
-  40          HashGraceAdvPart     1   0  42                                               0  hash_table_id=1
-  41          Goto                 0  33   0                                               0
-  42          Integer              0  20   0                                               0  r[20]=0
-  43          HashClose            1   0   0                                               0
-  44          OpenPseudo           1  11   2                                               0  2 columns in r[11]
-  45          SorterSort           0  61   0                                               0
-  46            SorterData         0  11   1                                               0  r[11]=data
-  47            Column             1   0  22                                               0  r[22]=pseudo.column 0
-  48            Compare            7  22   1  k(1, Binary)                                 0  r[7..7]==r[22..22]
-  49            Jump              50  54  50                                               0  ; start new group if comparison is not equal
-  50            Gosub              4  65   0                                               0  ; check if ended group had data, and output if so
-  51            Move              22   7   1                                               0  r[7..7]=r[22..22]
-  52            IfPos              6  77   0                                               0  r[6]>0 -> r[6]-=0, goto 77; check abort flag
-  53            Gosub             14  74   0                                               0  ; goto clear accumulator subroutine
-  54            Column             1   1  23                                               0  r[23]=pseudo.column 1
-  55            AggStep            0  24   9  count                                        0  accum=r[9] step(r[24])
-  56            AggStep            0  23  10  sum                                          0  accum=r[10] step(r[23])
-  57            If                 5  59   0                                               0  if r[5] goto 59; don't emit group columns if continuing existing group
-  58            Column             1   0   8                                               0  r[8]=pseudo.column 0
-  59            Integer            1   5   0                                               0  r[5]=1; indicate data in accumulator
-  60          SorterNext           0  46   0                                               0
-  61          Gosub                4  65   0                                               0  ; emit row for final group
-  62          Goto                 0  77   0                                               0  ; group by finished
-  63          Integer              1   6   0                                               0  r[6]=1
-  64        Return                 4   0   0                                               0
-  65        IfPos                  5  67   0                                               0  r[5]>0 -> r[5]-=0, goto 67; output group by row subroutine start
-  66      Return                   4   0   0                                               0
-  67      AggFinal                 0   9   0  count                                        0  accum=r[9]
-  68      AggFinal                 0  10   0  sum                                          0  accum=r[10]
-  69      Copy                     8   1   0                                               0  r[1]=r[8]
-  70      Copy                     9   2   0                                               0  r[2]=r[9]
-  71      Copy                    10   3   0                                               0  r[3]=r[10]
-  72      ResultRow                1   3   0                                               0  output=r[1..3]
-  73    Return                     4   0   0                                               0
-  74    Null                       0   8  10                                               0  r[8..10]=NULL; clear accumulator subroutine start
-  75    Integer                    0   5   0                                               0  r[5]=0
-  76  Return                      14   0   0                                               0
-  77  Halt                         0   0   0                                               0
-  78  Transaction                  0   1   3                                               0  iDb=0 tx_mode=Read
-  79  Integer                      1  24   0                                               0  r[24]=1
-  80  Goto                         0   1   0                                               0
+addr  opcode                    p1  p2  p3  p4                                          p5  comment
+   0        Init                 0  74   0                                               0  Start at 74
+   1        Null                 0   9  10                                               0  r[9..10]=NULL
+   2        SorterOpen           0   2   0  k(1,B)                                       0  cursor=0
+   3        Integer              0   6   0                                               0  r[6]=0; clear group by abort flag
+   4        Null                 0   7   0                                               0  r[7]=NULL; initialize group by comparison registers to NULL
+   5        Gosub               14  70   0                                               0  ; go to clear accumulator subroutine
+   6        OpenRead             2   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
+   7        OpenRead             3   3   0  k(4,B,B,B,B)                                 0  table=h_items, root=3, iDb=0
+   8        Once                17   0   0                                               0  goto 17
+   9        OpenRead             4   2   0  k(3,B,B,B)                                   0  table=h_orders, root=2, iDb=0
+  10        Rewind               4  16   0                                               0  Rewind table h_orders
+  11          Column             4   1  15                                               0  r[15]=h_orders.customer_name
+  12          Affinity          15   1   0                                               0  r[15..16] = A
+  13          Column             4   1  16                                               0  r[16]=h_orders.customer_name
+  14          HashBuild          4  15   1  r=[1] budget=67108864 payload=r[16]..r[16]   0
+  15        Next                 4  11   0                                               0
+  16        HashBuildFinalize    1   0   0                                               0
+  17        Rewind               3  31   0                                               0  Rewind table h_items
+  18          Column             3   1  17                                               0  r[17]=h_items.order_name
+  19          Affinity          17   1   0                                               0  r[17..18] = A
+  20          RowId              3  19   0                                               0  r[19]=h_items.rowid
+  21          Integer            0  20   0                                               0  r[20]=0
+  22          HashProbe          1  17   1  r[21]=30 payload=r[18]..r[18]                0
+  23          Copy              18  12   0                                               0  r[12]=r[18]
+  24          Column             3   3  13                                               0  r[13]=h_items.quantity
+  25          MakeRecord        12   2  11                                               0  r[11]=mkrec(r[12..13])
+  26          SorterInsert       0  11   0  0                                            0  key=r[11]
+  27          IfPos             20  38   0                                               0  r[20]>0 -> r[20]-=0, goto 38
+  28          HashNext           1  21  30   payload=r[18]..r[18]                        0
+  29          Goto               0  23   0                                               0
+  30        Next                 3  18   0                                               0
+  31        HashGraceInit        1   0  43                                               0  hash_table_id=1
+  32        Integer              1  20   0                                               0  r[20]=1
+  33        HashGraceLoadPart    1   0  42                                               0  hash_table_id=1
+  34        HashGraceNextProbe   1  17  40                                               0  hash_table_id=1 keys=r[17]..r[17] probe_rowid_dest=r[19]
+  35        SeekRowid            3  19  34                                               0  if (r[19]!=cursor 3 for table h_items.rowid) goto 34
+  36        HashProbe            1  17   1  r[21]=34 payload=r[18]..r[18]                0
+  37        Goto                 0  23   0                                               0
+  38        HashNext             1  21  34   payload=r[18]..r[18]                        0
+  39        Goto                 0  23   0                                               0
+  40        HashGraceAdvPart     1   0  42                                               0  hash_table_id=1
+  41        Goto                 0  33   0                                               0
+  42        Integer              0  20   0                                               0  r[20]=0
+  43        HashClose            1   0   0                                               0
+  44        OpenPseudo           1  11   2                                               0  2 columns in r[11]
+  45        SorterSort           0  61   0                                               0
+  46          SorterData         0  11   1                                               0  r[11]=data
+  47          Column             1   0  22                                               0  r[22]=pseudo.column 0
+  48          Compare            7  22   1  k(1, Binary)                                 0  r[7..7]==r[22..22]
+  49          Jump              50  54  50                                               0  ; start new group if comparison is not equal
+  50          Gosub              4  63   0                                               0  ; check if ended group had data, and output if so
+  51          Move              22   7   1                                               0  r[7..7]=r[22..22]
+  52          IfPos              6  73   0                                               0  r[6]>0 -> r[6]-=0, goto 73; check abort flag
+  53          Gosub             14  70   0                                               0  ; goto clear accumulator subroutine
+  54          Column             1   1  23                                               0  r[23]=pseudo.column 1
+  55          AggStep            0  24   9  count                                        0  accum=r[9] step(r[24])
+  56          AggStep            0  23  10  sum                                          0  accum=r[10] step(r[23])
+  57          If                 5  59   0                                               0  if r[5] goto 59; don't emit group columns if continuing existing group
+  58          Column             1   0   8                                               0  r[8]=pseudo.column 0
+  59          Integer            1   5   0                                               0  r[5]=1; indicate data in accumulator
+  60        SorterNext           0  46   0                                               0
+  61        Gosub                4  63   0                                               0  ; emit row for final group
+  62        Halt                 0   0   0                                               0  ; group by finished
+  63        IfPos                5  65   0                                               0  r[5]>0 -> r[5]-=0, goto 65; output group by row subroutine start
+  64      Return                 4   0   0                                               0
+  65      AggFinal               0   9   0  count                                        0  accum=r[9]
+  66      AggFinal               0  10   0  sum                                          0  accum=r[10]
+  67      Copy                   8   1   2                                               0  r[1]=r[8]
+  68      ResultRow              1   3   0                                               0  output=r[1..3]
+  69    Return                   4   0   0                                               0
+  70    Null                     0   8  10                                               0  r[8..10]=NULL; clear accumulator subroutine start
+  71    Integer                  0   5   0                                               0  r[5]=0
+  72  Return                    14   0   0                                               0
+  73  Halt                       0   0   0                                               0
+  74  Transaction                0   1   3                                               0  iDb=0 tx_mode=Read
+  75  Integer                    1  24   0                                               0  r[24]=1
+  76  Goto                       0   1   0                                               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-with-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-with-aggregation.snap
@@ -30,86 +30,82 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4                    p5  comment
-   0          Init               0  80   0                         0  Start at 80
-   1          SorterOpen         0   2   0  k(2,-B,Binary)         0  cursor=0
-   2          Null               0  13  14                         0  r[13..14]=NULL
-   3          SorterOpen         1   4   0  k(2,B,B)               0  cursor=1
-   4          Integer            0   8   0                         0  r[8]=0; clear group by abort flag
-   5          Null               0   9  10                         0  r[9..10]=NULL; initialize group by comparison registers to NULL
-   6          Gosub             20  67   0                         0  ; go to clear accumulator subroutine
-   7          OpenRead           3   2   0  k(5,B,B,B,B,B)         0  table=customers, root=2, iDb=0
-   8          OpenRead           4   4   0  k(5,B,B,B,B,B)         0  table=orders, root=4, iDb=0
-   9          OpenRead           5   8   0  k(2,B)                 0  index=idx_orders_customer_id, root=8, iDb=0
-  10          Rewind             3  29   0                         0  Rewind table customers
-  11            Integer          0  21   0                         0  r[21]=0
-  12            RowId            3  22   0                         0  r[22]=customers.rowid
-  13            SeekGE           5  24  22                         0  key=[22..22]
-  14              IdxGT          5  24  22                         0  key=[22..22]
-  15              DeferredSeek   5   4   0                         0
-  16              Integer        1  21   0                         0  r[21]=1
-  17              RowId          3  16   0                         0  r[16]=customers.rowid
-  18              Column         3   1  17                         0  r[17]=customers.name
-  19              IdxRowId       5  18   0                         0  r[18]=cursor 5 for index idx_orders_customer_id.rowid
-  20              Column         4   4  19                         0  r[19]=orders.total_amount
-  21              MakeRecord    16   4  15                         0  r[15]=mkrec(r[16..19])
-  22              SorterInsert   1  15   0  0                      0  key=r[15]
-  23            Next             5  14   0                         0
-  24            IfPos           21  28   0                         0  r[21]>0 -> r[21]-=0, goto 28
-  25            NullRow          4   0   0                         0  Set cursor 4 to a (pseudo) NULL row
-  26            NullRow          5   0   0                         0  Set cursor 5 to a (pseudo) NULL row
-  27            Goto             0  16   0                         0
-  28          Next               3  11   0                         0
-  29          OpenPseudo         2  15   4                         0  4 columns in r[15]
-  30          SorterSort         1  49   0                         0
-  31            SorterData       1  15   2                         0  r[15]=data
-  32            Column           2   0  23                         0  r[23]=pseudo.column 0
-  33            Column           2   1  24                         0  r[24]=pseudo.column 1
-  34            Compare          9  23   2  k(2, Binary, Binary)   0  r[9..10]==r[23..24]
-  35            Jump            36  40  36                         0  ; start new group if comparison is not equal
-  36            Gosub            6  53   0                         0  ; check if ended group had data, and output if so
-  37            Move            23   9   2                         0  r[9..10]=r[23..24]
-  38            IfPos            8  70   0                         0  r[8]>0 -> r[8]-=0, goto 70; check abort flag
-  39            Gosub           20  67   0                         0  ; goto clear accumulator subroutine
-  40            Column           2   2  25                         0  r[25]=pseudo.column 2
-  41            Column           2   3  26                         0  r[26]=pseudo.column 3
-  42            AggStep          0  25  13  count                  0  accum=r[13] step(r[25])
-  43            AggStep          0  26  14  sum                    0  accum=r[14] step(r[26])
-  44            If               7  47   0                         0  if r[7] goto 47; don't emit group columns if continuing existing group
-  45            Column           2   0  11                         0  r[11]=pseudo.column 0
-  46            Column           2   1  12                         0  r[12]=pseudo.column 1
-  47            Integer          1   7   0                         0  r[7]=1; indicate data in accumulator
-  48          SorterNext         1  31   0                         0
-  49          Gosub              6  53   0                         0  ; emit row for final group
-  50          Goto               0  70   0                         0  ; group by finished
-  51          Integer            1   8   0                         0  r[8]=1
-  52        Return               6   0   0                         0
-  53        IfPos                7  55   0                         0  r[7]>0 -> r[7]-=0, goto 55; output group by row subroutine start
-  54      Return                 6   0   0                         0
-  55      AggFinal               0  13   0  count                  0  accum=r[13]
-  56      AggFinal               0  14   0  sum                    0  accum=r[14]
-  57      Copy                  14  27   0                         0  r[27]=r[14]
-  58      NotNull               27  60   0                         0  r[27]!=NULL -> goto 60
-  59      Integer                0  27   0                         0  r[27]=0
-  60      Sequence               0  28   0                         0
-  61      Copy                  11  29   0                         0  r[29]=r[11]
-  62      Copy                  12  30   0                         0  r[30]=r[12]
-  63      Copy                  13  31   0                         0  r[31]=r[13]
-  64      MakeRecord            27   5   5                         0  r[5]=mkrec(r[27..31])
-  65      SorterInsert           0   5   0  0                      0  key=r[5]
-  66    Return                   6   0   0                         0
-  67    Null                     0  11  14                         0  r[11..14]=NULL; clear accumulator subroutine start
-  68    Integer                  0   7   0                         0  r[7]=0
-  69  Return                    20   0   0                         0
-  70  OpenPseudo                 6   5   5                         0  5 columns in r[5]
-  71  SorterSort                 0  79   0                         0
-  72    SorterData               0   5   6                         0  r[5]=data
-  73    Column                   6   2   1                         0  r[1]=pseudo.column 2
-  74    Column                   6   3   2                         0  r[2]=pseudo.column 3
-  75    Column                   6   4   3                         0  r[3]=pseudo.column 4
-  76    Column                   6   0   4                         0  r[4]=pseudo.column 0
-  77    ResultRow                1   4   0                         0  output=r[1..4]
-  78  SorterNext                 0  72   0                         0
-  79  Halt                       0   0   0                         0
-  80  Transaction                0   1  10                         0  iDb=0 tx_mode=Read
-  81  Goto                       0   1   0                         0
+addr  opcode                  p1  p2  p3  p4                    p5  comment
+   0        Init               0  76   0                         0  Start at 76
+   1        SorterOpen         0   2   0  k(2,-B,Binary)         0  cursor=0
+   2        Null               0  13  14                         0  r[13..14]=NULL
+   3        SorterOpen         1   4   0  k(2,B,B)               0  cursor=1
+   4        Integer            0   8   0                         0  r[8]=0; clear group by abort flag
+   5        Null               0   9  10                         0  r[9..10]=NULL; initialize group by comparison registers to NULL
+   6        Gosub             20  63   0                         0  ; go to clear accumulator subroutine
+   7        OpenRead           3   2   0  k(5,B,B,B,B,B)         0  table=customers, root=2, iDb=0
+   8        OpenRead           4   4   0  k(5,B,B,B,B,B)         0  table=orders, root=4, iDb=0
+   9        OpenRead           5   8   0  k(2,B)                 0  index=idx_orders_customer_id, root=8, iDb=0
+  10        Rewind             3  29   0                         0  Rewind table customers
+  11          Integer          0  21   0                         0  r[21]=0
+  12          RowId            3  22   0                         0  r[22]=customers.rowid
+  13          SeekGE           5  24  22                         0  key=[22..22]
+  14            IdxGT          5  24  22                         0  key=[22..22]
+  15            DeferredSeek   5   4   0                         0
+  16            Integer        1  21   0                         0  r[21]=1
+  17            RowId          3  16   0                         0  r[16]=customers.rowid
+  18            Column         3   1  17                         0  r[17]=customers.name
+  19            IdxRowId       5  18   0                         0  r[18]=cursor 5 for index idx_orders_customer_id.rowid
+  20            Column         4   4  19                         0  r[19]=orders.total_amount
+  21            MakeRecord    16   4  15                         0  r[15]=mkrec(r[16..19])
+  22            SorterInsert   1  15   0  0                      0  key=r[15]
+  23          Next             5  14   0                         0
+  24          IfPos           21  28   0                         0  r[21]>0 -> r[21]-=0, goto 28
+  25          NullRow          4   0   0                         0  Set cursor 4 to a (pseudo) NULL row
+  26          NullRow          5   0   0                         0  Set cursor 5 to a (pseudo) NULL row
+  27          Goto             0  16   0                         0
+  28        Next               3  11   0                         0
+  29        OpenPseudo         2  15   4                         0  4 columns in r[15]
+  30        SorterSort         1  49   0                         0
+  31          SorterData       1  15   2                         0  r[15]=data
+  32          Column           2   0  23                         0  r[23]=pseudo.column 0
+  33          Column           2   1  24                         0  r[24]=pseudo.column 1
+  34          Compare          9  23   2  k(2, Binary, Binary)   0  r[9..10]==r[23..24]
+  35          Jump            36  40  36                         0  ; start new group if comparison is not equal
+  36          Gosub            6  51   0                         0  ; check if ended group had data, and output if so
+  37          Move            23   9   2                         0  r[9..10]=r[23..24]
+  38          IfPos            8  66   0                         0  r[8]>0 -> r[8]-=0, goto 66; check abort flag
+  39          Gosub           20  63   0                         0  ; goto clear accumulator subroutine
+  40          Column           2   2  25                         0  r[25]=pseudo.column 2
+  41          Column           2   3  26                         0  r[26]=pseudo.column 3
+  42          AggStep          0  25  13  count                  0  accum=r[13] step(r[25])
+  43          AggStep          0  26  14  sum                    0  accum=r[14] step(r[26])
+  44          If               7  47   0                         0  if r[7] goto 47; don't emit group columns if continuing existing group
+  45          Column           2   0  11                         0  r[11]=pseudo.column 0
+  46          Column           2   1  12                         0  r[12]=pseudo.column 1
+  47          Integer          1   7   0                         0  r[7]=1; indicate data in accumulator
+  48        SorterNext         1  31   0                         0
+  49        Gosub              6  51   0                         0  ; emit row for final group
+  50        Goto               0  66   0                         0  ; group by finished
+  51        IfPos              7  53   0                         0  r[7]>0 -> r[7]-=0, goto 53; output group by row subroutine start
+  52      Return               6   0   0                         0
+  53      AggFinal             0  13   0  count                  0  accum=r[13]
+  54      AggFinal             0  14   0  sum                    0  accum=r[14]
+  55      Copy                14  27   0                         0  r[27]=r[14]
+  56      NotNull             27  58   0                         0  r[27]!=NULL -> goto 58
+  57      Integer              0  27   0                         0  r[27]=0
+  58      Sequence             0  28   0                         0
+  59      Copy                11  29   2                         0  r[29]=r[11]
+  60      MakeRecord          27   5   5                         0  r[5]=mkrec(r[27..31])
+  61      SorterInsert         0   5   0  0                      0  key=r[5]
+  62    Return                 6   0   0                         0
+  63    Null                   0  11  14                         0  r[11..14]=NULL; clear accumulator subroutine start
+  64    Integer                0   7   0                         0  r[7]=0
+  65  Return                  20   0   0                         0
+  66  OpenPseudo               6   5   5                         0  5 columns in r[5]
+  67  SorterSort               0  75   0                         0
+  68    SorterData             0   5   6                         0  r[5]=data
+  69    Column                 6   2   1                         0  r[1]=pseudo.column 2
+  70    Column                 6   3   2                         0  r[2]=pseudo.column 3
+  71    Column                 6   4   3                         0  r[3]=pseudo.column 4
+  72    Column                 6   0   4                         0  r[4]=pseudo.column 0
+  73    ResultRow              1   4   0                         0  output=r[1..4]
+  74  SorterNext               0  68   0                         0
+  75  Halt                     0   0   0                         0
+  76  Transaction              0   1  10                         0  iDb=0 tx_mode=Read
+  77  Goto                     0   1   0                         0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__delete-with-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__delete-with-subquery.snap
@@ -53,8 +53,8 @@ addr  opcode            p1  p2  p3  p4            p5  comment
   29  OpenWrite          5  13   0                 0  root=13; iDb=0
   30  OpenWrite          6  12   0                 0  root=12; iDb=0
   31    RowSetRead       1  42   9                 0
-  32    NotExists        1  41   9                 0
-  33    NotExists        1  41   9                 0
+  32    NotExists        1  31   9                 0
+  33    NotExists        1  31   9                 0
   34    Column           1   2  10                 0  r[10]=orders.product_id
   35    RowId            1  11   0                 0  r[11]=orders.rowid
   36    IdxDelete        2  10   2                 1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-multiple-rows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-multiple-rows.snap
@@ -19,7 +19,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4              p5  comment
-   0  Init              0  52   0                   0  Start at 52
+   0  Init              0  46   0                   0  Start at 46
    1  InitCoroutine     2  21   2                   0
    2  Integer           1   3   0                   0  r[3]=1
    3  String8           0   4   0  Widget           0  r[4]='Widget'
@@ -41,35 +41,29 @@ addr  opcode           p1  p2  p3  p4              p5  comment
   19  Yield             2   0   0                   0
   20  EndCoroutine      2   0   0                   0
   21  OpenWrite         1   2   0                   0  root=2; iDb=0
-  22    Yield           2  50   0                   0
+  22    Yield           2  45   0                   0
   23    Copy            3   8   0                   0  r[8]=r[3]
   24    SoftNull        9   0   0                   0
-  25    Copy            4  10   0                   0  r[10]=r[4]
-  26    Copy            5  11   0                   0  r[11]=r[5]
-  27    Copy            6  12   0                   0  r[12]=r[6]
-  28    Copy            7  13   0                   0  r[13]=r[7]
-  29    OpenWrite       0  11   0                   0  root=11; iDb=0
-  30    Affinity        9   5   0                   0  r[9..14] = D, B, E, D, B
-  31    NotNull         8  33   0                   0  r[8]!=NULL -> goto 33
-  32    Goto            0  35   0                   0
-  33    MustBeInt       8   0   0                   0
-  34    Goto            0  36   0                   0
-  35    NewRowid        1   8   0                   0  r[8]=rowid
-  36    HaltIfNull   1299   0  10  products.name    0
-  37    HaltIfNull   1299   0  11  products.price   0
-  38    NotExists       1  40   8                   0
-  39    Halt         1555   0   0  products.id      0
-  40    Copy           13  15   0                   0  r[15]=r[13]
-  41    Copy            8  16   0                   0  r[16]=r[8]
-  42    MakeRecord      9   5  14                   0  r[14]=mkrec(r[9..13])
-  43    Copy           13  17   0                   0  r[17]=r[13]
-  44    Copy            8  18   0                   0  r[18]=r[8]
-  45    MakeRecord     17   2  19                   0  r[19]=mkrec(r[17..18]); for idx_products_category
-  46    IdxInsert       0  19  17                   2  key=r[19]
-  47    Insert          1  14   8  products         0  intkey=r[8] data=r[14]
-  48    Goto            0  49   0                   0
-  49  Goto              0  22   0                   0
-  50  Goto              0  51   0                   0
-  51  Halt              0   0   0                   0
-  52  Transaction       0   2  10                   0  iDb=0 tx_mode=Write
-  53  Goto              0   1   0                   0
+  25    Copy            4  10   3                   0  r[10]=r[4]
+  26    OpenWrite       0  11   0                   0  root=11; iDb=0
+  27    Affinity        9   5   0                   0  r[9..14] = D, B, E, D, B
+  28    IsNull          8  31   0                   0  if (r[8]==NULL) goto 31
+  29    MustBeInt       8   0   0                   0
+  30    Goto            0  32   0                   0
+  31    NewRowid        1   8   0                   0  r[8]=rowid
+  32    HaltIfNull   1299   0  10  products.name    0
+  33    HaltIfNull   1299   0  11  products.price   0
+  34    NotExists       1  36   8                   0
+  35    Halt         1555   0   0  products.id      0
+  36    Copy           13  15   0                   0  r[15]=r[13]
+  37    Copy            8  16   0                   0  r[16]=r[8]
+  38    MakeRecord      9   5  14                   0  r[14]=mkrec(r[9..13])
+  39    Copy           13  17   0                   0  r[17]=r[13]
+  40    Copy            8  18   0                   0  r[18]=r[8]
+  41    MakeRecord     17   2  19                   0  r[19]=mkrec(r[17..18]); for idx_products_category
+  42    IdxInsert       0  19  17                   2  key=r[19]
+  43    Insert          1  14   8  products         0  intkey=r[8] data=r[14]
+  44  Goto              0  22   0                   0
+  45  Halt              0   0   0                   0
+  46  Transaction       0   2  10                   0  iDb=0 tx_mode=Write
+  47  Goto              0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-abort-multi-unique.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-abort-multi-unique.snap
@@ -14,7 +14,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4             p5  comment
-   0  Init            0  42   0                  0  Start at 42
+   0  Init            0  39   0                  0  Start at 39
    1  OpenWrite       2   8   0                  0  root=8; iDb=0
    2  Integer         1   2   0                  0  r[2]=1
    3  SoftNull        3   0   0                  0
@@ -24,37 +24,34 @@ addr  opcode         p1  p2  p3  p4             p5  comment
    7  OpenWrite       0  10   0                  0  root=10; iDb=0
    8  OpenWrite       1   9   0                  0  root=9; iDb=0
    9  Affinity        3   4   0                  0  r[3..7] = D, B, B, B
-  10  NotNull         2  12   0                  0  r[2]!=NULL -> goto 12
-  11  Goto            0  14   0                  0
-  12  MustBeInt       2   0   0                  0
-  13  Goto            0  15   0                  0
-  14  NewRowid        2   2   0                  0  r[2]=rowid
-  15  HaltIfNull   1299   0   4  items.sku       0
-  16  HaltIfNull   1299   0   5  items.barcode   0
-  17  NotExists       2  19   2                  0
-  18  Halt         1555   0   0  items.id        0
-  19  Copy            5   8   0                  0  r[8]=r[5]
-  20  Copy            2   9   0                  0  r[9]=r[2]
-  21  Affinity        8   1   0                  0  r[8..9] = B
-  22  NoConflict      0  24   8  1               0  key=r[8..8]
-  23  Halt         2067   0   0  items.barcode   0
-  24  Copy            4  10   0                  0  r[10]=r[4]
-  25  Copy            2  11   0                  0  r[11]=r[2]
-  26  Affinity       10   1   0                  0  r[10..11] = B
-  27  NoConflict      1  29  10  1               0  key=r[10..10]
-  28  Halt         2067   0   0  items.sku       0
-  29  MakeRecord      3   4   7                  0  r[7]=mkrec(r[3..6])
-  30  Copy            5  12   0                  0  r[12]=r[5]
-  31  Copy            2  13   0                  0  r[13]=r[2]
-  32  MakeRecord     12   2  14                  0  r[14]=mkrec(r[12..13]); for sqlite_autoindex_items_2
-  33  IdxInsert       0  14  12                  2  key=r[14]
-  34  Copy            4  15   0                  0  r[15]=r[4]
-  35  Copy            2  16   0                  0  r[16]=r[2]
-  36  MakeRecord     15   2  17                  0  r[17]=mkrec(r[15..16]); for sqlite_autoindex_items_1
-  37  IdxInsert       1  17  15                  2  key=r[17]
-  38  Insert          2   7   2  items           0  intkey=r[2] data=r[7]
-  39  Goto            0  40   0                  0
-  40  Goto            0  41   0                  0
-  41  Halt            0   0   0                  0
-  42  Transaction     0   2  10                  0  iDb=0 tx_mode=Write
-  43  Goto            0   1   0                  0
+  10  IsNull          2  13   0                  0  if (r[2]==NULL) goto 13
+  11  MustBeInt       2   0   0                  0
+  12  Goto            0  14   0                  0
+  13  NewRowid        2   2   0                  0  r[2]=rowid
+  14  HaltIfNull   1299   0   4  items.sku       0
+  15  HaltIfNull   1299   0   5  items.barcode   0
+  16  NotExists       2  18   2                  0
+  17  Halt         1555   0   0  items.id        0
+  18  Copy            5   8   0                  0  r[8]=r[5]
+  19  Copy            2   9   0                  0  r[9]=r[2]
+  20  Affinity        8   1   0                  0  r[8..9] = B
+  21  NoConflict      0  23   8  1               0  key=r[8..8]
+  22  Halt         2067   0   0  items.barcode   0
+  23  Copy            4  10   0                  0  r[10]=r[4]
+  24  Copy            2  11   0                  0  r[11]=r[2]
+  25  Affinity       10   1   0                  0  r[10..11] = B
+  26  NoConflict      1  28  10  1               0  key=r[10..10]
+  27  Halt         2067   0   0  items.sku       0
+  28  MakeRecord      3   4   7                  0  r[7]=mkrec(r[3..6])
+  29  Copy            5  12   0                  0  r[12]=r[5]
+  30  Copy            2  13   0                  0  r[13]=r[2]
+  31  MakeRecord     12   2  14                  0  r[14]=mkrec(r[12..13]); for sqlite_autoindex_items_2
+  32  IdxInsert       0  14  12                  2  key=r[14]
+  33  Copy            4  15   0                  0  r[15]=r[4]
+  34  Copy            2  16   0                  0  r[16]=r[2]
+  35  MakeRecord     15   2  17                  0  r[17]=mkrec(r[15..16]); for sqlite_autoindex_items_1
+  36  IdxInsert       1  17  15                  2  key=r[17]
+  37  Insert          2   7   2  items           0  intkey=r[2] data=r[7]
+  38  Halt            0   0   0                  0
+  39  Transaction     0   2  10                  0  iDb=0 tx_mode=Write
+  40  Goto            0   1   0                  0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-fail-multi-unique.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-fail-multi-unique.snap
@@ -14,7 +14,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4             p5  comment
-   0  Init            0  42   0                  0  Start at 42
+   0  Init            0  39   0                  0  Start at 39
    1  OpenWrite       2   8   0                  0  root=8; iDb=0
    2  Integer         1   2   0                  0  r[2]=1
    3  SoftNull        3   0   0                  0
@@ -24,37 +24,34 @@ addr  opcode         p1  p2  p3  p4             p5  comment
    7  OpenWrite       0  10   0                  0  root=10; iDb=0
    8  OpenWrite       1   9   0                  0  root=9; iDb=0
    9  Affinity        3   4   0                  0  r[3..7] = D, B, B, B
-  10  NotNull         2  12   0                  0  r[2]!=NULL -> goto 12
-  11  Goto            0  14   0                  0
-  12  MustBeInt       2   0   0                  0
-  13  Goto            0  15   0                  0
-  14  NewRowid        2   2   0                  0  r[2]=rowid
-  15  HaltIfNull   1299   0   4  items.sku       0
-  16  HaltIfNull   1299   0   5  items.barcode   0
-  17  NotExists       2  19   2                  0
-  18  Halt         1555   0   0  items.id        0
-  19  Copy            5   8   0                  0  r[8]=r[5]
-  20  Copy            2   9   0                  0  r[9]=r[2]
-  21  Affinity        8   1   0                  0  r[8..9] = B
-  22  NoConflict      0  24   8  1               0  key=r[8..8]
-  23  Halt         2067   0   0  items.barcode   0
-  24  Copy            4  10   0                  0  r[10]=r[4]
-  25  Copy            2  11   0                  0  r[11]=r[2]
-  26  Affinity       10   1   0                  0  r[10..11] = B
-  27  NoConflict      1  29  10  1               0  key=r[10..10]
-  28  Halt         2067   0   0  items.sku       0
-  29  MakeRecord      3   4   7                  0  r[7]=mkrec(r[3..6])
-  30  Copy            5  12   0                  0  r[12]=r[5]
-  31  Copy            2  13   0                  0  r[13]=r[2]
-  32  MakeRecord     12   2  14                  0  r[14]=mkrec(r[12..13]); for sqlite_autoindex_items_2
-  33  IdxInsert       0  14  12                  2  key=r[14]
-  34  Copy            4  15   0                  0  r[15]=r[4]
-  35  Copy            2  16   0                  0  r[16]=r[2]
-  36  MakeRecord     15   2  17                  0  r[17]=mkrec(r[15..16]); for sqlite_autoindex_items_1
-  37  IdxInsert       1  17  15                  2  key=r[17]
-  38  Insert          2   7   2  items           0  intkey=r[2] data=r[7]
-  39  Goto            0  40   0                  0
-  40  Goto            0  41   0                  0
-  41  Halt            0   0   0                  0
-  42  Transaction     0   2  10                  0  iDb=0 tx_mode=Write
-  43  Goto            0   1   0                  0
+  10  IsNull          2  13   0                  0  if (r[2]==NULL) goto 13
+  11  MustBeInt       2   0   0                  0
+  12  Goto            0  14   0                  0
+  13  NewRowid        2   2   0                  0  r[2]=rowid
+  14  HaltIfNull   1299   0   4  items.sku       0
+  15  HaltIfNull   1299   0   5  items.barcode   0
+  16  NotExists       2  18   2                  0
+  17  Halt         1555   0   0  items.id        0
+  18  Copy            5   8   0                  0  r[8]=r[5]
+  19  Copy            2   9   0                  0  r[9]=r[2]
+  20  Affinity        8   1   0                  0  r[8..9] = B
+  21  NoConflict      0  23   8  1               0  key=r[8..8]
+  22  Halt         2067   0   0  items.barcode   0
+  23  Copy            4  10   0                  0  r[10]=r[4]
+  24  Copy            2  11   0                  0  r[11]=r[2]
+  25  Affinity       10   1   0                  0  r[10..11] = B
+  26  NoConflict      1  28  10  1               0  key=r[10..10]
+  27  Halt         2067   0   0  items.sku       0
+  28  MakeRecord      3   4   7                  0  r[7]=mkrec(r[3..6])
+  29  Copy            5  12   0                  0  r[12]=r[5]
+  30  Copy            2  13   0                  0  r[13]=r[2]
+  31  MakeRecord     12   2  14                  0  r[14]=mkrec(r[12..13]); for sqlite_autoindex_items_2
+  32  IdxInsert       0  14  12                  2  key=r[14]
+  33  Copy            4  15   0                  0  r[15]=r[4]
+  34  Copy            2  16   0                  0  r[16]=r[2]
+  35  MakeRecord     15   2  17                  0  r[17]=mkrec(r[15..16]); for sqlite_autoindex_items_1
+  36  IdxInsert       1  17  15                  2  key=r[17]
+  37  Insert          2   7   2  items           0  intkey=r[2] data=r[7]
+  38  Halt            0   0   0                  0
+  39  Transaction     0   2  10                  0  iDb=0 tx_mode=Write
+  40  Goto            0   1   0                  0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-ignore-multi-unique.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-ignore-multi-unique.snap
@@ -13,52 +13,47 @@ QUERY PLAN
 
 
 BYTECODE
-addr  opcode         p1  p2  p3  p4             p5  comment
-   0  Init            0  46   0                  0  Start at 46
-   1  OpenWrite       2   8   0                  0  root=8; iDb=0
-   2  Integer         1   2   0                  0  r[2]=1
-   3  SoftNull        3   0   0                  0
-   4  String8         0   4   0  SKU-001         0  r[4]='SKU-001'
-   5  String8         0   5   0  BC-001          0  r[5]='BC-001'
-   6  String8         0   6   0  Widget          0  r[6]='Widget'
-   7  OpenWrite       0  10   0                  0  root=10; iDb=0
-   8  OpenWrite       1   9   0                  0  root=9; iDb=0
-   9  Affinity        3   4   0                  0  r[3..7] = D, B, B, B
-  10  NotNull         2  12   0                  0  r[2]!=NULL -> goto 12
-  11  Goto            0  14   0                  0
-  12  MustBeInt       2   0   0                  0
-  13  Goto            0  15   0                  0
-  14  NewRowid        2   2   0                  0  r[2]=rowid
-  15  IsNull          4  44   0                  0  if (r[4]==NULL) goto 44
-  16  IsNull          5  44   0                  0  if (r[5]==NULL) goto 44
-  17  NotExists       2  20   2                  0
-  18  Copy            2   1   0                  0  r[1]=r[2]
-  19  Goto            0  43   0                  0
-  20  Copy            5   8   0                  0  r[8]=r[5]
-  21  Copy            2   9   0                  0  r[9]=r[2]
-  22  Affinity        8   1   0                  0  r[8..9] = B
-  23  NoConflict      0  26   8  1               0  key=r[8..8]
-  24  Goto            0  44   0                  0
-  25  Halt         2067   0   0  items.barcode   0
-  26  Copy            4  10   0                  0  r[10]=r[4]
-  27  Copy            2  11   0                  0  r[11]=r[2]
-  28  Affinity       10   1   0                  0  r[10..11] = B
-  29  NoConflict      1  32  10  1               0  key=r[10..10]
-  30  Goto            0  44   0                  0
-  31  Halt         2067   0   0  items.sku       0
-  32  MakeRecord      3   4   7                  0  r[7]=mkrec(r[3..6])
-  33  Copy            5  12   0                  0  r[12]=r[5]
-  34  Copy            2  13   0                  0  r[13]=r[2]
-  35  MakeRecord     12   2  14                  0  r[14]=mkrec(r[12..13]); for sqlite_autoindex_items_2
-  36  IdxInsert       0  14  12                  2  key=r[14]
-  37  Copy            4  15   0                  0  r[15]=r[4]
-  38  Copy            2  16   0                  0  r[16]=r[2]
-  39  MakeRecord     15   2  17                  0  r[17]=mkrec(r[15..16]); for sqlite_autoindex_items_1
-  40  IdxInsert       1  17  15                  2  key=r[17]
-  41  Insert          2   7   2  items           0  intkey=r[2] data=r[7]
-  42  Goto            0  44   0                  0
-  43  Goto            0  44   0                  0
-  44  Goto            0  45   0                  0
-  45  Halt            0   0   0                  0
-  46  Transaction     0   2  10                  0  iDb=0 tx_mode=Write
-  47  Goto            0   1   0                  0
+addr  opcode       p1  p2  p3  p4       p5  comment
+   0  Init          0  41   0            0  Start at 41
+   1  OpenWrite     2   8   0            0  root=8; iDb=0
+   2  Integer       1   2   0            0  r[2]=1
+   3  SoftNull      3   0   0            0
+   4  String8       0   4   0  SKU-001   0  r[4]='SKU-001'
+   5  String8       0   5   0  BC-001    0  r[5]='BC-001'
+   6  String8       0   6   0  Widget    0  r[6]='Widget'
+   7  OpenWrite     0  10   0            0  root=10; iDb=0
+   8  OpenWrite     1   9   0            0  root=9; iDb=0
+   9  Affinity      3   4   0            0  r[3..7] = D, B, B, B
+  10  IsNull        2  13   0            0  if (r[2]==NULL) goto 13
+  11  MustBeInt     2   0   0            0
+  12  Goto          0  14   0            0
+  13  NewRowid      2   2   0            0  r[2]=rowid
+  14  IsNull        4  40   0            0  if (r[4]==NULL) goto 40
+  15  IsNull        5  40   0            0  if (r[5]==NULL) goto 40
+  16  NotExists     2  19   2            0
+  17  Copy          2   1   0            0  r[1]=r[2]
+  18  Halt          0   0   0            0
+  19  Copy          5   8   0            0  r[8]=r[5]
+  20  Copy          2   9   0            0  r[9]=r[2]
+  21  Affinity      8   1   0            0  r[8..9] = B
+  22  NoConflict    0  24   8  1         0  key=r[8..8]
+  23  Halt          0   0   0            0
+  24  Copy          4  10   0            0  r[10]=r[4]
+  25  Copy          2  11   0            0  r[11]=r[2]
+  26  Affinity     10   1   0            0  r[10..11] = B
+  27  NoConflict    1  29  10  1         0  key=r[10..10]
+  28  Halt          0   0   0            0
+  29  MakeRecord    3   4   7            0  r[7]=mkrec(r[3..6])
+  30  Copy          5  12   0            0  r[12]=r[5]
+  31  Copy          2  13   0            0  r[13]=r[2]
+  32  MakeRecord   12   2  14            0  r[14]=mkrec(r[12..13]); for sqlite_autoindex_items_2
+  33  IdxInsert     0  14  12            2  key=r[14]
+  34  Copy          4  15   0            0  r[15]=r[4]
+  35  Copy          2  16   0            0  r[16]=r[2]
+  36  MakeRecord   15   2  17            0  r[17]=mkrec(r[15..16]); for sqlite_autoindex_items_1
+  37  IdxInsert     1  17  15            2  key=r[17]
+  38  Insert        2   7   2  items     0  intkey=r[2] data=r[7]
+  39  Halt          0   0   0            0
+  40  Halt          0   0   0            0
+  41  Transaction   0   2  10            0  iDb=0 tx_mode=Write
+  42  Goto          0   1   0            0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-ignore.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-ignore.snap
@@ -13,41 +13,37 @@ QUERY PLAN
 
 
 BYTECODE
-addr  opcode         p1  p2  p3  p4                p5  comment
-   0  Init            0  35   0                     0  Start at 35
-   1  OpenWrite       1   3   0                     0  root=3; iDb=0
-   2  Integer         1   2   0                     0  r[2]=1
-   3  SoftNull        3   0   0                     0
-   4  String8         0   4   0  jane@example.com   0  r[4]='jane@example.com'
-   5  String8         0   5   0  Jane Doe           0  r[5]='Jane Doe'
-   6  String8         0   6   0  active             0  r[6]='active'
-   7  OpenWrite       0   4   0                     0  root=4; iDb=0
-   8  Affinity        3   4   0                     0  r[3..7] = D, B, B, B
-   9  NotNull         2  11   0                     0  r[2]!=NULL -> goto 11
-  10  Goto            0  13   0                     0
-  11  MustBeInt       2   0   0                     0
-  12  Goto            0  14   0                     0
-  13  NewRowid        1   2   0                     0  r[2]=rowid
-  14  IsNull          4  33   0                     0  if (r[4]==NULL) goto 33
-  15  IsNull          5  33   0                     0  if (r[5]==NULL) goto 33
-  16  NotExists       1  19   2                     0
-  17  Copy            2   1   0                     0  r[1]=r[2]
-  18  Goto            0  32   0                     0
-  19  Copy            4   8   0                     0  r[8]=r[4]
-  20  Copy            2   9   0                     0  r[9]=r[2]
-  21  Affinity        8   1   0                     0  r[8..9] = B
-  22  NoConflict      0  25   8  1                  0  key=r[8..8]
-  23  Goto            0  33   0                     0
-  24  Halt         2067   0   0  users.email        0
-  25  MakeRecord      3   4   7                     0  r[7]=mkrec(r[3..6])
-  26  Copy            4  10   0                     0  r[10]=r[4]
-  27  Copy            2  11   0                     0  r[11]=r[2]
-  28  MakeRecord     10   2  12                     0  r[12]=mkrec(r[10..11]); for sqlite_autoindex_users_1
-  29  IdxInsert       0  12  10                     2  key=r[12]
-  30  Insert          1   7   2  users              0  intkey=r[2] data=r[7]
-  31  Goto            0  33   0                     0
-  32  Goto            0  33   0                     0
-  33  Goto            0  34   0                     0
-  34  Halt            0   0   0                     0
-  35  Transaction     0   2  10                     0  iDb=0 tx_mode=Write
-  36  Goto            0   1   0                     0
+addr  opcode       p1  p2  p3  p4                p5  comment
+   0  Init          0  31   0                     0  Start at 31
+   1  OpenWrite     1   3   0                     0  root=3; iDb=0
+   2  Integer       1   2   0                     0  r[2]=1
+   3  SoftNull      3   0   0                     0
+   4  String8       0   4   0  jane@example.com   0  r[4]='jane@example.com'
+   5  String8       0   5   0  Jane Doe           0  r[5]='Jane Doe'
+   6  String8       0   6   0  active             0  r[6]='active'
+   7  OpenWrite     0   4   0                     0  root=4; iDb=0
+   8  Affinity      3   4   0                     0  r[3..7] = D, B, B, B
+   9  IsNull        2  12   0                     0  if (r[2]==NULL) goto 12
+  10  MustBeInt     2   0   0                     0
+  11  Goto          0  13   0                     0
+  12  NewRowid      1   2   0                     0  r[2]=rowid
+  13  IsNull        4  30   0                     0  if (r[4]==NULL) goto 30
+  14  IsNull        5  30   0                     0  if (r[5]==NULL) goto 30
+  15  NotExists     1  18   2                     0
+  16  Copy          2   1   0                     0  r[1]=r[2]
+  17  Halt          0   0   0                     0
+  18  Copy          4   8   0                     0  r[8]=r[4]
+  19  Copy          2   9   0                     0  r[9]=r[2]
+  20  Affinity      8   1   0                     0  r[8..9] = B
+  21  NoConflict    0  23   8  1                  0  key=r[8..8]
+  22  Halt          0   0   0                     0
+  23  MakeRecord    3   4   7                     0  r[7]=mkrec(r[3..6])
+  24  Copy          4  10   0                     0  r[10]=r[4]
+  25  Copy          2  11   0                     0  r[11]=r[2]
+  26  MakeRecord   10   2  12                     0  r[12]=mkrec(r[10..11]); for sqlite_autoindex_users_1
+  27  IdxInsert     0  12  10                     2  key=r[12]
+  28  Insert        1   7   2  users              0  intkey=r[2] data=r[7]
+  29  Halt          0   0   0                     0
+  30  Halt          0   0   0                     0
+  31  Transaction   0   2  10                     0  iDb=0 tx_mode=Write
+  32  Goto          0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace-multi-notnull-default-partial.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace-multi-notnull-default-partial.snap
@@ -12,35 +12,32 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4               p5  comment
-   0  Init            0  29   0                    0  Start at 29
+   0  Init            0  26   0                    0  Start at 26
    1  OpenWrite       0   2   0                    0  root=2; iDb=0
    2  Integer         1   2   0                    0  r[2]=1
    3  SoftNull        3   0   0                    0
    4  Integer       100   4   0                    0  r[4]=100
    5  Affinity        3   3   0                    0  r[3..6] = D, D, B
-   6  NotNull         2   8   0                    0  r[2]!=NULL -> goto 8
-   7  Goto            0  10   0                    0
-   8  MustBeInt       2   0   0                    0
-   9  Goto            0  11   0                    0
-  10  NewRowid        0   2   0                    0  r[2]=rowid
-  11  NotNull         4  14   0                    0  r[4]!=NULL -> goto 14
-  12  Integer        42   4   0                    0  r[4]=42
-  13  Affinity        4   1   0                    0  r[4..5] = D
-  14  HaltIfNull   1299   0   4  t_defaults.val    0
-  15  NotNull         5  18   0                    0  r[5]!=NULL -> goto 18
-  16  String8         0   5   0  unnamed           0  r[5]='unnamed'
-  17  Affinity        5   1   0                    0  r[5..6] = B
-  18  HaltIfNull   1299   0   5  t_defaults.name   0
-  19  NotExists       0  24   2                    0
-  20  Copy            2   1   0                    0  r[1]=r[2]
-  21  SeekRowid       0   1  28                    0  if (r[1]!=cursor 0 for table t_defaults.rowid) goto 28
-  22  Delete          0   0   0  t_defaults        0
-  23  Goto            0  24   0                    0
-  24  MakeRecord      3   3   6                    0  r[6]=mkrec(r[3..5])
-  25  Insert          0   6   2  t_defaults        2  intkey=r[2] data=r[6]
-  26  Goto            0  27   0                    0
-  27  Goto            0  28   0                    0
-  28  Halt            0   0   0                    0
-  29  Transaction     0   2   1                    0  iDb=0 tx_mode=Write
-  30  String8         0   5   0  unnamed           0  r[5]='unnamed'
-  31  Goto            0   1   0                    0
+   6  IsNull          2   9   0                    0  if (r[2]==NULL) goto 9
+   7  MustBeInt       2   0   0                    0
+   8  Goto            0  10   0                    0
+   9  NewRowid        0   2   0                    0  r[2]=rowid
+  10  NotNull         4  13   0                    0  r[4]!=NULL -> goto 13
+  11  Integer        42   4   0                    0  r[4]=42
+  12  Affinity        4   1   0                    0  r[4..5] = D
+  13  HaltIfNull   1299   0   4  t_defaults.val    0
+  14  NotNull         5  17   0                    0  r[5]!=NULL -> goto 17
+  15  String8         0   5   0  unnamed           0  r[5]='unnamed'
+  16  Affinity        5   1   0                    0  r[5..6] = B
+  17  HaltIfNull   1299   0   5  t_defaults.name   0
+  18  NotExists       0  22   2                    0
+  19  Copy            2   1   0                    0  r[1]=r[2]
+  20  SeekRowid       0   1  25                    0  if (r[1]!=cursor 0 for table t_defaults.rowid) goto 25
+  21  Delete          0   0   0  t_defaults        0
+  22  MakeRecord      3   3   6                    0  r[6]=mkrec(r[3..5])
+  23  Insert          0   6   2  t_defaults        2  intkey=r[2] data=r[6]
+  24  Halt            0   0   0                    0
+  25  Halt            0   0   0                    0
+  26  Transaction     0   2   1                    0  iDb=0 tx_mode=Write
+  27  String8         0   5   0  unnamed           0  r[5]='unnamed'
+  28  Goto            0   1   0                    0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace-multi-notnull-default.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace-multi-notnull-default.snap
@@ -12,35 +12,32 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4               p5  comment
-   0  Init            0  30   0                    0  Start at 30
+   0  Init            0  27   0                    0  Start at 27
    1  OpenWrite       0   2   0                    0  root=2; iDb=0
    2  Integer         1   2   0                    0  r[2]=1
    3  SoftNull        3   0   0                    0
    4  Integer       100   4   0                    0  r[4]=100
    5  String8         0   5   0  hello             0  r[5]='hello'
    6  Affinity        3   3   0                    0  r[3..6] = D, D, B
-   7  NotNull         2   9   0                    0  r[2]!=NULL -> goto 9
-   8  Goto            0  11   0                    0
-   9  MustBeInt       2   0   0                    0
-  10  Goto            0  12   0                    0
-  11  NewRowid        0   2   0                    0  r[2]=rowid
-  12  NotNull         4  15   0                    0  r[4]!=NULL -> goto 15
-  13  Integer        42   4   0                    0  r[4]=42
-  14  Affinity        4   1   0                    0  r[4..5] = D
-  15  HaltIfNull   1299   0   4  t_defaults.val    0
-  16  NotNull         5  19   0                    0  r[5]!=NULL -> goto 19
-  17  String8         0   5   0  unnamed           0  r[5]='unnamed'
-  18  Affinity        5   1   0                    0  r[5..6] = B
-  19  HaltIfNull   1299   0   5  t_defaults.name   0
-  20  NotExists       0  25   2                    0
-  21  Copy            2   1   0                    0  r[1]=r[2]
-  22  SeekRowid       0   1  29                    0  if (r[1]!=cursor 0 for table t_defaults.rowid) goto 29
-  23  Delete          0   0   0  t_defaults        0
-  24  Goto            0  25   0                    0
-  25  MakeRecord      3   3   6                    0  r[6]=mkrec(r[3..5])
-  26  Insert          0   6   2  t_defaults        2  intkey=r[2] data=r[6]
-  27  Goto            0  28   0                    0
-  28  Goto            0  29   0                    0
-  29  Halt            0   0   0                    0
-  30  Transaction     0   2   1                    0  iDb=0 tx_mode=Write
-  31  Goto            0   1   0                    0
+   7  IsNull          2  10   0                    0  if (r[2]==NULL) goto 10
+   8  MustBeInt       2   0   0                    0
+   9  Goto            0  11   0                    0
+  10  NewRowid        0   2   0                    0  r[2]=rowid
+  11  NotNull         4  14   0                    0  r[4]!=NULL -> goto 14
+  12  Integer        42   4   0                    0  r[4]=42
+  13  Affinity        4   1   0                    0  r[4..5] = D
+  14  HaltIfNull   1299   0   4  t_defaults.val    0
+  15  NotNull         5  18   0                    0  r[5]!=NULL -> goto 18
+  16  String8         0   5   0  unnamed           0  r[5]='unnamed'
+  17  Affinity        5   1   0                    0  r[5..6] = B
+  18  HaltIfNull   1299   0   5  t_defaults.name   0
+  19  NotExists       0  23   2                    0
+  20  Copy            2   1   0                    0  r[1]=r[2]
+  21  SeekRowid       0   1  26                    0  if (r[1]!=cursor 0 for table t_defaults.rowid) goto 26
+  22  Delete          0   0   0  t_defaults        0
+  23  MakeRecord      3   3   6                    0  r[6]=mkrec(r[3..5])
+  24  Insert          0   6   2  t_defaults        2  intkey=r[2] data=r[6]
+  25  Halt            0   0   0                    0
+  26  Halt            0   0   0                    0
+  27  Transaction     0   2   1                    0  iDb=0 tx_mode=Write
+  28  Goto            0   1   0                    0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace-multi-unique.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace-multi-unique.snap
@@ -14,7 +14,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4             p5  comment
-   0  Init            0  65   0                  0  Start at 65
+   0  Init            0  60   0                  0  Start at 60
    1  OpenWrite       2   8   0                  0  root=8; iDb=0
    2  Integer         1   2   0                  0  r[2]=1
    3  SoftNull        3   0   0                  0
@@ -24,60 +24,55 @@ addr  opcode         p1  p2  p3  p4             p5  comment
    7  OpenWrite       0  10   0                  0  root=10; iDb=0
    8  OpenWrite       1   9   0                  0  root=9; iDb=0
    9  Affinity        3   4   0                  0  r[3..7] = D, B, B, B
-  10  NotNull         2  12   0                  0  r[2]!=NULL -> goto 12
-  11  Goto            0  14   0                  0
-  12  MustBeInt       2   0   0                  0
-  13  Goto            0  15   0                  0
-  14  NewRowid        2   2   0                  0  r[2]=rowid
-  15  HaltIfNull   1299   0   4  items.sku       0
-  16  HaltIfNull   1299   0   5  items.barcode   0
-  17  NotExists       2  28   2                  0
-  18  Copy            2   1   0                  0  r[1]=r[2]
-  19  SeekRowid       2   1  64                  0  if (r[1]!=cursor 2 for table items.rowid) goto 64
-  20  Column          2   2   8                  0  r[8]=items.barcode
-  21  Copy            1   9   0                  0  r[9]=r[1]
-  22  IdxDelete       0   8   2                  1
-  23  Column          2   1  10                  0  r[10]=items.sku
-  24  Copy            1  11   0                  0  r[11]=r[1]
-  25  IdxDelete       1  10   2                  1
-  26  Delete          2   0   0  items           0
-  27  Goto            0  28   0                  0
-  28  Copy            5  12   0                  0  r[12]=r[5]
-  29  Copy            2  13   0                  0  r[13]=r[2]
-  30  Affinity       12   1   0                  0  r[12..13] = B
-  31  NoConflict      0  42  12  1               0  key=r[12..12]
-  32  IdxRowId        0   1   0                  0  r[1]=cursor 0.rowid
-  33  SeekRowid       2   1  64                  0  if (r[1]!=cursor 2 for table items.rowid) goto 64
-  34  Column          2   2  14                  0  r[14]=items.barcode
-  35  Copy            1  15   0                  0  r[15]=r[1]
-  36  IdxDelete       0  14   2                  1
-  37  Column          2   1  16                  0  r[16]=items.sku
-  38  Copy            1  17   0                  0  r[17]=r[1]
-  39  IdxDelete       1  16   2                  1
-  40  Delete          2   0   0  items           0
-  41  Goto            0  42   0                  0
-  42  MakeRecord     12   2  18                  0  r[18]=mkrec(r[12..13]); for sqlite_autoindex_items_2
-  43  IdxInsert       0  18  12                  2  key=r[18]
-  44  Copy            4  19   0                  0  r[19]=r[4]
-  45  Copy            2  20   0                  0  r[20]=r[2]
-  46  Affinity       19   1   0                  0  r[19..20] = B
-  47  NoConflict      1  58  19  1               0  key=r[19..19]
-  48  IdxRowId        1   1   0                  0  r[1]=cursor 1.rowid
-  49  SeekRowid       2   1  64                  0  if (r[1]!=cursor 2 for table items.rowid) goto 64
-  50  Column          2   2  21                  0  r[21]=items.barcode
-  51  Copy            1  22   0                  0  r[22]=r[1]
-  52  IdxDelete       0  21   2                  1
-  53  Column          2   1  23                  0  r[23]=items.sku
-  54  Copy            1  24   0                  0  r[24]=r[1]
-  55  IdxDelete       1  23   2                  1
-  56  Delete          2   0   0  items           0
-  57  Goto            0  58   0                  0
-  58  MakeRecord     19   2  25                  0  r[25]=mkrec(r[19..20]); for sqlite_autoindex_items_1
-  59  IdxInsert       1  25  19                  2  key=r[25]
-  60  MakeRecord      3   4   7                  0  r[7]=mkrec(r[3..6])
-  61  Insert          2   7   2  items           2  intkey=r[2] data=r[7]
-  62  Goto            0  63   0                  0
-  63  Goto            0  64   0                  0
-  64  Halt            0   0   0                  0
-  65  Transaction     0   2  10                  0  iDb=0 tx_mode=Write
-  66  Goto            0   1   0                  0
+  10  IsNull          2  13   0                  0  if (r[2]==NULL) goto 13
+  11  MustBeInt       2   0   0                  0
+  12  Goto            0  14   0                  0
+  13  NewRowid        2   2   0                  0  r[2]=rowid
+  14  HaltIfNull   1299   0   4  items.sku       0
+  15  HaltIfNull   1299   0   5  items.barcode   0
+  16  NotExists       2  26   2                  0
+  17  Copy            2   1   0                  0  r[1]=r[2]
+  18  SeekRowid       2   1  59                  0  if (r[1]!=cursor 2 for table items.rowid) goto 59
+  19  Column          2   2   8                  0  r[8]=items.barcode
+  20  Copy            1   9   0                  0  r[9]=r[1]
+  21  IdxDelete       0   8   2                  1
+  22  Column          2   1  10                  0  r[10]=items.sku
+  23  Copy            1  11   0                  0  r[11]=r[1]
+  24  IdxDelete       1  10   2                  1
+  25  Delete          2   0   0  items           0
+  26  Copy            5  12   0                  0  r[12]=r[5]
+  27  Copy            2  13   0                  0  r[13]=r[2]
+  28  Affinity       12   1   0                  0  r[12..13] = B
+  29  NoConflict      0  39  12  1               0  key=r[12..12]
+  30  IdxRowId        0   1   0                  0  r[1]=cursor 0.rowid
+  31  SeekRowid       2   1  59                  0  if (r[1]!=cursor 2 for table items.rowid) goto 59
+  32  Column          2   2  14                  0  r[14]=items.barcode
+  33  Copy            1  15   0                  0  r[15]=r[1]
+  34  IdxDelete       0  14   2                  1
+  35  Column          2   1  16                  0  r[16]=items.sku
+  36  Copy            1  17   0                  0  r[17]=r[1]
+  37  IdxDelete       1  16   2                  1
+  38  Delete          2   0   0  items           0
+  39  MakeRecord     12   2  18                  0  r[18]=mkrec(r[12..13]); for sqlite_autoindex_items_2
+  40  IdxInsert       0  18  12                  2  key=r[18]
+  41  Copy            4  19   0                  0  r[19]=r[4]
+  42  Copy            2  20   0                  0  r[20]=r[2]
+  43  Affinity       19   1   0                  0  r[19..20] = B
+  44  NoConflict      1  54  19  1               0  key=r[19..19]
+  45  IdxRowId        1   1   0                  0  r[1]=cursor 1.rowid
+  46  SeekRowid       2   1  59                  0  if (r[1]!=cursor 2 for table items.rowid) goto 59
+  47  Column          2   2  21                  0  r[21]=items.barcode
+  48  Copy            1  22   0                  0  r[22]=r[1]
+  49  IdxDelete       0  21   2                  1
+  50  Column          2   1  23                  0  r[23]=items.sku
+  51  Copy            1  24   0                  0  r[24]=r[1]
+  52  IdxDelete       1  23   2                  1
+  53  Delete          2   0   0  items           0
+  54  MakeRecord     19   2  25                  0  r[25]=mkrec(r[19..20]); for sqlite_autoindex_items_1
+  55  IdxInsert       1  25  19                  2  key=r[25]
+  56  MakeRecord      3   4   7                  0  r[7]=mkrec(r[3..6])
+  57  Insert          2   7   2  items           2  intkey=r[2] data=r[7]
+  58  Halt            0   0   0                  0
+  59  Halt            0   0   0                  0
+  60  Transaction     0   2  10                  0  iDb=0 tx_mode=Write
+  61  Goto            0   1   0                  0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-replace.snap
@@ -14,7 +14,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4                p5  comment
-   0  Init            0  42   0                     0  Start at 42
+   0  Init            0  38   0                     0  Start at 38
    1  OpenWrite       1   3   0                     0  root=3; iDb=0
    2  Integer         1   2   0                     0  r[2]=1
    3  SoftNull        3   0   0                     0
@@ -23,38 +23,34 @@ addr  opcode         p1  p2  p3  p4                p5  comment
    6  String8         0   6   0  active             0  r[6]='active'
    7  OpenWrite       0   4   0                     0  root=4; iDb=0
    8  Affinity        3   4   0                     0  r[3..7] = D, B, B, B
-   9  NotNull         2  11   0                     0  r[2]!=NULL -> goto 11
-  10  Goto            0  13   0                     0
-  11  MustBeInt       2   0   0                     0
-  12  Goto            0  14   0                     0
-  13  NewRowid        1   2   0                     0  r[2]=rowid
-  14  HaltIfNull   1299   0   4  users.email        0
-  15  HaltIfNull   1299   0   5  users.name         0
-  16  NotExists       1  24   2                     0
-  17  Copy            2   1   0                     0  r[1]=r[2]
-  18  SeekRowid       1   1  41                     0  if (r[1]!=cursor 1 for table users.rowid) goto 41
-  19  Column          1   1   8                     0  r[8]=users.email
-  20  Copy            1   9   0                     0  r[9]=r[1]
-  21  IdxDelete       0   8   2                     1
-  22  Delete          1   0   0  users              0
-  23  Goto            0  24   0                     0
-  24  Copy            4  10   0                     0  r[10]=r[4]
-  25  Copy            2  11   0                     0  r[11]=r[2]
-  26  Affinity       10   1   0                     0  r[10..11] = B
-  27  NoConflict      0  35  10  1                  0  key=r[10..10]
-  28  IdxRowId        0   1   0                     0  r[1]=cursor 0.rowid
-  29  SeekRowid       1   1  41                     0  if (r[1]!=cursor 1 for table users.rowid) goto 41
-  30  Column          1   1  12                     0  r[12]=users.email
-  31  Copy            1  13   0                     0  r[13]=r[1]
-  32  IdxDelete       0  12   2                     1
-  33  Delete          1   0   0  users              0
-  34  Goto            0  35   0                     0
-  35  MakeRecord     10   2  14                     0  r[14]=mkrec(r[10..11]); for sqlite_autoindex_users_1
-  36  IdxInsert       0  14  10                     2  key=r[14]
-  37  MakeRecord      3   4   7                     0  r[7]=mkrec(r[3..6])
-  38  Insert          1   7   2  users              2  intkey=r[2] data=r[7]
-  39  Goto            0  40   0                     0
-  40  Goto            0  41   0                     0
-  41  Halt            0   0   0                     0
-  42  Transaction     0   2  10                     0  iDb=0 tx_mode=Write
-  43  Goto            0   1   0                     0
+   9  IsNull          2  12   0                     0  if (r[2]==NULL) goto 12
+  10  MustBeInt       2   0   0                     0
+  11  Goto            0  13   0                     0
+  12  NewRowid        1   2   0                     0  r[2]=rowid
+  13  HaltIfNull   1299   0   4  users.email        0
+  14  HaltIfNull   1299   0   5  users.name         0
+  15  NotExists       1  22   2                     0
+  16  Copy            2   1   0                     0  r[1]=r[2]
+  17  SeekRowid       1   1  37                     0  if (r[1]!=cursor 1 for table users.rowid) goto 37
+  18  Column          1   1   8                     0  r[8]=users.email
+  19  Copy            1   9   0                     0  r[9]=r[1]
+  20  IdxDelete       0   8   2                     1
+  21  Delete          1   0   0  users              0
+  22  Copy            4  10   0                     0  r[10]=r[4]
+  23  Copy            2  11   0                     0  r[11]=r[2]
+  24  Affinity       10   1   0                     0  r[10..11] = B
+  25  NoConflict      0  32  10  1                  0  key=r[10..10]
+  26  IdxRowId        0   1   0                     0  r[1]=cursor 0.rowid
+  27  SeekRowid       1   1  37                     0  if (r[1]!=cursor 1 for table users.rowid) goto 37
+  28  Column          1   1  12                     0  r[12]=users.email
+  29  Copy            1  13   0                     0  r[13]=r[1]
+  30  IdxDelete       0  12   2                     1
+  31  Delete          1   0   0  users              0
+  32  MakeRecord     10   2  14                     0  r[14]=mkrec(r[10..11]); for sqlite_autoindex_users_1
+  33  IdxInsert       0  14  10                     2  key=r[14]
+  34  MakeRecord      3   4   7                     0  r[7]=mkrec(r[3..6])
+  35  Insert          1   7   2  users              2  intkey=r[2] data=r[7]
+  36  Halt            0   0   0                     0
+  37  Halt            0   0   0                     0
+  38  Transaction     0   2  10                     0  iDb=0 tx_mode=Write
+  39  Goto            0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-rollback-multi-unique.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-or-rollback-multi-unique.snap
@@ -14,7 +14,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4             p5  comment
-   0  Init            0  42   0                  0  Start at 42
+   0  Init            0  39   0                  0  Start at 39
    1  OpenWrite       2   8   0                  0  root=8; iDb=0
    2  Integer         1   2   0                  0  r[2]=1
    3  SoftNull        3   0   0                  0
@@ -24,37 +24,34 @@ addr  opcode         p1  p2  p3  p4             p5  comment
    7  OpenWrite       0  10   0                  0  root=10; iDb=0
    8  OpenWrite       1   9   0                  0  root=9; iDb=0
    9  Affinity        3   4   0                  0  r[3..7] = D, B, B, B
-  10  NotNull         2  12   0                  0  r[2]!=NULL -> goto 12
-  11  Goto            0  14   0                  0
-  12  MustBeInt       2   0   0                  0
-  13  Goto            0  15   0                  0
-  14  NewRowid        2   2   0                  0  r[2]=rowid
-  15  HaltIfNull   1299   0   4  items.sku       0
-  16  HaltIfNull   1299   0   5  items.barcode   0
-  17  NotExists       2  19   2                  0
-  18  Halt         1555   0   0  items.id        0
-  19  Copy            5   8   0                  0  r[8]=r[5]
-  20  Copy            2   9   0                  0  r[9]=r[2]
-  21  Affinity        8   1   0                  0  r[8..9] = B
-  22  NoConflict      0  24   8  1               0  key=r[8..8]
-  23  Halt         2067   0   0  items.barcode   0
-  24  Copy            4  10   0                  0  r[10]=r[4]
-  25  Copy            2  11   0                  0  r[11]=r[2]
-  26  Affinity       10   1   0                  0  r[10..11] = B
-  27  NoConflict      1  29  10  1               0  key=r[10..10]
-  28  Halt         2067   0   0  items.sku       0
-  29  MakeRecord      3   4   7                  0  r[7]=mkrec(r[3..6])
-  30  Copy            5  12   0                  0  r[12]=r[5]
-  31  Copy            2  13   0                  0  r[13]=r[2]
-  32  MakeRecord     12   2  14                  0  r[14]=mkrec(r[12..13]); for sqlite_autoindex_items_2
-  33  IdxInsert       0  14  12                  2  key=r[14]
-  34  Copy            4  15   0                  0  r[15]=r[4]
-  35  Copy            2  16   0                  0  r[16]=r[2]
-  36  MakeRecord     15   2  17                  0  r[17]=mkrec(r[15..16]); for sqlite_autoindex_items_1
-  37  IdxInsert       1  17  15                  2  key=r[17]
-  38  Insert          2   7   2  items           0  intkey=r[2] data=r[7]
-  39  Goto            0  40   0                  0
-  40  Goto            0  41   0                  0
-  41  Halt            0   0   0                  0
-  42  Transaction     0   2  10                  0  iDb=0 tx_mode=Write
-  43  Goto            0   1   0                  0
+  10  IsNull          2  13   0                  0  if (r[2]==NULL) goto 13
+  11  MustBeInt       2   0   0                  0
+  12  Goto            0  14   0                  0
+  13  NewRowid        2   2   0                  0  r[2]=rowid
+  14  HaltIfNull   1299   0   4  items.sku       0
+  15  HaltIfNull   1299   0   5  items.barcode   0
+  16  NotExists       2  18   2                  0
+  17  Halt         1555   0   0  items.id        0
+  18  Copy            5   8   0                  0  r[8]=r[5]
+  19  Copy            2   9   0                  0  r[9]=r[2]
+  20  Affinity        8   1   0                  0  r[8..9] = B
+  21  NoConflict      0  23   8  1               0  key=r[8..8]
+  22  Halt         2067   0   0  items.barcode   0
+  23  Copy            4  10   0                  0  r[10]=r[4]
+  24  Copy            2  11   0                  0  r[11]=r[2]
+  25  Affinity       10   1   0                  0  r[10..11] = B
+  26  NoConflict      1  28  10  1               0  key=r[10..10]
+  27  Halt         2067   0   0  items.sku       0
+  28  MakeRecord      3   4   7                  0  r[7]=mkrec(r[3..6])
+  29  Copy            5  12   0                  0  r[12]=r[5]
+  30  Copy            2  13   0                  0  r[13]=r[2]
+  31  MakeRecord     12   2  14                  0  r[14]=mkrec(r[12..13]); for sqlite_autoindex_items_2
+  32  IdxInsert       0  14  12                  2  key=r[14]
+  33  Copy            4  15   0                  0  r[15]=r[4]
+  34  Copy            2  16   0                  0  r[16]=r[2]
+  35  MakeRecord     15   2  17                  0  r[17]=mkrec(r[15..16]); for sqlite_autoindex_items_1
+  36  IdxInsert       1  17  15                  2  key=r[17]
+  37  Insert          2   7   2  items           0  intkey=r[2] data=r[7]
+  38  Halt            0   0   0                  0
+  39  Transaction     0   2  10                  0  iDb=0 tx_mode=Write
+  40  Goto            0   1   0                  0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-select.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-select.snap
@@ -19,7 +19,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode            p1  p2  p3  p4                         p5  comment
-   0  Init               0  42   0                              0  Start at 42
+   0  Init               0  36   0                              0  Start at 36
    1  InitCoroutine      2  15   2                              0
    2  OpenRead           0   5   0  k(6,B,B,B,B,B,B)            0  table=orders, root=5, iDb=0
    3  Rewind             0  14   0                              0  Rewind table orders
@@ -35,32 +35,26 @@ addr  opcode            p1  p2  p3  p4                         p5  comment
   13  Next               0   4   0                              0
   14  EndCoroutine       2   0   0                              0
   15  OpenWrite          1   7   0                              0  root=7; iDb=0
-  16    Yield            2  40   0                              0
+  16    Yield            2  35   0                              0
   17    Copy             3  11   0                              0  r[11]=r[3]
   18    SoftNull        12   0   0                              0
-  19    Copy             4  13   0                              0  r[13]=r[4]
-  20    Copy             5  14   0                              0  r[14]=r[5]
-  21    Copy             6  15   0                              0  r[15]=r[6]
-  22    Copy             7  16   0                              0  r[16]=r[7]
-  23    Null             0  17   0                              0  r[17]=NULL
-  24    Affinity        12   6   0                              0  r[12..18] = D, D, D, D, E, B
-  25    NotNull         11  27   0                              0  r[11]!=NULL -> goto 27
-  26    Goto             0  29   0                              0
-  27    MustBeInt       11   0   0                              0
-  28    Goto             0  30   0                              0
-  29    NewRowid         1  11   0                              0  r[11]=rowid
-  30    HaltIfNull    1299   0  13  order_archive.user_id       0
-  31    HaltIfNull    1299   0  14  order_archive.product_id    0
-  32    HaltIfNull    1299   0  15  order_archive.quantity      0
-  33    HaltIfNull    1299   0  16  order_archive.total_price   0
-  34    NotExists        1  36  11                              0
-  35    Halt          1555   0   0  order_archive.id            0
-  36    MakeRecord      12   6  18                              0  r[18]=mkrec(r[12..17])
-  37    Insert           1  18  11  order_archive               0  intkey=r[11] data=r[18]
-  38    Goto             0  39   0                              0
-  39  Goto               0  16   0                              0
-  40  Goto               0  41   0                              0
-  41  Halt               0   0   0                              0
-  42  Transaction        0   2  10                              0  iDb=0 tx_mode=Write
-  43  String8            0  10   0  2024-01-01                  0  r[10]='2024-01-01'
-  44  Goto               0   1   0                              0
+  19    Copy             4  13   3                              0  r[13]=r[4]
+  20    Null             0  17   0                              0  r[17]=NULL
+  21    Affinity        12   6   0                              0  r[12..18] = D, D, D, D, E, B
+  22    IsNull          11  25   0                              0  if (r[11]==NULL) goto 25
+  23    MustBeInt       11   0   0                              0
+  24    Goto             0  26   0                              0
+  25    NewRowid         1  11   0                              0  r[11]=rowid
+  26    HaltIfNull    1299   0  13  order_archive.user_id       0
+  27    HaltIfNull    1299   0  14  order_archive.product_id    0
+  28    HaltIfNull    1299   0  15  order_archive.quantity      0
+  29    HaltIfNull    1299   0  16  order_archive.total_price   0
+  30    NotExists        1  32  11                              0
+  31    Halt          1555   0   0  order_archive.id            0
+  32    MakeRecord      12   6  18                              0  r[18]=mkrec(r[12..17])
+  33    Insert           1  18  11  order_archive               0  intkey=r[11] data=r[18]
+  34  Goto               0  16   0                              0
+  35  Halt               0   0   0                              0
+  36  Transaction        0   2  10                              0  iDb=0 tx_mode=Write
+  37  String8            0  10   0  2024-01-01                  0  r[10]='2024-01-01'
+  38  Goto               0   1   0                              0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-single-row.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-single-row.snap
@@ -16,7 +16,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4              p5  comment
-   0  Init            0  30   0                   0  Start at 30
+   0  Init            0  27   0                   0  Start at 27
    1  OpenWrite       1   2   0                   0  root=2; iDb=0
    2  Integer         1   2   0                   0  r[2]=1
    3  SoftNull        3   0   0                   0
@@ -26,25 +26,22 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    7  String8         0   7   0  Electronics      0  r[7]='Electronics'
    8  OpenWrite       0  11   0                   0  root=11; iDb=0
    9  Affinity        3   5   0                   0  r[3..8] = D, B, E, D, B
-  10  NotNull         2  12   0                   0  r[2]!=NULL -> goto 12
-  11  Goto            0  14   0                   0
-  12  MustBeInt       2   0   0                   0
-  13  Goto            0  15   0                   0
-  14  NewRowid        1   2   0                   0  r[2]=rowid
-  15  HaltIfNull   1299   0   4  products.name    0
-  16  HaltIfNull   1299   0   5  products.price   0
-  17  NotExists       1  19   2                   0
-  18  Halt         1555   0   0  products.id      0
-  19  Copy            7   9   0                   0  r[9]=r[7]
-  20  Copy            2  10   0                   0  r[10]=r[2]
-  21  MakeRecord      3   5   8                   0  r[8]=mkrec(r[3..7])
-  22  Copy            7  11   0                   0  r[11]=r[7]
-  23  Copy            2  12   0                   0  r[12]=r[2]
-  24  MakeRecord     11   2  13                   0  r[13]=mkrec(r[11..12]); for idx_products_category
-  25  IdxInsert       0  13  11                   2  key=r[13]
-  26  Insert          1   8   2  products         0  intkey=r[2] data=r[8]
-  27  Goto            0  28   0                   0
-  28  Goto            0  29   0                   0
-  29  Halt            0   0   0                   0
-  30  Transaction     0   2  10                   0  iDb=0 tx_mode=Write
-  31  Goto            0   1   0                   0
+  10  IsNull          2  13   0                   0  if (r[2]==NULL) goto 13
+  11  MustBeInt       2   0   0                   0
+  12  Goto            0  14   0                   0
+  13  NewRowid        1   2   0                   0  r[2]=rowid
+  14  HaltIfNull   1299   0   4  products.name    0
+  15  HaltIfNull   1299   0   5  products.price   0
+  16  NotExists       1  18   2                   0
+  17  Halt         1555   0   0  products.id      0
+  18  Copy            7   9   0                   0  r[9]=r[7]
+  19  Copy            2  10   0                   0  r[10]=r[2]
+  20  MakeRecord      3   5   8                   0  r[8]=mkrec(r[3..7])
+  21  Copy            7  11   0                   0  r[11]=r[7]
+  22  Copy            2  12   0                   0  r[12]=r[2]
+  23  MakeRecord     11   2  13                   0  r[13]=mkrec(r[11..12]); for idx_products_category
+  24  IdxInsert       0  13  11                   2  key=r[13]
+  25  Insert          1   8   2  products         0  intkey=r[2] data=r[8]
+  26  Halt            0   0   0                   0
+  27  Transaction     0   2  10                   0  iDb=0 tx_mode=Write
+  28  Goto            0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__delete-returning-expr.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__delete-returning-expr.snap
@@ -15,14 +15,14 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4      p5  comment
-   0  Init             0  35   0           0  Start at 35
+   0  Init             0  32   0           0  Start at 32
    1  OpenEphemeral    0   1   0           0  cursor=0 is_table=true
    2  OpenWrite        1   2   0           0  root=2; iDb=0
    3  OpenWrite        2   3   0           0  root=3; iDb=0
-   4  Rewind           1  28   0           0  Rewind table t1
+   4  Rewind           1  25   0           0  Rewind table t1
    5    Column         1   2   2           0  r[2]=t1.value
    6    RealAffinity   2   0   0           0
-   7    Le             2   3  27  Binary   0  if r[2]<=r[3] goto 27
+   7    Le             2   3  24  Binary   0  if r[2]<=r[3] goto 24
    8    RowId          1   4   0           0  r[4]=t1.rowid
    9    RowId          1   5   0           0  r[5]=t1.rowid
   10    Column         1   1   6           0  r[6]=t1.name
@@ -32,24 +32,21 @@ addr  opcode          p1  p2  p3  p4      p5  comment
   14    IdxDelete      2   8   2           1
   15    Delete         1   0   0  t1       0
   16    Copy           4  10   0           0  r[10]=r[4]
-  17    Copy           6  11   0           0  r[11]=r[6]
-  18    Copy           7  12   0           0  r[12]=r[7]
-  19    Copy           4  13   0           0  r[13]=r[4]
-  20    Copy           6  14   0           0  r[14]=r[6]
-  21    Copy           7  15   0           0  r[15]=r[7]
-  22    Copy          13  16   0           0  r[16]=r[13]
-  23    Copy          14  17   0           0  r[17]=r[14]
-  24    MakeRecord    16   2  18           0  r[18]=mkrec(r[16..17])
-  25    NewRowid       0  19   0           0  r[19]=rowid
-  26    Insert         0  18  19           4  intkey=r[19] data=r[18]
-  27  Next             1   5   0           0
-  28  FkCheck          0   0   0           0
-  29  Rewind           0  34   0           0  Rewind  ephemeral(t1)
-  30    Column         0   0  20           0  r[20]=ephemeral(t1).id
-  31    Column         0   1  21           0  r[21]=ephemeral(t1).name
-  32    ResultRow     20   2   0           0  output=r[20..21]
-  33  Next             0  30   0           0
-  34  Halt             0   0   0           0
-  35  Transaction      0   2   2           0  iDb=0 tx_mode=Write
-  36  Real             0   3   0  15.0     0  r[3]=15
-  37  Goto             0   1   0           0
+  17    Copy           6  11   1           0  r[11]=r[6]
+  18    Copy           4  13   0           0  r[13]=r[4]
+  19    Copy           6  14   1           0  r[14]=r[6]
+  20    Copy          13  16   1           0  r[16]=r[13]
+  21    MakeRecord    16   2  18           0  r[18]=mkrec(r[16..17])
+  22    NewRowid       0  19   0           0  r[19]=rowid
+  23    Insert         0  18  19           4  intkey=r[19] data=r[18]
+  24  Next             1   5   0           0
+  25  FkCheck          0   0   0           0
+  26  Rewind           0  31   0           0  Rewind  ephemeral(t1)
+  27    Column         0   0  20           0  r[20]=ephemeral(t1).id
+  28    Column         0   1  21           0  r[21]=ephemeral(t1).name
+  29    ResultRow     20   2   0           0  output=r[20..21]
+  30  Next             0  27   0           0
+  31  Halt             0   0   0           0
+  32  Transaction      0   2   2           0  iDb=0 tx_mode=Write
+  33  Real             0   3   0  15.0     0  r[3]=15
+  34  Goto             0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__delete-returning-star.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__delete-returning-star.snap
@@ -15,11 +15,11 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4  p5  comment
-   0  Init            0  33   0       0  Start at 33
+   0  Init            0  29   0       0  Start at 29
    1  OpenEphemeral   0   1   0       0  cursor=0 is_table=true
    2  OpenWrite       1   2   0       0  root=2; iDb=0
    3  OpenWrite       2   3   0       0  root=3; iDb=0
-   4  SeekRowid       1   1  25       0  if (r[1]!=cursor 1 for table t1.rowid) goto 25
+   4  SeekRowid       1   1  21       0  if (r[1]!=cursor 1 for table t1.rowid) goto 21
    5  RowId           1   2   0       0  r[2]=t1.rowid
    6  RowId           1   3   0       0  r[3]=t1.rowid
    7  Column          1   1   4       0  r[4]=t1.name
@@ -29,25 +29,21 @@ addr  opcode         p1  p2  p3  p4  p5  comment
   11  IdxDelete       2   6   2       1
   12  Delete          1   0   0  t1   0
   13  Copy            2   8   0       0  r[8]=r[2]
-  14  Copy            4   9   0       0  r[9]=r[4]
-  15  Copy            5  10   0       0  r[10]=r[5]
-  16  Copy            2  11   0       0  r[11]=r[2]
-  17  Copy            4  12   0       0  r[12]=r[4]
-  18  Copy            5  13   0       0  r[13]=r[5]
-  19  Copy           11  14   0       0  r[14]=r[11]
-  20  Copy           12  15   0       0  r[15]=r[12]
-  21  Copy           13  16   0       0  r[16]=r[13]
-  22  MakeRecord     14   3  17       0  r[17]=mkrec(r[14..16])
-  23  NewRowid        0  18   0       0  r[18]=rowid
-  24  Insert          0  17  18       4  intkey=r[18] data=r[17]
-  25  FkCheck         0   0   0       0
-  26  Rewind          0  32   0       0  Rewind  ephemeral(t1)
-  27    Column        0   0  19       0  r[19]=ephemeral(t1).id
-  28    Column        0   1  20       0  r[20]=ephemeral(t1).name
-  29    Column        0   2  21       0  r[21]=ephemeral(t1).value
-  30    ResultRow    19   3   0       0  output=r[19..21]
-  31  Next            0  27   0       0
-  32  Halt            0   0   0       0
-  33  Transaction     0   2   2       0  iDb=0 tx_mode=Write
-  34  Integer         2   1   0       0  r[1]=2
-  35  Goto            0   1   0       0
+  14  Copy            4   9   1       0  r[9]=r[4]
+  15  Copy            2  11   0       0  r[11]=r[2]
+  16  Copy            4  12   1       0  r[12]=r[4]
+  17  Copy           11  14   2       0  r[14]=r[11]
+  18  MakeRecord     14   3  17       0  r[17]=mkrec(r[14..16])
+  19  NewRowid        0  18   0       0  r[18]=rowid
+  20  Insert          0  17  18       4  intkey=r[18] data=r[17]
+  21  FkCheck         0   0   0       0
+  22  Rewind          0  28   0       0  Rewind  ephemeral(t1)
+  23    Column        0   0  19       0  r[19]=ephemeral(t1).id
+  24    Column        0   1  20       0  r[20]=ephemeral(t1).name
+  25    Column        0   2  21       0  r[21]=ephemeral(t1).value
+  26    ResultRow    19   3   0       0  output=r[19..21]
+  27  Next            0  23   0       0
+  28  Halt            0   0   0       0
+  29  Transaction     0   2   2       0  iDb=0 tx_mode=Write
+  30  Integer         2   1   0       0  r[1]=2
+  31  Goto            0   1   0       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__insert-returning-expr.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__insert-returning-expr.snap
@@ -14,7 +14,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4     p5  comment
-   0  Init              0  46   0          0  Start at 46
+   0  Init              0  43   0          0  Start at 43
    1  OpenEphemeral     1   1   0          0  cursor=1 is_table=true
    2  OpenWrite         2   2   0          0  root=2; iDb=0
    3  Integer           1   2   0          0  r[2]=1
@@ -23,42 +23,39 @@ addr  opcode           p1  p2  p3  p4     p5  comment
    6  Real              0   5   0  10.0    0  r[5]=10
    7  OpenWrite         0   3   0          0  root=3; iDb=0
    8  Affinity          3   3   0          0  r[3..6] = D, B, E
-   9  NotNull           2  11   0          0  r[2]!=NULL -> goto 11
-  10  Goto              0  13   0          0
-  11  MustBeInt         2   0   0          0
-  12  Goto              0  14   0          0
-  13  NewRowid          2   2   0          0  r[2]=rowid
-  14  NotExists         2  16   2          0
-  15  Halt           1555   0   0  t1.id   0
-  16  Copy              4   7   0          0  r[7]=r[4]
-  17  Copy              2   8   0          0  r[8]=r[2]
-  18  MakeRecord        3   3   6          0  r[6]=mkrec(r[3..5])
-  19  Copy              4   9   0          0  r[9]=r[4]
-  20  Copy              2  10   0          0  r[10]=r[2]
-  21  MakeRecord        9   2  11          0  r[11]=mkrec(r[9..10]); for idx_t1_name
-  22  IdxInsert         0  11   9          2  key=r[11]
-  23  Insert            2   6   2  t1      0  intkey=r[2] data=r[6]
-  24  Copy              2  12   0          0  r[12]=r[2]
-  25  Copy              4  13   0          0  r[13]=r[4]
-  26  Copy              5  14   0          0  r[14]=r[5]
-  27  Copy             12  15   0          0  r[15]=r[12]
-  28  Copy             13  18   0          0  r[18]=r[13]
-  29  Function          0  18  16  upper   0  r[16]=func(r[18])
-  30  Copy             14  19   0          0  r[19]=r[14]
-  31  Integer           2  20   0          0  r[20]=2
-  32  Multiply         19  20  17          0  r[17]=r[19]*r[20]
-  33  MakeRecord       15   3  21          0  r[21]=mkrec(r[15..17])
-  34  NewRowid          1  22   0          0  r[22]=rowid
-  35  Insert            1  21  22          4  intkey=r[22] data=r[21]
-  36  Goto              0  37   0          0
-  37  Goto              0  38   0          0
-  38  FkCheck           0   0   0          0
-  39  Rewind            1  45   0          0  Rewind  ephemeral(t1)
-  40    Column          1   0  23          0  r[23]=ephemeral(t1).id
-  41    Column          1   1  24          0  r[24]=ephemeral(t1).name
-  42    Column          1   2  25          0  r[25]=ephemeral(t1).value
-  43    ResultRow      23   3   0          0  output=r[23..25]
-  44  Next              1  40   0          0
-  45  Halt              0   0   0          0
-  46  Transaction       0   2   2          0  iDb=0 tx_mode=Write
-  47  Goto              0   1   0          0
+   9  IsNull            2  12   0          0  if (r[2]==NULL) goto 12
+  10  MustBeInt         2   0   0          0
+  11  Goto              0  13   0          0
+  12  NewRowid          2   2   0          0  r[2]=rowid
+  13  NotExists         2  15   2          0
+  14  Halt           1555   0   0  t1.id   0
+  15  Copy              4   7   0          0  r[7]=r[4]
+  16  Copy              2   8   0          0  r[8]=r[2]
+  17  MakeRecord        3   3   6          0  r[6]=mkrec(r[3..5])
+  18  Copy              4   9   0          0  r[9]=r[4]
+  19  Copy              2  10   0          0  r[10]=r[2]
+  20  MakeRecord        9   2  11          0  r[11]=mkrec(r[9..10]); for idx_t1_name
+  21  IdxInsert         0  11   9          2  key=r[11]
+  22  Insert            2   6   2  t1      0  intkey=r[2] data=r[6]
+  23  Copy              2  12   0          0  r[12]=r[2]
+  24  Copy              4  13   1          0  r[13]=r[4]
+  25  Copy             12  15   0          0  r[15]=r[12]
+  26  Copy             13  18   0          0  r[18]=r[13]
+  27  Function          0  18  16  upper   0  r[16]=func(r[18])
+  28  Copy             14  19   0          0  r[19]=r[14]
+  29  Integer           2  20   0          0  r[20]=2
+  30  Multiply         19  20  17          0  r[17]=r[19]*r[20]
+  31  MakeRecord       15   3  21          0  r[21]=mkrec(r[15..17])
+  32  NewRowid          1  22   0          0  r[22]=rowid
+  33  Insert            1  21  22          4  intkey=r[22] data=r[21]
+  34  Goto              0  35   0          0
+  35  FkCheck           0   0   0          0
+  36  Rewind            1  42   0          0  Rewind  ephemeral(t1)
+  37    Column          1   0  23          0  r[23]=ephemeral(t1).id
+  38    Column          1   1  24          0  r[24]=ephemeral(t1).name
+  39    Column          1   2  25          0  r[25]=ephemeral(t1).value
+  40    ResultRow      23   3   0          0  output=r[23..25]
+  41  Next              1  37   0          0
+  42  Halt              0   0   0          0
+  43  Transaction       0   2   2          0  iDb=0 tx_mode=Write
+  44  Goto              0   1   0          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__insert-returning-star.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__insert-returning-star.snap
@@ -14,7 +14,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4     p5  comment
-   0  Init              0  55   0          0  Start at 55
+   0  Init              0  48   0          0  Start at 48
    1  OpenEphemeral     1   1   0          0  cursor=1 is_table=true
    2  InitCoroutine     2  12   3          0
    3  Integer           1   3   0          0  r[3]=1
@@ -27,47 +27,40 @@ addr  opcode           p1  p2  p3  p4     p5  comment
   10  Yield             2   0   0          0
   11  EndCoroutine      2   0   0          0
   12  OpenWrite         2   2   0          0  root=2; iDb=0
-  13    Yield           2  46   0          0
+  13    Yield           2  40   0          0
   14    Copy            3   6   0          0  r[6]=r[3]
   15    SoftNull        7   0   0          0
-  16    Copy            4   8   0          0  r[8]=r[4]
-  17    Copy            5   9   0          0  r[9]=r[5]
-  18    OpenWrite       0   3   0          0  root=3; iDb=0
-  19    Affinity        7   3   0          0  r[7..10] = D, B, E
-  20    NotNull         6  22   0          0  r[6]!=NULL -> goto 22
-  21    Goto            0  24   0          0
-  22    MustBeInt       6   0   0          0
-  23    Goto            0  25   0          0
-  24    NewRowid        2   6   0          0  r[6]=rowid
-  25    NotExists       2  27   6          0
-  26    Halt         1555   0   0  t1.id   0
-  27    Copy            8  11   0          0  r[11]=r[8]
-  28    Copy            6  12   0          0  r[12]=r[6]
-  29    MakeRecord      7   3  10          0  r[10]=mkrec(r[7..9])
-  30    Copy            8  13   0          0  r[13]=r[8]
-  31    Copy            6  14   0          0  r[14]=r[6]
-  32    MakeRecord     13   2  15          0  r[15]=mkrec(r[13..14]); for idx_t1_name
-  33    IdxInsert       0  15  13          2  key=r[15]
-  34    Insert          2  10   6  t1      0  intkey=r[6] data=r[10]
-  35    Copy            6  16   0          0  r[16]=r[6]
-  36    Copy            8  17   0          0  r[17]=r[8]
-  37    Copy            9  18   0          0  r[18]=r[9]
-  38    Copy           16  19   0          0  r[19]=r[16]
-  39    Copy           17  20   0          0  r[20]=r[17]
-  40    Copy           18  21   0          0  r[21]=r[18]
-  41    MakeRecord     19   3  22          0  r[22]=mkrec(r[19..21])
-  42    NewRowid        1  23   0          0  r[23]=rowid
-  43    Insert          1  22  23          4  intkey=r[23] data=r[22]
-  44    Goto            0  45   0          0
-  45  Goto              0  13   0          0
-  46  Goto              0  47   0          0
-  47  FkCheck           0   0   0          0
-  48  Rewind            1  54   0          0  Rewind  ephemeral(t1)
-  49    Column          1   0  24          0  r[24]=ephemeral(t1).id
-  50    Column          1   1  25          0  r[25]=ephemeral(t1).name
-  51    Column          1   2  26          0  r[26]=ephemeral(t1).value
-  52    ResultRow      24   3   0          0  output=r[24..26]
-  53  Next              1  49   0          0
-  54  Halt              0   0   0          0
-  55  Transaction       0   2   2          0  iDb=0 tx_mode=Write
-  56  Goto              0   1   0          0
+  16    Copy            4   8   1          0  r[8]=r[4]
+  17    OpenWrite       0   3   0          0  root=3; iDb=0
+  18    Affinity        7   3   0          0  r[7..10] = D, B, E
+  19    IsNull          6  22   0          0  if (r[6]==NULL) goto 22
+  20    MustBeInt       6   0   0          0
+  21    Goto            0  23   0          0
+  22    NewRowid        2   6   0          0  r[6]=rowid
+  23    NotExists       2  25   6          0
+  24    Halt         1555   0   0  t1.id   0
+  25    Copy            8  11   0          0  r[11]=r[8]
+  26    Copy            6  12   0          0  r[12]=r[6]
+  27    MakeRecord      7   3  10          0  r[10]=mkrec(r[7..9])
+  28    Copy            8  13   0          0  r[13]=r[8]
+  29    Copy            6  14   0          0  r[14]=r[6]
+  30    MakeRecord     13   2  15          0  r[15]=mkrec(r[13..14]); for idx_t1_name
+  31    IdxInsert       0  15  13          2  key=r[15]
+  32    Insert          2  10   6  t1      0  intkey=r[6] data=r[10]
+  33    Copy            6  16   0          0  r[16]=r[6]
+  34    Copy            8  17   1          0  r[17]=r[8]
+  35    Copy           16  19   2          0  r[19]=r[16]
+  36    MakeRecord     19   3  22          0  r[22]=mkrec(r[19..21])
+  37    NewRowid        1  23   0          0  r[23]=rowid
+  38    Insert          1  22  23          4  intkey=r[23] data=r[22]
+  39  Goto              0  13   0          0
+  40  FkCheck           0   0   0          0
+  41  Rewind            1  47   0          0  Rewind  ephemeral(t1)
+  42    Column          1   0  24          0  r[24]=ephemeral(t1).id
+  43    Column          1   1  25          0  r[25]=ephemeral(t1).name
+  44    Column          1   2  26          0  r[26]=ephemeral(t1).value
+  45    ResultRow      24   3   0          0  output=r[24..26]
+  46  Next              1  42   0          0
+  47  Halt              0   0   0          0
+  48  Transaction       0   2   2          0  iDb=0 tx_mode=Write
+  49  Goto              0   1   0          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__update-returning-expr.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__update-returning-expr.snap
@@ -15,12 +15,12 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4        p5  comment
-   0  Init             0  34   0             0  Start at 34
+   0  Init             0  33   0             0  Start at 33
    1  OpenEphemeral    0   1   0             0  cursor=0 is_table=true
    2  OpenWrite        1   2   0             0  root=2; iDb=0
-   3  Rewind           1  26   0             0  Rewind table t1
+   3  Rewind           1  25   0             0  Rewind table t1
    4    RowId          1   1   0             0  r[1]=t1.rowid
-   5    IsNull         1  26   0             0  if (r[1]==NULL) goto 26
+   5    IsNull         1  25   0             0  if (r[1]==NULL) goto 25
    6    Null           0   2   0             0  r[2]=NULL
    7    Column         1   1   3             0  r[3]=t1.name
    8    Column         1   2   5             0  r[5]=t1.value
@@ -30,25 +30,24 @@ addr  opcode          p1  p2  p3  p4        p5  comment
   12    MakeRecord     2   3   7             0  r[7]=mkrec(r[2..4])
   13    Insert         1   7   1  t1         8  intkey=r[1] data=r[7]
   14    Copy           1   8   0             0  r[8]=r[1]
-  15    Copy           3   9   0             0  r[9]=r[3]
-  16    Copy           4  10   0             0  r[10]=r[4]
-  17    Copy           8  11   0             0  r[11]=r[8]
-  18    Copy           9  14   0             0  r[14]=r[9]
-  19    String8        0  15   0  -updated   0  r[15]='-updated'
-  20    Concat        15  14  12             0  r[12]=r[14] + r[15]
-  21    Copy          10  13   0             0  r[13]=r[10]
-  22    MakeRecord    11   3  16             0  r[16]=mkrec(r[11..13])
-  23    NewRowid       0  17   0             0  r[17]=rowid
-  24    Insert         0  16  17             4  intkey=r[17] data=r[16]
-  25  Next             1   4   0             0
-  26  FkCheck          0   0   0             0
-  27  Rewind           0  33   0             0  Rewind  ephemeral(t1)
-  28    Column         0   0  18             0  r[18]=ephemeral(t1).id
-  29    Column         0   1  19             0  r[19]=ephemeral(t1).name
-  30    Column         0   2  20             0  r[20]=ephemeral(t1).value
-  31    ResultRow     18   3   0             0  output=r[18..20]
-  32  Next             0  28   0             0
-  33  Halt             0   0   0             0
-  34  Transaction      0   2   2             0  iDb=0 tx_mode=Write
-  35  Integer          2   6   0             0  r[6]=2
-  36  Goto             0   1   0             0
+  15    Copy           3   9   1             0  r[9]=r[3]
+  16    Copy           8  11   0             0  r[11]=r[8]
+  17    Copy           9  14   0             0  r[14]=r[9]
+  18    String8        0  15   0  -updated   0  r[15]='-updated'
+  19    Concat        15  14  12             0  r[12]=r[14] + r[15]
+  20    Copy          10  13   0             0  r[13]=r[10]
+  21    MakeRecord    11   3  16             0  r[16]=mkrec(r[11..13])
+  22    NewRowid       0  17   0             0  r[17]=rowid
+  23    Insert         0  16  17             4  intkey=r[17] data=r[16]
+  24  Next             1   4   0             0
+  25  FkCheck          0   0   0             0
+  26  Rewind           0  32   0             0  Rewind  ephemeral(t1)
+  27    Column         0   0  18             0  r[18]=ephemeral(t1).id
+  28    Column         0   1  19             0  r[19]=ephemeral(t1).name
+  29    Column         0   2  20             0  r[20]=ephemeral(t1).value
+  30    ResultRow     18   3   0             0  output=r[18..20]
+  31  Next             0  27   0             0
+  32  Halt             0   0   0             0
+  33  Transaction      0   2   2             0  iDb=0 tx_mode=Write
+  34  Integer          2   6   0             0  r[6]=2
+  35  Goto             0   1   0             0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__update-returning-star.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__update-returning-star.snap
@@ -15,16 +15,16 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4     p5  comment
-   0  Init             0  36   0          0  Start at 36
+   0  Init             0  33   0          0  Start at 33
    1  OpenEphemeral    0   1   0          0  cursor=0 is_table=true
    2  OpenWrite        1   2   0          0  root=2; iDb=0
    3  OpenWrite        2   3   0          0  root=3; iDb=0
    4  String8          0   1   0  alice   0  r[1]='alice'
-   5  SeekGE           2  28   1          0  key=[1..1]
-   6    IdxGT          2  28   1          0  key=[1..1]
+   5  SeekGE           2  25   1          0  key=[1..1]
+   6    IdxGT          2  25   1          0  key=[1..1]
    7    DeferredSeek   2   1   0          0
    8    RowId          1   2   0          0  r[2]=t1.rowid
-   9    IsNull         2  28   0          0  if (r[2]==NULL) goto 28
+   9    IsNull         2  25   0          0  if (r[2]==NULL) goto 25
   10    Null           0   3   0          0  r[3]=NULL
   11    Column         2   0   4          0  r[4]=idx_t1_name.name
   12    Column         1   2   6          0  r[6]=t1.value
@@ -34,23 +34,20 @@ addr  opcode          p1  p2  p3  p4     p5  comment
   16    MakeRecord     3   3   8          0  r[8]=mkrec(r[3..5])
   17    Insert         1   8   2  t1      8  intkey=r[2] data=r[8]
   18    Copy           2   9   0          0  r[9]=r[2]
-  19    Copy           4  10   0          0  r[10]=r[4]
-  20    Copy           5  11   0          0  r[11]=r[5]
-  21    Copy           9  12   0          0  r[12]=r[9]
-  22    Copy          10  13   0          0  r[13]=r[10]
-  23    Copy          11  14   0          0  r[14]=r[11]
-  24    MakeRecord    12   3  15          0  r[15]=mkrec(r[12..14])
-  25    NewRowid       0  16   0          0  r[16]=rowid
-  26    Insert         0  15  16          4  intkey=r[16] data=r[15]
-  27  Next             2   6   0          0
-  28  FkCheck          0   0   0          0
-  29  Rewind           0  35   0          0  Rewind  ephemeral(t1)
-  30    Column         0   0  17          0  r[17]=ephemeral(t1).id
-  31    Column         0   1  18          0  r[18]=ephemeral(t1).name
-  32    Column         0   2  19          0  r[19]=ephemeral(t1).value
-  33    ResultRow     17   3   0          0  output=r[17..19]
-  34  Next             0  30   0          0
-  35  Halt             0   0   0          0
-  36  Transaction      0   2   2          0  iDb=0 tx_mode=Write
-  37  Integer          1   7   0          0  r[7]=1
-  38  Goto             0   1   0          0
+  19    Copy           4  10   1          0  r[10]=r[4]
+  20    Copy           9  12   2          0  r[12]=r[9]
+  21    MakeRecord    12   3  15          0  r[15]=mkrec(r[12..14])
+  22    NewRowid       0  16   0          0  r[16]=rowid
+  23    Insert         0  15  16          4  intkey=r[16] data=r[15]
+  24  Next             2   6   0          0
+  25  FkCheck          0   0   0          0
+  26  Rewind           0  32   0          0  Rewind  ephemeral(t1)
+  27    Column         0   0  17          0  r[17]=ephemeral(t1).id
+  28    Column         0   1  18          0  r[18]=ephemeral(t1).name
+  29    Column         0   2  19          0  r[19]=ephemeral(t1).value
+  30    ResultRow     17   3   0          0  output=r[17..19]
+  31  Next             0  27   0          0
+  32  Halt             0   0   0          0
+  33  Transaction      0   2   2          0  iDb=0 tx_mode=Write
+  34  Integer          1   7   0          0  r[7]=1
+  35  Goto             0   1   0          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__upsert-returning.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__upsert-returning.snap
@@ -16,7 +16,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4   p5  comment
-   0  Init            0  58   0        0  Start at 58
+   0  Init            0  50   0        0  Start at 50
    1  OpenEphemeral   0   1   0        0  cursor=0 is_table=true
    2  OpenWrite       1   2   0        0  root=2; iDb=0
    3  Integer         1   2   0        0  r[2]=1
@@ -24,55 +24,47 @@ addr  opcode         p1  p2  p3  p4   p5  comment
    5  String8         0   4   0  new   0  r[4]='new'
    6  Integer         0   5   0        0  r[5]=0
    7  Affinity        3   3   0        0  r[3..6] = D, B, D
-   8  NotNull         2  10   0        0  r[2]!=NULL -> goto 10
-   9  Goto            0  12   0        0
-  10  MustBeInt       2   0   0        0
-  11  Goto            0  13   0        0
-  12  NewRowid        1   2   0        0  r[2]=rowid
-  13  NotExists       1  16   2        0
-  14  Copy            2   1   0        0  r[1]=r[2]
-  15  Goto            0  28   0        0
-  16  MakeRecord      3   3   6        0  r[6]=mkrec(r[3..5])
-  17  Insert          1   6   2  t2    0  intkey=r[2] data=r[6]
-  18  Copy            2   7   0        0  r[7]=r[2]
-  19  Copy            4   8   0        0  r[8]=r[4]
-  20  Copy            5   9   0        0  r[9]=r[5]
-  21  Copy            7  10   0        0  r[10]=r[7]
-  22  Copy            8  11   0        0  r[11]=r[8]
-  23  Copy            9  12   0        0  r[12]=r[9]
-  24  MakeRecord     10   3  13        0  r[13]=mkrec(r[10..12])
-  25  NewRowid        0  14   0        0  r[14]=rowid
-  26  Insert          0  13  14        4  intkey=r[14] data=r[13]
-  27  Goto            0  49   0        0
-  28  SeekRowid       1   1  49        0  if (r[1]!=cursor 1 for table t2.rowid) goto 49
-  29  RowId           1  15   0        0  r[15]=t2.rowid
-  30  Column          1   1  16        0  r[16]=t2.name
-  31  Column          1   2  17  0     0  r[17]=t2.counter
-  32  Copy           15  18   2        0  r[18]=r[15]
-  33  Copy           17  21   0        0  r[21]=r[17]
-  34  Integer         1  22   0        0  r[22]=1
-  35  Add            21  22  20        0  r[20]=r[21]+r[22]
-  36  Affinity       18   3   0        0  r[18..21] = D, B, D
-  37  MakeRecord     18   3  23        0  r[23]=mkrec(r[18..20])
-  38  Insert          1  23   1  t2    8  intkey=r[1] data=r[23]
-  39  Copy            1  24   0        0  r[24]=r[1]
-  40  Copy           19  25   0        0  r[25]=r[19]
-  41  Copy           20  26   0        0  r[26]=r[20]
-  42  Copy           24  27   0        0  r[27]=r[24]
-  43  Copy           25  28   0        0  r[28]=r[25]
-  44  Copy           26  29   0        0  r[29]=r[26]
-  45  MakeRecord     27   3  30        0  r[30]=mkrec(r[27..29])
-  46  NewRowid        0  31   0        0  r[31]=rowid
-  47  Insert          0  30  31        4  intkey=r[31] data=r[30]
-  48  Goto            0  49   0        0
-  49  Goto            0  50   0        0
-  50  FkCheck         0   0   0        0
-  51  Rewind          0  57   0        0  Rewind  ephemeral(t2)
-  52    Column        0   0  32        0  r[32]=ephemeral(t2).id
-  53    Column        0   1  33        0  r[33]=ephemeral(t2).name
-  54    Column        0   2  34        0  r[34]=ephemeral(t2).counter
-  55    ResultRow    32   3   0        0  output=r[32..34]
-  56  Next            0  52   0        0
-  57  Halt            0   0   0        0
-  58  Transaction     0   2   1        0  iDb=0 tx_mode=Write
-  59  Goto            0   1   0        0
+   8  IsNull          2  11   0        0  if (r[2]==NULL) goto 11
+   9  MustBeInt       2   0   0        0
+  10  Goto            0  12   0        0
+  11  NewRowid        1   2   0        0  r[2]=rowid
+  12  NotExists       1  15   2        0
+  13  Copy            2   1   0        0  r[1]=r[2]
+  14  Goto            0  24   0        0
+  15  MakeRecord      3   3   6        0  r[6]=mkrec(r[3..5])
+  16  Insert          1   6   2  t2    0  intkey=r[2] data=r[6]
+  17  Copy            2   7   0        0  r[7]=r[2]
+  18  Copy            4   8   1        0  r[8]=r[4]
+  19  Copy            7  10   2        0  r[10]=r[7]
+  20  MakeRecord     10   3  13        0  r[13]=mkrec(r[10..12])
+  21  NewRowid        0  14   0        0  r[14]=rowid
+  22  Insert          0  13  14        4  intkey=r[14] data=r[13]
+  23  Goto            0  42   0        0
+  24  SeekRowid       1   1  42        0  if (r[1]!=cursor 1 for table t2.rowid) goto 42
+  25  RowId           1  15   0        0  r[15]=t2.rowid
+  26  Column          1   1  16        0  r[16]=t2.name
+  27  Column          1   2  17  0     0  r[17]=t2.counter
+  28  Copy           15  18   2        0  r[18]=r[15]
+  29  Copy           17  21   0        0  r[21]=r[17]
+  30  Integer         1  22   0        0  r[22]=1
+  31  Add            21  22  20        0  r[20]=r[21]+r[22]
+  32  Affinity       18   3   0        0  r[18..21] = D, B, D
+  33  MakeRecord     18   3  23        0  r[23]=mkrec(r[18..20])
+  34  Insert          1  23   1  t2    8  intkey=r[1] data=r[23]
+  35  Copy            1  24   0        0  r[24]=r[1]
+  36  Copy           19  25   1        0  r[25]=r[19]
+  37  Copy           24  27   2        0  r[27]=r[24]
+  38  MakeRecord     27   3  30        0  r[30]=mkrec(r[27..29])
+  39  NewRowid        0  31   0        0  r[31]=rowid
+  40  Insert          0  30  31        4  intkey=r[31] data=r[30]
+  41  Goto            0  42   0        0
+  42  FkCheck         0   0   0        0
+  43  Rewind          0  49   0        0  Rewind  ephemeral(t2)
+  44    Column        0   0  32        0  r[32]=ephemeral(t2).id
+  45    Column        0   1  33        0  r[33]=ephemeral(t2).name
+  46    Column        0   2  34        0  r[34]=ephemeral(t2).counter
+  47    ResultRow    32   3   0        0  output=r[32..34]
+  48  Next            0  44   0        0
+  49  Halt            0   0   0        0
+  50  Transaction     0   2   1        0  iDb=0 tx_mode=Write
+  51  Goto            0   1   0        0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/schema/snapshots/schema__explain-begin-deferred-no-transaction-opcodes.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/schema/snapshots/schema__explain-begin-deferred-no-transaction-opcodes.snap
@@ -10,7 +10,6 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode      p1  p2  p3  p4  p5  comment
-   0  Init         0   3   0       0  Start at 3
+   0  Init         0   1   0       0  Start at 1
    1  AutoCommit   0   0   0       0  auto_commit=false, rollback=false
    2  Halt         0   0   0       0
-   3  Goto         0   1   0       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__subquery-with-union.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__subquery-with-union.snap
@@ -26,7 +26,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4              p5  comment
-   0  Init            0  33   0                   0  Start at 33
+   0  Init            0  32   0                   0  Start at 32
    1  InitCoroutine   1  24   2                   0
    2  OpenEphemeral   0   0   0                   0  cursor=0 is_table=false
    3  OpenRead        1   2   0  k(4,B,B,B,B)     0  table=current_employees, root=2, iDb=0
@@ -51,14 +51,13 @@ addr  opcode         p1  p2  p3  p4              p5  comment
   22  Close           0   0   0                   0
   23  EndCoroutine    1   0   0                   0
   24  InitCoroutine   1   0   2                   0
-  25    Yield         1  32   0                   0
+  25    Yield         1  31   0                   0
   26    Copy          3   9   0                   0  r[9]=r[3]
-  27    Ne            9  10  31  Binary           0  if r[9]!=r[10] goto 31
-  28    Copy          2   6   0                   0  r[6]=r[2]
-  29    Copy          3   7   0                   0  r[7]=r[3]
-  30    ResultRow     6   2   0                   0  output=r[6..7]
-  31  Goto            0  25   0                   0
-  32  Halt            0   0   0                   0
-  33  Transaction     0   1   6                   0  iDb=0 tx_mode=Read
-  34  String8         0  10   0  Engineering      0  r[10]='Engineering'
-  35  Goto            0   1   0                   0
+  27    Ne            9  10  25  Binary           0  if r[9]!=r[10] goto 25
+  28    Copy          2   6   1                   0  r[6]=r[2]
+  29    ResultRow     6   2   0                   0  output=r[6..7]
+  30  Goto            0  25   0                   0
+  31  Halt            0   0   0                   0
+  32  Transaction     0   1   6                   0  iDb=0 tx_mode=Read
+  33  String8         0  10   0  Engineering      0  r[10]='Engineering'
+  34  Goto            0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-order-by-literals.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-order-by-literals.snap
@@ -15,7 +15,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4        p5  comment
-   0  Init             0  34   0             0  Start at 34
+   0  Init             0   1   0             0  Start at 1
    1  OpenEphemeral    0   0   0             0  cursor=0 is_table=false
    2  OpenEphemeral    1   0   0             0  cursor=1 is_table=false
    3  Integer          1   1   0             0  r[1]=1
@@ -33,20 +33,18 @@ addr  opcode          p1  p2  p3  p4        p5  comment
   15  Next             1  10   0             0
   16  Close            1   0   0             0
   17  SorterOpen       2   2   0  k(2,B,B)   0  cursor=2
-  18  Rewind           0  26   0             0  Rewind  ephemeral(compound_collection)
+  18  Rewind           0  25   0             0  Rewind  ephemeral(compound_collection)
   19    Column         0   0   7             0  r[7]=ephemeral(compound_collection).2
   20    Column         0   1   8             0  r[8]=ephemeral(compound_collection).column 1
-  21    Copy           7   9   0             0  r[9]=r[7]
-  22    Copy           8  10   0             0  r[10]=r[8]
-  23    MakeRecord     9   2  11             0  r[11]=mkrec(r[9..10])
-  24    SorterInsert   2  11   0  0          0  key=r[11]
-  25  Next             0  19   0             0
-  26  Close            0   0   0             0
-  27  OpenPseudo       3  11   2             0  2 columns in r[11]
-  28  SorterSort       2  33   0             0
-  29    SorterData     2  11   3             0  r[11]=data
-  30    Column         3   0  12             0  r[12]=pseudo.column 0
-  31    ResultRow     12   1   0             0  output=r[12]
-  32  SorterNext       2  29   0             0
-  33  Halt             0   0   0             0
-  34  Goto             0   1   0             0
+  21    Copy           7   9   1             0  r[9]=r[7]
+  22    MakeRecord     9   2  11             0  r[11]=mkrec(r[9..10])
+  23    SorterInsert   2  11   0  0          0  key=r[11]
+  24  Next             0  19   0             0
+  25  Close            0   0   0             0
+  26  OpenPseudo       3  11   2             0  2 columns in r[11]
+  27  SorterSort       2  32   0             0
+  28    SorterData     2  11   3             0  r[11]=data
+  29    Column         3   0  12             0  r[12]=pseudo.column 0
+  30    ResultRow     12   1   0             0  output=r[12]
+  31  SorterNext       2  28   0             0
+  32  Halt             0   0   0             0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-subquery-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-subquery-aggregation.snap
@@ -34,78 +34,76 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                  p1  p2  p3  p4              p5  comment
-   0          Init             0  71   0                   0  Start at 71
-   1          InitCoroutine    1  21   2                   0
-   2          OpenRead         0   2   0  k(4,B,B,B,B)     0  table=current_employees, root=2, iDb=0
-   3          Rewind           0   8   0                   0  Rewind table current_employees
-   4            Column         0   1   2                   0  r[2]=current_employees.name
-   5            Column         0   2   3                   0  r[3]=current_employees.department
-   6            Yield          1   0   0                   0
-   7          Next             0   4   0                   0
-   8          OpenRead         1   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
-   9          Rewind           1  14   0                   0  Rewind table former_employees
-  10            Column         1   1   2                   0  r[2]=former_employees.name
-  11            Column         1   2   3                   0  r[3]=former_employees.department
-  12            Yield          1   0   0                   0
-  13          Next             1  10   0                   0
-  14          OpenRead         2   4   0  k(4,B,B,B,B)     0  table=contractors, root=4, iDb=0
-  15          Rewind           2  20   0                   0  Rewind table contractors
-  16            Column         2   1   2                   0  r[2]=contractors.name
-  17            Column         2   2   3                   0  r[3]=contractors.department
-  18            Yield          1   0   0                   0
-  19          Next             2  16   0                   0
-  20          EndCoroutine     1   0   0                   0
-  21          SorterOpen       3   1   0  k(1,-B)          0  cursor=3
-  22          Null             0  12   0                   0  r[12]=NULL
-  23          SorterOpen       4   1   0  k(1,-B)          0  cursor=4
-  24          Integer          0   9   0                   0  r[9]=0; clear group by abort flag
-  25          Null             0  10   0                   0  r[10]=NULL; initialize group by comparison registers to NULL
-  26          Gosub           15  60   0                   0  ; go to clear accumulator subroutine
-  27          InitCoroutine    1   0   2                   0
-  28            Yield          1  33   0                   0
-  29            Copy           3  14   0                   0  r[14]=r[3]
-  30            MakeRecord    14   1  13                   0  r[13]=mkrec(r[14..14])
-  31            SorterInsert   4  13   0  0                0  key=r[13]
-  32          Goto             0  28   0                   0
-  33          OpenPseudo       5  13   1                   0  1 columns in r[13]
-  34          SorterSort       4  48   0                   0
-  35            SorterData     4  13   5                   0  r[13]=data
-  36            Column         5   0  16                   0  r[16]=pseudo.column 0
-  37            Compare       10  16   1  k(1, Binary)     0  r[10..10]==r[16..16]
-  38            Jump          39  43  39                   0  ; start new group if comparison is not equal
-  39            Gosub          7  52   0                   0  ; check if ended group had data, and output if so
-  40            Move          16  10   1                   0  r[10..10]=r[16..16]
-  41            IfPos          9  63   0                   0  r[9]>0 -> r[9]-=0, goto 63; check abort flag
-  42            Gosub         15  60   0                   0  ; goto clear accumulator subroutine
-  43            AggStep        0  17  12  count            0  accum=r[12] step(r[17])
-  44            If             8  46   0                   0  if r[8] goto 46; don't emit group columns if continuing existing group
-  45            Column         5   0  11                   0  r[11]=pseudo.column 0
-  46            Integer        1   8   0                   0  r[8]=1; indicate data in accumulator
-  47          SorterNext       4  35   0                   0
-  48          Gosub            7  52   0                   0  ; emit row for final group
-  49          Goto             0  63   0                   0  ; group by finished
-  50          Integer          1   9   0                   0  r[9]=1
-  51        Return             7   0   0                   0
-  52        IfPos              8  54   0                   0  r[8]>0 -> r[8]-=0, goto 54; output group by row subroutine start
-  53      Return               7   0   0                   0
-  54      AggFinal             0  12   0  count            0  accum=r[12]
-  55      Copy                12  18   0                   0  r[18]=r[12]
-  56      Copy                11  19   0                   0  r[19]=r[11]
-  57      MakeRecord          18   2   6                   0  r[6]=mkrec(r[18..19])
-  58      SorterInsert         3   6   0  0                0  key=r[6]
-  59    Return                 7   0   0                   0
-  60    Null                   0  11  12                   0  r[11..12]=NULL; clear accumulator subroutine start
-  61    Integer                0   8   0                   0  r[8]=0
-  62  Return                  15   0   0                   0
-  63  OpenPseudo               6   6   2                   0  2 columns in r[6]
-  64  SorterSort               3  70   0                   0
-  65    SorterData             3   6   6                   0  r[6]=data
-  66    Column                 6   1   4                   0  r[4]=pseudo.column 1
-  67    Column                 6   0   5                   0  r[5]=pseudo.column 0
-  68    ResultRow              4   2   0                   0  output=r[4..5]
-  69  SorterNext               3  65   0                   0
-  70  Halt                     0   0   0                   0
-  71  Transaction              0   1   6                   0  iDb=0 tx_mode=Read
-  72  Integer                  1  17   0                   0  r[17]=1
-  73  Goto                     0   1   0                   0
+addr  opcode                p1  p2  p3  p4              p5  comment
+   0        Init             0  69   0                   0  Start at 69
+   1        InitCoroutine    1  21   2                   0
+   2        OpenRead         0   2   0  k(4,B,B,B,B)     0  table=current_employees, root=2, iDb=0
+   3        Rewind           0   8   0                   0  Rewind table current_employees
+   4          Column         0   1   2                   0  r[2]=current_employees.name
+   5          Column         0   2   3                   0  r[3]=current_employees.department
+   6          Yield          1   0   0                   0
+   7        Next             0   4   0                   0
+   8        OpenRead         1   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
+   9        Rewind           1  14   0                   0  Rewind table former_employees
+  10          Column         1   1   2                   0  r[2]=former_employees.name
+  11          Column         1   2   3                   0  r[3]=former_employees.department
+  12          Yield          1   0   0                   0
+  13        Next             1  10   0                   0
+  14        OpenRead         2   4   0  k(4,B,B,B,B)     0  table=contractors, root=4, iDb=0
+  15        Rewind           2  20   0                   0  Rewind table contractors
+  16          Column         2   1   2                   0  r[2]=contractors.name
+  17          Column         2   2   3                   0  r[3]=contractors.department
+  18          Yield          1   0   0                   0
+  19        Next             2  16   0                   0
+  20        EndCoroutine     1   0   0                   0
+  21        SorterOpen       3   1   0  k(1,-B)          0  cursor=3
+  22        Null             0  12   0                   0  r[12]=NULL
+  23        SorterOpen       4   1   0  k(1,-B)          0  cursor=4
+  24        Integer          0   9   0                   0  r[9]=0; clear group by abort flag
+  25        Null             0  10   0                   0  r[10]=NULL; initialize group by comparison registers to NULL
+  26        Gosub           15  58   0                   0  ; go to clear accumulator subroutine
+  27        InitCoroutine    1   0   2                   0
+  28          Yield          1  33   0                   0
+  29          Copy           3  14   0                   0  r[14]=r[3]
+  30          MakeRecord    14   1  13                   0  r[13]=mkrec(r[14..14])
+  31          SorterInsert   4  13   0  0                0  key=r[13]
+  32        Goto             0  28   0                   0
+  33        OpenPseudo       5  13   1                   0  1 columns in r[13]
+  34        SorterSort       4  48   0                   0
+  35          SorterData     4  13   5                   0  r[13]=data
+  36          Column         5   0  16                   0  r[16]=pseudo.column 0
+  37          Compare       10  16   1  k(1, Binary)     0  r[10..10]==r[16..16]
+  38          Jump          39  43  39                   0  ; start new group if comparison is not equal
+  39          Gosub          7  50   0                   0  ; check if ended group had data, and output if so
+  40          Move          16  10   1                   0  r[10..10]=r[16..16]
+  41          IfPos          9  61   0                   0  r[9]>0 -> r[9]-=0, goto 61; check abort flag
+  42          Gosub         15  58   0                   0  ; goto clear accumulator subroutine
+  43          AggStep        0  17  12  count            0  accum=r[12] step(r[17])
+  44          If             8  46   0                   0  if r[8] goto 46; don't emit group columns if continuing existing group
+  45          Column         5   0  11                   0  r[11]=pseudo.column 0
+  46          Integer        1   8   0                   0  r[8]=1; indicate data in accumulator
+  47        SorterNext       4  35   0                   0
+  48        Gosub            7  50   0                   0  ; emit row for final group
+  49        Goto             0  61   0                   0  ; group by finished
+  50        IfPos            8  52   0                   0  r[8]>0 -> r[8]-=0, goto 52; output group by row subroutine start
+  51      Return             7   0   0                   0
+  52      AggFinal           0  12   0  count            0  accum=r[12]
+  53      Copy              12  18   0                   0  r[18]=r[12]
+  54      Copy              11  19   0                   0  r[19]=r[11]
+  55      MakeRecord        18   2   6                   0  r[6]=mkrec(r[18..19])
+  56      SorterInsert       3   6   0  0                0  key=r[6]
+  57    Return               7   0   0                   0
+  58    Null                 0  11  12                   0  r[11..12]=NULL; clear accumulator subroutine start
+  59    Integer              0   8   0                   0  r[8]=0
+  60  Return                15   0   0                   0
+  61  OpenPseudo             6   6   2                   0  2 columns in r[6]
+  62  SorterSort             3  68   0                   0
+  63    SorterData           3   6   6                   0  r[6]=data
+  64    Column               6   1   4                   0  r[4]=pseudo.column 1
+  65    Column               6   0   5                   0  r[5]=pseudo.column 0
+  66    ResultRow            4   2   0                   0  output=r[4..5]
+  67  SorterNext             3  63   0                   0
+  68  Halt                   0   0   0                   0
+  69  Transaction            0   1   6                   0  iDb=0 tx_mode=Read
+  70  Integer                1  17   0                   0  r[17]=1
+  71  Goto                   0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -31,124 +31,118 @@ QUERY PLAN
 `--SEARCH p USING INDEX idx_products_category (category_id=?)
 
 BYTECODE
-addr  opcode                            p1   p2   p3  p4              p5  comment
-   0                    Init             0  117    0                   0  Start at 117
-   1                    Once            54    0    0                   0  goto 54
-   2                    BeginSubrtn      2    0    0                   0  r[2]=NULL
-   3                    Null             0    1    0                   0  r[1]=NULL
-   4                    InitCoroutine    3   42    5                   0
-   5                    Null             0   11    0                   0  r[11]=NULL
-   6                    Integer          0    8    0                   0  r[8]=0; clear group by abort flag
-   7                    Null             0    9    0                   0  r[9]=NULL; initialize group by comparison registers to NULL
-   8                    Gosub           15   38    0                   0  ; go to clear accumulator subroutine
-   9                    OpenRead         0    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  10                    OpenRead         1    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  11                    Rewind           1   27    0                   0  Rewind index idx_products_category
-  12                      DeferredSeek   1    0    0                   0
-  13                      Column         1    0   13                   0  r[13]=idx_products_category.category_id
-  14                      Column         0    3   14                   0  r[14]=products.price
-  15                      RealAffinity  14    0    0                   0
-  16                      Compare        9   13    1  k(1, Binary)     0  r[9..9]==r[13..13]
-  17                      Jump          18   22   18                   0  ; start new group if comparison is not equal
-  18                      Gosub          6   31    0                   0  ; check if ended group had data, and output if so
-  19                      Move          13    9    1                   0  r[9..9]=r[13..13]
-  20                      IfPos          8   41    0                   0  r[8]>0 -> r[8]-=0, goto 41; check abort flag
-  21                      Gosub         15   38    0                   0  ; goto clear accumulator subroutine
-  22                      AggStep        0   14   11  avg              0  accum=r[11] step(r[14])
-  23                      If             7   25    0                   0  if r[7] goto 25; don't emit group columns if continuing existing group
-  24                      Column         1    0   10                   0  r[10]=idx_products_category.category_id
-  25                      Integer        1    7    0                   0  r[7]=1; indicate data in accumulator
-  26                    Next             1   12    0                   0
-  27                    Gosub            6   31    0                   0  ; emit row for final group
-  28                    Goto             0   41    0                   0  ; group by finished
-  29                    Integer          1    8    0                   0  r[8]=1
-  30                  Return             6    0    0                   0
-  31                  IfPos              7   33    0                   0  r[7]>0 -> r[7]-=0, goto 33; output group by row subroutine start
-  32                Return               6    0    0                   0
-  33                AggFinal             0   11    0  avg              0  accum=r[11]
-  34                Copy                10    4    0                   0  r[4]=r[10]
-  35                Copy                11    5    0                   0  r[5]=r[11]
-  36                Yield                3    0    0                   0
-  37              Return                 6    0    0                   0
-  38              Null                   0   10   11                   0  r[10..11]=NULL; clear accumulator subroutine start
-  39              Integer                0    7    0                   0  r[7]=0
-  40            Return                  15    0    0                   0
-  41            EndCoroutine             3    0    0                   0
-  42            Null                     0   17    0                   0  r[17]=NULL
-  43            Integer                  1   18    0                   0  r[18]=1; LIMIT counter
-  44            IfNot                   18   50    0                   0  if !r[18] goto 50
-  45            InitCoroutine            3    0    5                   0
-  46              Yield                  3   50    0                   0
-  47              Copy                   5   19    0                   0  r[19]=r[5]
-  48              AggStep                0   19   17  max(Binary)      0  accum=r[17] step(r[19])
-  49            Goto                     0   46    0                   0
-  50            AggFinal                 0   17    0  max              0  accum=r[17]
-  51            Copy                    17   16    0                   0  r[16]=r[17]
-  52            Copy                    16    1    0                   0  r[1]=r[16]
-  53          Return                     2    0    1                   0
-  54          OpenEphemeral              2    1    0                   0  cursor=2 is_table=true
-  55          Null                       0   29    0                   0  r[29]=NULL
-  56          Integer                    0   26    0                   0  r[26]=0; clear group by abort flag
-  57          Null                       0   27    0                   0  r[27]=NULL; initialize group by comparison registers to NULL
-  58          Gosub                     33   90    0                   0  ; go to clear accumulator subroutine
-  59          OpenRead                   3    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  60          OpenRead                   4    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  61          Rewind                     4   77    0                   0  Rewind index idx_products_category
-  62            DeferredSeek             4    3    0                   0
-  63            Column                   4    0   31                   0  r[31]=idx_products_category.category_id
-  64            Column                   3    3   32                   0  r[32]=products.price
-  65            RealAffinity            32    0    0                   0
-  66            Compare                 27   31    1  k(1, Binary)     0  r[27..27]==r[31..31]
-  67            Jump                    68   72   68                   0  ; start new group if comparison is not equal
-  68            Gosub                   24   81    0                   0  ; check if ended group had data, and output if so
-  69            Move                    31   27    1                   0  r[27..27]=r[31..31]
-  70            IfPos                   26   93    0                   0  r[26]>0 -> r[26]-=0, goto 93; check abort flag
-  71            Gosub                   33   90    0                   0  ; goto clear accumulator subroutine
-  72            AggStep                  0   32   29  avg              0  accum=r[29] step(r[32])
-  73            If                      25   75    0                   0  if r[25] goto 75; don't emit group columns if continuing existing group
-  74            Column                   4    0   28                   0  r[28]=idx_products_category.category_id
-  75            Integer                  1   25    0                   0  r[25]=1; indicate data in accumulator
-  76          Next                       4   62    0                   0
-  77          Gosub                     24   81    0                   0  ; emit row for final group
-  78          Goto                       0   93    0                   0  ; group by finished
-  79          Integer                    1   26    0                   0  r[26]=1
-  80        Return                      24    0    0                   0
-  81        IfPos                       25   83    0                   0  r[25]>0 -> r[25]-=0, goto 83; output group by row subroutine start
-  82      Return                        24    0    0                   0
-  83      AggFinal                       0   29    0  avg              0  accum=r[29]
-  84      Copy                          28   22    0                   0  r[22]=r[28]
-  85      Copy                          29   23    0                   0  r[23]=r[29]
-  86      MakeRecord                    22    2   34                   0  r[34]=mkrec(r[22..23]); for
-  87      NewRowid                       2   35    0                   0  r[35]=rowid
-  88      Insert                         2   34   35                   4  intkey=r[35] data=r[34]
-  89    Return                          24    0    0                   0
-  90    Null                             0   28   29                   0  r[28..29]=NULL; clear accumulator subroutine start
-  91    Integer                          0   25    0                   0  r[25]=0
-  92  Return                            33    0    0                   0
-  93  OpenRead                           5    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  94  OpenRead                           6    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  95  Rewind                             2  116    0                   0  Rewind  ephemeral()
-  96    Column                           2    0   20                   0  r[20]=ephemeral().category_id
-  97    Column                           2    1   21                   0  r[21]=ephemeral().avg_price
-  98    Copy                            20   39    0                   0  r[39]=r[20]
-  99    IsNull                          39  115    0                   0  if (r[39]==NULL) goto 115
- 100    Affinity                        39    1    0                   0  r[39..40] = C
- 101    SeekGE                           6  115   39                   0  key=[39..39]
- 102      IdxGT                          6  115   39                   0  key=[39..39]
- 103      DeferredSeek                   6    5    0                   0
- 104      Column                         5    3   41                   0  r[41]=products.price
- 105      RealAffinity                  41    0    0                   0
- 106      Copy                           1   43    0                   0  r[43]=r[1]
- 107      Multiply                      43   44   42                   0  r[42]=r[43]*r[44]
- 108      Le                            41   42  114  Binary           0  if r[41]<=r[42] goto 114
- 109      Column                         5    1   36                   0  r[36]=products.name
- 110      Column                         5    3   37                   0  r[37]=products.price
- 111      RealAffinity                  37    0    0                   0
- 112      Copy                          21   38    0                   0  r[38]=r[21]
- 113      ResultRow                     36    3    0                   0  output=r[36..38]
- 114    Next                             6  102    0                   0
- 115  Next                               2   96    0                   0
- 116  Halt                               0    0    0                   0
- 117  Transaction                        0    1   11                   0  iDb=0 tx_mode=Read
- 118  Real                               0   44    0  0.8              0  r[44]=0.8
- 119  Goto                               0    1    0                   0
+addr  opcode                        p1   p2   p3  p4              p5  comment
+   0                Init             0  111    0                   0  Start at 111
+   1                Once            51    0    0                   0  goto 51
+   2                BeginSubrtn      2    0    0                   0  r[2]=NULL
+   3                Null             0    1    0                   0  r[1]=NULL
+   4                InitCoroutine    3   39    5                   0
+   5                Null             0   11    0                   0  r[11]=NULL
+   6                Integer          0    8    0                   0  r[8]=0; clear group by abort flag
+   7                Null             0    9    0                   0  r[9]=NULL; initialize group by comparison registers to NULL
+   8                Gosub           15   35    0                   0  ; go to clear accumulator subroutine
+   9                OpenRead         0    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  10                OpenRead         1    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  11                Rewind           1   27    0                   0  Rewind index idx_products_category
+  12                  DeferredSeek   1    0    0                   0
+  13                  Column         1    0   13                   0  r[13]=idx_products_category.category_id
+  14                  Column         0    3   14                   0  r[14]=products.price
+  15                  RealAffinity  14    0    0                   0
+  16                  Compare        9   13    1  k(1, Binary)     0  r[9..9]==r[13..13]
+  17                  Jump          18   22   18                   0  ; start new group if comparison is not equal
+  18                  Gosub          6   29    0                   0  ; check if ended group had data, and output if so
+  19                  Move          13    9    1                   0  r[9..9]=r[13..13]
+  20                  IfPos          8   38    0                   0  r[8]>0 -> r[8]-=0, goto 38; check abort flag
+  21                  Gosub         15   35    0                   0  ; goto clear accumulator subroutine
+  22                  AggStep        0   14   11  avg              0  accum=r[11] step(r[14])
+  23                  If             7   25    0                   0  if r[7] goto 25; don't emit group columns if continuing existing group
+  24                  Column         1    0   10                   0  r[10]=idx_products_category.category_id
+  25                  Integer        1    7    0                   0  r[7]=1; indicate data in accumulator
+  26                Next             1   12    0                   0
+  27                Gosub            6   29    0                   0  ; emit row for final group
+  28                Goto             0   38    0                   0  ; group by finished
+  29                IfPos            7   31    0                   0  r[7]>0 -> r[7]-=0, goto 31; output group by row subroutine start
+  30              Return             6    0    0                   0
+  31              AggFinal           0   11    0  avg              0  accum=r[11]
+  32              Copy              10    4    1                   0  r[4]=r[10]
+  33              Yield              3    0    0                   0
+  34            Return               6    0    0                   0
+  35            Null                 0   10   11                   0  r[10..11]=NULL; clear accumulator subroutine start
+  36            Integer              0    7    0                   0  r[7]=0
+  37          Return                15    0    0                   0
+  38          EndCoroutine           3    0    0                   0
+  39          Null                   0   17    0                   0  r[17]=NULL
+  40          Integer                1   18    0                   0  r[18]=1; LIMIT counter
+  41          IfNot                 18   47    0                   0  if !r[18] goto 47
+  42          InitCoroutine          3    0    5                   0
+  43            Yield                3   47    0                   0
+  44            Copy                 5   19    0                   0  r[19]=r[5]
+  45            AggStep              0   19   17  max(Binary)      0  accum=r[17] step(r[19])
+  46          Goto                   0   43    0                   0
+  47          AggFinal               0   17    0  max              0  accum=r[17]
+  48          Copy                  17   16    0                   0  r[16]=r[17]
+  49          Copy                  16    1    0                   0  r[1]=r[16]
+  50        Return                   2    0    1                   0
+  51        OpenEphemeral            2    1    0                   0  cursor=2 is_table=true
+  52        Null                     0   29    0                   0  r[29]=NULL
+  53        Integer                  0   26    0                   0  r[26]=0; clear group by abort flag
+  54        Null                     0   27    0                   0  r[27]=NULL; initialize group by comparison registers to NULL
+  55        Gosub                   33   84    0                   0  ; go to clear accumulator subroutine
+  56        OpenRead                 3    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  57        OpenRead                 4    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  58        Rewind                   4   74    0                   0  Rewind index idx_products_category
+  59          DeferredSeek           4    3    0                   0
+  60          Column                 4    0   31                   0  r[31]=idx_products_category.category_id
+  61          Column                 3    3   32                   0  r[32]=products.price
+  62          RealAffinity          32    0    0                   0
+  63          Compare               27   31    1  k(1, Binary)     0  r[27..27]==r[31..31]
+  64          Jump                  65   69   65                   0  ; start new group if comparison is not equal
+  65          Gosub                 24   76    0                   0  ; check if ended group had data, and output if so
+  66          Move                  31   27    1                   0  r[27..27]=r[31..31]
+  67          IfPos                 26   87    0                   0  r[26]>0 -> r[26]-=0, goto 87; check abort flag
+  68          Gosub                 33   84    0                   0  ; goto clear accumulator subroutine
+  69          AggStep                0   32   29  avg              0  accum=r[29] step(r[32])
+  70          If                    25   72    0                   0  if r[25] goto 72; don't emit group columns if continuing existing group
+  71          Column                 4    0   28                   0  r[28]=idx_products_category.category_id
+  72          Integer                1   25    0                   0  r[25]=1; indicate data in accumulator
+  73        Next                     4   59    0                   0
+  74        Gosub                   24   76    0                   0  ; emit row for final group
+  75        Goto                     0   87    0                   0  ; group by finished
+  76        IfPos                   25   78    0                   0  r[25]>0 -> r[25]-=0, goto 78; output group by row subroutine start
+  77      Return                    24    0    0                   0
+  78      AggFinal                   0   29    0  avg              0  accum=r[29]
+  79      Copy                      28   22    1                   0  r[22]=r[28]
+  80      MakeRecord                22    2   34                   0  r[34]=mkrec(r[22..23]); for
+  81      NewRowid                   2   35    0                   0  r[35]=rowid
+  82      Insert                     2   34   35                   4  intkey=r[35] data=r[34]
+  83    Return                      24    0    0                   0
+  84    Null                         0   28   29                   0  r[28..29]=NULL; clear accumulator subroutine start
+  85    Integer                      0   25    0                   0  r[25]=0
+  86  Return                        33    0    0                   0
+  87  OpenRead                       5    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  88  OpenRead                       6    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  89  Rewind                         2  110    0                   0  Rewind  ephemeral()
+  90    Column                       2    0   20                   0  r[20]=ephemeral().category_id
+  91    Column                       2    1   21                   0  r[21]=ephemeral().avg_price
+  92    Copy                        20   39    0                   0  r[39]=r[20]
+  93    IsNull                      39  109    0                   0  if (r[39]==NULL) goto 109
+  94    Affinity                    39    1    0                   0  r[39..40] = C
+  95    SeekGE                       6  109   39                   0  key=[39..39]
+  96      IdxGT                      6  109   39                   0  key=[39..39]
+  97      DeferredSeek               6    5    0                   0
+  98      Column                     5    3   41                   0  r[41]=products.price
+  99      RealAffinity              41    0    0                   0
+ 100      Copy                       1   43    0                   0  r[43]=r[1]
+ 101      Multiply                  43   44   42                   0  r[42]=r[43]*r[44]
+ 102      Le                        41   42  108  Binary           0  if r[41]<=r[42] goto 108
+ 103      Column                     5    1   36                   0  r[36]=products.name
+ 104      Column                     5    3   37                   0  r[37]=products.price
+ 105      RealAffinity              37    0    0                   0
+ 106      Copy                      21   38    0                   0  r[38]=r[21]
+ 107      ResultRow                 36    3    0                   0  output=r[36..38]
+ 108    Next                         6   96    0                   0
+ 109  Next                           2   90    0                   0
+ 110  Halt                           0    0    0                   0
+ 111  Transaction                    0    1   11                   0  iDb=0 tx_mode=Read
+ 112  Real                           0   44    0  0.8              0  r[44]=0.8
+ 113  Goto                           0    1    0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -98,10 +98,10 @@ addr  opcode              p1  p2  p3  p4            p5  comment
   51  InitCoroutine        1   0   2                 0
   52    Yield              1  67   0                 0
   53    Copy              11  30   0                 0  r[30]=r[11]
-  54    IsNull            30  66   0                 0  if (r[30]==NULL) goto 66
+  54    IsNull            30  52   0                 0  if (r[30]==NULL) goto 52
   55    Affinity          30   1   0                 0  r[30..31] = C
-  56    SeekGE             3  66  30                 0  key=[30..30]
-  57      IdxGT            3  66  30                 0  key=[30..30]
+  56    SeekGE             3  52  30                 0  key=[30..30]
+  57      IdxGT            3  52  30                 0  key=[30..30]
   58      Column           3   1  14                 0  r[14]=ephemeral(ephemeral_subquery_t8).id
   59      Column           3   0  15                 0  r[15]=ephemeral(ephemeral_subquery_t8).customer_id
   60      Column           3   2  16                 0  r[16]=ephemeral(ephemeral_subquery_t8).total_amount

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
@@ -36,167 +36,158 @@ QUERY PLAN
 `--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
 
 BYTECODE
-addr  opcode                                       p1   p2   p3  p4            p5  comment
-   0                              Init              0  161    0                 0  Start at 161
-   1                              Once             54    0    0                 0  goto 54
-   2                              BeginSubrtn       3    0    0                 0  r[3]=NULL
-   3                              Null              0    1    0                 0  r[1]=NULL
-   4                              InitCoroutine     4   42    5                 0
-   5                              Null              0   12    0                 0  r[12]=NULL
-   6                              Integer           0    9    0                 0  r[9]=0; clear group by abort flag
-   7                              Null              0   10    0                 0  r[10]=NULL; initialize group by comparison registers to NULL
-   8                              Gosub            16   38    0                 0  ; go to clear accumulator subroutine
-   9                              OpenRead          0    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-  10                              OpenRead          1    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-  11                              Rewind            1   27    0                 0  Rewind index idx_orders_customer
-  12                                DeferredSeek    1    0    0                 0
-  13                                Column          1    0   14                 0  r[14]=idx_orders_customer.customer_id
-  14                                Column          0    3   15                 0  r[15]=orders.total_amount
-  15                                RealAffinity   15    0    0                 0
-  16                                Compare        10   14    1  k(1, Binary)   0  r[10..10]==r[14..14]
-  17                                Jump           18   22   18                 0  ; start new group if comparison is not equal
-  18                                Gosub           7   31    0                 0  ; check if ended group had data, and output if so
-  19                                Move           14   10    1                 0  r[10..10]=r[14..14]
-  20                                IfPos           9   41    0                 0  r[9]>0 -> r[9]-=0, goto 41; check abort flag
-  21                                Gosub          16   38    0                 0  ; goto clear accumulator subroutine
-  22                                AggStep         0   15   12  sum            0  accum=r[12] step(r[15])
-  23                                If              8   25    0                 0  if r[8] goto 25; don't emit group columns if continuing existing group
-  24                                Column          1    0   11                 0  r[11]=idx_orders_customer.customer_id
-  25                                Integer         1    8    0                 0  r[8]=1; indicate data in accumulator
-  26                              Next              1   12    0                 0
-  27                              Gosub             7   31    0                 0  ; emit row for final group
-  28                              Goto              0   41    0                 0  ; group by finished
-  29                              Integer           1    9    0                 0  r[9]=1
-  30                            Return              7    0    0                 0
-  31                            IfPos               8   33    0                 0  r[8]>0 -> r[8]-=0, goto 33; output group by row subroutine start
-  32                          Return                7    0    0                 0
-  33                          AggFinal              0   12    0  sum            0  accum=r[12]
-  34                          Copy                 11    5    0                 0  r[5]=r[11]
-  35                          Copy                 12    6    0                 0  r[6]=r[12]
-  36                          Yield                 4    0    0                 0
-  37                        Return                  7    0    0                 0
-  38                        Null                    0   11   12                 0  r[11..12]=NULL; clear accumulator subroutine start
-  39                        Integer                 0    8    0                 0  r[8]=0
-  40                      Return                   16    0    0                 0
-  41                      EndCoroutine              4    0    0                 0
-  42                      Null                      0   18    0                 0  r[18]=NULL
-  43                      Integer                   1   19    0                 0  r[19]=1; LIMIT counter
-  44                      IfNot                    19   50    0                 0  if !r[19] goto 50
-  45                      InitCoroutine             4    0    5                 0
-  46                        Yield                   4   50    0                 0
-  47                        Copy                    6   20    0                 0  r[20]=r[6]
-  48                        AggStep                 0   20   18  avg            0  accum=r[18] step(r[20])
-  49                      Goto                      0   46    0                 0
-  50                      AggFinal                  0   18    0  avg            0  accum=r[18]
-  51                      Copy                     18   17    0                 0  r[17]=r[18]
-  52                      Copy                     17    1    0                 0  r[1]=r[17]
-  53                    Return                      3    0    1                 0
-  54                    Once                      107    0    0                 0  goto 107
-  55                    BeginSubrtn                21    0    0                 0  r[21]=NULL
-  56                    Null                        0    2    0                 0  r[2]=NULL
-  57                    InitCoroutine              22   95   58                 0
-  58                    Null                        0   30    0                 0  r[30]=NULL
-  59                    Integer                     0   27    0                 0  r[27]=0; clear group by abort flag
-  60                    Null                        0   28    0                 0  r[28]=NULL; initialize group by comparison registers to NULL
-  61                    Gosub                      34   91    0                 0  ; go to clear accumulator subroutine
-  62                    OpenRead                    2    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-  63                    OpenRead                    3    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-  64                    Rewind                      3   80    0                 0  Rewind index idx_orders_customer
-  65                      DeferredSeek              3    2    0                 0
-  66                      Column                    3    0   32                 0  r[32]=idx_orders_customer.customer_id
-  67                      Column                    2    3   33                 0  r[33]=orders.total_amount
-  68                      RealAffinity             33    0    0                 0
-  69                      Compare                  28   32    1  k(1, Binary)   0  r[28..28]==r[32..32]
-  70                      Jump                     71   75   71                 0  ; start new group if comparison is not equal
-  71                      Gosub                    25   84    0                 0  ; check if ended group had data, and output if so
-  72                      Move                     32   28    1                 0  r[28..28]=r[32..32]
-  73                      IfPos                    27   94    0                 0  r[27]>0 -> r[27]-=0, goto 94; check abort flag
-  74                      Gosub                    34   91    0                 0  ; goto clear accumulator subroutine
-  75                      AggStep                   0   33   30  sum            0  accum=r[30] step(r[33])
-  76                      If                       26   78    0                 0  if r[26] goto 78; don't emit group columns if continuing existing group
-  77                      Column                    3    0   29                 0  r[29]=idx_orders_customer.customer_id
-  78                      Integer                   1   26    0                 0  r[26]=1; indicate data in accumulator
-  79                    Next                        3   65    0                 0
-  80                    Gosub                      25   84    0                 0  ; emit row for final group
-  81                    Goto                        0   94    0                 0  ; group by finished
-  82                    Integer                     1   27    0                 0  r[27]=1
-  83                  Return                       25    0    0                 0
-  84                  IfPos                        26   86    0                 0  r[26]>0 -> r[26]-=0, goto 86; output group by row subroutine start
-  85                Return                         25    0    0                 0
-  86                AggFinal                        0   30    0  sum            0  accum=r[30]
-  87                Copy                           29   23    0                 0  r[23]=r[29]
-  88                Copy                           30   24    0                 0  r[24]=r[30]
-  89                Yield                          22    0    0                 0
-  90              Return                           25    0    0                 0
-  91              Null                              0   29   30                 0  r[29..30]=NULL; clear accumulator subroutine start
-  92              Integer                           0   26    0                 0  r[26]=0
-  93            Return                             34    0    0                 0
-  94            EndCoroutine                       22    0    0                 0
-  95            Null                                0   36    0                 0  r[36]=NULL
-  96            Integer                             1   37    0                 0  r[37]=1; LIMIT counter
-  97            IfNot                              37  103    0                 0  if !r[37] goto 103
-  98            InitCoroutine                      22    0   58                 0
-  99              Yield                            22  103    0                 0
- 100              Copy                             24   38    0                 0  r[38]=r[24]
- 101              AggStep                           0   38   36  avg            0  accum=r[36] step(r[38])
- 102            Goto                                0   99    0                 0
- 103            AggFinal                            0   36    0  avg            0  accum=r[36]
- 104            Copy                               36   35    0                 0  r[35]=r[36]
- 105            Copy                               35    2    0                 0  r[2]=r[35]
- 106          Return                               21    0    1                 0
- 107          OpenEphemeral                         4    1    0                 0  cursor=4 is_table=true
- 108          Null                                  0   48    0                 0  r[48]=NULL
- 109          Integer                               0   45    0                 0  r[45]=0; clear group by abort flag
- 110          Null                                  0   46    0                 0  r[46]=NULL; initialize group by comparison registers to NULL
- 111          Gosub                                52  143    0                 0  ; go to clear accumulator subroutine
- 112          OpenRead                              5    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
- 113          OpenRead                              6    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
- 114          Rewind                                6  130    0                 0  Rewind index idx_orders_customer
- 115            DeferredSeek                        6    5    0                 0
- 116            Column                              6    0   50                 0  r[50]=idx_orders_customer.customer_id
- 117            Column                              5    3   51                 0  r[51]=orders.total_amount
- 118            RealAffinity                       51    0    0                 0
- 119            Compare                            46   50    1  k(1, Binary)   0  r[46..46]==r[50..50]
- 120            Jump                              121  125  121                 0  ; start new group if comparison is not equal
- 121            Gosub                              43  134    0                 0  ; check if ended group had data, and output if so
- 122            Move                               50   46    1                 0  r[46..46]=r[50..50]
- 123            IfPos                              45  146    0                 0  r[45]>0 -> r[45]-=0, goto 146; check abort flag
- 124            Gosub                              52  143    0                 0  ; goto clear accumulator subroutine
- 125            AggStep                             0   51   48  sum            0  accum=r[48] step(r[51])
- 126            If                                 44  128    0                 0  if r[44] goto 128; don't emit group columns if continuing existing group
- 127            Column                              6    0   47                 0  r[47]=idx_orders_customer.customer_id
- 128            Integer                             1   44    0                 0  r[44]=1; indicate data in accumulator
- 129          Next                                  6  115    0                 0
- 130          Gosub                                43  134    0                 0  ; emit row for final group
- 131          Goto                                  0  146    0                 0  ; group by finished
- 132          Integer                               1   45    0                 0  r[45]=1
- 133        Return                                 43    0    0                 0
- 134        IfPos                                  44  136    0                 0  r[44]>0 -> r[44]-=0, goto 136; output group by row subroutine start
- 135      Return                                   43    0    0                 0
- 136      AggFinal                                  0   48    0  sum            0  accum=r[48]
- 137      Copy                                     47   41    0                 0  r[41]=r[47]
- 138      Copy                                     48   42    0                 0  r[42]=r[48]
- 139      MakeRecord                               41    2   53                 0  r[53]=mkrec(r[41..42]); for
- 140      NewRowid                                  4   54    0                 0  r[54]=rowid
- 141      Insert                                    4   53   54                 4  intkey=r[54] data=r[53]
- 142    Return                                     43    0    0                 0
- 143    Null                                        0   47   48                 0  r[47..48]=NULL; clear accumulator subroutine start
- 144    Integer                                     0   44    0                 0  r[44]=0
- 145  Return                                       52    0    0                 0
- 146  OpenRead                                      7    6    0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
- 147  Rewind                                        4  160    0                 0  Rewind  ephemeral()
- 148    Column                                      4    0   39                 0  r[39]=ephemeral().customer_id
- 149    Column                                      4    1   40                 0  r[40]=ephemeral().total
- 150    Copy                                       40   59    0                 0  r[59]=r[40]
- 151    Copy                                        1   60    0                 0  r[60]=r[1]
- 152    Le                                         59   60  159  Binary         0  if r[59]<=r[60] goto 159
- 153    Copy                                       39   61    0                 0  r[61]=r[39]
- 154    SeekRowid                                   7   61  159                 0  if (r[61]!=cursor 7 for table customers.rowid) goto 159
- 155    Column                                      7    1   55                 0  r[55]=customers.name
- 156    Copy                                       40   56    0                 0  r[56]=r[40]
- 157    Copy                                        2   57    0                 0  r[57]=r[2]
- 158    ResultRow                                  55    3    0                 0  output=r[55..57]
- 159  Next                                          4  148    0                 0
- 160  Halt                                          0    0    0                 0
- 161  Transaction                                   0    1   11                 0  iDb=0 tx_mode=Read
- 162  Goto                                          0    1    0                 0
+addr  opcode                                 p1   p2   p3  p4            p5  comment
+   0                        Init              0  152    0                 0  Start at 152
+   1                        Once             51    0    0                 0  goto 51
+   2                        BeginSubrtn       3    0    0                 0  r[3]=NULL
+   3                        Null              0    1    0                 0  r[1]=NULL
+   4                        InitCoroutine     4   39    5                 0
+   5                        Null              0   12    0                 0  r[12]=NULL
+   6                        Integer           0    9    0                 0  r[9]=0; clear group by abort flag
+   7                        Null              0   10    0                 0  r[10]=NULL; initialize group by comparison registers to NULL
+   8                        Gosub            16   35    0                 0  ; go to clear accumulator subroutine
+   9                        OpenRead          0    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  10                        OpenRead          1    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+  11                        Rewind            1   27    0                 0  Rewind index idx_orders_customer
+  12                          DeferredSeek    1    0    0                 0
+  13                          Column          1    0   14                 0  r[14]=idx_orders_customer.customer_id
+  14                          Column          0    3   15                 0  r[15]=orders.total_amount
+  15                          RealAffinity   15    0    0                 0
+  16                          Compare        10   14    1  k(1, Binary)   0  r[10..10]==r[14..14]
+  17                          Jump           18   22   18                 0  ; start new group if comparison is not equal
+  18                          Gosub           7   29    0                 0  ; check if ended group had data, and output if so
+  19                          Move           14   10    1                 0  r[10..10]=r[14..14]
+  20                          IfPos           9   38    0                 0  r[9]>0 -> r[9]-=0, goto 38; check abort flag
+  21                          Gosub          16   35    0                 0  ; goto clear accumulator subroutine
+  22                          AggStep         0   15   12  sum            0  accum=r[12] step(r[15])
+  23                          If              8   25    0                 0  if r[8] goto 25; don't emit group columns if continuing existing group
+  24                          Column          1    0   11                 0  r[11]=idx_orders_customer.customer_id
+  25                          Integer         1    8    0                 0  r[8]=1; indicate data in accumulator
+  26                        Next              1   12    0                 0
+  27                        Gosub             7   29    0                 0  ; emit row for final group
+  28                        Goto              0   38    0                 0  ; group by finished
+  29                        IfPos             8   31    0                 0  r[8]>0 -> r[8]-=0, goto 31; output group by row subroutine start
+  30                      Return              7    0    0                 0
+  31                      AggFinal            0   12    0  sum            0  accum=r[12]
+  32                      Copy               11    5    1                 0  r[5]=r[11]
+  33                      Yield               4    0    0                 0
+  34                    Return                7    0    0                 0
+  35                    Null                  0   11   12                 0  r[11..12]=NULL; clear accumulator subroutine start
+  36                    Integer               0    8    0                 0  r[8]=0
+  37                  Return                 16    0    0                 0
+  38                  EndCoroutine            4    0    0                 0
+  39                  Null                    0   18    0                 0  r[18]=NULL
+  40                  Integer                 1   19    0                 0  r[19]=1; LIMIT counter
+  41                  IfNot                  19   47    0                 0  if !r[19] goto 47
+  42                  InitCoroutine           4    0    5                 0
+  43                    Yield                 4   47    0                 0
+  44                    Copy                  6   20    0                 0  r[20]=r[6]
+  45                    AggStep               0   20   18  avg            0  accum=r[18] step(r[20])
+  46                  Goto                    0   43    0                 0
+  47                  AggFinal                0   18    0  avg            0  accum=r[18]
+  48                  Copy                   18   17    0                 0  r[17]=r[18]
+  49                  Copy                   17    1    0                 0  r[1]=r[17]
+  50                Return                    3    0    1                 0
+  51                Once                    101    0    0                 0  goto 101
+  52                BeginSubrtn              21    0    0                 0  r[21]=NULL
+  53                Null                      0    2    0                 0  r[2]=NULL
+  54                InitCoroutine            22   89   55                 0
+  55                Null                      0   30    0                 0  r[30]=NULL
+  56                Integer                   0   27    0                 0  r[27]=0; clear group by abort flag
+  57                Null                      0   28    0                 0  r[28]=NULL; initialize group by comparison registers to NULL
+  58                Gosub                    34   85    0                 0  ; go to clear accumulator subroutine
+  59                OpenRead                  2    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  60                OpenRead                  3    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+  61                Rewind                    3   77    0                 0  Rewind index idx_orders_customer
+  62                  DeferredSeek            3    2    0                 0
+  63                  Column                  3    0   32                 0  r[32]=idx_orders_customer.customer_id
+  64                  Column                  2    3   33                 0  r[33]=orders.total_amount
+  65                  RealAffinity           33    0    0                 0
+  66                  Compare                28   32    1  k(1, Binary)   0  r[28..28]==r[32..32]
+  67                  Jump                   68   72   68                 0  ; start new group if comparison is not equal
+  68                  Gosub                  25   79    0                 0  ; check if ended group had data, and output if so
+  69                  Move                   32   28    1                 0  r[28..28]=r[32..32]
+  70                  IfPos                  27   88    0                 0  r[27]>0 -> r[27]-=0, goto 88; check abort flag
+  71                  Gosub                  34   85    0                 0  ; goto clear accumulator subroutine
+  72                  AggStep                 0   33   30  sum            0  accum=r[30] step(r[33])
+  73                  If                     26   75    0                 0  if r[26] goto 75; don't emit group columns if continuing existing group
+  74                  Column                  3    0   29                 0  r[29]=idx_orders_customer.customer_id
+  75                  Integer                 1   26    0                 0  r[26]=1; indicate data in accumulator
+  76                Next                      3   62    0                 0
+  77                Gosub                    25   79    0                 0  ; emit row for final group
+  78                Goto                      0   88    0                 0  ; group by finished
+  79                IfPos                    26   81    0                 0  r[26]>0 -> r[26]-=0, goto 81; output group by row subroutine start
+  80              Return                     25    0    0                 0
+  81              AggFinal                    0   30    0  sum            0  accum=r[30]
+  82              Copy                       29   23    1                 0  r[23]=r[29]
+  83              Yield                      22    0    0                 0
+  84            Return                       25    0    0                 0
+  85            Null                          0   29   30                 0  r[29..30]=NULL; clear accumulator subroutine start
+  86            Integer                       0   26    0                 0  r[26]=0
+  87          Return                         34    0    0                 0
+  88          EndCoroutine                   22    0    0                 0
+  89          Null                            0   36    0                 0  r[36]=NULL
+  90          Integer                         1   37    0                 0  r[37]=1; LIMIT counter
+  91          IfNot                          37   97    0                 0  if !r[37] goto 97
+  92          InitCoroutine                  22    0   55                 0
+  93            Yield                        22   97    0                 0
+  94            Copy                         24   38    0                 0  r[38]=r[24]
+  95            AggStep                       0   38   36  avg            0  accum=r[36] step(r[38])
+  96          Goto                            0   93    0                 0
+  97          AggFinal                        0   36    0  avg            0  accum=r[36]
+  98          Copy                           36   35    0                 0  r[35]=r[36]
+  99          Copy                           35    2    0                 0  r[2]=r[35]
+ 100        Return                           21    0    1                 0
+ 101        OpenEphemeral                     4    1    0                 0  cursor=4 is_table=true
+ 102        Null                              0   48    0                 0  r[48]=NULL
+ 103        Integer                           0   45    0                 0  r[45]=0; clear group by abort flag
+ 104        Null                              0   46    0                 0  r[46]=NULL; initialize group by comparison registers to NULL
+ 105        Gosub                            52  134    0                 0  ; go to clear accumulator subroutine
+ 106        OpenRead                          5    4    0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+ 107        OpenRead                          6    9    0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+ 108        Rewind                            6  124    0                 0  Rewind index idx_orders_customer
+ 109          DeferredSeek                    6    5    0                 0
+ 110          Column                          6    0   50                 0  r[50]=idx_orders_customer.customer_id
+ 111          Column                          5    3   51                 0  r[51]=orders.total_amount
+ 112          RealAffinity                   51    0    0                 0
+ 113          Compare                        46   50    1  k(1, Binary)   0  r[46..46]==r[50..50]
+ 114          Jump                          115  119  115                 0  ; start new group if comparison is not equal
+ 115          Gosub                          43  126    0                 0  ; check if ended group had data, and output if so
+ 116          Move                           50   46    1                 0  r[46..46]=r[50..50]
+ 117          IfPos                          45  137    0                 0  r[45]>0 -> r[45]-=0, goto 137; check abort flag
+ 118          Gosub                          52  134    0                 0  ; goto clear accumulator subroutine
+ 119          AggStep                         0   51   48  sum            0  accum=r[48] step(r[51])
+ 120          If                             44  122    0                 0  if r[44] goto 122; don't emit group columns if continuing existing group
+ 121          Column                          6    0   47                 0  r[47]=idx_orders_customer.customer_id
+ 122          Integer                         1   44    0                 0  r[44]=1; indicate data in accumulator
+ 123        Next                              6  109    0                 0
+ 124        Gosub                            43  126    0                 0  ; emit row for final group
+ 125        Goto                              0  137    0                 0  ; group by finished
+ 126        IfPos                            44  128    0                 0  r[44]>0 -> r[44]-=0, goto 128; output group by row subroutine start
+ 127      Return                             43    0    0                 0
+ 128      AggFinal                            0   48    0  sum            0  accum=r[48]
+ 129      Copy                               47   41    1                 0  r[41]=r[47]
+ 130      MakeRecord                         41    2   53                 0  r[53]=mkrec(r[41..42]); for
+ 131      NewRowid                            4   54    0                 0  r[54]=rowid
+ 132      Insert                              4   53   54                 4  intkey=r[54] data=r[53]
+ 133    Return                               43    0    0                 0
+ 134    Null                                  0   47   48                 0  r[47..48]=NULL; clear accumulator subroutine start
+ 135    Integer                               0   44    0                 0  r[44]=0
+ 136  Return                                 52    0    0                 0
+ 137  OpenRead                                7    6    0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+ 138  Rewind                                  4  151    0                 0  Rewind  ephemeral()
+ 139    Column                                4    0   39                 0  r[39]=ephemeral().customer_id
+ 140    Column                                4    1   40                 0  r[40]=ephemeral().total
+ 141    Copy                                 40   59    0                 0  r[59]=r[40]
+ 142    Copy                                  1   60    0                 0  r[60]=r[1]
+ 143    Le                                   59   60  150  Binary         0  if r[59]<=r[60] goto 150
+ 144    Copy                                 39   61    0                 0  r[61]=r[39]
+ 145    SeekRowid                             7   61  150                 0  if (r[61]!=cursor 7 for table customers.rowid) goto 150
+ 146    Column                                7    1   55                 0  r[55]=customers.name
+ 147    Copy                                 40   56    0                 0  r[56]=r[40]
+ 148    Copy                                  2   57    0                 0  r[57]=r[2]
+ 149    ResultRow                            55    3    0                 0  output=r[55..57]
+ 150  Next                                    4  139    0                 0
+ 151  Halt                                    0    0    0                 0
+ 152  Transaction                             0    1   11                 0  iDb=0 tx_mode=Read
+ 153  Goto                                    0    1    0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referencing-previous.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referencing-previous.snap
@@ -49,97 +49,90 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4              p5  comment
-   0          Init               0  90   0                   0  Start at 90
-   1          InitCoroutine      1  69   2                   0
-   2          InitCoroutine      2  57   3                   0
-   3          InitCoroutine      3  47   4                   0
-   4          Null               0  12  13                   0  r[12..13]=NULL
-   5          Integer            0   9   0                   0  r[9]=0; clear group by abort flag
-   6          Null               0  10   0                   0  r[10]=NULL; initialize group by comparison registers to NULL
-   7          Gosub             18  43   0                   0  ; go to clear accumulator subroutine
-   8          OpenRead           0   5   0  k(5,B,B,B,B,B)   0  table=order_items, root=5, iDb=0
-   9          OpenRead           1  11   0  k(2,B)           0  index=idx_order_items_product, root=11, iDb=0
-  10          Rewind             1  30   0                   0  Rewind index idx_order_items_product
-  11            DeferredSeek     1   0   0                   0
-  12            Column           1   0  15                   0  r[15]=idx_order_items_product.product_id
-  13            Column           0   3  16                   0  r[16]=order_items.quantity
-  14            Column           0   3  19                   0  r[19]=order_items.quantity
-  15            Column           0   4  20                   0  r[20]=order_items.unit_price
-  16            RealAffinity    20   0   0                   0
-  17            Multiply        19  20  17                   0  r[17]=r[19]*r[20]
-  18            Compare         10  15   1  k(1, Binary)     0  r[10..10]==r[15..15]
-  19            Jump            20  24  20                   0  ; start new group if comparison is not equal
-  20            Gosub            7  34   0                   0  ; check if ended group had data, and output if so
-  21            Move            15  10   1                   0  r[10..10]=r[15..15]
-  22            IfPos            9  46   0                   0  r[9]>0 -> r[9]-=0, goto 46; check abort flag
-  23            Gosub           18  43   0                   0  ; goto clear accumulator subroutine
-  24            AggStep          0  16  12  sum              0  accum=r[12] step(r[16])
-  25            AggStep          0  17  13  sum              0  accum=r[13] step(r[17])
-  26            If               8  28   0                   0  if r[8] goto 28; don't emit group columns if continuing existing group
-  27            Column           1   0  11                   0  r[11]=idx_order_items_product.product_id
-  28            Integer          1   8   0                   0  r[8]=1; indicate data in accumulator
-  29          Next               1  11   0                   0
-  30          Gosub              7  34   0                   0  ; emit row for final group
-  31          Goto               0  46   0                   0  ; group by finished
-  32          Integer            1   9   0                   0  r[9]=1
-  33        Return               7   0   0                   0
-  34        IfPos                8  36   0                   0  r[8]>0 -> r[8]-=0, goto 36; output group by row subroutine start
-  35      Return                 7   0   0                   0
-  36      AggFinal               0  12   0  sum              0  accum=r[12]
-  37      AggFinal               0  13   0  sum              0  accum=r[13]
-  38      Copy                  11   4   0                   0  r[4]=r[11]
-  39      Copy                  12   5   0                   0  r[5]=r[12]
-  40      Copy                  13   6   0                   0  r[6]=r[13]
-  41      Yield                  3   0   0                   0
-  42    Return                   7   0   0                   0
-  43    Null                     0  11  13                   0  r[11..13]=NULL; clear accumulator subroutine start
-  44    Integer                  0   8   0                   0  r[8]=0
-  45  Return                    18   0   0                   0
-  46  EndCoroutine               3   0   0                   0
-  47  InitCoroutine              3   0   4                   0
-  48    Yield                    3  56   0                   0
-  49    Copy                     6  25   0                   0  r[25]=r[6]
-  50    Le                      25  26  55  Binary           0  if r[25]<=r[26] goto 55
-  51    Copy                     4  21   0                   0  r[21]=r[4]
-  52    Copy                     5  22   0                   0  r[22]=r[5]
-  53    Copy                     6  23   0                   0  r[23]=r[6]
-  54    Yield                    2   0   0                   0
-  55  Goto                       0  48   0                   0
-  56  EndCoroutine               2   0   0                   0
-  57  OpenRead                   2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  58  InitCoroutine              2   0   3                   0
-  59    Yield                    2  68   0                   0
-  60    Copy                    21  31   0                   0  r[31]=r[21]
-  61    SeekRowid                2  31  67                   0  if (r[31]!=cursor 2 for table products.rowid) goto 67
-  62    Column                   2   1  27                   0  r[27]=products.name
-  63    Column                   2   2  28                   0  r[28]=products.category_id
-  64    Copy                    22  29   0                   0  r[29]=r[22]
-  65    Copy                    23  30   0                   0  r[30]=r[23]
-  66    Yield                    1   0   0                   0
-  67  Goto                       0  59   0                   0
-  68  EndCoroutine               1   0   0                   0
-  69  SorterOpen                 3   1   0  k(1,-B)          0  cursor=3
-  70  OpenRead                   4   3   0  k(3,B,B,B)       0  table=categories, root=3, iDb=0
-  71  InitCoroutine              1   0   2                   0
-  72    Yield                    1  81   0                   0
-  73    Copy                    28  36   0                   0  r[36]=r[28]
-  74    SeekRowid                4  36  80                   0  if (r[36]!=cursor 4 for table categories.rowid) goto 80
-  75    Copy                    30  37   0                   0  r[37]=r[30]
-  76    Copy                    27  38   0                   0  r[38]=r[27]
-  77    Column                   4   1  39                   0  r[39]=categories.name
-  78    MakeRecord              37   3  35                   0  r[35]=mkrec(r[37..39])
-  79    SorterInsert             3  35   0  0                0  key=r[35]
-  80  Goto                       0  72   0                   0
-  81  OpenPseudo                 5  35   3                   0  3 columns in r[35]
-  82  SorterSort                 3  89   0                   0
-  83    SorterData               3  35   5                   0  r[35]=data
-  84    Column                   5   1  32                   0  r[32]=pseudo.column 1
-  85    Column                   5   2  33                   0  r[33]=pseudo.column 2
-  86    Column                   5   0  34                   0  r[34]=pseudo.column 0
-  87    ResultRow               32   3   0                   0  output=r[32..34]
-  88  SorterNext                 3  83   0                   0
-  89  Halt                       0   0   0                   0
-  90  Transaction                0   1  11                   0  iDb=0 tx_mode=Read
-  91  Integer                 1000  26   0                   0  r[26]=1000
-  92  Goto                       0   1   0                   0
+addr  opcode                  p1  p2  p3  p4              p5  comment
+   0        Init               0  83   0                   0  Start at 83
+   1        InitCoroutine      1  62   2                   0
+   2        InitCoroutine      2  51   3                   0
+   3        InitCoroutine      3  43   4                   0
+   4        Null               0  12  13                   0  r[12..13]=NULL
+   5        Integer            0   9   0                   0  r[9]=0; clear group by abort flag
+   6        Null               0  10   0                   0  r[10]=NULL; initialize group by comparison registers to NULL
+   7        Gosub             18  39   0                   0  ; go to clear accumulator subroutine
+   8        OpenRead           0   5   0  k(5,B,B,B,B,B)   0  table=order_items, root=5, iDb=0
+   9        OpenRead           1  11   0  k(2,B)           0  index=idx_order_items_product, root=11, iDb=0
+  10        Rewind             1  30   0                   0  Rewind index idx_order_items_product
+  11          DeferredSeek     1   0   0                   0
+  12          Column           1   0  15                   0  r[15]=idx_order_items_product.product_id
+  13          Column           0   3  16                   0  r[16]=order_items.quantity
+  14          Column           0   3  19                   0  r[19]=order_items.quantity
+  15          Column           0   4  20                   0  r[20]=order_items.unit_price
+  16          RealAffinity    20   0   0                   0
+  17          Multiply        19  20  17                   0  r[17]=r[19]*r[20]
+  18          Compare         10  15   1  k(1, Binary)     0  r[10..10]==r[15..15]
+  19          Jump            20  24  20                   0  ; start new group if comparison is not equal
+  20          Gosub            7  32   0                   0  ; check if ended group had data, and output if so
+  21          Move            15  10   1                   0  r[10..10]=r[15..15]
+  22          IfPos            9  42   0                   0  r[9]>0 -> r[9]-=0, goto 42; check abort flag
+  23          Gosub           18  39   0                   0  ; goto clear accumulator subroutine
+  24          AggStep          0  16  12  sum              0  accum=r[12] step(r[16])
+  25          AggStep          0  17  13  sum              0  accum=r[13] step(r[17])
+  26          If               8  28   0                   0  if r[8] goto 28; don't emit group columns if continuing existing group
+  27          Column           1   0  11                   0  r[11]=idx_order_items_product.product_id
+  28          Integer          1   8   0                   0  r[8]=1; indicate data in accumulator
+  29        Next               1  11   0                   0
+  30        Gosub              7  32   0                   0  ; emit row for final group
+  31        Goto               0  42   0                   0  ; group by finished
+  32        IfPos              8  34   0                   0  r[8]>0 -> r[8]-=0, goto 34; output group by row subroutine start
+  33      Return               7   0   0                   0
+  34      AggFinal             0  12   0  sum              0  accum=r[12]
+  35      AggFinal             0  13   0  sum              0  accum=r[13]
+  36      Copy                11   4   2                   0  r[4]=r[11]
+  37      Yield                3   0   0                   0
+  38    Return                 7   0   0                   0
+  39    Null                   0  11  13                   0  r[11..13]=NULL; clear accumulator subroutine start
+  40    Integer                0   8   0                   0  r[8]=0
+  41  Return                  18   0   0                   0
+  42  EndCoroutine             3   0   0                   0
+  43  InitCoroutine            3   0   4                   0
+  44    Yield                  3  50   0                   0
+  45    Copy                   6  25   0                   0  r[25]=r[6]
+  46    Le                    25  26  44  Binary           0  if r[25]<=r[26] goto 44
+  47    Copy                   4  21   2                   0  r[21]=r[4]
+  48    Yield                  2   0   0                   0
+  49  Goto                     0  44   0                   0
+  50  EndCoroutine             2   0   0                   0
+  51  OpenRead                 2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  52  InitCoroutine            2   0   3                   0
+  53    Yield                  2  61   0                   0
+  54    Copy                  21  31   0                   0  r[31]=r[21]
+  55    SeekRowid              2  31  53                   0  if (r[31]!=cursor 2 for table products.rowid) goto 53
+  56    Column                 2   1  27                   0  r[27]=products.name
+  57    Column                 2   2  28                   0  r[28]=products.category_id
+  58    Copy                  22  29   1                   0  r[29]=r[22]
+  59    Yield                  1   0   0                   0
+  60  Goto                     0  53   0                   0
+  61  EndCoroutine             1   0   0                   0
+  62  SorterOpen               3   1   0  k(1,-B)          0  cursor=3
+  63  OpenRead                 4   3   0  k(3,B,B,B)       0  table=categories, root=3, iDb=0
+  64  InitCoroutine            1   0   2                   0
+  65    Yield                  1  74   0                   0
+  66    Copy                  28  36   0                   0  r[36]=r[28]
+  67    SeekRowid              4  36  65                   0  if (r[36]!=cursor 4 for table categories.rowid) goto 65
+  68    Copy                  30  37   0                   0  r[37]=r[30]
+  69    Copy                  27  38   0                   0  r[38]=r[27]
+  70    Column                 4   1  39                   0  r[39]=categories.name
+  71    MakeRecord            37   3  35                   0  r[35]=mkrec(r[37..39])
+  72    SorterInsert           3  35   0  0                0  key=r[35]
+  73  Goto                     0  65   0                   0
+  74  OpenPseudo               5  35   3                   0  3 columns in r[35]
+  75  SorterSort               3  82   0                   0
+  76    SorterData             3  35   5                   0  r[35]=data
+  77    Column                 5   1  32                   0  r[32]=pseudo.column 1
+  78    Column                 5   2  33                   0  r[33]=pseudo.column 2
+  79    Column                 5   0  34                   0  r[34]=pseudo.column 0
+  80    ResultRow             32   3   0                   0  output=r[32..34]
+  81  SorterNext               3  76   0                   0
+  82  Halt                     0   0   0                   0
+  83  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
+  84  Integer               1000  26   0                   0  r[26]=1000
+  85  Goto                     0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
@@ -30,82 +30,79 @@ QUERY PLAN
       `--USE SORTER FOR GROUP BY
 
 BYTECODE
-addr  opcode                      p1  p2  p3  p4              p5  comment
-   0            Init               0  76   0                   0  Start at 76
-   1            OpenRead           0   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-   2            Rewind             0  75   0                   0  Rewind table employees
-   3              BeginSubrtn      5   0   0                   0  r[5]=NULL
-   4              Null             0   1   0                   0  r[1]=NULL
-   5              OpenEphemeral    1   0   0                   0  cursor=1 is_table=false
-   6              Null             0  15   0                   0  r[15]=NULL
-   7              SorterOpen       2   2   0  k(1,B)           0  cursor=2
-   8              Integer          0  12   0                   0  r[12]=0; clear group by abort flag
-   9              Null             0  13   0                   0  r[13]=NULL; initialize group by comparison registers to NULL
-  10              Gosub           19  49   0                   0  ; go to clear accumulator subroutine
-  11              OpenRead         4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-  12              Rewind           4  19   0                   0  Rewind table employees
-  13                Column         4   3  17                   0  r[17]=employees.department
-  14                Column         4   4  18                   0  r[18]=employees.salary
-  15                RealAffinity  18   0   0                   0
-  16                MakeRecord    17   2  16                   0  r[16]=mkrec(r[17..18])
-  17                SorterInsert   2  16   0  0                0  key=r[16]
-  18              Next             4  13   0                   0
-  19              OpenPseudo       3  16   2                   0  2 columns in r[16]
-  20              SorterSort       2  35   0                   0
-  21                SorterData     2  16   3                   0  r[16]=data
-  22                Column         3   0  20                   0  r[20]=pseudo.column 0
-  23                Compare       13  20   1  k(1, Binary)     0  r[13..13]==r[20..20]
-  24                Jump          25  29  25                   0  ; start new group if comparison is not equal
-  25                Gosub         10  39   0                   0  ; check if ended group had data, and output if so
-  26                Move          20  13   1                   0  r[13..13]=r[20..20]
-  27                IfPos         12  52   0                   0  r[12]>0 -> r[12]-=0, goto 52; check abort flag
-  28                Gosub         19  49   0                   0  ; goto clear accumulator subroutine
-  29                Column         3   1  21                   0  r[21]=pseudo.column 1
-  30                AggStep        0  21  15  avg              0  accum=r[15] step(r[21])
-  31                If            11  33   0                   0  if r[11] goto 33; don't emit group columns if continuing existing group
-  32                Column         3   0  14                   0  r[14]=pseudo.column 0
-  33                Integer        1  11   0                   0  r[11]=1; indicate data in accumulator
-  34              SorterNext       2  21   0                   0
-  35              Gosub           10  39   0                   0  ; emit row for final group
-  36              Goto             0  52   0                   0  ; group by finished
-  37              Integer          1  12   0                   0  r[12]=1
-  38            Return            10   0   0                   0
-  39            IfPos             11  41   0                   0  r[11]>0 -> r[11]-=0, goto 41; output group by row subroutine start
-  40          Return              10   0   0                   0
-  41          AggFinal             0  15   0  avg              0  accum=r[15]
-  42          Copy                14   8   0                   0  r[8]=r[14]
-  43          Copy                15   9   0                   0  r[9]=r[15]
-  44          Copy                 8  23   1                   0  r[23]=r[8]
-  45          Sequence             1  25   0                   0
-  46          MakeRecord          23   3  22                   0  r[22]=mkrec(r[23..25]); for ephemeral_subquery_t6
-  47          IdxInsert            1  22   0                   8  key=r[22]
-  48        Return                10   0   0                   0
-  49        Null                   0  14  15                   0  r[14..15]=NULL; clear accumulator subroutine start
-  50        Integer                0  11   0                   0  r[11]=0
-  51      Return                  19   0   0                   0
-  52      Integer                  1  27   0                   0  r[27]=1; LIMIT counter
-  53      IfNot                   27  64   0                   0  if !r[27] goto 64
-  54      Column                   0   3  28                   0  r[28]=employees.department
-  55      IsNull                  28  64   0                   0  if (r[28]==NULL) goto 64
-  56      SeekGE                   1  64  28                   0  key=[28..28]
-  57        IdxGT                  1  64  28                   0  key=[28..28]
-  58        Column                 1   0   6                   0  r[6]=ephemeral(ephemeral_subquery_t6).department
-  59        Column                 1   1   7                   0  r[7]=ephemeral(ephemeral_subquery_t6).avg_salary
-  60        Column                 1   1  26                   0  r[26]=ephemeral(ephemeral_subquery_t6).avg_salary
-  61        Copy                  26   1   0                   0  r[1]=r[26]
-  62        DecrJumpZero          27  64   0                   0  if (--r[27]==0) goto 64
-  63      Next                     1  57   0                   0
-  64    Return                     5   0   1                   0
-  65    Column                     0   4  30                   0  r[30]=employees.salary
-  66    RealAffinity              30   0   0                   0
-  67    Copy                       1  31   0                   0  r[31]=r[1]
-  68    Le                        30  31  74  Binary           0  if r[30]<=r[31] goto 74
-  69    Column                     0   1   2                   0  r[2]=employees.name
-  70    Column                     0   3   3                   0  r[3]=employees.department
-  71    Column                     0   4   4                   0  r[4]=employees.salary
-  72    RealAffinity               4   0   0                   0
-  73    ResultRow                  2   3   0                   0  output=r[2..4]
-  74  Next                         0   3   0                   0
-  75  Halt                         0   0   0                   0
-  76  Transaction                  0   1  11                   0  iDb=0 tx_mode=Read
-  77  Goto                         0   1   0                   0
+addr  opcode                    p1  p2  p3  p4              p5  comment
+   0          Init               0  73   0                   0  Start at 73
+   1          OpenRead           0   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+   2          Rewind             0  72   0                   0  Rewind table employees
+   3            BeginSubrtn      5   0   0                   0  r[5]=NULL
+   4            Null             0   1   0                   0  r[1]=NULL
+   5            OpenEphemeral    1   0   0                   0  cursor=1 is_table=false
+   6            Null             0  15   0                   0  r[15]=NULL
+   7            SorterOpen       2   2   0  k(1,B)           0  cursor=2
+   8            Integer          0  12   0                   0  r[12]=0; clear group by abort flag
+   9            Null             0  13   0                   0  r[13]=NULL; initialize group by comparison registers to NULL
+  10            Gosub           19  46   0                   0  ; go to clear accumulator subroutine
+  11            OpenRead         4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+  12            Rewind           4  19   0                   0  Rewind table employees
+  13              Column         4   3  17                   0  r[17]=employees.department
+  14              Column         4   4  18                   0  r[18]=employees.salary
+  15              RealAffinity  18   0   0                   0
+  16              MakeRecord    17   2  16                   0  r[16]=mkrec(r[17..18])
+  17              SorterInsert   2  16   0  0                0  key=r[16]
+  18            Next             4  13   0                   0
+  19            OpenPseudo       3  16   2                   0  2 columns in r[16]
+  20            SorterSort       2  35   0                   0
+  21              SorterData     2  16   3                   0  r[16]=data
+  22              Column         3   0  20                   0  r[20]=pseudo.column 0
+  23              Compare       13  20   1  k(1, Binary)     0  r[13..13]==r[20..20]
+  24              Jump          25  29  25                   0  ; start new group if comparison is not equal
+  25              Gosub         10  37   0                   0  ; check if ended group had data, and output if so
+  26              Move          20  13   1                   0  r[13..13]=r[20..20]
+  27              IfPos         12  49   0                   0  r[12]>0 -> r[12]-=0, goto 49; check abort flag
+  28              Gosub         19  46   0                   0  ; goto clear accumulator subroutine
+  29              Column         3   1  21                   0  r[21]=pseudo.column 1
+  30              AggStep        0  21  15  avg              0  accum=r[15] step(r[21])
+  31              If            11  33   0                   0  if r[11] goto 33; don't emit group columns if continuing existing group
+  32              Column         3   0  14                   0  r[14]=pseudo.column 0
+  33              Integer        1  11   0                   0  r[11]=1; indicate data in accumulator
+  34            SorterNext       2  21   0                   0
+  35            Gosub           10  37   0                   0  ; emit row for final group
+  36            Goto             0  49   0                   0  ; group by finished
+  37            IfPos           11  39   0                   0  r[11]>0 -> r[11]-=0, goto 39; output group by row subroutine start
+  38          Return            10   0   0                   0
+  39          AggFinal           0  15   0  avg              0  accum=r[15]
+  40          Copy              14   8   1                   0  r[8]=r[14]
+  41          Copy               8  23   1                   0  r[23]=r[8]
+  42          Sequence           1  25   0                   0
+  43          MakeRecord        23   3  22                   0  r[22]=mkrec(r[23..25]); for ephemeral_subquery_t6
+  44          IdxInsert          1  22   0                   8  key=r[22]
+  45        Return              10   0   0                   0
+  46        Null                 0  14  15                   0  r[14..15]=NULL; clear accumulator subroutine start
+  47        Integer              0  11   0                   0  r[11]=0
+  48      Return                19   0   0                   0
+  49      Integer                1  27   0                   0  r[27]=1; LIMIT counter
+  50      IfNot                 27  61   0                   0  if !r[27] goto 61
+  51      Column                 0   3  28                   0  r[28]=employees.department
+  52      IsNull                28  61   0                   0  if (r[28]==NULL) goto 61
+  53      SeekGE                 1  61  28                   0  key=[28..28]
+  54        IdxGT                1  61  28                   0  key=[28..28]
+  55        Column               1   0   6                   0  r[6]=ephemeral(ephemeral_subquery_t6).department
+  56        Column               1   1   7                   0  r[7]=ephemeral(ephemeral_subquery_t6).avg_salary
+  57        Column               1   1  26                   0  r[26]=ephemeral(ephemeral_subquery_t6).avg_salary
+  58        Copy                26   1   0                   0  r[1]=r[26]
+  59        DecrJumpZero        27  61   0                   0  if (--r[27]==0) goto 61
+  60      Next                   1  54   0                   0
+  61    Return                   5   0   1                   0
+  62    Column                   0   4  30                   0  r[30]=employees.salary
+  63    RealAffinity            30   0   0                   0
+  64    Copy                     1  31   0                   0  r[31]=r[1]
+  65    Le                      30  31  71  Binary           0  if r[30]<=r[31] goto 71
+  66    Column                   0   1   2                   0  r[2]=employees.name
+  67    Column                   0   3   3                   0  r[3]=employees.department
+  68    Column                   0   4   4                   0  r[4]=employees.salary
+  69    RealAffinity             4   0   0                   0
+  70    ResultRow                2   3   0                   0  output=r[2..4]
+  71  Next                       0   3   0                   0
+  72  Halt                       0   0   0                   0
+  73  Transaction                0   1  11                   0  iDb=0 tx_mode=Read
+  74  Goto                       0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__delete-returning-target-selfread.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__delete-returning-target-selfread.snap
@@ -19,50 +19,48 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4          p5  comment
-   0    Init            0  44   0               0  Start at 44
+   0    Init            0  42   0               0  Start at 42
    1    OpenEphemeral   0   1   0               0  cursor=0 is_table=true
    2    OpenWrite       1   2   0               0  root=2; iDb=0
-   3    Rewind          1  37   0               0  Rewind table t
+   3    Rewind          1  35   0               0  Rewind table t
    4    Integer         3   2   0               0  r[2]=3
    5      RowId         1   3   0               0  r[3]=t.rowid
-   6      Ge            3   2  37               0  if r[3]>=r[2] goto 37
+   6      Ge            3   2  35               0  if r[3]>=r[2] goto 35
    7      RowId         1   4   0               0  r[4]=t.rowid
    8      RowId         1   5   0               0  r[5]=t.rowid
    9      Column        1   1   6               0  r[6]=t.grp
   10      Column        1   2   7               0  r[7]=t.val
   11      Delete        1   0   0  t            0
   12      Copy          4   8   0               0  r[8]=r[4]
-  13      Copy          6   9   0               0  r[9]=r[6]
-  14      Copy          7  10   0               0  r[10]=r[7]
-  15      BeginSubrtn  11   0   0               0  r[11]=NULL
-  16      Null          0   1   0               0  r[1]=NULL
-  17      Null          0  13   0               0  r[13]=NULL
-  18      Integer       1  14   0               0  r[14]=1; LIMIT counter
-  19      IfNot        14  24   0               0  if !r[14] goto 24
-  20      OpenRead      2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
-  21      Rewind        2  24   0               0  Rewind table t
-  22        AggStep     0  15  13  count        0  accum=r[13] step(r[15])
-  23      Next          2  22   0               0
-  24      AggFinal      0  13   0  count        0  accum=r[13]
-  25      Copy         13  12   0               0  r[12]=r[13]
-  26      Copy         12   1   0               0  r[1]=r[12]
-  27    Return         11   0   1               0
-  28    Copy            4  16   0               0  r[16]=r[4]
-  29    Copy            6  17   0               0  r[17]=r[6]
-  30    Copy            7  18   0               0  r[18]=r[7]
-  31    Copy           16  19   0               0  r[19]=r[16]
-  32    Copy            1  20   0               0  r[20]=r[1]
-  33    MakeRecord     19   2  21               0  r[21]=mkrec(r[19..20])
-  34    NewRowid        0  22   0               0  r[22]=rowid
-  35    Insert          0  21  22               4  intkey=r[22] data=r[21]
-  36  Next              1   5   0               0
-  37  FkCheck           0   0   0               0
-  38  Rewind            0  43   0               0  Rewind  ephemeral(t)
-  39    Column          0   0  23               0  r[23]=ephemeral(t).id
-  40    Column          0   1  24               0  r[24]=ephemeral(t).grp
-  41    ResultRow      23   2   0               0  output=r[23..24]
-  42  Next              0  39   0               0
-  43  Halt              0   0   0               0
-  44  Transaction       0   2   1               0  iDb=0 tx_mode=Write
-  45  Integer           1  15   0               0  r[15]=1
-  46  Goto              0   1   0               0
+  13      Copy          6   9   1               0  r[9]=r[6]
+  14      BeginSubrtn  11   0   0               0  r[11]=NULL
+  15      Null          0   1   0               0  r[1]=NULL
+  16      Null          0  13   0               0  r[13]=NULL
+  17      Integer       1  14   0               0  r[14]=1; LIMIT counter
+  18      IfNot        14  23   0               0  if !r[14] goto 23
+  19      OpenRead      2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
+  20      Rewind        2  23   0               0  Rewind table t
+  21        AggStep     0  15  13  count        0  accum=r[13] step(r[15])
+  22      Next          2  21   0               0
+  23      AggFinal      0  13   0  count        0  accum=r[13]
+  24      Copy         13  12   0               0  r[12]=r[13]
+  25      Copy         12   1   0               0  r[1]=r[12]
+  26    Return         11   0   1               0
+  27    Copy            4  16   0               0  r[16]=r[4]
+  28    Copy            6  17   1               0  r[17]=r[6]
+  29    Copy           16  19   0               0  r[19]=r[16]
+  30    Copy            1  20   0               0  r[20]=r[1]
+  31    MakeRecord     19   2  21               0  r[21]=mkrec(r[19..20])
+  32    NewRowid        0  22   0               0  r[22]=rowid
+  33    Insert          0  21  22               4  intkey=r[22] data=r[21]
+  34  Next              1   5   0               0
+  35  FkCheck           0   0   0               0
+  36  Rewind            0  41   0               0  Rewind  ephemeral(t)
+  37    Column          0   0  23               0  r[23]=ephemeral(t).id
+  38    Column          0   1  24               0  r[24]=ephemeral(t).grp
+  39    ResultRow      23   2   0               0  output=r[23..24]
+  40  Next              0  37   0               0
+  41  Halt              0   0   0               0
+  42  Transaction       0   2   1               0  iDb=0 tx_mode=Write
+  43  Integer           1  15   0               0  r[15]=1
+  44  Goto              0   1   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-join.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-join.snap
@@ -28,63 +28,58 @@ QUERY PLAN
 `--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
 
 BYTECODE
-addr  opcode                   p1  p2  p3  p4            p5  comment
-   0          Init              0  55   0                 0  Start at 55
-   1          InitCoroutine     1  42   2                 0
-   2          Null              0  10  11                 0  r[10..11]=NULL
-   3          Integer           0   7   0                 0  r[7]=0; clear group by abort flag
-   4          Null              0   8   0                 0  r[8]=NULL; initialize group by comparison registers to NULL
-   5          Gosub            15  38   0                 0  ; go to clear accumulator subroutine
-   6          OpenRead          0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   7          OpenRead          1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-   8          Rewind            1  25   0                 0  Rewind index idx_orders_customer
-   9            DeferredSeek    1   0   0                 0
-  10            Column          1   0  13                 0  r[13]=idx_orders_customer.customer_id
-  11            Column          0   3  14                 0  r[14]=orders.total_amount
-  12            RealAffinity   14   0   0                 0
-  13            Compare         8  13   1  k(1, Binary)   0  r[8..8]==r[13..13]
-  14            Jump           15  19  15                 0  ; start new group if comparison is not equal
-  15            Gosub           5  29   0                 0  ; check if ended group had data, and output if so
-  16            Move           13   8   1                 0  r[8..8]=r[13..13]
-  17            IfPos           7  41   0                 0  r[7]>0 -> r[7]-=0, goto 41; check abort flag
-  18            Gosub          15  38   0                 0  ; goto clear accumulator subroutine
-  19            AggStep         0  16  10  count          0  accum=r[10] step(r[16])
-  20            AggStep         0  14  11  sum            0  accum=r[11] step(r[14])
-  21            If              6  23   0                 0  if r[6] goto 23; don't emit group columns if continuing existing group
-  22            Column          1   0   9                 0  r[9]=idx_orders_customer.customer_id
-  23            Integer         1   6   0                 0  r[6]=1; indicate data in accumulator
-  24          Next              1   9   0                 0
-  25          Gosub             5  29   0                 0  ; emit row for final group
-  26          Goto              0  41   0                 0  ; group by finished
-  27          Integer           1   7   0                 0  r[7]=1
-  28        Return              5   0   0                 0
-  29        IfPos               6  31   0                 0  r[6]>0 -> r[6]-=0, goto 31; output group by row subroutine start
-  30      Return                5   0   0                 0
-  31      AggFinal              0  10   0  count          0  accum=r[10]
-  32      AggFinal              0  11   0  sum            0  accum=r[11]
-  33      Copy                  9   2   0                 0  r[2]=r[9]
-  34      Copy                 10   3   0                 0  r[3]=r[10]
-  35      Copy                 11   4   0                 0  r[4]=r[11]
-  36      Yield                 1   0   0                 0
-  37    Return                  5   0   0                 0
-  38    Null                    0   9  11                 0  r[9..11]=NULL; clear accumulator subroutine start
-  39    Integer                 0   6   0                 0  r[6]=0
-  40  Return                   15   0   0                 0
-  41  EndCoroutine              1   0   0                 0
-  42  OpenRead                  2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  43  InitCoroutine             1   0   2                 0
-  44    Yield                   1  54   0                 0
-  45    Copy                    4  21   0                 0  r[21]=r[4]
-  46    Le                     21  22  53  Binary         0  if r[21]<=r[22] goto 53
-  47    Copy                    2  23   0                 0  r[23]=r[2]
-  48    SeekRowid               2  23  53                 0  if (r[23]!=cursor 2 for table customers.rowid) goto 53
-  49    Column                  2   1  17                 0  r[17]=customers.name
-  50    Copy                    3  18   0                 0  r[18]=r[3]
-  51    Copy                    4  19   0                 0  r[19]=r[4]
-  52    ResultRow              17   3   0                 0  output=r[17..19]
-  53  Goto                      0  44   0                 0
-  54  Halt                      0   0   0                 0
-  55  Transaction               0   1  11                 0  iDb=0 tx_mode=Read
-  56  Integer                   1  16   0                 0  r[16]=1
-  57  Integer                 500  22   0                 0  r[22]=500
-  58  Goto                      0   1   0                 0
+addr  opcode                 p1  p2  p3  p4            p5  comment
+   0        Init              0  50   0                 0  Start at 50
+   1        InitCoroutine     1  38   2                 0
+   2        Null              0  10  11                 0  r[10..11]=NULL
+   3        Integer           0   7   0                 0  r[7]=0; clear group by abort flag
+   4        Null              0   8   0                 0  r[8]=NULL; initialize group by comparison registers to NULL
+   5        Gosub            15  34   0                 0  ; go to clear accumulator subroutine
+   6        OpenRead          0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   7        OpenRead          1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   8        Rewind            1  25   0                 0  Rewind index idx_orders_customer
+   9          DeferredSeek    1   0   0                 0
+  10          Column          1   0  13                 0  r[13]=idx_orders_customer.customer_id
+  11          Column          0   3  14                 0  r[14]=orders.total_amount
+  12          RealAffinity   14   0   0                 0
+  13          Compare         8  13   1  k(1, Binary)   0  r[8..8]==r[13..13]
+  14          Jump           15  19  15                 0  ; start new group if comparison is not equal
+  15          Gosub           5  27   0                 0  ; check if ended group had data, and output if so
+  16          Move           13   8   1                 0  r[8..8]=r[13..13]
+  17          IfPos           7  37   0                 0  r[7]>0 -> r[7]-=0, goto 37; check abort flag
+  18          Gosub          15  34   0                 0  ; goto clear accumulator subroutine
+  19          AggStep         0  16  10  count          0  accum=r[10] step(r[16])
+  20          AggStep         0  14  11  sum            0  accum=r[11] step(r[14])
+  21          If              6  23   0                 0  if r[6] goto 23; don't emit group columns if continuing existing group
+  22          Column          1   0   9                 0  r[9]=idx_orders_customer.customer_id
+  23          Integer         1   6   0                 0  r[6]=1; indicate data in accumulator
+  24        Next              1   9   0                 0
+  25        Gosub             5  27   0                 0  ; emit row for final group
+  26        Goto              0  37   0                 0  ; group by finished
+  27        IfPos             6  29   0                 0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
+  28      Return              5   0   0                 0
+  29      AggFinal            0  10   0  count          0  accum=r[10]
+  30      AggFinal            0  11   0  sum            0  accum=r[11]
+  31      Copy                9   2   2                 0  r[2]=r[9]
+  32      Yield               1   0   0                 0
+  33    Return                5   0   0                 0
+  34    Null                  0   9  11                 0  r[9..11]=NULL; clear accumulator subroutine start
+  35    Integer               0   6   0                 0  r[6]=0
+  36  Return                 15   0   0                 0
+  37  EndCoroutine            1   0   0                 0
+  38  OpenRead                2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  39  InitCoroutine           1   0   2                 0
+  40    Yield                 1  49   0                 0
+  41    Copy                  4  21   0                 0  r[21]=r[4]
+  42    Le                   21  22  40  Binary         0  if r[21]<=r[22] goto 40
+  43    Copy                  2  23   0                 0  r[23]=r[2]
+  44    SeekRowid             2  23  40                 0  if (r[23]!=cursor 2 for table customers.rowid) goto 40
+  45    Column                2   1  17                 0  r[17]=customers.name
+  46    Copy                  3  18   1                 0  r[18]=r[3]
+  47    ResultRow            17   3   0                 0  output=r[17..19]
+  48  Goto                    0  40   0                 0
+  49  Halt                    0   0   0                 0
+  50  Transaction             0   1  11                 0  iDb=0 tx_mode=Read
+  51  Integer                 1  16   0                 0  r[16]=1
+  52  Integer               500  22   0                 0  r[22]=500
+  53  Goto                    0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
@@ -30,69 +30,66 @@ QUERY PLAN
    `--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4            p5  comment
-   0          Init               0  63   0                 0  Start at 63
-   1          OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
-   2          InitCoroutine      3  40   3                 0
-   3          Null               0  11   0                 0  r[11]=NULL
-   4          Integer            0   8   0                 0  r[8]=0; clear group by abort flag
-   5          Null               0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
-   6          Gosub             15  36   0                 0  ; go to clear accumulator subroutine
-   7          OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   8          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-   9          Rewind             2  25   0                 0  Rewind index idx_orders_customer
-  10            DeferredSeek     2   1   0                 0
-  11            Column           2   0  13                 0  r[13]=idx_orders_customer.customer_id
-  12            Column           1   3  14                 0  r[14]=orders.total_amount
-  13            RealAffinity    14   0   0                 0
-  14            Compare          9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
-  15            Jump            16  20  16                 0  ; start new group if comparison is not equal
-  16            Gosub            6  29   0                 0  ; check if ended group had data, and output if so
-  17            Move            13   9   1                 0  r[9..9]=r[13..13]
-  18            IfPos            8  39   0                 0  r[8]>0 -> r[8]-=0, goto 39; check abort flag
-  19            Gosub           15  36   0                 0  ; goto clear accumulator subroutine
-  20            AggStep          0  14  11  sum            0  accum=r[11] step(r[14])
-  21            If               7  23   0                 0  if r[7] goto 23; don't emit group columns if continuing existing group
-  22            Column           2   0  10                 0  r[10]=idx_orders_customer.customer_id
-  23            Integer          1   7   0                 0  r[7]=1; indicate data in accumulator
-  24          Next               2  10   0                 0
-  25          Gosub              6  29   0                 0  ; emit row for final group
-  26          Goto               0  39   0                 0  ; group by finished
-  27          Integer            1   8   0                 0  r[8]=1
-  28        Return               6   0   0                 0
-  29        IfPos                7  31   0                 0  r[7]>0 -> r[7]-=0, goto 31; output group by row subroutine start
-  30      Return                 6   0   0                 0
-  31      AggFinal               0  11   0  sum            0  accum=r[11]
-  32      Copy                  10   4   0                 0  r[4]=r[10]
-  33      Copy                  11   5   0                 0  r[5]=r[11]
-  34      Yield                  3   0   0                 0
-  35    Return                   6   0   0                 0
-  36    Null                     0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
-  37    Integer                  0   7   0                 0  r[7]=0
-  38  Return                    15   0   0                 0
-  39  EndCoroutine               3   0   0                 0
-  40  OpenRead                   3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  41  InitCoroutine              3   0   3                 0
-  42    Yield                    3  53   0                 0
-  43    Copy                     4  18   0                 0  r[18]=r[4]
-  44    SeekRowid                3  18  52                 0  if (r[18]!=cursor 3 for table customers.rowid) goto 52
-  45    Column                   3   1  16                 0  r[16]=customers.name
-  46    Copy                     5  17   0                 0  r[17]=r[5]
-  47    Copy                    17  20   0                 0  r[20]=r[17]
-  48    Copy                    16  21   0                 0  r[21]=r[16]
-  49    Sequence                 0  22   0                 0
-  50    MakeRecord              20   3  19                 0  r[19]=mkrec(r[20..22]); for ephemeral_subquery_t4
-  51    IdxInsert                0  19   0                 8  key=r[19]
-  52  Goto                       0  42   0                 0
-  53  Last                       0  62   0                 0
-  54  Integer                 1000  25   0                 0  r[25]=1000
-  55    IdxLE                    0  62  25                 0  key=[25..25]
-  56    Column                   0   1   1                 0  r[1]=ephemeral(ephemeral_subquery_t4).name
-  57    Column                   0   0   2                 0  r[2]=ephemeral(ephemeral_subquery_t4).total_spent
-  58    Column                   0   1  23                 0  r[23]=ephemeral(ephemeral_subquery_t4).name
-  59    Column                   0   0  24                 0  r[24]=ephemeral(ephemeral_subquery_t4).total_spent
-  60    ResultRow               23   2   0                 0  output=r[23..24]
-  61  Prev                       0  55   0                 0
-  62  Halt                       0   0   0                 0
-  63  Transaction                0   1  11                 0  iDb=0 tx_mode=Read
-  64  Goto                       0   1   0                 0
+addr  opcode                  p1  p2  p3  p4            p5  comment
+   0        Init               0  60   0                 0  Start at 60
+   1        OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
+   2        InitCoroutine      3  37   3                 0
+   3        Null               0  11   0                 0  r[11]=NULL
+   4        Integer            0   8   0                 0  r[8]=0; clear group by abort flag
+   5        Null               0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
+   6        Gosub             15  33   0                 0  ; go to clear accumulator subroutine
+   7        OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   8        OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   9        Rewind             2  25   0                 0  Rewind index idx_orders_customer
+  10          DeferredSeek     2   1   0                 0
+  11          Column           2   0  13                 0  r[13]=idx_orders_customer.customer_id
+  12          Column           1   3  14                 0  r[14]=orders.total_amount
+  13          RealAffinity    14   0   0                 0
+  14          Compare          9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
+  15          Jump            16  20  16                 0  ; start new group if comparison is not equal
+  16          Gosub            6  27   0                 0  ; check if ended group had data, and output if so
+  17          Move            13   9   1                 0  r[9..9]=r[13..13]
+  18          IfPos            8  36   0                 0  r[8]>0 -> r[8]-=0, goto 36; check abort flag
+  19          Gosub           15  33   0                 0  ; goto clear accumulator subroutine
+  20          AggStep          0  14  11  sum            0  accum=r[11] step(r[14])
+  21          If               7  23   0                 0  if r[7] goto 23; don't emit group columns if continuing existing group
+  22          Column           2   0  10                 0  r[10]=idx_orders_customer.customer_id
+  23          Integer          1   7   0                 0  r[7]=1; indicate data in accumulator
+  24        Next               2  10   0                 0
+  25        Gosub              6  27   0                 0  ; emit row for final group
+  26        Goto               0  36   0                 0  ; group by finished
+  27        IfPos              7  29   0                 0  r[7]>0 -> r[7]-=0, goto 29; output group by row subroutine start
+  28      Return               6   0   0                 0
+  29      AggFinal             0  11   0  sum            0  accum=r[11]
+  30      Copy                10   4   1                 0  r[4]=r[10]
+  31      Yield                3   0   0                 0
+  32    Return                 6   0   0                 0
+  33    Null                   0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
+  34    Integer                0   7   0                 0  r[7]=0
+  35  Return                  15   0   0                 0
+  36  EndCoroutine             3   0   0                 0
+  37  OpenRead                 3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  38  InitCoroutine            3   0   3                 0
+  39    Yield                  3  50   0                 0
+  40    Copy                   4  18   0                 0  r[18]=r[4]
+  41    SeekRowid              3  18  39                 0  if (r[18]!=cursor 3 for table customers.rowid) goto 39
+  42    Column                 3   1  16                 0  r[16]=customers.name
+  43    Copy                   5  17   0                 0  r[17]=r[5]
+  44    Copy                  17  20   0                 0  r[20]=r[17]
+  45    Copy                  16  21   0                 0  r[21]=r[16]
+  46    Sequence               0  22   0                 0
+  47    MakeRecord            20   3  19                 0  r[19]=mkrec(r[20..22]); for ephemeral_subquery_t4
+  48    IdxInsert              0  19   0                 8  key=r[19]
+  49  Goto                     0  39   0                 0
+  50  Last                     0  59   0                 0
+  51  Integer               1000  25   0                 0  r[25]=1000
+  52    IdxLE                  0  59  25                 0  key=[25..25]
+  53    Column                 0   1   1                 0  r[1]=ephemeral(ephemeral_subquery_t4).name
+  54    Column                 0   0   2                 0  r[2]=ephemeral(ephemeral_subquery_t4).total_spent
+  55    Column                 0   1  23                 0  r[23]=ephemeral(ephemeral_subquery_t4).name
+  56    Column                 0   0  24                 0  r[24]=ephemeral(ephemeral_subquery_t4).total_spent
+  57    ResultRow             23   2   0                 0  output=r[23..24]
+  58  Prev                     0  52   0                 0
+  59  Halt                     0   0   0                 0
+  60  Transaction              0   1  11                 0  iDb=0 tx_mode=Read
+  61  Goto                     0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__exists-correlated.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__exists-correlated.snap
@@ -24,11 +24,11 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode             p1  p2  p3  p4            p5  comment
-   0  Init                0  20   0                 0  Start at 20
+   0  Init                0  19   0                 0  Start at 19
    1  OpenRead            0   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
    2  OpenRead            1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
    3  OpenRead            2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-   4  Rewind              0  19   0                 0  Rewind table customers
+   4  Rewind              0  18   0                 0  Rewind table customers
    5    RowId             0   4   0                 0  r[4]=customers.rowid
    6    SeekGE            2  17   4                 0  key=[4..4]
    7      IdxGT           2  17   4                 0  key=[4..4]
@@ -39,11 +39,10 @@ addr  opcode             p1  p2  p3  p4            p5  comment
   12      RowId           0   2   0                 0  r[2]=customers.rowid
   13      Column          0   1   3                 0  r[3]=customers.name
   14      ResultRow       2   2   0                 0  output=r[2..3]
-  15      Goto            0  18   0                 0  ; semi-join: early out after first match
+  15      Goto            0  17   0                 0  ; semi-join: early out after first match
   16    Next              2   7   0                 0
-  17    Goto              0  18   0                 0  ; semi-join: no match, skip outer row
-  18  Next                0   5   0                 0
-  19  Halt                0   0   0                 0
-  20  Transaction         0   1  11                 0  iDb=0 tx_mode=Read
-  21  Integer           500   7   0                 0  r[7]=500
-  22  Goto                0   1   0                 0
+  17  Next                0   5   0                 0
+  18  Halt                0   0   0                 0
+  19  Transaction         0   1  11                 0  iDb=0 tx_mode=Read
+  20  Integer           500   7   0                 0  r[7]=500
+  21  Goto                0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
@@ -23,64 +23,61 @@ QUERY PLAN
    `--SEARCH gv2 USING INDEX idx_grouped_values_grp (grp=?)
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4            p5  comment
-   0            Init             0  58   0                 0  Start at 58
-   1            Null             0   9   0                 0  r[9]=NULL
-   2            Integer          0   6   0                 0  r[6]=0; clear group by abort flag
-   3            Null             0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
-   4            Gosub           13  54   0                 0  ; go to clear accumulator subroutine
-   5            OpenRead         0   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
-   6            OpenRead         1   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
-   7            Rewind           1  22   0                 0  Rewind index idx_grouped_values_grp
-   8              DeferredSeek   1   0   0                 0
-   9              Column         1   0  11                 0  r[11]=idx_grouped_values_grp.grp
-  10              Column         0   1  12                 0  r[12]=grouped_values.val
-  11              Compare        7  11   1  k(1, Binary)   0  r[7..7]==r[11..11]
-  12              Jump          13  17  13                 0  ; start new group if comparison is not equal
-  13              Gosub          4  26   0                 0  ; check if ended group had data, and output if so
-  14              Move          11   7   1                 0  r[7..7]=r[11..11]
-  15              IfPos          6  57   0                 0  r[6]>0 -> r[6]-=0, goto 57; check abort flag
-  16              Gosub         13  54   0                 0  ; goto clear accumulator subroutine
-  17              AggStep        0  12   9  sum            0  accum=r[9] step(r[12])
-  18              If             5  20   0                 0  if r[5] goto 20; don't emit group columns if continuing existing group
-  19              Column         1   0   8                 0  r[8]=idx_grouped_values_grp.grp
-  20              Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
-  21            Next             1   8   0                 0
-  22            Gosub            4  26   0                 0  ; emit row for final group
-  23            Goto             0  57   0                 0  ; group by finished
-  24            Integer          1   6   0                 0  r[6]=1
-  25          Return             4   0   0                 0
-  26          IfPos              5  28   0                 0  r[5]>0 -> r[5]-=0, goto 28; output group by row subroutine start
-  27        Return               4   0   0                 0
-  28        AggFinal             0   9   0  sum            0  accum=r[9]
-  29        BeginSubrtn         14   0   0                 0  r[14]=NULL
-  30        Null                 0   1   0                 0  r[1]=NULL
-  31        Null                 0  16   0                 0  r[16]=NULL
-  32        Integer              1  17   0                 0  r[17]=1; LIMIT counter
-  33        IfNot               17  44   0                 0  if !r[17] goto 44
-  34        OpenRead             2   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
-  35        OpenRead             3   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
-  36        Copy                 8  18   0                 0  r[18]=r[8]
-  37        IsNull              18  44   0                 0  if (r[18]==NULL) goto 44
-  38        SeekGE               3  44  18                 0  key=[18..18]
-  39          IdxGT              3  44  18                 0  key=[18..18]
-  40          DeferredSeek       3   2   0                 0
-  41          Column             2   1  19                 0  r[19]=grouped_values.val
-  42          AggStep            0  19  16  max(Binary)    0  accum=r[16] step(r[19])
-  43        Next                 3  39   0                 0
-  44        AggFinal             0  16   0  max            0  accum=r[16]
-  45        Copy                16  15   0                 0  r[15]=r[16]
-  46        Copy                15   1   0                 0  r[1]=r[15]
-  47      Return                14   0   1                 0
-  48      Copy                   1  20   0                 0  r[20]=r[1]
-  49      IsNull                20  27   0                 0  if (r[20]==NULL) goto 27
-  50      Copy                   8   2   0                 0  r[2]=r[8]
-  51      Copy                   9   3   0                 0  r[3]=r[9]
-  52      ResultRow              2   2   0                 0  output=r[2..3]
-  53    Return                   4   0   0                 0
-  54    Null                     0   8   9                 0  r[8..9]=NULL; clear accumulator subroutine start
-  55    Integer                  0   5   0                 0  r[5]=0
-  56  Return                    13   0   0                 0
-  57  Halt                       0   0   0                 0
-  58  Transaction                0   1   2                 0  iDb=0 tx_mode=Read
-  59  Goto                       0   1   0                 0
+addr  opcode                  p1  p2  p3  p4            p5  comment
+   0          Init             0  55   0                 0  Start at 55
+   1          Null             0   9   0                 0  r[9]=NULL
+   2          Integer          0   6   0                 0  r[6]=0; clear group by abort flag
+   3          Null             0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
+   4          Gosub           13  51   0                 0  ; go to clear accumulator subroutine
+   5          OpenRead         0   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+   6          OpenRead         1   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+   7          Rewind           1  22   0                 0  Rewind index idx_grouped_values_grp
+   8            DeferredSeek   1   0   0                 0
+   9            Column         1   0  11                 0  r[11]=idx_grouped_values_grp.grp
+  10            Column         0   1  12                 0  r[12]=grouped_values.val
+  11            Compare        7  11   1  k(1, Binary)   0  r[7..7]==r[11..11]
+  12            Jump          13  17  13                 0  ; start new group if comparison is not equal
+  13            Gosub          4  24   0                 0  ; check if ended group had data, and output if so
+  14            Move          11   7   1                 0  r[7..7]=r[11..11]
+  15            IfPos          6  54   0                 0  r[6]>0 -> r[6]-=0, goto 54; check abort flag
+  16            Gosub         13  51   0                 0  ; goto clear accumulator subroutine
+  17            AggStep        0  12   9  sum            0  accum=r[9] step(r[12])
+  18            If             5  20   0                 0  if r[5] goto 20; don't emit group columns if continuing existing group
+  19            Column         1   0   8                 0  r[8]=idx_grouped_values_grp.grp
+  20            Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
+  21          Next             1   8   0                 0
+  22          Gosub            4  24   0                 0  ; emit row for final group
+  23          Halt             0   0   0                 0  ; group by finished
+  24          IfPos            5  26   0                 0  r[5]>0 -> r[5]-=0, goto 26; output group by row subroutine start
+  25        Return             4   0   0                 0
+  26        AggFinal           0   9   0  sum            0  accum=r[9]
+  27        BeginSubrtn       14   0   0                 0  r[14]=NULL
+  28        Null               0   1   0                 0  r[1]=NULL
+  29        Null               0  16   0                 0  r[16]=NULL
+  30        Integer            1  17   0                 0  r[17]=1; LIMIT counter
+  31        IfNot             17  42   0                 0  if !r[17] goto 42
+  32        OpenRead           2   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+  33        OpenRead           3   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+  34        Copy               8  18   0                 0  r[18]=r[8]
+  35        IsNull            18  42   0                 0  if (r[18]==NULL) goto 42
+  36        SeekGE             3  42  18                 0  key=[18..18]
+  37          IdxGT            3  42  18                 0  key=[18..18]
+  38          DeferredSeek     3   2   0                 0
+  39          Column           2   1  19                 0  r[19]=grouped_values.val
+  40          AggStep          0  19  16  max(Binary)    0  accum=r[16] step(r[19])
+  41        Next               3  37   0                 0
+  42        AggFinal           0  16   0  max            0  accum=r[16]
+  43        Copy              16  15   0                 0  r[15]=r[16]
+  44        Copy              15   1   0                 0  r[1]=r[15]
+  45      Return              14   0   1                 0
+  46      Copy                 1  20   0                 0  r[20]=r[1]
+  47      IsNull              20  25   0                 0  if (r[20]==NULL) goto 25
+  48      Copy                 8   2   1                 0  r[2]=r[8]
+  49      ResultRow            2   2   0                 0  output=r[2..3]
+  50    Return                 4   0   0                 0
+  51    Null                   0   8   9                 0  r[8..9]=NULL; clear accumulator subroutine start
+  52    Integer                0   5   0                 0  r[5]=0
+  53  Return                  13   0   0                 0
+  54  Halt                     0   0   0                 0
+  55  Transaction              0   1   2                 0  iDb=0 tx_mode=Read
+  56  Goto                     0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -24,73 +24,70 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4              p5  comment
-   0            Init             0  67   0                   0  Start at 67
-   1            SorterOpen       0   2   0  k(2,-B,Binary)   0  cursor=0
-   2            Null             0  10   0                   0  r[10]=NULL
-   3            Integer          0   7   0                   0  r[7]=0; clear group by abort flag
-   4            Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
-   5            Gosub           14  56   0                   0  ; go to clear accumulator subroutine
-   6            OpenRead         1   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-   7            OpenRead         2   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
-   8            Rewind           2  23   0                   0  Rewind index idx_grouped_values_grp
-   9              DeferredSeek   2   1   0                   0
-  10              Column         2   0  12                   0  r[12]=idx_grouped_values_grp.grp
-  11              Column         1   1  13                   0  r[13]=grouped_values.val
-  12              Compare        8  12   1  k(1, Binary)     0  r[8..8]==r[12..12]
-  13              Jump          14  18  14                   0  ; start new group if comparison is not equal
-  14              Gosub          5  27   0                   0  ; check if ended group had data, and output if so
-  15              Move          12   8   1                   0  r[8..8]=r[12..12]
-  16              IfPos          7  59   0                   0  r[7]>0 -> r[7]-=0, goto 59; check abort flag
-  17              Gosub         14  56   0                   0  ; goto clear accumulator subroutine
-  18              AggStep        0  13  10  sum              0  accum=r[10] step(r[13])
-  19              If             6  21   0                   0  if r[6] goto 21; don't emit group columns if continuing existing group
-  20              Column         2   0   9                   0  r[9]=idx_grouped_values_grp.grp
-  21              Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
-  22            Next             2   9   0                   0
-  23            Gosub            5  27   0                   0  ; emit row for final group
-  24            Goto             0  59   0                   0  ; group by finished
-  25            Integer          1   7   0                   0  r[7]=1
-  26          Return             5   0   0                   0
-  27          IfPos              6  29   0                   0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
-  28        Return               5   0   0                   0
-  29        AggFinal             0  10   0  sum              0  accum=r[10]
-  30        BeginSubrtn         15   0   0                   0  r[15]=NULL
-  31        Null                 0   1   0                   0  r[1]=NULL
-  32        Null                 0  17   0                   0  r[17]=NULL
-  33        Integer              1  18   0                   0  r[18]=1; LIMIT counter
-  34        IfNot               18  45   0                   0  if !r[18] goto 45
-  35        OpenRead             3   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-  36        OpenRead             4   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
-  37        Copy                 9  19   0                   0  r[19]=r[9]
-  38        IsNull              19  45   0                   0  if (r[19]==NULL) goto 45
-  39        SeekGE               4  45  19                   0  key=[19..19]
-  40          IdxGT              4  45  19                   0  key=[19..19]
-  41          DeferredSeek       4   3   0                   0
-  42          Column             3   1  20                   0  r[20]=grouped_values.val
-  43          AggStep            0  20  17  max(Binary)      0  accum=r[17] step(r[20])
-  44        Next                 4  40   0                   0
-  45        AggFinal             0  17   0  max              0  accum=r[17]
-  46        Copy                17  16   0                   0  r[16]=r[17]
-  47        Copy                16   1   0                   0  r[1]=r[16]
-  48      Return                15   0   1                   0
-  49      Copy                   1  21   0                   0  r[21]=r[1]
-  50      Sequence               0  22   0                   0
-  51      Copy                   9  23   0                   0  r[23]=r[9]
-  52      Copy                  10  24   0                   0  r[24]=r[10]
-  53      MakeRecord            21   4   4                   0  r[4]=mkrec(r[21..24])
-  54      SorterInsert           0   4   0  0                0  key=r[4]
-  55    Return                   5   0   0                   0
-  56    Null                     0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
-  57    Integer                  0   6   0                   0  r[6]=0
-  58  Return                    14   0   0                   0
-  59  OpenPseudo                 5   4   4                   0  4 columns in r[4]
-  60  SorterSort                 0  66   0                   0
-  61    SorterData               0   4   5                   0  r[4]=data
-  62    Column                   5   2   2                   0  r[2]=pseudo.column 2
-  63    Column                   5   3   3                   0  r[3]=pseudo.column 3
-  64    ResultRow                2   2   0                   0  output=r[2..3]
-  65  SorterNext                 0  61   0                   0
-  66  Halt                       0   0   0                   0
-  67  Transaction                0   1   2                   0  iDb=0 tx_mode=Read
-  68  Goto                       0   1   0                   0
+addr  opcode                  p1  p2  p3  p4              p5  comment
+   0          Init             0  64   0                   0  Start at 64
+   1          SorterOpen       0   2   0  k(2,-B,Binary)   0  cursor=0
+   2          Null             0  10   0                   0  r[10]=NULL
+   3          Integer          0   7   0                   0  r[7]=0; clear group by abort flag
+   4          Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
+   5          Gosub           14  53   0                   0  ; go to clear accumulator subroutine
+   6          OpenRead         1   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
+   7          OpenRead         2   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
+   8          Rewind           2  23   0                   0  Rewind index idx_grouped_values_grp
+   9            DeferredSeek   2   1   0                   0
+  10            Column         2   0  12                   0  r[12]=idx_grouped_values_grp.grp
+  11            Column         1   1  13                   0  r[13]=grouped_values.val
+  12            Compare        8  12   1  k(1, Binary)     0  r[8..8]==r[12..12]
+  13            Jump          14  18  14                   0  ; start new group if comparison is not equal
+  14            Gosub          5  25   0                   0  ; check if ended group had data, and output if so
+  15            Move          12   8   1                   0  r[8..8]=r[12..12]
+  16            IfPos          7  56   0                   0  r[7]>0 -> r[7]-=0, goto 56; check abort flag
+  17            Gosub         14  53   0                   0  ; goto clear accumulator subroutine
+  18            AggStep        0  13  10  sum              0  accum=r[10] step(r[13])
+  19            If             6  21   0                   0  if r[6] goto 21; don't emit group columns if continuing existing group
+  20            Column         2   0   9                   0  r[9]=idx_grouped_values_grp.grp
+  21            Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
+  22          Next             2   9   0                   0
+  23          Gosub            5  25   0                   0  ; emit row for final group
+  24          Goto             0  56   0                   0  ; group by finished
+  25          IfPos            6  27   0                   0  r[6]>0 -> r[6]-=0, goto 27; output group by row subroutine start
+  26        Return             5   0   0                   0
+  27        AggFinal           0  10   0  sum              0  accum=r[10]
+  28        BeginSubrtn       15   0   0                   0  r[15]=NULL
+  29        Null               0   1   0                   0  r[1]=NULL
+  30        Null               0  17   0                   0  r[17]=NULL
+  31        Integer            1  18   0                   0  r[18]=1; LIMIT counter
+  32        IfNot             18  43   0                   0  if !r[18] goto 43
+  33        OpenRead           3   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
+  34        OpenRead           4   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
+  35        Copy               9  19   0                   0  r[19]=r[9]
+  36        IsNull            19  43   0                   0  if (r[19]==NULL) goto 43
+  37        SeekGE             4  43  19                   0  key=[19..19]
+  38          IdxGT            4  43  19                   0  key=[19..19]
+  39          DeferredSeek     4   3   0                   0
+  40          Column           3   1  20                   0  r[20]=grouped_values.val
+  41          AggStep          0  20  17  max(Binary)      0  accum=r[17] step(r[20])
+  42        Next               4  38   0                   0
+  43        AggFinal           0  17   0  max              0  accum=r[17]
+  44        Copy              17  16   0                   0  r[16]=r[17]
+  45        Copy              16   1   0                   0  r[1]=r[16]
+  46      Return              15   0   1                   0
+  47      Copy                 1  21   0                   0  r[21]=r[1]
+  48      Sequence             0  22   0                   0
+  49      Copy                 9  23   1                   0  r[23]=r[9]
+  50      MakeRecord          21   4   4                   0  r[4]=mkrec(r[21..24])
+  51      SorterInsert         0   4   0  0                0  key=r[4]
+  52    Return                 5   0   0                   0
+  53    Null                   0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
+  54    Integer                0   6   0                   0  r[6]=0
+  55  Return                  14   0   0                   0
+  56  OpenPseudo               5   4   4                   0  4 columns in r[4]
+  57  SorterSort               0  63   0                   0
+  58    SorterData             0   4   5                   0  r[4]=data
+  59    Column                 5   2   2                   0  r[2]=pseudo.column 2
+  60    Column                 5   3   3                   0  r[3]=pseudo.column 3
+  61    ResultRow              2   2   0                   0  output=r[2..3]
+  62  SorterNext               0  58   0                   0
+  63  Halt                     0   0   0                   0
+  64  Transaction              0   1   2                   0  iDb=0 tx_mode=Read
+  65  Goto                     0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
@@ -24,59 +24,57 @@ QUERY PLAN
 `--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4            p5  comment
-   0          Init               0  53   0                 0  Start at 53
-   1          Once              42   0   0                 0  goto 42
-   2          OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
-   3          Null               0   7   0                 0  r[7]=NULL
-   4          Integer            0   4   0                 0  r[4]=0; clear group by abort flag
-   5          Null               0   5   0                 0  r[5]=NULL; initialize group by comparison registers to NULL
-   6          Gosub             11  39   0                 0  ; go to clear accumulator subroutine
-   7          OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   8          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-   9          Rewind             2  25   0                 0  Rewind index idx_orders_customer
-  10            DeferredSeek     2   1   0                 0
-  11            Column           2   0   9                 0  r[9]=idx_orders_customer.customer_id
-  12            Column           1   3  10                 0  r[10]=orders.total_amount
-  13            RealAffinity    10   0   0                 0
-  14            Compare          5   9   1  k(1, Binary)   0  r[5..5]==r[9..9]
-  15            Jump            16  20  16                 0  ; start new group if comparison is not equal
-  16            Gosub            2  29   0                 0  ; check if ended group had data, and output if so
-  17            Move             9   5   1                 0  r[5..5]=r[9..9]
-  18            IfPos            4  42   0                 0  r[4]>0 -> r[4]-=0, goto 42; check abort flag
-  19            Gosub           11  39   0                 0  ; goto clear accumulator subroutine
-  20            AggStep          0  10   7  sum            0  accum=r[7] step(r[10])
-  21            If               3  23   0                 0  if r[3] goto 23; don't emit group columns if continuing existing group
-  22            Column           2   0   6                 0  r[6]=idx_orders_customer.customer_id
-  23            Integer          1   3   0                 0  r[3]=1; indicate data in accumulator
-  24          Next               2  10   0                 0
-  25          Gosub              2  29   0                 0  ; emit row for final group
-  26          Goto               0  42   0                 0  ; group by finished
-  27          Integer            1   4   0                 0  r[4]=1
-  28        Return               2   0   0                 0
-  29        IfPos                3  31   0                 0  r[3]>0 -> r[3]-=0, goto 31; output group by row subroutine start
-  30      Return                 2   0   0                 0
-  31      AggFinal               0   7   0  sum            0  accum=r[7]
-  32      Copy                   7  13   0                 0  r[13]=r[7]
-  33      Integer             1000  14   0                 0  r[14]=1000
-  34      Le                    13  14  30                 0  if r[13]<=r[14] goto 30
-  35      Copy                   6   1   0                 0  r[1]=r[6]
-  36      MakeRecord             1   1  15                 0  r[15]=mkrec(r[1..1]); for ephemeral_index_where_sub_t2
-  37      IdxInsert              0  15   0                 8  key=r[15]
-  38    Return                   2   0   0                 0
-  39    Null                     0   6   7                 0  r[6..7]=NULL; clear accumulator subroutine start
-  40    Integer                  0   3   0                 0  r[3]=0
-  41  Return                    11   0   0                 0
-  42  OpenRead                   3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  43  NullRow                    0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
-  44  Rewind                     0  52   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t2)
-  45    Column                   0   0  18                 0  r[18]=ephemeral(ephemeral_index_where_sub_t2).customer_id
-  46    IsNull                  18  51   0                 0  if (r[18]==NULL) goto 51
-  47    SeekRowid                3  18  51                 0  if (r[18]!=cursor 3 for table customers.rowid) goto 51
-  48    RowId                    3  16   0                 0  r[16]=customers.rowid
-  49    Column                   3   1  17                 0  r[17]=customers.name
-  50    ResultRow               16   2   0                 0  output=r[16..17]
-  51  Next                       0  45   0                 0
-  52  Halt                       0   0   0                 0
-  53  Transaction                0   1  11                 0  iDb=0 tx_mode=Read
-  54  Goto                       0   1   0                 0
+addr  opcode                  p1  p2  p3  p4            p5  comment
+   0        Init               0  51   0                 0  Start at 51
+   1        Once              40   0   0                 0  goto 40
+   2        OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
+   3        Null               0   7   0                 0  r[7]=NULL
+   4        Integer            0   4   0                 0  r[4]=0; clear group by abort flag
+   5        Null               0   5   0                 0  r[5]=NULL; initialize group by comparison registers to NULL
+   6        Gosub             11  37   0                 0  ; go to clear accumulator subroutine
+   7        OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   8        OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   9        Rewind             2  25   0                 0  Rewind index idx_orders_customer
+  10          DeferredSeek     2   1   0                 0
+  11          Column           2   0   9                 0  r[9]=idx_orders_customer.customer_id
+  12          Column           1   3  10                 0  r[10]=orders.total_amount
+  13          RealAffinity    10   0   0                 0
+  14          Compare          5   9   1  k(1, Binary)   0  r[5..5]==r[9..9]
+  15          Jump            16  20  16                 0  ; start new group if comparison is not equal
+  16          Gosub            2  27   0                 0  ; check if ended group had data, and output if so
+  17          Move             9   5   1                 0  r[5..5]=r[9..9]
+  18          IfPos            4  40   0                 0  r[4]>0 -> r[4]-=0, goto 40; check abort flag
+  19          Gosub           11  37   0                 0  ; goto clear accumulator subroutine
+  20          AggStep          0  10   7  sum            0  accum=r[7] step(r[10])
+  21          If               3  23   0                 0  if r[3] goto 23; don't emit group columns if continuing existing group
+  22          Column           2   0   6                 0  r[6]=idx_orders_customer.customer_id
+  23          Integer          1   3   0                 0  r[3]=1; indicate data in accumulator
+  24        Next               2  10   0                 0
+  25        Gosub              2  27   0                 0  ; emit row for final group
+  26        Goto               0  40   0                 0  ; group by finished
+  27        IfPos              3  29   0                 0  r[3]>0 -> r[3]-=0, goto 29; output group by row subroutine start
+  28      Return               2   0   0                 0
+  29      AggFinal             0   7   0  sum            0  accum=r[7]
+  30      Copy                 7  13   0                 0  r[13]=r[7]
+  31      Integer           1000  14   0                 0  r[14]=1000
+  32      Le                  13  14  28                 0  if r[13]<=r[14] goto 28
+  33      Copy                 6   1   0                 0  r[1]=r[6]
+  34      MakeRecord           1   1  15                 0  r[15]=mkrec(r[1..1]); for ephemeral_index_where_sub_t2
+  35      IdxInsert            0  15   0                 8  key=r[15]
+  36    Return                 2   0   0                 0
+  37    Null                   0   6   7                 0  r[6..7]=NULL; clear accumulator subroutine start
+  38    Integer                0   3   0                 0  r[3]=0
+  39  Return                  11   0   0                 0
+  40  OpenRead                 3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  41  NullRow                  0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  42  Rewind                   0  50   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t2)
+  43    Column                 0   0  18                 0  r[18]=ephemeral(ephemeral_index_where_sub_t2).customer_id
+  44    IsNull                18  49   0                 0  if (r[18]==NULL) goto 49
+  45    SeekRowid              3  18  49                 0  if (r[18]!=cursor 3 for table customers.rowid) goto 49
+  46    RowId                  3  16   0                 0  r[16]=customers.rowid
+  47    Column                 3   1  17                 0  r[17]=customers.name
+  48    ResultRow             16   2   0                 0  output=r[16..17]
+  49  Next                     0  43   0                 0
+  50  Halt                     0   0   0                 0
+  51  Transaction              0   1  11                 0  iDb=0 tx_mode=Read
+  52  Goto                     0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__subquery-within-cte.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__subquery-within-cte.snap
@@ -64,7 +64,7 @@ addr  opcode             p1  p2  p3  p4              p5  comment
   30  InitCoroutine       1   0   2                   0
   31    Yield             1  39   0                   0
   32    Copy              7  13   0                   0  r[13]=r[7]
-  33    Le               13  14  38  Binary           0  if r[13]<=r[14] goto 38
+  33    Le               13  14  31  Binary           0  if r[13]<=r[14] goto 31
   34    Copy              7  15   0                   0  r[15]=r[7]
   35    Copy              6  16   0                   0  r[16]=r[6]
   36    MakeRecord       15   2  11                   0  r[11]=mkrec(r[15..16])

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__update-returning-target-selfread.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__update-returning-target-selfread.snap
@@ -20,15 +20,15 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4          p5  comment
-   0    Init            0  50   0               0  Start at 50
+   0    Init            0  48   0               0  Start at 48
    1    OpenEphemeral   0   1   0               0  cursor=0 is_table=true
    2    OpenWrite       1   2   0               0  root=2; iDb=0
-   3    Rewind          1  43   0               0  Rewind table t
+   3    Rewind          1  41   0               0  Rewind table t
    4    Integer         3   2   0               0  r[2]=3
    5      RowId         1   3   0               0  r[3]=t.rowid
-   6      Ge            3   2  43               0  if r[3]>=r[2] goto 43
+   6      Ge            3   2  41               0  if r[3]>=r[2] goto 41
    7      RowId         1   4   0               0  r[4]=t.rowid
-   8      IsNull        4  43   0               0  if (r[4]==NULL) goto 43
+   8      IsNull        4  41   0               0  if (r[4]==NULL) goto 41
    9      Null          0   5   0               0  r[5]=NULL
   10      Column        1   1   6               0  r[6]=t.grp
   11      Column        1   2   8               0  r[8]=t.val
@@ -37,41 +37,39 @@ addr  opcode           p1  p2  p3  p4          p5  comment
   14      MakeRecord    5   3  10               0  r[10]=mkrec(r[5..7])
   15      Insert        1  10   4  t            8  intkey=r[4] data=r[10]
   16      Copy          4  11   0               0  r[11]=r[4]
-  17      Copy          6  12   0               0  r[12]=r[6]
-  18      Copy          7  13   0               0  r[13]=r[7]
-  19      BeginSubrtn  14   0   0               0  r[14]=NULL
-  20      Null          0   1   0               0  r[1]=NULL
-  21      Null          0  16   0               0  r[16]=NULL
-  22      Integer       1  17   0               0  r[17]=1; LIMIT counter
-  23      IfNot        17  30   0               0  if !r[17] goto 30
-  24      OpenRead      2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
-  25      Rewind        2  30   0               0  Rewind table t
-  26        Column      2   2  19               0  r[19]=t.val
-  27        Lt         19  20  29  Binary       0  if r[19]<r[20] goto 29
-  28        AggStep     0  21  16  count        0  accum=r[16] step(r[21])
-  29      Next          2  26   0               0
-  30      AggFinal      0  16   0  count        0  accum=r[16]
-  31      Copy         16  15   0               0  r[15]=r[16]
-  32      Copy         15   1   0               0  r[1]=r[15]
-  33    Return         14   0   1               0
-  34    Copy            4  22   0               0  r[22]=r[4]
-  35    Copy            6  23   0               0  r[23]=r[6]
-  36    Copy            7  24   0               0  r[24]=r[7]
-  37    Copy           22  25   0               0  r[25]=r[22]
-  38    Copy            1  26   0               0  r[26]=r[1]
-  39    MakeRecord     25   2  27               0  r[27]=mkrec(r[25..26])
-  40    NewRowid        0  28   0               0  r[28]=rowid
-  41    Insert          0  27  28               4  intkey=r[28] data=r[27]
-  42  Next              1   5   0               0
-  43  FkCheck           0   0   0               0
-  44  Rewind            0  49   0               0  Rewind  ephemeral(t)
-  45    Column          0   0  29               0  r[29]=ephemeral(t).id
-  46    Column          0   1  30               0  r[30]=ephemeral(t).grp
-  47    ResultRow      29   2   0               0  output=r[29..30]
-  48  Next              0  45   0               0
-  49  Halt              0   0   0               0
-  50  Transaction       0   2   1               0  iDb=0 tx_mode=Write
-  51  Integer           1   9   0               0  r[9]=1
-  52  Integer          21  20   0               0  r[20]=21
-  53  Integer           1  21   0               0  r[21]=1
-  54  Goto              0   1   0               0
+  17      Copy          6  12   1               0  r[12]=r[6]
+  18      BeginSubrtn  14   0   0               0  r[14]=NULL
+  19      Null          0   1   0               0  r[1]=NULL
+  20      Null          0  16   0               0  r[16]=NULL
+  21      Integer       1  17   0               0  r[17]=1; LIMIT counter
+  22      IfNot        17  29   0               0  if !r[17] goto 29
+  23      OpenRead      2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
+  24      Rewind        2  29   0               0  Rewind table t
+  25        Column      2   2  19               0  r[19]=t.val
+  26        Lt         19  20  28  Binary       0  if r[19]<r[20] goto 28
+  27        AggStep     0  21  16  count        0  accum=r[16] step(r[21])
+  28      Next          2  25   0               0
+  29      AggFinal      0  16   0  count        0  accum=r[16]
+  30      Copy         16  15   0               0  r[15]=r[16]
+  31      Copy         15   1   0               0  r[1]=r[15]
+  32    Return         14   0   1               0
+  33    Copy            4  22   0               0  r[22]=r[4]
+  34    Copy            6  23   1               0  r[23]=r[6]
+  35    Copy           22  25   0               0  r[25]=r[22]
+  36    Copy            1  26   0               0  r[26]=r[1]
+  37    MakeRecord     25   2  27               0  r[27]=mkrec(r[25..26])
+  38    NewRowid        0  28   0               0  r[28]=rowid
+  39    Insert          0  27  28               4  intkey=r[28] data=r[27]
+  40  Next              1   5   0               0
+  41  FkCheck           0   0   0               0
+  42  Rewind            0  47   0               0  Rewind  ephemeral(t)
+  43    Column          0   0  29               0  r[29]=ephemeral(t).id
+  44    Column          0   1  30               0  r[30]=ephemeral(t).grp
+  45    ResultRow      29   2   0               0  output=r[29..30]
+  46  Next              0  43   0               0
+  47  Halt              0   0   0               0
+  48  Transaction       0   2   1               0  iDb=0 tx_mode=Write
+  49  Integer           1   9   0               0  r[9]=1
+  50  Integer          21  20   0               0  r[20]=21
+  51  Integer           1  21   0               0  r[21]=1
+  52  Goto              0   1   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q1-pricing-summary.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q1-pricing-summary.snap
@@ -35,99 +35,88 @@ QUERY PLAN
 `--USE SORTER FOR GROUP BY
 
 BYTECODE
-addr  opcode                  p1  p2  p3  p4                                     p5  comment
-   0          Init             0  88   0                                          0  Start at 88
-   1          Null             0  18  25                                          0  r[18..25]=NULL
-   2          SorterOpen       0   6   0  k(2,B,B)                                0  cursor=0
-   3          Integer          0  13   0                                          0  r[13]=0; clear group by abort flag
-   4          Null             0  14  15                                          0  r[14..15]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           33  84   0                                          0  ; go to clear accumulator subroutine
-   6          OpenRead         2  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   7          Rewind           2  19   0                                          0  Rewind table lineitem
-   8            Column         2  10  35                                          0  r[35]=lineitem.L_SHIPDATE
-   9            Gt            35  36  18  Binary                                  0  if r[35]>r[36] goto 18
-  10            Column         2   8  27                                          0  r[27]=lineitem.L_RETURNFLAG
-  11            Column         2   9  28                                          0  r[28]=lineitem.L_LINESTATUS
-  12            Column         2   4  29                                          0  r[29]=lineitem.L_QUANTITY
-  13            Column         2   5  30                                          0  r[30]=lineitem.L_EXTENDEDPRICE
-  14            Column         2   6  31                                          0  r[31]=lineitem.L_DISCOUNT
-  15            Column         2   7  32                                          0  r[32]=lineitem.L_TAX
-  16            MakeRecord    27   6  26                                          0  r[26]=mkrec(r[27..32])
-  17            SorterInsert   0  26   0  0                                       0  key=r[26]
-  18          Next             2   8   0                                          0
-  19          OpenPseudo       1  26   6                                          0  6 columns in r[26]
-  20          SorterSort       0  58   0                                          0
-  21            SorterData     0  26   1                                          0  r[26]=data
-  22            Column         1   0  37                                          0  r[37]=pseudo.column 0
-  23            Column         1   1  38                                          0  r[38]=pseudo.column 1
-  24            Compare       14  37   2  k(2, Binary, Binary)                    0  r[14..15]==r[37..38]
-  25            Jump          26  30  26                                          0  ; start new group if comparison is not equal
-  26            Gosub         11  62   0                                          0  ; check if ended group had data, and output if so
-  27            Move          37  14   2                                          0  r[14..15]=r[37..38]
-  28            IfPos         13  87   0                                          0  r[13]>0 -> r[13]-=0, goto 87; check abort flag
-  29            Gosub         33  84   0                                          0  ; goto clear accumulator subroutine
-  30            Column         1   2  39                                          0  r[39]=pseudo.column 2
-  31            Column         1   3  40                                          0  r[40]=pseudo.column 3
-  32            Column         1   4  41                                          0  r[41]=pseudo.column 4
-  33            Column         1   5  42                                          0  r[42]=pseudo.column 5
-  34            AggStep        0  39  18  sum                                     0  accum=r[18] step(r[39])
-  35            AggStep        0  40  19  sum                                     0  accum=r[19] step(r[40])
-  36            Copy          40  44   0                                          0  r[44]=r[40]
-  37            Copy          41  47   0                                          0  r[47]=r[41]
-  38            Subtract      46  47  45                                          0  r[45]=r[46]-r[47]
-  39            Multiply      44  45  43                                          0  r[43]=r[44]*r[45]
-  40            AggStep        0  43  20  sum                                     0  accum=r[20] step(r[43])
-  41            Copy          40  51   0                                          0  r[51]=r[40]
-  42            Copy          41  54   0                                          0  r[54]=r[41]
-  43            Subtract      53  54  52                                          0  r[52]=r[53]-r[54]
-  44            Multiply      51  52  49                                          0  r[49]=r[51]*r[52]
-  45            Copy          42  56   0                                          0  r[56]=r[42]
-  46            Add           55  56  50                                          0  r[50]=r[55]+r[56]
-  47            Multiply      49  50  48                                          0  r[48]=r[49]*r[50]
-  48            AggStep        0  48  21  sum                                     0  accum=r[21] step(r[48])
-  49            AggStep        0  39  22  avg                                     0  accum=r[22] step(r[39])
-  50            AggStep        0  40  23  avg                                     0  accum=r[23] step(r[40])
-  51            AggStep        0  41  24  avg                                     0  accum=r[24] step(r[41])
-  52            AggStep        0  57  25  count                                   0  accum=r[25] step(r[57])
-  53            If            12  56   0                                          0  if r[12] goto 56; don't emit group columns if continuing existing group
-  54            Column         1   0  16                                          0  r[16]=pseudo.column 0
-  55            Column         1   1  17                                          0  r[17]=pseudo.column 1
-  56            Integer        1  12   0                                          0  r[12]=1; indicate data in accumulator
-  57          SorterNext       0  21   0                                          0
-  58          Gosub           11  62   0                                          0  ; emit row for final group
-  59          Goto             0  87   0                                          0  ; group by finished
-  60          Integer          1  13   0                                          0  r[13]=1
-  61        Return            11   0   0                                          0
-  62        IfPos             12  64   0                                          0  r[12]>0 -> r[12]-=0, goto 64; output group by row subroutine start
-  63      Return              11   0   0                                          0
-  64      AggFinal             0  18   0  sum                                     0  accum=r[18]
-  65      AggFinal             0  19   0  sum                                     0  accum=r[19]
-  66      AggFinal             0  20   0  sum                                     0  accum=r[20]
-  67      AggFinal             0  21   0  sum                                     0  accum=r[21]
-  68      AggFinal             0  22   0  avg                                     0  accum=r[22]
-  69      AggFinal             0  23   0  avg                                     0  accum=r[23]
-  70      AggFinal             0  24   0  avg                                     0  accum=r[24]
-  71      AggFinal             0  25   0  count                                   0  accum=r[25]
-  72      Copy                16   1   0                                          0  r[1]=r[16]
-  73      Copy                17   2   0                                          0  r[2]=r[17]
-  74      Copy                18   3   0                                          0  r[3]=r[18]
-  75      Copy                19   4   0                                          0  r[4]=r[19]
-  76      Copy                20   5   0                                          0  r[5]=r[20]
-  77      Copy                21   6   0                                          0  r[6]=r[21]
-  78      Copy                22   7   0                                          0  r[7]=r[22]
-  79      Copy                23   8   0                                          0  r[8]=r[23]
-  80      Copy                24   9   0                                          0  r[9]=r[24]
-  81      Copy                25  10   0                                          0  r[10]=r[25]
-  82      ResultRow            1  10   0                                          0  output=r[1..10]
-  83    Return                11   0   0                                          0
-  84    Null                   0  16  25                                          0  r[16..25]=NULL; clear accumulator subroutine start
-  85    Integer                0  12   0                                          0  r[12]=0
-  86  Return                  33   0   0                                          0
-  87  Halt                     0   0   0                                          0
-  88  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
-  89  String8                  0  36   0  1998-12-01                              0  r[36]='1998-12-01'
-  90  Integer                  1  46   0                                          0  r[46]=1
-  91  Integer                  1  53   0                                          0  r[53]=1
-  92  Integer                  1  55   0                                          0  r[55]=1
-  93  Integer                  1  57   0                                          0  r[57]=1
-  94  Goto                     0   1   0                                          0
+addr  opcode                p1  p2  p3  p4                                     p5  comment
+   0        Init             0  77   0                                          0  Start at 77
+   1        Null             0  18  25                                          0  r[18..25]=NULL
+   2        SorterOpen       0   6   0  k(2,B,B)                                0  cursor=0
+   3        Integer          0  13   0                                          0  r[13]=0; clear group by abort flag
+   4        Null             0  14  15                                          0  r[14..15]=NULL; initialize group by comparison registers to NULL
+   5        Gosub           33  73   0                                          0  ; go to clear accumulator subroutine
+   6        OpenRead         2  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+   7        Rewind           2  19   0                                          0  Rewind table lineitem
+   8          Column         2  10  35                                          0  r[35]=lineitem.L_SHIPDATE
+   9          Gt            35  36  18  Binary                                  0  if r[35]>r[36] goto 18
+  10          Column         2   8  27                                          0  r[27]=lineitem.L_RETURNFLAG
+  11          Column         2   9  28                                          0  r[28]=lineitem.L_LINESTATUS
+  12          Column         2   4  29                                          0  r[29]=lineitem.L_QUANTITY
+  13          Column         2   5  30                                          0  r[30]=lineitem.L_EXTENDEDPRICE
+  14          Column         2   6  31                                          0  r[31]=lineitem.L_DISCOUNT
+  15          Column         2   7  32                                          0  r[32]=lineitem.L_TAX
+  16          MakeRecord    27   6  26                                          0  r[26]=mkrec(r[27..32])
+  17          SorterInsert   0  26   0  0                                       0  key=r[26]
+  18        Next             2   8   0                                          0
+  19        OpenPseudo       1  26   6                                          0  6 columns in r[26]
+  20        SorterSort       0  58   0                                          0
+  21          SorterData     0  26   1                                          0  r[26]=data
+  22          Column         1   0  37                                          0  r[37]=pseudo.column 0
+  23          Column         1   1  38                                          0  r[38]=pseudo.column 1
+  24          Compare       14  37   2  k(2, Binary, Binary)                    0  r[14..15]==r[37..38]
+  25          Jump          26  30  26                                          0  ; start new group if comparison is not equal
+  26          Gosub         11  60   0                                          0  ; check if ended group had data, and output if so
+  27          Move          37  14   2                                          0  r[14..15]=r[37..38]
+  28          IfPos         13  76   0                                          0  r[13]>0 -> r[13]-=0, goto 76; check abort flag
+  29          Gosub         33  73   0                                          0  ; goto clear accumulator subroutine
+  30          Column         1   2  39                                          0  r[39]=pseudo.column 2
+  31          Column         1   3  40                                          0  r[40]=pseudo.column 3
+  32          Column         1   4  41                                          0  r[41]=pseudo.column 4
+  33          Column         1   5  42                                          0  r[42]=pseudo.column 5
+  34          AggStep        0  39  18  sum                                     0  accum=r[18] step(r[39])
+  35          AggStep        0  40  19  sum                                     0  accum=r[19] step(r[40])
+  36          Copy          40  44   0                                          0  r[44]=r[40]
+  37          Copy          41  47   0                                          0  r[47]=r[41]
+  38          Subtract      46  47  45                                          0  r[45]=r[46]-r[47]
+  39          Multiply      44  45  43                                          0  r[43]=r[44]*r[45]
+  40          AggStep        0  43  20  sum                                     0  accum=r[20] step(r[43])
+  41          Copy          40  51   0                                          0  r[51]=r[40]
+  42          Copy          41  54   0                                          0  r[54]=r[41]
+  43          Subtract      53  54  52                                          0  r[52]=r[53]-r[54]
+  44          Multiply      51  52  49                                          0  r[49]=r[51]*r[52]
+  45          Copy          42  56   0                                          0  r[56]=r[42]
+  46          Add           55  56  50                                          0  r[50]=r[55]+r[56]
+  47          Multiply      49  50  48                                          0  r[48]=r[49]*r[50]
+  48          AggStep        0  48  21  sum                                     0  accum=r[21] step(r[48])
+  49          AggStep        0  39  22  avg                                     0  accum=r[22] step(r[39])
+  50          AggStep        0  40  23  avg                                     0  accum=r[23] step(r[40])
+  51          AggStep        0  41  24  avg                                     0  accum=r[24] step(r[41])
+  52          AggStep        0  57  25  count                                   0  accum=r[25] step(r[57])
+  53          If            12  56   0                                          0  if r[12] goto 56; don't emit group columns if continuing existing group
+  54          Column         1   0  16                                          0  r[16]=pseudo.column 0
+  55          Column         1   1  17                                          0  r[17]=pseudo.column 1
+  56          Integer        1  12   0                                          0  r[12]=1; indicate data in accumulator
+  57        SorterNext       0  21   0                                          0
+  58        Gosub           11  60   0                                          0  ; emit row for final group
+  59        Halt             0   0   0                                          0  ; group by finished
+  60        IfPos           12  62   0                                          0  r[12]>0 -> r[12]-=0, goto 62; output group by row subroutine start
+  61      Return            11   0   0                                          0
+  62      AggFinal           0  18   0  sum                                     0  accum=r[18]
+  63      AggFinal           0  19   0  sum                                     0  accum=r[19]
+  64      AggFinal           0  20   0  sum                                     0  accum=r[20]
+  65      AggFinal           0  21   0  sum                                     0  accum=r[21]
+  66      AggFinal           0  22   0  avg                                     0  accum=r[22]
+  67      AggFinal           0  23   0  avg                                     0  accum=r[23]
+  68      AggFinal           0  24   0  avg                                     0  accum=r[24]
+  69      AggFinal           0  25   0  count                                   0  accum=r[25]
+  70      Copy              16   1   9                                          0  r[1]=r[16]
+  71      ResultRow          1  10   0                                          0  output=r[1..10]
+  72    Return              11   0   0                                          0
+  73    Null                 0  16  25                                          0  r[16..25]=NULL; clear accumulator subroutine start
+  74    Integer              0  12   0                                          0  r[12]=0
+  75  Return                33   0   0                                          0
+  76  Halt                   0   0   0                                          0
+  77  Transaction            0   1   8                                          0  iDb=0 tx_mode=Read
+  78  String8                0  36   0  1998-12-01                              0  r[36]='1998-12-01'
+  79  Integer                1  46   0                                          0  r[46]=1
+  80  Integer                1  53   0                                          0  r[53]=1
+  81  Integer                1  55   0                                          0  r[55]=1
+  82  Integer                1  57   0                                          0  r[57]=1
+  83  Goto                   0   1   0                                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
@@ -47,94 +47,92 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4                  p5  comment
-   0            Init             0  87   0                       0  Start at 87
-   1            SorterOpen       0   1   0  k(1,-B)              0  cursor=0
-   2            Null             0  10   0                       0  r[10]=NULL
-   3            Integer          0   7   0                       0  r[7]=0; clear group by abort flag
-   4            Null             0   8   0                       0  r[8]=NULL; initialize group by comparison registers to NULL
-   5            Gosub           14  76   0                       0  ; go to clear accumulator subroutine
-   6            OpenRead         1   6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
-   7            OpenRead         2   7   0  k(3,B,B)             0  index=sqlite_autoindex_partsupp_1, root=7, iDb=0
-   8            OpenRead         3   5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
-   9            OpenRead         4   2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
-  10            Rewind           2  33   0                       0  Rewind index sqlite_autoindex_partsupp_1
-  11              DeferredSeek   2   1   0                       0
-  12              Column         2   1  15                       0  r[15]=sqlite_autoindex_partsupp_1.ps_suppkey
-  13              SeekRowid      3  15  32                       0  if (r[15]!=cursor 3 for table supplier.rowid) goto 32
-  14              Column         3   3  16                       0  r[16]=supplier.S_NATIONKEY
-  15              SeekRowid      4  16  32                       0  if (r[16]!=cursor 4 for table nation.rowid) goto 32
-  16              Column         4   1  18                       0  r[18]=nation.N_NAME
-  17              Ne            18  19  32  Binary               0  if r[18]!=r[19] goto 32
-  18              Column         2   0  12                       0  r[12]=sqlite_autoindex_partsupp_1.ps_partkey
-  19              Column         1   3  20                       0  r[20]=partsupp.PS_SUPPLYCOST
-  20              Column         1   2  21                       0  r[21]=partsupp.PS_AVAILQTY
-  21              Multiply      20  21  13                       0  r[13]=r[20]*r[21]
-  22              Compare        8  12   1  k(1, Binary)         0  r[8..8]==r[12..12]
-  23              Jump          24  28  24                       0  ; start new group if comparison is not equal
-  24              Gosub          5  37   0                       0  ; check if ended group had data, and output if so
-  25              Move          12   8   1                       0  r[8..8]=r[12..12]
-  26              IfPos          7  79   0                       0  r[7]>0 -> r[7]-=0, goto 79; check abort flag
-  27              Gosub         14  76   0                       0  ; goto clear accumulator subroutine
-  28              AggStep        0  13  10  sum                  0  accum=r[10] step(r[13])
-  29              If             6  31   0                       0  if r[6] goto 31; don't emit group columns if continuing existing group
-  30              Column         2   0   9                       0  r[9]=sqlite_autoindex_partsupp_1.ps_partkey
-  31              Integer        1   6   0                       0  r[6]=1; indicate data in accumulator
-  32            Next             2  11   0                       0
-  33            Gosub            5  37   0                       0  ; emit row for final group
-  34            Goto             0  79   0                       0  ; group by finished
-  35            Integer          1   7   0                       0  r[7]=1
-  36          Return             5   0   0                       0
-  37          IfPos              6  39   0                       0  r[6]>0 -> r[6]-=0, goto 39; output group by row subroutine start
-  38        Return               5   0   0                       0
-  39        AggFinal             0  10   0  sum                  0  accum=r[10]
-  40        Once                68   0   0                       0  goto 68
-  41        BeginSubrtn         22   0   0                       0  r[22]=NULL
-  42        Null                 0   1   0                       0  r[1]=NULL
-  43        Null                 0  24   0                       0  r[24]=NULL
-  44        Integer              1  25   0                       0  r[25]=1; LIMIT counter
-  45        IfNot               25  62   0                       0  if !r[25] goto 62
-  46        OpenRead             5   6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
-  47        OpenRead             6   5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
-  48        OpenRead             7   2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
-  49        Rewind               5  62   0                       0  Rewind table partsupp
-  50          Column             5   1  26                       0  r[26]=partsupp.PS_SUPPKEY
-  51          SeekRowid          6  26  61                       0  if (r[26]!=cursor 6 for table supplier.rowid) goto 61
-  52          Column             6   3  27                       0  r[27]=supplier.S_NATIONKEY
-  53          SeekRowid          7  27  61                       0  if (r[27]!=cursor 7 for table nation.rowid) goto 61
-  54          Column             7   1  29                       0  r[29]=nation.N_NAME
-  55          String8            0  30   0  ARGENTINA            0  r[30]='ARGENTINA'
-  56          Ne                29  30  61  Binary               0  if r[29]!=r[30] goto 61
-  57          Column             5   3  32                       0  r[32]=partsupp.PS_SUPPLYCOST
-  58          Column             5   2  33                       0  r[33]=partsupp.PS_AVAILQTY
-  59          Multiply          32  33  31                       0  r[31]=r[32]*r[33]
-  60          AggStep            0  31  24  sum                  0  accum=r[24] step(r[31])
-  61        Next                 5  50   0                       0
-  62        AggFinal             0  24   0  sum                  0  accum=r[24]
-  63        Copy                24  34   0                       0  r[34]=r[24]
-  64        Real                 0  35   0  0.0001               0  r[35]=0.0001
-  65        Multiply            34  35  23                       0  r[23]=r[34]*r[35]
-  66        Copy                23   1   0                       0  r[1]=r[23]
-  67      Return                22   0   1                       0
-  68      Copy                  10  37   0                       0  r[37]=r[10]
-  69      Copy                   1  38   0                       0  r[38]=r[1]
-  70      Le                    37  38  38                       0  if r[37]<=r[38] goto 38
-  71      Copy                  10  39   0                       0  r[39]=r[10]
-  72      Copy                   9  40   0                       0  r[40]=r[9]
-  73      MakeRecord            39   2   4                       0  r[4]=mkrec(r[39..40])
-  74      SorterInsert           0   4   0  0                    0  key=r[4]
-  75    Return                   5   0   0                       0
-  76    Null                     0   9  10                       0  r[9..10]=NULL; clear accumulator subroutine start
-  77    Integer                  0   6   0                       0  r[6]=0
-  78  Return                    14   0   0                       0
-  79  OpenPseudo                 8   4   2                       0  2 columns in r[4]
-  80  SorterSort                 0  86   0                       0
-  81    SorterData               0   4   8                       0  r[4]=data
-  82    Column                   8   1   2                       0  r[2]=pseudo.column 1
-  83    Column                   8   0   3                       0  r[3]=pseudo.column 0
-  84    ResultRow                2   2   0                       0  output=r[2..3]
-  85  SorterNext                 0  81   0                       0
-  86  Halt                       0   0   0                       0
-  87  Transaction                0   1   8                       0  iDb=0 tx_mode=Read
-  88  String8                    0  19   0  ARGENTINA            0  r[19]='ARGENTINA'
-  89  Goto                       0   1   0                       0
+addr  opcode                  p1  p2  p3  p4                  p5  comment
+   0          Init             0  85   0                       0  Start at 85
+   1          SorterOpen       0   1   0  k(1,-B)              0  cursor=0
+   2          Null             0  10   0                       0  r[10]=NULL
+   3          Integer          0   7   0                       0  r[7]=0; clear group by abort flag
+   4          Null             0   8   0                       0  r[8]=NULL; initialize group by comparison registers to NULL
+   5          Gosub           14  74   0                       0  ; go to clear accumulator subroutine
+   6          OpenRead         1   6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
+   7          OpenRead         2   7   0  k(3,B,B)             0  index=sqlite_autoindex_partsupp_1, root=7, iDb=0
+   8          OpenRead         3   5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
+   9          OpenRead         4   2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
+  10          Rewind           2  33   0                       0  Rewind index sqlite_autoindex_partsupp_1
+  11            DeferredSeek   2   1   0                       0
+  12            Column         2   1  15                       0  r[15]=sqlite_autoindex_partsupp_1.ps_suppkey
+  13            SeekRowid      3  15  32                       0  if (r[15]!=cursor 3 for table supplier.rowid) goto 32
+  14            Column         3   3  16                       0  r[16]=supplier.S_NATIONKEY
+  15            SeekRowid      4  16  32                       0  if (r[16]!=cursor 4 for table nation.rowid) goto 32
+  16            Column         4   1  18                       0  r[18]=nation.N_NAME
+  17            Ne            18  19  32  Binary               0  if r[18]!=r[19] goto 32
+  18            Column         2   0  12                       0  r[12]=sqlite_autoindex_partsupp_1.ps_partkey
+  19            Column         1   3  20                       0  r[20]=partsupp.PS_SUPPLYCOST
+  20            Column         1   2  21                       0  r[21]=partsupp.PS_AVAILQTY
+  21            Multiply      20  21  13                       0  r[13]=r[20]*r[21]
+  22            Compare        8  12   1  k(1, Binary)         0  r[8..8]==r[12..12]
+  23            Jump          24  28  24                       0  ; start new group if comparison is not equal
+  24            Gosub          5  35   0                       0  ; check if ended group had data, and output if so
+  25            Move          12   8   1                       0  r[8..8]=r[12..12]
+  26            IfPos          7  77   0                       0  r[7]>0 -> r[7]-=0, goto 77; check abort flag
+  27            Gosub         14  74   0                       0  ; goto clear accumulator subroutine
+  28            AggStep        0  13  10  sum                  0  accum=r[10] step(r[13])
+  29            If             6  31   0                       0  if r[6] goto 31; don't emit group columns if continuing existing group
+  30            Column         2   0   9                       0  r[9]=sqlite_autoindex_partsupp_1.ps_partkey
+  31            Integer        1   6   0                       0  r[6]=1; indicate data in accumulator
+  32          Next             2  11   0                       0
+  33          Gosub            5  35   0                       0  ; emit row for final group
+  34          Goto             0  77   0                       0  ; group by finished
+  35          IfPos            6  37   0                       0  r[6]>0 -> r[6]-=0, goto 37; output group by row subroutine start
+  36        Return             5   0   0                       0
+  37        AggFinal           0  10   0  sum                  0  accum=r[10]
+  38        Once              66   0   0                       0  goto 66
+  39        BeginSubrtn       22   0   0                       0  r[22]=NULL
+  40        Null               0   1   0                       0  r[1]=NULL
+  41        Null               0  24   0                       0  r[24]=NULL
+  42        Integer            1  25   0                       0  r[25]=1; LIMIT counter
+  43        IfNot             25  60   0                       0  if !r[25] goto 60
+  44        OpenRead           5   6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
+  45        OpenRead           6   5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
+  46        OpenRead           7   2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
+  47        Rewind             5  60   0                       0  Rewind table partsupp
+  48          Column           5   1  26                       0  r[26]=partsupp.PS_SUPPKEY
+  49          SeekRowid        6  26  59                       0  if (r[26]!=cursor 6 for table supplier.rowid) goto 59
+  50          Column           6   3  27                       0  r[27]=supplier.S_NATIONKEY
+  51          SeekRowid        7  27  59                       0  if (r[27]!=cursor 7 for table nation.rowid) goto 59
+  52          Column           7   1  29                       0  r[29]=nation.N_NAME
+  53          String8          0  30   0  ARGENTINA            0  r[30]='ARGENTINA'
+  54          Ne              29  30  59  Binary               0  if r[29]!=r[30] goto 59
+  55          Column           5   3  32                       0  r[32]=partsupp.PS_SUPPLYCOST
+  56          Column           5   2  33                       0  r[33]=partsupp.PS_AVAILQTY
+  57          Multiply        32  33  31                       0  r[31]=r[32]*r[33]
+  58          AggStep          0  31  24  sum                  0  accum=r[24] step(r[31])
+  59        Next               5  48   0                       0
+  60        AggFinal           0  24   0  sum                  0  accum=r[24]
+  61        Copy              24  34   0                       0  r[34]=r[24]
+  62        Real               0  35   0  0.0001               0  r[35]=0.0001
+  63        Multiply          34  35  23                       0  r[23]=r[34]*r[35]
+  64        Copy              23   1   0                       0  r[1]=r[23]
+  65      Return              22   0   1                       0
+  66      Copy                10  37   0                       0  r[37]=r[10]
+  67      Copy                 1  38   0                       0  r[38]=r[1]
+  68      Le                  37  38  36                       0  if r[37]<=r[38] goto 36
+  69      Copy                10  39   0                       0  r[39]=r[10]
+  70      Copy                 9  40   0                       0  r[40]=r[9]
+  71      MakeRecord          39   2   4                       0  r[4]=mkrec(r[39..40])
+  72      SorterInsert         0   4   0  0                    0  key=r[4]
+  73    Return                 5   0   0                       0
+  74    Null                   0   9  10                       0  r[9..10]=NULL; clear accumulator subroutine start
+  75    Integer                0   6   0                       0  r[6]=0
+  76  Return                  14   0   0                       0
+  77  OpenPseudo               8   4   2                       0  2 columns in r[4]
+  78  SorterSort               0  84   0                       0
+  79    SorterData             0   4   8                       0  r[4]=data
+  80    Column                 8   1   2                       0  r[2]=pseudo.column 1
+  81    Column                 8   0   3                       0  r[3]=pseudo.column 0
+  82    ResultRow              2   2   0                       0  output=r[2..3]
+  83  SorterNext               0  79   0                       0
+  84  Halt                     0   0   0                       0
+  85  Transaction              0   1   8                       0  iDb=0 tx_mode=Read
+  86  String8                  0  19   0  ARGENTINA            0  r[19]='ARGENTINA'
+  87  Goto                     0   1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q12-shipping-modes.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q12-shipping-modes.snap
@@ -43,103 +43,99 @@ QUERY PLAN
 `--USE SORTER FOR GROUP BY
 
 BYTECODE
-addr  opcode                  p1  p2  p3  p4                                     p5  comment
-   0          Init             0  93   0                                          0  Start at 93
-   1          Null             0   9  10                                          0  r[9..10]=NULL
-   2          SorterOpen       0   2   0  k(1,B)                                  0  cursor=0
-   3          Integer          0   6   0                                          0  r[6]=0; clear group by abort flag
-   4          Null             0   7   0                                          0  r[7]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           14  89   0                                          0  ; go to clear accumulator subroutine
-   6          OpenRead         2   9   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=orders, root=9, iDb=0
-   7          OpenRead         3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   8          Rewind           3  29   0                                          0  Rewind table lineitem
-   9            Column         3  14  15                                          0  r[15]=lineitem.L_SHIPMODE
-  10            Eq            15  16  12  Binary                                  0  if r[15]==r[16] goto 12
-  11            Ne            15  17  28  Binary                                  0  if r[15]!=r[17] goto 28
-  12            Column         3  11  19                                          0  r[19]=lineitem.L_COMMITDATE
-  13            Column         3  12  20                                          0  r[20]=lineitem.L_RECEIPTDATE
-  14            Ge            19  20  28  Binary                                  0  if r[19]>=r[20] goto 28
-  15            Column         3  10  22                                          0  r[22]=lineitem.L_SHIPDATE
-  16            Column         3  11  23                                          0  r[23]=lineitem.L_COMMITDATE
-  17            Ge            22  23  28  Binary                                  0  if r[22]>=r[23] goto 28
-  18            Column         3  12  25                                          0  r[25]=lineitem.L_RECEIPTDATE
-  19            Lt            25  26  28  Binary                                  0  if r[25]<r[26] goto 28
-  20            Column         3  12  28                                          0  r[28]=lineitem.L_RECEIPTDATE
-  21            Ge            28  29  28  Binary                                  0  if r[28]>=r[29] goto 28
-  22            Column         3   0  30                                          0  r[30]=lineitem.L_ORDERKEY
-  23            SeekRowid      2  30  28                                          0  if (r[30]!=cursor 2 for table orders.rowid) goto 28
-  24            Column         3  14  12                                          0  r[12]=lineitem.L_SHIPMODE
-  25            Column         2   5  13                                          0  r[13]=orders.O_ORDERPRIORITY
-  26            MakeRecord    12   2  11                                          0  r[11]=mkrec(r[12..13])
-  27            SorterInsert   0  11   0  0                                       0  key=r[11]
-  28          Next             3   9   0                                          0
-  29          OpenPseudo       1  11   2                                          0  2 columns in r[11]
-  30          SorterSort       0  76   0                                          0
-  31            SorterData     0  11   1                                          0  r[11]=data
-  32            Column         1   0  31                                          0  r[31]=pseudo.column 0
-  33            Compare        7  31   1  k(1, Binary)                            0  r[7..7]==r[31..31]
-  34            Jump          35  39  35                                          0  ; start new group if comparison is not equal
-  35            Gosub          4  80   0                                          0  ; check if ended group had data, and output if so
-  36            Move          31   7   1                                          0  r[7..7]=r[31..31]
-  37            IfPos          6  92   0                                          0  r[6]>0 -> r[6]-=0, goto 92; check abort flag
-  38            Gosub         14  89   0                                          0  ; goto clear accumulator subroutine
-  39            Column         1   1  32                                          0  r[32]=pseudo.column 1
-  40            Copy          32  37   0                                          0  r[37]=r[32]
-  41            String8        0  38   0  1-URGENT                                0  r[38]='1-URGENT'
-  42            Integer        1  35   0                                          0  r[35]=1
-  43            Eq            37  38  45                                          0  if r[37]==r[38] goto 45
-  44            ZeroOrNull    37  35  38                                          0  ((r[37]=NULL)|(r[38]=NULL)) ? r[35]=NULL : r[35]=0
-  45            Copy          32  39   0                                          0  r[39]=r[32]
-  46            String8        0  40   0  2-HIGH                                  0  r[40]='2-HIGH'
-  47            Integer        1  36   0                                          0  r[36]=1
-  48            Eq            39  40  50                                          0  if r[39]==r[40] goto 50
-  49            ZeroOrNull    39  36  40                                          0  ((r[39]=NULL)|(r[40]=NULL)) ? r[36]=NULL : r[36]=0
-  50            Or            36  35  34                                          0  r[34]=(r[35] || r[36])
-  51            IfNot         34  54   1                                          0  if !r[34] goto 54
-  52            Integer        1  33   0                                          0  r[33]=1
-  53            Goto           0  55   0                                          0
-  54            Integer        0  33   0                                          0  r[33]=0
-  55            AggStep        0  33   9  sum                                     0  accum=r[9] step(r[33])
-  56            Copy          32  45   0                                          0  r[45]=r[32]
-  57            String8        0  46   0  1-URGENT                                0  r[46]='1-URGENT'
-  58            Integer        1  43   0                                          0  r[43]=1
-  59            Ne            45  46  61                                          0  if r[45]!=r[46] goto 61
-  60            ZeroOrNull    45  43  46                                          0  ((r[45]=NULL)|(r[46]=NULL)) ? r[43]=NULL : r[43]=0
-  61            Copy          32  47   0                                          0  r[47]=r[32]
-  62            String8        0  48   0  2-HIGH                                  0  r[48]='2-HIGH'
-  63            Integer        1  44   0                                          0  r[44]=1
-  64            Ne            47  48  66                                          0  if r[47]!=r[48] goto 66
-  65            ZeroOrNull    47  44  48                                          0  ((r[47]=NULL)|(r[48]=NULL)) ? r[44]=NULL : r[44]=0
-  66            And           44  43  42                                          0  r[42]=(r[43] && r[44])
-  67            IfNot         42  70   1                                          0  if !r[42] goto 70
-  68            Integer        1  41   0                                          0  r[41]=1
-  69            Goto           0  71   0                                          0
-  70            Integer        0  41   0                                          0  r[41]=0
-  71            AggStep        0  41  10  sum                                     0  accum=r[10] step(r[41])
-  72            If             5  74   0                                          0  if r[5] goto 74; don't emit group columns if continuing existing group
-  73            Column         1   0   8                                          0  r[8]=pseudo.column 0
-  74            Integer        1   5   0                                          0  r[5]=1; indicate data in accumulator
-  75          SorterNext       0  31   0                                          0
-  76          Gosub            4  80   0                                          0  ; emit row for final group
-  77          Goto             0  92   0                                          0  ; group by finished
-  78          Integer          1   6   0                                          0  r[6]=1
-  79        Return             4   0   0                                          0
-  80        IfPos              5  82   0                                          0  r[5]>0 -> r[5]-=0, goto 82; output group by row subroutine start
-  81      Return               4   0   0                                          0
-  82      AggFinal             0   9   0  sum                                     0  accum=r[9]
-  83      AggFinal             0  10   0  sum                                     0  accum=r[10]
-  84      Copy                 8   1   0                                          0  r[1]=r[8]
-  85      Copy                 9   2   0                                          0  r[2]=r[9]
-  86      Copy                10   3   0                                          0  r[3]=r[10]
-  87      ResultRow            1   3   0                                          0  output=r[1..3]
-  88    Return                 4   0   0                                          0
-  89    Null                   0   8  10                                          0  r[8..10]=NULL; clear accumulator subroutine start
-  90    Integer                0   5   0                                          0  r[5]=0
-  91  Return                  14   0   0                                          0
-  92  Halt                     0   0   0                                          0
-  93  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
-  94  String8                  0  16   0  FOB                                     0  r[16]='FOB'
-  95  String8                  0  17   0  SHIP                                    0  r[17]='SHIP'
-  96  String8                  0  26   0  1994-01-01                              0  r[26]='1994-01-01'
-  97  String8                  0  29   0  1995-01-01                              0  r[29]='1995-01-01'
-  98  Goto                     0   1   0                                          0
+addr  opcode                p1  p2  p3  p4                                     p5  comment
+   0        Init             0  89   0                                          0  Start at 89
+   1        Null             0   9  10                                          0  r[9..10]=NULL
+   2        SorterOpen       0   2   0  k(1,B)                                  0  cursor=0
+   3        Integer          0   6   0                                          0  r[6]=0; clear group by abort flag
+   4        Null             0   7   0                                          0  r[7]=NULL; initialize group by comparison registers to NULL
+   5        Gosub           14  85   0                                          0  ; go to clear accumulator subroutine
+   6        OpenRead         2   9   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=orders, root=9, iDb=0
+   7        OpenRead         3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+   8        Rewind           3  29   0                                          0  Rewind table lineitem
+   9          Column         3  14  15                                          0  r[15]=lineitem.L_SHIPMODE
+  10          Eq            15  16  12  Binary                                  0  if r[15]==r[16] goto 12
+  11          Ne            15  17  28  Binary                                  0  if r[15]!=r[17] goto 28
+  12          Column         3  11  19                                          0  r[19]=lineitem.L_COMMITDATE
+  13          Column         3  12  20                                          0  r[20]=lineitem.L_RECEIPTDATE
+  14          Ge            19  20  28  Binary                                  0  if r[19]>=r[20] goto 28
+  15          Column         3  10  22                                          0  r[22]=lineitem.L_SHIPDATE
+  16          Column         3  11  23                                          0  r[23]=lineitem.L_COMMITDATE
+  17          Ge            22  23  28  Binary                                  0  if r[22]>=r[23] goto 28
+  18          Column         3  12  25                                          0  r[25]=lineitem.L_RECEIPTDATE
+  19          Lt            25  26  28  Binary                                  0  if r[25]<r[26] goto 28
+  20          Column         3  12  28                                          0  r[28]=lineitem.L_RECEIPTDATE
+  21          Ge            28  29  28  Binary                                  0  if r[28]>=r[29] goto 28
+  22          Column         3   0  30                                          0  r[30]=lineitem.L_ORDERKEY
+  23          SeekRowid      2  30  28                                          0  if (r[30]!=cursor 2 for table orders.rowid) goto 28
+  24          Column         3  14  12                                          0  r[12]=lineitem.L_SHIPMODE
+  25          Column         2   5  13                                          0  r[13]=orders.O_ORDERPRIORITY
+  26          MakeRecord    12   2  11                                          0  r[11]=mkrec(r[12..13])
+  27          SorterInsert   0  11   0  0                                       0  key=r[11]
+  28        Next             3   9   0                                          0
+  29        OpenPseudo       1  11   2                                          0  2 columns in r[11]
+  30        SorterSort       0  76   0                                          0
+  31          SorterData     0  11   1                                          0  r[11]=data
+  32          Column         1   0  31                                          0  r[31]=pseudo.column 0
+  33          Compare        7  31   1  k(1, Binary)                            0  r[7..7]==r[31..31]
+  34          Jump          35  39  35                                          0  ; start new group if comparison is not equal
+  35          Gosub          4  78   0                                          0  ; check if ended group had data, and output if so
+  36          Move          31   7   1                                          0  r[7..7]=r[31..31]
+  37          IfPos          6  88   0                                          0  r[6]>0 -> r[6]-=0, goto 88; check abort flag
+  38          Gosub         14  85   0                                          0  ; goto clear accumulator subroutine
+  39          Column         1   1  32                                          0  r[32]=pseudo.column 1
+  40          Copy          32  37   0                                          0  r[37]=r[32]
+  41          String8        0  38   0  1-URGENT                                0  r[38]='1-URGENT'
+  42          Integer        1  35   0                                          0  r[35]=1
+  43          Eq            37  38  45                                          0  if r[37]==r[38] goto 45
+  44          ZeroOrNull    37  35  38                                          0  ((r[37]=NULL)|(r[38]=NULL)) ? r[35]=NULL : r[35]=0
+  45          Copy          32  39   0                                          0  r[39]=r[32]
+  46          String8        0  40   0  2-HIGH                                  0  r[40]='2-HIGH'
+  47          Integer        1  36   0                                          0  r[36]=1
+  48          Eq            39  40  50                                          0  if r[39]==r[40] goto 50
+  49          ZeroOrNull    39  36  40                                          0  ((r[39]=NULL)|(r[40]=NULL)) ? r[36]=NULL : r[36]=0
+  50          Or            36  35  34                                          0  r[34]=(r[35] || r[36])
+  51          IfNot         34  54   1                                          0  if !r[34] goto 54
+  52          Integer        1  33   0                                          0  r[33]=1
+  53          Goto           0  55   0                                          0
+  54          Integer        0  33   0                                          0  r[33]=0
+  55          AggStep        0  33   9  sum                                     0  accum=r[9] step(r[33])
+  56          Copy          32  45   0                                          0  r[45]=r[32]
+  57          String8        0  46   0  1-URGENT                                0  r[46]='1-URGENT'
+  58          Integer        1  43   0                                          0  r[43]=1
+  59          Ne            45  46  61                                          0  if r[45]!=r[46] goto 61
+  60          ZeroOrNull    45  43  46                                          0  ((r[45]=NULL)|(r[46]=NULL)) ? r[43]=NULL : r[43]=0
+  61          Copy          32  47   0                                          0  r[47]=r[32]
+  62          String8        0  48   0  2-HIGH                                  0  r[48]='2-HIGH'
+  63          Integer        1  44   0                                          0  r[44]=1
+  64          Ne            47  48  66                                          0  if r[47]!=r[48] goto 66
+  65          ZeroOrNull    47  44  48                                          0  ((r[47]=NULL)|(r[48]=NULL)) ? r[44]=NULL : r[44]=0
+  66          And           44  43  42                                          0  r[42]=(r[43] && r[44])
+  67          IfNot         42  70   1                                          0  if !r[42] goto 70
+  68          Integer        1  41   0                                          0  r[41]=1
+  69          Goto           0  71   0                                          0
+  70          Integer        0  41   0                                          0  r[41]=0
+  71          AggStep        0  41  10  sum                                     0  accum=r[10] step(r[41])
+  72          If             5  74   0                                          0  if r[5] goto 74; don't emit group columns if continuing existing group
+  73          Column         1   0   8                                          0  r[8]=pseudo.column 0
+  74          Integer        1   5   0                                          0  r[5]=1; indicate data in accumulator
+  75        SorterNext       0  31   0                                          0
+  76        Gosub            4  78   0                                          0  ; emit row for final group
+  77        Halt             0   0   0                                          0  ; group by finished
+  78        IfPos            5  80   0                                          0  r[5]>0 -> r[5]-=0, goto 80; output group by row subroutine start
+  79      Return             4   0   0                                          0
+  80      AggFinal           0   9   0  sum                                     0  accum=r[9]
+  81      AggFinal           0  10   0  sum                                     0  accum=r[10]
+  82      Copy               8   1   2                                          0  r[1]=r[8]
+  83      ResultRow          1   3   0                                          0  output=r[1..3]
+  84    Return               4   0   0                                          0
+  85    Null                 0   8  10                                          0  r[8..10]=NULL; clear accumulator subroutine start
+  86    Integer              0   5   0                                          0  r[5]=0
+  87  Return                14   0   0                                          0
+  88  Halt                   0   0   0                                          0
+  89  Transaction            0   1   8                                          0  iDb=0 tx_mode=Read
+  90  String8                0  16   0  FOB                                     0  r[16]='FOB'
+  91  String8                0  17   0  SHIP                                    0  r[17]='SHIP'
+  92  String8                0  26   0  1994-01-01                              0  r[26]='1994-01-01'
+  93  String8                0  29   0  1995-01-01                              0  r[29]='1995-01-01'
+  94  Goto                   0   1   0                                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q13-customer-distribution.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q13-customer-distribution.snap
@@ -40,155 +40,150 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                                p1   p2   p3  p4                                          p5  comment
-   0                    Init                 0  147    0                                               0  Start at 147
-   1                    InitCoroutine        1   96    2                                               0
-   2                    Null                 0    9    0                                               0  r[9]=NULL
-   3                    SorterOpen           0    2    0  k(1,B)                                       0  cursor=0
-   4                    Integer              0    6    0                                               0  r[6]=0; clear group by abort flag
-   5                    Null                 0    7    0                                               0  r[7]=NULL; initialize group by comparison registers to NULL
-   6                    Gosub               13   92    0                                               0  ; go to clear accumulator subroutine
-   7                    OpenRead             2    8    0  k(8,B,B,B,B,B,B,B,B)                         0  table=customer, root=8, iDb=0
-   8                    OpenRead             3    9    0  k(9,B,B,B,B,B,B,B,B,B)                       0  table=orders, root=9, iDb=0
-   9                    Integer              0   14    0                                               0  r[14]=0
-  10                    Once                19    0    0                                               0  goto 19
-  11                    OpenRead             4    8    0  k(8,B,B,B,B,B,B,B,B)                         0  table=customer, root=8, iDb=0
-  12                    Rewind               4   18    0                                               0  Rewind table customer
-  13                      RowId              4   15    0                                               0  r[15]=customer.rowid
-  14                      Affinity          15    1    0                                               0  r[15..16] = C
-  15                      RowId              4   16    0                                               0  r[16]=customer.rowid
-  16                      HashBuild          4   15    1  r=[1] budget=67108864 payload=r[16]..r[16]   0
-  17                    Next                 4   13    0                                               0
-  18                    HashBuildFinalize    1    0    0                                               0
-  19                    HashResetMatched     1    0    0                                               0
-  20                    Rewind               3   41    0                                               0  Rewind table orders
-  21                      Column             3    1   17                                               0  r[17]=orders.O_CUSTKEY
-  22                      Affinity          17    1    0                                               0  r[17..18] = C
-  23                      RowId              3   19    0                                               0  r[19]=orders.rowid
-  24                      Integer            0   20    0                                               0  r[20]=0
-  25                      HashProbe          1   17    1  r[21]=40 payload=r[18]..r[18]                0
-  26                      Column             3    8   24                                               0  r[24]=orders.O_COMMENT
-  27                      Function           1   23   22  like(2)                                      0  r[22]=func(r[23..24])
-  28                      If                22   37    1                                               0  if r[22] goto 37
-  29                      HashMarkMatched    1    0    0                                               0
-  30                      Gosub             25   32    0                                               0
-  31                      Goto               0   37    0                                               0
-  32                      Copy              18   11    0                                               0  r[11]=r[18]
-  33                      RowId              3   12    0                                               0  r[12]=orders.rowid
-  34                      MakeRecord        11    2   10                                               0  r[10]=mkrec(r[11..12])
-  35                      SorterInsert       0   10    0  0                                            0  key=r[10]
-  36                    Return              25    0    0                                               0
-  37                    IfPos               20   54    0                                               0  r[20]>0 -> r[20]-=0, goto 54
-  38                    HashNext             1   21   40   payload=r[18]..r[18]                        0
-  39                    Goto                 0   26    0                                               0
-  40                  Next                   3   21    0                                               0
-  41                  NullRow                3    0    0                                               0  Set cursor 3 to a (pseudo) NULL row
-  42                  HashScanUnmatched      1   21   47                                               0  hash_table_id=1 payload=r[18]..r[18]
-  43                  SeekRowid              2   21   47                                               0  if (r[21]!=cursor 2 for table customer.rowid) goto 47
-  44                  Gosub                 25   32    0                                               0
-  45                  HashNextUnmatched      1   21   47                                               0  hash_table_id=1 payload=r[18]..r[18]
-  46                  Goto                   0   43    0                                               0
-  47                  HashGraceInit          1    0   65                                               0  hash_table_id=1
-  48                  Integer                1   20    0                                               0  r[20]=1
-  49                  HashGraceLoadPart      1    0   64                                               0  hash_table_id=1
-  50                  HashGraceNextProbe     1   17   56                                               0  hash_table_id=1 keys=r[17]..r[17] probe_rowid_dest=r[19]
-  51                  SeekRowid              3   19   50                                               0  if (r[19]!=cursor 3 for table orders.rowid) goto 50
-  52                  HashProbe              1   17    1  r[21]=50 payload=r[18]..r[18]                0
-  53                  Goto                   0   26    0                                               0
-  54                  HashNext               1   21   50   payload=r[18]..r[18]                        0
-  55                  Goto                   0   26    0                                               0
-  56                  NullRow                3    0    0                                               0  Set cursor 3 to a (pseudo) NULL row
-  57                  HashScanUnmatched      1   21   62                                               0  hash_table_id=1 payload=r[18]..r[18]
-  58                  SeekRowid              2   21   62                                               0  if (r[21]!=cursor 2 for table customer.rowid) goto 62
-  59                  Gosub                 25   32    0                                               0
-  60                  HashNextUnmatched      1   21   62                                               0  hash_table_id=1 payload=r[18]..r[18]
-  61                  Goto                   0   58    0                                               0
-  62                  HashGraceAdvPart       1    0   64                                               0  hash_table_id=1
-  63                  Goto                   0   49    0                                               0
-  64                  Integer                0   20    0                                               0  r[20]=0
-  65                  OpenPseudo             1   10    2                                               0  2 columns in r[10]
-  66                  SorterSort             0   81    0                                               0
-  67                    SorterData           0   10    1                                               0  r[10]=data
-  68                    Column               1    0   26                                               0  r[26]=pseudo.column 0
-  69                    Compare              7   26    1  k(1, Binary)                                 0  r[7..7]==r[26..26]
-  70                    Jump                71   75   71                                               0  ; start new group if comparison is not equal
-  71                    Gosub                4   85    0                                               0  ; check if ended group had data, and output if so
-  72                    Move                26    7    1                                               0  r[7..7]=r[26..26]
-  73                    IfPos                6   95    0                                               0  r[6]>0 -> r[6]-=0, goto 95; check abort flag
-  74                    Gosub               13   92    0                                               0  ; goto clear accumulator subroutine
-  75                    Column               1    1   27                                               0  r[27]=pseudo.column 1
-  76                    AggStep              0   27    9  count                                        0  accum=r[9] step(r[27])
-  77                    If                   5   79    0                                               0  if r[5] goto 79; don't emit group columns if continuing existing group
-  78                    Column               1    0    8                                               0  r[8]=pseudo.column 0
-  79                    Integer              1    5    0                                               0  r[5]=1; indicate data in accumulator
-  80                  SorterNext             0   67    0                                               0
-  81                  Gosub                  4   85    0                                               0  ; emit row for final group
-  82                  Goto                   0   95    0                                               0  ; group by finished
-  83                  Integer                1    6    0                                               0  r[6]=1
-  84                Return                   4    0    0                                               0
-  85                IfPos                    5   87    0                                               0  r[5]>0 -> r[5]-=0, goto 87; output group by row subroutine start
-  86              Return                     4    0    0                                               0
-  87              AggFinal                   0    9    0  count                                        0  accum=r[9]
-  88              Copy                       8    2    0                                               0  r[2]=r[8]
-  89              Copy                       9    3    0                                               0  r[3]=r[9]
-  90              Yield                      1    0    0                                               0
-  91            Return                       4    0    0                                               0
-  92            Null                         0    8    9                                               0  r[8..9]=NULL; clear accumulator subroutine start
-  93            Integer                      0    5    0                                               0  r[5]=0
-  94          Return                        13    0    0                                               0
-  95          EndCoroutine                   1    0    0                                               0
-  96          SorterOpen                     5    3    0  k(3,-B,-B,Binary)                            0  cursor=5
-  97          Null                           0   36    0                                               0  r[36]=NULL
-  98          SorterOpen                     6    1    0  k(1,-B)                                      0  cursor=6
-  99          Integer                        0   33    0                                               0  r[33]=0; clear group by abort flag
- 100          Null                           0   34    0                                               0  r[34]=NULL; initialize group by comparison registers to NULL
- 101          Gosub                         39  136    0                                               0  ; go to clear accumulator subroutine
- 102          InitCoroutine                  1    0    2                                               0
- 103            Yield                        1  108    0                                               0
- 104            Copy                         3   38    0                                               0  r[38]=r[3]
- 105            MakeRecord                  38    1   37                                               0  r[37]=mkrec(r[38..38])
- 106            SorterInsert                 6   37    0  0                                            0  key=r[37]
- 107          Goto                           0  103    0                                               0
- 108          OpenPseudo                     7   37    1                                               0  1 columns in r[37]
- 109          SorterSort                     6  123    0                                               0
- 110            SorterData                   6   37    7                                               0  r[37]=data
- 111            Column                       7    0   40                                               0  r[40]=pseudo.column 0
- 112            Compare                     34   40    1  k(1, Binary)                                 0  r[34..34]==r[40..40]
- 113            Jump                       114  118  114                                               0  ; start new group if comparison is not equal
- 114            Gosub                       31  127    0                                               0  ; check if ended group had data, and output if so
- 115            Move                        40   34    1                                               0  r[34..34]=r[40..40]
- 116            IfPos                       33  139    0                                               0  r[33]>0 -> r[33]-=0, goto 139; check abort flag
- 117            Gosub                       39  136    0                                               0  ; goto clear accumulator subroutine
- 118            AggStep                      0   41   36  count                                        0  accum=r[36] step(r[41])
- 119            If                          32  121    0                                               0  if r[32] goto 121; don't emit group columns if continuing existing group
- 120            Column                       7    0   35                                               0  r[35]=pseudo.column 0
- 121            Integer                      1   32    0                                               0  r[32]=1; indicate data in accumulator
- 122          SorterNext                     6  110    0                                               0
- 123          Gosub                         31  127    0                                               0  ; emit row for final group
- 124          Goto                           0  139    0                                               0  ; group by finished
- 125          Integer                        1   33    0                                               0  r[33]=1
- 126        Return                          31    0    0                                               0
- 127        IfPos                           32  129    0                                               0  r[32]>0 -> r[32]-=0, goto 129; output group by row subroutine start
- 128      Return                            31    0    0                                               0
- 129      AggFinal                           0   36    0  count                                        0  accum=r[36]
- 130      Copy                              36   42    0                                               0  r[42]=r[36]
- 131      Copy                              35   43    0                                               0  r[43]=r[35]
- 132      Sequence                           5   44    0                                               0
- 133      MakeRecord                        42    3   30                                               0  r[30]=mkrec(r[42..44])
- 134      SorterInsert                       5   30    0  0                                            0  key=r[30]
- 135    Return                              31    0    0                                               0
- 136    Null                                 0   35   36                                               0  r[35..36]=NULL; clear accumulator subroutine start
- 137    Integer                              0   32    0                                               0  r[32]=0
- 138  Return                                39    0    0                                               0
- 139  OpenPseudo                             8   30    3                                               0  3 columns in r[30]
- 140  SorterSort                             5  146    0                                               0
- 141    SorterData                           5   30    8                                               0  r[30]=data
- 142    Column                               8    1   28                                               0  r[28]=pseudo.column 1
- 143    Column                               8    0   29                                               0  r[29]=pseudo.column 0
- 144    ResultRow                           28    2    0                                               0  output=r[28..29]
- 145  SorterNext                             5  141    0                                               0
- 146  Halt                                   0    0    0                                               0
- 147  Transaction                            0    1    8                                               0  iDb=0 tx_mode=Read
- 148  String8                                0   23    0  %express%packages%                           0  r[23]='%express%packages%'
- 149  Integer                                1   41    0                                               0  r[41]=1
- 150  Goto                                   0    1    0                                               0
+addr  opcode                            p1   p2   p3  p4                                          p5  comment
+   0                Init                 0  142    0                                               0  Start at 142
+   1                InitCoroutine        1   93    2                                               0
+   2                Null                 0    9    0                                               0  r[9]=NULL
+   3                SorterOpen           0    2    0  k(1,B)                                       0  cursor=0
+   4                Integer              0    6    0                                               0  r[6]=0; clear group by abort flag
+   5                Null                 0    7    0                                               0  r[7]=NULL; initialize group by comparison registers to NULL
+   6                Gosub               13   89    0                                               0  ; go to clear accumulator subroutine
+   7                OpenRead             2    8    0  k(8,B,B,B,B,B,B,B,B)                         0  table=customer, root=8, iDb=0
+   8                OpenRead             3    9    0  k(9,B,B,B,B,B,B,B,B,B)                       0  table=orders, root=9, iDb=0
+   9                Integer              0   14    0                                               0  r[14]=0
+  10                Once                19    0    0                                               0  goto 19
+  11                OpenRead             4    8    0  k(8,B,B,B,B,B,B,B,B)                         0  table=customer, root=8, iDb=0
+  12                Rewind               4   18    0                                               0  Rewind table customer
+  13                  RowId              4   15    0                                               0  r[15]=customer.rowid
+  14                  Affinity          15    1    0                                               0  r[15..16] = C
+  15                  RowId              4   16    0                                               0  r[16]=customer.rowid
+  16                  HashBuild          4   15    1  r=[1] budget=67108864 payload=r[16]..r[16]   0
+  17                Next                 4   13    0                                               0
+  18                HashBuildFinalize    1    0    0                                               0
+  19                HashResetMatched     1    0    0                                               0
+  20                Rewind               3   41    0                                               0  Rewind table orders
+  21                  Column             3    1   17                                               0  r[17]=orders.O_CUSTKEY
+  22                  Affinity          17    1    0                                               0  r[17..18] = C
+  23                  RowId              3   19    0                                               0  r[19]=orders.rowid
+  24                  Integer            0   20    0                                               0  r[20]=0
+  25                  HashProbe          1   17    1  r[21]=40 payload=r[18]..r[18]                0
+  26                  Column             3    8   24                                               0  r[24]=orders.O_COMMENT
+  27                  Function           1   23   22  like(2)                                      0  r[22]=func(r[23..24])
+  28                  If                22   37    1                                               0  if r[22] goto 37
+  29                  HashMarkMatched    1    0    0                                               0
+  30                  Gosub             25   32    0                                               0
+  31                  Goto               0   37    0                                               0
+  32                  Copy              18   11    0                                               0  r[11]=r[18]
+  33                  RowId              3   12    0                                               0  r[12]=orders.rowid
+  34                  MakeRecord        11    2   10                                               0  r[10]=mkrec(r[11..12])
+  35                  SorterInsert       0   10    0  0                                            0  key=r[10]
+  36                Return              25    0    0                                               0
+  37                IfPos               20   54    0                                               0  r[20]>0 -> r[20]-=0, goto 54
+  38                HashNext             1   21   40   payload=r[18]..r[18]                        0
+  39                Goto                 0   26    0                                               0
+  40              Next                   3   21    0                                               0
+  41              NullRow                3    0    0                                               0  Set cursor 3 to a (pseudo) NULL row
+  42              HashScanUnmatched      1   21   47                                               0  hash_table_id=1 payload=r[18]..r[18]
+  43              SeekRowid              2   21   47                                               0  if (r[21]!=cursor 2 for table customer.rowid) goto 47
+  44              Gosub                 25   32    0                                               0
+  45              HashNextUnmatched      1   21   47                                               0  hash_table_id=1 payload=r[18]..r[18]
+  46              Goto                   0   43    0                                               0
+  47              HashGraceInit          1    0   65                                               0  hash_table_id=1
+  48              Integer                1   20    0                                               0  r[20]=1
+  49              HashGraceLoadPart      1    0   64                                               0  hash_table_id=1
+  50              HashGraceNextProbe     1   17   56                                               0  hash_table_id=1 keys=r[17]..r[17] probe_rowid_dest=r[19]
+  51              SeekRowid              3   19   50                                               0  if (r[19]!=cursor 3 for table orders.rowid) goto 50
+  52              HashProbe              1   17    1  r[21]=50 payload=r[18]..r[18]                0
+  53              Goto                   0   26    0                                               0
+  54              HashNext               1   21   50   payload=r[18]..r[18]                        0
+  55              Goto                   0   26    0                                               0
+  56              NullRow                3    0    0                                               0  Set cursor 3 to a (pseudo) NULL row
+  57              HashScanUnmatched      1   21   62                                               0  hash_table_id=1 payload=r[18]..r[18]
+  58              SeekRowid              2   21   62                                               0  if (r[21]!=cursor 2 for table customer.rowid) goto 62
+  59              Gosub                 25   32    0                                               0
+  60              HashNextUnmatched      1   21   62                                               0  hash_table_id=1 payload=r[18]..r[18]
+  61              Goto                   0   58    0                                               0
+  62              HashGraceAdvPart       1    0   64                                               0  hash_table_id=1
+  63              Goto                   0   49    0                                               0
+  64              Integer                0   20    0                                               0  r[20]=0
+  65              OpenPseudo             1   10    2                                               0  2 columns in r[10]
+  66              SorterSort             0   81    0                                               0
+  67                SorterData           0   10    1                                               0  r[10]=data
+  68                Column               1    0   26                                               0  r[26]=pseudo.column 0
+  69                Compare              7   26    1  k(1, Binary)                                 0  r[7..7]==r[26..26]
+  70                Jump                71   75   71                                               0  ; start new group if comparison is not equal
+  71                Gosub                4   83    0                                               0  ; check if ended group had data, and output if so
+  72                Move                26    7    1                                               0  r[7..7]=r[26..26]
+  73                IfPos                6   92    0                                               0  r[6]>0 -> r[6]-=0, goto 92; check abort flag
+  74                Gosub               13   89    0                                               0  ; goto clear accumulator subroutine
+  75                Column               1    1   27                                               0  r[27]=pseudo.column 1
+  76                AggStep              0   27    9  count                                        0  accum=r[9] step(r[27])
+  77                If                   5   79    0                                               0  if r[5] goto 79; don't emit group columns if continuing existing group
+  78                Column               1    0    8                                               0  r[8]=pseudo.column 0
+  79                Integer              1    5    0                                               0  r[5]=1; indicate data in accumulator
+  80              SorterNext             0   67    0                                               0
+  81              Gosub                  4   83    0                                               0  ; emit row for final group
+  82              Goto                   0   92    0                                               0  ; group by finished
+  83              IfPos                  5   85    0                                               0  r[5]>0 -> r[5]-=0, goto 85; output group by row subroutine start
+  84            Return                   4    0    0                                               0
+  85            AggFinal                 0    9    0  count                                        0  accum=r[9]
+  86            Copy                     8    2    1                                               0  r[2]=r[8]
+  87            Yield                    1    0    0                                               0
+  88          Return                     4    0    0                                               0
+  89          Null                       0    8    9                                               0  r[8..9]=NULL; clear accumulator subroutine start
+  90          Integer                    0    5    0                                               0  r[5]=0
+  91        Return                      13    0    0                                               0
+  92        EndCoroutine                 1    0    0                                               0
+  93        SorterOpen                   5    3    0  k(3,-B,-B,Binary)                            0  cursor=5
+  94        Null                         0   36    0                                               0  r[36]=NULL
+  95        SorterOpen                   6    1    0  k(1,-B)                                      0  cursor=6
+  96        Integer                      0   33    0                                               0  r[33]=0; clear group by abort flag
+  97        Null                         0   34    0                                               0  r[34]=NULL; initialize group by comparison registers to NULL
+  98        Gosub                       39  131    0                                               0  ; go to clear accumulator subroutine
+  99        InitCoroutine                1    0    2                                               0
+ 100          Yield                      1  105    0                                               0
+ 101          Copy                       3   38    0                                               0  r[38]=r[3]
+ 102          MakeRecord                38    1   37                                               0  r[37]=mkrec(r[38..38])
+ 103          SorterInsert               6   37    0  0                                            0  key=r[37]
+ 104        Goto                         0  100    0                                               0
+ 105        OpenPseudo                   7   37    1                                               0  1 columns in r[37]
+ 106        SorterSort                   6  120    0                                               0
+ 107          SorterData                 6   37    7                                               0  r[37]=data
+ 108          Column                     7    0   40                                               0  r[40]=pseudo.column 0
+ 109          Compare                   34   40    1  k(1, Binary)                                 0  r[34..34]==r[40..40]
+ 110          Jump                     111  115  111                                               0  ; start new group if comparison is not equal
+ 111          Gosub                     31  122    0                                               0  ; check if ended group had data, and output if so
+ 112          Move                      40   34    1                                               0  r[34..34]=r[40..40]
+ 113          IfPos                     33  134    0                                               0  r[33]>0 -> r[33]-=0, goto 134; check abort flag
+ 114          Gosub                     39  131    0                                               0  ; goto clear accumulator subroutine
+ 115          AggStep                    0   41   36  count                                        0  accum=r[36] step(r[41])
+ 116          If                        32  118    0                                               0  if r[32] goto 118; don't emit group columns if continuing existing group
+ 117          Column                     7    0   35                                               0  r[35]=pseudo.column 0
+ 118          Integer                    1   32    0                                               0  r[32]=1; indicate data in accumulator
+ 119        SorterNext                   6  107    0                                               0
+ 120        Gosub                       31  122    0                                               0  ; emit row for final group
+ 121        Goto                         0  134    0                                               0  ; group by finished
+ 122        IfPos                       32  124    0                                               0  r[32]>0 -> r[32]-=0, goto 124; output group by row subroutine start
+ 123      Return                        31    0    0                                               0
+ 124      AggFinal                       0   36    0  count                                        0  accum=r[36]
+ 125      Copy                          36   42    0                                               0  r[42]=r[36]
+ 126      Copy                          35   43    0                                               0  r[43]=r[35]
+ 127      Sequence                       5   44    0                                               0
+ 128      MakeRecord                    42    3   30                                               0  r[30]=mkrec(r[42..44])
+ 129      SorterInsert                   5   30    0  0                                            0  key=r[30]
+ 130    Return                          31    0    0                                               0
+ 131    Null                             0   35   36                                               0  r[35..36]=NULL; clear accumulator subroutine start
+ 132    Integer                          0   32    0                                               0  r[32]=0
+ 133  Return                            39    0    0                                               0
+ 134  OpenPseudo                         8   30    3                                               0  3 columns in r[30]
+ 135  SorterSort                         5  141    0                                               0
+ 136    SorterData                       5   30    8                                               0  r[30]=data
+ 137    Column                           8    1   28                                               0  r[28]=pseudo.column 1
+ 138    Column                           8    0   29                                               0  r[29]=pseudo.column 0
+ 139    ResultRow                       28    2    0                                               0  output=r[28..29]
+ 140  SorterNext                         5  136    0                                               0
+ 141  Halt                               0    0    0                                               0
+ 142  Transaction                        0    1    8                                               0  iDb=0 tx_mode=Read
+ 143  String8                            0   23    0  %express%packages%                           0  r[23]='%express%packages%'
+ 144  Integer                            1   41    0                                               0  r[41]=1
+ 145  Goto                               0    1    0                                               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q4-order-priority.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q4-order-priority.snap
@@ -37,67 +37,63 @@ QUERY PLAN
 `--USE SORTER FOR GROUP BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4                                     p5  comment
-   0          Init               0  58   0                                          0  Start at 58
-   1          Null               0   9   0                                          0  r[9]=NULL
-   2          SorterOpen         0   1   0  k(1,B)                                  0  cursor=0
-   3          Integer            0   6   0                                          0  r[6]=0; clear group by abort flag
-   4          Null               0   7   0                                          0  r[7]=NULL; initialize group by comparison registers to NULL
-   5          Gosub             12  54   0                                          0  ; go to clear accumulator subroutine
-   6          OpenRead           2   9   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=orders, root=9, iDb=0
-   7          OpenRead           3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   8          OpenRead           4  11   0  k(3,B,B)                                0  index=sqlite_autoindex_lineitem_1, root=11, iDb=0
-   9          Rewind             2  28   0                                          0  Rewind table orders
-  10            Column           2   4  14                                          0  r[14]=orders.O_ORDERDATE
-  11            Lt              14  15  27  Binary                                  0  if r[14]<r[15] goto 27
-  12            Column           2   4  17                                          0  r[17]=orders.O_ORDERDATE
-  13            Ge              17  18  27  Binary                                  0  if r[17]>=r[18] goto 27
-  14            RowId            2  19   0                                          0  r[19]=orders.rowid
-  15            SeekGE           4  26  19                                          0  key=[19..19]
-  16              IdxGT          4  26  19                                          0  key=[19..19]
-  17              DeferredSeek   4   3   0                                          0
-  18              Column         3  11  21                                          0  r[21]=lineitem.L_COMMITDATE
-  19              Column         3  12  22                                          0  r[22]=lineitem.L_RECEIPTDATE
-  20              Ge            21  22  25  Binary                                  0  if r[21]>=r[22] goto 25
-  21              Column         2   5  11                                          0  r[11]=orders.O_ORDERPRIORITY
-  22              MakeRecord    11   1  10                                          0  r[10]=mkrec(r[11..11])
-  23              SorterInsert   0  10   0  0                                       0  key=r[10]
-  24              Goto           0  27   0                                          0  ; semi-join: early out after first match
-  25            Next             4  16   0                                          0
-  26            Goto             0  27   0                                          0  ; semi-join: no match, skip outer row
-  27          Next               2  10   0                                          0
-  28          OpenPseudo         1  10   1                                          0  1 columns in r[10]
-  29          SorterSort         0  43   0                                          0
-  30            SorterData       0  10   1                                          0  r[10]=data
-  31            Column           1   0  23                                          0  r[23]=pseudo.column 0
-  32            Compare          7  23   1  k(1, Binary)                            0  r[7..7]==r[23..23]
-  33            Jump            34  38  34                                          0  ; start new group if comparison is not equal
-  34            Gosub            4  47   0                                          0  ; check if ended group had data, and output if so
-  35            Move            23   7   1                                          0  r[7..7]=r[23..23]
-  36            IfPos            6  57   0                                          0  r[6]>0 -> r[6]-=0, goto 57; check abort flag
-  37            Gosub           12  54   0                                          0  ; goto clear accumulator subroutine
-  38            AggStep          0  24   9  count                                   0  accum=r[9] step(r[24])
-  39            If               5  41   0                                          0  if r[5] goto 41; don't emit group columns if continuing existing group
-  40            Column           1   0   8                                          0  r[8]=pseudo.column 0
-  41            Integer          1   5   0                                          0  r[5]=1; indicate data in accumulator
-  42          SorterNext         0  30   0                                          0
-  43          Gosub              4  47   0                                          0  ; emit row for final group
-  44          Goto               0  57   0                                          0  ; group by finished
-  45          Integer            1   6   0                                          0  r[6]=1
-  46        Return               4   0   0                                          0
-  47        IfPos                5  49   0                                          0  r[5]>0 -> r[5]-=0, goto 49; output group by row subroutine start
-  48      Return                 4   0   0                                          0
-  49      AggFinal               0   9   0  count                                   0  accum=r[9]
-  50      Copy                   8   2   0                                          0  r[2]=r[8]
-  51      Copy                   9   3   0                                          0  r[3]=r[9]
-  52      ResultRow              2   2   0                                          0  output=r[2..3]
-  53    Return                   4   0   0                                          0
-  54    Null                     0   8   9                                          0  r[8..9]=NULL; clear accumulator subroutine start
-  55    Integer                  0   5   0                                          0  r[5]=0
-  56  Return                    12   0   0                                          0
-  57  Halt                       0   0   0                                          0
-  58  Transaction                0   1   8                                          0  iDb=0 tx_mode=Read
-  59  String8                    0  15   0  1997-06-01                              0  r[15]='1997-06-01'
-  60  String8                    0  18   0  1997-09-01                              0  r[18]='1997-09-01'
-  61  Integer                    1  24   0                                          0  r[24]=1
-  62  Goto                       0   1   0                                          0
+addr  opcode                  p1  p2  p3  p4                                     p5  comment
+   0        Init               0  54   0                                          0  Start at 54
+   1        Null               0   9   0                                          0  r[9]=NULL
+   2        SorterOpen         0   1   0  k(1,B)                                  0  cursor=0
+   3        Integer            0   6   0                                          0  r[6]=0; clear group by abort flag
+   4        Null               0   7   0                                          0  r[7]=NULL; initialize group by comparison registers to NULL
+   5        Gosub             12  50   0                                          0  ; go to clear accumulator subroutine
+   6        OpenRead           2   9   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=orders, root=9, iDb=0
+   7        OpenRead           3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+   8        OpenRead           4  11   0  k(3,B,B)                                0  index=sqlite_autoindex_lineitem_1, root=11, iDb=0
+   9        Rewind             2  27   0                                          0  Rewind table orders
+  10          Column           2   4  14                                          0  r[14]=orders.O_ORDERDATE
+  11          Lt              14  15  26  Binary                                  0  if r[14]<r[15] goto 26
+  12          Column           2   4  17                                          0  r[17]=orders.O_ORDERDATE
+  13          Ge              17  18  26  Binary                                  0  if r[17]>=r[18] goto 26
+  14          RowId            2  19   0                                          0  r[19]=orders.rowid
+  15          SeekGE           4  26  19                                          0  key=[19..19]
+  16            IdxGT          4  26  19                                          0  key=[19..19]
+  17            DeferredSeek   4   3   0                                          0
+  18            Column         3  11  21                                          0  r[21]=lineitem.L_COMMITDATE
+  19            Column         3  12  22                                          0  r[22]=lineitem.L_RECEIPTDATE
+  20            Ge            21  22  25  Binary                                  0  if r[21]>=r[22] goto 25
+  21            Column         2   5  11                                          0  r[11]=orders.O_ORDERPRIORITY
+  22            MakeRecord    11   1  10                                          0  r[10]=mkrec(r[11..11])
+  23            SorterInsert   0  10   0  0                                       0  key=r[10]
+  24            Goto           0  26   0                                          0  ; semi-join: early out after first match
+  25          Next             4  16   0                                          0
+  26        Next               2  10   0                                          0
+  27        OpenPseudo         1  10   1                                          0  1 columns in r[10]
+  28        SorterSort         0  42   0                                          0
+  29          SorterData       0  10   1                                          0  r[10]=data
+  30          Column           1   0  23                                          0  r[23]=pseudo.column 0
+  31          Compare          7  23   1  k(1, Binary)                            0  r[7..7]==r[23..23]
+  32          Jump            33  37  33                                          0  ; start new group if comparison is not equal
+  33          Gosub            4  44   0                                          0  ; check if ended group had data, and output if so
+  34          Move            23   7   1                                          0  r[7..7]=r[23..23]
+  35          IfPos            6  53   0                                          0  r[6]>0 -> r[6]-=0, goto 53; check abort flag
+  36          Gosub           12  50   0                                          0  ; goto clear accumulator subroutine
+  37          AggStep          0  24   9  count                                   0  accum=r[9] step(r[24])
+  38          If               5  40   0                                          0  if r[5] goto 40; don't emit group columns if continuing existing group
+  39          Column           1   0   8                                          0  r[8]=pseudo.column 0
+  40          Integer          1   5   0                                          0  r[5]=1; indicate data in accumulator
+  41        SorterNext         0  29   0                                          0
+  42        Gosub              4  44   0                                          0  ; emit row for final group
+  43        Halt               0   0   0                                          0  ; group by finished
+  44        IfPos              5  46   0                                          0  r[5]>0 -> r[5]-=0, goto 46; output group by row subroutine start
+  45      Return               4   0   0                                          0
+  46      AggFinal             0   9   0  count                                   0  accum=r[9]
+  47      Copy                 8   2   1                                          0  r[2]=r[8]
+  48      ResultRow            2   2   0                                          0  output=r[2..3]
+  49    Return                 4   0   0                                          0
+  50    Null                   0   8   9                                          0  r[8..9]=NULL; clear accumulator subroutine start
+  51    Integer                0   5   0                                          0  r[5]=0
+  52  Return                  12   0   0                                          0
+  53  Halt                     0   0   0                                          0
+  54  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
+  55  String8                  0  15   0  1997-06-01                              0  r[15]='1997-06-01'
+  56  String8                  0  18   0  1997-09-01                              0  r[18]='1997-09-01'
+  57  Integer                  1  24   0                                          0  r[24]=1
+  58  Goto                     0   1   0                                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
@@ -27,8 +27,8 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1   p2  p3  p4                     p5  comment
-   0          Init             0  175   0                          0  Start at 175
-   1          InitCoroutine    1  102   2                          0
+   0          Init             0  114   0                          0  Start at 114
+   1          InitCoroutine    1   69   2                          0
    2          InitCoroutine    2   14   3                          0
    3          OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
    4          OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
@@ -47,164 +47,103 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
   17          Null             0   27   0                          0  r[27]=NULL
   18          Null             0   28   0                          0  r[28]=NULL
   19          InitCoroutine    2    0   3                          0
-  20            Yield          2   62   0                          0
-  21            Compare        3   28   1  k(1, Binary)            0  r[3..3]==r[28..28]; compare partition keys to detect new partition
-  22            Jump          23   26  23                          0
-  23            Gosub         29   63   0                          0  ; detected new partition
-  24            Null           0   27   0                          0  r[27]=NULL
-  25            Copy           3   28   0                          0  r[28]=r[3]
-  26            NotNull       27   34   0                          0  r[27]!=NULL -> goto 34
-  27            Null           0   15  18                          0  r[15..18]=NULL; reset accumulator registers
-  28            MakeRecord     3    4  31                          0  r[31]=mkrec(r[3..6])
-  29            NewRowid       3   27   0                          0  r[27]=rowid
-  30            Insert         3   31  27  buffer_table_window_1   2  intkey=r[27] data=r[31]
-  31            Rewind         2   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  32            Rewind         4   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  33            Goto           0   61   0                          0
+  20              Yield        2   38   0                          0
+  21              Compare      3   28   1  k(1, Binary)            0  r[3..3]==r[28..28]; compare partition keys to detect new partition
+  22              Jump        23   26  23                          0
+  23              Gosub       29   39   0                          0  ; detected new partition
+  24              Null         0   27   0                          0  r[27]=NULL
+  25              Copy         3   28   0                          0  r[28]=r[3]
+  26              NotNull     27   34   0                          0  r[27]!=NULL -> goto 34
+  27              Null         0   15  18                          0  r[15..18]=NULL; reset accumulator registers
+  28              MakeRecord   3    4  31                          0  r[31]=mkrec(r[3..6])
+  29              NewRowid     3   27   0                          0  r[27]=rowid
+  30              Insert       3   31  27  buffer_table_window_1   2  intkey=r[27] data=r[31]
+  31              Rewind       2   20   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  32              Rewind       4   20   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  33            Goto           0   20   0                          0
   34            MakeRecord     3    4  32                          0  r[32]=mkrec(r[3..6])
   35            NewRowid       3   27   0                          0  r[27]=rowid
   36            Insert         3   32  27  buffer_table_window_1   2  intkey=r[27] data=r[32]
-  37            Goto           0   61   0                          0
-  38            AggStep        0   33  15  count                   0  accum=r[15] step(r[33])
-  39            Column         4    3  34                          0  r[34]=ephemeral(buffer_table_window_1).salary
-  40            AggStep        0   34  16  min(Binary)             0  accum=r[16] step(r[34])
-  41            Column         4    3  35                          0  r[35]=ephemeral(buffer_table_window_1).salary
-  42            AggStep        0   35  17  max(Binary)             0  accum=r[17] step(r[35])
-  43            Column         4    3  36                          0  r[36]=ephemeral(buffer_table_window_1).salary
-  44            AggStep        0   36  18  avg                     0  accum=r[18] step(r[36])
-  45            Next           4   47   0                          0
-  46            Goto           0   48   0                          0
-  47            Goto           0   38   0                          0
-  48            AggValue       0   15  19  count                   0  accum=r[15] dest=r[19]
-  49            AggValue       0   16  20  min                     0  accum=r[16] dest=r[20]
-  50            AggValue       0   17  21  max                     0  accum=r[17] dest=r[21]
-  51            AggValue       0   18  22  avg                     0  accum=r[18] dest=r[22]
-  52            Column         2    1  23                          0  r[23]=ephemeral(buffer_table_window_1).emp_id
-  53            Column         2    2  24                          0  r[24]=ephemeral(buffer_table_window_1).name
-  54            Column         2    0  25                          0  r[25]=ephemeral(buffer_table_window_1).department
-  55            Column         2    3  26                          0  r[26]=ephemeral(buffer_table_window_1).salary
-  56            Gosub         30   91   0                          0
-  57            Delete         2    0   0  buffer_table_window_1   0
-  58            Next           2   60   0                          0
-  59            Goto           0   61   0                          0
-  60            Goto           0   52   0                          0
-  61          Goto             0   20   0                          0
-  62          Null             0   29   0                          0  r[29]=NULL; return remaining buffered rows
-  63          Rewind           3   88   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  64          AggStep          0   37  15  count                   0  accum=r[15] step(r[37])
-  65          Column           4    3  38                          0  r[38]=ephemeral(buffer_table_window_1).salary
-  66          AggStep          0   38  16  min(Binary)             0  accum=r[16] step(r[38])
-  67          Column           4    3  39                          0  r[39]=ephemeral(buffer_table_window_1).salary
-  68          AggStep          0   39  17  max(Binary)             0  accum=r[17] step(r[39])
-  69          Column           4    3  40                          0  r[40]=ephemeral(buffer_table_window_1).salary
-  70          AggStep          0   40  18  avg                     0  accum=r[18] step(r[40])
-  71          Next             4   73   0                          0
-  72          Goto             0   74   0                          0
-  73          Goto             0   64   0                          0
-  74          AggValue         0   15  19  count                   0  accum=r[15] dest=r[19]
-  75          AggValue         0   16  20  min                     0  accum=r[16] dest=r[20]
-  76          AggValue         0   17  21  max                     0  accum=r[17] dest=r[21]
-  77          AggValue         0   18  22  avg                     0  accum=r[18] dest=r[22]
-  78          Column           2    1  23                          0  r[23]=ephemeral(buffer_table_window_1).emp_id
-  79          Column           2    2  24                          0  r[24]=ephemeral(buffer_table_window_1).name
-  80          Column           2    0  25                          0  r[25]=ephemeral(buffer_table_window_1).department
-  81          Column           2    3  26                          0  r[26]=ephemeral(buffer_table_window_1).salary
-  82          Gosub           30   91   0                          0
-  83          Delete           2    0   0  buffer_table_window_1   0
-  84          Next             2   86   0                          0
-  85          Goto             0   88   0                          0
-  86          Goto             0   78   0                          0
-  87          Goto             0   74   0                          0
-  88          ResetSorter      2    0   0                          0  cursor=2
-  89        Return            29    0   1                          0
-  90        Goto               0  101   0                          0
-  91        Copy              23    7   0                          0  r[7]=r[23]
-  92        Copy              24    8   0                          0  r[8]=r[24]
-  93        Copy              25    9   0                          0  r[9]=r[25]
-  94        Copy              26   10   0                          0  r[10]=r[26]
-  95        Copy              19   11   0                          0  r[11]=r[19]
-  96        Copy              20   12   0                          0  r[12]=r[20]
-  97        Copy              21   13   0                          0  r[13]=r[21]
-  98        Copy              22   14   0                          0  r[14]=r[22]
-  99        Yield              1    0   0                          0
- 100      Return              30    0   0                          0
- 101      EndCoroutine         1    0   0                          0
- 102      OpenEphemeral        5    1   0                          0  cursor=5 is_table=true
- 103      OpenDup              6    5   0                          0  new_cursor=6, original_cursor=5
- 104      OpenDup              7    5   0                          0  new_cursor=7, original_cursor=5
- 105      Null                 0   60   0                          0  r[60]=NULL
- 106      InitCoroutine        1    0   2                          0
- 107        Yield              1  139   0                          0
- 108        NotNull           60  116   0                          0  r[60]!=NULL -> goto 116
- 109        Null               0   50  50                          0  r[50..50]=NULL; reset accumulator registers
- 110        MakeRecord         7    8  63                          0  r[63]=mkrec(r[7..14])
- 111        NewRowid           6   60   0                          0  r[60]=rowid
- 112        Insert             6   63  60  buffer_table_window_0   2  intkey=r[60] data=r[63]
- 113        Rewind             5  115   0                          0  Rewind  ephemeral(buffer_table_window_0)
- 114        Rewind             7  115   0                          0  Rewind  ephemeral(buffer_table_window_0)
- 115        Goto               0  138   0                          0
- 116        MakeRecord         7    8  64                          0  r[64]=mkrec(r[7..14])
- 117        NewRowid           6   60   0                          0  r[60]=rowid
- 118        Insert             6   64  60  buffer_table_window_0   2  intkey=r[60] data=r[64]
- 119        Goto               0  138   0                          0
- 120        AggStep            0   65  50  count                   0  accum=r[50] step(r[65])
- 121        Next               7  123   0                          0
- 122        Goto               0  124   0                          0
- 123        Goto               0  120   0                          0
- 124        AggValue           0   50  51  count                   0  accum=r[50] dest=r[51]
- 125        Column             5    0  52                          0  r[52]=ephemeral(buffer_table_window_0).emp_id
- 126        Column             5    1  53                          0  r[53]=ephemeral(buffer_table_window_0).name
- 127        Column             5    2  54                          0  r[54]=ephemeral(buffer_table_window_0).department
- 128        Column             5    3  55                          0  r[55]=ephemeral(buffer_table_window_0).salary
- 129        Column             5    4  56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
- 130        Column             5    5  57                          0  r[57]=ephemeral(buffer_table_window_0).column 5
- 131        Column             5    6  58                          0  r[58]=ephemeral(buffer_table_window_0).column 6
- 132        Column             5    7  59                          0  r[59]=ephemeral(buffer_table_window_0).column 7
- 133        Gosub             62  163   0                          0
- 134        Delete             5    0   0  buffer_table_window_0   0
- 135        Next               5  137   0                          0
- 136        Goto               0  138   0                          0
- 137        Goto               0  125   0                          0
- 138      Goto                 0  107   0                          0
- 139      Null                 0   61   0                          0  r[61]=NULL; return remaining buffered rows
- 140      Rewind               6  160   0                          0  Rewind  ephemeral(buffer_table_window_0)
- 141      AggStep              0   66  50  count                   0  accum=r[50] step(r[66])
- 142      Next                 7  144   0                          0
- 143      Goto                 0  145   0                          0
- 144      Goto                 0  141   0                          0
- 145      AggValue             0   50  51  count                   0  accum=r[50] dest=r[51]
- 146      Column               5    0  52                          0  r[52]=ephemeral(buffer_table_window_0).emp_id
- 147      Column               5    1  53                          0  r[53]=ephemeral(buffer_table_window_0).name
- 148      Column               5    2  54                          0  r[54]=ephemeral(buffer_table_window_0).department
- 149      Column               5    3  55                          0  r[55]=ephemeral(buffer_table_window_0).salary
- 150      Column               5    4  56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
- 151      Column               5    5  57                          0  r[57]=ephemeral(buffer_table_window_0).column 5
- 152      Column               5    6  58                          0  r[58]=ephemeral(buffer_table_window_0).column 6
- 153      Column               5    7  59                          0  r[59]=ephemeral(buffer_table_window_0).column 7
- 154      Gosub               62  163   0                          0
- 155      Delete               5    0   0  buffer_table_window_0   0
- 156      Next                 5  158   0                          0
- 157      Goto                 0  160   0                          0
- 158      Goto                 0  146   0                          0
- 159      Goto                 0  145   0                          0
- 160      ResetSorter          5    0   0                          0  cursor=5
- 161    Return                61    0   1                          0
- 162    Goto                   0  174   0                          0
- 163    Copy                  52   41   0                          0  r[41]=r[52]
- 164    Copy                  53   42   0                          0  r[42]=r[53]
- 165    Copy                  54   43   0                          0  r[43]=r[54]
- 166    Copy                  55   44   0                          0  r[44]=r[55]
- 167    Copy                  51   45   0                          0  r[45]=r[51]
- 168    Copy                  56   46   0                          0  r[46]=r[56]
- 169    Copy                  57   47   0                          0  r[47]=r[57]
- 170    Copy                  58   48   0                          0  r[48]=r[58]
- 171    Copy                  59   49   0                          0  r[49]=r[59]
- 172    ResultRow             41    9   0                          0  output=r[41..49]
- 173  Return                  62    0   0                          0
- 174  Halt                     0    0   0                          0
- 175  Transaction              0    1   7                          0  iDb=0 tx_mode=Read
- 176  Integer                  1   33   0                          0  r[33]=1
- 177  Integer                  1   37   0                          0  r[37]=1
- 178  Integer                  1   65   0                          0  r[65]=1
- 179  Integer                  1   66   0                          0  r[66]=1
- 180  Goto                     0    1   0                          0
+  37          Goto             0   20   0                          0
+  38          Null             0   29   0                          0  r[29]=NULL; return remaining buffered rows
+  39          Rewind           3   61   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  40            AggStep        0   37  15  count                   0  accum=r[15] step(r[37])
+  41            Column         4    3  38                          0  r[38]=ephemeral(buffer_table_window_1).salary
+  42            AggStep        0   38  16  min(Binary)             0  accum=r[16] step(r[38])
+  43            Column         4    3  39                          0  r[39]=ephemeral(buffer_table_window_1).salary
+  44            AggStep        0   39  17  max(Binary)             0  accum=r[17] step(r[39])
+  45            Column         4    3  40                          0  r[40]=ephemeral(buffer_table_window_1).salary
+  46            AggStep        0   40  18  avg                     0  accum=r[18] step(r[40])
+  47          Next             4   40   0                          0
+  48          Goto             0   49   0                          0
+  49          AggValue         0   15  19  count                   0  accum=r[15] dest=r[19]
+  50          AggValue         0   16  20  min                     0  accum=r[16] dest=r[20]
+  51          AggValue         0   17  21  max                     0  accum=r[17] dest=r[21]
+  52          AggValue         0   18  22  avg                     0  accum=r[18] dest=r[22]
+  53            Column         2    1  23                          0  r[23]=ephemeral(buffer_table_window_1).emp_id
+  54            Column         2    2  24                          0  r[24]=ephemeral(buffer_table_window_1).name
+  55            Column         2    0  25                          0  r[25]=ephemeral(buffer_table_window_1).department
+  56            Column         2    3  26                          0  r[26]=ephemeral(buffer_table_window_1).salary
+  57            Gosub         30   64   0                          0
+  58            Delete         2    0   0  buffer_table_window_1   0
+  59          Next             2   53   0                          0
+  60          Goto             0   61   0                          0
+  61          ResetSorter      2    0   0                          0  cursor=2
+  62        Return            29    0   1                          0
+  63        Goto               0   68   0                          0
+  64        Copy              23    7   3                          0  r[7]=r[23]
+  65        Copy              19   11   3                          0  r[11]=r[19]
+  66        Yield              1    0   0                          0
+  67      Return              30    0   0                          0
+  68      EndCoroutine         1    0   0                          0
+  69      OpenEphemeral        5    1   0                          0  cursor=5 is_table=true
+  70      OpenDup              6    5   0                          0  new_cursor=6, original_cursor=5
+  71      OpenDup              7    5   0                          0  new_cursor=7, original_cursor=5
+  72      Null                 0   60   0                          0  r[60]=NULL
+  73      InitCoroutine        1    0   2                          0
+  74          Yield            1   87   0                          0
+  75          NotNull         60   83   0                          0  r[60]!=NULL -> goto 83
+  76          Null             0   50  50                          0  r[50..50]=NULL; reset accumulator registers
+  77          MakeRecord       7    8  63                          0  r[63]=mkrec(r[7..14])
+  78          NewRowid         6   60   0                          0  r[60]=rowid
+  79          Insert           6   63  60  buffer_table_window_0   2  intkey=r[60] data=r[63]
+  80          Rewind           5   74   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  81          Rewind           7   74   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  82        Goto               0   74   0                          0
+  83        MakeRecord         7    8  64                          0  r[64]=mkrec(r[7..14])
+  84        NewRowid           6   60   0                          0  r[60]=rowid
+  85        Insert             6   64  60  buffer_table_window_0   2  intkey=r[60] data=r[64]
+  86      Goto                 0   74   0                          0
+  87      Null                 0   61   0                          0  r[61]=NULL; return remaining buffered rows
+  88      Rewind               6  105   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  89        AggStep            0   66  50  count                   0  accum=r[50] step(r[66])
+  90      Next                 7   89   0                          0
+  91      Goto                 0   92   0                          0
+  92      AggValue             0   50  51  count                   0  accum=r[50] dest=r[51]
+  93        Column             5    0  52                          0  r[52]=ephemeral(buffer_table_window_0).emp_id
+  94        Column             5    1  53                          0  r[53]=ephemeral(buffer_table_window_0).name
+  95        Column             5    2  54                          0  r[54]=ephemeral(buffer_table_window_0).department
+  96        Column             5    3  55                          0  r[55]=ephemeral(buffer_table_window_0).salary
+  97        Column             5    4  56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
+  98        Column             5    5  57                          0  r[57]=ephemeral(buffer_table_window_0).column 5
+  99        Column             5    6  58                          0  r[58]=ephemeral(buffer_table_window_0).column 6
+ 100        Column             5    7  59                          0  r[59]=ephemeral(buffer_table_window_0).column 7
+ 101        Gosub             62  108   0                          0
+ 102        Delete             5    0   0  buffer_table_window_0   0
+ 103      Next                 5   93   0                          0
+ 104      Goto                 0  105   0                          0
+ 105      ResetSorter          5    0   0                          0  cursor=5
+ 106    Return                61    0   1                          0
+ 107    Halt                   0    0   0                          0
+ 108    Copy                  52   41   3                          0  r[41]=r[52]
+ 109    Copy                  51   45   0                          0  r[45]=r[51]
+ 110    Copy                  56   46   3                          0  r[46]=r[56]
+ 111    ResultRow             41    9   0                          0  output=r[41..49]
+ 112  Return                  62    0   0                          0
+ 113  Halt                     0    0   0                          0
+ 114  Transaction              0    1   7                          0  iDb=0 tx_mode=Read
+ 115  Integer                  1   33   0                          0  r[33]=1
+ 116  Integer                  1   37   0                          0  r[37]=1
+ 117  Integer                  1   65   0                          0  r[65]=1
+ 118  Integer                  1   66   0                          0  r[66]=1
+ 119  Goto                     0    1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
@@ -37,10 +37,10 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                           p1   p2   p3  p4                     p5  comment
-   0                  Init              0  366    0                          0  Start at 366
-   1                  InitCoroutine     1  291    2                          0
-   2                  InitCoroutine     2  203    3                          0
-   3                  InitCoroutine     3  110    4                          0
+   0                  Init              0  298    0                          0  Start at 298
+   1                  InitCoroutine     1  231    2                          0
+   2                  InitCoroutine     2  150    3                          0
+   3                  InitCoroutine     3   84    4                          0
    4                  InitCoroutine     4   21    5                          0
    5                  OpenRead          0    2    0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
    6                  OpenRead          1    3    0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
@@ -65,343 +65,275 @@ addr  opcode                           p1   p2   p3  p4                     p5  
   25                  Null              0   28    0                          0  r[28]=NULL
   26                  Null              0   29    0                          0  r[29]=NULL
   27                  InitCoroutine     4    0    5                          0
-  28                    Yield           4   64    0                          0
-  29                    Compare         5   29    1  k(1, Binary)            0  r[5..5]==r[29..29]; compare partition keys to detect new partition
-  30                    Jump           31   34   31                          0
-  31                    Gosub          30   65    0                          0  ; detected new partition
-  32                    Null            0   28    0                          0  r[28]=NULL
-  33                    Copy            5   29    0                          0  r[29]=r[5]
-  34                    NotNull        28   42    0                          0  r[28]!=NULL -> goto 42
-  35                    Null            0   20   20                          0  r[20..20]=NULL; reset accumulator registers
-  36                    MakeRecord      5    6   32                          0  r[32]=mkrec(r[5..10])
-  37                    NewRowid        5   28    0                          0  r[28]=rowid
-  38                    Insert          5   32   28  buffer_table_window_3   2  intkey=r[28] data=r[32]
-  39                    Rewind          4   41    0                          0  Rewind  ephemeral(buffer_table_window_3)
-  40                    Rewind          6   41    0                          0  Rewind  ephemeral(buffer_table_window_3)
-  41                    Goto            0   63    0                          0
+  28                      Yield         4   46    0                          0
+  29                      Compare       5   29    1  k(1, Binary)            0  r[5..5]==r[29..29]; compare partition keys to detect new partition
+  30                      Jump         31   34   31                          0
+  31                      Gosub        30   47    0                          0  ; detected new partition
+  32                      Null          0   28    0                          0  r[28]=NULL
+  33                      Copy          5   29    0                          0  r[29]=r[5]
+  34                      NotNull      28   42    0                          0  r[28]!=NULL -> goto 42
+  35                      Null          0   20   20                          0  r[20..20]=NULL; reset accumulator registers
+  36                      MakeRecord    5    6   32                          0  r[32]=mkrec(r[5..10])
+  37                      NewRowid      5   28    0                          0  r[28]=rowid
+  38                      Insert        5   32   28  buffer_table_window_3   2  intkey=r[28] data=r[32]
+  39                      Rewind        4   28    0                          0  Rewind  ephemeral(buffer_table_window_3)
+  40                      Rewind        6   28    0                          0  Rewind  ephemeral(buffer_table_window_3)
+  41                    Goto            0   28    0                          0
   42                    MakeRecord      5    6   33                          0  r[33]=mkrec(r[5..10])
   43                    NewRowid        5   28    0                          0  r[28]=rowid
   44                    Insert          5   33   28  buffer_table_window_3   2  intkey=r[28] data=r[33]
-  45                    Goto            0   63    0                          0
-  46                    Column          6    3   34                          0  r[34]=ephemeral(buffer_table_window_3).salary
-  47                    AggStep         0   34   20  avg                     0  accum=r[20] step(r[34])
-  48                    Next            6   50    0                          0
-  49                    Goto            0   51    0                          0
-  50                    Goto            0   46    0                          0
-  51                    AggValue        0   20   21  avg                     0  accum=r[20] dest=r[21]
-  52                    Column          4    1   22                          0  r[22]=ephemeral(buffer_table_window_3).department
-  53                    Column          4    0   23                          0  r[23]=ephemeral(buffer_table_window_3).region
-  54                    Column          4    2   24                          0  r[24]=ephemeral(buffer_table_window_3).amount
-  55                    Column          4    3   25                          0  r[25]=ephemeral(buffer_table_window_3).salary
-  56                    Column          4    4   26                          0  r[26]=ephemeral(buffer_table_window_3).emp_id
-  57                    Column          4    5   27                          0  r[27]=ephemeral(buffer_table_window_3).name
-  58                    Gosub          31   87    0                          0
-  59                    Delete          4    0    0  buffer_table_window_3   0
-  60                    Next            4   62    0                          0
-  61                    Goto            0   63    0                          0
-  62                    Goto            0   52    0                          0
-  63                  Goto              0   28    0                          0
-  64                  Null              0   30    0                          0  r[30]=NULL; return remaining buffered rows
-  65                  Rewind            5   84    0                          0  Rewind  ephemeral(buffer_table_window_3)
-  66                  Column            6    3   35                          0  r[35]=ephemeral(buffer_table_window_3).salary
-  67                  AggStep           0   35   20  avg                     0  accum=r[20] step(r[35])
-  68                  Next              6   70    0                          0
-  69                  Goto              0   71    0                          0
-  70                  Goto              0   66    0                          0
-  71                  AggValue          0   20   21  avg                     0  accum=r[20] dest=r[21]
-  72                  Column            4    1   22                          0  r[22]=ephemeral(buffer_table_window_3).department
-  73                  Column            4    0   23                          0  r[23]=ephemeral(buffer_table_window_3).region
-  74                  Column            4    2   24                          0  r[24]=ephemeral(buffer_table_window_3).amount
-  75                  Column            4    3   25                          0  r[25]=ephemeral(buffer_table_window_3).salary
-  76                  Column            4    4   26                          0  r[26]=ephemeral(buffer_table_window_3).emp_id
-  77                  Column            4    5   27                          0  r[27]=ephemeral(buffer_table_window_3).name
-  78                  Gosub            31   87    0                          0
-  79                  Delete            4    0    0  buffer_table_window_3   0
-  80                  Next              4   82    0                          0
-  81                  Goto              0   84    0                          0
-  82                  Goto              0   72    0                          0
-  83                  Goto              0   71    0                          0
-  84                  ResetSorter       4    0    0                          0  cursor=4
-  85                Return             30    0    1                          0
-  86                Goto                0   97    0                          0
-  87                Copy               22   36    0                          0  r[36]=r[22]
-  88                Copy               23   37    0                          0  r[37]=r[23]
-  89                Copy               24   38    0                          0  r[38]=r[24]
-  90                Copy               25   39    0                          0  r[39]=r[25]
-  91                Copy               26   40    0                          0  r[40]=r[26]
-  92                Copy               27   41    0                          0  r[41]=r[27]
-  93                Copy               21   42    0                          0  r[42]=r[21]
-  94                MakeRecord         36    7   19                          0  r[19]=mkrec(r[36..42])
-  95                SorterInsert        3   19    0  0                       0  key=r[19]
-  96              Return               31    0    0                          0
-  97              OpenPseudo            7   19    7                          0  7 columns in r[19]
-  98              SorterSort            3  109    0                          0
-  99                SorterData          3   19    7                          0  r[19]=data
- 100                Column              7    0   12                          0  r[12]=pseudo.column 0
- 101                Column              7    1   13                          0  r[13]=pseudo.column 1
- 102                Column              7    2   14                          0  r[14]=pseudo.column 2
- 103                Column              7    3   15                          0  r[15]=pseudo.column 3
- 104                Column              7    4   16                          0  r[16]=pseudo.column 4
- 105                Column              7    5   17                          0  r[17]=pseudo.column 5
- 106                Column              7    6   18                          0  r[18]=pseudo.column 6
- 107                Yield               3    0    0                          0
- 108              SorterNext            3   99    0                          0
- 109              EndCoroutine          3    0    0                          0
- 110              SorterOpen            8    2    0  k(2,B,-B)               0  cursor=8
- 111              OpenEphemeral         9    1    0                          0  cursor=9 is_table=true
- 112              OpenDup              10    9    0                          0  new_cursor=10, original_cursor=9
- 113              OpenDup              11    9    0                          0  new_cursor=11, original_cursor=9
- 114              Null                  0   61    0                          0  r[61]=NULL
- 115              Null                  0   62    0                          0  r[62]=NULL
- 116              InitCoroutine         3    0    4                          0
- 117                Yield               3  154    0                          0
- 118                Compare            12   62    1  k(1, Binary)            0  r[12..12]==r[62..62]; compare partition keys to detect new partition
- 119                Jump              120  123  120                          0
- 120                Gosub              63  155    0                          0  ; detected new partition
- 121                Null                0   61    0                          0  r[61]=NULL
- 122                Copy               12   62    0                          0  r[62]=r[12]
- 123                NotNull            61  131    0                          0  r[61]!=NULL -> goto 131
- 124                Null                0   52   52                          0  r[52..52]=NULL; reset accumulator registers
- 125                MakeRecord         12    7   65                          0  r[65]=mkrec(r[12..18])
- 126                NewRowid           10   61    0                          0  r[61]=rowid
- 127                Insert             10   65   61  buffer_table_window_2   2  intkey=r[61] data=r[65]
- 128                Rewind              9  130    0                          0  Rewind  ephemeral(buffer_table_window_2)
- 129                Rewind             11  130    0                          0  Rewind  ephemeral(buffer_table_window_2)
- 130                Goto                0  153    0                          0
- 131                MakeRecord         12    7   66                          0  r[66]=mkrec(r[12..18])
- 132                NewRowid           10   61    0                          0  r[61]=rowid
- 133                Insert             10   66   61  buffer_table_window_2   2  intkey=r[61] data=r[66]
- 134                Goto                0  153    0                          0
- 135                Column             11    2   67                          0  r[67]=ephemeral(buffer_table_window_2).amount
- 136                AggStep             0   67   52  sum                     0  accum=r[52] step(r[67])
- 137                Next               11  139    0                          0
- 138                Goto                0  140    0                          0
- 139                Goto                0  135    0                          0
- 140                AggValue            0   52   53  sum                     0  accum=r[52] dest=r[53]
- 141                Column              9    1   54                          0  r[54]=ephemeral(buffer_table_window_2).region
- 142                Column              9    2   55                          0  r[55]=ephemeral(buffer_table_window_2).amount
- 143                Column              9    0   56                          0  r[56]=ephemeral(buffer_table_window_2).department
- 144                Column              9    3   57                          0  r[57]=ephemeral(buffer_table_window_2).salary
- 145                Column              9    4   58                          0  r[58]=ephemeral(buffer_table_window_2).emp_id
- 146                Column              9    5   59                          0  r[59]=ephemeral(buffer_table_window_2).name
- 147                Column              9    6   60                          0  r[60]=ephemeral(buffer_table_window_2).column 6
- 148                Gosub              64  178    0                          0
- 149                Delete              9    0    0  buffer_table_window_2   0
- 150                Next                9  152    0                          0
- 151                Goto                0  153    0                          0
- 152                Goto                0  141    0                          0
- 153              Goto                  0  117    0                          0
- 154              Null                  0   63    0                          0  r[63]=NULL; return remaining buffered rows
- 155              Rewind               10  175    0                          0  Rewind  ephemeral(buffer_table_window_2)
- 156              Column               11    2   68                          0  r[68]=ephemeral(buffer_table_window_2).amount
- 157              AggStep               0   68   52  sum                     0  accum=r[52] step(r[68])
- 158              Next                 11  160    0                          0
- 159              Goto                  0  161    0                          0
- 160              Goto                  0  156    0                          0
- 161              AggValue              0   52   53  sum                     0  accum=r[52] dest=r[53]
- 162              Column                9    1   54                          0  r[54]=ephemeral(buffer_table_window_2).region
- 163              Column                9    2   55                          0  r[55]=ephemeral(buffer_table_window_2).amount
- 164              Column                9    0   56                          0  r[56]=ephemeral(buffer_table_window_2).department
- 165              Column                9    3   57                          0  r[57]=ephemeral(buffer_table_window_2).salary
- 166              Column                9    4   58                          0  r[58]=ephemeral(buffer_table_window_2).emp_id
- 167              Column                9    5   59                          0  r[59]=ephemeral(buffer_table_window_2).name
- 168              Column                9    6   60                          0  r[60]=ephemeral(buffer_table_window_2).column 6
- 169              Gosub                64  178    0                          0
- 170              Delete                9    0    0  buffer_table_window_2   0
- 171              Next                  9  173    0                          0
- 172              Goto                  0  175    0                          0
- 173              Goto                  0  162    0                          0
- 174              Goto                  0  161    0                          0
- 175              ResetSorter           9    0    0                          0  cursor=9
- 176            Return                 63    0    1                          0
- 177            Goto                    0  189    0                          0
- 178            Copy                   54   69    0                          0  r[69]=r[54]
- 179            Copy                   55   70    0                          0  r[70]=r[55]
- 180            Copy                   56   71    0                          0  r[71]=r[56]
- 181            Copy                   57   72    0                          0  r[72]=r[57]
- 182            Copy                   58   73    0                          0  r[73]=r[58]
- 183            Copy                   59   74    0                          0  r[74]=r[59]
- 184            Copy                   53   75    0                          0  r[75]=r[53]
- 185            Copy                   60   76    0                          0  r[76]=r[60]
- 186            MakeRecord             69    8   51                          0  r[51]=mkrec(r[69..76])
- 187            SorterInsert            8   51    0  0                       0  key=r[51]
- 188          Return                   64    0    0                          0
- 189          OpenPseudo               12   51    8                          0  8 columns in r[51]
- 190          SorterSort                8  202    0                          0
- 191            SorterData              8   51   12                          0  r[51]=data
- 192            Column                 12    0   43                          0  r[43]=pseudo.column 0
- 193            Column                 12    1   44                          0  r[44]=pseudo.column 1
- 194            Column                 12    2   45                          0  r[45]=pseudo.column 2
- 195            Column                 12    3   46                          0  r[46]=pseudo.column 3
- 196            Column                 12    4   47                          0  r[47]=pseudo.column 4
- 197            Column                 12    5   48                          0  r[48]=pseudo.column 5
- 198            Column                 12    6   49                          0  r[49]=pseudo.column 6
- 199            Column                 12    7   50                          0  r[50]=pseudo.column 7
- 200            Yield                   2    0    0                          0
- 201          SorterNext                8  191    0                          0
- 202          EndCoroutine              2    0    0                          0
- 203          SorterOpen               13    2    0  k(2,B,-B)               0  cursor=13
- 204          OpenEphemeral            14    1    0                          0  cursor=14 is_table=true
- 205          OpenDup                  15   14    0                          0  new_cursor=15, original_cursor=14
- 206          OpenDup                  16   14    0                          0  new_cursor=16, original_cursor=14
- 207          Null                      0   97    0                          0  r[97]=NULL
- 208          Null                      0   98    0                          0  r[98]=NULL
- 209          InitCoroutine             2    0    3                          0
- 210            Yield                   2  243    0                          0
- 211            Copy                   44  100    0                          0  r[100]=r[44]
- 212            Compare                43   98    1  k(1, Binary)            0  r[43..43]==r[98..98]; compare partition keys to detect new partition
- 213            Jump                  214  217  214                          0
- 214            Gosub                  99  244    0                          0  ; detected new partition
- 215            Null                    0   97    0                          0  r[97]=NULL
- 216            Copy                   43   98    0                          0  r[98]=r[43]
- 217            NotNull                97  225    0                          0  r[97]!=NULL -> goto 225
- 218            Null                    0   87   87                          0  r[87..87]=NULL; initialize per-cursor peer-reference registers for new partition
- 219            MakeRecord             43    8  102                          0  r[102]=mkrec(r[43..50])
- 220            NewRowid               15   97    0                          0  r[97]=rowid
- 221            Insert                 15  102   97  buffer_table_window_1   2  intkey=r[97] data=r[102]
- 222            Rewind                 14  224    0                          0  Rewind  ephemeral(buffer_table_window_1)
- 223            Rewind                 16  224    0                          0  Rewind  ephemeral(buffer_table_window_1)
- 224            Goto                    0  242    0                          0
- 225            MakeRecord             43    8  103                          0  r[103]=mkrec(r[43..50])
- 226            NewRowid               15   97    0                          0  r[97]=rowid
- 227            Insert                 15  103   97  buffer_table_window_1   2  intkey=r[97] data=r[103]
- 228            AggStep                 0    0   87  row_number              0  accum=r[87] step(r[0])
- 229            Next                   16  230    0                          0
- 230            AggValue                0   87   88  row_number              0  accum=r[87] dest=r[88]
- 231            Column                 14    2   89                          0  r[89]=ephemeral(buffer_table_window_1).department
- 232            Column                 14    3   90                          0  r[90]=ephemeral(buffer_table_window_1).salary
- 233            Column                 14    4   91                          0  r[91]=ephemeral(buffer_table_window_1).emp_id
- 234            Column                 14    5   92                          0  r[92]=ephemeral(buffer_table_window_1).name
- 235            Column                 14    1   93                          0  r[93]=ephemeral(buffer_table_window_1).amount
- 236            Column                 14    0   94                          0  r[94]=ephemeral(buffer_table_window_1).region
- 237            Column                 14    6   95                          0  r[95]=ephemeral(buffer_table_window_1).column 6
- 238            Column                 14    7   96                          0  r[96]=ephemeral(buffer_table_window_1).column 7
- 239            Gosub                 101  264    0                          0
- 240            Delete                 14    0    0  buffer_table_window_1   0
- 241            Next                   14  242    0                          0
- 242          Goto                      0  210    0                          0
- 243          Null                      0   99    0                          0  r[99]=NULL; return remaining buffered rows
- 244          Rewind                   15  261    0                          0  Rewind  ephemeral(buffer_table_window_1)
- 245          AggStep                   0    0   87  row_number              0  accum=r[87] step(r[0])
- 246          Next                     16  247    0                          0
- 247          AggValue                  0   87   88  row_number              0  accum=r[87] dest=r[88]
- 248          Column                   14    2   89                          0  r[89]=ephemeral(buffer_table_window_1).department
- 249          Column                   14    3   90                          0  r[90]=ephemeral(buffer_table_window_1).salary
- 250          Column                   14    4   91                          0  r[91]=ephemeral(buffer_table_window_1).emp_id
- 251          Column                   14    5   92                          0  r[92]=ephemeral(buffer_table_window_1).name
- 252          Column                   14    1   93                          0  r[93]=ephemeral(buffer_table_window_1).amount
- 253          Column                   14    0   94                          0  r[94]=ephemeral(buffer_table_window_1).region
- 254          Column                   14    6   95                          0  r[95]=ephemeral(buffer_table_window_1).column 6
- 255          Column                   14    7   96                          0  r[96]=ephemeral(buffer_table_window_1).column 7
- 256          Gosub                   101  264    0                          0
- 257          Delete                   14    0    0  buffer_table_window_1   0
- 258          Next                     14  260    0                          0
- 259          Goto                      0  261    0                          0
- 260          Goto                      0  247    0                          0
- 261          ResetSorter              14    0    0                          0  cursor=14
- 262        Return                     99    0    1                          0
- 263        Goto                        0  276    0                          0
- 264        Copy                       89  104    0                          0  r[104]=r[89]
- 265        Copy                       90  105    0                          0  r[105]=r[90]
- 266        Copy                       91  106    0                          0  r[106]=r[91]
- 267        Copy                       92  107    0                          0  r[107]=r[92]
- 268        Copy                       93  108    0                          0  r[108]=r[93]
- 269        Copy                       94  109    0                          0  r[109]=r[94]
- 270        Copy                       88  110    0                          0  r[110]=r[88]
- 271        Copy                       95  111    0                          0  r[111]=r[95]
- 272        Copy                       96  112    0                          0  r[112]=r[96]
- 273        MakeRecord                104    9   86                          0  r[86]=mkrec(r[104..112])
- 274        SorterInsert               13   86    0  0                       0  key=r[86]
- 275      Return                      101    0    0                          0
- 276      OpenPseudo                   17   86    9                          0  9 columns in r[86]
- 277      SorterSort                   13  290    0                          0
- 278        SorterData                 13   86   17                          0  r[86]=data
- 279        Column                     17    0   77                          0  r[77]=pseudo.column 0
- 280        Column                     17    1   78                          0  r[78]=pseudo.column 1
- 281        Column                     17    2   79                          0  r[79]=pseudo.column 2
- 282        Column                     17    3   80                          0  r[80]=pseudo.column 3
- 283        Column                     17    4   81                          0  r[81]=pseudo.column 4
- 284        Column                     17    5   82                          0  r[82]=pseudo.column 5
- 285        Column                     17    6   83                          0  r[83]=pseudo.column 6
- 286        Column                     17    7   84                          0  r[84]=pseudo.column 7
- 287        Column                     17    8   85                          0  r[85]=pseudo.column 8
- 288        Yield                       1    0    0                          0
- 289      SorterNext                   13  278    0                          0
- 290      EndCoroutine                  1    0    0                          0
- 291      OpenEphemeral                18    1    0                          0  cursor=18 is_table=true
- 292      OpenDup                      19   18    0                          0  new_cursor=19, original_cursor=18
- 293      OpenDup                      20   18    0                          0  new_cursor=20, original_cursor=18
- 294      Null                          0  134    0                          0  r[134]=NULL
- 295      Null                          0  135    0                          0  r[135]=NULL
- 296      InitCoroutine                 1    0    2                          0
- 297        Yield                       1  331    0                          0
- 298        Copy                       78  137    0                          0  r[137]=r[78]
- 299        Compare                    77  135    1  k(1, Binary)            0  r[77..77]==r[135..135]; compare partition keys to detect new partition
- 300        Jump                      301  304  301                          0
- 301        Gosub                     136  332    0                          0  ; detected new partition
- 302        Null                        0  134    0                          0  r[134]=NULL
- 303        Copy                       77  135    0                          0  r[135]=r[77]
- 304        NotNull                   134  312    0                          0  r[134]!=NULL -> goto 312
- 305        Null                        0  123  123                          0  r[123..123]=NULL; initialize per-cursor peer-reference registers for new partition
- 306        MakeRecord                 77    9  139                          0  r[139]=mkrec(r[77..85])
- 307        NewRowid                   19  134    0                          0  r[134]=rowid
- 308        Insert                     19  139  134  buffer_table_window_0   2  intkey=r[134] data=r[139]
- 309        Rewind                     18  311    0                          0  Rewind  ephemeral(buffer_table_window_0)
- 310        Rewind                     20  311    0                          0  Rewind  ephemeral(buffer_table_window_0)
- 311        Goto                        0  330    0                          0
- 312        MakeRecord                 77    9  140                          0  r[140]=mkrec(r[77..85])
- 313        NewRowid                   19  134    0                          0  r[134]=rowid
- 314        Insert                     19  140  134  buffer_table_window_0   2  intkey=r[134] data=r[140]
- 315        AggStep                     0    0  123  row_number              0  accum=r[123] step(r[0])
- 316        Next                       20  317    0                          0
- 317        AggValue                    0  123  124  row_number              0  accum=r[123] dest=r[124]
- 318        Column                     18    2  125                          0  r[125]=ephemeral(buffer_table_window_0).emp_id
- 319        Column                     18    3  126                          0  r[126]=ephemeral(buffer_table_window_0).name
- 320        Column                     18    0  127                          0  r[127]=ephemeral(buffer_table_window_0).department
- 321        Column                     18    1  128                          0  r[128]=ephemeral(buffer_table_window_0).salary
- 322        Column                     18    4  129                          0  r[129]=ephemeral(buffer_table_window_0).amount
- 323        Column                     18    5  130                          0  r[130]=ephemeral(buffer_table_window_0).region
- 324        Column                     18    6  131                          0  r[131]=ephemeral(buffer_table_window_0).column 6
- 325        Column                     18    7  132                          0  r[132]=ephemeral(buffer_table_window_0).column 7
- 326        Column                     18    8  133                          0  r[133]=ephemeral(buffer_table_window_0).column 8
- 327        Gosub                     138  353    0                          0
- 328        Delete                     18    0    0  buffer_table_window_0   0
- 329        Next                       18  330    0                          0
- 330      Goto                          0  297    0                          0
- 331      Null                          0  136    0                          0  r[136]=NULL; return remaining buffered rows
- 332      Rewind                       19  350    0                          0  Rewind  ephemeral(buffer_table_window_0)
- 333      AggStep                       0    0  123  row_number              0  accum=r[123] step(r[0])
- 334      Next                         20  335    0                          0
- 335      AggValue                      0  123  124  row_number              0  accum=r[123] dest=r[124]
- 336      Column                       18    2  125                          0  r[125]=ephemeral(buffer_table_window_0).emp_id
- 337      Column                       18    3  126                          0  r[126]=ephemeral(buffer_table_window_0).name
- 338      Column                       18    0  127                          0  r[127]=ephemeral(buffer_table_window_0).department
- 339      Column                       18    1  128                          0  r[128]=ephemeral(buffer_table_window_0).salary
- 340      Column                       18    4  129                          0  r[129]=ephemeral(buffer_table_window_0).amount
- 341      Column                       18    5  130                          0  r[130]=ephemeral(buffer_table_window_0).region
- 342      Column                       18    6  131                          0  r[131]=ephemeral(buffer_table_window_0).column 6
- 343      Column                       18    7  132                          0  r[132]=ephemeral(buffer_table_window_0).column 7
- 344      Column                       18    8  133                          0  r[133]=ephemeral(buffer_table_window_0).column 8
- 345      Gosub                       138  353    0                          0
- 346      Delete                       18    0    0  buffer_table_window_0   0
- 347      Next                         18  349    0                          0
- 348      Goto                          0  350    0                          0
- 349      Goto                          0  335    0                          0
- 350      ResetSorter                  18    0    0                          0  cursor=18
- 351    Return                        136    0    1                          0
- 352    Goto                            0  365    0                          0
- 353    Copy                          125  113    0                          0  r[113]=r[125]
- 354    Copy                          126  114    0                          0  r[114]=r[126]
- 355    Copy                          127  115    0                          0  r[115]=r[127]
- 356    Copy                          128  116    0                          0  r[116]=r[128]
- 357    Copy                          129  117    0                          0  r[117]=r[129]
- 358    Copy                          130  118    0                          0  r[118]=r[130]
- 359    Copy                          124  119    0                          0  r[119]=r[124]
- 360    Copy                          131  120    0                          0  r[120]=r[131]
- 361    Copy                          132  121    0                          0  r[121]=r[132]
- 362    Copy                          133  122    0                          0  r[122]=r[133]
- 363    ResultRow                     113   10    0                          0  output=r[113..122]
- 364  Return                          138    0    0                          0
- 365  Halt                              0    0    0                          0
- 366  Transaction                       0    1    7                          0  iDb=0 tx_mode=Read
- 367  Goto                              0    1    0                          0
+  45                  Goto              0   28    0                          0
+  46                  Null              0   30    0                          0  r[30]=NULL; return remaining buffered rows
+  47                  Rewind            5   63    0                          0  Rewind  ephemeral(buffer_table_window_3)
+  48                    Column          6    3   35                          0  r[35]=ephemeral(buffer_table_window_3).salary
+  49                    AggStep         0   35   20  avg                     0  accum=r[20] step(r[35])
+  50                  Next              6   48    0                          0
+  51                  Goto              0   52    0                          0
+  52                  AggValue          0   20   21  avg                     0  accum=r[20] dest=r[21]
+  53                    Column          4    1   22                          0  r[22]=ephemeral(buffer_table_window_3).department
+  54                    Column          4    0   23                          0  r[23]=ephemeral(buffer_table_window_3).region
+  55                    Column          4    2   24                          0  r[24]=ephemeral(buffer_table_window_3).amount
+  56                    Column          4    3   25                          0  r[25]=ephemeral(buffer_table_window_3).salary
+  57                    Column          4    4   26                          0  r[26]=ephemeral(buffer_table_window_3).emp_id
+  58                    Column          4    5   27                          0  r[27]=ephemeral(buffer_table_window_3).name
+  59                    Gosub          31   66    0                          0
+  60                    Delete          4    0    0  buffer_table_window_3   0
+  61                  Next              4   53    0                          0
+  62                  Goto              0   63    0                          0
+  63                  ResetSorter       4    0    0                          0  cursor=4
+  64                Return             30    0    1                          0
+  65                Goto                0   71    0                          0
+  66                Copy               22   36    5                          0  r[36]=r[22]
+  67                Copy               21   42    0                          0  r[42]=r[21]
+  68                MakeRecord         36    7   19                          0  r[19]=mkrec(r[36..42])
+  69                SorterInsert        3   19    0  0                       0  key=r[19]
+  70              Return               31    0    0                          0
+  71              OpenPseudo            7   19    7                          0  7 columns in r[19]
+  72              SorterSort            3   83    0                          0
+  73                SorterData          3   19    7                          0  r[19]=data
+  74                Column              7    0   12                          0  r[12]=pseudo.column 0
+  75                Column              7    1   13                          0  r[13]=pseudo.column 1
+  76                Column              7    2   14                          0  r[14]=pseudo.column 2
+  77                Column              7    3   15                          0  r[15]=pseudo.column 3
+  78                Column              7    4   16                          0  r[16]=pseudo.column 4
+  79                Column              7    5   17                          0  r[17]=pseudo.column 5
+  80                Column              7    6   18                          0  r[18]=pseudo.column 6
+  81                Yield               3    0    0                          0
+  82              SorterNext            3   73    0                          0
+  83              EndCoroutine          3    0    0                          0
+  84              SorterOpen            8    2    0  k(2,B,-B)               0  cursor=8
+  85              OpenEphemeral         9    1    0                          0  cursor=9 is_table=true
+  86              OpenDup              10    9    0                          0  new_cursor=10, original_cursor=9
+  87              OpenDup              11    9    0                          0  new_cursor=11, original_cursor=9
+  88              Null                  0   61    0                          0  r[61]=NULL
+  89              Null                  0   62    0                          0  r[62]=NULL
+  90              InitCoroutine         3    0    4                          0
+  91                  Yield             3  109    0                          0
+  92                  Compare          12   62    1  k(1, Binary)            0  r[12..12]==r[62..62]; compare partition keys to detect new partition
+  93                  Jump             94   97   94                          0
+  94                  Gosub            63  110    0                          0  ; detected new partition
+  95                  Null              0   61    0                          0  r[61]=NULL
+  96                  Copy             12   62    0                          0  r[62]=r[12]
+  97                  NotNull          61  105    0                          0  r[61]!=NULL -> goto 105
+  98                  Null              0   52   52                          0  r[52..52]=NULL; reset accumulator registers
+  99                  MakeRecord       12    7   65                          0  r[65]=mkrec(r[12..18])
+ 100                  NewRowid         10   61    0                          0  r[61]=rowid
+ 101                  Insert           10   65   61  buffer_table_window_2   2  intkey=r[61] data=r[65]
+ 102                  Rewind            9   91    0                          0  Rewind  ephemeral(buffer_table_window_2)
+ 103                  Rewind           11   91    0                          0  Rewind  ephemeral(buffer_table_window_2)
+ 104                Goto                0   91    0                          0
+ 105                MakeRecord         12    7   66                          0  r[66]=mkrec(r[12..18])
+ 106                NewRowid           10   61    0                          0  r[61]=rowid
+ 107                Insert             10   66   61  buffer_table_window_2   2  intkey=r[61] data=r[66]
+ 108              Goto                  0   91    0                          0
+ 109              Null                  0   63    0                          0  r[63]=NULL; return remaining buffered rows
+ 110              Rewind               10  127    0                          0  Rewind  ephemeral(buffer_table_window_2)
+ 111                Column             11    2   68                          0  r[68]=ephemeral(buffer_table_window_2).amount
+ 112                AggStep             0   68   52  sum                     0  accum=r[52] step(r[68])
+ 113              Next                 11  111    0                          0
+ 114              Goto                  0  115    0                          0
+ 115              AggValue              0   52   53  sum                     0  accum=r[52] dest=r[53]
+ 116                Column              9    1   54                          0  r[54]=ephemeral(buffer_table_window_2).region
+ 117                Column              9    2   55                          0  r[55]=ephemeral(buffer_table_window_2).amount
+ 118                Column              9    0   56                          0  r[56]=ephemeral(buffer_table_window_2).department
+ 119                Column              9    3   57                          0  r[57]=ephemeral(buffer_table_window_2).salary
+ 120                Column              9    4   58                          0  r[58]=ephemeral(buffer_table_window_2).emp_id
+ 121                Column              9    5   59                          0  r[59]=ephemeral(buffer_table_window_2).name
+ 122                Column              9    6   60                          0  r[60]=ephemeral(buffer_table_window_2).column 6
+ 123                Gosub              64  130    0                          0
+ 124                Delete              9    0    0  buffer_table_window_2   0
+ 125              Next                  9  116    0                          0
+ 126              Goto                  0  127    0                          0
+ 127              ResetSorter           9    0    0                          0  cursor=9
+ 128            Return                 63    0    1                          0
+ 129            Goto                    0  136    0                          0
+ 130            Copy                   54   69    5                          0  r[69]=r[54]
+ 131            Copy                   53   75    0                          0  r[75]=r[53]
+ 132            Copy                   60   76    0                          0  r[76]=r[60]
+ 133            MakeRecord             69    8   51                          0  r[51]=mkrec(r[69..76])
+ 134            SorterInsert            8   51    0  0                       0  key=r[51]
+ 135          Return                   64    0    0                          0
+ 136          OpenPseudo               12   51    8                          0  8 columns in r[51]
+ 137          SorterSort                8  149    0                          0
+ 138            SorterData              8   51   12                          0  r[51]=data
+ 139            Column                 12    0   43                          0  r[43]=pseudo.column 0
+ 140            Column                 12    1   44                          0  r[44]=pseudo.column 1
+ 141            Column                 12    2   45                          0  r[45]=pseudo.column 2
+ 142            Column                 12    3   46                          0  r[46]=pseudo.column 3
+ 143            Column                 12    4   47                          0  r[47]=pseudo.column 4
+ 144            Column                 12    5   48                          0  r[48]=pseudo.column 5
+ 145            Column                 12    6   49                          0  r[49]=pseudo.column 6
+ 146            Column                 12    7   50                          0  r[50]=pseudo.column 7
+ 147            Yield                   2    0    0                          0
+ 148          SorterNext                8  138    0                          0
+ 149          EndCoroutine              2    0    0                          0
+ 150          SorterOpen               13    2    0  k(2,B,-B)               0  cursor=13
+ 151          OpenEphemeral            14    1    0                          0  cursor=14 is_table=true
+ 152          OpenDup                  15   14    0                          0  new_cursor=15, original_cursor=14
+ 153          OpenDup                  16   14    0                          0  new_cursor=16, original_cursor=14
+ 154          Null                      0   97    0                          0  r[97]=NULL
+ 155          Null                      0   98    0                          0  r[98]=NULL
+ 156          InitCoroutine             2    0    3                          0
+ 157                Yield               2  190    0                          0
+ 158                Copy               44  100    0                          0  r[100]=r[44]
+ 159                Compare            43   98    1  k(1, Binary)            0  r[43..43]==r[98..98]; compare partition keys to detect new partition
+ 160                Jump              161  164  161                          0
+ 161                Gosub              99  191    0                          0  ; detected new partition
+ 162                Null                0   97    0                          0  r[97]=NULL
+ 163                Copy               43   98    0                          0  r[98]=r[43]
+ 164                NotNull            97  172    0                          0  r[97]!=NULL -> goto 172
+ 165                Null                0   87   87                          0  r[87..87]=NULL; initialize per-cursor peer-reference registers for new partition
+ 166                MakeRecord         43    8  102                          0  r[102]=mkrec(r[43..50])
+ 167                NewRowid           15   97    0                          0  r[97]=rowid
+ 168                Insert             15  102   97  buffer_table_window_1   2  intkey=r[97] data=r[102]
+ 169                Rewind             14  157    0                          0  Rewind  ephemeral(buffer_table_window_1)
+ 170                Rewind             16  157    0                          0  Rewind  ephemeral(buffer_table_window_1)
+ 171              Goto                  0  157    0                          0
+ 172              MakeRecord           43    8  103                          0  r[103]=mkrec(r[43..50])
+ 173              NewRowid             15   97    0                          0  r[97]=rowid
+ 174              Insert               15  103   97  buffer_table_window_1   2  intkey=r[97] data=r[103]
+ 175              AggStep               0    0   87  row_number              0  accum=r[87] step(r[0])
+ 176              Next                 16  177    0                          0
+ 177              AggValue              0   87   88  row_number              0  accum=r[87] dest=r[88]
+ 178              Column               14    2   89                          0  r[89]=ephemeral(buffer_table_window_1).department
+ 179              Column               14    3   90                          0  r[90]=ephemeral(buffer_table_window_1).salary
+ 180              Column               14    4   91                          0  r[91]=ephemeral(buffer_table_window_1).emp_id
+ 181              Column               14    5   92                          0  r[92]=ephemeral(buffer_table_window_1).name
+ 182              Column               14    1   93                          0  r[93]=ephemeral(buffer_table_window_1).amount
+ 183              Column               14    0   94                          0  r[94]=ephemeral(buffer_table_window_1).region
+ 184              Column               14    6   95                          0  r[95]=ephemeral(buffer_table_window_1).column 6
+ 185              Column               14    7   96                          0  r[96]=ephemeral(buffer_table_window_1).column 7
+ 186              Gosub               101  210    0                          0
+ 187              Delete               14    0    0  buffer_table_window_1   0
+ 188            Next                   14  157    0                          0
+ 189          Goto                      0  157    0                          0
+ 190          Null                      0   99    0                          0  r[99]=NULL; return remaining buffered rows
+ 191          Rewind                   15  207    0                          0  Rewind  ephemeral(buffer_table_window_1)
+ 192          AggStep                   0    0   87  row_number              0  accum=r[87] step(r[0])
+ 193          Next                     16  194    0                          0
+ 194            AggValue                0   87   88  row_number              0  accum=r[87] dest=r[88]
+ 195            Column                 14    2   89                          0  r[89]=ephemeral(buffer_table_window_1).department
+ 196            Column                 14    3   90                          0  r[90]=ephemeral(buffer_table_window_1).salary
+ 197            Column                 14    4   91                          0  r[91]=ephemeral(buffer_table_window_1).emp_id
+ 198            Column                 14    5   92                          0  r[92]=ephemeral(buffer_table_window_1).name
+ 199            Column                 14    1   93                          0  r[93]=ephemeral(buffer_table_window_1).amount
+ 200            Column                 14    0   94                          0  r[94]=ephemeral(buffer_table_window_1).region
+ 201            Column                 14    6   95                          0  r[95]=ephemeral(buffer_table_window_1).column 6
+ 202            Column                 14    7   96                          0  r[96]=ephemeral(buffer_table_window_1).column 7
+ 203            Gosub                 101  210    0                          0
+ 204            Delete                 14    0    0  buffer_table_window_1   0
+ 205          Next                     14  194    0                          0
+ 206          Goto                      0  207    0                          0
+ 207          ResetSorter              14    0    0                          0  cursor=14
+ 208        Return                     99    0    1                          0
+ 209        Goto                        0  216    0                          0
+ 210        Copy                       89  104    5                          0  r[104]=r[89]
+ 211        Copy                       88  110    0                          0  r[110]=r[88]
+ 212        Copy                       95  111    1                          0  r[111]=r[95]
+ 213        MakeRecord                104    9   86                          0  r[86]=mkrec(r[104..112])
+ 214        SorterInsert               13   86    0  0                       0  key=r[86]
+ 215      Return                      101    0    0                          0
+ 216      OpenPseudo                   17   86    9                          0  9 columns in r[86]
+ 217      SorterSort                   13  230    0                          0
+ 218        SorterData                 13   86   17                          0  r[86]=data
+ 219        Column                     17    0   77                          0  r[77]=pseudo.column 0
+ 220        Column                     17    1   78                          0  r[78]=pseudo.column 1
+ 221        Column                     17    2   79                          0  r[79]=pseudo.column 2
+ 222        Column                     17    3   80                          0  r[80]=pseudo.column 3
+ 223        Column                     17    4   81                          0  r[81]=pseudo.column 4
+ 224        Column                     17    5   82                          0  r[82]=pseudo.column 5
+ 225        Column                     17    6   83                          0  r[83]=pseudo.column 6
+ 226        Column                     17    7   84                          0  r[84]=pseudo.column 7
+ 227        Column                     17    8   85                          0  r[85]=pseudo.column 8
+ 228        Yield                       1    0    0                          0
+ 229      SorterNext                   13  218    0                          0
+ 230      EndCoroutine                  1    0    0                          0
+ 231      OpenEphemeral                18    1    0                          0  cursor=18 is_table=true
+ 232      OpenDup                      19   18    0                          0  new_cursor=19, original_cursor=18
+ 233      OpenDup                      20   18    0                          0  new_cursor=20, original_cursor=18
+ 234      Null                          0  134    0                          0  r[134]=NULL
+ 235      Null                          0  135    0                          0  r[135]=NULL
+ 236      InitCoroutine                 1    0    2                          0
+ 237            Yield                   1  271    0                          0
+ 238            Copy                   78  137    0                          0  r[137]=r[78]
+ 239            Compare                77  135    1  k(1, Binary)            0  r[77..77]==r[135..135]; compare partition keys to detect new partition
+ 240            Jump                  241  244  241                          0
+ 241            Gosub                 136  272    0                          0  ; detected new partition
+ 242            Null                    0  134    0                          0  r[134]=NULL
+ 243            Copy                   77  135    0                          0  r[135]=r[77]
+ 244            NotNull               134  252    0                          0  r[134]!=NULL -> goto 252
+ 245            Null                    0  123  123                          0  r[123..123]=NULL; initialize per-cursor peer-reference registers for new partition
+ 246            MakeRecord             77    9  139                          0  r[139]=mkrec(r[77..85])
+ 247            NewRowid               19  134    0                          0  r[134]=rowid
+ 248            Insert                 19  139  134  buffer_table_window_0   2  intkey=r[134] data=r[139]
+ 249            Rewind                 18  237    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 250            Rewind                 20  237    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 251          Goto                      0  237    0                          0
+ 252          MakeRecord               77    9  140                          0  r[140]=mkrec(r[77..85])
+ 253          NewRowid                 19  134    0                          0  r[134]=rowid
+ 254          Insert                   19  140  134  buffer_table_window_0   2  intkey=r[134] data=r[140]
+ 255          AggStep                   0    0  123  row_number              0  accum=r[123] step(r[0])
+ 256          Next                     20  257    0                          0
+ 257          AggValue                  0  123  124  row_number              0  accum=r[123] dest=r[124]
+ 258          Column                   18    2  125                          0  r[125]=ephemeral(buffer_table_window_0).emp_id
+ 259          Column                   18    3  126                          0  r[126]=ephemeral(buffer_table_window_0).name
+ 260          Column                   18    0  127                          0  r[127]=ephemeral(buffer_table_window_0).department
+ 261          Column                   18    1  128                          0  r[128]=ephemeral(buffer_table_window_0).salary
+ 262          Column                   18    4  129                          0  r[129]=ephemeral(buffer_table_window_0).amount
+ 263          Column                   18    5  130                          0  r[130]=ephemeral(buffer_table_window_0).region
+ 264          Column                   18    6  131                          0  r[131]=ephemeral(buffer_table_window_0).column 6
+ 265          Column                   18    7  132                          0  r[132]=ephemeral(buffer_table_window_0).column 7
+ 266          Column                   18    8  133                          0  r[133]=ephemeral(buffer_table_window_0).column 8
+ 267          Gosub                   138  292    0                          0
+ 268          Delete                   18    0    0  buffer_table_window_0   0
+ 269        Next                       18  237    0                          0
+ 270      Goto                          0  237    0                          0
+ 271      Null                          0  136    0                          0  r[136]=NULL; return remaining buffered rows
+ 272      Rewind                       19  289    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 273      AggStep                       0    0  123  row_number              0  accum=r[123] step(r[0])
+ 274      Next                         20  275    0                          0
+ 275        AggValue                    0  123  124  row_number              0  accum=r[123] dest=r[124]
+ 276        Column                     18    2  125                          0  r[125]=ephemeral(buffer_table_window_0).emp_id
+ 277        Column                     18    3  126                          0  r[126]=ephemeral(buffer_table_window_0).name
+ 278        Column                     18    0  127                          0  r[127]=ephemeral(buffer_table_window_0).department
+ 279        Column                     18    1  128                          0  r[128]=ephemeral(buffer_table_window_0).salary
+ 280        Column                     18    4  129                          0  r[129]=ephemeral(buffer_table_window_0).amount
+ 281        Column                     18    5  130                          0  r[130]=ephemeral(buffer_table_window_0).region
+ 282        Column                     18    6  131                          0  r[131]=ephemeral(buffer_table_window_0).column 6
+ 283        Column                     18    7  132                          0  r[132]=ephemeral(buffer_table_window_0).column 7
+ 284        Column                     18    8  133                          0  r[133]=ephemeral(buffer_table_window_0).column 8
+ 285        Gosub                     138  292    0                          0
+ 286        Delete                     18    0    0  buffer_table_window_0   0
+ 287      Next                         18  275    0                          0
+ 288      Goto                          0  289    0                          0
+ 289      ResetSorter                  18    0    0                          0  cursor=18
+ 290    Return                        136    0    1                          0
+ 291    Halt                            0    0    0                          0
+ 292    Copy                          125  113    5                          0  r[113]=r[125]
+ 293    Copy                          124  119    0                          0  r[119]=r[124]
+ 294    Copy                          131  120    2                          0  r[120]=r[131]
+ 295    ResultRow                     113   10    0                          0  output=r[113..122]
+ 296  Return                          138    0    0                          0
+ 297  Halt                              0    0    0                          0
+ 298  Transaction                       0    1    7                          0  iDb=0 tx_mode=Read
+ 299  Goto                              0    1    0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
@@ -24,8 +24,8 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1   p2  p3  p4                     p5  comment
-   0          Init             0  157   0                          0  Start at 157
-   1          InitCoroutine    1   83   2                          0
+   0          Init             0  112   0                          0  Start at 112
+   1          InitCoroutine    1   61   2                          0
    2          InitCoroutine    2   14   3                          0
    3          OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
    4          OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
@@ -44,144 +44,99 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
   17          Null             0   18   0                          0  r[18]=NULL
   18          Null             0   19   0                          0  r[19]=NULL
   19          InitCoroutine    2    0   3                          0
-  20            Yield          2   54   0                          0
-  21            Compare        3   19   1  k(1, Binary)            0  r[3..3]==r[19..19]; compare partition keys to detect new partition
-  22            Jump          23   26  23                          0
-  23            Gosub         20   55   0                          0  ; detected new partition
-  24            Null           0   18   0                          0  r[18]=NULL
-  25            Copy           3   19   0                          0  r[19]=r[3]
-  26            NotNull       18   34   0                          0  r[18]!=NULL -> goto 34
-  27            Null           0   12  12                          0  r[12..12]=NULL; reset accumulator registers
-  28            MakeRecord     3    4  22                          0  r[22]=mkrec(r[3..6])
-  29            NewRowid       3   18   0                          0  r[18]=rowid
-  30            Insert         3   22  18  buffer_table_window_1   2  intkey=r[18] data=r[22]
-  31            Rewind         2   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  32            Rewind         4   33   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  33            Goto           0   53   0                          0
+  20              Yield        2   38   0                          0
+  21              Compare      3   19   1  k(1, Binary)            0  r[3..3]==r[19..19]; compare partition keys to detect new partition
+  22              Jump        23   26  23                          0
+  23              Gosub       20   39   0                          0  ; detected new partition
+  24              Null         0   18   0                          0  r[18]=NULL
+  25              Copy         3   19   0                          0  r[19]=r[3]
+  26              NotNull     18   34   0                          0  r[18]!=NULL -> goto 34
+  27              Null         0   12  12                          0  r[12..12]=NULL; reset accumulator registers
+  28              MakeRecord   3    4  22                          0  r[22]=mkrec(r[3..6])
+  29              NewRowid     3   18   0                          0  r[18]=rowid
+  30              Insert       3   22  18  buffer_table_window_1   2  intkey=r[18] data=r[22]
+  31              Rewind       2   20   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  32              Rewind       4   20   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  33            Goto           0   20   0                          0
   34            MakeRecord     3    4  23                          0  r[23]=mkrec(r[3..6])
   35            NewRowid       3   18   0                          0  r[18]=rowid
   36            Insert         3   23  18  buffer_table_window_1   2  intkey=r[18] data=r[23]
-  37            Goto           0   53   0                          0
-  38            Column         4    3  24                          0  r[24]=ephemeral(buffer_table_window_1).salary
-  39            AggStep        0   24  12  sum                     0  accum=r[12] step(r[24])
-  40            Next           4   42   0                          0
-  41            Goto           0   43   0                          0
-  42            Goto           0   38   0                          0
-  43            AggValue       0   12  13  sum                     0  accum=r[12] dest=r[13]
-  44            Column         2    1  14                          0  r[14]=ephemeral(buffer_table_window_1).emp_id
-  45            Column         2    2  15                          0  r[15]=ephemeral(buffer_table_window_1).name
-  46            Column         2    0  16                          0  r[16]=ephemeral(buffer_table_window_1).department
-  47            Column         2    3  17                          0  r[17]=ephemeral(buffer_table_window_1).salary
-  48            Gosub         21   75   0                          0
-  49            Delete         2    0   0  buffer_table_window_1   0
-  50            Next           2   52   0                          0
-  51            Goto           0   53   0                          0
-  52            Goto           0   44   0                          0
-  53          Goto             0   20   0                          0
-  54          Null             0   20   0                          0  r[20]=NULL; return remaining buffered rows
-  55          Rewind           3   72   0                          0  Rewind  ephemeral(buffer_table_window_1)
-  56          Column           4    3  25                          0  r[25]=ephemeral(buffer_table_window_1).salary
-  57          AggStep          0   25  12  sum                     0  accum=r[12] step(r[25])
-  58          Next             4   60   0                          0
-  59          Goto             0   61   0                          0
-  60          Goto             0   56   0                          0
-  61          AggValue         0   12  13  sum                     0  accum=r[12] dest=r[13]
-  62          Column           2    1  14                          0  r[14]=ephemeral(buffer_table_window_1).emp_id
-  63          Column           2    2  15                          0  r[15]=ephemeral(buffer_table_window_1).name
-  64          Column           2    0  16                          0  r[16]=ephemeral(buffer_table_window_1).department
-  65          Column           2    3  17                          0  r[17]=ephemeral(buffer_table_window_1).salary
-  66          Gosub           21   75   0                          0
-  67          Delete           2    0   0  buffer_table_window_1   0
-  68          Next             2   70   0                          0
-  69          Goto             0   72   0                          0
-  70          Goto             0   62   0                          0
-  71          Goto             0   61   0                          0
-  72          ResetSorter      2    0   0                          0  cursor=2
-  73        Return            20    0   1                          0
-  74        Goto               0   82   0                          0
-  75        Copy              14    7   0                          0  r[7]=r[14]
-  76        Copy              15    8   0                          0  r[8]=r[15]
-  77        Copy              16    9   0                          0  r[9]=r[16]
-  78        Copy              17   10   0                          0  r[10]=r[17]
-  79        Copy              13   11   0                          0  r[11]=r[13]
-  80        Yield              1    0   0                          0
-  81      Return              21    0   0                          0
-  82      EndCoroutine         1    0   0                          0
-  83      OpenEphemeral        5    1   0                          0  cursor=5 is_table=true
-  84      OpenDup              6    5   0                          0  new_cursor=6, original_cursor=5
-  85      OpenDup              7    5   0                          0  new_cursor=7, original_cursor=5
-  86      Null                 0   39   0                          0  r[39]=NULL
-  87      InitCoroutine        1    0   2                          0
-  88        Yield              1  118   0                          0
-  89        NotNull           39   97   0                          0  r[39]!=NULL -> goto 97
-  90        Null               0   32  32                          0  r[32..32]=NULL; reset accumulator registers
-  91        MakeRecord         7    5  42                          0  r[42]=mkrec(r[7..11])
-  92        NewRowid           6   39   0                          0  r[39]=rowid
-  93        Insert             6   42  39  buffer_table_window_0   2  intkey=r[39] data=r[42]
-  94        Rewind             5   96   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  95        Rewind             7   96   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  96        Goto               0  117   0                          0
-  97        MakeRecord         7    5  43                          0  r[43]=mkrec(r[7..11])
-  98        NewRowid           6   39   0                          0  r[39]=rowid
-  99        Insert             6   43  39  buffer_table_window_0   2  intkey=r[39] data=r[43]
- 100        Goto               0  117   0                          0
- 101        Column             7    3  44                          0  r[44]=ephemeral(buffer_table_window_0).salary
- 102        AggStep            0   44  32  sum                     0  accum=r[32] step(r[44])
- 103        Next               7  105   0                          0
- 104        Goto               0  106   0                          0
- 105        Goto               0  101   0                          0
- 106        AggValue           0   32  33  sum                     0  accum=r[32] dest=r[33]
- 107        Column             5    0  34                          0  r[34]=ephemeral(buffer_table_window_0).emp_id
- 108        Column             5    1  35                          0  r[35]=ephemeral(buffer_table_window_0).name
- 109        Column             5    2  36                          0  r[36]=ephemeral(buffer_table_window_0).department
- 110        Column             5    3  37                          0  r[37]=ephemeral(buffer_table_window_0).salary
- 111        Column             5    4  38                          0  r[38]=ephemeral(buffer_table_window_0).column 4
- 112        Gosub             41  140   0                          0
- 113        Delete             5    0   0  buffer_table_window_0   0
- 114        Next               5  116   0                          0
- 115        Goto               0  117   0                          0
- 116        Goto               0  107   0                          0
- 117      Goto                 0   88   0                          0
- 118      Null                 0   40   0                          0  r[40]=NULL; return remaining buffered rows
- 119      Rewind               6  137   0                          0  Rewind  ephemeral(buffer_table_window_0)
- 120      Column               7    3  45                          0  r[45]=ephemeral(buffer_table_window_0).salary
- 121      AggStep              0   45  32  sum                     0  accum=r[32] step(r[45])
- 122      Next                 7  124   0                          0
- 123      Goto                 0  125   0                          0
- 124      Goto                 0  120   0                          0
- 125      AggValue             0   32  33  sum                     0  accum=r[32] dest=r[33]
- 126      Column               5    0  34                          0  r[34]=ephemeral(buffer_table_window_0).emp_id
- 127      Column               5    1  35                          0  r[35]=ephemeral(buffer_table_window_0).name
- 128      Column               5    2  36                          0  r[36]=ephemeral(buffer_table_window_0).department
- 129      Column               5    3  37                          0  r[37]=ephemeral(buffer_table_window_0).salary
- 130      Column               5    4  38                          0  r[38]=ephemeral(buffer_table_window_0).column 4
- 131      Gosub               41  140   0                          0
- 132      Delete               5    0   0  buffer_table_window_0   0
- 133      Next                 5  135   0                          0
- 134      Goto                 0  137   0                          0
- 135      Goto                 0  126   0                          0
- 136      Goto                 0  125   0                          0
- 137      ResetSorter          5    0   0                          0  cursor=5
- 138    Return                40    0   1                          0
- 139    Goto                   0  156   0                          0
- 140    Copy                  34   26   0                          0  r[26]=r[34]
- 141    Copy                  35   27   0                          0  r[27]=r[35]
- 142    Copy                  36   28   0                          0  r[28]=r[36]
- 143    Copy                  37   29   0                          0  r[29]=r[37]
- 144    Copy                  37   48   0                          0  r[48]=r[37]
- 145    Cast                  48    0   0                          0  affinity(r[48]=Real)
- 146    Multiply              48   49  46                          0  r[46]=r[48]*r[49]
- 147    Copy                  33   47   0                          0  r[47]=r[33]
- 148    Divide                46   47  30                          0  r[30]=r[46]/r[47]
- 149    Copy                  37   52   0                          0  r[52]=r[37]
- 150    Cast                  52    0   0                          0  affinity(r[52]=Real)
- 151    Multiply              52   53  50                          0  r[50]=r[52]*r[53]
- 152    Copy                  38   51   0                          0  r[51]=r[38]
- 153    Divide                50   51  31                          0  r[31]=r[50]/r[51]
- 154    ResultRow             26    6   0                          0  output=r[26..31]
- 155  Return                  41    0   0                          0
- 156  Halt                     0    0   0                          0
- 157  Transaction              0    1   7                          0  iDb=0 tx_mode=Read
- 158  Real                     0   49   0  100.0                   0  r[49]=100
- 159  Real                     0   53   0  100.0                   0  r[53]=100
- 160  Goto                     0    1   0                          0
+  37          Goto             0   20   0                          0
+  38          Null             0   20   0                          0  r[20]=NULL; return remaining buffered rows
+  39          Rewind           3   53   0                          0  Rewind  ephemeral(buffer_table_window_1)
+  40            Column         4    3  25                          0  r[25]=ephemeral(buffer_table_window_1).salary
+  41            AggStep        0   25  12  sum                     0  accum=r[12] step(r[25])
+  42          Next             4   40   0                          0
+  43          Goto             0   44   0                          0
+  44          AggValue         0   12  13  sum                     0  accum=r[12] dest=r[13]
+  45            Column         2    1  14                          0  r[14]=ephemeral(buffer_table_window_1).emp_id
+  46            Column         2    2  15                          0  r[15]=ephemeral(buffer_table_window_1).name
+  47            Column         2    0  16                          0  r[16]=ephemeral(buffer_table_window_1).department
+  48            Column         2    3  17                          0  r[17]=ephemeral(buffer_table_window_1).salary
+  49            Gosub         21   56   0                          0
+  50            Delete         2    0   0  buffer_table_window_1   0
+  51          Next             2   45   0                          0
+  52          Goto             0   53   0                          0
+  53          ResetSorter      2    0   0                          0  cursor=2
+  54        Return            20    0   1                          0
+  55        Goto               0   60   0                          0
+  56        Copy              14    7   3                          0  r[7]=r[14]
+  57        Copy              13   11   0                          0  r[11]=r[13]
+  58        Yield              1    0   0                          0
+  59      Return              21    0   0                          0
+  60      EndCoroutine         1    0   0                          0
+  61      OpenEphemeral        5    1   0                          0  cursor=5 is_table=true
+  62      OpenDup              6    5   0                          0  new_cursor=6, original_cursor=5
+  63      OpenDup              7    5   0                          0  new_cursor=7, original_cursor=5
+  64      Null                 0   39   0                          0  r[39]=NULL
+  65      InitCoroutine        1    0   2                          0
+  66          Yield            1   79   0                          0
+  67          NotNull         39   75   0                          0  r[39]!=NULL -> goto 75
+  68          Null             0   32  32                          0  r[32..32]=NULL; reset accumulator registers
+  69          MakeRecord       7    5  42                          0  r[42]=mkrec(r[7..11])
+  70          NewRowid         6   39   0                          0  r[39]=rowid
+  71          Insert           6   42  39  buffer_table_window_0   2  intkey=r[39] data=r[42]
+  72          Rewind           5   66   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  73          Rewind           7   66   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  74        Goto               0   66   0                          0
+  75        MakeRecord         7    5  43                          0  r[43]=mkrec(r[7..11])
+  76        NewRowid           6   39   0                          0  r[39]=rowid
+  77        Insert             6   43  39  buffer_table_window_0   2  intkey=r[39] data=r[43]
+  78      Goto                 0   66   0                          0
+  79      Null                 0   40   0                          0  r[40]=NULL; return remaining buffered rows
+  80      Rewind               6   95   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  81        Column             7    3  45                          0  r[45]=ephemeral(buffer_table_window_0).salary
+  82        AggStep            0   45  32  sum                     0  accum=r[32] step(r[45])
+  83      Next                 7   81   0                          0
+  84      Goto                 0   85   0                          0
+  85      AggValue             0   32  33  sum                     0  accum=r[32] dest=r[33]
+  86        Column             5    0  34                          0  r[34]=ephemeral(buffer_table_window_0).emp_id
+  87        Column             5    1  35                          0  r[35]=ephemeral(buffer_table_window_0).name
+  88        Column             5    2  36                          0  r[36]=ephemeral(buffer_table_window_0).department
+  89        Column             5    3  37                          0  r[37]=ephemeral(buffer_table_window_0).salary
+  90        Column             5    4  38                          0  r[38]=ephemeral(buffer_table_window_0).column 4
+  91        Gosub             41   98   0                          0
+  92        Delete             5    0   0  buffer_table_window_0   0
+  93      Next                 5   86   0                          0
+  94      Goto                 0   95   0                          0
+  95      ResetSorter          5    0   0                          0  cursor=5
+  96    Return                40    0   1                          0
+  97    Halt                   0    0   0                          0
+  98    Copy                  34   26   3                          0  r[26]=r[34]
+  99    Copy                  37   48   0                          0  r[48]=r[37]
+ 100    Cast                  48    0   0                          0  affinity(r[48]=Real)
+ 101    Multiply              48   49  46                          0  r[46]=r[48]*r[49]
+ 102    Copy                  33   47   0                          0  r[47]=r[33]
+ 103    Divide                46   47  30                          0  r[30]=r[46]/r[47]
+ 104    Copy                  37   52   0                          0  r[52]=r[37]
+ 105    Cast                  52    0   0                          0  affinity(r[52]=Real)
+ 106    Multiply              52   53  50                          0  r[50]=r[52]*r[53]
+ 107    Copy                  38   51   0                          0  r[51]=r[38]
+ 108    Divide                50   51  31                          0  r[31]=r[50]/r[51]
+ 109    ResultRow             26    6   0                          0  output=r[26..31]
+ 110  Return                  41    0   0                          0
+ 111  Halt                     0    0   0                          0
+ 112  Transaction              0    1   7                          0  iDb=0 tx_mode=Read
+ 113  Real                     0   49   0  100.0                   0  r[49]=100
+ 114  Real                     0   53   0  100.0                   0  r[53]=100
+ 115  Goto                     0    1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
@@ -21,73 +21,69 @@ QUERY PLAN
    `--SCAN employees USING INDEX idx_employees_salary
 
 BYTECODE
-addr  opcode              p1  p2  p3  p4                     p5  comment
-   0      Init             0  67   0                          0  Start at 67
-   1      InitCoroutine    1  13   2                          0
-   2      OpenRead         0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   3      OpenRead         1   5   0  k(2,B)                  0  index=idx_employees_salary, root=5, iDb=0
-   4      Last             1  12   0                          0
-   5        DeferredSeek   1   0   0                          0
-   6        Column         1   0   2                          0  r[2]=idx_employees_salary.salary
-   7        IdxRowId       1   3   0                          0  r[3]=cursor 1 for index idx_employees_salary.rowid
-   8        Column         0   1   4                          0  r[4]=employees.name
-   9        Column         0   2   5                          0  r[5]=employees.department
-  10        Yield          1   0   0                          0
-  11      Prev             1   5   0                          0
-  12      EndCoroutine     1   0   0                          0
-  13      OpenEphemeral    2   1   0                          0  cursor=2 is_table=true
-  14      OpenDup          3   2   0                          0  new_cursor=3, original_cursor=2
-  15      OpenDup          4   2   0                          0  new_cursor=4, original_cursor=2
-  16      Null             0  17   0                          0  r[17]=NULL
-  17      InitCoroutine    1   0   2                          0
-  18        Yield          1  42   0                          0
-  19        Copy           2  19   0                          0  r[19]=r[2]
-  20        NotNull       17  28   0                          0  r[17]!=NULL -> goto 28
-  21        Null           0  11  11                          0  r[11..11]=NULL; initialize per-cursor peer-reference registers for new partition
-  22        MakeRecord     2   4  21                          0  r[21]=mkrec(r[2..5])
-  23        NewRowid       3  17   0                          0  r[17]=rowid
-  24        Insert         3  21  17  buffer_table_window_0   2  intkey=r[17] data=r[21]
-  25        Rewind         2  27   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  26        Rewind         4  27   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  27        Goto           0  41   0                          0
-  28        MakeRecord     2   4  22                          0  r[22]=mkrec(r[2..5])
-  29        NewRowid       3  17   0                          0  r[17]=rowid
-  30        Insert         3  22  17  buffer_table_window_0   2  intkey=r[17] data=r[22]
-  31        AggStep        0   0  11  row_number              0  accum=r[11] step(r[0])
-  32        Next           4  33   0                          0
-  33        AggValue       0  11  12  row_number              0  accum=r[11] dest=r[12]
-  34        Column         2   1  13                          0  r[13]=ephemeral(buffer_table_window_0).emp_id
-  35        Column         2   2  14                          0  r[14]=ephemeral(buffer_table_window_0).name
-  36        Column         2   3  15                          0  r[15]=ephemeral(buffer_table_window_0).department
-  37        Column         2   0  16                          0  r[16]=ephemeral(buffer_table_window_0).salary
-  38        Gosub         20  59   0                          0
-  39        Delete         2   0   0  buffer_table_window_0   0
-  40        Next           2  41   0                          0
-  41      Goto             0  18   0                          0
-  42      Null             0  18   0                          0  r[18]=NULL; return remaining buffered rows
-  43      Rewind           3  56   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  44      AggStep          0   0  11  row_number              0  accum=r[11] step(r[0])
-  45      Next             4  46   0                          0
-  46      AggValue         0  11  12  row_number              0  accum=r[11] dest=r[12]
-  47      Column           2   1  13                          0  r[13]=ephemeral(buffer_table_window_0).emp_id
-  48      Column           2   2  14                          0  r[14]=ephemeral(buffer_table_window_0).name
-  49      Column           2   3  15                          0  r[15]=ephemeral(buffer_table_window_0).department
-  50      Column           2   0  16                          0  r[16]=ephemeral(buffer_table_window_0).salary
-  51      Gosub           20  59   0                          0
-  52      Delete           2   0   0  buffer_table_window_0   0
-  53      Next             2  55   0                          0
-  54      Goto             0  56   0                          0
-  55      Goto             0  46   0                          0
-  56      ResetSorter      2   0   0                          0  cursor=2
-  57    Return            18   0   1                          0
-  58    Goto               0  66   0                          0
-  59    Copy              13   6   0                          0  r[6]=r[13]
-  60    Copy              14   7   0                          0  r[7]=r[14]
-  61    Copy              15   8   0                          0  r[8]=r[15]
-  62    Copy              16   9   0                          0  r[9]=r[16]
-  63    Copy              12  10   0                          0  r[10]=r[12]
-  64    ResultRow          6   5   0                          0  output=r[6..10]
-  65  Return              20   0   0                          0
-  66  Halt                 0   0   0                          0
-  67  Transaction          0   1   7                          0  iDb=0 tx_mode=Read
-  68  Goto                 0   1   0                          0
+addr  opcode                p1  p2  p3  p4                     p5  comment
+   0      Init               0  63   0                          0  Start at 63
+   1      InitCoroutine      1  13   2                          0
+   2      OpenRead           0   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   3      OpenRead           1   5   0  k(2,B)                  0  index=idx_employees_salary, root=5, iDb=0
+   4      Last               1  12   0                          0
+   5        DeferredSeek     1   0   0                          0
+   6        Column           1   0   2                          0  r[2]=idx_employees_salary.salary
+   7        IdxRowId         1   3   0                          0  r[3]=cursor 1 for index idx_employees_salary.rowid
+   8        Column           0   1   4                          0  r[4]=employees.name
+   9        Column           0   2   5                          0  r[5]=employees.department
+  10        Yield            1   0   0                          0
+  11      Prev               1   5   0                          0
+  12      EndCoroutine       1   0   0                          0
+  13      OpenEphemeral      2   1   0                          0  cursor=2 is_table=true
+  14      OpenDup            3   2   0                          0  new_cursor=3, original_cursor=2
+  15      OpenDup            4   2   0                          0  new_cursor=4, original_cursor=2
+  16      Null               0  17   0                          0  r[17]=NULL
+  17      InitCoroutine      1   0   2                          0
+  18            Yield        1  42   0                          0
+  19            Copy         2  19   0                          0  r[19]=r[2]
+  20            NotNull     17  28   0                          0  r[17]!=NULL -> goto 28
+  21            Null         0  11  11                          0  r[11..11]=NULL; initialize per-cursor peer-reference registers for new partition
+  22            MakeRecord   2   4  21                          0  r[21]=mkrec(r[2..5])
+  23            NewRowid     3  17   0                          0  r[17]=rowid
+  24            Insert       3  21  17  buffer_table_window_0   2  intkey=r[17] data=r[21]
+  25            Rewind       2  18   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  26            Rewind       4  18   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  27          Goto           0  18   0                          0
+  28          MakeRecord     2   4  22                          0  r[22]=mkrec(r[2..5])
+  29          NewRowid       3  17   0                          0  r[17]=rowid
+  30          Insert         3  22  17  buffer_table_window_0   2  intkey=r[17] data=r[22]
+  31          AggStep        0   0  11  row_number              0  accum=r[11] step(r[0])
+  32          Next           4  33   0                          0
+  33          AggValue       0  11  12  row_number              0  accum=r[11] dest=r[12]
+  34          Column         2   1  13                          0  r[13]=ephemeral(buffer_table_window_0).emp_id
+  35          Column         2   2  14                          0  r[14]=ephemeral(buffer_table_window_0).name
+  36          Column         2   3  15                          0  r[15]=ephemeral(buffer_table_window_0).department
+  37          Column         2   0  16                          0  r[16]=ephemeral(buffer_table_window_0).salary
+  38          Gosub         20  58   0                          0
+  39          Delete         2   0   0  buffer_table_window_0   0
+  40        Next             2  18   0                          0
+  41      Goto               0  18   0                          0
+  42      Null               0  18   0                          0  r[18]=NULL; return remaining buffered rows
+  43      Rewind             3  55   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  44      AggStep            0   0  11  row_number              0  accum=r[11] step(r[0])
+  45      Next               4  46   0                          0
+  46        AggValue         0  11  12  row_number              0  accum=r[11] dest=r[12]
+  47        Column           2   1  13                          0  r[13]=ephemeral(buffer_table_window_0).emp_id
+  48        Column           2   2  14                          0  r[14]=ephemeral(buffer_table_window_0).name
+  49        Column           2   3  15                          0  r[15]=ephemeral(buffer_table_window_0).department
+  50        Column           2   0  16                          0  r[16]=ephemeral(buffer_table_window_0).salary
+  51        Gosub           20  58   0                          0
+  52        Delete           2   0   0  buffer_table_window_0   0
+  53      Next               2  46   0                          0
+  54      Goto               0  55   0                          0
+  55      ResetSorter        2   0   0                          0  cursor=2
+  56    Return              18   0   1                          0
+  57    Halt                 0   0   0                          0
+  58    Copy                13   6   3                          0  r[6]=r[13]
+  59    Copy                12  10   0                          0  r[10]=r[12]
+  60    ResultRow            6   5   0                          0  output=r[6..10]
+  61  Return                20   0   0                          0
+  62  Halt                   0   0   0                          0
+  63  Transaction            0   1   7                          0  iDb=0 tx_mode=Read
+  64  Goto                   0   1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__running-total.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__running-total.snap
@@ -28,208 +28,202 @@ QUERY PLAN
    `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                   p1   p2   p3  p4                     p5  comment
-   0          Init              0  202    0                          0  Start at 202
-   1          InitCoroutine     1  120    2                          0
-   2          InitCoroutine     2   23    3                          0
-   3          SorterOpen        0    2    0  k(2,B,B)                0  cursor=0
-   4          OpenRead          1    3    0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
-   5          Rewind            1   13    0                          0  Rewind table sales
-   6            Column          1    1    8                          0  r[8]=sales.emp_id
-   7            Column          1    2    9                          0  r[9]=sales.sale_date
-   8            RowId           1   10    0                          0  r[10]=sales.rowid
-   9            Column          1    3   11                          0  r[11]=sales.amount
-  10            MakeRecord      8    4    7                          0  r[7]=mkrec(r[8..11])
-  11            SorterInsert    0    7    0  0                       0  key=r[7]
-  12          Next              1    6    0                          0
-  13          OpenPseudo        2    7    4                          0  4 columns in r[7]
-  14          SorterSort        0   22    0                          0
-  15            SorterData      0    7    2                          0  r[7]=data
-  16            Column          2    0    3                          0  r[3]=pseudo.column 0
-  17            Column          2    1    4                          0  r[4]=pseudo.column 1
-  18            Column          2    2    5                          0  r[5]=pseudo.column 2
-  19            Column          2    3    6                          0  r[6]=pseudo.column 3
-  20            Yield           2    0    0                          0
-  21          SorterNext        0   15    0                          0
-  22          EndCoroutine      2    0    0                          0
-  23          SorterOpen        3    1    0  k(1,B)                  0  cursor=3
-  24          OpenEphemeral     4    1    0                          0  cursor=4 is_table=true
-  25          OpenDup           5    4    0                          0  new_cursor=5, original_cursor=4
-  26          OpenDup           6    4    0                          0  new_cursor=6, original_cursor=4
-  27          Null              0   24    0                          0  r[24]=NULL
-  28          Null              0   25    0                          0  r[25]=NULL
-  29          InitCoroutine     2    0    3                          0
-  30            Yield           2   74    0                          0
-  31            Copy            4   27    0                          0  r[27]=r[4]
-  32            Compare         3   25    1  k(1, Binary)            0  r[3..3]==r[25..25]; compare partition keys to detect new partition
-  33            Jump           34   37   34                          0
-  34            Gosub          26   75    0                          0  ; detected new partition
-  35            Null            0   24    0                          0  r[24]=NULL
-  36            Copy            3   25    0                          0  r[25]=r[3]
-  37            NotNull        24   47    0                          0  r[24]!=NULL -> goto 47
-  38            Copy           27   28    0                          0  r[28]=r[27]; initialize per-cursor peer-reference registers for new partition
-  39            Copy           27   29    0                          0  r[29]=r[27]
-  40            Null            0   18   18                          0  r[18..18]=NULL; reset accumulator registers
-  41            MakeRecord      3    4   31                          0  r[31]=mkrec(r[3..6])
-  42            NewRowid        5   24    0                          0  r[24]=rowid
-  43            Insert          5   31   24  buffer_table_window_1   2  intkey=r[24] data=r[31]
-  44            Rewind          4   46    0                          0  Rewind  ephemeral(buffer_table_window_1)
-  45            Rewind          6   46    0                          0  Rewind  ephemeral(buffer_table_window_1)
-  46            Goto            0   73    0                          0
-  47            MakeRecord      3    4   32                          0  r[32]=mkrec(r[3..6])
-  48            NewRowid        5   24    0                          0  r[24]=rowid
-  49            Insert          5   32   24  buffer_table_window_1   2  intkey=r[24] data=r[32]
-  50            Compare        27   29    1  k(1, Binary)            0  r[27..27]==r[29..29]; compare ORDER BY columns to detect peer
-  51            Jump           52   73   52                          0
-  52            Column          6    3   33                          0  r[33]=ephemeral(buffer_table_window_1).amount
-  53            AggStep         0   33   18  sum                     0  accum=r[18] step(r[33])
-  54            Next            6   56    0                          0
-  55            Goto            0   60    0                          0
-  56            Column          6    1   34                          0  r[34]=ephemeral(buffer_table_window_1).sale_date
-  57            Compare        29   34    1  k(1, Binary)            0  r[29..29]==r[34..34]
-  58            Jump           59   52   59                          0
-  59            Copy           34   29    0                          0  r[29]=r[34]
-  60            AggValue        0   18   19  sum                     0  accum=r[18] dest=r[19]
-  61            Column          4    1   20                          0  r[20]=ephemeral(buffer_table_window_1).sale_date
-  62            Column          4    2   21                          0  r[21]=ephemeral(buffer_table_window_1).sale_id
-  63            Column          4    0   22                          0  r[22]=ephemeral(buffer_table_window_1).emp_id
-  64            Column          4    3   23                          0  r[23]=ephemeral(buffer_table_window_1).amount
-  65            Gosub          30  101    0                          0
-  66            Delete          4    0    0  buffer_table_window_1   0
-  67            Next            4   69    0                          0
-  68            Goto            0   73    0                          0
-  69            Column          4    1   35                          0  r[35]=ephemeral(buffer_table_window_1).sale_date
-  70            Compare        28   35    1  k(1, Binary)            0  r[28..28]==r[35..35]
-  71            Jump           72   61   72                          0
-  72            Copy           35   28    0                          0  r[28]=r[35]
-  73          Goto              0   30    0                          0
-  74          Null              0   26    0                          0  r[26]=NULL; return remaining buffered rows
-  75          Rewind            5   98    0                          0  Rewind  ephemeral(buffer_table_window_1)
-  76          Column            6    3   36                          0  r[36]=ephemeral(buffer_table_window_1).amount
-  77          AggStep           0   36   18  sum                     0  accum=r[18] step(r[36])
-  78          Next              6   80    0                          0
-  79          Goto              0   84    0                          0
-  80          Column            6    1   37                          0  r[37]=ephemeral(buffer_table_window_1).sale_date
-  81          Compare          29   37    1  k(1, Binary)            0  r[29..29]==r[37..37]
-  82          Jump             83   76   83                          0
-  83          Copy             37   29    0                          0  r[29]=r[37]
-  84          AggValue          0   18   19  sum                     0  accum=r[18] dest=r[19]
-  85          Column            4    1   20                          0  r[20]=ephemeral(buffer_table_window_1).sale_date
-  86          Column            4    2   21                          0  r[21]=ephemeral(buffer_table_window_1).sale_id
-  87          Column            4    0   22                          0  r[22]=ephemeral(buffer_table_window_1).emp_id
-  88          Column            4    3   23                          0  r[23]=ephemeral(buffer_table_window_1).amount
-  89          Gosub            30  101    0                          0
-  90          Delete            4    0    0  buffer_table_window_1   0
-  91          Next              4   93    0                          0
-  92          Goto              0   98    0                          0
-  93          Column            4    1   38                          0  r[38]=ephemeral(buffer_table_window_1).sale_date
-  94          Compare          28   38    1  k(1, Binary)            0  r[28..28]==r[38..38]
-  95          Jump             96   85   96                          0
-  96          Copy             38   28    0                          0  r[28]=r[38]
-  97          Goto              0   84    0                          0
-  98          ResetSorter       4    0    0                          0  cursor=4
-  99        Return             26    0    1                          0
- 100        Goto                0  109    0                          0
- 101        Copy               20   39    0                          0  r[39]=r[20]
- 102        Copy               21   40    0                          0  r[40]=r[21]
- 103        Copy               22   41    0                          0  r[41]=r[22]
- 104        Copy               23   42    0                          0  r[42]=r[23]
- 105        Copy               19   43    0                          0  r[43]=r[19]
- 106        MakeRecord         39    5   17                          0  r[17]=mkrec(r[39..43])
- 107        SorterInsert        3   17    0  0                       0  key=r[17]
- 108      Return               30    0    0                          0
- 109      OpenPseudo            7   17    5                          0  5 columns in r[17]
- 110      SorterSort            3  119    0                          0
- 111        SorterData          3   17    7                          0  r[17]=data
- 112        Column              7    0   12                          0  r[12]=pseudo.column 0
- 113        Column              7    1   13                          0  r[13]=pseudo.column 1
- 114        Column              7    2   14                          0  r[14]=pseudo.column 2
- 115        Column              7    3   15                          0  r[15]=pseudo.column 3
- 116        Column              7    4   16                          0  r[16]=pseudo.column 4
- 117        Yield               1    0    0                          0
- 118      SorterNext            3  111    0                          0
- 119      EndCoroutine          1    0    0                          0
- 120      OpenEphemeral         8    1    0                          0  cursor=8 is_table=true
- 121      OpenDup               9    8    0                          0  new_cursor=9, original_cursor=8
- 122      OpenDup              10    8    0                          0  new_cursor=10, original_cursor=8
- 123      Null                  0   57    0                          0  r[57]=NULL
- 124      InitCoroutine         1    0    2                          0
- 125        Yield               1  165    0                          0
- 126        Copy               12   59    0                          0  r[59]=r[12]
- 127        NotNull            57  137    0                          0  r[57]!=NULL -> goto 137
- 128        Copy               59   60    0                          0  r[60]=r[59]; initialize per-cursor peer-reference registers for new partition
- 129        Copy               59   61    0                          0  r[61]=r[59]
- 130        Null                0   50   50                          0  r[50..50]=NULL; reset accumulator registers
- 131        MakeRecord         12    5   63                          0  r[63]=mkrec(r[12..16])
- 132        NewRowid            9   57    0                          0  r[57]=rowid
- 133        Insert              9   63   57  buffer_table_window_0   2  intkey=r[57] data=r[63]
- 134        Rewind              8  136    0                          0  Rewind  ephemeral(buffer_table_window_0)
- 135        Rewind             10  136    0                          0  Rewind  ephemeral(buffer_table_window_0)
- 136        Goto                0  164    0                          0
- 137        MakeRecord         12    5   64                          0  r[64]=mkrec(r[12..16])
- 138        NewRowid            9   57    0                          0  r[57]=rowid
- 139        Insert              9   64   57  buffer_table_window_0   2  intkey=r[57] data=r[64]
- 140        Compare            59   61    1  k(1, Binary)            0  r[59..59]==r[61..61]; compare ORDER BY columns to detect peer
- 141        Jump              142  164  142                          0
- 142        Column             10    3   65                          0  r[65]=ephemeral(buffer_table_window_0).amount
- 143        AggStep             0   65   50  sum                     0  accum=r[50] step(r[65])
- 144        Next               10  146    0                          0
- 145        Goto                0  150    0                          0
- 146        Column             10    0   66                          0  r[66]=ephemeral(buffer_table_window_0).sale_date
- 147        Compare            61   66    1  k(1, Binary)            0  r[61..61]==r[66..66]
- 148        Jump              149  142  149                          0
- 149        Copy               66   61    0                          0  r[61]=r[66]
- 150        AggValue            0   50   51  sum                     0  accum=r[50] dest=r[51]
- 151        Column              8    1   52                          0  r[52]=ephemeral(buffer_table_window_0).sale_id
- 152        Column              8    2   53                          0  r[53]=ephemeral(buffer_table_window_0).emp_id
- 153        Column              8    0   54                          0  r[54]=ephemeral(buffer_table_window_0).sale_date
- 154        Column              8    3   55                          0  r[55]=ephemeral(buffer_table_window_0).amount
- 155        Column              8    4   56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
- 156        Gosub              62  193    0                          0
- 157        Delete              8    0    0  buffer_table_window_0   0
- 158        Next                8  160    0                          0
- 159        Goto                0  164    0                          0
- 160        Column              8    0   67                          0  r[67]=ephemeral(buffer_table_window_0).sale_date
- 161        Compare            60   67    1  k(1, Binary)            0  r[60..60]==r[67..67]
- 162        Jump              163  151  163                          0
- 163        Copy               67   60    0                          0  r[60]=r[67]
- 164      Goto                  0  125    0                          0
- 165      Null                  0   58    0                          0  r[58]=NULL; return remaining buffered rows
- 166      Rewind                9  190    0                          0  Rewind  ephemeral(buffer_table_window_0)
- 167      Column               10    3   68                          0  r[68]=ephemeral(buffer_table_window_0).amount
- 168      AggStep               0   68   50  sum                     0  accum=r[50] step(r[68])
- 169      Next                 10  171    0                          0
- 170      Goto                  0  175    0                          0
- 171      Column               10    0   69                          0  r[69]=ephemeral(buffer_table_window_0).sale_date
- 172      Compare              61   69    1  k(1, Binary)            0  r[61..61]==r[69..69]
- 173      Jump                174  167  174                          0
- 174      Copy                 69   61    0                          0  r[61]=r[69]
- 175      AggValue              0   50   51  sum                     0  accum=r[50] dest=r[51]
- 176      Column                8    1   52                          0  r[52]=ephemeral(buffer_table_window_0).sale_id
- 177      Column                8    2   53                          0  r[53]=ephemeral(buffer_table_window_0).emp_id
- 178      Column                8    0   54                          0  r[54]=ephemeral(buffer_table_window_0).sale_date
- 179      Column                8    3   55                          0  r[55]=ephemeral(buffer_table_window_0).amount
- 180      Column                8    4   56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
- 181      Gosub                62  193    0                          0
- 182      Delete                8    0    0  buffer_table_window_0   0
- 183      Next                  8  185    0                          0
- 184      Goto                  0  190    0                          0
- 185      Column                8    0   70                          0  r[70]=ephemeral(buffer_table_window_0).sale_date
- 186      Compare              60   70    1  k(1, Binary)            0  r[60..60]==r[70..70]
- 187      Jump                188  176  188                          0
- 188      Copy                 70   60    0                          0  r[60]=r[70]
- 189      Goto                  0  175    0                          0
- 190      ResetSorter           8    0    0                          0  cursor=8
- 191    Return                 58    0    1                          0
- 192    Goto                    0  201    0                          0
- 193    Copy                   52   44    0                          0  r[44]=r[52]
- 194    Copy                   53   45    0                          0  r[45]=r[53]
- 195    Copy                   54   46    0                          0  r[46]=r[54]
- 196    Copy                   55   47    0                          0  r[47]=r[55]
- 197    Copy                   51   48    0                          0  r[48]=r[51]
- 198    Copy                   56   49    0                          0  r[49]=r[56]
- 199    ResultRow              44    6    0                          0  output=r[44..49]
- 200  Return                   62    0    0                          0
- 201  Halt                      0    0    0                          0
- 202  Transaction               0    1    7                          0  iDb=0 tx_mode=Read
- 203  Goto                      0    1    0                          0
+addr  opcode                     p1   p2   p3  p4                     p5  comment
+   0          Init                0  196    0                          0  Start at 196
+   1          InitCoroutine       1  117    2                          0
+   2          InitCoroutine       2   23    3                          0
+   3          SorterOpen          0    2    0  k(2,B,B)                0  cursor=0
+   4          OpenRead            1    3    0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
+   5          Rewind              1   13    0                          0  Rewind table sales
+   6            Column            1    1    8                          0  r[8]=sales.emp_id
+   7            Column            1    2    9                          0  r[9]=sales.sale_date
+   8            RowId             1   10    0                          0  r[10]=sales.rowid
+   9            Column            1    3   11                          0  r[11]=sales.amount
+  10            MakeRecord        8    4    7                          0  r[7]=mkrec(r[8..11])
+  11            SorterInsert      0    7    0  0                       0  key=r[7]
+  12          Next                1    6    0                          0
+  13          OpenPseudo          2    7    4                          0  4 columns in r[7]
+  14          SorterSort          0   22    0                          0
+  15            SorterData        0    7    2                          0  r[7]=data
+  16            Column            2    0    3                          0  r[3]=pseudo.column 0
+  17            Column            2    1    4                          0  r[4]=pseudo.column 1
+  18            Column            2    2    5                          0  r[5]=pseudo.column 2
+  19            Column            2    3    6                          0  r[6]=pseudo.column 3
+  20            Yield             2    0    0                          0
+  21          SorterNext          0   15    0                          0
+  22          EndCoroutine        2    0    0                          0
+  23          SorterOpen          3    1    0  k(1,B)                  0  cursor=3
+  24          OpenEphemeral       4    1    0                          0  cursor=4 is_table=true
+  25          OpenDup             5    4    0                          0  new_cursor=5, original_cursor=4
+  26          OpenDup             6    4    0                          0  new_cursor=6, original_cursor=4
+  27          Null                0   24    0                          0  r[24]=NULL
+  28          Null                0   25    0                          0  r[25]=NULL
+  29          InitCoroutine       2    0    3                          0
+  30                Yield         2   74    0                          0
+  31                Copy          4   27    0                          0  r[27]=r[4]
+  32                Compare       3   25    1  k(1, Binary)            0  r[3..3]==r[25..25]; compare partition keys to detect new partition
+  33                Jump         34   37   34                          0
+  34                Gosub        26   75    0                          0  ; detected new partition
+  35                Null          0   24    0                          0  r[24]=NULL
+  36                Copy          3   25    0                          0  r[25]=r[3]
+  37                NotNull      24   47    0                          0  r[24]!=NULL -> goto 47
+  38                Copy         27   28    0                          0  r[28]=r[27]; initialize per-cursor peer-reference registers for new partition
+  39                Copy         27   29    0                          0  r[29]=r[27]
+  40                Null          0   18   18                          0  r[18..18]=NULL; reset accumulator registers
+  41                MakeRecord    3    4   31                          0  r[31]=mkrec(r[3..6])
+  42                NewRowid      5   24    0                          0  r[24]=rowid
+  43                Insert        5   31   24  buffer_table_window_1   2  intkey=r[24] data=r[31]
+  44                Rewind        4   30    0                          0  Rewind  ephemeral(buffer_table_window_1)
+  45                Rewind        6   30    0                          0  Rewind  ephemeral(buffer_table_window_1)
+  46              Goto            0   30    0                          0
+  47              MakeRecord      3    4   32                          0  r[32]=mkrec(r[3..6])
+  48              NewRowid        5   24    0                          0  r[24]=rowid
+  49              Insert          5   32   24  buffer_table_window_1   2  intkey=r[24] data=r[32]
+  50              Compare        27   29    1  k(1, Binary)            0  r[27..27]==r[29..29]; compare ORDER BY columns to detect peer
+  51              Jump           52   30   52                          0
+  52              Column          6    3   33                          0  r[33]=ephemeral(buffer_table_window_1).amount
+  53              AggStep         0   33   18  sum                     0  accum=r[18] step(r[33])
+  54              Next            6   56    0                          0
+  55              Goto            0   60    0                          0
+  56              Column          6    1   34                          0  r[34]=ephemeral(buffer_table_window_1).sale_date
+  57              Compare        29   34    1  k(1, Binary)            0  r[29..29]==r[34..34]
+  58              Jump           59   52   59                          0
+  59              Copy           34   29    0                          0  r[29]=r[34]
+  60              AggValue        0   18   19  sum                     0  accum=r[18] dest=r[19]
+  61              Column          4    1   20                          0  r[20]=ephemeral(buffer_table_window_1).sale_date
+  62              Column          4    2   21                          0  r[21]=ephemeral(buffer_table_window_1).sale_id
+  63              Column          4    0   22                          0  r[22]=ephemeral(buffer_table_window_1).emp_id
+  64              Column          4    3   23                          0  r[23]=ephemeral(buffer_table_window_1).amount
+  65              Gosub          30  101    0                          0
+  66              Delete          4    0    0  buffer_table_window_1   0
+  67              Next            4   69    0                          0
+  68            Goto              0   30    0                          0
+  69            Column            4    1   35                          0  r[35]=ephemeral(buffer_table_window_1).sale_date
+  70            Compare          28   35    1  k(1, Binary)            0  r[28..28]==r[35..35]
+  71            Jump             72   61   72                          0
+  72            Copy             35   28    0                          0  r[28]=r[35]
+  73          Goto                0   30    0                          0
+  74          Null                0   26    0                          0  r[26]=NULL; return remaining buffered rows
+  75          Rewind              5   98    0                          0  Rewind  ephemeral(buffer_table_window_1)
+  76          Column              6    3   36                          0  r[36]=ephemeral(buffer_table_window_1).amount
+  77          AggStep             0   36   18  sum                     0  accum=r[18] step(r[36])
+  78          Next                6   80    0                          0
+  79          Goto                0   84    0                          0
+  80          Column              6    1   37                          0  r[37]=ephemeral(buffer_table_window_1).sale_date
+  81          Compare            29   37    1  k(1, Binary)            0  r[29..29]==r[37..37]
+  82          Jump               83   76   83                          0
+  83          Copy               37   29    0                          0  r[29]=r[37]
+  84          AggValue            0   18   19  sum                     0  accum=r[18] dest=r[19]
+  85          Column              4    1   20                          0  r[20]=ephemeral(buffer_table_window_1).sale_date
+  86          Column              4    2   21                          0  r[21]=ephemeral(buffer_table_window_1).sale_id
+  87          Column              4    0   22                          0  r[22]=ephemeral(buffer_table_window_1).emp_id
+  88          Column              4    3   23                          0  r[23]=ephemeral(buffer_table_window_1).amount
+  89          Gosub              30  101    0                          0
+  90          Delete              4    0    0  buffer_table_window_1   0
+  91          Next                4   93    0                          0
+  92          Goto                0   98    0                          0
+  93          Column              4    1   38                          0  r[38]=ephemeral(buffer_table_window_1).sale_date
+  94          Compare            28   38    1  k(1, Binary)            0  r[28..28]==r[38..38]
+  95          Jump               96   85   96                          0
+  96          Copy               38   28    0                          0  r[28]=r[38]
+  97          Goto                0   84    0                          0
+  98          ResetSorter         4    0    0                          0  cursor=4
+  99        Return               26    0    1                          0
+ 100        Goto                  0  106    0                          0
+ 101        Copy                 20   39    3                          0  r[39]=r[20]
+ 102        Copy                 19   43    0                          0  r[43]=r[19]
+ 103        MakeRecord           39    5   17                          0  r[17]=mkrec(r[39..43])
+ 104        SorterInsert          3   17    0  0                       0  key=r[17]
+ 105      Return                 30    0    0                          0
+ 106      OpenPseudo              7   17    5                          0  5 columns in r[17]
+ 107      SorterSort              3  116    0                          0
+ 108        SorterData            3   17    7                          0  r[17]=data
+ 109        Column                7    0   12                          0  r[12]=pseudo.column 0
+ 110        Column                7    1   13                          0  r[13]=pseudo.column 1
+ 111        Column                7    2   14                          0  r[14]=pseudo.column 2
+ 112        Column                7    3   15                          0  r[15]=pseudo.column 3
+ 113        Column                7    4   16                          0  r[16]=pseudo.column 4
+ 114        Yield                 1    0    0                          0
+ 115      SorterNext              3  108    0                          0
+ 116      EndCoroutine            1    0    0                          0
+ 117      OpenEphemeral           8    1    0                          0  cursor=8 is_table=true
+ 118      OpenDup                 9    8    0                          0  new_cursor=9, original_cursor=8
+ 119      OpenDup                10    8    0                          0  new_cursor=10, original_cursor=8
+ 120      Null                    0   57    0                          0  r[57]=NULL
+ 121      InitCoroutine           1    0    2                          0
+ 122            Yield             1  162    0                          0
+ 123            Copy             12   59    0                          0  r[59]=r[12]
+ 124            NotNull          57  134    0                          0  r[57]!=NULL -> goto 134
+ 125            Copy             59   60    0                          0  r[60]=r[59]; initialize per-cursor peer-reference registers for new partition
+ 126            Copy             59   61    0                          0  r[61]=r[59]
+ 127            Null              0   50   50                          0  r[50..50]=NULL; reset accumulator registers
+ 128            MakeRecord       12    5   63                          0  r[63]=mkrec(r[12..16])
+ 129            NewRowid          9   57    0                          0  r[57]=rowid
+ 130            Insert            9   63   57  buffer_table_window_0   2  intkey=r[57] data=r[63]
+ 131            Rewind            8  122    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 132            Rewind           10  122    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 133          Goto                0  122    0                          0
+ 134          MakeRecord         12    5   64                          0  r[64]=mkrec(r[12..16])
+ 135          NewRowid            9   57    0                          0  r[57]=rowid
+ 136          Insert              9   64   57  buffer_table_window_0   2  intkey=r[57] data=r[64]
+ 137          Compare            59   61    1  k(1, Binary)            0  r[59..59]==r[61..61]; compare ORDER BY columns to detect peer
+ 138          Jump              139  122  139                          0
+ 139          Column             10    3   65                          0  r[65]=ephemeral(buffer_table_window_0).amount
+ 140          AggStep             0   65   50  sum                     0  accum=r[50] step(r[65])
+ 141          Next               10  143    0                          0
+ 142          Goto                0  147    0                          0
+ 143          Column             10    0   66                          0  r[66]=ephemeral(buffer_table_window_0).sale_date
+ 144          Compare            61   66    1  k(1, Binary)            0  r[61..61]==r[66..66]
+ 145          Jump              146  139  146                          0
+ 146          Copy               66   61    0                          0  r[61]=r[66]
+ 147          AggValue            0   50   51  sum                     0  accum=r[50] dest=r[51]
+ 148          Column              8    1   52                          0  r[52]=ephemeral(buffer_table_window_0).sale_id
+ 149          Column              8    2   53                          0  r[53]=ephemeral(buffer_table_window_0).emp_id
+ 150          Column              8    0   54                          0  r[54]=ephemeral(buffer_table_window_0).sale_date
+ 151          Column              8    3   55                          0  r[55]=ephemeral(buffer_table_window_0).amount
+ 152          Column              8    4   56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
+ 153          Gosub              62  190    0                          0
+ 154          Delete              8    0    0  buffer_table_window_0   0
+ 155          Next                8  157    0                          0
+ 156        Goto                  0  122    0                          0
+ 157        Column                8    0   67                          0  r[67]=ephemeral(buffer_table_window_0).sale_date
+ 158        Compare              60   67    1  k(1, Binary)            0  r[60..60]==r[67..67]
+ 159        Jump                160  148  160                          0
+ 160        Copy                 67   60    0                          0  r[60]=r[67]
+ 161      Goto                    0  122    0                          0
+ 162      Null                    0   58    0                          0  r[58]=NULL; return remaining buffered rows
+ 163      Rewind                  9  187    0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 164      Column                 10    3   68                          0  r[68]=ephemeral(buffer_table_window_0).amount
+ 165      AggStep                 0   68   50  sum                     0  accum=r[50] step(r[68])
+ 166      Next                   10  168    0                          0
+ 167      Goto                    0  172    0                          0
+ 168      Column                 10    0   69                          0  r[69]=ephemeral(buffer_table_window_0).sale_date
+ 169      Compare                61   69    1  k(1, Binary)            0  r[61..61]==r[69..69]
+ 170      Jump                  171  164  171                          0
+ 171      Copy                   69   61    0                          0  r[61]=r[69]
+ 172      AggValue                0   50   51  sum                     0  accum=r[50] dest=r[51]
+ 173      Column                  8    1   52                          0  r[52]=ephemeral(buffer_table_window_0).sale_id
+ 174      Column                  8    2   53                          0  r[53]=ephemeral(buffer_table_window_0).emp_id
+ 175      Column                  8    0   54                          0  r[54]=ephemeral(buffer_table_window_0).sale_date
+ 176      Column                  8    3   55                          0  r[55]=ephemeral(buffer_table_window_0).amount
+ 177      Column                  8    4   56                          0  r[56]=ephemeral(buffer_table_window_0).column 4
+ 178      Gosub                  62  190    0                          0
+ 179      Delete                  8    0    0  buffer_table_window_0   0
+ 180      Next                    8  182    0                          0
+ 181      Goto                    0  187    0                          0
+ 182      Column                  8    0   70                          0  r[70]=ephemeral(buffer_table_window_0).sale_date
+ 183      Compare                60   70    1  k(1, Binary)            0  r[60..60]==r[70..70]
+ 184      Jump                  185  173  185                          0
+ 185      Copy                   70   60    0                          0  r[60]=r[70]
+ 186      Goto                    0  172    0                          0
+ 187      ResetSorter             8    0    0                          0  cursor=8
+ 188    Return                   58    0    1                          0
+ 189    Halt                      0    0    0                          0
+ 190    Copy                     52   44    3                          0  r[44]=r[52]
+ 191    Copy                     51   48    0                          0  r[48]=r[51]
+ 192    Copy                     56   49    0                          0  r[49]=r[56]
+ 193    ResultRow                44    6    0                          0  output=r[44..49]
+ 194  Return                     62    0    0                          0
+ 195  Halt                        0    0    0                          0
+ 196  Transaction                 0    1    7                          0  iDb=0 tx_mode=Read
+ 197  Goto                        0    1    0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
@@ -23,88 +23,82 @@ QUERY PLAN
    `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode              p1  p2  p3  p4                     p5  comment
-   0      Init             0  82   0                          0  Start at 82
-   1      InitCoroutine    1  24   2                          0
-   2      SorterOpen       0   2   0  k(2,B,-B)               0  cursor=0
-   3      OpenRead         1   3   0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
-   4      Rewind           1  13   0                          0  Rewind table sales
-   5        Column         1   2   8                          0  r[8]=sales.sale_date
-   6        Column         1   3   9                          0  r[9]=sales.amount
-   7        RowId          1  10   0                          0  r[10]=sales.rowid
-   8        Column         1   1  11                          0  r[11]=sales.emp_id
-   9        Column         1   4  12                          0  r[12]=sales.region
-  10        MakeRecord     8   5   7                          0  r[7]=mkrec(r[8..12])
-  11        SorterInsert   0   7   0  0                       0  key=r[7]
-  12      Next             1   5   0                          0
-  13      OpenPseudo       2   7   5                          0  5 columns in r[7]
-  14      SorterSort       0  23   0                          0
-  15        SorterData     0   7   2                          0  r[7]=data
-  16        Column         2   0   2                          0  r[2]=pseudo.column 0
-  17        Column         2   1   3                          0  r[3]=pseudo.column 1
-  18        Column         2   2   4                          0  r[4]=pseudo.column 2
-  19        Column         2   3   5                          0  r[5]=pseudo.column 3
-  20        Column         2   4   6                          0  r[6]=pseudo.column 4
-  21        Yield          1   0   0                          0
-  22      SorterNext       0  15   0                          0
-  23      EndCoroutine     1   0   0                          0
-  24      OpenEphemeral    3   1   0                          0  cursor=3 is_table=true
-  25      OpenDup          4   3   0                          0  new_cursor=4, original_cursor=3
-  26      OpenDup          5   3   0                          0  new_cursor=5, original_cursor=3
-  27      Null             0  26   0                          0  r[26]=NULL
-  28      InitCoroutine    1   0   2                          0
-  29        Yield          1  55   0                          0
-  30        Copy           2  28   0                          0  r[28]=r[2]
-  31        Copy           3  29   0                          0  r[29]=r[3]
-  32        NotNull       26  40   0                          0  r[26]!=NULL -> goto 40
-  33        Null           0  19  19                          0  r[19..19]=NULL; initialize per-cursor peer-reference registers for new partition
-  34        MakeRecord     2   5  31                          0  r[31]=mkrec(r[2..6])
-  35        NewRowid       4  26   0                          0  r[26]=rowid
-  36        Insert         4  31  26  buffer_table_window_0   2  intkey=r[26] data=r[31]
-  37        Rewind         3  39   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  38        Rewind         5  39   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  39        Goto           0  54   0                          0
-  40        MakeRecord     2   5  32                          0  r[32]=mkrec(r[2..6])
-  41        NewRowid       4  26   0                          0  r[26]=rowid
-  42        Insert         4  32  26  buffer_table_window_0   2  intkey=r[26] data=r[32]
-  43        AggStep        0   0  19  row_number              0  accum=r[19] step(r[0])
-  44        Next           5  45   0                          0
-  45        AggValue       0  19  20  row_number              0  accum=r[19] dest=r[20]
-  46        Column         3   2  21                          0  r[21]=ephemeral(buffer_table_window_0).sale_id
-  47        Column         3   3  22                          0  r[22]=ephemeral(buffer_table_window_0).emp_id
-  48        Column         3   0  23                          0  r[23]=ephemeral(buffer_table_window_0).sale_date
-  49        Column         3   1  24                          0  r[24]=ephemeral(buffer_table_window_0).amount
-  50        Column         3   4  25                          0  r[25]=ephemeral(buffer_table_window_0).region
-  51        Gosub         30  73   0                          0
-  52        Delete         3   0   0  buffer_table_window_0   0
-  53        Next           3  54   0                          0
-  54      Goto             0  29   0                          0
-  55      Null             0  27   0                          0  r[27]=NULL; return remaining buffered rows
-  56      Rewind           4  70   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  57      AggStep          0   0  19  row_number              0  accum=r[19] step(r[0])
-  58      Next             5  59   0                          0
-  59      AggValue         0  19  20  row_number              0  accum=r[19] dest=r[20]
-  60      Column           3   2  21                          0  r[21]=ephemeral(buffer_table_window_0).sale_id
-  61      Column           3   3  22                          0  r[22]=ephemeral(buffer_table_window_0).emp_id
-  62      Column           3   0  23                          0  r[23]=ephemeral(buffer_table_window_0).sale_date
-  63      Column           3   1  24                          0  r[24]=ephemeral(buffer_table_window_0).amount
-  64      Column           3   4  25                          0  r[25]=ephemeral(buffer_table_window_0).region
-  65      Gosub           30  73   0                          0
-  66      Delete           3   0   0  buffer_table_window_0   0
-  67      Next             3  69   0                          0
-  68      Goto             0  70   0                          0
-  69      Goto             0  59   0                          0
-  70      ResetSorter      3   0   0                          0  cursor=3
-  71    Return            27   0   1                          0
-  72    Goto               0  81   0                          0
-  73    Copy              21  13   0                          0  r[13]=r[21]
-  74    Copy              22  14   0                          0  r[14]=r[22]
-  75    Copy              23  15   0                          0  r[15]=r[23]
-  76    Copy              24  16   0                          0  r[16]=r[24]
-  77    Copy              25  17   0                          0  r[17]=r[25]
-  78    Copy              20  18   0                          0  r[18]=r[20]
-  79    ResultRow         13   6   0                          0  output=r[13..18]
-  80  Return              30   0   0                          0
-  81  Halt                 0   0   0                          0
-  82  Transaction          0   1   7                          0  iDb=0 tx_mode=Read
-  83  Goto                 0   1   0                          0
+addr  opcode                p1  p2  p3  p4                     p5  comment
+   0      Init               0  76   0                          0  Start at 76
+   1      InitCoroutine      1  24   2                          0
+   2      SorterOpen         0   2   0  k(2,B,-B)               0  cursor=0
+   3      OpenRead           1   3   0  k(5,B,B,B,B,B)          0  table=sales, root=3, iDb=0
+   4      Rewind             1  13   0                          0  Rewind table sales
+   5        Column           1   2   8                          0  r[8]=sales.sale_date
+   6        Column           1   3   9                          0  r[9]=sales.amount
+   7        RowId            1  10   0                          0  r[10]=sales.rowid
+   8        Column           1   1  11                          0  r[11]=sales.emp_id
+   9        Column           1   4  12                          0  r[12]=sales.region
+  10        MakeRecord       8   5   7                          0  r[7]=mkrec(r[8..12])
+  11        SorterInsert     0   7   0  0                       0  key=r[7]
+  12      Next               1   5   0                          0
+  13      OpenPseudo         2   7   5                          0  5 columns in r[7]
+  14      SorterSort         0  23   0                          0
+  15        SorterData       0   7   2                          0  r[7]=data
+  16        Column           2   0   2                          0  r[2]=pseudo.column 0
+  17        Column           2   1   3                          0  r[3]=pseudo.column 1
+  18        Column           2   2   4                          0  r[4]=pseudo.column 2
+  19        Column           2   3   5                          0  r[5]=pseudo.column 3
+  20        Column           2   4   6                          0  r[6]=pseudo.column 4
+  21        Yield            1   0   0                          0
+  22      SorterNext         0  15   0                          0
+  23      EndCoroutine       1   0   0                          0
+  24      OpenEphemeral      3   1   0                          0  cursor=3 is_table=true
+  25      OpenDup            4   3   0                          0  new_cursor=4, original_cursor=3
+  26      OpenDup            5   3   0                          0  new_cursor=5, original_cursor=3
+  27      Null               0  26   0                          0  r[26]=NULL
+  28      InitCoroutine      1   0   2                          0
+  29            Yield        1  54   0                          0
+  30            Copy         2  28   1                          0  r[28]=r[2]
+  31            NotNull     26  39   0                          0  r[26]!=NULL -> goto 39
+  32            Null         0  19  19                          0  r[19..19]=NULL; initialize per-cursor peer-reference registers for new partition
+  33            MakeRecord   2   5  31                          0  r[31]=mkrec(r[2..6])
+  34            NewRowid     4  26   0                          0  r[26]=rowid
+  35            Insert       4  31  26  buffer_table_window_0   2  intkey=r[26] data=r[31]
+  36            Rewind       3  29   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  37            Rewind       5  29   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  38          Goto           0  29   0                          0
+  39          MakeRecord     2   5  32                          0  r[32]=mkrec(r[2..6])
+  40          NewRowid       4  26   0                          0  r[26]=rowid
+  41          Insert         4  32  26  buffer_table_window_0   2  intkey=r[26] data=r[32]
+  42          AggStep        0   0  19  row_number              0  accum=r[19] step(r[0])
+  43          Next           5  44   0                          0
+  44          AggValue       0  19  20  row_number              0  accum=r[19] dest=r[20]
+  45          Column         3   2  21                          0  r[21]=ephemeral(buffer_table_window_0).sale_id
+  46          Column         3   3  22                          0  r[22]=ephemeral(buffer_table_window_0).emp_id
+  47          Column         3   0  23                          0  r[23]=ephemeral(buffer_table_window_0).sale_date
+  48          Column         3   1  24                          0  r[24]=ephemeral(buffer_table_window_0).amount
+  49          Column         3   4  25                          0  r[25]=ephemeral(buffer_table_window_0).region
+  50          Gosub         30  71   0                          0
+  51          Delete         3   0   0  buffer_table_window_0   0
+  52        Next             3  29   0                          0
+  53      Goto               0  29   0                          0
+  54      Null               0  27   0                          0  r[27]=NULL; return remaining buffered rows
+  55      Rewind             4  68   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  56      AggStep            0   0  19  row_number              0  accum=r[19] step(r[0])
+  57      Next               5  58   0                          0
+  58        AggValue         0  19  20  row_number              0  accum=r[19] dest=r[20]
+  59        Column           3   2  21                          0  r[21]=ephemeral(buffer_table_window_0).sale_id
+  60        Column           3   3  22                          0  r[22]=ephemeral(buffer_table_window_0).emp_id
+  61        Column           3   0  23                          0  r[23]=ephemeral(buffer_table_window_0).sale_date
+  62        Column           3   1  24                          0  r[24]=ephemeral(buffer_table_window_0).amount
+  63        Column           3   4  25                          0  r[25]=ephemeral(buffer_table_window_0).region
+  64        Gosub           30  71   0                          0
+  65        Delete           3   0   0  buffer_table_window_0   0
+  66      Next               3  58   0                          0
+  67      Goto               0  68   0                          0
+  68      ResetSorter        3   0   0                          0  cursor=3
+  69    Return              27   0   1                          0
+  70    Halt                 0   0   0                          0
+  71    Copy                21  13   4                          0  r[13]=r[21]
+  72    Copy                20  18   0                          0  r[18]=r[20]
+  73    ResultRow           13   6   0                          0  output=r[13..18]
+  74  Return                30   0   0                          0
+  75  Halt                   0   0   0                          0
+  76  Transaction            0   1   7                          0  iDb=0 tx_mode=Read
+  77  Goto                   0   1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
@@ -22,109 +22,104 @@ QUERY PLAN
    `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                      p1   p2  p3  p4                     p5  comment
-   0              Init             0  102   0                          0  Start at 102
-   1              InitCoroutine    1   51   2                          0
-   2              SorterOpen       0    1   0  k(1,-B)                 0  cursor=0
-   3              Null             0   11  12                          0  r[11..12]=NULL
-   4              Integer          0    8   0                          0  r[8]=0; clear group by abort flag
-   5              Null             0    9   0                          0  r[9]=NULL; initialize group by comparison registers to NULL
-   6              Gosub           16   39   0                          0  ; go to clear accumulator subroutine
-   7              OpenRead         1    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
-   8              OpenRead         2    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
-   9              Rewind           2   25   0                          0  Rewind index idx_employees_department
-  10                DeferredSeek   2    1   0                          0
-  11                Column         2    0  14                          0  r[14]=idx_employees_department.department
-  12                Column         1    3  15                          0  r[15]=employees.salary
-  13                Compare        9   14   1  k(1, Binary)            0  r[9..9]==r[14..14]
-  14                Jump          15   19  15                          0  ; start new group if comparison is not equal
-  15                Gosub          6   29   0                          0  ; check if ended group had data, and output if so
-  16                Move          14    9   1                          0  r[9..9]=r[14..14]
-  17                IfPos          8   42   0                          0  r[8]>0 -> r[8]-=0, goto 42; check abort flag
-  18                Gosub         16   39   0                          0  ; goto clear accumulator subroutine
-  19                AggStep        0   15  11  sum                     0  accum=r[11] step(r[15])
-  20                AggStep        0   17  12  count                   0  accum=r[12] step(r[17])
-  21                If             7   23   0                          0  if r[7] goto 23; don't emit group columns if continuing existing group
-  22                Column         2    0  10                          0  r[10]=idx_employees_department.department
-  23                Integer        1    7   0                          0  r[7]=1; indicate data in accumulator
-  24              Next             2   10   0                          0
-  25              Gosub            6   29   0                          0  ; emit row for final group
-  26              Goto             0   42   0                          0  ; group by finished
-  27              Integer          1    8   0                          0  r[8]=1
-  28            Return             6    0   0                          0
-  29            IfPos              7   31   0                          0  r[7]>0 -> r[7]-=0, goto 31; output group by row subroutine start
-  30          Return               6    0   0                          0
-  31          AggFinal             0   11   0  sum                     0  accum=r[11]
-  32          AggFinal             0   12   0  count                   0  accum=r[12]
-  33          Copy                11   18   0                          0  r[18]=r[11]
-  34          Copy                10   19   0                          0  r[19]=r[10]
-  35          Copy                12   20   0                          0  r[20]=r[12]
-  36          MakeRecord          18    3   5                          0  r[5]=mkrec(r[18..20])
-  37          SorterInsert         0    5   0  0                       0  key=r[5]
-  38        Return                 6    0   0                          0
-  39        Null                   0   10  12                          0  r[10..12]=NULL; clear accumulator subroutine start
-  40        Integer                0    7   0                          0  r[7]=0
-  41      Return                  16    0   0                          0
-  42      OpenPseudo               3    5   3                          0  3 columns in r[5]
-  43      SorterSort               0   50   0                          0
-  44        SorterData             0    5   3                          0  r[5]=data
-  45        Column                 3    0   2                          0  r[2]=pseudo.column 0
-  46        Column                 3    1   3                          0  r[3]=pseudo.column 1
-  47        Column                 3    2   4                          0  r[4]=pseudo.column 2
-  48        Yield                  1    0   0                          0
-  49      SorterNext               0   44   0                          0
-  50      EndCoroutine             1    0   0                          0
-  51      OpenEphemeral            4    1   0                          0  cursor=4 is_table=true
-  52      OpenDup                  5    4   0                          0  new_cursor=5, original_cursor=4
-  53      OpenDup                  6    4   0                          0  new_cursor=6, original_cursor=4
-  54      Null                     0   30   0                          0  r[30]=NULL
-  55      InitCoroutine            1    0   2                          0
-  56        Yield                  1   79   0                          0
-  57        Copy                   2   32   0                          0  r[32]=r[2]
-  58        NotNull               30   66   0                          0  r[30]!=NULL -> goto 66
-  59        Null                   0   25  25                          0  r[25..25]=NULL; initialize per-cursor peer-reference registers for new partition
-  60        MakeRecord             2    3  34                          0  r[34]=mkrec(r[2..4])
-  61        NewRowid               5   30   0                          0  r[30]=rowid
-  62        Insert                 5   34  30  buffer_table_window_0   2  intkey=r[30] data=r[34]
-  63        Rewind                 4   65   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  64        Rewind                 6   65   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  65        Goto                   0   78   0                          0
-  66        MakeRecord             2    3  35                          0  r[35]=mkrec(r[2..4])
-  67        NewRowid               5   30   0                          0  r[30]=rowid
-  68        Insert                 5   35  30  buffer_table_window_0   2  intkey=r[30] data=r[35]
-  69        AggStep                0    0  25  row_number              0  accum=r[25] step(r[0])
-  70        Next                   6   71   0                          0
-  71        AggValue               0   25  26  row_number              0  accum=r[25] dest=r[26]
-  72        Column                 4    1  27                          0  r[27]=ephemeral(buffer_table_window_0).department
-  73        Column                 4    2  28                          0  r[28]=ephemeral(buffer_table_window_0).column 2
-  74        Column                 4    0  29                          0  r[29]=ephemeral(buffer_table_window_0).column 0
-  75        Gosub                 33   95   0                          0
-  76        Delete                 4    0   0  buffer_table_window_0   0
-  77        Next                   4   78   0                          0
-  78      Goto                     0   56   0                          0
-  79      Null                     0   31   0                          0  r[31]=NULL; return remaining buffered rows
-  80      Rewind                   5   92   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  81      AggStep                  0    0  25  row_number              0  accum=r[25] step(r[0])
-  82      Next                     6   83   0                          0
-  83      AggValue                 0   25  26  row_number              0  accum=r[25] dest=r[26]
-  84      Column                   4    1  27                          0  r[27]=ephemeral(buffer_table_window_0).department
-  85      Column                   4    2  28                          0  r[28]=ephemeral(buffer_table_window_0).column 2
-  86      Column                   4    0  29                          0  r[29]=ephemeral(buffer_table_window_0).column 0
-  87      Gosub                   33   95   0                          0
-  88      Delete                   4    0   0  buffer_table_window_0   0
-  89      Next                     4   91   0                          0
-  90      Goto                     0   92   0                          0
-  91      Goto                     0   83   0                          0
-  92      ResetSorter              4    0   0                          0  cursor=4
-  93    Return                    31    0   1                          0
-  94    Goto                       0  101   0                          0
-  95    Copy                      27   21   0                          0  r[21]=r[27]
-  96    Copy                      28   22   0                          0  r[22]=r[28]
-  97    Copy                      29   23   0                          0  r[23]=r[29]
-  98    Copy                      26   24   0                          0  r[24]=r[26]
-  99    ResultRow                 21    4   0                          0  output=r[21..24]
- 100  Return                      33    0   0                          0
- 101  Halt                         0    0   0                          0
- 102  Transaction                  0    1   7                          0  iDb=0 tx_mode=Read
- 103  Integer                      1   17   0                          0  r[17]=1
- 104  Goto                         0    1   0                          0
+addr  opcode                    p1  p2  p3  p4                     p5  comment
+   0            Init             0  97   0                          0  Start at 97
+   1            InitCoroutine    1  49   2                          0
+   2            SorterOpen       0   1   0  k(1,-B)                 0  cursor=0
+   3            Null             0  11  12                          0  r[11..12]=NULL
+   4            Integer          0   8   0                          0  r[8]=0; clear group by abort flag
+   5            Null             0   9   0                          0  r[9]=NULL; initialize group by comparison registers to NULL
+   6            Gosub           16  37   0                          0  ; go to clear accumulator subroutine
+   7            OpenRead         1   2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
+   8            OpenRead         2   4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
+   9            Rewind           2  25   0                          0  Rewind index idx_employees_department
+  10              DeferredSeek   2   1   0                          0
+  11              Column         2   0  14                          0  r[14]=idx_employees_department.department
+  12              Column         1   3  15                          0  r[15]=employees.salary
+  13              Compare        9  14   1  k(1, Binary)            0  r[9..9]==r[14..14]
+  14              Jump          15  19  15                          0  ; start new group if comparison is not equal
+  15              Gosub          6  27   0                          0  ; check if ended group had data, and output if so
+  16              Move          14   9   1                          0  r[9..9]=r[14..14]
+  17              IfPos          8  40   0                          0  r[8]>0 -> r[8]-=0, goto 40; check abort flag
+  18              Gosub         16  37   0                          0  ; goto clear accumulator subroutine
+  19              AggStep        0  15  11  sum                     0  accum=r[11] step(r[15])
+  20              AggStep        0  17  12  count                   0  accum=r[12] step(r[17])
+  21              If             7  23   0                          0  if r[7] goto 23; don't emit group columns if continuing existing group
+  22              Column         2   0  10                          0  r[10]=idx_employees_department.department
+  23              Integer        1   7   0                          0  r[7]=1; indicate data in accumulator
+  24            Next             2  10   0                          0
+  25            Gosub            6  27   0                          0  ; emit row for final group
+  26            Goto             0  40   0                          0  ; group by finished
+  27            IfPos            7  29   0                          0  r[7]>0 -> r[7]-=0, goto 29; output group by row subroutine start
+  28          Return             6   0   0                          0
+  29          AggFinal           0  11   0  sum                     0  accum=r[11]
+  30          AggFinal           0  12   0  count                   0  accum=r[12]
+  31          Copy              11  18   0                          0  r[18]=r[11]
+  32          Copy              10  19   0                          0  r[19]=r[10]
+  33          Copy              12  20   0                          0  r[20]=r[12]
+  34          MakeRecord        18   3   5                          0  r[5]=mkrec(r[18..20])
+  35          SorterInsert       0   5   0  0                       0  key=r[5]
+  36        Return               6   0   0                          0
+  37        Null                 0  10  12                          0  r[10..12]=NULL; clear accumulator subroutine start
+  38        Integer              0   7   0                          0  r[7]=0
+  39      Return                16   0   0                          0
+  40      OpenPseudo             3   5   3                          0  3 columns in r[5]
+  41      SorterSort             0  48   0                          0
+  42        SorterData           0   5   3                          0  r[5]=data
+  43        Column               3   0   2                          0  r[2]=pseudo.column 0
+  44        Column               3   1   3                          0  r[3]=pseudo.column 1
+  45        Column               3   2   4                          0  r[4]=pseudo.column 2
+  46        Yield                1   0   0                          0
+  47      SorterNext             0  42   0                          0
+  48      EndCoroutine           1   0   0                          0
+  49      OpenEphemeral          4   1   0                          0  cursor=4 is_table=true
+  50      OpenDup                5   4   0                          0  new_cursor=5, original_cursor=4
+  51      OpenDup                6   4   0                          0  new_cursor=6, original_cursor=4
+  52      Null                   0  30   0                          0  r[30]=NULL
+  53      InitCoroutine          1   0   2                          0
+  54            Yield            1  77   0                          0
+  55            Copy             2  32   0                          0  r[32]=r[2]
+  56            NotNull         30  64   0                          0  r[30]!=NULL -> goto 64
+  57            Null             0  25  25                          0  r[25..25]=NULL; initialize per-cursor peer-reference registers for new partition
+  58            MakeRecord       2   3  34                          0  r[34]=mkrec(r[2..4])
+  59            NewRowid         5  30   0                          0  r[30]=rowid
+  60            Insert           5  34  30  buffer_table_window_0   2  intkey=r[30] data=r[34]
+  61            Rewind           4  54   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  62            Rewind           6  54   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  63          Goto               0  54   0                          0
+  64          MakeRecord         2   3  35                          0  r[35]=mkrec(r[2..4])
+  65          NewRowid           5  30   0                          0  r[30]=rowid
+  66          Insert             5  35  30  buffer_table_window_0   2  intkey=r[30] data=r[35]
+  67          AggStep            0   0  25  row_number              0  accum=r[25] step(r[0])
+  68          Next               6  69   0                          0
+  69          AggValue           0  25  26  row_number              0  accum=r[25] dest=r[26]
+  70          Column             4   1  27                          0  r[27]=ephemeral(buffer_table_window_0).department
+  71          Column             4   2  28                          0  r[28]=ephemeral(buffer_table_window_0).column 2
+  72          Column             4   0  29                          0  r[29]=ephemeral(buffer_table_window_0).column 0
+  73          Gosub             33  92   0                          0
+  74          Delete             4   0   0  buffer_table_window_0   0
+  75        Next                 4  54   0                          0
+  76      Goto                   0  54   0                          0
+  77      Null                   0  31   0                          0  r[31]=NULL; return remaining buffered rows
+  78      Rewind                 5  89   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  79      AggStep                0   0  25  row_number              0  accum=r[25] step(r[0])
+  80      Next                   6  81   0                          0
+  81        AggValue             0  25  26  row_number              0  accum=r[25] dest=r[26]
+  82        Column               4   1  27                          0  r[27]=ephemeral(buffer_table_window_0).department
+  83        Column               4   2  28                          0  r[28]=ephemeral(buffer_table_window_0).column 2
+  84        Column               4   0  29                          0  r[29]=ephemeral(buffer_table_window_0).column 0
+  85        Gosub               33  92   0                          0
+  86        Delete               4   0   0  buffer_table_window_0   0
+  87      Next                   4  81   0                          0
+  88      Goto                   0  89   0                          0
+  89      ResetSorter            4   0   0                          0  cursor=4
+  90    Return                  31   0   1                          0
+  91    Halt                     0   0   0                          0
+  92    Copy                    27  21   2                          0  r[21]=r[27]
+  93    Copy                    26  24   0                          0  r[24]=r[26]
+  94    ResultRow               21   4   0                          0  output=r[21..24]
+  95  Return                    33   0   0                          0
+  96  Halt                       0   0   0                          0
+  97  Transaction                0   1   7                          0  iDb=0 tx_mode=Read
+  98  Integer                    1  17   0                          0  r[17]=1
+  99  Goto                       0   1   0                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
@@ -35,9 +35,9 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1   p2  p3  p4                     p5  comment
-   0          Init             0  170   0                          0  Start at 170
-   1          InitCoroutine    1  110   2                          0
-   2          InitCoroutine    2   84   3                          0
+   0          Init             0  137   0                          0  Start at 137
+   1          InitCoroutine    1   83   2                          0
+   2          InitCoroutine    2   62   3                          0
    3          InitCoroutine    3   15   4                          0
    4          OpenRead         0    2   0  k(5,B,B,B,B,B)          0  table=employees, root=2, iDb=0
    5          OpenRead         1    4   0  k(2,B)                  0  index=idx_employees_department, root=4, iDb=0
@@ -56,154 +56,121 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
   18          Null             0   19   0                          0  r[19]=NULL
   19          Null             0   20   0                          0  r[20]=NULL
   20          InitCoroutine    3    0   4                          0
-  21            Yield          3   55   0                          0
-  22            Compare        4   20   1  k(1, Binary)            0  r[4..4]==r[20..20]; compare partition keys to detect new partition
-  23            Jump          24   27  24                          0
-  24            Gosub         21   56   0                          0  ; detected new partition
-  25            Null           0   19   0                          0  r[19]=NULL
-  26            Copy           4   20   0                          0  r[20]=r[4]
-  27            NotNull       19   35   0                          0  r[19]!=NULL -> goto 35
-  28            Null           0   13  13                          0  r[13..13]=NULL; reset accumulator registers
-  29            MakeRecord     4    4  23                          0  r[23]=mkrec(r[4..7])
-  30            NewRowid       3   19   0                          0  r[19]=rowid
-  31            Insert         3   23  19  buffer_table_window_0   2  intkey=r[19] data=r[23]
-  32            Rewind         2   34   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  33            Rewind         4   34   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  34            Goto           0   54   0                          0
+  21              Yield        3   39   0                          0
+  22              Compare      4   20   1  k(1, Binary)            0  r[4..4]==r[20..20]; compare partition keys to detect new partition
+  23              Jump        24   27  24                          0
+  24              Gosub       21   40   0                          0  ; detected new partition
+  25              Null         0   19   0                          0  r[19]=NULL
+  26              Copy         4   20   0                          0  r[20]=r[4]
+  27              NotNull     19   35   0                          0  r[19]!=NULL -> goto 35
+  28              Null         0   13  13                          0  r[13..13]=NULL; reset accumulator registers
+  29              MakeRecord   4    4  23                          0  r[23]=mkrec(r[4..7])
+  30              NewRowid     3   19   0                          0  r[19]=rowid
+  31              Insert       3   23  19  buffer_table_window_0   2  intkey=r[19] data=r[23]
+  32              Rewind       2   21   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  33              Rewind       4   21   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  34            Goto           0   21   0                          0
   35            MakeRecord     4    4  24                          0  r[24]=mkrec(r[4..7])
   36            NewRowid       3   19   0                          0  r[19]=rowid
   37            Insert         3   24  19  buffer_table_window_0   2  intkey=r[19] data=r[24]
-  38            Goto           0   54   0                          0
-  39            Column         4    3  25                          0  r[25]=ephemeral(buffer_table_window_0).salary
-  40            AggStep        0   25  13  avg                     0  accum=r[13] step(r[25])
-  41            Next           4   43   0                          0
-  42            Goto           0   44   0                          0
-  43            Goto           0   39   0                          0
-  44            AggValue       0   13  14  avg                     0  accum=r[13] dest=r[14]
-  45            Column         2    1  15                          0  r[15]=ephemeral(buffer_table_window_0).emp_id
-  46            Column         2    2  16                          0  r[16]=ephemeral(buffer_table_window_0).name
-  47            Column         2    0  17                          0  r[17]=ephemeral(buffer_table_window_0).department
-  48            Column         2    3  18                          0  r[18]=ephemeral(buffer_table_window_0).salary
-  49            Gosub         22   76   0                          0
-  50            Delete         2    0   0  buffer_table_window_0   0
-  51            Next           2   53   0                          0
-  52            Goto           0   54   0                          0
-  53            Goto           0   45   0                          0
-  54          Goto             0   21   0                          0
-  55          Null             0   21   0                          0  r[21]=NULL; return remaining buffered rows
-  56          Rewind           3   73   0                          0  Rewind  ephemeral(buffer_table_window_0)
-  57          Column           4    3  26                          0  r[26]=ephemeral(buffer_table_window_0).salary
-  58          AggStep          0   26  13  avg                     0  accum=r[13] step(r[26])
-  59          Next             4   61   0                          0
-  60          Goto             0   62   0                          0
-  61          Goto             0   57   0                          0
-  62          AggValue         0   13  14  avg                     0  accum=r[13] dest=r[14]
-  63          Column           2    1  15                          0  r[15]=ephemeral(buffer_table_window_0).emp_id
-  64          Column           2    2  16                          0  r[16]=ephemeral(buffer_table_window_0).name
-  65          Column           2    0  17                          0  r[17]=ephemeral(buffer_table_window_0).department
-  66          Column           2    3  18                          0  r[18]=ephemeral(buffer_table_window_0).salary
-  67          Gosub           22   76   0                          0
-  68          Delete           2    0   0  buffer_table_window_0   0
-  69          Next             2   71   0                          0
-  70          Goto             0   73   0                          0
-  71          Goto             0   63   0                          0
-  72          Goto             0   62   0                          0
-  73          ResetSorter      2    0   0                          0  cursor=2
-  74        Return            21    0   1                          0
-  75        Goto               0   83   0                          0
-  76        Copy              15    8   0                          0  r[8]=r[15]
-  77        Copy              16    9   0                          0  r[9]=r[16]
-  78        Copy              17   10   0                          0  r[10]=r[17]
-  79        Copy              18   11   0                          0  r[11]=r[18]
-  80        Copy              14   12   0                          0  r[12]=r[14]
-  81        Yield              2    0   0                          0
-  82      Return              22    0   0                          0
-  83      EndCoroutine         2    0   0                          0
-  84      SorterOpen           5    1   0  k(1,-B)                 0  cursor=5
-  85      InitCoroutine        2    0   3                          0
-  86        Yield              2   98   0                          0
-  87        Copy              11   40   0                          0  r[40]=r[11]
-  88        Copy              12   41   0                          0  r[41]=r[12]
-  89        Subtract          40   41  34                          0  r[34]=r[40]-r[41]
-  90        Copy               8   35   0                          0  r[35]=r[8]
-  91        Copy               9   36   0                          0  r[36]=r[9]
-  92        Copy              10   37   0                          0  r[37]=r[10]
-  93        Copy              11   38   0                          0  r[38]=r[11]
-  94        Copy              12   39   0                          0  r[39]=r[12]
-  95        MakeRecord        34    6  33                          0  r[33]=mkrec(r[34..39])
-  96        SorterInsert       5   33   0  0                       0  key=r[33]
-  97      Goto                 0   86   0                          0
-  98      OpenPseudo           6   33   6                          0  6 columns in r[33]
-  99      SorterSort           5  109   0                          0
- 100        SorterData         5   33   6                          0  r[33]=data
- 101        Column             6    0  27                          0  r[27]=pseudo.column 0
- 102        Column             6    1  28                          0  r[28]=pseudo.column 1
- 103        Column             6    2  29                          0  r[29]=pseudo.column 2
- 104        Column             6    3  30                          0  r[30]=pseudo.column 3
- 105        Column             6    4  31                          0  r[31]=pseudo.column 4
- 106        Column             6    5  32                          0  r[32]=pseudo.column 5
- 107        Yield              1    0   0                          0
- 108      SorterNext           5  100   0                          0
- 109      EndCoroutine         1    0   0                          0
- 110      OpenEphemeral        7    1   0                          0  cursor=7 is_table=true
- 111      OpenDup              8    7   0                          0  new_cursor=8, original_cursor=7
- 112      OpenDup              9    7   0                          0  new_cursor=9, original_cursor=7
- 113      Null                 0   56   0                          0  r[56]=NULL
- 114      InitCoroutine        1    0   2                          0
- 115        Yield              1  140   0                          0
- 116        Copy              27   58   0                          0  r[58]=r[27]
- 117        NotNull           56  125   0                          0  r[56]!=NULL -> goto 125
- 118        Null               0   49  49                          0  r[49..49]=NULL; initialize per-cursor peer-reference registers for new partition
- 119        MakeRecord        27    6  60                          0  r[60]=mkrec(r[27..32])
- 120        NewRowid           8   56   0                          0  r[56]=rowid
- 121        Insert             8   60  56  buffer_table_window_0   2  intkey=r[56] data=r[60]
- 122        Rewind             7  124   0                          0  Rewind  ephemeral(buffer_table_window_0)
- 123        Rewind             9  124   0                          0  Rewind  ephemeral(buffer_table_window_0)
- 124        Goto               0  139   0                          0
- 125        MakeRecord        27    6  61                          0  r[61]=mkrec(r[27..32])
- 126        NewRowid           8   56   0                          0  r[56]=rowid
- 127        Insert             8   61  56  buffer_table_window_0   2  intkey=r[56] data=r[61]
- 128        AggStep            0    0  49  row_number              0  accum=r[49] step(r[0])
- 129        Next               9  130   0                          0
- 130        AggValue           0   49  50  row_number              0  accum=r[49] dest=r[50]
- 131        Column             7    1  51                          0  r[51]=ephemeral(buffer_table_window_0).emp_id
- 132        Column             7    2  52                          0  r[52]=ephemeral(buffer_table_window_0).name
- 133        Column             7    3  53                          0  r[53]=ephemeral(buffer_table_window_0).department
- 134        Column             7    4  54                          0  r[54]=ephemeral(buffer_table_window_0).salary
- 135        Column             7    5  55                          0  r[55]=ephemeral(buffer_table_window_0).dept_avg
- 136        Gosub             59  158   0                          0
- 137        Delete             7    0   0  buffer_table_window_0   0
- 138        Next               7  139   0                          0
- 139      Goto                 0  115   0                          0
- 140      Null                 0   57   0                          0  r[57]=NULL; return remaining buffered rows
- 141      Rewind               8  155   0                          0  Rewind  ephemeral(buffer_table_window_0)
- 142      AggStep              0    0  49  row_number              0  accum=r[49] step(r[0])
- 143      Next                 9  144   0                          0
- 144      AggValue             0   49  50  row_number              0  accum=r[49] dest=r[50]
- 145      Column               7    1  51                          0  r[51]=ephemeral(buffer_table_window_0).emp_id
- 146      Column               7    2  52                          0  r[52]=ephemeral(buffer_table_window_0).name
- 147      Column               7    3  53                          0  r[53]=ephemeral(buffer_table_window_0).department
- 148      Column               7    4  54                          0  r[54]=ephemeral(buffer_table_window_0).salary
- 149      Column               7    5  55                          0  r[55]=ephemeral(buffer_table_window_0).dept_avg
- 150      Gosub               59  158   0                          0
- 151      Delete               7    0   0  buffer_table_window_0   0
- 152      Next                 7  154   0                          0
- 153      Goto                 0  155   0                          0
- 154      Goto                 0  144   0                          0
- 155      ResetSorter          7    0   0                          0  cursor=7
- 156    Return                57    0   1                          0
- 157    Goto                   0  169   0                          0
- 158    Copy                  51   42   0                          0  r[42]=r[51]
- 159    Copy                  52   43   0                          0  r[43]=r[52]
- 160    Copy                  53   44   0                          0  r[44]=r[53]
- 161    Copy                  54   45   0                          0  r[45]=r[54]
- 162    Copy                  55   46   0                          0  r[46]=r[55]
- 163    Copy                  54   62   0                          0  r[62]=r[54]
- 164    Copy                  55   63   0                          0  r[63]=r[55]
- 165    Subtract              62   63  47                          0  r[47]=r[62]-r[63]
- 166    Copy                  50   48   0                          0  r[48]=r[50]
- 167    ResultRow             42    7   0                          0  output=r[42..48]
- 168  Return                  59    0   0                          0
- 169  Halt                     0    0   0                          0
- 170  Transaction              0    1   7                          0  iDb=0 tx_mode=Read
- 171  Goto                     0    1   0                          0
+  38          Goto             0   21   0                          0
+  39          Null             0   21   0                          0  r[21]=NULL; return remaining buffered rows
+  40          Rewind           3   54   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  41            Column         4    3  26                          0  r[26]=ephemeral(buffer_table_window_0).salary
+  42            AggStep        0   26  13  avg                     0  accum=r[13] step(r[26])
+  43          Next             4   41   0                          0
+  44          Goto             0   45   0                          0
+  45          AggValue         0   13  14  avg                     0  accum=r[13] dest=r[14]
+  46            Column         2    1  15                          0  r[15]=ephemeral(buffer_table_window_0).emp_id
+  47            Column         2    2  16                          0  r[16]=ephemeral(buffer_table_window_0).name
+  48            Column         2    0  17                          0  r[17]=ephemeral(buffer_table_window_0).department
+  49            Column         2    3  18                          0  r[18]=ephemeral(buffer_table_window_0).salary
+  50            Gosub         22   57   0                          0
+  51            Delete         2    0   0  buffer_table_window_0   0
+  52          Next             2   46   0                          0
+  53          Goto             0   54   0                          0
+  54          ResetSorter      2    0   0                          0  cursor=2
+  55        Return            21    0   1                          0
+  56        Goto               0   61   0                          0
+  57        Copy              15    8   3                          0  r[8]=r[15]
+  58        Copy              14   12   0                          0  r[12]=r[14]
+  59        Yield              2    0   0                          0
+  60      Return              22    0   0                          0
+  61      EndCoroutine         2    0   0                          0
+  62      SorterOpen           5    1   0  k(1,-B)                 0  cursor=5
+  63      InitCoroutine        2    0   3                          0
+  64        Yield              2   71   0                          0
+  65        Copy              11   40   1                          0  r[40]=r[11]
+  66        Subtract          40   41  34                          0  r[34]=r[40]-r[41]
+  67        Copy               8   35   4                          0  r[35]=r[8]
+  68        MakeRecord        34    6  33                          0  r[33]=mkrec(r[34..39])
+  69        SorterInsert       5   33   0  0                       0  key=r[33]
+  70      Goto                 0   64   0                          0
+  71      OpenPseudo           6   33   6                          0  6 columns in r[33]
+  72      SorterSort           5   82   0                          0
+  73        SorterData         5   33   6                          0  r[33]=data
+  74        Column             6    0  27                          0  r[27]=pseudo.column 0
+  75        Column             6    1  28                          0  r[28]=pseudo.column 1
+  76        Column             6    2  29                          0  r[29]=pseudo.column 2
+  77        Column             6    3  30                          0  r[30]=pseudo.column 3
+  78        Column             6    4  31                          0  r[31]=pseudo.column 4
+  79        Column             6    5  32                          0  r[32]=pseudo.column 5
+  80        Yield              1    0   0                          0
+  81      SorterNext           5   73   0                          0
+  82      EndCoroutine         1    0   0                          0
+  83      OpenEphemeral        7    1   0                          0  cursor=7 is_table=true
+  84      OpenDup              8    7   0                          0  new_cursor=8, original_cursor=7
+  85      OpenDup              9    7   0                          0  new_cursor=9, original_cursor=7
+  86      Null                 0   56   0                          0  r[56]=NULL
+  87      InitCoroutine        1    0   2                          0
+  88            Yield          1  113   0                          0
+  89            Copy          27   58   0                          0  r[58]=r[27]
+  90            NotNull       56   98   0                          0  r[56]!=NULL -> goto 98
+  91            Null           0   49  49                          0  r[49..49]=NULL; initialize per-cursor peer-reference registers for new partition
+  92            MakeRecord    27    6  60                          0  r[60]=mkrec(r[27..32])
+  93            NewRowid       8   56   0                          0  r[56]=rowid
+  94            Insert         8   60  56  buffer_table_window_0   2  intkey=r[56] data=r[60]
+  95            Rewind         7   88   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  96            Rewind         9   88   0                          0  Rewind  ephemeral(buffer_table_window_0)
+  97          Goto             0   88   0                          0
+  98          MakeRecord      27    6  61                          0  r[61]=mkrec(r[27..32])
+  99          NewRowid         8   56   0                          0  r[56]=rowid
+ 100          Insert           8   61  56  buffer_table_window_0   2  intkey=r[56] data=r[61]
+ 101          AggStep          0    0  49  row_number              0  accum=r[49] step(r[0])
+ 102          Next             9  103   0                          0
+ 103          AggValue         0   49  50  row_number              0  accum=r[49] dest=r[50]
+ 104          Column           7    1  51                          0  r[51]=ephemeral(buffer_table_window_0).emp_id
+ 105          Column           7    2  52                          0  r[52]=ephemeral(buffer_table_window_0).name
+ 106          Column           7    3  53                          0  r[53]=ephemeral(buffer_table_window_0).department
+ 107          Column           7    4  54                          0  r[54]=ephemeral(buffer_table_window_0).salary
+ 108          Column           7    5  55                          0  r[55]=ephemeral(buffer_table_window_0).dept_avg
+ 109          Gosub           59  130   0                          0
+ 110          Delete           7    0   0  buffer_table_window_0   0
+ 111        Next               7   88   0                          0
+ 112      Goto                 0   88   0                          0
+ 113      Null                 0   57   0                          0  r[57]=NULL; return remaining buffered rows
+ 114      Rewind               8  127   0                          0  Rewind  ephemeral(buffer_table_window_0)
+ 115      AggStep              0    0  49  row_number              0  accum=r[49] step(r[0])
+ 116      Next                 9  117   0                          0
+ 117        AggValue           0   49  50  row_number              0  accum=r[49] dest=r[50]
+ 118        Column             7    1  51                          0  r[51]=ephemeral(buffer_table_window_0).emp_id
+ 119        Column             7    2  52                          0  r[52]=ephemeral(buffer_table_window_0).name
+ 120        Column             7    3  53                          0  r[53]=ephemeral(buffer_table_window_0).department
+ 121        Column             7    4  54                          0  r[54]=ephemeral(buffer_table_window_0).salary
+ 122        Column             7    5  55                          0  r[55]=ephemeral(buffer_table_window_0).dept_avg
+ 123        Gosub             59  130   0                          0
+ 124        Delete             7    0   0  buffer_table_window_0   0
+ 125      Next                 7  117   0                          0
+ 126      Goto                 0  127   0                          0
+ 127      ResetSorter          7    0   0                          0  cursor=7
+ 128    Return                57    0   1                          0
+ 129    Halt                   0    0   0                          0
+ 130    Copy                  51   42   4                          0  r[42]=r[51]
+ 131    Copy                  54   62   1                          0  r[62]=r[54]
+ 132    Subtract              62   63  47                          0  r[47]=r[62]-r[63]
+ 133    Copy                  50   48   0                          0  r[48]=r[50]
+ 134    ResultRow             42    7   0                          0  output=r[42..48]
+ 135  Return                  59    0   0                          0
+ 136  Halt                     0    0   0                          0
+ 137  Transaction              0    1   7                          0  iDb=0 tx_mode=Read
+ 138  Goto                     0    1   0                          0


### PR DESCRIPTION
## Description

Adds `core/vdbe/peephole.rs`: a peephole pass over finished bytecode programs, run in `ProgramBuilder::build_prepared_program` right after label resolution. Trigger and FK-action subprograms build through the same path, so they are optimized too. `EXPLAIN QUERY PLAN` programs are skipped (their `Insn::Explain` rows carry raw instruction indices and are never executed for performance).

Rules, applied in order, followed by a single compaction:

1. **Jump threading** — every branch operand landing on a `Goto` is retargeted to the end of the `Goto` chain (memoized, linear, cycle-guarded). A `Goto` whose destination is a plain `Halt` becomes a copy of that `Halt`.
2. **Branch-over-Goto inversion** — `cond -> +2; Goto L` becomes `inverted-cond -> L`. Pairs: `If`↔`IfNot`, `IsNull`↔`NotNull`, `Eq`↔`Ne`, `Lt`↔`Ge`, `Le`↔`Gt`; `JUMP_IF_NULL` / `jump_if_null` flips with the condition.
3. **Copy merge** — runs of adjacent `Copy`s over contiguous registers merge into one `Copy` with a larger `extra_amount`.
4. **Affinity fold** — a standalone `Affinity` directly before a `MakeRecord` over the same register range moves its affinity string onto `MakeRecord.affinity_str` (`op_make_record` applies affinities with the same `apply_affinity_char` loop as `op_affinity`, including the register write-back).
5. **Jump-to-next deletion** — `Goto`/side-effect-free conditionals whose only destination is the next instruction are deleted.
6. **Unreachable sweep** — worklist reachability from instruction 0; `Gosub`/`Yield` keep their dynamically-entered return points alive, `Goto`/`Jump`/`Halt` do not fall through.

Compaction drops dead instructions and remaps every branch operand through a new exhaustive `Insn::for_each_branch_offset` visitor — one source of truth for which fields hold jump targets, now also used by `resolve_labels` (this fixed two opcodes the old hand-written match missed: `IfNeg`, `SequenceTest`). A live operand pointing at a deleted instruction is a debug assertion. EXPLAIN comments move with their instructions.

Example: a single-row INSERT goes 21 → 18 instructions — `NotNull +2; Goto check_fail` becomes one `IsNull check_fail`, and the `Goto +1; Goto +1; Halt` epilogue collapses into a bare `Halt`.

**Escape hatch:** `TURSO_PEEPHOLE=0` disables the pass (read once per process). `TURSO_PEEPHOLE_STATS=1` prints cumulative per-rule counters at process exit.

**Performance of the pass itself:** it runs on every prepare, so the internals avoid per-program allocations (thread-local scratch), collect jump targets once inside rule 1's operand walk, gate rules on opcode presence, and skip compaction when nothing died. Measured by the ignored `time_the_pass_manually` harness: ~105 ns on a small program with nothing to rewrite, ~190 ns on one that shrinks.

## Motivation and context

Programs execute strictly fewer instructions and dispatches afterwards. Evidence gathered during development:

**Rule hits over the full conformance corpus** (both corpora, 87k prepared programs, all tests green): 63k jumps threaded, 99k `Goto`→`Halt`, 121k unreachable instructions deleted, 5.5k branches inverted, 6.4k copies merged, 1.8k jumps-to-next deleted. Affinity-fold fires rarely (11) for structural reasons verified by instrumentation: UPDATE's main-record path already sets `MakeRecord.affinity_str`, index records span one more register than their `Affinity` (the appended rowid must stay unconverted), and INSERT separates the pair with constraint checks — all correct skips.

**Deliberately skipped for safety:** comparisons with non-BLOB affinity or custom collations are never deleted as jump-to-next (`op_comparison` writes affinity-converted operands back into the registers, and collation lookup can fail at runtime); `NotExists`/`Found`/`DecrJumpZero`/seek opcodes are never inverted or deleted (both sides have side effects); affinity folds are skipped when a branch enters the window; `Goto` cycles are left alone. `NULL_EQ` comparisons stay exact complements under inversion because NULL cases are decided before `JUMP_IF_NULL` is consulted; a runtime differential test pins the flag-flip semantics for ordinary comparisons too.

**Static TPC-H instruction counts** (EXPLAIN, off → on): 2,035 → 1,962 (−3.6%), up to −11.6% on Q1.

**Runtime**: TPC-H `compare.sh` median-of-3 total 110.0 s → 110.5 s (+0.5%, inside this machine's noise; the rusqlite rows of the criterion TPC-H bench bound noise at ±6% and every turso delta sits inside it). Execution-bound workloads are unchanged within measurement resolution, as expected for jump-level rewrites on scan-heavy queries.

**Prepare-time cost (the honest tradeoff):** drift-immune in-process measurement (`prepare_overhead_manually`, alternating on/off blocks) shows `SELECT 1` prepare +313 ns (+9.4%), `LIMIT 1` +5.6%, a GROUP BY statement +19%, single-row INSERT +4–11%. Phase profiling shows the time spread across the three operand walks with ~100–150 ns fixed cost — no single fixable hotspot short of a redesign. This exceeds the ideal on prepare-only microbenchmarks; it is per-prepare only, bought back at execution, and `TURSO_PEEPHOLE=0` removes it entirely for prepare-dominated workloads. A cheaper single-scan unreachable sweep was tried and rejected because it kept dead window-function regions alive (dead cycles reference each other) — the committed snapshots encode the precise worklist's strictly better output.

**Validation:** workspace `cargo test` (1,936 tests), `make test`, both conformance corpora (10,097 + 1,451 passed), strict clippy, and `scripts/diff.sh` result comparisons against sqlite3 are green. 75 bytecode snapshots regenerated under `CI=1` (release, so hash-join memory budgets match CI), net −445 lines; diffs hand-reviewed. Two golden VDBE-trace tests were updated to the optimized bytecode. Two pre-existing environment-bound failures in the local `make test` run (`big-db-mvcc` timeout, `expr_depth_or_chain_at_limit` stack overflow) reproduce identically with the pass disabled on the same binary.

## Description of AI Usage

This PR was implemented end-to-end by Claude Code (Fable 5) in a remote session from a task description. The workflow: read `execute.rs` semantics for every opcode a rule touches before writing the rule (which surfaced the comparison write-back and `JUMP_IF_NULL` subtleties encoded as preconditions above), unit tests per rule plus EXPLAIN-level and runtime differential tests, full test/conformance/snapshot gates, then benchmarking with off-vs-off control runs — which showed the container's clock drifts ±5–19%, so pass cost was measured with in-process alternating harnesses that are kept in the tree as `#[ignore]`d tests. The commits are structured for review: visitor refactor, the pass itself, snapshot regeneration, and the prepare-cost optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MumSGfyTrYba3dQGFLtU6Q