### PR TITLE
bindings/swift: add SwiftPM package and xcframework build pipeline

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -48,6 +48,10 @@ bindings/java:
   - changed-files:
       - any-glob-to-any-file: "bindings/java/**/*"
 
+bindings/swift:
+  - changed-files:
+      - any-glob-to-any-file: "bindings/swift/**/*"
+
 parser:
   - changed-files:
       - any-glob-to-any-file: "vendored/sqlite3-parser/*"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,50 @@
+name: Swift Tests
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  working-directory: bindings/swift
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_RETRY: 10
+
+jobs:
+  test:
+    runs-on: blacksmith-6vcpu-macos-latest
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        working-directory: ${{ env.working-directory }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust(stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust-swift"
+          cache-on-failure: true
+
+      - name: Build xcframework
+        run: make xcframework
+
+      - name: Run tests
+        run: swift test

--- a/bindings/swift/.gitignore
+++ b/bindings/swift/.gitignore
@@ -1,0 +1,2 @@
+.build/
+TursoSdkKit.xcframework/

--- a/bindings/swift/Makefile
+++ b/bindings/swift/Makefile
@@ -1,0 +1,39 @@
+WORKSPACE_ROOT := ../..
+CRATE := turso_sdk_kit
+LIB := libturso_sdk_kit.a
+TARGET_DIR := $(WORKSPACE_ROOT)/target
+APPLE_TARGETS := aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-darwin x86_64-apple-darwin
+BUILD_DIR := .build/xcframework
+
+# Must track the platforms declared in Package.swift. Without these, rustc
+# stamps the build machine's OS version onto the objects and the archive
+# silently stops being loadable on the versions the package advertises.
+export MACOSX_DEPLOYMENT_TARGET := 13.0
+export IPHONEOS_DEPLOYMENT_TARGET := 16.0
+
+.PHONY: rust-targets xcframework clean test
+
+rust-targets:
+	rustup target add $(APPLE_TARGETS)
+
+xcframework: clean
+	for t in $(APPLE_TARGETS); do \
+		cargo build -p $(CRATE) --release --target $$t || exit 1; \
+	done
+	mkdir -p $(BUILD_DIR)/headers $(BUILD_DIR)/macos
+	cp $(WORKSPACE_ROOT)/sdk-kit/turso.h $(BUILD_DIR)/headers/
+	cp Support/module.modulemap $(BUILD_DIR)/headers/
+	lipo -create -output $(BUILD_DIR)/macos/$(LIB) \
+		$(TARGET_DIR)/aarch64-apple-darwin/release/$(LIB) \
+		$(TARGET_DIR)/x86_64-apple-darwin/release/$(LIB)
+	xcodebuild -create-xcframework \
+		-library $(TARGET_DIR)/aarch64-apple-ios/release/$(LIB) -headers $(BUILD_DIR)/headers \
+		-library $(TARGET_DIR)/aarch64-apple-ios-sim/release/$(LIB) -headers $(BUILD_DIR)/headers \
+		-library $(BUILD_DIR)/macos/$(LIB) -headers $(BUILD_DIR)/headers \
+		-output TursoSdkKit.xcframework
+
+clean:
+	rm -rf TursoSdkKit.xcframework $(BUILD_DIR)
+
+test: xcframework
+	swift test

--- a/bindings/swift/Makefile
+++ b/bindings/swift/Makefile
@@ -1,0 +1,42 @@
+WORKSPACE_ROOT := ../..
+CRATE := turso_sdk_kit
+LIB := libturso_sdk_kit.a
+TARGET_DIR := $(WORKSPACE_ROOT)/target
+APPLE_TARGETS := aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-darwin x86_64-apple-darwin
+BUILD_DIR := .build/xcframework
+
+# Must track the platforms declared in Package.swift. Without these, rustc
+# stamps the build machine's OS version onto the objects and the archive
+# silently stops being loadable on the versions the package advertises.
+export MACOSX_DEPLOYMENT_TARGET := 13.0
+export IPHONEOS_DEPLOYMENT_TARGET := 16.0
+
+.PHONY: rust-targets xcframework clean test
+
+rust-targets:
+	rustup target add $(APPLE_TARGETS)
+
+# rust-targets is a prerequisite because rust-toolchain.toml pins the
+# toolchain, so the Apple targets must be added to that pinned toolchain
+# rather than to whatever rustup happens to default to.
+xcframework: rust-targets clean
+	for t in $(APPLE_TARGETS); do \
+		cargo build -p $(CRATE) --release --target $$t || exit 1; \
+	done
+	mkdir -p $(BUILD_DIR)/headers $(BUILD_DIR)/macos
+	cp $(WORKSPACE_ROOT)/sdk-kit/turso.h $(BUILD_DIR)/headers/
+	cp Support/module.modulemap $(BUILD_DIR)/headers/
+	lipo -create -output $(BUILD_DIR)/macos/$(LIB) \
+		$(TARGET_DIR)/aarch64-apple-darwin/release/$(LIB) \
+		$(TARGET_DIR)/x86_64-apple-darwin/release/$(LIB)
+	xcodebuild -create-xcframework \
+		-library $(TARGET_DIR)/aarch64-apple-ios/release/$(LIB) -headers $(BUILD_DIR)/headers \
+		-library $(TARGET_DIR)/aarch64-apple-ios-sim/release/$(LIB) -headers $(BUILD_DIR)/headers \
+		-library $(BUILD_DIR)/macos/$(LIB) -headers $(BUILD_DIR)/headers \
+		-output TursoSdkKit.xcframework
+
+clean:
+	rm -rf TursoSdkKit.xcframework $(BUILD_DIR)
+
+test: xcframework
+	swift test

--- a/bindings/swift/Package.swift
+++ b/bindings/swift/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "Turso",
+    platforms: [.iOS(.v16), .macOS(.v13)],
+    products: [
+        .library(name: "Turso", targets: ["Turso"])
+    ],
+    targets: [
+        .binaryTarget(name: "TursoSdkKit", path: "TursoSdkKit.xcframework"),
+        .target(
+            name: "Turso",
+            dependencies: ["TursoSdkKit"],
+            linkerSettings: [
+                .linkedFramework("Security"),
+                .linkedFramework("CoreServices"),
+            ]
+        ),
+        .testTarget(name: "TursoTests", dependencies: ["Turso"]),
+    ]
+)

--- a/bindings/swift/Sources/Turso/Turso.swift
+++ b/bindings/swift/Sources/Turso/Turso.swift
@@ -1,0 +1,8 @@
+import CTurso
+
+public enum TursoRuntime {
+    /// Turso engine version (sem-ver string).
+    public static var version: String {
+        String(cString: turso_version())
+    }
+}

--- a/bindings/swift/Support/module.modulemap
+++ b/bindings/swift/Support/module.modulemap
@@ -1,0 +1,4 @@
+module CTurso {
+    header "turso.h"
+    export *
+}

--- a/bindings/swift/Tests/TursoTests/SmokeTests.swift
+++ b/bindings/swift/Tests/TursoTests/SmokeTests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import Turso
+
+@Test func versionIsSemver() {
+    let version = TursoRuntime.version
+    #expect(!version.isEmpty)
+    #expect(version.split(separator: ".").count >= 3)
+}


### PR DESCRIPTION
First slice of Swift bindings for Turso, towards #1950.

This PR is deliberately just the foundation: the build pipeline that turns `turso_sdk_kit` into an xcframework, and a SwiftPM package that links it. The only API it exposes is `TursoRuntime.version`, which exists to prove the seam works end to end — Rust static libs for the four Apple targets, the C header, the module map, and SwiftPM linking against all of it.

The actual API layer (a `Database`/`Connection` design built on Swift 6 actors and strict concurrency) is written and follows in a separate PR. Splitting it that way keeps the build plumbing and the API design from landing in one review.

## What's here

- `bindings/swift/Makefile` — builds `turso_sdk_kit` for `aarch64-apple-ios`, `aarch64-apple-ios-sim`, and both macOS arches, `lipo`s the macOS pair, and assembles `TursoSdkKit.xcframework`.
- `bindings/swift/Package.swift` — SwiftPM package with a binary target for the xcframework; Swift 6 tools version, iOS 16 / macOS 13 floor.
- A smoke test asserting `turso_version()` round-trips into a Swift string.
- A macOS CI job mirroring the existing react-native iOS job, plus a labeler entry.

## Notes and open questions

- **The xcframework is gitignored, not committed.** A fresh clone needs `make -C bindings/swift xcframework` before `swift build` works. That keeps a large binary out of git, but it also means the package isn't consumable straight from a git URL. Happy to change this if you'd rather ship it another way — a release artifact plus a remote `binaryTarget` checksum being the other obvious option.
- **CI runs on every PR**, matching `react-native.yml`. If macOS runner minutes are a concern I can add a `paths:` filter so it only fires on `bindings/swift/**`.
- The `bindings/swift` label needs creating repo-side before the labeler entry does anything.

Tested locally on macOS 15 (Apple silicon): `make -C bindings/swift xcframework && swift test`.
