### PR TITLE
tests/integration: extract shared UnreliableIo crash-simulation module

### DIFF
--- a/tests/integration/checkpoint_crash_atomicity.rs
+++ b/tests/integration/checkpoint_crash_atomicity.rs
@@ -16,324 +16,18 @@
 //! database, or right after a WAL-resetting checkpoint) was acknowledged
 //! without any fsync covering its frames.
 //!
-//! The crash model here is a test-side IO substrate: every write is volatile
-//! until the file it targets is fsynced; at the simulated power-loss point the
-//! durable image plus an arbitrary (here: alternating) subset of the unsynced
-//! DB-file writes survives, and all unsynced WAL writes are lost. This is a
-//! legal power-loss outcome (the kernel may write back dirty DB pages while
-//! the WAL tail never reaches the platter).
+//! The crash model is the shared [`crate::unreliable_io::UnreliableIo`]: every
+//! write is volatile until the file it targets is fsynced; at the simulated
+//! power-loss point the durable image plus an arbitrary (alternating) subset
+//! of the unsynced DB-file writes survives, and all unsynced WAL writes are
+//! lost. This is a legal power-loss outcome (the kernel may write back dirty
+//! DB pages while the WAL tail never reaches the platter).
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use turso_core::{
-    io::FileSyncType, Buffer, Clock, Completion, Database, DatabaseOpts, File, MonotonicInstant,
-    OpenFlags, SqliteDialect, WallClockInstant, IO,
-};
+use turso_core::{Database, DatabaseOpts, OpenFlags, SqliteDialect};
 
