### PR TITLE
sdk-kit: expose page codecs through C ABI

### DIFF
--- a/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
@@ -301,6 +301,8 @@ public static class TursoBindings
             Vfs = IntPtr.Zero,
             EncryptionCipher = cipherString.Pointer,
             EncryptionHexKey = hexkeyString.Pointer,
+            PageCodec = IntPtr.Zero,
+            OpenFlags = 0,
         };
 
         var status = TursoInterop.DatabaseNew(ref config, out var databasePtr, out var errorPtr);

--- a/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
@@ -43,6 +43,8 @@ internal struct TursoDatabaseConfig
     public IntPtr Vfs;
     public IntPtr EncryptionCipher;
     public IntPtr EncryptionHexKey;
+    public IntPtr PageCodec;
+    public uint OpenFlags;
 }
 
 internal static class TursoInterop

--- a/bindings/go/bindings_db.go
+++ b/bindings/go/bindings_db.go
@@ -145,6 +145,8 @@ type turso_database_config_t struct {
 	vfs                   uintptr // const char* or null
 	encryption_cipher     uintptr // const char* or null
 	encryption_hexkey     uintptr // const char* or null
+	page_codec            uintptr // const turso_page_codec_v1_t* or null
+	open_flags            uint32
 }
 
 // C extern method types

--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -211,6 +211,8 @@ pub fn py_turso_database_open(config: &PyTursoDatabaseConfig) -> PyResult<PyTurs
         vfs: config.vfs.clone(),
         io: None,
         db_file: None,
+        page_codec: None,
+        open_flags: Default::default(),
     });
     let result = database.open().map_err(turso_error_to_py_err)?;
     // async_io is false - so db.open() will return result immediately

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -182,6 +182,8 @@ pub fn py_turso_sync_new(
         vfs: IoBackend::Default,
         io: None,
         db_file: None,
+        page_codec: None,
+        open_flags: Default::default(),
     };
     // calculate and set reserved_bytes from cipher if necessary
     let reserved_bytes = sync_config

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -303,6 +303,8 @@ impl Builder {
                 vfs: self.vfs,
                 io: self.io,
                 db_file: None,
+                page_codec: None,
+                open_flags: Default::default(),
             });
         while let Some(io_c) = db.open()?.io() {
             // At this point IO must already be created

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -360,6 +360,8 @@ impl Builder {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: Default::default(),
         };
 
         let url = if let Some(remote_url) = &self.remote_url {

--- a/sdk-kit/README.md
+++ b/sdk-kit/README.md
@@ -9,8 +9,25 @@ Key ideas:
 - Clear status codes: Done/Row/Io/Error/etc. No hidden blocking or exceptions.
 - Minimal surface: open database, connect, prepare, bind, step/execute, read rows, finalize.
 - Ownership model and lifetimes are explicit for C consumers.
+- Optional page codecs: callers can provide a synchronous page transform callback table to decode/encode legacy encrypted database pages without linking that crypto into Turso core.
 
 Note: turso.h is the single C header exported by the crate and can be translated to bindings.rs with rust-bindgen.
+
+## External page codecs
+
+`turso_database_config_t.page_codec` accepts a versioned `turso_page_codec_v1_t` callback table. The callbacks transform complete page images between on-disk bytes and plaintext SQLite pages. They are intended for compatibility layers such as legacy SQLite codec formats where the application supplies the crypto implementation.
+
+Codec rules:
+
+- callbacks are synchronous and must not perform Turso I/O or re-enter the same database;
+- `probe_header` may inspect the raw first 512 bytes and report page size/reserved bytes before Turso parses page 1;
+- `decode_page` and `encode_page` receive a page number and location (`DATABASE` or `WAL`) and must write exactly one page to the output buffer;
+- `codec_id` must be a stable, non-secret identifier for the codec configuration and must change whenever the page transform could produce different bytes;
+- the callback context and function pointers must remain valid until `turso_database_deinit`;
+- callback failures are surfaced as database open/read/write errors.
+
+Language bindings can expose this generic surface by wrapping `turso_page_codec_v1_t`
+with binding-specific lifetime management for the callback context.
 
 ## Rust example
 

--- a/sdk-kit/README.md
+++ b/sdk-kit/README.md
@@ -23,7 +23,7 @@ Codec rules:
 - `probe_header` may inspect the raw first 512 bytes and report page size/reserved bytes before Turso parses page 1;
 - `decode_page` and `encode_page` receive a page number and location (`DATABASE` or `WAL`) and must write exactly one page to the output buffer;
 - `codec_id` must be a stable, non-secret identifier for the codec configuration and must change whenever the page transform could produce different bytes;
-- the callback context and function pointers must remain valid until `turso_database_deinit`;
+- the callback context and function pointers must remain valid until the codec `destroy` callback is invoked;
 - callback failures are surfaced as database open/read/write errors.
 
 Language bindings can expose this generic surface by wrapping `turso_page_codec_v1_t`

--- a/sdk-kit/src/bindings.rs
+++ b/sdk-kit/src/bindings.rs
@@ -307,6 +307,64 @@ impl Default for turso_config_t {
         }
     }
 }
