### PR TITLE
core/vdbe: generalize LIKE/GLOB contains fast path to multi-segment patterns

### DIFF
--- a/core/benches/sql_functions/likeop.rs
+++ b/core/benches/sql_functions/likeop.rs
@@ -475,3 +475,19 @@ fn glob_contains_long_text(bencher: Bencher) {
     let text = "the quick brown fox jumps over a sleeping cat. ".repeat(20) + "the lazy dog sleeps";
     bencher.bench_local(|| black_box(Value::exec_glob(black_box(pattern), black_box(&text))));
 }
+
+#[cfg(feature = "nanosecond-bench")]
+#[turso_macros::divan_bench]
+fn like_multi_segment_long_text(bencher: Bencher) {
+    // TPC-H q13 shape: two ordered segments over a comment-length text
+    let pattern = "%express%packages%";
+    let text = "carefully final deposits detect slyly agai express nag quickly packages haggle";
+    bencher.bench_local(|| {
+        black_box(Value::exec_like(
+            black_box(pattern),
+            black_box(text),
+            Some('\\'),
+        ))
+        .unwrap()
+    });
+}

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1288,15 +1288,28 @@ impl Value {
             // Fall through to pattern_compare if boundary check fails (multi-byte UTF-8)
         }
 
-        // 4. Fast Path: '%abc%' (Contains)
+        // 4. Fast Path: '%abc%', '%abc%def%', ... (ordered substrings)
+        // Greedy leftmost matching per segment is equivalent to SQLite's
+        // patternCompare here: '%a%b%' matches iff 'a' occurs and 'b' occurs
+        // after it, and taking each earliest occurrence never rules out a
+        // later match. TPC-H q13/q16 run this shape per row.
         if !has_escape
             && pattern.len() >= 2
             && pattern.starts_with('%')
             && pattern.ends_with('%')
-            && !pattern[1..pattern.len() - 1].contains(['%', '_'])
+            && !pattern.contains('_')
         {
-            let needle = &pattern[1..pattern.len() - 1];
-            return Ok(contains_ignore_ascii_case(text, needle));
+            let mut haystack = text.as_bytes();
+            for seg in pattern[1..pattern.len() - 1].split('%') {
+                if seg.is_empty() {
+                    continue;
+                }
+                match find_ignore_ascii_case(haystack, seg.as_bytes()) {
+                    Some(i) => haystack = &haystack[i + seg.len()..],
+                    None => return Ok(false),
+                }
+            }
+            return Ok(true);
         }
 
         Ok(pattern_compare(pattern, text, &LIKE_INFO, escape) == CompareResult::Match)
@@ -1338,14 +1351,24 @@ impl Value {
             // Fall through to pattern_compare if boundary check fails (multi-byte UTF-8)
         }
 
-        // 4. Fast Path: '*abc*' (Contains)
+        // 4. Fast Path: '*abc*', '*abc*def*', ... (ordered substrings)
+        // Greedy leftmost matching per segment, as in exec_like's fast path.
         if pattern.len() >= 2
             && pattern.starts_with('*')
             && pattern.ends_with('*')
-            && !pattern[1..pattern.len() - 1].contains(GLOB_CHARS)
+            && !pattern.contains(['?', '['])
         {
-            let needle = &pattern[1..pattern.len() - 1];
-            return Ok(find_subslice(text.as_bytes(), needle.as_bytes()).is_some());
+            let mut haystack = text.as_bytes();
+            for seg in pattern[1..pattern.len() - 1].split('*') {
+                if seg.is_empty() {
+                    continue;
+                }
+                match find_subslice(haystack, seg.as_bytes()) {
+                    Some(i) => haystack = &haystack[i + seg.len()..],
+                    None => return Ok(false),
+                }
+            }
+            return Ok(true);
         }
 
         Ok(pattern_compare(pattern, text, &GLOB_INFO, None) == CompareResult::Match)
@@ -1586,14 +1609,12 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 /// UTF-8, so its first byte is never a continuation byte and cannot match in
 /// the middle of a multi-byte character.
 #[inline(never)]
