### PR TITLE
cli: show all lines of multi-line values in pretty mode

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1278,7 +1278,6 @@ impl Limbo {
             match stepper.next_row() {
                 Ok(Some(row)) => {
                     let mut table_row = Row::new();
-                    table_row.max_height(1);
                     for (idx, value) in row.get_values().enumerate() {
                         let (content, alignment) = match value {
                             Value::Null => (null_value.clone(), CellAlignment::Left),


### PR DESCRIPTION
Pretty mode capped every table row at a height of one line, so any
multi-line value was cut down to its first line with a truncation
indicator. `SELECT json_pretty(...)` therefore printed only `{…`
instead of the indented JSON.

Drop the `max_height(1)` cap on pretty-mode rows so cells expand to
fit every line of their content, matching how sqlite3's box mode
renders multi-line values. Width-based wrapping to the terminal is
unchanged.

Fixes #1192