+pub const turso_codec_location_t_TURSO_CODEC_LOCATION_DATABASE: turso_codec_location_t = 0;
+pub const turso_codec_location_t_TURSO_CODEC_LOCATION_WAL: turso_codec_location_t = 1;
+pub type turso_codec_location_t = ::std::os::raw::c_uint;
+pub const turso_database_open_flags_t_TURSO_DATABASE_OPEN_DEFAULT: turso_database_open_flags_t = 0;
+pub const turso_database_open_flags_t_TURSO_DATABASE_OPEN_READONLY: turso_database_open_flags_t = 1;
+pub type turso_database_open_flags_t = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct turso_page_codec_header_info_t {
+    pub page_size: u32,
+    pub reserved_space: u8,
+    pub is_supported: u8,
+}
+pub type turso_page_codec_probe_header_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        ctx: *mut ::std::os::raw::c_void,
+        raw_page1_prefix: *const u8,
+        raw_len: usize,
+        out: *mut turso_page_codec_header_info_t,
+        error: *mut *const ::std::os::raw::c_char,
+    ) -> i32,
+>;
+pub type turso_page_codec_transform_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        ctx: *mut ::std::os::raw::c_void,
+        page_no: u32,
+        location: turso_codec_location_t,
+        input: *const u8,
+        input_len: usize,
+        output: *mut u8,
+        output_len: usize,
+        error: *mut *const ::std::os::raw::c_char,
+    ) -> i32,
+>;
+pub type turso_page_codec_destroy_t =
+    ::std::option::Option<unsafe extern "C" fn(ctx: *mut ::std::os::raw::c_void)>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct turso_page_codec_v1_t {
+    pub abi_version: u32,
+    pub ctx: *mut ::std::os::raw::c_void,
+    pub reserved_space: u8,
+    #[doc = " Stable, non-secret identifier for this codec configuration. Must change whenever encoded bytes could differ."]
+    pub codec_id: [u8; 16usize],
+    pub destroy: turso_page_codec_destroy_t,
+    pub probe_header: turso_page_codec_probe_header_t,
+    pub decode_page: turso_page_codec_transform_t,
+    pub encode_page: turso_page_codec_transform_t,
+}
+impl Default for turso_page_codec_v1_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[doc = " Database description."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -323,6 +381,10 @@ pub struct turso_database_config_t {
     pub encryption_cipher: *const ::std::os::raw::c_char,
     #[doc = " optional encryption hexkey\n as encryption is experimental - experimental_features must have \"encryption\" in the list"]
     pub encryption_hexkey: *const ::std::os::raw::c_char,
+    #[doc = " optional external page codec; callback context must remain valid and thread-safe until destroy is called"]
+    pub page_codec: *const turso_page_codec_v1_t,
+    #[doc = " optional bitmask of turso_database_open_flags_t values"]
+    pub open_flags: u32,
 }
 impl Default for turso_database_config_t {
     fn default() -> Self {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    ffi::CString,
+    ffi::{CStr, CString},
     fmt::Display,
     ops::Deref,
     sync::{
@@ -10,8 +10,6 @@ use std::{
     task::Waker,
     time::Duration,
 };
-use turso_core::SqliteDialect;
-
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
     fmt::{self, format::Writer},
@@ -22,7 +20,8 @@ use tracing_subscriber::{
 use turso_core::{
     storage::database::DatabaseFile, types::AsValueRef, Connection, Database, DatabaseOpts,
     DatabaseStorage, EncryptionKey, IOResult, LimboError, OpenDbAsyncState, OpenFlags, OpenOptions,
-    QueryMode, Statement, StepResult, IO,
+    PageCodec, PageCodecContext, PageCodecHeaderInfo, PageCodecId, PageLocation, QueryMode,
+    SqliteDialect, Statement, StepResult, IO,
 };
 
 use crate::{
@@ -180,6 +179,191 @@ pub struct TursoDatabaseConfig {
     /// optional custom DatabaseStorage provided by the caller
     /// if provided, caller must guarantee that IO used by the TursoDatabase will be consistent with underlying DatabaseStorage IO
     pub db_file: Option<Arc<dyn DatabaseStorage>>,
+
+    /// optional external page codec provided by the caller
+    pub page_codec: Option<Arc<dyn PageCodec>>,
+
+    /// database open flags
+    pub open_flags: OpenFlags,
+}
+
+#[derive(Clone)]
+struct CApiPageCodec {
+    inner: Arc<CApiPageCodecInner>,
+}
+
+struct CApiPageCodecInner {
+    raw: c::turso_page_codec_v1_t,
+}
+
+// SAFETY: external page codecs are an FFI contract. Callers that install a codec must keep the
+// context and callbacks valid and thread-safe for the database lifetime.
+unsafe impl Send for CApiPageCodecInner {}
+// SAFETY: see the Send impl; Turso may read/write pages through shared database state.
+unsafe impl Sync for CApiPageCodecInner {}
+
+impl std::fmt::Debug for CApiPageCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CApiPageCodec")
+            .field("abi_version", &self.inner.raw.abi_version)
+            .field("ctx", &"<opaque>")
+            .finish()
+    }
+}
+
+impl Drop for CApiPageCodecInner {
+    fn drop(&mut self) {
+        if let Some(destroy) = self.raw.destroy {
+            unsafe { destroy(self.raw.ctx) };
+        }
+    }
+}
+
+impl CApiPageCodec {
+    unsafe fn from_capi(codec: *const c::turso_page_codec_v1_t) -> Result<Self, TursoError> {
+        if codec.is_null() {
+            return Err(TursoError::Misuse(
+                "page codec pointer must be not null".to_string(),
+            ));
+        }
+        let raw = unsafe { *codec };
+        if raw.abi_version != 1 {
+            return Err(TursoError::Misuse(format!(
+                "unsupported page codec ABI version {}",
+                raw.abi_version
+            )));
+        }
+        if raw.decode_page.is_none() || raw.encode_page.is_none() {
+            return Err(TursoError::Misuse(
+                "page codec decode_page and encode_page callbacks are required".to_string(),
+            ));
+        }
+        if raw.codec_id == [0; 16] {
+            return Err(TursoError::Misuse(
+                "page codec codec_id must be a stable non-zero identifier".to_string(),
+            ));
+        }
+        Ok(Self {
+            inner: Arc::new(CApiPageCodecInner { raw }),
+        })
+    }
+
+    fn callback_error(error: *const std::ffi::c_char, operation: &str) -> LimboError {
+        if error.is_null() {
+            return LimboError::InvalidArgument(format!("page codec {operation} failed"));
+        }
+        let message = unsafe { CStr::from_ptr(error) }.to_string_lossy();
+        LimboError::InvalidArgument(format!("page codec {operation} failed: {message}"))
+    }
+
+    fn location_to_c(location: PageLocation) -> c::turso_codec_location_t {
+        match location {
+            PageLocation::Database => c::turso_codec_location_t_TURSO_CODEC_LOCATION_DATABASE,
+            PageLocation::Wal => c::turso_codec_location_t_TURSO_CODEC_LOCATION_WAL,
+        }
+    }
+
+    fn transform(
+        &self,
+        operation: &str,
+        callback: c::turso_page_codec_transform_t,
+        context: PageCodecContext,
+        page: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), LimboError> {
+        let Some(callback) = callback else {
+            return Err(LimboError::InvalidArgument(format!(
+                "page codec {operation} callback is not configured"
+            )));
+        };
+        let mut error = std::ptr::null();
+        let status = unsafe {
+            callback(
+                self.inner.raw.ctx,
+                context.page_no,
+                Self::location_to_c(context.location),
+                page.as_ptr(),
+                page.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                &mut error,
+            )
+        };
+        if status != 0 {
+            return Err(Self::callback_error(error, operation));
+        }
+        Ok(())
+    }
+}
+
+impl PageCodec for CApiPageCodec {
+    fn codec_id(&self) -> PageCodecId {
+        PageCodecId::new(self.inner.raw.codec_id)
+    }
+
+    fn bootstrap_page_info(
+        &self,
+        raw_page1_prefix: &[u8],
+    ) -> Result<PageCodecHeaderInfo, LimboError> {
+        let Some(probe_header) = self.inner.raw.probe_header else {
+            return PageCodecHeaderInfo::from_visible_sqlite_header(raw_page1_prefix);
+        };
+        let mut out = c::turso_page_codec_header_info_t::default();
+        let mut error = std::ptr::null();
+        let status = unsafe {
+            probe_header(
+                self.inner.raw.ctx,
+                raw_page1_prefix.as_ptr(),
+                raw_page1_prefix.len(),
+                &mut out,
+                &mut error,
+            )
+        };
+        if status != 0 {
+            return Err(Self::callback_error(error, "probe_header"));
+        }
+        if out.is_supported == 0 {
+            return Err(LimboError::NotADB);
+        }
+        Ok(PageCodecHeaderInfo {
+            page_size: out.page_size as usize,
+            reserved_space: out.reserved_space,
+        })
+    }
+
+    fn required_reserved_bytes(&self) -> u8 {
+        self.inner.raw.reserved_space
+    }
+
+    fn encode_page(
+        &self,
+        context: PageCodecContext,
+        page: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), LimboError> {
+        self.transform(
+            "encode_page",
+            self.inner.raw.encode_page,
+            context,
+            page,
+            output,
+        )
+    }
+
+    fn decode_page(
+        &self,
+        context: PageCodecContext,
+        page: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), LimboError> {
+        self.transform(
+            "decode_page",
+            self.inner.raw.decode_page,
+            context,
+            page,
+            output,
+        )
+    }
 }
 
 impl TursoDatabaseConfig {
@@ -335,6 +519,12 @@ impl TursoDatabaseConfig {
                 "either both encryption cipher and key must be set or no".to_string(),
             ));
         }
+        if encryption_cipher.is_some() && !config.page_codec.is_null() {
+            return Err(TursoError::Misuse(
+                "built-in encryption cannot be combined with an external page codec".to_string(),
+            ));
+        }
+        let open_flags = open_flags_from_capi(config.open_flags)?;
         Ok(Self {
             path: str_from_c_str(config.path)?.to_string(),
             experimental_features: if !config.experimental_features.is_null() {
@@ -354,7 +544,28 @@ impl TursoDatabaseConfig {
             },
             io: None,
             db_file: None,
+            page_codec: if !config.page_codec.is_null() {
+                Some(Arc::new(CApiPageCodec::from_capi(config.page_codec)?))
+            } else {
+                None
+            },
+            open_flags,
         })
+    }
+}
+
+fn open_flags_from_capi(flags: u32) -> Result<OpenFlags, TursoError> {
+    const READONLY: u32 = c::turso_database_open_flags_t_TURSO_DATABASE_OPEN_READONLY;
+    if flags & !READONLY != 0 {
+        return Err(TursoError::Misuse(format!(
+            "unknown database open flags: 0x{flags:x}"
+        )));
+    }
+
+    if flags & READONLY != 0 {
+        Ok(OpenFlags::ReadOnly)
+    } else {
+        Ok(OpenFlags::default())
     }
 }
 
@@ -758,8 +969,14 @@ impl TursoDatabase {
                             "encryption is experimental and must be explicitly enabled through experimental features list".to_string(),
                         ));
                     }
