### PR TITLE
core/vdbe: cleanup journal-mode checkpoint on statement reset

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -19687,6 +19687,68 @@ fn test_passive_checkpoint_truncate_wal_tolerates_concurrent_drop_of_checkpointe
     assert_integrity_ok(&conn_c);
 }
 
+#[test]
+fn dropped_journal_mode_mvcc_checkpoint_releases_lock() {
+    use crate::StepResult;
+
+    let _ = tracing_subscriber::fmt::try_init();
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
+
+    let injector = FixedYieldInjector::new([
+        CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
+    ]);
+
+    conn.set_yield_injector(Some(injector.clone()));
+
+    let mut stmt = conn.prepare("PRAGMA journal_mode = WAL").unwrap();
+
+    // Step the statement until the injected yield fires, then abandon it.
+    let first_yield = loop {
+        match stmt.step() {
+            Ok(StepResult::IO | StepResult::Yield) => {
+                if injector.is_empty() {
+                    break true;
+                }
+            }
+            Ok(StepResult::Done) => break false,
+            Ok(StepResult::Row) => {}
+            Ok(other) => panic!("unexpected journal_mode step result: {other:?}"),
+            Err(err) => panic!("unexpected journal_mode error: {err:?}"),
+        }
+    };
+    assert!(
+        first_yield,
+        "injected checkpoint yield point never fired; scenario not exercised"
+    );
+
+    // Abandon the in-flight PRAGMA mid-checkpoint.
+    drop(stmt);
+    conn.set_yield_injector(None);
+
+    // Another connection must still be able to use the database.
+    let observer = db.connect();
+
+    observer
+        .execute("INSERT INTO t VALUES (2, 'b')")
+        .expect("insert after abandoned journal_mode checkpoint must not be Busy");
+
+    let rows = {
+        let mut stmt = observer.query("SELECT count(*) FROM t").unwrap().unwrap();
+        stmt.run_collect_rows()
+            .expect("select after abandoned journal_mode checkpoint must not be Busy")
+    };
+    assert_eq!(rows.len(), 1);
+
+    observer
+        .execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        .expect("checkpoint after abandoned journal_mode checkpoint must not be Busy");
+}
+
 /// Repro for https://github.com/tursodatabase/turso/issues/7956.
 ///
 /// A passive checkpoint must materialize CREATE at its snapshot, but publishing

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -19699,9 +19699,8 @@ fn dropped_journal_mode_mvcc_checkpoint_releases_lock() {
         .unwrap();
     conn.execute("INSERT INTO t VALUES (1, 'a')").unwrap();
 
-    let injector = FixedYieldInjector::new([
-        CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
-    ]);
+    let injector =
+        FixedYieldInjector::new([CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point()]);
 
     conn.set_yield_injector(Some(injector.clone()));
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1031,6 +1031,11 @@ impl ProgramState {
         // CheckpointStateMachine again, so release its checkpoint lock before
         // replacing commit_state with Ready.
         self.commit_state.cleanup_mvcc_checkpoint_state();
+        // PRAGMA journal_mode owns its MVCC checkpoint state in `active_op_state`.
+        // If a statement is reset/dropped while that nested checkpoint is parked
+        // (e.g. yielded at AfterDurableBoundaryAdvanced), we must run its cleanup
+        // to release any held locks before clearing the active opcode state.
+        self.active_op_state.cleanup_journal_mode_checkpoint().ok();
         self.active_op_state.clear();
         self.seek_state = OpSeekState::Start;
         self.commit_state = CommitState::Ready;


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->
Fixes https://github.com/tursodatabase/turso/issues/7483.  Release the MVCC/journal-mode checkpoint state held by a parked `JournalMode` opcode when a statement is reset or dropped. Call `active_op_state.cleanup_journal_mode_checkpoint()` before clearing the active opcode state so any held locks are released.

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
I used AI to understand the structure of this project, scope out and polish changes that were required. Additionally, AI was also used to generate some parts of this comment.