### PR TITLE
core: use index seeks for IS, like SQLite

### DIFF
--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -349,10 +349,7 @@ pub fn translate_condition_expr(
         // Handle IS TRUE/IS FALSE/IS NOT TRUE/IS NOT FALSE in conditions
         // Delegate to translate_expr which handles these correctly with IsTrue instruction
         ast::Expr::Binary(_, ast::Operator::Is | ast::Operator::IsNot, e2)
-            if matches!(
-                e2.as_ref(),
-                ast::Expr::Literal(ast::Literal::True) | ast::Expr::Literal(ast::Literal::False)
-            ) =>
+            if truth_test_rhs(e2).is_some() =>
         {
             let reg = program.alloc_register();
             translate_expr(program, Some(referenced_tables), expr, reg, resolver)?;

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -106,7 +106,8 @@ pub use translator::{
     resolve_expr, translate_expr, translate_expr_no_constant_opt, NoConstantOptReason,
 };
 pub use utils::{
-    as_binary_components, maybe_apply_affinity, sanitize_string, unwrap_parens, unwrap_parens_owned,
+    as_binary_components, maybe_apply_affinity, sanitize_string, truth_test_rhs, unwrap_parens,
+    unwrap_parens_owned,
 };
 pub use vectors::expr_vector_size;
 pub use walk::{

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -382,17 +382,9 @@ pub fn translate_expr(
         ast::Expr::Binary(e1, op, e2) => {
             // Handle IS TRUE/IS FALSE/IS NOT TRUE/IS NOT FALSE specially.
             // These use truth semantics (only non-zero numbers are truthy) rather than equality.
-            if let Some((is_not, is_true_literal)) = match (op, e2.as_ref()) {
-                (ast::Operator::Is, ast::Expr::Literal(ast::Literal::True)) => Some((false, true)),
-                (ast::Operator::Is, ast::Expr::Literal(ast::Literal::False)) => {
-                    Some((false, false))
-                }
-                (ast::Operator::IsNot, ast::Expr::Literal(ast::Literal::True)) => {
-                    Some((true, true))
-                }
-                (ast::Operator::IsNot, ast::Expr::Literal(ast::Literal::False)) => {
-                    Some((true, false))
-                }
+            if let Some((is_not, is_true_literal)) = match (op, truth_test_rhs(e2)) {
+                (ast::Operator::Is, Some(is_true_literal)) => Some((false, is_true_literal)),
+                (ast::Operator::IsNot, Some(is_true_literal)) => Some((true, is_true_literal)),
                 _ => None,
             } {
                 let reg = program.alloc_register();

--- a/core/translate/expr/utils.rs
+++ b/core/translate/expr/utils.rs
@@ -69,6 +69,27 @@ pub fn unwrap_parens(expr: &ast::Expr) -> Result<&ast::Expr> {
     }
 }
 
+/// If the right-hand side of `IS` / `IS NOT` is the TRUE or FALSE keyword —
+/// possibly inside parentheses or under COLLATE — return its boolean value.
+/// `x IS TRUE` and friends then test the truth of x instead of comparing
+/// values. SQLite behaves the same way: it resolves the keyword after
+/// skipping COLLATE, and its grammar collapses parentheses (resolve.c,
+/// `sqlite3ExprSkipCollateAndLikely`). A unary `+` blocks the keyword there
+/// too, so `x IS +TRUE` stays an ordinary comparison with 1.
+///
+/// Every place that decides "is this a truth test?" — the expression
+/// evaluator, the condition emitter, and the index-seek guard in the
+/// optimizer — must call this one function, so they cannot drift apart.
+pub fn truth_test_rhs(expr: &ast::Expr) -> Option<bool> {
+    match expr {
+        ast::Expr::Literal(ast::Literal::True) => Some(true),
+        ast::Expr::Literal(ast::Literal::False) => Some(false),
+        ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => truth_test_rhs(&exprs[0]),
+        ast::Expr::Collate(inner, _) => truth_test_rhs(inner),
+        _ => None,
+    }
+}
+
 /// Recursively unwrap parentheses from an owned Expr.
 /// Returns how many pairs of parentheses were removed.
 pub fn unwrap_parens_owned(expr: ast::Expr) -> Result<(ast::Expr, usize)> {

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -389,6 +389,7 @@ where
         num_regs,
         target_pc: done,
         eq_only: true,
+        null_matching_mask: 0,
     });
 
     let loop_top = program.allocate_label();

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -389,7 +389,7 @@ where
         num_regs,
         target_pc: done,
         eq_only: true,
-        null_matching_mask: 0,
+        null_matching_mask: Default::default(),
     });
 
     let loop_top = program.allocate_label();

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -448,11 +448,55 @@ fn emit_loop_source<'a>(
     }
 }
 
+/// Whether every column a condition reads holds the right value at the
+/// unmatched-row scan point.
+///
+/// A column is readable if its table's cursor is one of `allowed` and so still
+/// positioned, or if it lives in `payload_regs` — this hash join's payload,
+/// which the unmatched scan reloads for each row it produces. Registers cached
+/// by anything else are stale here: nothing refills them once the probe loop has
+/// exited. Skipping a condition whose columns are all readable silently drops it
+/// from the null-extended rows, letting through rows the query filtered out.
+fn condition_operands_are_available(
+    expr: &Expr,
+    table_references: &TableReferences,
+    allowed: &TableMask,
+    resolver: &Resolver,
+    payload_regs: Range<usize>,
+) -> bool {
+    let mut ok = true;
+    let _ = walk_expr(expr, &mut |e: &Expr| -> Result<WalkControl> {
+        let (Expr::Column { table, .. } | Expr::RowId { table, .. }) = e else {
+            return Ok(WalkControl::Continue);
+        };
+        if resolver
+            .resolve_cached_expr_reg(e)
+            .is_some_and(|(reg, ..)| payload_regs.contains(&reg))
+        {
+            return Ok(WalkControl::SkipChildren);
+        }
+        if let Some(idx) = table_references
+            .joined_tables()
+            .iter()
+            .position(|t| t.internal_id == *table)
+        {
+            if !allowed.get(idx) {
+                ok = false;
+                return Ok(WalkControl::SkipChildren);
+            }
+        }
+        // Outer query references are already in scope — allow them.
+        Ok(WalkControl::Continue)
+    });
+    ok
+}
+
 /// Emit WHERE conditions and inner-loop entry for an unmatched outer hash join row.
 ///
 /// Filters applicable WHERE terms (non-ON, non-consumed), optionally restricted to
-/// `build_table_idx` / `probe_table_idx` when a Gosub wraps inner tables. Then either
-/// enters the inner-loop subroutine via Gosub or calls `emit_loop` directly.
+/// the ones whose columns are readable here when a Gosub wraps inner tables. Then
+/// either enters the inner-loop subroutine via Gosub or calls `emit_loop` directly.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn emit_unmatched_row_conditions_and_loop<'a>(
     program: &mut ProgramBuilder,
     t_ctx: &mut TranslateCtx<'a>,
@@ -461,6 +505,7 @@ pub(super) fn emit_unmatched_row_conditions_and_loop<'a>(
     probe_table_idx: usize,
     skip_label: BranchOffset,
     gosub: Option<(usize, BranchOffset)>,
+    payload_regs: Range<usize>,
 ) -> Result<()> {
     let has_gosub = gosub.is_some();
     let allowed_tables = {
@@ -483,14 +528,22 @@ pub(super) fn emit_unmatched_row_conditions_and_loop<'a>(
         }
         m
     };
-    for cond in plan
+    let conditions = plan
         .where_clause
         .iter()
         .filter(|c| !c.consumed && c.from_outer_join.is_none())
         .filter(|c| {
-            !has_gosub || expr_tables_subset_of(&c.expr, &plan.table_references, &allowed_tables)
+            !has_gosub
+                || condition_operands_are_available(
+                    &c.expr,
+                    &plan.table_references,
+                    &allowed_tables,
+                    &t_ctx.resolver,
+                    payload_regs.clone(),
+                )
         })
-    {
+        .collect::<Vec<_>>();
+    for cond in conditions {
         let jump_target_when_true = program.allocate_label();
         let condition_metadata = ConditionMetadata {
             jump_if_condition_is_true: false,

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -534,10 +534,15 @@ pub(super) fn emit_autoindex(
         affinity_str: affinity_str.map(|s| (**s).clone()),
     });
     // Skip bloom filter for non-binary collations since it uses binary hashing.
+    // Also skip it when any seek key component comes from a NULL-matching `IS`:
+    // the probe treats a NULL key as "definitely absent", which would skip rows
+    // whose key IS NULL, so such a seek never probes — and then building the
+    // filter would be wasted work on every row.
     let use_bloom_filter = index.columns.iter().take(num_seek_keys).all(|col| {
         col.collation
             .is_none_or(|coll| matches!(coll, CollationSeq::Binary | CollationSeq::Unset))
-    }) && seek_def.start.op.eq_only();
+    }) && seek_def.start.op.eq_only()
+        && (0..num_seek_keys).all(|i| !seek_def.is_null_matching_key_component(i));
     if use_bloom_filter {
         program.emit_insn(Insn::FilterAdd {
             cursor_id: index_cursor_id,

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -1088,6 +1088,10 @@ impl<'a, 'plan> HashProbeCloseEmitter<'a, 'plan> {
                     self.hash_ctx
                         .inner_loop_gosub_reg
                         .zip(self.hash_ctx.labels.inner_loop_gosub),
+                    payload_regs(
+                        self.hash_ctx.payload_start_reg,
+                        self.hash_ctx.payload_columns.len(),
+                    ),
                 )?;
             }
         }
@@ -1181,6 +1185,7 @@ pub(super) fn emit_hash_join_unmatched_build_rows<'a>(
         hash_ctx
             .inner_loop_gosub_reg
             .zip(hash_ctx.labels.inner_loop_gosub),
+        payload_regs(payload_dest_reg, num_payload),
     )?;
 
     program.preassign_label_to_next_insn(label_next_unmatched);
@@ -1196,6 +1201,15 @@ pub(super) fn emit_hash_join_unmatched_build_rows<'a>(
     });
     program.preassign_label_to_next_insn(done_unmatched);
     Ok(())
+}
+
+/// The registers holding this hash join's payload, which the unmatched-row paths
+/// refill for every row they emit. Empty when the join carries no payload.
+fn payload_regs(start_reg: Option<usize>, num_payload: usize) -> Range<usize> {
+    match start_reg {
+        Some(start) => start..start + num_payload,
+        None => 0..0,
+    }
 }
 
 /// Grace Hash Join processing loop after the probe cursor is exhausted.
@@ -1373,6 +1387,7 @@ impl GraceHashLoop {
                     hash_ctx
                         .inner_loop_gosub_reg
                         .zip(hash_ctx.labels.inner_loop_gosub),
+                    payload_regs(payload_dest_reg, num_payload),
                 )?;
             }
 
@@ -1430,6 +1445,7 @@ impl GraceHashLoop {
                     hash_ctx
                         .inner_loop_gosub_reg
                         .zip(hash_ctx.labels.inner_loop_gosub),
+                    payload_regs(payload_dest_reg, num_payload),
                 )?;
 
                 program.preassign_label_to_next_insn(grace_next_unmatched);

--- a/core/translate/main_loop/mod.rs
+++ b/core/translate/main_loop/mod.rs
@@ -36,7 +36,6 @@ use crate::{
     },
     turso_assert, turso_assert_eq,
     types::SeekOp,