+                    if self.config.encryption.is_some() && self.config.page_codec.is_some() {
+                        return Err(TursoError::Misuse(
+                            "built-in encryption cannot be combined with an external page codec"
+                                .to_string(),
+                        ));
+                    }
 
-                    let mut open_flags = OpenFlags::default();
+                    let mut open_flags = self.config.open_flags;
                     if opts.enable_multiprocess_wal {
                         open_flags |= OpenFlags::NoLock;
                     }
@@ -795,7 +1012,8 @@ impl TursoDatabase {
                         .storage(db_file)
                         .flags(open_flags)
                         .db_opts(opts)
-                        .encryption(self.config.encryption.clone());
+                        .encryption(self.config.encryption.clone())
+                        .page_codec(self.config.page_codec.clone());
                     match Database::open_async(
                         &mut state.open_db_state,
                         io.clone(),
@@ -835,17 +1053,18 @@ impl TursoDatabase {
             ));
         };
 
-        // Parse encryption key if configured - needed for connect_with_encryption
-        // which sets up encryption context before reading pages
-        let encryption_key = if let Some(ref encryption_opts) = self.config.encryption {
-            Some(EncryptionKey::from_hex_string(&encryption_opts.hexkey)?)
+        let connection = if let Some(page_codec) = &self.config.page_codec {
+            db.connect_with_page_codec(page_codec.clone())?
         } else {
-            None
+            // Parse encryption key if configured - needed for connect_with_encryption
+            // which sets up encryption context before reading pages.
+            let encryption_key = if let Some(ref encryption_opts) = self.config.encryption {
+                Some(EncryptionKey::from_hex_string(&encryption_opts.hexkey)?)
+            } else {
+                None
+            };
+            db.connect_with_encryption(encryption_key)?
         };
-
-        // Use connect_with_encryption to properly set up encryption context
-        // before the pager reads page 1. This is required for encrypted databases.
-        let connection = db.connect_with_encryption(encryption_key)?;
 
         Ok(TursoConnection::new(&self.config, connection))
     }
