### PR TITLE
core/json: use SIMD byte search in JSON parse and serialize paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,6 +2203,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +2596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,6 +2655,16 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -7332,6 +7361,7 @@ dependencies = [
  "env_logger",
  "fallible-iterator 0.3.0",
  "fastbloom",
+ "faster-hex",
  "getrandom 0.2.15",
  "getrandom 0.3.2",
  "hex",
@@ -7343,6 +7373,7 @@ dependencies = [
  "libloading 0.8.6",
  "libm",
  "loom",
+ "memchr",
  "memory-stats",
  "miette",
  "mimalloc",

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -53,6 +53,23 @@ This project depends on pastey, distributed by the pastey authors:
 * License: licenses/core/pastey-mit-license.md (MIT License)
 * Homepage: https://github.com/AS1100K/pastey
 
+This project depends on memchr, distributed by Andrew Gallant:
+
+* License: licenses/core/memchr-mit-license.md (MIT License)
+* License: licenses/core/memchr-unlicense.md (The Unlicense)
+* Homepage: https://github.com/BurntSushi/memchr
+
+This project depends on simdutf8, distributed by the simdutf8 authors:
+
+* License: licenses/core/simdutf8-apache-license.md (Apache License v2.0)
+* License: licenses/core/simdutf8-mit-license.md (MIT License)
+* Homepage: https://github.com/rusticstuff/simdutf8
+
+This project depends on faster-hex, distributed by the faster-hex authors:
+
+* License: licenses/core/faster-hex-mit-license.md (MIT License)
+* Homepage: https://github.com/nervosnetwork/faster-hex
+
 This project depends on windows-sys, distributed by the Microsoft:
 
 * License: licenses/core/windows-apache.license.md (Apache License v2.0)

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -137,6 +137,8 @@ bigdecimal = "0.4"
 num-bigint = "0.4"
 num-traits = "0.2"
 stacker = { version = "0.1", optional = true }
+memchr = "2.7"
+faster-hex = { version = "0.10", default-features = false, features = ["std"] }
 
 [target.'cfg(not(any(target_family = "wasm", all(target_os = "windows", target_arch = "aarch64"))))'.dependencies]
 simsimd = "6.5.3"

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -21,6 +21,31 @@ const SIZE_MARKER_32BIT: u8 = 14;
 const MAX_JSON_DEPTH: usize = 1000;
 const INFINITY_CHAR_COUNT: u8 = 8;
 
+/// Position of the first byte `<= 0x1F` (JSON control character), if any.
+///
+/// Chunked OR-accumulation instead of `iter().position` so LLVM can vectorize
+/// the scan; `memchr` cannot express a byte-range search.
+fn find_control_byte(bytes: &[u8]) -> Option<usize> {
+    const CHUNK: usize = 32;
+    let mut offset = 0;
+    let mut chunks = bytes.chunks_exact(CHUNK);
+    for chunk in &mut chunks {
+        let mut any = 0u8;
+        for &b in chunk {
+            any |= u8::from(b <= 0x1F);
+        }
+        if any != 0 {
+            return chunk.iter().position(|&b| b <= 0x1F).map(|p| offset + p);
+        }
+        offset += CHUNK;
+    }
+    chunks
+        .remainder()
+        .iter()
+        .position(|&b| b <= 0x1F)
+        .map(|p| offset + p)
+}
+
 const fn make_whitespace_table() -> [u8; 256] {
     let mut table = [0u8; 256];
 
@@ -1047,7 +1072,7 @@ impl Jsonb {
             }
             ElementType::TEXT | ElementType::TEXTJ | ElementType::TEXT5 | ElementType::TEXTRAW => {
                 let payload = &self.data[payload_start..payload_end];
-                std::str::from_utf8(payload).map_err(|_| {
+                simdutf8::basic::from_utf8(payload).map_err(|_| {
                     LimboError::ParseError("Invalid UTF-8 in text payload".to_string())
                 })?;
                 Ok(())
@@ -1294,36 +1319,43 @@ impl Jsonb {
 
         match kind {
             ElementType::TEXT | ElementType::TEXTRAW | ElementType::TEXTJ => {
-                let word = from_utf8(word_slice).map_err(|_| {
+                let word = simdutf8::basic::from_utf8(word_slice).map_err(|_| {
                     LimboError::ParseError("Failed to serialize string!".to_string())
                 })?;
 
+                // Only control bytes need escaping for TEXTJ (its payload
+                // already carries JSON escape sequences verbatim); TEXT also
+                // escapes quotes and backslashes. Jump between escape sites
+                // with SIMD search instead of testing every byte.
+                let textj = *kind == ElementType::TEXTJ;
+                let find_escape = |bytes: &[u8]| -> Option<usize> {
+                    if textj {
+                        return find_control_byte(bytes);
+                    }
+                    let special = memchr::memchr2(b'"', b'\\', bytes);
+                    let limit = special.unwrap_or(bytes.len());
+                    find_control_byte(&bytes[..limit]).or(special)
+                };
+
                 let mut last_end = 0;
                 let bytes = word.as_bytes();
-                for i in 0..bytes.len() {
+                while let Some(off) = find_escape(&bytes[last_end..]) {
+                    let i = last_end + off;
                     let b = bytes[i];
-                    let needs_escape = if *kind == ElementType::TEXTJ {
-                        b <= 0x1F
-                    } else {
-                        b == b'"' || b == b'\\' || b <= 0x1F
-                    };
-
-                    if needs_escape {
-                        string.push_str(&word[last_end..i]);
-                        match b {
-                            b'"' => string.push_str("\\\""),
-                            b'\\' => string.push_str("\\\\"),
-                            0x08 => string.push_str("\\b"),
-                            0x0C => string.push_str("\\f"),
-                            b'\n' => string.push_str("\\n"),
-                            b'\r' => string.push_str("\\r"),
-                            b'\t' => string.push_str("\\t"),
-                            c => {
-                                let _ = write!(string, "\\u{c:04x}");
-                            }
+                    string.push_str(&word[last_end..i]);
+                    match b {
+                        b'"' => string.push_str("\\\""),
+                        b'\\' => string.push_str("\\\\"),
+                        0x08 => string.push_str("\\b"),
+                        0x0C => string.push_str("\\f"),
+                        b'\n' => string.push_str("\\n"),
+                        b'\r' => string.push_str("\\r"),
+                        b'\t' => string.push_str("\\t"),
+                        c => {
+                            let _ = write!(string, "\\u{c:04x}");
                         }
-                        last_end = i + 1;
                     }
+                    last_end = i + 1;
                 }
                 string.push_str(&word[last_end..]);
             }
@@ -1832,39 +1864,31 @@ impl Jsonb {
         let mut len = 0;
 
         if quoted {
-            // Try to find the closing quote and check for simple string
-            let mut end_pos = pos;
-            let is_simple = true;
+            // Simple string fast path: the string is simple if the closing
+            // quote appears before any backslash or control byte. memchr2
+            // finds the first quote/backslash with SIMD; the skipped span is
+            // then checked for control bytes.
+            if let Some(off) = memchr::memchr2(quote, b'\\', &input[pos..]) {
+                let end_pos = pos + off;
+                if input[end_pos] == quote && find_control_byte(&input[pos..end_pos]).is_none() {
+                    let len = end_pos - pos;
+                    let header_pos = self.data.len();
 
-            while end_pos < input.len() {
-                let c = input[end_pos];
-                if c == quote {
-                    // Found end of string - check if it's simple
-                    if is_simple {
-                        let len = end_pos - pos;
-                        let header_pos = self.data.len();
-
-                        // Write header and content
-                        if len <= 11 {
-                            self.data
-                                .push((ElementType::TEXT as u8) | ((len as u8) << 4));
-                        } else {
-                            self.write_element_header(header_pos, ElementType::TEXT, len, false)
-                                .map_err(|_| PError::Message {
-                                    msg: "Failed to write header".to_string(),
-                                    location: Some(pos),
-                                })?;
-                        }
-
-                        self.data.extend_from_slice(&input[pos..end_pos]);
-                        return Ok(end_pos + 1); // Skip past closing quote
+                    // Write header and content
+                    if len <= 11 {
+                        self.data
+                            .push((ElementType::TEXT as u8) | ((len as u8) << 4));
+                    } else {
+                        self.write_element_header(header_pos, ElementType::TEXT, len, false)
+                            .map_err(|_| PError::Message {
+                                msg: "Failed to write header".to_string(),
+                                location: Some(pos),
+                            })?;
                     }
-                    break;
-                } else if c == b'\\' || c < 32 {
-                    // Not a simple string
-                    break;
+
+                    self.data.extend_from_slice(&input[pos..end_pos]);
+                    return Ok(end_pos + 1); // Skip past closing quote
                 }
-                end_pos += 1;
             }
         }
 

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -97,9 +97,9 @@ pub fn convert_dbtype_to_jsonb(val: impl AsValueRef, strict: Conv) -> crate::Res
 }
 
 fn parse_as_json_text(slice: &[u8], mode: Conv) -> crate::Result<Jsonb> {
-    let zero_pos = slice.iter().position(|&b| b == 0).unwrap_or(slice.len());
+    let zero_pos = memchr::memchr(0, slice).unwrap_or(slice.len());
     let truncated = &slice[..zero_pos];
-    let str = std::str::from_utf8(truncated)
+    let str = simdutf8::basic::from_utf8(truncated)
         .map_err(|_| LimboError::ParseError("malformed JSON".to_string()))?;
     Jsonb::from_str_with_mode(str, mode).map_err(Into::into)
 }

--- a/licenses/core/faster-hex-mit-license.md
+++ b/licenses/core/faster-hex-mit-license.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Nervos Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/core/memchr-mit-license.md
+++ b/licenses/core/memchr-mit-license.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Andrew Gallant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/licenses/core/memchr-unlicense.md
+++ b/licenses/core/memchr-unlicense.md
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/licenses/core/simdutf8-apache-license.md
+++ b/licenses/core/simdutf8-apache-license.md
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/licenses/core/simdutf8-mit-license.md
+++ b/licenses/core/simdutf8-mit-license.md
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Description

Split 1/7 of #8053 — rebased on current `main`.

The JSON text parser scanned strings byte-at-a-time for the closing quote, and serialization tested every byte for escape characters. Both loops dominate `json()`/`jsonb()` time on string-heavy payloads.

- `memchr2` finds the closing quote or backslash in the simple-string fast path
- a chunked vectorizable scan handles control bytes (memchr cannot express byte ranges)
- SIMD search jumps between escape sites when rendering JSONB back to text
- UTF-8 validation of JSON input and JSONB text payloads goes through `simdutf8`; error details were already discarded at both call sites, so `basic::from_utf8` is a drop-in

Adds `memchr` and `faster-hex` (used by #8157) as direct dependencies, with license files and NOTICE entries. `simdutf8` was already a dependency and only needed its NOTICE entry.

Note: the parse-side scan added here is walked back to scalar in #8159, after benchmarks showed it lost on the short keys and values that dominate real JSON. Serialization keeps the vectorized scan.

## Motivation and context

String operations are hot per-row paths in SQL execution. Splitting #8053 so each piece can be reviewed and landed on its own.

The stack, each PR based on the one before it — merge in order:

| # | PR | What |
|---|---|---|
| 1 | **this PR** | json SIMD scans + dependencies |
| 2 | #8157 | SIMD search in LIKE/GLOB/instr/replace/quote/hex |
| 3 | #8158 | long-input benchmarks |
| 4 | #8159 | the four measurement-driven tuning commits |
| 5 | #8160 | multi-segment LIKE/GLOB fast path |
| 6 | #8161 | scalar paths for small hex/unhex/quote |

#8162 is independent — it branches off `main` and can land any time.

## Tests

`cargo test -p turso_core --lib json` (160 passed); json sqltests; workspace clippy clean.

## Description of AI Usage

The original work in #8053 was AI-assisted (Claude Code); this split was performed by Claude Code as well — rebasing onto current `main`, regrouping the commits, and verifying each branch builds, lints, and tests on its own. The commits keep their original authorship and messages, apart from two message edits noted where `main` had moved underneath them.