### PR TITLE
core/translate: route CREATE TEMP VIEW to the temp schema

### DIFF
--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -266,12 +266,13 @@ pub fn translate_inner(
             select,
             columns,
             if_not_exists,
-            ..
+            temporary,
         } => view::translate_create_view(
             &view_name,
             resolver,
             &select,
             &columns,
+            temporary,
             if_not_exists,
             program,
         )?,

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -310,10 +310,17 @@ pub fn translate_create_view(
     resolver: &Resolver,
     select_stmt: &ast::Select,
     columns: &[ast::IndexedColumn],
+    temporary: bool,
     if_not_exists: bool,
     program: &mut ProgramBuilder,
 ) -> Result<()> {
-    let database_id = resolver.resolve_database_id(view_name)?;
+    // TEMP views always live in the temp schema. The parser rejects
+    // CREATE TEMP VIEW with a database name other than "temp".
+    let database_id = if temporary {
+        crate::TEMP_DB_ID
+    } else {
+        resolver.resolve_database_id(view_name)?
+    };
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
     program.begin_write_on_database(database_id, schema_cookie)?;
     let normalized_view_name = normalize_ident(view_name.name.as_str());
@@ -421,7 +428,9 @@ pub fn translate_drop_view(
     if_exists: bool,
     program: &mut ProgramBuilder,
 ) -> Result<()> {
-    let database_id = resolver.resolve_database_id(view_name)?;
+    // Unqualified names search the temp schema first, then main, then
+    // attached databases, so DROP VIEW finds temp views like SQLite does.
+    let database_id = resolver.resolve_existing_table_database_id_qualified(view_name)?;
     let schema_cookie = resolver.with_schema(database_id, |s| s.schema_version);
     program.begin_write_on_database(database_id, schema_cookie)?;
     let normalized_view_name = normalize_ident(view_name.name.as_str());

--- a/sqlite/conformance/sqlite-sqltests/temp-view.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/temp-view.sqltest
@@ -1,0 +1,37 @@
+@database :memory:
+
+test create-temp-view-lives-in-temp-schema-not-main {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1);
+    CREATE TEMP VIEW tv AS SELECT x FROM t;
+    SELECT count(*) FROM sqlite_schema WHERE type = 'view' AND name = 'tv';
+    SELECT count(*) FROM temp.sqlite_schema WHERE type = 'view' AND name = 'tv';
+    SELECT x FROM tv;
+    SELECT x FROM temp.tv;
+}
+expect {
+    0
+    1
+    1
+    1
+}
+
+test create-temporary-view-lives-in-temp-schema-not-main {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (2);
+    CREATE TEMPORARY VIEW tv2 AS SELECT x FROM t;
+    SELECT count(*) FROM sqlite_schema WHERE type = 'view' AND name = 'tv2';
+    SELECT count(*) FROM temp.sqlite_schema WHERE type = 'view' AND name = 'tv2';
+    SELECT x FROM tv2;
+}
+expect {
+    0
+    1
+    2
+}
+
+test create-temp-view-qualified-main-is-rejected {
+    CREATE TEMP VIEW main.bad AS SELECT 1;
+}
+expect error {
+}

--- a/sqlite/conformance/sqlite-sqltests/views.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/views.sqltest
@@ -400,6 +400,16 @@ expect {
     z
 }
 
+test drop-view-finds-temp-view-with-unqualified-name {
+    CREATE TABLE t(x);
+    CREATE TEMP VIEW tv AS SELECT x FROM t;
+    DROP VIEW tv;
+    SELECT count(*) FROM temp.sqlite_schema WHERE type = 'view' AND name = 'tv';
+}
+expect {
+    0
+}
+
 @cross-check-integrity
 test view-star-does-not-inherit-source-primary-key {
     CREATE TABLE view_pk_source(id INTEGER PRIMARY KEY, value TEXT);

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -855,6 +855,15 @@ impl<'a> Parser<'a> {
         eat_assert!(self, TK_VIEW);
         let if_not_exists = self.parse_if_not_exists()?;
         let view_name = self.parse_fullname(false)?;
+        if temporary {
+            if let Some(ref db_name) = view_name.db_name {
+                if !db_name.as_str().eq_ignore_ascii_case("TEMP") {
+                    return Err(Error::Custom(
+                        "temporary table name must be unqualified".to_owned(),
+                    ));
+                }
+            }
+        }
         let columns = self.parse_eid_list(true)?;
         eat_expect!(self, TK_AS);
         let select = self.parse_select()?;


### PR DESCRIPTION
The parser set temporary=true on Stmt::CreateView, but the dispatch in
translate_inner destructured it away with `..`, so a temp view was
created as a regular persistent view in the main schema. A user asking
for a session-scoped view durably polluted the shared sqlite_schema.

Wire the flag through to translate_create_view and resolve temp views
to TEMP_DB_ID, the same way translate_create_table handles temp tables.
The read path already searches temp before main and the temp schema is
per-connection, so lookup and drop-on-close need no extra work.

Two adjacent gaps had to close for temp views to behave like SQLite:

- translate_drop_view resolved unqualified names straight to main, so
  DROP VIEW could never find a temp view. Use the temp-first search
  order (resolve_existing_table_database_id_qualified), matching
  DROP TABLE.
- The parser now rejects CREATE TEMP VIEW with a database name other
  than "temp" ("temporary table name must be unqualified"), mirroring
  parse_create_table and SQLite.

Tests: sqlite-sqltests/temp-view.sqltest regression test; new DROP VIEW
coverage in sqlite-sqltests/views.sqltest; full sqlite-sqltests suite,
cargo test -p turso_core -p turso_parser -p core_tester all pass.

Fixes #8175