@@ -1583,10 +1802,16 @@ impl TursoStatement {
 #[cfg(test)]
 mod tests {
     use crate::{
-        rsapi::{TursoDatabase, TursoDatabaseConfig, TursoError, TursoStatusCode, FINALIZED_ERR},
+        rsapi::{
+            OpenFlags, TursoDatabase, TursoDatabaseConfig, TursoError, TursoStatusCode,
+            FINALIZED_ERR,
+        },
         IoBackend,
     };
-    use turso_core::Value;
+    use std::sync::Arc;
+    use turso_core::{
+        LimboError, PageCodec, PageCodecContext, PageCodecHeaderInfo, PageCodecId, Value,
+    };
 
     fn config_with_features(features: Option<&str>) -> TursoDatabaseConfig {
         TursoDatabaseConfig {
@@ -1597,7 +1822,99 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         }
+    }
+
+    #[derive(Debug)]
+    struct XorPageCodec {
+        mask: u8,
+        reserved_bytes: u8,
+    }
+
+    impl XorPageCodec {
+        fn transform(&self, page: &[u8], output: &mut [u8]) {
+            for (input, output) in page.iter().zip(output.iter_mut()) {
+                *output = *input ^ self.mask;
+            }
+        }
+    }
+
+    impl PageCodec for XorPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"sdk-xor-codec---";
+            id[15] = self.mask;
+            PageCodecId::new(id)
+        }
+
+        fn bootstrap_page_info(
+            &self,
+            raw_page1_prefix: &[u8],
+        ) -> turso_core::Result<PageCodecHeaderInfo> {
+            if raw_page1_prefix.len() < 21 {
+                return Err(LimboError::NotADB);
+            }
+
+            let decoded_magic = raw_page1_prefix[..16]
+                .iter()
+                .map(|byte| byte ^ self.mask)
+                .collect::<Vec<_>>();
+            if decoded_magic.as_slice() != b"SQLite format 3\0" {
+                return Err(LimboError::NotADB);
+            }
+
+            let ps_raw = u16::from_be_bytes([
+                raw_page1_prefix[16] ^ self.mask,
+                raw_page1_prefix[17] ^ self.mask,
+            ]);
+            let page_size = if ps_raw == 1 { 65536 } else { ps_raw as usize };
+            Ok(PageCodecHeaderInfo {
+                page_size,
+                reserved_space: raw_page1_prefix[20] ^ self.mask,
+            })
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            self.reserved_bytes
+        }
+
+        fn encode_page(
+            &self,
+            _context: PageCodecContext,
+            page: &[u8],
+            output: &mut [u8],
+        ) -> turso_core::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            _context: PageCodecContext,
+            page: &[u8],
+            output: &mut [u8],
+        ) -> turso_core::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+    }
+
+    fn open_database_with_page_codec(path: &str, codec: Arc<dyn PageCodec>) -> Arc<TursoDatabase> {
+        let db = TursoDatabase::new(TursoDatabaseConfig {
+            path: path.to_string(),
+            experimental_features: None,
+            async_io: false,
+            encryption: None,
+            vfs: IoBackend::Default,
+            io: None,
+            db_file: None,
+            page_codec: Some(codec),
+            open_flags: OpenFlags::default(),
+        });
+        let result = db.open().unwrap();
+        assert!(!result.is_io());
+        db
     }
 
     #[test]
