### PR TITLE
core/vdbe: use SIMD search in LIKE, GLOB, instr, replace, quote, hex

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -330,7 +330,6 @@ impl Value {
     }
 
     pub fn exec_quote(&self) -> Self {
-        use std::fmt::Write;
         match self {
             Value::Null => Value::build_text("NULL"),
             Value::Numeric(Numeric::Integer(i)) => Value::build_text(i.to_string()),
@@ -341,25 +340,21 @@ impl Value {
                 // SQLite returns X'hexdigits' for blobs
                 let mut quoted = String::with_capacity(3 + b.len() * 2);
                 quoted.push_str("X'");
-                for byte in b.iter() {
-                    write!(&mut quoted, "{byte:02X}").expect("unable to write hex bytes");
-                }
+                quoted.push_str(&faster_hex::hex_string_upper(b));
                 quoted.push('\'');
                 Value::build_text(quoted)
             }
             Value::Text(s) => {
-                let mut quoted = String::with_capacity(s.as_str().len() + 2);
+                let text = sqlite_text_prefix(s.as_str());
+                let mut quoted = String::with_capacity(text.len() + 2);
                 quoted.push('\'');
-                for c in s.as_str().chars() {
-                    if c == '\0' {
-                        break;
-                    } else if c == '\'' {
-                        quoted.push('\'');
-                        quoted.push(c);
-                    } else {
-                        quoted.push(c);
-                    }
+                let mut last_end = 0;
+                for i in memchr::memchr_iter(b'\'', text.as_bytes()) {
+                    quoted.push_str(&text[last_end..i]);
+                    quoted.push_str("''");
+                    last_end = i + 1;
                 }
+                quoted.push_str(&text[last_end..]);
                 quoted.push('\'');
                 Value::build_text(quoted)
             }
@@ -572,10 +567,7 @@ impl Value {
             if pattern.is_empty() {
                 return Value::from_i64(1);
             }
-            let result = reg
-                .windows(pattern.len())
-                .position(|window| window == *pattern)
-                .map_or(0, |i| i + 1);
+            let result = memchr::memmem::find(reg, pattern).map_or(0, |i| i + 1);
             return Value::from_i64(result as i64);
         }
 
@@ -597,7 +589,7 @@ impl Value {
             }
         };
 
-        match reg.find(pattern) {
+        match memchr::memmem::find(reg.as_bytes(), pattern.as_bytes()) {
             Some(byte_pos) => {
                 // Convert byte position to character position (1-indexed)
                 let char_pos = reg[..byte_pos].chars().count() + 1;
@@ -621,9 +613,9 @@ impl Value {
         match self {
             Value::Text(_) | Value::Numeric(_) => {
                 let text = self.to_string();
-                Value::build_text(hex::encode_upper(text))
+                Value::build_text(faster_hex::hex_string_upper(text.as_bytes()))
             }
-            Value::Blob(blob_bytes) => Value::build_text(hex::encode_upper(blob_bytes)),
+            Value::Blob(blob_bytes) => Value::build_text(faster_hex::hex_string_upper(blob_bytes)),
             Value::Null => Value::build_text(""),
         }
     }
@@ -636,7 +628,7 @@ impl Value {
                     Some(text) => {
                         let input = &text[0..text.find('\0').unwrap_or(text.len())];
                         let mut bytes = crate::alloc::vec![0; input.len() / 2];
-                        match hex::decode_to_slice(input, &mut bytes) {
+                        match faster_hex::hex_decode(input.as_bytes(), &mut bytes) {
                             Ok(()) => Value::from_blob(bytes),
                             Err(_) => Value::Null,
                         }
@@ -1031,9 +1023,17 @@ impl Value {
                     return Ok(Value::Text(source.clone()));
                 }
 
-                let result = source
-                    .as_str()
-                    .replace(pattern.as_str(), replacement.as_str());
+                let source = source.as_str();
+                let pattern = pattern.as_str();
+                let replacement = replacement.as_str();
+                let mut result = String::with_capacity(source.len());
+                let mut last_end = 0;
+                for i in memchr::memmem::find_iter(source.as_bytes(), pattern.as_bytes()) {
+                    result.push_str(&source[last_end..i]);
+                    result.push_str(replacement);
+                    last_end = i + pattern.len();
+                }
+                result.push_str(&source[last_end..]);
                 Ok(Value::build_text(result))
             }
             _ => unreachable!("text cast should never fail"),
@@ -1295,6 +1295,17 @@ impl Value {
             // Fall through to pattern_compare if boundary check fails (multi-byte UTF-8)
         }
 
+        // 4. Fast Path: '%abc%' (Contains)
+        if !has_escape
+            && pattern.len() >= 2
+            && pattern.starts_with('%')
+            && pattern.ends_with('%')
+            && !pattern[1..pattern.len() - 1].contains(['%', '_'])
+        {
+            let needle = &pattern[1..pattern.len() - 1];
+            return Ok(contains_ignore_ascii_case(text, needle));
+        }
+
         Ok(pattern_compare(pattern, text, &LIKE_INFO, escape) == CompareResult::Match)
     }
 
@@ -1332,6 +1343,16 @@ impl Value {
                 return Ok(&text[start..] == suffix);
             }
             // Fall through to pattern_compare if boundary check fails (multi-byte UTF-8)
+        }
+
+        // 4. Fast Path: '*abc*' (Contains)
+        if pattern.len() >= 2
+            && pattern.starts_with('*')
+            && pattern.ends_with('*')
+            && !pattern[1..pattern.len() - 1].contains(GLOB_CHARS)
+        {
+            let needle = &pattern[1..pattern.len() - 1];
+            return Ok(memchr::memmem::find(text.as_bytes(), needle.as_bytes()).is_some());
         }
 
         Ok(pattern_compare(pattern, text, &GLOB_INFO, None) == CompareResult::Match)
@@ -1511,6 +1532,46 @@ const GLOB_INFO: PatternInfo = PatternInfo {
     match_set: Some('['),
     no_case: false,
 };
+
+/// ASCII-case-insensitive substring search built on SIMD byte search.
+///
+/// SQLite's LIKE folds only ASCII letters, so candidate positions are located
+/// by scanning for both case variants of the needle's first byte with memchr,
+/// then confirmed with a byte-wise ASCII-case-insensitive comparison.
+/// Byte-level matching is equivalent to char-level here: the needle is valid
+/// UTF-8, so its first byte is never a continuation byte and cannot match in
+/// the middle of a multi-byte character.
+fn contains_ignore_ascii_case(text: &str, needle: &str) -> bool {
+    let haystack = text.as_bytes();
+    let needle = needle.as_bytes();
+    if needle.is_empty() {
+        return true;
+    }
+    if needle.len() > haystack.len() {
+        return false;
+    }
+    let last_start = haystack.len() - needle.len();
+    let first = needle[0];
+    let (lower, upper) = (first.to_ascii_lowercase(), first.to_ascii_uppercase());
+    let tail = &needle[1..];
+    let mut start = 0;
+    loop {
+        let candidates = &haystack[start..last_start + 1];
+        let found = if lower == upper {
+            memchr::memchr(first, candidates)
+        } else {
+            memchr::memchr2(lower, upper, candidates)
+        };
+        let Some(offset) = found else {
+            return false;
+        };
+        let i = start + offset;
+        if haystack[i + 1..i + needle.len()].eq_ignore_ascii_case(tail) {
+            return true;
+        }
+        start = i + 1;
+    }
+}
 
 /// LIKE and GLOB pattern matching based on SQLite's patternCompare algorithm (src/func.c).
 /// Uses recursive descent with early termination via `NoWildcardMatch` to avoid
@@ -2230,6 +2291,10 @@ mod tests {
         );
         let expected = Value::build_text("2.042747795102219097e+05");
         assert_eq!(input.exec_quote(), expected);
+
+        let input = blob(&[0x01, 0xab, 0xff]);
+        let expected = Value::build_text("X'01ABFF'");
+        assert_eq!(input.exec_quote(), expected);
     }
 
     #[test]
@@ -2784,6 +2849,43 @@ mod tests {
         assert!(!Value::exec_like("%a.a", "aaaa", None).unwrap());
         assert!(!Value::exec_like("a.a%", "aaaa", None).unwrap());
         assert!(!Value::exec_like("%a.ab", "aaaa", None).unwrap());
+    }
+
+    #[test]
+    fn test_like_contains_fast_path() {
+        // ASCII case folding, both directions
+        assert!(Value::exec_like("%AbC%", "xxabcyy", None).unwrap());
+        assert!(Value::exec_like("%abc%", "xxABCyy", None).unwrap());
+        // Repeated candidate first bytes before the real match
+        assert!(Value::exec_like("%aab%", "aaaaab", None).unwrap());
+        assert!(!Value::exec_like("%aab%", "aaaaa", None).unwrap());
+        // Needle longer than text
+        assert!(!Value::exec_like("%abcdef%", "abc", None).unwrap());
+        // Empty needle matches everything
+        assert!(Value::exec_like("%%", "anything", None).unwrap());
+        assert!(Value::exec_like("%%", "", None).unwrap());
+        // Multi-byte UTF-8 needles are matched exactly, without case folding
+        assert!(Value::exec_like("%€b%", "a€bc", None).unwrap());
+        assert!(!Value::exec_like("%äb%", "ÄB", None).unwrap());
+        // Needle at the very start and very end
+        assert!(Value::exec_like("%ab%", "abzz", None).unwrap());
+        assert!(Value::exec_like("%ab%", "zzab", None).unwrap());
+        // An escape char inside the needle must bypass the fast path
+        assert!(Value::exec_like("%aXb%", "ab", Some('X')).unwrap());
+        assert!(!Value::exec_like("%aXb%", "aXb", Some('X')).unwrap());
+    }
+
+    #[test]
+    fn test_glob_contains_fast_path() {
+        assert!(Value::exec_glob("*abc*", "xxabcyy").unwrap());
+        // GLOB is case-sensitive
+        assert!(!Value::exec_glob("*abc*", "xxABCyy").unwrap());
+        assert!(Value::exec_glob("**", "anything").unwrap());
+        assert!(Value::exec_glob("**", "").unwrap());
+        assert!(!Value::exec_glob("*abc*", "ab").unwrap());
+        // Inner wildcard chars must bypass the fast path
+        assert!(Value::exec_glob("*a?c*", "xxabcyy").unwrap());
+        assert!(Value::exec_glob("*a[bd]c*", "xxadcyy").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Description

Split 2/7 of #8053. **Stacked on #8156** — review the top commit only; merge that one first.

`LIKE '%needle%'` and `GLOB '*needle*'` fell through to the generic char-by-char patternCompare state machine even though they are plain substring searches; TPC-H q9 runs exactly this shape per part row. Adds contains fast paths:

- `memmem` for GLOB
- for LIKE, a `memchr`-based scan over both case variants of the needle's first byte followed by an ASCII-case-insensitive compare, matching SQLite's ASCII-only folding

Byte-level matching cannot land mid-character because a valid UTF-8 needle never starts with a continuation byte.

Other string functions swap scalar scans for SIMD-backed crates: `instr()`'s naive `windows().position()` blob scan and scalar text find become `memmem`; `replace()` loops over `memmem::find_iter`; `quote()` renders blobs with `faster-hex` instead of one `write!("{:02X}")` per byte and finds quotes to double with `memchr`; `hex()`/`unhex()` switch from the scalar `hex` crate to `faster-hex`.

Rebase note: the original commit also swapped `op_array_element`'s hand-rolled ASCII prescan for `simdutf8`. `main` has since removed that validation block entirely, so that hunk is dropped and the commit message no longer mentions it.

## Motivation and context

String operations are hot per-row paths in SQL execution. See #8156 for the full split layout.

## Tests

New unit tests pin the contains fast-path edges (case folding both directions, multi-byte UTF-8 needles, empty needles, escape bypass). `cargo test -p turso_core --lib vdbe::value` (44 passed); like/glob/scalar-functions sqltests; workspace clippy clean. The original PR's randomized differential run against SQLite 3.45 over LIKE/GLOB/instr/replace/quote/hex/unhex was byte-identical.

## Description of AI Usage

Original work in #8053 was AI-assisted (Claude Code); the split and rebase were done by Claude Code, with each branch built, linted, and tested standalone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ssjo9W9HY77s7HNLChHvE1)_