### PR TITLE
core: tune SIMD string and JSON scan paths from benchmark results

### DIFF
--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -46,14 +46,13 @@ fn find_control_byte(bytes: &[u8]) -> Option<usize> {
         .map(|p| offset + p)
 }
 
-/// Position of the first byte that terminates or complicates a JSON string:
-/// the closing `quote`, a backslash, or a control byte (`< 0x20`).
+/// Position of the first byte a JSON string rendering must escape or stop at:
+/// `quote`, a backslash, or a control byte (`< 0x20`).
 ///
-/// Most JSON strings are short keys/values whose terminator sits within the
-/// first few bytes, so the prefix is scanned scalar with per-byte early exit;
-/// only long strings continue into the chunked OR-accumulated scan that LLVM
-/// autovectorizes. `memchr2` cannot fold in the control-byte range test, and
-/// a chunk-first scan wastes work on the short-string common case.
+/// The prefix is scanned scalar with per-byte early exit — escapes near the
+/// start are common enough that chunk-first scanning wastes work — and only
+/// longer clean runs continue into the chunked OR-accumulated scan that LLVM
+/// autovectorizes. `memchr2` cannot fold in the control-byte range test.
 #[inline]
 fn find_string_special(bytes: &[u8], quote: u8) -> Option<usize> {
     const SCALAR_PREFIX: usize = 16;
@@ -1920,10 +1919,26 @@ impl Jsonb {
 
         if quoted {
             // Simple string fast path: the string is simple if the closing
-            // quote appears before any backslash or control byte.
-            if let Some(off) = find_string_special(&input[pos..], quote) {
-                let end_pos = pos + off;
-                if input[end_pos] == quote {
+            // quote appears before any backslash or control byte. This stays
+            // a scalar per-byte loop on purpose: parsed JSON strings are
+            // overwhelmingly short keys/values, and benchmarks showed both a
+            // memchr2 two-pass scan and a chunked vectorized scan losing to
+            // it here (see find_string_special, which serialization does use
+            // for its longer, rarer-escape payloads).
+            let mut end_pos = pos;
+            let mut found = false;
+            while end_pos < input.len() {
+                let c = input[end_pos];
+                if c == quote {
+                    found = true;
+                    break;
+                } else if c == b'\\' || c < 32 {
+                    break;
+                }
+                end_pos += 1;
+            }
+            if end_pos < input.len() {
+                if found {
                     let len = end_pos - pos;
                     let header_pos = self.data.len();
 

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -1937,26 +1937,24 @@ impl Jsonb {
                 }
                 end_pos += 1;
             }
-            if end_pos < input.len() {
-                if found {
-                    let len = end_pos - pos;
-                    let header_pos = self.data.len();
+            if found {
+                let len = end_pos - pos;
+                let header_pos = self.data.len();
 
-                    // Write header and content
-                    if len <= 11 {
-                        self.data
-                            .push((ElementType::TEXT as u8) | ((len as u8) << 4));
-                    } else {
-                        self.write_element_header(header_pos, ElementType::TEXT, len, false)
-                            .map_err(|_| PError::Message {
-                                msg: "Failed to write header".to_string(),
-                                location: Some(pos),
-                            })?;
-                    }
-
-                    self.data.extend_from_slice(&input[pos..end_pos]);
-                    return Ok(end_pos + 1); // Skip past closing quote
+                // Write header and content
+                if len <= 11 {
+                    self.data
+                        .push((ElementType::TEXT as u8) | ((len as u8) << 4));
+                } else {
+                    self.write_element_header(header_pos, ElementType::TEXT, len, false)
+                        .map_err(|_| PError::Message {
+                            msg: "Failed to write header".to_string(),
+                            location: Some(pos),
+                        })?;
                 }
+
+                self.data.extend_from_slice(&input[pos..end_pos]);
+                return Ok(end_pos + 1); // Skip past closing quote
             }
         }
 

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -46,6 +46,38 @@ fn find_control_byte(bytes: &[u8]) -> Option<usize> {
         .map(|p| offset + p)
 }
 
+/// Position of the first byte that terminates or complicates a JSON string:
+/// the closing `quote`, a backslash, or a control byte (`< 0x20`).
+///
+/// One fused chunked pass that LLVM autovectorizes. `memchr2` cannot fold in
+/// the control-byte range test, and a separate second pass costs more than it
+/// saves on the short strings typical of JSON keys and values.
+#[inline]
+fn find_string_special(bytes: &[u8], quote: u8) -> Option<usize> {
+    const CHUNK: usize = 16;
+    let is_special = |b: u8| (b == quote) | (b == b'\\') | (b < 0x20);
+    let mut offset = 0;
+    let mut chunks = bytes.chunks_exact(CHUNK);
+    for chunk in &mut chunks {
+        let mut any = false;
+        for &b in chunk {
+            any |= is_special(b);
+        }
+        if any {
+            return chunk
+                .iter()
+                .position(|&b| is_special(b))
+                .map(|p| offset + p);
+        }
+        offset += CHUNK;
+    }
+    chunks
+        .remainder()
+        .iter()
+        .position(|&b| is_special(b))
+        .map(|p| offset + p)
+}
+
 const fn make_whitespace_table() -> [u8; 256] {
     let mut table = [0u8; 256];
 
@@ -1326,15 +1358,14 @@ impl Jsonb {
                 // Only control bytes need escaping for TEXTJ (its payload
                 // already carries JSON escape sequences verbatim); TEXT also
                 // escapes quotes and backslashes. Jump between escape sites
-                // with SIMD search instead of testing every byte.
+                // with a vectorized scan instead of testing every byte.
                 let textj = *kind == ElementType::TEXTJ;
                 let find_escape = |bytes: &[u8]| -> Option<usize> {
                     if textj {
-                        return find_control_byte(bytes);
+                        find_control_byte(bytes)
+                    } else {
+                        find_string_special(bytes, b'"')
                     }
-                    let special = memchr::memchr2(b'"', b'\\', bytes);
-                    let limit = special.unwrap_or(bytes.len());
-                    find_control_byte(&bytes[..limit]).or(special)
                 };
 
                 let mut last_end = 0;
@@ -1865,12 +1896,10 @@ impl Jsonb {
 
         if quoted {
             // Simple string fast path: the string is simple if the closing
-            // quote appears before any backslash or control byte. memchr2
-            // finds the first quote/backslash with SIMD; the skipped span is
-            // then checked for control bytes.
-            if let Some(off) = memchr::memchr2(quote, b'\\', &input[pos..]) {
+            // quote appears before any backslash or control byte.
+            if let Some(off) = find_string_special(&input[pos..], quote) {
                 let end_pos = pos + off;
-                if input[end_pos] == quote && find_control_byte(&input[pos..end_pos]).is_none() {
+                if input[end_pos] == quote {
                     let len = end_pos - pos;
                     let header_pos = self.data.len();
 

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -49,15 +49,29 @@ fn find_control_byte(bytes: &[u8]) -> Option<usize> {
 /// Position of the first byte that terminates or complicates a JSON string:
 /// the closing `quote`, a backslash, or a control byte (`< 0x20`).
 ///
-/// One fused chunked pass that LLVM autovectorizes. `memchr2` cannot fold in
-/// the control-byte range test, and a separate second pass costs more than it
-/// saves on the short strings typical of JSON keys and values.
+/// Most JSON strings are short keys/values whose terminator sits within the
+/// first few bytes, so the prefix is scanned scalar with per-byte early exit;
+/// only long strings continue into the chunked OR-accumulated scan that LLVM
+/// autovectorizes. `memchr2` cannot fold in the control-byte range test, and
+/// a chunk-first scan wastes work on the short-string common case.
 #[inline]
 fn find_string_special(bytes: &[u8], quote: u8) -> Option<usize> {
-    const CHUNK: usize = 16;
+    const SCALAR_PREFIX: usize = 16;
+    const CHUNK: usize = 32;
     let is_special = |b: u8| (b == quote) | (b == b'\\') | (b < 0x20);
-    let mut offset = 0;
-    let mut chunks = bytes.chunks_exact(CHUNK);
+
+    let scalar_end = bytes.len().min(SCALAR_PREFIX);
+    for (i, &b) in bytes[..scalar_end].iter().enumerate() {
+        if is_special(b) {
+            return Some(i);
+        }
+    }
+    if scalar_end == bytes.len() {
+        return None;
+    }
+
+    let mut offset = SCALAR_PREFIX;
+    let mut chunks = bytes[SCALAR_PREFIX..].chunks_exact(CHUNK);
     for chunk in &mut chunks {
         let mut any = false;
         for &b in chunk {
@@ -1104,7 +1118,12 @@ impl Jsonb {
             }
             ElementType::TEXT | ElementType::TEXTJ | ElementType::TEXT5 | ElementType::TEXTRAW => {
                 let payload = &self.data[payload_start..payload_end];
-                simdutf8::basic::from_utf8(payload).map_err(|_| {
+                if payload.len() < 64 {
+                    from_utf8(payload).ok()
+                } else {
+                    simdutf8::basic::from_utf8(payload).ok()
+                }
+                .ok_or_else(|| {
                     LimboError::ParseError("Invalid UTF-8 in text payload".to_string())
                 })?;
                 Ok(())
@@ -1351,9 +1370,14 @@ impl Jsonb {
 
         match kind {
             ElementType::TEXT | ElementType::TEXTRAW | ElementType::TEXTJ => {
-                let word = simdutf8::basic::from_utf8(word_slice).map_err(|_| {
-                    LimboError::ParseError("Failed to serialize string!".to_string())
-                })?;
+                // simdutf8 wins on bulk input but has per-call setup that
+                // loses to std on the short strings typical of JSON.
+                let word = if word_slice.len() < 64 {
+                    from_utf8(word_slice).ok()
+                } else {
+                    simdutf8::basic::from_utf8(word_slice).ok()
+                }
+                .ok_or_else(|| LimboError::ParseError("Failed to serialize string!".to_string()))?;
 
                 // Only control bytes need escaping for TEXTJ (its payload
                 // already carries JSON escape sequences verbatim); TEXT also

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -99,8 +99,14 @@ pub fn convert_dbtype_to_jsonb(val: impl AsValueRef, strict: Conv) -> crate::Res
 fn parse_as_json_text(slice: &[u8], mode: Conv) -> crate::Result<Jsonb> {
     let zero_pos = memchr::memchr(0, slice).unwrap_or(slice.len());
     let truncated = &slice[..zero_pos];
-    let str = simdutf8::basic::from_utf8(truncated)
-        .map_err(|_| LimboError::ParseError("malformed JSON".to_string()))?;
+    // simdutf8 wins on bulk input but has per-call setup that loses to std on
+    // tiny payloads.
+    let str = if truncated.len() < 64 {
+        std::str::from_utf8(truncated).ok()
+    } else {
+        simdutf8::basic::from_utf8(truncated).ok()
+    }
+    .ok_or_else(|| LimboError::ParseError("malformed JSON".to_string()))?;
     Jsonb::from_str_with_mode(str, mode).map_err(Into::into)
 }
 

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1557,8 +1557,22 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     if needle.is_empty() {
         return Some(0);
     }
+    if needle.len() > haystack.len() {
+        return None;
+    }
     if haystack.len() < SIMD_SEARCH_MIN_HAYSTACK {
-        return haystack.windows(needle.len()).position(|w| w == needle);
+        // memchr over first-byte candidates; no memmem searcher setup.
+        let last_start = haystack.len() - needle.len();
+        let tail = &needle[1..];
+        let mut start = 0;
+        while let Some(off) = memchr::memchr(needle[0], &haystack[start..last_start + 1]) {
+            let i = start + off;
+            if haystack[i + 1..i + needle.len()] == *tail {
+                return Some(i);
+            }
+            start = i + 1;
+        }
+        return None;
     }
     memchr::memmem::find(haystack, needle)
 }

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -567,7 +567,7 @@ impl Value {
             if pattern.is_empty() {
                 return Value::from_i64(1);
             }
-            let result = memchr::memmem::find(reg, pattern).map_or(0, |i| i + 1);
+            let result = find_subslice(reg, pattern).map_or(0, |i| i + 1);
             return Value::from_i64(result as i64);
         }
 
@@ -589,7 +589,7 @@ impl Value {
             }
         };
 
-        match memchr::memmem::find(reg.as_bytes(), pattern.as_bytes()) {
+        match find_subslice(reg.as_bytes(), pattern.as_bytes()) {
             Some(byte_pos) => {
                 // Convert byte position to character position (1-indexed)
                 let char_pos = reg[..byte_pos].chars().count() + 1;
@@ -1023,18 +1023,11 @@ impl Value {
                     return Ok(Value::Text(source.clone()));
                 }
 
-                let source = source.as_str();
-                let pattern = pattern.as_str();
-                let replacement = replacement.as_str();
-                let mut result = String::with_capacity(source.len());
-                let mut last_end = 0;
-                for i in memchr::memmem::find_iter(source.as_bytes(), pattern.as_bytes()) {
-                    result.push_str(&source[last_end..i]);
-                    result.push_str(replacement);
-                    last_end = i + pattern.len();
-                }
-                result.push_str(&source[last_end..]);
-                Ok(Value::build_text(result))
+                Ok(Value::build_text(replace_all(
+                    source.as_str(),
+                    pattern.as_str(),
+                    replacement.as_str(),
+                )))
             }
             _ => unreachable!("text cast should never fail"),
         }
@@ -1352,7 +1345,7 @@ impl Value {
             && !pattern[1..pattern.len() - 1].contains(GLOB_CHARS)
         {
             let needle = &pattern[1..pattern.len() - 1];
-            return Ok(memchr::memmem::find(text.as_bytes(), needle.as_bytes()).is_some());
+            return Ok(find_subslice(text.as_bytes(), needle.as_bytes()).is_some());
         }
 
         Ok(pattern_compare(pattern, text, &GLOB_INFO, None) == CompareResult::Match)
@@ -1533,6 +1526,43 @@ const GLOB_INFO: PatternInfo = PatternInfo {
     no_case: false,
 };
 
+/// Below this haystack size the scalar search wins: `memmem::find`'s per-call
+/// searcher construction costs more than scanning the whole haystack.
+const SIMD_SEARCH_MIN_HAYSTACK: usize = 64;
+
+/// replace() body: SIMD `memmem` scan over large sources, std's searcher for
+/// small ones. Outlined for the same code-size reason as [`find_subslice`].
+#[inline(never)]
+fn replace_all(source: &str, pattern: &str, replacement: &str) -> String {
+    if source.len() < SIMD_SEARCH_MIN_HAYSTACK {
+        return source.replace(pattern, replacement);
+    }
+    let mut result = String::with_capacity(source.len());
+    let mut last_end = 0;
+    for i in memchr::memmem::find_iter(source.as_bytes(), pattern.as_bytes()) {
+        result.push_str(&source[last_end..i]);
+        result.push_str(replacement);
+        last_end = i + pattern.len();
+    }
+    result.push_str(&source[last_end..]);
+    result
+}
+
+/// Substring search: SIMD `memmem` for large haystacks, scalar for small.
+///
+/// `#[inline(never)]` keeps the expanded memmem machinery out of the callers,
+/// whose other (non-search) paths otherwise pay for the code bloat.
+#[inline(never)]
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    if haystack.len() < SIMD_SEARCH_MIN_HAYSTACK {
+        return haystack.windows(needle.len()).position(|w| w == needle);
+    }
+    memchr::memmem::find(haystack, needle)
+}
+
 /// ASCII-case-insensitive substring search built on SIMD byte search.
 ///
 /// SQLite's LIKE folds only ASCII letters, so candidate positions are located
@@ -1541,6 +1571,7 @@ const GLOB_INFO: PatternInfo = PatternInfo {
 /// Byte-level matching is equivalent to char-level here: the needle is valid
 /// UTF-8, so its first byte is never a continuation byte and cannot match in
 /// the middle of a multi-byte character.
+#[inline(never)]
 fn contains_ignore_ascii_case(text: &str, needle: &str) -> bool {
     let haystack = text.as_bytes();
     let needle = needle.as_bytes();


### PR DESCRIPTION
## Description

Split 4/7 of #8053. **Stacked on #8158** — review the top four commits.

The four measurement-driven follow-ups to #8156 and #8157, kept together because each one only makes sense as a correction to the one before it:

1. **`core: fix small-input regressions in SIMD string search paths`** — JSON parse/serialize slowed 7–29% on realistic payloads (memchr2 plus a second control-byte pass loses to a fused scan on short strings), so both scans become one fused chunked scanner that LLVM autovectorizes. In the vdbe, inlined memmem searcher construction bloated `exec_like`/`exec_glob`/`exec_instr` enough to slow every pattern shape ~2x, so the search helpers are outlined with `#[inline(never)]` and fall back to scalar below a 64-byte haystack.
2. **`core: tune SIMD scan entry costs for short JSON strings and instr`** — scan a 16-byte prefix scalar with per-byte early exit before entering the vectorized chunk loop; gate per-string `simdutf8` validation to inputs ≥64 bytes; replace `instr()`'s small-haystack `windows().position()` with a memchr first-byte candidate scan.
3. **`core/json: keep scalar scan in the JSON string parse fast path`** — an interleaved A/B showed the chunked scan still regressing `jsonb()` parsing 3–23%; parsed JSON strings are overwhelmingly short keys and values. The parse-side scan goes back to the original scalar loop. Serialization keeps the vectorized scan, where escape-free runs dominate.
4. **`core/json: collapse redundant bounds check in string fast path`** — `clippy::collapsible_if`.

Net effect: large-input wins from #8157 are unchanged, and the small-input paths are back at or above the pre-SIMD baseline.

## Motivation and context

These were bundled rather than split further because commit 3 partially reverts commit 1, and commit 2 tunes thresholds commit 1 introduced. Landing them separately would ship a known regression in between. See #8156 for the full split layout.

## Tests

`cargo test -p turso_core --lib` — 2277 passed, 0 failed. Workspace clippy clean.

## Description of AI Usage

Original work in #8053 was AI-assisted (Claude Code); the split and rebase were done by Claude Code, with each branch built, linted, and tested standalone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ssjo9W9HY77s7HNLChHvE1)_