@@ -1634,6 +1951,77 @@ mod tests {
     }
 
     #[test]
+    pub fn page_codec_is_applied_to_sdk_connections() {
+        let temp_file = tempfile::NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_str().unwrap();
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0xa5,
+            reserved_bytes: 1,
+        });
+
+        {
+            let db = open_database_with_page_codec(db_path, codec.clone());
+            let conn = db.connect().unwrap();
+
+            let mut stmt = conn
+                .prepare_single("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+                .unwrap();
+            assert_eq!(stmt.execute(None).unwrap().status, TursoStatusCode::Done);
+
+            let mut stmt = conn
+                .prepare_single("INSERT INTO test (id, value) VALUES (1, 'secret_data')")
+                .unwrap();
+            assert_eq!(stmt.execute(None).unwrap().status, TursoStatusCode::Done);
+
+            let mut stmt = conn
+                .prepare_single("PRAGMA wal_checkpoint(TRUNCATE)")
+                .unwrap();
+            assert_eq!(stmt.execute(None).unwrap().status, TursoStatusCode::Done);
+        }
+
+        let raw_database = std::fs::read(db_path).unwrap();
+        assert_ne!(&raw_database[..16], b"SQLite format 3\0");
+
+        {
+            let db = open_database_with_page_codec(db_path, codec);
+            let conn = db.connect().unwrap();
+
+            let mut stmt = conn
+                .prepare_single("SELECT value FROM test WHERE id = 1")
+                .unwrap();
+            assert_eq!(stmt.step(None).unwrap(), TursoStatusCode::Row);
+            assert_eq!(stmt.row_value(0).unwrap().to_text(), Some("secret_data"));
+        }
+    }
+
+    #[test]
+    pub fn page_codec_rejects_multiprocess_wal_through_sdk_open() {
+        let db = TursoDatabase::new(TursoDatabaseConfig {
+            path: ":memory:".to_string(),
+            experimental_features: Some("multiprocess_wal".to_string()),
+            async_io: false,
+            encryption: None,
+            vfs: IoBackend::Default,
+            io: None,
+            db_file: None,
+            page_codec: Some(Arc::new(XorPageCodec {
+                mask: 0xa5,
+                reserved_bytes: 1,
+            })),
+            open_flags: OpenFlags::default(),
+        });
+
+        let error = db.open().unwrap_err();
+        match error {
+            TursoError::Error(message) => assert_eq!(
+                message,
+                "Invalid argument supplied: external page codecs are not supported with experimental multiprocess WAL"
+            ),
+            error => panic!("expected multiprocess WAL rejection, got {error:?}"),
+        }
+    }
+
+    #[test]
     pub fn test_db_concurrent_use() {
         use std::sync::{Arc, Barrier};
 
@@ -1647,6 +2035,8 @@ mod tests {
                 vfs: IoBackend::Default,
                 io: None,
                 db_file: None,
+                page_codec: None,
+                open_flags: OpenFlags::default(),
             });
             let result = db.open().unwrap();
             assert!(!result.is_io());
