### PR TITLE
Fix partial index alias panic

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -6009,24 +6009,55 @@ impl Index {
         ok
     }
 
+    /// Bind a copy of this index's WHERE clause against the given table references.
+    ///
+    /// Returns `Ok(None)` when the index has no WHERE clause. Binding errors are
+    /// propagated, never swallowed: callers must not treat `None` as "binding failed".
+    ///
+    /// The predicate may qualify columns with the table's real name
+    /// (e.g. `CREATE INDEX i ON t(a) WHERE t.b > 0`), while the DML statement
+    /// may refer to that table only under an alias (e.g. `UPDATE t AS z ...`).
+    /// Rewrite such qualifiers to the identifier the statement uses, so the
+    /// predicate always resolves against the index's own table, like in SQLite.
     pub fn bind_where_expr(
         &self,
         table_refs: Option<&mut TableReferences>,
         resolver: &Resolver,
-    ) -> Option<ast::Expr> {
+    ) -> crate::Result<Option<ast::Expr>> {
         let Some(where_clause) = &self.where_clause else {
-            return None;
+            return Ok(None);
         };
         let mut expr = where_clause.clone();
+        let target_identifier = table_refs.as_deref().and_then(|refs| {
+            refs.joined_tables()
+                .iter()
+                .map(|jt| (&jt.identifier, jt.table.get_name()))
+                .chain(
+                    refs.outer_query_refs()
+                        .iter()
+                        .map(|r| (&r.identifier, r.table.get_name())),
+                )
+                .find(|(_, table_name)| normalize_ident(table_name) == self.table_name)
+                .map(|(identifier, _)| identifier.clone())
+        });
+        if let Some(identifier) = target_identifier {
+            walk_expr_mut(&mut expr, &mut |e: &mut Expr| {
+                if let Expr::Qualified(ns, _) | Expr::DoublyQualified(_, ns, _) = e {
+                    if normalize_ident(ns.as_str()) == self.table_name {
+                        *ns = Name::exact(identifier.clone());
+                    }
+                }
+                Ok(WalkControl::Continue)
+            })?;
+        }
         bind_and_rewrite_expr(
             &mut expr,
             table_refs,
             None,
             resolver,
             BindingBehavior::ResultColumnsNotAllowed,
-        )
-        .ok()?;
-        Some(*expr)
+        )?;
+        Ok(Some(*expr))
     }
 }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -6029,16 +6029,31 @@ impl Index {
         };
         let mut expr = where_clause.clone();
         let target_identifier = table_refs.as_deref().and_then(|refs| {
-            refs.joined_tables()
+            // Only a real b-tree table can be the DML target that owns this index.
+            // A CTE or subquery sharing the table's name (e.g. `WITH t AS ...
+            // UPDATE t ...`) must not be picked, so match on b-tree identity.
+            let mut matches = refs
+                .joined_tables()
                 .iter()
-                .map(|jt| (&jt.identifier, jt.table.get_name()))
+                .map(|jt| (&jt.identifier, &jt.table))
                 .chain(
                     refs.outer_query_refs()
                         .iter()
-                        .map(|r| (&r.identifier, r.table.get_name())),
+                        .map(|r| (&r.identifier, &r.table)),
                 )
-                .find(|(_, table_name)| normalize_ident(table_name) == self.table_name)
-                .map(|(identifier, _)| identifier.clone())
+                .filter(|(_, table)| {
+                    table
+                        .btree()
+                        .is_some_and(|bt| normalize_ident(&bt.name) == self.table_name)
+                })
+                .map(|(identifier, _)| identifier);
+            let target = matches.next().cloned();
+            assert!(
+                matches.next().is_none(),
+                "multiple table references match the table of partial index {}",
+                self.name
+            );
+            target
         });
         if let Some(identifier) = target_identifier {
             walk_expr_mut(&mut expr, &mut |e: &mut Expr| {

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -993,7 +993,7 @@ pub fn translate_alter_table(
                         }],
                     );
                     let where_copy = index
-                        .bind_where_expr(Some(&mut table_references), resolver)
+                        .bind_where_expr(Some(&mut table_references), resolver)?
                         .ok_or_else(|| {
                             LimboError::ParseError(
                                 "index where clause unexpectedly missing".to_string(),

--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -709,8 +709,8 @@ fn emit_delete_row_common(
         for (index, index_cursor_id) in indexes_to_delete {
             let skip_delete_label = if index.where_clause.is_some() {
                 let where_copy = index
-                    .bind_where_expr(Some(table_references), resolver)
-                    .expect("where clause to exist");
+                    .bind_where_expr(Some(table_references), resolver)?
+                    .expect("index.where_clause was checked to be Some above");
                 let skip_label = program.allocate_label();
                 let reg = program.alloc_register();
                 translate_expr_no_constant_opt(

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -1782,8 +1782,8 @@ fn emit_update_insns<'a>(
             // This means that we need to bind the column references to a copy of the index Expr,
             // so we can emit Insn::Column instructions and refer to the old values.
             let where_clause = index
-                .bind_where_expr(Some(table_references), resolver)
-                .expect("where clause to exist");
+                .bind_where_expr(Some(table_references), resolver)?
+                .expect("index.where_clause was checked to be Some above");
             let old_satisfied_reg = program.alloc_register();
             translate_expr_no_constant_opt(
                 program,

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -350,7 +350,7 @@ fn emit_refill_index(
         }],
         vec![],
     );
-    let where_clause = idx.bind_where_expr(Some(&mut table_references), resolver);
+    let where_clause = idx.bind_where_expr(Some(&mut table_references), resolver)?;
 
     if idx
         .index_method

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -3827,8 +3827,8 @@ fn emit_replace_delete_conflicting_row(
             .expect("index to exist");
         let skip_delete_label = if index.where_clause.is_some() {
             let where_copy = index
-                .bind_where_expr(Some(table_references), resolver)
-                .expect("where clause to exist");
+                .bind_where_expr(Some(table_references), resolver)?
+                .expect("index.where_clause was checked to be Some above");
             let skip_label = program.allocate_label();
             let reg = program.alloc_register();
             translate_expr_no_constant_opt(

--- a/sqlite/conformance/sqlite-sqltests/partial_idx.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/partial_idx.sqltest
@@ -1538,3 +1538,15 @@ expect {
     1|10|-5
     0
 }
+
+@cross-check-integrity
+test partial-index-qualified-where-update-with-cte-named-like-target {
+    CREATE TABLE t (a INTEGER, b INTEGER);
+    CREATE INDEX t_positive_b ON t(a) WHERE t.b > 0;
+    INSERT INTO t VALUES (1, 1);
+    WITH t(x) AS (SELECT 2) UPDATE t SET a = 5 WHERE b > 0;
+    SELECT a, b FROM t;
+}
+expect {
+    5|1
+}

--- a/sqlite/conformance/sqlite-sqltests/partial_idx.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/partial_idx.sqltest
@@ -1466,3 +1466,75 @@ expect {
 snapshot-eqp partial-index-multi-index-or-rejects-unproven-partial-index-eqp {
     SELECT a, b, c FROM indexed_items WHERE a = 2 OR c = 3 ORDER BY b, c;
 }
+
+setup partial_index_qualified_where_alias_schema {
+    CREATE TABLE orders (id INTEGER PRIMARY KEY, amount INTEGER, active INTEGER);
+    CREATE INDEX idx_active_amount ON orders(amount) WHERE orders.active = 1;
+    INSERT INTO orders VALUES (1, 10, 1), (2, 20, 0), (3, 30, 1);
+}
+
+@setup partial_index_qualified_where_alias_schema
+@cross-check-integrity
+test partial-index-qualified-where-update-aliased-table {
+    UPDATE orders AS o SET amount = amount + 100;
+    SELECT id, amount, active FROM orders ORDER BY id;
+}
+expect {
+    1|110|1
+    2|120|0
+    3|130|1
+}
+
+@setup partial_index_qualified_where_alias_schema
+@cross-check-integrity
+test partial-index-qualified-where-update-aliased-table-moves-rows-in-and-out-of-index {
+    UPDATE orders AS o SET active = 1 - active;
+    SELECT id, amount, active FROM orders ORDER BY id;
+}
+expect {
+    1|10|0
+    2|20|1
+    3|30|0
+}
+
+@setup partial_index_qualified_where_alias_schema
+@cross-check-integrity
+test partial-index-qualified-where-delete-from-aliased-table {
+    DELETE FROM orders AS o WHERE o.amount > 15;
+    SELECT id, amount, active FROM orders ORDER BY id;
+}
+expect {
+    1|10|1
+}
+
+@cross-check-integrity
+test partial-index-qualified-where-update-from-with-aliased-target {
+    CREATE TABLE src_totals (a INTEGER, b INTEGER);
+    CREATE TABLE deltas (a INTEGER, b INTEGER);
+    CREATE INDEX src_totals_positive_b ON src_totals(a) WHERE src_totals.b > 0;
+    INSERT INTO src_totals VALUES (1, 1), (2, 5), (3, 1);
+    INSERT INTO deltas VALUES (1, 100), (3, 100);
+    UPDATE src_totals AS z SET b = -z.b FROM deltas WHERE z.a = deltas.a;
+    SELECT a, b FROM src_totals ORDER BY a;
+    SELECT a FROM src_totals INDEXED BY src_totals_positive_b WHERE a > -1000 AND b > 0 ORDER BY a;
+}
+expect {
+    1|-1
+    2|5
+    3|-1
+    2
+}
+
+@cross-check-integrity
+test partial-index-qualified-where-upsert-with-aliased-target {
+    CREATE TABLE v (k INTEGER PRIMARY KEY, c INTEGER, d INTEGER);
+    CREATE INDEX v_positive_d ON v(c) WHERE v.d > 0;
+    INSERT INTO v VALUES (1, 10, 1);
+    INSERT INTO v AS z VALUES (1, 20, -1) ON CONFLICT(k) DO UPDATE SET d = -5;
+    SELECT k, c, d FROM v ORDER BY k;
+    SELECT count(*) FROM v INDEXED BY v_positive_d WHERE c > -1000 AND d > 0;
+}
+expect {
+    1|10|-5
+    0
+}


### PR DESCRIPTION
The query now panics:
```
turso> CREATE TABLE t(a, b);
turso> CREATE INDEX i ON t(a) WHERE t.b > 0;
turso> UPDATE t AS z SET a = 1;

thread 'main' (3838572) panicked at core/translate/emitter/update.rs:1786:18:
where clause to exist
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The problem is two fold:
- Incorrect resolution of tables under partial index WHERE clause when original table was aliased in the top query
- The missing error propagation which was masked with None result which triggered panic in the expect

This PR fixes table name resolution of partial index WHERE clauses in update VDBE emit phase and propagate proper error from the resolution.