### PR TITLE
testing/sqltest: declare strict capability for the Rust backend

### DIFF
--- a/testing/sqltest/src/backends/rust.rs
+++ b/testing/sqltest/src/backends/rust.rs
@@ -83,6 +83,7 @@ impl SqlBackend for RustBackend {
     fn capabilities(&self) -> HashSet<Capability> {
         HashSet::from_iter([
             Capability::Trigger,
+            Capability::Strict,
             Capability::MaterializedViews,
             Capability::CustomTypes,
         ])


### PR DESCRIPTION
STRICT tables are not experimental and work unconditionally in the engine, but the Rust-bindings backend omitted Capability::Strict, so every test marked '@requires strict' was silently skipped under --backend rust. Declare the capability so those tests actually run.

Tests: full conformance suite passes on the rust backend with the previously-skipped strict-gated tests now running.