### PR TITLE
core/bench: add long-input benchmarks for SIMD-sensitive string paths

### DIFF
--- a/core/benches/sql_functions/likeop.rs
+++ b/core/benches/sql_functions/likeop.rs
@@ -433,3 +433,45 @@ fn glob_unicode_pattern(bencher: Bencher) {
         ))
     });
 }
+
+// =============================================================================
+// Contains Fast-Path Benchmarks (SIMD-sensitive sizes)
+// =============================================================================
+
+#[cfg(feature = "nanosecond-bench")]
+#[turso_macros::divan_bench]
+fn like_contains_long_text_match(bencher: Bencher) {
+    let pattern = "%lazy dog%";
+    let text = "the quick brown fox jumps over a sleeping cat. ".repeat(20) + "the lazy dog sleeps";
+    bencher.bench_local(|| {
+        black_box(Value::exec_like(
+            black_box(pattern),
+            black_box(&text),
+            Some('\\'),
+        ))
+        .unwrap()
+    });
+}
+
+#[cfg(feature = "nanosecond-bench")]
+#[turso_macros::divan_bench]
+fn like_contains_long_text_no_match(bencher: Bencher) {
+    let pattern = "%lazy dog%";
+    let text = "the quick brown fox jumps over a sleeping cat. ".repeat(20);
+    bencher.bench_local(|| {
+        black_box(Value::exec_like(
+            black_box(pattern),
+            black_box(&text),
+            Some('\\'),
+        ))
+        .unwrap()
+    });
+}
+
+#[cfg(feature = "nanosecond-bench")]
+#[turso_macros::divan_bench]
+fn glob_contains_long_text(bencher: Bencher) {
+    let pattern = "*lazy dog*";
+    let text = "the quick brown fox jumps over a sleeping cat. ".repeat(20) + "the lazy dog sleeps";
+    bencher.bench_local(|| black_box(Value::exec_glob(black_box(pattern), black_box(&text))));
+}

--- a/core/benches/sql_functions/value.rs
+++ b/core/benches/sql_functions/value.rs
@@ -1050,3 +1050,76 @@ fn exec_randomblob_large(bencher: Bencher) {
         )
     });
 }
+
+// =============================================================================
+// Long-Input String Functions (SIMD-sensitive sizes)
+// =============================================================================
+
+fn long_text_haystack() -> String {
+    "the quick brown fox jumps over the lazy dog. ".repeat(100)
+}
+
+#[turso_macros::divan_bench]
+fn instr_long_text_found_late(bencher: Bencher) {
+    let mut text = long_text_haystack();
+    text.push_str("needle in the haystack");
+    let value = Value::build_text(text);
+    let pattern = Value::build_text("needle");
+    bencher.bench_local(|| black_box(black_box(&value).exec_instr(black_box(&pattern))));
+}
+
+#[turso_macros::divan_bench]
+fn instr_long_text_not_found(bencher: Bencher) {
+    let value = Value::build_text(long_text_haystack());
+    let pattern = Value::build_text("needle");
+    bencher.bench_local(|| black_box(black_box(&value).exec_instr(black_box(&pattern))));
+}
+
+#[turso_macros::divan_bench]
+fn instr_long_blob(bencher: Bencher) {
+    let mut blob = vec![0xABu8; 4096];
+    blob.extend_from_slice(&[1, 2, 3, 4]);
+    let value = Value::from_slice(&blob).expect(turso_core::alloc::ALLOC_ERR_MSG);
+    let pattern = Value::from_slice(&[1, 2, 3, 4]).expect(turso_core::alloc::ALLOC_ERR_MSG);
+    bencher.bench_local(|| black_box(black_box(&value).exec_instr(black_box(&pattern))));
+}
+
+#[turso_macros::divan_bench]
+fn replace_long_text(bencher: Bencher) {
+    let source = Value::build_text(long_text_haystack());
+    let pattern = Value::build_text("fox");
+    let replacement = Value::build_text("cat");
+    bencher.bench_local(|| {
+        black_box(Value::exec_replace(
+            black_box(&source),
+            black_box(&pattern),
+            black_box(&replacement),
+        ))
+    });
+}
+
+#[turso_macros::divan_bench]
+fn quote_long_text_no_quotes(bencher: Bencher) {
+    let value = Value::build_text(long_text_haystack());
+    bencher.bench_local(|| black_box(black_box(&value).exec_quote()));
+}
+
+#[turso_macros::divan_bench]
+fn quote_long_blob(bencher: Bencher) {
+    let blob = vec![0x5Au8; 4096];
+    let value = Value::from_slice(&blob).expect(turso_core::alloc::ALLOC_ERR_MSG);
+    bencher.bench_local(|| black_box(black_box(&value).exec_quote()));
+}
+
+#[turso_macros::divan_bench]
+fn hex_long_blob(bencher: Bencher) {
+    let blob = vec![0x5Au8; 4096];
+    let value = Value::from_slice(&blob).expect(turso_core::alloc::ALLOC_ERR_MSG);
+    bencher.bench_local(|| black_box(black_box(&value).exec_hex()));
+}
+
+#[turso_macros::divan_bench]
+fn unhex_long_text(bencher: Bencher) {
+    let value = Value::build_text("5A".repeat(4096));
+    bencher.bench_local(|| black_box(black_box(&value).exec_unhex(None)));
+}


### PR DESCRIPTION
## Description

Split 3/7 of #8053. **Stacked on #8157** — review the top commit only.

Existing string-function benches use inputs under ~45 bytes, below the crossover where vectorized search shows up. Adds 1–8 KiB variants for `instr`, `replace`, `quote`, `hex`, `unhex`, and the LIKE/GLOB contains fast paths, so the SIMD changes are visible and regressions are caught.

Benchmarks only — no engine code changes.

## Motivation and context

Without long-input coverage the wins in #8157 are invisible to CodSpeed and a small-input regression can hide behind them. Split 4/7 (`...-04-simd-tuning`) is driven entirely by what these benchmarks measured. See #8156 for the full split layout.

## Tests

`cargo clippy -p turso_core --all-targets --all-features` clean (benches compile under the `nanosecond-bench` feature).

## Description of AI Usage

Original work in #8053 was AI-assisted (Claude Code); the split and rebase were done by Claude Code, with each branch built, linted, and tested standalone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ssjo9W9HY77s7HNLChHvE1)_