-fn contains_ignore_ascii_case(text: &str, needle: &str) -> bool {
-    let haystack = text.as_bytes();
-    let needle = needle.as_bytes();
+fn find_ignore_ascii_case(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     if needle.is_empty() {
-        return true;
+        return Some(0);
     }
     if needle.len() > haystack.len() {
-        return false;
+        return None;
     }
     let last_start = haystack.len() - needle.len();
     let first = needle[0];
@@ -1607,12 +1628,10 @@ fn contains_ignore_ascii_case(text: &str, needle: &str) -> bool {
         } else {
             memchr::memchr2(lower, upper, candidates)
         };
-        let Some(offset) = found else {
-            return false;
-        };
+        let offset = found?;
         let i = start + offset;
         if haystack[i + 1..i + needle.len()].eq_ignore_ascii_case(tail) {
-            return true;
+            return Some(i);
         }
         start = i + 1;
     }
@@ -2918,6 +2937,18 @@ mod tests {
         // An escape char inside the needle must bypass the fast path
         assert!(Value::exec_like("%aXb%", "ab", Some('X')).unwrap());
         assert!(!Value::exec_like("%aXb%", "aXb", Some('X')).unwrap());
+        // Multi-segment: substrings must appear in order
+        assert!(Value::exec_like("%ab%cd%", "xabycdz", None).unwrap());
+        assert!(!Value::exec_like("%ab%cd%", "xcdyabz", None).unwrap());
+        assert!(Value::exec_like("%express%packages%", "EXPRESS PACKAGES", None).unwrap());
+        assert!(!Value::exec_like("%express%packages%", "packages express", None).unwrap());
+        // Greedy leftmost matching must not rule out later segments
+        assert!(Value::exec_like("%aa%a%", "aaa", None).unwrap());
+        assert!(!Value::exec_like("%aa%a%", "aab", None).unwrap());
+        // Consecutive percents collapse
+        assert!(Value::exec_like("%ab%%cd%", "abcd", None).unwrap());
+        // Underscore anywhere bypasses the fast path
+        assert!(Value::exec_like("%a_b%c%", "xaybzc", None).unwrap());
     }
 
     #[test]
@@ -2931,6 +2962,10 @@ mod tests {
         // Inner wildcard chars must bypass the fast path
         assert!(Value::exec_glob("*a?c*", "xxabcyy").unwrap());
         assert!(Value::exec_glob("*a[bd]c*", "xxadcyy").unwrap());
+        // Multi-segment: substrings must appear in order, case-sensitively
+        assert!(Value::exec_glob("*ab*cd*", "xabycdz").unwrap());
+        assert!(!Value::exec_glob("*ab*cd*", "xcdyabz").unwrap());
+        assert!(!Value::exec_glob("*ab*cd*", "xAByCDz").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Description

Split 5/7 of #8053. **Stacked on #8159** — review the top commit only.

TPC-H q13 runs `o_comment NOT LIKE '%express%packages%'` per joined orders row and q16 filters supplier comments the same way; the single-needle contains fast path from #8157 missed these, so they fell back to the char-by-char patternCompare state machine.

Extends the fast path to any `'%a%b%...%'` / `'*a*b*...*'` pattern without `_` (or `?`/`[`) by matching segments greedily leftmost with the SIMD searchers. Greedy leftmost is equivalent to patternCompare for this shape: taking each segment's earliest occurrence never rules out a later match.

Also adds a `like_multi_segment_long_text` benchmark in the q13 shape.

Measured on the 1.2 GB SF1 TPC-H database (`perf/tpc-h/compare.sh`, release binaries, warm cache): q13's predicate over 1.5M orders went 887 ms → 623 ms (**-30%**).

## Motivation and context

See #8156 for the full split layout.

## Tests

New multi-segment unit tests (ordering, greedy overlap, collapsed percents, case folding). `cargo test -p turso_core --lib` — 2277 passed, 0 failed. Workspace clippy clean. The original PR's randomized differential run against SQLite, including multi-wildcard patterns, stayed byte-identical.

## Description of AI Usage

Original work in #8053 was AI-assisted (Claude Code); the split and rebase were done by Claude Code, with each branch built, linted, and tested standalone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ssjo9W9HY77s7HNLChHvE1)_