### PR TITLE
core: stop scalar VALUES subqueries after first row

### DIFF
--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -104,6 +104,7 @@ pub fn emit_query<'a>(
 
     // Handle VALUES clause - emit values after subqueries are prepared
     if !plan.values.is_empty() {
+        init_limit(program, t_ctx, &plan.limit, &plan.offset)?;
         let reg_result_cols_start = emit_values(program, plan, t_ctx)?;
         program.preassign_label_to_next_insn(after_main_loop_label);
         return Ok(reg_result_cols_start);

--- a/core/translate/values.rs
+++ b/core/translate/values.rs
@@ -1,8 +1,9 @@
 use crate::translate::emitter::TranslateCtx;
 use crate::translate::expr::{translate_expr_no_constant_opt, NoConstantOptReason};
 use crate::translate::plan::{QueryDestination, SelectPlan};
-use crate::translate::result_row::{emit_columns_to_destination, emit_offset};
-use crate::turso_assert_eq;
+use crate::translate::result_row::{
+    emit_columns_to_destination, emit_offset, emit_result_row_and_limit,
+};
 use crate::vdbe::builder::ProgramBuilder;
 use crate::vdbe::insn::{to_u32, IdxInsertFlags, InsertFlags, Insn};
 use crate::vdbe::BranchOffset;
@@ -217,20 +218,8 @@ fn emit_values_to_destination(
                 dest: *result_reg,
             });
         }
-        QueryDestination::RowValueSubqueryResult {
-            result_reg_start,
-            num_regs,
-        } => {
-            turso_assert_eq!(
-                row_len,
-                *num_regs,
-                "row value subqueries must have matching result columns and registers"
-            );
-            program.emit_insn(Insn::Copy {
-                src_reg: start_reg,
-                dst_reg: *result_reg_start,
-                extra_amount: num_regs - 1,
-            });
+        QueryDestination::RowValueSubqueryResult { .. } => {
+            emit_result_row_and_limit(program, plan, start_reg, t_ctx.limit_ctx, Some(end_label))?;
         }
         QueryDestination::RowSet { .. } => {
             unreachable!("RowSet query destination should not be used in values emission")

--- a/sqlite/conformance/sqlite-sqltests/subquery/expressions.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/subquery/expressions.sqltest
@@ -386,6 +386,13 @@ expect {
 # Subqueries with LIMIT edge cases
 # =============================================================================
 
+test subquery-scalar-values-uses-first-row {
+    SELECT (VALUES(1),(2),(3));
+}
+expect {
+    1
+}
+
 test subquery-limit-zero {
     SELECT * FROM (SELECT 1 UNION SELECT 2 LIMIT 0);
 }


### PR DESCRIPTION
## Summary

Fix scalar `VALUES` subqueries returning the last row instead of the first.

Reuse the existing subquery limit when emitting `VALUES` rows.

## Tests

- `subquery/expressions.sqltest` (84 passed)
- `cargo clippy -p turso_core --all-features --all-targets -- --deny=warnings`

Fixes #7976
