### PR TITLE
core/translate: resolve outer CTEs through nested CTEs

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -110,11 +110,66 @@ fn collect_cte_definitions(with: With, program: &mut ProgramBuilder) -> Result<V
     Ok(definitions)
 }
 
-/// Collect all table names referenced in a SELECT's FROM clause.
-/// Used to determine which earlier CTEs a CTE directly depends on.
+struct LocalCteReferences {
+    name: String,
+    references: Vec<String>,
+}
+
+/// Collect table names needed from the surrounding scope, including dependencies
+/// of local CTEs reachable from the SELECT body.
 fn collect_from_clause_table_refs(select: &Select, out: &mut Vec<String>) {
-    collect_from_select_body(&select.body, out);
-    collect_subquery_table_refs_in_select_exprs(select, out);
+    let local_ctes = select
+        .with
+        .as_ref()
+        .map(|with| {
+            with.ctes
+                .iter()
+                .map(|cte| {
+                    let mut references = Vec::new();
+                    collect_from_clause_table_refs(&cte.select, &mut references);
+                    LocalCteReferences {
+                        name: normalize_ident(cte.tbl_name.as_str()),
+                        references,
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut direct_references = Vec::new();
+    collect_from_select_body(&select.body, &mut direct_references);
+    collect_subquery_table_refs_in_select_exprs(select, &mut direct_references);
+
+    let mut visiting = Vec::new();
+    for reference in direct_references {
+        expand_local_cte_references(&reference, &local_ctes, &mut visiting, out);
+    }
+}
+
+fn expand_local_cte_references(
+    name: &str,
+    local_ctes: &[LocalCteReferences],
+    visiting: &mut Vec<usize>,
+    out: &mut Vec<String>,
+) {
+    let Some((index, local_cte)) = local_ctes
+        .iter()
+        .enumerate()
+        .find(|(_, cte)| cte.name == name)
+    else {
+        out.push(name.to_string());
+        return;
+    };
+
+    if visiting.contains(&index) {
+        return;
+    }
+
+    visiting.push(index);
+    for reference in &local_cte.references {
+        expand_local_cte_references(reference, local_ctes, visiting, out);
+    }
+    visiting.pop();
 }
 
 fn collect_from_select_body(body: &ast::SelectBody, out: &mut Vec<String>) {

--- a/sqlite/conformance/sqlite-sqltests/cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/cte.sqltest
@@ -1202,8 +1202,78 @@ expect {
 }
 
 # =============================================================================
+# Nested CTE dependencies
+# =============================================================================
+
+test cte-nested-reads-outer-cte {
+    WITH a AS (SELECT 1),
+         b AS (WITH c AS (SELECT * FROM a) SELECT * FROM c)
+    SELECT * FROM b;
+}
+expect {
+    1
+}
+
+test cte-nested-dependency-chain-reads-outer-cte {
+    WITH a AS (SELECT 1),
+         b AS (
+             WITH d AS (SELECT * FROM a),
+                  c AS (SELECT * FROM d)
+             SELECT * FROM c
+         )
+    SELECT * FROM b;
+}
+expect {
+    1
+}
+
+test cte-forward-nested-dependency-chain-reads-outer-cte {
+    WITH a AS (SELECT 1),
+         b AS (
+             WITH c AS (SELECT * FROM d),
+                  d AS (SELECT * FROM a)
+             SELECT * FROM c
+         )
+    SELECT * FROM b;
+}
+expect {
+    1
+}
+
+test cte-unused-nested-cte-does-not-read-outer-cte {
+    WITH a AS (SELECT * FROM no_such_table),
+         b AS (WITH unused AS (SELECT * FROM a) SELECT 1)
+    SELECT * FROM b;
+}
+expect {
+    1
+}
+
+# =============================================================================
 # CTE name shadowing in nested scopes
 # =============================================================================
+
+test cte-shadow-does-not-plan-outer-cte {
+    WITH a AS (SELECT * FROM no_such_table),
+         b AS (WITH a AS (SELECT 1) SELECT * FROM a)
+    SELECT * FROM b;
+}
+expect {
+    1
+}
+
+test cte-forward-shadow-does-not-plan-outer-cte {
+    WITH a AS (SELECT * FROM no_such_table),
+         b AS (
+             WITH c AS (SELECT * FROM a),
+                  a AS (SELECT 1)
+             SELECT * FROM c
+         )
+    SELECT * FROM b;
+}
+expect {
+    1
+}
 
 # Inner CTE shadows outer CTE in EXISTS subquery
 test cte-shadow-in-exists {


### PR DESCRIPTION
Fixes #8107

Updated CTE dependency collection to follow local CTEs used by a SELECT before deciding which CTEs are needed from the surrounding `WITH` clause. This allows a nested CTE to reference an
outer CTE while preserving local name shadowing, unused nested CTE behavior, and forward references.

Also added tests for the reported query, nested dependency chains, shadowing, unused nested CTEs, and forward references.

## Description of AI Usage

Codex helped trace the issue, then I mentioned my solution in a somewhat related PR, and he implemented the fix.