@@ -1708,6 +2098,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1728,6 +2120,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1758,6 +2152,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1781,6 +2177,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1831,6 +2229,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1890,6 +2290,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1922,6 +2324,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1951,6 +2355,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1976,6 +2382,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -2002,6 +2410,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -2052,6 +2462,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -2140,6 +2552,8 @@ mod tests {
                     vfs: IoBackend::Default,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 let result = db.open().unwrap();
                 assert!(!result.is_io());
@@ -2180,6 +2594,8 @@ mod tests {
                     vfs: IoBackend::Default,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 let result = db.open().unwrap();
                 assert!(!result.is_io());
@@ -2206,6 +2622,8 @@ mod tests {
                     vfs: IoBackend::Default,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 assert!(db.open().is_err(), "Opening with wrong key should fail");
             }
@@ -2220,6 +2638,8 @@ mod tests {
                     vfs: IoBackend::Default,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 let result = db.open();
                 println!("result: {result:?}");
@@ -2255,6 +2675,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let _ = db_a.open().unwrap();
         let conn_a = db_a.connect().unwrap();
@@ -2292,6 +2714,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let _ = db_a2.open().unwrap();
         let conn_a2 = db_a2.connect().unwrap();
@@ -2326,6 +2750,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -2360,6 +2786,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1839,13 +1839,41 @@ mod tests {
                 *output = *input ^ self.mask;
             }
         }
+
+        fn stable_config_fingerprint(&self) -> [u8; 16] {
+            fn mix(mut hash: u64, byte: u8) -> u64 {
+                hash ^= byte as u64;
+                hash.wrapping_mul(0x0000_0100_0000_01b3)
+            }
+
+            let mut hash1 = 0xcbf2_9ce4_8422_2325;
+            for byte in b"turso-sdk-xor-page-codec-v1" {
+                hash1 = mix(hash1, *byte);
+            }
+            hash1 = mix(hash1, b'm');
+            hash1 = mix(hash1, self.mask);
+            hash1 = mix(hash1, b'r');
+            hash1 = mix(hash1, self.reserved_bytes);
+
+            let mut hash2 = 0x9ae1_6a3b_2f90_404f;
+            for byte in b"turso-sdk-xor-page-codec-v1".iter().rev() {
+                hash2 = mix(hash2, *byte);
+            }
+            hash2 = mix(hash2, b'r');
+            hash2 = mix(hash2, self.reserved_bytes);
+            hash2 = mix(hash2, b'm');
+            hash2 = mix(hash2, self.mask);
+
+            let mut id = [0; 16];
+            id[..8].copy_from_slice(&hash1.to_le_bytes());
+            id[8..].copy_from_slice(&hash2.to_le_bytes());
+            id
+        }
     }
 
     impl PageCodec for XorPageCodec {
         fn codec_id(&self) -> PageCodecId {
-            let mut id = *b"sdk-xor-codec---";
-            id[15] = self.mask;
-            PageCodecId::new(id)
+            PageCodecId::new(self.stable_config_fingerprint())
         }
 
         fn bootstrap_page_info(
@@ -1898,6 +1926,28 @@ mod tests {
             self.transform(page, output);
             Ok(())
         }
+    }
+
+    #[test]
+    pub fn page_codec_id_tracks_full_test_codec_configuration() {
+        let base = XorPageCodec {
+            mask: 0xa5,
+            reserved_bytes: 1,
+        }
+        .codec_id();
+        let different_mask = XorPageCodec {
+            mask: 0x5a,
+            reserved_bytes: 1,
+        }
+        .codec_id();
+        let different_reserved_bytes = XorPageCodec {
+            mask: 0xa5,
+            reserved_bytes: 2,
+        }
+        .codec_id();
+
+        assert_ne!(base, different_mask);
+        assert_ne!(base, different_reserved_bytes);
     }
 
     fn open_database_with_page_codec(path: &str, codec: Arc<dyn PageCodec>) -> Arc<TursoDatabase> {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -226,7 +226,18 @@ impl CApiPageCodec {
                 "page codec pointer must be not null".to_string(),
             ));
         }
-        let raw = unsafe { *codec };
+        let raw = unsafe {
+            c::turso_page_codec_v1_t {
+                abi_version: (*codec).abi_version,
+                ctx: (*codec).ctx,
+                reserved_space: (*codec).reserved_space,
+                codec_id: (*codec).codec_id,
+                destroy: (*codec).destroy,
+                probe_header: (*codec).probe_header,
+                decode_page: (*codec).decode_page,
+                encode_page: (*codec).encode_page,
+            }
+        };
         if raw.abi_version != 1 {
             return Err(TursoError::Misuse(format!(
                 "unsupported page codec ABI version {}",
@@ -1801,6 +1812,7 @@ impl TursoStatement {
 
 #[cfg(test)]
 mod tests {
+    use super::{c, CApiPageCodec};
     use crate::{
         rsapi::{
             OpenFlags, TursoDatabase, TursoDatabaseConfig, TursoError, TursoStatusCode,
@@ -1808,7 +1820,11 @@ mod tests {
         },
         IoBackend,
     };
-    use std::sync::Arc;
+    use std::{
+        ffi::{c_char, c_void},
+        mem::MaybeUninit,
+        sync::Arc,
+    };
     use turso_core::{
         LimboError, PageCodec, PageCodecContext, PageCodecHeaderInfo, PageCodecId, Value,
     };
@@ -1824,6 +1840,39 @@ mod tests {
             db_file: None,
             page_codec: None,
             open_flags: OpenFlags::default(),
+        }
+    }
+
+    #[test]
+    fn capi_page_codec_does_not_read_c_struct_padding() {
+        unsafe extern "C" fn transform(
+            _ctx: *mut c_void,
+            _page_no: u32,
+            _location: c::turso_codec_location_t,
+            _input: *const u8,
+            _input_len: usize,
+            _output: *mut u8,
+            _output_len: usize,
+            _error: *mut *const c_char,
+        ) -> i32 {
+            0
+        }
+
+        let mut codec = MaybeUninit::<c::turso_page_codec_v1_t>::uninit();
+        let codec = codec.as_mut_ptr();
+        unsafe {
+            std::ptr::addr_of_mut!((*codec).abi_version).write(1);
+            std::ptr::addr_of_mut!((*codec).ctx).write(std::ptr::null_mut());
+            std::ptr::addr_of_mut!((*codec).reserved_space).write(16);
+            std::ptr::addr_of_mut!((*codec).codec_id).write([1; 16]);
+            std::ptr::addr_of_mut!((*codec).destroy).write(None);
+            std::ptr::addr_of_mut!((*codec).probe_header).write(None);
+            std::ptr::addr_of_mut!((*codec).decode_page).write(Some(transform));
+            std::ptr::addr_of_mut!((*codec).encode_page).write(Some(transform));
+
+            let codec = CApiPageCodec::from_capi(codec).unwrap();
+            assert_eq!(codec.inner.raw.codec_id, [1; 16]);
+            assert_eq!(codec.inner.raw.reserved_space, 16);
         }
     }
 

--- a/sdk-kit/turso.h
+++ b/sdk-kit/turso.h
@@ -196,6 +196,57 @@ typedef struct
     const char *log_level;
 } turso_config_t;
 
+typedef enum
+{
+    TURSO_CODEC_LOCATION_DATABASE = 0,
+    TURSO_CODEC_LOCATION_WAL = 1,
+} turso_codec_location_t;
+
+typedef enum
+{
+    TURSO_DATABASE_OPEN_DEFAULT = 0,
+    TURSO_DATABASE_OPEN_READONLY = 1,
+} turso_database_open_flags_t;
+
+typedef struct
+{
+    uint32_t page_size;
+    uint8_t reserved_space;
+    uint8_t is_supported;
+} turso_page_codec_header_info_t;
+
+typedef int32_t (*turso_page_codec_probe_header_t)(
+    void *ctx,
+    const uint8_t *raw_page1_prefix,
+    size_t raw_len,
+    turso_page_codec_header_info_t *out,
+    const char **error);
+
+typedef int32_t (*turso_page_codec_transform_t)(
+    void *ctx,
+    uint32_t page_no,
+    turso_codec_location_t location,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_len,
+    const char **error);
+
+typedef void (*turso_page_codec_destroy_t)(void *ctx);
+
+typedef struct
+{
+    uint32_t abi_version;
+    void *ctx;
+    uint8_t reserved_space;
+    /** Stable, non-secret identifier for this codec configuration. Must change whenever encoded bytes could differ. */
+    uint8_t codec_id[16];
+    turso_page_codec_destroy_t destroy;
+    turso_page_codec_probe_header_t probe_header;
+    turso_page_codec_transform_t decode_page;
+    turso_page_codec_transform_t encode_page;
+} turso_page_codec_v1_t;
+
 /**
  * Database description.
  */
@@ -227,6 +278,10 @@ typedef struct
      * as encryption is experimental - experimental_features must have "encryption" in the list
      */
     const char *encryption_hexkey;
+    /** optional external page codec; callback context must remain valid and thread-safe until destroy is called */
+    const turso_page_codec_v1_t *page_codec;
+    /** optional bitmask of turso_database_open_flags_t values */
+    uint32_t open_flags;
 } turso_database_config_t;
 
 /** Setup global database info */

--- a/sync/sdk-kit/bindgen.sh
+++ b/sync/sdk-kit/bindgen.sh
@@ -19,6 +19,9 @@ bindgen turso_sync.h -o src/bindings.rs \
     --blocklist-type "turso_connection_t" \
     --blocklist-type "turso_status_t" \
     --blocklist-type "turso_slice_ref_t" \
+    --blocklist-type "turso_codec_location_t" \
+    --blocklist-type "turso_database_open_flags_t" \
+    --blocklist-type "turso_page_codec_.*_t" \
     --rustified-enum "turso_sync_io_request_type_t" \
     --rustified-enum "turso_sync_database_io_request_type_t" \
     --rustified-enum "turso_sync_operation_result_type_t" \

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -98,6 +98,8 @@ fn test_sdk_close_finalizes_leaked_statements() {
         vfs: IoBackend::Default,
         io: None,
         db_file: None,
+        page_codec: None,
+        open_flags: OpenFlags::default(),
     });
     let _ = db_a.open().unwrap();
     let conn_a = db_a.connect().unwrap();


### PR DESCRIPTION
## Summary
This is a follow-up to #8095, which added the core/storage page-codec interface now merged on main.

- exposes page-codec callbacks and configuration through the SDK-kit C ABI
- routes configured codecs through SDK database open and connection paths
- documents and validates opaque, non-secret configuration-specific codec_id[16] values
- updates the shared Go, Python, and Rust binding configuration surfaces

## Safety and compatibility
- rejects all-zero codec IDs
- rejects external page codecs with multiprocess WAL
- preserves C callback page-number/location semantics while adapting to #8095's merged core API
- test codec IDs fingerprint the complete transform configuration without exposing key material

## Validation
- focused SDK page-codec tests
- SDK-kit test/check/clippy
- Python cargo check, sync SDK build, and Go smoke test