### PR TITLE
core: fix attached-database tx handling

### DIFF
--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -190,6 +190,10 @@ pub fn translate_inner(
     }
 
     let is_select = matches!(stmt, ast::Stmt::Select { .. });
+    let is_dml = matches!(
+        stmt,
+        ast::Stmt::Delete { .. } | ast::Stmt::Insert { .. } | ast::Stmt::Update { .. }
+    );
 
     match stmt {
         ast::Stmt::AlterTable(alter) => {
@@ -465,9 +469,16 @@ pub fn translate_inner(
         }
     };
 
-    // Indicate write operations so that in the epilogue we can emit the correct type of transaction
     if is_write {
-        program.begin_write_operation()?;
+        if is_dml {
+            // DML translators register their actual write database. Keep a
+            // main read transaction to coordinate connection-level autocommit,
+            // without upgrading an unrelated main snapshot for attached-only
+            // writes.
+            program.begin_read_operation()?;
+        } else {
+            program.begin_write_operation()?;
+        }
     }
 
     // Indicate read operations so that in the epilogue we can emit the correct type of transaction

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3597,6 +3597,21 @@ fn open_connection_named_savepoints_for_db(
     })
 }
 
+fn load_active_non_main_wal_headers_for_named_savepoint(conn: &Connection) -> Result<IOResult<()>> {
+    conn.with_all_attached_pagers_with_index(|pagers| {
+        for (db_id, pager) in pagers {
+            if conn.mv_store_for_db(*db_id).is_some() || !pager.holds_read_lock() {
+                continue;
+            }
+            match pager_db_size_for_named_savepoint(pager)? {
+                IOResult::Done(_) => {}
+                IOResult::IO(io) => return Ok(IOResult::IO(io)),
+            }
+        }
+        Ok(IOResult::Done(()))
+    })
+}
+
 enum SavepointMirror<'a> {
     Begin(&'a crate::connection::NamedSavepointFrame),
     Release(&'a str),
@@ -4491,6 +4506,12 @@ pub fn op_savepoint(
 
     match *op {
         SavepointOp::Begin => {
+            // Mirroring mutates several pager savepoint stacks and therefore
+            // cannot yield halfway through. Load every active WAL header
+            // before opening the first savepoint so an I/O yield is restartable.
+            if let IOResult::IO(io) = load_active_non_main_wal_headers_for_named_savepoint(&conn)? {
+                return Ok(InsnFunctionStepResult::IO(io));
+            }
             conn.with_savepoint_schema_snapshot(
                 |main_schema_snapshot, temp_schema_snapshot, staged_schema_snapshot| {
                     let starts_transaction = conn.auto_commit.load(Ordering::SeqCst);
@@ -17848,6 +17869,31 @@ mod tests {
         })
         .unwrap();
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_savepoint_loads_evicted_attached_header_before_mirroring() {
+        let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            "savepoint-main.db",
+            OpenFlags::Create,
+            DatabaseOpts::new().with_attach(true),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("ATTACH 'savepoint-aux.db' AS aux").unwrap();
+        conn.execute("CREATE TABLE aux.t(x)").unwrap();
+
+        let attached_db_id = conn.get_database_id_by_name("aux").unwrap();
+        let attached_pager = conn.get_pager_from_database_index(&attached_db_id).unwrap();
+        attached_pager.begin_read_tx().unwrap();
+        attached_pager.clear_page_cache(false);
+
+        conn.execute("SAVEPOINT s").unwrap();
+        conn.execute("RELEASE s").unwrap();
     }
 
     #[test]

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -1,4 +1,5 @@
 use crate::common::{do_flush, limbo_exec_rows, sqlite_exec_rows, ExecRows, TempDatabase};
+use anyhow::Context;
 use rusqlite::params;
 use rusqlite::Connection as RusqliteConnection;
 use std::fs::File;
@@ -80,6 +81,43 @@ fn test_attached_schema_refreshes_after_other_connection_create(
     );
     assert_eq!(rows[0], vec![rusqlite::types::Value::Integer(1)]);
 
+    Ok(())
+}
+
+#[turso_macros::test]
+fn test_attached_write_does_not_upgrade_stale_main_snapshot(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let aux_path = tmp_db.path.with_extension("attach_busy_snapshot.db");
+    let conn1 = tmp_db.connect_limbo();
+    let conn2 = tmp_db.connect_limbo();
+
+    conn1.execute("CREATE TABLE main_t(x INTEGER)")?;
+    conn1.execute("INSERT INTO main_t VALUES (1)")?;
+    conn1.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn2.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn1.execute("CREATE TABLE aux.t(x INTEGER)")?;
+    conn1.execute("INSERT INTO aux.t VALUES (1)")?;
+
+    conn1.execute("BEGIN")?;
+    let main_rows = limbo_exec_rows(&conn1, "SELECT x FROM main_t");
+    assert_eq!(main_rows, vec![vec![rusqlite::types::Value::Integer(1)]]);
+
+    conn2
+        .execute("UPDATE main_t SET x = 2")
+        .context("update main")?;
+    conn2
+        .execute("UPDATE aux.t SET x = 2")
+        .context("update aux")?;
+
+    conn1
+        .execute("DELETE FROM aux.t")
+        .context("delete from aux")?;
+    let rows = limbo_exec_rows(&conn1, "SELECT x FROM aux.t");
+    assert!(rows.is_empty());
+    let main_rows = limbo_exec_rows(&conn1, "SELECT x FROM main_t");
+    assert_eq!(main_rows, vec![vec![rusqlite::types::Value::Integer(1)]]);
+    conn1.execute("ROLLBACK")?;
     Ok(())
 }
 


### PR DESCRIPTION
Fix attached-database transaction handling found by simulator seed
`6453668919561448913`.

Attached-only DML incorrectly opened a write transaction on `main`. If the connection held a stale main snapshot, the statement failed with `BusySnapshot` before modifying the attached database, causing the simulator's expected and actual rows to diverge.

This change keeps `main` read-only for the attached-only DML while retaining it for the connection-level autocommit coordination.  preloads active attached WAL headers before mirroring named savepoints, so an I/O yield cannot leave partially mutated savepoint state