### PR TITLE
postgres: explain simple queries

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -1046,12 +1046,7 @@ impl Connection {
         stmt: ast::Stmt,
         input: &str,
     ) -> Result<Statement> {
-        self.prepare_stmt_with_input_and_origin(
-            stmt,
-            input,
-            StatementOrigin::Root,
-            &PrepareOptions::default(),
-        )
+        self.prepare_translated_cmd(ast::Cmd::Stmt(stmt), input)
     }
 
     pub fn prepare_translated_stmt_with_options(
@@ -1060,13 +1055,32 @@ impl Connection {
         input: &str,
         prepare_options: &PrepareOptions,
     ) -> Result<Statement> {
-        self.prepare_stmt_with_input_and_origin(stmt, input, StatementOrigin::Root, prepare_options)
+        self.prepare_translated_cmd_with_options(ast::Cmd::Stmt(stmt), input, prepare_options)
+    }
+
+    /// Prepare an already-translated command while keeping the original SQL
+    /// text.
+    pub fn prepare_translated_cmd(
+        self: &Arc<Connection>,
+        cmd: ast::Cmd,
+        input: &str,
+    ) -> Result<Statement> {
+        self.prepare_translated_cmd_with_options(cmd, input, &PrepareOptions::default())
+    }
+
+    pub fn prepare_translated_cmd_with_options(
+        self: &Arc<Connection>,
+        cmd: ast::Cmd,
+        input: &str,
+        prepare_options: &PrepareOptions,
+    ) -> Result<Statement> {
+        self.prepare_cmd_with_input_and_origin(cmd, input, StatementOrigin::Root, prepare_options)
     }
 
     #[turso_macros::trace_stack]
-    fn prepare_stmt_with_input_and_origin(
+    fn prepare_cmd_with_input_and_origin(
         self: &Arc<Connection>,
-        stmt: ast::Stmt,
+        cmd: ast::Cmd,
         input: &str,
         origin: StatementOrigin,
         prepare_options: &PrepareOptions,
@@ -1079,8 +1093,7 @@ impl Connection {
             self.start_nested();
         }
         let result = (|| {
-            let (program, pager, mode) =
-                self.compile_cmd(Cmd::Stmt(stmt), input, origin, prepare_options)?;
+            let (program, pager, mode) = self.compile_cmd(cmd, input, origin, prepare_options)?;
             Ok(Statement::new_with_origin(
                 program,
                 pager,

--- a/postgres/conformance/pg-sqltests/explain.sqltest
+++ b/postgres/conformance/pg-sqltests/explain.sqltest
@@ -1,0 +1,90 @@
+# EXPLAIN through the PostgreSQL frontend.
+#
+# Simple EXPLAIN is intentionally mapped to SQLite's EXPLAIN QUERY PLAN.
+# PostgreSQL EXPLAIN options are rejected until their output semantics exist.
+
+@database :memory:
+
+setup explain_table {
+    CREATE TABLE t (id int);
+    INSERT INTO t VALUES (1), (2);
+}
+
+setup dml_items {
+    CREATE TABLE items (id int primary key, value int);
+    INSERT INTO items VALUES (1, 10);
+}
+
+@setup explain_table
+test explain-select {
+    EXPLAIN SELECT id FROM t WHERE id = 1;
+}
+expect {
+    1|0|0|SCAN t
+}
+
+@setup dml_items
+test explain-insert-does-not-execute {
+    EXPLAIN INSERT INTO items VALUES (2, 20);
+    SELECT id, value FROM items;
+}
+expect {
+    1|10
+}
+
+@setup dml_items
+test explain-update-does-not-execute {
+    EXPLAIN UPDATE items SET value = 99 WHERE id = 1;
+    SELECT id, value FROM items;
+}
+expect {
+    2|0|0|SEARCH items USING INTEGER PRIMARY KEY (rowid=?)
+    1|10
+}
+
+@setup dml_items
+test explain-delete-does-not-execute {
+    EXPLAIN DELETE FROM items WHERE id = 1;
+    SELECT id, value FROM items;
+}
+expect {
+    2|0|0|SEARCH items USING INTEGER PRIMARY KEY (rowid=?)
+    1|10
+}
+
+test explain-result {
+    EXPLAIN SELECT 1;
+}
+expect {
+    1|0|0|SCAN CONSTANT ROW
+}
+
+test explain-analyze-errors {
+    EXPLAIN ANALYZE SELECT 1;
+}
+expect error {}
+
+test explain-options-error {
+    EXPLAIN (VERBOSE) SELECT 1;
+}
+expect error {}
+
+test explain-verbose-errors {
+    EXPLAIN VERBOSE SELECT 1;
+}
+expect error {}
+
+test explain-costs-off-errors {
+    EXPLAIN (COSTS OFF) SELECT 1;
+}
+expect error {}
+
+test explain-buffers-errors {
+    EXPLAIN (BUFFERS) SELECT 1;
+}
+expect error {}
+
+test explain-format-json-errors {
+    EXPLAIN (FORMAT JSON) SELECT 1;
+}
+expect error {}

--- a/postgres/frontend/session.rs
+++ b/postgres/frontend/session.rs
@@ -186,7 +186,7 @@ fn prepare_statement(pg_conn: &Arc<PgConnectionInner>, sql: &str) -> Result<Stat
     let translated = translator
         .translate_with_prereqs(&parse_result)
         .map_err(|e| LimboError::ParseError(e.to_string()))?;
-    reject_catalog_dml(&translated.stmt)?;
+    reject_catalog_dml(translated.cmd.stmt())?;
 
     let options = {
         let state = pg_conn.session_state.lock().unwrap();
@@ -205,7 +205,7 @@ fn prepare_statement(pg_conn: &Arc<PgConnectionInner>, sql: &str) -> Result<Stat
 
     pg_conn
         .conn
-        .prepare_translated_stmt_with_options(translated.stmt, sql, &options)
+        .prepare_translated_cmd_with_options(translated.cmd, sql, &options)
 }
 
 fn reject_catalog_dml(stmt: &ast::Stmt) -> Result<()> {

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -9,14 +9,15 @@ use pg_query::{NodeRef, ParseResult};
 use turso_parser::ast;
 use turso_parser::ast::GroupBy;
 
-/// Result of translating a PostgreSQL statement, which may include
+/// Result of translating a PostgreSQL command, which may include
 /// prerequisite statements (e.g., implicit CREATE SEQUENCE for serial columns).
+#[derive(Debug)]
 pub struct TranslateResult {
-    /// Prerequisite statements that must be executed before the main statement.
+    /// Prerequisite statements that must be executed before the main command.
     /// For example, serial columns generate implicit CREATE SEQUENCE statements.
     pub prereqs: Vec<ast::Stmt>,
-    /// The main translated statement.
-    pub stmt: ast::Stmt,
+    /// The main translated command.
+    pub cmd: ast::Cmd,
 }
 
 /// Translates a PostgreSQL query into Turso's AST
@@ -99,10 +100,16 @@ impl PostgreSQLTranslator {
     /// For statements that may generate prerequisites (e.g., serial columns),
     /// use `translate_with_prereqs` instead.
     pub fn translate(&self, parse_result: &ParseResult) -> Result<ast::Stmt, ParseError> {
-        self.translate_with_prereqs(parse_result).map(|r| r.stmt)
+        let translated = self.translate_with_prereqs(parse_result)?;
+        let ast::Cmd::Stmt(stmt) = translated.cmd else {
+            return Err(ParseError::ParseError(
+                "expected a PostgreSQL statement".to_string(),
+            ));
+        };
+        Ok(stmt)
     }
 
-    /// Translate a PostgreSQL parse result, returning both the main statement
+    /// Translate a PostgreSQL parse result, returning both the main command
     /// and any prerequisite statements (e.g., implicit CREATE SEQUENCE for serial columns).
     pub fn translate_with_prereqs(
         &self,
@@ -116,11 +123,26 @@ impl PostgreSQLTranslator {
 
         // CREATE TABLE is special: serial columns generate prerequisite CREATE SEQUENCE stmts
         if let NodeRef::CreateStmt(create) = &node.0 {
-            return self.translate_create_table_with_prereqs(create);
+            let translated = self.translate_create_table_with_prereqs(create)?;
+            return Ok(TranslateResult {
+                prereqs: translated.prereqs,
+                cmd: translated.cmd,
+            });
         }
 
-        // All other statements have no prerequisites
-        let stmt = match &node.0 {
+        let cmd = match node.0 {
+            NodeRef::ExplainStmt(explain) => self.translate_explain(explain)?,
+            node => ast::Cmd::Stmt(self.translate_node(node)?),
+        };
+
+        Ok(TranslateResult {
+            prereqs: vec![],
+            cmd,
+        })
+    }
+
+    fn translate_node(&self, node: NodeRef<'_>) -> Result<ast::Stmt, ParseError> {
+        Ok(match node {
             NodeRef::SelectStmt(select) => {
                 // Top-level SELECT ... INTO is PG's legacy spelling of
                 // CREATE TABLE AS.
@@ -153,15 +175,29 @@ impl PostgreSQLTranslator {
             _ => {
                 return Err(ParseError::ParseError(format!(
                     "{} is not supported",
-                    node_ref_name(&node.0)
+                    node_ref_name(&node)
                 )))
             }
-        };
-
-        Ok(TranslateResult {
-            prereqs: vec![],
-            stmt,
         })
+    }
+
+    fn translate_explain(
+        &self,
+        explain: &pg_query::protobuf::ExplainStmt,
+    ) -> Result<ast::Cmd, ParseError> {
+        if !explain.options.is_empty() {
+            return Err(ParseError::ParseError(
+                "EXPLAIN options are not supported".to_string(),
+            ));
+        }
+        let query = explain
+            .query
+            .as_ref()
+            .and_then(|query| query.node.as_ref())
+            .ok_or_else(|| ParseError::ParseError("EXPLAIN missing statement".to_string()))?;
+        Ok(ast::Cmd::ExplainQueryPlan(
+            self.translate_node(query.to_ref())?,
+        ))
     }
 
     /// Translate a PostgreSQL CREATE TABLE statement into Turso AST.
@@ -323,7 +359,10 @@ impl PostgreSQLTranslator {
             })
             .collect();
 
-        Ok(TranslateResult { prereqs, stmt })
+        Ok(TranslateResult {
+            prereqs,
+            cmd: ast::Cmd::Stmt(stmt),
+        })
     }
 
     /// Translate a single PG column definition for CREATE TABLE to a Turso AST ColumnDefinition.
@@ -6786,6 +6825,32 @@ mod tests {
             assert!(
                 err.to_string().contains("not supported"),
                 "expected loud error for {sql}, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_simple_explain_translates_to_query_plan() {
+        let translator = PostgreSQLTranslator::new();
+        let parsed = crate::parse("EXPLAIN SELECT 1").unwrap();
+        let translated = translator.translate_with_prereqs(&parsed).unwrap();
+        assert!(translated.prereqs.is_empty());
+        assert!(matches!(translated.cmd, ast::Cmd::ExplainQueryPlan(_)));
+    }
+
+    #[test]
+    fn test_explain_options_error() {
+        let translator = PostgreSQLTranslator::new();
+        for sql in [
+            "EXPLAIN ANALYZE SELECT 1",
+            "EXPLAIN (VERBOSE) SELECT 1",
+            "EXPLAIN (COSTS OFF) SELECT 1",
+        ] {
+            let parsed = crate::parse(sql).unwrap();
+            let err = translator.translate_with_prereqs(&parsed).unwrap_err();
+            assert!(
+                err.to_string().contains("EXPLAIN options"),
+                "expected EXPLAIN option error for {sql}, got: {err}"
             );
         }
     }

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -6856,6 +6856,25 @@ mod tests {
     }
 
     #[test]
+    fn test_explain_missing_statement_error() {
+        let translator = PostgreSQLTranslator::new();
+        for query in [
+            None,
+            Some(Box::new(pg_query::protobuf::Node { node: None })),
+        ] {
+            let explain = pg_query::protobuf::ExplainStmt {
+                query,
+                options: vec![],
+            };
+            let err = translator.translate_explain(&explain).unwrap_err();
+            assert!(
+                err.to_string().contains("EXPLAIN missing statement"),
+                "expected missing statement error, got: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn test_array_overlaps_operator() {
         let translator = PostgreSQLTranslator::new();
         let sql = "SELECT id FROM posts WHERE tags && '{\"ORM\"}'";


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

Add basic support for bare `EXPLAIN <statement>` to the PostgreSQL frontend by translating it to SQLite `EXPLAIN QUERY PLAN <statement>`.

The result set uses SQLite EQP's four-column shape (`id`, `parent`, `notused`, `detail`). 

### What changed

- Preserve command-level translation results from the PostgreSQL translator by storing `ast::Cmd` in `TranslateResult`.
- Add a command-level prepare path for already-translated ASTs so `Cmd::ExplainQueryPlan` survives until `compile_cmd()` sets `QueryMode::ExplainQueryPlan`.
- Translate bare PostgreSQL `EXPLAIN <statement>` to `ast::Cmd::ExplainQueryPlan(<translated statement>)`.
- Keep normal translation statement-only through `translate()`, which errors if the translated command is not `Cmd::Stmt`.
- Reject PostgreSQL EXPLAIN options.
- Add pgwire sqltests for simple SELECT, DML non-execution, and rejected option forms.

### Limitations

- Output is SQLite `EXPLAIN QUERY PLAN`, not PostgreSQL-compatible `QUERY PLAN` text.
- PostgreSQL EXPLAIN options (`ANALYZE`, `VERBOSE`, `COSTS OFF`, `BUFFERS`, `FORMAT JSON`, timing, etc.) are not supported.

### Validation

```text
cargo fmt --check
cargo test -p turso_pg_parser explain --offline
git diff --check
make -C postgres/conformance run-one FILE=pg-sqltests/explain.sqltest
cargo test -p tursopg --offline explain
```

The pgwire sqltest corpus covers the PostgreSQL frontend path through a running `tursopg` server.

## Motivation and context

PostgreSQL clients commonly issue bare `EXPLAIN` to inspect a statement plan. Before this change, the PostgreSQL translator rejected `ExplainStmt` as unsupported because the frontend translation path only returned normal statements.

This PR wires `ExplainStmt` through command-level translation and translates to SQLite EQP.

## Description of AI Usage

AI assistance was used for repository exploration, implementation, test development, #8014 comparison, validation, and drafting this PR description. The contributor directed the design choices, reviewed the changes iteratively, and is responsible for the final code and description.

## Demo output

Run with:

```text
scripts/local/tursopg-pgwire.sh demo
```

The script recreates a small TPC-H-shaped dataset with `nation`, `customer`, `orders`, and `lineitem` tables, adds indexes, and runs the EXPLAIN queries through `psql -e`.

```text
tursopg pgwire server started (pid 2364790, 127.0.0.1:5433)
Connect with: scripts/local/tursopg-pgwire.sh psql
DROP TABLE
DROP TABLE
DROP TABLE
DROP TABLE
CREATE TABLE
CREATE TABLE
CREATE TABLE
CREATE TABLE
INSERT 0 2
INSERT 0 3
INSERT 0 3
INSERT 0 3
CREATE INDEX
CREATE INDEX
EXPLAIN SELECT 1
 id | parent | notused |      detail       
----+--------+---------+-------------------
 1  | 0      | 0       | SCAN CONSTANT ROW
(1 row)

EXPLAIN SELECT * FROM customer WHERE c_nationkey = 1
 id | parent | notused |                             detail                              
----+--------+---------+-----------------------------------------------------------------
 1  | 0      | 0       | SEARCH customer USING INDEX customer_nation_idx (c_nationkey=?)
(1 row)

EXPLAIN SELECT c.c_name, o.o_totalprice FROM customer c JOIN orders o ON o.o_custkey = c.c_custkey WHERE c.c_nationkey = 1
 id | parent | notused |                          detail                          
----+--------+---------+----------------------------------------------------------
 1  | 0      | 0       | SEARCH c USING INDEX customer_nation_idx (c_nationkey=?)
 2  | 0      | 0       | SEARCH o USING INDEX orders_customer_idx (o_custkey=?)
(2 rows)

EXPLAIN SELECT n.n_name, count(*) FROM customer c JOIN nation n ON n.n_nationkey = c.c_nationkey GROUP BY n.n_name
 id | parent | notused |                           detail                            
----+--------+---------+-------------------------------------------------------------
 1  | 0      | 0       | SCAN customer AS c USING COVERING INDEX customer_nation_idx
 2  | 0      | 0       | SEARCH n USING INTEGER PRIMARY KEY (rowid=?)
 5  | 0      | 0       | USE SORTER FOR GROUP BY
(3 rows)

EXPLAIN SELECT * FROM orders ORDER BY o_totalprice LIMIT 2
 id | parent | notused |         detail          
----+--------+---------+-------------------------
 1  | 0      | 0       | SCAN orders
 15 | 0      | 0       | USE SORTER FOR ORDER BY
(2 rows)

EXPLAIN INSERT INTO customer VALUES (4, 'Customer#000000004', 1)
 id | parent | notused | detail 
----+--------+---------+--------
(0 rows)

EXPLAIN UPDATE customer SET c_nationkey = 2 WHERE c_custkey = 1
 id | parent | notused |                       detail                        
----+--------+---------+-----------------------------------------------------
 3  | 0      | 0       | SEARCH customer USING INTEGER PRIMARY KEY (rowid=?)
(1 row)

EXPLAIN DELETE FROM customer WHERE c_custkey = 3
 id | parent | notused |                       detail                        
----+--------+---------+-----------------------------------------------------
 3  | 0      | 0       | SEARCH customer USING INTEGER PRIMARY KEY (rowid=?)
(1 row)

EXPLAIN DELETE FROM customer WHERE c_name = 'Customer#000000003'
 id | parent | notused |    detail     
----+--------+---------+---------------
 3  | 0      | 0       | SCAN customer
(1 row)
```