-    util::expr_tables_subset_of,
     vdbe::{
         affinity::{self, Affinity},
         builder::{
@@ -48,7 +47,7 @@ use crate::{
     },
     Result,
 };
-use std::{borrow::Cow, collections::HashSet, sync::Arc};
+use std::{borrow::Cow, collections::HashSet, ops::Range, sync::Arc};
 use turso_macros::turso_assert_some;
 
 mod body;

--- a/core/translate/main_loop/multi_index.rs
+++ b/core/translate/main_loop/multi_index.rs
@@ -282,6 +282,7 @@ fn emit_in_seek_multi_index_branch(
             target_pc: next_value_label,
             is_index: true,
             eq_only: false,
+            null_matching_mask: 0,
         });
         program.preassign_label_to_next_insn(branch_loop_start);
         program.emit_insn(Insn::IdxGT {

--- a/core/translate/main_loop/multi_index.rs
+++ b/core/translate/main_loop/multi_index.rs
@@ -282,7 +282,7 @@ fn emit_in_seek_multi_index_branch(
             target_pc: next_value_label,
             is_index: true,
             eq_only: false,
-            null_matching_mask: 0,
+            null_matching_mask: Default::default(),
         });
         program.preassign_label_to_next_insn(branch_loop_start);
         program.emit_insn(Insn::IdxGT {

--- a/core/translate/main_loop/open.rs
+++ b/core/translate/main_loop/open.rs
@@ -477,6 +477,7 @@ impl OpenLoop {
                                     target_pc: next_val_label,
                                     is_index: true,
                                     eq_only: false,
+                                    null_matching_mask: 0,
                                 });
                                 program.preassign_label_to_next_insn(loop_start);
                                 program.emit_insn(Insn::IdxGT {

--- a/core/translate/main_loop/open.rs
+++ b/core/translate/main_loop/open.rs
@@ -477,7 +477,7 @@ impl OpenLoop {
                                     target_pc: next_val_label,
                                     is_index: true,
                                     eq_only: false,
-                                    null_matching_mask: 0,
+                                    null_matching_mask: Default::default(),
                                 });
                                 program.preassign_label_to_next_insn(loop_start);
                                 program.emit_insn(Insn::IdxGT {

--- a/core/translate/main_loop/seek.rs
+++ b/core/translate/main_loop/seek.rs
@@ -225,13 +225,18 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
                     affinities,
                 });
             }
-            // The bloom filter neither stores nor probes NULLs (a NULL key can
-            // never satisfy `=`), so a NULL-matching seek cannot use it: probing
-            // would report "definitely not present" for keys that do match.
-            if use_bloom_filter && null_matching_mask.is_empty() {
+            if use_bloom_filter {
                 turso_assert!(
                     idx.ephemeral,
                     "bloom filter can only be used with ephemeral indexes"
+                );
+                // The probe treats a NULL key as "definitely absent", which
+                // would skip rows whose key IS NULL. `emit_autoindex` never
+                // builds a filter for a NULL-matching seek, so probing one
+                // here means the build and probe decisions have diverged.
+                turso_assert!(
+                    null_matching_mask.is_empty(),
+                    "a NULL-matching seek must not probe a bloom filter"
                 );
                 self.program.emit_insn(Insn::Filter {
                     cursor_id: self.seek_cursor_id,

--- a/core/translate/main_loop/seek.rs
+++ b/core/translate/main_loop/seek.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::translate::plan::BitSet;
 use turso_parser::ast::NullsOrder;
 
 fn index_seek_affinities(seek_def: &SeekDef, seek_key: &SeekKey) -> String {
@@ -199,9 +200,12 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
         // Which key components match NULL rather than comparing with `=`; the
         // seek and the bloom-filter probe keep their "NULL key cannot match"
         // shortcut for the rest.
-        let null_matching_mask = (0..num_regs.min(64))
-            .filter(|i| self.seek_def.is_null_matching_key_component(*i))
-            .fold(0u64, |mask, i| mask | (1u64 << i));
+        let mut null_matching_mask = BitSet::default();
+        for i in 0..num_regs {
+            if self.seek_def.is_null_matching_key_component(i) {
+                null_matching_mask.set(i)?;
+            }
+        }
 
         if let Some(idx) = self.seek_index {
             encode_seek_keys_for_custom_types(
@@ -224,7 +228,7 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
             // The bloom filter neither stores nor probes NULLs (a NULL key can
             // never satisfy `=`), so a NULL-matching seek cannot use it: probing
             // would report "definitely not present" for keys that do match.
-            if use_bloom_filter && null_matching_mask == 0 {
+            if use_bloom_filter && null_matching_mask.is_empty() {
                 turso_assert!(
                     idx.ephemeral,
                     "bloom filter can only be used with ephemeral indexes"

--- a/core/translate/main_loop/seek.rs
+++ b/core/translate/main_loop/seek.rs
@@ -176,7 +176,13 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
                         &self.t_ctx.resolver,
                         NoConstantOptReason::RegisterReuse,
                     )?;
-                    if !expr.is_nonnull(self.tables) {
+                    // A NULL key can never satisfy `=`, so the loop is done as
+                    // soon as one shows up. `IS` matches NULL instead: keep the
+                    // NULL in the seek register and let the index comparison
+                    // find the rows whose key component is NULL.
+                    if !expr.is_nonnull(self.tables)
+                        && !self.seek_def.is_null_matching_key_component(i)
+                    {
                         self.program.emit_insn(Insn::IsNull {
                             reg,
                             target_pc: self.loop_end,
@@ -190,6 +196,12 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
             }
         }
         let num_regs = self.seek_def.size(&self.seek_def.start);
+        // Which key components match NULL rather than comparing with `=`; the
+        // seek and the bloom-filter probe keep their "NULL key cannot match"
+        // shortcut for the rest.
+        let null_matching_mask = (0..num_regs.min(64))
+            .filter(|i| self.seek_def.is_null_matching_key_component(*i))
+            .fold(0u64, |mask, i| mask | (1u64 << i));
 
         if let Some(idx) = self.seek_index {
             encode_seek_keys_for_custom_types(
@@ -209,7 +221,10 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
                     affinities,
                 });
             }
-            if use_bloom_filter {
+            // The bloom filter neither stores nor probes NULLs (a NULL key can
+            // never satisfy `=`), so a NULL-matching seek cannot use it: probing
+            // would report "definitely not present" for keys that do match.
+            if use_bloom_filter && null_matching_mask == 0 {
                 turso_assert!(
                     idx.ephemeral,
                     "bloom filter can only be used with ephemeral indexes"
@@ -231,6 +246,7 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
                 num_regs,
                 target_pc: self.loop_end,
                 eq_only,
+                null_matching_mask,
             }),
             SeekOp::GT => self.program.emit_insn(Insn::SeekGT {
                 is_index: self.is_index,
@@ -246,6 +262,7 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
                 num_regs,
                 target_pc: self.loop_end,
                 eq_only,
+                null_matching_mask,
             }),
             SeekOp::LT => self.program.emit_insn(Insn::SeekLT {
                 is_index: self.is_index,

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -294,7 +294,9 @@ pub(super) fn choose_best_btree_candidate(
                     0,
                     schema,
                     EqualityPrefixScope::AnyEquality,
-                ) == order_target.columns.len();
+                )
+                .consumed
+                    == order_target.columns.len();
                 let all_opposite_direction = btree_access_order_consumed(
                     rhs_table,
                     IterationDirection::Backwards,
@@ -304,7 +306,9 @@ pub(super) fn choose_best_btree_candidate(
                     0,
                     schema,
                     EqualityPrefixScope::AnyEquality,
-                ) == order_target.columns.len();
+                )
+                .consumed
+                    == order_target.columns.len();
 
                 let satisfies_order = all_same_direction || all_opposite_direction;
                 if satisfies_order {
@@ -1802,7 +1806,9 @@ fn materialized_subquery_order_properties(
         0,
         schema,
         EqualityPrefixScope::AnyEquality,
-    ) == order_target.columns.len();
+    )
+    .consumed
+        == order_target.columns.len();
     let all_opposite_direction = btree_access_order_consumed(
         rhs_table,
         IterationDirection::Backwards,
@@ -1812,7 +1818,9 @@ fn materialized_subquery_order_properties(
         0,
         schema,
         EqualityPrefixScope::AnyEquality,
-    ) == order_target.columns.len();
+    )
+    .consumed
+        == order_target.columns.len();
 
     if !(all_same_direction || all_opposite_direction) {
         return (IterationDirection::Forwards, false, Cost(0.0));

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -1040,6 +1040,18 @@ pub fn find_equijoin_conditions(
             continue;
         }
 
+        // An ON-clause term of an outer join decides what counts as a match
+        // for that join only. A term that belongs to a *different* join's ON
+        // clause may legally mention only these two tables (an ON clause can
+        // reference any table to its left), but it must not become this
+        // join's key — it filters the rows of its own join instead.
+        if where_term
+            .from_outer_join
+            .is_some_and(|owner| owner != probe_table_id)
+        {
+            continue;
+        }
+
         let Ok(Some((lhs, op, rhs))) = as_binary_components(&where_term.expr) else {
             continue;
         };

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -504,6 +504,17 @@ pub fn constraints_from_where_clause(
 
             // Try to extract as binary expression first
             if let Some((lhs, operator, rhs)) = as_binary_components(&term.expr)? {
+                // `x IS TRUE` checks whether x is true; it does not compare x
+                // with 1. For example, `2 IS TRUE` is true, so an index lookup
+                // for 1 would miss that row. The same rule applies to FALSE.
+                if matches!(operator.as_ast_operator(), Some(ast::Operator::Is))
+                    && matches!(
+                        rhs,
+                        ast::Expr::Literal(ast::Literal::True | ast::Literal::False)
+                    )
+                {
+                    continue;
+                }
                 // Resolve the comparison affinity once per term per SQLite's
                 // `comparisonAffinity` (see `Constraint::comparison_affinity`)
                 // and propagate it to every constraint derived from this term.

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -511,6 +511,19 @@ pub fn constraints_from_where_clause(
                     .as_ast_operator()
                     .filter(|op| op.is_comparison())
                     .map(|_| comparison_affinity(lhs, rhs, Some(table_references), None));
+                // `IS` is the one seek-usable operator that can be TRUE for a
+                // null-extended row (`e.id IS NULL`). Such a WHERE term must not
+                // constrain the loop of an outer join's RHS table: filtering the
+                // RHS by it removes the very rows whose absence produces the null
+                // extension, so an antijoin would report every LHS row as
+                // unmatched. Terms from that join's own ON clause are fine, since
+                // they define what counts as a match.
+                let usable = !matches!(operator.as_ast_operator(), Some(ast::Operator::Is))
+                    || !table_reference
+                        .join_info
+                        .as_ref()
+                        .is_some_and(|join| join.is_outer())
+                    || term.from_outer_join == Some(table_reference.internal_id);
                 // If either the LHS or RHS of the constraint is a column from the table, add the constraint.
                 match lhs {
                     ast::Expr::Column { table, column, .. } => {
@@ -532,7 +545,7 @@ pub fn constraints_from_where_clause(
                                     params,
                                     false,
                                 ),
-                                usable: true,
+                                usable,
                                 is_rowid: false,
                                 comparison_affinity: cmp_aff,
                             });
@@ -561,7 +574,7 @@ pub fn constraints_from_where_clause(
                                     params,
                                     true,
                                 ),
-                                usable: true,
+                                usable,
                                 is_rowid: true,
                                 comparison_affinity: cmp_aff,
                             });
@@ -599,7 +612,7 @@ pub fn constraints_from_where_clause(
                             constraining_expr: None,
                             lhs_mask: table_mask_from_expr(rhs, table_references, subqueries)?,
                             selectivity,
-                            usable: true,
+                            usable,
                             is_rowid: false,
                             comparison_affinity: cmp_aff,
                         });
@@ -626,7 +639,7 @@ pub fn constraints_from_where_clause(
                                     params,
                                     false,
                                 ),
-                                usable: true,
+                                usable,
                                 is_rowid: false,
                                 comparison_affinity: cmp_aff,
                             });
@@ -655,7 +668,7 @@ pub fn constraints_from_where_clause(
                                     params,
                                     true,
                                 ),
-                                usable: true,
+                                usable,
                                 is_rowid: true,
                                 comparison_affinity: cmp_aff,
                             });
@@ -693,7 +706,7 @@ pub fn constraints_from_where_clause(
                             constraining_expr: None,
                             lhs_mask: table_mask_from_expr(lhs, table_references, subqueries)?,
                             selectivity,
-                            usable: true,
+                            usable,
                             is_rowid: false,
                             comparison_affinity: cmp_aff,
                         });
@@ -856,9 +869,9 @@ pub fn constraints_from_where_clause(
         // sort equalities first so that index keys will be properly constructed.
         // see e.g.: https://www.solarwinds.com/blog/the-left-prefix-index-rule
         cs.constraints.sort_by(|a, b| {
-            if a.operator == ast::Operator::Equals.into() {
+            if is_equality_operator(a.operator) {
                 Ordering::Less
-            } else if b.operator == ast::Operator::Equals.into() {
+            } else if is_equality_operator(b.operator) {
                 Ordering::Greater
             } else {
                 Ordering::Equal
@@ -1199,7 +1212,7 @@ pub fn usable_constraints_for_lhs_mask(
         }
         let operator = constraints[cref.constraint_vec_pos].operator;
         let table_col_pos = constraints[cref.constraint_vec_pos].table_col_pos;
-        if operator == ast::Operator::Equals.into()
+        if is_equality_operator(operator)
             && usable
                 .last()
                 .is_some_and(|x| x.table_col_pos == table_col_pos)
@@ -1209,7 +1222,7 @@ pub fn usable_constraints_for_lhs_mask(
             continue;
         }
         let constraint_group = match operator.as_ast_operator() {
-            Some(ast::Operator::Equals) => RangeConstraintRef {
+            Some(ast::Operator::Equals | ast::Operator::Is) => RangeConstraintRef {
                 table_col_pos,
                 index_col_pos: cref.index_col_pos,
                 sort_order: cref.sort_order,
@@ -1612,6 +1625,22 @@ pub fn convert_to_vtab_constraint(
         })
         .collect();
     Ok(constraints)
+}
+
+/// Whether `op` constrains an index column to a single value, making it usable
+/// as an index seek key.
+///
+/// `IS` belongs here next to `=`: SQLite treats it as an index-usable equality
+/// that additionally matches NULL (`x IS NULL` seeks the index's NULL entries,
+/// and `x IS ?` with a NULL bind finds the rows whose key component is NULL).
+/// The only difference is in codegen: an `=` seek can stop early when its key is
+/// NULL because `NULL = NULL` is not true, while an `IS` seek must seek with the
+/// NULL key. See [`SeekDef::is_null_matching_key_component`].
+pub fn is_equality_operator(op: ConstraintOperator) -> bool {
+    matches!(
+        op.as_ast_operator(),
+        Some(ast::Operator::Equals | ast::Operator::Is)
+    )
 }
 
 fn to_ext_constraint_op(op: &ConstraintOperator) -> Option<ConstraintOp> {

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use crate::{turso_assert, turso_debug_assert};
 use smallvec::SmallVec;
-use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
+use std::{collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintOp};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
 
@@ -868,15 +868,11 @@ pub fn constraints_from_where_clause(
         }
         // sort equalities first so that index keys will be properly constructed.
         // see e.g.: https://www.solarwinds.com/blog/the-left-prefix-index-rule
-        cs.constraints.sort_by(|a, b| {
-            if is_equality_operator(a.operator) {
-                Ordering::Less
-            } else if is_equality_operator(b.operator) {
-                Ordering::Greater
-            } else {
-                Ordering::Equal
-            }
-        });
+        // A stable partition, not a comparison: comparing two equalities as
+        // "less" in both directions is not a valid ordering, and now that `IS`
+        // counts as an equality there are more pairs that would hit it.
+        cs.constraints
+            .sort_by_key(|c| !is_equality_operator(c.operator));
 
         // For each constraint we found, add a reference to it for each index that may be able to use it.
         for (i, constraint) in cs.constraints.iter_mut().enumerate() {

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -4,11 +4,13 @@ use crate::{
     translate::{
         collate::get_collseq_from_expr,
         expr::{
-            as_binary_components, comparison_affinity, get_expr_affinity, unwrap_parens,
-            walk_expr_mut, WalkControl,
+            as_binary_components, comparison_affinity, get_expr_affinity, unwrap_parens, walk_expr_mut, WalkControl,
         },
         expression_index::normalize_expr_for_index_matching,
-        plan::{JoinOrderMember, JoinedTable, NonFromClauseSubquery, TableReferences, WhereTerm},
+        plan::{
+            is_non_null_literal, JoinOrderMember, JoinedTable, NonFromClauseSubquery,
+            TableReferences, WhereTerm,
+        },
         planner::{
             break_predicate_at_and_boundaries, rewrite_between_exprs, table_mask_from_expr,
             TableMask, ROWID_STRS,
@@ -90,6 +92,14 @@ pub struct Constraint {
     /// not yet plumb per-column affinity into the index-selection path, so
     /// such constraints fall through to scans).
     pub comparison_affinity: Option<Affinity>,
+    /// Whether this constraint's seek key can be NULL and still match rows.
+    /// True only for `IS` whose constraining value is not known to be
+    /// non-NULL. `a IS 5` gets false: a literal 5 is never NULL, so the
+    /// constraint filters exactly like `a = 5`. `a IS NULL`, `a IS ?` and
+    /// `a IS other.col` get true — an index (even a UNIQUE one) can store
+    /// many NULL keys, so such a constraint can match many rows and its cost
+    /// and row estimates must not be taken from equality statistics.
+    pub null_matching: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -379,10 +389,19 @@ fn estimate_constraint_selectivity(
     table_reference: &JoinedTable,
     column: Option<&Column>,
     operator: ConstraintOperator,
+    null_matching: bool,
     index: Option<&Index>,
     params: &CostModelParams,
     is_rowid: bool,
 ) -> f64 {
+    // `a IS 5` filters exactly like `a = 5` — the key is never NULL — so give
+    // it the `=` estimate. Only a NULL-matching `IS` keeps its own, much less
+    // selective, estimate (see [Constraint::null_matching]).
+    let operator = if operator.as_ast_operator() == Some(ast::Operator::Is) && !null_matching {
+        ConstraintOperator::from(ast::Operator::Equals)
+    } else {
+        operator
+    };
     estimate_selectivity(
         schema,
         table_reference.table.get_name(),
@@ -535,6 +554,12 @@ pub fn constraints_from_where_clause(
                         .as_ref()
                         .is_some_and(|join| join.is_outer())
                     || term.from_outer_join == Some(table_reference.internal_id);
+                // See [Constraint::null_matching]. The constraining value sits
+                // on the opposite side of the constrained column.
+                let null_matching = |constraining_expr: &ast::Expr| {
+                    matches!(operator.as_ast_operator(), Some(ast::Operator::Is))
+                        && !is_non_null_literal(constraining_expr)
+                };
                 // If either the LHS or RHS of the constraint is a column from the table, add the constraint.
                 match lhs {
                     ast::Expr::Column { table, column, .. } => {
@@ -552,6 +577,7 @@ pub fn constraints_from_where_clause(
                                     table_reference,
                                     Some(table_column),
                                     operator,
+                                    null_matching(rhs),
                                     index_for_column(*column),
                                     params,
                                     false,
@@ -559,6 +585,7 @@ pub fn constraints_from_where_clause(
                                 usable,
                                 is_rowid: false,
                                 comparison_affinity: cmp_aff,
+                                null_matching: null_matching(rhs),
                             });
                         }
                     }
@@ -581,6 +608,7 @@ pub fn constraints_from_where_clause(
                                     table_reference,
                                     col,
                                     operator,
+                                    null_matching(rhs),
                                     None,
                                     params,
                                     true,
@@ -588,6 +616,7 @@ pub fn constraints_from_where_clause(
                                 usable,
                                 is_rowid: true,
                                 comparison_affinity: cmp_aff,
+                                null_matching: null_matching(rhs),
                             });
                         }
                     }
@@ -603,6 +632,7 @@ pub fn constraints_from_where_clause(
                             table_reference,
                             None,
                             operator,
+                            null_matching(rhs),
                             None,
                             params,
                             false,
@@ -626,6 +656,7 @@ pub fn constraints_from_where_clause(
                             usable,
                             is_rowid: false,
                             comparison_affinity: cmp_aff,
+                            null_matching: null_matching(rhs),
                         });
                     }
                     _ => {}
@@ -646,6 +677,7 @@ pub fn constraints_from_where_clause(
                                     table_reference,
                                     Some(table_column),
                                     operator,
+                                    null_matching(lhs),
                                     index_for_column(*column),
                                     params,
                                     false,
@@ -653,6 +685,7 @@ pub fn constraints_from_where_clause(
                                 usable,
                                 is_rowid: false,
                                 comparison_affinity: cmp_aff,
+                                null_matching: null_matching(lhs),
                             });
                         }
                     }
@@ -675,6 +708,7 @@ pub fn constraints_from_where_clause(
                                     table_reference,
                                     col,
                                     operator,
+                                    null_matching(lhs),
                                     None,
                                     params,
                                     true,
@@ -682,6 +716,7 @@ pub fn constraints_from_where_clause(
                                 usable,
                                 is_rowid: true,
                                 comparison_affinity: cmp_aff,
+                                null_matching: null_matching(lhs),
                             });
                         }
                     }
@@ -697,6 +732,7 @@ pub fn constraints_from_where_clause(
                             table_reference,
                             None,
                             operator,
+                            null_matching(lhs),
                             None,
                             params,
                             false,
@@ -720,6 +756,7 @@ pub fn constraints_from_where_clause(
                             usable,
                             is_rowid: false,
                             comparison_affinity: cmp_aff,
+                            null_matching: null_matching(lhs),
                         });
                     }
                     _ => {}
@@ -773,6 +810,7 @@ pub fn constraints_from_where_clause(
                             usable: false, // IN uses a separate seek path, not the range-seek model
                             is_rowid,
                             comparison_affinity: cmp_aff,
+                            null_matching: false,
                         });
                     }
                     ast::Expr::RowId { table, .. } if *table == table_reference.internal_id => {
@@ -790,6 +828,7 @@ pub fn constraints_from_where_clause(
                             usable: false,
                             is_rowid: true,
                             comparison_affinity: cmp_aff,
+                            null_matching: false,
                         });
                     }
                     _ => {}
@@ -853,6 +892,7 @@ pub fn constraints_from_where_clause(
                                 usable: false, // IN uses a separate seek path (consider_in_list_seek)
                                 is_rowid,
                                 comparison_affinity: cmp_aff,
+                                null_matching: false,
                             });
                         }
                         ast::Expr::RowId { table, .. } if *table == table_reference.internal_id => {
@@ -870,6 +910,7 @@ pub fn constraints_from_where_clause(
                                 usable: false,
                                 is_rowid: true,
                                 comparison_affinity: cmp_aff,
+                                null_matching: false,
                             });
                         }
                         _ => {}
@@ -1042,6 +1083,10 @@ pub struct EqConstraintRef {
     /// entire query (true for `col = 5`, false for `t2.x = t1.b` where the
     /// value changes per outer row in a nested-loop join).
     pub is_const: bool,
+    /// Whether this equality comes from `IS` instead of `=`. An `IS` equality
+    /// matches NULL keys, and an index (even a UNIQUE one) can store many NULL
+    /// keys, so an `IS` equality does not pin the column to at most one row.
+    pub null_matching: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1237,6 +1282,7 @@ pub fn usable_constraints_for_lhs_mask(
                 eq: Some(EqConstraintRef {
                     constraint_pos: cref.constraint_vec_pos,
                     is_const: constraints[cref.constraint_vec_pos].lhs_mask.is_empty(),
+                    null_matching: constraints[cref.constraint_vec_pos].null_matching,
                 }),
                 lower_bound: None,
                 upper_bound: None,
@@ -1505,7 +1551,20 @@ fn estimate_bound_expr_selectivity(
         let index = col_pos.and_then(|pos| {
             selectivity_index_for_column(schema, table_reference, available_indexes, pos)
         });
-        estimate_constraint_selectivity(schema, table_reference, col, op, index, params, is_rowid)
+        // For `IS`, the key can be NULL unless one side is a non-NULL literal
+        // (the constrained column is on the other side).
+        let null_matching = op.as_ast_operator() == Some(ast::Operator::Is)
+            && !(is_non_null_literal(lhs) || is_non_null_literal(rhs));
+        estimate_constraint_selectivity(
+            schema,
+            table_reference,
+            col,
+            op,
+            null_matching,
+            index,
+            params,
+            is_rowid,
+        )
     };
 
     match expr {
@@ -1577,6 +1636,7 @@ fn estimate_bound_expr_selectivity(
                     not: *not,
                     estimated_values: rhs.len() as f64,
                 },
+                false,
                 index,
                 params,
                 is_rowid,
@@ -1874,11 +1934,15 @@ pub(crate) fn analyze_binary_term_for_index(
     }
 
     let table_column = table_col_pos.and_then(|pos| table_reference.table.columns().get(pos));
+    // See [Constraint::null_matching].
+    let null_matching = operator.as_ast_operator() == Some(ast::Operator::Is)
+        && !is_non_null_literal(constraining_expr);
     let selectivity = estimate_constraint_selectivity(
         schema,
         table_reference,
         table_column,
         operator,
+        null_matching,
         best_index.as_deref(),
         params,
         is_rowid,
@@ -1928,6 +1992,7 @@ pub(crate) fn analyze_binary_term_for_index(
         usable: true,
         is_rowid,
         comparison_affinity: Some(affinity),
+        null_matching,
     };
 
     Some(AnalyzedTerm {
@@ -1958,6 +2023,7 @@ fn find_best_index_for_constraint(
                 Some(EqConstraintRef {
                     constraint_pos: 0,
                     is_const: false,
+                    null_matching: false,
                 })
             } else {
                 None
@@ -1989,6 +2055,7 @@ fn find_best_index_for_constraint(
                 Some(EqConstraintRef {
                     constraint_pos: 0,
                     is_const: false,
+                    null_matching: false,
                 })
             } else {
                 None
@@ -2026,6 +2093,7 @@ fn find_best_index_for_constraint(
                             Some(EqConstraintRef {
                                 constraint_pos: 0,
                                 is_const: false,
+                                null_matching: false,
                             })
                         } else {
                             None

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -541,25 +541,37 @@ pub fn constraints_from_where_clause(
                     .as_ast_operator()
                     .filter(|op| op.is_comparison())
                     .map(|_| comparison_affinity(lhs, rhs, Some(table_references), None));
-                // `IS` is the one seek-usable operator that can be TRUE for a
-                // null-extended row (`e.id IS NULL`). Such a WHERE term must not
-                // constrain the loop of an outer join's RHS table: filtering the
-                // RHS by it removes the very rows whose absence produces the null
-                // extension, so an antijoin would report every LHS row as
-                // unmatched. Terms from that join's own ON clause are fine, since
-                // they define what counts as a match.
-                let usable = !matches!(operator.as_ast_operator(), Some(ast::Operator::Is))
-                    || !table_reference
-                        .join_info
-                        .as_ref()
-                        .is_some_and(|join| join.is_outer())
-                    || term.from_outer_join == Some(table_reference.internal_id);
+                // A WHERE term must not constrain the loop of a table that an
+                // outer join can null-extend, with two exceptions below.
+                // Consuming the term into the access path filters that table's
+                // rows, which changes which rows of the other side count as
+                // unmatched — and the join then emits null-extended rows the
+                // consumed term is never checked against.
+                //
+                // Exception 1: terms from that join's own ON clause define what
+                // counts as a match, so they are always fine.
+                //
+                // Exception 2: on the right side of a plain LEFT JOIN, the
+                // engine re-checks consumed terms when it emits the
+                // null-extended row, so any operator except `IS` stays usable
+                // there: such terms are never TRUE on a null-extended row, so
+                // the re-check removes the bogus rows. `IS` (e.g. `e.id IS
+                // NULL`) *is* TRUE on the null-extended row, so no re-check can
+                // repair it — it is unusable for every null-extendable table.
+                // A FULL JOIN synthesizes its extra rows by jumping past the
+                // scan with no re-check, so nothing is usable for any table a
+                // FULL JOIN can null-extend.
+                let is_op = matches!(operator.as_ast_operator(), Some(ast::Operator::Is));
+                let usable = term.from_outer_join == Some(table_reference.internal_id)
+                    || if is_op {
+                        !table_references.outer_join_may_null_extend(table_reference.internal_id)
+                    } else {
+                        !table_references.full_join_may_null_extend(table_reference.internal_id)
+                    };
                 // See [Constraint::null_matching]. The constraining value sits
                 // on the opposite side of the constrained column.
-                let null_matching = |constraining_expr: &ast::Expr| {
-                    matches!(operator.as_ast_operator(), Some(ast::Operator::Is))
-                        && !is_non_null_literal(constraining_expr)
-                };
+                let null_matching =
+                    |constraining_expr: &ast::Expr| is_op && !is_non_null_literal(constraining_expr);
                 // If either the LHS or RHS of the constraint is a column from the table, add the constraint.
                 match lhs {
                     ast::Expr::Column { table, column, .. } => {

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -4,7 +4,8 @@ use crate::{
     translate::{
         collate::get_collseq_from_expr,
         expr::{
-            as_binary_components, comparison_affinity, get_expr_affinity, unwrap_parens, walk_expr_mut, WalkControl,
+            as_binary_components, comparison_affinity, get_expr_affinity, truth_test_rhs,
+            unwrap_parens, walk_expr_mut, WalkControl,
         },
         expression_index::normalize_expr_for_index_matching,
         plan::{
@@ -525,12 +526,11 @@ pub fn constraints_from_where_clause(
             if let Some((lhs, operator, rhs)) = as_binary_components(&term.expr)? {
                 // `x IS TRUE` checks whether x is true; it does not compare x
                 // with 1. For example, `2 IS TRUE` is true, so an index lookup
-                // for 1 would miss that row. The same rule applies to FALSE.
+                // for 1 would miss that row. The same rule applies to FALSE,
+                // and it holds through parentheses and COLLATE: `x IS (TRUE)`
+                // is still a truth test (see [truth_test_rhs]).
                 if matches!(operator.as_ast_operator(), Some(ast::Operator::Is))
-                    && matches!(
-                        rhs,
-                        ast::Expr::Literal(ast::Literal::True | ast::Literal::False)
-                    )
+                    && truth_test_rhs(rhs).is_some()
                 {
                     continue;
                 }
@@ -570,8 +570,9 @@ pub fn constraints_from_where_clause(
                     };
                 // See [Constraint::null_matching]. The constraining value sits
                 // on the opposite side of the constrained column.
-                let null_matching =
-                    |constraining_expr: &ast::Expr| is_op && !is_non_null_literal(constraining_expr);
+                let null_matching = |constraining_expr: &ast::Expr| {
+                    is_op && !is_non_null_literal(constraining_expr)
+                };
                 // If either the LHS or RHS of the constraint is a column from the table, add the constraint.
                 match lhs {
                     ast::Expr::Column { table, column, .. } => {

--- a/core/translate/optimizer/cost.rs
+++ b/core/translate/optimizer/cost.rs
@@ -182,9 +182,12 @@ pub(crate) fn is_unique_point_lookup(
     index_info: IndexInfo,
     usable_constraint_refs: &[RangeConstraintRef],
 ) -> bool {
+    // Only plain `=` equalities count. An `IS` equality matches NULL keys, and
+    // a UNIQUE index can store many NULL keys, so a key with an `IS` component
+    // can return many rows.
     let eq_count = usable_constraint_refs
         .iter()
-        .take_while(|cref| cref.eq.is_some())
+        .take_while(|cref| cref.eq.as_ref().is_some_and(|eq| !eq.null_matching))
         .count();
     index_info.unique && eq_count >= index_info.column_count
 }
@@ -301,6 +304,18 @@ fn estimate_rows_from_analyze_stats(
         .iter()
         .take_while(|cref| cref.eq.is_some())
         .count();
+
+    // The per-key average must not be applied to a key that can be NULL:
+    // NULL keys pile up in one bucket (think `deleted_at IS NULL` matching
+    // most of the table), so the average across all keys says nothing about
+    // that bucket. Decline, so the caller falls back to the pessimistic
+    // heuristic estimate for `IS`.
+    if constraint_refs[..eq_prefix_len]
+        .iter()
+        .any(|cref| cref.eq.as_ref().is_some_and(|eq| eq.null_matching))
+    {
+        return None;
+    }
 
     if eq_prefix_len == 0 {
         // Pure range scan — ANALYZE per-distinct-value stats don't apply.

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -53,8 +53,7 @@ use crate::{
 use crate::{turso_assert, turso_assert_eq, turso_debug_assert, turso_soft_unreachable};
 use constraints::{
     can_use_partial_index, constraints_from_where_clause, partial_index,
-    partial_index_predicate_terms, usable_constraints_for_join_order, Constraint,
-    ConstraintOperator, ConstraintRef,
+    partial_index_predicate_terms, usable_constraints_for_join_order, Constraint, ConstraintRef,
 };
 use cost::Cost;
 use join::{compute_best_join_order_with_context, BestJoinOrderResult, JoinPlanningContext};
@@ -800,7 +799,6 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
     plan.simple_aggregate = detect_simple_aggregate(plan);
     let best_join_order = optimize_table_access(
         schema,
-        resolver.dialect.as_ref(),
         resolver,
         &mut plan.result_columns,
         &mut plan.table_references,
@@ -881,7 +879,6 @@ fn optimize_delete_plan(plan: &mut DeletePlan, resolver: &Resolver) -> Result<()
 
     let _ = optimize_table_access(
         schema,
-        resolver.dialect.as_ref(),
         resolver,
         &mut plan.result_columns,
         &mut plan.table_references,
@@ -944,7 +941,6 @@ fn optimize_update_plan(
     let available_indexes = AvailableIndexes::for_table_references(resolver, &target_tables);
     let optimize_result = optimize_table_access(
         schema,
-        resolver.dialect.as_ref(),
         resolver,
         &mut [],
         &mut target_tables,
@@ -1674,121 +1670,72 @@ fn base_row_estimate(
     }
 }
 
-/// Returns true if a WHERE-term predicate is null-rejecting for a table.
+/// Returns true if a WHERE-term predicate is null-rejecting for a table: the
+/// term can never be TRUE when every column of the table is NULL. On a row an
+/// outer join null-extended, every column of the table IS NULL, so such a
+/// term filters that row out — the join then behaves like an inner join and
+/// can be rewritten to one.
 ///
-/// Non-rejecting cases include:
-/// - `IS`/`IS NOT` comparisons, which can evaluate true for NULL-containing inputs.
-/// - Expressions that route the table's values through NULL-masking functions
-///   like `ifnull`/`coalesce`.
+/// Port of SQLite's `impliesNotNullRow` (expr.c). Conservative: returns false
+/// when unsure. `IS`, `IS NOT` and `IS NULL` tests, functions, CASE and row
+/// values can all turn NULL inputs into TRUE (or into non-NULL values a
+/// comparison then accepts), so nothing below them counts. A comparison or an
+/// arithmetic expression yields NULL when an input is NULL, so for those it
+/// is enough that one input mentions the table.
 fn where_term_is_null_rejecting_for_table(
     expr: &ast::Expr,
-    operator: ConstraintOperator,
     table_id: ast::TableInternalId,
-    dialect: &dyn crate::dialect::Dialect,
 ) -> bool {
-    if matches!(
-        operator,
-        ConstraintOperator::AstNativeOperator(ast::Operator::Is | ast::Operator::IsNot)
-    ) {
-        return false;
-    }
-
-    !expr_has_null_masking_for_table(expr, table_id, dialect)
-}
-
-/// Returns true if an expression references a column from `table_id`.
-fn expr_references_table(expr: &ast::Expr, table_id: ast::TableInternalId) -> bool {
-    use crate::translate::expr::{walk_expr, WalkControl};
-    let mut found = false;
-    let _ = walk_expr(expr, &mut |inner: &ast::Expr| -> Result<WalkControl> {
-        match inner {
-            ast::Expr::Column { table, .. } | ast::Expr::RowId { table, .. }
-                if *table == table_id =>
-            {
-                found = true;
-                return Ok(WalkControl::SkipChildren);
-            }
-            _ => {}
-        }
-        Ok(WalkControl::Continue)
-    });
-    found
-}
-
-/// Returns true if an expression is a NULL check on a column from `table_id`.
-/// Matches patterns like `col IS NULL`, `col IS NOT NULL`, `IsNull(col)`, `NotNull(col)`.
-fn is_null_check_on_table(expr: &ast::Expr, table_id: ast::TableInternalId) -> bool {
+    use ast::Operator::*;
+    let rejects = |e: &ast::Expr| where_term_is_null_rejecting_for_table(e, table_id);
     match expr {
-        ast::Expr::IsNull(inner) | ast::Expr::NotNull(inner) => {
-            expr_references_table(inner, table_id)
-        }
-        ast::Expr::Binary(lhs, ast::Operator::Is | ast::Operator::IsNot, rhs) => {
-            (matches!(rhs.as_ref(), ast::Expr::Literal(ast::Literal::Null))
-                && expr_references_table(lhs, table_id))
-                || (matches!(lhs.as_ref(), ast::Expr::Literal(ast::Literal::Null))
-                    && expr_references_table(rhs, table_id))
-        }
+        ast::Expr::Column { table, .. } | ast::Expr::RowId { table, .. } => *table == table_id,
+
+        // These can be TRUE (or produce a non-NULL value) even when every
+        // input is NULL, so nothing below them proves anything.
+        ast::Expr::Binary(_, Is | IsNot, _)
+        | ast::Expr::IsNull(_)
+        | ast::Expr::NotNull(_)
+        | ast::Expr::Case { .. }
+        | ast::Expr::FunctionCall { .. }
+        | ast::Expr::FunctionCallStar { .. }
+        | ast::Expr::Like { .. } => false,
+
+        // Both arms must reject on their own: `x OR y` can be TRUE through
+        // the other arm, and under a NOT so can `x AND y`. (Top-level WHERE
+        // terms are already split on AND, so an AND here sits under a NOT or
+        // inside parentheses, where the polarity is unknown.)
+        ast::Expr::Binary(lhs, And | Or, rhs) => rejects(lhs) && rejects(rhs),
+
+        // A comparison with a NULL input is never TRUE, and an arithmetic or
+        // concatenation result with a NULL input is NULL. Either side counts.
+        ast::Expr::Binary(lhs, _, rhs) => rejects(lhs) || rejects(rhs),
+
+        // NULL is never in a list. (An empty list has no such guarantee:
+        // `x NOT IN ()` is TRUE for NULL x.)
+        ast::Expr::InList {
+            lhs,
+            rhs: in_list_values,
+            ..
+        } => !in_list_values.is_empty() && rejects(lhs),
+
+        // `x NOT BETWEEN y AND z` can be TRUE for NULL x only when y or z is
+        // NULL too, so it is enough that x rejects, or both bounds do.
+        ast::Expr::Between {
+            lhs, start, end, ..
+        } => rejects(lhs) || (rejects(start) && rejects(end)),
+
+        // NULL-propagating wrappers.
+        ast::Expr::Unary(_, inner) | ast::Expr::Cast { expr: inner, .. } => rejects(inner),
+        ast::Expr::Collate(inner, _) => rejects(inner),
+        // A single-element parenthesized expression is just grouping; a
+        // row value (more elements) is compared element-wise and can be
+        // TRUE with a NULL element.
+        ast::Expr::Parenthesized(exprs) => exprs.len() == 1 && rejects(&exprs[0]),
+
+        // Literals, parameters, subqueries, and anything else: no proof.
         _ => false,
     }
-}
-
-/// Returns true if an expression uses a NULL-masking construct over columns from `table_id`.
-/// This includes NULL-masking functions (COALESCE, IFNULL) and CASE/IIF expressions
-/// that explicitly handle the NULL case for columns from the target table.
-fn expr_has_null_masking_for_table(
-    expr: &ast::Expr,
-    table_id: ast::TableInternalId,
-    dialect: &dyn crate::dialect::Dialect,
-) -> bool {
-    use crate::translate::expr::{walk_expr, WalkControl};
-    let mut found = false;
-    let _ = walk_expr(expr, &mut |e: &ast::Expr| -> Result<WalkControl> {
-        match e {
-            ast::Expr::FunctionCall { name, args, .. } => {
-                if let Ok(Some(func)) = dialect.resolve_function(name.as_str(), args.len()) {
-                    // IIF(cond, then, else) is like CASE WHEN cond THEN then ELSE else END.
-                    // If the condition is a null check on the target table, IIF masks nulls.
-                    if matches!(
-                        func,
-                        crate::function::Func::Scalar(crate::function::ScalarFunc::Iif)
-                    ) {
-                        if let Some(cond) = args.first() {
-                            if is_null_check_on_table(cond, table_id) {
-                                found = true;
-                                return Ok(WalkControl::SkipChildren);
-                            }
-                        }
-                        return Ok(WalkControl::Continue);
-                    }
-                    if !func.can_mask_nulls() {
-                        return Ok(WalkControl::Continue);
-                    }
-                    for arg in args {
-                        if expr_references_table(arg, table_id) {
-                            found = true;
-                            return Ok(WalkControl::SkipChildren);
-                        }
-                    }
-                }
-            }
-            // CASE WHEN <null-check-on-table> THEN ... ELSE ... END
-            // If any WHEN condition checks for NULL on a column from the target table,
-            // the CASE explicitly handles NULLs and can produce non-NULL results.
-            ast::Expr::Case {
-                when_then_pairs, ..
-            } => {
-                for (when_expr, _) in when_then_pairs {
-                    if is_null_check_on_table(when_expr, table_id) {
-                        found = true;
-                        return Ok(WalkControl::SkipChildren);
-                    }
-                }
-            }
-            _ => {}
-        }
-        Ok(WalkControl::Continue)
-    });
-    found
 }
 
 /// Enforce INDEXED BY / NOT INDEXED hints by validating index existence and
@@ -1873,7 +1820,6 @@ fn enforce_indexed_by_hints(
 #[allow(clippy::too_many_arguments)]
 fn optimize_table_access(
     schema: &Schema,
-    dialect: &dyn crate::dialect::Dialect,
     resolver: &Resolver,
     result_columns: &mut [ResultSetColumn],
     table_references: &mut TableReferences,
@@ -2004,35 +1950,22 @@ fn optimize_table_access(
     // -> recompute constraints if we rewrote a LEFT JOIN into an INNER JOIN.
     loop {
         let mut outer_join_rewritten = false;
-        for (i, t) in table_references
-            .joined_tables_mut()
-            .iter_mut()
-            .enumerate()
-            .filter(|(_, t)| {
-                t.join_info
-                    .as_ref()
-                    // Skip FULL OUTER JOIN tables: removing `outer` would suppress
-                    // unmatched-probe-row emission and prevent LeftJoinMetadata
-                    // allocation needed by the hash join.
-                    .is_some_and(|join_info| join_info.is_outer() && !join_info.is_full_outer())
-            })
-        {
-            // Check if there's a constraint that would filter out NULL rows,
-            // allowing us to convert the LEFT JOIN into an INNER JOIN for join reordering purposes.
-            // Most binary ops like x = foo filter out NULL rows, but
-            // IS NULL constraints do NOT - they specifically KEEP them.
-            // So we should not convert LEFT JOIN to INNER JOIN based on IS NULL constraints.
-            // Also, expressions wrapped in ifnull()/coalesce() are NOT null-rejecting because
-            // they explicitly handle NULLs and can produce non-NULL values for NULL inputs.
-            if constraints_per_table[i].constraints.iter().any(|c| {
-                let is_from_where = where_clause[c.where_clause_pos.0].from_outer_join.is_none();
-                let is_null_rejecting = where_term_is_null_rejecting_for_table(
-                    &where_clause[c.where_clause_pos.0].expr,
-                    c.operator,
-                    t.internal_id,
-                    dialect,
-                );
-                is_from_where && is_null_rejecting
+        for t in table_references.joined_tables_mut().iter_mut().filter(|t| {
+            t.join_info
+                .as_ref()
+                // Skip FULL OUTER JOIN tables: removing `outer` would suppress
+                // unmatched-probe-row emission and prevent LeftJoinMetadata
+                // allocation needed by the hash join.
+                .is_some_and(|join_info| join_info.is_outer() && !join_info.is_full_outer())
+        }) {
+            // Check if a WHERE term filters out the join's null-extended rows,
+            // allowing us to convert the LEFT JOIN into an INNER JOIN for join
+            // reordering purposes. This looks at the raw WHERE terms, not the
+            // extracted constraints, so terms that never become constraints
+            // (like `t.v = 5 OR t.w = 7`) also count.
+            if where_clause.iter().any(|term| {
+                term.from_outer_join.is_none()
+                    && where_term_is_null_rejecting_for_table(&term.expr, t.internal_id)
             }) {
                 t.join_info.as_mut().unwrap().join_type = JoinType::Inner;
                 for term in where_clause.iter_mut() {
@@ -3890,18 +3823,15 @@ mod tests {
             Box::new(Expr::Literal(ast::Literal::Numeric("127".into()))),
         );
 
-        assert!(!where_term_is_null_rejecting_for_table(
-            &expr,
-            ast::Operator::GreaterEquals.into(),
-            table,
-            &crate::dialect::SqliteDialect,
-        ));
+        assert!(!where_term_is_null_rejecting_for_table(&expr, table));
     }
 
     #[test]
     fn null_rejection_detection_requires_target_table_reference() {
         let target_table = TableInternalId::from(7);
         let other_table = TableInternalId::from(8);
+        // A term that never mentions the target table can be TRUE on the
+        // join's null-extended rows, so it proves nothing about them.
         let expr = Expr::Binary(
             Box::new(fn_call(
                 "coalesce",
@@ -3919,12 +3849,7 @@ mod tests {
             Box::new(Expr::Literal(ast::Literal::Numeric("1".into()))),
         );
 
-        assert!(where_term_is_null_rejecting_for_table(
-            &expr,
-            ast::Operator::Greater.into(),
-            target_table,
-            &crate::dialect::SqliteDialect,
-        ));
+        assert!(!where_term_is_null_rejecting_for_table(&expr, target_table));
     }
 
     #[test]
@@ -3953,12 +3878,7 @@ mod tests {
             Box::new(Expr::Literal(ast::Literal::Numeric("2".into()))),
         );
 
-        assert!(!where_term_is_null_rejecting_for_table(
-            &expr,
-            ast::Operator::Equals.into(),
-            table,
-            &crate::dialect::SqliteDialect,
-        ));
+        assert!(!where_term_is_null_rejecting_for_table(&expr, table));
     }
 
     #[test]
@@ -3975,12 +3895,7 @@ mod tests {
             Box::new(Expr::Literal(ast::Literal::Null)),
         );
 
-        assert!(!where_term_is_null_rejecting_for_table(
-            &expr,
-            ast::Operator::Is.into(),
-            table,
-            &crate::dialect::SqliteDialect,
-        ));
+        assert!(!where_term_is_null_rejecting_for_table(&expr, table));
     }
 
     #[test]
@@ -4002,12 +3917,7 @@ mod tests {
             }),
         );
 
-        assert!(!where_term_is_null_rejecting_for_table(
-            &expr,
-            ast::Operator::Is.into(),
-            table,
-            &crate::dialect::SqliteDialect,
-        ));
+        assert!(!where_term_is_null_rejecting_for_table(&expr, table));
     }
 
     #[test]
@@ -4024,12 +3934,7 @@ mod tests {
             Box::new(Expr::Literal(ast::Literal::Numeric("5".into()))),
         );
 
-        assert!(!where_term_is_null_rejecting_for_table(
-            &expr,
-            ast::Operator::Is.into(),
-            table,
-            &crate::dialect::SqliteDialect,
-        ));
+        assert!(!where_term_is_null_rejecting_for_table(&expr, table));
     }
 
     #[test]
@@ -4046,12 +3951,7 @@ mod tests {
             Box::new(Expr::Literal(ast::Literal::Numeric("5".into()))),
         );
 
-        assert!(!where_term_is_null_rejecting_for_table(
-            &expr,
-            ast::Operator::IsNot.into(),
-            table,
-            &crate::dialect::SqliteDialect,
-        ));
+        assert!(!where_term_is_null_rejecting_for_table(&expr, table));
     }
 
     #[test]
@@ -4081,12 +3981,7 @@ mod tests {
             Box::new(Expr::Literal(ast::Literal::Numeric("0".into()))),
         );
 
-        assert!(!where_term_is_null_rejecting_for_table(
-            &expr,
-            ast::Operator::Greater.into(),
-            table,
-            &crate::dialect::SqliteDialect,
-        ));
+        assert!(!where_term_is_null_rejecting_for_table(&expr, table));
     }
 
     #[test]
@@ -4120,12 +4015,71 @@ mod tests {
             Box::new(Expr::Literal(ast::Literal::Numeric("0".into()))),
         );
 
-        // CASE without IS NULL check doesn't mask nulls, so it IS null-rejecting
+        // Any CASE can turn NULL inputs into a non-NULL result (here the ELSE
+        // arm yields 0 for a NULL t.col), so no CASE term proves anything
+        // about null-extended rows. Same rule as SQLite's impliesNotNullRow.
+        assert!(!where_term_is_null_rejecting_for_table(&expr, table));
+    }
+
+    #[test]
+    fn null_rejection_detection_null_test_nested_in_comparison_not_rejecting() {
+        let table = TableInternalId::from(18);
+        // (t.col IS NULL) = 1 — TRUE on a null-extended row.
+        let expr = Expr::Binary(
+            Box::new(Expr::Parenthesized(vec![Box::new(Expr::IsNull(Box::new(
+                Expr::Column {
+                    database: None,
+                    table,
+                    column: 0,
+                    is_rowid_alias: false,
+                },
+            )))])),
+            ast::Operator::Equals,
+            Box::new(Expr::Literal(ast::Literal::Numeric("1".into()))),
+        );
+
+        assert!(!where_term_is_null_rejecting_for_table(&expr, table));
+    }
+
+    #[test]
+    fn null_rejection_detection_or_needs_both_arms() {
+        let table = TableInternalId::from(19);
+        let other_table = TableInternalId::from(20);
+        let col = |t: TableInternalId, c: usize| Expr::Column {
+            database: None,
+            table: t,
+            column: c,
+            is_rowid_alias: false,
+        };
+        let eq_five = |t: TableInternalId, c: usize| {
+            Expr::Binary(
+                Box::new(col(t, c)),
+                ast::Operator::Equals,
+                Box::new(Expr::Literal(ast::Literal::Numeric("5".into()))),
+            )
+        };
+
+        // t.a = 5 OR t.b = 5: both arms are false when t's columns are NULL.
+        let both_arms_on_table = Expr::Binary(
+            Box::new(eq_five(table, 0)),
+            ast::Operator::Or,
+            Box::new(eq_five(table, 1)),
+        );
         assert!(where_term_is_null_rejecting_for_table(
-            &expr,
-            ast::Operator::Greater.into(),
-            table,
-            &crate::dialect::SqliteDialect,
+            &both_arms_on_table,
+            table
+        ));
+
+        // t.a = 5 OR u.x = 5: the u arm can make the OR true on t's
+        // null-extended rows.
+        let one_arm_on_other_table = Expr::Binary(
+            Box::new(eq_five(table, 0)),
+            ast::Operator::Or,
+            Box::new(eq_five(other_table, 0)),
+        );
+        assert!(!where_term_is_null_rejecting_for_table(
+            &one_arm_on_other_table,
+            table
         ));
     }
 
@@ -4156,11 +4110,6 @@ mod tests {
             Box::new(Expr::Literal(ast::Literal::Numeric("0".into()))),
         );
 
-        assert!(!where_term_is_null_rejecting_for_table(
-            &expr,
-            ast::Operator::Greater.into(),
-            table,
-            &crate::dialect::SqliteDialect,
-        ));
+        assert!(!where_term_is_null_rejecting_for_table(&expr, table));
     }
 }

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -769,13 +769,19 @@ fn evaluate_multi_index_branches(
 /// Whether a multi-index scan on `table` may be driven by `term`.
 ///
 /// The scan *is* the term's evaluation: rows failing it are never visited, and
-/// the term is marked consumed so nothing checks it again. For an outer join's
-/// right-hand table that only holds for the join's own ON clause, which defines
-/// what counts as a match. Any other term must also reject the null-extended row
-/// the join emits when nothing matched, and that row is produced by jumping
-/// straight past the scan — so consuming such a term silently drops it.
-fn multi_index_can_consume_term(table: &JoinedTable, term: &WhereTerm) -> bool {
-    !table.join_info.as_ref().is_some_and(|join| join.is_outer())
+/// the term is marked consumed so nothing checks it again. For a table that an
+/// outer join can null-extend (the right-hand table of a LEFT/FULL JOIN, or
+/// any table on the left side of a FULL JOIN) that only holds for the join's
+/// own ON clause, which defines what counts as a match. Any other term must
+/// also reject the null-extended row the join emits when nothing matched, and
+/// that row is produced by jumping straight past the scan — so consuming such
+/// a term silently drops it.
+fn multi_index_can_consume_term(
+    table: &JoinedTable,
+    term: &WhereTerm,
+    table_references: &TableReferences,
+) -> bool {
+    !table_references.outer_join_may_null_extend(table.internal_id)
         || term.from_outer_join == Some(table.internal_id)
 }
 
@@ -816,7 +822,7 @@ fn analyze_and_terms_for_multi_index(
         if term.consumed || matches!(&term.expr, ast::Expr::Binary(_, ast::Operator::Or, _)) {
             continue;
         }
-        if !multi_index_can_consume_term(table_reference, term) {
+        if !multi_index_can_consume_term(table_reference, term, table_references) {
             continue;
         }
 
@@ -964,7 +970,7 @@ pub fn consider_multi_index_union(
         if term.consumed {
             continue;
         }
-        if !multi_index_can_consume_term(rhs_table, term) {
+        if !multi_index_can_consume_term(rhs_table, term, table_references) {
             continue;
         }
 

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -766,6 +766,19 @@ fn evaluate_multi_index_branches(
     }
 }
 
+/// Whether a multi-index scan on `table` may be driven by `term`.
+///
+/// The scan *is* the term's evaluation: rows failing it are never visited, and
+/// the term is marked consumed so nothing checks it again. For an outer join's
+/// right-hand table that only holds for the join's own ON clause, which defines
+/// what counts as a match. Any other term must also reject the null-extended row
+/// the join emits when nothing matched, and that row is produced by jumping
+/// straight past the scan — so consuming such a term silently drops it.
+fn multi_index_can_consume_term(table: &JoinedTable, term: &WhereTerm) -> bool {
+    !table.join_info.as_ref().is_some_and(|join| join.is_outer())
+        || term.from_outer_join == Some(table.internal_id)
+}
+
 #[allow(clippy::too_many_arguments)]
 /// Analyze top-level AND terms to determine whether they can be executed as an
 /// AND-by-intersection plan.
@@ -801,6 +814,9 @@ fn analyze_and_terms_for_multi_index(
 
     for (where_term_idx, term) in where_clause.iter().enumerate() {
         if term.consumed || matches!(&term.expr, ast::Expr::Binary(_, ast::Operator::Or, _)) {
+            continue;
+        }
+        if !multi_index_can_consume_term(table_reference, term) {
             continue;
         }
 
@@ -946,6 +962,9 @@ pub fn consider_multi_index_union(
 ) -> Result<Option<AccessMethod>> {
     for (where_term_idx, term) in where_clause.iter().enumerate() {
         if term.consumed {
+            continue;
+        }
+        if !multi_index_can_consume_term(rhs_table, term) {
             continue;
         }
 

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -310,21 +310,24 @@ pub fn plan_satisfies_order_target(
                         "access_method.params::Subquery must be for a FromClauseSubquery table"
                     );
                 };
-                subquery_intrinsic_order_consumed(
-                    table_ref.internal_id,
-                    from_clause_subquery,
-                    *iter_dir,
-                    &order_target.columns[target_col_idx..],
-                    schema,
-                )
+                OrderConsumption {
+                    consumed: subquery_intrinsic_order_consumed(
+                        table_ref.internal_id,
+                        from_clause_subquery,
+                        *iter_dir,
+                        &order_target.columns[target_col_idx..],
+                        schema,
+                    ),
+                    includes_rowid: false,
+                }
             }
             _ => return false,
         };
 
-        if consumed == 0 {
+        if consumed.consumed == 0 {
             return false;
         }
-        target_col_idx += consumed;
+        target_col_idx += consumed.consumed;
         if target_col_idx == num_cols_in_order_target {
             return true;
         }
@@ -345,7 +348,7 @@ pub fn plan_satisfies_order_target(
                         })
                 });
         if next_term_comes_from_later_loop
-            && !access_method_emits_unique_order_prefix(access_method, consumed)
+            && !access_method_emits_unique_order_prefix(access_method, &consumed)
         {
             return false;
         }
@@ -355,27 +358,30 @@ pub fn plan_satisfies_order_target(
 
 fn access_method_emits_unique_order_prefix(
     access_method: &AccessMethod,
-    consumed_order_terms: usize,
+    order_consumption: &OrderConsumption,
 ) -> bool {
+    // Rows always differ in rowid, so a consumed prefix that includes the
+    // rowid never repeats.
+    if order_consumption.includes_rowid {
+        return true;
+    }
+    // Otherwise the only safe claim is a point lookup: a UNIQUE index with
+    // every column pinned by plain `=` returns at most one row. Anything
+    // weaker can emit duplicate prefixes: an `IS` equality matches NULL keys
+    // (a UNIQUE index stores any number of NULL keys), and counting
+    // equality-pinned columns together with consumed ORDER BY terms counts
+    // the same column twice when the ORDER BY mentions the equality column.
     match &access_method.params {
         AccessMethodParams::BTreeTable {
             index,
             constraint_refs,
             ..
-        } => access_path_makes_consumed_prefix_unique(
-            index.as_deref(),
-            constraint_refs,
-            consumed_order_terms,
-        ),
+        } => is_unique_point_lookup(index_info_for_access(index.as_deref()), constraint_refs),
         AccessMethodParams::MaterializedSubquery {
             index,
             constraint_refs,
             ..
-        } => access_path_makes_consumed_prefix_unique(
-            Some(index.as_ref()),
-            constraint_refs,
-            consumed_order_terms,
-        ),
+        } => is_unique_point_lookup(index_info_for_access(Some(index.as_ref())), constraint_refs),
         AccessMethodParams::Subquery { .. }
         | AccessMethodParams::RecursiveCteInput
         | AccessMethodParams::HashJoin { .. }
@@ -383,40 +389,6 @@ fn access_method_emits_unique_order_prefix(
         | AccessMethodParams::IndexMethod { .. }
         | AccessMethodParams::MultiIndexScan { .. }
         | AccessMethodParams::InSeek { .. } => false,
-    }
-}
-
-fn access_path_makes_consumed_prefix_unique(
-    index: Option<&Index>,
-    constraint_refs: &[RangeConstraintRef],
-    consumed_order_terms: usize,
-) -> bool {
-    if is_unique_point_lookup(index_info_for_access(index), constraint_refs) {
-        return true;
-    }
-
-    match index {
-        // Table scans only provide rowid order. If that rowid term was consumed,
-        // the prefix is unique even though the scan obviously returns many rows.
-        None => consumed_order_terms >= 1,
-        Some(index) => {
-            let eq_prefix_len = constraint_refs
-                .iter()
-                .take_while(|constraint| constraint.eq.is_some())
-                .count();
-            let unique_prefix_terms = eq_prefix_len + consumed_order_terms;
-
-            // Unique indexes become prefix-unique once all key columns are either
-            // fixed by equality or consumed as ORDER BY terms.
-            if index.unique && unique_prefix_terms >= index.columns.len() {
-                return true;
-            }
-
-            // Rowid tables keep duplicate secondary-index keys ordered by rowid.
-            // If the consumed ORDER BY terms already include that implicit rowid
-            // suffix, the emitted prefix is unique too.
-            index.has_rowid && unique_prefix_terms > index.columns.len()
-        }
     }
 }
 
@@ -649,19 +621,22 @@ fn finalized_scan_subquery_order_consumed(
     }
 
     match &joined_table.op {
-        Operation::Scan(Scan::BTreeTable { index, .. }) => btree_access_order_consumed(
-            joined_table,
-            effective_iter_dir,
-            index.as_deref(),
-            &[],
-            &OrderTarget {
-                columns: mapped_target,
-                purpose: OrderTargetPurpose::EliminatesSort(EliminatesSortBy::Order),
-            },
-            0,
-            schema,
-            EqualityPrefixScope::ConstantEquality,
-        ),
+        Operation::Scan(Scan::BTreeTable { index, .. }) => {
+            btree_access_order_consumed(
+                joined_table,
+                effective_iter_dir,
+                index.as_deref(),
+                &[],
+                &OrderTarget {
+                    columns: mapped_target,
+                    purpose: OrderTargetPurpose::EliminatesSort(EliminatesSortBy::Order),
+                },
+                0,
+                schema,
+                EqualityPrefixScope::ConstantEquality,
+            )
+            .consumed
+        }
         Operation::Scan(Scan::Subquery { .. }) => {
             let Table::FromClauseSubquery(from_clause_subquery) = &joined_table.table else {
                 return 0;
@@ -777,6 +752,25 @@ fn target_matches_index_column(
     }
 }
 
+/// What a single-table btree access path contributes to an ORDER BY / GROUP BY
+/// target. See [`btree_access_order_consumed`].
+pub(super) struct OrderConsumption {
+    /// How many leading order-target columns the access path satisfies.
+    pub consumed: usize,
+    /// Whether one of those consumed columns is the table's rowid (directly,
+    /// through a rowid alias, or through the implicit rowid suffix of a
+    /// secondary index). Every row has a different rowid, so a consumed prefix
+    /// that includes the rowid never repeats across the rows this loop emits.
+    pub includes_rowid: bool,
+}
+
+impl OrderConsumption {
+    pub const NONE: OrderConsumption = OrderConsumption {
+        consumed: 0,
+        includes_rowid: false,
+    };
+}
+
 /// Return how many leading `order_target` columns this single-table btree
 /// access path can satisfy.
 ///
@@ -796,10 +790,10 @@ pub(super) fn btree_access_order_consumed(
     start_col: usize,
     schema: &Schema,
     equality_prefix_scope: EqualityPrefixScope,
-) -> usize {
+) -> OrderConsumption {
     let target_columns = &order_target.columns[start_col..];
     let Some(first_target_col) = target_columns.first() else {
-        return 0;
+        return OrderConsumption::NONE;
     };
 
     let rowid_alias_col = table_ref
@@ -812,30 +806,39 @@ pub(super) fn btree_access_order_consumed(
         None => {
             // Without an index, only rowid order is available.
             if first_target_col.table_id != table_ref.internal_id {
-                return 0;
+                return OrderConsumption::NONE;
             }
             match first_target_col.target {
                 ColumnTarget::RowId => {}
                 ColumnTarget::Column(col_no) => {
                     let Some(rowid_alias_col) = rowid_alias_col else {
-                        return 0;
+                        return OrderConsumption::NONE;
                     };
                     if col_no != rowid_alias_col {
-                        return 0;
+                        return OrderConsumption::NONE;
                     }
                 }
-                ColumnTarget::Expr(_) => return 0,
+                ColumnTarget::Expr(_) => return OrderConsumption::NONE,
             }
             let correct_order = if iter_dir == IterationDirection::Forwards {
                 first_target_col.order == SortOrder::Asc
             } else {
                 first_target_col.order == SortOrder::Desc
             };
-            usize::from(correct_order)
+            OrderConsumption {
+                consumed: usize::from(correct_order),
+                includes_rowid: correct_order,
+            }
         }
         Some(index) => {
             let mut col_idx = 0;
             let mut idx_pos = 0;
+            let mut includes_rowid = false;
+            let target_is_rowid = |target_col: &ColumnOrder| match target_col.target {
+                ColumnTarget::RowId => true,
+                ColumnTarget::Column(col_no) => rowid_alias_col == Some(col_no),
+                ColumnTarget::Expr(_) => false,
+            };
             while col_idx < target_columns.len() && idx_pos < index.columns.len() {
                 let target_col = &target_columns[col_idx];
                 if target_col.table_id != table_ref.internal_id {
@@ -913,6 +916,10 @@ pub(super) fn btree_access_order_consumed(
                     }
                 }
 
+                if target_is_rowid(target_col) {
+                    // The index explicitly contains the rowid alias column.
+                    includes_rowid = true;
+                }
                 col_idx += 1;
                 idx_pos += 1;
             }
@@ -921,24 +928,24 @@ pub(super) fn btree_access_order_consumed(
             // by rowid. That implicit suffix can satisfy one extra ORDER BY term.
             if col_idx < target_columns.len() && idx_pos == index.columns.len() && index.has_rowid {
                 let target_col = &target_columns[col_idx];
-                let rowid_matches = match target_col.target {
-                    ColumnTarget::RowId => true,
-                    ColumnTarget::Column(col_no) => {
-                        rowid_alias_col.is_some_and(|alias| alias == col_no)
-                    }
-                    ColumnTarget::Expr(_) => false,
-                };
                 let correct_order = if iter_dir == IterationDirection::Forwards {
                     target_col.order == SortOrder::Asc
                 } else {
                     target_col.order == SortOrder::Desc
                 };
-                if target_col.table_id == table_ref.internal_id && rowid_matches && correct_order {
+                if target_col.table_id == table_ref.internal_id
+                    && target_is_rowid(target_col)
+                    && correct_order
+                {
                     col_idx += 1;
+                    includes_rowid = true;
                 }
             }
 
-            col_idx
+            OrderConsumption {
+                consumed: col_idx,
+                includes_rowid,
+            }
         }
     }
 }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2968,14 +2968,34 @@ impl SeekDef {
     /// be NULL, while an `IS` seek must seek with the NULL key because index keys
     /// compare NULLs as equal. Only equality prefix components can be
     /// NULL-matching; range bounds never are.
+    ///
+    /// `x IS 5` does not count: a literal 5 is never NULL, so the component
+    /// behaves exactly like `x = 5`.
     pub fn is_null_matching_key_component(&self, pos: usize) -> bool {
         self.prefix.get(pos).is_some_and(|component| {
-            matches!(
-                component.eq.as_ref().map(|(op, _, _)| op),
-                Some(ast::Operator::Is)
-            )
+            component
+                .eq
+                .as_ref()
+                .is_some_and(|(op, expr, _)| *op == ast::Operator::Is && !is_non_null_literal(expr))
         })
     }
+}
+
+/// True only for literal values that are never NULL: numbers, strings, blobs,
+/// TRUE and FALSE. Columns and parameters do not count — their runtime value
+/// can be NULL. A column does not count even when declared NOT NULL, because
+/// an outer join can still null-extend it.
+pub fn is_non_null_literal(expr: &ast::Expr) -> bool {
+    matches!(
+        expr,
+        ast::Expr::Literal(
+            ast::Literal::Numeric(_)
+                | ast::Literal::String(_)
+                | ast::Literal::Blob(_)
+                | ast::Literal::True
+                | ast::Literal::False
+        )
+    )
 }
 
 /// Build the affinity string for a synthesized ephemeral seek index.

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2952,6 +2952,23 @@ impl SeekDef {
             _t: PhantomData,
         }
     }
+
+    /// Whether the key component at `pos` came from a NULL-matching equality
+    /// (`x IS <expr>`) rather than `x = <expr>`.
+    ///
+    /// A NULL key value means different things for the two: `NULL = NULL` is not
+    /// true, so an `=` seek can skip the loop entirely once its key turns out to
+    /// be NULL, while an `IS` seek must seek with the NULL key because index keys
+    /// compare NULLs as equal. Only equality prefix components can be
+    /// NULL-matching; range bounds never are.
+    pub fn is_null_matching_key_component(&self, pos: usize) -> bool {
+        self.prefix.get(pos).is_some_and(|component| {
+            matches!(
+                component.eq.as_ref().map(|(op, _, _)| op),
+                Some(ast::Operator::Is)
+            )
+        })
+    }
 }
 
 /// Build the affinity string for a synthesized ephemeral seek index.

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1361,6 +1361,54 @@ impl TableReferences {
         &mut self.joined_tables
     }
 
+    /// Whether an outer join in the FROM list can give this table's columns
+    /// NULLs ("null-extend" it).
+    ///
+    /// The right-hand table of a LEFT or FULL JOIN — the table that carries
+    /// the `join_info` — gets NULLs when a left-side row has no match. A FULL
+    /// JOIN *also* gives NULLs to every table on its left side when a
+    /// right-side row has no match, and those tables carry no `join_info` of
+    /// their own, so checking only `table.join_info` misses them. (This is
+    /// SQLite's `JT_LTORJ` bit.)
+    pub fn outer_join_may_null_extend(&self, table: TableInternalId) -> bool {
+        let Some(pos) = self
+            .joined_tables
+            .iter()
+            .position(|t| t.internal_id == table)
+        else {
+            return false;
+        };
+        if self.joined_tables[pos]
+            .join_info
+            .as_ref()
+            .is_some_and(JoinInfo::is_outer)
+        {
+            return true;
+        }
+        self.joined_tables[pos + 1..]
+            .iter()
+            .any(|t| t.join_info.as_ref().is_some_and(JoinInfo::is_full_outer))
+    }
+
+    /// Like [Self::outer_join_may_null_extend], but true only when the
+    /// null extension comes from a FULL JOIN. Matters because the two join
+    /// kinds emit their null-extended rows differently: a LEFT JOIN re-checks
+    /// consumed WHERE terms when it emits the null-extended row, while a FULL
+    /// JOIN synthesizes its extra rows by jumping past the scan entirely, so a
+    /// consumed term is never checked against them.
+    pub fn full_join_may_null_extend(&self, table: TableInternalId) -> bool {
+        let Some(pos) = self
+            .joined_tables
+            .iter()
+            .position(|t| t.internal_id == table)
+        else {
+            return false;
+        };
+        self.joined_tables[pos..]
+            .iter()
+            .any(|t| t.join_info.as_ref().is_some_and(JoinInfo::is_full_outer))
+    }
+
     /// Resets the expression index usages for all joined tables.
     pub fn reset_expression_index_usages(&mut self) {
         for table in self.joined_tables.iter_mut() {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2319,7 +2319,14 @@ impl Operation {
                 // All index columns must have equality constraints.
                 let num_index_cols = idx.columns.len();
                 let num_eq_prefix = seek_def.prefix.iter().filter(|c| c.eq.is_some()).count();
-                num_eq_prefix == num_index_cols
+                if num_eq_prefix != num_index_cols {
+                    return false;
+                }
+                // Only plain `=` components guarantee one row. An `IS`
+                // component matches NULL keys, and a UNIQUE index stores every
+                // NULL key separately, so e.g. `WHERE a IS NULL` can touch
+                // many rows.
+                (0..seek_def.prefix.len()).all(|i| !seek_def.is_null_matching_key_component(i))
             }
             // Table scans, hash joins, multi-index scans, etc. are not single-row.
             _ => false,

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -2359,7 +2359,7 @@ fn emit_window_full_scan(
         num_regs: 1,
         target_pc: label_break,
         eq_only: false,
-        null_matching_mask: 0,
+        null_matching_mask: Default::default(),
     });
     program.preassign_label_to_next_insn(label_loop);
     program.emit_insn(Insn::RowId {
@@ -3342,7 +3342,7 @@ fn emit_function_inverse(
                 num_regs: 1,
                 target_pc: label_skip,
                 eq_only: false,
-                null_matching_mask: 0,
+                null_matching_mask: Default::default(),
             });
             program.emit_insn(Insn::Delete {
                 cursor_id: state.cursor,

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -2359,6 +2359,7 @@ fn emit_window_full_scan(
         num_regs: 1,
         target_pc: label_break,
         eq_only: false,
+        null_matching_mask: 0,
     });
     program.preassign_label_to_next_insn(label_loop);
     program.emit_insn(Insn::RowId {
@@ -3341,6 +3342,7 @@ fn emit_function_inverse(
                 num_regs: 1,
                 target_pc: label_skip,
                 eq_only: false,
+                null_matching_mask: 0,
             });
             program.emit_insn(Insn::Delete {
                 cursor_id: state.cursor,

--- a/core/util.rs
+++ b/core/util.rs
@@ -3,8 +3,8 @@ use crate::numeric::StrToF64;
 use crate::schema::ColDef;
 use crate::translate::emitter::TransactionMode;
 use crate::translate::expr::{walk_expr, walk_expr_mut, WalkControl};
-use crate::translate::plan::{BitSet, JoinedTable, TableReferences};
-use crate::translate::planner::{parse_row_id, TableMask};
+use crate::translate::plan::{BitSet, JoinedTable};
+use crate::translate::planner::parse_row_id;
 use crate::types::IOResult;
 use crate::IO;
 use crate::{
@@ -422,36 +422,6 @@ pub fn check_literal_equivalency(lhs: &Literal, rhs: &Literal) -> bool {
         (Literal::CurrentTimestamp, Literal::CurrentTimestamp) => true,
         _ => false,
     }
-}
-
-/// Returns true if every Column/RowId table reference in `expr` is contained
-/// in `allowed`. Constants (no table refs) pass.
-pub(crate) fn expr_tables_subset_of(
-    expr: &Expr,
-    table_references: &TableReferences,
-    allowed: &TableMask,
-) -> bool {
-    let mut ok = true;
-    let _ = walk_expr(expr, &mut |e: &Expr| -> Result<WalkControl> {
-        match e {
-            Expr::Column { table, .. } | Expr::RowId { table, .. } => {
-                if let Some(idx) = table_references
-                    .joined_tables()
-                    .iter()
-                    .position(|t| t.internal_id == *table)
-                {
-                    if !allowed.get(idx) {
-                        ok = false;
-                        return Ok(WalkControl::SkipChildren);
-                    }
-                }
-                // Outer query references are already in scope — allow them.
-            }
-            _ => {}
-        }
-        Ok(WalkControl::Continue)
-    });
-    ok
 }
 
 /// bind AST identifiers to either Column or Rowid if possible

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5771,11 +5771,26 @@ pub fn op_seek(
         Insn::SeekLE { eq_only, .. } => *eq_only,
         _ => false,
     };
+    let null_matching_mask = match insn {
+        Insn::SeekGE {
+            null_matching_mask, ..
+        } => *null_matching_mask,
+        Insn::SeekLE {
+            null_matching_mask, ..
+        } => *null_matching_mask,
+        _ => 0,
+    };
 
     if is_eq_only
         && state.registers[start_reg..start_reg + num_regs]
             .iter()
-            .any(|value| value.is_null())
+            .enumerate()
+            .any(|(i, value)| {
+                // A NULL-matching component (`x IS ?`) seeks with the NULL key:
+                // index keys compare NULLs as equal, so such a key can match.
+                let null_matching = i < 64 && (null_matching_mask >> i) & 1 == 1;
+                value.is_null() && !null_matching
+            })
     {
         // Exact-match seeks use "=" semantics across the full unpacked key.
         // If any key column is NULL, the comparison is unknown, so no row can match.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -5766,32 +5766,27 @@ pub fn op_seek(
         target_pc.is_offset(),
         "op_seek: target_pc should be an offset, is: {target_pc:?}"
     );
-    let is_eq_only = match insn {
-        Insn::SeekGE { eq_only, .. } => *eq_only,
-        Insn::SeekLE { eq_only, .. } => *eq_only,
-        _ => false,
-    };
-    let null_matching_mask = match insn {
+    let has_null_that_cannot_match = match insn {
         Insn::SeekGE {
-            null_matching_mask, ..
-        } => *null_matching_mask,
-        Insn::SeekLE {
-            null_matching_mask, ..
-        } => *null_matching_mask,
-        _ => 0,
-    };
-
-    if is_eq_only
-        && state.registers[start_reg..start_reg + num_regs]
+            eq_only: true,
+            null_matching_mask,
+            ..
+        }
+        | Insn::SeekLE {
+            eq_only: true,
+            null_matching_mask,
+            ..
+        } => state.registers[start_reg..start_reg + num_regs]
             .iter()
             .enumerate()
             .any(|(i, value)| {
-                // A NULL-matching component (`x IS ?`) seeks with the NULL key:
-                // index keys compare NULLs as equal, so such a key can match.
-                let null_matching = i < 64 && (null_matching_mask >> i) & 1 == 1;
-                value.is_null() && !null_matching
-            })
-    {
+                // `IS` can match NULL. `=` cannot.
+                value.is_null() && !null_matching_mask.get(i)
+            }),
+        _ => false,
+    };
+
+    if has_null_that_cannot_match {
         // Exact-match seeks use "=" semantics across the full unpacked key.
         // If any key column is NULL, the comparison is unknown, so no row can match.
         // Translation often emits IsNull guards earlier, but outer joins can still

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -998,6 +998,13 @@ pub enum Insn {
         num_regs: usize,
         target_pc: BranchOffset,
         eq_only: bool,
+        /// Bitmask over the `num_regs` key registers (bit `i` = `start_reg + i`)
+        /// marking components that came from a NULL-matching equality (`x IS ?`).
+        /// An `eq_only` seek normally cannot match when a key register is NULL, so it
+        /// jumps to `target_pc`; masked components skip that check and seek with the
+        /// NULL key, because index keys compare NULLs as equal. Bits at position
+        /// >= 64 are treated as unset.
+        null_matching_mask: u64,
     },
 
     /// If cursor_id refers to an SQL table (B-Tree that uses integer keys), use the value in start_reg as the key.
@@ -1035,6 +1042,13 @@ pub enum Insn {
         num_regs: usize,
         target_pc: BranchOffset,
         eq_only: bool,
+        /// Bitmask over the `num_regs` key registers (bit `i` = `start_reg + i`)
+        /// marking components that came from a NULL-matching equality (`x IS ?`).
+        /// An `eq_only` seek normally cannot match when a key register is NULL, so it
+        /// jumps to `target_pc`; masked components skip that check and seek with the
+        /// NULL key, because index keys compare NULLs as equal. Bits at position
+        /// >= 64 are treated as unset.
+        null_matching_mask: u64,
     },
 
     // If cursor_id refers to an SQL table (B-Tree that uses integer keys), use the value in start_reg as the key.

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -15,7 +15,7 @@ use crate::{
     schema::{BTreeTable, CheckConstraint, Column, ForeignKey, Index},
     storage::{pager::CreateBTreeFlags, wal::CheckpointMode},
     sync::{Arc, OnceLock, Weak},
-    translate::{collate::CollationSeq, emitter::TransactionMode},
+    translate::{collate::CollationSeq, emitter::TransactionMode, plan::BitSet},
     types::KeyInfo,
     vdbe::affinity::Affinity,
     PreparedProgram, Value,
@@ -998,13 +998,9 @@ pub enum Insn {
         num_regs: usize,
         target_pc: BranchOffset,
         eq_only: bool,
-        /// Bitmask over the `num_regs` key registers (bit `i` = `start_reg + i`)
-        /// marking components that came from a NULL-matching equality (`x IS ?`).
-        /// An `eq_only` seek normally cannot match when a key register is NULL, so it
-        /// jumps to `target_pc`; masked components skip that check and seek with the
-        /// NULL key, because index keys compare NULLs as equal. Bits at position
-        /// >= 64 are treated as unset.
-        null_matching_mask: u64,
+        /// Key columns that use `IS` instead of `=`. NULL may match in these
+        /// columns, so the seek must not stop when their key value is NULL.
+        null_matching_mask: BitSet,
     },
 
     /// If cursor_id refers to an SQL table (B-Tree that uses integer keys), use the value in start_reg as the key.
@@ -1042,13 +1038,9 @@ pub enum Insn {
         num_regs: usize,
         target_pc: BranchOffset,
         eq_only: bool,
-        /// Bitmask over the `num_regs` key registers (bit `i` = `start_reg + i`)
-        /// marking components that came from a NULL-matching equality (`x IS ?`).
-        /// An `eq_only` seek normally cannot match when a key register is NULL, so it
-        /// jumps to `target_pc`; masked components skip that check and seek with the
-        /// NULL key, because index keys compare NULLs as equal. Bits at position
-        /// >= 64 are treated as unset.
-        null_matching_mask: u64,
+        /// Key columns that use `IS` instead of `=`. NULL may match in these
+        /// columns, so the seek must not stop when their key value is NULL.
+        null_matching_mask: BitSet,
     },
 
     // If cursor_id refers to an SQL table (B-Tree that uses integer keys), use the value in start_reg as the key.

--- a/sql_generation/generation/predicate/binary.rs
+++ b/sql_generation/generation/predicate/binary.rs
@@ -75,6 +75,18 @@ impl Predicate {
                 ),
                 (
                     1,
+                    Box::new(|_| {
+                        // `IS` seeks the index like `=` but compares NULLs as equal,
+                        // so it is true for this row even when the value is NULL.
+                        Some(Expr::Binary(
+                            Box::new(qualified_column_expr(&table_name, &column.name)),
+                            ast::Operator::Is,
+                            Box::new(Expr::Literal(value.into())),
+                        ))
+                    }),
+                ),
+                (
+                    1,
                     Box::new(|rng| {
                         let v = SimValue::arbitrary_from(rng, context, &column.column_type);
                         if &v == value {
@@ -184,6 +196,21 @@ impl Predicate {
                     )
                 }),
                 Box::new(|rng| {
+                    // `x IS <other value>` is false, and unlike `x <> <other value>`
+                    // it stays false rather than NULL when the column is NULL.
+                    let v = loop {
+                        let v = SimValue::arbitrary_from(rng, context, &column.column_type);
+                        if &v != value {
+                            break v;
+                        }
+                    };
+                    Expr::Binary(
+                        Box::new(qualified_column_expr(&table_name, &column.name)),
+                        ast::Operator::Is,
+                        Box::new(Expr::Literal(v.into())),
+                    )
+                }),
+                Box::new(|rng| {
                     let gt_value =
                         GTValue::arbitrary_from(rng, context, (value, column.column_type)).0;
                     Expr::Binary(
@@ -233,6 +260,15 @@ impl SimplePredicate {
                     Expr::Binary(
                         Box::new(qualified_column_expr(table_name, &column.column.name)),
                         ast::Operator::Equals,
+                        Box::new(Expr::Literal(column_value.into())),
+                    )
+                }),
+                Box::new(|_rng| {
+                    // `IS` seeks the index like `=` but compares NULLs as equal,
+                    // so it is true for this row even when the value is NULL.
+                    Expr::Binary(
+                        Box::new(qualified_column_expr(table_name, &column.column.name)),
+                        ast::Operator::Is,
                         Box::new(Expr::Literal(column_value.into())),
                     )
                 }),

--- a/sqlite/conformance/sqlite-sqltests/full-join-on-clause-operand-order.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/full-join-on-clause-operand-order.sqltest
@@ -1,0 +1,31 @@
+@database :memory:
+
+# A FULL JOIN needs an equality in the ON clause to build its hash join.
+# Both operand orders must be accepted: `t1.a = t2.b` and `t2.b = t1.a`
+# mean the same thing.
+
+test full-join-on-clause-accepts-left-to-right-operands {
+    CREATE TABLE t1(a);
+    CREATE TABLE t2(b);
+    INSERT INTO t1 VALUES (1), (2);
+    INSERT INTO t2 VALUES (2), (3);
+    SELECT quote(a), quote(b) FROM t1 FULL JOIN t2 ON t1.a = t2.b ORDER BY 1, 2;
+}
+expect {
+    1|NULL
+    2|2
+    NULL|3
+}
+
+test full-join-on-clause-accepts-right-to-left-operands {
+    CREATE TABLE t3(a);
+    CREATE TABLE t4(b);
+    INSERT INTO t3 VALUES (1), (2);
+    INSERT INTO t4 VALUES (2), (3);
+    SELECT quote(a), quote(b) FROM t3 FULL JOIN t4 ON t4.b = t3.a ORDER BY 1, 2;
+}
+expect {
+    1|NULL
+    2|2
+    NULL|3
+}

--- a/sqlite/conformance/sqlite-sqltests/full-join-where-terms.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/full-join-where-terms.sqltest
@@ -1,0 +1,67 @@
+@database :memory:
+
+# A FULL JOIN null-extends BOTH sides: the right table gets NULLs when a left
+# row has no match, and every table on the left side gets NULLs when a right
+# row has no match. `x IS ...` can be TRUE on such a NULL-extended row, so an
+# `IS` WHERE term must never be consumed into the access path of any table a
+# FULL JOIN can null-extend — consuming it changes which rows count as matched
+# and drops the filter from the null-extended rows.
+
+test full-join-where-is-null-on-left-table-must-filter-matched-rows {
+    CREATE TABLE t1(a);
+    CREATE INDEX t1a ON t1(a);
+    CREATE TABLE t2(b);
+    INSERT INTO t1 VALUES (1), (2), (NULL);
+    INSERT INTO t2 VALUES (2), (3);
+    SELECT quote(a), quote(b) FROM t1 FULL OUTER JOIN t2 ON t1.a = t2.b
+    WHERE t1.a IS NULL ORDER BY 1, 2;
+}
+expect {
+    NULL|3
+    NULL|NULL
+}
+
+test full-join-where-is-value-on-left-table-must-filter-null-extended-rows {
+    CREATE TABLE t3(a);
+    CREATE INDEX t3a ON t3(a);
+    CREATE TABLE t4(b);
+    INSERT INTO t3 VALUES (1), (2), (NULL);
+    INSERT INTO t4 VALUES (2), (3);
+    SELECT quote(a), quote(b) FROM t3 FULL OUTER JOIN t4 ON t3.a = t4.b
+    WHERE t3.a IS 2 ORDER BY 1, 2;
+}
+expect {
+    2|2
+}
+
+test full-join-where-is-null-on-rowid-alias-of-left-table {
+    CREATE TABLE t5(id INTEGER PRIMARY KEY, n);
+    CREATE TABLE t6(pid, v);
+    INSERT INTO t5 VALUES (1, 'p1'), (2, 'p2');
+    INSERT INTO t6 VALUES (1, 'x'), (3, 'w');
+    SELECT quote(t5.n), quote(t6.v) FROM t5 FULL JOIN t6 ON t5.id = t6.pid
+    WHERE t5.id IS NULL ORDER BY 1, 2;
+}
+expect {
+    NULL|'w'
+}
+
+# Terms that can never be true on a null-extended row (like `=`) have the same
+# problem on a FULL JOIN, through a different door: the FULL JOIN emits its
+# null-extended rows by jumping past the scan, so a term consumed into the
+# access path is never checked against them. On the right side of a plain LEFT
+# JOIN the engine re-checks consumed terms when it emits the null-extended row,
+# but no such re-check exists for the rows a FULL JOIN synthesizes.
+
+test full-join-where-eq-on-left-table-must-filter-null-extended-rows {
+    CREATE TABLE t7(id, n);
+    CREATE INDEX t7i ON t7(id);
+    CREATE TABLE t8(pid, v);
+    INSERT INTO t7 VALUES (1, 'p1'), (2, 'p2');
+    INSERT INTO t8 VALUES (1, 'x'), (3, 'w');
+    SELECT quote(t7.n), quote(t8.v) FROM t7 FULL JOIN t8 ON t7.id = t8.pid
+    WHERE t7.id = 1 ORDER BY 1, 2;
+}
+expect {
+    'p1'|'x'
+}

--- a/sqlite/conformance/sqlite-sqltests/hash-join-key-from-wrong-on-clause.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/hash-join-key-from-wrong-on-clause.sqltest
@@ -1,0 +1,24 @@
+@database :memory:
+
+# An ON-clause term belongs to one specific join: it decides what counts as a
+# match for THAT join only. Here `x0.c = x1.a` sits in x2's ON clause (legal:
+# it references only tables to its left), so it filters which x2 rows match —
+# it must NOT become the join condition between x0 and x1, whose own ON
+# clause is the constant 0 (no x1 row ever matches, every x0 row gets one
+# null-extended x1 row).
+
+test on-clause-term-must-not-drive-an-earlier-join {
+    CREATE TABLE t1(c);
+    CREATE TABLE t2(a, d);
+    CREATE TABLE t3(a);
+    INSERT INTO t1 VALUES (NULL), (3);
+    INSERT INTO t2 VALUES (1, NULL), (3, 3);
+    INSERT INTO t3 VALUES (3), (NULL);
+    SELECT quote(x0.c), quote(x1.a), quote(x2.a)
+    FROM t1 x0 LEFT JOIN t3 x1 ON 0 LEFT JOIN t2 x2 ON x0.c = x1.a
+    ORDER BY 1, 2, 3;
+}
+expect {
+    3|NULL|NULL
+    NULL|NULL|NULL
+}

--- a/sqlite/conformance/sqlite-sqltests/is-operator-index-seek-order-by.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/is-operator-index-seek-order-by.sqltest
@@ -1,0 +1,73 @@
+@database :memory:
+
+# A UNIQUE index stores every NULL key separately, so `x IS NULL` can match
+# many rows even when the index is unique. The planner must not treat such a
+# seek as a single-row lookup: if it does, it skips the sorter for
+# ORDER BY (x, <inner loop column>) and rows come out in nested-loop order
+# instead of sorted order.
+
+test is-null-seek-on-unique-index-keeps-the-sorter {
+    CREATE TABLE t1(x);
+    CREATE UNIQUE INDEX i1 ON t1(x);
+    CREATE TABLE t2(y);
+    INSERT INTO t1 VALUES (NULL), (NULL);
+    INSERT INTO t2 VALUES (1), (2);
+    SELECT t2.y FROM t1 JOIN t2 WHERE t1.x IS NULL ORDER BY t1.x, t2.rowid;
+}
+expect {
+    1
+    1
+    2
+    2
+}
+
+# The same wrong "one row per seek" claim can be reached with plain `=` when
+# the ORDER BY mentions the equality column itself: the column is then counted
+# twice (once as an equality, once as a consumed ORDER BY term), which makes
+# the planner believe the ORDER BY prefix reached the rowid.
+
+test eq-seek-on-non-unique-index-keeps-the-sorter {
+    CREATE TABLE t5(x);
+    CREATE INDEX i5 ON t5(x);
+    CREATE TABLE t6(y);
+    INSERT INTO t5 VALUES (5), (5);
+    INSERT INTO t6 VALUES (1), (2);
+    SELECT t6.y FROM t5 JOIN t6 WHERE t5.x = 5 ORDER BY t5.x, t6.rowid;
+}
+expect {
+    1
+    1
+    2
+    2
+}
+
+test eq-seek-on-partial-unique-index-prefix-keeps-the-sorter {
+    CREATE TABLE t7(x, z);
+    CREATE UNIQUE INDEX i7 ON t7(x, z);
+    CREATE TABLE t8(y);
+    INSERT INTO t7 VALUES (5, 1), (5, 2);
+    INSERT INTO t8 VALUES (1), (2);
+    SELECT t8.y FROM t7 JOIN t8 WHERE t7.x = 5 ORDER BY t7.x, t8.rowid;
+}
+expect {
+    1
+    1
+    2
+    2
+}
+
+test is-null-seek-on-unique-column-keeps-the-sorter-with-forced-inner-index {
+    CREATE TABLE t3(a UNIQUE);
+    CREATE TABLE t4(c);
+    CREATE INDEX t4c ON t4(c);
+    INSERT INTO t3 VALUES (NULL), (NULL);
+    INSERT INTO t4 VALUES (2), (1);
+    SELECT quote(t3.a), t4.c FROM t3 CROSS JOIN t4 INDEXED BY t4c
+    WHERE t3.a IS NULL ORDER BY t3.a, t4.c;
+}
+expect {
+    NULL|1
+    NULL|1
+    NULL|2
+    NULL|2
+}

--- a/sqlite/conformance/sqlite-sqltests/is-true-false-truth-tests.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/is-true-false-truth-tests.sqltest
@@ -1,0 +1,50 @@
+@database :memory:
+
+# `x IS TRUE` / `x IS FALSE` (and the IS NOT forms) test the truth of x; they
+# do not compare x with 1 or 0. SQLite still applies the truth test when the
+# TRUE/FALSE keyword sits inside parentheses or under COLLATE, because it
+# resolves the keyword after skipping those wrappers (resolve.c, and the
+# grammar collapses parentheses). `2 IS TRUE` is 1, so `2 IS (TRUE)` must be
+# 1 too.
+
+test is-true-through-parentheses {
+    SELECT 2 IS (TRUE), 2 IS ((TRUE)), 0 IS (FALSE), NULL IS (TRUE);
+}
+expect {
+    1|1|1|0
+}
+
+test is-not-through-parentheses {
+    SELECT 2 IS NOT (FALSE), NULL IS NOT (FALSE), 0 IS NOT (TRUE);
+}
+expect {
+    1|1|1
+}
+
+test is-true-through-collate {
+    SELECT 2 IS TRUE COLLATE NOCASE, 2 IS (TRUE) COLLATE NOCASE;
+}
+expect {
+    1|1
+}
+
+test indexed-is-parenthesized-true-is-a-truth-test {
+    CREATE TABLE t(x);
+    CREATE INDEX ti ON t(x);
+    INSERT INTO t VALUES (0), (1), (2), (NULL);
+    SELECT x FROM t WHERE x IS (TRUE) ORDER BY x;
+}
+expect {
+    1
+    2
+}
+
+test indexed-is-parenthesized-false-is-a-truth-test {
+    CREATE TABLE u(x);
+    CREATE INDEX ui ON u(x);
+    INSERT INTO u VALUES (0), (1), (2), (NULL);
+    SELECT x FROM u WHERE x IS (FALSE) ORDER BY x;
+}
+expect {
+    0
+}

--- a/sqlite/conformance/sqlite-sqltests/left-join-null-rejecting-terms.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/left-join-null-rejecting-terms.sqltest
@@ -1,0 +1,55 @@
+@database :memory:
+
+# A LEFT JOIN may only be rewritten to an inner join when the WHERE clause
+# rejects the join's null-extended rows — i.e. the term can never be TRUE when
+# every column of the right table is NULL. A NULL test hidden inside a bigger
+# expression breaks that rule: `(b.x IS NULL) = 1` is TRUE on the
+# null-extended row, so the rewrite would wrongly delete it.
+
+test left-join-survives-a-nested-null-test-in-where {
+    CREATE TABLE a(x);
+    CREATE TABLE b(x);
+    INSERT INTO a VALUES (1);
+    INSERT INTO b VALUES (2);
+    SELECT count(*) FROM a LEFT JOIN b ON a.x = b.x WHERE (b.x IS NULL) = 1;
+}
+expect {
+    1
+}
+
+test left-join-survives-a-nested-null-test-under-not {
+    CREATE TABLE c(x);
+    CREATE TABLE d(x);
+    INSERT INTO c VALUES (1);
+    INSERT INTO d VALUES (2);
+    SELECT count(*) FROM c LEFT JOIN d ON c.x = d.x WHERE NOT (d.x IS NOT NULL);
+}
+expect {
+    1
+}
+
+test left-join-survives-a-case-term-in-where {
+    CREATE TABLE e(x);
+    CREATE TABLE f(x);
+    INSERT INTO e VALUES (1);
+    INSERT INTO f VALUES (2);
+    SELECT count(*) FROM e LEFT JOIN f ON e.x = f.x
+    WHERE CASE WHEN f.x > 5 THEN f.x ELSE 1 END > 0;
+}
+expect {
+    1
+}
+
+# The other direction: a null-rejecting OR of terms on the right table must
+# still filter correctly (whether or not the join is rewritten to inner).
+
+test left-join-where-or-terms-filter-null-extended-rows {
+    CREATE TABLE g(id);
+    CREATE TABLE h(id, v, w);
+    INSERT INTO g VALUES (1), (2);
+    INSERT INTO h VALUES (1, 5, 0);
+    SELECT g.id FROM g LEFT JOIN h ON g.id = h.id WHERE h.v = 5 OR h.w = 7;
+}
+expect {
+    1
+}

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-for-nulls-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-for-nulls-after-analyze.snap
@@ -10,19 +10,20 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SCAN items
+`--SEARCH items USING INDEX idx_items_cat (category=?)
 
 BYTECODE
-addr  opcode         p1  p2  p3  p4          p5  comment
-   0  Init            0  10   0               0  Start at 10
-   1  OpenRead        0   2   0  k(3,B,B,B)   0  table=items, root=2, iDb=0
-   2  Rewind          0   9   0               0  Rewind table items
-   3    Column        0   1   4               0  r[4]=items.category
-   4    NotNull       4   8   0               0  r[4]!=NULL -> goto 8
-   5    RowId         0   1   0               0  r[1]=items.rowid
-   6    ColumnRange   0   1   2  2            0  r[2..3]=items.category..subcategory
-   7    ResultRow     1   3   0               0  output=r[1..3]
-   8  Next            0   3   0               0
-   9  Halt            0   0   0               0
-  10  Transaction     0   1   3               0  iDb=0 tx_mode=Read
-  11  Goto            0   1   0               0
+addr  opcode         p1  p2  p3  p4        p5  comment
+   0  Init            0  11   0             0  Start at 11
+   1  OpenRead        0   3   0  k(3,B,B)   0  index=idx_items_cat, root=3, iDb=0
+   2  Null            0   4   0             0  r[4]=NULL
+   3  Affinity        4   1   0             0  r[4..5] = B
+   4  SeekGE          0  10   4             0  key=[4..4]
+   5    IdxGT         0  10   4             0  key=[4..4]
+   6    IdxRowId      0   1   0             0  r[1]=cursor 0 for index idx_items_cat.rowid
+   7    ColumnRange   0   0   2  2          0  r[2..3]=idx_items_cat.category..subcategory
+   8    ResultRow     1   3   0             0  output=r[1..3]
+   9  Next            0   5   0             0
+  10  Halt            0   0   0             0
+  11  Transaction     0   1   3             0  iDb=0 tx_mode=Read
+  12  Goto            0   1   0             0

--- a/sqlite/conformance/turso-sqltests/is-operator-index-seek.sqltest
+++ b/sqlite/conformance/turso-sqltests/is-operator-index-seek.sqltest
@@ -144,7 +144,9 @@ expect {
 
 # TRUE and FALSE on the right of IS check boolean value, not equality. For
 # example, 2 and text '1' are true even though neither is equal to integer 1.
-# The special rule only applies when TRUE or FALSE is directly on the right.
+# The rule applies when TRUE or FALSE is on the right, also inside
+# parentheses or under COLLATE — but not on the left, and not under a unary
+# `+`, which turns it back into an ordinary comparison with 1 or 0.
 test is-true-and-false-keep-boolean-semantics-with-an-index {
     CREATE TABLE t (x);
     CREATE INDEX ti ON t (x);
@@ -152,6 +154,7 @@ test is-true-and-false-keep-boolean-semantics-with-an-index {
 
     SELECT 'true', quote(x) FROM t WHERE x IS TRUE ORDER BY rowid;
     SELECT 'false', quote(x) FROM t WHERE x IS FALSE ORDER BY rowid;
+    SELECT 'paren', quote(x) FROM t WHERE x IS (TRUE) ORDER BY rowid;
 
     SELECT 'left', quote(x) FROM t WHERE TRUE IS x;
     SELECT 'plus', quote(x) FROM t WHERE x IS +TRUE;
@@ -164,6 +167,10 @@ expect {
     false|0
     false|'true'
     false|'x'
+    paren|1
+    paren|2
+    paren|-1
+    paren|'1'
     left|1
     plus|1
 }

--- a/sqlite/conformance/turso-sqltests/is-operator-index-seek.sqltest
+++ b/sqlite/conformance/turso-sqltests/is-operator-index-seek.sqltest
@@ -1,0 +1,90 @@
+@database :memory:
+
+# `IS` is an index-usable, NULL-matching equality, exactly like SQLite: it seeks
+# the index (see the query-plan tests below) and a NULL key component matches the
+# rows whose key component is NULL, which `=` can never do.
+
+test is-matches-null-key-component-on-composite-pk {
+    CREATE TABLE t (a, b, c, PRIMARY KEY (a, b));
+    INSERT INTO t VALUES ('a1', NULL, 'c1'), ('a1', 'b1', 'c2'), ('a2', 'b2', 'c3'), (NULL, NULL, 'c4');
+
+    SELECT c FROM t WHERE a IS 'a1' AND b IS NULL;
+}
+expect {
+    c1
+}
+
+test equals-never-matches-null-key-component {
+    CREATE TABLE t (a, b, c, PRIMARY KEY (a, b));
+    INSERT INTO t VALUES ('a1', NULL, 'c1'), ('a1', 'b1', 'c2');
+
+    SELECT count(*) FROM t WHERE a = 'a1' AND b = NULL;
+}
+expect {
+    0
+}
+
+test is-matches-null-in-every-key-component {
+    CREATE TABLE t (a, b, c, PRIMARY KEY (a, b));
+    INSERT INTO t VALUES ('a1', NULL, 'c1'), (NULL, NULL, 'c4'), (NULL, 'b6', 'c6');
+
+    SELECT c FROM t WHERE a IS NULL AND b IS NULL;
+}
+expect {
+    c4
+}
+
+test is-mixed-with-equals-on-the-same-key {
+    CREATE TABLE t (a, b, c, PRIMARY KEY (a, b));
+    INSERT INTO t VALUES ('a1', NULL, 'c1'), ('a1', 'b1', 'c2');
+
+    SELECT c FROM t WHERE a = 'a1' AND b IS NULL;
+}
+expect {
+    c1
+}
+
+test is-deletes-row-with-null-key-component {
+    CREATE TABLE t (a, b, c, PRIMARY KEY (a, b));
+    INSERT INTO t VALUES ('a1', NULL, 'c1'), ('a1', 'b1', 'c2');
+    DELETE FROM t WHERE a IS 'a1' AND b IS NULL;
+
+    SELECT c FROM t ORDER BY c;
+}
+expect {
+    c2
+}
+
+test is-updates-row-with-null-key-component {
+    CREATE TABLE t (a, b, c, PRIMARY KEY (a, b));
+    INSERT INTO t VALUES ('a1', NULL, 'c1'), ('a1', 'b1', 'c2');
+    UPDATE t SET c = 'updated' WHERE a IS 'a1' AND b IS NULL;
+
+    SELECT c FROM t ORDER BY c;
+}
+expect {
+    c2
+    updated
+}
+
+test is-matches-null-on-single-column-primary-key {
+    CREATE TABLE s (k, v);
+    CREATE UNIQUE INDEX si ON s (k);
+    INSERT INTO s VALUES ('k1', 'v1'), (NULL, 'v2');
+
+    SELECT v FROM s WHERE k IS NULL;
+}
+expect {
+    v2
+}
+
+test is-null-matches-across-a-left-join {
+    CREATE TABLE t (a, b, c, PRIMARY KEY (a, b));
+    INSERT INTO t VALUES ('a1', NULL, 'c1'), (NULL, 'a1', 'c2');
+
+    SELECT t1.c, t2.c FROM t t1 LEFT JOIN t t2 ON t1.a IS t2.b ORDER BY t1.c;
+}
+expect {
+    c1|c2
+    c2|c1
+}

--- a/sqlite/conformance/turso-sqltests/is-operator-index-seek.sqltest
+++ b/sqlite/conformance/turso-sqltests/is-operator-index-seek.sqltest
@@ -142,6 +142,32 @@ expect {
     0
 }
 
+# TRUE and FALSE on the right of IS check boolean value, not equality. For
+# example, 2 and text '1' are true even though neither is equal to integer 1.
+# The special rule only applies when TRUE or FALSE is directly on the right.
+test is-true-and-false-keep-boolean-semantics-with-an-index {
+    CREATE TABLE t (x);
+    CREATE INDEX ti ON t (x);
+    INSERT INTO t VALUES (NULL), (0), (1), (2), (-1), ('1'), ('true'), ('x');
+
+    SELECT 'true', quote(x) FROM t WHERE x IS TRUE ORDER BY rowid;
+    SELECT 'false', quote(x) FROM t WHERE x IS FALSE ORDER BY rowid;
+
+    SELECT 'left', quote(x) FROM t WHERE TRUE IS x;
+    SELECT 'plus', quote(x) FROM t WHERE x IS +TRUE;
+}
+expect {
+    true|1
+    true|2
+    true|-1
+    true|'1'
+    false|0
+    false|'true'
+    false|'x'
+    left|1
+    plus|1
+}
+
 # The antijoin idiom. `e.id IS NULL` is TRUE for a null-extended row, so it must
 # not be pushed into the loop of the LEFT JOIN's right-hand table: doing so
 # removes the very rows whose absence produces the null extension, and every

--- a/sqlite/conformance/turso-sqltests/is-operator-index-seek.sqltest
+++ b/sqlite/conformance/turso-sqltests/is-operator-index-seek.sqltest
@@ -88,3 +88,74 @@ expect {
     c1|c2
     c2|c1
 }
+
+# A UNIQUE index accepts any number of NULLs, so a NULL key component can match
+# more than one row. The seek must return all of them, not stop at the first.
+test is-matches-every-row-with-a-null-key-component {
+    CREATE TABLE t (a, b, c, PRIMARY KEY (a, b));
+    INSERT INTO t VALUES ('a1', NULL, 'c1'), ('a1', NULL, 'c2'), ('a1', NULL, 'c3'), ('a1', 'b1', 'c4'), ('a2', NULL, 'c5');
+
+    SELECT c FROM t WHERE a IS 'a1' AND b IS NULL ORDER BY c;
+}
+expect {
+    c1
+    c2
+    c3
+}
+
+test is-matches-every-null-in-a-unique-index {
+    CREATE TABLE s (k, v);
+    CREATE UNIQUE INDEX si ON s (k);
+    INSERT INTO s VALUES ('k1', 'v1'), (NULL, 'v2'), (NULL, 'v3'), (NULL, 'v4');
+
+    SELECT v FROM s WHERE k IS NULL ORDER BY v;
+}
+expect {
+    v2
+    v3
+    v4
+}
+
+# A descending index stores NULLs at the other end, so the seek runs backwards
+# from the NULL key instead of forwards.
+test is-matches-null-key-component-on-descending-index {
+    CREATE TABLE t (a, b, c);
+    CREATE INDEX ti ON t (a DESC, b ASC);
+    INSERT INTO t VALUES (1, NULL, 'c1'), (1, NULL, 'c2'), (1, 2, 'c3'), (NULL, NULL, 'c4');
+
+    SELECT c FROM t WHERE a IS 1 AND b IS NULL ORDER BY c;
+}
+expect {
+    c1
+    c2
+}
+
+# A rowid is never NULL, so seeking a table b-tree with a NULL key finds nothing
+# even though `IS` matches NULL in an index.
+test is-null-never-matches-a-rowid {
+    CREATE TABLE r (k INTEGER PRIMARY KEY, v);
+    INSERT INTO r VALUES (1, 'v1'), (2, 'v2');
+
+    SELECT count(*) FROM r WHERE k IS NULL;
+}
+expect {
+    0
+}
+
+# The antijoin idiom. `e.id IS NULL` is TRUE for a null-extended row, so it must
+# not be pushed into the loop of the LEFT JOIN's right-hand table: doing so
+# removes the very rows whose absence produces the null extension, and every
+# left row comes back as unmatched.
+test is-null-in-where-does-not-constrain-a-left-join-rhs {
+    CREATE TABLE p (id INTEGER PRIMARY KEY, n);
+    CREATE TABLE e (id INTEGER PRIMARY KEY, pid, v);
+    CREATE INDEX ei ON e (pid);
+    INSERT INTO p VALUES (1, 'p1'), (2, 'p2'), (3, 'p3');
+    INSERT INTO e VALUES (10, 1, 'x'), (11, 1, 'y');
+
+    SELECT p.n FROM p LEFT JOIN e ON e.pid = p.id WHERE e.id IS NULL ORDER BY p.n;
+}
+expect {
+    p2
+    p3
+}

--- a/testing/differential-oracle/sql_gen/src/ast.rs
+++ b/testing/differential-oracle/sql_gen/src/ast.rs
@@ -1806,7 +1806,7 @@ pub enum BinOp {
     BitOr,
     LeftShift,
     RightShift,
-    // Null-safe comparison (stubs — weight 0)
+    // Null-safe comparison
     Is,
     IsNot,
     // Pattern matching (stub — weight 0)
@@ -1853,6 +1853,10 @@ impl fmt::Display for BinOp {
 
 impl BinOp {
     /// Returns comparison operators.
+    ///
+    /// `IS` / `IS NOT` are here because they are ordinary comparisons that happen
+    /// to compare NULLs as equal, and because `IS` seeks an index the same way `=`
+    /// does — so leaving them out hid a whole class of query plans.
     pub fn comparison() -> &'static [BinOp] {
         &[
             BinOp::Eq,
@@ -1861,6 +1865,8 @@ impl BinOp {
             BinOp::Le,
             BinOp::Gt,
             BinOp::Ge,
+            BinOp::Is,
+            BinOp::IsNot,
         ]
     }
 

--- a/tests/fuzz/join.rs
+++ b/tests/fuzz/join.rs
@@ -233,7 +233,11 @@ mod join_fuzz_tests {
                 let mut preds = Vec::new();
                 for _ in 0..num_preds {
                     let col = join_cols[rng.random_range(0..join_cols.len())];
-                    preds.push(format!("{left_alias}.{col} = {right_alias}.{col}"));
+                    // 25% chance of `IS` instead of `=`. Both seek the index, but
+                    // `IS` also joins NULL to NULL, so it produces matches where
+                    // `=` produces the null-extended row of a LEFT JOIN.
+                    let op = if rng.random_bool(0.25) { "IS" } else { "=" };
+                    preds.push(format!("{left_alias}.{col} {op} {right_alias}.{col}"));
                 }
                 preds.sort();
                 preds.dedup();
@@ -267,7 +271,7 @@ mod join_fuzz_tests {
                 let col = cols[rng.random_range(0..cols.len())];
                 // EXISTS/NOT EXISTS only when indexes exist — without indexes,
                 // non-unnested correlated subqueries cause pathological O(n²) scans.
-                let max_kind = if add_indexes { 6 } else { 4 };
+                let max_kind = if add_indexes { 7 } else { 5 };
                 let kind = rng.random_range(0..max_kind);
                 let cond = match kind {
                     0 => {
@@ -280,9 +284,16 @@ mod join_fuzz_tests {
                     }
                     2 => format!("{alias}.{col} IS NULL"),
                     3 => format!("{alias}.{col} IS NOT NULL"),
-                    4 | 5 => {
+                    // `IS` against a literal seeks the index like `=`, but it stays
+                    // TRUE for a null-extended row, so it must not be pushed into
+                    // the loop of a LEFT JOIN's right-hand table.
+                    4 => {
+                        let val = rng.random_range(-10..=20);
+                        format!("{alias}.{col} IS {val}")
+                    }
+                    5 | 6 => {
                         // EXISTS / NOT EXISTS correlated subquery
-                        let not = if kind == 5 { "NOT " } else { "" };
+                        let not = if kind == 6 { "NOT " } else { "" };
                         let target_table = tables[rng.random_range(0..tables.len())];
                         let sub_col = ["a", "b", "c", "d"][rng.random_range(0..4)];
                         let extra = if rng.random_bool(0.3) {

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -87,7 +87,10 @@ mod fuzz_tests {
         let limbo_conn = db.connect_limbo();
         helpers::execute_on_both(&limbo_conn, &sqlite_conn, &insert, "");
 
-        const COMPARISONS: [&str; 4] = ["<", "<=", ">", ">="];
+        // `=` and `IS` both seek the rowid directly. A rowid is never NULL, so
+        // `x IS NULL` must find nothing, and the non-integer values below have to
+        // go through the same affinity handling as `=`.
+        const COMPARISONS: [&str; 6] = ["=", "IS", "<", "<=", ">", ">="];
         const ORDER_BY: [Option<&str>; 4] = [
             None,
             Some("ORDER BY x"),
@@ -183,8 +186,10 @@ mod fuzz_tests {
             .execute(db.init_sql.as_ref().unwrap(), [])
             .unwrap();
 
+        // A non-INTEGER PRIMARY KEY is a UNIQUE index, and a UNIQUE index accepts
+        // any number of NULLs. `x IS NULL` has to find all three of them.
         let insert = format!(
-            "INSERT INTO t VALUES {}",
+            "INSERT INTO t VALUES {}, (NULL), (NULL), (NULL)",
             (0..10000)
                 .map(|x| format!("({x})"))
                 .collect::<Vec<_>>()
@@ -196,7 +201,7 @@ mod fuzz_tests {
         let limbo_conn = db.connect_limbo();
         limbo_exec_rows(&limbo_conn, &insert);
 
-        const COMPARISONS: [&str; 5] = ["=", "<", "<=", ">", ">="];
+        const COMPARISONS: [&str; 6] = ["=", "IS", "<", "<=", ">", ">="];
 
         const ORDER_BY: [Option<&str>; 4] = [
             None,
@@ -207,7 +212,9 @@ mod fuzz_tests {
 
         for comp in COMPARISONS.iter() {
             for order_by in ORDER_BY.iter() {
-                for max in 0..=10000 {
+                // "NULL" as the last value: `=` matches nothing, `IS` matches the
+                // three NULL rows.
+                for max in (0..=10000).map(|x| x.to_string()).chain(["NULL".into()]) {
                     let query = format!(
                         "SELECT * FROM t WHERE x {} {} {} LIMIT 3",
                         comp,
@@ -321,29 +328,44 @@ mod fuzz_tests {
             }
         }
 
-        const COMPARISONS: [&str; 5] = ["=", "<", "<=", ">", ">="];
+        // `IS` seeks the index just like `=`, but it also matches rows whose key
+        // component is NULL. Both belong in the equality prefix of a seek key.
+        const EQUALITIES: [&str; 2] = ["=", "IS"];
+        const COMPARISONS: [&str; 6] = ["=", "IS", "<", "<=", ">", ">="];
 
-        // For verifying index scans, we only care about cases where all but potentially the last column are constrained by an equality (=),
+        // For verifying index scans, we only care about cases where all but potentially the last column are constrained by an equality (= or IS),
         // because this is the only way to utilize an index efficiently for seeking. This is called the "left-prefix rule" of indexes.
         // Hence we generate constraint combinations in this manner; as soon as a comparison is not an equality, we stop generating more constraints for the where clause.
         // Examples:
-        // x = 1 AND y = 2 AND z > 3
-        // x = 1 AND y > 2
+        // x = 1 AND y IS 2 AND z > 3
+        // x IS NULL AND y > 2
         // x > 1
         let col_comp_first = COMPARISONS
             .iter()
             .cloned()
             .map(|x| (Some(x), None, None))
             .collect::<Vec<_>>();
-        let col_comp_second = COMPARISONS
+        let col_comp_second = EQUALITIES
             .iter()
             .cloned()
-            .map(|x| (Some("="), Some(x), None))
+            .flat_map(|eq| {
+                COMPARISONS
+                    .iter()
+                    .cloned()
+                    .map(move |x| (Some(eq), Some(x), None))
+            })
             .collect::<Vec<_>>();
-        let col_comp_third = COMPARISONS
+        let col_comp_third = EQUALITIES
             .iter()
             .cloned()
-            .map(|x| (Some("="), Some("="), Some(x)))
+            .flat_map(|eq1| {
+                EQUALITIES.iter().cloned().flat_map(move |eq2| {
+                    COMPARISONS
+                        .iter()
+                        .cloned()
+                        .map(move |x| (Some(eq1), Some(eq2), Some(x)))
+                })
+            })
             .collect::<Vec<_>>();
 
         let all_comps = [col_comp_first, col_comp_second, col_comp_third].concat();
@@ -419,6 +441,12 @@ mod fuzz_tests {
             // Use a small limit to make the test complete faster
             let limit = 5;
 
+            /// Whether the operator pins the column to a single value, so it can be
+            /// part of an index seek key's equality prefix.
+            fn is_equality(operator: &str) -> bool {
+                operator == "=" || operator == "IS"
+            }
+
             /// Generate a comparison string (e.g. x > 10 AND x < 20) or just x > 10.
             fn generate_comparison(
                 operator: &str,
@@ -426,13 +454,16 @@ mod fuzz_tests {
                 col_val: i32,
                 rng: &mut ChaCha8Rng,
             ) -> String {
-                // 5% chance of using NULL as the comparison value
-                let val_str = if rng.random_range(0..20) == 0 {
+                // 5% chance of using NULL as the comparison value, except for `IS`,
+                // where a NULL key is the whole point: it matches the rows whose key
+                // component is NULL instead of matching nothing.
+                let null_chance = if operator == "IS" { 3 } else { 20 };
+                let val_str = if rng.random_range(0..null_chance) == 0 {
                     "NULL".to_string()
                 } else {
                     col_val.to_string()
                 };
-                if operator != "=" && rng.random_range(0..3) == 1 {
+                if !is_equality(operator) && rng.random_range(0..3) == 1 {
                     let val2 = if rng.random_range(0..20) == 0 {
                         "NULL".to_string()
                     } else {
@@ -499,11 +530,11 @@ mod fuzz_tests {
                     let order_by_only_equalities = !order_by_components.is_empty()
                         && order_by_components.iter().all(|o: &String| {
                             if o.starts_with("x ") {
-                                comp1 == Some("=")
+                                comp1.is_some_and(is_equality)
                             } else if o.starts_with("y ") {
-                                comp2 == Some("=")
+                                comp2.is_some_and(is_equality)
                             } else {
-                                comp3 == Some("=")
+                                comp3.is_some_and(is_equality)
                             }
                         });
 

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -4,6 +4,7 @@ mod test_ddl;
 mod test_ephemeral_cleanup;
 mod test_hash_join_materialization;
 mod test_in_seek;
+mod test_is_seek;
 mod test_materialized_subquery;
 mod test_read_path;
 mod test_vacuum;

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -6,6 +6,7 @@ mod test_hash_join_materialization;
 mod test_in_seek;
 mod test_is_seek;
 mod test_materialized_subquery;
+mod test_multi_index_scan;
 mod test_read_path;
 mod test_vacuum;
 mod test_write_path;

--- a/tests/integration/query_processing/test_hash_join_materialization.rs
+++ b/tests/integration/query_processing/test_hash_join_materialization.rs
@@ -283,3 +283,98 @@ ORDER BY t1.id, t2.id, t3.id, sub_t4.a LIMIT 50";
         "Mismatch after outer join conversion with hash join materialization"
     );
 }
+
+#[test]
+/// Regression: a join predicate silently dropped from the null-extended rows of
+/// a hash join.
+///
+/// `t3.d IS t4.d` belongs to the inner join with t4, so it must filter the rows
+/// that the preceding LEFT JOIN null-extends. The unmatched-row scan skipped it,
+/// because it only kept conditions whose tables were still cursor-positioned and
+/// t4's value arrives in a hash payload register instead. Every operator that is
+/// TRUE for a null-extended row exposes this — `=` and `<` hide it by evaluating
+/// to NULL there.
+fn hash_join_unmatched_rows_apply_payload_backed_predicates() {
+    let _ = env_logger::try_init();
+    let tmp_db = TempDatabase::new_empty();
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+    let conn = tmp_db.connect_limbo();
+    let schema = [
+        "CREATE TABLE t1(id INTEGER PRIMARY KEY, c INT, d INT)",
+        "CREATE TABLE t2(id INTEGER PRIMARY KEY, c INT, d INT)",
+        "CREATE TABLE t3(id INTEGER PRIMARY KEY, c INT, d INT)",
+        "CREATE TABLE t4(id INTEGER PRIMARY KEY, c INT, d INT)",
+    ];
+    for stmt in &schema {
+        limbo_exec_rows(&conn, stmt);
+        sqlite_conn.execute(stmt, []).unwrap();
+    }
+
+    sqlite_conn.execute("BEGIN", []).unwrap();
+    conn.execute("BEGIN").unwrap();
+    for i in 0..30_i64 {
+        let d = i % 5;
+        let stmts = [
+            format!("INSERT INTO t1 VALUES ({}, {}, {d})", i + 1, i % 3),
+            format!("INSERT INTO t2 VALUES ({}, {}, {d})", i + 101, i % 3),
+            // t3.c never matches t2.c, so the LEFT JOIN null-extends every row.
+            format!("INSERT INTO t3 VALUES ({}, {}, {d})", i + 201, 900 + i),
+            format!(
+                "INSERT INTO t4 VALUES ({}, {}, {})",
+                i + 301,
+                i % 3,
+                if i % 4 == 0 {
+                    "NULL".to_string()
+                } else {
+                    d.to_string()
+                }
+            ),
+        ];
+        for stmt in &stmts {
+            conn.execute(stmt).unwrap();
+            sqlite_conn.execute(stmt, []).unwrap();
+        }
+    }
+    conn.execute("COMMIT").unwrap();
+    sqlite_conn.execute("COMMIT", []).unwrap();
+
+    for predicate in [
+        "t3.d IS t4.d",
+        "t3.d IS NOT t4.d",
+        "ifnull(t3.d, -9) = ifnull(t4.d, -9)",
+    ] {
+        let query = format!(
+            "SELECT count(*) FROM t1 \
+JOIN t2 ON t1.d = t2.d \
+LEFT JOIN t3 ON t2.c = t3.c \
+JOIN t4 ON {predicate}"
+        );
+
+        let explain_rows = limbo_exec_rows(&conn, &format!("EXPLAIN {query}"));
+        let has_unmatched_scan = explain_rows.iter().any(|row| {
+            row.get(1)
+                .and_then(value_as_text)
+                .is_some_and(|op| op == "HashScanUnmatched")
+        });
+        assert!(
+            has_unmatched_scan,
+            "expected a hash join unmatched-row scan for `{predicate}`"
+        );
+
+        let sqlite_rows = sqlite_exec_rows(&sqlite_conn, &query);
+        let limbo_rows = limbo_exec_rows(&conn, &query);
+        assert_eq!(
+            sqlite_rows, limbo_rows,
+            "null-extended rows were not filtered by `{predicate}`"
+        );
+        // Guard against the assertion passing because both sides return nothing.
+        assert!(
+            sqlite_rows
+                .first()
+                .and_then(|row| row.first())
+                .and_then(value_as_i64)
+                .is_some_and(|count| count > 0),
+            "`{predicate}` should match some rows"
+        );
+    }
+}

--- a/tests/integration/query_processing/test_is_seek.rs
+++ b/tests/integration/query_processing/test_is_seek.rs
@@ -129,3 +129,44 @@ fn is_operator_seek_matches_null_key_components() {
         vec!["c2".to_string(), "c3".to_string()]
     );
 }
+
+#[test]
+fn is_operator_seek_matches_null_in_65th_key_column() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    const WIDTH: usize = 65;
+    let columns = (1..=WIDTH)
+        .map(|i| format!("c{i}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let values = (1..=WIDTH)
+        .map(|i| if i == WIDTH { "NULL" } else { "1" })
+        .collect::<Vec<_>>()
+        .join(", ");
+    for statement in [
+        format!("CREATE TABLE t ({columns})"),
+        format!("CREATE INDEX ti ON t ({columns})"),
+        format!("INSERT INTO t VALUES ({values})"),
+    ] {
+        limbo_exec_rows(&conn, &statement);
+    }
+
+    // Column 65 is the first column that does not fit in one 64-bit word.
+    let predicate = (1..=WIDTH)
+        .map(|i| {
+            if i == WIDTH {
+                format!("c{i} IS NULL")
+            } else {
+                format!("c{i} = 1")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ");
+    let query = format!("SELECT count(*) FROM t WHERE {predicate}");
+
+    assert_eq!(
+        limbo_exec_rows(&conn, &query),
+        vec![vec![Value::Integer(1)]]
+    );
+}

--- a/tests/integration/query_processing/test_is_seek.rs
+++ b/tests/integration/query_processing/test_is_seek.rs
@@ -262,6 +262,38 @@ fn is_null_seek_does_not_use_average_rows_per_key_from_analyze() {
     );
 }
 
+/// `x IS 'a'` behaves exactly like `x = 'a'`: the key is a non-NULL literal,
+/// so a fully-constrained UNIQUE index returns at most one row and the sorter
+/// can be skipped. `x IS NULL` gives no such bound, so its sorter must stay.
+#[test]
+fn is_with_non_null_literal_key_is_a_point_lookup_for_order_by() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE t1(x UNIQUE)");
+    limbo_exec_rows(&conn, "CREATE TABLE t2(y)");
+    limbo_exec_rows(&conn, "INSERT INTO t1 VALUES ('a'), ('b')");
+    limbo_exec_rows(&conn, "INSERT INTO t2 VALUES (1), (2)");
+
+    let literal_key = query_plan(
+        &conn,
+        "SELECT t2.y FROM t1 JOIN t2 WHERE t1.x IS 'a' ORDER BY t1.x, t2.rowid",
+    );
+    assert!(
+        !literal_key.contains("USE SORTER"),
+        "IS 'a' pins one row of t1, so t2's rowid order already satisfies ORDER BY:\n{literal_key}"
+    );
+
+    let null_key = query_plan(
+        &conn,
+        "SELECT t2.y FROM t1 JOIN t2 WHERE t1.x IS NULL ORDER BY t1.x, t2.rowid",
+    );
+    assert!(
+        null_key.contains("USE SORTER"),
+        "IS NULL can match many rows of t1, so the sorter must stay:\n{null_key}"
+    );
+}
+
 #[test]
 fn is_operator_seek_matches_null_in_65th_key_column() {
     let tmp_db = TempDatabase::new_empty();

--- a/tests/integration/query_processing/test_is_seek.rs
+++ b/tests/integration/query_processing/test_is_seek.rs
@@ -1,0 +1,105 @@
+use crate::common::{limbo_exec_rows, TempDatabase};
+use rusqlite::types::Value;
+
+fn query_plan(conn: &std::sync::Arc<turso_core::Connection>, query: &str) -> String {
+    limbo_exec_rows(conn, &format!("EXPLAIN QUERY PLAN {query}"))
+        .iter()
+        .filter_map(|row| match row.get(3) {
+            Some(Value::Text(plan)) => Some(plan.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// `IS` is an index-usable equality in SQLite, not just a filter: it seeks the
+/// index and additionally matches NULL. Without the seek, every NULL-safe
+/// identity lookup (e.g. sync replay of a row whose composite primary key has a
+/// NULL component) degrades to a full table scan.
+#[test]
+fn is_operator_uses_index_seek() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE t(a, b, c, PRIMARY KEY (a, b))");
+    limbo_exec_rows(&conn, "CREATE TABLE s(k TEXT PRIMARY KEY, v)");
+
+    for query in [
+        "SELECT * FROM t WHERE a IS ? AND b IS ?",
+        "DELETE FROM t WHERE a IS ? AND b IS ?",
+        "UPDATE t SET c = ? WHERE a IS ? AND b IS ?",
+    ] {
+        let plan = query_plan(&conn, query);
+        assert!(
+            plan.contains("SEARCH t USING INDEX sqlite_autoindex_t_1 (a=? AND b=?)"),
+            "expected a two-column index seek for `{query}`, got:\n{plan}"
+        );
+    }
+
+    let plan = query_plan(&conn, "SELECT * FROM s WHERE k IS ?");
+    assert!(
+        plan.contains("SEARCH s USING INDEX sqlite_autoindex_s_1 (k=?)"),
+        "expected an index seek for a single-column key, got:\n{plan}"
+    );
+
+    // Mixing the two: the `=` prefix and the NULL-matching component both seek.
+    let plan = query_plan(&conn, "SELECT * FROM t WHERE a = ? AND b IS ?");
+    assert!(
+        plan.contains("SEARCH t USING INDEX sqlite_autoindex_t_1 (a=? AND b=?)"),
+        "expected a two-column index seek for a mixed `=`/`IS` key, got:\n{plan}"
+    );
+}
+
+/// The seek must still find rows whose key component is NULL: `IS` compares
+/// NULLs as equal, so the NULL travels into the seek key instead of ending the
+/// loop the way an `=` seek does.
+#[test]
+fn is_operator_seek_matches_null_key_components() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE t(a, b, c, PRIMARY KEY (a, b))");
+    limbo_exec_rows(
+        &conn,
+        "INSERT INTO t VALUES ('a1', NULL, 'c1'), ('a1', 'b1', 'c2'), (NULL, NULL, 'c3')",
+    );
+
+    let text = |rows: Vec<Vec<Value>>| -> Vec<String> {
+        rows.iter()
+            .map(|row| match row.first() {
+                Some(Value::Text(value)) => value.clone(),
+                other => panic!("unexpected row value: {other:?}"),
+            })
+            .collect()
+    };
+
+    assert_eq!(
+        text(limbo_exec_rows(
+            &conn,
+            "SELECT c FROM t WHERE a IS 'a1' AND b IS NULL"
+        )),
+        vec!["c1".to_string()]
+    );
+    assert_eq!(
+        text(limbo_exec_rows(
+            &conn,
+            "SELECT c FROM t WHERE a IS NULL AND b IS NULL"
+        )),
+        vec!["c3".to_string()]
+    );
+    assert_eq!(
+        text(limbo_exec_rows(
+            &conn,
+            "SELECT c FROM t WHERE a = 'a1' AND b IS NULL"
+        )),
+        vec!["c1".to_string()]
+    );
+    // `=` keeps its semantics: NULL never matches.
+    assert!(limbo_exec_rows(&conn, "SELECT c FROM t WHERE a = 'a1' AND b = NULL").is_empty());
+
+    limbo_exec_rows(&conn, "DELETE FROM t WHERE a IS 'a1' AND b IS NULL");
+    assert_eq!(
+        text(limbo_exec_rows(&conn, "SELECT c FROM t ORDER BY c")),
+        vec!["c2".to_string(), "c3".to_string()]
+    );
+}

--- a/tests/integration/query_processing/test_is_seek.rs
+++ b/tests/integration/query_processing/test_is_seek.rs
@@ -1,4 +1,4 @@
-use crate::common::{limbo_exec_rows, TempDatabase};
+use crate::common::{limbo_exec_rows, limbo_exec_rows_fallible, TempDatabase};
 use rusqlite::types::Value;
 
 fn query_plan(conn: &std::sync::Arc<turso_core::Connection>, query: &str) -> String {
@@ -128,6 +128,81 @@ fn is_operator_seek_matches_null_key_components() {
         text(limbo_exec_rows(&conn, "SELECT c FROM t ORDER BY c")),
         vec!["c2".to_string(), "c3".to_string()]
     );
+}
+
+/// A UNIQUE index stores every NULL key separately, so `WHERE a IS NULL` can
+/// touch many rows even though the index is unique. The statement journal must
+/// stay enabled for such an UPDATE: if the statement fails halfway, the rows it
+/// already changed must be restored.
+#[test]
+fn failed_update_with_is_seek_on_unique_index_rolls_back_every_row() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE t(a, b NOT NULL)");
+    limbo_exec_rows(&conn, "CREATE UNIQUE INDEX ta ON t(a)");
+    limbo_exec_rows(&conn, "INSERT INTO t VALUES (NULL, 1), (NULL, 2)");
+
+    limbo_exec_rows(&conn, "BEGIN");
+    // Row 1 gets b = 5, then row 2 hits the NOT NULL constraint. The whole
+    // statement must roll back, including the change to row 1 that was
+    // already applied.
+    let result = limbo_exec_rows_fallible(
+        &tmp_db,
+        &conn,
+        "UPDATE t SET b = CASE WHEN b = 1 THEN 5 ELSE NULL END WHERE a IS NULL",
+    );
+    assert!(
+        result.is_err(),
+        "expected the UPDATE to fail on NOT NULL, got {result:?}"
+    );
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT b FROM t ORDER BY rowid"),
+        vec![vec![Value::Integer(1)], vec![Value::Integer(2)]],
+        "the failed UPDATE must not leave row 1 changed"
+    );
+    limbo_exec_rows(&conn, "COMMIT");
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT b FROM t ORDER BY rowid"),
+        vec![vec![Value::Integer(1)], vec![Value::Integer(2)]],
+        "the change from the failed UPDATE must not survive COMMIT"
+    );
+}
+
+/// Same as above, but the many-NULL-rows key component sits at the end of a
+/// composite UNIQUE index behind an `IS <non-NULL>` component.
+#[test]
+fn failed_update_with_composite_is_seek_on_unique_index_rolls_back_every_row() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE t(k1, k2, b NOT NULL)");
+    limbo_exec_rows(&conn, "CREATE UNIQUE INDEX tk ON t(k1, k2)");
+    limbo_exec_rows(
+        &conn,
+        "INSERT INTO t VALUES (1, NULL, 1), (1, NULL, 2), (2, 'x', 3)",
+    );
+
+    limbo_exec_rows(&conn, "BEGIN");
+    let result = limbo_exec_rows_fallible(
+        &tmp_db,
+        &conn,
+        "UPDATE t SET b = CASE WHEN b = 1 THEN 5 ELSE NULL END WHERE k1 IS 1 AND k2 IS NULL",
+    );
+    assert!(
+        result.is_err(),
+        "expected the UPDATE to fail on NOT NULL, got {result:?}"
+    );
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT b FROM t ORDER BY rowid"),
+        vec![
+            vec![Value::Integer(1)],
+            vec![Value::Integer(2)],
+            vec![Value::Integer(3)]
+        ],
+        "the failed UPDATE must not leave row 1 changed"
+    );
+    limbo_exec_rows(&conn, "COMMIT");
 }
 
 #[test]

--- a/tests/integration/query_processing/test_is_seek.rs
+++ b/tests/integration/query_processing/test_is_seek.rs
@@ -50,6 +50,32 @@ fn is_operator_uses_index_seek() {
     );
 }
 
+#[test]
+fn is_true_and_false_do_not_use_equality_seeks() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE t(x)");
+    limbo_exec_rows(&conn, "CREATE INDEX ti ON t(x)");
+    for literal in ["TRUE", "FALSE"] {
+        let plan = query_plan(&conn, &format!("SELECT * FROM t WHERE x IS {literal}"));
+        assert!(
+            plan.contains("SCAN t"),
+            "`IS {literal}` checks boolean value and cannot seek one key, got:\n{plan}"
+        );
+    }
+    for query in [
+        "SELECT * FROM t WHERE TRUE IS x",
+        "SELECT * FROM t WHERE x IS +TRUE",
+    ] {
+        let plan = query_plan(&conn, query);
+        assert!(
+            plan.contains("SEARCH t USING INDEX ti (x=?)"),
+            "expected an index seek for `{query}`, got:\n{plan}"
+        );
+    }
+}
+
 /// The seek must still find rows whose key component is NULL: `IS` compares
 /// NULLs as equal, so the NULL travels into the seek key instead of ending the
 /// loop the way an `=` seek does.

--- a/tests/integration/query_processing/test_is_seek.rs
+++ b/tests/integration/query_processing/test_is_seek.rs
@@ -205,6 +205,63 @@ fn failed_update_with_composite_is_seek_on_unique_index_rolls_back_every_row() {
     limbo_exec_rows(&conn, "COMMIT");
 }
 
+/// Rows: `a` is NULL for 90% of the 2000 rows and holds a distinct value on
+/// every 10th row. sqlite_stat1 then reports ~10 average rows per `a` key
+/// (2000 rows / 201 distinct keys, NULLs counting as one key) even though the
+/// NULL bucket alone holds 1800 rows. `b` cycles 0..100, so every `b` value
+/// matches ~20 rows.
+fn create_null_heavy_table(conn: &std::sync::Arc<turso_core::Connection>, a_index_ddl: &str) {
+    limbo_exec_rows(conn, "CREATE TABLE t(id INTEGER PRIMARY KEY, a, b)");
+    limbo_exec_rows(conn, a_index_ddl);
+    limbo_exec_rows(conn, "CREATE INDEX t_b ON t(b)");
+    let values = (0..2000)
+        .map(|i| {
+            let a = if i % 10 == 0 {
+                i.to_string()
+            } else {
+                "NULL".to_string()
+            };
+            format!("({}, {}, {})", i + 1, a, i % 100)
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    limbo_exec_rows(conn, &format!("INSERT INTO t VALUES {values}"));
+    limbo_exec_rows(conn, "ANALYZE");
+}
+
+/// A UNIQUE index bounds each non-NULL key to one row, but puts no bound on
+/// NULL keys. `a IS NULL` here matches 1800 of 2000 rows, while `b = 5`
+/// matches 20 — the planner must not treat the unique index as a 1-row lookup
+/// and must pick the `b` index.
+#[test]
+fn is_null_on_unique_index_is_not_costed_as_one_row() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+    create_null_heavy_table(&conn, "CREATE UNIQUE INDEX t_a ON t(a)");
+
+    let plan = query_plan(&conn, "SELECT count(*) FROM t WHERE a IS NULL AND b = 5");
+    assert!(
+        plan.contains("USING INDEX t_b"),
+        "the b index matches 20 rows, a IS NULL matches 1800 — expected t_b, got:\n{plan}"
+    );
+}
+
+/// sqlite_stat1 stores the average rows per distinct key (~10 here), but the
+/// NULL bucket alone holds 1800 rows. The planner must not apply the per-key
+/// average to a NULL seek key; the `b` index (20 rows) must win.
+#[test]
+fn is_null_seek_does_not_use_average_rows_per_key_from_analyze() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+    create_null_heavy_table(&conn, "CREATE INDEX t_a ON t(a)");
+
+    let plan = query_plan(&conn, "SELECT count(*) FROM t WHERE a IS NULL AND b = 5");
+    assert!(
+        plan.contains("USING INDEX t_b"),
+        "the b index matches 20 rows, a IS NULL matches 1800 — expected t_b, got:\n{plan}"
+    );
+}
+
 #[test]
 fn is_operator_seek_matches_null_in_65th_key_column() {
     let tmp_db = TempDatabase::new_empty();

--- a/tests/integration/query_processing/test_is_seek.rs
+++ b/tests/integration/query_processing/test_is_seek.rs
@@ -294,6 +294,56 @@ fn is_with_non_null_literal_key_is_a_point_lookup_for_order_by() {
     );
 }
 
+/// An `IS`-driven seek never probes the bloom filter (the probe treats a NULL
+/// key as "definitely absent", which would skip matching NULL rows), so the
+/// ephemeral autoindex build must not pay for `FilterAdd` on every row either.
+#[test]
+fn is_seek_on_autoindex_does_not_build_a_bloom_filter_nothing_probes() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE big(k, v)");
+    limbo_exec_rows(&conn, "CREATE TABLE small(k)");
+
+    let opcodes = |query: &str| -> Vec<String> {
+        limbo_exec_rows(&conn, &format!("EXPLAIN {query}"))
+            .iter()
+            .filter_map(|row| match row.get(1) {
+                Some(Value::Text(op)) => Some(op.clone()),
+                _ => None,
+            })
+            .collect()
+    };
+
+    let is_join = opcodes("SELECT big.v FROM small JOIN big ON big.k IS small.k");
+    let builds = is_join.iter().any(|op| op == "FilterAdd");
+    let probes = is_join.iter().any(|op| op == "Filter");
+    assert!(
+        !builds && !probes,
+        "an IS seek cannot probe the filter, so nothing may build one: \
+         FilterAdd={builds}, Filter={probes}\n{is_join:?}"
+    );
+
+    // Controls: the same autoindex with a key that is never NULL keeps its
+    // bloom filter — both for `=` and for `IS` with a non-NULL literal.
+    // (The plain `ON big.k = small.k` join would pick a hash join instead of
+    // the autoindex, so these use a literal key like the IS case above
+    // cannot.)
+    for query in [
+        "SELECT big.v FROM small CROSS JOIN big WHERE big.k = 'x'",
+        "SELECT big.v FROM small CROSS JOIN big WHERE big.k IS 'x'",
+    ] {
+        let ops = opcodes(query);
+        let builds = ops.iter().any(|op| op == "FilterAdd");
+        let probes = ops.iter().any(|op| op == "Filter");
+        assert!(
+            builds && probes,
+            "a non-NULL key must keep both filter build and probe for \
+             `{query}`: FilterAdd={builds}, Filter={probes}\n{ops:?}"
+        );
+    }
+}
+
 #[test]
 fn is_operator_seek_matches_null_in_65th_key_column() {
     let tmp_db = TempDatabase::new_empty();

--- a/tests/integration/query_processing/test_multi_index_scan.rs
+++ b/tests/integration/query_processing/test_multi_index_scan.rs
@@ -1,0 +1,110 @@
+use crate::common::{limbo_exec_rows, TempDatabase};
+use core_tester::common::sqlite_exec_rows;
+use rusqlite::types::Value;
+
+#[test]
+/// Regression: a multi-index OR scan driving an outer join's right-hand table
+/// silently dropped the predicate it was built from.
+///
+/// The scan *is* the predicate: rows failing it are never visited, and the term
+/// is marked consumed so nothing checks it again. That only holds for rows the
+/// scan actually produces. When nothing matches, the LEFT JOIN emits a
+/// null-extended row by jumping straight past the scan, so `t3.b = t4.b OR
+/// t3.c = t4.c` — which belongs to the *inner* join with t4 and must reject that
+/// row — never ran, and the query returned every (t1, t4) pair.
+fn multi_index_or_scan_not_used_for_outer_join_rhs() {
+    let _ = env_logger::try_init();
+    let tmp_db = TempDatabase::new_empty();
+    let sqlite_conn = rusqlite::Connection::open_in_memory().unwrap();
+    let conn = tmp_db.connect_limbo();
+
+    let mut ddl = vec![
+        "CREATE TABLE t1(id INTEGER PRIMARY KEY, a INT, b INT, c INT)".to_string(),
+        "CREATE TABLE t3(id INTEGER PRIMARY KEY, a INT, b INT, c INT)".to_string(),
+        "CREATE TABLE t4(id INTEGER PRIMARY KEY, a INT, b INT, c INT)".to_string(),
+    ];
+    for table in ["t1", "t3", "t4"] {
+        for col in ["a", "b", "c"] {
+            ddl.push(format!("CREATE INDEX {table}_{col}_idx ON {table}({col})"));
+        }
+    }
+    for stmt in &ddl {
+        limbo_exec_rows(&conn, stmt);
+        sqlite_conn.execute(stmt, []).unwrap();
+    }
+
+    sqlite_conn.execute("BEGIN", []).unwrap();
+    conn.execute("BEGIN").unwrap();
+    for i in 0..30_i64 {
+        let stmts = [
+            format!(
+                "INSERT INTO t1 VALUES ({}, {}, {}, {})",
+                i + 1,
+                i % 7,
+                i % 5,
+                i % 3
+            ),
+            // t3.a is always >= 900, so every ON condition below leaves t3
+            // unmatched and the LEFT JOIN null-extends every row.
+            format!(
+                "INSERT INTO t3 VALUES ({}, {}, {}, {})",
+                i + 201,
+                900 + i,
+                i % 5,
+                i % 3
+            ),
+            format!(
+                "INSERT INTO t4 VALUES ({}, {}, {}, {})",
+                i + 301,
+                i % 7,
+                if i % 4 == 0 { 8 } else { i % 5 },
+                i % 3
+            ),
+        ];
+        for stmt in &stmts {
+            conn.execute(stmt).unwrap();
+            sqlite_conn.execute(stmt, []).unwrap();
+        }
+    }
+    conn.execute("COMMIT").unwrap();
+    sqlite_conn.execute("COMMIT", []).unwrap();
+
+    // Each of these leaves t3 unmatched; `IS` reaches the plan through the
+    // NULL-matching seek, the others through a plain range comparison.
+    for on_condition in ["t1.a IS t3.a", "t1.a > t3.a", "t3.a < 0"] {
+        let query = format!(
+            "SELECT count(*) FROM t1 \
+LEFT JOIN t3 ON {on_condition} \
+JOIN t4 ON t3.b = t4.b OR t3.c = t4.c \
+WHERE t4.b = 8"
+        );
+        let sqlite_rows = sqlite_exec_rows(&sqlite_conn, &query);
+        let limbo_rows = limbo_exec_rows(&conn, &query);
+        assert_eq!(
+            sqlite_rows, limbo_rows,
+            "null-extended rows were not filtered by the OR condition, ON `{on_condition}`"
+        );
+    }
+
+    // The optimization itself still applies where it is sound: the same OR
+    // condition over an inner join.
+    let inner = "SELECT count(*) FROM t1 \
+JOIN t3 ON t1.a = t3.a \
+JOIN t4 ON t3.b = t4.b OR t3.c = t4.c";
+    let plan = limbo_exec_rows(&conn, &format!("EXPLAIN QUERY PLAN {inner}"))
+        .iter()
+        .filter_map(|row| match row.get(3) {
+            Some(Value::Text(text)) => Some(text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        plan.contains("MULTI-INDEX OR t3"),
+        "expected the multi-index OR scan to still be used for an inner join, got:\n{plan}"
+    );
+    assert_eq!(
+        sqlite_exec_rows(&sqlite_conn, inner),
+        limbo_exec_rows(&conn, inner)
+    );
+}

--- a/tests/integration/query_processing/test_multi_index_scan.rs
+++ b/tests/integration/query_processing/test_multi_index_scan.rs
@@ -1,4 +1,37 @@
 use crate::common::{limbo_exec_rows, TempDatabase};
+
+/// `h.v = 5 OR h.w = 7` can never be TRUE when every column of `h` is NULL,
+/// so the LEFT JOIN behaves like an inner join and must be rewritten to one —
+/// which in turn lets the OR term drive a multi-index scan, like SQLite does.
+#[test]
+fn null_rejecting_or_term_converts_left_join_and_uses_multi_index_scan() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE g(id INTEGER PRIMARY KEY)");
+    limbo_exec_rows(&conn, "CREATE TABLE h(id INTEGER, v INTEGER, w INTEGER)");
+    limbo_exec_rows(&conn, "CREATE INDEX hv ON h(v)");
+    limbo_exec_rows(&conn, "CREATE INDEX hw ON h(w)");
+
+    let plan = {
+        let rows = limbo_exec_rows(
+            &conn,
+            "EXPLAIN QUERY PLAN SELECT * FROM g LEFT JOIN h ON g.id = h.id WHERE h.v = 5 OR h.w = 7",
+        );
+        rows.iter()
+            .filter_map(|row| match row.get(3) {
+                Some(rusqlite::types::Value::Text(plan)) => Some(plan.as_str().to_string()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    assert!(
+        plan.contains("MULTI-INDEX OR"),
+        "expected the OR term to drive a multi-index scan after the join is \
+         rewritten to inner, got:\n{plan}"
+    );
+}
 use core_tester::common::sqlite_exec_rows;
 use rusqlite::types::Value;
 


### PR DESCRIPTION
`x IS <expr>` is an index-usable equality in SQLite: it seeks, and it matches NULL where `=` cannot. Turso extracted `Is` constraints but never admitted them as seek keys, so `WHERE a IS ? AND b IS ?` on a composite primary key produced a full scan where `=` produced `SEARCH t USING INDEX ... (a=? AND b=?)`. Any NULL-safe identity lookup therefore cost a table scan per row.

- `constraints.rs`: `is_equality_operator()` admits `Is` alongside `Equals` when building seek keys and when sorting equalities to the front of the key.
- `plan.rs` / `main_loop/seek.rs`: `SeekDef::is_null_matching_key_component()` marks the components that came from `IS`. Those skip the `IsNull` shortcut that ends an `=` seek early, so the NULL travels into the seek key and the index comparison finds the rows whose key component is NULL.
- `vdbe/insn.rs` + `execute.rs`: `SeekGE`/`SeekLE` carry a `null_matching_mask`, so the runtime "an eq_only seek with a NULL key cannot match" shortcut still applies to the `=` components of the same key, where it guards against outer joins null-extending a register after non-null analysis has run.
- `main_loop/seek.rs`: a NULL-matching seek skips the bloom-filter probe. The filter neither stores nor probes NULLs, so probing would report "definitely not present" for keys that do match.
- `constraints.rs`: an `IS` term from the WHERE clause cannot constrain the loop of an outer join's RHS table. `IS` is the first seek-usable operator that is TRUE for a null-extended row, so pushing it into the RHS loop removes the rows whose absence produces the null extension — the antijoin idiom `LEFT JOIN e ON ... WHERE e.id IS NULL` would return every LHS row. Terms from that join's own ON clause stay usable: they define what counts as a match.
