### PR TITLE
core/vdbe: roll back attached implicit transaction on statement abort

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3867,6 +3867,9 @@ pub fn op_transaction_inner(
                 // 2. Start transaction if needed
                 if let Some(mv_store) = mv_store.as_ref() {
                     if is_secondary_db {
+                        if conn.get_auto_commit() && !conn.is_nested_stmt() {
+                            state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
+                        }
                         // Attached databases don't participate in the connection-level
                         // transaction state machine above (phase 1), so the pager read
                         // tx that the main DB path starts on None→Read isn't triggered
@@ -4062,6 +4065,9 @@ pub fn op_transaction_inner(
                     // transactions on the attached pager, since the connection-level
                     // transaction state may already be Read/Write from the main database.
                     if is_secondary_db {
+                        if conn.get_auto_commit() && !conn.is_nested_stmt() {
+                            state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
+                        }
                         // If the pager already holds a read lock (e.g., after
                         // SchemaUpdated reprepare or prior write tx), skip
                         // locks that are already held.

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1081,9 +1081,6 @@ impl ProgramState {
         if is_already_committing {
             return true;
         }
-        if self.auto_txn_cleanup != TxnCleanup::RollbackTxn {
-            return false;
-        }
         let active_writers = connection.n_active_writes.load(Ordering::SeqCst);
         turso_assert!(
             active_writers <= 1,
@@ -1098,16 +1095,45 @@ impl ProgramState {
         if connection.mv_store().is_some() {
             // MVCC keeps one tx id on the connection. A writer waits for
             // sibling readers, and a reader waits for sibling readers/writers.
-            return connection.n_active_root_statements.load(Ordering::SeqCst) == 1
+            return self.auto_txn_cleanup == TxnCleanup::RollbackTxn
+                && connection.n_active_root_statements.load(Ordering::SeqCst) == 1
                 && (self.is_active_write || active_writers == 0);
         }
-        if self.is_active_write {
-            // Pager/WAL writers can finish while sibling readers remain active.
-            // The readers keep their cursors and release them when they finish.
+        if self.auto_txn_cleanup == TxnCleanup::RollbackTxn && self.is_active_write {
+            // Pager/WAL writers can finish while sibling readers remain
+            // active, like SQLite commits when the halting statement is the
+            // only writer (the nVdbeWrite check in sqlite3VdbeHalt). The
+            // readers keep their cursors and release them when they finish.
             return true;
         }
-        // Pager/WAL readers do not wait for sibling readers.
-        active_writers == 0
+        // Non-main pagers keep their transaction state on the pager itself,
+        // like SQLite keeps it on the Btree handle (Btree.inTrans), and the
+        // transaction is shared by every statement on the connection.
+        let attached_txn_open = || {
+            connection.with_all_attached_pagers_with_index(|pagers| {
+                pagers
+                    .iter()
+                    .any(|(_, pager)| pager.holds_read_lock() || pager.holds_write_lock())
+            })
+        };
+        if connection.n_active_root_statements.load(Ordering::SeqCst) > 1 {
+            // Readers can finish while sibling readers remain active, but a
+            // shared attached transaction may only be finished by the last
+            // active statement, like SQLite's btreeEndTransaction keeps the
+            // transaction open while db->nVdbeRead > 1.
+            return self.auto_txn_cleanup == TxnCleanup::RollbackTxn
+                && active_writers == 0
+                && !attached_txn_open();
+        }
+        // This is the last active statement: finish its own transaction, or
+        // an attached transaction a deferring sibling left behind — SQLite's
+        // vdbeCommit visits every database on halt, so leftovers are closed
+        // even by a statement that never started a transaction itself.
+        if active_writers != 0 {
+            return false;
+        }
+        self.auto_txn_cleanup == TxnCleanup::RollbackTxn
+            || (connection.get_auto_commit() && attached_txn_open())
     }
 
     #[inline]

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -680,6 +680,107 @@ fn test_wal_dropping_one_reader_does_not_close_sibling_reader_transaction() {
 }
 
 #[test]
+fn test_wal_dropping_one_attached_reader_keeps_sibling_reader_locked() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io,
+        ":memory:wal-attached-sibling-readers",
+        OpenFlags::default(),
+        DatabaseOpts::new().with_attach(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    drive_attach(&conn, ":memory:wal-attached-sibling-readers-aux", "aux");
+    conn.execute("CREATE TABLE aux.rows(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute("INSERT INTO aux.rows VALUES (10), (20)")
+        .unwrap();
+
+    let mut first = conn.prepare("SELECT id FROM aux.rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut first), 10);
+    let mut second = conn.prepare("SELECT id FROM aux.rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut second), 10);
+
+    drop(first);
+    let detach_err = conn
+        .execute("DETACH aux")
+        .expect_err("the sibling reader must keep the attached database locked");
+    assert!(
+        matches!(detach_err, LimboError::InvalidArgument(ref message) if message == "database aux is locked"),
+        "expected attached database lock error, got {detach_err:?}"
+    );
+    assert_eq!(
+        step_returning_id(&mut second),
+        20,
+        "dropping one attached reader must not close the transaction under its sibling"
+    );
+    finish_without_rows(&mut second);
+    conn.execute("DETACH aux").unwrap();
+}
+
+#[test]
+fn review_attached_writer_success_is_not_lost_when_sibling_dropped() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io,
+        ":memory:review-attached-writer-main",
+        OpenFlags::default(),
+        DatabaseOpts::new().with_attach(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    let aux = ":memory:review-attached-writer-aux";
+    drive_attach(&conn, aux, "aux");
+    conn.execute("CREATE TABLE rows(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute("INSERT INTO rows VALUES (1), (2)").unwrap();
+    conn.execute("CREATE TABLE aux.rows(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute("INSERT INTO aux.rows VALUES (10)").unwrap();
+
+    let mut reader = conn.prepare("SELECT id FROM rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut reader), 1);
+    conn.execute("UPDATE aux.rows SET id = 11").unwrap();
+    drop(reader);
+
+    assert_eq!(ids_from_query(&conn, "SELECT id FROM aux.rows"), vec![11]);
+}
+
+#[test]
+fn review_transactionless_last_sibling_closes_attached_txn() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io,
+        ":memory:review-attached-transactionless-main",
+        OpenFlags::default(),
+        DatabaseOpts::new().with_attach(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    let aux = ":memory:review-attached-transactionless-aux";
+    drive_attach(&conn, aux, "aux");
+    conn.execute("CREATE TABLE aux.rows(id INTEGER PRIMARY KEY)")
+        .unwrap();
+    conn.execute("INSERT INTO aux.rows VALUES (10), (20)")
+        .unwrap();
+
+    let mut literal = conn.prepare("SELECT 1").unwrap();
+    assert_eq!(step_returning_id(&mut literal), 1);
+    let mut attached = conn.prepare("SELECT id FROM aux.rows ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut attached), 10);
+    assert_eq!(drain_returning_ids(&mut attached), vec![20]);
+    finish_without_rows(&mut literal);
+
+    conn.execute("DETACH aux").unwrap();
+}
+
+#[test]
 fn test_insert_select_is_busy_while_returning_writer_is_active() {
     let env = SameConnectionMvcc::new(":memory:suspended-insert-select-resume");
     env.setup_rows_and_source_tables();

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -610,3 +610,75 @@ fn test_begin_deferred_emits_no_transaction_opcodes(_tmp_db: TempDatabase) -> an
     );
     Ok(())
 }
+
+/// Regression test: an I/O error while a write statement begins its
+/// transaction on an attached database must roll the attached transaction
+/// back. The attached Transaction opcode runs before the main-database one,
+/// so when it fails nothing has marked the implicit transaction for rollback
+/// on abort; without the attached-side marking the failed statement leaves
+/// the attached WAL write lock held, and the next statement on the
+/// connection — even one that never touches the attached database — tries to
+/// commit that leftover transaction at halt and fails in its place.
+#[test]
+fn test_attached_write_txn_rolled_back_after_io_error() -> anyhow::Result<()> {
+    use crate::queued_io::{QueuedIo, QueuedIoOpKind};
+
+    let io = Arc::new(QueuedIo::new());
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        "queued-attach-lock.db",
+        OpenFlags::default(),
+        DatabaseOpts::new().with_attach(true),
+        None,
+        Arc::new(SqliteDialect),
+    )?;
+
+    let conn = db.connect()?;
+    conn.execute("ATTACH 'queued-attach-lock-aux.db' AS aux1")?;
+    conn.execute("CREATE TABLE main_t (x INTEGER)")?;
+    conn.execute("INSERT INTO main_t VALUES (1)")?;
+    conn.execute("CREATE TABLE aux1.t (a INTEGER)")?;
+    conn.execute("INSERT INTO aux1.t VALUES (1)")?;
+    // Move the attached database's pages out of its WAL so the header read
+    // below hits the database file, where the fault is targeted.
+    conn.execute("PRAGMA aux1.wal_checkpoint(TRUNCATE)")?;
+
+    // A write from another connection advances the attached WAL, so `conn`'s
+    // next attached read transaction sees the database as changed, drops its
+    // cached pages and cached schema cookie, and must re-read the header page
+    // from disk inside its attached Transaction opcode.
+    let conn2 = db.connect()?;
+    conn2.execute("ATTACH 'queued-attach-lock-aux.db' AS aux1")?;
+    conn2.execute("INSERT INTO aux1.t VALUES (2)")?;
+
+    // Fail every attached-database read from here on. The UPDATE dies inside
+    // its attached Transaction opcode: after the write lock is taken, while
+    // re-reading the header page for the schema-cookie check.
+    io.fault_after("queued-attach-lock-aux.db", QueuedIoOpKind::Pread, 0);
+    let result = conn.execute("UPDATE aux1.t SET a = a + 10");
+    assert!(
+        result.is_err(),
+        "UPDATE should fail under the injected read fault"
+    );
+
+    // The failed statement must have rolled back the attached write
+    // transaction. If it leaked, this main-only statement commits the
+    // leftover transaction at halt, hits the still-failing attached read,
+    // and errors even though it never touches the attached database.
+    let rows = limbo_exec_rows(&conn, "SELECT count(*) FROM main_t");
+    assert_eq!(rows, vec![vec![rusqlite::types::Value::Integer(1)]]);
+
+    io.clear_fault();
+
+    // The connection keeps working normally afterwards.
+    conn.execute("UPDATE aux1.t SET a = a + 10")?;
+    let rows = limbo_exec_rows(&conn, "SELECT a FROM aux1.t ORDER BY a");
+    assert_eq!(
+        rows,
+        vec![
+            vec![rusqlite::types::Value::Integer(11)],
+            vec![rusqlite::types::Value::Integer(12)],
+        ]
+    );
+    Ok(())
+}


### PR DESCRIPTION
A write statement on an attached database can fail after opening its
implicit transaction but before the main-database Transaction opcode
marks the statement for cleanup. That leaked the attached transaction
and made a later, unrelated statement fail while trying to finish it.

Mark attached implicit transactions for rollback in autocommit mode.
Non-main pagers keep their transaction state on the pager itself, like
SQLite keeps it on the Btree handle, and the transaction is shared by
every statement on the connection. Statement halt now follows SQLite:
a writer finishes its transaction immediately, a shared attached
transaction is only finished by the last active statement (like
btreeEndTransaction keeps it open while nVdbeRead > 1), and the last
statement closes leftover attached transactions even if it never
started one (like vdbeCommit visits every database on halt). This
keeps sibling cursors and the DETACH lock alive when another reader is
dropped, and keeps a completed write from being rolled back when a
sibling statement is dropped.

Broken since 171d28413 ("feat: full write support for ATTACH
databases") added attached writes; the attached MVCC path introduced by
311478145 ("feat: per-database MVCC transactions for attached
databases") had the same missing cleanup marker.

Found by the simulator: seed 12086451745559231127 with the
write_heavy_spill profile failed with CompletionError(Aborted).

Tests: attached I/O failure regression, WAL sibling-reader and
dropped-sibling writer lifecycle coverage, and transactionless
leftover-transaction cleanup coverage.