### PR TITLE
core/translate: keep outer aliases out of nested FROM

### DIFF
--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1484,6 +1484,18 @@ impl TableReferences {
             .find(|t| t.identifier == identifier)
     }
 
+    pub(super) fn find_outer_cte_source_by_identifier(
+        &self,
+        identifier: &str,
+    ) -> Option<&OuterQueryReference> {
+        self.outer_query_refs.iter().find(|outer_ref| {
+            outer_ref.identifier == identifier
+                && ((outer_ref.cte_id.is_some()
+                    && (outer_ref.cte_definition_only || outer_ref.cte_select.is_some()))
+                    || matches!(outer_ref.table, Table::RecursiveCteInput(_)))
+        })
+    }
+
     /// Marks the pre-planned [OuterQueryReference] with the given identifier as
     /// "CTE definition only". This prevents it from being used for column
     /// resolution while still allowing CTE definition lookup in subquery FROM

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1617,7 +1617,7 @@ fn parse_table(
 
         // A CTE can read another CTE defined by the surrounding WITH clause.
         if let Some(outer_ref) =
-            table_references.find_outer_query_ref_by_identifier(&normalized_qualified_name)
+            table_references.find_outer_cte_source_by_identifier(&normalized_qualified_name)
         {
             if !args.is_empty() {
                 if matches!(outer_ref.table, Table::RecursiveCteInput(_)) {
@@ -1856,7 +1856,7 @@ fn parse_table(
     // but it's not part of the join order.
     if qualified_name.db_name.is_none() {
         if let Some(outer_ref) =
-            table_references.find_outer_query_ref_by_identifier(&normalized_qualified_name)
+            table_references.find_outer_cte_source_by_identifier(&normalized_qualified_name)
         {
             if matches!(outer_ref.table, Table::FromClauseSubquery(_)) {
                 table_references.add_joined_table(JoinedTable {

--- a/sqlite/conformance/sqlite-sqltests/cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/cte.sqltest
@@ -1464,6 +1464,15 @@ expect {
     2
 }
 
+test cte-alias-is-not-visible-as-inner-from-source {
+    WITH original(x) AS (VALUES(1))
+    SELECT * FROM original AS alias
+    WHERE EXISTS (SELECT 1 FROM alias);
+}
+expect error {
+    no such table: alias
+}
+
 # An unqualified column in a correlated subquery resolves against a CTE joined
 # in the outer FROM clause, same as a plain table.
 test cte-unqualified-correlated-ref-in-exists {

--- a/sqlite/conformance/sqlite-sqltests/subquery/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/subquery/memory.sqltest
@@ -1594,3 +1594,33 @@ test from-subquery-outer-ref-in-correlated-subquery {
 expect {
     2
 }
+
+@cross-check-integrity
+test from-subquery-alias-does-not-shadow-schema-table {
+    create table target(value);
+    create table source(id, marker);
+    insert into target values (1);
+    insert into source values (1, 0), (2, 0);
+    select target.id
+    from (select id, marker, 0 as value from source) as target
+    where not exists (
+        select 1 from target as inner_target
+        where inner_target.value = target.marker
+    )
+    order by target.id;
+}
+expect {
+    1
+    2
+}
+
+test from-subquery-alias-is-not-visible-as-inner-from-source {
+    create table source(id);
+    insert into source values (1);
+    select *
+    from (select id from source) as missing
+    where exists (select 1 from missing);
+}
+expect error {
+    no such table: missing
+}


### PR DESCRIPTION
## Summary

Fix nested `FROM` clauses resolving an outer query alias instead of a schema table.

Restrict cross-scope `FROM` lookup to CTE sources.

## Tests

- targeted SQL conformance tests
- `cargo clippy -p turso_core --all-features --all-targets -- --deny=warnings`

Fixes #7392