-/// A single not-yet-durable file mutation.
-enum UnsyncedOp {
-    Write { pos: usize, data: Vec<u8> },
-    Truncate { len: usize },
-}
-
-impl UnsyncedOp {
-    fn apply(&self, image: &mut Vec<u8>) {
-        match self {
-            UnsyncedOp::Write { pos, data } => {
-                let end = pos + data.len();
-                if image.len() < end {
-                    image.resize(end, 0);
-                }
-                image[*pos..end].copy_from_slice(data);
-            }
-            UnsyncedOp::Truncate { len } => {
-                image.resize(*len, 0);
-            }
-        }
-    }
-}
-
-#[derive(Default)]
-struct FileShadow {
-    /// Bytes guaranteed to be on stable storage (covered by an fsync).
-    durable: Vec<u8>,
-    /// Writes/truncates issued since the last fsync, in submission order.
-    unsynced: Vec<UnsyncedOp>,
-}
-
-impl FileShadow {
-    fn promote_all(&mut self) {
-        for op in self.unsynced.drain(..) {
-            let durable = &mut self.durable;
-            op.apply(durable);
-        }
-    }
-}
-
-/// The captured post-crash disk state.
-struct CrashSnapshot {
-    files: HashMap<String, Vec<u8>>,
-    db_writes_persisted: usize,
-    db_writes_dropped: usize,
-}
-
-struct CrashSimState {
-    files: Mutex<HashMap<String, Arc<Mutex<FileShadow>>>>,
-    /// When set, the next fsync of this file (with pending writes) is the
-    /// simulated power-loss point.
-    armed_db_path: Mutex<Option<String>>,
-    snapshot: Mutex<Option<CrashSnapshot>>,
-}
-
-impl CrashSimState {
-    /// Builds the post-crash disk image: durable bytes everywhere, plus an
-    /// alternating subset of the unsynced writes to the crash-target file
-    /// (torn writeback), and none of the unsynced writes to any other file
-    /// (the WAL tail is lost).
-    fn build_crash_snapshot(&self, db_path: &str) -> CrashSnapshot {
-        let files = self.files.lock().unwrap();
-        let mut images = HashMap::new();
-        let mut persisted = 0usize;
-        let mut dropped = 0usize;
-        for (path, shadow) in files.iter() {
-            let shadow = shadow.lock().unwrap();
-            let mut image = shadow.durable.clone();
-            if path == db_path {
-                let mut write_idx = 0usize;
-                for op in &shadow.unsynced {
-                    if matches!(op, UnsyncedOp::Write { .. }) {
-                        if write_idx % 2 == 0 {
-                            op.apply(&mut image);
-                            persisted += 1;
-                        } else {
-                            dropped += 1;
-                        }
-                        write_idx += 1;
-                    }
-                }
-            }
-            images.insert(path.clone(), image);
-        }
-        CrashSnapshot {
-            files: images,
-            db_writes_persisted: persisted,
-            db_writes_dropped: dropped,
-        }
-    }
-}
-
-struct CrashSimIo {
-    inner: Arc<dyn IO>,
-    state: Arc<CrashSimState>,
-}
-
-impl CrashSimIo {
-    fn new() -> Self {
-        Self {
-            inner: Arc::new(turso_core::MemoryIO::new()),
-            state: Arc::new(CrashSimState {
-                files: Mutex::new(HashMap::new()),
-                armed_db_path: Mutex::new(None),
-                snapshot: Mutex::new(None),
-            }),
-        }
-    }
-
-    /// Settle: pretend everything written so far reached stable storage
-    /// (baseline state before the scenario under test).
-    fn mark_all_durable(&self) {
-        for shadow in self.state.files.lock().unwrap().values() {
-            shadow.lock().unwrap().promote_all();
-        }
-    }
-
-    /// Arm the power-loss trigger: the next fsync of `db_path` that has
-    /// pending (unsynced) writes captures the crash snapshot.
-    fn arm_crash_on_db_sync(&self, db_path: &str) {
-        *self.state.armed_db_path.lock().unwrap() = Some(db_path.to_string());
-    }
-
-    fn take_crash_snapshot(&self) -> Option<CrashSnapshot> {
-        self.state.snapshot.lock().unwrap().take()
-    }
-
-    /// The disk image a power loss right now would leave behind in the
-    /// strictest legal outcome: fsync-covered bytes only, every unsynced
-    /// write in every file lost.
-    fn durable_disk_snapshot(&self) -> HashMap<String, Vec<u8>> {
-        self.state
-            .files
-            .lock()
-            .unwrap()
-            .iter()
-            .map(|(path, shadow)| (path.clone(), shadow.lock().unwrap().durable.clone()))
-            .collect()
-    }
-
-    /// True when `path` has writes not yet covered by a successful fsync.
-    fn has_unsynced_writes(&self, path: &str) -> bool {
-        self.state
-            .files
-            .lock()
-            .unwrap()
-            .get(path)
-            .is_some_and(|shadow| !shadow.lock().unwrap().unsynced.is_empty())
-    }
-}
-
-impl Clock for CrashSimIo {
-    fn current_time_monotonic(&self) -> MonotonicInstant {
-        self.inner.current_time_monotonic()
-    }
-    fn current_time_wall_clock(&self) -> WallClockInstant {
-        self.inner.current_time_wall_clock()
-    }
-}
-
-impl IO for CrashSimIo {
-    fn open_file(
-        &self,
-        path: &str,
-        flags: OpenFlags,
-        direct: bool,
-    ) -> turso_core::Result<Arc<dyn File>> {
-        let inner = self.inner.open_file(path, flags, direct)?;
-        let shadow = self
-            .state
-            .files
-            .lock()
-            .unwrap()
-            .entry(path.to_string())
-            .or_default()
-            .clone();
-        Ok(Arc::new(CrashSimFile {
-            path: path.to_string(),
-            inner,
-            shadow,
-            state: self.state.clone(),
-        }))
-    }
-
-    fn remove_file(&self, path: &str) -> turso_core::Result<()> {
-        self.state.files.lock().unwrap().remove(path);
-        self.inner.remove_file(path)
-    }
-
-    fn step(&self) -> turso_core::Result<()> {
-        self.inner.step()
-    }
-
-    fn cancel(&self, completions: &[Completion]) -> turso_core::Result<()> {
-        self.inner.cancel(completions)
-    }
-
-    fn drain_completions(&self, completions: &[Completion]) -> turso_core::Result<()> {
-        self.inner.drain_completions(completions)
-    }
-
-    fn file_id(&self, path: &str) -> turso_core::Result<turso_core::io::FileId> {
-        self.inner.file_id(path)
-    }
-
-    fn fill_bytes(&self, dest: &mut [u8]) {
-        self.inner.fill_bytes(dest);
-    }
-
-    fn generate_random_number(&self) -> i64 {
-        self.inner.generate_random_number()
-    }
-}
-
-struct CrashSimFile {
-    path: String,
-    inner: Arc<dyn File>,
-    shadow: Arc<Mutex<FileShadow>>,
-    state: Arc<CrashSimState>,
-}
-
-impl File for CrashSimFile {
-    fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
-        self.inner.lock_file(exclusive)
-    }
-
-    fn unlock_file(&self) -> turso_core::Result<()> {
-        self.inner.unlock_file()
-    }
-
-    fn pread(&self, pos: u64, c: Completion) -> turso_core::Result<Completion> {
-        self.inner.pread(pos, c)
-    }
-
-    fn pwrite(
-        &self,
-        pos: u64,
-        buffer: Arc<Buffer>,
-        c: Completion,
-    ) -> turso_core::Result<Completion> {
-        self.shadow
-            .lock()
-            .unwrap()
-            .unsynced
-            .push(UnsyncedOp::Write {
-                pos: pos as usize,
-                data: buffer.as_slice().to_vec(),
-            });
-        self.inner.pwrite(pos, buffer, c)
-    }
-
-    fn pwritev(
-        &self,
-        pos: u64,
-        buffers: Vec<Arc<Buffer>>,
-        c: Completion,
-    ) -> turso_core::Result<Completion> {
-        {
-            let mut shadow = self.shadow.lock().unwrap();
-            let mut off = pos as usize;
-            for buffer in &buffers {
-                shadow.unsynced.push(UnsyncedOp::Write {
-                    pos: off,
-                    data: buffer.as_slice().to_vec(),
-                });
-                off += buffer.len();
-            }
-        }
-        self.inner.pwritev(pos, buffers, c)
-    }
-
-    fn sync(&self, c: Completion, sync_type: FileSyncType) -> turso_core::Result<Completion> {
-        // Simulated power loss: crash while the armed file's fsync is in
-        // flight, i.e. after its writes were submitted but before any of them
-        // were made durable.
-        let crash_here = {
-            let armed = self.state.armed_db_path.lock().unwrap();
-            armed.as_deref() == Some(self.path.as_str())
-                && !self.shadow.lock().unwrap().unsynced.is_empty()
-        };
-        if crash_here {
-            let mut snapshot = self.state.snapshot.lock().unwrap();
-            if snapshot.is_none() {
-                *snapshot = Some(self.state.build_crash_snapshot(&self.path));
-            }
-        }
-        self.shadow.lock().unwrap().promote_all();
-        self.inner.sync(c, sync_type)
-    }
-
-    fn truncate(&self, len: u64, c: Completion) -> turso_core::Result<Completion> {
-        self.shadow
-            .lock()
-            .unwrap()
-            .unsynced
-            .push(UnsyncedOp::Truncate { len: len as usize });
-        self.inner.truncate(len, c)
-    }
-
-    fn size(&self) -> turso_core::Result<u64> {
-        self.inner.size()
-    }
-}
+use crate::unreliable_io::UnreliableIo;
 
 fn query_rows(conn: &Arc<turso_core::Connection>, sql: &str) -> anyhow::Result<Vec<String>> {
     let mut stmt = conn.prepare(sql)?;
@@ -360,7 +54,7 @@ fn run_checkpoint_crash_scenario(sync_pragma: &str) -> anyhow::Result<()> {
     let old = "A".repeat(120);
     let new = "B".repeat(120);
 
-    let io = Arc::new(CrashSimIo::new());
+    let io = Arc::new(UnreliableIo::new());
     let db = Database::open_file_with_flags(
         io.clone(),
         db_path_sim,
@@ -387,18 +81,18 @@ fn run_checkpoint_crash_scenario(sync_pragma: &str) -> anyhow::Result<()> {
 
     // Checkpoint T's frames into the DB file; power loss strikes while the
     // backfilled pages are being forced to disk.
-    io.arm_crash_on_db_sync(db_path_sim);
+    io.arm_crash_on_sync(db_path_sim);
     conn.execute("PRAGMA wal_checkpoint(PASSIVE)")?;
 
     let snapshot = io
         .take_crash_snapshot()
         .expect("checkpoint never issued the post-backfill DB fsync; crash point not reached");
     assert!(
-        snapshot.db_writes_persisted >= 1 && snapshot.db_writes_dropped >= 1,
+        snapshot.writes_persisted >= 1 && snapshot.writes_dropped >= 1,
         "crash model must persist a strict subset of the backfill writes \
          (persisted={}, dropped={}); grow the workload if the backfill was a single write",
-        snapshot.db_writes_persisted,
-        snapshot.db_writes_dropped,
+        snapshot.writes_persisted,
+        snapshot.writes_dropped,
     );
 
     // Materialize the post-crash disk state and recover with a fresh database.
@@ -471,10 +165,10 @@ fn checkpoint_backfill_crash_under_synchronous_full_control() -> anyhow::Result<
 /// file is lost) and recovers the surviving image with a fresh database.
 /// Returns the tempdir alongside the connection to keep the files alive.
 fn crash_now_and_recover(
-    io: &CrashSimIo,
+    io: &UnreliableIo,
     db_path_sim: &str,
 ) -> anyhow::Result<(tempfile::TempDir, Arc<turso_core::Connection>)> {
-    let files = io.durable_disk_snapshot();
+    let files = io.durable_files();
     let dir = tempfile::TempDir::new()?;
     let db_path = dir.path().join("recovered.db");
     std::fs::write(
@@ -504,7 +198,7 @@ fn crash_now_and_recover(
 #[test]
 fn full_commit_right_after_truncate_checkpoint_survives_power_loss() -> anyhow::Result<()> {
     let db_path_sim = "full-commit-after-truncate-checkpoint.db";
-    let io = Arc::new(CrashSimIo::new());
+    let io = Arc::new(UnreliableIo::new());
     let db = Database::open_file_with_flags(
         io.clone(),
         db_path_sim,
@@ -545,7 +239,7 @@ fn full_commit_right_after_truncate_checkpoint_survives_power_loss() -> anyhow::
 #[test]
 fn first_full_commit_on_fresh_database_fsyncs_the_wal() -> anyhow::Result<()> {
     let db_path_sim = "first-full-commit-on-fresh-database.db";
-    let io = Arc::new(CrashSimIo::new());
+    let io = Arc::new(UnreliableIo::new());
     let db = Database::open_file_with_flags(
         io.clone(),
         db_path_sim,

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -25,6 +25,7 @@ mod stmt_journal;
 mod stmt_readonly;
 mod storage;
 mod trigger;
+mod unreliable_io;
 mod wal;
 
 #[cfg(test)]

--- a/tests/integration/unreliable_io.rs
+++ b/tests/integration/unreliable_io.rs
@@ -1,0 +1,348 @@
+//! A test IO that simulates unreliable storage: the bytes actually on disk
+//! can lag behind what the process has written.
+//!
+//! Real storage only guarantees a write after an fsync of its file; until
+//! then the write sits in the OS page cache and may or may not reach the
+//! platter. This module tracks that gap for every file: reads and the live
+//! database always see all writes (the page-cache view), but each write
+//! stays volatile until the next fsync of its file promotes it to durable.
+//!
+//! A test can then materialize the disk image each kind of failure leaves
+//! behind:
+//!
+//! - Process crash: the OS and its page cache survive, so no write is lost.
+//!   Just reopen the database on the same [`UnreliableIo`].
+//! - Power loss or kernel crash, strictest outcome: only fsync-acknowledged
+//!   bytes survive; every unsynced write is lost.
+//!   [`UnreliableIo::durable_files`] returns that image for every file.
+//! - Power loss during a specific file's fsync, with torn writeback: arm it
+//!   with [`UnreliableIo::arm_crash_on_sync`] and collect
+//!   [`UnreliableIo::take_crash_snapshot`]. An arbitrary (alternating)
+//!   subset of the target file's unsynced writes survives and all other
+//!   files keep only their durable bytes — also a legal outcome, because
+//!   the kernel may write back some dirty pages while others never reach
+//!   the platter.
+//!
+//! To reopen a database on a materialized post-crash image, write each
+//! file's bytes to disk and open with the regular platform IO.
+//!
+//! Other kinds of storage misbehavior tests need — injected write or fsync
+//! errors, reordered writeback — belong in this module too.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use turso_core::{
+    io::FileSyncType, Buffer, Clock, Completion, File, MonotonicInstant, OpenFlags,
+    WallClockInstant, IO,
+};
+
+/// A single not-yet-durable file mutation.
+enum UnsyncedOp {
+    Write { pos: usize, data: Vec<u8> },
+    Truncate { len: usize },
+}
+
+impl UnsyncedOp {
+    fn apply(&self, image: &mut Vec<u8>) {
+        match self {
+            UnsyncedOp::Write { pos, data } => {
+                let end = pos + data.len();
+                if image.len() < end {
+                    image.resize(end, 0);
+                }
+                image[*pos..end].copy_from_slice(data);
+            }
+            UnsyncedOp::Truncate { len } => {
+                image.resize(*len, 0);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct FileShadow {
+    /// Bytes guaranteed to be on stable storage (covered by an fsync).
+    durable: Vec<u8>,
+    /// Writes/truncates issued since the last fsync, in submission order.
+    unsynced: Vec<UnsyncedOp>,
+}
+
+impl FileShadow {
+    fn promote_all(&mut self) {
+        for op in self.unsynced.drain(..) {
+            op.apply(&mut self.durable);
+        }
+    }
+}
+
+/// The captured post-crash disk state.
+pub struct CrashSnapshot {
+    /// Per-file disk image at the crash point.
+    pub files: HashMap<String, Vec<u8>>,
+    /// Unsynced writes to the crash-target file that made it to disk.
+    pub writes_persisted: usize,
+    /// Unsynced writes to the crash-target file that were lost.
+    pub writes_dropped: usize,
+}
+
+struct UnreliableIoState {
+    files: Mutex<HashMap<String, Arc<Mutex<FileShadow>>>>,
+    /// When set, the next fsync of this file (with pending writes) is the
+    /// simulated power-loss point.
+    armed_path: Mutex<Option<String>>,
+    snapshot: Mutex<Option<CrashSnapshot>>,
+}
+
+impl UnreliableIoState {
+    /// Builds the post-crash disk image: durable bytes everywhere, plus an
+    /// alternating subset of the unsynced writes to the crash-target file
+    /// (torn writeback), and none of the unsynced writes to any other file.
+    fn build_crash_snapshot(&self, crash_path: &str) -> CrashSnapshot {
+        let files = self.files.lock().unwrap();
+        let mut images = HashMap::new();
+        let mut persisted = 0usize;
+        let mut dropped = 0usize;
+        for (path, shadow) in files.iter() {
+            let shadow = shadow.lock().unwrap();
+            let mut image = shadow.durable.clone();
+            if path == crash_path {
+                let mut write_idx = 0usize;
+                for op in &shadow.unsynced {
+                    if matches!(op, UnsyncedOp::Write { .. }) {
+                        if write_idx % 2 == 0 {
+                            op.apply(&mut image);
+                            persisted += 1;
+                        } else {
+                            dropped += 1;
+                        }
+                        write_idx += 1;
+                    }
+                }
+            }
+            images.insert(path.clone(), image);
+        }
+        CrashSnapshot {
+            files: images,
+            writes_persisted: persisted,
+            writes_dropped: dropped,
+        }
+    }
+}
+
+pub struct UnreliableIo {
+    inner: Arc<dyn IO>,
+    state: Arc<UnreliableIoState>,
+}
+
+impl Default for UnreliableIo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UnreliableIo {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(turso_core::MemoryIO::new()),
+            state: Arc::new(UnreliableIoState {
+                files: Mutex::new(HashMap::new()),
+                armed_path: Mutex::new(None),
+                snapshot: Mutex::new(None),
+            }),
+        }
+    }
+
+    /// Settle: pretend everything written so far reached stable storage
+    /// (baseline state before the scenario under test).
+    pub fn mark_all_durable(&self) {
+        for shadow in self.state.files.lock().unwrap().values() {
+            shadow.lock().unwrap().promote_all();
+        }
+    }
+
+    /// Arm the power-loss trigger: the next fsync of `path` that has
+    /// pending (unsynced) writes captures the crash snapshot.
+    pub fn arm_crash_on_sync(&self, path: &str) {
+        *self.state.armed_path.lock().unwrap() = Some(path.to_string());
+    }
+
+    pub fn take_crash_snapshot(&self) -> Option<CrashSnapshot> {
+        self.state.snapshot.lock().unwrap().take()
+    }
+
+    /// Simulate power loss right now: return, for each file, only the bytes
+    /// that were fsync-acknowledged. Every unsynced write is lost.
+    pub fn durable_files(&self) -> HashMap<String, Vec<u8>> {
+        self.state
+            .files
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(path, shadow)| (path.clone(), shadow.lock().unwrap().durable.clone()))
+            .collect()
+    }
+
+    /// True when `path` has writes not yet covered by a successful fsync.
+    pub fn has_unsynced_writes(&self, path: &str) -> bool {
+        self.state
+            .files
+            .lock()
+            .unwrap()
+            .get(path)
+            .is_some_and(|shadow| !shadow.lock().unwrap().unsynced.is_empty())
+    }
+}
+
+impl Clock for UnreliableIo {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        self.inner.current_time_monotonic()
+    }
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        self.inner.current_time_wall_clock()
+    }
+}
+
+impl IO for UnreliableIo {
+    fn open_file(
+        &self,
+        path: &str,
+        flags: OpenFlags,
+        direct: bool,
+    ) -> turso_core::Result<Arc<dyn File>> {
+        let inner = self.inner.open_file(path, flags, direct)?;
+        let shadow = self
+            .state
+            .files
+            .lock()
+            .unwrap()
+            .entry(path.to_string())
+            .or_default()
+            .clone();
+        Ok(Arc::new(UnreliableFile {
+            path: path.to_string(),
+            inner,
+            shadow,
+            state: self.state.clone(),
+        }))
+    }
+
+    fn remove_file(&self, path: &str) -> turso_core::Result<()> {
+        self.state.files.lock().unwrap().remove(path);
+        self.inner.remove_file(path)
+    }
+
+    fn step(&self) -> turso_core::Result<()> {
+        self.inner.step()
+    }
+
+    fn cancel(&self, completions: &[Completion]) -> turso_core::Result<()> {
+        self.inner.cancel(completions)
+    }
+
+    fn drain_completions(&self, completions: &[Completion]) -> turso_core::Result<()> {
+        self.inner.drain_completions(completions)
+    }
+
+    fn file_id(&self, path: &str) -> turso_core::Result<turso_core::io::FileId> {
+        self.inner.file_id(path)
+    }
+
+    fn fill_bytes(&self, dest: &mut [u8]) {
+        self.inner.fill_bytes(dest);
+    }
+
+    fn generate_random_number(&self) -> i64 {
+        self.inner.generate_random_number()
+    }
+}
+
+struct UnreliableFile {
+    path: String,
+    inner: Arc<dyn File>,
+    shadow: Arc<Mutex<FileShadow>>,
+    state: Arc<UnreliableIoState>,
+}
+
+impl File for UnreliableFile {
+    fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
+        self.inner.lock_file(exclusive)
+    }
+
+    fn unlock_file(&self) -> turso_core::Result<()> {
+        self.inner.unlock_file()
+    }
+
+    fn pread(&self, pos: u64, c: Completion) -> turso_core::Result<Completion> {
+        self.inner.pread(pos, c)
+    }
+
+    fn pwrite(
+        &self,
+        pos: u64,
+        buffer: Arc<Buffer>,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        self.shadow
+            .lock()
+            .unwrap()
+            .unsynced
+            .push(UnsyncedOp::Write {
+                pos: pos as usize,
+                data: buffer.as_slice().to_vec(),
+            });
+        self.inner.pwrite(pos, buffer, c)
+    }
+
+    fn pwritev(
+        &self,
+        pos: u64,
+        buffers: Vec<Arc<Buffer>>,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        {
+            let mut shadow = self.shadow.lock().unwrap();
+            let mut off = pos as usize;
+            for buffer in &buffers {
+                shadow.unsynced.push(UnsyncedOp::Write {
+                    pos: off,
+                    data: buffer.as_slice().to_vec(),
+                });
+                off += buffer.len();
+            }
+        }
+        self.inner.pwritev(pos, buffers, c)
+    }
+
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> turso_core::Result<Completion> {
+        // Simulated power loss: crash while the armed file's fsync is in
+        // flight, i.e. after its writes were submitted but before any of them
+        // were made durable.
+        let crash_here = {
+            let armed = self.state.armed_path.lock().unwrap();
+            armed.as_deref() == Some(self.path.as_str())
+                && !self.shadow.lock().unwrap().unsynced.is_empty()
+        };
+        if crash_here {
+            let mut snapshot = self.state.snapshot.lock().unwrap();
+            if snapshot.is_none() {
+                *snapshot = Some(self.state.build_crash_snapshot(&self.path));
+            }
+        }
+        self.shadow.lock().unwrap().promote_all();
+        self.inner.sync(c, sync_type)
+    }
+
+    fn truncate(&self, len: u64, c: Completion) -> turso_core::Result<Completion> {
+        self.shadow
+            .lock()
+            .unwrap()
+            .unsynced
+            .push(UnsyncedOp::Truncate { len: len as usize });
+        self.inner.truncate(len, c)
+    }
+
+    fn size(&self) -> turso_core::Result<u64> {
+        self.inner.size()
+    }
+}


### PR DESCRIPTION
Pull the crash-simulating IO out of checkpoint_crash_atomicity.rs into a
shared tests/integration/unreliable_io.rs module so other tests can
simulate crashes and storage failures without duplicating the machinery.
This is the test infrastructure half of PR #8103, extracted so the
upcoming power-loss recovery test (issue #7995) lands on a clean
foundation.

The module models unreliable storage in general, not one failure kind:
it tracks the gap between issued writes and fsync-covered bytes, and a
test picks the failure to materialize — process crash (nothing lost),
power loss (only durable bytes survive), or power loss mid-fsync with
torn writeback. Injected I/O errors and reordered writeback belong here
too as tests grow to need them.

The API is generalized while moving: arm_crash_on_db_sync becomes
arm_crash_on_sync and the snapshot counters drop their db_ prefix, since
any file can be the crash target, and durable_disk_snapshot becomes
durable_files. durable_files returns per-path byte images so a test can
materialize the post-crash disk state and reopen it with the regular
platform IO, which is exactly what the power-loss test needs.

Tests: cargo test -p core_tester --test integration_tests checkpoint_crash;
cargo clippy -p core_tester --all-features --all-targets
