### PR TITLE
core/optimizer: unnest more correlated subqueries

### DIFF
--- a/core/benches/prepare_benchmark.rs
+++ b/core/benches/prepare_benchmark.rs
@@ -25,7 +25,10 @@ static ALLOC: AllocProfiler<MiMalloc> = AllocProfiler::new(MiMalloc);
 
 #[cfg(not(feature = "codspeed"))]
 fn main() {
-    divan::Divan::default().sample_count(50).main();
+    divan::Divan::default()
+        .sample_count(50)
+        .config_with_args()
+        .main();
 }
 
 #[cfg(feature = "codspeed")]

--- a/core/benches/prepare_benchmark.rs
+++ b/core/benches/prepare_benchmark.rs
@@ -285,6 +285,41 @@ fn subquery_exists_correlated(bencher: Bencher) {
     );
 }
 
+#[turso_macros::divan_bench(args = [3, 5, 7])]
+fn subquery_two_correlated_wide_join(bencher: Bencher, tables: usize) {
+    let (db, conn) = open_db();
+    for i in 0..tables {
+        execute(
+            &db,
+            &conn,
+            &format!("CREATE TABLE wide_outer_{i} (id INTEGER PRIMARY KEY, k INTEGER, v REAL)"),
+        );
+    }
+    execute(
+        &db,
+        &conn,
+        "CREATE TABLE wide_inner_avg (k INTEGER, v REAL)",
+    );
+    execute(&db, &conn, "CREATE TABLE wide_inner_in (k INTEGER, v REAL)");
+
+    let mut sql = String::from("SELECT t0.id FROM wide_outer_0 t0");
+    for i in 1..tables {
+        sql.push_str(&format!(
+            " JOIN wide_outer_{i} t{i} ON t{i}.k = t{}.k",
+            i - 1
+        ));
+    }
+    sql.push_str(
+        " WHERE t0.v < (SELECT avg(a.v) FROM wide_inner_avg a WHERE a.k = t0.k) \
+           AND t1.v IN (SELECT b.v FROM wide_inner_in b WHERE b.k = t1.k)",
+    );
+
+    let _warmup = conn.prepare(&sql).unwrap();
+    bencher.bench_local(|| {
+        black_box(conn.prepare(black_box(&sql)).unwrap());
+    });
+}
+
 #[turso_macros::divan_bench]
 fn subquery_from_derived_table(bencher: Bencher) {
     bench_prepare(

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -5373,8 +5373,9 @@ impl Column {
 
     #[inline]
     pub const fn set_collation(&mut self, c: Option<CollationSeq>) {
+        self.raw &= !COLL_MASK;
         if let Some(c) = c {
-            self.raw = (self.raw & !COLL_MASK) | (((c.to_bits() as u32) << COLL_SHIFT) & COLL_MASK);
+            self.raw |= ((c.to_bits() as u32) << COLL_SHIFT) & COLL_MASK;
         }
     }
 

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -465,6 +465,7 @@ fn ensure_delete_uses_rowset(program: &mut ProgramBuilder, plan: &mut DeletePlan
         non_from_clause_subqueries: vec![],
         input_cardinality_hint: None,
         estimated_output_rows: None,
+        estimated_cost: None,
         simple_aggregate: None,
         phantom_params: vec![],
     };

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -990,6 +990,7 @@ fn build_materialized_build_input_plan(
         non_from_clause_subqueries: plan.non_from_clause_subqueries.clone(),
         input_cardinality_hint: None,
         estimated_output_rows: None,
+        estimated_cost: None,
         simple_aggregate: None,
         phantom_params: vec![],
     };

--- a/core/translate/main_loop/open.rs
+++ b/core/translate/main_loop/open.rs
@@ -397,17 +397,9 @@ impl OpenLoop {
                                             None,
                                         );
                                     }
-                                    MaterializedFromClauseSubqueryStorage::DirectIndex => {
-                                        let index = index.as_ref().expect(
-                                            "direct-index materialized subquery requires index",
-                                        );
-                                        emit_materialized_subquery_result_columns(
-                                            program,
-                                            from_clause_subquery,
-                                            index_cursor_id,
-                                            Some(index.as_ref()),
-                                        );
-                                    }
+                                    // Expressions read direct index columns when they need them.
+                                    // Copying all columns here would only write unused registers.
+                                    MaterializedFromClauseSubqueryStorage::DirectIndex => {}
                                 }
                             } else {
                                 // Only emit DeferredSeek for non-subquery tables

--- a/core/translate/optimizer/OPTIMIZER.md
+++ b/core/translate/optimizer/OPTIMIZER.md
@@ -23,6 +23,10 @@ Query optimization is obviously an important part of any SQL-based database engi
 6. `order.rs`
    - Determines if sort operations can be eliminated based on the chosen access methods and join order
 
+7. `unnest.rs`
+   - Changes a correlated subquery into a join when both forms give the same rows
+   - Leaves all other forms as subqueries
+
 ## Join reordering and optimal index selection
 
 **The goals of query optimization are at least the following:**
@@ -44,17 +48,22 @@ i.e. straight from the 70s! The DP algorithm is explained below.
 
 ### Current high level flow of the optimizer
 
-1. **SQL rewriting**
+1. **Choose how to run correlated subqueries**
+   - Keep the query as written as one choice.
+   - Make a second choice by changing supported `EXISTS`, `IN`, and subqueries that return one aggregate value into joins.
+   - Plan both choices and keep the one with the lower cost.
+   - On equal cost, keep the join because it avoids one subquery call per outer row.
+2. **SQL rewriting**
   - Rewrite certain SQL expressions to another form (not a lot currently; e.g. rewrite BETWEEN as two comparisons)
   - Eliminate constant conditions: e.g. `WHERE 1` is removed, `WHERE 0` short-circuits the whole query because it is trivially false.
-2. **Check whether there is an "interesting order"** that we should consider when evaluating indexes and join orders
+3. **Check whether there is an "interesting order"** that we should consider when evaluating indexes and join orders
     - Is there a GROUP BY? an ORDER BY? Both?
-3. **Convert WHERE clause conjucts to Constraints**
+4. **Convert WHERE clause conjucts to Constraints**
     - E.g. in `WHERE t.x = 5`, the expression `5` _constrains_  table `t` to values of `x` that are exactly `5`.
     - E.g. in `Where t.x = u.x`, the expression `u.x` constrains `t`, AND `t.x` constrains `u`.
     - Per table, each constraint has an estimated _selectivity_ (how much it filters the result set); this affects join order calculations, see the paragraph on _Estimation_  below.
     - Per table, constraints are also analyzed for whether one or multiple of them can be used as an index seek key to avoid a full scan.
-4. **Compute the best join order using a dynamic programming algorithm:**
+5. **Compute the best join order using a dynamic programming algorithm:**
   - `n` = number of tables considered
   - `n=1`: find the lowest _cost_ way to access each single table, given the constraints of the query. Memoize the result.
   - `n=2`: for each table found in the `n=1` step, find the best way to join that table with each other table. Memoize the result.
@@ -76,7 +85,7 @@ i.e. straight from the 70s! The DP algorithm is explained below.
     - If it is now worse than the best sorted plan, then choose the sorted plan as the best plan for the query.
       - This allows us to eliminate a sorting operation.
     - If the best overall plan is still best even with the sorting penalty, then keep it. A sorting operation is later applied to sort the rows according to the desired order.
-5. **Mutate the plan's `join_order` and `Operation`s to match the computed best plan.**
+6. **Mutate the plan's `join_order` and `Operation`s to match the computed best plan.**
 
 ### Estimation of cost and cardinalities + a note on table statistics
 

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -11,8 +11,8 @@ use crate::stats::AnalyzeStats;
 use crate::translate::collate::CollationSeq;
 use crate::translate::expr::{as_binary_components, walk_expr, WalkControl};
 use crate::translate::optimizer::constraints::{
-    convert_to_vtab_constraint, ordered_materialized_key_columns, partial_index,
-    partial_index_predicate_terms, BinaryExprSide, Constraint, ConstraintOperator,
+    automatic_index_terms, convert_to_vtab_constraint, ordered_materialized_key_columns,
+    partial_index, partial_index_predicate_terms, BinaryExprSide, Constraint, ConstraintOperator,
     RangeConstraintRef,
 };
 use crate::translate::optimizer::cost::{rows_per_leaf_page_for_index, RowCountEstimate};
@@ -35,8 +35,8 @@ use super::{
         usable_constraints_for_join_order, usable_constraints_for_lhs_mask, TableConstraints,
     },
     cost::{
-        estimate_btree_depth, estimate_cost_for_scan_or_seek, estimate_index_cost,
-        estimate_rows_per_seek, AnalyzeCtx, Cost, IndexInfo,
+        estimate_btree_depth, estimate_cost_for_scan_or_seek, estimate_ephemeral_index_build_cost,
+        estimate_index_cost, estimate_rows_per_seek, AnalyzeCtx, Cost, IndexInfo,
     },
     join::JoinPlanningContext,
     multi_index::{
@@ -874,6 +874,97 @@ fn find_best_access_method_for_btree(
         },
     };
 
+    let is_full_outer = rhs_table
+        .join_info
+        .as_ref()
+        .is_some_and(|join_info| join_info.is_full_outer());
+    let uses_full_table_scan = matches!(
+        &best_access_method.params,
+        AccessMethodParams::BTreeTable {
+            index: None,
+            constraint_refs,
+            ..
+        } if constraint_refs.is_empty()
+    );
+    let has_ready_term = rhs_constraints.constraints.iter().any(|constraint| {
+        lhs_mask.contains_all_set_bits_of(&constraint.lhs_mask)
+            && constraint.can_drive_index_seek(rhs_table.columns(), rhs_table.table.is_strict())
+    });
+    if rhs_table.indexed.is_none()
+        && uses_full_table_scan
+        && has_ready_term
+        && !lhs_mask.is_empty()
+        && !is_full_outer
+    {
+        // A temporary index uses the table column's text order. It cannot use
+        // a custom text order that appears only in the join condition.
+        let index_terms: Vec<_> = automatic_index_terms(rhs_table, rhs_constraints)
+            .into_iter()
+            .filter(|term| {
+                let constraint = &rhs_constraints.constraints[term.constraint_vec_pos];
+                let where_term = &where_clause[constraint.where_clause_pos.0];
+                !expr_uses_custom_collation(&where_term.expr)
+            })
+            .collect();
+        let constraint_refs = usable_constraints_for_join_order(
+            &rhs_constraints.constraints,
+            &index_terms,
+            join_order,
+        )?;
+        if !constraint_refs.is_empty() {
+            let index = Arc::new(super::ephemeral_index_build(rhs_table, &constraint_refs)?);
+            let index_info = IndexInfo {
+                unique: false,
+                column_count: index.columns.len(),
+                covering: true,
+                rows_per_leaf_page: rows_per_leaf_page_for_index(
+                    index.columns.len(),
+                    rhs_table,
+                    params.rows_per_table_page,
+                ),
+            };
+            let rows_per_seek = estimate_rows_per_seek(
+                index_info,
+                &rhs_constraints.constraints,
+                &constraint_refs,
+                base_row_count,
+                None,
+            );
+            let scan_cost = estimate_cost_for_scan_or_seek(
+                None,
+                &[],
+                &[],
+                1.0,
+                base_row_count,
+                false,
+                params,
+                None,
+            );
+            let build_cost = estimate_ephemeral_index_build_cost(*base_row_count, params);
+            let seek_cost = Cost(
+                input_cardinality * params.cpu_cost_per_seek
+                    + input_cardinality * rows_per_seek * params.cpu_cost_per_row,
+            );
+            let cost = scan_cost + build_cost + seek_cost;
+            if cost < best_access_method.cost {
+                best_access_method = AccessMethod {
+                    cost,
+                    estimated_rows_per_outer_row: rows_per_seek,
+                    residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
+                    consumed_where_terms: consumed_where_terms_from_constraint_refs(
+                        &rhs_constraints.constraints,
+                        &constraint_refs,
+                    ),
+                    params: AccessMethodParams::BTreeTable {
+                        iter_dir: best.iter_dir,
+                        index: Some(index),
+                        constraint_refs,
+                    },
+                };
+            }
+        }
+    }
+
     // Skip alternative access methods (in-seek, multi-index) when INDEXED BY or NOT INDEXED
     // is specified — the user explicitly requested a specific index or no index.
     if rhs_table.indexed.is_none() && rhs_table.btree().is_some_and(|b| b.has_rowid) {
@@ -1671,7 +1762,7 @@ fn find_best_access_method_for_subquery(
     );
     let one_pass_scan_cost =
         estimate_cost_for_scan_or_seek(None, &[], &[], 1.0, base_row_count, false, params, None);
-    let append_build_cost = Cost(*base_row_count * params.cpu_cost_per_seek);
+    let append_build_cost = estimate_ephemeral_index_build_cost(*base_row_count, params);
     let seek_setup_cost = if table_materialization_required || can_direct_materialize_index {
         // Both table-backed materialization and direct-index materialization avoid
         // the extra "scan table into probe index" pass. They differ in storage,

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -35,8 +35,8 @@ use super::{
         usable_constraints_for_join_order, usable_constraints_for_lhs_mask, TableConstraints,
     },
     cost::{
-        estimate_cost_for_scan_or_seek, estimate_index_cost, estimate_rows_per_seek, AnalyzeCtx,
-        Cost, IndexInfo,
+        estimate_btree_depth, estimate_cost_for_scan_or_seek, estimate_index_cost,
+        estimate_rows_per_seek, AnalyzeCtx, Cost, IndexInfo,
     },
     join::JoinPlanningContext,
     multi_index::{
@@ -535,13 +535,7 @@ pub(super) fn choose_best_in_seek_candidate(
     };
 
     let base = *base_row_count;
-    let tree_depth = if base <= 1.0 {
-        1.0
-    } else {
-        (base.ln() / params.rows_per_table_page.ln())
-            .ceil()
-            .max(1.0)
-    };
+    let tree_depth = estimate_btree_depth(base, params.rows_per_table_page);
     let mut best_in_seek = None;
     let mut best_in_seek_cost = best_cost;
 
@@ -1476,16 +1470,19 @@ fn find_best_access_method_for_subquery(
         params,
         None,
     );
+    let subquery_cost = subquery.plan.estimated_cost().unwrap_or(0.0);
     let coroutine_reexecution_overhead =
         Cost((input_cardinality - 1.0).max(0.0) * *base_row_count * params.cpu_cost_per_seek);
-    let coroutine_cost = coroutine_scan_cost + coroutine_reexecution_overhead;
+    let coroutine_cost = coroutine_scan_cost
+        + coroutine_reexecution_overhead
+        + Cost(input_cardinality * subquery_cost);
     let table_materialization_required = subquery.requires_table_materialization();
     let can_direct_materialize_index = subquery.supports_direct_index_materialization();
     let scan_cost = if table_materialization_required {
         // Explicit MATERIALIZED hints and shared CTEs already produce a table-backed
         // row source. Scanning them behaves like rescanning cached rows, not rerunning
         // a coroutine body for each outer probe.
-        coroutine_scan_cost
+        coroutine_scan_cost + Cost(subquery_cost)
     } else {
         // The generic scan model treats repeated probes like cached rescans of a
         // row source. A coroutine-backed subquery is slightly more expensive: each
@@ -1690,7 +1687,7 @@ fn find_best_access_method_for_subquery(
         input_cardinality * params.cpu_cost_per_seek
             + input_cardinality * estimated_rows_per_outer_row * params.cpu_cost_per_row,
     );
-    let total_cost = seek_setup_cost + seek_cost;
+    let total_cost = Cost(subquery_cost) + seek_setup_cost + seek_cost;
 
     if total_cost >= scan_cost + order_satisfiability_bonus {
         return Ok(Some(AccessMethod {

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -8,19 +8,19 @@ use turso_parser::ast::{self, SortOrder, TableInternalId};
 use crate::alloc::{TursoIteratorExt, TursoTryWithCapacityExt, TursoVecExt};
 use crate::schema::Schema;
 use crate::stats::AnalyzeStats;
-use crate::translate::collate::CollationSeq;
 use crate::translate::expr::{as_binary_components, walk_expr, WalkControl};
 use crate::translate::optimizer::constraints::{
-    automatic_index_terms, convert_to_vtab_constraint, ordered_materialized_key_columns,
+    convert_to_vtab_constraint, expr_uses_custom_collation, ordered_ephemeral_key_columns,
     partial_index, partial_index_predicate_terms, BinaryExprSide, Constraint, ConstraintOperator,
     RangeConstraintRef,
 };
 use crate::translate::optimizer::cost::{rows_per_leaf_page_for_index, RowCountEstimate};
 use crate::translate::optimizer::cost_params::CostModelParams;
 use crate::translate::plan::{
-    plan_has_outer_scope_dependency, HashJoinKey, HashJoinType, NonFromClauseSubquery,
+    plan_has_outer_scope_dependency, HashJoinKey, HashJoinType, NonFromClauseSubquery, Plan,
     SetOperation, SubqueryState, TableReferences, WhereTerm,
 };
+use crate::util::exprs_are_equivalent;
 use crate::vdbe::affinity::Affinity;
 use crate::vdbe::hash_table::DEFAULT_MEM_BUDGET;
 use crate::{
@@ -53,30 +53,14 @@ use crate::translate::planner::TableMask;
 #[derive(Debug, Clone)]
 /// Represents a way to access a table.
 pub struct AccessMethod {
-    /// The estimated number of page fetches.
-    /// CPU costs are folded into the same scalar cost model.
+    /// The estimated page and CPU work for this path.
     pub cost: Cost,
     /// Estimated rows produced per outer row before applying remaining filters.
     pub estimated_rows_per_outer_row: f64,
-    /// Whether join cardinality should still apply planner-side selectivity after
-    /// using this access path's own row estimate.
-    pub residual_constraints: ResidualConstraintMode,
     /// WHERE-term indices already accounted for by this access path's row estimate.
     pub consumed_where_terms: SmallVec<[usize; 4]>,
     /// Table-type specific access method details.
     pub params: AccessMethodParams,
-}
-
-/// Describes whether join planning should still apply residual WHERE-term
-/// selectivity after choosing an access path.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ResidualConstraintMode {
-    /// Apply the selectivity of all relevant WHERE terms that this access path
-    /// did not already consume.
-    ApplyUnconsumed,
-    /// The access path already provided its own final row estimate; do not
-    /// multiply any planner-side residual selectivity on top.
-    None,
 }
 
 /// Table‑specific details of how an [`AccessMethod`] operates.
@@ -88,6 +72,9 @@ pub enum AccessMethodParams {
         iter_dir: IterationDirection,
         /// The index that is being used, if any. For rowid based searches (and full table scans), this is None.
         index: Option<Arc<Index>>,
+        /// True when this path needs a temporary index.
+        /// The index is built after the planner chooses one plan.
+        build_index: bool,
         /// The constraint references that are being used, if any.
         /// An empty list of constraint refs means a scan (full table or index);
         /// a non-empty list means a search.
@@ -172,7 +159,7 @@ pub enum AccessMethodParams {
 pub(super) struct ChosenBtreeCandidate {
     pub(super) iter_dir: IterationDirection,
     pub(super) index: Option<Arc<Index>>,
-    pub(super) constraint_refs: Vec<RangeConstraintRef>,
+    pub(super) constraint_refs: SmallVec<[RangeConstraintRef; 2]>,
     pub(super) base_row_count: RowCountEstimate,
     pub(super) cost: Cost,
 }
@@ -237,7 +224,7 @@ pub(super) fn choose_best_btree_candidate(
     let mut best_choice = ChosenBtreeCandidate {
         iter_dir: IterationDirection::Forwards,
         index: None,
-        constraint_refs: vec![],
+        constraint_refs: SmallVec::new(),
         base_row_count,
         cost: best_cost,
     };
@@ -459,7 +446,7 @@ pub(super) fn choose_best_btree_candidate(
             best_choice = ChosenBtreeCandidate {
                 iter_dir,
                 index: candidate.index.clone(),
-                constraint_refs: usable_constraint_refs.clone(),
+                constraint_refs: usable_constraint_refs,
                 base_row_count: candidate_base_row_count,
                 cost,
             };
@@ -668,7 +655,6 @@ fn consider_in_seek_access_method(
     .map(|chosen| AccessMethod {
         cost: chosen.cost,
         estimated_rows_per_outer_row: chosen.estimated_rows_per_outer_row,
-        residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
         consumed_where_terms: smallvec::smallvec![chosen.constraint_idx],
         params: AccessMethodParams::InSeek {
             index: chosen.index,
@@ -678,33 +664,51 @@ fn consider_in_seek_access_method(
     }))
 }
 
-fn residual_literal_in_list_eval_cost(
-    constraints: &[Constraint],
-    where_clause: &[WhereTerm],
-    consumed_where_terms: &[usize],
+/// Add the cost of ready `WHERE` conditions.
+fn cost_with_where_work(
+    method: &AccessMethod,
+    ready_where: &[(usize, usize)],
     input_cardinality: f64,
-    rows_per_outer_row: f64,
     params: &CostModelParams,
 ) -> Cost {
-    let eval_count = input_cardinality * rows_per_outer_row;
-    let comparison_count: f64 = constraints
+    let used_steps: usize = ready_where
         .iter()
-        .filter(|constraint| !consumed_where_terms.contains(&constraint.where_clause_pos.0))
-        .filter(|constraint| {
-            where_clause
-                .get(constraint.where_clause_pos.0)
-                .is_some_and(|term| matches!(term.expr, ast::Expr::InList { .. }))
-        })
-        .filter_map(|constraint| match constraint.operator {
-            ConstraintOperator::In {
-                not: false,
-                estimated_values,
-            } => Some(estimated_values),
-            _ => None,
-        })
+        .filter(|(term_idx, _)| method.consumed_where_terms.contains(term_idx))
+        .map(|(_, step_count)| step_count)
         .sum();
+    let remaining_steps: usize = ready_where
+        .iter()
+        .filter(|(term_idx, _)| !method.consumed_where_terms.contains(term_idx))
+        .map(|(_, step_count)| step_count)
+        .sum();
+    let output_rows = input_cardinality * method.estimated_rows_per_outer_row;
+    let used_rows = input_cardinality.max(output_rows);
+    let work = used_rows * used_steps as f64 + output_rows * remaining_steps as f64;
+    method.cost + Cost(work * params.cpu_cost_per_where_step)
+}
 
-    Cost(eval_count * comparison_count * params.cpu_cost_per_row)
+pub(super) fn add_where_cost(
+    method: &mut AccessMethod,
+    ready_where: &[(usize, usize)],
+    input_cardinality: f64,
+    params: &CostModelParams,
+) {
+    method.cost = cost_with_where_work(method, ready_where, input_cardinality, params);
+}
+
+fn replace_if_cheaper(
+    best_method: &mut AccessMethod,
+    best_cost: &mut Cost,
+    method: AccessMethod,
+    ready_where: &[(usize, usize)],
+    input_cardinality: f64,
+    params: &CostModelParams,
+) {
+    let cost = cost_with_where_work(&method, ready_where, input_cardinality, params);
+    if cost < *best_cost {
+        *best_method = method;
+        *best_cost = cost;
+    }
 }
 
 /// Return the best [AccessMethod] for a given join order.
@@ -712,9 +716,11 @@ fn residual_literal_in_list_eval_cost(
 pub fn find_best_access_method_for_join_order(
     rhs_table: &JoinedTable,
     rhs_constraints: &TableConstraints,
+    lhs_mask: &TableMask,
     join_order: &[JoinOrderMember],
     planning_context: JoinPlanningContext<'_>,
     where_clause: &[WhereTerm],
+    ready_where: &[(usize, usize)],
     available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
@@ -728,9 +734,11 @@ pub fn find_best_access_method_for_join_order(
         Table::BTree(_) => find_best_access_method_for_btree(
             rhs_table,
             rhs_constraints,
+            lhs_mask,
             join_order,
             planning_context.maybe_order_target,
             where_clause,
+            ready_where,
             available_indexes,
             table_references,
             subqueries,
@@ -754,6 +762,7 @@ pub fn find_best_access_method_for_join_order(
             rhs_constraints,
             join_order,
             planning_context,
+            ready_where,
             schema,
             input_cardinality,
             base_row_count,
@@ -771,7 +780,6 @@ pub fn find_best_access_method_for_join_order(
                 None,
             ),
             estimated_rows_per_outer_row: 1.0,
-            residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
             consumed_where_terms: SmallVec::new(),
             params: AccessMethodParams::RecursiveCteInput,
         })),
@@ -782,9 +790,11 @@ pub fn find_best_access_method_for_join_order(
 fn find_best_access_method_for_btree(
     rhs_table: &JoinedTable,
     rhs_constraints: &TableConstraints,
+    lhs_mask: &TableMask,
     join_order: &[JoinOrderMember],
     maybe_order_target: Option<&OrderTarget>,
     where_clause: &[WhereTerm],
+    ready_where: &[(usize, usize)],
     available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
     subqueries: &[NonFromClauseSubquery],
@@ -795,15 +805,10 @@ fn find_best_access_method_for_btree(
     params: &CostModelParams,
 ) -> Result<Option<AccessMethod>> {
     let rhs_table_idx = join_order.last().unwrap().original_idx;
-    let lhs_mask: TableMask = join_order
-        .iter()
-        .take(join_order.len() - 1)
-        .map(|member| member.original_idx)
-        .try_collect()?;
     let best = choose_best_btree_candidate(
         rhs_table,
         rhs_constraints,
-        &lhs_mask,
+        lhs_mask,
         rhs_table_idx,
         maybe_order_target,
         schema,
@@ -865,14 +870,16 @@ fn find_best_access_method_for_btree(
     let mut best_access_method = AccessMethod {
         cost: best.cost,
         estimated_rows_per_outer_row,
-        residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
         consumed_where_terms,
         params: AccessMethodParams::BTreeTable {
             iter_dir: best.iter_dir,
             index: best.index,
-            constraint_refs: best.constraint_refs,
+            build_index: false,
+            constraint_refs: best.constraint_refs.into_vec(),
         },
     };
+    let mut best_cost_with_filters =
+        cost_with_where_work(&best_access_method, ready_where, input_cardinality, params);
 
     let is_full_outer = rhs_table
         .join_info
@@ -882,43 +889,32 @@ fn find_best_access_method_for_btree(
         &best_access_method.params,
         AccessMethodParams::BTreeTable {
             index: None,
+            build_index: false,
             constraint_refs,
             ..
         } if constraint_refs.is_empty()
     );
-    let has_ready_term = rhs_constraints.constraints.iter().any(|constraint| {
-        lhs_mask.contains_all_set_bits_of(&constraint.lhs_mask)
-            && constraint.can_drive_index_seek(rhs_table.columns(), rhs_table.table.is_strict())
-    });
-    if rhs_table.indexed.is_none()
-        && uses_full_table_scan
-        && has_ready_term
-        && !lhs_mask.is_empty()
-        && !is_full_outer
+    if rhs_table.indexed.is_none() && uses_full_table_scan && !lhs_mask.is_empty() && !is_full_outer
     {
-        // A temporary index uses the table column's text order. It cannot use
-        // a custom text order that appears only in the join condition.
-        let index_terms: Vec<_> = automatic_index_terms(rhs_table, rhs_constraints)
-            .into_iter()
-            .filter(|term| {
-                let constraint = &rhs_constraints.constraints[term.constraint_vec_pos];
-                let where_term = &where_clause[constraint.where_clause_pos.0];
-                !expr_uses_custom_collation(&where_term.expr)
-            })
-            .collect();
-        let constraint_refs = usable_constraints_for_join_order(
+        let constraint_refs = usable_constraints_for_lhs_mask(
             &rhs_constraints.constraints,
-            &index_terms,
-            join_order,
-        )?;
+            &rhs_constraints.temporary_index_terms,
+            lhs_mask,
+            rhs_table_idx,
+        );
         if !constraint_refs.is_empty() {
-            let index = Arc::new(super::ephemeral_index_build(rhs_table, &constraint_refs)?);
+            let column_count = rhs_table
+                .columns()
+                .iter()
+                .enumerate()
+                .filter(|(column_idx, _)| rhs_table.column_is_used(*column_idx))
+                .count();
             let index_info = IndexInfo {
                 unique: false,
-                column_count: index.columns.len(),
+                column_count,
                 covering: true,
                 rows_per_leaf_page: rows_per_leaf_page_for_index(
-                    index.columns.len(),
+                    column_count,
                     rhs_table,
                     params.rows_per_table_page,
                 ),
@@ -946,45 +942,42 @@ fn find_best_access_method_for_btree(
                     + input_cardinality * rows_per_seek * params.cpu_cost_per_row,
             );
             let cost = scan_cost + build_cost + seek_cost;
-            if cost < best_access_method.cost {
-                best_access_method = AccessMethod {
-                    cost,
-                    estimated_rows_per_outer_row: rows_per_seek,
-                    residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
-                    consumed_where_terms: consumed_where_terms_from_constraint_refs(
-                        &rhs_constraints.constraints,
-                        &constraint_refs,
-                    ),
-                    params: AccessMethodParams::BTreeTable {
-                        iter_dir: best.iter_dir,
-                        index: Some(index),
-                        constraint_refs,
-                    },
-                };
-            }
+            let temporary_index = AccessMethod {
+                cost,
+                estimated_rows_per_outer_row: rows_per_seek,
+                consumed_where_terms: consumed_where_terms_from_constraint_refs(
+                    &rhs_constraints.constraints,
+                    &constraint_refs,
+                ),
+                params: AccessMethodParams::BTreeTable {
+                    iter_dir: best.iter_dir,
+                    index: None,
+                    build_index: true,
+                    constraint_refs: Vec::new(),
+                },
+            };
+            replace_if_cheaper(
+                &mut best_access_method,
+                &mut best_cost_with_filters,
+                temporary_index,
+                ready_where,
+                input_cardinality,
+                params,
+            );
         }
     }
 
     // Skip alternative access methods (in-seek, multi-index) when INDEXED BY or NOT INDEXED
     // is specified — the user explicitly requested a specific index or no index.
     if rhs_table.indexed.is_none() && rhs_table.btree().is_some_and(|b| b.has_rowid) {
-        let in_seek_threshold = best_access_method.cost
-            + residual_literal_in_list_eval_cost(
-                &rhs_constraints.constraints,
-                where_clause,
-                &best_access_method.consumed_where_terms,
-                input_cardinality,
-                best_access_method.estimated_rows_per_outer_row,
-                params,
-            );
         if let Some(in_seek_method) = consider_in_seek_access_method(
             rhs_table,
             rhs_constraints,
-            &lhs_mask,
+            lhs_mask,
             input_cardinality,
             base_row_count,
             params,
-            in_seek_threshold,
+            best_cost_with_filters,
         )? {
             let mut in_seek_method = in_seek_method;
             if let AccessMethodParams::InSeek { index, .. } = &in_seek_method.params {
@@ -997,7 +990,14 @@ fn find_best_access_method_for_btree(
                     );
                 }
             }
-            best_access_method = in_seek_method;
+            replace_if_cheaper(
+                &mut best_access_method,
+                &mut best_cost_with_filters,
+                in_seek_method,
+                ready_where,
+                input_cardinality,
+                params,
+            );
         }
 
         if let Some(multi_idx_method) = consider_multi_index_union(
@@ -1010,11 +1010,18 @@ fn find_best_access_method_for_btree(
             input_cardinality,
             base_row_count,
             params,
-            best_access_method.cost,
-            &lhs_mask,
+            best_cost_with_filters,
+            lhs_mask,
             analyze_stats,
         )? {
-            best_access_method = multi_idx_method;
+            replace_if_cheaper(
+                &mut best_access_method,
+                &mut best_cost_with_filters,
+                multi_idx_method,
+                ready_where,
+                input_cardinality,
+                params,
+            );
         }
 
         if let Some(multi_idx_and_method) = consider_multi_index_intersection(
@@ -1027,11 +1034,18 @@ fn find_best_access_method_for_btree(
             input_cardinality,
             base_row_count,
             params,
-            best_access_method.cost,
-            &lhs_mask,
+            best_cost_with_filters,
+            lhs_mask,
             analyze_stats,
         )? {
-            best_access_method = multi_idx_and_method;
+            replace_if_cheaper(
+                &mut best_access_method,
+                &mut best_cost_with_filters,
+                multi_idx_and_method,
+                ready_where,
+                input_cardinality,
+                params,
+            );
         }
     }
 
@@ -1054,8 +1068,35 @@ fn find_best_access_method_for_vtab(
 
     match best_index_result {
         Ok(index_info) => {
+            if index_info.constraint_usages.len() != vtab_constraints.len() {
+                return Err(LimboError::ExtensionError(format!(
+                    "Constraint usage count mismatch (expected {}, got {})",
+                    vtab_constraints.len(),
+                    index_info.constraint_usages.len()
+                )));
+            }
+            let has_row_estimate = index_info.estimated_rows != u32::MAX;
+            let estimated_rows_per_outer_row = if has_row_estimate {
+                f64::from(index_info.estimated_rows)
+            } else {
+                *base_row_count
+            };
+            // A row estimate includes each condition passed to the virtual table.
+            // Do not apply the same row cut again in the join planner.
+            let consumed_where_terms = if has_row_estimate {
+                vtab_constraints
+                    .iter()
+                    .zip(&index_info.constraint_usages)
+                    .filter(|(_, usage)| usage.argv_index.is_some())
+                    .map(|(vtab_constraint, _)| {
+                        constraints[vtab_constraint.index].where_clause_pos.0
+                    })
+                    .collect()
+            } else {
+                SmallVec::new()
+            };
             Ok(Some(AccessMethod {
-                // TODO: Base cost on `IndexInfo::estimated_cost` and output cardinality on `IndexInfo::estimated_rows`
+                // TODO: Base cost on `IndexInfo::estimated_cost`.
                 cost: estimate_cost_for_scan_or_seek(
                     None,
                     &[],
@@ -1066,9 +1107,8 @@ fn find_best_access_method_for_vtab(
                     params,
                     None,
                 ),
-                estimated_rows_per_outer_row: *base_row_count,
-                residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
-                consumed_where_terms: SmallVec::new(),
+                estimated_rows_per_outer_row,
+                consumed_where_terms,
                 params: AccessMethodParams::VirtualTable {
                     idx_num: index_info.idx_num,
                     idx_str: index_info.idx_str,
@@ -1082,88 +1122,58 @@ fn find_best_access_method_for_vtab(
     }
 }
 
-/// Collect all table IDs referenced in an expression.
-fn collect_table_refs(expr: &ast::Expr) -> Option<Vec<TableInternalId>> {
-    let mut tables = Vec::new();
+/// Return the one table read by an expression.
+fn one_table_in_expr(expr: &ast::Expr) -> Option<TableInternalId> {
+    let mut table = None;
+    let mut has_more_than_one = false;
     let result = walk_expr(expr, &mut |e| {
         match e {
-            ast::Expr::Column { table, .. } | ast::Expr::RowId { table, .. } => {
-                if !tables.contains(table) {
-                    tables.push(*table);
+            ast::Expr::Column {
+                table: found_table, ..
+            }
+            | ast::Expr::RowId {
+                table: found_table, ..
+            } => {
+                if table.is_some_and(|table| table != *found_table) {
+                    has_more_than_one = true;
+                } else {
+                    table = Some(*found_table);
                 }
             }
             _ => {}
         }
         Ok(WalkControl::Continue)
     });
-    result.ok().map(|_| tables)
+    result.ok()?;
+    (!has_more_than_one).then_some(table).flatten()
 }
 
-/// Detect equi-join conditions between exactly two tables for hash join.
+/// Return the two tables used by one equal test.
+pub(super) fn tables_in_equal_test(expr: &ast::Expr) -> Option<(TableInternalId, TableInternalId)> {
+    let Ok(Some((left, operator, right))) = as_binary_components(expr) else {
+        return None;
+    };
+    if !matches!(operator.as_ast_operator(), Some(ast::Operator::Equals)) {
+        return None;
+    }
+    Some((one_table_in_expr(left)?, one_table_in_expr(right)?))
+}
+
+/// Find equal tests that a hash join can use.
 ///
-/// Returns `HashJoinKey` entries pointing at `WHERE` terms of the form:
-///   <build-only expr> = <probe-only expr>
-/// or
-///   <probe-only expr> = <build-only expr>
-///
-/// Both sides may be arbitrary expressions (e.g. `lower(t1.a) = substr(t2.b,1,3)`),
-/// but each side must reference columns from exactly one table:
-/// - the build side must reference only `build_table_id`
-/// - the probe side must reference only `probe_table_id`
-///
-/// This function does *not* mark any terms as consumed; the caller is responsible
-/// for doing so if a hash join is selected.
-pub fn find_equijoin_conditions(
+/// Each side must read one table. This function does not mark a test as used.
+fn find_hash_join_keys(
     build_table_id: TableInternalId,
     probe_table_id: TableInternalId,
-    where_clause: &[WhereTerm],
-) -> Vec<HashJoinKey> {
-    let mut join_keys = Vec::new();
+    terms: impl Iterator<Item = (usize, TableInternalId, TableInternalId)>,
+) -> SmallVec<[HashJoinKey; 2]> {
+    let mut join_keys = SmallVec::new();
 
-    for (where_idx, where_term) in where_clause.iter().enumerate() {
-        if where_term.consumed {
-            continue;
-        }
-
-        // An ON-clause term of an outer join decides what counts as a match
-        // for that join only. A term that belongs to a *different* join's ON
-        // clause may legally mention only these two tables (an ON clause can
-        // reference any table to its left), but it must not become this
-        // join's key — it filters the rows of its own join instead.
-        if where_term
-            .from_outer_join
-            .is_some_and(|owner| owner != probe_table_id)
-        {
-            continue;
-        }
-
-        let Ok(Some((lhs, op, rhs))) = as_binary_components(&where_term.expr) else {
-            continue;
-        };
-        if !matches!(op.as_ast_operator(), Some(ast::Operator::Equals)) {
-            continue;
-        }
-
-        let Some(lhs_tables) = collect_table_refs(lhs) else {
-            continue;
-        };
-        let Some(rhs_tables) = collect_table_refs(rhs) else {
-            continue;
-        };
-
-        // Require each side to reference exactly one table. This prevents
-        // constants or multi-table expressions from being considered join keys.
-        if lhs_tables.len() != 1 || rhs_tables.len() != 1 {
-            continue;
-        }
-
-        let lhs_tid = lhs_tables[0];
-        let rhs_tid = rhs_tables[0];
-
+    for (where_idx, lhs_table, rhs_table) in terms {
         // Accept either orientation: build=probe or probe=build.
-        let build_side = if lhs_tid == build_table_id && rhs_tid == probe_table_id {
+        let build_side = if lhs_table == build_table_id && rhs_table == probe_table_id {
             Some(BinaryExprSide::Lhs)
-        } else if rhs_tid == build_table_id && lhs_tid == probe_table_id {
+        } else if rhs_table == build_table_id && lhs_table == probe_table_id {
             Some(BinaryExprSide::Rhs)
         } else {
             None
@@ -1178,20 +1188,6 @@ pub fn find_equijoin_conditions(
     }
 
     join_keys
-}
-
-fn expr_uses_custom_collation(expr: &ast::Expr) -> bool {
-    let mut uses_custom = false;
-    let _ = walk_expr(expr, &mut |expr| -> Result<WalkControl> {
-        if let ast::Expr::Collate(_, collation_name) = expr {
-            uses_custom = CollationSeq::known_custom(collation_name.as_str()).is_some();
-            if uses_custom {
-                return Ok(WalkControl::SkipChildren);
-            }
-        }
-        Ok(WalkControl::Continue)
-    });
-    uses_custom
 }
 
 /// Estimate the cost of a hash join between two tables.
@@ -1247,6 +1243,7 @@ pub fn try_hash_join_access_method(
     build_constraints: &TableConstraints,
     probe_constraints: &TableConstraints,
     where_clause: &mut [WhereTerm],
+    equal_terms: impl Iterator<Item = (usize, TableInternalId, TableInternalId)>,
     build_cardinality: f64,
     probe_cardinality: f64,
     probe_multiplier: f64,
@@ -1350,20 +1347,11 @@ pub fn try_hash_join_access_method(
         }
     }
 
-    let join_keys = find_equijoin_conditions(
+    let join_keys = find_hash_join_keys(
         build_table.internal_id,
         probe_table.internal_id,
-        where_clause,
-    )
-    .into_iter()
-    .filter(|join_key| {
-        let probe_expr = join_key.get_probe_expr(where_clause);
-        let Some(probe_tables) = collect_table_refs(probe_expr) else {
-            return false;
-        };
-        probe_tables.len() == 1 && probe_tables[0] == probe_table.internal_id
-    })
-    .collect::<Vec<_>>();
+        equal_terms,
+    );
     tracing::debug!(
         build_table = build_table.table.get_name(),
         probe_table = probe_table.table.get_name(),
@@ -1394,9 +1382,6 @@ pub fn try_hash_join_access_method(
     if hash_join_type != HashJoinType::FullOuter {
         for join_key in &join_keys {
             let probe_expr = join_key.get_probe_expr(where_clause);
-            let probe_tables = collect_table_refs(probe_expr).unwrap_or_default();
-            let probe_is_single_table =
-                probe_tables.len() == 1 && probe_tables[0] == probe_table.internal_id;
             let probe_is_simple_column =
                 expr_is_simple_column_from_table(probe_expr, probe_table.internal_id);
             let build_expr = join_key.get_build_expr(where_clause);
@@ -1404,7 +1389,7 @@ pub fn try_hash_join_access_method(
                 expr_is_simple_column_from_table(build_expr, build_table.internal_id);
             // Check probe table constraints for index on join column, only when the probe side
             // references the probe table alone and is a simple column/rowid reference.
-            if probe_is_single_table && probe_is_simple_column {
+            if probe_is_simple_column {
                 if let Some(constraint) = probe_constraints
                     .constraints
                     .iter()
@@ -1458,6 +1443,25 @@ pub fn try_hash_join_access_method(
         }
     }
 
+    let join_selectivity = join_keys
+        .iter()
+        .map(|key| {
+            probe_constraints
+                .constraints
+                .iter()
+                .find(|constraint| constraint.where_clause_pos.0 == key.where_clause_idx)
+                .map_or(params.sel_eq_unindexed, |constraint| constraint.selectivity)
+        })
+        .product::<f64>();
+    let rows_per_build_row = probe_cardinality * join_selectivity;
+    let estimated_rows_per_outer_row = match hash_join_type {
+        HashJoinType::Inner => rows_per_build_row,
+        HashJoinType::LeftOuter => rows_per_build_row.max(1.0),
+        HashJoinType::FullOuter => rows_per_build_row
+            .max(1.0)
+            .max(probe_cardinality / build_cardinality.max(1.0)),
+    };
+
     let cost = estimate_hash_join_cost(
         build_cardinality,
         probe_cardinality,
@@ -1467,13 +1471,12 @@ pub fn try_hash_join_access_method(
     );
     Some(AccessMethod {
         cost,
-        estimated_rows_per_outer_row: probe_cardinality,
-        residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
+        estimated_rows_per_outer_row,
         consumed_where_terms: join_keys.iter().map(|key| key.where_clause_idx).collect(),
         params: AccessMethodParams::HashJoin {
             build_table_idx,
             probe_table_idx,
-            join_keys,
+            join_keys: join_keys.into_vec(),
             mem_budget: DEFAULT_MEM_BUDGET,
             materialize_build_input: false,
             use_bloom_filter: false,
@@ -1543,6 +1546,7 @@ fn find_best_access_method_for_subquery(
     rhs_constraints: &TableConstraints,
     join_order: &[JoinOrderMember],
     planning_context: JoinPlanningContext<'_>,
+    ready_where: &[(usize, usize)],
     schema: &Schema,
     input_cardinality: f64,
     base_row_count: RowCountEstimate,
@@ -1591,7 +1595,6 @@ fn find_best_access_method_for_subquery(
             // enclosing CTE/subquery might otherwise be shareable.
             cost: coroutine_cost,
             estimated_rows_per_outer_row: *base_row_count,
-            residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
             consumed_where_terms: SmallVec::new(),
             params: AccessMethodParams::Subquery {
                 iter_dir: IterationDirection::Forwards,
@@ -1652,7 +1655,6 @@ fn find_best_access_method_for_subquery(
             return Ok(Some(AccessMethod {
                 cost: scan_cost,
                 estimated_rows_per_outer_row: *base_row_count,
-                residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
                 consumed_where_terms: SmallVec::new(),
                 params: AccessMethodParams::Subquery { iter_dir },
             }));
@@ -1663,7 +1665,6 @@ fn find_best_access_method_for_subquery(
         return Ok(Some(AccessMethod {
             cost: scan_cost,
             estimated_rows_per_outer_row: *base_row_count,
-            residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
             consumed_where_terms: SmallVec::new(),
             params: AccessMethodParams::Subquery {
                 iter_dir: IterationDirection::Forwards,
@@ -1672,12 +1673,11 @@ fn find_best_access_method_for_subquery(
     }
 
     let usable_constraints: Vec<&Constraint> = usable.iter().map(|(_, c)| *c).collect();
-    let key_col_positions = ordered_materialized_key_columns(&usable_constraints);
+    let key_col_positions = ordered_ephemeral_key_columns(&usable_constraints);
     if key_col_positions.is_empty() {
         return Ok(Some(AccessMethod {
             cost: scan_cost,
             estimated_rows_per_outer_row: *base_row_count,
-            residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
             consumed_where_terms: SmallVec::new(),
             params: AccessMethodParams::Subquery {
                 iter_dir: IterationDirection::Forwards,
@@ -1727,7 +1727,6 @@ fn find_best_access_method_for_subquery(
         return Ok(Some(AccessMethod {
             cost: scan_cost,
             estimated_rows_per_outer_row: *base_row_count,
-            residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
             consumed_where_terms: SmallVec::new(),
             params: AccessMethodParams::Subquery {
                 iter_dir: IterationDirection::Forwards,
@@ -1748,18 +1747,23 @@ fn find_best_access_method_for_subquery(
             params,
         );
 
-    let estimated_rows_per_outer_row = estimate_rows_per_seek(
-        IndexInfo {
-            unique: false,
-            column_count: key_col_positions.len(),
-            covering: true,
-            rows_per_leaf_page: params.rows_per_table_page,
-        },
-        &rhs_constraints.constraints,
-        &usable_constraint_refs,
-        base_row_count,
-        None,
-    );
+    let estimated_rows_per_outer_row =
+        if grouped_subquery_lookup_is_unique(subquery, &usable_constraint_refs) {
+            1.0
+        } else {
+            estimate_rows_per_seek(
+                IndexInfo {
+                    unique: false,
+                    column_count: key_col_positions.len(),
+                    covering: true,
+                    rows_per_leaf_page: params.rows_per_table_page,
+                },
+                &rhs_constraints.constraints,
+                &usable_constraint_refs,
+                base_row_count,
+                None,
+            )
+        };
     let one_pass_scan_cost =
         estimate_cost_for_scan_or_seek(None, &[], &[], 1.0, base_row_count, false, params, None);
     let append_build_cost = estimate_ephemeral_index_build_cost(*base_row_count, params);
@@ -1779,23 +1783,17 @@ fn find_best_access_method_for_subquery(
             + input_cardinality * estimated_rows_per_outer_row * params.cpu_cost_per_row,
     );
     let total_cost = Cost(subquery_cost) + seek_setup_cost + seek_cost;
-
-    if total_cost >= scan_cost + order_satisfiability_bonus {
-        return Ok(Some(AccessMethod {
-            cost: scan_cost,
-            estimated_rows_per_outer_row: *base_row_count,
-            residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
-            consumed_where_terms: SmallVec::new(),
-            params: AccessMethodParams::Subquery {
-                iter_dir: IterationDirection::Forwards,
-            },
-        }));
-    }
-
-    Ok(Some(AccessMethod {
+    let scan_method = AccessMethod {
+        cost: scan_cost,
+        estimated_rows_per_outer_row: *base_row_count,
+        consumed_where_terms: SmallVec::new(),
+        params: AccessMethodParams::Subquery {
+            iter_dir: IterationDirection::Forwards,
+        },
+    };
+    let index_method = AccessMethod {
         cost: total_cost,
         estimated_rows_per_outer_row,
-        residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
         consumed_where_terms: consumed_where_terms_from_constraint_refs(
             &rhs_constraints.constraints,
             &usable_constraint_refs,
@@ -1805,7 +1803,42 @@ fn find_best_access_method_for_subquery(
             constraint_refs: usable_constraint_refs,
             iter_dir,
         },
-    }))
+    };
+    let scan_cost = cost_with_where_work(&scan_method, ready_where, input_cardinality, params);
+    let index_cost = cost_with_where_work(&index_method, ready_where, input_cardinality, params);
+
+    if index_cost >= scan_cost + order_satisfiability_bonus {
+        Ok(Some(scan_method))
+    } else {
+        Ok(Some(index_method))
+    }
+}
+
+/// A grouped query has at most one row for one full group key.
+fn grouped_subquery_lookup_is_unique(
+    subquery: &FromClauseSubquery,
+    constraint_refs: &[RangeConstraintRef],
+) -> bool {
+    let Plan::Select(plan) = subquery.plan.as_ref() else {
+        return false;
+    };
+    let Some(group_by) = &plan.group_by else {
+        return false;
+    };
+    if group_by.exprs.is_empty() {
+        return false;
+    }
+
+    group_by.exprs.iter().all(|group_expr| {
+        plan.result_columns
+            .iter()
+            .position(|column| exprs_are_equivalent(&column.expr, group_expr))
+            .is_some_and(|column_pos| {
+                constraint_refs.iter().any(|constraint| {
+                    constraint.table_col_pos == Some(column_pos) && constraint.eq.is_some()
+                })
+            })
+    })
 }
 
 /// Describe the temporary index layout we would build on top of a materialized

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -285,6 +285,42 @@ pub struct TableConstraints {
     pub candidates: Vec<ConstraintUseCandidate>,
 }
 
+/// Build the search terms for an automatic index.
+///
+/// Terms for the same table column use the same index column.
+pub(super) fn automatic_index_terms(
+    table: &JoinedTable,
+    constraints: &TableConstraints,
+) -> Vec<ConstraintRef> {
+    let columns = table.columns();
+    let is_strict = table.table.is_strict();
+    let mut index_columns: SmallVec<[usize; 4]> = constraints
+        .constraints
+        .iter()
+        .filter(|term| term.can_drive_index_seek(columns, is_strict))
+        .filter_map(|term| term.table_col_pos)
+        .collect();
+    index_columns.sort_unstable();
+    index_columns.dedup();
+
+    let mut terms: Vec<_> = constraints
+        .constraints
+        .iter()
+        .enumerate()
+        .filter(|(_, term)| term.can_drive_index_seek(columns, is_strict))
+        .filter_map(|(term_index, term)| {
+            Some(ConstraintRef {
+                constraint_vec_pos: term_index,
+                index_col_pos: index_columns.binary_search(&term.table_col_pos?).ok()?,
+                sort_order: SortOrder::Asc,
+                nulls_order: ast::NullsOrder::First,
+            })
+        })
+        .collect();
+    terms.sort_by_key(|term| term.index_col_pos);
+    terms
+}
+
 /// Estimate selectivity for IN expressions given the number of values and table row count.
 fn estimate_in_selectivity(in_list_len: f64, row_count: f64, not: bool) -> f64 {
     if not {

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -2,10 +2,10 @@ use crate::alloc::TursoIteratorExt;
 use crate::{
     schema::{Column, Index, Schema},
     translate::{
-        collate::get_collseq_from_expr,
+        collate::{get_collseq_from_expr, CollationSeq},
         expr::{
             as_binary_components, comparison_affinity, get_expr_affinity, truth_test_rhs,
-            unwrap_parens, walk_expr_mut, WalkControl,
+            unwrap_parens, walk_expr, walk_expr_mut, WalkControl,
         },
         expression_index::normalize_expr_for_index_matching,
         plan::{
@@ -283,6 +283,8 @@ pub struct TableConstraints {
     pub constraints: Vec<Constraint>,
     /// Candidates for indexes that may use the constraints to perform a lookup.
     pub candidates: Vec<ConstraintUseCandidate>,
+    /// Conditions that a temporary index may use for a lookup.
+    pub temporary_index_terms: SmallVec<[ConstraintRef; 4]>,
 }
 
 /// Build the search terms for an automatic index.
@@ -291,27 +293,28 @@ pub struct TableConstraints {
 pub(super) fn automatic_index_terms(
     table: &JoinedTable,
     constraints: &TableConstraints,
-) -> Vec<ConstraintRef> {
+) -> SmallVec<[ConstraintRef; 4]> {
     let columns = table.columns();
     let is_strict = table.table.is_strict();
-    let mut index_columns: SmallVec<[usize; 4]> = constraints
+    let usable_constraints: SmallVec<[&Constraint; 4]> = constraints
         .constraints
         .iter()
         .filter(|term| term.can_drive_index_seek(columns, is_strict))
-        .filter_map(|term| term.table_col_pos)
         .collect();
-    index_columns.sort_unstable();
-    index_columns.dedup();
+    let index_columns = ordered_ephemeral_key_columns(&usable_constraints);
 
-    let mut terms: Vec<_> = constraints
+    let mut terms: SmallVec<[ConstraintRef; 4]> = constraints
         .constraints
         .iter()
         .enumerate()
         .filter(|(_, term)| term.can_drive_index_seek(columns, is_strict))
         .filter_map(|(term_index, term)| {
+            let table_col_pos = term.table_col_pos?;
             Some(ConstraintRef {
                 constraint_vec_pos: term_index,
-                index_col_pos: index_columns.binary_search(&term.table_col_pos?).ok()?,
+                index_col_pos: index_columns
+                    .iter()
+                    .position(|column| *column == table_col_pos)?,
                 sort_order: SortOrder::Asc,
                 nulls_order: ast::NullsOrder::First,
             })
@@ -319,6 +322,22 @@ pub(super) fn automatic_index_terms(
         .collect();
     terms.sort_by_key(|term| term.index_col_pos);
     terms
+}
+
+/// Return true when an expression names a custom text order.
+pub(super) fn expr_uses_custom_collation(expr: &ast::Expr) -> bool {
+    let mut uses_custom = false;
+    walk_expr(expr, &mut |expr| -> Result<WalkControl> {
+        if let ast::Expr::Collate(_, collation_name) = expr {
+            uses_custom = CollationSeq::known_custom(collation_name.as_str()).is_some();
+            if uses_custom {
+                return Ok(WalkControl::SkipChildren);
+            }
+        }
+        Ok(WalkControl::Continue)
+    })
+    .expect("reading a constraint cannot fail");
+    uses_custom
 }
 
 /// Estimate selectivity for IN expressions given the number of values and table row count.
@@ -524,6 +543,7 @@ pub fn constraints_from_where_clause(
         let mut cs = TableConstraints {
             table_id: table_reference.internal_id,
             constraints: Vec::new(),
+            temporary_index_terms: SmallVec::new(),
             candidates: available_indexes
                 .indexes_for_table(table_reference.internal_id)
                 .map_or(Vec::new(), |indexes| {
@@ -1108,6 +1128,14 @@ pub fn constraints_from_where_clause(
             }
             true
         });
+        cs.temporary_index_terms = automatic_index_terms(table_reference, &cs)
+            .into_iter()
+            .filter(|term| {
+                let constraint = &cs.constraints[term.constraint_vec_pos];
+                let where_term = &where_clause[constraint.where_clause_pos.0];
+                !expr_uses_custom_collation(&where_term.expr)
+            })
+            .collect();
         constraints.push(cs);
     }
 
@@ -1248,10 +1276,10 @@ pub fn usable_constraints_for_lhs_mask(
     refs: &[ConstraintRef],
     lhs_mask: &TableMask,
     table_idx: usize,
-) -> Vec<RangeConstraintRef> {
+) -> SmallVec<[RangeConstraintRef; 2]> {
     turso_debug_assert!(refs.is_sorted_by_key(|x| x.index_col_pos));
 
-    let mut usable: Vec<RangeConstraintRef> = Vec::new();
+    let mut usable: SmallVec<[RangeConstraintRef; 2]> = SmallVec::new();
     let mut current_required_column_pos = 0;
     for cref in refs.iter() {
         let constraint = &constraints[cref.constraint_vec_pos];
@@ -1377,31 +1405,23 @@ pub fn usable_constraints_for_join_order<'a>(
         .take(join_order.len() - 1)
         .map(|j| j.original_idx)
         .try_collect()?;
-    Ok(usable_constraints_for_lhs_mask(
-        constraints,
-        refs,
-        &lhs_mask,
-        table_idx,
-    ))
+    Ok(usable_constraints_for_lhs_mask(constraints, refs, &lhs_mask, table_idx).into_vec())
 }
 
-/// Order synthetic key columns for a materialized subquery seek index.
+/// Order key columns for a temporary index.
 ///
-/// Unlike ordinary index analysis, the ephemeral index does not have a fixed
-/// on-disk column order, so we can choose one that matches the intended probe
-/// shape. Equalities come first, followed by columns that are constrained only
-/// by ranges. Columns that have both equality and range predicates stay in the
-/// equality prefix; the range side is redundant for key ordering.
-pub fn ordered_materialized_key_columns(constraints: &[&Constraint]) -> Vec<usize> {
-    let mut equality_cols = Vec::new();
-    let mut range_only_cols = Vec::new();
+/// Equalities come first because an index cannot use a column after a range.
+/// A column with both an equality and a range stays in the equality part.
+pub fn ordered_ephemeral_key_columns(constraints: &[&Constraint]) -> SmallVec<[usize; 4]> {
+    let mut equality_cols = SmallVec::<[usize; 4]>::new();
+    let mut range_only_cols = SmallVec::<[usize; 4]>::new();
 
     for constraint in constraints {
         let Some(col_pos) = constraint.table_col_pos else {
             continue;
         };
         match constraint.operator.as_ast_operator() {
-            Some(ast::Operator::Equals) => equality_cols.push(col_pos),
+            Some(ast::Operator::Equals | ast::Operator::Is) => equality_cols.push(col_pos),
             Some(
                 ast::Operator::Greater
                 | ast::Operator::GreaterEquals

--- a/core/translate/optimizer/cost.rs
+++ b/core/translate/optimizer/cost.rs
@@ -98,6 +98,18 @@ fn estimate_scan_cost(base_row_count: f64, num_scans: f64, params: &CostModelPar
     Cost(io_cost + cpu_cost)
 }
 
+/// Estimate the work to add every row to a new in-memory index.
+///
+/// Each insert searches the part of the index that was already built. A
+/// balanced index needs about log2(rows) comparisons per insert.
+pub(super) fn estimate_ephemeral_index_build_cost(
+    row_count: f64,
+    params: &CostModelParams,
+) -> Cost {
+    let comparisons_per_row = row_count.max(2.0).log2();
+    Cost(row_count * comparisons_per_row * params.cpu_cost_per_seek)
+}
+
 /// Estimate how many B-tree levels an index search reads.
 pub(super) fn estimate_btree_depth(row_count: f64, rows_per_page: f64) -> f64 {
     if row_count <= 1.0 {

--- a/core/translate/optimizer/cost.rs
+++ b/core/translate/optimizer/cost.rs
@@ -98,6 +98,15 @@ fn estimate_scan_cost(base_row_count: f64, num_scans: f64, params: &CostModelPar
     Cost(io_cost + cpu_cost)
 }
 
+/// Estimate how many B-tree levels an index search reads.
+pub(super) fn estimate_btree_depth(row_count: f64, rows_per_page: f64) -> f64 {
+    if row_count <= 1.0 {
+        1.0
+    } else {
+        (row_count.ln() / rows_per_page.ln()).ceil().max(1.0)
+    }
+}
+
 /// Estimate IO and CPU cost for index-based access.
 ///
 /// This properly separates the number of B-tree seeks from the number of rows
@@ -350,13 +359,7 @@ pub fn estimate_cost_for_scan_or_seek(
 ) -> Cost {
     let base_row_count = *base_row_count;
 
-    let tree_depth = if base_row_count <= 1.0 {
-        1.0
-    } else {
-        (base_row_count.ln() / params.rows_per_table_page.ln())
-            .ceil()
-            .max(1.0)
-    };
+    let tree_depth = estimate_btree_depth(base_row_count, params.rows_per_table_page);
 
     let Some(index_info) = index_info else {
         // Full table scan (no index)

--- a/core/translate/optimizer/cost.rs
+++ b/core/translate/optimizer/cost.rs
@@ -1,8 +1,10 @@
 use crate::schema::Index;
 use crate::stats::AnalyzeStats;
 use crate::sync::Arc;
+use crate::translate::expr::{walk_expr, WalkControl};
 use crate::translate::optimizer::constraints::RangeConstraintRef;
 use crate::translate::plan::JoinedTable;
+use turso_parser::ast;
 
 use super::constraints::Constraint;
 use super::cost_params::CostModelParams;
@@ -12,6 +14,40 @@ use super::cost_params::CostModelParams;
 /// This is used to estimate the cost of scans, seeks, and joins.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct Cost(pub f64);
+
+/// Count the operations needed to check one `WHERE` expression.
+pub fn where_expr_steps(expr: &ast::Expr) -> usize {
+    let mut steps = 0;
+    walk_expr(expr, &mut |expr| {
+        steps += where_node_steps(expr);
+        Ok(WalkControl::Continue)
+    })
+    .expect("counting WHERE operations cannot fail");
+    steps.max(1)
+}
+
+pub fn where_node_steps(expr: &ast::Expr) -> usize {
+    match expr {
+        ast::Expr::Between { .. } => 2,
+        ast::Expr::InList { rhs, .. } => rhs.len().max(1),
+        ast::Expr::Case {
+            when_then_pairs, ..
+        } => when_then_pairs.len().max(1),
+        ast::Expr::Register(_)
+        | ast::Expr::Collate(..)
+        | ast::Expr::DoublyQualified(..)
+        | ast::Expr::Id(_)
+        | ast::Expr::Column { .. }
+        | ast::Expr::RowId { .. }
+        | ast::Expr::Literal(_)
+        | ast::Expr::Name(_)
+        | ast::Expr::Parenthesized(_)
+        | ast::Expr::Qualified(..)
+        | ast::Expr::Variable(_)
+        | ast::Expr::Default => 0,
+        _ => 1,
+    }
+}
 
 impl std::ops::Add for Cost {
     type Output = Cost;

--- a/core/translate/optimizer/cost_params.rs
+++ b/core/translate/optimizer/cost_params.rs
@@ -58,6 +58,9 @@ pub struct CostModelParams {
     /// CPU cost per row processed (relative to page IO = 1.0).
     pub cpu_cost_per_row: f64,
 
+    /// CPU cost for one extra operation in a `WHERE` condition.
+    pub cpu_cost_per_where_step: f64,
+
     /// CPU cost per index seek (key comparisons).
     pub cpu_cost_per_seek: f64,
 
@@ -117,6 +120,7 @@ impl CostModelParams {
             // Scan/Seek costs
             cache_reuse_factor: 0.2,
             cpu_cost_per_row: 0.003,
+            cpu_cost_per_where_step: 0.003,
             cpu_cost_per_seek: 0.01,
             index_bonus: 0.5,
 
@@ -250,6 +254,7 @@ impl CostModelParams {
         // Cost multipliers must be non-negative
         let cost_params = [
             ("cpu_cost_per_row", self.cpu_cost_per_row),
+            ("cpu_cost_per_where_step", self.cpu_cost_per_where_step),
             ("cpu_cost_per_seek", self.cpu_cost_per_seek),
             ("sort_cpu_per_row", self.sort_cpu_per_row),
             ("hash_cpu_cost", self.hash_cpu_cost),

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -45,13 +45,18 @@ use crate::{
 /// join planner as we add order-aware access path choices.
 pub(crate) struct JoinPlanningContext<'a> {
     pub maybe_order_target: Option<&'a OrderTarget>,
+    /// Stop growing a join plan after it costs more than another query form.
+    pub cost_limit: Option<Cost>,
 }
 
 impl<'a> JoinPlanningContext<'a> {
     /// Convenience constructor used by the default planner entrypoints and tests.
     #[cfg_attr(not(test), allow(dead_code))]
     fn default_with_order_target(maybe_order_target: Option<&'a OrderTarget>) -> Self {
-        Self { maybe_order_target }
+        Self {
+            maybe_order_target,
+            cost_limit: None,
+        }
     }
 }
 
@@ -1115,7 +1120,12 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
 
     // Keep track of the current best cost so we can short-circuit planning for subplans
     // that already exceed the cost of the current best plan.
-    let cost_upper_bound = best_plan.as_ref().map_or(Cost(f64::MAX), |plan| plan.cost);
+    let mut cost_upper_bound = best_plan.as_ref().map_or(Cost(f64::MAX), |plan| plan.cost);
+    if let Some(cost_limit) = planning_context.cost_limit {
+        if cost_limit < cost_upper_bound {
+            cost_upper_bound = cost_limit;
+        }
+    }
 
     // Keep track of the best plan for a given subset of tables.
     // Consider this example: we have tables a,b,c,d to join.
@@ -1174,7 +1184,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
     // Example:
     // "a LEFT JOIN b" can NOT be reordered as "b LEFT JOIN a".
     // If there are outer joins in the plan, ensure correct ordering.
-    let left_join_illegal_map = {
+    let (left_join_illegal_map, required_lhs_by_table) = {
         let ordering_constrained_count = joined_tables
             .iter()
             .filter(|t| {
@@ -1187,11 +1197,12 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
             .iter()
             .any(|t| t.join_info.as_ref().is_some_and(|j| j.is_full_outer()));
         if ordering_constrained_count == 0 && !has_full_outer {
-            None
+            (None, None)
         } else {
             // map from rhs table index to lhs table index
             let mut left_join_illegal_map: HashMap<usize, TableMask> =
                 HashMap::with_capacity_and_hasher(ordering_constrained_count, Default::default());
+            let mut required_lhs_by_table = vec![TableMask::default(); num_tables];
             for (i, _) in joined_tables.iter().enumerate() {
                 for (j, joined_table) in joined_tables.iter().enumerate().skip(i + 1) {
                     // LEFT/FULL OUTER, SEMI, and ANTI joins all require the RHS table
@@ -1201,6 +1212,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                         .as_ref()
                         .is_some_and(|j| j.is_ordering_constrained())
                     {
+                        required_lhs_by_table[j].set(i)?;
                         // bitwise OR the masks
                         if let Some(illegal_lhs) = left_join_illegal_map.get_mut(&i) {
                             illegal_lhs.set(j)?;
@@ -1221,7 +1233,8 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                 if !t.join_info.as_ref().is_some_and(|j| j.is_full_outer()) {
                     continue;
                 }
-                for j in (k + 1)..joined_tables.len() {
+                for (j, required_lhs) in required_lhs_by_table.iter_mut().enumerate().skip(k + 1) {
+                    required_lhs.set(k)?;
                     if let Some(illegal_lhs) = left_join_illegal_map.get_mut(&k) {
                         illegal_lhs.set(j)?;
                     } else {
@@ -1231,7 +1244,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                     }
                 }
             }
-            Some(left_join_illegal_map)
+            (Some(left_join_illegal_map), Some(required_lhs_by_table))
         }
     };
 
@@ -1240,6 +1253,13 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
     for subset_size in 2..=num_tables {
         for mask in generate_join_bitmasks(num_tables, subset_size) {
             let mask = mask?;
+            if required_lhs_by_table.as_ref().is_some_and(|required| {
+                required.iter().enumerate().any(|(table, required)| {
+                    mask.get(table) && !mask.contains_all_set_bits_of(required)
+                })
+            }) {
+                continue;
+            }
             // Keep track of the best way to join this subset of tables per possible last table.
             // This preserves alternative join orders that may be more expensive for the subset
             // but enable cheaper joins when adding more tables.

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -17,7 +17,7 @@ use crate::{
     schema::Schema,
     stats::AnalyzeStats,
     translate::{
-        expr::{walk_expr, WalkControl},
+        expr::{expr_references_subquery_id, walk_expr, WalkControl},
         optimizer::{
             access_method::{
                 estimate_hash_join_cost, try_hash_join_access_method, AccessMethodParams,
@@ -31,7 +31,7 @@ use crate::{
         },
         plan::{
             HashJoinKey, HashJoinType, JoinOrderMember, JoinedTable, NonFromClauseSubquery,
-            TableReferences, WhereTerm,
+            SubqueryState, TableReferences, WhereTerm,
         },
         planner::TableMask,
     },
@@ -59,11 +59,15 @@ impl<'a> JoinPlanningContext<'a> {
 // This is a safety limit, not a cost tuning parameter.
 const MAX_MATERIALIZED_BUILD_ROWS: f64 = 200_000.0;
 
+/// Estimate how much the remaining `WHERE` terms cut the row count.
+///
+/// Some callers skip a term because they need the count before that term runs.
 fn constraint_output_multipliers(
     rhs_constraints: &TableConstraints,
     lhs_mask: &TableMask,
     rhs_self_mask: TableMask,
     consumed_where_terms: &[usize],
+    skipped_where_terms: &[usize],
     params: &CostModelParams,
 ) -> f64 {
     let mut multiplier = 1.0;
@@ -89,6 +93,7 @@ fn constraint_output_multipliers(
             || constraint.lhs_mask == rhs_self_mask
             || constraint.lhs_mask.is_empty())
             && !consumed_where_terms.contains(&constraint.where_clause_pos.0)
+            && !skipped_where_terms.contains(&constraint.where_clause_pos.0)
     }) {
         multiplier *= constraint.selectivity;
 
@@ -113,6 +118,81 @@ fn constraint_output_multipliers(
     multiplier
 }
 
+/// Count calls to each subquery when all of its outer tables have been read.
+#[allow(clippy::too_many_arguments)]
+fn count_subquery_calls_after_join(
+    subqueries: &[NonFromClauseSubquery],
+    joined_tables: &[JoinedTable],
+    prior_tables: &TableMask,
+    new_table_number: usize,
+    outer_rows: f64,
+    method: &AccessMethod,
+    new_table_constraints: &TableConstraints,
+    new_table_mask: TableMask,
+    where_clause: &[WhereTerm],
+    params: &CostModelParams,
+) -> SmallVec<[(TableInternalId, f64); 2]> {
+    let mut current_tables = prior_tables.clone();
+    current_tables
+        .set(new_table_number)
+        .expect("the joined table count was checked before join planning");
+
+    let rows_before_filters = outer_rows * method.estimated_rows_per_outer_row;
+    let mut subquery_calls = SmallVec::new();
+
+    for subquery in subqueries.iter().filter(|subquery| subquery.correlated) {
+        let SubqueryState::Unevaluated {
+            plan: Some(inner_plan),
+        } = &subquery.state
+        else {
+            continue;
+        };
+        let mut required_tables = TableMask::default();
+        for table_id in inner_plan.used_outer_query_ref_ids() {
+            let Some(table_number) = joined_tables
+                .iter()
+                .position(|table| table.internal_id == table_id)
+            else {
+                continue;
+            };
+            required_tables
+                .set(table_number)
+                .expect("the joined table count was checked before join planning");
+        }
+        if required_tables.is_empty()
+            || !current_tables.contains_all_set_bits_of(&required_tables)
+            || prior_tables.contains_all_set_bits_of(&required_tables)
+        {
+            continue;
+        }
+
+        let skipped_where_terms: SmallVec<[usize; 2]> = where_clause
+            .iter()
+            .enumerate()
+            .filter_map(|(index, term)| {
+                expr_references_subquery_id(&term.expr, subquery.internal_id).then_some(index)
+            })
+            .collect();
+        let rows = match method.residual_constraints {
+            ResidualConstraintMode::ApplyUnconsumed => {
+                let multiplier = constraint_output_multipliers(
+                    new_table_constraints,
+                    prior_tables,
+                    new_table_mask.clone(),
+                    &method.consumed_where_terms,
+                    &skipped_where_terms,
+                    params,
+                );
+                rows_before_filters * multiplier
+            }
+            ResidualConstraintMode::None => rows_before_filters,
+        };
+        subquery_calls.push((subquery.internal_id, rows.max(1.0)));
+    }
+
+    subquery_calls
+}
+
 /// Represents an n-ary join, anywhere from 1 table to N tables.
 #[derive(Debug, Clone)]
 pub struct JoinN {
@@ -122,6 +202,8 @@ pub struct JoinN {
     pub output_cardinality: f64,
     /// Estimated execution cost of this N-ary join.
     pub cost: Cost,
+    /// Expected calls to correlated subqueries that can now run.
+    pub subquery_calls: SmallVec<[(TableInternalId, f64); 2]>,
 }
 
 impl JoinN {
@@ -199,6 +281,11 @@ pub fn join_lhs_and_rhs<'a>(
         return Ok(None);
     };
 
+    let lhs_mask = match lhs {
+        Some(lhs) => lhs.table_numbers().try_collect()?,
+        None => TableMask::default(),
+    };
+
     // Check if this access method will trigger ephemeral index creation.
     if let AccessMethodParams::BTreeTable {
         index: None,
@@ -207,22 +294,15 @@ pub fn join_lhs_and_rhs<'a>(
     } = &method.params
     {
         if constraint_refs.is_empty() {
-            // Check if there are usable constraints that will create an ephemeral index
-            let lhs_mask_for_ephemeral: TableMask = match lhs {
-                Some(l) => l.table_numbers().try_collect()?,
-                None => TableMask::default(),
-            };
-            let has_usable_constraints = rhs_constraints.constraints.iter().any(|c| {
-                c.usable
-                    && c.table_col_pos.is_some()
-                    && lhs_mask_for_ephemeral.contains_all_set_bits_of(&c.lhs_mask)
+            let has_usable_constraints = rhs_constraints.constraints.iter().any(|constraint| {
+                constraint.usable
+                    && constraint.table_col_pos.is_some()
+                    && lhs_mask.contains_all_set_bits_of(&constraint.lhs_mask)
             });
 
             if has_usable_constraints && lhs.is_some() {
-                // Add ephemeral index build cost: scan the table once to build the index
-                // This is similar to the build phase of a hash join
-                let ephemeral_build_cost = *rhs_base_rows * 0.003;
-                method.cost = method.cost + Cost(ephemeral_build_cost);
+                let build_cost = *rhs_base_rows * params.cpu_cost_per_row;
+                method.cost = method.cost + Cost(build_cost);
             }
         }
     }
@@ -232,11 +312,6 @@ pub fn join_lhs_and_rhs<'a>(
     let mut best_access_method = method;
 
     // Reuse for hash cost and output cardinality computation
-    let lhs_mask = match lhs {
-        Some(l) => l.table_numbers().try_collect()?,
-        None => TableMask::default(),
-    };
-
     // Self-constraints are conditions comparing columns within the same table
     // (e.g., t.col1 < t.col2). Include them in selectivity since they filter rows.
     let rhs_self_mask = {
@@ -752,8 +827,9 @@ pub fn join_lhs_and_rhs<'a>(
     let unconsumed_constraint_multiplier = constraint_output_multipliers(
         rhs_constraints,
         &lhs_mask,
-        rhs_self_mask,
+        rhs_self_mask.clone(),
         &best_access_method.consumed_where_terms,
+        &[],
         params,
     );
     let residual_multiplier = match best_access_method.residual_constraints {
@@ -762,6 +838,21 @@ pub fn join_lhs_and_rhs<'a>(
     };
     let output_cardinality =
         input_cardinality * best_access_method.estimated_rows_per_outer_row * residual_multiplier;
+    let mut subquery_calls = lhs
+        .map(|lhs| lhs.subquery_calls.clone())
+        .unwrap_or_default();
+    subquery_calls.extend(count_subquery_calls_after_join(
+        subqueries,
+        joined_tables,
+        &lhs_mask,
+        rhs_table_number,
+        input_cardinality,
+        &best_access_method,
+        rhs_constraints,
+        rhs_self_mask,
+        where_clause,
+        params,
+    ));
 
     access_methods_arena.push(best_access_method);
 
@@ -773,6 +864,7 @@ pub fn join_lhs_and_rhs<'a>(
         data: best_access_methods,
         output_cardinality,
         cost,
+        subquery_calls,
     }))
 }
 

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -836,8 +836,17 @@ pub fn join_lhs_and_rhs<'a>(
         ResidualConstraintMode::ApplyUnconsumed => unconsumed_constraint_multiplier,
         ResidualConstraintMode::None => 1.0,
     };
-    let output_cardinality =
-        input_cardinality * best_access_method.estimated_rows_per_outer_row * residual_multiplier;
+    let output_cardinality = if joined_tables[rhs_table_number]
+        .join_info
+        .as_ref()
+        .is_some_and(|join_info| join_info.is_semi_or_anti())
+    {
+        // A semi join or anti join can keep or remove a left row. It cannot
+        // make copies of that row.
+        input_cardinality
+    } else {
+        input_cardinality * best_access_method.estimated_rows_per_outer_row * residual_multiplier
+    };
     let mut subquery_calls = lhs
         .map(|lhs| lhs.subquery_calls.clone())
         .unwrap_or_default();

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -131,11 +131,9 @@ fn count_subquery_calls_after_join(
     new_table_mask: TableMask,
     where_clause: &[WhereTerm],
     params: &CostModelParams,
-) -> SmallVec<[(TableInternalId, f64); 2]> {
+) -> Result<SmallVec<[(TableInternalId, f64); 2]>> {
     let mut current_tables = prior_tables.clone();
-    current_tables
-        .set(new_table_number)
-        .expect("the joined table count was checked before join planning");
+    current_tables.set(new_table_number)?;
 
     let rows_before_filters = outer_rows * method.estimated_rows_per_outer_row;
     let mut subquery_calls = SmallVec::new();
@@ -155,9 +153,7 @@ fn count_subquery_calls_after_join(
             else {
                 continue;
             };
-            required_tables
-                .set(table_number)
-                .expect("the joined table count was checked before join planning");
+            required_tables.set(table_number)?;
         }
         if required_tables.is_empty()
             || !current_tables.contains_all_set_bits_of(&required_tables)
@@ -193,7 +189,7 @@ fn count_subquery_calls_after_join(
         subquery_calls.push((subquery.internal_id, rows.max(1.0)));
     }
 
-    subquery_calls
+    Ok(subquery_calls)
 }
 
 /// Represents an n-ary join, anywhere from 1 table to N tables.
@@ -845,7 +841,7 @@ pub fn join_lhs_and_rhs<'a>(
         rhs_self_mask,
         where_clause,
         params,
-    ));
+    )?);
 
     access_methods_arena.push(best_access_method);
 

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -3,10 +3,10 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use smallvec::SmallVec;
 
-use turso_parser::ast::{Expr, Operator, TableInternalId};
+use turso_parser::ast::{Operator, TableInternalId};
 
 use super::{
-    access_method::{find_best_access_method_for_join_order, AccessMethod},
+    access_method::{add_where_cost, find_best_access_method_for_join_order, AccessMethod},
     constraints::{usable_constraints_for_lhs_mask, TableConstraints},
     cost_params::CostModelParams,
     order::OrderTarget,
@@ -17,15 +17,15 @@ use crate::{
     schema::Schema,
     stats::AnalyzeStats,
     translate::{
-        expr::{expr_references_subquery_id, walk_expr, WalkControl},
+        expr::expr_references_subquery_id,
         optimizer::{
             access_method::{
-                estimate_hash_join_cost, try_hash_join_access_method, AccessMethodParams,
-                ResidualConstraintMode,
+                estimate_hash_join_cost, tables_in_equal_test, try_hash_join_access_method,
+                AccessMethodParams,
             },
             cost::{
-                estimate_rows_per_seek, rows_per_leaf_page_for_index, AnalyzeCtx, Cost, IndexInfo,
-                RowCountEstimate,
+                estimate_rows_per_seek, rows_per_leaf_page_for_index, where_expr_steps, AnalyzeCtx,
+                Cost, IndexInfo, RowCountEstimate,
             },
             order::plan_satisfies_order_target,
         },
@@ -33,7 +33,7 @@ use crate::{
             HashJoinKey, HashJoinType, JoinOrderMember, JoinedTable, NonFromClauseSubquery,
             SubqueryState, TableReferences, WhereTerm,
         },
-        planner::TableMask,
+        planner::{table_mask_from_expr, TableMask},
     },
     LimboError, Result,
 };
@@ -123,6 +123,34 @@ fn constraint_output_multipliers(
     multiplier
 }
 
+/// Return the row count after one table and its ready filters.
+fn rows_after_join(
+    input_cardinality: f64,
+    method: &AccessMethod,
+    rhs_constraints: &TableConstraints,
+    lhs_mask: &TableMask,
+    rhs_mask: TableMask,
+    rhs_table: &JoinedTable,
+    params: &CostModelParams,
+) -> f64 {
+    if rhs_table
+        .join_info
+        .as_ref()
+        .is_some_and(|join_info| join_info.is_semi_or_anti())
+    {
+        return input_cardinality;
+    }
+    let remaining_filter_selectivity = constraint_output_multipliers(
+        rhs_constraints,
+        lhs_mask,
+        rhs_mask,
+        &method.consumed_where_terms,
+        &[],
+        params,
+    );
+    input_cardinality * method.estimated_rows_per_outer_row * remaining_filter_selectivity
+}
+
 /// Count calls to each subquery when all of its outer tables have been read.
 #[allow(clippy::too_many_arguments)]
 fn count_subquery_calls_after_join(
@@ -177,24 +205,69 @@ fn count_subquery_calls_after_join(
         } else {
             SmallVec::new()
         };
-        let rows = match method.residual_constraints {
-            ResidualConstraintMode::ApplyUnconsumed => {
-                let multiplier = constraint_output_multipliers(
-                    new_table_constraints,
-                    prior_tables,
-                    new_table_mask.clone(),
-                    &method.consumed_where_terms,
-                    &skipped_where_terms,
-                    params,
-                );
-                rows_before_filters * multiplier
-            }
-            ResidualConstraintMode::None => rows_before_filters,
-        };
+        let multiplier = constraint_output_multipliers(
+            new_table_constraints,
+            prior_tables,
+            new_table_mask.clone(),
+            &method.consumed_where_terms,
+            &skipped_where_terms,
+            params,
+        );
+        let rows = rows_before_filters * multiplier;
         subquery_calls.push((subquery.internal_id, rows.max(1.0)));
     }
 
     Ok(subquery_calls)
+}
+
+/// Count subquery calls for the chosen join plan.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn count_subquery_calls_for_plan(
+    plan: &JoinN,
+    access_methods: &[AccessMethod],
+    constraints: &[TableConstraints],
+    joined_tables: &[JoinedTable],
+    where_clause: &[WhereTerm],
+    subqueries: &[NonFromClauseSubquery],
+    initial_input_cardinality: f64,
+    params: &CostModelParams,
+) -> Result<SmallVec<[(TableInternalId, f64); 2]>> {
+    if !subqueries.iter().any(|subquery| subquery.correlated) {
+        return Ok(SmallVec::new());
+    }
+
+    let mut calls = SmallVec::new();
+    let mut prior_tables = TableMask::default();
+    let mut input_cardinality = initial_input_cardinality;
+
+    for (table_number, access_method_index) in &plan.data {
+        let method = &access_methods[*access_method_index];
+        let mut table_mask = TableMask::default();
+        table_mask.set(*table_number)?;
+        calls.extend(count_subquery_calls_after_join(
+            subqueries,
+            joined_tables,
+            &prior_tables,
+            *table_number,
+            input_cardinality,
+            method,
+            &constraints[*table_number],
+            table_mask.clone(),
+            where_clause,
+            params,
+        )?);
+        input_cardinality = rows_after_join(
+            input_cardinality,
+            method,
+            &constraints[*table_number],
+            &prior_tables,
+            table_mask,
+            &joined_tables[*table_number],
+            params,
+        );
+        prior_tables.set(*table_number)?;
+    }
+    Ok(calls)
 }
 
 /// Represents an n-ary join, anywhere from 1 table to N tables.
@@ -206,8 +279,12 @@ pub struct JoinN {
     pub output_cardinality: f64,
     /// Estimated execution cost of this N-ary join.
     pub cost: Cost,
-    /// Expected calls to correlated subqueries that can now run.
-    pub subquery_calls: SmallVec<[(TableInternalId, f64); 2]>,
+}
+
+struct WhereTermInfo {
+    table_mask: TableMask,
+    extra_steps: usize,
+    equal_tables: Option<(TableInternalId, TableInternalId, Option<TableInternalId>)>,
 }
 
 impl JoinN {
@@ -233,7 +310,7 @@ impl JoinN {
 /// - Probe->build chaining is only allowed when the build input is materialized from the
 ///   join prefix; rebuilding from the full table would ignore prior join filters.
 #[allow(clippy::too_many_arguments)]
-pub fn join_lhs_and_rhs<'a>(
+fn join_lhs_and_rhs<'a>(
     lhs: Option<&JoinN>,
     initial_input_cardinality: f64,
     rhs_table_reference: &JoinedTable,
@@ -246,7 +323,7 @@ pub fn join_lhs_and_rhs<'a>(
     cost_upper_bound: Cost,
     joined_tables: &[JoinedTable],
     where_clause: &mut [WhereTerm],
-    where_term_table_ids: &[HashSet<TableInternalId>],
+    where_terms: &[WhereTermInfo],
     subqueries: &[NonFromClauseSubquery],
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
@@ -265,13 +342,28 @@ pub fn join_lhs_and_rhs<'a>(
         .get(rhs_table_number)
         .copied()
         .unwrap_or_else(|| RowCountEstimate::hardcoded_fallback(params));
+    let lhs_mask = match lhs {
+        Some(lhs) => lhs.table_numbers().try_collect()?,
+        None => TableMask::default(),
+    };
+    let mut joined_mask = lhs_mask.try_clone()?;
+    joined_mask.set(rhs_table_number)?;
+    let ready_where = ready_where_work(
+        where_clause,
+        where_terms,
+        &joined_mask,
+        rhs_table_number,
+        rhs_table_reference.internal_id,
+    );
 
     let Some(method) = find_best_access_method_for_join_order(
         rhs_table_reference,
         rhs_constraints,
+        &lhs_mask,
         join_order,
         planning_context,
         where_clause,
+        &ready_where,
         available_indexes,
         table_references,
         subqueries,
@@ -285,14 +377,15 @@ pub fn join_lhs_and_rhs<'a>(
         return Ok(None);
     };
 
-    let lhs_mask = match lhs {
-        Some(lhs) => lhs.table_numbers().try_collect()?,
-        None => TableMask::default(),
-    };
-
     let lhs_cost = lhs.map_or(Cost(0.0), |l| l.cost);
     // If we have a previous table, consider hash join as an alternative
     let mut best_access_method = method;
+    add_where_cost(
+        &mut best_access_method,
+        &ready_where,
+        input_cardinality,
+        params,
+    );
 
     // Reuse for hash cost and output cardinality computation
     // Self-constraints are conditions comparing columns within the same table
@@ -303,18 +396,9 @@ pub fn join_lhs_and_rhs<'a>(
         m
     };
 
-    let rhs_internal_id = rhs_table_reference.internal_id;
-    let lhs_internal_ids: HashSet<TableInternalId> = lhs
-        .map(|l| {
-            l.table_numbers()
-                .map(|table_no| joined_tables[table_no].internal_id)
-                .collect()
-        })
-        .unwrap_or_default();
     let has_join_constraint = lhs.is_some()
-        && where_term_table_ids.iter().any(|table_ids| {
-            table_ids.contains(&rhs_internal_id)
-                && table_ids.iter().any(|id| lhs_internal_ids.contains(id))
+        && where_terms.iter().any(|term| {
+            term.table_mask.get(rhs_table_number) && term.table_mask.intersects(&lhs_mask)
         });
     if lhs.is_some() && !has_join_constraint {
         let rhs_self_constraint_selectivity =
@@ -344,9 +428,11 @@ pub fn join_lhs_and_rhs<'a>(
             best_access_method.params,
             AccessMethodParams::BTreeTable {
                 ref index,
+                build_index,
                 ref constraint_refs,
                 ..
             } if !constraint_refs.is_empty()
+                && !build_index
                 && index.as_ref().is_none_or(|index| !index.ephemeral)
         );
 
@@ -386,10 +472,12 @@ pub fn join_lhs_and_rhs<'a>(
                     let arena = &access_methods_arena;
                     arena.get(am_idx).is_some_and(|am| {
                         if let AccessMethodParams::BTreeTable {
-                            constraint_refs, ..
+                            build_index,
+                            constraint_refs,
+                            ..
                         } = &am.params
                         {
-                            !constraint_refs.is_empty()
+                            *build_index || !constraint_refs.is_empty()
                         } else {
                             false
                         }
@@ -529,9 +617,10 @@ pub fn join_lhs_and_rhs<'a>(
                         matches!(
                             &am.params,
                             AccessMethodParams::BTreeTable {
+                                build_index,
                                 constraint_refs,
                                 ..
-                            } if constraint_refs.is_empty()
+                            } if !build_index && constraint_refs.is_empty()
                         )
                     })
                 })
@@ -569,6 +658,13 @@ pub fn join_lhs_and_rhs<'a>(
                     lhs_constraints,
                     rhs_constraints,
                     where_clause,
+                    where_terms.iter().enumerate().filter_map(|(index, term)| {
+                        let (left, right, owner) = term.equal_tables?;
+                        // An outer join condition belongs to that join only.
+                        owner
+                            .is_none_or(|owner| owner == rhs_table_reference.internal_id)
+                            .then_some((index, left, right))
+                    }),
                     build_cardinality,
                     probe_cardinality,
                     probe_multiplier,
@@ -719,6 +815,12 @@ pub fn join_lhs_and_rhs<'a>(
                             );
                         }
                     }
+                    add_where_cost(
+                        &mut hash_join_method,
+                        &ready_where,
+                        input_cardinality,
+                        params,
+                    );
                     // FULL OUTER requires hash join for the unmatched-build scan.
                     let is_full_outer = matches!(
                         &hash_join_method.params,
@@ -753,17 +855,18 @@ pub fn join_lhs_and_rhs<'a>(
                 Cost(cost_estimate.estimated_cost * input_cardinality)
             };
 
-            if fts_cost < best_access_method.cost {
-                best_access_method = AccessMethod {
-                    cost: fts_cost,
-                    estimated_rows_per_outer_row: cost_estimate.estimated_rows as f64,
-                    residual_constraints: ResidualConstraintMode::None,
-                    consumed_where_terms: candidate.where_covered.into_iter().collect(),
-                    params: AccessMethodParams::IndexMethod {
-                        query: candidate.to_query(),
-                        where_covered: candidate.where_covered,
-                    },
-                };
+            let mut index_method = AccessMethod {
+                cost: fts_cost,
+                estimated_rows_per_outer_row: cost_estimate.estimated_rows as f64,
+                consumed_where_terms: candidate.where_covered.into_iter().collect(),
+                params: AccessMethodParams::IndexMethod {
+                    query: candidate.to_query(),
+                    where_covered: candidate.where_covered,
+                },
+            };
+            add_where_cost(&mut index_method, &ready_where, input_cardinality, params);
+            if index_method.cost < best_access_method.cost {
+                best_access_method = index_method;
             }
         }
     }
@@ -809,44 +912,15 @@ pub fn join_lhs_and_rhs<'a>(
     // Join planning only applies the selectivity of WHERE terms that the chosen
     // access path did not already consume.
     //
-    let unconsumed_constraint_multiplier = constraint_output_multipliers(
-        rhs_constraints,
-        &lhs_mask,
-        rhs_self_mask.clone(),
-        &best_access_method.consumed_where_terms,
-        &[],
-        params,
-    );
-    let residual_multiplier = match best_access_method.residual_constraints {
-        ResidualConstraintMode::ApplyUnconsumed => unconsumed_constraint_multiplier,
-        ResidualConstraintMode::None => 1.0,
-    };
-    let output_cardinality = if joined_tables[rhs_table_number]
-        .join_info
-        .as_ref()
-        .is_some_and(|join_info| join_info.is_semi_or_anti())
-    {
-        // A semi join or anti join can keep or remove a left row. It cannot
-        // make copies of that row.
-        input_cardinality
-    } else {
-        input_cardinality * best_access_method.estimated_rows_per_outer_row * residual_multiplier
-    };
-    let mut subquery_calls = lhs
-        .map(|lhs| lhs.subquery_calls.clone())
-        .unwrap_or_default();
-    subquery_calls.extend(count_subquery_calls_after_join(
-        subqueries,
-        joined_tables,
-        &lhs_mask,
-        rhs_table_number,
+    let output_cardinality = rows_after_join(
         input_cardinality,
         &best_access_method,
         rhs_constraints,
+        &lhs_mask,
         rhs_self_mask,
-        where_clause,
+        &joined_tables[rhs_table_number],
         params,
-    )?);
+    );
 
     access_methods_arena.push(best_access_method);
 
@@ -858,7 +932,6 @@ pub fn join_lhs_and_rhs<'a>(
         data: best_access_methods,
         output_cardinality,
         cost,
-        subquery_calls,
     }))
 }
 
@@ -1040,7 +1113,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
     // The DP algorithm has O(2^n) complexity which becomes prohibitively slow
     // beyond ~12 tables. The greedy algorithm is O(n²) and produces good
     // (though not always optimal) plans.
-    let where_term_table_ids = build_where_term_table_ids(where_clause, joined_tables);
+    let where_terms = build_where_term_info(where_clause, table_references, subqueries)?;
     if num_tables > GREEDY_JOIN_THRESHOLD {
         return compute_greedy_join_order(
             joined_tables,
@@ -1050,7 +1123,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
             base_table_rows,
             access_methods_arena,
             where_clause,
-            &where_term_table_ids,
+            &where_terms,
             subqueries,
             index_method_candidates,
             params,
@@ -1070,7 +1143,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
         access_methods_arena,
         constraints,
         where_clause,
-        &where_term_table_ids,
+        &where_terms,
         subqueries,
         index_method_candidates,
         params,
@@ -1090,6 +1163,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                 plan,
                 access_methods_arena,
                 joined_tables,
+                constraints,
                 order_target,
                 schema,
             ),
@@ -1165,7 +1239,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
             cost_upper_bound,
             joined_tables,
             where_clause,
-            &where_term_table_ids,
+            &where_terms,
             subqueries,
             index_method_candidates,
             params,
@@ -1327,6 +1401,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                     turso_assert_eq!(join_order.len(), subset_size);
 
                     // Calculate the best way to join LHS with RHS.
+                    let arena_len = access_methods_arena.len();
                     let rel = join_lhs_and_rhs(
                         Some(lhs),
                         initial_input_cardinality,
@@ -1340,7 +1415,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                         cost_upper_bound,
                         joined_tables,
                         where_clause,
-                        &where_term_table_ids,
+                        &where_terms,
                         subqueries,
                         index_method_candidates,
                         params,
@@ -1352,6 +1427,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                     join_order.clear();
 
                     let Some(rel) = rel else {
+                        access_methods_arena.truncate(arena_len);
                         continue;
                     };
 
@@ -1361,6 +1437,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                                 &rel,
                                 access_methods_arena,
                                 joined_tables,
+                                constraints,
                                 order_target,
                                 schema,
                             )
@@ -1372,6 +1449,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                     if rel.cost >= cost_upper_bound {
                         // But if it isn't, skip.
                         if !satisfies_order_target {
+                            access_methods_arena.truncate(arena_len);
                             continue;
                         }
                         let existing_ordered_cost: Cost = best_ordered_for_mask
@@ -1379,6 +1457,8 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                             .map_or(Cost(f64::MAX), |p: &JoinN| p.cost);
                         if rel.cost < existing_ordered_cost {
                             best_ordered_for_mask = Some(rel);
+                        } else {
+                            access_methods_arena.truncate(arena_len);
                         }
                         continue;
                     }
@@ -1389,6 +1469,8 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                     };
                     if should_replace {
                         best_for_mask_by_last.insert(rhs_idx, rel);
+                    } else {
+                        access_methods_arena.truncate(arena_len);
                     }
                 }
             }
@@ -1405,6 +1487,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                                 &rel,
                                 access_methods_arena,
                                 joined_tables,
+                                constraints,
                                 order_target,
                                 schema,
                             )
@@ -1492,7 +1575,7 @@ pub const GREEDY_JOIN_THRESHOLD: usize = 12;
 ///
 /// Respects outer join ordering constraints.
 #[allow(clippy::too_many_arguments)]
-pub fn compute_greedy_join_order<'a>(
+fn compute_greedy_join_order<'a>(
     joined_tables: &[JoinedTable],
     initial_input_cardinality: f64,
     planning_context: JoinPlanningContext<'_>,
@@ -1500,7 +1583,7 @@ pub fn compute_greedy_join_order<'a>(
     base_table_rows: &[RowCountEstimate],
     access_methods_arena: &'a mut Vec<AccessMethod>,
     where_clause: &mut [WhereTerm],
-    where_term_table_ids: &[HashSet<TableInternalId>],
+    where_terms: &[WhereTermInfo],
     subqueries: &[NonFromClauseSubquery],
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
@@ -1566,7 +1649,7 @@ pub fn compute_greedy_join_order<'a>(
         Cost(f64::MAX),
         joined_tables,
         where_clause,
-        where_term_table_ids,
+        where_terms,
         subqueries,
         index_method_candidates,
         params,
@@ -1599,14 +1682,9 @@ pub fn compute_greedy_join_order<'a>(
                     continue;
                 }
             }
-            let connected = where_term_table_ids.iter().any(|table_ids| {
-                let table_id = joined_tables[idx].internal_id;
-                table_ids.contains(&table_id)
-                    && current_mask
-                        .iter()
-                        .map(|table_no| joined_tables[table_no].internal_id)
-                        .any(|id| table_ids.contains(&id))
-            });
+            let connected = where_terms
+                .iter()
+                .any(|term| term.table_mask.get(idx) && term.table_mask.intersects(&current_mask));
             if connected {
                 has_connected_candidate = true;
                 break;
@@ -1621,13 +1699,8 @@ pub fn compute_greedy_join_order<'a>(
                 }
             }
             if has_connected_candidate {
-                let connected = where_term_table_ids.iter().any(|table_ids| {
-                    let table_id = joined_tables[idx].internal_id;
-                    table_ids.contains(&table_id)
-                        && current_mask
-                            .iter()
-                            .map(|table_no| joined_tables[table_no].internal_id)
-                            .any(|id| table_ids.contains(&id))
+                let connected = where_terms.iter().any(|term| {
+                    term.table_mask.get(idx) && term.table_mask.intersects(&current_mask)
                 });
                 if !connected {
                     continue;
@@ -1653,7 +1726,7 @@ pub fn compute_greedy_join_order<'a>(
                 Cost(f64::MAX),
                 joined_tables,
                 where_clause,
-                where_term_table_ids,
+                where_terms,
                 subqueries,
                 index_method_candidates,
                 params,
@@ -1955,7 +2028,7 @@ fn get_best_seek_score(
 /// in the SQL query. This is used as an upper bound for any other plans -- we can give up enumerating
 /// permutations if they exceed this cost during enumeration.
 #[allow(clippy::too_many_arguments)]
-pub fn compute_naive_left_deep_plan<'a>(
+fn compute_naive_left_deep_plan<'a>(
     joined_tables: &[JoinedTable],
     initial_input_cardinality: f64,
     planning_context: JoinPlanningContext<'_>,
@@ -1963,7 +2036,7 @@ pub fn compute_naive_left_deep_plan<'a>(
     access_methods_arena: &'a mut Vec<AccessMethod>,
     constraints: &'a [TableConstraints],
     where_clause: &mut [WhereTerm],
-    where_term_table_ids: &[HashSet<TableInternalId>],
+    where_terms: &[WhereTermInfo],
     subqueries: &[NonFromClauseSubquery],
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
@@ -1999,7 +2072,7 @@ pub fn compute_naive_left_deep_plan<'a>(
         Cost(f64::MAX),
         joined_tables,
         where_clause,
-        where_term_table_ids,
+        where_terms,
         subqueries,
         index_method_candidates,
         params,
@@ -2027,7 +2100,7 @@ pub fn compute_naive_left_deep_plan<'a>(
             Cost(f64::MAX),
             joined_tables,
             where_clause,
-            where_term_table_ids,
+            where_terms,
             subqueries,
             index_method_candidates,
             params,
@@ -2044,37 +2117,55 @@ pub fn compute_naive_left_deep_plan<'a>(
     Ok(best_plan)
 }
 
-/// Precompute table IDs referenced by each WHERE term for join-order decisions.
-fn build_where_term_table_ids(
+/// Read the table IDs and extra work for each `WHERE` term once.
+fn build_where_term_info(
     where_clause: &[WhereTerm],
-    joined_tables: &[JoinedTable],
-) -> Vec<HashSet<TableInternalId>> {
-    let joined_ids: HashSet<TableInternalId> =
-        joined_tables.iter().map(|t| t.internal_id).collect();
+    table_references: &TableReferences,
+    subqueries: &[NonFromClauseSubquery],
+) -> Result<Vec<WhereTermInfo>> {
     where_clause
         .iter()
-        .map(|term| expr_table_ids_filtered(&term.expr, &joined_ids))
+        .map(|term| {
+            Ok(WhereTermInfo {
+                table_mask: table_mask_from_expr(&term.expr, table_references, subqueries)?,
+                // FIXME: The row cost also includes one simple condition. Give row work
+                // and condition work separate costs so this does not need to subtract one.
+                extra_steps: where_expr_steps(&term.expr).saturating_sub(1),
+                equal_tables: (!term.consumed)
+                    .then(|| tables_in_equal_test(&term.expr))
+                    .flatten()
+                    .map(|(left, right)| (left, right, term.from_outer_join)),
+            })
+        })
         .collect()
 }
 
-/// Collect table IDs from an expression that belong to the joined tables set.
-fn expr_table_ids_filtered(
-    expr: &Expr,
-    joined_ids: &HashSet<TableInternalId>,
-) -> HashSet<TableInternalId> {
-    let mut tables = HashSet::default();
-    let _ = walk_expr(expr, &mut |node| {
-        match node {
-            Expr::Column { table, .. } | Expr::RowId { table, .. } => {
-                if joined_ids.contains(table) {
-                    tables.insert(*table);
-                }
+/// Return the extra `WHERE` work that can run after this table.
+fn ready_where_work(
+    where_clause: &[WhereTerm],
+    where_terms: &[WhereTermInfo],
+    joined_mask: &TableMask,
+    rhs_table_number: usize,
+    rhs_table_id: TableInternalId,
+) -> SmallVec<[(usize, usize); 4]> {
+    where_clause
+        .iter()
+        .zip(where_terms)
+        .enumerate()
+        .filter_map(|(term_idx, (term, info))| {
+            if term.consumed || info.extra_steps == 0 {
+                return None;
             }
-            _ => {}
-        }
-        Ok(WalkControl::Continue)
-    });
-    tables
+            let ready = match term.from_outer_join {
+                Some(table_id) => table_id == rhs_table_id,
+                None => {
+                    info.table_mask.get(rhs_table_number)
+                        && joined_mask.contains_all_set_bits_of(&info.table_mask)
+                }
+            };
+            ready.then_some((term_idx, info.extra_steps))
+        })
+        .collect()
 }
 
 /// Iterator that generates all possible size k bitmasks for a given number of tables.
@@ -2164,6 +2255,175 @@ mod tests {
         Schema::default()
     }
 
+    fn single_table_plan_cost(where_expr: Expr) -> Cost {
+        let table =
+            _create_btree_table("test_table", _create_column_list(&["value"], Type::Integer));
+        let mut table_id_counter = TableRefIdCounter::new();
+        let joined_tables = vec![_create_table_reference(
+            table,
+            None,
+            table_id_counter.next(),
+        )];
+        let table_references = TableReferences::new(joined_tables, vec![]);
+        let available_indexes = AvailableIndexes::default();
+        let mut where_clause = vec![WhereTerm::from(where_expr)];
+        let constraints = constraints_from_where_clause(
+            &where_clause,
+            &table_references,
+            &available_indexes,
+            &[],
+            &empty_schema(),
+            &DEFAULT_PARAMS,
+        )
+        .unwrap();
+        let mut access_methods = Vec::new();
+        let base_rows = default_base_rows(1);
+        let schema = empty_schema();
+        compute_best_join_order(
+            table_references.joined_tables(),
+            1.0,
+            None,
+            &constraints,
+            &base_rows,
+            &mut access_methods,
+            &mut where_clause,
+            &[],
+            &[],
+            &DEFAULT_PARAMS,
+            &AnalyzeStats::default(),
+            &available_indexes,
+            &table_references,
+            &schema,
+        )
+        .unwrap()
+        .unwrap()
+        .best_plan
+        .cost
+    }
+
+    #[test]
+    fn automatic_index_puts_equalities_before_ranges() {
+        let mut table_id_counter = TableRefIdCounter::new();
+        let outer = _create_table_reference(
+            _create_btree_table("outer_rows", _create_column_list(&["k"], Type::Integer)),
+            None,
+            table_id_counter.next(),
+        );
+        let inner = _create_table_reference(
+            _create_btree_table(
+                "inner_rows",
+                _create_column_list(&["x", "k"], Type::Integer),
+            ),
+            Some(JoinInfo {
+                join_type: JoinType::Inner,
+                using: vec![],
+                no_reorder: false,
+            }),
+            table_id_counter.next(),
+        );
+        let inner_id = inner.internal_id;
+        let outer_id = outer.internal_id;
+        let table_references = TableReferences::new(vec![outer, inner], vec![]);
+        let where_clause = vec![
+            _create_binary_expr(
+                _create_column_expr(inner_id, 0, false),
+                Operator::Greater,
+                _create_numeric_literal("10"),
+            ),
+            _create_binary_expr(
+                _create_column_expr(inner_id, 1, false),
+                Operator::Equals,
+                _create_column_expr(outer_id, 0, false),
+            ),
+        ];
+        let constraints = constraints_from_where_clause(
+            &where_clause,
+            &table_references,
+            &AvailableIndexes::default(),
+            &[],
+            &empty_schema(),
+            &DEFAULT_PARAMS,
+        )
+        .unwrap();
+
+        let operators: Vec<_> = constraints[1]
+            .temporary_index_terms
+            .iter()
+            .map(|term| {
+                constraints[1].constraints[term.constraint_vec_pos]
+                    .operator
+                    .as_ast_operator()
+                    .unwrap()
+            })
+            .collect();
+
+        assert_eq!(operators, vec![Operator::Equals, Operator::Greater]);
+    }
+
+    /// `WHERE` work waits for every table it needs.
+    #[test]
+    fn where_work_runs_after_the_needed_tables() -> Result<()> {
+        let mut table_id_counter = TableRefIdCounter::new();
+        let first_id = table_id_counter.next();
+        let second_id = table_id_counter.next();
+        let joined_tables = vec![
+            _create_table_reference(
+                _create_btree_table("first", _create_column_list(&["value"], Type::Integer)),
+                None,
+                first_id,
+            ),
+            _create_table_reference(
+                _create_btree_table("second", _create_column_list(&["value"], Type::Integer)),
+                None,
+                second_id,
+            ),
+        ];
+        let table_references = TableReferences::new(joined_tables, vec![]);
+        let check = |table_id| {
+            _create_binary_expr(
+                _create_column_expr(table_id, 0, false),
+                Operator::Equals,
+                _create_numeric_literal("1"),
+            )
+            .expr
+        };
+        let two_table_where = vec![WhereTerm::from(Expr::Binary(
+            Box::new(check(first_id)),
+            Operator::Or,
+            Box::new(check(second_id)),
+        ))];
+        let where_terms = build_where_term_info(&two_table_where, &table_references, &[])?;
+
+        let mut joined_mask = TableMask::default();
+        joined_mask.set(0)?;
+        assert!(
+            ready_where_work(&two_table_where, &where_terms, &joined_mask, 0, first_id).is_empty()
+        );
+
+        joined_mask.set(1)?;
+        let ready = ready_where_work(&two_table_where, &where_terms, &joined_mask, 1, second_id);
+        assert_eq!(ready.as_slice(), &[(0, where_terms[0].extra_steps)]);
+        let mut term = WhereTerm::from(Expr::Binary(
+            Box::new(check(first_id)),
+            Operator::Or,
+            Box::new(check(first_id)),
+        ));
+        term.from_outer_join = Some(second_id);
+        let outer_join_where = vec![term];
+        let where_terms = build_where_term_info(&outer_join_where, &table_references, &[])?;
+
+        let mut joined_mask = TableMask::default();
+        joined_mask.set(0)?;
+        assert!(
+            ready_where_work(&outer_join_where, &where_terms, &joined_mask, 0, first_id).is_empty()
+        );
+
+        joined_mask.set(1)?;
+        let ready = ready_where_work(&outer_join_where, &where_terms, &joined_mask, 1, second_id);
+        assert_eq!(ready.as_slice(), &[(0, where_terms[0].extra_steps)]);
+        Ok(())
+    }
+
     #[test]
     fn test_generate_bitmasks() -> std::result::Result<(), TryReserveError> {
         let bitmasks = generate_join_bitmasks(4, 2).collect::<std::result::Result<Vec<_>, _>>()?;
@@ -2238,6 +2498,29 @@ mod tests {
         );
 
         assert!(composite_score > single_col_score);
+    }
+
+    #[test]
+    fn plan_cost_counts_long_where_condition() {
+        let table_id = TableInternalId::default();
+        let check = |value| {
+            Expr::Binary(
+                Box::new(_create_column_expr(table_id, 0, false)),
+                Operator::Equals,
+                Box::new(_create_numeric_literal(value)),
+            )
+        };
+        let simple_cost = single_table_plan_cost(check("1"));
+        let long_cost = single_table_plan_cost(Expr::Binary(
+            Box::new(check("1")),
+            Operator::Or,
+            Box::new(check("2")),
+        ));
+
+        assert!(
+            long_cost > simple_cost,
+            "simple cost: {simple_cost:?}, long cost: {long_cost:?}"
+        );
     }
 
     #[test]
@@ -2883,15 +3166,29 @@ mod tests {
 
         let access_method = &access_methods_arena[best_plan.data[1].1];
         let (iter_dir, index, constraint_refs) = _as_btree(access_method);
-        assert!(!constraint_refs.is_empty());
+        assert!(constraint_refs.is_empty());
         assert!(iter_dir == IterationDirection::Forwards);
-        assert!(index.is_some_and(|index| index.ephemeral));
+        assert!(index.is_none());
+        assert!(matches!(
+            access_method.params,
+            AccessMethodParams::BTreeTable {
+                build_index: true,
+                ..
+            }
+        ));
 
         let access_method = &access_methods_arena[best_plan.data[2].1];
         let (iter_dir, index, constraint_refs) = _as_btree(access_method);
-        assert!(!constraint_refs.is_empty());
+        assert!(constraint_refs.is_empty());
         assert!(iter_dir == IterationDirection::Forwards);
-        assert!(index.is_some_and(|index| index.ephemeral));
+        assert!(index.is_none());
+        assert!(matches!(
+            access_method.params,
+            AccessMethodParams::BTreeTable {
+                build_index: true,
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -3650,6 +3947,7 @@ mod tests {
                 iter_dir,
                 index,
                 constraint_refs,
+                ..
             } => (*iter_dir, index.clone(), constraint_refs),
             _ => panic!("expected BTreeTable access method"),
         }
@@ -3785,5 +4083,63 @@ mod tests {
             }
             _ => panic!("Unexpected access method for t2"),
         }
+    }
+
+    #[test]
+    fn hash_join_uses_estimated_matches_for_row_count() {
+        let t1 = _create_btree_table("t1", _create_column_list(&["value"], Type::Integer));
+        let mut t2 = _create_btree_table("t2", _create_column_list(&["value"], Type::Integer));
+        Arc::get_mut(&mut t2).unwrap().root_page = 2;
+        let mut table_id_counter = TableRefIdCounter::new();
+        let joined_tables = vec![
+            _create_table_reference(t1, None, table_id_counter.next()),
+            _create_table_reference(
+                t2,
+                Some(JoinInfo {
+                    join_type: JoinType::Inner,
+                    using: vec![],
+                    no_reorder: false,
+                }),
+                table_id_counter.next(),
+            ),
+        ];
+        let mut where_clause = vec![_create_binary_expr(
+            _create_column_expr(joined_tables[0].internal_id, 0, false),
+            Operator::Equals,
+            _create_column_expr(joined_tables[1].internal_id, 0, false),
+        )];
+        let table_references = TableReferences::new(joined_tables, vec![]);
+        let available_indexes = AvailableIndexes::default();
+        let constraints = constraints_from_where_clause(
+            &where_clause,
+            &table_references,
+            &available_indexes,
+            &[],
+            &empty_schema(),
+            &DEFAULT_PARAMS,
+        )
+        .unwrap();
+        let method = try_hash_join_access_method(
+            &table_references.joined_tables()[0],
+            &table_references.joined_tables()[1],
+            0,
+            1,
+            &constraints[0],
+            &constraints[1],
+            &mut where_clause,
+            std::iter::once((
+                0,
+                table_references.joined_tables()[0].internal_id,
+                table_references.joined_tables()[1].internal_id,
+            )),
+            1_000.0,
+            1_000.0,
+            1.0,
+            &[],
+            &DEFAULT_PARAMS,
+        )
+        .unwrap();
+
+        assert!(method.estimated_rows_per_outer_row < 1_000.0);
     }
 }

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -166,13 +166,16 @@ fn count_subquery_calls_after_join(
             continue;
         }
 
-        let skipped_where_terms: SmallVec<[usize; 2]> = where_clause
-            .iter()
-            .enumerate()
-            .filter_map(|(index, term)| {
-                expr_references_subquery_id(&term.expr, subquery.internal_id).then_some(index)
-            })
-            .collect();
+        let first_subquery_term = where_clause.iter().enumerate().find_map(|(index, term)| {
+            expr_references_subquery_id(&term.expr, subquery.internal_id).then_some(index)
+        });
+        // A WHERE term cannot cut the call count for a subquery in that term
+        // or in an earlier term. Terms before it may cut the count.
+        let skipped_where_terms: SmallVec<[usize; 2]> = if let Some(first) = first_subquery_term {
+            (first..where_clause.len()).collect()
+        } else {
+            SmallVec::new()
+        };
         let rows = match method.residual_constraints {
             ResidualConstraintMode::ApplyUnconsumed => {
                 let multiplier = constraint_output_multipliers(

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -262,7 +262,7 @@ pub fn join_lhs_and_rhs<'a>(
         .copied()
         .unwrap_or_else(|| RowCountEstimate::hardcoded_fallback(params));
 
-    let Some(mut method) = find_best_access_method_for_join_order(
+    let Some(method) = find_best_access_method_for_join_order(
         rhs_table_reference,
         rhs_constraints,
         join_order,
@@ -285,27 +285,6 @@ pub fn join_lhs_and_rhs<'a>(
         Some(lhs) => lhs.table_numbers().try_collect()?,
         None => TableMask::default(),
     };
-
-    // Check if this access method will trigger ephemeral index creation.
-    if let AccessMethodParams::BTreeTable {
-        index: None,
-        constraint_refs,
-        ..
-    } = &method.params
-    {
-        if constraint_refs.is_empty() {
-            let has_usable_constraints = rhs_constraints.constraints.iter().any(|constraint| {
-                constraint.usable
-                    && constraint.table_col_pos.is_some()
-                    && lhs_mask.contains_all_set_bits_of(&constraint.lhs_mask)
-            });
-
-            if has_usable_constraints && lhs.is_some() {
-                let build_cost = *rhs_base_rows * params.cpu_cost_per_row;
-                method.cost = method.cost + Cost(build_cost);
-            }
-        }
-    }
 
     let lhs_cost = lhs.map_or(Cost(0.0), |l| l.cost);
     // If we have a previous table, consider hash join as an alternative
@@ -360,9 +339,11 @@ pub fn join_lhs_and_rhs<'a>(
         let rhs_has_selective_seek = matches!(
             best_access_method.params,
             AccessMethodParams::BTreeTable {
+                ref index,
                 ref constraint_refs,
                 ..
             } if !constraint_refs.is_empty()
+                && index.as_ref().is_none_or(|index| !index.ephemeral)
         );
 
         // The probe table must NOT be the build table of any earlier hash join,
@@ -2871,26 +2852,27 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        // Verify that t2 is chosen first due to its equality filter
-        assert_eq!(best_plan.table_numbers().next().unwrap(), 1);
-        // Verify table scan is used since there are no indexes
+        // Put the table with no filter first. The two inner tables can then
+        // build an automatic index once instead of scanning once per outer row.
+        assert_eq!(best_plan.table_numbers().collect::<Vec<_>>(), vec![2, 1, 0]);
+
         let access_method = &access_methods_arena[best_plan.data[0].1];
         let (iter_dir, index, constraint_refs) = _as_btree(access_method);
         assert!(constraint_refs.is_empty());
         assert!(iter_dir == IterationDirection::Forwards);
         assert!(index.is_none());
-        // Verify that t1 is chosen next due to its inequality filter
+
         let access_method = &access_methods_arena[best_plan.data[1].1];
         let (iter_dir, index, constraint_refs) = _as_btree(access_method);
-        assert!(constraint_refs.is_empty());
+        assert!(!constraint_refs.is_empty());
         assert!(iter_dir == IterationDirection::Forwards);
-        assert!(index.is_none());
-        // Verify that t3 is chosen last due to no filters
+        assert!(index.is_some_and(|index| index.ephemeral));
+
         let access_method = &access_methods_arena[best_plan.data[2].1];
         let (iter_dir, index, constraint_refs) = _as_btree(access_method);
-        assert!(constraint_refs.is_empty());
+        assert!(!constraint_refs.is_empty());
         assert!(iter_dir == IterationDirection::Forwards);
-        assert!(index.is_none());
+        assert!(index.is_some_and(|index| index.ephemeral));
     }
 
     #[test]

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1496,7 +1496,10 @@ fn plan_correlated_subqueries(
     subquery_calls: &[(TableInternalId, f64)],
 ) -> Result<()> {
     for subquery in &mut plan.non_from_clause_subqueries {
-        if !subquery.correlated {
+        // Write statements plan their subqueries while the statement is built.
+        // Planning them again can reuse changed fields such as an ORDER BY that
+        // the first plan removed.
+        if !subquery.correlated || subquery.origin.is_write_statement() {
             continue;
         }
         let call_count = subquery_calls

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -765,7 +765,7 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
     transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
 
-    unnest::unnest_exists_subqueries(plan)?;
+    unnest::rewrite_correlated_subqueries(plan, resolver)?;
     // EXISTS only needs 1 row. Add LIMIT 1 to surviving (non-unnested) EXISTS
     // subqueries. This is done here rather than in the subquery planner so that
     // unnesting sees the plan without an artificial LIMIT.

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -894,14 +894,15 @@ fn find_select_plan_form(
     }
 
     let table_cost = table_plan.as_ref().map(|table_plan| table_plan.join.cost);
-    let subquery_calls = table_plan
+    let mut subquery_calls = table_plan
         .as_ref()
         .map(|table_plan| table_plan.join.subquery_calls.clone())
         .unwrap_or_default();
 
     if let Some(table_plan) = table_plan.as_ref() {
-        let mut rows =
+        let rows_before_limit =
             estimate_select_output_rows(plan, table_plan.join.output_cardinality, schema);
+        let mut rows = rows_before_limit;
         // Clamp to LIMIT when it's a literal non-negative number.
         // Negative LIMIT means "no limit" in SQLite, so we skip those.
         if let Some(limit) = &plan.limit {
@@ -922,6 +923,14 @@ fn find_select_plan_form(
                 };
                 if let Some(limit_rows) = limit_rows {
                     rows = rows.min(limit_rows);
+                    if rows_before_limit > 0.0 {
+                        // These call counts cover the full result. LIMIT only
+                        // needs the same share of those calls.
+                        let call_scale = (rows / rows_before_limit).min(1.0);
+                        for (_, calls) in &mut subquery_calls {
+                            *calls *= call_scale;
+                        }
+                    }
                 }
             }
         }

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -569,15 +569,24 @@ pub fn optimize_plan(
 }
 
 fn optimize_recursive_cte_query(query: &mut Plan, resolver: &Resolver) -> Result<()> {
+    let mut cache = SubqueryPlanCache::default();
+    optimize_recursive_cte_query_with_cache(query, resolver, &mut cache)
+}
+
+fn optimize_recursive_cte_query_with_cache(
+    query: &mut Plan,
+    resolver: &Resolver,
+    cache: &mut SubqueryPlanCache,
+) -> Result<()> {
     match query {
-        Plan::Select(select) => optimize_select_plan(select, resolver),
+        Plan::Select(select) => optimize_select_plan_with_cache(select, resolver, cache),
         Plan::CompoundSelect {
             left, right_most, ..
         } => {
             for (select, _) in left {
-                optimize_select_plan(select, resolver)?;
+                optimize_select_plan_with_cache(select, resolver, cache)?;
             }
-            optimize_select_plan(right_most, resolver)
+            optimize_select_plan_with_cache(right_most, resolver, cache)
         }
         Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => Err(
             LimboError::InternalError("recursive CTE query is not a SELECT".to_string()),
@@ -757,6 +766,14 @@ struct TableAccessPlan {
     sort_eliminated: bool,
 }
 
+#[derive(Default)]
+struct SubqueryPlanCache {
+    // The original and changed forms copy the same child subqueries. Keep a
+    // finished child plan so the next copy does not plan that child again.
+    from_clause: HashMap<TableInternalId, Plan>,
+    correlated: HashMap<(TableInternalId, u64), Plan>,
+}
+
 /**
  * Make a few passes over the plan to optimize it.
  * TODO: these could probably be done in less passes,
@@ -764,12 +781,22 @@ struct TableAccessPlan {
  */
 #[turso_macros::trace_stack]
 pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
+    let mut cache = SubqueryPlanCache::default();
+    optimize_select_plan_with_cache(plan, resolver, &mut cache)
+}
+
+#[turso_macros::trace_stack]
+fn optimize_select_plan_with_cache(
+    plan: &mut SelectPlan,
+    resolver: &Resolver,
+    cache: &mut SubqueryPlanCache,
+) -> Result<()> {
     if !plan
         .non_from_clause_subqueries
         .iter()
         .any(|subquery| subquery.correlated)
     {
-        return optimize_select_plan_form(plan, resolver);
+        return optimize_select_plan_form(plan, resolver, cache);
     }
 
     // TODO: Let join search run a correlated subquery as soon as all columns
@@ -777,7 +804,7 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
     // join tables in one search. Until then, both forms need their own search.
     let mut rewritten = plan.clone();
     if !unnest::rewrite_correlated_subqueries(&mut rewritten, resolver)? {
-        return optimize_select_plan_form(plan, resolver);
+        return optimize_select_plan_form(plan, resolver, cache);
     }
 
     let has_full_join = plan.table_references.joined_tables().iter().any(|table| {
@@ -794,14 +821,14 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
             .iter()
             .any(|subquery| subquery.correlated);
     if full_join_rewrite_is_complete {
-        let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver)?;
+        let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver, cache, false)?;
         *plan = rewritten;
         apply_select_table_plan(plan, rewritten_table_plan, resolver)?;
         return Ok(());
     }
 
-    let original_table_plan = find_select_plan_form(plan, resolver)?;
-    let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver)?;
+    let original_table_plan = find_select_plan_form(plan, resolver, cache, true)?;
+    let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver, cache, false)?;
     let use_rewritten = matches!(
         (plan.estimated_cost, rewritten.estimated_cost),
         (Some(original_cost), Some(rewritten_cost)) if rewritten_cost <= original_cost
@@ -818,8 +845,12 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
 }
 
 /// Choose table reads for one version of a query.
-fn optimize_select_plan_form(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
-    let table_plan = find_select_plan_form(plan, resolver)?;
+fn optimize_select_plan_form(
+    plan: &mut SelectPlan,
+    resolver: &Resolver,
+    cache: &mut SubqueryPlanCache,
+) -> Result<()> {
+    let table_plan = find_select_plan_form(plan, resolver, cache, false)?;
     apply_select_table_plan(plan, table_plan, resolver)
 }
 
@@ -827,6 +858,8 @@ fn optimize_select_plan_form(plan: &mut SelectPlan, resolver: &Resolver) -> Resu
 fn find_select_plan_form(
     plan: &mut SelectPlan,
     resolver: &Resolver,
+    cache: &mut SubqueryPlanCache,
+    save_subquery_plans: bool,
 ) -> Result<Option<TableAccessPlan>> {
     let schema = resolver.schema();
     #[cfg(feature = "optimizer_params")]
@@ -860,7 +893,7 @@ fn find_select_plan_form(
             }
         }
     }
-    optimize_subqueries(plan, resolver)?;
+    optimize_subqueries(plan, resolver, cache, save_subquery_plans)?;
     let available_indexes =
         AvailableIndexes::for_table_references(resolver, &plan.table_references);
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
@@ -870,7 +903,7 @@ fn find_select_plan_form(
         plan.contains_constant_false_condition = true;
         plan.estimated_output_rows = Some(0.0);
         plan.estimated_cost = Some(0.0);
-        plan_correlated_subqueries(plan, resolver, &[])?;
+        plan_correlated_subqueries(plan, resolver, &[], cache, save_subquery_plans)?;
         return Ok(None);
     }
 
@@ -942,7 +975,13 @@ fn find_select_plan_form(
         plan.estimated_output_rows = Some(rows);
     }
 
-    plan_correlated_subqueries(plan, resolver, &subquery_calls)?;
+    plan_correlated_subqueries(
+        plan,
+        resolver,
+        &subquery_calls,
+        cache,
+        save_subquery_plans,
+    )?;
 
     let table_cost = table_cost.or_else(|| {
         plan.table_references
@@ -1482,24 +1521,43 @@ fn update_from_set_result_columns(set_clauses: &[UpdateSetClause]) -> Vec<Result
         .collect()
 }
 
-fn optimize_subqueries(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
+fn optimize_subqueries(
+    plan: &mut SelectPlan,
+    resolver: &Resolver,
+    cache: &mut SubqueryPlanCache,
+    save_plans: bool,
+) -> Result<()> {
     for table in plan.table_references.joined_tables_mut() {
         if let Table::FromClauseSubquery(from_clause_subquery) = &mut table.table {
             let from_clause_subquery = Arc::make_mut(from_clause_subquery);
+            if let Some(cached) = cache.from_clause.remove(&table.internal_id) {
+                from_clause_subquery.plan = Box::new(cached);
+                continue;
+            }
             // Use match to handle both SelectPlan and CompoundSelect variants
             match from_clause_subquery.plan.as_mut() {
-                Plan::Select(select_plan) => optimize_select_plan(select_plan, resolver)?,
+                Plan::Select(select_plan) => {
+                    optimize_select_plan_with_cache(select_plan, resolver, cache)?
+                }
                 Plan::CompoundSelect {
                     left, right_most, ..
                 } => {
-                    optimize_select_plan(right_most, resolver)?;
+                    optimize_select_plan_with_cache(right_most, resolver, cache)?;
                     for (select_plan, _) in left {
-                        optimize_select_plan(select_plan, resolver)?;
+                        optimize_select_plan_with_cache(select_plan, resolver, cache)?;
                     }
                 }
                 Plan::RecursiveCte(recursive_cte) => {
-                    optimize_recursive_cte_query(&mut recursive_cte.initial_query, resolver)?;
-                    optimize_recursive_cte_query(&mut recursive_cte.recursive_query, resolver)?;
+                    optimize_recursive_cte_query_with_cache(
+                        &mut recursive_cte.initial_query,
+                        resolver,
+                        cache,
+                    )?;
+                    optimize_recursive_cte_query_with_cache(
+                        &mut recursive_cte.recursive_query,
+                        resolver,
+                        cache,
+                    )?;
                 }
                 Plan::Delete(_) | Plan::Update(_) => {
                     turso_soft_unreachable!(
@@ -1510,6 +1568,12 @@ fn optimize_subqueries(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()>
                             .to_string(),
                     ));
                 }
+            }
+            if save_plans {
+                cache.from_clause.insert(
+                    table.internal_id,
+                    from_clause_subquery.plan.as_ref().clone(),
+                );
             }
         }
     }
@@ -1522,6 +1586,8 @@ fn plan_correlated_subqueries(
     plan: &mut SelectPlan,
     resolver: &Resolver,
     subquery_calls: &[(TableInternalId, f64)],
+    cache: &mut SubqueryPlanCache,
+    save_plans: bool,
 ) -> Result<()> {
     for subquery in &mut plan.non_from_clause_subqueries {
         // Write statements plan their subqueries while the statement is built.
@@ -1541,15 +1607,28 @@ fn plan_correlated_subqueries(
         else {
             continue;
         };
-        optimize_plan_for_calls(inner_plan, resolver, call_count)?;
+        let key = (subquery.internal_id, call_count.to_bits());
+        if let Some(cached) = cache.correlated.remove(&key) {
+            **inner_plan = cached;
+            continue;
+        }
+        optimize_plan_for_calls(inner_plan, resolver, call_count, cache)?;
+        if save_plans {
+            cache.correlated.insert(key, inner_plan.as_ref().clone());
+        }
     }
 
     Ok(())
 }
 
 /// Set how many times a plan will run, then plan its table reads again.
-fn optimize_plan_for_calls(plan: &mut Plan, resolver: &Resolver, call_count: f64) -> Result<()> {
-    let optimize = |plan: &mut SelectPlan| -> Result<()> {
+fn optimize_plan_for_calls(
+    plan: &mut Plan,
+    resolver: &Resolver,
+    call_count: f64,
+    cache: &mut SubqueryPlanCache,
+) -> Result<()> {
+    let mut optimize = |plan: &mut SelectPlan| -> Result<()> {
         if plan
             .input_cardinality_hint
             .is_some_and(|hint| hint >= call_count)
@@ -1557,7 +1636,7 @@ fn optimize_plan_for_calls(plan: &mut Plan, resolver: &Resolver, call_count: f64
             return Ok(());
         }
         plan.input_cardinality_hint = Some(call_count);
-        optimize_select_plan(plan, resolver)
+        optimize_select_plan_with_cache(plan, resolver, cache)
     };
 
     match plan {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -4061,6 +4061,33 @@ mod tests {
     }
 
     #[test]
+    fn null_rejection_detection_treats_empty_not_in_as_non_rejecting() {
+        let table = TableInternalId::from(15);
+        let column = Expr::Column {
+            database: None,
+            table,
+            column: 0,
+            is_rowid_alias: false,
+        };
+        let not_in_empty = Expr::InList {
+            lhs: Box::new(column.clone()),
+            not: true,
+            rhs: vec![],
+        };
+        let in_value = Expr::InList {
+            lhs: Box::new(column),
+            not: false,
+            rhs: vec![Box::new(Expr::Literal(ast::Literal::Numeric("1".into())))],
+        };
+
+        assert!(!where_term_is_null_rejecting_for_table(
+            &not_in_empty,
+            table
+        ));
+        assert!(where_term_is_null_rejecting_for_table(&in_value, table));
+    }
+
+    #[test]
     fn null_rejection_detection_treats_is_between_columns_as_non_rejecting() {
         let table = TableInternalId::from(12);
         let expr = Expr::Binary(

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -916,14 +916,17 @@ fn optimize_select_plan_with_cache(
             .iter()
             .any(|subquery| subquery.correlated);
     if full_join_rewrite_is_complete {
-        let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver, cache, false)?;
+        let rewritten_table_plan =
+            find_select_plan_form(&mut rewritten, resolver, cache, false, None)?;
         *plan = rewritten;
         apply_select_table_plan(plan, rewritten_table_plan, resolver)?;
         return Ok(());
     }
 
-    let original_table_plan = find_select_plan_form(plan, resolver, cache, true)?;
-    let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver, cache, false)?;
+    let original_table_plan = find_select_plan_form(plan, resolver, cache, true, None)?;
+    let cost_limit = plan.estimated_cost.map(Cost);
+    let rewritten_table_plan =
+        find_select_plan_form(&mut rewritten, resolver, cache, false, cost_limit)?;
     let use_rewritten = matches!(
         (plan.estimated_cost, rewritten.estimated_cost),
         (Some(original_cost), Some(rewritten_cost)) if rewritten_cost <= original_cost
@@ -945,7 +948,7 @@ fn optimize_select_plan_form(
     resolver: &Resolver,
     cache: &mut SubqueryPlanCache,
 ) -> Result<()> {
-    let table_plan = find_select_plan_form(plan, resolver, cache, false)?;
+    let table_plan = find_select_plan_form(plan, resolver, cache, false, None)?;
     apply_select_table_plan(plan, table_plan, resolver)
 }
 
@@ -955,6 +958,7 @@ fn find_select_plan_form(
     resolver: &Resolver,
     cache: &mut SubqueryPlanCache,
     save_subquery_plans: bool,
+    cost_limit: Option<Cost>,
 ) -> Result<Option<TableAccessPlan>> {
     let schema = resolver.schema();
     #[cfg(feature = "optimizer_params")]
@@ -1016,6 +1020,7 @@ fn find_select_plan_form(
         &mut plan.limit,
         &mut plan.offset,
         plan.input_cardinality_hint.unwrap_or(1.0),
+        cost_limit,
     )?;
 
     if matches!(plan.simple_aggregate, Some(SimpleAggregate::MinMax(_)))
@@ -2251,6 +2256,7 @@ fn optimize_table_access(
         limit,
         offset,
         initial_input_cardinality,
+        None,
     )?
     else {
         return Ok(None);
@@ -2285,6 +2291,7 @@ fn find_table_access_plan(
     limit: &mut Option<Box<Expr>>,
     offset: &mut Option<Box<Expr>>,
     initial_input_cardinality: f64,
+    cost_limit: Option<Cost>,
 ) -> Result<Option<TableAccessPlan>> {
     // When optimizer_params feature is enabled, use lazily-loaded params (cached process-wide).
     // Otherwise, use the compile-time static for zero overhead.
@@ -2453,6 +2460,7 @@ fn find_table_access_plan(
 
     let planning_context = JoinPlanningContext {
         maybe_order_target: maybe_order_target.as_ref(),
+        cost_limit,
     };
 
     let Some(best_join_order_result) = compute_best_join_order_with_context(

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1794,6 +1794,64 @@ fn base_row_estimate(
     }
 }
 
+/// Read a group count from ANALYZE for a simple list of table columns.
+///
+/// For an index that starts with the GROUP BY columns, sqlite_stat1 stores the
+/// total row count and the average rows for one key. Dividing them gives the
+/// number of groups.
+fn group_count_from_analyze(plan: &SelectPlan, group_by: &GroupBy, schema: &Schema) -> Option<f64> {
+    let mut table_id = None;
+    let mut columns: SmallVec<[usize; 4]> = SmallVec::new();
+    for expr in &group_by.exprs {
+        let Expr::Column { table, column, .. } = expr else {
+            return None;
+        };
+        if table_id.is_some_and(|id| id != *table) {
+            return None;
+        }
+        table_id = Some(*table);
+        columns.push(*column);
+    }
+
+    let table_id = table_id?;
+    let table = plan
+        .table_references
+        .joined_tables()
+        .iter()
+        .find(|table| table.internal_id == table_id)?;
+    let btree = table.btree()?;
+    let table_stats = schema.analyze_stats.table_stats(&btree.name)?;
+
+    table_stats
+        .index_stats
+        .iter()
+        .filter_map(|(index_name, index_stats)| {
+            let index = schema.get_index(&btree.name, index_name)?;
+            if index.where_clause.is_some() || index.columns.len() < columns.len() {
+                return None;
+            }
+            let columns_match =
+                index
+                    .columns
+                    .iter()
+                    .zip(&columns)
+                    .all(|(index_column, group_column)| {
+                        index_column.expr.is_none() && index_column.pos_in_table == *group_column
+                    });
+            if !columns_match {
+                return None;
+            }
+            let total_rows = index_stats.total_rows? as f64;
+            let rows_per_group = *index_stats
+                .avg_rows_per_distinct_prefix
+                .get(columns.len().checked_sub(1)?)? as f64;
+            (rows_per_group > 0.0).then_some(total_rows / rows_per_group)
+        })
+        .fold(None, |best: Option<f64>, groups| {
+            Some(best.map_or(groups, |best| best.max(groups)))
+        })
+}
+
 /// Estimate the rows returned by a SELECT after grouping or an aggregate.
 fn estimate_select_output_rows(plan: &SelectPlan, input_rows: f64, schema: &Schema) -> f64 {
     let calls = plan.input_cardinality_hint.unwrap_or(1.0);
@@ -1806,6 +1864,9 @@ fn estimate_select_output_rows(plan: &SelectPlan, input_rows: f64, schema: &Sche
     };
     if group_by.exprs.is_empty() {
         return calls;
+    }
+    if let Some(groups) = group_count_from_analyze(plan, group_by, schema) {
+        return input_rows.min(calls * groups.max(1.0));
     }
 
     let mut table_ids: SmallVec<[TableInternalId; 2]> = SmallVec::new();

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -52,7 +52,7 @@ use crate::{
 };
 use crate::{turso_assert, turso_assert_eq, turso_debug_assert, turso_soft_unreachable};
 use constraints::{
-    can_use_partial_index, constraints_from_where_clause, partial_index,
+    automatic_index_terms, can_use_partial_index, constraints_from_where_clause, partial_index,
     partial_index_predicate_terms, usable_constraints_for_join_order, Constraint, ConstraintRef,
 };
 use cost::Cost;
@@ -63,6 +63,7 @@ use order::{
     EliminatesSortBy, OrderTargetPurpose,
 };
 use rustc_hash::FxHashMap as HashMap;
+use smallvec::SmallVec;
 use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintUsage};
 use turso_parser::ast::RefAct;
@@ -747,9 +748,17 @@ fn detect_simple_aggregate(plan: &SelectPlan) -> Option<SimpleAggregate> {
     }
 }
 
+/// The table plan chosen for one SELECT.
 struct OptimizeTableAccessResult {
+    /// Tables in the order they will be read.
     join_order: Vec<JoinOrderMember>,
+    /// Rows expected from the full join.
     output_rows: f64,
+    /// Work expected from the full join.
+    cost: Cost,
+    /// Expected calls to each correlated subquery.
+    subquery_calls: SmallVec<[(TableInternalId, f64); 2]>,
+    /// Whether `min` or `max` can stop after the first row.
     min_max_fast_path: bool,
 }
 
@@ -760,24 +769,63 @@ struct OptimizeTableAccessResult {
  */
 #[turso_macros::trace_stack]
 pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
-    let schema = resolver.schema();
     // Transform MATCH expressions to fts_match() for FTS optimizer recognition
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
+    transform_match_to_fts_match(
+        &mut plan.where_clause,
+        resolver.schema(),
+        &plan.table_references,
+    )?;
 
-    unnest::rewrite_correlated_subqueries(plan, resolver)?;
-    // EXISTS only needs 1 row. Add LIMIT 1 to surviving (non-unnested) EXISTS
-    // subqueries. This is done here rather than in the subquery planner so that
-    // unnesting sees the plan without an artificial LIMIT.
-    for sub in &mut plan.non_from_clause_subqueries {
-        if matches!(sub.query_type, ast::SubqueryType::Exists { .. }) {
+    if !plan
+        .non_from_clause_subqueries
+        .iter()
+        .any(|subquery| subquery.correlated)
+    {
+        return optimize_select_plan_form(plan, resolver);
+    }
+
+    let mut rewritten = plan.clone();
+    if !unnest::rewrite_correlated_subqueries(&mut rewritten, resolver)? {
+        return optimize_select_plan_form(plan, resolver);
+    }
+
+    optimize_select_plan_form(plan, resolver)?;
+    optimize_select_plan_form(&mut rewritten, resolver)?;
+
+    if matches!(
+        (plan.estimated_cost, rewritten.estimated_cost),
+        (Some(original_cost), Some(rewritten_cost)) if rewritten_cost <= original_cost
+    ) {
+        // Equal work is better without one subquery call per outer row.
+        *plan = rewritten;
+    }
+
+    Ok(())
+}
+
+/// Choose table reads for one version of a query.
+fn optimize_select_plan_form(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
+    let schema = resolver.schema();
+    #[cfg(feature = "optimizer_params")]
+    let params: &cost_params::CostModelParams = &cost_params::LOADED_PARAMS;
+    #[cfg(not(feature = "optimizer_params"))]
+    let params: &cost_params::CostModelParams = &cost_params::DEFAULT_PARAMS;
+    plan.estimated_output_rows = None;
+    plan.estimated_cost = None;
+
+    // EXISTS only needs one row. Add LIMIT 1 to subqueries left after the
+    // rewrite. The rewrite must see the limit written by the user, if any.
+    for subquery in &mut plan.non_from_clause_subqueries {
+        if matches!(subquery.query_type, ast::SubqueryType::Exists { .. }) {
             if let SubqueryState::Unevaluated {
-                plan: Some(inner), ..
-            } = &mut sub.state
+                plan: Some(inner_plan),
+                ..
+            } = &mut subquery.state
             {
-                if let Plan::Select(ref mut inner) = inner.as_mut() {
-                    if inner.limit.is_none() {
-                        inner.limit = Some(Box::new(Expr::Literal(ast::Literal::Numeric(
+                if let Plan::Select(ref mut inner_plan) = inner_plan.as_mut() {
+                    if inner_plan.limit.is_none() {
+                        inner_plan.limit = Some(Box::new(Expr::Literal(ast::Literal::Numeric(
                             "1".to_string(),
                         ))));
                     }
@@ -793,6 +841,8 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
         eliminate_constant_conditions(&mut plan.where_clause)?
     {
         plan.contains_constant_false_condition = true;
+        plan.estimated_output_rows = Some(0.0);
+        plan.estimated_cost = Some(0.0);
         return Ok(());
     }
 
@@ -821,6 +871,12 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
         plan.simple_aggregate = None;
     }
 
+    let table_cost = best_join_order.as_ref().map(|result| result.cost);
+    let subquery_calls = best_join_order
+        .as_ref()
+        .map(|result| result.subquery_calls.clone())
+        .unwrap_or_default();
+
     if let Some(OptimizeTableAccessResult {
         join_order,
         output_rows,
@@ -828,32 +884,70 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
     }) = best_join_order
     {
         plan.join_order = join_order;
-        let mut est = output_rows;
+        let mut rows = estimate_select_output_rows(plan, output_rows, schema);
         // Clamp to LIMIT when it's a literal non-negative number.
         // Negative LIMIT means "no limit" in SQLite, so we skip those.
-        if let Some(limit_expr) = &plan.limit {
-            if let Ok(val) = crate::util::parse_signed_number(limit_expr) {
-                let limit_f64 = match val {
-                    crate::types::Value::Numeric(Numeric::Integer(i)) if i >= 0 => Some(i as f64),
-                    crate::types::Value::Numeric(Numeric::Float(f)) => {
-                        let f: f64 = f.into();
-                        if f >= 0.0 {
-                            Some(f)
+        if let Some(limit) = &plan.limit {
+            if let Ok(value) = crate::util::parse_signed_number(limit) {
+                let limit_rows = match value {
+                    crate::types::Value::Numeric(Numeric::Integer(value)) if value >= 0 => {
+                        Some(value as f64)
+                    }
+                    crate::types::Value::Numeric(Numeric::Float(value)) => {
+                        let value: f64 = value.into();
+                        if value >= 0.0 {
+                            Some(value)
                         } else {
                             None
                         }
                     }
                     _ => None,
                 };
-                if let Some(limit_val) = limit_f64 {
-                    est = est.min(limit_val);
+                if let Some(limit_rows) = limit_rows {
+                    rows = rows.min(limit_rows);
                 }
             }
         }
-        plan.estimated_output_rows = Some(est);
+        plan.estimated_output_rows = Some(rows);
     }
 
-    reoptimize_correlated_subqueries(plan, resolver)?;
+    replan_correlated_subqueries(plan, resolver, &subquery_calls)?;
+
+    let table_cost = table_cost.or_else(|| {
+        plan.table_references
+            .joined_tables()
+            .is_empty()
+            .then_some(Cost(0.0))
+    });
+    if let Some(table_cost) = table_cost {
+        let subquery_cost =
+            plan.non_from_clause_subqueries
+                .iter()
+                .try_fold(0.0, |total, subquery| {
+                    let SubqueryState::Unevaluated {
+                        plan: Some(inner_plan),
+                    } = &subquery.state
+                    else {
+                        return None;
+                    };
+                    let calls = if subquery.correlated {
+                        subquery_calls
+                            .iter()
+                            .find_map(|(id, calls)| (*id == subquery.internal_id).then_some(*calls))
+                            .unwrap_or_else(|| plan.input_cardinality_hint.unwrap_or(1.0))
+                    } else {
+                        1.0
+                    };
+                    // Starting the subquery program takes work on every call.
+                    let call_cost = calls.max(1.0) * params.cpu_cost_per_seek;
+                    inner_plan
+                        .estimated_cost()
+                        .map(|cost| total + cost + call_cost)
+                });
+        if let Some(subquery_cost) = subquery_cost {
+            plan.estimated_cost = Some(table_cost.0 + subquery_cost);
+        }
+    }
 
     Ok(())
 }
@@ -1255,6 +1349,7 @@ fn build_update_write_set_plan(
         window: None,
         input_cardinality_hint: None,
         estimated_output_rows: None,
+        estimated_cost: None,
         // For regular UPDATEs, only WHERE-clause subqueries move into the ephemeral plan.
         // For UPDATE ... FROM, SET expressions become part of the ephemeral SELECT payload,
         // so their subqueries move too.
@@ -1373,81 +1468,77 @@ fn optimize_subqueries(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()>
     Ok(())
 }
 
-/// Re-run correlated subqueries once the enclosing plan has learned a better
-/// estimate for how many times they will be invoked.
+/// Plan each correlated subquery again with its expected number of calls.
 ///
-/// This converges because `input_cardinality_hint` is monotonic within one
-/// optimization pass: once a plan receives a hint, later re-entry compares
-/// against that stored hint and skips re-optimization unless the new hint is
-/// strictly larger. The recursive call therefore only propagates larger hints
-/// down the subquery tree; it does not oscillate based on newly estimated row
-/// counts.
-fn reoptimize_correlated_subqueries(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
-    let Some(invocation_hint) = plan
-        .input_cardinality_hint
-        .or(plan.estimated_output_rows)
-        .filter(|hint| *hint > 1.0)
-    else {
-        return Ok(());
-    };
-
+/// Start from the saved plan because the first pass may have removed terms that
+/// are now part of an index search.
+fn replan_correlated_subqueries(
+    plan: &mut SelectPlan,
+    resolver: &Resolver,
+    subquery_calls: &[(TableInternalId, f64)],
+) -> Result<()> {
     for subquery in &mut plan.non_from_clause_subqueries {
         if !subquery.correlated {
             continue;
         }
+        let call_count = subquery_calls
+            .iter()
+            .find_map(|(id, calls)| (*id == subquery.internal_id).then_some(*calls))
+            .unwrap_or_else(|| plan.input_cardinality_hint.unwrap_or(1.0))
+            .max(1.0);
         let SubqueryState::Unevaluated {
             plan: Some(inner_plan),
         } = &mut subquery.state
         else {
             continue;
         };
-        let Plan::Select(ref mut inner_plan) = inner_plan.as_mut() else {
+        if call_count <= 1.0 {
+            continue;
+        }
+        let Some(saved_plan) = &subquery.saved_plan else {
             continue;
         };
-        if !select_plan_contains_cte_from_clause_subquery(inner_plan) {
-            continue;
+        *inner_plan = saved_plan.clone();
+        if matches!(subquery.query_type, ast::SubqueryType::Exists { .. }) {
+            if let Plan::Select(inner_plan) = inner_plan.as_mut() {
+                if inner_plan.limit.is_none() {
+                    inner_plan.limit = Some(Box::new(Expr::Literal(ast::Literal::Numeric(
+                        "1".to_string(),
+                    ))));
+                }
+            }
         }
-
-        if inner_plan
-            .input_cardinality_hint
-            .is_some_and(|hint| hint >= invocation_hint)
-        {
-            continue;
-        }
-
-        inner_plan.input_cardinality_hint = Some(invocation_hint);
-        optimize_select_plan(inner_plan, resolver)?;
+        optimize_plan_for_calls(inner_plan, resolver, call_count)?;
     }
 
     Ok(())
 }
 
-/// Return whether this plan contains any FROM-clause CTE reference whose
-/// access-path choice may change when the enclosing invocation count grows.
-fn select_plan_contains_cte_from_clause_subquery(plan: &SelectPlan) -> bool {
-    plan.table_references
-        .joined_tables()
-        .iter()
-        .any(|table| match &table.table {
-            Table::FromClauseSubquery(subquery) => {
-                subquery.cte_id().is_some()
-                    || match subquery.plan.as_ref() {
-                        Plan::Select(select_plan) => {
-                            select_plan_contains_cte_from_clause_subquery(select_plan)
-                        }
-                        Plan::CompoundSelect {
-                            left, right_most, ..
-                        } => {
-                            left.iter().any(|(select_plan, _)| {
-                                select_plan_contains_cte_from_clause_subquery(select_plan)
-                            }) || select_plan_contains_cte_from_clause_subquery(right_most)
-                        }
-                        Plan::RecursiveCte(_) => false,
-                        Plan::Delete(_) | Plan::Update(_) => false,
-                    }
+/// Set how many times a plan will run, then plan its table reads again.
+fn optimize_plan_for_calls(plan: &mut Plan, resolver: &Resolver, call_count: f64) -> Result<()> {
+    let optimize = |plan: &mut SelectPlan| -> Result<()> {
+        if plan
+            .input_cardinality_hint
+            .is_some_and(|hint| hint >= call_count)
+        {
+            return Ok(());
+        }
+        plan.input_cardinality_hint = Some(call_count);
+        optimize_select_plan(plan, resolver)
+    };
+
+    match plan {
+        Plan::Select(plan) => optimize(plan),
+        Plan::CompoundSelect {
+            left, right_most, ..
+        } => {
+            for (plan, _) in left {
+                optimize(plan)?;
             }
-            _ => false,
-        })
+            optimize(right_most)
+        }
+        Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => Ok(()),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1668,6 +1759,58 @@ fn base_row_estimate(
         },
         _ => RowCountEstimate::hardcoded_fallback(params),
     }
+}
+
+/// Estimate the rows returned by a SELECT after grouping or an aggregate.
+fn estimate_select_output_rows(plan: &SelectPlan, input_rows: f64, schema: &Schema) -> f64 {
+    let calls = plan.input_cardinality_hint.unwrap_or(1.0);
+    let Some(group_by) = &plan.group_by else {
+        return if plan.aggregates.is_empty() {
+            input_rows
+        } else {
+            calls
+        };
+    };
+    if group_by.exprs.is_empty() {
+        return calls;
+    }
+
+    let mut table_ids: SmallVec<[TableInternalId; 2]> = SmallVec::new();
+    for expr in &group_by.exprs {
+        crate::translate::expr::walk_expr(expr, &mut |expr| -> Result<
+            crate::translate::expr::WalkControl,
+        > {
+            let table_id = match expr {
+                Expr::Column { table, .. } | Expr::RowId { table, .. } => Some(*table),
+                _ => None,
+            };
+            if let Some(table_id) = table_id {
+                if !table_ids.contains(&table_id) {
+                    table_ids.push(table_id);
+                }
+            }
+            Ok(crate::translate::expr::WalkControl::Continue)
+        })
+        .expect("walking a GROUP BY expression cannot fail");
+    }
+    if table_ids.is_empty() {
+        return calls;
+    }
+
+    #[cfg(feature = "optimizer_params")]
+    let params: &cost_params::CostModelParams = &cost_params::LOADED_PARAMS;
+    #[cfg(not(feature = "optimizer_params"))]
+    let params: &cost_params::CostModelParams = &cost_params::DEFAULT_PARAMS;
+
+    let rows_per_call = table_ids.iter().try_fold(1.0, |rows, table_id| {
+        let table = plan
+            .table_references
+            .joined_tables()
+            .iter()
+            .find(|table| table.internal_id == *table_id)?;
+        Some(rows * *base_row_estimate(schema, table, params))
+    });
+    rows_per_call.map_or(input_rows, |rows| input_rows.min(calls * rows))
 }
 
 /// Returns true if a WHERE-term predicate is null-rejecting for a table: the
@@ -2240,65 +2383,18 @@ fn optimize_table_access(
                             });
                         continue;
                     };
-                    // Ephemeral indexes mirror rowid/column lookups; expression-index
-                    // constraints (table_col_pos == None) fall back to a scan.
-                    let table_columns = table_references.joined_tables()[table_idx].table.columns();
-                    let is_strict = table_references.joined_tables()[table_idx]
-                        .table
-                        .is_strict();
-                    let usable: Vec<(usize, &Constraint)> = table_constraints
-                        .constraints
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, c)| c.can_drive_index_seek(table_columns, is_strict))
-                        .collect();
                     // Find this table's position in best_join_order (which excludes build tables)
                     let join_order_pos = best_join_order
                         .iter()
                         .position(|m| m.original_idx == table_idx)
                         .unwrap_or_else(|| best_join_order.len().saturating_sub(1));
-
-                    // Build a mapping from table_col_pos to index_col_pos.
-                    // Multiple constraints on the same column should share the same index_col_pos.
-                    //
-                    // This is important when a column appears in multiple constraints.
-                    // For example, in:
-                    //   SELECT * FROM t1 LEFT JOIN t2 ON t1.a = t2.a AND t1.c = t2.c WHERE t2.a = 17
-                    //
-                    // The constraints on t2 are:
-                    //   t2.a = t1.a (from ON clause)
-                    //   t2.c = t1.c (from ON clause)
-                    //   t2.a = 17   (from WHERE clause)
-                    //
-                    // Both t2.a constraints must map to index_col_pos=0. If we incorrectly
-                    // assigned sequential index positions (0, 1, 2), the seek key would include
-                    // 3 components but the ephemeral index only has 2 key columns (t2.a, t2.c),
-                    // causing the seek to compare against the wrong columns and return no results.
-                    let unique_col_positions: BitSet = usable
-                        .iter()
-                        .map(|(_, c)| c.table_col_pos.expect("table_col_pos was Some above"))
-                        .try_collect()?;
-                    // Map each usable constraint to a ConstraintRef.
-                    // Multiple constraints with the same table_col_pos share the same index_col_pos.
-                    let mut temp_constraint_refs: Vec<ConstraintRef> = usable
-                        .iter()
-                        .map(|(orig_idx, c)| {
-                            let table_col_pos =
-                                c.table_col_pos.expect("table_col_pos was Some above");
-                            let index_col_pos = unique_col_positions.rank(table_col_pos);
-                            ConstraintRef {
-                                constraint_vec_pos: *orig_idx, // index in the original constraints vec
-                                index_col_pos,
-                                sort_order: SortOrder::Asc,
-                                nulls_order: ast::NullsOrder::First,
-                            }
-                        })
-                        .collect();
-
-                    temp_constraint_refs.sort_by_key(|x| x.index_col_pos);
+                    let index_terms = automatic_index_terms(
+                        &table_references.joined_tables()[table_idx],
+                        table_constraints,
+                    );
                     let usable_constraint_refs = usable_constraints_for_join_order(
                         &table_constraints.constraints,
-                        &temp_constraint_refs,
+                        &index_terms,
                         &best_join_order[..=join_order_pos],
                     )?;
 
@@ -2669,6 +2765,8 @@ fn optimize_table_access(
     Ok(Some(OptimizeTableAccessResult {
         join_order: best_join_order,
         output_rows: final_output_cardinality,
+        cost: best_plan.cost,
+        subquery_calls: best_plan.subquery_calls,
         min_max_fast_path: matches!(simple_aggregate, Some(SimpleAggregate::MinMax(_)))
             && sort_eliminated,
     }))

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -64,7 +64,11 @@ use order::{
 };
 use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
-use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
+use std::{
+    cmp::Ordering,
+    collections::{BTreeSet, VecDeque},
+    sync::Arc,
+};
 use turso_ext::{ConstraintInfo, ConstraintUsage};
 use turso_parser::ast::RefAct;
 use turso_parser::ast::{self, Expr, SortOrder, SubqueryType, TableInternalId, TriggerEvent};
@@ -546,6 +550,7 @@ pub fn optimize_plan(
     plan: &mut Plan,
     resolver: &Resolver,
 ) -> Result<()> {
+    let resources_before = subquery_resources(plan);
     match plan {
         Plan::Select(plan) => optimize_select_plan(plan, resolver)?,
         Plan::Delete(plan) => optimize_delete_plan(plan, resolver)?,
@@ -563,9 +568,99 @@ pub fn optimize_plan(
             optimize_recursive_cte_query(&mut recursive_cte.recursive_query, resolver)?;
         }
     }
+    let resources_after = subquery_resources(plan);
+    for cursor_id in resources_before
+        .cursor_ids
+        .difference(&resources_after.cursor_ids)
+    {
+        program.release_cursor_id(*cursor_id);
+    }
+    for (start, count) in resources_before
+        .register_ranges
+        .difference(&resources_after.register_ranges)
+    {
+        program.release_registers(*start, *count);
+    }
     // When debug tracing is enabled, print the optimized plan as a SQL string for debugging
     tracing::debug!(plan_sql = plan.to_string());
     Ok(())
+}
+
+#[derive(Default)]
+struct SubqueryResources {
+    cursor_ids: BTreeSet<usize>,
+    register_ranges: BTreeSet<(usize, usize)>,
+}
+
+/// Find result storage reserved by subqueries in a plan.
+fn subquery_resources(plan: &Plan) -> SubqueryResources {
+    fn add_subqueries(subqueries: &[NonFromClauseSubquery], resources: &mut SubqueryResources) {
+        for subquery in subqueries {
+            match &subquery.query_type {
+                SubqueryType::Exists { .. } => {}
+                SubqueryType::RowValue {
+                    result_reg_start,
+                    num_regs,
+                } => {
+                    resources
+                        .register_ranges
+                        .insert((*result_reg_start, *num_regs));
+                }
+                SubqueryType::In { cursor_id, .. } => {
+                    resources.cursor_ids.insert(*cursor_id);
+                }
+            }
+            if let SubqueryState::Unevaluated {
+                plan: Some(child_plan),
+            } = &subquery.state
+            {
+                add_plan(child_plan, resources);
+            }
+        }
+    }
+
+    fn add_select(plan: &SelectPlan, resources: &mut SubqueryResources) {
+        add_subqueries(&plan.non_from_clause_subqueries, resources);
+        for table in plan.table_references.joined_tables() {
+            if let Table::FromClauseSubquery(subquery) = &table.table {
+                add_plan(&subquery.plan, resources);
+            }
+        }
+    }
+
+    fn add_plan(plan: &Plan, resources: &mut SubqueryResources) {
+        match plan {
+            Plan::Select(plan) => add_select(plan, resources),
+            Plan::CompoundSelect {
+                left, right_most, ..
+            } => {
+                for (plan, _) in left {
+                    add_select(plan, resources);
+                }
+                add_select(right_most, resources);
+            }
+            Plan::RecursiveCte(plan) => {
+                add_plan(&plan.initial_query, resources);
+                add_plan(&plan.recursive_query, resources);
+            }
+            Plan::Delete(plan) => {
+                add_subqueries(&plan.non_from_clause_subqueries, resources);
+                if let Some(rowset_plan) = &plan.rowset_plan {
+                    add_select(rowset_plan, resources);
+                }
+            }
+            Plan::Update(plan) => {
+                add_subqueries(&plan.non_from_clause_subqueries, resources);
+                if let Some(write_set_plan) = &plan.write_set_plan {
+                    add_select(&write_set_plan.select, resources);
+                }
+            }
+        }
+    }
+
+    let mut resources = SubqueryResources::default();
+    add_plan(plan, &mut resources);
+    resources
 }
 
 fn optimize_recursive_cte_query(query: &mut Plan, resolver: &Resolver) -> Result<()> {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -52,8 +52,8 @@ use crate::{
 };
 use crate::{turso_assert, turso_assert_eq, turso_debug_assert, turso_soft_unreachable};
 use constraints::{
-    automatic_index_terms, can_use_partial_index, constraints_from_where_clause, partial_index,
-    partial_index_predicate_terms, usable_constraints_for_join_order, Constraint, ConstraintRef,
+    can_use_partial_index, constraints_from_where_clause, partial_index,
+    partial_index_predicate_terms, Constraint,
 };
 use cost::Cost;
 use join::{compute_best_join_order_with_context, BestJoinOrderResult, JoinN, JoinPlanningContext};
@@ -780,9 +780,6 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
         return optimize_select_plan_form(plan, resolver);
     }
 
-    let original_table_plan = find_select_plan_form(plan, resolver)?;
-    let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver)?;
-
     let has_full_join = plan.table_references.joined_tables().iter().any(|table| {
         table
             .join_info
@@ -796,11 +793,19 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
             .non_from_clause_subqueries
             .iter()
             .any(|subquery| subquery.correlated);
-    let use_rewritten = full_join_rewrite_is_complete
-        || matches!(
-            (plan.estimated_cost, rewritten.estimated_cost),
-            (Some(original_cost), Some(rewritten_cost)) if rewritten_cost <= original_cost
-        );
+    if full_join_rewrite_is_complete {
+        let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver)?;
+        *plan = rewritten;
+        apply_select_table_plan(plan, rewritten_table_plan, resolver)?;
+        return Ok(());
+    }
+
+    let original_table_plan = find_select_plan_form(plan, resolver)?;
+    let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver)?;
+    let use_rewritten = matches!(
+        (plan.estimated_cost, rewritten.estimated_cost),
+        (Some(original_cost), Some(rewritten_cost)) if rewritten_cost <= original_cost
+    );
     if use_rewritten {
         // Equal work is better without one subquery call per outer row.
         *plan = rewritten;
@@ -2439,96 +2444,24 @@ fn apply_table_access_plan(
                     sort_eliminated,
                 );
                 if constraint_refs.is_empty() {
-                    let is_leftmost_table = i == 0;
-                    let uses_index = index.is_some();
-                    let try_to_build_ephemeral_index = !is_leftmost_table && !uses_index;
-
-                    if !try_to_build_ephemeral_index {
-                        if let Some(index) = partial_index(index.as_ref()) {
-                            let is_outer_join = table_references.joined_tables()[table_idx]
-                                .join_info
-                                .as_ref()
-                                .is_some_and(|join_info| join_info.is_outer());
-                            mark_partial_index_predicate_terms_consumed(
-                                index,
-                                &table_references.joined_tables()[table_idx],
-                                where_clause,
-                                is_outer_join,
-                            );
-                        }
-                        table_references.joined_tables_mut()[table_idx].op =
-                            Operation::Scan(Scan::BTreeTable {
-                                iter_dir: *iter_dir,
-                                index: index.clone(),
-                            });
-                        continue;
-                    }
-                    // This branch means we have a full table scan for a non-outermost table.
-                    // Try to construct an ephemeral index since it's going to be better than a scan.
-                    let table_id = table_references.joined_tables()[table_idx].internal_id;
-                    let table_constraints = constraints_per_table
-                        .iter()
-                        .find(|c| c.table_id == table_id);
-                    let Some(table_constraints) = table_constraints else {
-                        table_references.joined_tables_mut()[table_idx].op =
-                            Operation::Scan(Scan::BTreeTable {
-                                iter_dir: *iter_dir,
-                                index: index.clone(),
-                            });
-                        continue;
-                    };
-                    // Find this table's position in best_join_order (which excludes build tables)
-                    let join_order_pos = best_join_order
-                        .iter()
-                        .position(|m| m.original_idx == table_idx)
-                        .unwrap_or_else(|| best_join_order.len().saturating_sub(1));
-                    let index_terms = automatic_index_terms(
-                        &table_references.joined_tables()[table_idx],
-                        table_constraints,
-                    );
-                    let usable_constraint_refs = usable_constraints_for_join_order(
-                        &table_constraints.constraints,
-                        &index_terms,
-                        &best_join_order[..=join_order_pos],
-                    )?;
-
-                    if usable_constraint_refs.is_empty() {
-                        table_references.joined_tables_mut()[table_idx].op =
-                            Operation::Scan(Scan::BTreeTable {
-                                iter_dir: *iter_dir,
-                                index: index.clone(),
-                            });
-                        continue;
-                    }
-                    let ephemeral_index = ephemeral_index_build(
-                        &table_references.joined_tables_mut()[table_idx],
-                        &usable_constraint_refs,
-                    )?;
-
-                    mark_seek_constraints_consumed(
-                        &table_constraints.constraints,
-                        &usable_constraint_refs,
-                        where_clause,
-                        table_references.joined_tables()[table_idx]
+                    if let Some(index) = partial_index(index.as_ref()) {
+                        let is_outer_join = table_references.joined_tables()[table_idx]
                             .join_info
                             .as_ref()
-                            .is_some_and(|ji| ji.is_outer()),
-                        hash_join_build_only_tables.get(table_idx),
-                    );
-
-                    let ephemeral_index = Arc::new(ephemeral_index);
+                            .is_some_and(|join_info| join_info.is_outer());
+                        mark_partial_index_predicate_terms_consumed(
+                            index,
+                            &table_references.joined_tables()[table_idx],
+                            where_clause,
+                            is_outer_join,
+                        );
+                    }
                     table_references.joined_tables_mut()[table_idx].op =
-                        Operation::Search(Search::Seek {
-                            index: Some(ephemeral_index),
-                            seek_def: build_seek_def_from_constraints(
-                                &table_constraints.constraints,
-                                &usable_constraint_refs,
-                                *iter_dir,
-                                where_clause,
-                                Some(table_references),
-                                Some(resolver),
-                            )?,
+                        Operation::Scan(Scan::BTreeTable {
+                            iter_dir: *iter_dir,
+                            index: index.clone(),
                         });
+                    continue;
                 } else {
                     let is_outer_join = table_references.joined_tables()[table_idx]
                         .join_info
@@ -3396,6 +3329,8 @@ fn ephemeral_index_build(
         .columns()
         .iter()
         .enumerate()
+        // Only copy columns that the query reads.
+        .filter(|(index, _)| table_reference.column_is_used(*index))
         .map(|(i, c)| {
             let expr = match c.generated_type() {
                 GeneratedType::Virtual { .. } => c.generated_expr().cloned(),
@@ -3411,8 +3346,6 @@ fn ephemeral_index_build(
                 expr: expr.map(Box::new),
             }
         })
-        // only include columns that are used in the query
-        .filter(|c| table_reference.column_is_used(c.pos_in_table))
         .try_collect()?;
     // sort so that constraints first, then rest in whatever order they were in in the table
     ephemeral_columns.sort_by(|a, b| {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -783,10 +783,24 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
     let original_table_plan = find_select_plan_form(plan, resolver)?;
     let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver)?;
 
-    let use_rewritten = matches!(
-        (plan.estimated_cost, rewritten.estimated_cost),
-        (Some(original_cost), Some(rewritten_cost)) if rewritten_cost <= original_cost
-    );
+    let has_full_join = plan.table_references.joined_tables().iter().any(|table| {
+        table
+            .join_info
+            .as_ref()
+            .is_some_and(JoinInfo::is_full_outer)
+    });
+    // The correlated form cannot run on every matched and unmatched FULL JOIN
+    // row yet. A complete semi-join or anti-join rewrite can, so use it.
+    let full_join_rewrite_is_complete = has_full_join
+        && !rewritten
+            .non_from_clause_subqueries
+            .iter()
+            .any(|subquery| subquery.correlated);
+    let use_rewritten = full_join_rewrite_is_complete
+        || matches!(
+            (plan.estimated_cost, rewritten.estimated_cost),
+            (Some(original_cost), Some(rewritten_cost)) if rewritten_cost <= original_cost
+        );
     if use_rewritten {
         // Equal work is better without one subquery call per outer row.
         *plan = rewritten;

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -56,7 +56,10 @@ use constraints::{
     partial_index_predicate_terms, Constraint,
 };
 use cost::Cost;
-use join::{compute_best_join_order_with_context, BestJoinOrderResult, JoinN, JoinPlanningContext};
+use join::{
+    compute_best_join_order_with_context, count_subquery_calls_for_plan, BestJoinOrderResult,
+    JoinN, JoinPlanningContext,
+};
 use lift_common_subexpressions::lift_common_subexpressions_from_binary_or_terms;
 use order::{
     compute_order_target, plan_satisfies_order_target, simple_aggregate_order_target,
@@ -857,6 +860,7 @@ struct TableAccessPlan {
     access_methods: Vec<AccessMethod>,
     constraints: Vec<TableConstraints>,
     join: JoinN,
+    subquery_calls: SmallVec<[(TableInternalId, f64); 2]>,
     order_target: Option<OrderTarget>,
     sort_eliminated: bool,
 }
@@ -1034,7 +1038,7 @@ fn find_select_plan_form(
     let table_cost = table_plan.as_ref().map(|table_plan| table_plan.join.cost);
     let mut subquery_calls = table_plan
         .as_ref()
-        .map(|table_plan| table_plan.join.subquery_calls.clone())
+        .map(|table_plan| table_plan.subquery_calls.clone())
         .unwrap_or_default();
 
     if let Some(table_plan) = table_plan.as_ref() {
@@ -1075,13 +1079,7 @@ fn find_select_plan_form(
         plan.estimated_output_rows = Some(rows);
     }
 
-    plan_correlated_subqueries(
-        plan,
-        resolver,
-        &subquery_calls,
-        cache,
-        save_subquery_plans,
-    )?;
+    plan_correlated_subqueries(plan, resolver, &subquery_calls, cache, save_subquery_plans)?;
 
     let table_cost = table_cost.or_else(|| {
         plan.table_references
@@ -2509,15 +2507,27 @@ fn find_table_access_plan(
             &best_plan,
             &access_methods_arena,
             table_references.joined_tables(),
+            &constraints_per_table,
             order_target,
             schema,
         )
     });
+    let subquery_calls = count_subquery_calls_for_plan(
+        &best_plan,
+        &access_methods_arena,
+        &constraints_per_table,
+        table_references.joined_tables(),
+        where_clause,
+        subqueries,
+        initial_input_cardinality,
+        params,
+    )?;
 
     Ok(Some(TableAccessPlan {
         access_methods: access_methods_arena,
         constraints: constraints_per_table,
         join: best_plan,
+        subquery_calls,
         order_target: maybe_order_target,
         sort_eliminated,
     }))
@@ -2540,6 +2550,7 @@ fn apply_table_access_plan(
         access_methods: mut access_methods_arena,
         constraints: constraints_per_table,
         join: best_plan,
+        subquery_calls: _,
         order_target: maybe_order_target,
         sort_eliminated,
     } = plan;
@@ -2678,8 +2689,30 @@ fn apply_table_access_plan(
             AccessMethodParams::BTreeTable {
                 iter_dir,
                 index,
+                build_index,
                 constraint_refs,
             } => {
+                if *build_index {
+                    turso_assert!(index.is_none(), "a new temporary index must not exist yet");
+                    let prior_tables: TableMask =
+                        best_table_numbers.iter().take(i).copied().try_collect()?;
+                    *constraint_refs = constraints::usable_constraints_for_lhs_mask(
+                        &constraints_per_table[table_idx].constraints,
+                        &constraints_per_table[table_idx].temporary_index_terms,
+                        &prior_tables,
+                        table_idx,
+                    )
+                    .into_vec();
+                    turso_assert!(
+                        !constraint_refs.is_empty(),
+                        "a temporary index must have a search key"
+                    );
+                    *index = Some(Arc::new(ephemeral_index_build(
+                        &table_references.joined_tables()[table_idx],
+                        constraint_refs,
+                    )?));
+                    *build_index = false;
+                }
                 maybe_remove_index_candidate(
                     index,
                     &table_references.joined_tables()[table_idx],
@@ -2976,10 +3009,13 @@ fn apply_table_access_plan(
 
     let mut probe_pos_by_table: Vec<Option<usize>> =
         vec![None; table_references.joined_tables().len()];
+    let mut hash_build_by_probe: Vec<Option<usize>> =
+        vec![None; table_references.joined_tables().len()];
     for (pos, member) in best_join_order.iter().enumerate() {
         let table = &table_references.joined_tables()[member.original_idx];
-        if matches!(table.op, Operation::HashJoin(_)) {
+        if let Operation::HashJoin(hash_join_op) = &table.op {
             probe_pos_by_table[member.original_idx] = Some(pos);
+            hash_build_by_probe[member.original_idx] = Some(hash_join_op.build_table_idx);
         }
     }
 
@@ -3006,10 +3042,17 @@ fn apply_table_access_plan(
         if build_table_was_prior_probe {
             continue;
         }
-        let prior_mask = best_join_order[..probe_pos]
+        let mut prior_mask: TableMask = best_join_order[..probe_pos]
             .iter()
             .map(|member| member.original_idx)
             .try_collect()?;
+        // A hash build table is read through its probe table. Include it when
+        // checking which earlier tables can filter this build input.
+        for member in &best_join_order[..probe_pos] {
+            if let Some(build_table_idx) = hash_build_by_probe[member.original_idx] {
+                prior_mask.set(build_table_idx)?;
+            }
+        }
         let join_key_indices: BitSet = hash_join_op
             .join_keys
             .iter()

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -748,20 +748,6 @@ fn detect_simple_aggregate(plan: &SelectPlan) -> Option<SimpleAggregate> {
     }
 }
 
-/// The table plan chosen for one SELECT.
-struct OptimizeTableAccessResult {
-    /// Tables in the order they will be read.
-    join_order: Vec<JoinOrderMember>,
-    /// Rows expected from the full join.
-    output_rows: f64,
-    /// Work expected from the full join.
-    cost: Cost,
-    /// Expected calls to each correlated subquery.
-    subquery_calls: SmallVec<[(TableInternalId, f64); 2]>,
-    /// Whether `min` or `max` can stop after the first row.
-    min_max_fast_path: bool,
-}
-
 /// The table reads chosen by the join search.
 struct TableAccessPlan {
     access_methods: Vec<AccessMethod>,
@@ -786,23 +772,27 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
         return optimize_select_plan_form(plan, resolver);
     }
 
-    // TODO: Keep both forms in one optimizer run instead of copying the full
-    // plan. Query parts that do not change should be shared, and the join
-    // planner must compare choices with different table lists.
+    // TODO: Let join search run a correlated subquery as soon as all columns
+    // that it needs are ready. It can then compare that step with the added
+    // join tables in one search. Until then, both forms need their own search.
     let mut rewritten = plan.clone();
     if !unnest::rewrite_correlated_subqueries(&mut rewritten, resolver)? {
         return optimize_select_plan_form(plan, resolver);
     }
 
-    optimize_select_plan_form(plan, resolver)?;
-    optimize_select_plan_form(&mut rewritten, resolver)?;
+    let original_table_plan = find_select_plan_form(plan, resolver)?;
+    let rewritten_table_plan = find_select_plan_form(&mut rewritten, resolver)?;
 
-    if matches!(
+    let use_rewritten = matches!(
         (plan.estimated_cost, rewritten.estimated_cost),
         (Some(original_cost), Some(rewritten_cost)) if rewritten_cost <= original_cost
-    ) {
+    );
+    if use_rewritten {
         // Equal work is better without one subquery call per outer row.
         *plan = rewritten;
+        apply_select_table_plan(plan, rewritten_table_plan, resolver)?;
+    } else {
+        apply_select_table_plan(plan, original_table_plan, resolver)?;
     }
 
     Ok(())
@@ -810,6 +800,15 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
 
 /// Choose table reads for one version of a query.
 fn optimize_select_plan_form(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
+    let table_plan = find_select_plan_form(plan, resolver)?;
+    apply_select_table_plan(plan, table_plan, resolver)
+}
+
+/// Find the table reads for one version of a query.
+fn find_select_plan_form(
+    plan: &mut SelectPlan,
+    resolver: &Resolver,
+) -> Result<Option<TableAccessPlan>> {
     let schema = resolver.schema();
     #[cfg(feature = "optimizer_params")]
     let params: &cost_params::CostModelParams = &cost_params::LOADED_PARAMS;
@@ -853,13 +852,12 @@ fn optimize_select_plan_form(plan: &mut SelectPlan, resolver: &Resolver) -> Resu
         plan.estimated_output_rows = Some(0.0);
         plan.estimated_cost = Some(0.0);
         plan_correlated_subqueries(plan, resolver, &[])?;
-        return Ok(());
+        return Ok(None);
     }
 
     plan.simple_aggregate = detect_simple_aggregate(plan);
-    let best_join_order = optimize_table_access(
+    let table_plan = find_table_access_plan(
         schema,
-        resolver,
         &mut plan.result_columns,
         &mut plan.table_references,
         &available_indexes,
@@ -874,27 +872,22 @@ fn optimize_select_plan_form(plan: &mut SelectPlan, resolver: &Resolver) -> Resu
     )?;
 
     if matches!(plan.simple_aggregate, Some(SimpleAggregate::MinMax(_)))
-        && !best_join_order
+        && !table_plan
             .as_ref()
-            .is_some_and(|result| result.min_max_fast_path)
+            .is_some_and(|table_plan| table_plan.sort_eliminated)
     {
         plan.simple_aggregate = None;
     }
 
-    let table_cost = best_join_order.as_ref().map(|result| result.cost);
-    let subquery_calls = best_join_order
+    let table_cost = table_plan.as_ref().map(|table_plan| table_plan.join.cost);
+    let subquery_calls = table_plan
         .as_ref()
-        .map(|result| result.subquery_calls.clone())
+        .map(|table_plan| table_plan.join.subquery_calls.clone())
         .unwrap_or_default();
 
-    if let Some(OptimizeTableAccessResult {
-        join_order,
-        output_rows,
-        ..
-    }) = best_join_order
-    {
-        plan.join_order = join_order;
-        let mut rows = estimate_select_output_rows(plan, output_rows, schema);
+    if let Some(table_plan) = table_plan.as_ref() {
+        let mut rows =
+            estimate_select_output_rows(plan, table_plan.join.output_cardinality, schema);
         // Clamp to LIMIT when it's a literal non-negative number.
         // Negative LIMIT means "no limit" in SQLite, so we skip those.
         if let Some(limit) = &plan.limit {
@@ -959,6 +952,26 @@ fn optimize_select_plan_form(plan: &mut SelectPlan, resolver: &Resolver) -> Resu
         }
     }
 
+    Ok(table_plan)
+}
+
+/// Write the winning table plan into one version of a query.
+fn apply_select_table_plan(
+    plan: &mut SelectPlan,
+    table_plan: Option<TableAccessPlan>,
+    resolver: &Resolver,
+) -> Result<()> {
+    let Some(table_plan) = table_plan else {
+        return Ok(());
+    };
+    plan.join_order = apply_table_access_plan(
+        resolver,
+        &mut plan.table_references,
+        &mut plan.where_clause,
+        &mut plan.order_by,
+        &mut plan.group_by,
+        table_plan,
+    )?;
     Ok(())
 }
 
@@ -1072,9 +1085,7 @@ fn optimize_update_plan(
         return Ok(());
     }
 
-    let join_order = optimize_result
-        .map(|result| result.join_order)
-        .unwrap_or_else(|| default_join_order(&target_tables));
+    let join_order = optimize_result.unwrap_or_else(|| default_join_order(&target_tables));
 
     build_update_write_set_plan(program, plan, Vec::new())?;
     plan.write_set_plan
@@ -1960,7 +1971,7 @@ fn optimize_table_access(
     limit: &mut Option<Box<Expr>>,
     offset: &mut Option<Box<Expr>>,
     initial_input_cardinality: f64,
-) -> Result<Option<OptimizeTableAccessResult>> {
+) -> Result<Option<Vec<JoinOrderMember>>> {
     let Some(plan) = find_table_access_plan(
         schema,
         result_columns,
@@ -1985,7 +1996,6 @@ fn optimize_table_access(
         where_clause,
         order_by,
         group_by,
-        simple_aggregate,
         plan,
     )?))
 }
@@ -2250,9 +2260,8 @@ fn apply_table_access_plan(
         Option<turso_parser::ast::NullsOrder>,
     )>,
     group_by: &mut Option<GroupBy>,
-    simple_aggregate: Option<&SimpleAggregate>,
     plan: TableAccessPlan,
-) -> Result<OptimizeTableAccessResult> {
+) -> Result<Vec<JoinOrderMember>> {
     let TableAccessPlan {
         access_methods: mut access_methods_arena,
         constraints: constraints_per_table,
@@ -2260,7 +2269,6 @@ fn apply_table_access_plan(
         order_target: maybe_order_target,
         sort_eliminated,
     } = plan;
-    let final_output_cardinality = best_plan.output_cardinality;
 
     if sort_eliminated {
         let order_target = maybe_order_target
@@ -2822,14 +2830,7 @@ fn apply_table_access_plan(
         }
     }
 
-    Ok(OptimizeTableAccessResult {
-        join_order: best_join_order,
-        output_rows: final_output_cardinality,
-        cost: best_plan.cost,
-        subquery_calls: best_plan.subquery_calls,
-        min_max_fast_path: matches!(simple_aggregate, Some(SimpleAggregate::MinMax(_)))
-            && sort_eliminated,
-    })
+    Ok(best_join_order)
 }
 
 fn build_vtab_scan_op(

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     translate::{
         insert::ROWID_COLUMN,
         optimizer::{
-            access_method::AccessMethodParams,
+            access_method::{AccessMethod, AccessMethodParams},
             constraints::{
                 ConstraintUseCandidate, RangeConstraintRef, SeekRangeConstraint, TableConstraints,
             },
@@ -56,7 +56,7 @@ use constraints::{
     partial_index_predicate_terms, usable_constraints_for_join_order, Constraint, ConstraintRef,
 };
 use cost::Cost;
-use join::{compute_best_join_order_with_context, BestJoinOrderResult, JoinPlanningContext};
+use join::{compute_best_join_order_with_context, BestJoinOrderResult, JoinN, JoinPlanningContext};
 use lift_common_subexpressions::lift_common_subexpressions_from_binary_or_terms;
 use order::{
     compute_order_target, plan_satisfies_order_target, simple_aggregate_order_target,
@@ -760,6 +760,15 @@ struct OptimizeTableAccessResult {
     subquery_calls: SmallVec<[(TableInternalId, f64); 2]>,
     /// Whether `min` or `max` can stop after the first row.
     min_max_fast_path: bool,
+}
+
+/// The table reads chosen by the join search.
+struct TableAccessPlan {
+    access_methods: Vec<AccessMethod>,
+    constraints: Vec<TableConstraints>,
+    join: JoinN,
+    order_target: Option<OrderTarget>,
+    sort_eliminated: bool,
 }
 
 /**
@@ -1931,17 +1940,7 @@ fn enforce_indexed_by_hints(
     Ok(())
 }
 
-/// Optimize the join order and index selection for a query.
-///
-/// This function does the following:
-/// - Computes a set of [Constraint]s for each table.
-/// - Using those constraints, computes the best join order for the list of [TableReference]s
-///   and selects the best [crate::translate::optimizer::access_method::AccessMethod] for each table in the join order.
-/// - Mutates the [Operation]s in `joined_tables` to use the selected access methods.
-/// - Removes predicates from the `where_clause` that are now redundant due to the selected access methods.
-/// - Removes sorting operations if the selected join order and access methods satisfy the [crate::translate::optimizer::order::OrderTarget].
-///
-/// Returns the join order if it was optimized, or None if the default join order was considered best.
+/// Choose table reads and write them into the query plan.
 #[allow(clippy::too_many_arguments)]
 fn optimize_table_access(
     schema: &Schema,
@@ -1962,6 +1961,55 @@ fn optimize_table_access(
     offset: &mut Option<Box<Expr>>,
     initial_input_cardinality: f64,
 ) -> Result<Option<OptimizeTableAccessResult>> {
+    let Some(plan) = find_table_access_plan(
+        schema,
+        result_columns,
+        table_references,
+        available_indexes,
+        where_clause,
+        order_by,
+        group_by,
+        simple_aggregate,
+        subqueries,
+        limit,
+        offset,
+        initial_input_cardinality,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(apply_table_access_plan(
+        resolver,
+        table_references,
+        where_clause,
+        order_by,
+        group_by,
+        simple_aggregate,
+        plan,
+    )?))
+}
+
+/// Find the best table reads without writing them into table operations.
+#[allow(clippy::too_many_arguments)]
+fn find_table_access_plan(
+    schema: &Schema,
+    result_columns: &mut [ResultSetColumn],
+    table_references: &mut TableReferences,
+    available_indexes: &AvailableIndexes,
+    where_clause: &mut [WhereTerm],
+    order_by: &mut Vec<(
+        Box<ast::Expr>,
+        SortOrder,
+        Option<turso_parser::ast::NullsOrder>,
+    )>,
+    group_by: &mut Option<GroupBy>,
+    simple_aggregate: Option<&SimpleAggregate>,
+    subqueries: &[NonFromClauseSubquery],
+    limit: &mut Option<Box<Expr>>,
+    offset: &mut Option<Box<Expr>>,
+    initial_input_cardinality: f64,
+) -> Result<Option<TableAccessPlan>> {
     // When optimizer_params feature is enabled, use lazily-loaded params (cached process-wide).
     // Otherwise, use the compile-time static for zero overhead.
     #[cfg(feature = "optimizer_params")]
@@ -2172,39 +2220,69 @@ fn optimize_table_access(
         best_plan
     };
 
-    let final_output_cardinality = best_plan.output_cardinality;
-
-    let mut sort_eliminated = false;
-
-    // Eliminate sorting if possible.
-    if let Some(order_target) = maybe_order_target.as_ref() {
-        let satisfies_order_target = plan_satisfies_order_target(
+    let sort_eliminated = maybe_order_target.as_ref().is_some_and(|order_target| {
+        plan_satisfies_order_target(
             &best_plan,
             &access_methods_arena,
-            table_references.joined_tables_mut(),
+            table_references.joined_tables(),
             order_target,
             schema,
-        );
-        if satisfies_order_target {
-            match &order_target.purpose {
-                OrderTargetPurpose::EliminatesSort(EliminatesSortBy::Group) => {
-                    if let Some(g) = group_by.as_mut() {
-                        g.sort_elided = true;
-                    }
+        )
+    });
+
+    Ok(Some(TableAccessPlan {
+        access_methods: access_methods_arena,
+        constraints: constraints_per_table,
+        join: best_plan,
+        order_target: maybe_order_target,
+        sort_eliminated,
+    }))
+}
+
+/// Write chosen table reads into the query plan.
+fn apply_table_access_plan(
+    resolver: &Resolver,
+    table_references: &mut TableReferences,
+    where_clause: &mut [WhereTerm],
+    order_by: &mut Vec<(
+        Box<ast::Expr>,
+        SortOrder,
+        Option<turso_parser::ast::NullsOrder>,
+    )>,
+    group_by: &mut Option<GroupBy>,
+    simple_aggregate: Option<&SimpleAggregate>,
+    plan: TableAccessPlan,
+) -> Result<OptimizeTableAccessResult> {
+    let TableAccessPlan {
+        access_methods: mut access_methods_arena,
+        constraints: constraints_per_table,
+        join: best_plan,
+        order_target: maybe_order_target,
+        sort_eliminated,
+    } = plan;
+    let final_output_cardinality = best_plan.output_cardinality;
+
+    if sort_eliminated {
+        let order_target = maybe_order_target
+            .as_ref()
+            .expect("a sort can only be removed when the query has an order target");
+        match &order_target.purpose {
+            OrderTargetPurpose::EliminatesSort(EliminatesSortBy::Group) => {
+                if let Some(group) = group_by.as_mut() {
+                    group.sort_elided = true;
                 }
-                OrderTargetPurpose::EliminatesSort(EliminatesSortBy::Order) => {
-                    order_by.clear();
-                }
-                OrderTargetPurpose::EliminatesSort(EliminatesSortBy::GroupByAndOrder) => {
-                    if let Some(g) = group_by.as_mut() {
-                        g.sort_elided = true;
-                    }
-                    order_by.clear();
-                }
-                OrderTargetPurpose::Extremum => {}
             }
+            OrderTargetPurpose::EliminatesSort(EliminatesSortBy::Order) => {
+                order_by.clear();
+            }
+            OrderTargetPurpose::EliminatesSort(EliminatesSortBy::GroupByAndOrder) => {
+                if let Some(group) = group_by.as_mut() {
+                    group.sort_elided = true;
+                }
+                order_by.clear();
+            }
+            OrderTargetPurpose::Extremum => {}
         }
-        sort_eliminated = satisfies_order_target;
     }
 
     let (best_access_methods, best_table_numbers) = (
@@ -2744,14 +2822,14 @@ fn optimize_table_access(
         }
     }
 
-    Ok(Some(OptimizeTableAccessResult {
+    Ok(OptimizeTableAccessResult {
         join_order: best_join_order,
         output_rows: final_output_cardinality,
         cost: best_plan.cost,
         subquery_calls: best_plan.subquery_calls,
         min_max_fast_path: matches!(simple_aggregate, Some(SimpleAggregate::MinMax(_)))
             && sort_eliminated,
-    }))
+    })
 }
 
 fn build_vtab_scan_op(

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -769,14 +769,6 @@ struct OptimizeTableAccessResult {
  */
 #[turso_macros::trace_stack]
 pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()> {
-    // Transform MATCH expressions to fts_match() for FTS optimizer recognition
-    #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(
-        &mut plan.where_clause,
-        resolver.schema(),
-        &plan.table_references,
-    )?;
-
     if !plan
         .non_from_clause_subqueries
         .iter()
@@ -785,6 +777,9 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
         return optimize_select_plan_form(plan, resolver);
     }
 
+    // TODO: Keep both forms in one optimizer run instead of copying the full
+    // plan. Query parts that do not change should be shared, and the join
+    // planner must compare choices with different table lists.
     let mut rewritten = plan.clone();
     if !unnest::rewrite_correlated_subqueries(&mut rewritten, resolver)? {
         return optimize_select_plan_form(plan, resolver);
@@ -813,6 +808,11 @@ fn optimize_select_plan_form(plan: &mut SelectPlan, resolver: &Resolver) -> Resu
     let params: &cost_params::CostModelParams = &cost_params::DEFAULT_PARAMS;
     plan.estimated_output_rows = None;
     plan.estimated_cost = None;
+
+    // A rewrite can move MATCH terms out of a subquery, so do this after the
+    // query form has been chosen.
+    #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
 
     // EXISTS only needs one row. Add LIMIT 1 to subqueries left after the
     // rewrite. The rewrite must see the limit written by the user, if any.
@@ -843,6 +843,7 @@ fn optimize_select_plan_form(plan: &mut SelectPlan, resolver: &Resolver) -> Resu
         plan.contains_constant_false_condition = true;
         plan.estimated_output_rows = Some(0.0);
         plan.estimated_cost = Some(0.0);
+        plan_correlated_subqueries(plan, resolver, &[])?;
         return Ok(());
     }
 
@@ -911,7 +912,7 @@ fn optimize_select_plan_form(plan: &mut SelectPlan, resolver: &Resolver) -> Resu
         plan.estimated_output_rows = Some(rows);
     }
 
-    replan_correlated_subqueries(plan, resolver, &subquery_calls)?;
+    plan_correlated_subqueries(plan, resolver, &subquery_calls)?;
 
     let table_cost = table_cost.or_else(|| {
         plan.table_references
@@ -1468,11 +1469,8 @@ fn optimize_subqueries(plan: &mut SelectPlan, resolver: &Resolver) -> Result<()>
     Ok(())
 }
 
-/// Plan each correlated subquery again with its expected number of calls.
-///
-/// Start from the saved plan because the first pass may have removed terms that
-/// are now part of an index search.
-fn replan_correlated_subqueries(
+/// Plan each correlated subquery with its expected number of calls.
+fn plan_correlated_subqueries(
     plan: &mut SelectPlan,
     resolver: &Resolver,
     subquery_calls: &[(TableInternalId, f64)],
@@ -1492,22 +1490,6 @@ fn replan_correlated_subqueries(
         else {
             continue;
         };
-        if call_count <= 1.0 {
-            continue;
-        }
-        let Some(saved_plan) = &subquery.saved_plan else {
-            continue;
-        };
-        *inner_plan = saved_plan.clone();
-        if matches!(subquery.query_type, ast::SubqueryType::Exists { .. }) {
-            if let Plan::Select(inner_plan) = inner_plan.as_mut() {
-                if inner_plan.limit.is_none() {
-                    inner_plan.limit = Some(Box::new(Expr::Literal(ast::Literal::Numeric(
-                        "1".to_string(),
-                    ))));
-                }
-            }
-        }
         optimize_plan_for_calls(inner_plan, resolver, call_count)?;
     }
 

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -12,7 +12,7 @@ use crate::stats::AnalyzeStats;
 use crate::translate::expr::expr_references_any_subquery;
 use crate::translate::optimizer::access_method::{
     choose_best_btree_candidate, choose_best_in_seek_candidate, AccessMethod, AccessMethodParams,
-    BranchReadMode, ChosenInSeekCandidate, ResidualConstraintMode,
+    BranchReadMode, ChosenInSeekCandidate,
 };
 use crate::translate::optimizer::constraints::{
     analyze_binary_term_for_index, can_use_partial_index, constraints_from_where_clause,
@@ -21,7 +21,7 @@ use crate::translate::optimizer::constraints::{
 };
 use crate::translate::optimizer::cost::{
     estimate_cost_for_scan_or_seek, estimate_rows_per_seek, rows_per_leaf_page_for_index,
-    AnalyzeCtx, Cost, IndexInfo, RowCountEstimate,
+    where_expr_steps, AnalyzeCtx, Cost, IndexInfo, RowCountEstimate,
 };
 use crate::translate::optimizer::cost_params::CostModelParams;
 use crate::translate::optimizer::AvailableIndexes;
@@ -385,7 +385,7 @@ fn choose_multi_index_branch_access(
                 index: chosen.index.clone(),
                 access: MultiIdxBranchAccess::Seek {
                     constraints: table_constraints.constraints.clone(),
-                    constraint_refs: chosen.constraint_refs.clone(),
+                    constraint_refs: chosen.constraint_refs.to_vec(),
                 },
                 cost: branch_cost,
                 estimated_rows: estimate_rows_per_seek(
@@ -668,6 +668,19 @@ fn evaluate_multi_index_branches(
     let mut branch_params = Vec::with_capacity(branches.len());
 
     for branch in branches {
+        let where_cost = branch
+            .union_prepost_filters
+            .as_ref()
+            .map(|filters| {
+                let pre_steps: usize = filters.pre_filter_exprs.iter().map(where_expr_steps).sum();
+                let post_steps: usize =
+                    filters.post_filter_exprs.iter().map(where_expr_steps).sum();
+                Cost(
+                    (pre_steps as f64 + branch.estimated_rows * post_steps as f64)
+                        * params.cpu_cost_per_where_step,
+                )
+            })
+            .unwrap_or(Cost(0.0));
         let post_filter_exprs = branch
             .union_prepost_filters
             .as_ref()
@@ -705,7 +718,7 @@ fn evaluate_multi_index_branches(
             residuals: branch.union_prepost_filters,
         };
 
-        branch_costs.push(branch.cost);
+        branch_costs.push(branch.cost + where_cost);
         branch_rows.push(params_for_branch.estimated_rows);
         branch_params.push(params_for_branch);
     }
@@ -753,7 +766,6 @@ fn evaluate_multi_index_branches(
         Some(AccessMethod {
             cost: multi_index_cost,
             estimated_rows_per_outer_row: estimated_rows,
-            residual_constraints: ResidualConstraintMode::ApplyUnconsumed,
             consumed_where_terms,
             params: AccessMethodParams::MultiIndexScan {
                 branches: branch_params,

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -1,4 +1,4 @@
-use crate::schema::{impl_effective_nulls_order, IndexColumn, Table};
+use crate::schema::{impl_effective_nulls_order, Table};
 use crate::turso_assert_greater_than_or_equal;
 use crate::{
     schema::{FromClauseSubquery, Index, Schema},
@@ -6,12 +6,14 @@ use crate::{
         collate::{get_collseq_from_expr, CollationSeq},
         expression_index::normalize_expr_for_index_matching,
         optimizer::access_method::AccessMethodParams,
-        optimizer::constraints::RangeConstraintRef,
+        optimizer::constraints::{
+            usable_constraints_for_lhs_mask, RangeConstraintRef, TableConstraints,
+        },
         plan::{
             GroupBy, HashJoinType, IterationDirection, JoinedTable, Operation, Plan, Scan,
             SimpleAggregate, TableReferences,
         },
-        planner::table_mask_from_expr,
+        planner::{table_mask_from_expr, TableMask},
     },
     util::exprs_are_equivalent,
 };
@@ -240,6 +242,7 @@ pub fn plan_satisfies_order_target(
     plan: &JoinN,
     access_methods_arena: &[AccessMethod],
     joined_tables: &[JoinedTable],
+    table_constraints: &[TableConstraints],
     order_target: &OrderTarget,
     schema: &Schema,
 ) -> bool {
@@ -254,6 +257,7 @@ pub fn plan_satisfies_order_target(
     }
 
     let mut target_col_idx = 0;
+    let mut prior_tables = TableMask::default();
     let num_cols_in_order_target = order_target.columns.len();
     for (loop_pos, (table_index, access_method_index)) in plan.data.iter().enumerate() {
         let access_method = &access_methods_arena[*access_method_index];
@@ -279,17 +283,37 @@ pub fn plan_satisfies_order_target(
             AccessMethodParams::BTreeTable {
                 iter_dir,
                 index: index_opt,
+                build_index,
                 constraint_refs,
-            } => btree_access_order_consumed(
-                table_ref,
-                *iter_dir,
-                index_opt.as_deref(),
-                constraint_refs,
-                order_target,
-                target_col_idx,
-                schema,
-                EqualityPrefixScope::ConstantEquality,
-            ),
+            } => {
+                if *build_index {
+                    let constraint_refs = usable_constraints_for_lhs_mask(
+                        &table_constraints[*table_index].constraints,
+                        &table_constraints[*table_index].temporary_index_terms,
+                        &prior_tables,
+                        *table_index,
+                    );
+                    temporary_index_order_consumed(
+                        table_ref,
+                        *iter_dir,
+                        &constraint_refs,
+                        order_target,
+                        target_col_idx,
+                        schema,
+                    )
+                } else {
+                    btree_access_order_consumed(
+                        table_ref,
+                        *iter_dir,
+                        index_opt.as_deref(),
+                        constraint_refs,
+                        order_target,
+                        target_col_idx,
+                        schema,
+                        EqualityPrefixScope::ConstantEquality,
+                    )
+                }
+            }
             AccessMethodParams::MaterializedSubquery {
                 index,
                 constraint_refs,
@@ -352,6 +376,9 @@ pub fn plan_satisfies_order_target(
         {
             return false;
         }
+        prior_tables
+            .set(*table_index)
+            .expect("a plan cannot contain more than the table limit");
     }
     target_col_idx == num_cols_in_order_target
 }
@@ -374,9 +401,13 @@ fn access_method_emits_unique_order_prefix(
     match &access_method.params {
         AccessMethodParams::BTreeTable {
             index,
+            build_index,
             constraint_refs,
             ..
-        } => is_unique_point_lookup(index_info_for_access(index.as_deref()), constraint_refs),
+        } => {
+            !*build_index
+                && is_unique_point_lookup(index_info_for_access(index.as_deref()), constraint_refs)
+        }
         AccessMethodParams::MaterializedSubquery {
             index,
             constraint_refs,
@@ -725,15 +756,39 @@ fn expr_to_column_order(
     })
 }
 
-fn target_matches_index_column(
+/// The index column values needed to check its row order.
+#[derive(Clone, Copy)]
+struct IndexOrderColumn<'a> {
+    pos_in_table: usize,
+    order: SortOrder,
+    nulls_order: Option<ast::NullsOrder>,
+    collation: Option<CollationSeq>,
+    expr: Option<&'a ast::Expr>,
+}
+
+impl IndexOrderColumn<'_> {
+    /// Return the NULL order for this scan direction.
+    fn nulls_order(self, iter_dir: IterationDirection) -> ast::NullsOrder {
+        let nulls_order = self
+            .nulls_order
+            .unwrap_or_else(|| ast::NullsOrder::default_for(self.order));
+        match iter_dir {
+            IterationDirection::Forwards => nulls_order,
+            IterationDirection::Backwards => nulls_order.reverse(),
+        }
+    }
+}
+
+/// Return true when an order term names this index column.
+fn target_matches_order_column(
     target_col: &ColumnOrder,
-    idx_col: &IndexColumn,
+    idx_col: IndexOrderColumn<'_>,
     table_ref: &JoinedTable,
 ) -> bool {
     if target_col.table_id != table_ref.internal_id {
         return false;
     }
-    match (&target_col.target, &idx_col.expr) {
+    match (&target_col.target, idx_col.expr) {
         (ColumnTarget::Column(col_no), _) => idx_col.pos_in_table == *col_no,
         (ColumnTarget::Expr(expr), Some(idx_expr)) => {
             let target_expr = unsafe { &**expr };
@@ -830,122 +885,197 @@ pub(super) fn btree_access_order_consumed(
                 includes_rowid: correct_order,
             }
         }
-        Some(index) => {
-            let mut col_idx = 0;
-            let mut idx_pos = 0;
-            let mut includes_rowid = false;
-            let target_is_rowid = |target_col: &ColumnOrder| match target_col.target {
-                ColumnTarget::RowId => true,
-                ColumnTarget::Column(col_no) => rowid_alias_col == Some(col_no),
-                ColumnTarget::Expr(_) => false,
-            };
-            while col_idx < target_columns.len() && idx_pos < index.columns.len() {
-                let target_col = &target_columns[col_idx];
-                if target_col.table_id != table_ref.internal_id {
-                    break;
-                }
+        Some(index) => index_columns_order_consumed(
+            table_ref,
+            iter_dir,
+            constraint_refs,
+            order_target,
+            target_columns,
+            schema,
+            equality_prefix_scope,
+            index.columns.iter().map(|column| IndexOrderColumn {
+                pos_in_table: column.pos_in_table,
+                order: column.order,
+                nulls_order: column.nulls_order,
+                collation: column.collation,
+                expr: column.expr.as_deref(),
+            }),
+            index.columns.len(),
+            index.has_rowid,
+            rowid_alias_col,
+        ),
+    }
+}
 
-                let idx_col = &index.columns[idx_pos];
-                let eq_prefix_usable = constraint_refs.iter().any(|constraint| {
-                    constraint.index_col_pos == idx_pos
-                        && constraint.eq.as_ref().is_some_and(|eq| {
-                            equality_prefix_scope == EqualityPrefixScope::AnyEquality || eq.is_const
-                        })
-                });
-                if eq_prefix_usable {
-                    // Equality-constrained prefix columns produce a single value
-                    // per seek, so they do not disturb the ordering of the
-                    // remaining suffix. If the ORDER BY / GROUP BY also mentions
-                    // the same column with the same collation, that target term
-                    // is satisfied trivially and can be consumed here too.
-                    if target_matches_index_column(target_col, idx_col, table_ref) {
-                        let same_collation =
-                            target_col.collation == idx_col.collation.unwrap_or_default();
-                        if !same_collation {
-                            break;
-                        }
-                        col_idx += 1;
-                    }
-                    idx_pos += 1;
-                    continue;
-                }
+/// Check the order supplied by a temporary index without building its columns.
+fn temporary_index_order_consumed(
+    table_ref: &JoinedTable,
+    iter_dir: IterationDirection,
+    constraint_refs: &[RangeConstraintRef],
+    order_target: &OrderTarget,
+    start_col: usize,
+    schema: &Schema,
+) -> OrderConsumption {
+    let target_columns = &order_target.columns[start_col..];
+    if target_columns.is_empty() {
+        return OrderConsumption::NONE;
+    }
+    let columns = table_ref.columns();
+    let column_count = columns
+        .iter()
+        .enumerate()
+        .filter(|(column_idx, _)| table_ref.column_is_used(*column_idx))
+        .count();
+    let rowid_alias_col = columns.iter().position(|column| column.is_rowid_alias());
+    let key_columns = constraint_refs.iter().map(|constraint| {
+        constraint
+            .table_col_pos
+            .expect("a temporary index key must name a table column")
+    });
+    let other_columns = columns
+        .iter()
+        .enumerate()
+        .filter(|(column_pos, _)| table_ref.column_is_used(*column_pos))
+        .filter(|(column_pos, _)| {
+            !constraint_refs
+                .iter()
+                .any(|constraint| constraint.table_col_pos == Some(*column_pos))
+        })
+        .map(|(column_pos, _)| column_pos);
+    let index_columns = key_columns.chain(other_columns).map(|column_pos| {
+        let column = &columns[column_pos];
+        IndexOrderColumn {
+            pos_in_table: column_pos,
+            order: SortOrder::Asc,
+            nulls_order: None,
+            collation: column.collation_opt(),
+            expr: column.generated_expr(),
+        }
+    });
 
-                if !target_matches_index_column(target_col, idx_col, table_ref) {
-                    break;
-                }
+    index_columns_order_consumed(
+        table_ref,
+        iter_dir,
+        constraint_refs,
+        order_target,
+        target_columns,
+        schema,
+        EqualityPrefixScope::ConstantEquality,
+        index_columns,
+        column_count,
+        table_ref.table.btree().is_some_and(|table| table.has_rowid),
+        rowid_alias_col,
+    )
+}
 
-                // Custom type columns store encoded blobs. The B-tree's bytewise
-                // ordering does not match the custom type's semantic ordering, so
-                // the index cannot satisfy ORDER BY for those columns.
-                if let ColumnTarget::Column(col_no) = &target_col.target {
-                    if let Some(col) = table_ref.table.columns().get(*col_no) {
-                        if schema
-                            .get_type_def(&col.ty_str, table_ref.table.is_strict())
-                            .is_some()
-                        {
-                            break;
-                        }
-                    }
-                }
-
+/// Return how many order terms these index columns supply.
+#[allow(clippy::too_many_arguments)]
+fn index_columns_order_consumed<'a>(
+    table_ref: &JoinedTable,
+    iter_dir: IterationDirection,
+    constraint_refs: &[RangeConstraintRef],
+    order_target: &OrderTarget,
+    target_columns: &[ColumnOrder],
+    schema: &Schema,
+    equality_prefix_scope: EqualityPrefixScope,
+    index_columns: impl Iterator<Item = IndexOrderColumn<'a>>,
+    column_count: usize,
+    has_rowid: bool,
+    rowid_alias_col: Option<usize>,
+) -> OrderConsumption {
+    let mut col_idx = 0;
+    let mut matched_columns = 0;
+    let mut index_columns = index_columns.enumerate();
+    let mut includes_rowid = false;
+    let target_is_rowid = |target_col: &ColumnOrder| match target_col.target {
+        ColumnTarget::RowId => true,
+        ColumnTarget::Column(col_no) => rowid_alias_col == Some(col_no),
+        ColumnTarget::Expr(_) => false,
+    };
+    while col_idx < target_columns.len() {
+        let Some((idx_pos, idx_col)) = index_columns.next() else {
+            break;
+        };
+        let target_col = &target_columns[col_idx];
+        if target_col.table_id != table_ref.internal_id {
+            break;
+        }
+        let eq_prefix_usable = constraint_refs.iter().any(|constraint| {
+            constraint.index_col_pos == idx_pos
+                && constraint.eq.as_ref().is_some_and(|eq| {
+                    equality_prefix_scope == EqualityPrefixScope::AnyEquality || eq.is_const
+                })
+        });
+        if eq_prefix_usable {
+            if target_matches_order_column(target_col, idx_col, table_ref) {
                 if target_col.collation != idx_col.collation.unwrap_or_default() {
                     break;
                 }
+                col_idx += 1;
+            }
+            matched_columns += 1;
+            continue;
+        }
 
-                let correct_order_for_direction = if iter_dir == IterationDirection::Forwards {
-                    target_col.order == idx_col.order
-                } else {
-                    target_col.order != idx_col.order
-                };
-                if !correct_order_for_direction {
+        if !target_matches_order_column(target_col, idx_col, table_ref) {
+            break;
+        }
+
+        // Custom type columns store encoded blobs. The B-tree's byte order
+        // does not match the custom type's order.
+        if let ColumnTarget::Column(col_no) = &target_col.target {
+            if let Some(col) = table_ref.table.columns().get(*col_no) {
+                if schema
+                    .get_type_def(&col.ty_str, table_ref.table.is_strict())
+                    .is_some()
+                {
                     break;
                 }
-
-                // An index scan delivers NULLs in a known position: by
-                // default NULLs come first on a forward scan and last on a
-                // reverse scan, and an explicit NULLS FIRST/LAST on the index
-                // column flips that. If the scan delivers NULLs in a different
-                // position than the query requests, the index cannot satisfy
-                // the ordering and we must fall back to a sorter. MIN/MAX skip
-                // NULLs entirely, so for them the position does not matter.
-                if !order_target.is_extremum() {
-                    let requested_nulls = target_col.effective_nulls_order();
-                    let effective_nulls = idx_col.effective_nulls_order_when_iterated(iter_dir);
-                    if requested_nulls != effective_nulls {
-                        break;
-                    }
-                }
-
-                if target_is_rowid(target_col) {
-                    // The index explicitly contains the rowid alias column.
-                    includes_rowid = true;
-                }
-                col_idx += 1;
-                idx_pos += 1;
-            }
-
-            // SQLite-style rowid tables keep equal secondary-index keys ordered
-            // by rowid. That implicit suffix can satisfy one extra ORDER BY term.
-            if col_idx < target_columns.len() && idx_pos == index.columns.len() && index.has_rowid {
-                let target_col = &target_columns[col_idx];
-                let correct_order = if iter_dir == IterationDirection::Forwards {
-                    target_col.order == SortOrder::Asc
-                } else {
-                    target_col.order == SortOrder::Desc
-                };
-                if target_col.table_id == table_ref.internal_id
-                    && target_is_rowid(target_col)
-                    && correct_order
-                {
-                    col_idx += 1;
-                    includes_rowid = true;
-                }
-            }
-
-            OrderConsumption {
-                consumed: col_idx,
-                includes_rowid,
             }
         }
+
+        if target_col.collation != idx_col.collation.unwrap_or_default() {
+            break;
+        }
+        let correct_order = if iter_dir == IterationDirection::Forwards {
+            target_col.order == idx_col.order
+        } else {
+            target_col.order != idx_col.order
+        };
+        if !correct_order {
+            break;
+        }
+        if !order_target.is_extremum()
+            && target_col.effective_nulls_order() != idx_col.nulls_order(iter_dir)
+        {
+            break;
+        }
+        if target_is_rowid(target_col) {
+            includes_rowid = true;
+        }
+        col_idx += 1;
+        matched_columns += 1;
+    }
+
+    // Rowid tables keep equal secondary-index keys ordered by rowid.
+    if col_idx < target_columns.len() && matched_columns == column_count && has_rowid {
+        let target_col = &target_columns[col_idx];
+        let correct_order = if iter_dir == IterationDirection::Forwards {
+            target_col.order == SortOrder::Asc
+        } else {
+            target_col.order == SortOrder::Desc
+        };
+        if target_col.table_id == table_ref.internal_id
+            && target_is_rowid(target_col)
+            && correct_order
+        {
+            col_idx += 1;
+            includes_rowid = true;
+        }
+    }
+
+    OrderConsumption {
+        consumed: col_idx,
+        includes_rowid,
     }
 }

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -929,7 +929,7 @@ fn can_move_join_term(
 ) -> bool {
     let mut has_outer_ref = false;
     walk_expr(expr, &mut |expr: &Expr| -> Result<WalkControl> {
-        if let Expr::Column { table, .. } = expr {
+        if let Expr::Column { table, .. } | Expr::RowId { table, .. } = expr {
             if outer_table_ids.contains(table) {
                 has_outer_ref = true;
             }
@@ -982,7 +982,7 @@ fn is_inner_outer_equal_check(
 fn collect_table_refs(expr: &Expr) -> SmallVec<[TableInternalId; 2]> {
     let mut tables = SmallVec::new();
     walk_expr(expr, &mut |expr: &Expr| -> Result<WalkControl> {
-        if let Expr::Column { table, .. } = expr {
+        if let Expr::Column { table, .. } | Expr::RowId { table, .. } = expr {
             if !tables.contains(table) {
                 tables.push(*table);
             }

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -49,6 +49,8 @@ use turso_parser::ast::{
 use crate::translate::plan::Plan;
 
 use crate::function::AggFunc;
+use crate::schema::Table;
+use crate::sync::Arc;
 use crate::translate::{
     collate::get_collseq_from_expr,
     emitter::Resolver,
@@ -473,6 +475,15 @@ fn try_rewrite_single_value_aggregate(
         }),
         subquery_id,
     )?;
+    // A scalar subquery result has no text order. Do not give its replacement
+    // the text order of the grouped table's first result column.
+    let Table::FromClauseSubquery(grouped_subquery) = &mut grouped_table.table else {
+        unreachable!("a grouped table must hold a subquery")
+    };
+    Arc::get_mut(grouped_subquery)
+        .expect("a new grouped subquery is not shared")
+        .columns[0]
+        .set_collation(None);
     for column in 0..grouped_table.columns().len() {
         grouped_table.mark_column_used(column);
     }

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -420,6 +420,7 @@ fn try_rewrite_single_value_aggregate(
     inner_plan.simple_aggregate = None;
     inner_plan.input_cardinality_hint = None;
     inner_plan.estimated_output_rows = None;
+    inner_plan.estimated_cost = None;
     inner_plan.table_references.clear_outer_query_refs();
 
     let mut group_columns: Vec<Expr> = Vec::new();

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -211,6 +211,12 @@ fn rewrite_as_semi_or_anti_join(
     join_type: JoinType,
     resolver: &Resolver<'_>,
 ) -> Result<bool> {
+    // A semi join needs a left table. Keep the subquery when the outer SELECT
+    // has no FROM clause.
+    if plan.table_references.joined_tables().is_empty() {
+        return Ok(false);
+    }
+
     if !can_rewrite_as_semi_join(&inner_plan, resolver)? {
         return Ok(false);
     }

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -1,30 +1,67 @@
-//! Changes a correlated `EXISTS` or `IN` subquery into a join when both forms
-//! give the same rows.
+//! Changes a correlated subquery into a join when both forms give the same rows.
 //!
 //! - `EXISTS` becomes a semi-join. It keeps an outer row when an inner row matches.
 //! - `NOT EXISTS` becomes an anti-join. It keeps an outer row when no inner row matches.
 //! - A direct positive `IN` becomes a semi-join with one extra equality test.
+//! - A subquery that returns one aggregate value is grouped by the columns that
+//!   link it to the outer query.
 //!
-//! The code only moves direct `=` checks between an inner and outer column.
-//! Other forms stay as subqueries. `NOT IN` also stays as a subquery because
-//! NULL values can change its result.
+//! The last rewrite turns this query:
+//!
+//! ```sql
+//! SELECT * FROM outer_table o
+//! WHERE o.value < (SELECT avg(i.value) FROM inner_table i WHERE i.key = o.key)
+//! ```
+//!
+//! into this form:
+//!
+//! ```sql
+//! SELECT * FROM outer_table o
+//! LEFT JOIN (
+//!   SELECT avg(value) AS avg_value, key FROM inner_table GROUP BY key
+//! ) i
+//!   ON i.key = o.key
+//! WHERE o.value < i.avg_value
+//! ```
+//!
+//! The code only moves direct `=` checks between an inner and outer column. Other
+//! forms stay as subqueries. `NOT IN` also stays as a subquery because NULL values
+//! can change its result. A one-value subquery stays as it is unless its result for
+//! an empty input is known.
 //!
 //! References:
 //! - SQLite subquery results: https://sqlite.org/lang_expr.html#subquery_expressions
 //! - PostgreSQL subquery results: https://www.postgresql.org/docs/current/functions-subquery.html
 //! - MySQL semi-joins: https://dev.mysql.com/doc/refman/8.4/en/semijoins-antijoins.html
+//! - MySQL scalar decorrelation: https://dev.mysql.com/doc/refman/8.4/en/correlated-subqueries.html
+//! - MySQL optimizer switches: https://dev.mysql.com/doc/refman/8.0/en/switchable-optimizations.html
 //! - MariaDB semi-joins: https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/subquery-optimizations/semi-join-subquery-optimizations
+//! - MariaDB materialization: https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/subquery-optimizations/optimization-strategies/semi-join-materialization-strategy
+//! - MariaDB subquery cache: https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/subquery-optimizations/subquery-cache
+//! - Neumann and Kemper, Unnesting Arbitrary Queries: https://db.cs.tum.edu/teaching/ws2122/foundationsde/unnesting.pdf
+//! - Neumann, A Formalization of Top-Down Unnesting: https://arxiv.org/abs/2412.04294
 
 use smallvec::SmallVec;
-use turso_parser::ast::{self, Expr, TableInternalId, UnaryOperator};
+use turso_parser::ast::{
+    self, Expr, FunctionTail, Name, SortOrder, TableInternalId, UnaryOperator,
+};
 
 use crate::translate::plan::Plan;
 
+use crate::function::AggFunc;
 use crate::translate::{
+    collate::get_collseq_from_expr,
     emitter::Resolver,
-    expr::{expr_contains_nondeterministic_scalar_function, walk_expr, WalkControl},
-    plan::{Distinctness, JoinInfo, JoinType, SelectPlan, SubqueryState, WhereTerm},
+    expr::{
+        expr_contains_nondeterministic_scalar_function, expr_references_subquery_id,
+        get_expr_affinity, walk_expr, walk_expr_mut, WalkControl,
+    },
+    plan::{
+        plan_is_correlated, Distinctness, GroupBy, JoinInfo, JoinType, JoinedTable,
+        QueryDestination, ResultSetColumn, SelectPlan, SubqueryState, TableReferences, WhereTerm,
+    },
 };
+use crate::util::exprs_are_equivalent;
 use crate::Result;
 
 /// Try each supported rewrite and return whether the plan changed.
@@ -55,8 +92,13 @@ pub fn rewrite_correlated_subqueries(
             subquery_index += 1;
             continue;
         }
-        let rewritten = matches!(subquery.query_type, ast::SubqueryType::In { .. })
-            && try_rewrite_in(plan, subquery_index, resolver)?;
+        let rewritten = match subquery.query_type {
+            ast::SubqueryType::In { .. } => try_rewrite_in(plan, subquery_index, resolver)?,
+            ast::SubqueryType::RowValue { num_regs: 1, .. } => {
+                try_rewrite_single_value_aggregate(plan, subquery_index, resolver)?
+            }
+            _ => false,
+        };
         if rewritten {
             changed = true;
             continue;
@@ -269,6 +311,476 @@ fn rewrite_as_semi_or_anti_join(
     plan.non_from_clause_subqueries.remove(subquery_index);
 
     Ok(true)
+}
+
+/// The value returned when no input row matches.
+#[derive(Clone, Copy)]
+enum EmptyInputValue {
+    /// SQL NULL.
+    Null,
+    /// Integer zero, as returned by `count`.
+    IntegerZero,
+    /// Real zero, as returned by `total`.
+    RealZero,
+}
+
+/// The inner and outer columns used by one `=` check.
+struct ColumnPair {
+    /// The column read by the inner query.
+    inner: Expr,
+    /// The column read from the outer query.
+    outer: Expr,
+    /// Whether the inner column was on the left side of the `=` check.
+    inner_was_left: bool,
+}
+
+/// Group an aggregate by the columns that link it to the outer query.
+///
+/// Use a left join because the old subquery returns one value even when no
+/// inner row matches.
+fn try_rewrite_single_value_aggregate(
+    plan: &mut SelectPlan,
+    subquery_index: usize,
+    resolver: &Resolver<'_>,
+) -> Result<bool> {
+    // Window planning keeps copies of its expressions. Leave those plans alone
+    // until all of those copies can be changed together.
+    if plan.window.is_some() {
+        return Ok(false);
+    }
+
+    let Some(inner_plan) = select_subquery_plan(plan, subquery_index) else {
+        return Ok(false);
+    };
+
+    if !can_rewrite_single_value_aggregate(&inner_plan, resolver)? {
+        return Ok(false);
+    }
+    let Some(empty_value) = result_on_empty_input(&inner_plan) else {
+        return Ok(false);
+    };
+    let subquery_id = plan.non_from_clause_subqueries[subquery_index].internal_id;
+
+    // A value used by an outer join condition must be ready before that join
+    // decides whether to fill its right side with NULL values.
+    if plan.where_clause.iter().any(|term| {
+        term.from_outer_join.is_some() && expr_references_subquery_id(&term.expr, subquery_id)
+    }) {
+        return Ok(false);
+    }
+
+    let outer_tables = inner_plan.table_references.outer_query_refs();
+    if outer_tables.iter().any(|outer_table| {
+        outer_table.is_used()
+            && (outer_table.scope_depth != 0
+                || plan
+                    .table_references
+                    .find_joined_table_by_internal_id(outer_table.internal_id)
+                    .is_none())
+    }) {
+        return Ok(false);
+    }
+    let outer_table_ids: Vec<_> = outer_tables.iter().map(|table| table.internal_id).collect();
+    let inner_table_ids: Vec<_> = inner_plan
+        .table_references
+        .joined_tables()
+        .iter()
+        .map(|table| table.internal_id)
+        .collect();
+
+    let mut pairs = Vec::new();
+    let mut inner_where = Vec::new();
+    for term in &inner_plan.where_clause {
+        let tables = collect_table_refs(&term.expr);
+        if !tables.iter().any(|table| outer_table_ids.contains(table)) {
+            let mut term = term.clone();
+            term.consumed = false;
+            inner_where.push(term);
+            continue;
+        }
+        if term.from_outer_join.is_some() {
+            return Ok(false);
+        }
+        let Some(pair) = read_column_pair(&term.expr, &outer_table_ids, &inner_table_ids) else {
+            return Ok(false);
+        };
+        if !column_pair_compares_the_same(&pair, &inner_plan.table_references) {
+            return Ok(false);
+        }
+        pairs.push(pair);
+    }
+    if pairs.is_empty() || uses_outer_tables_outside_where(&inner_plan, &outer_table_ids) {
+        return Ok(false);
+    }
+
+    let mut inner_plan = *inner_plan;
+    inner_plan.where_clause = inner_where;
+    inner_plan.limit = None;
+    inner_plan.query_destination = QueryDestination::placeholder_for_subquery();
+    inner_plan.simple_aggregate = None;
+    inner_plan.input_cardinality_hint = None;
+    inner_plan.estimated_output_rows = None;
+    inner_plan.table_references.clear_outer_query_refs();
+
+    let mut group_columns: Vec<Expr> = Vec::new();
+    let mut result_positions = Vec::with_capacity(pairs.len());
+    for pair in &pairs {
+        let column_index = group_columns
+            .iter()
+            .position(|existing| exprs_are_equivalent(existing, &pair.inner))
+            .unwrap_or_else(|| {
+                group_columns.push(pair.inner.clone());
+                group_columns.len() - 1
+            });
+        result_positions.push(column_index + 1);
+    }
+
+    for (index, column) in group_columns.iter().enumerate() {
+        inner_plan.result_columns.push(ResultSetColumn {
+            expr: column.clone(),
+            alias: Some(format!("correlation_key_{index}")),
+            implicit_column_name: None,
+            contains_aggregates: false,
+        });
+    }
+    let column_count = group_columns.len();
+    inner_plan.group_by = Some(GroupBy {
+        exprs: group_columns,
+        sort_order: vec![SortOrder::Asc; column_count],
+        nulls_order: vec![None; column_count],
+        sort_elided: false,
+        having: None,
+    });
+
+    let mut grouped_table = JoinedTable::new_subquery(
+        format!("scalar_subquery_{subquery_id}"),
+        inner_plan,
+        Some(JoinInfo {
+            join_type: JoinType::LeftOuter,
+            using: vec![],
+            no_reorder: false,
+        }),
+        subquery_id,
+    )?;
+    for column in 0..grouped_table.columns().len() {
+        grouped_table.mark_column_used(column);
+    }
+
+    let result_column = Expr::Column {
+        database: None,
+        table: subquery_id,
+        column: 0,
+        is_rowid_alias: false,
+    };
+    let replacement = match empty_value {
+        EmptyInputValue::Null => result_column,
+        EmptyInputValue::IntegerZero => coalesce_with_zero(result_column, "0"),
+        EmptyInputValue::RealZero => coalesce_with_zero(result_column, "0.0"),
+    };
+    if !replace_subquery_value(plan, subquery_id, &replacement)? {
+        return Ok(false);
+    }
+
+    for (pair, column) in pairs.into_iter().zip(result_positions) {
+        let grouped_column = Expr::Column {
+            database: None,
+            table: subquery_id,
+            column,
+            is_rowid_alias: false,
+        };
+        let (left, right) = if pair.inner_was_left {
+            (grouped_column, pair.outer)
+        } else {
+            (pair.outer, grouped_column)
+        };
+        plan.where_clause.push(WhereTerm {
+            expr: Expr::Binary(Box::new(left), ast::Operator::Equals, Box::new(right)),
+            from_outer_join: Some(subquery_id),
+            consumed: false,
+        });
+    }
+    plan.table_references.add_joined_table(grouped_table);
+    plan.non_from_clause_subqueries.remove(subquery_index);
+    Ok(true)
+}
+
+/// Return whether a one-value aggregate is simple enough to move into a join.
+fn can_rewrite_single_value_aggregate(plan: &SelectPlan, resolver: &Resolver<'_>) -> Result<bool> {
+    if plan.result_columns.len() != 1
+        || plan.aggregates.is_empty()
+        || plan.table_references.joined_tables().is_empty()
+        || plan.group_by.is_some()
+        || !plan.order_by.is_empty()
+        || plan.offset.is_some()
+        || !plan.values.is_empty()
+        || plan.window.is_some()
+        || !matches!(plan.distinctness, Distinctness::NonDistinct)
+        || !plan.non_from_clause_subqueries.is_empty()
+    {
+        return Ok(false);
+    }
+    if !matches!(
+        plan.limit.as_deref(),
+        Some(Expr::Literal(ast::Literal::Numeric(value))) if value.parse::<i64>() == Ok(1)
+    ) {
+        return Ok(false);
+    }
+    if plan
+        .table_references
+        .joined_tables()
+        .iter()
+        .any(|table| match &table.table {
+            crate::schema::Table::FromClauseSubquery(subquery) => {
+                plan_is_correlated(&subquery.plan)
+            }
+            _ => false,
+        })
+    {
+        return Ok(false);
+    }
+    for column in &plan.result_columns {
+        if expr_contains_nondeterministic_scalar_function(&column.expr, resolver)? {
+            return Ok(false);
+        }
+    }
+    for term in &plan.where_clause {
+        if expr_contains_nondeterministic_scalar_function(&term.expr, resolver)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Return the result for no input rows, if it is known.
+fn result_on_empty_input(plan: &SelectPlan) -> Option<EmptyInputValue> {
+    let expr = &plan.result_columns[0].expr;
+    for aggregate in &plan.aggregates {
+        if !exprs_are_equivalent(expr, &aggregate.original_expr) {
+            continue;
+        }
+        return match aggregate.func {
+            AggFunc::Count | AggFunc::Count0 => Some(EmptyInputValue::IntegerZero),
+            AggFunc::Total => Some(EmptyInputValue::RealZero),
+            AggFunc::Avg
+            | AggFunc::GroupConcat
+            | AggFunc::Max
+            | AggFunc::Min
+            | AggFunc::StringAgg
+            | AggFunc::Sum => Some(EmptyInputValue::Null),
+            _ => None,
+        };
+    }
+    is_null_on_empty_input(expr, &plan.aggregates).then_some(EmptyInputValue::Null)
+}
+
+/// Return whether an expression must be NULL when its input is empty.
+fn is_null_on_empty_input(expr: &Expr, aggregates: &[crate::translate::plan::Aggregate]) -> bool {
+    if aggregates.iter().any(|aggregate| {
+        exprs_are_equivalent(expr, &aggregate.original_expr)
+            && matches!(
+                aggregate.func,
+                AggFunc::Avg
+                    | AggFunc::GroupConcat
+                    | AggFunc::Max
+                    | AggFunc::Min
+                    | AggFunc::StringAgg
+                    | AggFunc::Sum
+            )
+    }) {
+        return true;
+    }
+    match expr {
+        Expr::Binary(
+            left,
+            ast::Operator::Add
+            | ast::Operator::Subtract
+            | ast::Operator::Multiply
+            | ast::Operator::Divide
+            | ast::Operator::Modulus
+            | ast::Operator::BitwiseAnd
+            | ast::Operator::BitwiseOr
+            | ast::Operator::LeftShift
+            | ast::Operator::RightShift
+            | ast::Operator::Concat,
+            right,
+        ) => is_null_on_empty_input(left, aggregates) || is_null_on_empty_input(right, aggregates),
+        Expr::Unary(_, inner) | Expr::Cast { expr: inner, .. } | Expr::Collate(inner, _) => {
+            is_null_on_empty_input(inner, aggregates)
+        }
+        Expr::Parenthesized(exprs) if exprs.len() == 1 => {
+            is_null_on_empty_input(&exprs[0], aggregates)
+        }
+        _ => false,
+    }
+}
+
+/// Read an `=` check between one inner column and one outer column.
+fn read_column_pair(
+    expr: &Expr,
+    outer_table_ids: &[TableInternalId],
+    inner_table_ids: &[TableInternalId],
+) -> Option<ColumnPair> {
+    let Expr::Binary(left, ast::Operator::Equals, right) = expr else {
+        return None;
+    };
+    match (left.as_ref(), right.as_ref()) {
+        (
+            inner @ Expr::Column {
+                table: inner_table, ..
+            },
+            outer @ Expr::Column {
+                table: outer_table, ..
+            },
+        ) if inner_table_ids.contains(inner_table) && outer_table_ids.contains(outer_table) => {
+            Some(ColumnPair {
+                inner: inner.clone(),
+                outer: outer.clone(),
+                inner_was_left: true,
+            })
+        }
+        (
+            outer @ Expr::Column {
+                table: outer_table, ..
+            },
+            inner @ Expr::Column {
+                table: inner_table, ..
+            },
+        ) if outer_table_ids.contains(outer_table) && inner_table_ids.contains(inner_table) => {
+            Some(ColumnPair {
+                inner: inner.clone(),
+                outer: outer.clone(),
+                inner_was_left: false,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Return whether grouping and joining compare this column pair the same way.
+fn column_pair_compares_the_same(pair: &ColumnPair, tables: &TableReferences) -> bool {
+    // GROUP BY and the join must treat these values the same way. With
+    // different value types or text sort rules, two inner groups can both
+    // equal one outer value and copy its row.
+    if get_expr_affinity(&pair.inner, Some(tables), None)
+        != get_expr_affinity(&pair.outer, Some(tables), None)
+    {
+        return false;
+    }
+
+    let inner_collation = get_collseq_from_expr(&pair.inner, tables)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let outer_collation = get_collseq_from_expr(&pair.outer, tables)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    inner_collation == outer_collation
+}
+
+/// Return whether the plan uses an outer table outside its `WHERE` clause.
+fn uses_outer_tables_outside_where(plan: &SelectPlan, outer_table_ids: &[TableInternalId]) -> bool {
+    let uses_outer = |expr: &Expr| {
+        collect_table_refs(expr)
+            .iter()
+            .any(|table| outer_table_ids.contains(table))
+    };
+    plan.result_columns
+        .iter()
+        .any(|column| uses_outer(&column.expr))
+        || plan.order_by.iter().any(|(expr, _, _)| uses_outer(expr))
+        || plan.limit.as_deref().is_some_and(uses_outer)
+        || plan.offset.as_deref().is_some_and(uses_outer)
+        || plan.group_by.as_ref().is_some_and(|group| {
+            group.exprs.iter().any(&uses_outer)
+                || group
+                    .having
+                    .as_ref()
+                    .is_some_and(|having| having.iter().any(&uses_outer))
+        })
+}
+
+/// Keep the zero that `count` and `total` return for an empty input.
+fn coalesce_with_zero(value: Expr, zero: &str) -> Expr {
+    Expr::FunctionCall {
+        name: Name::exact("coalesce".to_string()),
+        distinctness: None,
+        args: vec![
+            Box::new(value),
+            Box::new(Expr::Literal(ast::Literal::Numeric(zero.to_string()))),
+        ],
+        order_by: vec![],
+        within_group: vec![],
+        filter_over: FunctionTail {
+            filter_clause: None,
+            over_clause: None,
+        },
+    }
+}
+
+/// Replace each use of one subquery value with a joined column.
+fn replace_subquery_value(
+    plan: &mut SelectPlan,
+    subquery_id: TableInternalId,
+    replacement: &Expr,
+) -> Result<bool> {
+    let mut found = false;
+    let mut replace = |expr: &mut Expr| -> Result<WalkControl> {
+        if matches!(
+            expr,
+            Expr::SubqueryResult {
+                subquery_id: id,
+                query_type: ast::SubqueryType::RowValue { num_regs: 1, .. },
+                ..
+            } if *id == subquery_id
+        ) {
+            *expr = replacement.clone();
+            found = true;
+            return Ok(WalkControl::SkipChildren);
+        }
+        Ok(WalkControl::Continue)
+    };
+
+    for column in &mut plan.result_columns {
+        walk_expr_mut(&mut column.expr, &mut replace)?;
+    }
+    for term in &mut plan.where_clause {
+        walk_expr_mut(&mut term.expr, &mut replace)?;
+    }
+    if let Some(group) = &mut plan.group_by {
+        for expr in &mut group.exprs {
+            walk_expr_mut(expr, &mut replace)?;
+        }
+        if let Some(having) = &mut group.having {
+            for expr in having {
+                walk_expr_mut(expr, &mut replace)?;
+            }
+        }
+    }
+    for (expr, _, _) in &mut plan.order_by {
+        walk_expr_mut(expr, &mut replace)?;
+    }
+    if let Some(limit) = &mut plan.limit {
+        walk_expr_mut(limit, &mut replace)?;
+    }
+    if let Some(offset) = &mut plan.offset {
+        walk_expr_mut(offset, &mut replace)?;
+    }
+    for row in &mut plan.values {
+        for expr in row {
+            walk_expr_mut(expr, &mut replace)?;
+        }
+    }
+    for aggregate in &mut plan.aggregates {
+        walk_expr_mut(&mut aggregate.original_expr, &mut replace)?;
+        for arg in &mut aggregate.args {
+            walk_expr_mut(arg, &mut replace)?;
+        }
+        if let Some(filter) = &mut aggregate.filter_expr {
+            walk_expr_mut(filter, &mut replace)?;
+        }
+    }
+    Ok(found)
 }
 
 /// Return whether a subquery is simple enough for a semi-join or anti-join.

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -550,6 +550,9 @@ fn can_rewrite_single_value_aggregate(plan: &SelectPlan, resolver: &Resolver<'_>
     {
         return Ok(false);
     }
+    if !aggregate_can_run_for_unused_rows(plan) {
+        return Ok(false);
+    }
     if !matches!(
         plan.limit.as_deref(),
         Some(Expr::Literal(ast::Literal::Numeric(value))) if value.parse::<i64>() == Ok(1)
@@ -583,6 +586,60 @@ fn can_rewrite_single_value_aggregate(plan: &SelectPlan, resolver: &Resolver<'_>
         }
     }
     Ok(true)
+}
+
+/// Return whether the aggregate can run for an inner row that no outer row uses.
+fn aggregate_can_run_for_unused_rows(plan: &SelectPlan) -> bool {
+    // The grouped form reads every inner key. sum can fail on integer overflow.
+    // A function or special operator in an argument or filter can also fail on
+    // its input. Keep those forms correlated so they only read requested keys.
+    if plan
+        .aggregates
+        .iter()
+        .any(|aggregate| matches!(aggregate.func, AggFunc::Sum))
+    {
+        return false;
+    }
+
+    let aggregate_expressions = plan
+        .aggregates
+        .iter()
+        .flat_map(|aggregate| aggregate.args.iter().chain(aggregate.filter_expr.iter()));
+    let filter_expressions = plan.where_clause.iter().map(|term| &term.expr);
+    !aggregate_expressions
+        .chain(filter_expressions)
+        .any(expression_can_fail_on_input)
+}
+
+/// Return whether an expression has an operation that can fail for some input.
+fn expression_can_fail_on_input(expr: &Expr) -> bool {
+    let mut can_fail = false;
+    walk_expr(expr, &mut |expr: &Expr| -> Result<WalkControl> {
+        if matches!(
+            expr,
+            Expr::FunctionCall { .. }
+                | Expr::FunctionCallStar { .. }
+                | Expr::Like { .. }
+                | Expr::Raise(_, _)
+                | Expr::Binary(
+                    _,
+                    ast::Operator::ArrowRight
+                        | ast::Operator::ArrowRightShift
+                        | ast::Operator::ArrayContains
+                        | ast::Operator::ArrayOverlap,
+                    _
+                )
+        ) {
+            can_fail = true;
+        }
+        Ok(if can_fail {
+            WalkControl::SkipChildren
+        } else {
+            WalkControl::Continue
+        })
+    })
+    .expect("walking an aggregate expression cannot fail");
+    can_fail
 }
 
 /// Return the result for no input rows, if it is known.

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -41,6 +41,7 @@
 //! - Neumann and Kemper, Unnesting Arbitrary Queries: https://db.cs.tum.edu/teaching/ws2122/foundationsde/unnesting.pdf
 //! - Neumann, A Formalization of Top-Down Unnesting: https://arxiv.org/abs/2412.04294
 
+use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
 use turso_parser::ast::{
     self, Expr, FunctionTail, Name, SortOrder, TableInternalId, UnaryOperator,
@@ -93,6 +94,7 @@ pub fn rewrite_correlated_subqueries(
         subquery_index += 1;
     }
 
+    let mut aggregate_replacements = HashMap::default();
     let mut subquery_index = 0;
     while subquery_index < plan.non_from_clause_subqueries.len() {
         let subquery = &plan.non_from_clause_subqueries[subquery_index];
@@ -100,16 +102,36 @@ pub fn rewrite_correlated_subqueries(
             subquery_index += 1;
             continue;
         }
-        let rewritten = match subquery.query_type {
-            ast::SubqueryType::In { .. } => try_rewrite_in(plan, subquery_index, resolver)?,
-            ast::SubqueryType::RowValue { num_regs: 1, .. } if !has_full_join => {
-                try_rewrite_single_value_aggregate(plan, subquery_index, resolver)?
+        let query_type = subquery.query_type.clone();
+        let subquery_id = subquery.internal_id;
+        let same_query = subquery.same_query;
+        match query_type {
+            ast::SubqueryType::In { .. } => {
+                if try_rewrite_in(plan, subquery_index, resolver)? {
+                    changed = true;
+                    continue;
+                }
             }
-            _ => false,
-        };
-        if rewritten {
-            changed = true;
-            continue;
+            ast::SubqueryType::RowValue { num_regs: 1, .. } if !has_full_join => {
+                if let Some(replacement) = same_query
+                    .and_then(|same_query| aggregate_replacements.get(&same_query))
+                    .cloned()
+                {
+                    if replace_subquery_value(plan, subquery_id, &replacement)? {
+                        plan.non_from_clause_subqueries.remove(subquery_index);
+                        changed = true;
+                        continue;
+                    }
+                }
+                if let Some(replacement) =
+                    try_rewrite_single_value_aggregate(plan, subquery_index, resolver)?
+                {
+                    aggregate_replacements.insert(subquery_id, replacement);
+                    changed = true;
+                    continue;
+                }
+            }
+            _ => {}
         }
         subquery_index += 1;
     }
@@ -369,11 +391,11 @@ fn try_rewrite_single_value_aggregate(
     plan: &mut SelectPlan,
     subquery_index: usize,
     resolver: &Resolver<'_>,
-) -> Result<bool> {
+) -> Result<Option<Expr>> {
     // Window planning keeps copies of its expressions. Leave those plans alone
     // until all of those copies can be changed together.
     if plan.window.is_some() {
-        return Ok(false);
+        return Ok(None);
     }
 
     let subquery_id = plan.non_from_clause_subqueries[subquery_index].internal_id;
@@ -383,18 +405,19 @@ fn try_rewrite_single_value_aggregate(
     if plan.where_clause.iter().any(|term| {
         term.from_outer_join.is_some() && expr_references_subquery_id(&term.expr, subquery_id)
     }) {
-        return Ok(false);
+        return Ok(None);
     }
     let Some(inner_plan) = select_subquery_plan(plan, subquery_index) else {
-        return Ok(false);
+        return Ok(None);
     };
 
     if !can_rewrite_single_value_aggregate(inner_plan, resolver)? {
-        return Ok(false);
+        return Ok(None);
     }
     let Some(empty_value) = result_on_empty_input(inner_plan) else {
-        return Ok(false);
+        return Ok(None);
     };
+
     let outer_tables = inner_plan.table_references.outer_query_refs();
     if outer_tables.iter().any(|outer_table| {
         outer_table.is_used()
@@ -404,7 +427,7 @@ fn try_rewrite_single_value_aggregate(
                     .find_joined_table_by_internal_id(outer_table.internal_id)
                     .is_none())
     }) {
-        return Ok(false);
+        return Ok(None);
     }
     // A grouped table linked to more than one outer table can move before one
     // of those tables after its left join becomes an inner join.
@@ -414,7 +437,7 @@ fn try_rewrite_single_value_aggregate(
         .count()
         != 1
     {
-        return Ok(false);
+        return Ok(None);
     }
     let outer_table_ids: Vec<_> = outer_tables.iter().map(|table| table.internal_id).collect();
     let inner_table_ids: Vec<_> = inner_plan
@@ -435,18 +458,18 @@ fn try_rewrite_single_value_aggregate(
             continue;
         }
         if term.from_outer_join.is_some() {
-            return Ok(false);
+            return Ok(None);
         }
         let Some(pair) = read_column_pair(&term.expr, &outer_table_ids, &inner_table_ids) else {
-            return Ok(false);
+            return Ok(None);
         };
         if !column_pair_compares_the_same(&pair, &inner_plan.table_references) {
-            return Ok(false);
+            return Ok(None);
         }
         pairs.push(pair);
     }
     if pairs.is_empty() || uses_outer_tables_outside_where(inner_plan, &outer_table_ids) {
-        return Ok(false);
+        return Ok(None);
     }
 
     let mut inner_plan = *take_select_subquery_plan(plan, subquery_index);
@@ -524,7 +547,7 @@ fn try_rewrite_single_value_aggregate(
         EmptyInputValue::RealZero => coalesce_with_zero(result_column, "0.0"),
     };
     if !replace_subquery_value(plan, subquery_id, &replacement)? {
-        return Ok(false);
+        return Ok(None);
     }
 
     for (pair, column) in pairs.into_iter().zip(result_positions) {
@@ -547,7 +570,7 @@ fn try_rewrite_single_value_aggregate(
     }
     plan.table_references.add_joined_table(grouped_table);
     plan.non_from_clause_subqueries.remove(subquery_index);
-    Ok(true)
+    Ok(Some(replacement))
 }
 
 /// Return whether a one-value aggregate is simple enough to move into a join.

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -71,6 +71,12 @@ pub fn rewrite_correlated_subqueries(
     plan: &mut SelectPlan,
     resolver: &Resolver<'_>,
 ) -> Result<bool> {
+    let has_full_join = plan.table_references.joined_tables().iter().any(|table| {
+        table
+            .join_info
+            .as_ref()
+            .is_some_and(JoinInfo::is_full_outer)
+    });
     let mut changed = false;
     let mut subquery_index = 0;
     while subquery_index < plan.non_from_clause_subqueries.len() {
@@ -96,7 +102,7 @@ pub fn rewrite_correlated_subqueries(
         }
         let rewritten = match subquery.query_type {
             ast::SubqueryType::In { .. } => try_rewrite_in(plan, subquery_index, resolver)?,
-            ast::SubqueryType::RowValue { num_regs: 1, .. } => {
+            ast::SubqueryType::RowValue { num_regs: 1, .. } if !has_full_join => {
                 try_rewrite_single_value_aggregate(plan, subquery_index, resolver)?
             }
             _ => false,
@@ -243,13 +249,10 @@ fn rewrite_as_semi_or_anti_join(
     // link into a later join could remove that row too early.
     let mut outer_table_ids_that_may_be_null: Vec<TableInternalId> = Vec::new();
     let outer_tables = plan.table_references.joined_tables();
-    for (index, table) in outer_tables.iter().enumerate() {
+    for table in outer_tables {
         if let Some(join_info) = &table.join_info {
-            if join_info.is_outer() {
+            if join_info.is_outer() && !join_info.is_full_outer() {
                 outer_table_ids_that_may_be_null.push(table.internal_id);
-            }
-            if join_info.is_full_outer() && index > 0 {
-                outer_table_ids_that_may_be_null.push(outer_tables[index - 1].internal_id);
             }
         }
     }

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -380,6 +380,16 @@ fn try_rewrite_single_value_aggregate(
     }) {
         return Ok(false);
     }
+    // A grouped table linked to more than one outer table can move before one
+    // of those tables after its left join becomes an inner join.
+    if outer_tables
+        .iter()
+        .filter(|outer_table| outer_table.is_used())
+        .count()
+        != 1
+    {
+        return Ok(false);
+    }
     let outer_table_ids: Vec<_> = outer_tables.iter().map(|table| table.internal_id).collect();
     let inner_table_ids: Vec<_> = inner_plan
         .table_references

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -173,11 +173,14 @@ fn try_rewrite_in(
     subquery_index: usize,
     resolver: &Resolver<'_>,
 ) -> Result<bool> {
-    let Some(inner_plan) = select_subquery_plan(plan, subquery_index) else {
-        return Ok(false);
-    };
     let subquery_id = plan.non_from_clause_subqueries[subquery_index].internal_id;
     let Some((where_term_index, left)) = find_in_term(&plan.where_clause, subquery_id) else {
+        return Ok(false);
+    };
+    if plan.table_references.joined_tables().is_empty() {
+        return Ok(false);
+    }
+    let Some(inner_plan) = select_subquery_plan(plan, subquery_index) else {
         return Ok(false);
     };
     let Some(right) = inner_plan
@@ -373,6 +376,15 @@ fn try_rewrite_single_value_aggregate(
         return Ok(false);
     }
 
+    let subquery_id = plan.non_from_clause_subqueries[subquery_index].internal_id;
+
+    // A value used by an outer join condition must be ready before that join
+    // decides whether to fill its right side with NULL values.
+    if plan.where_clause.iter().any(|term| {
+        term.from_outer_join.is_some() && expr_references_subquery_id(&term.expr, subquery_id)
+    }) {
+        return Ok(false);
+    }
     let Some(inner_plan) = select_subquery_plan(plan, subquery_index) else {
         return Ok(false);
     };
@@ -383,15 +395,6 @@ fn try_rewrite_single_value_aggregate(
     let Some(empty_value) = result_on_empty_input(inner_plan) else {
         return Ok(false);
     };
-    let subquery_id = plan.non_from_clause_subqueries[subquery_index].internal_id;
-
-    // A value used by an outer join condition must be ready before that join
-    // decides whether to fill its right side with NULL values.
-    if plan.where_clause.iter().any(|term| {
-        term.from_outer_join.is_some() && expr_references_subquery_id(&term.expr, subquery_id)
-    }) {
-        return Ok(false);
-    }
     let outer_tables = inner_plan.table_references.outer_query_refs();
     if outer_tables.iter().any(|outer_table| {
         outer_table.is_used()

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -1,187 +1,230 @@
-//! Unnesting pass: rewrites EXISTS/NOT EXISTS correlated subqueries into semi/anti-joins.
+//! Changes a correlated `EXISTS` or `IN` subquery into a join when both forms
+//! give the same rows.
 //!
-//! A correlated EXISTS subquery:
-//!   SELECT * FROM t1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.a = t1.a)
-//! is rewritten into a semi-join:
-//!   SELECT * FROM t1 SEMI JOIN t2 ON t2.a = t1.a
+//! - `EXISTS` becomes a semi-join. It keeps an outer row when an inner row matches.
+//! - `NOT EXISTS` becomes an anti-join. It keeps an outer row when no inner row matches.
+//! - A direct positive `IN` becomes a semi-join with one extra equality test.
 //!
-//! Similarly, NOT EXISTS becomes an anti-join.
+//! The code only moves direct `=` checks between an inner and outer column.
+//! Other forms stay as subqueries. `NOT IN` also stays as a subquery because
+//! NULL values can change its result.
 //!
-//! Base intuition for correctness:
-//! - `EXISTS(subquery)` is a yes/no test: did we find at least one inner row?
-//! - A semi-join is the same yes/no test, just run as a join loop:
-//!   keep the outer row once a matching inner row is found.
-//! - For correlated equality predicates (for example `inner.k = outer.k`), the
-//!   answer depends only on the key value `k`, not on outer row identity. If two
-//!   outer rows have the same `k`, they both either match or do not match.
-//!   That is why precomputing/joining by `k` preserves `EXISTS` truth values.
-//! - `NOT EXISTS(subquery)` is the opposite yes/no test.
-//! - An anti-join does exactly that:
-//!   keep the outer row only if no matching inner row is found.
-//! - The same key-value argument applies to anti-join: for a given `k`, either
-//!   every outer row with `k` survives (no inner match) or none survive.
-//!
-//! So the rewrite is semantics-preserving when we keep the same notion of
-//! "matching row" and do not move predicates across boundaries that change
-//! row existence (for example OUTER JOIN null-extension or inner-independent
-//! gates under `NOT EXISTS`, e.g. `NOT EXISTS (... WHERE corr AND 0)` is TRUE for every outer row).
-//!
-//! Canonical references used for blocker rationale in this module:
-//! - [SQLITE-EXISTS] https://sqlite.org/lang_expr.html#the_exists_operator
-//! - [PG-SUBQUERY] https://www.postgresql.org/docs/current/functions-subquery.html
-//! - [PG-JOIN-ORDER] https://www.postgresql.org/docs/current/queries-table-expressions.html
-//! - [MYSQL-SEMIJOIN] https://dev.mysql.com/doc/refman/8.4/en/semijoins-antijoins.html
+//! References:
+//! - SQLite subquery results: https://sqlite.org/lang_expr.html#subquery_expressions
+//! - PostgreSQL subquery results: https://www.postgresql.org/docs/current/functions-subquery.html
+//! - MySQL semi-joins: https://dev.mysql.com/doc/refman/8.4/en/semijoins-antijoins.html
+//! - MariaDB semi-joins: https://mariadb.com/docs/server/ha-and-performance/optimization-and-tuning/query-optimizations/subquery-optimizations/semi-join-subquery-optimizations
 
 use smallvec::SmallVec;
 use turso_parser::ast::{self, Expr, TableInternalId, UnaryOperator};
 
 use crate::translate::plan::Plan;
 
-use crate::function::{Deterministic, Func};
 use crate::translate::{
-    expr::{walk_expr, WalkControl},
-    plan::{JoinInfo, JoinType, SelectPlan, SubqueryState, WhereTerm},
+    emitter::Resolver,
+    expr::{expr_contains_nondeterministic_scalar_function, walk_expr, WalkControl},
+    plan::{Distinctness, JoinInfo, JoinType, SelectPlan, SubqueryState, WhereTerm},
 };
 use crate::Result;
 
-/// Attempt to unnest EXISTS/NOT EXISTS correlated subqueries into semi/anti-joins.
-/// This is called during the optimizer pipeline, after constant condition elimination
-/// and before table access optimization.
-pub fn unnest_exists_subqueries(plan: &mut SelectPlan) -> Result<()> {
-    let mut i = 0;
-    while i < plan.non_from_clause_subqueries.len() {
-        let subquery = &plan.non_from_clause_subqueries[i];
-        // Only consider unevaluated, correlated EXISTS subqueries.
-        if !subquery.correlated {
-            i += 1;
+/// Try each supported rewrite and return whether the plan changed.
+pub fn rewrite_correlated_subqueries(
+    plan: &mut SelectPlan,
+    resolver: &Resolver<'_>,
+) -> Result<bool> {
+    let mut changed = false;
+    let mut subquery_index = 0;
+    while subquery_index < plan.non_from_clause_subqueries.len() {
+        let subquery = &plan.non_from_clause_subqueries[subquery_index];
+        if !subquery.correlated || !matches!(subquery.query_type, ast::SubqueryType::Exists { .. })
+        {
+            subquery_index += 1;
             continue;
         }
-        let is_exists = matches!(subquery.query_type, ast::SubqueryType::Exists { .. });
-        if !is_exists {
-            i += 1;
+        if try_rewrite_exists(plan, subquery_index, resolver)? {
+            changed = true;
             continue;
         }
-        if try_unnest_exists(plan, i) {
-            // Subquery was removed from the vec; don't increment i.
-            continue;
-        }
-        i += 1;
+        subquery_index += 1;
     }
-    Ok(())
+
+    let mut subquery_index = 0;
+    while subquery_index < plan.non_from_clause_subqueries.len() {
+        let subquery = &plan.non_from_clause_subqueries[subquery_index];
+        if !subquery.correlated {
+            subquery_index += 1;
+            continue;
+        }
+        let rewritten = matches!(subquery.query_type, ast::SubqueryType::In { .. })
+            && try_rewrite_in(plan, subquery_index, resolver)?;
+        if rewritten {
+            changed = true;
+            continue;
+        }
+        subquery_index += 1;
+    }
+    Ok(changed)
 }
 
-/// Try to unnest a single EXISTS subquery at index `subquery_idx`.
-/// Returns true if the subquery was successfully unnested and removed.
-fn try_unnest_exists(plan: &mut SelectPlan, subquery_idx: usize) -> bool {
-    // 1. Extract the inner plan (if available).
-    let inner_plan = {
-        let subquery = &plan.non_from_clause_subqueries[subquery_idx];
-        let SubqueryState::Unevaluated { plan: inner } = &subquery.state else {
-            return false;
-        };
-        let Some(inner) = inner.as_ref() else {
-            return false;
-        };
-        let Plan::Select(inner) = inner.as_ref() else {
-            // Compound selects cannot be unnested.
-            return false;
-        };
-        inner.clone()
+/// Return the SELECT plan for a subquery that has not run yet.
+fn select_subquery_plan(plan: &SelectPlan, subquery_index: usize) -> Option<Box<SelectPlan>> {
+    let subquery = &plan.non_from_clause_subqueries[subquery_index];
+    let SubqueryState::Unevaluated { plan: inner } = &subquery.state else {
+        return None;
     };
-    let subquery_id = plan.non_from_clause_subqueries[subquery_idx].internal_id;
+    let Plan::Select(inner) = inner.as_ref()?.as_ref() else {
+        return None;
+    };
+    Some(inner.clone())
+}
 
-    // 2. Check blockers: the inner plan must be simple enough to unnest.
-    if !can_unnest_inner_plan(&inner_plan) {
-        return false;
-    }
+/// Try to change one `EXISTS` or `NOT EXISTS` into a join.
+fn try_rewrite_exists(
+    plan: &mut SelectPlan,
+    subquery_index: usize,
+    resolver: &Resolver<'_>,
+) -> Result<bool> {
+    let Some(inner_plan) = select_subquery_plan(plan, subquery_index) else {
+        return Ok(false);
+    };
+    let subquery_id = plan.non_from_clause_subqueries[subquery_index].internal_id;
 
-    // 3. Determine if this is EXISTS or NOT EXISTS by scanning the outer WHERE clause.
-    let Some(where_info) = find_exists_in_where(&plan.where_clause, subquery_id) else {
-        return false;
+    let Some(term) = find_exists_in_where(&plan.where_clause, subquery_id) else {
+        return Ok(false);
     };
 
-    let join_type = if where_info.negated {
+    let join_type = if term.negated {
         JoinType::Anti
     } else {
         JoinType::Semi
     };
 
-    // 4. Extract correlation predicates from the inner WHERE clause.
-    // These are predicates of the form `inner_col = outer_col` where one side
-    // references an outer query ref and the other side references an inner table.
+    rewrite_as_semi_or_anti_join(
+        plan,
+        subquery_index,
+        inner_plan,
+        term.index,
+        join_type,
+        resolver,
+    )
+}
+
+/// Turn a direct `IN` test that is not `NOT IN` into a semi-join.
+fn try_rewrite_in(
+    plan: &mut SelectPlan,
+    subquery_index: usize,
+    resolver: &Resolver<'_>,
+) -> Result<bool> {
+    let Some(inner_plan) = select_subquery_plan(plan, subquery_index) else {
+        return Ok(false);
+    };
+    let subquery_id = plan.non_from_clause_subqueries[subquery_index].internal_id;
+    let Some((where_term_index, left)) = find_in_term(&plan.where_clause, subquery_id) else {
+        return Ok(false);
+    };
+    let Some(right) = inner_plan
+        .result_columns
+        .first()
+        .map(|column| column.expr.clone())
+    else {
+        return Ok(false);
+    };
+    if inner_plan.result_columns.len() != 1
+        || expr_contains_nondeterministic_scalar_function(&left, resolver)?
+        || expr_contains_nondeterministic_scalar_function(&right, resolver)?
+    {
+        return Ok(false);
+    }
+
+    let mut inner_plan = inner_plan;
+    inner_plan.where_clause.push(WhereTerm {
+        expr: Expr::Binary(Box::new(left), ast::Operator::Equals, Box::new(right)),
+        from_outer_join: None,
+        consumed: false,
+    });
+    rewrite_as_semi_or_anti_join(
+        plan,
+        subquery_index,
+        inner_plan,
+        where_term_index,
+        JoinType::Semi,
+        resolver,
+    )
+}
+
+/// Move one simple subquery into the outer query as a semi-join or anti-join.
+fn rewrite_as_semi_or_anti_join(
+    plan: &mut SelectPlan,
+    subquery_index: usize,
+    inner_plan: Box<SelectPlan>,
+    where_term_index: usize,
+    join_type: JoinType,
+    resolver: &Resolver<'_>,
+) -> Result<bool> {
+    if !can_rewrite_as_semi_join(&inner_plan, resolver)? {
+        return Ok(false);
+    }
+
     let outer_table_ids: Vec<TableInternalId> = inner_plan
         .table_references
         .outer_query_refs()
         .iter()
-        .map(|r| r.internal_id)
+        .map(|reference| reference.internal_id)
         .collect();
     let inner_table_ids: Vec<TableInternalId> = inner_plan
         .table_references
         .joined_tables()
         .iter()
-        .map(|t| t.internal_id)
+        .map(|table| table.internal_id)
         .collect();
 
-    // All inner WHERE terms must be expressible as join predicates or filters
-    // on inner tables only. If any term references outer tables in a non-equality
-    // context, we bail out.
     for term in &inner_plan.where_clause {
-        if !is_valid_unnesting_predicate(&term.expr, &outer_table_ids, &inner_table_ids) {
-            return false;
+        if !can_move_join_term(&term.expr, &outer_table_ids, &inner_table_ids) {
+            return Ok(false);
         }
     }
 
-    // For anti-join rewrites, every inner WHERE term must reference an inner table.
-    // Principle ([SQLITE-EXISTS], [PG-SUBQUERY]): NOT EXISTS depends on inner-row
-    // emptiness, so inner-independent gates must stay under the quantifier.
-    // Example: `NOT EXISTS (... WHERE corr AND 0)` is TRUE for every outer row.
-    // Hoisting `0` to outer WHERE would reject all rows, so this rewrite is unsafe.
+    // Every NOT EXISTS term must use an inner table. Moving a constant false
+    // term into the outer query would reject a row that NOT EXISTS keeps.
     if join_type == JoinType::Anti {
         for term in &inner_plan.where_clause {
-            let refs = collect_table_refs(&term.expr);
-            if !refs.iter().any(|t| inner_table_ids.contains(t)) {
-                return false;
+            let tables = collect_table_refs(&term.expr);
+            if !tables.iter().any(|table| inner_table_ids.contains(table)) {
+                return Ok(false);
             }
         }
     }
 
-    // 4b. Block unnesting if any correlation predicate references a table that
-    // is on the nullable side of a LEFT/FULL OUTER JOIN in the outer plan.
-    // Principle ([PG-JOIN-ORDER]): OUTER JOIN null-extension is defined before
-    // WHERE filtering; moving such predicates across the boundary is not safe.
-    // Example: correlating to nullable RHS columns can drop rows that should
-    // survive as NULL-extended rows.
-    let mut nullable_outer_table_ids: Vec<TableInternalId> = Vec::new();
-    let joined = plan.table_references.joined_tables();
-    for (i, t) in joined.iter().enumerate() {
-        if let Some(ji) = &t.join_info {
-            if ji.is_outer() || ji.is_full_outer() {
-                // Right-side table of LEFT/FULL OUTER JOIN is nullable.
-                nullable_outer_table_ids.push(t.internal_id);
+    // Keep a link to a table that an outer join may fill with NULL. Moving the
+    // link into a later join could remove that row too early.
+    let mut outer_table_ids_that_may_be_null: Vec<TableInternalId> = Vec::new();
+    let outer_tables = plan.table_references.joined_tables();
+    for (index, table) in outer_tables.iter().enumerate() {
+        if let Some(join_info) = &table.join_info {
+            if join_info.is_outer() {
+                outer_table_ids_that_may_be_null.push(table.internal_id);
             }
-            if ji.is_full_outer() && i > 0 {
-                // Left-side table of FULL OUTER JOIN is also nullable.
-                nullable_outer_table_ids.push(joined[i - 1].internal_id);
+            if join_info.is_full_outer() && index > 0 {
+                outer_table_ids_that_may_be_null.push(outer_tables[index - 1].internal_id);
             }
         }
     }
-    if !nullable_outer_table_ids.is_empty() {
-        // Check if any correlation predicate touches a nullable outer table.
+    if !outer_table_ids_that_may_be_null.is_empty() {
         for term in &inner_plan.where_clause {
-            let refs = collect_table_refs(&term.expr);
-            if refs.iter().any(|t| nullable_outer_table_ids.contains(t)) {
-                return false;
+            let tables = collect_table_refs(&term.expr);
+            if tables
+                .iter()
+                .any(|table| outer_table_ids_that_may_be_null.contains(table))
+            {
+                return Ok(false);
             }
         }
     }
 
-    // 5. Perform the rewrite.
-    // Move inner tables into the outer plan as semi/anti-joined tables.
     let mut inner_plan = inner_plan;
     let inner_tables = std::mem::take(inner_plan.table_references.joined_tables_mut());
-    for (idx, mut table) in inner_tables.into_iter().enumerate() {
-        if idx == 0 {
-            // First inner table gets the semi/anti-join annotation.
+    for (index, mut table) in inner_tables.into_iter().enumerate() {
+        if index == 0 {
             table.join_info = Some(JoinInfo {
                 join_type,
                 using: vec![],
@@ -191,167 +234,139 @@ fn try_unnest_exists(plan: &mut SelectPlan, subquery_idx: usize) -> bool {
         plan.table_references.add_joined_table(table);
     }
 
-    // Move inner WHERE terms to the outer plan's WHERE clause.
-    // The outer_query_ref column references in these terms already point to the
-    // correct table IDs (they were set up during subquery planning), so they
-    // work correctly in the outer scope.
-    // Reset `consumed` since the inner optimizer may have marked terms consumed
-    // during its own optimization pass; in the outer plan they need re-evaluation.
+    // The terms now run in the outer plan, so prior access choices do not apply.
     for mut term in inner_plan.where_clause {
         term.consumed = false;
         plan.where_clause.push(term);
     }
 
-    // Move any inner non-FROM subqueries to the outer plan.
     for inner_subquery in inner_plan.non_from_clause_subqueries {
         plan.non_from_clause_subqueries.push(inner_subquery);
     }
 
-    // The inner plan's result columns are dropped (a semi/anti-join only tests
-    // for row existence, not column values). However, those result column
-    // expressions may contain bound parameters (e.g. `SELECT ?2 AS col`).
-    // We must remember these so the emitter registers them in the program's
-    // parameter list; otherwise bind-time validation (`has_slot`) fails.
-    for rc in &inner_plan.result_columns {
-        let _ = walk_expr(&rc.expr, &mut |e: &Expr| -> Result<WalkControl> {
-            if let Expr::Variable(variable) = e {
-                plan.phantom_params.push(variable.clone());
-            }
-            Ok(WalkControl::Continue)
-        });
-    }
-
-    // Replace the EXISTS/NOT EXISTS expression in the outer WHERE with a no-op (true).
-    // The semi/anti-join handles the filtering.
-    replace_exists_with_true(&mut plan.where_clause, where_info.where_term_idx);
-
-    // Remove the subquery from the outer plan's subquery list.
-    // Note: subquery_idx may have shifted if we inserted inner subqueries above,
-    // but we inserted at the END, so the original index is still valid.
-    plan.non_from_clause_subqueries.remove(subquery_idx);
-
-    true
-}
-
-/// Check if the inner plan is simple enough to unnest.
-fn can_unnest_inner_plan(plan: &SelectPlan) -> bool {
-    // Blocker ([MYSQL-SEMIJOIN]): only rewrite simple single-source subqueries.
-    // Principle: current VM early-out is loop-local; multi-table inners would
-    // need additional state to preserve existential semantics.
-    // Example: EXISTS over `i1 JOIN i2` can match only at deeper loop levels.
-    if plan.table_references.joined_tables().len() != 1 {
-        return false;
-    }
-    // Blocker ([PG-SUBQUERY], [SQLITE-EXISTS]): LIMIT can change emptiness.
-    // Example: `EXISTS(... LIMIT 0)` is always FALSE.
-    if plan.limit.is_some() {
-        return false;
-    }
-    // Blocker ([MYSQL-SEMIJOIN]): grouped subqueries require grouped rewrite.
-    // Example: GROUP BY/HAVING subquery is not equivalent to row-level semi-join.
-    if plan.group_by.is_some() {
-        return false;
-    }
-    // Blocker ([MYSQL-SEMIJOIN]): ORDER BY on a plain EXISTS is semantically
-    // irrelevant, but in practice appears with other complex constructs we
-    // don't decorrelate here (keep this pass intentionally conservative).
-    if !plan.order_by.is_empty() {
-        return false;
-    }
-    // Blocker ([MYSQL-SEMIJOIN]): DISTINCT + existential checks may require
-    // duplicate-elimination-aware planning.
-    // Example: DISTINCT in inner subquery should not change outer cardinality.
-    if !matches!(
-        plan.distinctness,
-        crate::translate::plan::Distinctness::NonDistinct
+    // EXISTS ignores its SELECT list. Keep any parameters from that list so
+    // callers can still bind them.
+    if matches!(
+        plan.non_from_clause_subqueries[subquery_index].query_type,
+        ast::SubqueryType::Exists { .. }
     ) {
-        return false;
-    }
-    // Blocker ([MYSQL-SEMIJOIN]): window frames are not row-local filters.
-    // Example: window function values depend on partition context.
-    if plan.window.is_some() {
-        return false;
-    }
-    // Blocker ([PG-SUBQUERY]): OFFSET changes emptiness independently of joins.
-    // Example: `EXISTS(... OFFSET 1000)` may become FALSE even with matches.
-    if plan.offset.is_some() {
-        return false;
-    }
-    // Blocker ([MYSQL-SEMIJOIN]): VALUES-based inners are not handled by this
-    // table-based rewrite path.
-    if !plan.values.is_empty() {
-        return false;
-    }
-    // Blocker ([PG-SUBQUERY]): aggregate subqueries can produce a row even when
-    // no base rows match, which breaks existential rewrite assumptions.
-    // Example: `EXISTS(SELECT count(*) FROM i WHERE false)` is TRUE.
-    if !plan.aggregates.is_empty() {
-        return false;
-    }
-    // Blocker ([MYSQL-SEMIJOIN]): nested correlated subqueries need layered
-    // decorrelation ordering not implemented in this pass.
-    // Example: inner WHERE contains `EXISTS (SELECT ... correlated to inner)`.
-    if plan.non_from_clause_subqueries.iter().any(|s| s.correlated) {
-        return false;
-    }
-    // Blocker ([PG-SUBQUERY]): side-effecting/volatile expressions may be
-    // evaluated a different number of times after rewrite.
-    // Example: `random()` under EXISTS should keep original evaluation behavior.
-    for term in &plan.where_clause {
-        if contains_nondeterministic_function(&term.expr) {
-            return false;
+        for result_column in &inner_plan.result_columns {
+            walk_expr(
+                &result_column.expr,
+                &mut |expr: &Expr| -> Result<WalkControl> {
+                    if let Expr::Variable(variable) = expr {
+                        plan.phantom_params.push(variable.clone());
+                    }
+                    Ok(WalkControl::Continue)
+                },
+            )
+            .expect("walking a result expression cannot fail");
         }
     }
-    true
+
+    replace_subquery_term_with_true(&mut plan.where_clause, where_term_index);
+
+    plan.non_from_clause_subqueries.remove(subquery_index);
+
+    Ok(true)
 }
 
-/// Information about where an EXISTS/NOT EXISTS expression appears in the WHERE clause.
-struct ExistsWhereInfo {
-    /// Index into the WHERE clause vector.
-    where_term_idx: usize,
-    /// Whether the EXISTS is negated (NOT EXISTS).
+/// Return whether a subquery is simple enough for a semi-join or anti-join.
+fn can_rewrite_as_semi_join(plan: &SelectPlan, resolver: &Resolver<'_>) -> Result<bool> {
+    // The current semi-join and anti-join loops stop after a match in one table.
+    // A joined inner query needs a separate implementation.
+    if plan.table_references.joined_tables().len() != 1 {
+        return Ok(false);
+    }
+    if plan.limit.is_some()
+        || plan.group_by.is_some()
+        || !plan.order_by.is_empty()
+        || !matches!(plan.distinctness, Distinctness::NonDistinct)
+        || plan.window.is_some()
+        || plan.offset.is_some()
+        || !plan.values.is_empty()
+    {
+        return Ok(false);
+    }
+
+    // An aggregate can return a row when its input table is empty.
+    if !plan.aggregates.is_empty() {
+        return Ok(false);
+    }
+
+    if plan
+        .non_from_clause_subqueries
+        .iter()
+        .any(|subquery| subquery.correlated)
+    {
+        return Ok(false);
+    }
+    if plan
+        .table_references
+        .joined_tables()
+        .iter()
+        .any(|table| match &table.table {
+            crate::schema::Table::FromClauseSubquery(subquery) => {
+                plan_is_correlated(&subquery.plan)
+            }
+            _ => false,
+        })
+    {
+        return Ok(false);
+    }
+
+    for term in &plan.where_clause {
+        if expr_contains_nondeterministic_scalar_function(&term.expr, resolver)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// The top-level `WHERE` term that uses an `EXISTS` result.
+struct ExistsTerm {
+    /// The term's position in the `WHERE` list.
+    index: usize,
+    /// Whether the term is `NOT EXISTS`.
     negated: bool,
 }
 
 /// Find the WHERE term that references the EXISTS subquery with the given ID.
-/// Returns None if the subquery is referenced in a context we can't unnest
+/// Returns `None` if the subquery appears where it cannot be moved into a join
 /// (e.g., inside OR, or referenced multiple times).
 fn find_exists_in_where(
     where_clause: &[WhereTerm],
     subquery_id: TableInternalId,
-) -> Option<ExistsWhereInfo> {
-    for (idx, term) in where_clause.iter().enumerate() {
-        // Blocker ([PG-JOIN-ORDER]): OUTER JOIN ON terms cannot be rewritten as
-        // normal WHERE terms without changing null-extension behavior.
-        // Example: `LEFT JOIN ... ON EXISTS(...)` must still emit unmatched rows.
+) -> Option<ExistsTerm> {
+    for (index, term) in where_clause.iter().enumerate() {
+        // An EXISTS inside an outer join condition must still allow the outer
+        // row through when it is false.
         if term.from_outer_join.is_some() {
             continue;
         }
-        // Check for direct EXISTS reference: SubqueryResult { Exists }
         if let Expr::SubqueryResult {
-            subquery_id: sid,
+            subquery_id: id,
             query_type: ast::SubqueryType::Exists { .. },
             ..
         } = &term.expr
         {
-            if *sid == subquery_id {
-                return Some(ExistsWhereInfo {
-                    where_term_idx: idx,
+            if *id == subquery_id {
+                return Some(ExistsTerm {
+                    index,
                     negated: false,
                 });
             }
         }
-        // Check for NOT EXISTS: Unary(Not, SubqueryResult { Exists })
         if let Expr::Unary(UnaryOperator::Not, inner) = &term.expr {
             if let Expr::SubqueryResult {
-                subquery_id: sid,
+                subquery_id: id,
                 query_type: ast::SubqueryType::Exists { .. },
                 ..
             } = inner.as_ref()
             {
-                if *sid == subquery_id {
-                    return Some(ExistsWhereInfo {
-                        where_term_idx: idx,
+                if *id == subquery_id {
+                    return Some(ExistsTerm {
+                        index,
                         negated: true,
                     });
                 }
@@ -361,106 +376,98 @@ fn find_exists_in_where(
     None
 }
 
-/// Check if a predicate expression is valid for unnesting.
-/// Valid predicates are:
-/// - Pure inner-table predicates (no outer refs)
-/// - Equality predicates between outer and inner columns (correlation predicates)
-/// - Any expression that doesn't reference outer tables in non-equality positions
-fn is_valid_unnesting_predicate(
+/// Find a direct IN term. IN under OR and NOT IN stay as subqueries.
+fn find_in_term(where_clause: &[WhereTerm], subquery_id: TableInternalId) -> Option<(usize, Expr)> {
+    where_clause.iter().enumerate().find_map(|(index, term)| {
+        if term.from_outer_join.is_some() {
+            return None;
+        }
+        let Expr::SubqueryResult {
+            subquery_id: id,
+            lhs: Some(left),
+            not_in: false,
+            query_type: ast::SubqueryType::In { .. },
+        } = &term.expr
+        else {
+            return None;
+        };
+        (*id == subquery_id).then(|| (index, left.as_ref().clone()))
+    })
+}
+
+/// Return whether an inner `WHERE` term can move into the outer query.
+fn can_move_join_term(
     expr: &Expr,
     outer_table_ids: &[TableInternalId],
     inner_table_ids: &[TableInternalId],
 ) -> bool {
-    // Check if the expression references any outer tables.
     let mut has_outer_ref = false;
-    let _ = walk_expr(expr, &mut |e: &Expr| -> Result<WalkControl> {
-        if let Expr::Column { table, .. } = e {
+    walk_expr(expr, &mut |expr: &Expr| -> Result<WalkControl> {
+        if let Expr::Column { table, .. } = expr {
             if outer_table_ids.contains(table) {
                 has_outer_ref = true;
             }
         }
         Ok(WalkControl::Continue)
-    });
+    })
+    .expect("walking a WHERE expression cannot fail");
 
     if !has_outer_ref {
-        // Pure inner predicate: always valid.
         return true;
     }
 
-    // For predicates with outer refs, we only support simple equality:
-    // inner_col = outer_col or outer_col = inner_col
-    is_correlation_equality(expr, outer_table_ids, inner_table_ids)
+    is_inner_outer_equal_check(expr, outer_table_ids, inner_table_ids)
 }
 
-/// Check if an expression is a simple equality between an outer and inner column reference.
-fn is_correlation_equality(
+/// One side of an `=` check may use inner tables and the other may use outer tables.
+fn is_inner_outer_equal_check(
     expr: &Expr,
     outer_table_ids: &[TableInternalId],
     inner_table_ids: &[TableInternalId],
 ) -> bool {
-    if let Expr::Binary(lhs, ast::Operator::Equals, rhs) = expr {
-        let lhs_tables = collect_table_refs(lhs);
-        let rhs_tables = collect_table_refs(rhs);
+    if let Expr::Binary(left, ast::Operator::Equals, right) = expr {
+        let left_tables = collect_table_refs(left);
+        let right_tables = collect_table_refs(right);
 
-        // One side references only outer tables, the other only inner tables.
-        let lhs_is_outer =
-            lhs_tables.iter().all(|t| outer_table_ids.contains(t)) && !lhs_tables.is_empty();
-        let lhs_is_inner =
-            lhs_tables.iter().all(|t| inner_table_ids.contains(t)) && !lhs_tables.is_empty();
-        let rhs_is_outer =
-            rhs_tables.iter().all(|t| outer_table_ids.contains(t)) && !rhs_tables.is_empty();
-        let rhs_is_inner =
-            rhs_tables.iter().all(|t| inner_table_ids.contains(t)) && !rhs_tables.is_empty();
+        let left_is_outer = left_tables
+            .iter()
+            .all(|table| outer_table_ids.contains(table))
+            && !left_tables.is_empty();
+        let left_is_inner = left_tables
+            .iter()
+            .all(|table| inner_table_ids.contains(table))
+            && !left_tables.is_empty();
+        let right_is_outer = right_tables
+            .iter()
+            .all(|table| outer_table_ids.contains(table))
+            && !right_tables.is_empty();
+        let right_is_inner = right_tables
+            .iter()
+            .all(|table| inner_table_ids.contains(table))
+            && !right_tables.is_empty();
 
-        (lhs_is_outer && rhs_is_inner) || (lhs_is_inner && rhs_is_outer)
+        (left_is_outer && right_is_inner) || (left_is_inner && right_is_outer)
     } else {
         false
     }
 }
 
-/// Collect all table IDs referenced by column expressions in an expression tree.
+/// Return each table used by an expression.
 fn collect_table_refs(expr: &Expr) -> SmallVec<[TableInternalId; 2]> {
-    let mut refs = SmallVec::new();
-    let _ = walk_expr(expr, &mut |e: &Expr| -> Result<WalkControl> {
-        if let Expr::Column { table, .. } = e {
-            if !refs.contains(table) {
-                refs.push(*table);
+    let mut tables = SmallVec::new();
+    walk_expr(expr, &mut |expr: &Expr| -> Result<WalkControl> {
+        if let Expr::Column { table, .. } = expr {
+            if !tables.contains(table) {
+                tables.push(*table);
             }
         }
         Ok(WalkControl::Continue)
-    });
-    refs
+    })
+    .expect("walking an expression cannot fail");
+    tables
 }
 
-/// Check if an expression tree contains any non-deterministic function calls
-/// (e.g. random(), changes(), last_insert_rowid()).
-fn contains_nondeterministic_function(expr: &Expr) -> bool {
-    let mut found = false;
-    let _ = walk_expr(expr, &mut |e: &Expr| -> Result<WalkControl> {
-        match e {
-            Expr::FunctionCall { name, args, .. } => {
-                if let Ok(Some(func)) = Func::resolve_function(name.as_str(), args.len()) {
-                    if !func.is_deterministic() {
-                        found = true;
-                    }
-                }
-            }
-            Expr::FunctionCallStar { name, .. } => {
-                // Star functions like count(*) — resolve with 0 args
-                if let Ok(Some(func)) = Func::resolve_function(name.as_str(), 0) {
-                    if !func.is_deterministic() {
-                        found = true;
-                    }
-                }
-            }
-            _ => {}
-        }
-        Ok(WalkControl::Continue)
-    });
-    found
-}
-
-/// Replace the WHERE term at the given index with a trivially-true expression.
-fn replace_exists_with_true(where_clause: &mut [WhereTerm], idx: usize) {
-    where_clause[idx].expr = Expr::Literal(ast::Literal::Numeric("1".to_string()));
+/// Replace a WHERE term after its join now performs the same test.
+fn replace_subquery_term_with_true(where_clause: &mut [WhereTerm], index: usize) {
+    where_clause[index].expr = Expr::Literal(ast::Literal::Numeric("1".to_string()));
 }

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -531,6 +531,9 @@ fn can_rewrite_single_value_aggregate(plan: &SelectPlan, resolver: &Resolver<'_>
         .joined_tables()
         .iter()
         .any(|table| match &table.table {
+            // A virtual table can store function arguments as hidden-column
+            // checks. Moving those checks would change the function call.
+            crate::schema::Table::Virtual(_) => true,
             crate::schema::Table::FromClauseSubquery(subquery) => {
                 plan_is_correlated(&subquery.plan)
             }

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -117,7 +117,7 @@ pub fn rewrite_correlated_subqueries(
 }
 
 /// Return the SELECT plan for a subquery that has not run yet.
-fn select_subquery_plan(plan: &SelectPlan, subquery_index: usize) -> Option<Box<SelectPlan>> {
+fn select_subquery_plan(plan: &SelectPlan, subquery_index: usize) -> Option<&SelectPlan> {
     let subquery = &plan.non_from_clause_subqueries[subquery_index];
     let SubqueryState::Unevaluated { plan: inner } = &subquery.state else {
         return None;
@@ -125,7 +125,19 @@ fn select_subquery_plan(plan: &SelectPlan, subquery_index: usize) -> Option<Box<
     let Plan::Select(inner) = inner.as_ref()?.as_ref() else {
         return None;
     };
-    Some(inner.clone())
+    Some(inner)
+}
+
+/// Take a SELECT plan after all rewrite checks have passed.
+fn take_select_subquery_plan(plan: &mut SelectPlan, subquery_index: usize) -> Box<SelectPlan> {
+    let subquery = &mut plan.non_from_clause_subqueries[subquery_index];
+    let SubqueryState::Unevaluated { plan: inner } = &mut subquery.state else {
+        unreachable!("a checked subquery must not have run")
+    };
+    let Plan::Select(inner) = *inner.take().expect("a checked subquery must have a plan") else {
+        unreachable!("a checked subquery must be a SELECT")
+    };
+    inner
 }
 
 /// Try to change one `EXISTS` or `NOT EXISTS` into a join.
@@ -134,14 +146,17 @@ fn try_rewrite_exists(
     subquery_index: usize,
     resolver: &Resolver<'_>,
 ) -> Result<bool> {
-    let Some(inner_plan) = select_subquery_plan(plan, subquery_index) else {
-        return Ok(false);
-    };
     let subquery_id = plan.non_from_clause_subqueries[subquery_index].internal_id;
 
     let Some(term) = find_exists_in_where(&plan.where_clause, subquery_id) else {
         return Ok(false);
     };
+    if plan.table_references.joined_tables().is_empty() {
+        return Ok(false);
+    }
+    if select_subquery_plan(plan, subquery_index).is_none() {
+        return Ok(false);
+    }
 
     let join_type = if term.negated {
         JoinType::Anti
@@ -149,14 +164,7 @@ fn try_rewrite_exists(
         JoinType::Semi
     };
 
-    rewrite_as_semi_or_anti_join(
-        plan,
-        subquery_index,
-        inner_plan,
-        term.index,
-        join_type,
-        resolver,
-    )
+    rewrite_as_semi_or_anti_join(plan, subquery_index, term.index, join_type, None, resolver)
 }
 
 /// Turn a direct `IN` test that is not `NOT IN` into a semi-join.
@@ -186,18 +194,17 @@ fn try_rewrite_in(
         return Ok(false);
     }
 
-    let mut inner_plan = inner_plan;
-    inner_plan.where_clause.push(WhereTerm {
+    let extra_term = WhereTerm {
         expr: Expr::Binary(Box::new(left), ast::Operator::Equals, Box::new(right)),
         from_outer_join: None,
         consumed: false,
-    });
+    };
     rewrite_as_semi_or_anti_join(
         plan,
         subquery_index,
-        inner_plan,
         where_term_index,
         JoinType::Semi,
+        Some(extra_term),
         resolver,
     )
 }
@@ -206,9 +213,9 @@ fn try_rewrite_in(
 fn rewrite_as_semi_or_anti_join(
     plan: &mut SelectPlan,
     subquery_index: usize,
-    inner_plan: Box<SelectPlan>,
     where_term_index: usize,
     join_type: JoinType,
+    extra_term: Option<WhereTerm>,
     resolver: &Resolver<'_>,
 ) -> Result<bool> {
     // A semi join needs a left table. Keep the subquery when the outer SELECT
@@ -217,7 +224,10 @@ fn rewrite_as_semi_or_anti_join(
         return Ok(false);
     }
 
-    if !can_rewrite_as_semi_join(&inner_plan, resolver)? {
+    let Some(inner_plan) = select_subquery_plan(plan, subquery_index) else {
+        return Ok(false);
+    };
+    if !can_rewrite_as_semi_join(inner_plan, resolver)? {
         return Ok(false);
     }
 
@@ -234,7 +244,7 @@ fn rewrite_as_semi_or_anti_join(
         .map(|table| table.internal_id)
         .collect();
 
-    for term in &inner_plan.where_clause {
+    for term in inner_plan.where_clause.iter().chain(extra_term.iter()) {
         if !can_move_join_term(&term.expr, &outer_table_ids, &inner_table_ids) {
             return Ok(false);
         }
@@ -243,7 +253,7 @@ fn rewrite_as_semi_or_anti_join(
     // Every NOT EXISTS term must use an inner table. Moving a constant false
     // term into the outer query would reject a row that NOT EXISTS keeps.
     if join_type == JoinType::Anti {
-        for term in &inner_plan.where_clause {
+        for term in inner_plan.where_clause.iter().chain(extra_term.iter()) {
             let tables = collect_table_refs(&term.expr);
             if !tables.iter().any(|table| inner_table_ids.contains(table)) {
                 return Ok(false);
@@ -263,7 +273,7 @@ fn rewrite_as_semi_or_anti_join(
         }
     }
     if !outer_table_ids_that_may_be_null.is_empty() {
-        for term in &inner_plan.where_clause {
+        for term in inner_plan.where_clause.iter().chain(extra_term.iter()) {
             let tables = collect_table_refs(&term.expr);
             if tables
                 .iter()
@@ -274,7 +284,10 @@ fn rewrite_as_semi_or_anti_join(
         }
     }
 
-    let mut inner_plan = inner_plan;
+    let mut inner_plan = take_select_subquery_plan(plan, subquery_index);
+    if let Some(extra_term) = extra_term {
+        inner_plan.where_clause.push(extra_term);
+    }
     let inner_tables = std::mem::take(inner_plan.table_references.joined_tables_mut());
     for (index, mut table) in inner_tables.into_iter().enumerate() {
         if index == 0 {
@@ -364,10 +377,10 @@ fn try_rewrite_single_value_aggregate(
         return Ok(false);
     };
 
-    if !can_rewrite_single_value_aggregate(&inner_plan, resolver)? {
+    if !can_rewrite_single_value_aggregate(inner_plan, resolver)? {
         return Ok(false);
     }
-    let Some(empty_value) = result_on_empty_input(&inner_plan) else {
+    let Some(empty_value) = result_on_empty_input(inner_plan) else {
         return Ok(false);
     };
     let subquery_id = plan.non_from_clause_subqueries[subquery_index].internal_id;
@@ -379,7 +392,6 @@ fn try_rewrite_single_value_aggregate(
     }) {
         return Ok(false);
     }
-
     let outer_tables = inner_plan.table_references.outer_query_refs();
     if outer_tables.iter().any(|outer_table| {
         outer_table.is_used()
@@ -430,11 +442,11 @@ fn try_rewrite_single_value_aggregate(
         }
         pairs.push(pair);
     }
-    if pairs.is_empty() || uses_outer_tables_outside_where(&inner_plan, &outer_table_ids) {
+    if pairs.is_empty() || uses_outer_tables_outside_where(inner_plan, &outer_table_ids) {
         return Ok(false);
     }
 
-    let mut inner_plan = *inner_plan;
+    let mut inner_plan = *take_select_subquery_plan(plan, subquery_index);
     inner_plan.where_clause = inner_where;
     inner_plan.limit = None;
     inner_plan.query_destination = QueryDestination::placeholder_for_subquery();

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1447,6 +1447,12 @@ impl TableReferences {
         &self.outer_query_refs
     }
 
+    /// Remove outer references after an optimizer rewrite has removed every
+    /// expression that uses them.
+    pub(crate) fn clear_outer_query_refs(&mut self) {
+        self.outer_query_refs.clear();
+    }
+
     /// Returns an immutable reference to the [OuterQueryReference] with the given internal ID.
     pub fn find_outer_query_ref_by_internal_id(
         &self,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -354,6 +354,13 @@ impl SubqueryOrigin {
     pub fn is_post_write_returning(self) -> bool {
         matches!(self, SubqueryOrigin::DmlReturning)
     }
+
+    pub fn is_write_statement(self) -> bool {
+        matches!(
+            self,
+            SubqueryOrigin::DmlWhere | SubqueryOrigin::DmlSet | SubqueryOrigin::DmlReturning
+        )
+    }
 }
 
 /// One ORDER BY key of a compound SELECT:
@@ -3622,9 +3629,6 @@ pub struct NonFromClauseSubquery {
     pub internal_id: TableInternalId,
     pub query_type: SubqueryType,
     pub state: SubqueryState,
-    /// A copy saved before the optimizer changed the plan.
-    /// It is used when the subquery needs a new estimate for its number of calls.
-    pub(crate) saved_plan: Option<Box<Plan>>,
     pub correlated: bool,
     pub origin: SubqueryOrigin,
     pub eval_phase: SubqueryEvalPhase,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3627,6 +3627,8 @@ impl SubqueryPosition {
 /// Currently only subqueries in the WHERE clause are supported.
 pub struct NonFromClauseSubquery {
     pub internal_id: TableInternalId,
+    /// An earlier scalar subquery with the same text in the same clause.
+    pub same_query: Option<TableInternalId>,
     pub query_type: SubqueryType,
     pub state: SubqueryState,
     pub correlated: bool,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -405,6 +405,21 @@ pub struct RecursiveCtePlan {
 }
 
 impl Plan {
+    /// Return the estimated work for this plan's expected number of calls.
+    pub(crate) fn estimated_cost(&self) -> Option<f64> {
+        match self {
+            Plan::Select(plan) => plan.estimated_cost,
+            Plan::CompoundSelect {
+                left, right_most, ..
+            } => left
+                .iter()
+                .map(|(plan, _)| plan.estimated_cost)
+                .chain(core::iter::once(right_most.estimated_cost))
+                .try_fold(0.0, |total, cost| cost.map(|cost| total + cost)),
+            Plan::RecursiveCte(_) | Plan::Delete(_) | Plan::Update(_) => None,
+        }
+    }
+
     /// Returns true if this SELECT plan contains a reference to the given table.
     /// For compound selects, checks all component selects.
     /// Returns false for Delete/Update plans.
@@ -767,6 +782,9 @@ pub struct SelectPlan {
     /// Estimated output rows from the optimizer's join order computation.
     /// Used to propagate cardinality estimates for CTE/subquery tables.
     pub estimated_output_rows: Option<f64>,
+    /// Estimated work for this query after its table reads are chosen.
+    /// Parent queries use this when they compare a subquery with a join.
+    pub(crate) estimated_cost: Option<f64>,
     /// When set, this query is a simple aggregate (COUNT(*), MIN, or MAX)
     /// that can be satisfied without a full table scan.
     pub simple_aggregate: Option<SimpleAggregate>,
@@ -3604,6 +3622,9 @@ pub struct NonFromClauseSubquery {
     pub internal_id: TableInternalId,
     pub query_type: SubqueryType,
     pub state: SubqueryState,
+    /// A copy saved before the optimizer changed the plan.
+    /// It is used when the subquery needs a new estimate for its number of calls.
+    pub(crate) saved_plan: Option<Box<Plan>>,
     pub correlated: bool,
     pub origin: SubqueryOrigin,
     pub eval_phase: SubqueryEvalPhase,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -391,6 +391,7 @@ fn prepare_one_select_plan(
                 non_from_clause_subqueries: vec![],
                 input_cardinality_hint: None,
                 estimated_output_rows: None,
+                estimated_cost: None,
                 simple_aggregate: None,
                 phantom_params: vec![],
             };
@@ -930,6 +931,7 @@ fn prepare_one_select_plan(
                 non_from_clause_subqueries,
                 input_cardinality_hint: None,
                 estimated_output_rows: None,
+                estimated_cost: None,
                 simple_aggregate: None,
                 phantom_params: vec![],
             };

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1760,6 +1760,15 @@ fn emit_indexed_materialized_subquery(
         };
     }
 
+    let build_end = if plan_is_correlated(plan) {
+        None
+    } else {
+        let label = program.allocate_label();
+        program.emit_insn(Insn::Once {
+            target_pc_when_reentered: label,
+        });
+        Some(label)
+    };
     program.emit_insn(Insn::OpenEphemeral {
         cursor_id,
         is_table: false,
@@ -1812,6 +1821,10 @@ fn emit_indexed_materialized_subquery(
         Plan::Delete(_) | Plan::Update(_) => {
             unreachable!("DELETE/UPDATE plans cannot be FROM clause subqueries")
         }
+    }
+
+    if let Some(build_end) = build_end {
+        program.preassign_label_to_next_insn(build_end);
     }
 
     Ok(result_columns_start_reg)

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::alloc::{TryClone, TursoSliceExt};
 
 use rustc_hash::FxHashMap as HashMap;
-use turso_parser::ast::{self, SortOrder, SubqueryType};
+use turso_parser::ast::{self, SortOrder, SubqueryType, TableInternalId};
 
 use crate::{
     alloc::TursoIteratorExt,
@@ -265,6 +265,7 @@ pub fn plan_subqueries_from_select_plan(
         None => Vec::new(),
     };
     let mut cse_map: Vec<(ast::Expr, ast::Expr)> = Vec::new();
+    let mut same_query_map: Vec<(ast::Expr, TableInternalId, SubqueryOrigin)> = Vec::new();
     // WHERE
     {
         crate::stack::trace_stack!("select_where");
@@ -279,6 +280,7 @@ pub fn plan_subqueries_from_select_plan(
             SubqueryOrigin::SelectWhere,
             SubqueryPosition::Where.allow_correlated(),
             &mut cse_map,
+            &mut same_query_map,
             &[],
         )?;
     }
@@ -298,6 +300,7 @@ pub fn plan_subqueries_from_select_plan(
                 SubqueryOrigin::SelectGroupBy,
                 SubqueryPosition::GroupBy.allow_correlated(),
                 &mut cse_map,
+                &mut same_query_map,
                 &shared_subqueries,
             )?;
         }
@@ -314,6 +317,7 @@ pub fn plan_subqueries_from_select_plan(
                 SubqueryOrigin::SelectHaving,
                 !group_by.exprs.is_empty(),
                 &mut cse_map,
+                &mut same_query_map,
                 &[],
             )?;
         }
@@ -333,6 +337,7 @@ pub fn plan_subqueries_from_select_plan(
             SubqueryOrigin::SelectList,
             SubqueryPosition::ResultColumn.allow_correlated(),
             &mut cse_map,
+            &mut same_query_map,
             &shared_subqueries,
         )?;
     }
@@ -351,6 +356,7 @@ pub fn plan_subqueries_from_select_plan(
             SubqueryOrigin::SelectOrderBy,
             SubqueryPosition::OrderBy.allow_correlated(),
             &mut cse_map,
+            &mut same_query_map,
             &[],
         )?;
     }
@@ -369,6 +375,7 @@ pub fn plan_subqueries_from_select_plan(
             SubqueryOrigin::SelectLimitOffset,
             false,
             &mut cse_map,
+            &mut same_query_map,
             &[],
         );
         // Limit
@@ -432,6 +439,7 @@ pub fn plan_subqueries_from_where_clause(
         SubqueryOrigin::DmlWhere,
         SubqueryPosition::Where.allow_correlated(),
         &mut Vec::new(),
+        &mut Vec::new(),
         &[],
     )?;
 
@@ -462,6 +470,7 @@ pub fn plan_subqueries_from_values(
         SubqueryOrigin::SelectList,
         SubqueryPosition::ResultColumn.allow_correlated(),
         &mut Vec::new(),
+        &mut Vec::new(),
         &[],
     )?;
 
@@ -490,6 +499,7 @@ pub fn plan_subqueries_from_update_sets(
         SubqueryPosition::ResultColumn,
         SubqueryOrigin::DmlSet,
         SubqueryPosition::ResultColumn.allow_correlated(),
+        &mut Vec::new(),
         &mut Vec::new(),
         &[],
     )?;
@@ -527,6 +537,7 @@ pub fn plan_subqueries_from_returning(
         SubqueryOrigin::DmlReturning,
         SubqueryPosition::ResultColumn.allow_correlated(),
         &mut Vec::new(),
+        &mut Vec::new(),
         &[],
     )?;
 
@@ -557,6 +568,7 @@ pub fn plan_subqueries_from_trigger_when_clause(
         SubqueryOrigin::TriggerWhen,
         false,
         &mut Vec::new(),
+        &mut Vec::new(),
         &[],
     )
 }
@@ -575,6 +587,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
     origin: SubqueryOrigin,
     allow_correlated: bool,
     cse_map: &mut Vec<(ast::Expr, ast::Expr)>,
+    same_query_map: &mut Vec<(ast::Expr, TableInternalId, SubqueryOrigin)>,
     shared: &[ast::Expr],
 ) -> Result<()> {
     // Most subqueries can reference columns from the outer query,
@@ -635,6 +648,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
         origin,
         allow_correlated,
         cse_map,
+        same_query_map,
         shared,
     );
     for expr in exprs {
@@ -676,6 +690,7 @@ fn get_subquery_parser<'a>(
     origin: SubqueryOrigin,
     allow_correlated: bool,
     cse_map: &'a mut Vec<(ast::Expr, ast::Expr)>,
+    same_query_map: &'a mut Vec<(ast::Expr, TableInternalId, SubqueryOrigin)>,
     shared: &'a [ast::Expr],
 ) -> impl FnMut(&mut ast::Expr) -> Result<WalkControl> + 'a {
     let handle_unsupported_correlation =
@@ -744,6 +759,7 @@ fn get_subquery_parser<'a>(
                 }
                 out_subqueries.push(NonFromClauseSubquery {
                     internal_id: subquery_id,
+                    same_query: None,
                     query_type: subquery_type,
                     state: SubqueryState::Unevaluated {
                         plan: Some(Box::new(Plan::Select(plan))),
@@ -776,6 +792,10 @@ fn get_subquery_parser<'a>(
                 } else {
                     origin
                 };
+                let same_query = same_query_map.iter().find_map(|(query, id, query_origin)| {
+                    (*query_origin == effective_origin && *query == *expr).then_some(*id)
+                });
+                let same_query_key = same_query.is_none().then(|| expr.clone());
                 let subquery_id = program.table_reference_counter.next();
                 let outer_query_refs = {
                     crate::stack::trace_stack!("get_outer_refs");
@@ -871,9 +891,11 @@ fn get_subquery_parser<'a>(
                 };
                 *result_reg_start = reg_start;
                 *num_regs = reg_count;
+                let subquery_id = *subquery_id;
 
                 out_subqueries.push(NonFromClauseSubquery {
-                    internal_id: *subquery_id,
+                    internal_id: subquery_id,
+                    same_query,
                     query_type: SubqueryType::RowValue {
                         result_reg_start: reg_start,
                         num_regs: reg_count,
@@ -887,6 +909,9 @@ fn get_subquery_parser<'a>(
                 });
                 if let Some(key) = cse_key {
                     cse_map.push((key, expr.clone()));
+                }
+                if let Some(query) = same_query_key {
+                    same_query_map.push((query, subquery_id, effective_origin));
                 }
                 Ok(WalkControl::Continue)
             }
@@ -1021,6 +1046,7 @@ fn get_subquery_parser<'a>(
 
                 out_subqueries.push(NonFromClauseSubquery {
                     internal_id: subquery_id,
+                    same_query: None,
                     query_type: SubqueryType::In {
                         cursor_id,
                         affinity_str: in_affinity_str,

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -737,17 +737,17 @@ fn get_subquery_parser<'a>(
                 // rows, which matches SQLite.
                 plan.order_by.clear();
                 plan.distinctness = crate::translate::plan::Distinctness::NonDistinct;
-                let saved_plan = Box::new(Plan::Select(plan.clone()));
-                optimize_select_plan(&mut plan, resolver)?;
                 let correlated = select_plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
+                if !correlated || origin.is_write_statement() {
+                    optimize_select_plan(&mut plan, resolver)?;
+                }
                 out_subqueries.push(NonFromClauseSubquery {
                     internal_id: subquery_id,
                     query_type: subquery_type,
                     state: SubqueryState::Unevaluated {
                         plan: Some(Box::new(Plan::Select(plan))),
                     },
-                    saved_plan: correlated.then_some(saved_plan),
                     correlated,
                     origin,
                     eval_phase: origin.phase_floor(),
@@ -812,8 +812,11 @@ fn get_subquery_parser<'a>(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
-                let mut saved_plan = plan.clone();
-                optimize_select_plan(&mut plan, resolver)?;
+                let correlated = select_plan_has_outer_scope_dependency(&plan);
+                handle_unsupported_correlation(correlated, position, allow_correlated)?;
+                if !correlated || origin.is_write_statement() {
+                    optimize_select_plan(&mut plan, resolver)?;
+                }
                 let reg_count = plan.result_columns.len();
                 let reg_start = program.alloc_registers(reg_count);
 
@@ -835,10 +838,6 @@ fn get_subquery_parser<'a>(
                     result_reg_start: reg_start,
                     num_regs: reg_count,
                 };
-                saved_plan.query_destination = QueryDestination::RowValueSubqueryResult {
-                    result_reg_start: reg_start,
-                    num_regs: reg_count,
-                };
 
                 // Only inject LIMIT 1 if there's no existing limit, or the existing limit is > 1,
                 // If LIMIT 0, subquery should return no rows (NULL).
@@ -855,7 +854,6 @@ fn get_subquery_parser<'a>(
                     plan.limit = Some(Box::new(ast::Expr::Literal(ast::Literal::Numeric(
                         "1".to_string(),
                     ))));
-                    saved_plan.limit.clone_from(&plan.limit);
                 }
 
                 let ast::Expr::SubqueryResult {
@@ -874,9 +872,6 @@ fn get_subquery_parser<'a>(
                 *result_reg_start = reg_start;
                 *num_regs = reg_count;
 
-                let correlated = select_plan_has_outer_scope_dependency(&plan);
-                handle_unsupported_correlation(correlated, position, allow_correlated)?;
-
                 out_subqueries.push(NonFromClauseSubquery {
                     internal_id: *subquery_id,
                     query_type: SubqueryType::RowValue {
@@ -886,7 +881,6 @@ fn get_subquery_parser<'a>(
                     state: SubqueryState::Unevaluated {
                         plan: Some(Box::new(Plan::Select(plan))),
                     },
-                    saved_plan: correlated.then_some(Box::new(Plan::Select(saved_plan))),
                     correlated,
                     origin: effective_origin,
                     eval_phase: effective_origin.phase_floor(),
@@ -917,33 +911,25 @@ fn get_subquery_parser<'a>(
                     QueryDestination::Unset,
                     connection,
                 )?;
-                let mut saved_plan = plan.clone();
-                let mut plan = match plan {
-                    Plan::Select(mut select_plan) => {
-                        optimize_select_plan(&mut select_plan, resolver)?;
-                        Plan::Select(select_plan)
-                    }
-                    Plan::CompoundSelect {
-                        mut left,
-                        mut right_most,
-                        limit,
-                        offset,
-                        order_by,
-                    } => {
-                        optimize_select_plan(&mut right_most, resolver)?;
-                        for (select_plan, _) in left.iter_mut() {
+                let mut plan = plan;
+                let correlated = plan_has_outer_scope_dependency(&plan);
+                handle_unsupported_correlation(correlated, position, allow_correlated)?;
+                if !correlated || origin.is_write_statement() {
+                    match &mut plan {
+                        Plan::Select(select_plan) => {
                             optimize_select_plan(select_plan, resolver)?;
                         }
                         Plan::CompoundSelect {
-                            left,
-                            right_most,
-                            limit,
-                            offset,
-                            order_by,
+                            left, right_most, ..
+                        } => {
+                            optimize_select_plan(right_most, resolver)?;
+                            for (select_plan, _) in left.iter_mut() {
+                                optimize_select_plan(select_plan, resolver)?;
+                            }
                         }
+                        _ => unreachable!("prepare_select_plan cannot return Delete/Update"),
                     }
-                    _ => unreachable!("prepare_select_plan cannot return Delete/Update"),
-                };
+                }
                 let result_columns = plan.select_result_columns();
                 let table_references = plan.select_table_references();
                 // e.g. (x,y) IN (SELECT ...)
@@ -1023,9 +1009,6 @@ fn get_subquery_parser<'a>(
                     affinity_str: Some(in_affinity_str.clone()),
                     is_delete: false,
                 };
-                *saved_plan.select_query_destination_mut().unwrap() =
-                    plan.select_query_destination_mut().unwrap().clone();
-
                 *expr = ast::Expr::SubqueryResult {
                     subquery_id,
                     lhs: Some(lhs),
@@ -1036,9 +1019,6 @@ fn get_subquery_parser<'a>(
                     },
                 };
 
-                let correlated = plan_has_outer_scope_dependency(&plan);
-                handle_unsupported_correlation(correlated, position, allow_correlated)?;
-
                 out_subqueries.push(NonFromClauseSubquery {
                     internal_id: subquery_id,
                     query_type: SubqueryType::In {
@@ -1048,7 +1028,6 @@ fn get_subquery_parser<'a>(
                     state: SubqueryState::Unevaluated {
                         plan: Some(Box::new(plan)),
                     },
-                    saved_plan: correlated.then_some(Box::new(saved_plan)),
                     correlated,
                     origin,
                     eval_phase: origin.phase_floor(),

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -737,6 +737,7 @@ fn get_subquery_parser<'a>(
                 // rows, which matches SQLite.
                 plan.order_by.clear();
                 plan.distinctness = crate::translate::plan::Distinctness::NonDistinct;
+                let saved_plan = Box::new(Plan::Select(plan.clone()));
                 optimize_select_plan(&mut plan, resolver)?;
                 let correlated = select_plan_has_outer_scope_dependency(&plan);
                 handle_unsupported_correlation(correlated, position, allow_correlated)?;
@@ -746,6 +747,7 @@ fn get_subquery_parser<'a>(
                     state: SubqueryState::Unevaluated {
                         plan: Some(Box::new(Plan::Select(plan))),
                     },
+                    saved_plan: correlated.then_some(saved_plan),
                     correlated,
                     origin,
                     eval_phase: origin.phase_floor(),
@@ -810,6 +812,7 @@ fn get_subquery_parser<'a>(
                         "compound SELECT queries not supported yet in WHERE clause subqueries"
                     );
                 };
+                let mut saved_plan = plan.clone();
                 optimize_select_plan(&mut plan, resolver)?;
                 let reg_count = plan.result_columns.len();
                 let reg_start = program.alloc_registers(reg_count);
@@ -832,6 +835,10 @@ fn get_subquery_parser<'a>(
                     result_reg_start: reg_start,
                     num_regs: reg_count,
                 };
+                saved_plan.query_destination = QueryDestination::RowValueSubqueryResult {
+                    result_reg_start: reg_start,
+                    num_regs: reg_count,
+                };
 
                 // Only inject LIMIT 1 if there's no existing limit, or the existing limit is > 1,
                 // If LIMIT 0, subquery should return no rows (NULL).
@@ -848,6 +855,7 @@ fn get_subquery_parser<'a>(
                     plan.limit = Some(Box::new(ast::Expr::Literal(ast::Literal::Numeric(
                         "1".to_string(),
                     ))));
+                    saved_plan.limit.clone_from(&plan.limit);
                 }
 
                 let ast::Expr::SubqueryResult {
@@ -878,6 +886,7 @@ fn get_subquery_parser<'a>(
                     state: SubqueryState::Unevaluated {
                         plan: Some(Box::new(Plan::Select(plan))),
                     },
+                    saved_plan: correlated.then_some(Box::new(Plan::Select(saved_plan))),
                     correlated,
                     origin: effective_origin,
                     eval_phase: effective_origin.phase_floor(),
@@ -908,6 +917,7 @@ fn get_subquery_parser<'a>(
                     QueryDestination::Unset,
                     connection,
                 )?;
+                let mut saved_plan = plan.clone();
                 let mut plan = match plan {
                     Plan::Select(mut select_plan) => {
                         optimize_select_plan(&mut select_plan, resolver)?;
@@ -1013,6 +1023,8 @@ fn get_subquery_parser<'a>(
                     affinity_str: Some(in_affinity_str.clone()),
                     is_delete: false,
                 };
+                *saved_plan.select_query_destination_mut().unwrap() =
+                    plan.select_query_destination_mut().unwrap().clone();
 
                 *expr = ast::Expr::SubqueryResult {
                     subquery_id,
@@ -1036,6 +1048,7 @@ fn get_subquery_parser<'a>(
                     state: SubqueryState::Unevaluated {
                         plan: Some(Box::new(plan)),
                     },
+                    saved_plan: correlated.then_some(Box::new(saved_plan)),
                     correlated,
                     origin,
                     eval_phase: origin.phase_floor(),

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1578,9 +1578,11 @@ pub fn emit_from_clause_subqueries(
             }
 
             let result_columns_start = match execution_mode {
-                FromClauseSubqueryExecutionMode::Coroutine => {
-                    emit_from_clause_subquery(program, from_clause_subquery.plan.as_mut(), t_ctx)?
-                }
+                FromClauseSubqueryExecutionMode::Coroutine => Some(emit_from_clause_subquery(
+                    program,
+                    from_clause_subquery.plan.as_mut(),
+                    t_ctx,
+                )?),
                 FromClauseSubqueryExecutionMode::MaterializedTable => {
                     let (result_columns_start, cte_cursor_id, cte_table) =
                         emit_materialized_subquery_table(
@@ -1600,7 +1602,7 @@ pub fn emit_from_clause_subqueries(
                             },
                         );
                     }
-                    result_columns_start
+                    Some(result_columns_start)
                 }
                 FromClauseSubqueryExecutionMode::DirectMaterializedIndex(direct_index) => {
                     emit_indexed_materialized_subquery(
@@ -1610,13 +1612,15 @@ pub fn emit_from_clause_subqueries(
                         table_reference.internal_id,
                         direct_index.index,
                         direct_index.affinity_str,
-                        from_clause_subquery.columns.len(),
-                    )?
+                    )?;
+                    None
                 }
             };
 
-            from_clause_subquery.result_columns_start_reg = Some(result_columns_start);
-            program.set_subquery_result_reg(table_reference.internal_id, result_columns_start);
+            from_clause_subquery.result_columns_start_reg = result_columns_start;
+            if let Some(result_columns_start) = result_columns_start {
+                program.set_subquery_result_reg(table_reference.internal_id, result_columns_start);
+            }
         }
 
         program.pop_current_parent_explain();
@@ -1745,11 +1749,9 @@ fn emit_indexed_materialized_subquery(
     internal_id: ast::TableInternalId,
     index: Arc<Index>,
     affinity_str: Option<Arc<String>>,
-    num_columns: usize,
-) -> Result<usize> {
+) -> Result<()> {
     let cursor_id = program
         .alloc_cursor_index_if_not_exists(CursorKey::index(internal_id, index.clone()), &index)?;
-    let result_columns_start_reg = program.alloc_registers(num_columns);
 
     if let Some(dest) = plan.select_query_destination_mut() {
         *dest = QueryDestination::EphemeralIndex {
@@ -1827,7 +1829,7 @@ fn emit_indexed_materialized_subquery(
         program.preassign_label_to_next_insn(build_end);
     }
 
-    Ok(result_columns_start_reg)
+    Ok(())
 }
 
 fn emit_materialized_subquery_table(

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -238,6 +238,7 @@ fn prepare_window_subquery(
         non_from_clause_subqueries: vec![],
         input_cardinality_hint: None,
         estimated_output_rows: None,
+        estimated_cost: None,
         simple_aggregate: None,
         phantom_params: vec![],
     };

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1,6 +1,7 @@
 use crate::{alloc, turso_assert, turso_assert_eq, turso_debug_assert, Result, Value, ValueRef};
 
 use rustc_hash::FxHashMap as HashMap;
+use std::ops::Range;
 use tracing::{instrument, Level};
 use turso_parser::ast::{self, ResolveType, SortOrder, TableInternalId};
 
@@ -257,7 +258,9 @@ pub struct ProgramBuilder {
     /// True once any `Insn::Function` has been emitted. See [`Self::may_abort`].
     emitted_function_call: bool,
     next_free_register: usize,
+    free_register_ranges: Vec<Range<usize>>,
     next_free_cursor_id: usize,
+    free_cursor_ids: Vec<usize>,
     next_hash_table_id: usize,
     pub table_references: TableReferences,
     /// Current parsing nesting level
@@ -658,7 +661,9 @@ impl ProgramBuilder {
         Self {
             table_reference_counter: TableRefIdCounter::new(),
             next_free_register: 1,
+            free_register_ranges: Vec::new(),
             next_free_cursor_id: 0,
+            free_cursor_ids: Vec::new(),
             next_hash_table_id: HASH_TABLE_ID_BASE,
             insns: Vec::with_capacity(opts.approx_num_insns),
             cursor_ref: Vec::with_capacity(opts.num_cursors),
@@ -945,16 +950,66 @@ impl ProgramBuilder {
         self.constant_spans.truncate(idx);
     }
 
-    pub const fn alloc_register(&mut self) -> usize {
-        let reg = self.next_free_register;
-        self.next_free_register += 1;
-        reg
+    pub fn alloc_register(&mut self) -> usize {
+        self.alloc_registers(1)
     }
 
-    pub const fn alloc_registers(&mut self, amount: usize) -> usize {
+    pub fn alloc_registers(&mut self, amount: usize) -> usize {
+        if amount == 0 {
+            return self.next_free_register;
+        }
+        if let Some(index) = self
+            .free_register_ranges
+            .iter()
+            .position(|range| range.len() >= amount)
+        {
+            let reg = self.free_register_ranges[index].start;
+            self.free_register_ranges[index].start += amount;
+            if self.free_register_ranges[index].is_empty() {
+                self.free_register_ranges.remove(index);
+            }
+            return reg;
+        }
         let reg = self.next_free_register;
         self.next_free_register += amount;
         reg
+    }
+
+    /// Allow later code to use registers that a removed plan had reserved.
+    pub(crate) fn release_registers(&mut self, start: usize, amount: usize) {
+        if amount == 0 {
+            return;
+        }
+        let end = start.checked_add(amount).expect("register range overflow");
+        turso_assert!(start > 0 && end <= self.next_free_register);
+        self.free_register_ranges.push(start..end);
+        self.free_register_ranges
+            .sort_unstable_by_key(|range| range.start);
+
+        let mut merged: Vec<Range<usize>> = Vec::with_capacity(self.free_register_ranges.len());
+        for range in self.free_register_ranges.drain(..) {
+            if let Some(last) = merged.last_mut() {
+                turso_assert!(last.end <= range.start, "register range released twice");
+                if last.end == range.start {
+                    last.end = range.end;
+                    continue;
+                }
+            }
+            merged.push(range);
+        }
+        self.free_register_ranges = merged;
+
+        while self
+            .free_register_ranges
+            .last()
+            .is_some_and(|range| range.end == self.next_free_register)
+        {
+            let range = self
+                .free_register_ranges
+                .pop()
+                .expect("last register range was present");
+            self.next_free_register = range.start;
+        }
     }
 
     /// Returns the next register that will be allocated by alloc_register/alloc_registers.
@@ -1031,11 +1086,40 @@ impl ProgramBuilder {
     }
 
     fn _alloc_cursor_id(&mut self, key: Option<CursorKey>, cursor_type: CursorType) -> usize {
+        if let Some(cursor) = self.free_cursor_ids.pop() {
+            self.cursor_ref[cursor] = (key, cursor_type);
+            return cursor;
+        }
         let cursor = self.next_free_cursor_id;
         self.next_free_cursor_id += 1;
         self.cursor_ref.push((key, cursor_type));
         turso_assert_eq!(self.cursor_ref.len(), self.next_free_cursor_id);
         cursor
+    }
+
+    /// Allow later code to use a cursor that a removed plan had reserved.
+    pub(crate) fn release_cursor_id(&mut self, cursor_id: usize) {
+        turso_assert!(cursor_id < self.next_free_cursor_id);
+        turso_assert!(!self.free_cursor_ids.contains(&cursor_id));
+
+        if cursor_id + 1 == self.next_free_cursor_id {
+            self.cursor_ref.pop();
+            self.next_free_cursor_id -= 1;
+            while let Some(index) = self
+                .free_cursor_ids
+                .iter()
+                .position(|id| *id + 1 == self.next_free_cursor_id)
+            {
+                self.free_cursor_ids.remove(index);
+                self.cursor_ref.pop();
+                self.next_free_cursor_id -= 1;
+            }
+            return;
+        }
+
+        self.free_cursor_ids.push(cursor_id);
+        self.free_cursor_ids
+            .sort_unstable_by(|left, right| right.cmp(left));
     }
 
     pub fn add_pragma_result_column(&mut self, col_name: String) {

--- a/perf/tpc-h/queries/11.sql
+++ b/perf/tpc-h/queries/11.sql
@@ -1,6 +1,3 @@
--- LIMBO_SKIP: subquery in HAVING clausenot supported
-
-
 select
 	ps_partkey,
 	sum(ps_supplycost * ps_availqty) as value

--- a/perf/tpc-h/queries/17.sql
+++ b/perf/tpc-h/queries/17.sql
@@ -1,5 +1,4 @@
--- LIMBO_SKIP: query 17 is slow as hell in both Turso and Sqlite
-
+-- SQLITE_SKIP: this query takes more than 30 seconds
 
 select
 	sum(l_extendedprice) / 7.0 as avg_yearly

--- a/perf/tpc-h/queries/20.sql
+++ b/perf/tpc-h/queries/20.sql
@@ -1,5 +1,4 @@
--- LIMBO_SKIP: query 20 is slow as hell in both Turso and Sqlite
-
+-- SQLITE_SKIP: this query takes more than 30 seconds
 
 select
 	s_name,

--- a/sqlite/conformance/sqlite-sqltests/join/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/join/memory.sqltest
@@ -668,6 +668,31 @@ expect {
     3|3|3
 }
 
+# The second hash join builds a3 after an earlier hash join reads a2. The a2
+# table is no longer in the main join order, but a2.b still filters the a3 rows
+# used by the second hash join. Keep that filter when a4 has no matching row.
+@cross-check-integrity
+test left-hash-join-build-keeps-filter-from-prior-hash-build {
+    CREATE TABLE a1(id INTEGER PRIMARY KEY, b, c, d);
+    CREATE TABLE a2(id INTEGER PRIMARY KEY, b, c, d);
+    CREATE TABLE a3(id INTEGER PRIMARY KEY, a, b, c, d);
+    CREATE TABLE a4(id INTEGER PRIMARY KEY, b, c, d);
+    INSERT INTO a1 VALUES (1, 0, 0, 1);
+    INSERT INTO a2 VALUES (2, 10, 0, 1), (3, 20, 0, 1);
+    INSERT INTO a3 VALUES (4, -1, 10, 1, 1), (5, -1, 20, 1, 1);
+    SELECT a1.id, a2.id, a3.id, a4.id
+    FROM a1
+    LEFT JOIN a2 ON a1.d = a2.d AND a1.d IS a2.d
+    LEFT JOIN a3 ON a2.b = a3.b
+    LEFT JOIN a4 ON a3.c = a4.c AND a3.c IS a4.c AND a3.d = a4.d
+    WHERE a3.a = -1 AND a2.b <> -5
+    ORDER BY a1.id, a2.id, a3.id, a4.id;
+}
+expect {
+    1|2|4|
+    1|3|5|
+}
+
 # Regression: hash outer join unmatched scan must apply WHERE predicates
 # that reference outer tables (issue #5797).
 @cross-check-integrity

--- a/sqlite/conformance/sqlite-sqltests/join/outer_hash_join.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/join/outer_hash_join.sqltest
@@ -1543,10 +1543,9 @@ expect {
     3|1|3
 }
 
-# Regression: FULL OUTER with correlated NOT EXISTS subquery.
-# Used to fail with misleading "FULL OUTER JOIN requires an equality condition
-# in the ON clause". Now gives a specific error about correlated subqueries.
-@skip-if sqlite "supported in sqlite"
+# A correlated NOT EXISTS after FULL OUTER JOIN is supported. This empty case
+# used to fail before join planning. Non-empty cases in unnest-correlated.sqltest
+# check the rows from both matched and missing sides.
 @cross-check-integrity
 test full-outer-with-not-exists-subquery {
     CREATE TABLE t(x);
@@ -1555,8 +1554,7 @@ test full-outer-with-not-exists-subquery {
     SELECT t.x, u.x FROM t FULL OUTER JOIN u ON t.x=u.x
     WHERE NOT EXISTS (SELECT * FROM v WHERE v.x=t.x);
 }
-expect error {
-    FULL OUTER JOIN is not supported with correlated subqueries that reference the joined tables
+expect {
 }
 
 # Regression: FULL OUTER with IN subquery on probe table column.

--- a/sqlite/conformance/sqlite-sqltests/multi_index_or_compound.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/multi_index_or_compound.sqltest
@@ -311,6 +311,39 @@ snapshot-eqp compound-or-benchmark-shape-eqp {
     WHERE n.type = 'entity';
 }
 
+# ANALYZE must not make a temporary type index win when it leaves the full
+# join condition to run for every matching pair.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+@skip-if mvcc "MVCC does not reload sqlite_stat1 after this test changes it"
+@setup benchmark_shape_schema
+test compound-or-analyzed-benchmark-shape-eqp {
+    ANALYZE;
+    DELETE FROM sqlite_stat1;
+    INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES
+        ('node', 'sqlite_autoindex_node_1', '2286 1'),
+        ('edge', 'sqlite_autoindex_edge_1', '2787 1'),
+        ('edge', 'idx_edge_label', '2787 200'),
+        ('edge', 'idx_edge_fromId', '2787 3'),
+        ('edge', 'idx_edge_toId', '2787 2');
+    ANALYZE sqlite_schema;
+
+    EXPLAIN QUERY PLAN
+    SELECT DISTINCT n.id
+    FROM node n
+    JOIN edge e
+      ON (
+        (e.fromId = 'uuid' AND e.toId = n.id AND e.label = 'requires')
+        OR
+        (e.toId = 'uuid' AND e.fromId = n.id AND e.label = 'requires')
+      )
+    WHERE n.type = 'course';
+}
+expect {
+    1|0|0|SEARCH e USING INDEX idx_edge_label (label=?)
+    2|0|0|MULTI-INDEX OR n (sqlite_autoindex_node_1, sqlite_autoindex_node_1)
+    4|0|0|USE HASH TABLE FOR DISTINCT
+}
+
 # Snapshot EQP: correlated subquery residuals should fall back to a regular scan
 @setup correlated_subquery_schema
 snapshot-eqp compound-or-correlated-subquery-eqp {

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-after-analyze.snap
@@ -17,34 +17,24 @@ info:
 ---
 QUERY PLAN
 |--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
-`--SEARCH p USING COVERING INDEX ephemeral_purchases_t2 (customer_id=?)
+`--SCAN purchases AS p
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4          p5  comment
-   0  Init             0  24   0               0  Start at 24
+   0  Init             0  14   0               0  Start at 14
    1  OpenRead         0   2   0  k(2,B,B)     0  table=customers, root=2, iDb=0
    2  OpenRead         1   3   0  k(3,B,B,B)   0  table=purchases, root=3, iDb=0
-   3  SeekRowid        0   3  23               0  if (r[3]!=cursor 0 for table customers.rowid) goto 23
-   4  Once            13   0   0               0  goto 13
-   5  OpenAutoindex    2   0   0               0  cursor=2
-   6  Rewind           1   7   0               0  Rewind table purchases
-   7    ColumnRange    1   1   4  2            0  r[4..5]=purchases.customer_id..amount
-   8    RowId          1   6   0               0  r[6]=purchases.rowid
-   9    MakeRecord     4   3   7               0  r[7]=mkrec(r[4..6]); for ephemeral_purchases_t2
-  10    FilterAdd      2   4   1               0  bloom_filter_add(r[4..5])
-  11    IdxInsert      2   7   4               0  key=r[7]
-  12  Next             1   7   0               0
-  13  RowId            0   8   0               0  r[8]=customers.rowid
-  14  Filter           2  23   8               1  if !bloom_filter(r[8..9]) goto 23
-  15  SeekGE           2  23   8               0  key=[8..8]
-  16    IdxGT          2  23   8               0  key=[8..8]
-  17    DeferredSeek   2   1   0               0
-  18    Column         0   1   1               0  r[1]=customers.name
-  19    Column         2   1   2               0  r[2]=ephemeral(ephemeral_purchases_t2).amount
-  20    RealAffinity   2   0   0               0
-  21    ResultRow      1   2   0               0  output=r[1..2]
-  22  Next             2  16   0               0
-  23  Halt             0   0   0               0
-  24  Transaction      0   1   4               0  iDb=0 tx_mode=Read
-  25  Integer          2   3   0               0  r[3]=2
-  26  Goto             0   1   0               0
+   3  SeekRowid        0   3  13               0  if (r[3]!=cursor 0 for table customers.rowid) goto 13
+   4  Rewind           1  13   0               0  Rewind table purchases
+   5    RowId          0   5   0               0  r[5]=customers.rowid
+   6    Column         1   1   6               0  r[6]=purchases.customer_id
+   7    Ne             5   6  12  Binary       0  if r[5]!=r[6] goto 12
+   8    Column         0   1   1               0  r[1]=customers.name
+   9    Column         1   2   2               0  r[2]=purchases.amount
+  10    RealAffinity   2   0   0               0
+  11    ResultRow      1   2   0               0  output=r[1..2]
+  12  Next             1   5   0               0
+  13  Halt             0   0   0               0
+  14  Transaction      0   1   4               0  iDb=0 tx_mode=Read
+  15  Integer          2   3   0               0  r[3]=2
+  16  Goto             0   1   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-aggregate-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-aggregate-after-analyze.snap
@@ -16,67 +16,79 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN customers AS c
-`--SEARCH p USING COVERING INDEX ephemeral_purchases_t2 (customer_id=?)
+|--SCAN purchases AS p
+|--SEARCH c USING COVERING INDEX ephemeral_customers_t1 (id=?)
+`--USE SORTER FOR GROUP BY
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4            p5  comment
-   0          Init               0  56   0                 0  Start at 56
+   0          Init               0  67   0                 0  Start at 67
    1          Null               0  10  11                 0  r[10..11]=NULL
-   2          Integer            0   6   0                 0  r[6]=0; clear group by abort flag
-   3          Null               0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
-   4          Gosub             16  52   0                 0  ; go to clear accumulator subroutine
-   5          OpenRead           0   2   0  k(2,B,B)       0  table=customers, root=2, iDb=0
-   6          OpenRead           1   3   0  k(3,B,B,B)     0  table=purchases, root=3, iDb=0
-   7          Rewind             0  39   0                 0  Rewind table customers
-   8            Once            17   0   0                 0  goto 17
-   9            OpenAutoindex    2   0   0                 0  cursor=2
-  10            Rewind           1  11   0                 0  Rewind table purchases
-  11              ColumnRange    1   1  17  2              0  r[17..18]=purchases.customer_id..amount
-  12              RowId          1  19   0                 0  r[19]=purchases.rowid
-  13              MakeRecord    17   3  20                 0  r[20]=mkrec(r[17..19]); for ephemeral_purchases_t2
-  14              FilterAdd      2  17   1                 0  bloom_filter_add(r[17..18])
-  15              IdxInsert      2  20  17                 0  key=r[20]
-  16            Next             1  11   0                 0
-  17            RowId            0  21   0                 0  r[21]=customers.rowid
-  18            Filter           2  38  21                 1  if !bloom_filter(r[21..22]) goto 38
-  19            SeekGE           2  38  21                 0  key=[21..21]
-  20              IdxGT          2  38  21                 0  key=[21..21]
-  21              DeferredSeek   2   1   0                 0
-  22              RowId          0  13   0                 0  r[13]=customers.rowid
-  23              Column         0   1  14                 0  r[14]=customers.name
-  24              Column         2   1  15                 0  r[15]=ephemeral(ephemeral_purchases_t2).amount
-  25              RealAffinity  15   0   0                 0
-  26              Compare        7  13   1  k(1, Binary)   0  r[7..7]==r[13..13]
-  27              Jump          28  32  28                 0  ; start new group if comparison is not equal
-  28              Gosub          4  43   0                 0  ; check if ended group had data, and output if so
-  29              Move          13   7   1                 0  r[7..7]=r[13..13]
-  30              IfPos          6  55   0                 0  r[6]>0 -> r[6]-=0, goto 55; check abort flag
-  31              Gosub         16  52   0                 0  ; goto clear accumulator subroutine
-  32              AggStep        0  22  10  count          0  accum=r[10] step(r[22])
-  33              AggStep        0  15  11  sum            0  accum=r[11] step(r[15])
-  34              If             5  36   0                 0  if r[5] goto 36; don't emit group columns if continuing existing group
-  35              Column         0   1   8                 0  r[8]=customers.name
-  36              Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
-  37            Next             2  20   0                 0
-  38          Next               0   8   0                 0
-  39          Gosub              4  43   0                 0  ; emit row for final group
-  40          Goto               0  55   0                 0  ; group by finished
-  41          Integer            1   6   0                 0  r[6]=1
-  42        Return               4   0   0                 0
-  43        IfPos                5  45   0                 0  r[5]>0 -> r[5]-=0, goto 45; output group by row subroutine start
-  44      Return                 4   0   0                 0
-  45      AggFinal               0  10   0  count          0  accum=r[10]
-  46      AggFinal               0  11   0  sum            0  accum=r[11]
-  47      Copy                   8   1   0                 0  r[1]=r[8]
-  48      Copy                  10   2   0                 0  r[2]=r[10]
-  49      Copy                  11   3   0                 0  r[3]=r[11]
-  50      ResultRow              1   3   0                 0  output=r[1..3]
-  51    Return                   4   0   0                 0
-  52    Null                     0   8  11                 0  r[8..11]=NULL; clear accumulator subroutine start
-  53    Integer                  0   5   0                 0  r[5]=0
-  54  Return                    16   0   0                 0
-  55  Halt                       0   0   0                 0
-  56  Transaction                0   1   4                 0  iDb=0 tx_mode=Read
-  57  Integer                    1  22   0                 0  r[22]=1
-  58  Goto                       0   1   0                 0
+   2          SorterOpen         0   3   0  k(1,B)         0  cursor=0
+   3          Integer            0   6   0                 0  r[6]=0; clear group by abort flag
+   4          Null               0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
+   5          Gosub             16  63   0                 0  ; go to clear accumulator subroutine
+   6          OpenRead           2   2   0  k(2,B,B)       0  table=customers, root=2, iDb=0
+   7          OpenRead           4   3   0  k(3,B,B,B)     0  table=purchases, root=3, iDb=0
+   8          Rewind             4  33   0                 0  Rewind table purchases
+   9            Once            19   0   0                 0  goto 19
+  10            OpenAutoindex    3   0   0                 0  cursor=3
+  11            Rewind           2  12   0                 0  Rewind table customers
+  12              RowId          2  17   0                 0  r[17]=customers.rowid
+  13              Column         2   1  18                 0  r[18]=customers.name
+  14              RowId          2  19   0                 0  r[19]=customers.rowid
+  15              MakeRecord    17   3  20                 0  r[20]=mkrec(r[17..19]); for ephemeral_customers_t1
+  16              FilterAdd      3  17   1                 0  bloom_filter_add(r[17..18])
+  17              IdxInsert      3  20  17                 0  key=r[20]
+  18            Next             2  12   0                 0
+  19            Column           4   1  21                 0  r[21]=purchases.customer_id
+  20            Affinity        21   1   0                 0  r[21..22] = C
+  21            Filter           3  32  21                 1  if !bloom_filter(r[21..22]) goto 32
+  22            SeekGE           3  32  21                 0  key=[21..21]
+  23              IdxGT          3  32  21                 0  key=[21..21]
+  24              DeferredSeek   3   2   0                 0
+  25              IdxRowId       3  13   0                 0  r[13]=cursor 3 for index ephemeral(ephemeral_customers_t1).rowid
+  26              Column         3   1  14                 0  r[14]=ephemeral(ephemeral_customers_t1).name
+  27              Column         4   2  15                 0  r[15]=purchases.amount
+  28              RealAffinity  15   0   0                 0
+  29              MakeRecord    13   3  12                 0  r[12]=mkrec(r[13..15])
+  30              SorterInsert   0  12   0  0              0  key=r[12]
+  31            Next             3  23   0                 0
+  32          Next               4   9   0                 0
+  33          OpenPseudo         1  12   3                 0  3 columns in r[12]
+  34          SorterSort         0  50   0                 0
+  35            SorterData       0  12   1                 0  r[12]=data
+  36            Column           1   0  22                 0  r[22]=pseudo.column 0
+  37            Compare          7  22   1  k(1, Binary)   0  r[7..7]==r[22..22]
+  38            Jump            39  43  39                 0  ; start new group if comparison is not equal
+  39            Gosub            4  54   0                 0  ; check if ended group had data, and output if so
+  40            Move            22   7   1                 0  r[7..7]=r[22..22]
+  41            IfPos            6  66   0                 0  r[6]>0 -> r[6]-=0, goto 66; check abort flag
+  42            Gosub           16  63   0                 0  ; goto clear accumulator subroutine
+  43            Column           1   2  23                 0  r[23]=pseudo.column 2
+  44            AggStep          0  24  10  count          0  accum=r[10] step(r[24])
+  45            AggStep          0  23  11  sum            0  accum=r[11] step(r[23])
+  46            If               5  48   0                 0  if r[5] goto 48; don't emit group columns if continuing existing group
+  47            Column           1   1   8                 0  r[8]=pseudo.column 1
+  48            Integer          1   5   0                 0  r[5]=1; indicate data in accumulator
+  49          SorterNext         0  35   0                 0
+  50          Gosub              4  54   0                 0  ; emit row for final group
+  51          Goto               0  66   0                 0  ; group by finished
+  52          Integer            1   6   0                 0  r[6]=1
+  53        Return               4   0   0                 0
+  54        IfPos                5  56   0                 0  r[5]>0 -> r[5]-=0, goto 56; output group by row subroutine start
+  55      Return                 4   0   0                 0
+  56      AggFinal               0  10   0  count          0  accum=r[10]
+  57      AggFinal               0  11   0  sum            0  accum=r[11]
+  58      Copy                   8   1   0                 0  r[1]=r[8]
+  59      Copy                  10   2   0                 0  r[2]=r[10]
+  60      Copy                  11   3   0                 0  r[3]=r[11]
+  61      ResultRow              1   3   0                 0  output=r[1..3]
+  62    Return                   4   0   0                 0
+  63    Null                     0   8  11                 0  r[8..11]=NULL; clear accumulator subroutine start
+  64    Integer                  0   5   0                 0  r[5]=0
+  65  Return                    16   0   0                 0
+  66  Halt                       0   0   0                 0
+  67  Transaction                0   1   4                 0  iDb=0 tx_mode=Read
+  68  Integer                    1  24   0                 0  r[24]=1
+  69  Goto                       0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__join-with-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__join-with-subquery.snap
@@ -33,7 +33,7 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN recent_orders
+|--SCAN customers AS c
+|--SEARCH recent_orders USING INDEX ephemeral_subquery_t3 (customer_id=?)
 |  `--SCAN orders USING INDEX idx_orders_customer_id
-|--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
 `--USE SORTER FOR ORDER BY

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
@@ -19,74 +19,38 @@ info:
 ---
 QUERY PLAN
 |--SCAN orders AS o
-`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
-   `--SCAN order_items AS oi USING COVERING INDEX idx_order_items_order
+`--CORRELATED SCALAR SUBQUERY 1
+   `--SEARCH oi USING INDEX idx_order_items_order (order_id=?)
 
 BYTECODE
-addr  opcode                 p1  p2  p3  p4            p5  comment
-   0          Init            0  62   0                 0  Start at 62
-   1          OpenEphemeral   0   0   0                 0  cursor=0 is_table=false
-   2          Null            0  11   0                 0  r[11]=NULL
-   3          Integer         0   8   0                 0  r[8]=0; clear group by abort flag
-   4          Null            0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
-   5          Gosub          14  35   0                 0  ; go to clear accumulator subroutine
-   6          OpenRead        1  10   0  k(2,B)         0  index=idx_order_items_order, root=10, iDb=0
-   7          Rewind          1  20   0                 0  Rewind index idx_order_items_order
-   8            Column        1   0  13                 0  r[13]=idx_order_items_order.order_id
-   9            Compare       9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
-  10            Jump         11  15  11                 0  ; start new group if comparison is not equal
-  11            Gosub         6  24   0                 0  ; check if ended group had data, and output if so
-  12            Move         13   9   1                 0  r[9..9]=r[13..13]
-  13            IfPos         8  38   0                 0  r[8]>0 -> r[8]-=0, goto 38; check abort flag
-  14            Gosub        14  35   0                 0  ; goto clear accumulator subroutine
-  15            AggStep       0  15  11  count          0  accum=r[11] step(r[15])
-  16            If            7  18   0                 0  if r[7] goto 18; don't emit group columns if continuing existing group
-  17            Column        1   0  10                 0  r[10]=idx_order_items_order.order_id
-  18            Integer       1   7   0                 0  r[7]=1; indicate data in accumulator
-  19          Next            1   8   0                 0
-  20          Gosub           6  24   0                 0  ; emit row for final group
-  21          Goto            0  38   0                 0  ; group by finished
-  22          Integer         1   8   0                 0  r[8]=1
-  23        Return            6   0   0                 0
-  24        IfPos             7  26   0                 0  r[7]>0 -> r[7]-=0, goto 26; output group by row subroutine start
-  25      Return              6   0   0                 0
-  26      AggFinal            0  11   0  count          0  accum=r[11]
-  27      Copy               11   4   0                 0  r[4]=r[11]
-  28      Copy               10   5   0                 0  r[5]=r[10]
-  29      Copy                5  17   0                 0  r[17]=r[5]
-  30      Copy                4  18   0                 0  r[18]=r[4]
-  31      Sequence            0  19   0                 0
-  32      MakeRecord         17   3  16                 0  r[16]=mkrec(r[17..19]); for ephemeral_subquery_t2
-  33      IdxInsert           0  16   0                 8  key=r[16]
-  34    Return                6   0   0                 0
-  35    Null                  0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
-  36    Integer               0   7   0                 0  r[7]=0
-  37  Return                 14   0   0                 0
-  38  OpenRead                2   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-  39  Rewind                  2  61   0                 0  Rewind table orders
-  40    Integer               0  23   0                 0  r[23]=0
-  41    RowId                 2  24   0                 0  r[24]=orders.rowid
-  42    SeekGE                0  56  24                 0  key=[24..24]
-  43      IdxGT               0  56  24                 0  key=[24..24]
-  44      Column              0   1   2                 0  r[2]=ephemeral(ephemeral_subquery_t2).count(*)
-  45      Column              0   0   3                 0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
-  46      Integer             1  23   0                 0  r[23]=1
-  47      Column              0   1  26                 0  r[26]=ephemeral(ephemeral_subquery_t2).count(*)
-  48      NotNull            26  50   0                 0  r[26]!=NULL -> goto 50
-  49      Integer             0  26   0                 0  r[26]=0
-  50      Lt                 26  27  55  Binary         0  if r[26]<r[27] goto 55
-  51      RowId               2  20   0                 0  r[20]=orders.rowid
-  52      ColumnRange         2   2  21  2              0  r[21..22]=orders.order_date..total_amount
-  53      RealAffinity       22   0   0                 0
-  54      ResultRow          20   3   0                 0  output=r[20..22]
-  55    Next                  0  43   0                 0
-  56    IfPos                23  60   0                 0  r[23]>0 -> r[23]-=0, goto 60
-  57    NullRow               0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
-  58    Null                  0   2   3                 0  r[2..3]=NULL
-  59    Goto                  0  46   0                 0
-  60  Next                    2  40   0                 0
-  61  Halt                    0   0   0                 0
-  62  Transaction             0   1  11                 0  iDb=0 tx_mode=Read
-  63  Integer                 1  15   0                 0  r[15]=1
-  64  Integer                 3  27   0                 0  r[27]=3
-  65  Goto                    0   1   0                 0
+addr  opcode           p1  p2  p3  p4            p5  comment
+   0    Init            0  26   0                 0  Start at 26
+   1    OpenRead        0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   2    Rewind          0  25   0                 0  Rewind table orders
+   3      BeginSubrtn   5   0   0                 0  r[5]=NULL
+   4      Null          0   1   0                 0  r[1]=NULL
+   5      Null          0   7   0                 0  r[7]=NULL
+   6      Integer       1   8   0                 0  r[8]=1; LIMIT counter
+   7      IfNot         8  14   0                 0  if !r[8] goto 14
+   8      OpenRead      1  10   0  k(2,B)         0  index=idx_order_items_order, root=10, iDb=0
+   9      RowId         0   9   0                 0  r[9]=orders.rowid
+  10      SeekGE        1  14   9                 0  key=[9..9]
+  11        IdxGT       1  14   9                 0  key=[9..9]
+  12        AggStep     0  10   7  count          0  accum=r[7] step(r[10])
+  13      Next          1  11   0                 0
+  14      AggFinal      0   7   0  count          0  accum=r[7]
+  15      Copy          7   6   0                 0  r[6]=r[7]
+  16      Copy          6   1   0                 0  r[1]=r[6]
+  17    Return          5   0   1                 0
+  18    Copy            1  12   0                 0  r[12]=r[1]
+  19    Lt             12  13  24                 0  if r[12]<r[13] goto 24
+  20    RowId           0   2   0                 0  r[2]=orders.rowid
+  21    ColumnRange     0   2   3  2              0  r[3..4]=orders.order_date..total_amount
+  22    RealAffinity    4   0   0                 0
+  23    ResultRow       2   3   0                 0  output=r[2..4]
+  24  Next              0   3   0                 0
+  25  Halt              0   0   0                 0
+  26  Transaction       0   1  11                 0  iDb=0 tx_mode=Read
+  27  Integer           1  10   0                 0  r[10]=1
+  28  Integer           3  13   0                 0  r[13]=3
+  29  Goto              0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
@@ -19,38 +19,74 @@ info:
 ---
 QUERY PLAN
 |--SCAN orders AS o
-`--CORRELATED SCALAR SUBQUERY 1
-   `--SEARCH oi USING COVERING INDEX idx_order_items_order (order_id=?)
+`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
+   `--SCAN order_items AS oi USING COVERING INDEX idx_order_items_order
 
 BYTECODE
-addr  opcode           p1  p2  p3  p4            p5  comment
-   0    Init            0  26   0                 0  Start at 26
-   1    OpenRead        0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   2    Rewind          0  25   0                 0  Rewind table orders
-   3      BeginSubrtn   5   0   0                 0  r[5]=NULL
-   4      Null          0   1   0                 0  r[1]=NULL
-   5      Null          0   7   0                 0  r[7]=NULL
-   6      Integer       1   8   0                 0  r[8]=1; LIMIT counter
-   7      IfNot         8  14   0                 0  if !r[8] goto 14
-   8      OpenRead      1  10   0  k(2,B)         0  index=idx_order_items_order, root=10, iDb=0
-   9      RowId         0   9   0                 0  r[9]=orders.rowid
-  10      SeekGE        1  14   9                 0  key=[9..9]
-  11        IdxGT       1  14   9                 0  key=[9..9]
-  12        AggStep     0  10   7  count          0  accum=r[7] step(r[10])
-  13      Next          1  11   0                 0
-  14      AggFinal      0   7   0  count          0  accum=r[7]
-  15      Copy          7   6   0                 0  r[6]=r[7]
-  16      Copy          6   1   0                 0  r[1]=r[6]
-  17    Return          5   0   1                 0
-  18    Copy            1  12   0                 0  r[12]=r[1]
-  19    Lt             12  13  24                 0  if r[12]<r[13] goto 24
-  20    RowId           0   2   0                 0  r[2]=orders.rowid
-  21    ColumnRange     0   2   3  2              0  r[3..4]=orders.order_date..total_amount
-  22    RealAffinity    4   0   0                 0
-  23    ResultRow       2   3   0                 0  output=r[2..4]
-  24  Next              0   3   0                 0
-  25  Halt              0   0   0                 0
-  26  Transaction       0   1  11                 0  iDb=0 tx_mode=Read
-  27  Integer           1  10   0                 0  r[10]=1
-  28  Integer           3  13   0                 0  r[13]=3
-  29  Goto              0   1   0                 0
+addr  opcode                 p1  p2  p3  p4            p5  comment
+   0          Init            0  62   0                 0  Start at 62
+   1          OpenEphemeral   0   0   0                 0  cursor=0 is_table=false
+   2          Null            0  11   0                 0  r[11]=NULL
+   3          Integer         0   8   0                 0  r[8]=0; clear group by abort flag
+   4          Null            0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
+   5          Gosub          14  35   0                 0  ; go to clear accumulator subroutine
+   6          OpenRead        1  10   0  k(2,B)         0  index=idx_order_items_order, root=10, iDb=0
+   7          Rewind          1  20   0                 0  Rewind index idx_order_items_order
+   8            Column        1   0  13                 0  r[13]=idx_order_items_order.order_id
+   9            Compare       9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
+  10            Jump         11  15  11                 0  ; start new group if comparison is not equal
+  11            Gosub         6  24   0                 0  ; check if ended group had data, and output if so
+  12            Move         13   9   1                 0  r[9..9]=r[13..13]
+  13            IfPos         8  38   0                 0  r[8]>0 -> r[8]-=0, goto 38; check abort flag
+  14            Gosub        14  35   0                 0  ; goto clear accumulator subroutine
+  15            AggStep       0  15  11  count          0  accum=r[11] step(r[15])
+  16            If            7  18   0                 0  if r[7] goto 18; don't emit group columns if continuing existing group
+  17            Column        1   0  10                 0  r[10]=idx_order_items_order.order_id
+  18            Integer       1   7   0                 0  r[7]=1; indicate data in accumulator
+  19          Next            1   8   0                 0
+  20          Gosub           6  24   0                 0  ; emit row for final group
+  21          Goto            0  38   0                 0  ; group by finished
+  22          Integer         1   8   0                 0  r[8]=1
+  23        Return            6   0   0                 0
+  24        IfPos             7  26   0                 0  r[7]>0 -> r[7]-=0, goto 26; output group by row subroutine start
+  25      Return              6   0   0                 0
+  26      AggFinal            0  11   0  count          0  accum=r[11]
+  27      Copy               11   4   0                 0  r[4]=r[11]
+  28      Copy               10   5   0                 0  r[5]=r[10]
+  29      Copy                5  17   0                 0  r[17]=r[5]
+  30      Copy                4  18   0                 0  r[18]=r[4]
+  31      Sequence            0  19   0                 0
+  32      MakeRecord         17   3  16                 0  r[16]=mkrec(r[17..19]); for ephemeral_subquery_t2
+  33      IdxInsert           0  16   0                 8  key=r[16]
+  34    Return                6   0   0                 0
+  35    Null                  0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
+  36    Integer               0   7   0                 0  r[7]=0
+  37  Return                 14   0   0                 0
+  38  OpenRead                2   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  39  Rewind                  2  61   0                 0  Rewind table orders
+  40    Integer               0  23   0                 0  r[23]=0
+  41    RowId                 2  24   0                 0  r[24]=orders.rowid
+  42    SeekGE                0  56  24                 0  key=[24..24]
+  43      IdxGT               0  56  24                 0  key=[24..24]
+  44      Column              0   1   2                 0  r[2]=ephemeral(ephemeral_subquery_t2).count(*)
+  45      Column              0   0   3                 0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
+  46      Integer             1  23   0                 0  r[23]=1
+  47      Column              0   1  26                 0  r[26]=ephemeral(ephemeral_subquery_t2).count(*)
+  48      NotNull            26  50   0                 0  r[26]!=NULL -> goto 50
+  49      Integer             0  26   0                 0  r[26]=0
+  50      Lt                 26  27  55  Binary         0  if r[26]<r[27] goto 55
+  51      RowId               2  20   0                 0  r[20]=orders.rowid
+  52      ColumnRange         2   2  21  2              0  r[21..22]=orders.order_date..total_amount
+  53      RealAffinity       22   0   0                 0
+  54      ResultRow          20   3   0                 0  output=r[20..22]
+  55    Next                  0  43   0                 0
+  56    IfPos                23  60   0                 0  r[23]>0 -> r[23]-=0, goto 60
+  57    NullRow               0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  58    Null                  0   2   3                 0  r[2..3]=NULL
+  59    Goto                  0  46   0                 0
+  60  Next                    2  40   0                 0
+  61  Halt                    0   0   0                 0
+  62  Transaction             0   1  11                 0  iDb=0 tx_mode=Read
+  63  Integer                 1  15   0                 0  r[15]=1
+  64  Integer                 3  27   0                 0  r[27]=3
+  65  Goto                    0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
@@ -19,38 +19,72 @@ info:
 ---
 QUERY PLAN
 |--SCAN orders AS o
-`--CORRELATED SCALAR SUBQUERY 1
-   `--SEARCH oi USING INDEX idx_order_items_order (order_id=?)
+`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
+   `--SCAN order_items AS oi USING COVERING INDEX idx_order_items_order
 
 BYTECODE
-addr  opcode           p1  p2  p3  p4            p5  comment
-   0    Init            0  26   0                 0  Start at 26
-   1    OpenRead        0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   2    Rewind          0  25   0                 0  Rewind table orders
-   3      BeginSubrtn   5   0   0                 0  r[5]=NULL
-   4      Null          0   1   0                 0  r[1]=NULL
-   5      Null          0   7   0                 0  r[7]=NULL
-   6      Integer       1   8   0                 0  r[8]=1; LIMIT counter
-   7      IfNot         8  14   0                 0  if !r[8] goto 14
-   8      OpenRead      1  10   0  k(2,B)         0  index=idx_order_items_order, root=10, iDb=0
-   9      RowId         0   9   0                 0  r[9]=orders.rowid
-  10      SeekGE        1  14   9                 0  key=[9..9]
-  11        IdxGT       1  14   9                 0  key=[9..9]
-  12        AggStep     0  10   7  count          0  accum=r[7] step(r[10])
-  13      Next          1  11   0                 0
-  14      AggFinal      0   7   0  count          0  accum=r[7]
-  15      Copy          7   6   0                 0  r[6]=r[7]
-  16      Copy          6   1   0                 0  r[1]=r[6]
-  17    Return          5   0   1                 0
-  18    Copy            1  12   0                 0  r[12]=r[1]
-  19    Lt             12  13  24                 0  if r[12]<r[13] goto 24
-  20    RowId           0   2   0                 0  r[2]=orders.rowid
-  21    ColumnRange     0   2   3  2              0  r[3..4]=orders.order_date..total_amount
-  22    RealAffinity    4   0   0                 0
-  23    ResultRow       2   3   0                 0  output=r[2..4]
-  24  Next              0   3   0                 0
-  25  Halt              0   0   0                 0
-  26  Transaction       0   1  11                 0  iDb=0 tx_mode=Read
-  27  Integer           1  10   0                 0  r[10]=1
-  28  Integer           3  13   0                 0  r[13]=3
-  29  Goto              0   1   0                 0
+addr  opcode                 p1  p2  p3  p4            p5  comment
+   0          Init            0  60   0                 0  Start at 60
+   1          Once           39   0   0                 0  goto 39
+   2          OpenEphemeral   0   0   0                 0  cursor=0 is_table=false
+   3          Null            0   8   0                 0  r[8]=NULL
+   4          Integer         0   5   0                 0  r[5]=0; clear group by abort flag
+   5          Null            0   6   0                 0  r[6]=NULL; initialize group by comparison registers to NULL
+   6          Gosub          11  36   0                 0  ; go to clear accumulator subroutine
+   7          OpenRead        1  10   0  k(2,B)         0  index=idx_order_items_order, root=10, iDb=0
+   8          Rewind          1  21   0                 0  Rewind index idx_order_items_order
+   9            Column        1   0  10                 0  r[10]=idx_order_items_order.order_id
+  10            Compare       6  10   1  k(1, Binary)   0  r[6..6]==r[10..10]
+  11            Jump         12  16  12                 0  ; start new group if comparison is not equal
+  12            Gosub         3  25   0                 0  ; check if ended group had data, and output if so
+  13            Move         10   6   1                 0  r[6..6]=r[10..10]
+  14            IfPos         5  39   0                 0  r[5]>0 -> r[5]-=0, goto 39; check abort flag
+  15            Gosub        11  36   0                 0  ; goto clear accumulator subroutine
+  16            AggStep       0  12   8  count          0  accum=r[8] step(r[12])
+  17            If            4  19   0                 0  if r[4] goto 19; don't emit group columns if continuing existing group
+  18            Column        1   0   7                 0  r[7]=idx_order_items_order.order_id
+  19            Integer       1   4   0                 0  r[4]=1; indicate data in accumulator
+  20          Next            1   9   0                 0
+  21          Gosub           3  25   0                 0  ; emit row for final group
+  22          Goto            0  39   0                 0  ; group by finished
+  23          Integer         1   5   0                 0  r[5]=1
+  24        Return            3   0   0                 0
+  25        IfPos             4  27   0                 0  r[4]>0 -> r[4]-=0, goto 27; output group by row subroutine start
+  26      Return              3   0   0                 0
+  27      AggFinal            0   8   0  count          0  accum=r[8]
+  28      Copy                8   1   0                 0  r[1]=r[8]
+  29      Copy                7   2   0                 0  r[2]=r[7]
+  30      Copy                2  14   0                 0  r[14]=r[2]
+  31      Copy                1  15   0                 0  r[15]=r[1]
+  32      Sequence            0  16   0                 0
+  33      MakeRecord         14   3  13                 0  r[13]=mkrec(r[14..16]); for ephemeral_subquery_t2
+  34      IdxInsert           0  13   0                 8  key=r[13]
+  35    Return                3   0   0                 0
+  36    Null                  0   7   8                 0  r[7..8]=NULL; clear accumulator subroutine start
+  37    Integer               0   4   0                 0  r[4]=0
+  38  Return                 11   0   0                 0
+  39  OpenRead                2   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  40  Rewind                  2  59   0                 0  Rewind table orders
+  41    Integer               0  20   0                 0  r[20]=0
+  42    RowId                 2  21   0                 0  r[21]=orders.rowid
+  43    SeekGE                0  55  21                 0  key=[21..21]
+  44      IdxGT               0  55  21                 0  key=[21..21]
+  45      Integer             1  20   0                 0  r[20]=1
+  46      Column              0   1  23                 0  r[23]=ephemeral(ephemeral_subquery_t2).count(*)
+  47      NotNull            23  49   0                 0  r[23]!=NULL -> goto 49
+  48      Integer             0  23   0                 0  r[23]=0
+  49      Lt                 23  24  54  Binary         0  if r[23]<r[24] goto 54
+  50      RowId               2  17   0                 0  r[17]=orders.rowid
+  51      ColumnRange         2   2  18  2              0  r[18..19]=orders.order_date..total_amount
+  52      RealAffinity       19   0   0                 0
+  53      ResultRow          17   3   0                 0  output=r[17..19]
+  54    Next                  0  44   0                 0
+  55    IfPos                20  58   0                 0  r[20]>0 -> r[20]-=0, goto 58
+  56    NullRow               0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  57    Goto                  0  45   0                 0
+  58  Next                    2  41   0                 0
+  59  Halt                    0   0   0                 0
+  60  Transaction             0   1  11                 0  iDb=0 tx_mode=Read
+  61  Integer                 1  12   0                 0  r[12]=1
+  62  Integer                 3  24   0                 0  r[24]=3
+  63  Goto                    0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
@@ -18,42 +18,79 @@ info:
 ---
 QUERY PLAN
 |--SCAN employees AS e
-`--CORRELATED SCALAR SUBQUERY 1
-   `--SCAN employees AS e2
+`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?)
+   |--SCAN employees AS e2
+   `--USE SORTER FOR GROUP BY
 
 BYTECODE
-addr  opcode              p1  p2  p3  p4              p5  comment
-   0    Init               0  32   0                   0  Start at 32
-   1    OpenRead           0   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-   2    Rewind             0  31   0                   0  Rewind table employees
-   3      BeginSubrtn      6   0   0                   0  r[6]=NULL
-   4      Null             0   1   0                   0  r[1]=NULL
-   5      Null             0   8   0                   0  r[8]=NULL
-   6      Integer          1   9   0                   0  r[9]=1; LIMIT counter
-   7      IfNot            9  17   0                   0  if !r[9] goto 17
-   8      OpenRead         1   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-   9      Rewind           1  17   0                   0  Rewind table employees
-  10        Column         1   3  11                   0  r[11]=employees.department
-  11        Column         0   3  12                   0  r[12]=employees.department
-  12        Ne            11  12  16  Binary           0  if r[11]!=r[12] goto 16
-  13        Column         1   4  13                   0  r[13]=employees.salary
-  14        RealAffinity  13   0   0                   0
-  15        AggStep        0  13   8  avg              0  accum=r[8] step(r[13])
-  16      Next             1  10   0                   0
-  17      AggFinal         0   8   0  avg              0  accum=r[8]
-  18      Copy             8   7   0                   0  r[7]=r[8]
-  19      Copy             7   1   0                   0  r[1]=r[7]
-  20    Return             6   0   1                   0
-  21    Column             0   4  15                   0  r[15]=employees.salary
-  22    RealAffinity      15   0   0                   0
-  23    Copy               1  16   0                   0  r[16]=r[1]
-  24    Le                15  16  30  Binary           0  if r[15]<=r[16] goto 30
-  25    RowId              0   2   0                   0  r[2]=employees.rowid
-  26    Column             0   1   3                   0  r[3]=employees.name
-  27    ColumnRange        0   3   4  2                0  r[4..5]=employees.department..salary
-  28    RealAffinity       5   0   0                   0
-  29    ResultRow          2   4   0                   0  output=r[2..5]
-  30  Next                 0   3   0                   0
-  31  Halt                 0   0   0                   0
-  32  Transaction          0   1  11                   0  iDb=0 tx_mode=Read
-  33  Goto                 0   1   0                   0
+addr  opcode                  p1  p2  p3  p4              p5  comment
+   0          Init             0  68   0                   0  Start at 68
+   1          OpenEphemeral    0   0   0                   0  cursor=0 is_table=false
+   2          Null             0  11   0                   0  r[11]=NULL
+   3          SorterOpen       1   2   0  k(1,B)           0  cursor=1
+   4          Integer          0   8   0                   0  r[8]=0; clear group by abort flag
+   5          Null             0   9   0                   0  r[9]=NULL; initialize group by comparison registers to NULL
+   6          Gosub           15  45   0                   0  ; go to clear accumulator subroutine
+   7          OpenRead         3   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+   8          Rewind           3  14   0                   0  Rewind table employees
+   9            ColumnRange    3   3  13  2                0  r[13..14]=employees.department..salary
+  10            RealAffinity  14   0   0                   0
+  11            MakeRecord    13   2  12                   0  r[12]=mkrec(r[13..14])
+  12            SorterInsert   1  12   0  0                0  key=r[12]
+  13          Next             3   9   0                   0
+  14          OpenPseudo       2  12   2                   0  2 columns in r[12]
+  15          SorterSort       1  30   0                   0
+  16            SorterData     1  12   2                   0  r[12]=data
+  17            Column         2   0  16                   0  r[16]=pseudo.column 0
+  18            Compare        9  16   1  k(1, Binary)     0  r[9..9]==r[16..16]
+  19            Jump          20  24  20                   0  ; start new group if comparison is not equal
+  20            Gosub          6  34   0                   0  ; check if ended group had data, and output if so
+  21            Move          16   9   1                   0  r[9..9]=r[16..16]
+  22            IfPos          8  48   0                   0  r[8]>0 -> r[8]-=0, goto 48; check abort flag
+  23            Gosub         15  45   0                   0  ; goto clear accumulator subroutine
+  24            Column         2   1  17                   0  r[17]=pseudo.column 1
+  25            AggStep        0  17  11  avg              0  accum=r[11] step(r[17])
+  26            If             7  28   0                   0  if r[7] goto 28; don't emit group columns if continuing existing group
+  27            Column         2   0  10                   0  r[10]=pseudo.column 0
+  28            Integer        1   7   0                   0  r[7]=1; indicate data in accumulator
+  29          SorterNext       1  16   0                   0
+  30          Gosub            6  34   0                   0  ; emit row for final group
+  31          Goto             0  48   0                   0  ; group by finished
+  32          Integer          1   8   0                   0  r[8]=1
+  33        Return             6   0   0                   0
+  34        IfPos              7  36   0                   0  r[7]>0 -> r[7]-=0, goto 36; output group by row subroutine start
+  35      Return               6   0   0                   0
+  36      AggFinal             0  11   0  avg              0  accum=r[11]
+  37      Copy                11   4   0                   0  r[4]=r[11]
+  38      Copy                10   5   0                   0  r[5]=r[10]
+  39      Copy                 5  19   0                   0  r[19]=r[5]
+  40      Copy                 4  20   0                   0  r[20]=r[4]
+  41      Sequence             0  21   0                   0
+  42      MakeRecord          19   3  18                   0  r[18]=mkrec(r[19..21]); for ephemeral_subquery_t2
+  43      IdxInsert            0  18   0                   8  key=r[18]
+  44    Return                 6   0   0                   0
+  45    Null                   0  10  11                   0  r[10..11]=NULL; clear accumulator subroutine start
+  46    Integer                0   7   0                   0  r[7]=0
+  47  Return                  15   0   0                   0
+  48  OpenRead                 4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+  49  Rewind                   4  67   0                   0  Rewind table employees
+  50    Column                 4   3  26                   0  r[26]=employees.department
+  51    IsNull                26  66   0                   0  if (r[26]==NULL) goto 66
+  52    SeekGE                 0  66  26                   0  key=[26..26]
+  53      IdxGT                0  66  26                   0  key=[26..26]
+  54      Column               0   1   2                   0  r[2]=ephemeral(ephemeral_subquery_t2).avg(e2.salary)
+  55      Column               0   0   3                   0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
+  56      Column               4   4  28                   0  r[28]=employees.salary
+  57      RealAffinity        28   0   0                   0
+  58      Column               0   1  29                   0  r[29]=ephemeral(ephemeral_subquery_t2).avg(e2.salary)
+  59      Le                  28  29  65  Binary           0  if r[28]<=r[29] goto 65
+  60      RowId                4  22   0                   0  r[22]=employees.rowid
+  61      Column               4   1  23                   0  r[23]=employees.name
+  62      ColumnRange          4   3  24  2                0  r[24..25]=employees.department..salary
+  63      RealAffinity        25   0   0                   0
+  64      ResultRow           22   4   0                   0  output=r[22..25]
+  65    Next                   0  53   0                   0
+  66  Next                     4  50   0                   0
+  67  Halt                     0   0   0                   0
+  68  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
+  69  Goto                     0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
@@ -17,81 +17,86 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN employees AS e
-`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?)
-   |--SCAN employees AS e2
-   `--USE SORTER FOR GROUP BY
+|--SCAN scalar_subquery_t2
+|  |--SCAN employees AS e2
+|  `--USE SORTER FOR GROUP BY
+`--SEARCH e USING INDEX ephemeral_employees_t1 (department=? AND salary>?)
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4              p5  comment
-   0          Init             0  69   0                   0  Start at 69
-   1          Once            49   0   0                   0  goto 49
-   2          OpenEphemeral    0   0   0                   0  cursor=0 is_table=false
-   3          Null             0  11   0                   0  r[11]=NULL
-   4          SorterOpen       1   2   0  k(1,B)           0  cursor=1
-   5          Integer          0   8   0                   0  r[8]=0; clear group by abort flag
-   6          Null             0   9   0                   0  r[9]=NULL; initialize group by comparison registers to NULL
-   7          Gosub           15  46   0                   0  ; go to clear accumulator subroutine
-   8          OpenRead         3   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-   9          Rewind           3  15   0                   0  Rewind table employees
-  10            ColumnRange    3   3  13  2                0  r[13..14]=employees.department..salary
-  11            RealAffinity  14   0   0                   0
-  12            MakeRecord    13   2  12                   0  r[12]=mkrec(r[13..14])
-  13            SorterInsert   1  12   0  0                0  key=r[12]
-  14          Next             3  10   0                   0
-  15          OpenPseudo       2  12   2                   0  2 columns in r[12]
-  16          SorterSort       1  31   0                   0
-  17            SorterData     1  12   2                   0  r[12]=data
-  18            Column         2   0  16                   0  r[16]=pseudo.column 0
-  19            Compare        9  16   1  k(1, Binary)     0  r[9..9]==r[16..16]
-  20            Jump          21  25  21                   0  ; start new group if comparison is not equal
-  21            Gosub          6  35   0                   0  ; check if ended group had data, and output if so
-  22            Move          16   9   1                   0  r[9..9]=r[16..16]
-  23            IfPos          8  49   0                   0  r[8]>0 -> r[8]-=0, goto 49; check abort flag
-  24            Gosub         15  46   0                   0  ; goto clear accumulator subroutine
-  25            Column         2   1  17                   0  r[17]=pseudo.column 1
-  26            AggStep        0  17  11  avg              0  accum=r[11] step(r[17])
-  27            If             7  29   0                   0  if r[7] goto 29; don't emit group columns if continuing existing group
-  28            Column         2   0  10                   0  r[10]=pseudo.column 0
-  29            Integer        1   7   0                   0  r[7]=1; indicate data in accumulator
-  30          SorterNext       1  17   0                   0
-  31          Gosub            6  35   0                   0  ; emit row for final group
-  32          Goto             0  49   0                   0  ; group by finished
-  33          Integer          1   8   0                   0  r[8]=1
-  34        Return             6   0   0                   0
-  35        IfPos              7  37   0                   0  r[7]>0 -> r[7]-=0, goto 37; output group by row subroutine start
-  36      Return               6   0   0                   0
-  37      AggFinal             0  11   0  avg              0  accum=r[11]
-  38      Copy                11   4   0                   0  r[4]=r[11]
-  39      Copy                10   5   0                   0  r[5]=r[10]
-  40      Copy                 5  19   0                   0  r[19]=r[5]
-  41      Copy                 4  20   0                   0  r[20]=r[4]
-  42      Sequence             0  21   0                   0
-  43      MakeRecord          19   3  18                   0  r[18]=mkrec(r[19..21]); for ephemeral_subquery_t2
-  44      IdxInsert            0  18   0                   8  key=r[18]
-  45    Return                 6   0   0                   0
-  46    Null                   0  10  11                   0  r[10..11]=NULL; clear accumulator subroutine start
-  47    Integer                0   7   0                   0  r[7]=0
-  48  Return                  15   0   0                   0
-  49  OpenRead                 4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-  50  Rewind                   4  68   0                   0  Rewind table employees
-  51    Column                 4   3  26                   0  r[26]=employees.department
-  52    IsNull                26  67   0                   0  if (r[26]==NULL) goto 67
-  53    SeekGE                 0  67  26                   0  key=[26..26]
-  54      IdxGT                0  67  26                   0  key=[26..26]
-  55      Column               0   1   2                   0  r[2]=ephemeral(ephemeral_subquery_t2).avg(e2.salary)
-  56      Column               0   0   3                   0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
-  57      Column               4   4  28                   0  r[28]=employees.salary
-  58      RealAffinity        28   0   0                   0
-  59      Column               0   1  29                   0  r[29]=ephemeral(ephemeral_subquery_t2).avg(e2.salary)
-  60      Le                  28  29  66  Binary           0  if r[28]<=r[29] goto 66
-  61      RowId                4  22   0                   0  r[22]=employees.rowid
-  62      Column               4   1  23                   0  r[23]=employees.name
-  63      ColumnRange          4   3  24  2                0  r[24..25]=employees.department..salary
-  64      RealAffinity        25   0   0                   0
-  65      ResultRow           22   4   0                   0  output=r[22..25]
-  66    Next                   0  54   0                   0
-  67  Next                     4  51   0                   0
-  68  Halt                     0   0   0                   0
-  69  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
-  70  Goto                     0   1   0                   0
+   0          Init             0  74   0                   0  Start at 74
+   1          InitCoroutine    2  45   2                   0
+   2          Null             0  10   0                   0  r[10]=NULL
+   3          SorterOpen       0   2   0  k(1,B)           0  cursor=0
+   4          Integer          0   7   0                   0  r[7]=0; clear group by abort flag
+   5          Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
+   6          Gosub           14  41   0                   0  ; go to clear accumulator subroutine
+   7          OpenRead         2   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+   8          Rewind           2  14   0                   0  Rewind table employees
+   9            ColumnRange    2   3  12  2                0  r[12..13]=employees.department..salary
+  10            RealAffinity  13   0   0                   0
+  11            MakeRecord    12   2  11                   0  r[11]=mkrec(r[12..13])
+  12            SorterInsert   0  11   0  0                0  key=r[11]
+  13          Next             2   9   0                   0
+  14          OpenPseudo       1  11   2                   0  2 columns in r[11]
+  15          SorterSort       0  30   0                   0
+  16            SorterData     0  11   1                   0  r[11]=data
+  17            Column         1   0  15                   0  r[15]=pseudo.column 0
+  18            Compare        8  15   1  k(1, Binary)     0  r[8..8]==r[15..15]
+  19            Jump          20  24  20                   0  ; start new group if comparison is not equal
+  20            Gosub          5  34   0                   0  ; check if ended group had data, and output if so
+  21            Move          15   8   1                   0  r[8..8]=r[15..15]
+  22            IfPos          7  44   0                   0  r[7]>0 -> r[7]-=0, goto 44; check abort flag
+  23            Gosub         14  41   0                   0  ; goto clear accumulator subroutine
+  24            Column         1   1  16                   0  r[16]=pseudo.column 1
+  25            AggStep        0  16  10  avg              0  accum=r[10] step(r[16])
+  26            If             6  28   0                   0  if r[6] goto 28; don't emit group columns if continuing existing group
+  27            Column         1   0   9                   0  r[9]=pseudo.column 0
+  28            Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
+  29          SorterNext       0  16   0                   0
+  30          Gosub            5  34   0                   0  ; emit row for final group
+  31          Goto             0  44   0                   0  ; group by finished
+  32          Integer          1   7   0                   0  r[7]=1
+  33        Return             5   0   0                   0
+  34        IfPos              6  36   0                   0  r[6]>0 -> r[6]-=0, goto 36; output group by row subroutine start
+  35      Return               5   0   0                   0
+  36      AggFinal             0  10   0  avg              0  accum=r[10]
+  37      Copy                10   3   0                   0  r[3]=r[10]
+  38      Copy                 9   4   0                   0  r[4]=r[9]
+  39      Yield                2   0   0                   0
+  40    Return                 5   0   0                   0
+  41    Null                   0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
+  42    Integer                0   6   0                   0  r[6]=0
+  43  Return                  14   0   0                   0
+  44  EndCoroutine             2   0   0                   0
+  45  OpenRead                 3   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+  46  InitCoroutine            2   0   2                   0
+  47    Yield                  2  73   0                   0
+  48    Once                  58   0   0                   0  goto 58
+  49    OpenAutoindex          4   0   0                   0  cursor=4
+  50    Rewind                 3  51   0                   0  Rewind table employees
+  51      ColumnRange          3   3  21  2                0  r[21..22]=employees.department..salary
+  52      RowId                3  23   0                   0  r[23]=employees.rowid
+  53      Column               3   1  24                   0  r[24]=employees.name
+  54      RowId                3  25   0                   0  r[25]=employees.rowid
+  55      MakeRecord          21   5  26                   0  r[26]=mkrec(r[21..25]); for ephemeral_employees_t1
+  56      IdxInsert            4  26  21                   0  key=r[26]
+  57    Next                   3  51   0                   0
+  58    Copy                   4  27   0                   0  r[27]=r[4]
+  59    IsNull                27  72   0                   0  if (r[27]==NULL) goto 72
+  60    Copy                   3  28   0                   0  r[28]=r[3]
+  61    IsNull                28  72   0                   0  if (r[28]==NULL) goto 72
+  62    Affinity              27   2   0                   0  r[27..29] = A, C
+  63    SeekGT                 4  72  27                   0  key=[27..28]
+  64      IdxGT                4  72  27                   0  key=[27..27]
+  65      DeferredSeek         4   3   0                   0
+  66      IdxRowId             4  17   0                   0  r[17]=cursor 4 for index ephemeral(ephemeral_employees_t1).rowid
+  67      Column               4   3  18                   0  r[18]=ephemeral(ephemeral_employees_t1).name
+  68      ColumnRange          4   0  19  2                0  r[19..20]=ephemeral(ephemeral_employees_t1).department..salary
+  69      RealAffinity        20   0   0                   0
+  70      ResultRow           17   4   0                   0  output=r[17..20]
+  71    Next                   4  64   0                   0
+  72  Goto                     0  47   0                   0
+  73  Halt                     0   0   0                   0
+  74  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
+  75  Goto                     0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
@@ -24,73 +24,74 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4              p5  comment
-   0          Init             0  68   0                   0  Start at 68
-   1          OpenEphemeral    0   0   0                   0  cursor=0 is_table=false
-   2          Null             0  11   0                   0  r[11]=NULL
-   3          SorterOpen       1   2   0  k(1,B)           0  cursor=1
-   4          Integer          0   8   0                   0  r[8]=0; clear group by abort flag
-   5          Null             0   9   0                   0  r[9]=NULL; initialize group by comparison registers to NULL
-   6          Gosub           15  45   0                   0  ; go to clear accumulator subroutine
-   7          OpenRead         3   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-   8          Rewind           3  14   0                   0  Rewind table employees
-   9            ColumnRange    3   3  13  2                0  r[13..14]=employees.department..salary
-  10            RealAffinity  14   0   0                   0
-  11            MakeRecord    13   2  12                   0  r[12]=mkrec(r[13..14])
-  12            SorterInsert   1  12   0  0                0  key=r[12]
-  13          Next             3   9   0                   0
-  14          OpenPseudo       2  12   2                   0  2 columns in r[12]
-  15          SorterSort       1  30   0                   0
-  16            SorterData     1  12   2                   0  r[12]=data
-  17            Column         2   0  16                   0  r[16]=pseudo.column 0
-  18            Compare        9  16   1  k(1, Binary)     0  r[9..9]==r[16..16]
-  19            Jump          20  24  20                   0  ; start new group if comparison is not equal
-  20            Gosub          6  34   0                   0  ; check if ended group had data, and output if so
-  21            Move          16   9   1                   0  r[9..9]=r[16..16]
-  22            IfPos          8  48   0                   0  r[8]>0 -> r[8]-=0, goto 48; check abort flag
-  23            Gosub         15  45   0                   0  ; goto clear accumulator subroutine
-  24            Column         2   1  17                   0  r[17]=pseudo.column 1
-  25            AggStep        0  17  11  avg              0  accum=r[11] step(r[17])
-  26            If             7  28   0                   0  if r[7] goto 28; don't emit group columns if continuing existing group
-  27            Column         2   0  10                   0  r[10]=pseudo.column 0
-  28            Integer        1   7   0                   0  r[7]=1; indicate data in accumulator
-  29          SorterNext       1  16   0                   0
-  30          Gosub            6  34   0                   0  ; emit row for final group
-  31          Goto             0  48   0                   0  ; group by finished
-  32          Integer          1   8   0                   0  r[8]=1
-  33        Return             6   0   0                   0
-  34        IfPos              7  36   0                   0  r[7]>0 -> r[7]-=0, goto 36; output group by row subroutine start
-  35      Return               6   0   0                   0
-  36      AggFinal             0  11   0  avg              0  accum=r[11]
-  37      Copy                11   4   0                   0  r[4]=r[11]
-  38      Copy                10   5   0                   0  r[5]=r[10]
-  39      Copy                 5  19   0                   0  r[19]=r[5]
-  40      Copy                 4  20   0                   0  r[20]=r[4]
-  41      Sequence             0  21   0                   0
-  42      MakeRecord          19   3  18                   0  r[18]=mkrec(r[19..21]); for ephemeral_subquery_t2
-  43      IdxInsert            0  18   0                   8  key=r[18]
-  44    Return                 6   0   0                   0
-  45    Null                   0  10  11                   0  r[10..11]=NULL; clear accumulator subroutine start
-  46    Integer                0   7   0                   0  r[7]=0
-  47  Return                  15   0   0                   0
-  48  OpenRead                 4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-  49  Rewind                   4  67   0                   0  Rewind table employees
-  50    Column                 4   3  26                   0  r[26]=employees.department
-  51    IsNull                26  66   0                   0  if (r[26]==NULL) goto 66
-  52    SeekGE                 0  66  26                   0  key=[26..26]
-  53      IdxGT                0  66  26                   0  key=[26..26]
-  54      Column               0   1   2                   0  r[2]=ephemeral(ephemeral_subquery_t2).avg(e2.salary)
-  55      Column               0   0   3                   0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
-  56      Column               4   4  28                   0  r[28]=employees.salary
-  57      RealAffinity        28   0   0                   0
-  58      Column               0   1  29                   0  r[29]=ephemeral(ephemeral_subquery_t2).avg(e2.salary)
-  59      Le                  28  29  65  Binary           0  if r[28]<=r[29] goto 65
-  60      RowId                4  22   0                   0  r[22]=employees.rowid
-  61      Column               4   1  23                   0  r[23]=employees.name
-  62      ColumnRange          4   3  24  2                0  r[24..25]=employees.department..salary
-  63      RealAffinity        25   0   0                   0
-  64      ResultRow           22   4   0                   0  output=r[22..25]
-  65    Next                   0  53   0                   0
-  66  Next                     4  50   0                   0
-  67  Halt                     0   0   0                   0
-  68  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
-  69  Goto                     0   1   0                   0
+   0          Init             0  69   0                   0  Start at 69
+   1          Once            49   0   0                   0  goto 49
+   2          OpenEphemeral    0   0   0                   0  cursor=0 is_table=false
+   3          Null             0  11   0                   0  r[11]=NULL
+   4          SorterOpen       1   2   0  k(1,B)           0  cursor=1
+   5          Integer          0   8   0                   0  r[8]=0; clear group by abort flag
+   6          Null             0   9   0                   0  r[9]=NULL; initialize group by comparison registers to NULL
+   7          Gosub           15  46   0                   0  ; go to clear accumulator subroutine
+   8          OpenRead         3   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+   9          Rewind           3  15   0                   0  Rewind table employees
+  10            ColumnRange    3   3  13  2                0  r[13..14]=employees.department..salary
+  11            RealAffinity  14   0   0                   0
+  12            MakeRecord    13   2  12                   0  r[12]=mkrec(r[13..14])
+  13            SorterInsert   1  12   0  0                0  key=r[12]
+  14          Next             3  10   0                   0
+  15          OpenPseudo       2  12   2                   0  2 columns in r[12]
+  16          SorterSort       1  31   0                   0
+  17            SorterData     1  12   2                   0  r[12]=data
+  18            Column         2   0  16                   0  r[16]=pseudo.column 0
+  19            Compare        9  16   1  k(1, Binary)     0  r[9..9]==r[16..16]
+  20            Jump          21  25  21                   0  ; start new group if comparison is not equal
+  21            Gosub          6  35   0                   0  ; check if ended group had data, and output if so
+  22            Move          16   9   1                   0  r[9..9]=r[16..16]
+  23            IfPos          8  49   0                   0  r[8]>0 -> r[8]-=0, goto 49; check abort flag
+  24            Gosub         15  46   0                   0  ; goto clear accumulator subroutine
+  25            Column         2   1  17                   0  r[17]=pseudo.column 1
+  26            AggStep        0  17  11  avg              0  accum=r[11] step(r[17])
+  27            If             7  29   0                   0  if r[7] goto 29; don't emit group columns if continuing existing group
+  28            Column         2   0  10                   0  r[10]=pseudo.column 0
+  29            Integer        1   7   0                   0  r[7]=1; indicate data in accumulator
+  30          SorterNext       1  17   0                   0
+  31          Gosub            6  35   0                   0  ; emit row for final group
+  32          Goto             0  49   0                   0  ; group by finished
+  33          Integer          1   8   0                   0  r[8]=1
+  34        Return             6   0   0                   0
+  35        IfPos              7  37   0                   0  r[7]>0 -> r[7]-=0, goto 37; output group by row subroutine start
+  36      Return               6   0   0                   0
+  37      AggFinal             0  11   0  avg              0  accum=r[11]
+  38      Copy                11   4   0                   0  r[4]=r[11]
+  39      Copy                10   5   0                   0  r[5]=r[10]
+  40      Copy                 5  19   0                   0  r[19]=r[5]
+  41      Copy                 4  20   0                   0  r[20]=r[4]
+  42      Sequence             0  21   0                   0
+  43      MakeRecord          19   3  18                   0  r[18]=mkrec(r[19..21]); for ephemeral_subquery_t2
+  44      IdxInsert            0  18   0                   8  key=r[18]
+  45    Return                 6   0   0                   0
+  46    Null                   0  10  11                   0  r[10..11]=NULL; clear accumulator subroutine start
+  47    Integer                0   7   0                   0  r[7]=0
+  48  Return                  15   0   0                   0
+  49  OpenRead                 4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+  50  Rewind                   4  68   0                   0  Rewind table employees
+  51    Column                 4   3  26                   0  r[26]=employees.department
+  52    IsNull                26  67   0                   0  if (r[26]==NULL) goto 67
+  53    SeekGE                 0  67  26                   0  key=[26..26]
+  54      IdxGT                0  67  26                   0  key=[26..26]
+  55      Column               0   1   2                   0  r[2]=ephemeral(ephemeral_subquery_t2).avg(e2.salary)
+  56      Column               0   0   3                   0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
+  57      Column               4   4  28                   0  r[28]=employees.salary
+  58      RealAffinity        28   0   0                   0
+  59      Column               0   1  29                   0  r[29]=ephemeral(ephemeral_subquery_t2).avg(e2.salary)
+  60      Le                  28  29  66  Binary           0  if r[28]<=r[29] goto 66
+  61      RowId                4  22   0                   0  r[22]=employees.rowid
+  62      Column               4   1  23                   0  r[23]=employees.name
+  63      ColumnRange          4   3  24  2                0  r[24..25]=employees.department..salary
+  64      RealAffinity        25   0   0                   0
+  65      ResultRow           22   4   0                   0  output=r[22..25]
+  66    Next                   0  54   0                   0
+  67  Next                     4  51   0                   0
+  68  Halt                     0   0   0                   0
+  69  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
+  70  Goto                     0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
@@ -17,86 +17,79 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN scalar_subquery_t2
-|  |--SCAN employees AS e2
-|  `--USE SORTER FOR GROUP BY
-`--SEARCH e USING INDEX ephemeral_employees_t1 (department=? AND salary>?)
+|--SCAN employees AS e
+`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?)
+   |--SCAN employees AS e2
+   `--USE SORTER FOR GROUP BY
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4              p5  comment
-   0          Init             0  74   0                   0  Start at 74
-   1          InitCoroutine    1  45   2                   0
-   2          Null             0   9   0                   0  r[9]=NULL
-   3          SorterOpen       0   2   0  k(1,B)           0  cursor=0
-   4          Integer          0   6   0                   0  r[6]=0; clear group by abort flag
-   5          Null             0   7   0                   0  r[7]=NULL; initialize group by comparison registers to NULL
-   6          Gosub           13  41   0                   0  ; go to clear accumulator subroutine
-   7          OpenRead         2   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-   8          Rewind           2  14   0                   0  Rewind table employees
-   9            ColumnRange    2   3  11  2                0  r[11..12]=employees.department..salary
-  10            RealAffinity  12   0   0                   0
-  11            MakeRecord    11   2  10                   0  r[10]=mkrec(r[11..12])
-  12            SorterInsert   0  10   0  0                0  key=r[10]
-  13          Next             2   9   0                   0
-  14          OpenPseudo       1  10   2                   0  2 columns in r[10]
-  15          SorterSort       0  30   0                   0
-  16            SorterData     0  10   1                   0  r[10]=data
-  17            Column         1   0  14                   0  r[14]=pseudo.column 0
-  18            Compare        7  14   1  k(1, Binary)     0  r[7..7]==r[14..14]
-  19            Jump          20  24  20                   0  ; start new group if comparison is not equal
-  20            Gosub          4  34   0                   0  ; check if ended group had data, and output if so
-  21            Move          14   7   1                   0  r[7..7]=r[14..14]
-  22            IfPos          6  44   0                   0  r[6]>0 -> r[6]-=0, goto 44; check abort flag
-  23            Gosub         13  41   0                   0  ; goto clear accumulator subroutine
-  24            Column         1   1  15                   0  r[15]=pseudo.column 1
-  25            AggStep        0  15   9  avg              0  accum=r[9] step(r[15])
-  26            If             5  28   0                   0  if r[5] goto 28; don't emit group columns if continuing existing group
-  27            Column         1   0   8                   0  r[8]=pseudo.column 0
-  28            Integer        1   5   0                   0  r[5]=1; indicate data in accumulator
-  29          SorterNext       0  16   0                   0
-  30          Gosub            4  34   0                   0  ; emit row for final group
-  31          Goto             0  44   0                   0  ; group by finished
-  32          Integer          1   6   0                   0  r[6]=1
-  33        Return             4   0   0                   0
-  34        IfPos              5  36   0                   0  r[5]>0 -> r[5]-=0, goto 36; output group by row subroutine start
-  35      Return               4   0   0                   0
-  36      AggFinal             0   9   0  avg              0  accum=r[9]
-  37      Copy                 9   2   0                   0  r[2]=r[9]
-  38      Copy                 8   3   0                   0  r[3]=r[8]
-  39      Yield                1   0   0                   0
-  40    Return                 4   0   0                   0
-  41    Null                   0   8   9                   0  r[8..9]=NULL; clear accumulator subroutine start
-  42    Integer                0   5   0                   0  r[5]=0
-  43  Return                  13   0   0                   0
-  44  EndCoroutine             1   0   0                   0
-  45  OpenRead                 3   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-  46  InitCoroutine            1   0   2                   0
-  47    Yield                  1  73   0                   0
-  48    Once                  58   0   0                   0  goto 58
-  49    OpenAutoindex          4   0   0                   0  cursor=4
-  50    Rewind                 3  51   0                   0  Rewind table employees
-  51      ColumnRange          3   3  20  2                0  r[20..21]=employees.department..salary
-  52      RowId                3  22   0                   0  r[22]=employees.rowid
-  53      Column               3   1  23                   0  r[23]=employees.name
-  54      RowId                3  24   0                   0  r[24]=employees.rowid
-  55      MakeRecord          20   5  25                   0  r[25]=mkrec(r[20..24]); for ephemeral_employees_t1
-  56      IdxInsert            4  25  20                   0  key=r[25]
-  57    Next                   3  51   0                   0
-  58    Copy                   3  26   0                   0  r[26]=r[3]
-  59    IsNull                26  72   0                   0  if (r[26]==NULL) goto 72
-  60    Copy                   2  27   0                   0  r[27]=r[2]
-  61    IsNull                27  72   0                   0  if (r[27]==NULL) goto 72
-  62    Affinity              26   2   0                   0  r[26..28] = A, C
-  63    SeekGT                 4  72  26                   0  key=[26..27]
-  64      IdxGT                4  72  26                   0  key=[26..26]
-  65      DeferredSeek         4   3   0                   0
-  66      IdxRowId             4  16   0                   0  r[16]=cursor 4 for index ephemeral(ephemeral_employees_t1).rowid
-  67      Column               4   3  17                   0  r[17]=ephemeral(ephemeral_employees_t1).name
-  68      ColumnRange          4   0  18  2                0  r[18..19]=ephemeral(ephemeral_employees_t1).department..salary
-  69      RealAffinity        19   0   0                   0
-  70      ResultRow           16   4   0                   0  output=r[16..19]
-  71    Next                   4  64   0                   0
-  72  Goto                     0  47   0                   0
-  73  Halt                     0   0   0                   0
-  74  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
-  75  Goto                     0   1   0                   0
+   0          Init             0  67   0                   0  Start at 67
+   1          Once            49   0   0                   0  goto 49
+   2          OpenEphemeral    0   0   0                   0  cursor=0 is_table=false
+   3          Null             0   8   0                   0  r[8]=NULL
+   4          SorterOpen       1   2   0  k(1,B)           0  cursor=1
+   5          Integer          0   5   0                   0  r[5]=0; clear group by abort flag
+   6          Null             0   6   0                   0  r[6]=NULL; initialize group by comparison registers to NULL
+   7          Gosub           12  46   0                   0  ; go to clear accumulator subroutine
+   8          OpenRead         3   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+   9          Rewind           3  15   0                   0  Rewind table employees
+  10            ColumnRange    3   3  10  2                0  r[10..11]=employees.department..salary
+  11            RealAffinity  11   0   0                   0
+  12            MakeRecord    10   2   9                   0  r[9]=mkrec(r[10..11])
+  13            SorterInsert   1   9   0  0                0  key=r[9]
+  14          Next             3  10   0                   0
+  15          OpenPseudo       2   9   2                   0  2 columns in r[9]
+  16          SorterSort       1  31   0                   0
+  17            SorterData     1   9   2                   0  r[9]=data
+  18            Column         2   0  13                   0  r[13]=pseudo.column 0
+  19            Compare        6  13   1  k(1, Binary)     0  r[6..6]==r[13..13]
+  20            Jump          21  25  21                   0  ; start new group if comparison is not equal
+  21            Gosub          3  35   0                   0  ; check if ended group had data, and output if so
+  22            Move          13   6   1                   0  r[6..6]=r[13..13]
+  23            IfPos          5  49   0                   0  r[5]>0 -> r[5]-=0, goto 49; check abort flag
+  24            Gosub         12  46   0                   0  ; goto clear accumulator subroutine
+  25            Column         2   1  14                   0  r[14]=pseudo.column 1
+  26            AggStep        0  14   8  avg              0  accum=r[8] step(r[14])
+  27            If             4  29   0                   0  if r[4] goto 29; don't emit group columns if continuing existing group
+  28            Column         2   0   7                   0  r[7]=pseudo.column 0
+  29            Integer        1   4   0                   0  r[4]=1; indicate data in accumulator
+  30          SorterNext       1  17   0                   0
+  31          Gosub            3  35   0                   0  ; emit row for final group
+  32          Goto             0  49   0                   0  ; group by finished
+  33          Integer          1   5   0                   0  r[5]=1
+  34        Return             3   0   0                   0
+  35        IfPos              4  37   0                   0  r[4]>0 -> r[4]-=0, goto 37; output group by row subroutine start
+  36      Return               3   0   0                   0
+  37      AggFinal             0   8   0  avg              0  accum=r[8]
+  38      Copy                 8   1   0                   0  r[1]=r[8]
+  39      Copy                 7   2   0                   0  r[2]=r[7]
+  40      Copy                 2  16   0                   0  r[16]=r[2]
+  41      Copy                 1  17   0                   0  r[17]=r[1]
+  42      Sequence             0  18   0                   0
+  43      MakeRecord          16   3  15                   0  r[15]=mkrec(r[16..18]); for ephemeral_subquery_t2
+  44      IdxInsert            0  15   0                   8  key=r[15]
+  45    Return                 3   0   0                   0
+  46    Null                   0   7   8                   0  r[7..8]=NULL; clear accumulator subroutine start
+  47    Integer                0   4   0                   0  r[4]=0
+  48  Return                  12   0   0                   0
+  49  OpenRead                 4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+  50  Rewind                   4  66   0                   0  Rewind table employees
+  51    Column                 4   3  23                   0  r[23]=employees.department
+  52    IsNull                23  65   0                   0  if (r[23]==NULL) goto 65
+  53    SeekGE                 0  65  23                   0  key=[23..23]
+  54      IdxGT                0  65  23                   0  key=[23..23]
+  55      Column               4   4  25                   0  r[25]=employees.salary
+  56      RealAffinity        25   0   0                   0
+  57      Column               0   1  26                   0  r[26]=ephemeral(ephemeral_subquery_t2).avg(e2.salary)
+  58      Le                  25  26  64  Binary           0  if r[25]<=r[26] goto 64
+  59      RowId                4  19   0                   0  r[19]=employees.rowid
+  60      Column               4   1  20                   0  r[20]=employees.name
+  61      ColumnRange          4   3  21  2                0  r[21..22]=employees.department..salary
+  62      RealAffinity        22   0   0                   0
+  63      ResultRow           19   4   0                   0  output=r[19..22]
+  64    Next                   0  54   0                   0
+  65  Next                     4  51   0                   0
+  66  Halt                     0   0   0                   0
+  67  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
+  68  Goto                     0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
@@ -25,76 +25,76 @@ QUERY PLAN
 BYTECODE
 addr  opcode                  p1  p2  p3  p4              p5  comment
    0          Init             0  74   0                   0  Start at 74
-   1          InitCoroutine    2  45   2                   0
-   2          Null             0  10   0                   0  r[10]=NULL
+   1          InitCoroutine    1  45   2                   0
+   2          Null             0   9   0                   0  r[9]=NULL
    3          SorterOpen       0   2   0  k(1,B)           0  cursor=0
-   4          Integer          0   7   0                   0  r[7]=0; clear group by abort flag
-   5          Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
-   6          Gosub           14  41   0                   0  ; go to clear accumulator subroutine
+   4          Integer          0   6   0                   0  r[6]=0; clear group by abort flag
+   5          Null             0   7   0                   0  r[7]=NULL; initialize group by comparison registers to NULL
+   6          Gosub           13  41   0                   0  ; go to clear accumulator subroutine
    7          OpenRead         2   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
    8          Rewind           2  14   0                   0  Rewind table employees
-   9            ColumnRange    2   3  12  2                0  r[12..13]=employees.department..salary
-  10            RealAffinity  13   0   0                   0
-  11            MakeRecord    12   2  11                   0  r[11]=mkrec(r[12..13])
-  12            SorterInsert   0  11   0  0                0  key=r[11]
+   9            ColumnRange    2   3  11  2                0  r[11..12]=employees.department..salary
+  10            RealAffinity  12   0   0                   0
+  11            MakeRecord    11   2  10                   0  r[10]=mkrec(r[11..12])
+  12            SorterInsert   0  10   0  0                0  key=r[10]
   13          Next             2   9   0                   0
-  14          OpenPseudo       1  11   2                   0  2 columns in r[11]
+  14          OpenPseudo       1  10   2                   0  2 columns in r[10]
   15          SorterSort       0  30   0                   0
-  16            SorterData     0  11   1                   0  r[11]=data
-  17            Column         1   0  15                   0  r[15]=pseudo.column 0
-  18            Compare        8  15   1  k(1, Binary)     0  r[8..8]==r[15..15]
+  16            SorterData     0  10   1                   0  r[10]=data
+  17            Column         1   0  14                   0  r[14]=pseudo.column 0
+  18            Compare        7  14   1  k(1, Binary)     0  r[7..7]==r[14..14]
   19            Jump          20  24  20                   0  ; start new group if comparison is not equal
-  20            Gosub          5  34   0                   0  ; check if ended group had data, and output if so
-  21            Move          15   8   1                   0  r[8..8]=r[15..15]
-  22            IfPos          7  44   0                   0  r[7]>0 -> r[7]-=0, goto 44; check abort flag
-  23            Gosub         14  41   0                   0  ; goto clear accumulator subroutine
-  24            Column         1   1  16                   0  r[16]=pseudo.column 1
-  25            AggStep        0  16  10  avg              0  accum=r[10] step(r[16])
-  26            If             6  28   0                   0  if r[6] goto 28; don't emit group columns if continuing existing group
-  27            Column         1   0   9                   0  r[9]=pseudo.column 0
-  28            Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
+  20            Gosub          4  34   0                   0  ; check if ended group had data, and output if so
+  21            Move          14   7   1                   0  r[7..7]=r[14..14]
+  22            IfPos          6  44   0                   0  r[6]>0 -> r[6]-=0, goto 44; check abort flag
+  23            Gosub         13  41   0                   0  ; goto clear accumulator subroutine
+  24            Column         1   1  15                   0  r[15]=pseudo.column 1
+  25            AggStep        0  15   9  avg              0  accum=r[9] step(r[15])
+  26            If             5  28   0                   0  if r[5] goto 28; don't emit group columns if continuing existing group
+  27            Column         1   0   8                   0  r[8]=pseudo.column 0
+  28            Integer        1   5   0                   0  r[5]=1; indicate data in accumulator
   29          SorterNext       0  16   0                   0
-  30          Gosub            5  34   0                   0  ; emit row for final group
+  30          Gosub            4  34   0                   0  ; emit row for final group
   31          Goto             0  44   0                   0  ; group by finished
-  32          Integer          1   7   0                   0  r[7]=1
-  33        Return             5   0   0                   0
-  34        IfPos              6  36   0                   0  r[6]>0 -> r[6]-=0, goto 36; output group by row subroutine start
-  35      Return               5   0   0                   0
-  36      AggFinal             0  10   0  avg              0  accum=r[10]
-  37      Copy                10   3   0                   0  r[3]=r[10]
-  38      Copy                 9   4   0                   0  r[4]=r[9]
-  39      Yield                2   0   0                   0
-  40    Return                 5   0   0                   0
-  41    Null                   0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
-  42    Integer                0   6   0                   0  r[6]=0
-  43  Return                  14   0   0                   0
-  44  EndCoroutine             2   0   0                   0
+  32          Integer          1   6   0                   0  r[6]=1
+  33        Return             4   0   0                   0
+  34        IfPos              5  36   0                   0  r[5]>0 -> r[5]-=0, goto 36; output group by row subroutine start
+  35      Return               4   0   0                   0
+  36      AggFinal             0   9   0  avg              0  accum=r[9]
+  37      Copy                 9   2   0                   0  r[2]=r[9]
+  38      Copy                 8   3   0                   0  r[3]=r[8]
+  39      Yield                1   0   0                   0
+  40    Return                 4   0   0                   0
+  41    Null                   0   8   9                   0  r[8..9]=NULL; clear accumulator subroutine start
+  42    Integer                0   5   0                   0  r[5]=0
+  43  Return                  13   0   0                   0
+  44  EndCoroutine             1   0   0                   0
   45  OpenRead                 3   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-  46  InitCoroutine            2   0   2                   0
-  47    Yield                  2  73   0                   0
+  46  InitCoroutine            1   0   2                   0
+  47    Yield                  1  73   0                   0
   48    Once                  58   0   0                   0  goto 58
   49    OpenAutoindex          4   0   0                   0  cursor=4
   50    Rewind                 3  51   0                   0  Rewind table employees
-  51      ColumnRange          3   3  21  2                0  r[21..22]=employees.department..salary
-  52      RowId                3  23   0                   0  r[23]=employees.rowid
-  53      Column               3   1  24                   0  r[24]=employees.name
-  54      RowId                3  25   0                   0  r[25]=employees.rowid
-  55      MakeRecord          21   5  26                   0  r[26]=mkrec(r[21..25]); for ephemeral_employees_t1
-  56      IdxInsert            4  26  21                   0  key=r[26]
+  51      ColumnRange          3   3  20  2                0  r[20..21]=employees.department..salary
+  52      RowId                3  22   0                   0  r[22]=employees.rowid
+  53      Column               3   1  23                   0  r[23]=employees.name
+  54      RowId                3  24   0                   0  r[24]=employees.rowid
+  55      MakeRecord          20   5  25                   0  r[25]=mkrec(r[20..24]); for ephemeral_employees_t1
+  56      IdxInsert            4  25  20                   0  key=r[25]
   57    Next                   3  51   0                   0
-  58    Copy                   4  27   0                   0  r[27]=r[4]
-  59    IsNull                27  72   0                   0  if (r[27]==NULL) goto 72
-  60    Copy                   3  28   0                   0  r[28]=r[3]
-  61    IsNull                28  72   0                   0  if (r[28]==NULL) goto 72
-  62    Affinity              27   2   0                   0  r[27..29] = A, C
-  63    SeekGT                 4  72  27                   0  key=[27..28]
-  64      IdxGT                4  72  27                   0  key=[27..27]
+  58    Copy                   3  26   0                   0  r[26]=r[3]
+  59    IsNull                26  72   0                   0  if (r[26]==NULL) goto 72
+  60    Copy                   2  27   0                   0  r[27]=r[2]
+  61    IsNull                27  72   0                   0  if (r[27]==NULL) goto 72
+  62    Affinity              26   2   0                   0  r[26..28] = A, C
+  63    SeekGT                 4  72  26                   0  key=[26..27]
+  64      IdxGT                4  72  26                   0  key=[26..26]
   65      DeferredSeek         4   3   0                   0
-  66      IdxRowId             4  17   0                   0  r[17]=cursor 4 for index ephemeral(ephemeral_employees_t1).rowid
-  67      Column               4   3  18                   0  r[18]=ephemeral(ephemeral_employees_t1).name
-  68      ColumnRange          4   0  19  2                0  r[19..20]=ephemeral(ephemeral_employees_t1).department..salary
-  69      RealAffinity        20   0   0                   0
-  70      ResultRow           17   4   0                   0  output=r[17..20]
+  66      IdxRowId             4  16   0                   0  r[16]=cursor 4 for index ephemeral(ephemeral_employees_t1).rowid
+  67      Column               4   3  17                   0  r[17]=ephemeral(ephemeral_employees_t1).name
+  68      ColumnRange          4   0  18  2                0  r[18..19]=ephemeral(ephemeral_employees_t1).department..salary
+  69      RealAffinity        19   0   0                   0
+  70      ResultRow           16   4   0                   0  output=r[16..19]
   71    Next                   4  64   0                   0
   72  Goto                     0  47   0                   0
   73  Halt                     0   0   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
@@ -17,46 +17,72 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN products AS p
-`--CORRELATED SCALAR SUBQUERY 1
-   `--SEARCH p2 USING INDEX idx_products_category (category_id=?)
+|--SCAN scalar_subquery_t2
+|  `--SCAN products AS p2 USING INDEX idx_products_category
+`--SEARCH p USING INDEX idx_products_category (category_id=?)
 
 BYTECODE
-addr  opcode              p1  p2  p3  p4              p5  comment
-   0    Init               0  35   0                   0  Start at 35
-   1    OpenRead           0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   2    Rewind             0  34   0                   0  Rewind table products
-   3      BeginSubrtn      5   0   0                   0  r[5]=NULL
-   4      Null             0   1   0                   0  r[1]=NULL
-   5      Null             0   7   0                   0  r[7]=NULL
-   6      Integer          1   8   0                   0  r[8]=1; LIMIT counter
-   7      IfNot            8  20   0                   0  if !r[8] goto 20
-   8      OpenRead         1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   9      OpenRead         2   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  10      Column           0   2   9                   0  r[9]=products.category_id
-  11      IsNull           9  20   0                   0  if (r[9]==NULL) goto 20
-  12      Affinity         9   1   0                   0  r[9..10] = C
-  13      SeekGE           2  20   9                   0  key=[9..9]
-  14        IdxGT          2  20   9                   0  key=[9..9]
-  15        DeferredSeek   2   1   0                   0
-  16        Column         1   3  10                   0  r[10]=products.price
-  17        RealAffinity  10   0   0                   0
-  18        AggStep        0  10   7  avg              0  accum=r[7] step(r[10])
-  19      Next             2  14   0                   0
-  20      AggFinal         0   7   0  avg              0  accum=r[7]
-  21      Copy             7   6   0                   0  r[6]=r[7]
-  22      Copy             6   1   0                   0  r[1]=r[6]
-  23    Return             5   0   1                   0
-  24    Column             0   3  12                   0  r[12]=products.price
-  25    RealAffinity      12   0   0                   0
-  26    Copy               1  13   0                   0  r[13]=r[1]
-  27    Le                12  13  33  Binary           0  if r[12]<=r[13] goto 33
-  28    RowId              0   2   0                   0  r[2]=products.rowid
-  29    Column             0   1   3                   0  r[3]=products.name
-  30    Column             0   3   4                   0  r[4]=products.price
-  31    RealAffinity       4   0   0                   0
-  32    ResultRow          2   3   0                   0  output=r[2..4]
-  33  Next                 0   3   0                   0
-  34  Halt                 0   0   0                   0
-  35  Transaction          0   1  11                   0  iDb=0 tx_mode=Read
-  36  Goto                 0   1   0                   0
+addr  opcode                  p1  p2  p3  p4              p5  comment
+   0          Init             0  61   0                   0  Start at 61
+   1          InitCoroutine    2  39   2                   0
+   2          Null             0  10   0                   0  r[10]=NULL
+   3          Integer          0   7   0                   0  r[7]=0; clear group by abort flag
+   4          Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
+   5          Gosub           14  35   0                   0  ; go to clear accumulator subroutine
+   6          OpenRead         0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   7          OpenRead         1   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+   8          Rewind           1  24   0                   0  Rewind index idx_products_category
+   9            DeferredSeek   1   0   0                   0
+  10            Column         1   0  12                   0  r[12]=idx_products_category.category_id
+  11            Column         0   3  13                   0  r[13]=products.price
+  12            RealAffinity  13   0   0                   0
+  13            Compare        8  12   1  k(1, Binary)     0  r[8..8]==r[12..12]
+  14            Jump          15  19  15                   0  ; start new group if comparison is not equal
+  15            Gosub          5  28   0                   0  ; check if ended group had data, and output if so
+  16            Move          12   8   1                   0  r[8..8]=r[12..12]
+  17            IfPos          7  38   0                   0  r[7]>0 -> r[7]-=0, goto 38; check abort flag
+  18            Gosub         14  35   0                   0  ; goto clear accumulator subroutine
+  19            AggStep        0  13  10  avg              0  accum=r[10] step(r[13])
+  20            If             6  22   0                   0  if r[6] goto 22; don't emit group columns if continuing existing group
+  21            Column         1   0   9                   0  r[9]=idx_products_category.category_id
+  22            Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
+  23          Next             1   9   0                   0
+  24          Gosub            5  28   0                   0  ; emit row for final group
+  25          Goto             0  38   0                   0  ; group by finished
+  26          Integer          1   7   0                   0  r[7]=1
+  27        Return             5   0   0                   0
+  28        IfPos              6  30   0                   0  r[6]>0 -> r[6]-=0, goto 30; output group by row subroutine start
+  29      Return               5   0   0                   0
+  30      AggFinal             0  10   0  avg              0  accum=r[10]
+  31      Copy                10   3   0                   0  r[3]=r[10]
+  32      Copy                 9   4   0                   0  r[4]=r[9]
+  33      Yield                2   0   0                   0
+  34    Return                 5   0   0                   0
+  35    Null                   0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
+  36    Integer                0   6   0                   0  r[6]=0
+  37  Return                  14   0   0                   0
+  38  EndCoroutine             2   0   0                   0
+  39  OpenRead                 2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  40  OpenRead                 3   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  41  InitCoroutine            2   0   2                   0
+  42    Yield                  2  60   0                   0
+  43    Copy                   4  18   0                   0  r[18]=r[4]
+  44    IsNull                18  59   0                   0  if (r[18]==NULL) goto 59
+  45    Affinity              18   1   0                   0  r[18..19] = C
+  46    SeekGE                 3  59  18                   0  key=[18..18]
+  47      IdxGT                3  59  18                   0  key=[18..18]
+  48      DeferredSeek         3   2   0                   0
+  49      Column               2   3  20                   0  r[20]=products.price
+  50      RealAffinity        20   0   0                   0
+  51      Copy                 3  21   0                   0  r[21]=r[3]
+  52      Le                  20  21  58  Binary           0  if r[20]<=r[21] goto 58
+  53      IdxRowId             3  15   0                   0  r[15]=cursor 3 for index idx_products_category.rowid
+  54      Column               2   1  16                   0  r[16]=products.name
+  55      Column               2   3  17                   0  r[17]=products.price
+  56      RealAffinity        17   0   0                   0
+  57      ResultRow           15   3   0                   0  output=r[15..17]
+  58    Next                   3  47   0                   0
+  59  Goto                     0  42   0                   0
+  60  Halt                     0   0   0                   0
+  61  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
+  62  Goto                     0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
@@ -17,72 +17,46 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN scalar_subquery_t2
-|  `--SCAN products AS p2 USING INDEX idx_products_category
-`--SEARCH p USING INDEX idx_products_category (category_id=?)
+|--SCAN products AS p
+`--CORRELATED SCALAR SUBQUERY 1
+   `--SEARCH p2 USING INDEX idx_products_category (category_id=?)
 
 BYTECODE
-addr  opcode                  p1  p2  p3  p4              p5  comment
-   0          Init             0  61   0                   0  Start at 61
-   1          InitCoroutine    2  39   2                   0
-   2          Null             0  10   0                   0  r[10]=NULL
-   3          Integer          0   7   0                   0  r[7]=0; clear group by abort flag
-   4          Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
-   5          Gosub           14  35   0                   0  ; go to clear accumulator subroutine
-   6          OpenRead         0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   7          OpenRead         1   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-   8          Rewind           1  24   0                   0  Rewind index idx_products_category
-   9            DeferredSeek   1   0   0                   0
-  10            Column         1   0  12                   0  r[12]=idx_products_category.category_id
-  11            Column         0   3  13                   0  r[13]=products.price
-  12            RealAffinity  13   0   0                   0
-  13            Compare        8  12   1  k(1, Binary)     0  r[8..8]==r[12..12]
-  14            Jump          15  19  15                   0  ; start new group if comparison is not equal
-  15            Gosub          5  28   0                   0  ; check if ended group had data, and output if so
-  16            Move          12   8   1                   0  r[8..8]=r[12..12]
-  17            IfPos          7  38   0                   0  r[7]>0 -> r[7]-=0, goto 38; check abort flag
-  18            Gosub         14  35   0                   0  ; goto clear accumulator subroutine
-  19            AggStep        0  13  10  avg              0  accum=r[10] step(r[13])
-  20            If             6  22   0                   0  if r[6] goto 22; don't emit group columns if continuing existing group
-  21            Column         1   0   9                   0  r[9]=idx_products_category.category_id
-  22            Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
-  23          Next             1   9   0                   0
-  24          Gosub            5  28   0                   0  ; emit row for final group
-  25          Goto             0  38   0                   0  ; group by finished
-  26          Integer          1   7   0                   0  r[7]=1
-  27        Return             5   0   0                   0
-  28        IfPos              6  30   0                   0  r[6]>0 -> r[6]-=0, goto 30; output group by row subroutine start
-  29      Return               5   0   0                   0
-  30      AggFinal             0  10   0  avg              0  accum=r[10]
-  31      Copy                10   3   0                   0  r[3]=r[10]
-  32      Copy                 9   4   0                   0  r[4]=r[9]
-  33      Yield                2   0   0                   0
-  34    Return                 5   0   0                   0
-  35    Null                   0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
-  36    Integer                0   6   0                   0  r[6]=0
-  37  Return                  14   0   0                   0
-  38  EndCoroutine             2   0   0                   0
-  39  OpenRead                 2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  40  OpenRead                 3   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  41  InitCoroutine            2   0   2                   0
-  42    Yield                  2  60   0                   0
-  43    Copy                   4  18   0                   0  r[18]=r[4]
-  44    IsNull                18  59   0                   0  if (r[18]==NULL) goto 59
-  45    Affinity              18   1   0                   0  r[18..19] = C
-  46    SeekGE                 3  59  18                   0  key=[18..18]
-  47      IdxGT                3  59  18                   0  key=[18..18]
-  48      DeferredSeek         3   2   0                   0
-  49      Column               2   3  20                   0  r[20]=products.price
-  50      RealAffinity        20   0   0                   0
-  51      Copy                 3  21   0                   0  r[21]=r[3]
-  52      Le                  20  21  58  Binary           0  if r[20]<=r[21] goto 58
-  53      IdxRowId             3  15   0                   0  r[15]=cursor 3 for index idx_products_category.rowid
-  54      Column               2   1  16                   0  r[16]=products.name
-  55      Column               2   3  17                   0  r[17]=products.price
-  56      RealAffinity        17   0   0                   0
-  57      ResultRow           15   3   0                   0  output=r[15..17]
-  58    Next                   3  47   0                   0
-  59  Goto                     0  42   0                   0
-  60  Halt                     0   0   0                   0
-  61  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
-  62  Goto                     0   1   0                   0
+addr  opcode              p1  p2  p3  p4              p5  comment
+   0    Init               0  35   0                   0  Start at 35
+   1    OpenRead           0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   2    Rewind             0  34   0                   0  Rewind table products
+   3      BeginSubrtn      5   0   0                   0  r[5]=NULL
+   4      Null             0   1   0                   0  r[1]=NULL
+   5      Null             0   7   0                   0  r[7]=NULL
+   6      Integer          1   8   0                   0  r[8]=1; LIMIT counter
+   7      IfNot            8  20   0                   0  if !r[8] goto 20
+   8      OpenRead         1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   9      OpenRead         2   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  10      Column           0   2   9                   0  r[9]=products.category_id
+  11      IsNull           9  20   0                   0  if (r[9]==NULL) goto 20
+  12      Affinity         9   1   0                   0  r[9..10] = C
+  13      SeekGE           2  20   9                   0  key=[9..9]
+  14        IdxGT          2  20   9                   0  key=[9..9]
+  15        DeferredSeek   2   1   0                   0
+  16        Column         1   3  10                   0  r[10]=products.price
+  17        RealAffinity  10   0   0                   0
+  18        AggStep        0  10   7  avg              0  accum=r[7] step(r[10])
+  19      Next             2  14   0                   0
+  20      AggFinal         0   7   0  avg              0  accum=r[7]
+  21      Copy             7   6   0                   0  r[6]=r[7]
+  22      Copy             6   1   0                   0  r[1]=r[6]
+  23    Return             5   0   1                   0
+  24    Column             0   3  12                   0  r[12]=products.price
+  25    RealAffinity      12   0   0                   0
+  26    Copy               1  13   0                   0  r[13]=r[1]
+  27    Le                12  13  33  Binary           0  if r[12]<=r[13] goto 33
+  28    RowId              0   2   0                   0  r[2]=products.rowid
+  29    Column             0   1   3                   0  r[3]=products.name
+  30    Column             0   3   4                   0  r[4]=products.price
+  31    RealAffinity       4   0   0                   0
+  32    ResultRow          2   3   0                   0  output=r[2..4]
+  33  Next                 0   3   0                   0
+  34  Halt                 0   0   0                   0
+  35  Transaction          0   1  11                   0  iDb=0 tx_mode=Read
+  36  Goto                 0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
@@ -18,45 +18,72 @@ info:
 ---
 QUERY PLAN
 |--SCAN products AS p
-`--CORRELATED SCALAR SUBQUERY 1
-   `--SEARCH p2 USING INDEX idx_products_category (category_id=?)
+`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?)
+   `--SCAN products AS p2 USING INDEX idx_products_category
 
 BYTECODE
-addr  opcode              p1  p2  p3  p4              p5  comment
-   0    Init               0  35   0                   0  Start at 35
-   1    OpenRead           0   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   2    Rewind             0  34   0                   0  Rewind table products
-   3      BeginSubrtn      5   0   0                   0  r[5]=NULL
-   4      Null             0   1   0                   0  r[1]=NULL
-   5      Null             0   7   0                   0  r[7]=NULL
-   6      Integer          1   8   0                   0  r[8]=1; LIMIT counter
-   7      IfNot            8  20   0                   0  if !r[8] goto 20
-   8      OpenRead         1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-   9      OpenRead         2   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  10      Column           0   2   9                   0  r[9]=products.category_id
-  11      IsNull           9  20   0                   0  if (r[9]==NULL) goto 20
-  12      Affinity         9   1   0                   0  r[9..10] = C
-  13      SeekGE           2  20   9                   0  key=[9..9]
-  14        IdxGT          2  20   9                   0  key=[9..9]
-  15        DeferredSeek   2   1   0                   0
-  16        Column         1   3  10                   0  r[10]=products.price
-  17        RealAffinity  10   0   0                   0
-  18        AggStep        0  10   7  avg              0  accum=r[7] step(r[10])
-  19      Next             2  14   0                   0
-  20      AggFinal         0   7   0  avg              0  accum=r[7]
-  21      Copy             7   6   0                   0  r[6]=r[7]
-  22      Copy             6   1   0                   0  r[1]=r[6]
-  23    Return             5   0   1                   0
-  24    Column             0   3  12                   0  r[12]=products.price
-  25    RealAffinity      12   0   0                   0
-  26    Copy               1  13   0                   0  r[13]=r[1]
-  27    Le                12  13  33  Binary           0  if r[12]<=r[13] goto 33
-  28    RowId              0   2   0                   0  r[2]=products.rowid
-  29    Column             0   1   3                   0  r[3]=products.name
-  30    Column             0   3   4                   0  r[4]=products.price
-  31    RealAffinity       4   0   0                   0
-  32    ResultRow          2   3   0                   0  output=r[2..4]
-  33  Next                 0   3   0                   0
-  34  Halt                 0   0   0                   0
-  35  Transaction          0   1  11                   0  iDb=0 tx_mode=Read
-  36  Goto                 0   1   0                   0
+addr  opcode                  p1  p2  p3  p4              p5  comment
+   0          Init             0  62   0                   0  Start at 62
+   1          Once            43   0   0                   0  goto 43
+   2          OpenEphemeral    0   0   0                   0  cursor=0 is_table=false
+   3          Null             0   8   0                   0  r[8]=NULL
+   4          Integer          0   5   0                   0  r[5]=0; clear group by abort flag
+   5          Null             0   6   0                   0  r[6]=NULL; initialize group by comparison registers to NULL
+   6          Gosub           12  40   0                   0  ; go to clear accumulator subroutine
+   7          OpenRead         1   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+   8          OpenRead         2   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+   9          Rewind           2  25   0                   0  Rewind index idx_products_category
+  10            DeferredSeek   2   1   0                   0
+  11            Column         2   0  10                   0  r[10]=idx_products_category.category_id
+  12            Column         1   3  11                   0  r[11]=products.price
+  13            RealAffinity  11   0   0                   0
+  14            Compare        6  10   1  k(1, Binary)     0  r[6..6]==r[10..10]
+  15            Jump          16  20  16                   0  ; start new group if comparison is not equal
+  16            Gosub          3  29   0                   0  ; check if ended group had data, and output if so
+  17            Move          10   6   1                   0  r[6..6]=r[10..10]
+  18            IfPos          5  43   0                   0  r[5]>0 -> r[5]-=0, goto 43; check abort flag
+  19            Gosub         12  40   0                   0  ; goto clear accumulator subroutine
+  20            AggStep        0  11   8  avg              0  accum=r[8] step(r[11])
+  21            If             4  23   0                   0  if r[4] goto 23; don't emit group columns if continuing existing group
+  22            Column         2   0   7                   0  r[7]=idx_products_category.category_id
+  23            Integer        1   4   0                   0  r[4]=1; indicate data in accumulator
+  24          Next             2  10   0                   0
+  25          Gosub            3  29   0                   0  ; emit row for final group
+  26          Goto             0  43   0                   0  ; group by finished
+  27          Integer          1   5   0                   0  r[5]=1
+  28        Return             3   0   0                   0
+  29        IfPos              4  31   0                   0  r[4]>0 -> r[4]-=0, goto 31; output group by row subroutine start
+  30      Return               3   0   0                   0
+  31      AggFinal             0   8   0  avg              0  accum=r[8]
+  32      Copy                 8   1   0                   0  r[1]=r[8]
+  33      Copy                 7   2   0                   0  r[2]=r[7]
+  34      Copy                 2  14   0                   0  r[14]=r[2]
+  35      Copy                 1  15   0                   0  r[15]=r[1]
+  36      Sequence             0  16   0                   0
+  37      MakeRecord          14   3  13                   0  r[13]=mkrec(r[14..16]); for ephemeral_subquery_t2
+  38      IdxInsert            0  13   0                   8  key=r[13]
+  39    Return                 3   0   0                   0
+  40    Null                   0   7   8                   0  r[7..8]=NULL; clear accumulator subroutine start
+  41    Integer                0   4   0                   0  r[4]=0
+  42  Return                  12   0   0                   0
+  43  OpenRead                 3   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  44  Rewind                   3  61   0                   0  Rewind table products
+  45    Column                 3   2  20                   0  r[20]=products.category_id
+  46    IsNull                20  60   0                   0  if (r[20]==NULL) goto 60
+  47    Affinity              20   1   0                   0  r[20..21] = C
+  48    SeekGE                 0  60  20                   0  key=[20..20]
+  49      IdxGT                0  60  20                   0  key=[20..20]
+  50      Column               3   3  22                   0  r[22]=products.price
+  51      RealAffinity        22   0   0                   0
+  52      Column               0   1  23                   0  r[23]=ephemeral(ephemeral_subquery_t2).avg(p2.price)
+  53      Le                  22  23  59  Binary           0  if r[22]<=r[23] goto 59
+  54      RowId                3  17   0                   0  r[17]=products.rowid
+  55      Column               3   1  18                   0  r[18]=products.name
+  56      Column               3   3  19                   0  r[19]=products.price
+  57      RealAffinity        19   0   0                   0
+  58      ResultRow           17   3   0                   0  output=r[17..19]
+  59    Next                   0  49   0                   0
+  60  Next                     3  45   0                   0
+  61  Halt                     0   0   0                   0
+  62  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
+  63  Goto                     0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-aggregation.snap
@@ -26,6 +26,6 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN category_stats AS cs
-|  `--SCAN products USING INDEX idx_products_category
-`--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
+|--SCAN categories AS c
+`--SEARCH cs USING INDEX ephemeral_subquery_t2 (category_id=? AND product_count>?)
+   `--SCAN products USING INDEX idx_products_category

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -27,127 +27,136 @@ QUERY PLAN
 |  `--SCAN category_avg
 |     `--SCAN products USING INDEX idx_products_category
 |--SCAN products USING INDEX idx_products_category
-|--SCAN category_avg AS ca
-`--SEARCH p USING INDEX idx_products_category (category_id=?)
+|--SCAN products AS p
+`--SEARCH ca USING INDEX ephemeral_subquery_t5 (category_id=?)
 
 BYTECODE
-addr  opcode                            p1   p2   p3  p4              p5  comment
-   0                    Init             0  116    0                   0  Start at 116
-   1                    Once            54    0    0                   0  goto 54
-   2                    BeginSubrtn      2    0    0                   0  r[2]=NULL
-   3                    Null             0    1    0                   0  r[1]=NULL
-   4                    InitCoroutine    3   42    5                   0
-   5                    Null             0   11    0                   0  r[11]=NULL
-   6                    Integer          0    8    0                   0  r[8]=0; clear group by abort flag
-   7                    Null             0    9    0                   0  r[9]=NULL; initialize group by comparison registers to NULL
-   8                    Gosub           15   38    0                   0  ; go to clear accumulator subroutine
-   9                    OpenRead         0    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  10                    OpenRead         1    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  11                    Rewind           1   27    0                   0  Rewind index idx_products_category
-  12                      DeferredSeek   1    0    0                   0
-  13                      Column         1    0   13                   0  r[13]=idx_products_category.category_id
-  14                      Column         0    3   14                   0  r[14]=products.price
-  15                      RealAffinity  14    0    0                   0
-  16                      Compare        9   13    1  k(1, Binary)     0  r[9..9]==r[13..13]
-  17                      Jump          18   22   18                   0  ; start new group if comparison is not equal
-  18                      Gosub          6   31    0                   0  ; check if ended group had data, and output if so
-  19                      Move          13    9    1                   0  r[9..9]=r[13..13]
-  20                      IfPos          8   41    0                   0  r[8]>0 -> r[8]-=0, goto 41; check abort flag
-  21                      Gosub         15   38    0                   0  ; goto clear accumulator subroutine
-  22                      AggStep        0   14   11  avg              0  accum=r[11] step(r[14])
-  23                      If             7   25    0                   0  if r[7] goto 25; don't emit group columns if continuing existing group
-  24                      Column         1    0   10                   0  r[10]=idx_products_category.category_id
-  25                      Integer        1    7    0                   0  r[7]=1; indicate data in accumulator
-  26                    Next             1   12    0                   0
-  27                    Gosub            6   31    0                   0  ; emit row for final group
-  28                    Goto             0   41    0                   0  ; group by finished
-  29                    Integer          1    8    0                   0  r[8]=1
-  30                  Return             6    0    0                   0
-  31                  IfPos              7   33    0                   0  r[7]>0 -> r[7]-=0, goto 33; output group by row subroutine start
-  32                Return               6    0    0                   0
-  33                AggFinal             0   11    0  avg              0  accum=r[11]
-  34                Copy                10    4    0                   0  r[4]=r[10]
-  35                Copy                11    5    0                   0  r[5]=r[11]
-  36                Yield                3    0    0                   0
-  37              Return                 6    0    0                   0
-  38              Null                   0   10   11                   0  r[10..11]=NULL; clear accumulator subroutine start
-  39              Integer                0    7    0                   0  r[7]=0
-  40            Return                  15    0    0                   0
-  41            EndCoroutine             3    0    0                   0
-  42            Null                     0   17    0                   0  r[17]=NULL
-  43            Integer                  1   18    0                   0  r[18]=1; LIMIT counter
-  44            IfNot                   18   50    0                   0  if !r[18] goto 50
-  45            InitCoroutine            3    0    5                   0
-  46              Yield                  3   50    0                   0
-  47              Copy                   5   19    0                   0  r[19]=r[5]
-  48              AggStep                0   19   17  max(Binary)      0  accum=r[17] step(r[19])
-  49            Goto                     0   46    0                   0
-  50            AggFinal                 0   17    0  max              0  accum=r[17]
-  51            Copy                    17   16    0                   0  r[16]=r[17]
-  52            Copy                    16    1    0                   0  r[1]=r[16]
-  53          Return                     2    0    1                   0
-  54          OpenEphemeral              2    1    0                   0  cursor=2 is_table=true
-  55          Null                       0   29    0                   0  r[29]=NULL
-  56          Integer                    0   26    0                   0  r[26]=0; clear group by abort flag
-  57          Null                       0   27    0                   0  r[27]=NULL; initialize group by comparison registers to NULL
-  58          Gosub                     33   90    0                   0  ; go to clear accumulator subroutine
-  59          OpenRead                   3    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  60          OpenRead                   4    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  61          Rewind                     4   77    0                   0  Rewind index idx_products_category
-  62            DeferredSeek             4    3    0                   0
-  63            Column                   4    0   31                   0  r[31]=idx_products_category.category_id
-  64            Column                   3    3   32                   0  r[32]=products.price
-  65            RealAffinity            32    0    0                   0
-  66            Compare                 27   31    1  k(1, Binary)     0  r[27..27]==r[31..31]
-  67            Jump                    68   72   68                   0  ; start new group if comparison is not equal
-  68            Gosub                   24   81    0                   0  ; check if ended group had data, and output if so
-  69            Move                    31   27    1                   0  r[27..27]=r[31..31]
-  70            IfPos                   26   93    0                   0  r[26]>0 -> r[26]-=0, goto 93; check abort flag
-  71            Gosub                   33   90    0                   0  ; goto clear accumulator subroutine
-  72            AggStep                  0   32   29  avg              0  accum=r[29] step(r[32])
-  73            If                      25   75    0                   0  if r[25] goto 75; don't emit group columns if continuing existing group
-  74            Column                   4    0   28                   0  r[28]=idx_products_category.category_id
-  75            Integer                  1   25    0                   0  r[25]=1; indicate data in accumulator
-  76          Next                       4   62    0                   0
-  77          Gosub                     24   81    0                   0  ; emit row for final group
-  78          Goto                       0   93    0                   0  ; group by finished
-  79          Integer                    1   26    0                   0  r[26]=1
-  80        Return                      24    0    0                   0
-  81        IfPos                       25   83    0                   0  r[25]>0 -> r[25]-=0, goto 83; output group by row subroutine start
-  82      Return                        24    0    0                   0
-  83      AggFinal                       0   29    0  avg              0  accum=r[29]
-  84      Copy                          28   22    0                   0  r[22]=r[28]
-  85      Copy                          29   23    0                   0  r[23]=r[29]
-  86      MakeRecord                    22    2   34                   0  r[34]=mkrec(r[22..23]); for
-  87      NewRowid                       2   35    0                   0  r[35]=rowid
-  88      Insert                         2   34   35                   4  intkey=r[35] data=r[34]
-  89    Return                          24    0    0                   0
-  90    Null                             0   28   29                   0  r[28..29]=NULL; clear accumulator subroutine start
-  91    Integer                          0   25    0                   0  r[25]=0
-  92  Return                            33    0    0                   0
-  93  OpenRead                           5    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  94  OpenRead                           6    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  95  Rewind                             2  115    0                   0  Rewind  ephemeral()
-  96    ColumnRange                      2    0   20  2                0  r[20..21]=ephemeral().category_id..avg_price
-  97    Copy                            20   39    0                   0  r[39]=r[20]
-  98    IsNull                          39  114    0                   0  if (r[39]==NULL) goto 114
-  99    Affinity                        39    1    0                   0  r[39..40] = C
- 100    SeekGE                           6  114   39                   0  key=[39..39]
- 101      IdxGT                          6  114   39                   0  key=[39..39]
- 102      DeferredSeek                   6    5    0                   0
- 103      Column                         5    3   41                   0  r[41]=products.price
- 104      RealAffinity                  41    0    0                   0
- 105      Copy                           1   43    0                   0  r[43]=r[1]
- 106      Multiply                      43   44   42                   0  r[42]=r[43]*r[44]
- 107      Le                            41   42  113  Binary           0  if r[41]<=r[42] goto 113
- 108      Column                         5    1   36                   0  r[36]=products.name
- 109      Column                         5    3   37                   0  r[37]=products.price
- 110      RealAffinity                  37    0    0                   0
- 111      Copy                          21   38    0                   0  r[38]=r[21]
- 112      ResultRow                     36    3    0                   0  output=r[36..38]
- 113    Next                             6  101    0                   0
- 114  Next                               2   96    0                   0
- 115  Halt                               0    0    0                   0
- 116  Transaction                        0    1   11                   0  iDb=0 tx_mode=Read
- 117  Real                               0   44    0  0.8              0  r[44]=0.8
- 118  Goto                               0    1    0                   0
+addr  opcode                             p1   p2   p3  p4              p5  comment
+   0                    Init              0  125    0                   0  Start at 125
+   1                    Once             54    0    0                   0  goto 54
+   2                    BeginSubrtn       2    0    0                   0  r[2]=NULL
+   3                    Null              0    1    0                   0  r[1]=NULL
+   4                    InitCoroutine     3   42    5                   0
+   5                    Null              0   11    0                   0  r[11]=NULL
+   6                    Integer           0    8    0                   0  r[8]=0; clear group by abort flag
+   7                    Null              0    9    0                   0  r[9]=NULL; initialize group by comparison registers to NULL
+   8                    Gosub            15   38    0                   0  ; go to clear accumulator subroutine
+   9                    OpenRead          0    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  10                    OpenRead          1    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  11                    Rewind            1   27    0                   0  Rewind index idx_products_category
+  12                      DeferredSeek    1    0    0                   0
+  13                      Column          1    0   13                   0  r[13]=idx_products_category.category_id
+  14                      Column          0    3   14                   0  r[14]=products.price
+  15                      RealAffinity   14    0    0                   0
+  16                      Compare         9   13    1  k(1, Binary)     0  r[9..9]==r[13..13]
+  17                      Jump           18   22   18                   0  ; start new group if comparison is not equal
+  18                      Gosub           6   31    0                   0  ; check if ended group had data, and output if so
+  19                      Move           13    9    1                   0  r[9..9]=r[13..13]
+  20                      IfPos           8   41    0                   0  r[8]>0 -> r[8]-=0, goto 41; check abort flag
+  21                      Gosub          15   38    0                   0  ; goto clear accumulator subroutine
+  22                      AggStep         0   14   11  avg              0  accum=r[11] step(r[14])
+  23                      If              7   25    0                   0  if r[7] goto 25; don't emit group columns if continuing existing group
+  24                      Column          1    0   10                   0  r[10]=idx_products_category.category_id
+  25                      Integer         1    7    0                   0  r[7]=1; indicate data in accumulator
+  26                    Next              1   12    0                   0
+  27                    Gosub             6   31    0                   0  ; emit row for final group
+  28                    Goto              0   41    0                   0  ; group by finished
+  29                    Integer           1    8    0                   0  r[8]=1
+  30                  Return              6    0    0                   0
+  31                  IfPos               7   33    0                   0  r[7]>0 -> r[7]-=0, goto 33; output group by row subroutine start
+  32                Return                6    0    0                   0
+  33                AggFinal              0   11    0  avg              0  accum=r[11]
+  34                Copy                 10    4    0                   0  r[4]=r[10]
+  35                Copy                 11    5    0                   0  r[5]=r[11]
+  36                Yield                 3    0    0                   0
+  37              Return                  6    0    0                   0
+  38              Null                    0   10   11                   0  r[10..11]=NULL; clear accumulator subroutine start
+  39              Integer                 0    7    0                   0  r[7]=0
+  40            Return                   15    0    0                   0
+  41            EndCoroutine              3    0    0                   0
+  42            Null                      0   17    0                   0  r[17]=NULL
+  43            Integer                   1   18    0                   0  r[18]=1; LIMIT counter
+  44            IfNot                    18   50    0                   0  if !r[18] goto 50
+  45            InitCoroutine             3    0    5                   0
+  46              Yield                   3   50    0                   0
+  47              Copy                    5   19    0                   0  r[19]=r[5]
+  48              AggStep                 0   19   17  max(Binary)      0  accum=r[17] step(r[19])
+  49            Goto                      0   46    0                   0
+  50            AggFinal                  0   17    0  max              0  accum=r[17]
+  51            Copy                     17   16    0                   0  r[16]=r[17]
+  52            Copy                     16    1    0                   0  r[1]=r[16]
+  53          Return                      2    0    1                   0
+  54          OpenEphemeral               2    1    0                   0  cursor=2 is_table=true
+  55          Null                        0   29    0                   0  r[29]=NULL
+  56          Integer                     0   26    0                   0  r[26]=0; clear group by abort flag
+  57          Null                        0   27    0                   0  r[27]=NULL; initialize group by comparison registers to NULL
+  58          Gosub                      33   90    0                   0  ; go to clear accumulator subroutine
+  59          OpenRead                    3    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  60          OpenRead                    4    8    0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  61          Rewind                      4   77    0                   0  Rewind index idx_products_category
+  62            DeferredSeek              4    3    0                   0
+  63            Column                    4    0   31                   0  r[31]=idx_products_category.category_id
+  64            Column                    3    3   32                   0  r[32]=products.price
+  65            RealAffinity             32    0    0                   0
+  66            Compare                  27   31    1  k(1, Binary)     0  r[27..27]==r[31..31]
+  67            Jump                     68   72   68                   0  ; start new group if comparison is not equal
+  68            Gosub                    24   81    0                   0  ; check if ended group had data, and output if so
+  69            Move                     31   27    1                   0  r[27..27]=r[31..31]
+  70            IfPos                    26   93    0                   0  r[26]>0 -> r[26]-=0, goto 93; check abort flag
+  71            Gosub                    33   90    0                   0  ; goto clear accumulator subroutine
+  72            AggStep                   0   32   29  avg              0  accum=r[29] step(r[32])
+  73            If                       25   75    0                   0  if r[25] goto 75; don't emit group columns if continuing existing group
+  74            Column                    4    0   28                   0  r[28]=idx_products_category.category_id
+  75            Integer                   1   25    0                   0  r[25]=1; indicate data in accumulator
+  76          Next                        4   62    0                   0
+  77          Gosub                      24   81    0                   0  ; emit row for final group
+  78          Goto                        0   93    0                   0  ; group by finished
+  79          Integer                     1   26    0                   0  r[26]=1
+  80        Return                       24    0    0                   0
+  81        IfPos                        25   83    0                   0  r[25]>0 -> r[25]-=0, goto 83; output group by row subroutine start
+  82      Return                         24    0    0                   0
+  83      AggFinal                        0   29    0  avg              0  accum=r[29]
+  84      Copy                           28   22    0                   0  r[22]=r[28]
+  85      Copy                           29   23    0                   0  r[23]=r[29]
+  86      MakeRecord                     22    2   34                   0  r[34]=mkrec(r[22..23]); for
+  87      NewRowid                        2   35    0                   0  r[35]=rowid
+  88      Insert                          2   34   35                   4  intkey=r[35] data=r[34]
+  89    Return                           24    0    0                   0
+  90    Null                              0   28   29                   0  r[28..29]=NULL; clear accumulator subroutine start
+  91    Integer                           0   25    0                   0  r[25]=0
+  92  Return                             33    0    0                   0
+  93  OpenRead                            5    2    0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  94  Rewind                              5  124    0                   0  Rewind table products
+  95    Column                            5    3   40                   0  r[40]=products.price
+  96    RealAffinity                     40    0    0                   0
+  97    Copy                              1   42    0                   0  r[42]=r[1]
+  98    Multiply                         42   43   41                   0  r[41]=r[42]*r[43]
+  99    Le                               40   41  123  Binary           0  if r[40]<=r[41] goto 123
+ 100    Once                            109    0    0                   0  goto 109
+ 101    OpenAutoindex                     6    0    0                   0  cursor=6
+ 102    Rewind                            2  103    0                   0  Rewind  ephemeral()
+ 103      ColumnRange                     2    0   44  2                0  r[44..45]=ephemeral().category_id..avg_price
+ 104      RowId                           2   46    0                   0  r[46]=ephemeral().rowid
+ 105      MakeRecord                     44    3   47                   0  r[47]=mkrec(r[44..46]); for ephemeral_subquery_t5
+ 106      FilterAdd                       6   44    1                   0  bloom_filter_add(r[44..45])
+ 107      IdxInsert                       6   47   44                   0  key=r[47]
+ 108    Next                              2  103    0                   0
+ 109    Column                            5    2   48                   0  r[48]=products.category_id
+ 110    IsNull                           48  123    0                   0  if (r[48]==NULL) goto 123
+ 111    Affinity                         48    1    0                   0  r[48..49] = C
+ 112    Filter                            6  123   48                   1  if !bloom_filter(r[48..49]) goto 123
+ 113    SeekGE                            6  123   48                   0  key=[48..48]
+ 114      IdxGT                           6  123   48                   0  key=[48..48]
+ 115      DeferredSeek                    6    2    0                   0
+ 116      ColumnRange                     2    0   20  2                0  r[20..21]=ephemeral().category_id..avg_price
+ 117      Column                          5    1   36                   0  r[36]=products.name
+ 118      Column                          5    3   37                   0  r[37]=products.price
+ 119      RealAffinity                   37    0    0                   0
+ 120      Column                          6    1   38                   0  r[38]=ephemeral(ephemeral_subquery_t5).avg_price
+ 121      ResultRow                      36    3    0                   0  output=r[36..38]
+ 122    Next                              6  114    0                   0
+ 123  Next                                5   95    0                   0
+ 124  Halt                                0    0    0                   0
+ 125  Transaction                         0    1   11                   0  iDb=0 tx_mode=Read
+ 126  Real                                0   43    0  0.8              0  r[43]=0.8
+ 127  Goto                                0    1    0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-chained.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-chained.snap
@@ -29,7 +29,7 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN customer_orders AS co
-|  `--SCAN orders USING INDEX idx_orders_customer
-`--SEARCH ac USING INDEX ephemeral_subquery_t2 (id=?)
-   `--SCAN customers
+|--SCAN active_customers AS ac
+|  `--SCAN customers
+`--SEARCH co USING INDEX ephemeral_subquery_t4 (customer_id=? AND order_count>?)
+   `--SCAN orders USING INDEX idx_orders_customer

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -43,72 +43,71 @@ QUERY PLAN
    `--SEARCH customers USING INTEGER PRIMARY KEY (rowid=?)
 
 BYTECODE
-addr  opcode             p1  p2  p3  p4            p5  comment
-   0  Init                0  64   0                 0  Start at 64
-   1  InitCoroutine       1  14   2                 0
-   2  OpenRead            1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   3  Rewind              1  13   0                 0  Rewind table orders
-   4    Column            1   3   6                 0  r[6]=orders.total_amount
-   5    RealAffinity      6   0   0                 0
-   6    Le                6   7  12  Binary         0  if r[6]<=r[7] goto 12
-   7    RowId             1   2   0                 0  r[2]=orders.rowid
-   8    Column            1   1   3                 0  r[3]=orders.customer_id
-   9    Column            1   3   4                 0  r[4]=orders.total_amount
-  10    RealAffinity      4   0   0                 0
-  11    Yield             1   0   0                 0
-  12  Next                1   4   0                 0
-  13  EndCoroutine        1   0   0                 0
-  14  Once               50   0   0                 0  goto 50
-  15  OpenEphemeral       2   0   0                 0  cursor=2 is_table=false
-  16  Once               37   0   0                 0  goto 37
-  17  OpenEphemeral       0   0   0                 0  cursor=0 is_table=false
-  18  InitCoroutine      10  31  19                 0
-  19  OpenRead            3   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-  20  Rewind              3  30   0                 0  Rewind table orders
-  21    Column            3   3  15                 0  r[15]=orders.total_amount
-  22    RealAffinity     15   0   0                 0
-  23    Le               15  16  29  Binary         0  if r[15]<=r[16] goto 29
-  24    RowId             3  11   0                 0  r[11]=orders.rowid
-  25    Column            3   1  12                 0  r[12]=orders.customer_id
-  26    Column            3   3  13                 0  r[13]=orders.total_amount
-  27    RealAffinity     13   0   0                 0
-  28    Yield            10   0   0                 0
-  29  Next                3  21   0                 0
-  30  EndCoroutine       10   0   0                 0
-  31  InitCoroutine      10   0  19                 0
-  32    Yield            10  37   0                 0
-  33    Copy             12  17   0                 0  r[17]=r[12]
-  34    MakeRecord       17   1  18                 0  r[18]=mkrec(r[17..17]); for ephemeral_index_where_sub_t4
-  35    IdxInsert         0  18   0                 8  key=r[18]
-  36  Goto                0  32   0                 0
-  37  OpenRead            4   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  38  NullRow             0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
-  39  Rewind              0  50   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t4)
-  40    Column            0   0  21                 0  r[21]=ephemeral(ephemeral_index_where_sub_t4).customer_id
-  41    IsNull           21  49   0                 0  if (r[21]==NULL) goto 49
-  42    SeekRowid         4  21  49                 0  if (r[21]!=cursor 4 for table customers.rowid) goto 49
-  43    RowId             4  19   0                 0  r[19]=customers.rowid
-  44    Column            4   1  20                 0  r[20]=customers.name
-  45    Copy             19  23   1                 0  r[23]=r[19]
-  46    Sequence          2  25   0                 0
-  47    MakeRecord       23   3  22                 0  r[22]=mkrec(r[23..25]); for ephemeral_subquery_t6
-  48    IdxInsert         2  22   0                 8  key=r[22]
-  49  Next                0  40   0                 0
-  50  InitCoroutine       1   0   2                 0
-  51    Yield             1  63   0                 0
-  52    Copy              3  28   0                 0  r[28]=r[3]
-  53    IsNull           28  62   0                 0  if (r[28]==NULL) goto 62
-  54    Affinity         28   1   0                 0  r[28..29] = C
-  55    SeekGE            2  62  28                 0  key=[28..28]
-  56      IdxGT           2  62  28                 0  key=[28..28]
-  57      ColumnRange     2   0   8  2              0  r[8..9]=ephemeral(ephemeral_subquery_t6).id..name
-  58      Column          2   1  26                 0  r[26]=ephemeral(ephemeral_subquery_t6).name
-  59      Copy            4  27   0                 0  r[27]=r[4]
-  60      ResultRow      26   2   0                 0  output=r[26..27]
-  61    Next              2  56   0                 0
-  62  Goto                0  51   0                 0
-  63  Halt                0   0   0                 0
-  64  Transaction         0   1  11                 0  iDb=0 tx_mode=Read
-  65  Integer          1000   7   0                 0  r[7]=1000
-  66  Integer          1000  16   0                 0  r[16]=1000
-  67  Goto                0   1   0                 0
+addr  opcode            p1  p2  p3  p4            p5  comment
+   0  Init               0  63   0                 0  Start at 63
+   1  InitCoroutine      1  14   2                 0
+   2  OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   3  Rewind             1  13   0                 0  Rewind table orders
+   4    Column           1   3   6                 0  r[6]=orders.total_amount
+   5    RealAffinity     6   0   0                 0
+   6    Le               6   7  12  Binary         0  if r[6]<=r[7] goto 12
+   7    RowId            1   2   0                 0  r[2]=orders.rowid
+   8    Column           1   1   3                 0  r[3]=orders.customer_id
+   9    Column           1   3   4                 0  r[4]=orders.total_amount
+  10    RealAffinity     4   0   0                 0
+  11    Yield            1   0   0                 0
+  12  Next               1   4   0                 0
+  13  EndCoroutine       1   0   0                 0
+  14  Once              50   0   0                 0  goto 50
+  15  OpenEphemeral      2   0   0                 0  cursor=2 is_table=false
+  16  Once              37   0   0                 0  goto 37
+  17  OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
+  18  InitCoroutine      8  31  19                 0
+  19  OpenRead           3   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  20  Rewind             3  30   0                 0  Rewind table orders
+  21    Column           3   3  13                 0  r[13]=orders.total_amount
+  22    RealAffinity    13   0   0                 0
+  23    Le              13  14  29  Binary         0  if r[13]<=r[14] goto 29
+  24    RowId            3   9   0                 0  r[9]=orders.rowid
+  25    Column           3   1  10                 0  r[10]=orders.customer_id
+  26    Column           3   3  11                 0  r[11]=orders.total_amount
+  27    RealAffinity    11   0   0                 0
+  28    Yield            8   0   0                 0
+  29  Next               3  21   0                 0
+  30  EndCoroutine       8   0   0                 0
+  31  InitCoroutine      8   0  19                 0
+  32    Yield            8  37   0                 0
+  33    Copy            10  15   0                 0  r[15]=r[10]
+  34    MakeRecord      15   1  16                 0  r[16]=mkrec(r[15..15]); for ephemeral_index_where_sub_t4
+  35    IdxInsert        0  16   0                 8  key=r[16]
+  36  Goto               0  32   0                 0
+  37  OpenRead           4   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  38  NullRow            0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  39  Rewind             0  50   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t4)
+  40    Column           0   0  19                 0  r[19]=ephemeral(ephemeral_index_where_sub_t4).customer_id
+  41    IsNull          19  49   0                 0  if (r[19]==NULL) goto 49
+  42    SeekRowid        4  19  49                 0  if (r[19]!=cursor 4 for table customers.rowid) goto 49
+  43    RowId            4  17   0                 0  r[17]=customers.rowid
+  44    Column           4   1  18                 0  r[18]=customers.name
+  45    Copy            17  21   1                 0  r[21]=r[17]
+  46    Sequence         2  23   0                 0
+  47    MakeRecord      21   3  20                 0  r[20]=mkrec(r[21..23]); for ephemeral_subquery_t6
+  48    IdxInsert        2  20   0                 8  key=r[20]
+  49  Next               0  40   0                 0
+  50  InitCoroutine      1   0   2                 0
+  51    Yield            1  62   0                 0
+  52    Copy             3  26   0                 0  r[26]=r[3]
+  53    IsNull          26  61   0                 0  if (r[26]==NULL) goto 61
+  54    Affinity        26   1   0                 0  r[26..27] = C
+  55    SeekGE           2  61  26                 0  key=[26..26]
+  56      IdxGT          2  61  26                 0  key=[26..26]
+  57      Column         2   1  24                 0  r[24]=ephemeral(ephemeral_subquery_t6).name
+  58      Copy           4  25   0                 0  r[25]=r[4]
+  59      ResultRow     24   2   0                 0  output=r[24..25]
+  60    Next             2  56   0                 0
+  61  Goto               0  51   0                 0
+  62  Halt               0   0   0                 0
+  63  Transaction        0   1  11                 0  iDb=0 tx_mode=Read
+  64  Integer         1000   7   0                 0  r[7]=1000
+  65  Integer         1000  14   0                 0  r[14]=1000
+  66  Goto               0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -34,86 +34,81 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN vip_customers AS v
-|  |--LIST SUBQUERY 1
-|  |  `--SCAN large_orders
-|  |     `--SCAN orders
-|  `--SEARCH customers USING INTEGER PRIMARY KEY (rowid=?)
-`--SEARCH l USING INDEX ephemeral_subquery_t8 (customer_id=?)
-   `--SCAN orders
+|--SCAN large_orders AS l
+|  `--SCAN orders
+`--SEARCH v USING INDEX ephemeral_subquery_t6 (id=?)
+   |--LIST SUBQUERY 1
+   |  `--SCAN large_orders
+   |     `--SCAN orders
+   `--SEARCH customers USING INTEGER PRIMARY KEY (rowid=?)
 
 BYTECODE
-addr  opcode              p1  p2  p3  p4            p5  comment
-   0  Init                 0  69   0                 0  Start at 69
-   1  InitCoroutine        1  34   2                 0
-   2  Once                23   0   0                 0  goto 23
-   3  OpenEphemeral        0   0   0                 0  cursor=0 is_table=false
-   4  InitCoroutine        2  17   5                 0
-   5  OpenRead             1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   6  Rewind               1  16   0                 0  Rewind table orders
-   7    Column             1   3   7                 0  r[7]=orders.total_amount
-   8    RealAffinity       7   0   0                 0
-   9    Le                 7   8  15  Binary         0  if r[7]<=r[8] goto 15
-  10    RowId              1   3   0                 0  r[3]=orders.rowid
-  11    Column             1   1   4                 0  r[4]=orders.customer_id
-  12    Column             1   3   5                 0  r[5]=orders.total_amount
-  13    RealAffinity       5   0   0                 0
-  14    Yield              2   0   0                 0
-  15  Next                 1   7   0                 0
-  16  EndCoroutine         2   0   0                 0
-  17  InitCoroutine        2   0   5                 0
-  18    Yield              2  23   0                 0
-  19    Copy               4   9   0                 0  r[9]=r[4]
-  20    MakeRecord         9   1  10                 0  r[10]=mkrec(r[9..9]); for ephemeral_index_where_sub_t4
-  21    IdxInsert          0  10   0                 8  key=r[10]
-  22  Goto                 0  18   0                 0
-  23  OpenRead             2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  24  NullRow              0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
-  25  Rewind               0  33   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t4)
-  26    Column             0   0  13                 0  r[13]=ephemeral(ephemeral_index_where_sub_t4).customer_id
-  27    IsNull            13  32   0                 0  if (r[13]==NULL) goto 32
-  28    SeekRowid          2  13  32                 0  if (r[13]!=cursor 2 for table customers.rowid) goto 32
-  29    RowId              2  11   0                 0  r[11]=customers.rowid
-  30    Column             2   1  12                 0  r[12]=customers.name
-  31    Yield              1   0   0                 0
-  32  Next                 0  26   0                 0
-  33  EndCoroutine         1   0   0                 0
-  34  Once                52   0   0                 0  goto 52
-  35  OpenEphemeral        3   0   0                 0  cursor=3 is_table=false
-  36  OpenRead             4   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-  37  Rewind               4  52   0                 0  Rewind table orders
-  38    Column             4   3  21                 0  r[21]=orders.total_amount
-  39    RealAffinity      21   0   0                 0
-  40    Le                21  22  51  Binary         0  if r[21]<=r[22] goto 51
-  41    RowId              4  17   0                 0  r[17]=orders.rowid
-  42    Column             4   1  18                 0  r[18]=orders.customer_id
-  43    Column             4   3  19                 0  r[19]=orders.total_amount
-  44    RealAffinity      19   0   0                 0
-  45    Copy              18  24   0                 0  r[24]=r[18]
-  46    Copy              17  25   0                 0  r[25]=r[17]
-  47    Copy              19  26   0                 0  r[26]=r[19]
-  48    Sequence           3  27   0                 0
-  49    MakeRecord        24   4  23                 0  r[23]=mkrec(r[24..27]); for ephemeral_subquery_t8
-  50    IdxInsert          3  23   0                 8  key=r[23]
-  51  Next                 4  38   0                 0
-  52  InitCoroutine        1   0   2                 0
-  53    Yield              1  68   0                 0
-  54    Copy              11  30   0                 0  r[30]=r[11]
-  55    IsNull            30  67   0                 0  if (r[30]==NULL) goto 67
-  56    Affinity          30   1   0                 0  r[30..31] = C
-  57    SeekGE             3  67  30                 0  key=[30..30]
-  58      IdxGT            3  67  30                 0  key=[30..30]
-  59      Column           3   1  14                 0  r[14]=ephemeral(ephemeral_subquery_t8).id
-  60      Column           3   0  15                 0  r[15]=ephemeral(ephemeral_subquery_t8).customer_id
-  61      Column           3   2  16                 0  r[16]=ephemeral(ephemeral_subquery_t8).total_amount
-  62      Copy            12  28   0                 0  r[28]=r[12]
-  63      Column           3   2  29                 0  r[29]=ephemeral(ephemeral_subquery_t8).total_amount
-  64      RealAffinity    29   0   0                 0
-  65      ResultRow       28   2   0                 0  output=r[28..29]
-  66    Next               3  58   0                 0
-  67  Goto                 0  53   0                 0
-  68  Halt                 0   0   0                 0
-  69  Transaction          0   1  11                 0  iDb=0 tx_mode=Read
-  70  Integer           1000   8   0                 0  r[8]=1000
-  71  Integer           1000  22   0                 0  r[22]=1000
-  72  Goto                 0   1   0                 0
+addr  opcode             p1  p2  p3  p4            p5  comment
+   0  Init                0  64   0                 0  Start at 64
+   1  InitCoroutine       1  14   2                 0
+   2  OpenRead            1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   3  Rewind              1  13   0                 0  Rewind table orders
+   4    Column            1   3   6                 0  r[6]=orders.total_amount
+   5    RealAffinity      6   0   0                 0
+   6    Le                6   7  12  Binary         0  if r[6]<=r[7] goto 12
+   7    RowId             1   2   0                 0  r[2]=orders.rowid
+   8    Column            1   1   3                 0  r[3]=orders.customer_id
+   9    Column            1   3   4                 0  r[4]=orders.total_amount
+  10    RealAffinity      4   0   0                 0
+  11    Yield             1   0   0                 0
+  12  Next                1   4   0                 0
+  13  EndCoroutine        1   0   0                 0
+  14  Once               50   0   0                 0  goto 50
+  15  OpenEphemeral       2   0   0                 0  cursor=2 is_table=false
+  16  Once               37   0   0                 0  goto 37
+  17  OpenEphemeral       0   0   0                 0  cursor=0 is_table=false
+  18  InitCoroutine      10  31  19                 0
+  19  OpenRead            3   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  20  Rewind              3  30   0                 0  Rewind table orders
+  21    Column            3   3  15                 0  r[15]=orders.total_amount
+  22    RealAffinity     15   0   0                 0
+  23    Le               15  16  29  Binary         0  if r[15]<=r[16] goto 29
+  24    RowId             3  11   0                 0  r[11]=orders.rowid
+  25    Column            3   1  12                 0  r[12]=orders.customer_id
+  26    Column            3   3  13                 0  r[13]=orders.total_amount
+  27    RealAffinity     13   0   0                 0
+  28    Yield            10   0   0                 0
+  29  Next                3  21   0                 0
+  30  EndCoroutine       10   0   0                 0
+  31  InitCoroutine      10   0  19                 0
+  32    Yield            10  37   0                 0
+  33    Copy             12  17   0                 0  r[17]=r[12]
+  34    MakeRecord       17   1  18                 0  r[18]=mkrec(r[17..17]); for ephemeral_index_where_sub_t4
+  35    IdxInsert         0  18   0                 8  key=r[18]
+  36  Goto                0  32   0                 0
+  37  OpenRead            4   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  38  NullRow             0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  39  Rewind              0  50   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t4)
+  40    Column            0   0  21                 0  r[21]=ephemeral(ephemeral_index_where_sub_t4).customer_id
+  41    IsNull           21  49   0                 0  if (r[21]==NULL) goto 49
+  42    SeekRowid         4  21  49                 0  if (r[21]!=cursor 4 for table customers.rowid) goto 49
+  43    RowId             4  19   0                 0  r[19]=customers.rowid
+  44    Column            4   1  20                 0  r[20]=customers.name
+  45    Copy             19  23   1                 0  r[23]=r[19]
+  46    Sequence          2  25   0                 0
+  47    MakeRecord       23   3  22                 0  r[22]=mkrec(r[23..25]); for ephemeral_subquery_t6
+  48    IdxInsert         2  22   0                 8  key=r[22]
+  49  Next                0  40   0                 0
+  50  InitCoroutine       1   0   2                 0
+  51    Yield             1  63   0                 0
+  52    Copy              3  28   0                 0  r[28]=r[3]
+  53    IsNull           28  62   0                 0  if (r[28]==NULL) goto 62
+  54    Affinity         28   1   0                 0  r[28..29] = C
+  55    SeekGE            2  62  28                 0  key=[28..28]
+  56      IdxGT           2  62  28                 0  key=[28..28]
+  57      ColumnRange     2   0   8  2              0  r[8..9]=ephemeral(ephemeral_subquery_t6).id..name
+  58      Column          2   1  26                 0  r[26]=ephemeral(ephemeral_subquery_t6).name
+  59      Copy            4  27   0                 0  r[27]=r[4]
+  60      ResultRow      26   2   0                 0  output=r[26..27]
+  61    Next              2  56   0                 0
+  62  Goto                0  51   0                 0
+  63  Halt                0   0   0                 0
+  64  Transaction         0   1  11                 0  iDb=0 tx_mode=Read
+  65  Integer          1000   7   0                 0  r[7]=1000
+  66  Integer          1000  16   0                 0  r[16]=1000
+  67  Goto                0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -44,7 +44,7 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode              p1  p2  p3  p4            p5  comment
-   0  Init                 0  68   0                 0  Start at 68
+   0  Init                 0  69   0                 0  Start at 69
    1  InitCoroutine        1  34   2                 0
    2  Once                23   0   0                 0  goto 23
    3  OpenEphemeral        0   0   0                 0  cursor=0 is_table=false
@@ -78,41 +78,42 @@ addr  opcode              p1  p2  p3  p4            p5  comment
   31    Yield              1   0   0                 0
   32  Next                 0  26   0                 0
   33  EndCoroutine         1   0   0                 0
-  34  OpenEphemeral        3   0   0                 0  cursor=3 is_table=false
-  35  OpenRead             4   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-  36  Rewind               4  51   0                 0  Rewind table orders
-  37    Column             4   3  21                 0  r[21]=orders.total_amount
-  38    RealAffinity      21   0   0                 0
-  39    Le                21  22  50  Binary         0  if r[21]<=r[22] goto 50
-  40    RowId              4  17   0                 0  r[17]=orders.rowid
-  41    Column             4   1  18                 0  r[18]=orders.customer_id
-  42    Column             4   3  19                 0  r[19]=orders.total_amount
-  43    RealAffinity      19   0   0                 0
-  44    Copy              18  24   0                 0  r[24]=r[18]
-  45    Copy              17  25   0                 0  r[25]=r[17]
-  46    Copy              19  26   0                 0  r[26]=r[19]
-  47    Sequence           3  27   0                 0
-  48    MakeRecord        24   4  23                 0  r[23]=mkrec(r[24..27]); for ephemeral_subquery_t8
-  49    IdxInsert          3  23   0                 8  key=r[23]
-  50  Next                 4  37   0                 0
-  51  InitCoroutine        1   0   2                 0
-  52    Yield              1  67   0                 0
-  53    Copy              11  30   0                 0  r[30]=r[11]
-  54    IsNull            30  66   0                 0  if (r[30]==NULL) goto 66
-  55    Affinity          30   1   0                 0  r[30..31] = C
-  56    SeekGE             3  66  30                 0  key=[30..30]
-  57      IdxGT            3  66  30                 0  key=[30..30]
-  58      Column           3   1  14                 0  r[14]=ephemeral(ephemeral_subquery_t8).id
-  59      Column           3   0  15                 0  r[15]=ephemeral(ephemeral_subquery_t8).customer_id
-  60      Column           3   2  16                 0  r[16]=ephemeral(ephemeral_subquery_t8).total_amount
-  61      Copy            12  28   0                 0  r[28]=r[12]
-  62      Column           3   2  29                 0  r[29]=ephemeral(ephemeral_subquery_t8).total_amount
-  63      RealAffinity    29   0   0                 0
-  64      ResultRow       28   2   0                 0  output=r[28..29]
-  65    Next               3  57   0                 0
-  66  Goto                 0  52   0                 0
-  67  Halt                 0   0   0                 0
-  68  Transaction          0   1  11                 0  iDb=0 tx_mode=Read
-  69  Integer           1000   8   0                 0  r[8]=1000
-  70  Integer           1000  22   0                 0  r[22]=1000
-  71  Goto                 0   1   0                 0
+  34  Once                52   0   0                 0  goto 52
+  35  OpenEphemeral        3   0   0                 0  cursor=3 is_table=false
+  36  OpenRead             4   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+  37  Rewind               4  52   0                 0  Rewind table orders
+  38    Column             4   3  21                 0  r[21]=orders.total_amount
+  39    RealAffinity      21   0   0                 0
+  40    Le                21  22  51  Binary         0  if r[21]<=r[22] goto 51
+  41    RowId              4  17   0                 0  r[17]=orders.rowid
+  42    Column             4   1  18                 0  r[18]=orders.customer_id
+  43    Column             4   3  19                 0  r[19]=orders.total_amount
+  44    RealAffinity      19   0   0                 0
+  45    Copy              18  24   0                 0  r[24]=r[18]
+  46    Copy              17  25   0                 0  r[25]=r[17]
+  47    Copy              19  26   0                 0  r[26]=r[19]
+  48    Sequence           3  27   0                 0
+  49    MakeRecord        24   4  23                 0  r[23]=mkrec(r[24..27]); for ephemeral_subquery_t8
+  50    IdxInsert          3  23   0                 8  key=r[23]
+  51  Next                 4  38   0                 0
+  52  InitCoroutine        1   0   2                 0
+  53    Yield              1  68   0                 0
+  54    Copy              11  30   0                 0  r[30]=r[11]
+  55    IsNull            30  67   0                 0  if (r[30]==NULL) goto 67
+  56    Affinity          30   1   0                 0  r[30..31] = C
+  57    SeekGE             3  67  30                 0  key=[30..30]
+  58      IdxGT            3  67  30                 0  key=[30..30]
+  59      Column           3   1  14                 0  r[14]=ephemeral(ephemeral_subquery_t8).id
+  60      Column           3   0  15                 0  r[15]=ephemeral(ephemeral_subquery_t8).customer_id
+  61      Column           3   2  16                 0  r[16]=ephemeral(ephemeral_subquery_t8).total_amount
+  62      Copy            12  28   0                 0  r[28]=r[12]
+  63      Column           3   2  29                 0  r[29]=ephemeral(ephemeral_subquery_t8).total_amount
+  64      RealAffinity    29   0   0                 0
+  65      ResultRow       28   2   0                 0  output=r[28..29]
+  66    Next               3  58   0                 0
+  67  Goto                 0  53   0                 0
+  68  Halt                 0   0   0                 0
+  69  Transaction          0   1  11                 0  iDb=0 tx_mode=Read
+  70  Integer           1000   8   0                 0  r[8]=1000
+  71  Integer           1000  22   0                 0  r[22]=1000
+  72  Goto                 0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
@@ -32,12 +32,12 @@ QUERY PLAN
 |  `--SCAN order_totals
 |     `--SCAN orders USING INDEX idx_orders_customer
 |--SCAN orders USING INDEX idx_orders_customer
-|--SCAN order_totals AS ot
-`--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
+|--SCAN customers AS c
+`--SEARCH ot USING INDEX ephemeral_subquery_t5 (customer_id=? AND total>?)
 
 BYTECODE
 addr  opcode                                       p1   p2   p3  p4            p5  comment
-   0                              Init              0  160    0                 0  Start at 160
+   0                              Init              0  170    0                 0  Start at 170
    1                              Once             54    0    0                 0  goto 54
    2                              BeginSubrtn       3    0    0                 0  r[3]=NULL
    3                              Null              0    1    0                 0  r[1]=NULL
@@ -184,18 +184,28 @@ addr  opcode                                       p1   p2   p3  p4            p
  144    Integer                                     0   44    0                 0  r[44]=0
  145  Return                                       52    0    0                 0
  146  OpenRead                                      7    6    0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
- 147  Rewind                                        4  159    0                 0  Rewind  ephemeral()
- 148    ColumnRange                                 4    0   39  2              0  r[39..40]=ephemeral().customer_id..total
- 149    Copy                                       40   59    0                 0  r[59]=r[40]
- 150    Copy                                        1   60    0                 0  r[60]=r[1]
- 151    Le                                         59   60  158  Binary         0  if r[59]<=r[60] goto 158
- 152    Copy                                       39   61    0                 0  r[61]=r[39]
- 153    SeekRowid                                   7   61  158                 0  if (r[61]!=cursor 7 for table customers.rowid) goto 158
- 154    Column                                      7    1   55                 0  r[55]=customers.name
- 155    Copy                                       40   56    0                 0  r[56]=r[40]
- 156    Copy                                        2   57    0                 0  r[57]=r[2]
- 157    ResultRow                                  55    3    0                 0  output=r[55..57]
- 158  Next                                          4  148    0                 0
- 159  Halt                                          0    0    0                 0
- 160  Transaction                                   0    1   11                 0  iDb=0 tx_mode=Read
- 161  Goto                                          0    1    0                 0
+ 147  Rewind                                        7  169    0                 0  Rewind table customers
+ 148    Once                                      156    0    0                 0  goto 156
+ 149    OpenAutoindex                               8    0    0                 0  cursor=8
+ 150    Rewind                                      4  151    0                 0  Rewind  ephemeral()
+ 151      ColumnRange                               4    0   58  2              0  r[58..59]=ephemeral().customer_id..total
+ 152      RowId                                     4   60    0                 0  r[60]=ephemeral().rowid
+ 153      MakeRecord                               58    3   61                 0  r[61]=mkrec(r[58..60]); for ephemeral_subquery_t5
+ 154      IdxInsert                                 8   61   58                 0  key=r[61]
+ 155    Next                                        4  151    0                 0
+ 156    RowId                                       7   62    0                 0  r[62]=customers.rowid
+ 157    Copy                                        1   63    0                 0  r[63]=r[1]
+ 158    IsNull                                     63  168    0                 0  if (r[63]==NULL) goto 168
+ 159    SeekGT                                      8  168   62                 0  key=[62..63]
+ 160      IdxGT                                     8  168   62                 0  key=[62..62]
+ 161      DeferredSeek                              8    4    0                 0
+ 162      ColumnRange                               4    0   39  2              0  r[39..40]=ephemeral().customer_id..total
+ 163      Column                                    7    1   55                 0  r[55]=customers.name
+ 164      Column                                    8    1   56                 0  r[56]=ephemeral(ephemeral_subquery_t5).total
+ 165      Copy                                      2   57    0                 0  r[57]=r[2]
+ 166      ResultRow                                55    3    0                 0  output=r[55..57]
+ 167    Next                                        8  160    0                 0
+ 168  Next                                          7  148    0                 0
+ 169  Halt                                          0    0    0                 0
+ 170  Transaction                                   0    1   11                 0  iDb=0 tx_mode=Read
+ 171  Goto                                          0    1    0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
@@ -31,78 +31,79 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                      p1  p2  p3  p4              p5  comment
-   0            Init               0  73   0                   0  Start at 73
+   0            Init               0  74   0                   0  Start at 74
    1            OpenRead           0   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-   2            Rewind             0  72   0                   0  Rewind table employees
+   2            Rewind             0  73   0                   0  Rewind table employees
    3              BeginSubrtn      5   0   0                   0  r[5]=NULL
    4              Null             0   1   0                   0  r[1]=NULL
-   5              OpenEphemeral    1   0   0                   0  cursor=1 is_table=false
-   6              Null             0  15   0                   0  r[15]=NULL
-   7              SorterOpen       2   2   0  k(1,B)           0  cursor=2
-   8              Integer          0  12   0                   0  r[12]=0; clear group by abort flag
-   9              Null             0  13   0                   0  r[13]=NULL; initialize group by comparison registers to NULL
-  10              Gosub           19  48   0                   0  ; go to clear accumulator subroutine
-  11              OpenRead         4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-  12              Rewind           4  18   0                   0  Rewind table employees
-  13                ColumnRange    4   3  17  2                0  r[17..18]=employees.department..salary
-  14                RealAffinity  18   0   0                   0
-  15                MakeRecord    17   2  16                   0  r[16]=mkrec(r[17..18])
-  16                SorterInsert   2  16   0  0                0  key=r[16]
-  17              Next             4  13   0                   0
-  18              OpenPseudo       3  16   2                   0  2 columns in r[16]
-  19              SorterSort       2  34   0                   0
-  20                SorterData     2  16   3                   0  r[16]=data
-  21                Column         3   0  20                   0  r[20]=pseudo.column 0
-  22                Compare       13  20   1  k(1, Binary)     0  r[13..13]==r[20..20]
-  23                Jump          24  28  24                   0  ; start new group if comparison is not equal
-  24                Gosub         10  38   0                   0  ; check if ended group had data, and output if so
-  25                Move          20  13   1                   0  r[13..13]=r[20..20]
-  26                IfPos         12  51   0                   0  r[12]>0 -> r[12]-=0, goto 51; check abort flag
-  27                Gosub         19  48   0                   0  ; goto clear accumulator subroutine
-  28                Column         3   1  21                   0  r[21]=pseudo.column 1
-  29                AggStep        0  21  15  avg              0  accum=r[15] step(r[21])
-  30                If            11  32   0                   0  if r[11] goto 32; don't emit group columns if continuing existing group
-  31                Column         3   0  14                   0  r[14]=pseudo.column 0
-  32                Integer        1  11   0                   0  r[11]=1; indicate data in accumulator
-  33              SorterNext       2  20   0                   0
-  34              Gosub           10  38   0                   0  ; emit row for final group
-  35              Goto             0  51   0                   0  ; group by finished
-  36              Integer          1  12   0                   0  r[12]=1
-  37            Return            10   0   0                   0
-  38            IfPos             11  40   0                   0  r[11]>0 -> r[11]-=0, goto 40; output group by row subroutine start
-  39          Return              10   0   0                   0
-  40          AggFinal             0  15   0  avg              0  accum=r[15]
-  41          Copy                14   8   0                   0  r[8]=r[14]
-  42          Copy                15   9   0                   0  r[9]=r[15]
-  43          Copy                 8  23   1                   0  r[23]=r[8]
-  44          Sequence             1  25   0                   0
-  45          MakeRecord          23   3  22                   0  r[22]=mkrec(r[23..25]); for ephemeral_subquery_t6
-  46          IdxInsert            1  22   0                   8  key=r[22]
-  47        Return                10   0   0                   0
-  48        Null                   0  14  15                   0  r[14..15]=NULL; clear accumulator subroutine start
-  49        Integer                0  11   0                   0  r[11]=0
-  50      Return                  19   0   0                   0
-  51      Integer                  1  27   0                   0  r[27]=1; LIMIT counter
-  52      IfNot                   27  62   0                   0  if !r[27] goto 62
-  53      Column                   0   3  28                   0  r[28]=employees.department
-  54      IsNull                  28  62   0                   0  if (r[28]==NULL) goto 62
-  55      SeekGE                   1  62  28                   0  key=[28..28]
-  56        IdxGT                  1  62  28                   0  key=[28..28]
-  57        ColumnRange            1   0   6  2                0  r[6..7]=ephemeral(ephemeral_subquery_t6).department..avg_salary
-  58        Column                 1   1  26                   0  r[26]=ephemeral(ephemeral_subquery_t6).avg_salary
-  59        Copy                  26   1   0                   0  r[1]=r[26]
-  60        DecrJumpZero          27  62   0                   0  if (--r[27]==0) goto 62
-  61      Next                     1  56   0                   0
-  62    Return                     5   0   1                   0
-  63    Column                     0   4  30                   0  r[30]=employees.salary
-  64    RealAffinity              30   0   0                   0
-  65    Copy                       1  31   0                   0  r[31]=r[1]
-  66    Le                        30  31  71  Binary           0  if r[30]<=r[31] goto 71
-  67    Column                     0   1   2                   0  r[2]=employees.name
-  68    ColumnRange                0   3   3  2                0  r[3..4]=employees.department..salary
-  69    RealAffinity               4   0   0                   0
-  70    ResultRow                  2   3   0                   0  output=r[2..4]
-  71  Next                         0   3   0                   0
-  72  Halt                         0   0   0                   0
-  73  Transaction                  0   1  11                   0  iDb=0 tx_mode=Read
-  74  Goto                         0   1   0                   0
+   5              Once            52   0   0                   0  goto 52
+   6              OpenEphemeral    1   0   0                   0  cursor=1 is_table=false
+   7              Null             0  15   0                   0  r[15]=NULL
+   8              SorterOpen       2   2   0  k(1,B)           0  cursor=2
+   9              Integer          0  12   0                   0  r[12]=0; clear group by abort flag
+  10              Null             0  13   0                   0  r[13]=NULL; initialize group by comparison registers to NULL
+  11              Gosub           19  49   0                   0  ; go to clear accumulator subroutine
+  12              OpenRead         4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
+  13              Rewind           4  19   0                   0  Rewind table employees
+  14                ColumnRange    4   3  17  2                0  r[17..18]=employees.department..salary
+  15                RealAffinity  18   0   0                   0
+  16                MakeRecord    17   2  16                   0  r[16]=mkrec(r[17..18])
+  17                SorterInsert   2  16   0  0                0  key=r[16]
+  18              Next             4  14   0                   0
+  19              OpenPseudo       3  16   2                   0  2 columns in r[16]
+  20              SorterSort       2  35   0                   0
+  21                SorterData     2  16   3                   0  r[16]=data
+  22                Column         3   0  20                   0  r[20]=pseudo.column 0
+  23                Compare       13  20   1  k(1, Binary)     0  r[13..13]==r[20..20]
+  24                Jump          25  29  25                   0  ; start new group if comparison is not equal
+  25                Gosub         10  39   0                   0  ; check if ended group had data, and output if so
+  26                Move          20  13   1                   0  r[13..13]=r[20..20]
+  27                IfPos         12  52   0                   0  r[12]>0 -> r[12]-=0, goto 52; check abort flag
+  28                Gosub         19  49   0                   0  ; goto clear accumulator subroutine
+  29                Column         3   1  21                   0  r[21]=pseudo.column 1
+  30                AggStep        0  21  15  avg              0  accum=r[15] step(r[21])
+  31                If            11  33   0                   0  if r[11] goto 33; don't emit group columns if continuing existing group
+  32                Column         3   0  14                   0  r[14]=pseudo.column 0
+  33                Integer        1  11   0                   0  r[11]=1; indicate data in accumulator
+  34              SorterNext       2  21   0                   0
+  35              Gosub           10  39   0                   0  ; emit row for final group
+  36              Goto             0  52   0                   0  ; group by finished
+  37              Integer          1  12   0                   0  r[12]=1
+  38            Return            10   0   0                   0
+  39            IfPos             11  41   0                   0  r[11]>0 -> r[11]-=0, goto 41; output group by row subroutine start
+  40          Return              10   0   0                   0
+  41          AggFinal             0  15   0  avg              0  accum=r[15]
+  42          Copy                14   8   0                   0  r[8]=r[14]
+  43          Copy                15   9   0                   0  r[9]=r[15]
+  44          Copy                 8  23   1                   0  r[23]=r[8]
+  45          Sequence             1  25   0                   0
+  46          MakeRecord          23   3  22                   0  r[22]=mkrec(r[23..25]); for ephemeral_subquery_t6
+  47          IdxInsert            1  22   0                   8  key=r[22]
+  48        Return                10   0   0                   0
+  49        Null                   0  14  15                   0  r[14..15]=NULL; clear accumulator subroutine start
+  50        Integer                0  11   0                   0  r[11]=0
+  51      Return                  19   0   0                   0
+  52      Integer                  1  27   0                   0  r[27]=1; LIMIT counter
+  53      IfNot                   27  63   0                   0  if !r[27] goto 63
+  54      Column                   0   3  28                   0  r[28]=employees.department
+  55      IsNull                  28  63   0                   0  if (r[28]==NULL) goto 63
+  56      SeekGE                   1  63  28                   0  key=[28..28]
+  57        IdxGT                  1  63  28                   0  key=[28..28]
+  58        ColumnRange            1   0   6  2                0  r[6..7]=ephemeral(ephemeral_subquery_t6).department..avg_salary
+  59        Column                 1   1  26                   0  r[26]=ephemeral(ephemeral_subquery_t6).avg_salary
+  60        Copy                  26   1   0                   0  r[1]=r[26]
+  61        DecrJumpZero          27  63   0                   0  if (--r[27]==0) goto 63
+  62      Next                     1  57   0                   0
+  63    Return                     5   0   1                   0
+  64    Column                     0   4  30                   0  r[30]=employees.salary
+  65    RealAffinity              30   0   0                   0
+  66    Copy                       1  31   0                   0  r[31]=r[1]
+  67    Le                        30  31  72  Binary           0  if r[30]<=r[31] goto 72
+  68    Column                     0   1   2                   0  r[2]=employees.name
+  69    ColumnRange                0   3   3  2                0  r[3..4]=employees.department..salary
+  70    RealAffinity               4   0   0                   0
+  71    ResultRow                  2   3   0                   0  output=r[2..4]
+  72  Next                         0   3   0                   0
+  73  Halt                         0   0   0                   0
+  74  Transaction                  0   1  11                   0  iDb=0 tx_mode=Read
+  75  Goto                         0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
@@ -31,79 +31,78 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                      p1  p2  p3  p4              p5  comment
-   0            Init               0  74   0                   0  Start at 74
+   0            Init               0  73   0                   0  Start at 73
    1            OpenRead           0   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
-   2            Rewind             0  73   0                   0  Rewind table employees
+   2            Rewind             0  72   0                   0  Rewind table employees
    3              BeginSubrtn      5   0   0                   0  r[5]=NULL
    4              Null             0   1   0                   0  r[1]=NULL
    5              Once            52   0   0                   0  goto 52
    6              OpenEphemeral    1   0   0                   0  cursor=1 is_table=false
-   7              Null             0  15   0                   0  r[15]=NULL
+   7              Null             0  13   0                   0  r[13]=NULL
    8              SorterOpen       2   2   0  k(1,B)           0  cursor=2
-   9              Integer          0  12   0                   0  r[12]=0; clear group by abort flag
-  10              Null             0  13   0                   0  r[13]=NULL; initialize group by comparison registers to NULL
-  11              Gosub           19  49   0                   0  ; go to clear accumulator subroutine
+   9              Integer          0  10   0                   0  r[10]=0; clear group by abort flag
+  10              Null             0  11   0                   0  r[11]=NULL; initialize group by comparison registers to NULL
+  11              Gosub           17  49   0                   0  ; go to clear accumulator subroutine
   12              OpenRead         4   7   0  k(5,B,B,B,B,B)   0  table=employees, root=7, iDb=0
   13              Rewind           4  19   0                   0  Rewind table employees
-  14                ColumnRange    4   3  17  2                0  r[17..18]=employees.department..salary
-  15                RealAffinity  18   0   0                   0
-  16                MakeRecord    17   2  16                   0  r[16]=mkrec(r[17..18])
-  17                SorterInsert   2  16   0  0                0  key=r[16]
+  14                ColumnRange    4   3  15  2                0  r[15..16]=employees.department..salary
+  15                RealAffinity  16   0   0                   0
+  16                MakeRecord    15   2  14                   0  r[14]=mkrec(r[15..16])
+  17                SorterInsert   2  14   0  0                0  key=r[14]
   18              Next             4  14   0                   0
-  19              OpenPseudo       3  16   2                   0  2 columns in r[16]
+  19              OpenPseudo       3  14   2                   0  2 columns in r[14]
   20              SorterSort       2  35   0                   0
-  21                SorterData     2  16   3                   0  r[16]=data
-  22                Column         3   0  20                   0  r[20]=pseudo.column 0
-  23                Compare       13  20   1  k(1, Binary)     0  r[13..13]==r[20..20]
+  21                SorterData     2  14   3                   0  r[14]=data
+  22                Column         3   0  18                   0  r[18]=pseudo.column 0
+  23                Compare       11  18   1  k(1, Binary)     0  r[11..11]==r[18..18]
   24                Jump          25  29  25                   0  ; start new group if comparison is not equal
-  25                Gosub         10  39   0                   0  ; check if ended group had data, and output if so
-  26                Move          20  13   1                   0  r[13..13]=r[20..20]
-  27                IfPos         12  52   0                   0  r[12]>0 -> r[12]-=0, goto 52; check abort flag
-  28                Gosub         19  49   0                   0  ; goto clear accumulator subroutine
-  29                Column         3   1  21                   0  r[21]=pseudo.column 1
-  30                AggStep        0  21  15  avg              0  accum=r[15] step(r[21])
-  31                If            11  33   0                   0  if r[11] goto 33; don't emit group columns if continuing existing group
-  32                Column         3   0  14                   0  r[14]=pseudo.column 0
-  33                Integer        1  11   0                   0  r[11]=1; indicate data in accumulator
+  25                Gosub          8  39   0                   0  ; check if ended group had data, and output if so
+  26                Move          18  11   1                   0  r[11..11]=r[18..18]
+  27                IfPos         10  52   0                   0  r[10]>0 -> r[10]-=0, goto 52; check abort flag
+  28                Gosub         17  49   0                   0  ; goto clear accumulator subroutine
+  29                Column         3   1  19                   0  r[19]=pseudo.column 1
+  30                AggStep        0  19  13  avg              0  accum=r[13] step(r[19])
+  31                If             9  33   0                   0  if r[9] goto 33; don't emit group columns if continuing existing group
+  32                Column         3   0  12                   0  r[12]=pseudo.column 0
+  33                Integer        1   9   0                   0  r[9]=1; indicate data in accumulator
   34              SorterNext       2  21   0                   0
-  35              Gosub           10  39   0                   0  ; emit row for final group
+  35              Gosub            8  39   0                   0  ; emit row for final group
   36              Goto             0  52   0                   0  ; group by finished
-  37              Integer          1  12   0                   0  r[12]=1
-  38            Return            10   0   0                   0
-  39            IfPos             11  41   0                   0  r[11]>0 -> r[11]-=0, goto 41; output group by row subroutine start
-  40          Return              10   0   0                   0
-  41          AggFinal             0  15   0  avg              0  accum=r[15]
-  42          Copy                14   8   0                   0  r[8]=r[14]
-  43          Copy                15   9   0                   0  r[9]=r[15]
-  44          Copy                 8  23   1                   0  r[23]=r[8]
-  45          Sequence             1  25   0                   0
-  46          MakeRecord          23   3  22                   0  r[22]=mkrec(r[23..25]); for ephemeral_subquery_t6
-  47          IdxInsert            1  22   0                   8  key=r[22]
-  48        Return                10   0   0                   0
-  49        Null                   0  14  15                   0  r[14..15]=NULL; clear accumulator subroutine start
-  50        Integer                0  11   0                   0  r[11]=0
-  51      Return                  19   0   0                   0
-  52      Integer                  1  27   0                   0  r[27]=1; LIMIT counter
-  53      IfNot                   27  63   0                   0  if !r[27] goto 63
-  54      Column                   0   3  28                   0  r[28]=employees.department
-  55      IsNull                  28  63   0                   0  if (r[28]==NULL) goto 63
-  56      SeekGE                   1  63  28                   0  key=[28..28]
-  57        IdxGT                  1  63  28                   0  key=[28..28]
-  58        ColumnRange            1   0   6  2                0  r[6..7]=ephemeral(ephemeral_subquery_t6).department..avg_salary
-  59        Column                 1   1  26                   0  r[26]=ephemeral(ephemeral_subquery_t6).avg_salary
-  60        Copy                  26   1   0                   0  r[1]=r[26]
-  61        DecrJumpZero          27  63   0                   0  if (--r[27]==0) goto 63
-  62      Next                     1  57   0                   0
-  63    Return                     5   0   1                   0
-  64    Column                     0   4  30                   0  r[30]=employees.salary
-  65    RealAffinity              30   0   0                   0
-  66    Copy                       1  31   0                   0  r[31]=r[1]
-  67    Le                        30  31  72  Binary           0  if r[30]<=r[31] goto 72
-  68    Column                     0   1   2                   0  r[2]=employees.name
-  69    ColumnRange                0   3   3  2                0  r[3..4]=employees.department..salary
-  70    RealAffinity               4   0   0                   0
-  71    ResultRow                  2   3   0                   0  output=r[2..4]
-  72  Next                         0   3   0                   0
-  73  Halt                         0   0   0                   0
-  74  Transaction                  0   1  11                   0  iDb=0 tx_mode=Read
-  75  Goto                         0   1   0                   0
+  37              Integer          1  10   0                   0  r[10]=1
+  38            Return             8   0   0                   0
+  39            IfPos              9  41   0                   0  r[9]>0 -> r[9]-=0, goto 41; output group by row subroutine start
+  40          Return               8   0   0                   0
+  41          AggFinal             0  13   0  avg              0  accum=r[13]
+  42          Copy                12   6   0                   0  r[6]=r[12]
+  43          Copy                13   7   0                   0  r[7]=r[13]
+  44          Copy                 6  21   1                   0  r[21]=r[6]
+  45          Sequence             1  23   0                   0
+  46          MakeRecord          21   3  20                   0  r[20]=mkrec(r[21..23]); for ephemeral_subquery_t6
+  47          IdxInsert            1  20   0                   8  key=r[20]
+  48        Return                 8   0   0                   0
+  49        Null                   0  12  13                   0  r[12..13]=NULL; clear accumulator subroutine start
+  50        Integer                0   9   0                   0  r[9]=0
+  51      Return                  17   0   0                   0
+  52      Integer                  1  25   0                   0  r[25]=1; LIMIT counter
+  53      IfNot                   25  62   0                   0  if !r[25] goto 62
+  54      Column                   0   3  26                   0  r[26]=employees.department
+  55      IsNull                  26  62   0                   0  if (r[26]==NULL) goto 62
+  56      SeekGE                   1  62  26                   0  key=[26..26]
+  57        IdxGT                  1  62  26                   0  key=[26..26]
+  58        Column                 1   1  24                   0  r[24]=ephemeral(ephemeral_subquery_t6).avg_salary
+  59        Copy                  24   1   0                   0  r[1]=r[24]
+  60        DecrJumpZero          25  62   0                   0  if (--r[25]==0) goto 62
+  61      Next                     1  57   0                   0
+  62    Return                     5   0   1                   0
+  63    Column                     0   4  28                   0  r[28]=employees.salary
+  64    RealAffinity              28   0   0                   0
+  65    Copy                       1  29   0                   0  r[29]=r[1]
+  66    Le                        28  29  71  Binary           0  if r[28]<=r[29] goto 71
+  67    Column                     0   1   2                   0  r[2]=employees.name
+  68    ColumnRange                0   3   3  2                0  r[3..4]=employees.department..salary
+  69    RealAffinity               4   0   0                   0
+  70    ResultRow                  2   3   0                   0  output=r[2..4]
+  71  Next                         0   3   0                   0
+  72  Halt                         0   0   0                   0
+  73  Transaction                  0   1  11                   0  iDb=0 tx_mode=Read
+  74  Goto                         0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-join.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-join.snap
@@ -23,68 +23,72 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN order_stats
-|  `--SCAN orders USING INDEX idx_orders_customer
-`--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
+|--SCAN customers AS c
+`--SEARCH order_stats USING INDEX ephemeral_subquery_t3 (customer_id=? AND total_spent>?)
+   `--SCAN orders USING INDEX idx_orders_customer
 
 BYTECODE
 addr  opcode                   p1  p2  p3  p4            p5  comment
-   0          Init              0  55   0                 0  Start at 55
-   1          InitCoroutine     1  42   2                 0
-   2          Null              0  10  11                 0  r[10..11]=NULL
-   3          Integer           0   7   0                 0  r[7]=0; clear group by abort flag
-   4          Null              0   8   0                 0  r[8]=NULL; initialize group by comparison registers to NULL
-   5          Gosub            15  38   0                 0  ; go to clear accumulator subroutine
-   6          OpenRead          0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   7          OpenRead          1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-   8          Rewind            1  25   0                 0  Rewind index idx_orders_customer
-   9            DeferredSeek    1   0   0                 0
-  10            Column          1   0  13                 0  r[13]=idx_orders_customer.customer_id
-  11            Column          0   3  14                 0  r[14]=orders.total_amount
-  12            RealAffinity   14   0   0                 0
-  13            Compare         8  13   1  k(1, Binary)   0  r[8..8]==r[13..13]
-  14            Jump           15  19  15                 0  ; start new group if comparison is not equal
-  15            Gosub           5  29   0                 0  ; check if ended group had data, and output if so
-  16            Move           13   8   1                 0  r[8..8]=r[13..13]
-  17            IfPos           7  41   0                 0  r[7]>0 -> r[7]-=0, goto 41; check abort flag
-  18            Gosub          15  38   0                 0  ; goto clear accumulator subroutine
-  19            AggStep         0  16  10  count          0  accum=r[10] step(r[16])
-  20            AggStep         0  14  11  sum            0  accum=r[11] step(r[14])
-  21            If              6  23   0                 0  if r[6] goto 23; don't emit group columns if continuing existing group
-  22            Column          1   0   9                 0  r[9]=idx_orders_customer.customer_id
-  23            Integer         1   6   0                 0  r[6]=1; indicate data in accumulator
-  24          Next              1   9   0                 0
-  25          Gosub             5  29   0                 0  ; emit row for final group
-  26          Goto              0  41   0                 0  ; group by finished
-  27          Integer           1   7   0                 0  r[7]=1
-  28        Return              5   0   0                 0
-  29        IfPos               6  31   0                 0  r[6]>0 -> r[6]-=0, goto 31; output group by row subroutine start
-  30      Return                5   0   0                 0
-  31      AggFinal              0  10   0  count          0  accum=r[10]
-  32      AggFinal              0  11   0  sum            0  accum=r[11]
-  33      Copy                  9   2   0                 0  r[2]=r[9]
-  34      Copy                 10   3   0                 0  r[3]=r[10]
-  35      Copy                 11   4   0                 0  r[4]=r[11]
-  36      Yield                 1   0   0                 0
-  37    Return                  5   0   0                 0
-  38    Null                    0   9  11                 0  r[9..11]=NULL; clear accumulator subroutine start
-  39    Integer                 0   6   0                 0  r[6]=0
-  40  Return                   15   0   0                 0
-  41  EndCoroutine              1   0   0                 0
-  42  OpenRead                  2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  43  InitCoroutine             1   0   2                 0
-  44    Yield                   1  54   0                 0
-  45    Copy                    4  21   0                 0  r[21]=r[4]
-  46    Le                     21  22  53  Binary         0  if r[21]<=r[22] goto 53
-  47    Copy                    2  23   0                 0  r[23]=r[2]
-  48    SeekRowid               2  23  53                 0  if (r[23]!=cursor 2 for table customers.rowid) goto 53
-  49    Column                  2   1  17                 0  r[17]=customers.name
-  50    Copy                    3  18   0                 0  r[18]=r[3]
-  51    Copy                    4  19   0                 0  r[19]=r[4]
-  52    ResultRow              17   3   0                 0  output=r[17..19]
-  53  Goto                      0  44   0                 0
-  54  Halt                      0   0   0                 0
-  55  Transaction               0   1  11                 0  iDb=0 tx_mode=Read
-  56  Integer                   1  16   0                 0  r[16]=1
-  57  Integer                 500  22   0                 0  r[22]=500
-  58  Goto                      0   1   0                 0
+   0          Init              0  60   0                 0  Start at 60
+   1          Once             47   0   0                 0  goto 47
+   2          OpenEphemeral     0   0   0                 0  cursor=0 is_table=false
+   3          Null              0   9  10                 0  r[9..10]=NULL
+   4          Integer           0   6   0                 0  r[6]=0; clear group by abort flag
+   5          Null              0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
+   6          Gosub            14  44   0                 0  ; go to clear accumulator subroutine
+   7          OpenRead          1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   8          OpenRead          2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   9          Rewind            2  26   0                 0  Rewind index idx_orders_customer
+  10            DeferredSeek    2   1   0                 0
+  11            Column          2   0  12                 0  r[12]=idx_orders_customer.customer_id
+  12            Column          1   3  13                 0  r[13]=orders.total_amount
+  13            RealAffinity   13   0   0                 0
+  14            Compare         7  12   1  k(1, Binary)   0  r[7..7]==r[12..12]
+  15            Jump           16  20  16                 0  ; start new group if comparison is not equal
+  16            Gosub           4  30   0                 0  ; check if ended group had data, and output if so
+  17            Move           12   7   1                 0  r[7..7]=r[12..12]
+  18            IfPos           6  47   0                 0  r[6]>0 -> r[6]-=0, goto 47; check abort flag
+  19            Gosub          14  44   0                 0  ; goto clear accumulator subroutine
+  20            AggStep         0  15   9  count          0  accum=r[9] step(r[15])
+  21            AggStep         0  13  10  sum            0  accum=r[10] step(r[13])
+  22            If              5  24   0                 0  if r[5] goto 24; don't emit group columns if continuing existing group
+  23            Column          2   0   8                 0  r[8]=idx_orders_customer.customer_id
+  24            Integer         1   5   0                 0  r[5]=1; indicate data in accumulator
+  25          Next              2  10   0                 0
+  26          Gosub             4  30   0                 0  ; emit row for final group
+  27          Goto              0  47   0                 0  ; group by finished
+  28          Integer           1   6   0                 0  r[6]=1
+  29        Return              4   0   0                 0
+  30        IfPos               5  32   0                 0  r[5]>0 -> r[5]-=0, goto 32; output group by row subroutine start
+  31      Return                4   0   0                 0
+  32      AggFinal              0   9   0  count          0  accum=r[9]
+  33      AggFinal              0  10   0  sum            0  accum=r[10]
+  34      Copy                  8   1   0                 0  r[1]=r[8]
+  35      Copy                  9   2   0                 0  r[2]=r[9]
+  36      Copy                 10   3   0                 0  r[3]=r[10]
+  37      Copy                  1  17   0                 0  r[17]=r[1]
+  38      Copy                  3  18   0                 0  r[18]=r[3]
+  39      Copy                  2  19   0                 0  r[19]=r[2]
+  40      Sequence              0  20   0                 0
+  41      MakeRecord           17   4  16                 0  r[16]=mkrec(r[17..20]); for ephemeral_subquery_t3
+  42      IdxInsert             0  16   0                 8  key=r[16]
+  43    Return                  4   0   0                 0
+  44    Null                    0   8  10                 0  r[8..10]=NULL; clear accumulator subroutine start
+  45    Integer                 0   5   0                 0  r[5]=0
+  46  Return                   14   0   0                 0
+  47  OpenRead                  3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  48  Rewind                    3  59   0                 0  Rewind table customers
+  49    RowId                   3  24   0                 0  r[24]=customers.rowid
+  50    Integer               500  25   0                 0  r[25]=500
+  51    SeekGT                  0  58  24                 0  key=[24..25]
+  52      IdxGT                 0  58  24                 0  key=[24..24]
+  53      Column                3   1  21                 0  r[21]=customers.name
+  54      Column                0   2  22                 0  r[22]=ephemeral(ephemeral_subquery_t3).total_orders
+  55      Column                0   1  23                 0  r[23]=ephemeral(ephemeral_subquery_t3).total_spent
+  56      ResultRow            21   3   0                 0  output=r[21..23]
+  57    Next                    0  52   0                 0
+  58  Next                      3  49   0                 0
+  59  Halt                      0   0   0                 0
+  60  Transaction               0   1  11                 0  iDb=0 tx_mode=Read
+  61  Integer                   1  15   0                 0  r[15]=1
+  62  Goto                      0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
@@ -24,76 +24,82 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SEARCH top_customers USING INDEX ephemeral_subquery_t4 (total_spent>?)
-   |--SCAN stats
-   |  `--SCAN orders USING INDEX idx_orders_customer
-   `--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
+|--SCAN top_customers
+|  |--SCAN stats
+|  |  `--SCAN orders USING INDEX idx_orders_customer
+|  `--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
+`--USE SORTER FOR ORDER BY
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4            p5  comment
-   0          Init               0  64   0                 0  Start at 64
-   1          Once              54   0   0                 0  goto 54
-   2          OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
-   3          InitCoroutine      3  41   4                 0
-   4          Null               0  11   0                 0  r[11]=NULL
-   5          Integer            0   8   0                 0  r[8]=0; clear group by abort flag
-   6          Null               0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
-   7          Gosub             15  37   0                 0  ; go to clear accumulator subroutine
-   8          OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   9          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-  10          Rewind             2  26   0                 0  Rewind index idx_orders_customer
-  11            DeferredSeek     2   1   0                 0
-  12            Column           2   0  13                 0  r[13]=idx_orders_customer.customer_id
-  13            Column           1   3  14                 0  r[14]=orders.total_amount
-  14            RealAffinity    14   0   0                 0
-  15            Compare          9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
-  16            Jump            17  21  17                 0  ; start new group if comparison is not equal
-  17            Gosub            6  30   0                 0  ; check if ended group had data, and output if so
-  18            Move            13   9   1                 0  r[9..9]=r[13..13]
-  19            IfPos            8  40   0                 0  r[8]>0 -> r[8]-=0, goto 40; check abort flag
-  20            Gosub           15  37   0                 0  ; goto clear accumulator subroutine
-  21            AggStep          0  14  11  sum            0  accum=r[11] step(r[14])
-  22            If               7  24   0                 0  if r[7] goto 24; don't emit group columns if continuing existing group
-  23            Column           2   0  10                 0  r[10]=idx_orders_customer.customer_id
-  24            Integer          1   7   0                 0  r[7]=1; indicate data in accumulator
-  25          Next               2  11   0                 0
-  26          Gosub              6  30   0                 0  ; emit row for final group
-  27          Goto               0  40   0                 0  ; group by finished
-  28          Integer            1   8   0                 0  r[8]=1
-  29        Return               6   0   0                 0
-  30        IfPos                7  32   0                 0  r[7]>0 -> r[7]-=0, goto 32; output group by row subroutine start
-  31      Return                 6   0   0                 0
-  32      AggFinal               0  11   0  sum            0  accum=r[11]
+   0          Init               0  68   0                 0  Start at 68
+   1          InitCoroutine      1  50   2                 0
+   2          InitCoroutine      2  40   3                 0
+   3          Null               0  10   0                 0  r[10]=NULL
+   4          Integer            0   7   0                 0  r[7]=0; clear group by abort flag
+   5          Null               0   8   0                 0  r[8]=NULL; initialize group by comparison registers to NULL
+   6          Gosub             14  36   0                 0  ; go to clear accumulator subroutine
+   7          OpenRead           0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   8          OpenRead           1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   9          Rewind             1  25   0                 0  Rewind index idx_orders_customer
+  10            DeferredSeek     1   0   0                 0
+  11            Column           1   0  12                 0  r[12]=idx_orders_customer.customer_id
+  12            Column           0   3  13                 0  r[13]=orders.total_amount
+  13            RealAffinity    13   0   0                 0
+  14            Compare          8  12   1  k(1, Binary)   0  r[8..8]==r[12..12]
+  15            Jump            16  20  16                 0  ; start new group if comparison is not equal
+  16            Gosub            5  29   0                 0  ; check if ended group had data, and output if so
+  17            Move            12   8   1                 0  r[8..8]=r[12..12]
+  18            IfPos            7  39   0                 0  r[7]>0 -> r[7]-=0, goto 39; check abort flag
+  19            Gosub           14  36   0                 0  ; goto clear accumulator subroutine
+  20            AggStep          0  13  10  sum            0  accum=r[10] step(r[13])
+  21            If               6  23   0                 0  if r[6] goto 23; don't emit group columns if continuing existing group
+  22            Column           1   0   9                 0  r[9]=idx_orders_customer.customer_id
+  23            Integer          1   6   0                 0  r[6]=1; indicate data in accumulator
+  24          Next               1  10   0                 0
+  25          Gosub              5  29   0                 0  ; emit row for final group
+  26          Goto               0  39   0                 0  ; group by finished
+  27          Integer            1   7   0                 0  r[7]=1
+  28        Return               5   0   0                 0
+  29        IfPos                6  31   0                 0  r[6]>0 -> r[6]-=0, goto 31; output group by row subroutine start
+  30      Return                 5   0   0                 0
+  31      AggFinal               0  10   0  sum            0  accum=r[10]
+  32      Copy                   9   3   0                 0  r[3]=r[9]
   33      Copy                  10   4   0                 0  r[4]=r[10]
-  34      Copy                  11   5   0                 0  r[5]=r[11]
-  35      Yield                  3   0   0                 0
-  36    Return                   6   0   0                 0
-  37    Null                     0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
-  38    Integer                  0   7   0                 0  r[7]=0
-  39  Return                    15   0   0                 0
-  40  EndCoroutine               3   0   0                 0
-  41  OpenRead                   3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  42  InitCoroutine              3   0   4                 0
-  43    Yield                    3  54   0                 0
-  44    Copy                     4  18   0                 0  r[18]=r[4]
-  45    SeekRowid                3  18  53                 0  if (r[18]!=cursor 3 for table customers.rowid) goto 53
-  46    Column                   3   1  16                 0  r[16]=customers.name
-  47    Copy                     5  17   0                 0  r[17]=r[5]
-  48    Copy                    17  20   0                 0  r[20]=r[17]
-  49    Copy                    16  21   0                 0  r[21]=r[16]
-  50    Sequence                 0  22   0                 0
-  51    MakeRecord              20   3  19                 0  r[19]=mkrec(r[20..22]); for ephemeral_subquery_t4
-  52    IdxInsert                0  19   0                 8  key=r[19]
-  53  Goto                       0  43   0                 0
-  54  Last                       0  63   0                 0
-  55  Integer                 1000  25   0                 0  r[25]=1000
-  56    IdxLE                    0  63  25                 0  key=[25..25]
-  57    Column                   0   1   1                 0  r[1]=ephemeral(ephemeral_subquery_t4).name
-  58    Column                   0   0   2                 0  r[2]=ephemeral(ephemeral_subquery_t4).total_spent
-  59    Column                   0   1  23                 0  r[23]=ephemeral(ephemeral_subquery_t4).name
-  60    Column                   0   0  24                 0  r[24]=ephemeral(ephemeral_subquery_t4).total_spent
-  61    ResultRow               23   2   0                 0  output=r[23..24]
-  62  Prev                       0  56   0                 0
-  63  Halt                       0   0   0                 0
-  64  Transaction                0   1  11                 0  iDb=0 tx_mode=Read
-  65  Goto                       0   1   0                 0
+  34      Yield                  2   0   0                 0
+  35    Return                   5   0   0                 0
+  36    Null                     0   9  10                 0  r[9..10]=NULL; clear accumulator subroutine start
+  37    Integer                  0   6   0                 0  r[6]=0
+  38  Return                    14   0   0                 0
+  39  EndCoroutine               2   0   0                 0
+  40  OpenRead                   2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  41  InitCoroutine              2   0   3                 0
+  42    Yield                    2  49   0                 0
+  43    Copy                     3  17   0                 0  r[17]=r[3]
+  44    SeekRowid                2  17  48                 0  if (r[17]!=cursor 2 for table customers.rowid) goto 48
+  45    Column                   2   1  15                 0  r[15]=customers.name
+  46    Copy                     4  16   0                 0  r[16]=r[4]
+  47    Yield                    1   0   0                 0
+  48  Goto                       0  42   0                 0
+  49  EndCoroutine               1   0   0                 0
+  50  SorterOpen                 3   1   0  k(1,-B)        0  cursor=3
+  51  InitCoroutine              1   0   2                 0
+  52    Yield                    1  60   0                 0
+  53    Copy                    16  22   0                 0  r[22]=r[16]
+  54    Le                      22  23  59  Binary         0  if r[22]<=r[23] goto 59
+  55    Copy                    16  24   0                 0  r[24]=r[16]
+  56    Copy                    15  25   0                 0  r[25]=r[15]
+  57    MakeRecord              24   2  20                 0  r[20]=mkrec(r[24..25])
+  58    SorterInsert             3  20   0  0              0  key=r[20]
+  59  Goto                       0  52   0                 0
+  60  OpenPseudo                 4  20   2                 0  2 columns in r[20]
+  61  SorterSort                 3  67   0                 0
+  62    SorterData               3  20   4                 0  r[20]=data
+  63    Column                   4   1  18                 0  r[18]=pseudo.column 1
+  64    Column                   4   0  19                 0  r[19]=pseudo.column 0
+  65    ResultRow               18   2   0                 0  output=r[18..19]
+  66  SorterNext                 3  62   0                 0
+  67  Halt                       0   0   0                 0
+  68  Transaction                0   1  11                 0  iDb=0 tx_mode=Read
+  69  Integer                 1000  23   0                 0  r[23]=1000
+  70  Goto                       0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
@@ -31,68 +31,69 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4            p5  comment
-   0          Init               0  63   0                 0  Start at 63
-   1          OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
-   2          InitCoroutine      3  40   3                 0
-   3          Null               0  11   0                 0  r[11]=NULL
-   4          Integer            0   8   0                 0  r[8]=0; clear group by abort flag
-   5          Null               0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
-   6          Gosub             15  36   0                 0  ; go to clear accumulator subroutine
-   7          OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   8          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-   9          Rewind             2  25   0                 0  Rewind index idx_orders_customer
-  10            DeferredSeek     2   1   0                 0
-  11            Column           2   0  13                 0  r[13]=idx_orders_customer.customer_id
-  12            Column           1   3  14                 0  r[14]=orders.total_amount
-  13            RealAffinity    14   0   0                 0
-  14            Compare          9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
-  15            Jump            16  20  16                 0  ; start new group if comparison is not equal
-  16            Gosub            6  29   0                 0  ; check if ended group had data, and output if so
-  17            Move            13   9   1                 0  r[9..9]=r[13..13]
-  18            IfPos            8  39   0                 0  r[8]>0 -> r[8]-=0, goto 39; check abort flag
-  19            Gosub           15  36   0                 0  ; goto clear accumulator subroutine
-  20            AggStep          0  14  11  sum            0  accum=r[11] step(r[14])
-  21            If               7  23   0                 0  if r[7] goto 23; don't emit group columns if continuing existing group
-  22            Column           2   0  10                 0  r[10]=idx_orders_customer.customer_id
-  23            Integer          1   7   0                 0  r[7]=1; indicate data in accumulator
-  24          Next               2  10   0                 0
-  25          Gosub              6  29   0                 0  ; emit row for final group
-  26          Goto               0  39   0                 0  ; group by finished
-  27          Integer            1   8   0                 0  r[8]=1
-  28        Return               6   0   0                 0
-  29        IfPos                7  31   0                 0  r[7]>0 -> r[7]-=0, goto 31; output group by row subroutine start
-  30      Return                 6   0   0                 0
-  31      AggFinal               0  11   0  sum            0  accum=r[11]
-  32      Copy                  10   4   0                 0  r[4]=r[10]
-  33      Copy                  11   5   0                 0  r[5]=r[11]
-  34      Yield                  3   0   0                 0
-  35    Return                   6   0   0                 0
-  36    Null                     0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
-  37    Integer                  0   7   0                 0  r[7]=0
-  38  Return                    15   0   0                 0
-  39  EndCoroutine               3   0   0                 0
-  40  OpenRead                   3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  41  InitCoroutine              3   0   3                 0
-  42    Yield                    3  53   0                 0
-  43    Copy                     4  18   0                 0  r[18]=r[4]
-  44    SeekRowid                3  18  52                 0  if (r[18]!=cursor 3 for table customers.rowid) goto 52
-  45    Column                   3   1  16                 0  r[16]=customers.name
-  46    Copy                     5  17   0                 0  r[17]=r[5]
-  47    Copy                    17  20   0                 0  r[20]=r[17]
-  48    Copy                    16  21   0                 0  r[21]=r[16]
-  49    Sequence                 0  22   0                 0
-  50    MakeRecord              20   3  19                 0  r[19]=mkrec(r[20..22]); for ephemeral_subquery_t4
-  51    IdxInsert                0  19   0                 8  key=r[19]
-  52  Goto                       0  42   0                 0
-  53  Last                       0  62   0                 0
-  54  Integer                 1000  25   0                 0  r[25]=1000
-  55    IdxLE                    0  62  25                 0  key=[25..25]
-  56    Column                   0   1   1                 0  r[1]=ephemeral(ephemeral_subquery_t4).name
-  57    Column                   0   0   2                 0  r[2]=ephemeral(ephemeral_subquery_t4).total_spent
-  58    Column                   0   1  23                 0  r[23]=ephemeral(ephemeral_subquery_t4).name
-  59    Column                   0   0  24                 0  r[24]=ephemeral(ephemeral_subquery_t4).total_spent
-  60    ResultRow               23   2   0                 0  output=r[23..24]
-  61  Prev                       0  55   0                 0
-  62  Halt                       0   0   0                 0
-  63  Transaction                0   1  11                 0  iDb=0 tx_mode=Read
-  64  Goto                       0   1   0                 0
+   0          Init               0  64   0                 0  Start at 64
+   1          Once              54   0   0                 0  goto 54
+   2          OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
+   3          InitCoroutine      3  41   4                 0
+   4          Null               0  11   0                 0  r[11]=NULL
+   5          Integer            0   8   0                 0  r[8]=0; clear group by abort flag
+   6          Null               0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
+   7          Gosub             15  37   0                 0  ; go to clear accumulator subroutine
+   8          OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   9          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+  10          Rewind             2  26   0                 0  Rewind index idx_orders_customer
+  11            DeferredSeek     2   1   0                 0
+  12            Column           2   0  13                 0  r[13]=idx_orders_customer.customer_id
+  13            Column           1   3  14                 0  r[14]=orders.total_amount
+  14            RealAffinity    14   0   0                 0
+  15            Compare          9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
+  16            Jump            17  21  17                 0  ; start new group if comparison is not equal
+  17            Gosub            6  30   0                 0  ; check if ended group had data, and output if so
+  18            Move            13   9   1                 0  r[9..9]=r[13..13]
+  19            IfPos            8  40   0                 0  r[8]>0 -> r[8]-=0, goto 40; check abort flag
+  20            Gosub           15  37   0                 0  ; goto clear accumulator subroutine
+  21            AggStep          0  14  11  sum            0  accum=r[11] step(r[14])
+  22            If               7  24   0                 0  if r[7] goto 24; don't emit group columns if continuing existing group
+  23            Column           2   0  10                 0  r[10]=idx_orders_customer.customer_id
+  24            Integer          1   7   0                 0  r[7]=1; indicate data in accumulator
+  25          Next               2  11   0                 0
+  26          Gosub              6  30   0                 0  ; emit row for final group
+  27          Goto               0  40   0                 0  ; group by finished
+  28          Integer            1   8   0                 0  r[8]=1
+  29        Return               6   0   0                 0
+  30        IfPos                7  32   0                 0  r[7]>0 -> r[7]-=0, goto 32; output group by row subroutine start
+  31      Return                 6   0   0                 0
+  32      AggFinal               0  11   0  sum            0  accum=r[11]
+  33      Copy                  10   4   0                 0  r[4]=r[10]
+  34      Copy                  11   5   0                 0  r[5]=r[11]
+  35      Yield                  3   0   0                 0
+  36    Return                   6   0   0                 0
+  37    Null                     0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
+  38    Integer                  0   7   0                 0  r[7]=0
+  39  Return                    15   0   0                 0
+  40  EndCoroutine               3   0   0                 0
+  41  OpenRead                   3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  42  InitCoroutine              3   0   4                 0
+  43    Yield                    3  54   0                 0
+  44    Copy                     4  18   0                 0  r[18]=r[4]
+  45    SeekRowid                3  18  53                 0  if (r[18]!=cursor 3 for table customers.rowid) goto 53
+  46    Column                   3   1  16                 0  r[16]=customers.name
+  47    Copy                     5  17   0                 0  r[17]=r[5]
+  48    Copy                    17  20   0                 0  r[20]=r[17]
+  49    Copy                    16  21   0                 0  r[21]=r[16]
+  50    Sequence                 0  22   0                 0
+  51    MakeRecord              20   3  19                 0  r[19]=mkrec(r[20..22]); for ephemeral_subquery_t4
+  52    IdxInsert                0  19   0                 8  key=r[19]
+  53  Goto                       0  43   0                 0
+  54  Last                       0  63   0                 0
+  55  Integer                 1000  25   0                 0  r[25]=1000
+  56    IdxLE                    0  63  25                 0  key=[25..25]
+  57    Column                   0   1   1                 0  r[1]=ephemeral(ephemeral_subquery_t4).name
+  58    Column                   0   0   2                 0  r[2]=ephemeral(ephemeral_subquery_t4).total_spent
+  59    Column                   0   1  23                 0  r[23]=ephemeral(ephemeral_subquery_t4).name
+  60    Column                   0   0  24                 0  r[24]=ephemeral(ephemeral_subquery_t4).total_spent
+  61    ResultRow               23   2   0                 0  output=r[23..24]
+  62  Prev                       0  56   0                 0
+  63  Halt                       0   0   0                 0
+  64  Transaction                0   1  11                 0  iDb=0 tx_mode=Read
+  65  Goto                       0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
@@ -25,81 +25,85 @@ info:
 ---
 QUERY PLAN
 |--SCAN top_customers
-|  |--SCAN stats
-|  |  `--SCAN orders USING INDEX idx_orders_customer
-|  `--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
+|  |--SCAN customers AS c
+|  `--SEARCH stats USING INDEX ephemeral_subquery_t3 (customer_id=?)
+|     `--SCAN orders USING INDEX idx_orders_customer
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4            p5  comment
-   0          Init               0  68   0                 0  Start at 68
-   1          InitCoroutine      1  50   2                 0
-   2          InitCoroutine      2  40   3                 0
-   3          Null               0  10   0                 0  r[10]=NULL
-   4          Integer            0   7   0                 0  r[7]=0; clear group by abort flag
-   5          Null               0   8   0                 0  r[8]=NULL; initialize group by comparison registers to NULL
-   6          Gosub             14  36   0                 0  ; go to clear accumulator subroutine
-   7          OpenRead           0   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
-   8          OpenRead           1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-   9          Rewind             1  25   0                 0  Rewind index idx_orders_customer
-  10            DeferredSeek     1   0   0                 0
-  11            Column           1   0  12                 0  r[12]=idx_orders_customer.customer_id
-  12            Column           0   3  13                 0  r[13]=orders.total_amount
-  13            RealAffinity    13   0   0                 0
-  14            Compare          8  12   1  k(1, Binary)   0  r[8..8]==r[12..12]
-  15            Jump            16  20  16                 0  ; start new group if comparison is not equal
-  16            Gosub            5  29   0                 0  ; check if ended group had data, and output if so
-  17            Move            12   8   1                 0  r[8..8]=r[12..12]
-  18            IfPos            7  39   0                 0  r[7]>0 -> r[7]-=0, goto 39; check abort flag
-  19            Gosub           14  36   0                 0  ; goto clear accumulator subroutine
-  20            AggStep          0  13  10  sum            0  accum=r[10] step(r[13])
-  21            If               6  23   0                 0  if r[6] goto 23; don't emit group columns if continuing existing group
-  22            Column           1   0   9                 0  r[9]=idx_orders_customer.customer_id
-  23            Integer          1   6   0                 0  r[6]=1; indicate data in accumulator
-  24          Next               1  10   0                 0
-  25          Gosub              5  29   0                 0  ; emit row for final group
-  26          Goto               0  39   0                 0  ; group by finished
-  27          Integer            1   7   0                 0  r[7]=1
-  28        Return               5   0   0                 0
-  29        IfPos                6  31   0                 0  r[6]>0 -> r[6]-=0, goto 31; output group by row subroutine start
-  30      Return                 5   0   0                 0
-  31      AggFinal               0  10   0  sum            0  accum=r[10]
-  32      Copy                   9   3   0                 0  r[3]=r[9]
-  33      Copy                  10   4   0                 0  r[4]=r[10]
-  34      Yield                  2   0   0                 0
-  35    Return                   5   0   0                 0
-  36    Null                     0   9  10                 0  r[9..10]=NULL; clear accumulator subroutine start
-  37    Integer                  0   6   0                 0  r[6]=0
-  38  Return                    14   0   0                 0
-  39  EndCoroutine               2   0   0                 0
-  40  OpenRead                   2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  41  InitCoroutine              2   0   3                 0
-  42    Yield                    2  49   0                 0
-  43    Copy                     3  17   0                 0  r[17]=r[3]
-  44    SeekRowid                2  17  48                 0  if (r[17]!=cursor 2 for table customers.rowid) goto 48
-  45    Column                   2   1  15                 0  r[15]=customers.name
-  46    Copy                     4  16   0                 0  r[16]=r[4]
-  47    Yield                    1   0   0                 0
-  48  Goto                       0  42   0                 0
-  49  EndCoroutine               1   0   0                 0
-  50  SorterOpen                 3   1   0  k(1,-B)        0  cursor=3
-  51  InitCoroutine              1   0   2                 0
-  52    Yield                    1  60   0                 0
-  53    Copy                    16  22   0                 0  r[22]=r[16]
-  54    Le                      22  23  59  Binary         0  if r[22]<=r[23] goto 59
-  55    Copy                    16  24   0                 0  r[24]=r[16]
-  56    Copy                    15  25   0                 0  r[25]=r[15]
-  57    MakeRecord              24   2  20                 0  r[20]=mkrec(r[24..25])
-  58    SorterInsert             3  20   0  0              0  key=r[20]
-  59  Goto                       0  52   0                 0
-  60  OpenPseudo                 4  20   2                 0  2 columns in r[20]
-  61  SorterSort                 3  67   0                 0
-  62    SorterData               3  20   4                 0  r[20]=data
-  63    Column                   4   1  18                 0  r[18]=pseudo.column 1
-  64    Column                   4   0  19                 0  r[19]=pseudo.column 0
-  65    ResultRow               18   2   0                 0  output=r[18..19]
-  66  SorterNext                 3  62   0                 0
-  67  Halt                       0   0   0                 0
-  68  Transaction                0   1  11                 0  iDb=0 tx_mode=Read
-  69  Integer                 1000  23   0                 0  r[23]=1000
-  70  Goto                       0   1   0                 0
+   0          Init               0  72   0                 0  Start at 72
+   1          InitCoroutine      1  54   2                 0
+   2          Once              43   0   0                 0  goto 43
+   3          OpenEphemeral      0   0   0                 0  cursor=0 is_table=false
+   4          Null               0   9   0                 0  r[9]=NULL
+   5          Integer            0   6   0                 0  r[6]=0; clear group by abort flag
+   6          Null               0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
+   7          Gosub             13  40   0                 0  ; go to clear accumulator subroutine
+   8          OpenRead           1   4   0  k(4,B,B,B,B)   0  table=orders, root=4, iDb=0
+   9          OpenRead           2   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+  10          Rewind             2  26   0                 0  Rewind index idx_orders_customer
+  11            DeferredSeek     2   1   0                 0
+  12            Column           2   0  11                 0  r[11]=idx_orders_customer.customer_id
+  13            Column           1   3  12                 0  r[12]=orders.total_amount
+  14            RealAffinity    12   0   0                 0
+  15            Compare          7  11   1  k(1, Binary)   0  r[7..7]==r[11..11]
+  16            Jump            17  21  17                 0  ; start new group if comparison is not equal
+  17            Gosub            4  30   0                 0  ; check if ended group had data, and output if so
+  18            Move            11   7   1                 0  r[7..7]=r[11..11]
+  19            IfPos            6  43   0                 0  r[6]>0 -> r[6]-=0, goto 43; check abort flag
+  20            Gosub           13  40   0                 0  ; goto clear accumulator subroutine
+  21            AggStep          0  12   9  sum            0  accum=r[9] step(r[12])
+  22            If               5  24   0                 0  if r[5] goto 24; don't emit group columns if continuing existing group
+  23            Column           2   0   8                 0  r[8]=idx_orders_customer.customer_id
+  24            Integer          1   5   0                 0  r[5]=1; indicate data in accumulator
+  25          Next               2  11   0                 0
+  26          Gosub              4  30   0                 0  ; emit row for final group
+  27          Goto               0  43   0                 0  ; group by finished
+  28          Integer            1   6   0                 0  r[6]=1
+  29        Return               4   0   0                 0
+  30        IfPos                5  32   0                 0  r[5]>0 -> r[5]-=0, goto 32; output group by row subroutine start
+  31      Return                 4   0   0                 0
+  32      AggFinal               0   9   0  sum            0  accum=r[9]
+  33      Copy                   8   2   0                 0  r[2]=r[8]
+  34      Copy                   9   3   0                 0  r[3]=r[9]
+  35      Copy                   2  15   1                 0  r[15]=r[2]
+  36      Sequence               0  17   0                 0
+  37      MakeRecord            15   3  14                 0  r[14]=mkrec(r[15..17]); for ephemeral_subquery_t3
+  38      IdxInsert              0  14   0                 8  key=r[14]
+  39    Return                   4   0   0                 0
+  40    Null                     0   8   9                 0  r[8..9]=NULL; clear accumulator subroutine start
+  41    Integer                  0   5   0                 0  r[5]=0
+  42  Return                    13   0   0                 0
+  43  OpenRead                   3   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  44  Rewind                     3  53   0                 0  Rewind table customers
+  45    RowId                    3  20   0                 0  r[20]=customers.rowid
+  46    SeekGE                   0  52  20                 0  key=[20..20]
+  47      IdxGT                  0  52  20                 0  key=[20..20]
+  48      Column                 3   1  18                 0  r[18]=customers.name
+  49      Column                 0   1  19                 0  r[19]=ephemeral(ephemeral_subquery_t3).total_spent
+  50      Yield                  1   0   0                 0
+  51    Next                     0  47   0                 0
+  52  Next                       3  45   0                 0
+  53  EndCoroutine               1   0   0                 0
+  54  SorterOpen                 4   1   0  k(1,-B)        0  cursor=4
+  55  InitCoroutine              1   0   2                 0
+  56    Yield                    1  64   0                 0
+  57    Copy                    19  25   0                 0  r[25]=r[19]
+  58    Le                      25  26  63  Binary         0  if r[25]<=r[26] goto 63
+  59    Copy                    19  27   0                 0  r[27]=r[19]
+  60    Copy                    18  28   0                 0  r[28]=r[18]
+  61    MakeRecord              27   2  23                 0  r[23]=mkrec(r[27..28])
+  62    SorterInsert             4  23   0  0              0  key=r[23]
+  63  Goto                       0  56   0                 0
+  64  OpenPseudo                 5  23   2                 0  2 columns in r[23]
+  65  SorterSort                 4  71   0                 0
+  66    SorterData               4  23   5                 0  r[23]=data
+  67    Column                   5   1  21                 0  r[21]=pseudo.column 1
+  68    Column                   5   0  22                 0  r[22]=pseudo.column 0
+  69    ResultRow               21   2   0                 0  output=r[21..22]
+  70  SorterNext                 4  66   0                 0
+  71  Halt                       0   0   0                 0
+  72  Transaction                0   1  11                 0  iDb=0 tx_mode=Read
+  73  Integer                 1000  26   0                 0  r[26]=1000
+  74  Goto                       0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
@@ -19,68 +19,104 @@ info:
 ---
 QUERY PLAN
 |--SCAN grouped_values AS gv USING INDEX idx_grouped_values_grp
-`--CORRELATED SCALAR SUBQUERY 1
-   `--SEARCH gv2 USING INDEX idx_grouped_values_grp (grp=?)
+`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
+   `--SCAN grouped_values AS gv2 USING INDEX idx_grouped_values_grp
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4            p5  comment
-   0            Init             0  58   0                 0  Start at 58
-   1            Null             0   9   0                 0  r[9]=NULL
-   2            Integer          0   6   0                 0  r[6]=0; clear group by abort flag
-   3            Null             0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
-   4            Gosub           13  54   0                 0  ; go to clear accumulator subroutine
-   5            OpenRead         0   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
-   6            OpenRead         1   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
-   7            Rewind           1  22   0                 0  Rewind index idx_grouped_values_grp
-   8              DeferredSeek   1   0   0                 0
-   9              Column         1   0  11                 0  r[11]=idx_grouped_values_grp.grp
-  10              Column         0   1  12                 0  r[12]=grouped_values.val
-  11              Compare        7  11   1  k(1, Binary)   0  r[7..7]==r[11..11]
-  12              Jump          13  17  13                 0  ; start new group if comparison is not equal
-  13              Gosub          4  26   0                 0  ; check if ended group had data, and output if so
-  14              Move          11   7   1                 0  r[7..7]=r[11..11]
-  15              IfPos          6  57   0                 0  r[6]>0 -> r[6]-=0, goto 57; check abort flag
-  16              Gosub         13  54   0                 0  ; goto clear accumulator subroutine
-  17              AggStep        0  12   9  sum            0  accum=r[9] step(r[12])
-  18              If             5  20   0                 0  if r[5] goto 20; don't emit group columns if continuing existing group
-  19              Column         1   0   8                 0  r[8]=idx_grouped_values_grp.grp
-  20              Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
-  21            Next             1   8   0                 0
-  22            Gosub            4  26   0                 0  ; emit row for final group
-  23            Goto             0  57   0                 0  ; group by finished
-  24            Integer          1   6   0                 0  r[6]=1
-  25          Return             4   0   0                 0
-  26          IfPos              5  28   0                 0  r[5]>0 -> r[5]-=0, goto 28; output group by row subroutine start
-  27        Return               4   0   0                 0
-  28        AggFinal             0   9   0  sum            0  accum=r[9]
-  29        BeginSubrtn         14   0   0                 0  r[14]=NULL
-  30        Null                 0   1   0                 0  r[1]=NULL
-  31        Null                 0  16   0                 0  r[16]=NULL
-  32        Integer              1  17   0                 0  r[17]=1; LIMIT counter
-  33        IfNot               17  44   0                 0  if !r[17] goto 44
-  34        OpenRead             2   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
-  35        OpenRead             3   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
-  36        Copy                 8  18   0                 0  r[18]=r[8]
-  37        IsNull              18  44   0                 0  if (r[18]==NULL) goto 44
-  38        SeekGE               3  44  18                 0  key=[18..18]
-  39          IdxGT              3  44  18                 0  key=[18..18]
-  40          DeferredSeek       3   2   0                 0
-  41          Column             2   1  19                 0  r[19]=grouped_values.val
-  42          AggStep            0  19  16  max(Binary)    0  accum=r[16] step(r[19])
-  43        Next                 3  39   0                 0
-  44        AggFinal             0  16   0  max            0  accum=r[16]
-  45        Copy                16  15   0                 0  r[15]=r[16]
-  46        Copy                15   1   0                 0  r[1]=r[15]
-  47      Return                14   0   1                 0
-  48      Copy                   1  20   0                 0  r[20]=r[1]
-  49      IsNull                20  27   0                 0  if (r[20]==NULL) goto 27
-  50      Copy                   8   2   0                 0  r[2]=r[8]
-  51      Copy                   9   3   0                 0  r[3]=r[9]
-  52      ResultRow              2   2   0                 0  output=r[2..3]
-  53    Return                   4   0   0                 0
-  54    Null                     0   8   9                 0  r[8..9]=NULL; clear accumulator subroutine start
-  55    Integer                  0   5   0                 0  r[5]=0
-  56  Return                    13   0   0                 0
-  57  Halt                       0   0   0                 0
-  58  Transaction                0   1   2                 0  iDb=0 tx_mode=Read
-  59  Goto                       0   1   0                 0
+addr  opcode                          p1  p2  p3  p4            p5  comment
+   0                  Init             0  94   0                 0  Start at 94
+   1                  OpenEphemeral    0   0   0                 0  cursor=0 is_table=false
+   2                  Null             0  11   0                 0  r[11]=NULL
+   3                  Integer          0   8   0                 0  r[8]=0; clear group by abort flag
+   4                  Null             0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
+   5                  Gosub           15  38   0                 0  ; go to clear accumulator subroutine
+   6                  OpenRead         1   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+   7                  OpenRead         2   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+   8                  Rewind           2  23   0                 0  Rewind index idx_grouped_values_grp
+   9                    DeferredSeek   2   1   0                 0
+  10                    Column         2   0  13                 0  r[13]=idx_grouped_values_grp.grp
+  11                    Column         1   1  14                 0  r[14]=grouped_values.val
+  12                    Compare        9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
+  13                    Jump          14  18  14                 0  ; start new group if comparison is not equal
+  14                    Gosub          6  27   0                 0  ; check if ended group had data, and output if so
+  15                    Move          13   9   1                 0  r[9..9]=r[13..13]
+  16                    IfPos          8  41   0                 0  r[8]>0 -> r[8]-=0, goto 41; check abort flag
+  17                    Gosub         15  38   0                 0  ; goto clear accumulator subroutine
+  18                    AggStep        0  14  11  max(Binary)    0  accum=r[11] step(r[14])
+  19                    If             7  21   0                 0  if r[7] goto 21; don't emit group columns if continuing existing group
+  20                    Column         2   0  10                 0  r[10]=idx_grouped_values_grp.grp
+  21                    Integer        1   7   0                 0  r[7]=1; indicate data in accumulator
+  22                  Next             2   9   0                 0
+  23                  Gosub            6  27   0                 0  ; emit row for final group
+  24                  Goto             0  41   0                 0  ; group by finished
+  25                  Integer          1   8   0                 0  r[8]=1
+  26                Return             6   0   0                 0
+  27                IfPos              7  29   0                 0  r[7]>0 -> r[7]-=0, goto 29; output group by row subroutine start
+  28              Return               6   0   0                 0
+  29              AggFinal             0  11   0  max            0  accum=r[11]
+  30              Copy                11   4   0                 0  r[4]=r[11]
+  31              Copy                10   5   0                 0  r[5]=r[10]
+  32              Copy                 5  17   0                 0  r[17]=r[5]
+  33              Copy                 4  18   0                 0  r[18]=r[4]
+  34              Sequence             0  19   0                 0
+  35              MakeRecord          17   3  16                 0  r[16]=mkrec(r[17..19]); for ephemeral_subquery_t2
+  36              IdxInsert            0  16   0                 8  key=r[16]
+  37            Return                 6   0   0                 0
+  38            Null                   0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
+  39            Integer                0   7   0                 0  r[7]=0
+  40          Return                  15   0   0                 0
+  41          Null                     0  28   0                 0  r[28]=NULL
+  42          Integer                  0  24   0                 0  r[24]=0; clear group by abort flag
+  43          Null                     0  25   0                 0  r[25]=NULL; initialize group by comparison registers to NULL
+  44          Gosub                   33  90   0                 0  ; go to clear accumulator subroutine
+  45          OpenRead                 3   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+  46          OpenRead                 4   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+  47          Rewind                   4  77   0                 0  Rewind index idx_grouped_values_grp
+  48            DeferredSeek           4   3   0                 0
+  49            Integer                0  34   0                 0  r[34]=0
+  50            Column                 4   0  35                 0  r[35]=idx_grouped_values_grp.grp
+  51            IsNull                35  72   0                 0  if (r[35]==NULL) goto 72
+  52            SeekGE                 0  72  35                 0  key=[35..35]
+  53              IdxGT                0  72  35                 0  key=[35..35]
+  54              Column               0   1   2                 0  r[2]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
+  55              Column               0   0   3                 0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
+  56              Integer              1  34   0                 0  r[34]=1
+  57              Column               4   0  30                 0  r[30]=idx_grouped_values_grp.grp
+  58              Column               0   1  31                 0  r[31]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
+  59              Column               3   1  32                 0  r[32]=grouped_values.val
+  60              Compare             25  30   1  k(1, Binary)   0  r[25..25]==r[30..30]
+  61              Jump                62  66  62                 0  ; start new group if comparison is not equal
+  62              Gosub               22  81   0                 0  ; check if ended group had data, and output if so
+  63              Move                30  25   1                 0  r[25..25]=r[30..30]
+  64              IfPos               24  93   0                 0  r[24]>0 -> r[24]-=0, goto 93; check abort flag
+  65              Gosub               33  90   0                 0  ; goto clear accumulator subroutine
+  66              AggStep              0  32  28  sum            0  accum=r[28] step(r[32])
+  67              If                  23  70   0                 0  if r[23] goto 70; don't emit group columns if continuing existing group
+  68              Column               4   0  26                 0  r[26]=idx_grouped_values_grp.grp
+  69              Column               0   1  27                 0  r[27]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
+  70              Integer              1  23   0                 0  r[23]=1; indicate data in accumulator
+  71            Next                   0  53   0                 0
+  72            IfPos                 34  76   0                 0  r[34]>0 -> r[34]-=0, goto 76
+  73            NullRow                0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  74            Null                   0   2   3                 0  r[2..3]=NULL
+  75            Goto                   0  56   0                 0
+  76          Next                     4  48   0                 0
+  77          Gosub                   22  81   0                 0  ; emit row for final group
+  78          Goto                     0  93   0                 0  ; group by finished
+  79          Integer                  1  24   0                 0  r[24]=1
+  80        Return                    22   0   0                 0
+  81        IfPos                     23  83   0                 0  r[23]>0 -> r[23]-=0, goto 83; output group by row subroutine start
+  82      Return                      22   0   0                 0
+  83      AggFinal                     0  28   0  sum            0  accum=r[28]
+  84      Copy                        27  36   0                 0  r[36]=r[27]
+  85      IsNull                      36  82   0                 0  if (r[36]==NULL) goto 82
+  86      Copy                        26  20   0                 0  r[20]=r[26]
+  87      Copy                        28  21   0                 0  r[21]=r[28]
+  88      ResultRow                   20   2   0                 0  output=r[20..21]
+  89    Return                        22   0   0                 0
+  90    Null                           0  26  28                 0  r[26..28]=NULL; clear accumulator subroutine start
+  91    Integer                        0  23   0                 0  r[23]=0
+  92  Return                          33   0   0                 0
+  93  Halt                             0   0   0                 0
+  94  Transaction                      0   1   2                 0  iDb=0 tx_mode=Read
+  95  Goto                             0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
@@ -19,104 +19,68 @@ info:
 ---
 QUERY PLAN
 |--SCAN grouped_values AS gv USING INDEX idx_grouped_values_grp
-`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
-   `--SCAN grouped_values AS gv2 USING INDEX idx_grouped_values_grp
+`--CORRELATED SCALAR SUBQUERY 1
+   `--SEARCH gv2 USING INDEX idx_grouped_values_grp (grp=?)
 
 BYTECODE
-addr  opcode                          p1  p2  p3  p4            p5  comment
-   0                  Init             0  94   0                 0  Start at 94
-   1                  OpenEphemeral    0   0   0                 0  cursor=0 is_table=false
-   2                  Null             0  11   0                 0  r[11]=NULL
-   3                  Integer          0   8   0                 0  r[8]=0; clear group by abort flag
-   4                  Null             0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
-   5                  Gosub           15  38   0                 0  ; go to clear accumulator subroutine
-   6                  OpenRead         1   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
-   7                  OpenRead         2   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
-   8                  Rewind           2  23   0                 0  Rewind index idx_grouped_values_grp
-   9                    DeferredSeek   2   1   0                 0
-  10                    Column         2   0  13                 0  r[13]=idx_grouped_values_grp.grp
-  11                    Column         1   1  14                 0  r[14]=grouped_values.val
-  12                    Compare        9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
-  13                    Jump          14  18  14                 0  ; start new group if comparison is not equal
-  14                    Gosub          6  27   0                 0  ; check if ended group had data, and output if so
-  15                    Move          13   9   1                 0  r[9..9]=r[13..13]
-  16                    IfPos          8  41   0                 0  r[8]>0 -> r[8]-=0, goto 41; check abort flag
-  17                    Gosub         15  38   0                 0  ; goto clear accumulator subroutine
-  18                    AggStep        0  14  11  max(Binary)    0  accum=r[11] step(r[14])
-  19                    If             7  21   0                 0  if r[7] goto 21; don't emit group columns if continuing existing group
-  20                    Column         2   0  10                 0  r[10]=idx_grouped_values_grp.grp
-  21                    Integer        1   7   0                 0  r[7]=1; indicate data in accumulator
-  22                  Next             2   9   0                 0
-  23                  Gosub            6  27   0                 0  ; emit row for final group
-  24                  Goto             0  41   0                 0  ; group by finished
-  25                  Integer          1   8   0                 0  r[8]=1
-  26                Return             6   0   0                 0
-  27                IfPos              7  29   0                 0  r[7]>0 -> r[7]-=0, goto 29; output group by row subroutine start
-  28              Return               6   0   0                 0
-  29              AggFinal             0  11   0  max            0  accum=r[11]
-  30              Copy                11   4   0                 0  r[4]=r[11]
-  31              Copy                10   5   0                 0  r[5]=r[10]
-  32              Copy                 5  17   0                 0  r[17]=r[5]
-  33              Copy                 4  18   0                 0  r[18]=r[4]
-  34              Sequence             0  19   0                 0
-  35              MakeRecord          17   3  16                 0  r[16]=mkrec(r[17..19]); for ephemeral_subquery_t2
-  36              IdxInsert            0  16   0                 8  key=r[16]
-  37            Return                 6   0   0                 0
-  38            Null                   0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
-  39            Integer                0   7   0                 0  r[7]=0
-  40          Return                  15   0   0                 0
-  41          Null                     0  28   0                 0  r[28]=NULL
-  42          Integer                  0  24   0                 0  r[24]=0; clear group by abort flag
-  43          Null                     0  25   0                 0  r[25]=NULL; initialize group by comparison registers to NULL
-  44          Gosub                   33  90   0                 0  ; go to clear accumulator subroutine
-  45          OpenRead                 3   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
-  46          OpenRead                 4   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
-  47          Rewind                   4  77   0                 0  Rewind index idx_grouped_values_grp
-  48            DeferredSeek           4   3   0                 0
-  49            Integer                0  34   0                 0  r[34]=0
-  50            Column                 4   0  35                 0  r[35]=idx_grouped_values_grp.grp
-  51            IsNull                35  72   0                 0  if (r[35]==NULL) goto 72
-  52            SeekGE                 0  72  35                 0  key=[35..35]
-  53              IdxGT                0  72  35                 0  key=[35..35]
-  54              Column               0   1   2                 0  r[2]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
-  55              Column               0   0   3                 0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
-  56              Integer              1  34   0                 0  r[34]=1
-  57              Column               4   0  30                 0  r[30]=idx_grouped_values_grp.grp
-  58              Column               0   1  31                 0  r[31]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
-  59              Column               3   1  32                 0  r[32]=grouped_values.val
-  60              Compare             25  30   1  k(1, Binary)   0  r[25..25]==r[30..30]
-  61              Jump                62  66  62                 0  ; start new group if comparison is not equal
-  62              Gosub               22  81   0                 0  ; check if ended group had data, and output if so
-  63              Move                30  25   1                 0  r[25..25]=r[30..30]
-  64              IfPos               24  93   0                 0  r[24]>0 -> r[24]-=0, goto 93; check abort flag
-  65              Gosub               33  90   0                 0  ; goto clear accumulator subroutine
-  66              AggStep              0  32  28  sum            0  accum=r[28] step(r[32])
-  67              If                  23  70   0                 0  if r[23] goto 70; don't emit group columns if continuing existing group
-  68              Column               4   0  26                 0  r[26]=idx_grouped_values_grp.grp
-  69              Column               0   1  27                 0  r[27]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
-  70              Integer              1  23   0                 0  r[23]=1; indicate data in accumulator
-  71            Next                   0  53   0                 0
-  72            IfPos                 34  76   0                 0  r[34]>0 -> r[34]-=0, goto 76
-  73            NullRow                0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
-  74            Null                   0   2   3                 0  r[2..3]=NULL
-  75            Goto                   0  56   0                 0
-  76          Next                     4  48   0                 0
-  77          Gosub                   22  81   0                 0  ; emit row for final group
-  78          Goto                     0  93   0                 0  ; group by finished
-  79          Integer                  1  24   0                 0  r[24]=1
-  80        Return                    22   0   0                 0
-  81        IfPos                     23  83   0                 0  r[23]>0 -> r[23]-=0, goto 83; output group by row subroutine start
-  82      Return                      22   0   0                 0
-  83      AggFinal                     0  28   0  sum            0  accum=r[28]
-  84      Copy                        27  36   0                 0  r[36]=r[27]
-  85      IsNull                      36  82   0                 0  if (r[36]==NULL) goto 82
-  86      Copy                        26  20   0                 0  r[20]=r[26]
-  87      Copy                        28  21   0                 0  r[21]=r[28]
-  88      ResultRow                   20   2   0                 0  output=r[20..21]
-  89    Return                        22   0   0                 0
-  90    Null                           0  26  28                 0  r[26..28]=NULL; clear accumulator subroutine start
-  91    Integer                        0  23   0                 0  r[23]=0
-  92  Return                          33   0   0                 0
-  93  Halt                             0   0   0                 0
-  94  Transaction                      0   1   2                 0  iDb=0 tx_mode=Read
-  95  Goto                             0   1   0                 0
+addr  opcode                    p1  p2  p3  p4            p5  comment
+   0            Init             0  58   0                 0  Start at 58
+   1            Null             0   9   0                 0  r[9]=NULL
+   2            Integer          0   6   0                 0  r[6]=0; clear group by abort flag
+   3            Null             0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
+   4            Gosub           13  54   0                 0  ; go to clear accumulator subroutine
+   5            OpenRead         0   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+   6            OpenRead         1   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+   7            Rewind           1  22   0                 0  Rewind index idx_grouped_values_grp
+   8              DeferredSeek   1   0   0                 0
+   9              Column         1   0  11                 0  r[11]=idx_grouped_values_grp.grp
+  10              Column         0   1  12                 0  r[12]=grouped_values.val
+  11              Compare        7  11   1  k(1, Binary)   0  r[7..7]==r[11..11]
+  12              Jump          13  17  13                 0  ; start new group if comparison is not equal
+  13              Gosub          4  26   0                 0  ; check if ended group had data, and output if so
+  14              Move          11   7   1                 0  r[7..7]=r[11..11]
+  15              IfPos          6  57   0                 0  r[6]>0 -> r[6]-=0, goto 57; check abort flag
+  16              Gosub         13  54   0                 0  ; goto clear accumulator subroutine
+  17              AggStep        0  12   9  sum            0  accum=r[9] step(r[12])
+  18              If             5  20   0                 0  if r[5] goto 20; don't emit group columns if continuing existing group
+  19              Column         1   0   8                 0  r[8]=idx_grouped_values_grp.grp
+  20              Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
+  21            Next             1   8   0                 0
+  22            Gosub            4  26   0                 0  ; emit row for final group
+  23            Goto             0  57   0                 0  ; group by finished
+  24            Integer          1   6   0                 0  r[6]=1
+  25          Return             4   0   0                 0
+  26          IfPos              5  28   0                 0  r[5]>0 -> r[5]-=0, goto 28; output group by row subroutine start
+  27        Return               4   0   0                 0
+  28        AggFinal             0   9   0  sum            0  accum=r[9]
+  29        BeginSubrtn         14   0   0                 0  r[14]=NULL
+  30        Null                 0   1   0                 0  r[1]=NULL
+  31        Null                 0  16   0                 0  r[16]=NULL
+  32        Integer              1  17   0                 0  r[17]=1; LIMIT counter
+  33        IfNot               17  44   0                 0  if !r[17] goto 44
+  34        OpenRead             2   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+  35        OpenRead             3   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+  36        Copy                 8  18   0                 0  r[18]=r[8]
+  37        IsNull              18  44   0                 0  if (r[18]==NULL) goto 44
+  38        SeekGE               3  44  18                 0  key=[18..18]
+  39          IdxGT              3  44  18                 0  key=[18..18]
+  40          DeferredSeek       3   2   0                 0
+  41          Column             2   1  19                 0  r[19]=grouped_values.val
+  42          AggStep            0  19  16  max(Binary)    0  accum=r[16] step(r[19])
+  43        Next                 3  39   0                 0
+  44        AggFinal             0  16   0  max            0  accum=r[16]
+  45        Copy                16  15   0                 0  r[15]=r[16]
+  46        Copy                15   1   0                 0  r[1]=r[15]
+  47      Return                14   0   1                 0
+  48      Copy                   1  20   0                 0  r[20]=r[1]
+  49      IsNull                20  27   0                 0  if (r[20]==NULL) goto 27
+  50      Copy                   8   2   0                 0  r[2]=r[8]
+  51      Copy                   9   3   0                 0  r[3]=r[9]
+  52      ResultRow              2   2   0                 0  output=r[2..3]
+  53    Return                   4   0   0                 0
+  54    Null                     0   8   9                 0  r[8..9]=NULL; clear accumulator subroutine start
+  55    Integer                  0   5   0                 0  r[5]=0
+  56  Return                    13   0   0                 0
+  57  Halt                       0   0   0                 0
+  58  Transaction                0   1   2                 0  iDb=0 tx_mode=Read
+  59  Goto                       0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
@@ -19,68 +19,102 @@ info:
 ---
 QUERY PLAN
 |--SCAN grouped_values AS gv USING INDEX idx_grouped_values_grp
-`--CORRELATED SCALAR SUBQUERY 1
-   `--SEARCH gv2 USING INDEX idx_grouped_values_grp (grp=?)
+`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
+   `--SCAN grouped_values AS gv2 USING INDEX idx_grouped_values_grp
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4            p5  comment
-   0            Init             0  58   0                 0  Start at 58
-   1            Null             0   9   0                 0  r[9]=NULL
-   2            Integer          0   6   0                 0  r[6]=0; clear group by abort flag
-   3            Null             0   7   0                 0  r[7]=NULL; initialize group by comparison registers to NULL
-   4            Gosub           13  54   0                 0  ; go to clear accumulator subroutine
-   5            OpenRead         0   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
-   6            OpenRead         1   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
-   7            Rewind           1  22   0                 0  Rewind index idx_grouped_values_grp
-   8              DeferredSeek   1   0   0                 0
-   9              Column         1   0  11                 0  r[11]=idx_grouped_values_grp.grp
-  10              Column         0   1  12                 0  r[12]=grouped_values.val
-  11              Compare        7  11   1  k(1, Binary)   0  r[7..7]==r[11..11]
-  12              Jump          13  17  13                 0  ; start new group if comparison is not equal
-  13              Gosub          4  26   0                 0  ; check if ended group had data, and output if so
-  14              Move          11   7   1                 0  r[7..7]=r[11..11]
-  15              IfPos          6  57   0                 0  r[6]>0 -> r[6]-=0, goto 57; check abort flag
-  16              Gosub         13  54   0                 0  ; goto clear accumulator subroutine
-  17              AggStep        0  12   9  sum            0  accum=r[9] step(r[12])
-  18              If             5  20   0                 0  if r[5] goto 20; don't emit group columns if continuing existing group
-  19              Column         1   0   8                 0  r[8]=idx_grouped_values_grp.grp
-  20              Integer        1   5   0                 0  r[5]=1; indicate data in accumulator
-  21            Next             1   8   0                 0
-  22            Gosub            4  26   0                 0  ; emit row for final group
-  23            Goto             0  57   0                 0  ; group by finished
-  24            Integer          1   6   0                 0  r[6]=1
-  25          Return             4   0   0                 0
-  26          IfPos              5  28   0                 0  r[5]>0 -> r[5]-=0, goto 28; output group by row subroutine start
-  27        Return               4   0   0                 0
-  28        AggFinal             0   9   0  sum            0  accum=r[9]
-  29        BeginSubrtn         14   0   0                 0  r[14]=NULL
-  30        Null                 0   1   0                 0  r[1]=NULL
-  31        Null                 0  16   0                 0  r[16]=NULL
-  32        Integer              1  17   0                 0  r[17]=1; LIMIT counter
-  33        IfNot               17  44   0                 0  if !r[17] goto 44
-  34        OpenRead             2   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
-  35        OpenRead             3   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
-  36        Copy                 8  18   0                 0  r[18]=r[8]
-  37        IsNull              18  44   0                 0  if (r[18]==NULL) goto 44
-  38        SeekGE               3  44  18                 0  key=[18..18]
-  39          IdxGT              3  44  18                 0  key=[18..18]
-  40          DeferredSeek       3   2   0                 0
-  41          Column             2   1  19                 0  r[19]=grouped_values.val
-  42          AggStep            0  19  16  max(Binary)    0  accum=r[16] step(r[19])
-  43        Next                 3  39   0                 0
-  44        AggFinal             0  16   0  max            0  accum=r[16]
-  45        Copy                16  15   0                 0  r[15]=r[16]
-  46        Copy                15   1   0                 0  r[1]=r[15]
-  47      Return                14   0   1                 0
-  48      Copy                   1  20   0                 0  r[20]=r[1]
-  49      IsNull                20  27   0                 0  if (r[20]==NULL) goto 27
-  50      Copy                   8   2   0                 0  r[2]=r[8]
-  51      Copy                   9   3   0                 0  r[3]=r[9]
-  52      ResultRow              2   2   0                 0  output=r[2..3]
-  53    Return                   4   0   0                 0
-  54    Null                     0   8   9                 0  r[8..9]=NULL; clear accumulator subroutine start
-  55    Integer                  0   5   0                 0  r[5]=0
-  56  Return                    13   0   0                 0
-  57  Halt                       0   0   0                 0
-  58  Transaction                0   1   2                 0  iDb=0 tx_mode=Read
-  59  Goto                       0   1   0                 0
+addr  opcode                          p1  p2  p3  p4            p5  comment
+   0                  Init             0  92   0                 0  Start at 92
+   1                  Once            42   0   0                 0  goto 42
+   2                  OpenEphemeral    0   0   0                 0  cursor=0 is_table=false
+   3                  Null             0   8   0                 0  r[8]=NULL
+   4                  Integer          0   5   0                 0  r[5]=0; clear group by abort flag
+   5                  Null             0   6   0                 0  r[6]=NULL; initialize group by comparison registers to NULL
+   6                  Gosub           12  39   0                 0  ; go to clear accumulator subroutine
+   7                  OpenRead         1   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+   8                  OpenRead         2   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+   9                  Rewind           2  24   0                 0  Rewind index idx_grouped_values_grp
+  10                    DeferredSeek   2   1   0                 0
+  11                    Column         2   0  10                 0  r[10]=idx_grouped_values_grp.grp
+  12                    Column         1   1  11                 0  r[11]=grouped_values.val
+  13                    Compare        6  10   1  k(1, Binary)   0  r[6..6]==r[10..10]
+  14                    Jump          15  19  15                 0  ; start new group if comparison is not equal
+  15                    Gosub          3  28   0                 0  ; check if ended group had data, and output if so
+  16                    Move          10   6   1                 0  r[6..6]=r[10..10]
+  17                    IfPos          5  42   0                 0  r[5]>0 -> r[5]-=0, goto 42; check abort flag
+  18                    Gosub         12  39   0                 0  ; goto clear accumulator subroutine
+  19                    AggStep        0  11   8  max(Binary)    0  accum=r[8] step(r[11])
+  20                    If             4  22   0                 0  if r[4] goto 22; don't emit group columns if continuing existing group
+  21                    Column         2   0   7                 0  r[7]=idx_grouped_values_grp.grp
+  22                    Integer        1   4   0                 0  r[4]=1; indicate data in accumulator
+  23                  Next             2  10   0                 0
+  24                  Gosub            3  28   0                 0  ; emit row for final group
+  25                  Goto             0  42   0                 0  ; group by finished
+  26                  Integer          1   5   0                 0  r[5]=1
+  27                Return             3   0   0                 0
+  28                IfPos              4  30   0                 0  r[4]>0 -> r[4]-=0, goto 30; output group by row subroutine start
+  29              Return               3   0   0                 0
+  30              AggFinal             0   8   0  max            0  accum=r[8]
+  31              Copy                 8   1   0                 0  r[1]=r[8]
+  32              Copy                 7   2   0                 0  r[2]=r[7]
+  33              Copy                 2  14   0                 0  r[14]=r[2]
+  34              Copy                 1  15   0                 0  r[15]=r[1]
+  35              Sequence             0  16   0                 0
+  36              MakeRecord          14   3  13                 0  r[13]=mkrec(r[14..16]); for ephemeral_subquery_t2
+  37              IdxInsert            0  13   0                 8  key=r[13]
+  38            Return                 3   0   0                 0
+  39            Null                   0   7   8                 0  r[7..8]=NULL; clear accumulator subroutine start
+  40            Integer                0   4   0                 0  r[4]=0
+  41          Return                  12   0   0                 0
+  42          Null                     0  25   0                 0  r[25]=NULL
+  43          Integer                  0  21   0                 0  r[21]=0; clear group by abort flag
+  44          Null                     0  22   0                 0  r[22]=NULL; initialize group by comparison registers to NULL
+  45          Gosub                   30  88   0                 0  ; go to clear accumulator subroutine
+  46          OpenRead                 3   2   0  k(3,B,B)       0  table=grouped_values, root=2, iDb=0
+  47          OpenRead                 4   3   0  k(2,B)         0  index=idx_grouped_values_grp, root=3, iDb=0
+  48          Rewind                   4  75   0                 0  Rewind index idx_grouped_values_grp
+  49            DeferredSeek           4   3   0                 0
+  50            Integer                0  31   0                 0  r[31]=0
+  51            Column                 4   0  32                 0  r[32]=idx_grouped_values_grp.grp
+  52            IsNull                32  71   0                 0  if (r[32]==NULL) goto 71
+  53            SeekGE                 0  71  32                 0  key=[32..32]
+  54              IdxGT                0  71  32                 0  key=[32..32]
+  55              Integer              1  31   0                 0  r[31]=1
+  56              Column               4   0  27                 0  r[27]=idx_grouped_values_grp.grp
+  57              Column               0   1  28                 0  r[28]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
+  58              Column               3   1  29                 0  r[29]=grouped_values.val
+  59              Compare             22  27   1  k(1, Binary)   0  r[22..22]==r[27..27]
+  60              Jump                61  65  61                 0  ; start new group if comparison is not equal
+  61              Gosub               19  79   0                 0  ; check if ended group had data, and output if so
+  62              Move                27  22   1                 0  r[22..22]=r[27..27]
+  63              IfPos               21  91   0                 0  r[21]>0 -> r[21]-=0, goto 91; check abort flag
+  64              Gosub               30  88   0                 0  ; goto clear accumulator subroutine
+  65              AggStep              0  29  25  sum            0  accum=r[25] step(r[29])
+  66              If                  20  69   0                 0  if r[20] goto 69; don't emit group columns if continuing existing group
+  67              Column               4   0  23                 0  r[23]=idx_grouped_values_grp.grp
+  68              Column               0   1  24                 0  r[24]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
+  69              Integer              1  20   0                 0  r[20]=1; indicate data in accumulator
+  70            Next                   0  54   0                 0
+  71            IfPos                 31  74   0                 0  r[31]>0 -> r[31]-=0, goto 74
+  72            NullRow                0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  73            Goto                   0  55   0                 0
+  74          Next                     4  49   0                 0
+  75          Gosub                   19  79   0                 0  ; emit row for final group
+  76          Goto                     0  91   0                 0  ; group by finished
+  77          Integer                  1  21   0                 0  r[21]=1
+  78        Return                    19   0   0                 0
+  79        IfPos                     20  81   0                 0  r[20]>0 -> r[20]-=0, goto 81; output group by row subroutine start
+  80      Return                      19   0   0                 0
+  81      AggFinal                     0  25   0  sum            0  accum=r[25]
+  82      Copy                        24  33   0                 0  r[33]=r[24]
+  83      IsNull                      33  80   0                 0  if (r[33]==NULL) goto 80
+  84      Copy                        23  17   0                 0  r[17]=r[23]
+  85      Copy                        25  18   0                 0  r[18]=r[25]
+  86      ResultRow                   17   2   0                 0  output=r[17..18]
+  87    Return                        19   0   0                 0
+  88    Null                           0  23  25                 0  r[23..25]=NULL; clear accumulator subroutine start
+  89    Integer                        0  20   0                 0  r[20]=0
+  90  Return                          30   0   0                 0
+  91  Halt                             0   0   0                 0
+  92  Transaction                      0   1   2                 0  iDb=0 tx_mode=Read
+  93  Goto                             0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -19,113 +19,77 @@ info:
 ---
 QUERY PLAN
 |--SCAN grouped_values AS gv USING INDEX idx_grouped_values_grp
-|--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
-|  `--SCAN grouped_values AS gv2 USING INDEX idx_grouped_values_grp
+|--CORRELATED SCALAR SUBQUERY 1
+|  `--SEARCH gv2 USING INDEX idx_grouped_values_grp (grp=?)
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                          p1   p2  p3  p4              p5  comment
-   0                  Init             0  102   0                   0  Start at 102
-   1                  OpenEphemeral    0    0   0                   0  cursor=0 is_table=false
-   2                  Null             0   11   0                   0  r[11]=NULL
-   3                  Integer          0    8   0                   0  r[8]=0; clear group by abort flag
-   4                  Null             0    9   0                   0  r[9]=NULL; initialize group by comparison registers to NULL
-   5                  Gosub           15   38   0                   0  ; go to clear accumulator subroutine
-   6                  OpenRead         1    2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-   7                  OpenRead         2    3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
-   8                  Rewind           2   23   0                   0  Rewind index idx_grouped_values_grp
-   9                    DeferredSeek   2    1   0                   0
-  10                    Column         2    0  13                   0  r[13]=idx_grouped_values_grp.grp
-  11                    Column         1    1  14                   0  r[14]=grouped_values.val
-  12                    Compare        9   13   1  k(1, Binary)     0  r[9..9]==r[13..13]
-  13                    Jump          14   18  14                   0  ; start new group if comparison is not equal
-  14                    Gosub          6   27   0                   0  ; check if ended group had data, and output if so
-  15                    Move          13    9   1                   0  r[9..9]=r[13..13]
-  16                    IfPos          8   41   0                   0  r[8]>0 -> r[8]-=0, goto 41; check abort flag
-  17                    Gosub         15   38   0                   0  ; goto clear accumulator subroutine
-  18                    AggStep        0   14  11  max(Binary)      0  accum=r[11] step(r[14])
-  19                    If             7   21   0                   0  if r[7] goto 21; don't emit group columns if continuing existing group
-  20                    Column         2    0  10                   0  r[10]=idx_grouped_values_grp.grp
-  21                    Integer        1    7   0                   0  r[7]=1; indicate data in accumulator
-  22                  Next             2    9   0                   0
-  23                  Gosub            6   27   0                   0  ; emit row for final group
-  24                  Goto             0   41   0                   0  ; group by finished
-  25                  Integer          1    8   0                   0  r[8]=1
-  26                Return             6    0   0                   0
-  27                IfPos              7   29   0                   0  r[7]>0 -> r[7]-=0, goto 29; output group by row subroutine start
-  28              Return               6    0   0                   0
-  29              AggFinal             0   11   0  max              0  accum=r[11]
-  30              Copy                11    4   0                   0  r[4]=r[11]
-  31              Copy                10    5   0                   0  r[5]=r[10]
-  32              Copy                 5   17   0                   0  r[17]=r[5]
-  33              Copy                 4   18   0                   0  r[18]=r[4]
-  34              Sequence             0   19   0                   0
-  35              MakeRecord          17    3  16                   0  r[16]=mkrec(r[17..19]); for ephemeral_subquery_t2
-  36              IdxInsert            0   16   0                   8  key=r[16]
-  37            Return                 6    0   0                   0
-  38            Null                   0   10  11                   0  r[10..11]=NULL; clear accumulator subroutine start
-  39            Integer                0    7   0                   0  r[7]=0
-  40          Return                  15    0   0                   0
-  41          SorterOpen               3    2   0  k(2,-B,Binary)   0  cursor=3
-  42          Null                     0   29   0                   0  r[29]=NULL
-  43          Integer                  0   25   0                   0  r[25]=0; clear group by abort flag
-  44          Null                     0   26   0                   0  r[26]=NULL; initialize group by comparison registers to NULL
-  45          Gosub                   34   92   0                   0  ; go to clear accumulator subroutine
-  46          OpenRead                 4    2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-  47          OpenRead                 5    3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
-  48          Rewind                   5   78   0                   0  Rewind index idx_grouped_values_grp
-  49            DeferredSeek           5    4   0                   0
-  50            Integer                0   35   0                   0  r[35]=0
-  51            Column                 5    0  36                   0  r[36]=idx_grouped_values_grp.grp
-  52            IsNull                36   73   0                   0  if (r[36]==NULL) goto 73
-  53            SeekGE                 0   73  36                   0  key=[36..36]
-  54              IdxGT                0   73  36                   0  key=[36..36]
-  55              Column               0    1   2                   0  r[2]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
-  56              Column               0    0   3                   0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
-  57              Integer              1   35   0                   0  r[35]=1
-  58              Column               5    0  31                   0  r[31]=idx_grouped_values_grp.grp
-  59              Column               0    1  32                   0  r[32]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
-  60              Column               4    1  33                   0  r[33]=grouped_values.val
-  61              Compare             26   31   1  k(1, Binary)     0  r[26..26]==r[31..31]
-  62              Jump                63   67  63                   0  ; start new group if comparison is not equal
-  63              Gosub               23   82   0                   0  ; check if ended group had data, and output if so
-  64              Move                31   26   1                   0  r[26..26]=r[31..31]
-  65              IfPos               25   95   0                   0  r[25]>0 -> r[25]-=0, goto 95; check abort flag
-  66              Gosub               34   92   0                   0  ; goto clear accumulator subroutine
-  67              AggStep              0   33  29  sum              0  accum=r[29] step(r[33])
-  68              If                  24   71   0                   0  if r[24] goto 71; don't emit group columns if continuing existing group
-  69              Column               5    0  27                   0  r[27]=idx_grouped_values_grp.grp
-  70              Column               0    1  28                   0  r[28]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
-  71              Integer              1   24   0                   0  r[24]=1; indicate data in accumulator
-  72            Next                   0   54   0                   0
-  73            IfPos                 35   77   0                   0  r[35]>0 -> r[35]-=0, goto 77
-  74            NullRow                0    0   0                   0  Set cursor 0 to a (pseudo) NULL row
-  75            Null                   0    2   3                   0  r[2..3]=NULL
-  76            Goto                   0   57   0                   0
-  77          Next                     5   49   0                   0
-  78          Gosub                   23   82   0                   0  ; emit row for final group
-  79          Goto                     0   95   0                   0  ; group by finished
-  80          Integer                  1   25   0                   0  r[25]=1
-  81        Return                    23    0   0                   0
-  82        IfPos                     24   84   0                   0  r[24]>0 -> r[24]-=0, goto 84; output group by row subroutine start
-  83      Return                      23    0   0                   0
-  84      AggFinal                     0   29   0  sum              0  accum=r[29]
-  85      Copy                        28   37   0                   0  r[37]=r[28]
-  86      Sequence                     3   38   0                   0
-  87      Copy                        27   39   0                   0  r[39]=r[27]
-  88      Copy                        29   40   0                   0  r[40]=r[29]
-  89      MakeRecord                  37    4  22                   0  r[22]=mkrec(r[37..40])
-  90      SorterInsert                 3   22   0  0                0  key=r[22]
-  91    Return                        23    0   0                   0
-  92    Null                           0   27  29                   0  r[27..29]=NULL; clear accumulator subroutine start
-  93    Integer                        0   24   0                   0  r[24]=0
-  94  Return                          34    0   0                   0
-  95  OpenPseudo                       6   22   4                   0  4 columns in r[22]
-  96  SorterSort                       3  101   0                   0
-  97    SorterData                     3   22   6                   0  r[22]=data
-  98    ColumnRange                    6    2  20  2                0  r[20..21]=pseudo.column 2..column 3
-  99    ResultRow                     20    2   0                   0  output=r[20..21]
- 100  SorterNext                       3   97   0                   0
- 101  Halt                             0    0   0                   0
- 102  Transaction                      0    1   2                   0  iDb=0 tx_mode=Read
- 103  Goto                             0    1   0                   0
+addr  opcode                    p1  p2  p3  p4              p5  comment
+   0            Init             0  66   0                   0  Start at 66
+   1            SorterOpen       0   2   0  k(2,-B,Binary)   0  cursor=0
+   2            Null             0  10   0                   0  r[10]=NULL
+   3            Integer          0   7   0                   0  r[7]=0; clear group by abort flag
+   4            Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
+   5            Gosub           14  56   0                   0  ; go to clear accumulator subroutine
+   6            OpenRead         1   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
+   7            OpenRead         2   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
+   8            Rewind           2  23   0                   0  Rewind index idx_grouped_values_grp
+   9              DeferredSeek   2   1   0                   0
+  10              Column         2   0  12                   0  r[12]=idx_grouped_values_grp.grp
+  11              Column         1   1  13                   0  r[13]=grouped_values.val
+  12              Compare        8  12   1  k(1, Binary)     0  r[8..8]==r[12..12]
+  13              Jump          14  18  14                   0  ; start new group if comparison is not equal
+  14              Gosub          5  27   0                   0  ; check if ended group had data, and output if so
+  15              Move          12   8   1                   0  r[8..8]=r[12..12]
+  16              IfPos          7  59   0                   0  r[7]>0 -> r[7]-=0, goto 59; check abort flag
+  17              Gosub         14  56   0                   0  ; goto clear accumulator subroutine
+  18              AggStep        0  13  10  sum              0  accum=r[10] step(r[13])
+  19              If             6  21   0                   0  if r[6] goto 21; don't emit group columns if continuing existing group
+  20              Column         2   0   9                   0  r[9]=idx_grouped_values_grp.grp
+  21              Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
+  22            Next             2   9   0                   0
+  23            Gosub            5  27   0                   0  ; emit row for final group
+  24            Goto             0  59   0                   0  ; group by finished
+  25            Integer          1   7   0                   0  r[7]=1
+  26          Return             5   0   0                   0
+  27          IfPos              6  29   0                   0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
+  28        Return               5   0   0                   0
+  29        AggFinal             0  10   0  sum              0  accum=r[10]
+  30        BeginSubrtn         15   0   0                   0  r[15]=NULL
+  31        Null                 0   1   0                   0  r[1]=NULL
+  32        Null                 0  17   0                   0  r[17]=NULL
+  33        Integer              1  18   0                   0  r[18]=1; LIMIT counter
+  34        IfNot               18  45   0                   0  if !r[18] goto 45
+  35        OpenRead             3   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
+  36        OpenRead             4   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
+  37        Copy                 9  19   0                   0  r[19]=r[9]
+  38        IsNull              19  45   0                   0  if (r[19]==NULL) goto 45
+  39        SeekGE               4  45  19                   0  key=[19..19]
+  40          IdxGT              4  45  19                   0  key=[19..19]
+  41          DeferredSeek       4   3   0                   0
+  42          Column             3   1  20                   0  r[20]=grouped_values.val
+  43          AggStep            0  20  17  max(Binary)      0  accum=r[17] step(r[20])
+  44        Next                 4  40   0                   0
+  45        AggFinal             0  17   0  max              0  accum=r[17]
+  46        Copy                17  16   0                   0  r[16]=r[17]
+  47        Copy                16   1   0                   0  r[1]=r[16]
+  48      Return                15   0   1                   0
+  49      Copy                   1  21   0                   0  r[21]=r[1]
+  50      Sequence               0  22   0                   0
+  51      Copy                   9  23   0                   0  r[23]=r[9]
+  52      Copy                  10  24   0                   0  r[24]=r[10]
+  53      MakeRecord            21   4   4                   0  r[4]=mkrec(r[21..24])
+  54      SorterInsert           0   4   0  0                0  key=r[4]
+  55    Return                   5   0   0                   0
+  56    Null                     0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
+  57    Integer                  0   6   0                   0  r[6]=0
+  58  Return                    14   0   0                   0
+  59  OpenPseudo                 5   4   4                   0  4 columns in r[4]
+  60  SorterSort                 0  65   0                   0
+  61    SorterData               0   4   5                   0  r[4]=data
+  62    ColumnRange              5   2   2  2                0  r[2..3]=pseudo.column 2..column 3
+  63    ResultRow                2   2   0                   0  output=r[2..3]
+  64  SorterNext                 0  61   0                   0
+  65  Halt                       0   0   0                   0
+  66  Transaction                0   1   2                   0  iDb=0 tx_mode=Read
+  67  Goto                       0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -19,77 +19,113 @@ info:
 ---
 QUERY PLAN
 |--SCAN grouped_values AS gv USING INDEX idx_grouped_values_grp
-|--CORRELATED SCALAR SUBQUERY 1
-|  `--SEARCH gv2 USING INDEX idx_grouped_values_grp (grp=?)
+|--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
+|  `--SCAN grouped_values AS gv2 USING INDEX idx_grouped_values_grp
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4              p5  comment
-   0            Init             0  66   0                   0  Start at 66
-   1            SorterOpen       0   2   0  k(2,-B,Binary)   0  cursor=0
-   2            Null             0  10   0                   0  r[10]=NULL
-   3            Integer          0   7   0                   0  r[7]=0; clear group by abort flag
-   4            Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
-   5            Gosub           14  56   0                   0  ; go to clear accumulator subroutine
-   6            OpenRead         1   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-   7            OpenRead         2   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
-   8            Rewind           2  23   0                   0  Rewind index idx_grouped_values_grp
-   9              DeferredSeek   2   1   0                   0
-  10              Column         2   0  12                   0  r[12]=idx_grouped_values_grp.grp
-  11              Column         1   1  13                   0  r[13]=grouped_values.val
-  12              Compare        8  12   1  k(1, Binary)     0  r[8..8]==r[12..12]
-  13              Jump          14  18  14                   0  ; start new group if comparison is not equal
-  14              Gosub          5  27   0                   0  ; check if ended group had data, and output if so
-  15              Move          12   8   1                   0  r[8..8]=r[12..12]
-  16              IfPos          7  59   0                   0  r[7]>0 -> r[7]-=0, goto 59; check abort flag
-  17              Gosub         14  56   0                   0  ; goto clear accumulator subroutine
-  18              AggStep        0  13  10  sum              0  accum=r[10] step(r[13])
-  19              If             6  21   0                   0  if r[6] goto 21; don't emit group columns if continuing existing group
-  20              Column         2   0   9                   0  r[9]=idx_grouped_values_grp.grp
-  21              Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
-  22            Next             2   9   0                   0
-  23            Gosub            5  27   0                   0  ; emit row for final group
-  24            Goto             0  59   0                   0  ; group by finished
-  25            Integer          1   7   0                   0  r[7]=1
-  26          Return             5   0   0                   0
-  27          IfPos              6  29   0                   0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
-  28        Return               5   0   0                   0
-  29        AggFinal             0  10   0  sum              0  accum=r[10]
-  30        BeginSubrtn         15   0   0                   0  r[15]=NULL
-  31        Null                 0   1   0                   0  r[1]=NULL
-  32        Null                 0  17   0                   0  r[17]=NULL
-  33        Integer              1  18   0                   0  r[18]=1; LIMIT counter
-  34        IfNot               18  45   0                   0  if !r[18] goto 45
-  35        OpenRead             3   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-  36        OpenRead             4   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
-  37        Copy                 9  19   0                   0  r[19]=r[9]
-  38        IsNull              19  45   0                   0  if (r[19]==NULL) goto 45
-  39        SeekGE               4  45  19                   0  key=[19..19]
-  40          IdxGT              4  45  19                   0  key=[19..19]
-  41          DeferredSeek       4   3   0                   0
-  42          Column             3   1  20                   0  r[20]=grouped_values.val
-  43          AggStep            0  20  17  max(Binary)      0  accum=r[17] step(r[20])
-  44        Next                 4  40   0                   0
-  45        AggFinal             0  17   0  max              0  accum=r[17]
-  46        Copy                17  16   0                   0  r[16]=r[17]
-  47        Copy                16   1   0                   0  r[1]=r[16]
-  48      Return                15   0   1                   0
-  49      Copy                   1  21   0                   0  r[21]=r[1]
-  50      Sequence               0  22   0                   0
-  51      Copy                   9  23   0                   0  r[23]=r[9]
-  52      Copy                  10  24   0                   0  r[24]=r[10]
-  53      MakeRecord            21   4   4                   0  r[4]=mkrec(r[21..24])
-  54      SorterInsert           0   4   0  0                0  key=r[4]
-  55    Return                   5   0   0                   0
-  56    Null                     0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
-  57    Integer                  0   6   0                   0  r[6]=0
-  58  Return                    14   0   0                   0
-  59  OpenPseudo                 5   4   4                   0  4 columns in r[4]
-  60  SorterSort                 0  65   0                   0
-  61    SorterData               0   4   5                   0  r[4]=data
-  62    ColumnRange              5   2   2  2                0  r[2..3]=pseudo.column 2..column 3
-  63    ResultRow                2   2   0                   0  output=r[2..3]
-  64  SorterNext                 0  61   0                   0
-  65  Halt                       0   0   0                   0
-  66  Transaction                0   1   2                   0  iDb=0 tx_mode=Read
-  67  Goto                       0   1   0                   0
+addr  opcode                          p1   p2  p3  p4              p5  comment
+   0                  Init             0  102   0                   0  Start at 102
+   1                  OpenEphemeral    0    0   0                   0  cursor=0 is_table=false
+   2                  Null             0   11   0                   0  r[11]=NULL
+   3                  Integer          0    8   0                   0  r[8]=0; clear group by abort flag
+   4                  Null             0    9   0                   0  r[9]=NULL; initialize group by comparison registers to NULL
+   5                  Gosub           15   38   0                   0  ; go to clear accumulator subroutine
+   6                  OpenRead         1    2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
+   7                  OpenRead         2    3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
+   8                  Rewind           2   23   0                   0  Rewind index idx_grouped_values_grp
+   9                    DeferredSeek   2    1   0                   0
+  10                    Column         2    0  13                   0  r[13]=idx_grouped_values_grp.grp
+  11                    Column         1    1  14                   0  r[14]=grouped_values.val
+  12                    Compare        9   13   1  k(1, Binary)     0  r[9..9]==r[13..13]
+  13                    Jump          14   18  14                   0  ; start new group if comparison is not equal
+  14                    Gosub          6   27   0                   0  ; check if ended group had data, and output if so
+  15                    Move          13    9   1                   0  r[9..9]=r[13..13]
+  16                    IfPos          8   41   0                   0  r[8]>0 -> r[8]-=0, goto 41; check abort flag
+  17                    Gosub         15   38   0                   0  ; goto clear accumulator subroutine
+  18                    AggStep        0   14  11  max(Binary)      0  accum=r[11] step(r[14])
+  19                    If             7   21   0                   0  if r[7] goto 21; don't emit group columns if continuing existing group
+  20                    Column         2    0  10                   0  r[10]=idx_grouped_values_grp.grp
+  21                    Integer        1    7   0                   0  r[7]=1; indicate data in accumulator
+  22                  Next             2    9   0                   0
+  23                  Gosub            6   27   0                   0  ; emit row for final group
+  24                  Goto             0   41   0                   0  ; group by finished
+  25                  Integer          1    8   0                   0  r[8]=1
+  26                Return             6    0   0                   0
+  27                IfPos              7   29   0                   0  r[7]>0 -> r[7]-=0, goto 29; output group by row subroutine start
+  28              Return               6    0   0                   0
+  29              AggFinal             0   11   0  max              0  accum=r[11]
+  30              Copy                11    4   0                   0  r[4]=r[11]
+  31              Copy                10    5   0                   0  r[5]=r[10]
+  32              Copy                 5   17   0                   0  r[17]=r[5]
+  33              Copy                 4   18   0                   0  r[18]=r[4]
+  34              Sequence             0   19   0                   0
+  35              MakeRecord          17    3  16                   0  r[16]=mkrec(r[17..19]); for ephemeral_subquery_t2
+  36              IdxInsert            0   16   0                   8  key=r[16]
+  37            Return                 6    0   0                   0
+  38            Null                   0   10  11                   0  r[10..11]=NULL; clear accumulator subroutine start
+  39            Integer                0    7   0                   0  r[7]=0
+  40          Return                  15    0   0                   0
+  41          SorterOpen               3    2   0  k(2,-B,Binary)   0  cursor=3
+  42          Null                     0   29   0                   0  r[29]=NULL
+  43          Integer                  0   25   0                   0  r[25]=0; clear group by abort flag
+  44          Null                     0   26   0                   0  r[26]=NULL; initialize group by comparison registers to NULL
+  45          Gosub                   34   92   0                   0  ; go to clear accumulator subroutine
+  46          OpenRead                 4    2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
+  47          OpenRead                 5    3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
+  48          Rewind                   5   78   0                   0  Rewind index idx_grouped_values_grp
+  49            DeferredSeek           5    4   0                   0
+  50            Integer                0   35   0                   0  r[35]=0
+  51            Column                 5    0  36                   0  r[36]=idx_grouped_values_grp.grp
+  52            IsNull                36   73   0                   0  if (r[36]==NULL) goto 73
+  53            SeekGE                 0   73  36                   0  key=[36..36]
+  54              IdxGT                0   73  36                   0  key=[36..36]
+  55              Column               0    1   2                   0  r[2]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
+  56              Column               0    0   3                   0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
+  57              Integer              1   35   0                   0  r[35]=1
+  58              Column               5    0  31                   0  r[31]=idx_grouped_values_grp.grp
+  59              Column               0    1  32                   0  r[32]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
+  60              Column               4    1  33                   0  r[33]=grouped_values.val
+  61              Compare             26   31   1  k(1, Binary)     0  r[26..26]==r[31..31]
+  62              Jump                63   67  63                   0  ; start new group if comparison is not equal
+  63              Gosub               23   82   0                   0  ; check if ended group had data, and output if so
+  64              Move                31   26   1                   0  r[26..26]=r[31..31]
+  65              IfPos               25   95   0                   0  r[25]>0 -> r[25]-=0, goto 95; check abort flag
+  66              Gosub               34   92   0                   0  ; goto clear accumulator subroutine
+  67              AggStep              0   33  29  sum              0  accum=r[29] step(r[33])
+  68              If                  24   71   0                   0  if r[24] goto 71; don't emit group columns if continuing existing group
+  69              Column               5    0  27                   0  r[27]=idx_grouped_values_grp.grp
+  70              Column               0    1  28                   0  r[28]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
+  71              Integer              1   24   0                   0  r[24]=1; indicate data in accumulator
+  72            Next                   0   54   0                   0
+  73            IfPos                 35   77   0                   0  r[35]>0 -> r[35]-=0, goto 77
+  74            NullRow                0    0   0                   0  Set cursor 0 to a (pseudo) NULL row
+  75            Null                   0    2   3                   0  r[2..3]=NULL
+  76            Goto                   0   57   0                   0
+  77          Next                     5   49   0                   0
+  78          Gosub                   23   82   0                   0  ; emit row for final group
+  79          Goto                     0   95   0                   0  ; group by finished
+  80          Integer                  1   25   0                   0  r[25]=1
+  81        Return                    23    0   0                   0
+  82        IfPos                     24   84   0                   0  r[24]>0 -> r[24]-=0, goto 84; output group by row subroutine start
+  83      Return                      23    0   0                   0
+  84      AggFinal                     0   29   0  sum              0  accum=r[29]
+  85      Copy                        28   37   0                   0  r[37]=r[28]
+  86      Sequence                     3   38   0                   0
+  87      Copy                        27   39   0                   0  r[39]=r[27]
+  88      Copy                        29   40   0                   0  r[40]=r[29]
+  89      MakeRecord                  37    4  22                   0  r[22]=mkrec(r[37..40])
+  90      SorterInsert                 3   22   0  0                0  key=r[22]
+  91    Return                        23    0   0                   0
+  92    Null                           0   27  29                   0  r[27..29]=NULL; clear accumulator subroutine start
+  93    Integer                        0   24   0                   0  r[24]=0
+  94  Return                          34    0   0                   0
+  95  OpenPseudo                       6   22   4                   0  4 columns in r[22]
+  96  SorterSort                       3  101   0                   0
+  97    SorterData                     3   22   6                   0  r[22]=data
+  98    ColumnRange                    6    2  20  2                0  r[20..21]=pseudo.column 2..column 3
+  99    ResultRow                     20    2   0                   0  output=r[20..21]
+ 100  SorterNext                       3   97   0                   0
+ 101  Halt                             0    0   0                   0
+ 102  Transaction                      0    1   2                   0  iDb=0 tx_mode=Read
+ 103  Goto                             0    1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -19,77 +19,111 @@ info:
 ---
 QUERY PLAN
 |--SCAN grouped_values AS gv USING INDEX idx_grouped_values_grp
-|--CORRELATED SCALAR SUBQUERY 1
-|  `--SEARCH gv2 USING INDEX idx_grouped_values_grp (grp=?)
+|--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
+|  `--SCAN grouped_values AS gv2 USING INDEX idx_grouped_values_grp
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4              p5  comment
-   0            Init             0  66   0                   0  Start at 66
-   1            SorterOpen       0   2   0  k(2,-B,Binary)   0  cursor=0
-   2            Null             0  10   0                   0  r[10]=NULL
-   3            Integer          0   7   0                   0  r[7]=0; clear group by abort flag
-   4            Null             0   8   0                   0  r[8]=NULL; initialize group by comparison registers to NULL
-   5            Gosub           14  56   0                   0  ; go to clear accumulator subroutine
-   6            OpenRead         1   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-   7            OpenRead         2   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
-   8            Rewind           2  23   0                   0  Rewind index idx_grouped_values_grp
-   9              DeferredSeek   2   1   0                   0
-  10              Column         2   0  12                   0  r[12]=idx_grouped_values_grp.grp
-  11              Column         1   1  13                   0  r[13]=grouped_values.val
-  12              Compare        8  12   1  k(1, Binary)     0  r[8..8]==r[12..12]
-  13              Jump          14  18  14                   0  ; start new group if comparison is not equal
-  14              Gosub          5  27   0                   0  ; check if ended group had data, and output if so
-  15              Move          12   8   1                   0  r[8..8]=r[12..12]
-  16              IfPos          7  59   0                   0  r[7]>0 -> r[7]-=0, goto 59; check abort flag
-  17              Gosub         14  56   0                   0  ; goto clear accumulator subroutine
-  18              AggStep        0  13  10  sum              0  accum=r[10] step(r[13])
-  19              If             6  21   0                   0  if r[6] goto 21; don't emit group columns if continuing existing group
-  20              Column         2   0   9                   0  r[9]=idx_grouped_values_grp.grp
-  21              Integer        1   6   0                   0  r[6]=1; indicate data in accumulator
-  22            Next             2   9   0                   0
-  23            Gosub            5  27   0                   0  ; emit row for final group
-  24            Goto             0  59   0                   0  ; group by finished
-  25            Integer          1   7   0                   0  r[7]=1
-  26          Return             5   0   0                   0
-  27          IfPos              6  29   0                   0  r[6]>0 -> r[6]-=0, goto 29; output group by row subroutine start
-  28        Return               5   0   0                   0
-  29        AggFinal             0  10   0  sum              0  accum=r[10]
-  30        BeginSubrtn         15   0   0                   0  r[15]=NULL
-  31        Null                 0   1   0                   0  r[1]=NULL
-  32        Null                 0  17   0                   0  r[17]=NULL
-  33        Integer              1  18   0                   0  r[18]=1; LIMIT counter
-  34        IfNot               18  45   0                   0  if !r[18] goto 45
-  35        OpenRead             3   2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
-  36        OpenRead             4   3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
-  37        Copy                 9  19   0                   0  r[19]=r[9]
-  38        IsNull              19  45   0                   0  if (r[19]==NULL) goto 45
-  39        SeekGE               4  45  19                   0  key=[19..19]
-  40          IdxGT              4  45  19                   0  key=[19..19]
-  41          DeferredSeek       4   3   0                   0
-  42          Column             3   1  20                   0  r[20]=grouped_values.val
-  43          AggStep            0  20  17  max(Binary)      0  accum=r[17] step(r[20])
-  44        Next                 4  40   0                   0
-  45        AggFinal             0  17   0  max              0  accum=r[17]
-  46        Copy                17  16   0                   0  r[16]=r[17]
-  47        Copy                16   1   0                   0  r[1]=r[16]
-  48      Return                15   0   1                   0
-  49      Copy                   1  21   0                   0  r[21]=r[1]
-  50      Sequence               0  22   0                   0
-  51      Copy                   9  23   0                   0  r[23]=r[9]
-  52      Copy                  10  24   0                   0  r[24]=r[10]
-  53      MakeRecord            21   4   4                   0  r[4]=mkrec(r[21..24])
-  54      SorterInsert           0   4   0  0                0  key=r[4]
-  55    Return                   5   0   0                   0
-  56    Null                     0   9  10                   0  r[9..10]=NULL; clear accumulator subroutine start
-  57    Integer                  0   6   0                   0  r[6]=0
-  58  Return                    14   0   0                   0
-  59  OpenPseudo                 5   4   4                   0  4 columns in r[4]
-  60  SorterSort                 0  65   0                   0
-  61    SorterData               0   4   5                   0  r[4]=data
-  62    ColumnRange              5   2   2  2                0  r[2..3]=pseudo.column 2..column 3
-  63    ResultRow                2   2   0                   0  output=r[2..3]
-  64  SorterNext                 0  61   0                   0
-  65  Halt                       0   0   0                   0
-  66  Transaction                0   1   2                   0  iDb=0 tx_mode=Read
-  67  Goto                       0   1   0                   0
+addr  opcode                          p1   p2  p3  p4              p5  comment
+   0                  Init             0  100   0                   0  Start at 100
+   1                  Once            42    0   0                   0  goto 42
+   2                  OpenEphemeral    0    0   0                   0  cursor=0 is_table=false
+   3                  Null             0    8   0                   0  r[8]=NULL
+   4                  Integer          0    5   0                   0  r[5]=0; clear group by abort flag
+   5                  Null             0    6   0                   0  r[6]=NULL; initialize group by comparison registers to NULL
+   6                  Gosub           12   39   0                   0  ; go to clear accumulator subroutine
+   7                  OpenRead         1    2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
+   8                  OpenRead         2    3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
+   9                  Rewind           2   24   0                   0  Rewind index idx_grouped_values_grp
+  10                    DeferredSeek   2    1   0                   0
+  11                    Column         2    0  10                   0  r[10]=idx_grouped_values_grp.grp
+  12                    Column         1    1  11                   0  r[11]=grouped_values.val
+  13                    Compare        6   10   1  k(1, Binary)     0  r[6..6]==r[10..10]
+  14                    Jump          15   19  15                   0  ; start new group if comparison is not equal
+  15                    Gosub          3   28   0                   0  ; check if ended group had data, and output if so
+  16                    Move          10    6   1                   0  r[6..6]=r[10..10]
+  17                    IfPos          5   42   0                   0  r[5]>0 -> r[5]-=0, goto 42; check abort flag
+  18                    Gosub         12   39   0                   0  ; goto clear accumulator subroutine
+  19                    AggStep        0   11   8  max(Binary)      0  accum=r[8] step(r[11])
+  20                    If             4   22   0                   0  if r[4] goto 22; don't emit group columns if continuing existing group
+  21                    Column         2    0   7                   0  r[7]=idx_grouped_values_grp.grp
+  22                    Integer        1    4   0                   0  r[4]=1; indicate data in accumulator
+  23                  Next             2   10   0                   0
+  24                  Gosub            3   28   0                   0  ; emit row for final group
+  25                  Goto             0   42   0                   0  ; group by finished
+  26                  Integer          1    5   0                   0  r[5]=1
+  27                Return             3    0   0                   0
+  28                IfPos              4   30   0                   0  r[4]>0 -> r[4]-=0, goto 30; output group by row subroutine start
+  29              Return               3    0   0                   0
+  30              AggFinal             0    8   0  max              0  accum=r[8]
+  31              Copy                 8    1   0                   0  r[1]=r[8]
+  32              Copy                 7    2   0                   0  r[2]=r[7]
+  33              Copy                 2   14   0                   0  r[14]=r[2]
+  34              Copy                 1   15   0                   0  r[15]=r[1]
+  35              Sequence             0   16   0                   0
+  36              MakeRecord          14    3  13                   0  r[13]=mkrec(r[14..16]); for ephemeral_subquery_t2
+  37              IdxInsert            0   13   0                   8  key=r[13]
+  38            Return                 3    0   0                   0
+  39            Null                   0    7   8                   0  r[7..8]=NULL; clear accumulator subroutine start
+  40            Integer                0    4   0                   0  r[4]=0
+  41          Return                  12    0   0                   0
+  42          SorterOpen               3    2   0  k(2,-B,Binary)   0  cursor=3
+  43          Null                     0   26   0                   0  r[26]=NULL
+  44          Integer                  0   22   0                   0  r[22]=0; clear group by abort flag
+  45          Null                     0   23   0                   0  r[23]=NULL; initialize group by comparison registers to NULL
+  46          Gosub                   31   90   0                   0  ; go to clear accumulator subroutine
+  47          OpenRead                 4    2   0  k(3,B,B)         0  table=grouped_values, root=2, iDb=0
+  48          OpenRead                 5    3   0  k(2,B)           0  index=idx_grouped_values_grp, root=3, iDb=0
+  49          Rewind                   5   76   0                   0  Rewind index idx_grouped_values_grp
+  50            DeferredSeek           5    4   0                   0
+  51            Integer                0   32   0                   0  r[32]=0
+  52            Column                 5    0  33                   0  r[33]=idx_grouped_values_grp.grp
+  53            IsNull                33   72   0                   0  if (r[33]==NULL) goto 72
+  54            SeekGE                 0   72  33                   0  key=[33..33]
+  55              IdxGT                0   72  33                   0  key=[33..33]
+  56              Integer              1   32   0                   0  r[32]=1
+  57              Column               5    0  28                   0  r[28]=idx_grouped_values_grp.grp
+  58              Column               0    1  29                   0  r[29]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
+  59              Column               4    1  30                   0  r[30]=grouped_values.val
+  60              Compare             23   28   1  k(1, Binary)     0  r[23..23]==r[28..28]
+  61              Jump                62   66  62                   0  ; start new group if comparison is not equal
+  62              Gosub               20   80   0                   0  ; check if ended group had data, and output if so
+  63              Move                28   23   1                   0  r[23..23]=r[28..28]
+  64              IfPos               22   93   0                   0  r[22]>0 -> r[22]-=0, goto 93; check abort flag
+  65              Gosub               31   90   0                   0  ; goto clear accumulator subroutine
+  66              AggStep              0   30  26  sum              0  accum=r[26] step(r[30])
+  67              If                  21   70   0                   0  if r[21] goto 70; don't emit group columns if continuing existing group
+  68              Column               5    0  24                   0  r[24]=idx_grouped_values_grp.grp
+  69              Column               0    1  25                   0  r[25]=ephemeral(ephemeral_subquery_t2).MAX(gv2.val)
+  70              Integer              1   21   0                   0  r[21]=1; indicate data in accumulator
+  71            Next                   0   55   0                   0
+  72            IfPos                 32   75   0                   0  r[32]>0 -> r[32]-=0, goto 75
+  73            NullRow                0    0   0                   0  Set cursor 0 to a (pseudo) NULL row
+  74            Goto                   0   56   0                   0
+  75          Next                     5   50   0                   0
+  76          Gosub                   20   80   0                   0  ; emit row for final group
+  77          Goto                     0   93   0                   0  ; group by finished
+  78          Integer                  1   22   0                   0  r[22]=1
+  79        Return                    20    0   0                   0
+  80        IfPos                     21   82   0                   0  r[21]>0 -> r[21]-=0, goto 82; output group by row subroutine start
+  81      Return                      20    0   0                   0
+  82      AggFinal                     0   26   0  sum              0  accum=r[26]
+  83      Copy                        25   34   0                   0  r[34]=r[25]
+  84      Sequence                     3   35   0                   0
+  85      Copy                        24   36   0                   0  r[36]=r[24]
+  86      Copy                        26   37   0                   0  r[37]=r[26]
+  87      MakeRecord                  34    4  19                   0  r[19]=mkrec(r[34..37])
+  88      SorterInsert                 3   19   0  0                0  key=r[19]
+  89    Return                        20    0   0                   0
+  90    Null                           0   24  26                   0  r[24..26]=NULL; clear accumulator subroutine start
+  91    Integer                        0   21   0                   0  r[21]=0
+  92  Return                          31    0   0                   0
+  93  OpenPseudo                       6   19   4                   0  4 columns in r[19]
+  94  SorterSort                       3   99   0                   0
+  95    SorterData                     3   19   6                   0  r[19]=data
+  96    ColumnRange                    6    2  17  2                0  r[17..18]=pseudo.column 2..column 3
+  97    ResultRow                     17    2   0                   0  output=r[17..18]
+  98  SorterNext                       3   95   0                   0
+  99  Halt                             0    0   0                   0
+ 100  Transaction                      0    1   2                   0  iDb=0 tx_mode=Read
+ 101  Goto                             0    1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-subquery-builds-once.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-subquery-builds-once.snap
@@ -1,0 +1,125 @@
+---
+source: subqueries.sqltest
+expression: |-
+  SELECT top.t,
+             (SELECT count(*)
+              FROM repeat_middle middle_rows
+              WHERE middle_rows.tk = top.t
+                AND middle_rows.sk IN (
+                        SELECT inner_rows.k
+                        FROM repeat_inner inner_rows
+                        GROUP BY inner_rows.k
+                        HAVING avg(inner_rows.x) > 0
+                    ))
+      FROM repeat_top top;
+info:
+  statement_type: SELECT
+  tables:
+  - repeat_inner
+  - repeat_middle
+  - repeat_top
+  setup_blocks:
+  - repeated_grouped_subquery
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN repeat_top AS top
+`--CORRELATED SCALAR SUBQUERY 1
+   |--LIST SUBQUERY 2
+   |  |--SCAN repeat_inner AS inner_rows
+   |  `--USE SORTER FOR GROUP BY
+   `--SCAN repeat_middle AS middle_rows
+
+BYTECODE
+addr  opcode                      p1  p2  p3  p4            p5  comment
+   0            Init               0  88   0                 0  Start at 88
+   1            OpenRead           1   2   0  k(2,B)         0  table=repeat_top, root=2, iDb=0
+   2            Rewind             1  87   0                 0  Rewind table repeat_top
+   3              BeginSubrtn      4   0   0                 0  r[4]=NULL
+   4              Null             0   1   0                 0  r[1]=NULL
+   5              Once            51   0   0                 0  goto 51
+   6              OpenEphemeral    0   0   0                 0  cursor=0 is_table=false
+   7              Null             0  11   0                 0  r[11]=NULL
+   8              SorterOpen       2   2   0  k(1,B)         0  cursor=2
+   9              Integer          0   8   0                 0  r[8]=0; clear group by abort flag
+  10              Null             0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
+  11              Gosub           15  48   0                 0  ; go to clear accumulator subroutine
+  12              OpenRead         4   4   0  k(3,B,B)       0  table=repeat_inner, root=4, iDb=0
+  13              Rewind           4  18   0                 0  Rewind table repeat_inner
+  14                ColumnRange    4   0  13  2              0  r[13..14]=repeat_inner.k..x
+  15                MakeRecord    13   2  12                 0  r[12]=mkrec(r[13..14])
+  16                SorterInsert   2  12   0  0              0  key=r[12]
+  17              Next             4  14   0                 0
+  18              OpenPseudo       3  12   2                 0  2 columns in r[12]
+  19              SorterSort       2  34   0                 0
+  20                SorterData     2  12   3                 0  r[12]=data
+  21                Column         3   0  16                 0  r[16]=pseudo.column 0
+  22                Compare        9  16   1  k(1, Binary)   0  r[9..9]==r[16..16]
+  23                Jump          24  28  24                 0  ; start new group if comparison is not equal
+  24                Gosub          6  38   0                 0  ; check if ended group had data, and output if so
+  25                Move          16   9   1                 0  r[9..9]=r[16..16]
+  26                IfPos          8  51   0                 0  r[8]>0 -> r[8]-=0, goto 51; check abort flag
+  27                Gosub         15  48   0                 0  ; goto clear accumulator subroutine
+  28                Column         3   1  17                 0  r[17]=pseudo.column 1
+  29                AggStep        0  17  11  avg            0  accum=r[11] step(r[17])
+  30                If             7  32   0                 0  if r[7] goto 32; don't emit group columns if continuing existing group
+  31                Column         3   0  10                 0  r[10]=pseudo.column 0
+  32                Integer        1   7   0                 0  r[7]=1; indicate data in accumulator
+  33              SorterNext       2  20   0                 0
+  34              Gosub            6  38   0                 0  ; emit row for final group
+  35              Goto             0  51   0                 0  ; group by finished
+  36              Integer          1   8   0                 0  r[8]=1
+  37            Return             6   0   0                 0
+  38            IfPos              7  40   0                 0  r[7]>0 -> r[7]-=0, goto 40; output group by row subroutine start
+  39          Return               6   0   0                 0
+  40          AggFinal             0  11   0  avg            0  accum=r[11]
+  41          Copy                11  19   0                 0  r[19]=r[11]
+  42          Integer              0  20   0                 0  r[20]=0
+  43          Le                  19  20  39                 0  if r[19]<=r[20] goto 39
+  44          Copy                10   5   0                 0  r[5]=r[10]
+  45          MakeRecord           5   1  21                 0  r[21]=mkrec(r[5..5]); for ephemeral_index_where_sub_t4
+  46          IdxInsert            0  21   0                 8  key=r[21]
+  47        Return                 6   0   0                 0
+  48        Null                   0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
+  49        Integer                0   7   0                 0  r[7]=0
+  50      Return                  15   0   0                 0
+  51      Null                     0  23   0                 0  r[23]=NULL
+  52      Integer                  1  24   0                 0  r[24]=1; LIMIT counter
+  53      IfNot                   24  79   0                 0  if !r[24] goto 79
+  54      OpenRead                 5   3   0  k(3,B,B)       0  table=repeat_middle, root=3, iDb=0
+  55      Rewind                   5  79   0                 0  Rewind table repeat_middle
+  56        Column                 5   1  26                 0  r[26]=repeat_middle.tk
+  57        Column                 1   0  27                 0  r[27]=repeat_top.t
+  58        Ne                    26  27  78  Binary         0  if r[26]!=r[27] goto 78
+  59        Integer                0  28   0                 0  r[28]=0
+  60        Column                 5   0  29                 0  r[29]=repeat_middle.sk
+  61        IsNull                29  65   0                 0  if (r[29]==NULL) goto 65
+  62        Affinity              29   1   0                 0  r[29..30] = C
+  63        NotFound               0  65  29                 0  if not found goto 65
+  64        Goto                   0  71   0                 0
+  65        Rewind                 0  73   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t4)
+  66          Column               0   0  30                 0  r[30]=ephemeral(ephemeral_index_where_sub_t4).k
+  67          Ne                  29  30  69  Binary         0  if r[29]!=r[30] goto 69
+  68          Goto                 0  75   0                 0
+  69        Next                   0  66   0                 0
+  70        Goto                   0  73   0                 0
+  71        Integer                1  28   0                 0  r[28]=1
+  72        Goto                   0  76   0                 0
+  73        Integer                0  28   0                 0  r[28]=0
+  74        Goto                   0  76   0                 0
+  75        Null                   0  28   0                 0  r[28]=NULL
+  76        IfNot                 28  78   1                 0  if !r[28] goto 78
+  77        AggStep                0  31  23  count          0  accum=r[23] step(r[31])
+  78      Next                     5  56   0                 0
+  79      AggFinal                 0  23   0  count          0  accum=r[23]
+  80      Copy                    23  22   0                 0  r[22]=r[23]
+  81      Copy                    22   1   0                 0  r[1]=r[22]
+  82    Return                     4   0   1                 0
+  83    Column                     1   0   2                 0  r[2]=repeat_top.t
+  84    Copy                       1   3   0                 0  r[3]=r[1]
+  85    ResultRow                  2   2   0                 0  output=r[2..3]
+  86  Next                         1   3   0                 0
+  87  Halt                         0   0   0                 0
+  88  Transaction                  0   1   3                 0  iDb=0 tx_mode=Read
+  89  Integer                      1  31   0                 0  r[31]=1
+  90  Goto                         0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
@@ -16,34 +16,70 @@ info:
 ---
 QUERY PLAN
 |--SCAN customers AS c
-`--CORRELATED SCALAR SUBQUERY 1
-   `--SEARCH orders USING COVERING INDEX idx_orders_customer (customer_id=?)
+`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
+   `--SCAN orders USING COVERING INDEX idx_orders_customer
 
 BYTECODE
-addr  opcode           p1  p2  p3  p4            p5  comment
-   0    Init            0  23   0                 0  Start at 23
-   1    OpenRead        0   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-   2    Rewind          0  22   0                 0  Rewind table customers
-   3      BeginSubrtn   4   0   0                 0  r[4]=NULL
-   4      Null          0   1   0                 0  r[1]=NULL
-   5      Null          0   6   0                 0  r[6]=NULL
-   6      Integer       1   7   0                 0  r[7]=1; LIMIT counter
-   7      IfNot         7  14   0                 0  if !r[7] goto 14
-   8      OpenRead      1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-   9      RowId         0   8   0                 0  r[8]=customers.rowid
-  10      SeekGE        1  14   8                 0  key=[8..8]
-  11        IdxGT       1  14   8                 0  key=[8..8]
-  12        AggStep     0   9   6  count          0  accum=r[6] step(r[9])
-  13      Next          1  11   0                 0
-  14      AggFinal      0   6   0  count          0  accum=r[6]
-  15      Copy          6   5   0                 0  r[5]=r[6]
-  16      Copy          5   1   0                 0  r[1]=r[5]
-  17    Return          4   0   1                 0
-  18    Column          0   1   2                 0  r[2]=customers.name
-  19    Copy            1   3   0                 0  r[3]=r[1]
-  20    ResultRow       2   2   0                 0  output=r[2..3]
-  21  Next              0   3   0                 0
-  22  Halt              0   0   0                 0
-  23  Transaction       0   1  11                 0  iDb=0 tx_mode=Read
-  24  Integer           1   9   0                 0  r[9]=1
-  25  Goto              0   1   0                 0
+addr  opcode                 p1  p2  p3  p4            p5  comment
+   0          Init            0  59   0                 0  Start at 59
+   1          OpenEphemeral   0   0   0                 0  cursor=0 is_table=false
+   2          Null            0  11   0                 0  r[11]=NULL
+   3          Integer         0   8   0                 0  r[8]=0; clear group by abort flag
+   4          Null            0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
+   5          Gosub          14  35   0                 0  ; go to clear accumulator subroutine
+   6          OpenRead        1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   7          Rewind          1  20   0                 0  Rewind index idx_orders_customer
+   8            Column        1   0  13                 0  r[13]=idx_orders_customer.customer_id
+   9            Compare       9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
+  10            Jump         11  15  11                 0  ; start new group if comparison is not equal
+  11            Gosub         6  24   0                 0  ; check if ended group had data, and output if so
+  12            Move         13   9   1                 0  r[9..9]=r[13..13]
+  13            IfPos         8  38   0                 0  r[8]>0 -> r[8]-=0, goto 38; check abort flag
+  14            Gosub        14  35   0                 0  ; goto clear accumulator subroutine
+  15            AggStep       0  15  11  count          0  accum=r[11] step(r[15])
+  16            If            7  18   0                 0  if r[7] goto 18; don't emit group columns if continuing existing group
+  17            Column        1   0  10                 0  r[10]=idx_orders_customer.customer_id
+  18            Integer       1   7   0                 0  r[7]=1; indicate data in accumulator
+  19          Next            1   8   0                 0
+  20          Gosub           6  24   0                 0  ; emit row for final group
+  21          Goto            0  38   0                 0  ; group by finished
+  22          Integer         1   8   0                 0  r[8]=1
+  23        Return            6   0   0                 0
+  24        IfPos             7  26   0                 0  r[7]>0 -> r[7]-=0, goto 26; output group by row subroutine start
+  25      Return              6   0   0                 0
+  26      AggFinal            0  11   0  count          0  accum=r[11]
+  27      Copy               11   4   0                 0  r[4]=r[11]
+  28      Copy               10   5   0                 0  r[5]=r[10]
+  29      Copy                5  17   0                 0  r[17]=r[5]
+  30      Copy                4  18   0                 0  r[18]=r[4]
+  31      Sequence            0  19   0                 0
+  32      MakeRecord         17   3  16                 0  r[16]=mkrec(r[17..19]); for ephemeral_subquery_t2
+  33      IdxInsert           0  16   0                 8  key=r[16]
+  34    Return                6   0   0                 0
+  35    Null                  0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
+  36    Integer               0   7   0                 0  r[7]=0
+  37  Return                 14   0   0                 0
+  38  OpenRead                2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  39  Rewind                  2  58   0                 0  Rewind table customers
+  40    Integer               0  22   0                 0  r[22]=0
+  41    RowId                 2  23   0                 0  r[23]=customers.rowid
+  42    SeekGE                0  53  23                 0  key=[23..23]
+  43      IdxGT               0  53  23                 0  key=[23..23]
+  44      Column              0   1   2                 0  r[2]=ephemeral(ephemeral_subquery_t2).count(*)
+  45      Column              0   0   3                 0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
+  46      Integer             1  22   0                 0  r[22]=1
+  47      Column              2   1  20                 0  r[20]=customers.name
+  48      Column              0   1  21                 0  r[21]=ephemeral(ephemeral_subquery_t2).count(*)
+  49      NotNull            21  51   0                 0  r[21]!=NULL -> goto 51
+  50      Integer             0  21   0                 0  r[21]=0
+  51      ResultRow          20   2   0                 0  output=r[20..21]
+  52    Next                  0  43   0                 0
+  53    IfPos                22  57   0                 0  r[22]>0 -> r[22]-=0, goto 57
+  54    NullRow               0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  55    Null                  0   2   3                 0  r[2..3]=NULL
+  56    Goto                  0  46   0                 0
+  57  Next                    2  40   0                 0
+  58  Halt                    0   0   0                 0
+  59  Transaction             0   1  11                 0  iDb=0 tx_mode=Read
+  60  Integer                 1  15   0                 0  r[15]=1
+  61  Goto                    0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
@@ -16,70 +16,34 @@ info:
 ---
 QUERY PLAN
 |--SCAN customers AS c
-`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
-   `--SCAN orders USING COVERING INDEX idx_orders_customer
+`--CORRELATED SCALAR SUBQUERY 1
+   `--SEARCH orders USING INDEX idx_orders_customer (customer_id=?)
 
 BYTECODE
-addr  opcode                 p1  p2  p3  p4            p5  comment
-   0          Init            0  59   0                 0  Start at 59
-   1          OpenEphemeral   0   0   0                 0  cursor=0 is_table=false
-   2          Null            0  11   0                 0  r[11]=NULL
-   3          Integer         0   8   0                 0  r[8]=0; clear group by abort flag
-   4          Null            0   9   0                 0  r[9]=NULL; initialize group by comparison registers to NULL
-   5          Gosub          14  35   0                 0  ; go to clear accumulator subroutine
-   6          OpenRead        1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-   7          Rewind          1  20   0                 0  Rewind index idx_orders_customer
-   8            Column        1   0  13                 0  r[13]=idx_orders_customer.customer_id
-   9            Compare       9  13   1  k(1, Binary)   0  r[9..9]==r[13..13]
-  10            Jump         11  15  11                 0  ; start new group if comparison is not equal
-  11            Gosub         6  24   0                 0  ; check if ended group had data, and output if so
-  12            Move         13   9   1                 0  r[9..9]=r[13..13]
-  13            IfPos         8  38   0                 0  r[8]>0 -> r[8]-=0, goto 38; check abort flag
-  14            Gosub        14  35   0                 0  ; goto clear accumulator subroutine
-  15            AggStep       0  15  11  count          0  accum=r[11] step(r[15])
-  16            If            7  18   0                 0  if r[7] goto 18; don't emit group columns if continuing existing group
-  17            Column        1   0  10                 0  r[10]=idx_orders_customer.customer_id
-  18            Integer       1   7   0                 0  r[7]=1; indicate data in accumulator
-  19          Next            1   8   0                 0
-  20          Gosub           6  24   0                 0  ; emit row for final group
-  21          Goto            0  38   0                 0  ; group by finished
-  22          Integer         1   8   0                 0  r[8]=1
-  23        Return            6   0   0                 0
-  24        IfPos             7  26   0                 0  r[7]>0 -> r[7]-=0, goto 26; output group by row subroutine start
-  25      Return              6   0   0                 0
-  26      AggFinal            0  11   0  count          0  accum=r[11]
-  27      Copy               11   4   0                 0  r[4]=r[11]
-  28      Copy               10   5   0                 0  r[5]=r[10]
-  29      Copy                5  17   0                 0  r[17]=r[5]
-  30      Copy                4  18   0                 0  r[18]=r[4]
-  31      Sequence            0  19   0                 0
-  32      MakeRecord         17   3  16                 0  r[16]=mkrec(r[17..19]); for ephemeral_subquery_t2
-  33      IdxInsert           0  16   0                 8  key=r[16]
-  34    Return                6   0   0                 0
-  35    Null                  0  10  11                 0  r[10..11]=NULL; clear accumulator subroutine start
-  36    Integer               0   7   0                 0  r[7]=0
-  37  Return                 14   0   0                 0
-  38  OpenRead                2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-  39  Rewind                  2  58   0                 0  Rewind table customers
-  40    Integer               0  22   0                 0  r[22]=0
-  41    RowId                 2  23   0                 0  r[23]=customers.rowid
-  42    SeekGE                0  53  23                 0  key=[23..23]
-  43      IdxGT               0  53  23                 0  key=[23..23]
-  44      Column              0   1   2                 0  r[2]=ephemeral(ephemeral_subquery_t2).count(*)
-  45      Column              0   0   3                 0  r[3]=ephemeral(ephemeral_subquery_t2).correlation_key_0
-  46      Integer             1  22   0                 0  r[22]=1
-  47      Column              2   1  20                 0  r[20]=customers.name
-  48      Column              0   1  21                 0  r[21]=ephemeral(ephemeral_subquery_t2).count(*)
-  49      NotNull            21  51   0                 0  r[21]!=NULL -> goto 51
-  50      Integer             0  21   0                 0  r[21]=0
-  51      ResultRow          20   2   0                 0  output=r[20..21]
-  52    Next                  0  43   0                 0
-  53    IfPos                22  57   0                 0  r[22]>0 -> r[22]-=0, goto 57
-  54    NullRow               0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
-  55    Null                  0   2   3                 0  r[2..3]=NULL
-  56    Goto                  0  46   0                 0
-  57  Next                    2  40   0                 0
-  58  Halt                    0   0   0                 0
-  59  Transaction             0   1  11                 0  iDb=0 tx_mode=Read
-  60  Integer                 1  15   0                 0  r[15]=1
-  61  Goto                    0   1   0                 0
+addr  opcode           p1  p2  p3  p4            p5  comment
+   0    Init            0  23   0                 0  Start at 23
+   1    OpenRead        0   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+   2    Rewind          0  22   0                 0  Rewind table customers
+   3      BeginSubrtn   4   0   0                 0  r[4]=NULL
+   4      Null          0   1   0                 0  r[1]=NULL
+   5      Null          0   6   0                 0  r[6]=NULL
+   6      Integer       1   7   0                 0  r[7]=1; LIMIT counter
+   7      IfNot         7  14   0                 0  if !r[7] goto 14
+   8      OpenRead      1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   9      RowId         0   8   0                 0  r[8]=customers.rowid
+  10      SeekGE        1  14   8                 0  key=[8..8]
+  11        IdxGT       1  14   8                 0  key=[8..8]
+  12        AggStep     0   9   6  count          0  accum=r[6] step(r[9])
+  13      Next          1  11   0                 0
+  14      AggFinal      0   6   0  count          0  accum=r[6]
+  15      Copy          6   5   0                 0  r[5]=r[6]
+  16      Copy          5   1   0                 0  r[1]=r[5]
+  17    Return          4   0   1                 0
+  18    Column          0   1   2                 0  r[2]=customers.name
+  19    Copy            1   3   0                 0  r[3]=r[1]
+  20    ResultRow       2   2   0                 0  output=r[2..3]
+  21  Next              0   3   0                 0
+  22  Halt              0   0   0                 0
+  23  Transaction       0   1  11                 0  iDb=0 tx_mode=Read
+  24  Integer           1   9   0                 0  r[9]=1
+  25  Goto              0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
@@ -16,34 +16,68 @@ info:
 ---
 QUERY PLAN
 |--SCAN customers AS c
-`--CORRELATED SCALAR SUBQUERY 1
-   `--SEARCH orders USING INDEX idx_orders_customer (customer_id=?)
+`--SEARCH scalar_subquery_t2 USING INDEX ephemeral_subquery_t2 (correlation_key_0=?) LEFT-JOIN
+   `--SCAN orders USING COVERING INDEX idx_orders_customer
 
 BYTECODE
-addr  opcode           p1  p2  p3  p4            p5  comment
-   0    Init            0  23   0                 0  Start at 23
-   1    OpenRead        0   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
-   2    Rewind          0  22   0                 0  Rewind table customers
-   3      BeginSubrtn   4   0   0                 0  r[4]=NULL
-   4      Null          0   1   0                 0  r[1]=NULL
-   5      Null          0   6   0                 0  r[6]=NULL
-   6      Integer       1   7   0                 0  r[7]=1; LIMIT counter
-   7      IfNot         7  14   0                 0  if !r[7] goto 14
-   8      OpenRead      1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
-   9      RowId         0   8   0                 0  r[8]=customers.rowid
-  10      SeekGE        1  14   8                 0  key=[8..8]
-  11        IdxGT       1  14   8                 0  key=[8..8]
-  12        AggStep     0   9   6  count          0  accum=r[6] step(r[9])
-  13      Next          1  11   0                 0
-  14      AggFinal      0   6   0  count          0  accum=r[6]
-  15      Copy          6   5   0                 0  r[5]=r[6]
-  16      Copy          5   1   0                 0  r[1]=r[5]
-  17    Return          4   0   1                 0
-  18    Column          0   1   2                 0  r[2]=customers.name
-  19    Copy            1   3   0                 0  r[3]=r[1]
-  20    ResultRow       2   2   0                 0  output=r[2..3]
-  21  Next              0   3   0                 0
-  22  Halt              0   0   0                 0
-  23  Transaction       0   1  11                 0  iDb=0 tx_mode=Read
-  24  Integer           1   9   0                 0  r[9]=1
-  25  Goto              0   1   0                 0
+addr  opcode                 p1  p2  p3  p4            p5  comment
+   0          Init            0  57   0                 0  Start at 57
+   1          Once           39   0   0                 0  goto 39
+   2          OpenEphemeral   0   0   0                 0  cursor=0 is_table=false
+   3          Null            0   8   0                 0  r[8]=NULL
+   4          Integer         0   5   0                 0  r[5]=0; clear group by abort flag
+   5          Null            0   6   0                 0  r[6]=NULL; initialize group by comparison registers to NULL
+   6          Gosub          11  36   0                 0  ; go to clear accumulator subroutine
+   7          OpenRead        1   9   0  k(2,B)         0  index=idx_orders_customer, root=9, iDb=0
+   8          Rewind          1  21   0                 0  Rewind index idx_orders_customer
+   9            Column        1   0  10                 0  r[10]=idx_orders_customer.customer_id
+  10            Compare       6  10   1  k(1, Binary)   0  r[6..6]==r[10..10]
+  11            Jump         12  16  12                 0  ; start new group if comparison is not equal
+  12            Gosub         3  25   0                 0  ; check if ended group had data, and output if so
+  13            Move         10   6   1                 0  r[6..6]=r[10..10]
+  14            IfPos         5  39   0                 0  r[5]>0 -> r[5]-=0, goto 39; check abort flag
+  15            Gosub        11  36   0                 0  ; goto clear accumulator subroutine
+  16            AggStep       0  12   8  count          0  accum=r[8] step(r[12])
+  17            If            4  19   0                 0  if r[4] goto 19; don't emit group columns if continuing existing group
+  18            Column        1   0   7                 0  r[7]=idx_orders_customer.customer_id
+  19            Integer       1   4   0                 0  r[4]=1; indicate data in accumulator
+  20          Next            1   9   0                 0
+  21          Gosub           3  25   0                 0  ; emit row for final group
+  22          Goto            0  39   0                 0  ; group by finished
+  23          Integer         1   5   0                 0  r[5]=1
+  24        Return            3   0   0                 0
+  25        IfPos             4  27   0                 0  r[4]>0 -> r[4]-=0, goto 27; output group by row subroutine start
+  26      Return              3   0   0                 0
+  27      AggFinal            0   8   0  count          0  accum=r[8]
+  28      Copy                8   1   0                 0  r[1]=r[8]
+  29      Copy                7   2   0                 0  r[2]=r[7]
+  30      Copy                2  14   0                 0  r[14]=r[2]
+  31      Copy                1  15   0                 0  r[15]=r[1]
+  32      Sequence            0  16   0                 0
+  33      MakeRecord         14   3  13                 0  r[13]=mkrec(r[14..16]); for ephemeral_subquery_t2
+  34      IdxInsert           0  13   0                 8  key=r[13]
+  35    Return                3   0   0                 0
+  36    Null                  0   7   8                 0  r[7..8]=NULL; clear accumulator subroutine start
+  37    Integer               0   4   0                 0  r[4]=0
+  38  Return                 11   0   0                 0
+  39  OpenRead                2   6   0  k(4,B,B,B,B)   0  table=customers, root=6, iDb=0
+  40  Rewind                  2  56   0                 0  Rewind table customers
+  41    Integer               0  19   0                 0  r[19]=0
+  42    RowId                 2  20   0                 0  r[20]=customers.rowid
+  43    SeekGE                0  52  20                 0  key=[20..20]
+  44      IdxGT               0  52  20                 0  key=[20..20]
+  45      Integer             1  19   0                 0  r[19]=1
+  46      Column              2   1  17                 0  r[17]=customers.name
+  47      Column              0   1  18                 0  r[18]=ephemeral(ephemeral_subquery_t2).count(*)
+  48      NotNull            18  50   0                 0  r[18]!=NULL -> goto 50
+  49      Integer             0  18   0                 0  r[18]=0
+  50      ResultRow          17   2   0                 0  output=r[17..18]
+  51    Next                  0  44   0                 0
+  52    IfPos                19  55   0                 0  r[19]>0 -> r[19]-=0, goto 55
+  53    NullRow               0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
+  54    Goto                  0  45   0                 0
+  55  Next                    2  41   0                 0
+  56  Halt                    0   0   0                 0
+  57  Transaction             0   1  11                 0  iDb=0 tx_mode=Read
+  58  Integer                 1  12   0                 0  r[12]=1
+  59  Goto                    0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/subqueries.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/subqueries.sqltest
@@ -86,6 +86,29 @@ snapshot scalar-subquery-simple-count {
     SELECT (SELECT count(*) FROM orders) AS order_count;
 }
 
+# The grouped table is inside a correlated subquery, but it does not use the
+# outer row. Its bytecode must use Once so the table is built one time.
+setup repeated_grouped_subquery {
+    CREATE TABLE repeat_top(t INTEGER);
+    CREATE TABLE repeat_middle(sk INTEGER, tk INTEGER);
+    CREATE TABLE repeat_inner(k INTEGER, x INTEGER);
+}
+
+@setup repeated_grouped_subquery
+snapshot grouped-subquery-builds-once {
+    SELECT top.t,
+           (SELECT count(*)
+            FROM repeat_middle middle_rows
+            WHERE middle_rows.tk = top.t
+              AND middle_rows.sk IN (
+                      SELECT inner_rows.k
+                      FROM repeat_inner inner_rows
+                      GROUP BY inner_rows.k
+                      HAVING avg(inner_rows.x) > 0
+                  ))
+    FROM repeat_top top;
+}
+
 # =============================================================================
 # EXISTS SUBQUERIES
 # =============================================================================

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
@@ -37,104 +37,142 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN partsupp USING INDEX sqlite_autoindex_partsupp_1
-|--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
+|--SCAN supplier
 |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
+|--SEARCH partsupp USING COVERING INDEX ephemeral_partsupp_t1 (PS_SUPPKEY=?)
+|--USE SORTER FOR GROUP BY
 |--SCALAR SUBQUERY 1
-|  |--SCAN partsupp
-|  |--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
-|  `--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
+|  |--SCAN supplier
+|  |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
+|  `--SEARCH partsupp USING COVERING INDEX ephemeral_partsupp_t5 (PS_SUPPKEY=?)
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode                    p1  p2  p3  p4                  p5  comment
-   0            Init             0  87   0                       0  Start at 87
-   1            SorterOpen       0   1   0  k(1,-B)              0  cursor=0
-   2            Null             0  10   0                       0  r[10]=NULL
-   3            Integer          0   7   0                       0  r[7]=0; clear group by abort flag
-   4            Null             0   8   0                       0  r[8]=NULL; initialize group by comparison registers to NULL
-   5            Gosub           14  76   0                       0  ; go to clear accumulator subroutine
-   6            OpenRead         1   6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
-   7            OpenRead         2   7   0  k(3,B,B)             0  index=sqlite_autoindex_partsupp_1, root=7, iDb=0
-   8            OpenRead         3   5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
-   9            OpenRead         4   2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
-  10            Rewind           2  33   0                       0  Rewind index sqlite_autoindex_partsupp_1
-  11              DeferredSeek   2   1   0                       0
-  12              Column         2   1  15                       0  r[15]=sqlite_autoindex_partsupp_1.ps_suppkey
-  13              SeekRowid      3  15  32                       0  if (r[15]!=cursor 3 for table supplier.rowid) goto 32
-  14              Column         3   3  16                       0  r[16]=supplier.S_NATIONKEY
-  15              SeekRowid      4  16  32                       0  if (r[16]!=cursor 4 for table nation.rowid) goto 32
-  16              Column         4   1  18                       0  r[18]=nation.N_NAME
-  17              Ne            18  19  32  Binary               0  if r[18]!=r[19] goto 32
-  18              Column         2   0  12                       0  r[12]=sqlite_autoindex_partsupp_1.ps_partkey
-  19              Column         1   3  20                       0  r[20]=partsupp.PS_SUPPLYCOST
-  20              Column         1   2  21                       0  r[21]=partsupp.PS_AVAILQTY
-  21              Multiply      20  21  13                       0  r[13]=r[20]*r[21]
-  22              Compare        8  12   1  k(1, Binary)         0  r[8..8]==r[12..12]
-  23              Jump          24  28  24                       0  ; start new group if comparison is not equal
-  24              Gosub          5  37   0                       0  ; check if ended group had data, and output if so
-  25              Move          12   8   1                       0  r[8..8]=r[12..12]
-  26              IfPos          7  79   0                       0  r[7]>0 -> r[7]-=0, goto 79; check abort flag
-  27              Gosub         14  76   0                       0  ; goto clear accumulator subroutine
-  28              AggStep        0  13  10  sum                  0  accum=r[10] step(r[13])
-  29              If             6  31   0                       0  if r[6] goto 31; don't emit group columns if continuing existing group
-  30              Column         2   0   9                       0  r[9]=sqlite_autoindex_partsupp_1.ps_partkey
-  31              Integer        1   6   0                       0  r[6]=1; indicate data in accumulator
-  32            Next             2  11   0                       0
-  33            Gosub            5  37   0                       0  ; emit row for final group
-  34            Goto             0  79   0                       0  ; group by finished
-  35            Integer          1   7   0                       0  r[7]=1
-  36          Return             5   0   0                       0
-  37          IfPos              6  39   0                       0  r[6]>0 -> r[6]-=0, goto 39; output group by row subroutine start
-  38        Return               5   0   0                       0
-  39        AggFinal             0  10   0  sum                  0  accum=r[10]
-  40        Once                68   0   0                       0  goto 68
-  41        BeginSubrtn         22   0   0                       0  r[22]=NULL
-  42        Null                 0   1   0                       0  r[1]=NULL
-  43        Null                 0  24   0                       0  r[24]=NULL
-  44        Integer              1  25   0                       0  r[25]=1; LIMIT counter
-  45        IfNot               25  62   0                       0  if !r[25] goto 62
-  46        OpenRead             5   6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
-  47        OpenRead             6   5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
-  48        OpenRead             7   2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
-  49        Rewind               5  62   0                       0  Rewind table partsupp
-  50          Column             5   1  26                       0  r[26]=partsupp.PS_SUPPKEY
-  51          SeekRowid          6  26  61                       0  if (r[26]!=cursor 6 for table supplier.rowid) goto 61
-  52          Column             6   3  27                       0  r[27]=supplier.S_NATIONKEY
-  53          SeekRowid          7  27  61                       0  if (r[27]!=cursor 7 for table nation.rowid) goto 61
-  54          Column             7   1  29                       0  r[29]=nation.N_NAME
-  55          String8            0  30   0  ARGENTINA            0  r[30]='ARGENTINA'
-  56          Ne                29  30  61  Binary               0  if r[29]!=r[30] goto 61
-  57          Column             5   3  32                       0  r[32]=partsupp.PS_SUPPLYCOST
-  58          Column             5   2  33                       0  r[33]=partsupp.PS_AVAILQTY
-  59          Multiply          32  33  31                       0  r[31]=r[32]*r[33]
-  60          AggStep            0  31  24  sum                  0  accum=r[24] step(r[31])
-  61        Next                 5  50   0                       0
-  62        AggFinal             0  24   0  sum                  0  accum=r[24]
-  63        Copy                24  34   0                       0  r[34]=r[24]
-  64        Real                 0  35   0  0.0001               0  r[35]=0.0001
-  65        Multiply            34  35  23                       0  r[23]=r[34]*r[35]
-  66        Copy                23   1   0                       0  r[1]=r[23]
-  67      Return                22   0   1                       0
-  68      Copy                  10  37   0                       0  r[37]=r[10]
-  69      Copy                   1  38   0                       0  r[38]=r[1]
-  70      Le                    37  38  38                       0  if r[37]<=r[38] goto 38
-  71      Copy                  10  39   0                       0  r[39]=r[10]
-  72      Copy                   9  40   0                       0  r[40]=r[9]
-  73      MakeRecord            39   2   4                       0  r[4]=mkrec(r[39..40])
-  74      SorterInsert           0   4   0  0                    0  key=r[4]
-  75    Return                   5   0   0                       0
-  76    Null                     0   9  10                       0  r[9..10]=NULL; clear accumulator subroutine start
-  77    Integer                  0   6   0                       0  r[6]=0
-  78  Return                    14   0   0                       0
-  79  OpenPseudo                 8   4   2                       0  2 columns in r[4]
-  80  SorterSort                 0  86   0                       0
-  81    SorterData               0   4   8                       0  r[4]=data
-  82    Column                   8   1   2                       0  r[2]=pseudo.column 1
-  83    Column                   8   0   3                       0  r[3]=pseudo.column 0
-  84    ResultRow                2   2   0                       0  output=r[2..3]
-  85  SorterNext                 0  81   0                       0
-  86  Halt                       0   0   0                       0
-  87  Transaction                0   1   8                       0  iDb=0 tx_mode=Read
-  88  String8                    0  19   0  ARGENTINA            0  r[19]='ARGENTINA'
-  89  Goto                       0   1   0                       0
+addr  opcode                       p1   p2  p3  p4                  p5  comment
+   0            Init                0  124   0                       0  Start at 124
+   1            SorterOpen          0    1   0  k(1,-B)              0  cursor=0
+   2            Null                0   10   0                       0  r[10]=NULL
+   3            SorterOpen          1    3   0  k(1,-B)              0  cursor=1
+   4            Integer             0    7   0                       0  r[7]=0; clear group by abort flag
+   5            Null                0    8   0                       0  r[8]=NULL; initialize group by comparison registers to NULL
+   6            Gosub              15  113   0                       0  ; go to clear accumulator subroutine
+   7            OpenRead            3    6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
+   8            OpenRead            5    5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
+   9            OpenRead            6    2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
+  10            Rewind              5   38   0                       0  Rewind table supplier
+  11              Column            5    3  16                       0  r[16]=supplier.S_NATIONKEY
+  12              SeekRowid         6   16  37                       0  if (r[16]!=cursor 6 for table nation.rowid) goto 37
+  13              Column            6    1  18                       0  r[18]=nation.N_NAME
+  14              Ne               18   19  37  Binary               0  if r[18]!=r[19] goto 37
+  15              Once             26    0   0                       0  goto 26
+  16              OpenAutoindex     4    0   0                       0  cursor=4
+  17              Rewind            3   18   0                       0  Rewind table partsupp
+  18                Column          3    1  20                       0  r[20]=partsupp.PS_SUPPKEY
+  19                Column          3    0  21                       0  r[21]=partsupp.PS_PARTKEY
+  20                ColumnRange     3    2  22  2                    0  r[22..23]=partsupp.PS_AVAILQTY..PS_SUPPLYCOST
+  21                RowId           3   24   0                       0  r[24]=partsupp.rowid
+  22                MakeRecord     20    5  25                       0  r[25]=mkrec(r[20..24]); for ephemeral_partsupp_t1
+  23                FilterAdd       4   20   1                       0  bloom_filter_add(r[20..21])
+  24                IdxInsert       4   25  20                       0  key=r[25]
+  25              Next              3   18   0                       0
+  26              RowId             5   26   0                       0  r[26]=supplier.rowid
+  27              Filter            4   37  26                       1  if !bloom_filter(r[26..27]) goto 37
+  28              SeekGE            4   37  26                       0  key=[26..26]
+  29                IdxGT           4   37  26                       0  key=[26..26]
+  30                DeferredSeek    4    3   0                       0
+  31                Column          4    1  12                       0  r[12]=ephemeral(ephemeral_partsupp_t1).PS_PARTKEY
+  32                Column          4    3  13                       0  r[13]=ephemeral(ephemeral_partsupp_t1).PS_SUPPLYCOST
+  33                Column          4    2  14                       0  r[14]=ephemeral(ephemeral_partsupp_t1).PS_AVAILQTY
+  34                MakeRecord     12    3  11                       0  r[11]=mkrec(r[12..14])
+  35                SorterInsert    1   11   0  0                    0  key=r[11]
+  36              Next              4   29   0                       0
+  37            Next                5   11   0                       0
+  38            OpenPseudo          2   11   3                       0  3 columns in r[11]
+  39            SorterSort          1   57   0                       0
+  40              SorterData        1   11   2                       0  r[11]=data
+  41              Column            2    0  27                       0  r[27]=pseudo.column 0
+  42              Compare           8   27   1  k(1, Binary)         0  r[8..8]==r[27..27]
+  43              Jump             44   48  44                       0  ; start new group if comparison is not equal
+  44              Gosub             5   61   0                       0  ; check if ended group had data, and output if so
+  45              Move             27    8   1                       0  r[8..8]=r[27..27]
+  46              IfPos             7  116   0                       0  r[7]>0 -> r[7]-=0, goto 116; check abort flag
+  47              Gosub            15  113   0                       0  ; goto clear accumulator subroutine
+  48              ColumnRange       2    1  28  2                    0  r[28..29]=pseudo.column 1..column 2
+  49              Copy             28   31   0                       0  r[31]=r[28]
+  50              Copy             29   32   0                       0  r[32]=r[29]
+  51              Multiply         31   32  30                       0  r[30]=r[31]*r[32]
+  52              AggStep           0   30  10  sum                  0  accum=r[10] step(r[30])
+  53              If                6   55   0                       0  if r[6] goto 55; don't emit group columns if continuing existing group
+  54              Column            2    0   9                       0  r[9]=pseudo.column 0
+  55              Integer           1    6   0                       0  r[6]=1; indicate data in accumulator
+  56            SorterNext          1   40   0                       0
+  57            Gosub               5   61   0                       0  ; emit row for final group
+  58            Goto                0  116   0                       0  ; group by finished
+  59            Integer             1    7   0                       0  r[7]=1
+  60          Return                5    0   0                       0
+  61          IfPos                 6   63   0                       0  r[6]>0 -> r[6]-=0, goto 63; output group by row subroutine start
+  62        Return                  5    0   0                       0
+  63        AggFinal                0   10   0  sum                  0  accum=r[10]
+  64        Once                  105    0   0                       0  goto 105
+  65        BeginSubrtn            33    0   0                       0  r[33]=NULL
+  66        Null                    0    1   0                       0  r[1]=NULL
+  67        Null                    0   35   0                       0  r[35]=NULL
+  68        Integer                 1   36   0                       0  r[36]=1; LIMIT counter
+  69        IfNot                  36   99   0                       0  if !r[36] goto 99
+  70        OpenRead                7    6   0  k(6,B,B,B,B,B)       0  table=partsupp, root=6, iDb=0
+  71        OpenRead                9    5   0  k(7,B,B,B,B,B,B,B)   0  table=supplier, root=5, iDb=0
+  72        OpenRead               10    2   0  k(4,B,B,B,B)         0  table=nation, root=2, iDb=0
+  73        Rewind                  9   99   0                       0  Rewind table supplier
+  74          Column                9    3  37                       0  r[37]=supplier.S_NATIONKEY
+  75          SeekRowid            10   37  98                       0  if (r[37]!=cursor 10 for table nation.rowid) goto 98
+  76          Column               10    1  39                       0  r[39]=nation.N_NAME
+  77          String8               0   40   0  ARGENTINA            0  r[40]='ARGENTINA'
+  78          Ne                   39   40  98  Binary               0  if r[39]!=r[40] goto 98
+  79          Once                 88    0   0                       0  goto 88
+  80          OpenAutoindex         8    0   0                       0  cursor=8
+  81          Rewind                7   82   0                       0  Rewind table partsupp
+  82            ColumnRange         7    1  41  3                    0  r[41..43]=partsupp.PS_SUPPKEY..PS_SUPPLYCOST
+  83            RowId               7   44   0                       0  r[44]=partsupp.rowid
+  84            MakeRecord         41    4  45                       0  r[45]=mkrec(r[41..44]); for ephemeral_partsupp_t5
+  85            FilterAdd           8   41   1                       0  bloom_filter_add(r[41..42])
+  86            IdxInsert           8   45  41                       0  key=r[45]
+  87          Next                  7   82   0                       0
+  88          RowId                 9   46   0                       0  r[46]=supplier.rowid
+  89          Filter                8   98  46                       1  if !bloom_filter(r[46..47]) goto 98
+  90          SeekGE                8   98  46                       0  key=[46..46]
+  91            IdxGT               8   98  46                       0  key=[46..46]
+  92            DeferredSeek        8    7   0                       0
+  93            Column              8    2  48                       0  r[48]=ephemeral(ephemeral_partsupp_t5).PS_SUPPLYCOST
+  94            Column              8    1  49                       0  r[49]=ephemeral(ephemeral_partsupp_t5).PS_AVAILQTY
+  95            Multiply           48   49  47                       0  r[47]=r[48]*r[49]
+  96            AggStep             0   47  35  sum                  0  accum=r[35] step(r[47])
+  97          Next                  8   91   0                       0
+  98        Next                    9   74   0                       0
+  99        AggFinal                0   35   0  sum                  0  accum=r[35]
+ 100        Copy                   35   50   0                       0  r[50]=r[35]
+ 101        Real                    0   51   0  0.0001               0  r[51]=0.0001
+ 102        Multiply               50   51  34                       0  r[34]=r[50]*r[51]
+ 103        Copy                   34    1   0                       0  r[1]=r[34]
+ 104      Return                   33    0   1                       0
+ 105      Copy                     10   53   0                       0  r[53]=r[10]
+ 106      Copy                      1   54   0                       0  r[54]=r[1]
+ 107      Le                       53   54  62                       0  if r[53]<=r[54] goto 62
+ 108      Copy                     10   55   0                       0  r[55]=r[10]
+ 109      Copy                      9   56   0                       0  r[56]=r[9]
+ 110      MakeRecord               55    2   4                       0  r[4]=mkrec(r[55..56])
+ 111      SorterInsert              0    4   0  0                    0  key=r[4]
+ 112    Return                      5    0   0                       0
+ 113    Null                        0    9  10                       0  r[9..10]=NULL; clear accumulator subroutine start
+ 114    Integer                     0    6   0                       0  r[6]=0
+ 115  Return                       15    0   0                       0
+ 116  OpenPseudo                   11    4   2                       0  2 columns in r[4]
+ 117  SorterSort                    0  123   0                       0
+ 118    SorterData                  0    4  11                       0  r[4]=data
+ 119    Column                     11    1   2                       0  r[2]=pseudo.column 1
+ 120    Column                     11    0   3                       0  r[3]=pseudo.column 0
+ 121    ResultRow                   2    2   0                       0  output=r[2..3]
+ 122  SorterNext                    0  118   0                       0
+ 123  Halt                          0    0   0                       0
+ 124  Transaction                   0    1   8                       0  iDb=0 tx_mode=Read
+ 125  String8                       0   19   0  ARGENTINA            0  r[19]='ARGENTINA'
+ 126  Goto                          0    1   0                       0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
@@ -29,54 +29,91 @@ info:
 QUERY PLAN
 |--SCAN lineitem
 |--SEARCH part USING INTEGER PRIMARY KEY (rowid=?)
-`--CORRELATED SCALAR SUBQUERY 1
-   `--SCAN lineitem
+`--SEARCH scalar_subquery_t3 USING INDEX ephemeral_subquery_t3 (correlation_key_0=?)
+   |--SCAN lineitem
+   `--USE SORTER FOR GROUP BY
 
 BYTECODE
-addr  opcode           p1  p2  p3  p4                                     p5  comment
-   0    Init            0  40   0                                          0  Start at 40
-   1    Null            0   3   0                                          0  r[3]=NULL
-   2    OpenRead        0  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   3    OpenRead        1   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
-   4    Rewind          0  35   0                                          0  Rewind table lineitem
-   5      Column        0   1   4                                          0  r[4]=lineitem.L_PARTKEY
-   6      SeekRowid     1   4  34                                          0  if (r[4]!=cursor 1 for table part.rowid) goto 34
-   7      Column        1   3   6                                          0  r[6]=part.P_BRAND
-   8      Ne            6   7  34  Binary                                  0  if r[6]!=r[7] goto 34
-   9      Column        1   6   9                                          0  r[9]=part.P_CONTAINER
-  10      Ne            9  10  34  Binary                                  0  if r[9]!=r[10] goto 34
-  11      BeginSubrtn  11   0   0                                          0  r[11]=NULL
-  12      Null          0   1   0                                          0  r[1]=NULL
-  13      Null          0  13   0                                          0  r[13]=NULL
-  14      Integer       1  14   0                                          0  r[14]=1; LIMIT counter
-  15      IfNot        14  24   0                                          0  if !r[14] goto 24
-  16      OpenRead      2  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-  17      Rewind        2  24   0                                          0  Rewind table lineitem
-  18        Column      2   1  16                                          0  r[16]=lineitem.L_PARTKEY
-  19        RowId       1  17   0                                          0  r[17]=part.rowid
-  20        Ne         16  17  23  Binary                                  0  if r[16]!=r[17] goto 23
-  21        Column      2   4  18                                          0  r[18]=lineitem.L_QUANTITY
-  22        AggStep     0  18  13  avg                                     0  accum=r[13] step(r[18])
-  23      Next          2  18   0                                          0
-  24      AggFinal      0  13   0  avg                                     0  accum=r[13]
-  25      Copy         13  20   0                                          0  r[20]=r[13]
-  26      Multiply     19  20  12                                          0  r[12]=r[19]*r[20]
-  27      Copy         12   1   0                                          0  r[1]=r[12]
-  28    Return         11   0   1                                          0
-  29    Column          0   4  22                                          0  r[22]=lineitem.L_QUANTITY
-  30    Copy            1  23   0                                          0  r[23]=r[1]
-  31    Ge             22  23  34  Binary                                  0  if r[22]>=r[23] goto 34
-  32    Column          0   5  24                                          0  r[24]=lineitem.L_EXTENDEDPRICE
-  33    AggStep         0  24   3  sum                                     0  accum=r[3] step(r[24])
-  34  Next              0   5   0                                          0
-  35  AggFinal          0   3   0  sum                                     0  accum=r[3]
-  36  Copy              3  25   0                                          0  r[25]=r[3]
-  37  Divide           25  26   2                                          0  r[2]=r[25]/r[26]
-  38  ResultRow         2   1   0                                          0  output=r[2]
-  39  Halt              0   0   0                                          0
-  40  Transaction       0   1   8                                          0  iDb=0 tx_mode=Read
-  41  String8           0   7   0  Brand#52                                0  r[7]='Brand#52'
-  42  String8           0  10   0  LG CAN                                  0  r[10]='LG CAN'
-  43  Real              0  19   0  0.2                                     0  r[19]=0.2
-  44  Real              0  26   0  7.0                                     0  r[26]=7
-  45  Goto              0   1   0                                          0
+addr  opcode                  p1  p2  p3  p4                                     p5  comment
+   0          Init             0  77   0                                          0  Start at 77
+   1          OpenEphemeral    0   0   0                                          0  cursor=0 is_table=false
+   2          Null             0  11   0                                          0  r[11]=NULL
+   3          SorterOpen       1   2   0  k(1,B)                                  0  cursor=1
+   4          Integer          0   8   0                                          0  r[8]=0; clear group by abort flag
+   5          Null             0   9   0                                          0  r[9]=NULL; initialize group by comparison registers to NULL
+   6          Gosub           15  47   0                                          0  ; go to clear accumulator subroutine
+   7          OpenRead         3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+   8          Rewind           3  14   0                                          0  Rewind table lineitem
+   9            Column         3   1  13                                          0  r[13]=lineitem.L_PARTKEY
+  10            Column         3   4  14                                          0  r[14]=lineitem.L_QUANTITY
+  11            MakeRecord    13   2  12                                          0  r[12]=mkrec(r[13..14])
+  12            SorterInsert   1  12   0  0                                       0  key=r[12]
+  13          Next             3   9   0                                          0
+  14          OpenPseudo       2  12   2                                          0  2 columns in r[12]
+  15          SorterSort       1  30   0                                          0
+  16            SorterData     1  12   2                                          0  r[12]=data
+  17            Column         2   0  16                                          0  r[16]=pseudo.column 0
+  18            Compare        9  16   1  k(1, Binary)                            0  r[9..9]==r[16..16]
+  19            Jump          20  24  20                                          0  ; start new group if comparison is not equal
+  20            Gosub          6  34   0                                          0  ; check if ended group had data, and output if so
+  21            Move          16   9   1                                          0  r[9..9]=r[16..16]
+  22            IfPos          8  50   0                                          0  r[8]>0 -> r[8]-=0, goto 50; check abort flag
+  23            Gosub         15  47   0                                          0  ; goto clear accumulator subroutine
+  24            Column         2   1  17                                          0  r[17]=pseudo.column 1
+  25            AggStep        0  17  11  avg                                     0  accum=r[11] step(r[17])
+  26            If             7  28   0                                          0  if r[7] goto 28; don't emit group columns if continuing existing group
+  27            Column         2   0  10                                          0  r[10]=pseudo.column 0
+  28            Integer        1   7   0                                          0  r[7]=1; indicate data in accumulator
+  29          SorterNext       1  16   0                                          0
+  30          Gosub            6  34   0                                          0  ; emit row for final group
+  31          Goto             0  50   0                                          0  ; group by finished
+  32          Integer          1   8   0                                          0  r[8]=1
+  33        Return             6   0   0                                          0
+  34        IfPos              7  36   0                                          0  r[7]>0 -> r[7]-=0, goto 36; output group by row subroutine start
+  35      Return               6   0   0                                          0
+  36      AggFinal             0  11   0  avg                                     0  accum=r[11]
+  37      Real                 0  18   0  0.2                                     0  r[18]=0.2
+  38      Copy                11  19   0                                          0  r[19]=r[11]
+  39      Multiply            18  19   4                                          0  r[4]=r[18]*r[19]
+  40      Copy                10   5   0                                          0  r[5]=r[10]
+  41      Copy                 5  21   0                                          0  r[21]=r[5]
+  42      Copy                 4  22   0                                          0  r[22]=r[4]
+  43      Sequence             0  23   0                                          0
+  44      MakeRecord          21   3  20                                          0  r[20]=mkrec(r[21..23]); for ephemeral_subquery_t3
+  45      IdxInsert            0  20   0                                          8  key=r[20]
+  46    Return                 6   0   0                                          0
+  47    Null                   0  10  11                                          0  r[10..11]=NULL; clear accumulator subroutine start
+  48    Integer                0   7   0                                          0  r[7]=0
+  49  Return                  15   0   0                                          0
+  50  Null                     0  25   0                                          0  r[25]=NULL
+  51  OpenRead                 4  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+  52  OpenRead                 5   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
+  53  Rewind                   4  72   0                                          0  Rewind table lineitem
+  54    Column                 4   1  26                                          0  r[26]=lineitem.L_PARTKEY
+  55    SeekRowid              5  26  71                                          0  if (r[26]!=cursor 5 for table part.rowid) goto 71
+  56    Column                 5   3  28                                          0  r[28]=part.P_BRAND
+  57    Ne                    28  29  71  Binary                                  0  if r[28]!=r[29] goto 71
+  58    Column                 5   6  31                                          0  r[31]=part.P_CONTAINER
+  59    Ne                    31  32  71  Binary                                  0  if r[31]!=r[32] goto 71
+  60    RowId                  5  33   0                                          0  r[33]=part.rowid
+  61    SeekGE                 0  71  33                                          0  key=[33..33]
+  62      IdxGT                0  71  33                                          0  key=[33..33]
+  63      Column               0   1   2                                          0  r[2]=ephemeral(ephemeral_subquery_t3).0.2 * avg(l_quantity)
+  64      Column               0   0   3                                          0  r[3]=ephemeral(ephemeral_subquery_t3).correlation_key_0
+  65      Column               4   4  35                                          0  r[35]=lineitem.L_QUANTITY
+  66      Column               0   1  36                                          0  r[36]=ephemeral(ephemeral_subquery_t3).0.2 * avg(l_quantity)
+  67      Ge                  35  36  70  Binary                                  0  if r[35]>=r[36] goto 70
+  68      Column               4   5  37                                          0  r[37]=lineitem.L_EXTENDEDPRICE
+  69      AggStep              0  37  25  sum                                     0  accum=r[25] step(r[37])
+  70    Next                   0  62   0                                          0
+  71  Next                     4  54   0                                          0
+  72  AggFinal                 0  25   0  sum                                     0  accum=r[25]
+  73  Copy                    25  38   0                                          0  r[38]=r[25]
+  74  Divide                  38  39  24                                          0  r[24]=r[38]/r[39]
+  75  ResultRow               24   1   0                                          0  output=r[24]
+  76  Halt                     0   0   0                                          0
+  77  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
+  78  String8                  0  29   0  Brand#52                                0  r[29]='Brand#52'
+  79  String8                  0  32   0  LG CAN                                  0  r[32]='LG CAN'
+  80  Real                     0  39   0  7.0                                     0  r[39]=7
+  81  Goto                     0   1   0                                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
@@ -35,85 +35,86 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                                     p5  comment
-   0          Init             0  77   0                                          0  Start at 77
-   1          OpenEphemeral    0   0   0                                          0  cursor=0 is_table=false
-   2          Null             0  11   0                                          0  r[11]=NULL
-   3          SorterOpen       1   2   0  k(1,B)                                  0  cursor=1
-   4          Integer          0   8   0                                          0  r[8]=0; clear group by abort flag
-   5          Null             0   9   0                                          0  r[9]=NULL; initialize group by comparison registers to NULL
-   6          Gosub           15  47   0                                          0  ; go to clear accumulator subroutine
-   7          OpenRead         3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   8          Rewind           3  14   0                                          0  Rewind table lineitem
-   9            Column         3   1  13                                          0  r[13]=lineitem.L_PARTKEY
-  10            Column         3   4  14                                          0  r[14]=lineitem.L_QUANTITY
-  11            MakeRecord    13   2  12                                          0  r[12]=mkrec(r[13..14])
-  12            SorterInsert   1  12   0  0                                       0  key=r[12]
-  13          Next             3   9   0                                          0
-  14          OpenPseudo       2  12   2                                          0  2 columns in r[12]
-  15          SorterSort       1  30   0                                          0
-  16            SorterData     1  12   2                                          0  r[12]=data
-  17            Column         2   0  16                                          0  r[16]=pseudo.column 0
-  18            Compare        9  16   1  k(1, Binary)                            0  r[9..9]==r[16..16]
-  19            Jump          20  24  20                                          0  ; start new group if comparison is not equal
-  20            Gosub          6  34   0                                          0  ; check if ended group had data, and output if so
-  21            Move          16   9   1                                          0  r[9..9]=r[16..16]
-  22            IfPos          8  50   0                                          0  r[8]>0 -> r[8]-=0, goto 50; check abort flag
-  23            Gosub         15  47   0                                          0  ; goto clear accumulator subroutine
-  24            Column         2   1  17                                          0  r[17]=pseudo.column 1
-  25            AggStep        0  17  11  avg                                     0  accum=r[11] step(r[17])
-  26            If             7  28   0                                          0  if r[7] goto 28; don't emit group columns if continuing existing group
-  27            Column         2   0  10                                          0  r[10]=pseudo.column 0
-  28            Integer        1   7   0                                          0  r[7]=1; indicate data in accumulator
-  29          SorterNext       1  16   0                                          0
-  30          Gosub            6  34   0                                          0  ; emit row for final group
-  31          Goto             0  50   0                                          0  ; group by finished
-  32          Integer          1   8   0                                          0  r[8]=1
-  33        Return             6   0   0                                          0
-  34        IfPos              7  36   0                                          0  r[7]>0 -> r[7]-=0, goto 36; output group by row subroutine start
-  35      Return               6   0   0                                          0
-  36      AggFinal             0  11   0  avg                                     0  accum=r[11]
-  37      Real                 0  18   0  0.2                                     0  r[18]=0.2
-  38      Copy                11  19   0                                          0  r[19]=r[11]
-  39      Multiply            18  19   4                                          0  r[4]=r[18]*r[19]
-  40      Copy                10   5   0                                          0  r[5]=r[10]
-  41      Copy                 5  21   0                                          0  r[21]=r[5]
-  42      Copy                 4  22   0                                          0  r[22]=r[4]
-  43      Sequence             0  23   0                                          0
-  44      MakeRecord          21   3  20                                          0  r[20]=mkrec(r[21..23]); for ephemeral_subquery_t3
-  45      IdxInsert            0  20   0                                          8  key=r[20]
-  46    Return                 6   0   0                                          0
-  47    Null                   0  10  11                                          0  r[10..11]=NULL; clear accumulator subroutine start
-  48    Integer                0   7   0                                          0  r[7]=0
-  49  Return                  15   0   0                                          0
-  50  Null                     0  25   0                                          0  r[25]=NULL
-  51  OpenRead                 4  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-  52  OpenRead                 5   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
-  53  Rewind                   4  72   0                                          0  Rewind table lineitem
-  54    Column                 4   1  26                                          0  r[26]=lineitem.L_PARTKEY
-  55    SeekRowid              5  26  71                                          0  if (r[26]!=cursor 5 for table part.rowid) goto 71
-  56    Column                 5   3  28                                          0  r[28]=part.P_BRAND
-  57    Ne                    28  29  71  Binary                                  0  if r[28]!=r[29] goto 71
-  58    Column                 5   6  31                                          0  r[31]=part.P_CONTAINER
-  59    Ne                    31  32  71  Binary                                  0  if r[31]!=r[32] goto 71
-  60    RowId                  5  33   0                                          0  r[33]=part.rowid
-  61    SeekGE                 0  71  33                                          0  key=[33..33]
-  62      IdxGT                0  71  33                                          0  key=[33..33]
-  63      Column               0   1   2                                          0  r[2]=ephemeral(ephemeral_subquery_t3).0.2 * avg(l_quantity)
-  64      Column               0   0   3                                          0  r[3]=ephemeral(ephemeral_subquery_t3).correlation_key_0
-  65      Column               4   4  35                                          0  r[35]=lineitem.L_QUANTITY
-  66      Column               0   1  36                                          0  r[36]=ephemeral(ephemeral_subquery_t3).0.2 * avg(l_quantity)
-  67      Ge                  35  36  70  Binary                                  0  if r[35]>=r[36] goto 70
-  68      Column               4   5  37                                          0  r[37]=lineitem.L_EXTENDEDPRICE
-  69      AggStep              0  37  25  sum                                     0  accum=r[25] step(r[37])
-  70    Next                   0  62   0                                          0
-  71  Next                     4  54   0                                          0
-  72  AggFinal                 0  25   0  sum                                     0  accum=r[25]
-  73  Copy                    25  38   0                                          0  r[38]=r[25]
-  74  Divide                  38  39  24                                          0  r[24]=r[38]/r[39]
-  75  ResultRow               24   1   0                                          0  output=r[24]
-  76  Halt                     0   0   0                                          0
-  77  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
-  78  String8                  0  29   0  Brand#52                                0  r[29]='Brand#52'
-  79  String8                  0  32   0  LG CAN                                  0  r[32]='LG CAN'
-  80  Real                     0  39   0  7.0                                     0  r[39]=7
-  81  Goto                     0   1   0                                          0
+   0          Init             0  78   0                                          0  Start at 78
+   1          Once            51   0   0                                          0  goto 51
+   2          OpenEphemeral    0   0   0                                          0  cursor=0 is_table=false
+   3          Null             0  11   0                                          0  r[11]=NULL
+   4          SorterOpen       1   2   0  k(1,B)                                  0  cursor=1
+   5          Integer          0   8   0                                          0  r[8]=0; clear group by abort flag
+   6          Null             0   9   0                                          0  r[9]=NULL; initialize group by comparison registers to NULL
+   7          Gosub           15  48   0                                          0  ; go to clear accumulator subroutine
+   8          OpenRead         3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+   9          Rewind           3  15   0                                          0  Rewind table lineitem
+  10            Column         3   1  13                                          0  r[13]=lineitem.L_PARTKEY
+  11            Column         3   4  14                                          0  r[14]=lineitem.L_QUANTITY
+  12            MakeRecord    13   2  12                                          0  r[12]=mkrec(r[13..14])
+  13            SorterInsert   1  12   0  0                                       0  key=r[12]
+  14          Next             3  10   0                                          0
+  15          OpenPseudo       2  12   2                                          0  2 columns in r[12]
+  16          SorterSort       1  31   0                                          0
+  17            SorterData     1  12   2                                          0  r[12]=data
+  18            Column         2   0  16                                          0  r[16]=pseudo.column 0
+  19            Compare        9  16   1  k(1, Binary)                            0  r[9..9]==r[16..16]
+  20            Jump          21  25  21                                          0  ; start new group if comparison is not equal
+  21            Gosub          6  35   0                                          0  ; check if ended group had data, and output if so
+  22            Move          16   9   1                                          0  r[9..9]=r[16..16]
+  23            IfPos          8  51   0                                          0  r[8]>0 -> r[8]-=0, goto 51; check abort flag
+  24            Gosub         15  48   0                                          0  ; goto clear accumulator subroutine
+  25            Column         2   1  17                                          0  r[17]=pseudo.column 1
+  26            AggStep        0  17  11  avg                                     0  accum=r[11] step(r[17])
+  27            If             7  29   0                                          0  if r[7] goto 29; don't emit group columns if continuing existing group
+  28            Column         2   0  10                                          0  r[10]=pseudo.column 0
+  29            Integer        1   7   0                                          0  r[7]=1; indicate data in accumulator
+  30          SorterNext       1  17   0                                          0
+  31          Gosub            6  35   0                                          0  ; emit row for final group
+  32          Goto             0  51   0                                          0  ; group by finished
+  33          Integer          1   8   0                                          0  r[8]=1
+  34        Return             6   0   0                                          0
+  35        IfPos              7  37   0                                          0  r[7]>0 -> r[7]-=0, goto 37; output group by row subroutine start
+  36      Return               6   0   0                                          0
+  37      AggFinal             0  11   0  avg                                     0  accum=r[11]
+  38      Real                 0  18   0  0.2                                     0  r[18]=0.2
+  39      Copy                11  19   0                                          0  r[19]=r[11]
+  40      Multiply            18  19   4                                          0  r[4]=r[18]*r[19]
+  41      Copy                10   5   0                                          0  r[5]=r[10]
+  42      Copy                 5  21   0                                          0  r[21]=r[5]
+  43      Copy                 4  22   0                                          0  r[22]=r[4]
+  44      Sequence             0  23   0                                          0
+  45      MakeRecord          21   3  20                                          0  r[20]=mkrec(r[21..23]); for ephemeral_subquery_t3
+  46      IdxInsert            0  20   0                                          8  key=r[20]
+  47    Return                 6   0   0                                          0
+  48    Null                   0  10  11                                          0  r[10..11]=NULL; clear accumulator subroutine start
+  49    Integer                0   7   0                                          0  r[7]=0
+  50  Return                  15   0   0                                          0
+  51  Null                     0  25   0                                          0  r[25]=NULL
+  52  OpenRead                 4  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+  53  OpenRead                 5   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
+  54  Rewind                   4  73   0                                          0  Rewind table lineitem
+  55    Column                 4   1  26                                          0  r[26]=lineitem.L_PARTKEY
+  56    SeekRowid              5  26  72                                          0  if (r[26]!=cursor 5 for table part.rowid) goto 72
+  57    Column                 5   3  28                                          0  r[28]=part.P_BRAND
+  58    Ne                    28  29  72  Binary                                  0  if r[28]!=r[29] goto 72
+  59    Column                 5   6  31                                          0  r[31]=part.P_CONTAINER
+  60    Ne                    31  32  72  Binary                                  0  if r[31]!=r[32] goto 72
+  61    RowId                  5  33   0                                          0  r[33]=part.rowid
+  62    SeekGE                 0  72  33                                          0  key=[33..33]
+  63      IdxGT                0  72  33                                          0  key=[33..33]
+  64      Column               0   1   2                                          0  r[2]=ephemeral(ephemeral_subquery_t3).0.2 * avg(l_quantity)
+  65      Column               0   0   3                                          0  r[3]=ephemeral(ephemeral_subquery_t3).correlation_key_0
+  66      Column               4   4  35                                          0  r[35]=lineitem.L_QUANTITY
+  67      Column               0   1  36                                          0  r[36]=ephemeral(ephemeral_subquery_t3).0.2 * avg(l_quantity)
+  68      Ge                  35  36  71  Binary                                  0  if r[35]>=r[36] goto 71
+  69      Column               4   5  37                                          0  r[37]=lineitem.L_EXTENDEDPRICE
+  70      AggStep              0  37  25  sum                                     0  accum=r[25] step(r[37])
+  71    Next                   0  63   0                                          0
+  72  Next                     4  55   0                                          0
+  73  AggFinal                 0  25   0  sum                                     0  accum=r[25]
+  74  Copy                    25  38   0                                          0  r[38]=r[25]
+  75  Divide                  38  39  24                                          0  r[24]=r[38]/r[39]
+  76  ResultRow               24   1   0                                          0  output=r[24]
+  77  Halt                     0   0   0                                          0
+  78  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
+  79  String8                  0  29   0  Brand#52                                0  r[29]='Brand#52'
+  80  String8                  0  32   0  LG CAN                                  0  r[32]='LG CAN'
+  81  Real                     0  39   0  7.0                                     0  r[39]=7
+  82  Goto                     0   1   0                                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
@@ -36,91 +36,91 @@ QUERY PLAN
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                                     p5  comment
    0          Init             0  84   0                                          0  Start at 84
-   1          InitCoroutine    2  47   2                                          0
-   2          Null             0  10   0                                          0  r[10]=NULL
+   1          InitCoroutine    1  47   2                                          0
+   2          Null             0   9   0                                          0  r[9]=NULL
    3          SorterOpen       0   2   0  k(1,B)                                  0  cursor=0
-   4          Integer          0   7   0                                          0  r[7]=0; clear group by abort flag
-   5          Null             0   8   0                                          0  r[8]=NULL; initialize group by comparison registers to NULL
-   6          Gosub           14  43   0                                          0  ; go to clear accumulator subroutine
+   4          Integer          0   6   0                                          0  r[6]=0; clear group by abort flag
+   5          Null             0   7   0                                          0  r[7]=NULL; initialize group by comparison registers to NULL
+   6          Gosub           13  43   0                                          0  ; go to clear accumulator subroutine
    7          OpenRead         2  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
    8          Rewind           2  14   0                                          0  Rewind table lineitem
-   9            Column         2   1  12                                          0  r[12]=lineitem.L_PARTKEY
-  10            Column         2   4  13                                          0  r[13]=lineitem.L_QUANTITY
-  11            MakeRecord    12   2  11                                          0  r[11]=mkrec(r[12..13])
-  12            SorterInsert   0  11   0  0                                       0  key=r[11]
+   9            Column         2   1  11                                          0  r[11]=lineitem.L_PARTKEY
+  10            Column         2   4  12                                          0  r[12]=lineitem.L_QUANTITY
+  11            MakeRecord    11   2  10                                          0  r[10]=mkrec(r[11..12])
+  12            SorterInsert   0  10   0  0                                       0  key=r[10]
   13          Next             2   9   0                                          0
-  14          OpenPseudo       1  11   2                                          0  2 columns in r[11]
+  14          OpenPseudo       1  10   2                                          0  2 columns in r[10]
   15          SorterSort       0  30   0                                          0
-  16            SorterData     0  11   1                                          0  r[11]=data
-  17            Column         1   0  15                                          0  r[15]=pseudo.column 0
-  18            Compare        8  15   1  k(1, Binary)                            0  r[8..8]==r[15..15]
+  16            SorterData     0  10   1                                          0  r[10]=data
+  17            Column         1   0  14                                          0  r[14]=pseudo.column 0
+  18            Compare        7  14   1  k(1, Binary)                            0  r[7..7]==r[14..14]
   19            Jump          20  24  20                                          0  ; start new group if comparison is not equal
-  20            Gosub          5  34   0                                          0  ; check if ended group had data, and output if so
-  21            Move          15   8   1                                          0  r[8..8]=r[15..15]
-  22            IfPos          7  46   0                                          0  r[7]>0 -> r[7]-=0, goto 46; check abort flag
-  23            Gosub         14  43   0                                          0  ; goto clear accumulator subroutine
-  24            Column         1   1  16                                          0  r[16]=pseudo.column 1
-  25            AggStep        0  16  10  avg                                     0  accum=r[10] step(r[16])
-  26            If             6  28   0                                          0  if r[6] goto 28; don't emit group columns if continuing existing group
-  27            Column         1   0   9                                          0  r[9]=pseudo.column 0
-  28            Integer        1   6   0                                          0  r[6]=1; indicate data in accumulator
+  20            Gosub          4  34   0                                          0  ; check if ended group had data, and output if so
+  21            Move          14   7   1                                          0  r[7..7]=r[14..14]
+  22            IfPos          6  46   0                                          0  r[6]>0 -> r[6]-=0, goto 46; check abort flag
+  23            Gosub         13  43   0                                          0  ; goto clear accumulator subroutine
+  24            Column         1   1  15                                          0  r[15]=pseudo.column 1
+  25            AggStep        0  15   9  avg                                     0  accum=r[9] step(r[15])
+  26            If             5  28   0                                          0  if r[5] goto 28; don't emit group columns if continuing existing group
+  27            Column         1   0   8                                          0  r[8]=pseudo.column 0
+  28            Integer        1   5   0                                          0  r[5]=1; indicate data in accumulator
   29          SorterNext       0  16   0                                          0
-  30          Gosub            5  34   0                                          0  ; emit row for final group
+  30          Gosub            4  34   0                                          0  ; emit row for final group
   31          Goto             0  46   0                                          0  ; group by finished
-  32          Integer          1   7   0                                          0  r[7]=1
-  33        Return             5   0   0                                          0
-  34        IfPos              6  36   0                                          0  r[6]>0 -> r[6]-=0, goto 36; output group by row subroutine start
-  35      Return               5   0   0                                          0
-  36      AggFinal             0  10   0  avg                                     0  accum=r[10]
-  37      Real                 0  17   0  0.2                                     0  r[17]=0.2
-  38      Copy                10  18   0                                          0  r[18]=r[10]
-  39      Multiply            17  18   3                                          0  r[3]=r[17]*r[18]
-  40      Copy                 9   4   0                                          0  r[4]=r[9]
-  41      Yield                2   0   0                                          0
-  42    Return                 5   0   0                                          0
-  43    Null                   0   9  10                                          0  r[9..10]=NULL; clear accumulator subroutine start
-  44    Integer                0   6   0                                          0  r[6]=0
-  45  Return                  14   0   0                                          0
-  46  EndCoroutine             2   0   0                                          0
-  47  Null                     0  20   0                                          0  r[20]=NULL
+  32          Integer          1   6   0                                          0  r[6]=1
+  33        Return             4   0   0                                          0
+  34        IfPos              5  36   0                                          0  r[5]>0 -> r[5]-=0, goto 36; output group by row subroutine start
+  35      Return               4   0   0                                          0
+  36      AggFinal             0   9   0  avg                                     0  accum=r[9]
+  37      Real                 0  16   0  0.2                                     0  r[16]=0.2
+  38      Copy                 9  17   0                                          0  r[17]=r[9]
+  39      Multiply            16  17   2                                          0  r[2]=r[16]*r[17]
+  40      Copy                 8   3   0                                          0  r[3]=r[8]
+  41      Yield                1   0   0                                          0
+  42    Return                 4   0   0                                          0
+  43    Null                   0   8   9                                          0  r[8..9]=NULL; clear accumulator subroutine start
+  44    Integer                0   5   0                                          0  r[5]=0
+  45  Return                  13   0   0                                          0
+  46  EndCoroutine             1   0   0                                          0
+  47  Null                     0  19   0                                          0  r[19]=NULL
   48  OpenRead                 3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
   49  OpenRead                 5   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
-  50  InitCoroutine            2   0   2                                          0
-  51    Yield                  2  79   0                                          0
-  52    Copy                   4  21   0                                          0  r[21]=r[4]
-  53    SeekRowid              5  21  78                                          0  if (r[21]!=cursor 5 for table part.rowid) goto 78
-  54    Column                 5   3  23                                          0  r[23]=part.P_BRAND
-  55    Ne                    23  24  78  Binary                                  0  if r[23]!=r[24] goto 78
-  56    Column                 5   6  26                                          0  r[26]=part.P_CONTAINER
-  57    Ne                    26  27  78  Binary                                  0  if r[26]!=r[27] goto 78
+  50  InitCoroutine            1   0   2                                          0
+  51    Yield                  1  79   0                                          0
+  52    Copy                   3  20   0                                          0  r[20]=r[3]
+  53    SeekRowid              5  20  78                                          0  if (r[20]!=cursor 5 for table part.rowid) goto 78
+  54    Column                 5   3  22                                          0  r[22]=part.P_BRAND
+  55    Ne                    22  23  78  Binary                                  0  if r[22]!=r[23] goto 78
+  56    Column                 5   6  25                                          0  r[25]=part.P_CONTAINER
+  57    Ne                    25  26  78  Binary                                  0  if r[25]!=r[26] goto 78
   58    Once                  67   0   0                                          0  goto 67
   59    OpenAutoindex          4   0   0                                          0  cursor=4
   60    Rewind                 3  61   0                                          0  Rewind table lineitem
-  61      Column               3   1  28                                          0  r[28]=lineitem.L_PARTKEY
-  62      ColumnRange          3   4  29  2                                       0  r[29..30]=lineitem.L_QUANTITY..L_EXTENDEDPRICE
-  63      RowId                3  31   0                                          0  r[31]=lineitem.rowid
-  64      MakeRecord          28   4  32                                          0  r[32]=mkrec(r[28..31]); for ephemeral_lineitem_t1
-  65      IdxInsert            4  32  28                                          0  key=r[32]
+  61      Column               3   1  27                                          0  r[27]=lineitem.L_PARTKEY
+  62      ColumnRange          3   4  28  2                                       0  r[28..29]=lineitem.L_QUANTITY..L_EXTENDEDPRICE
+  63      RowId                3  30   0                                          0  r[30]=lineitem.rowid
+  64      MakeRecord          27   4  31                                          0  r[31]=mkrec(r[27..30]); for ephemeral_lineitem_t1
+  65      IdxInsert            4  31  27                                          0  key=r[31]
   66    Next                   3  61   0                                          0
-  67    RowId                  5  33   0                                          0  r[33]=part.rowid
-  68    Null                   0  34   0                                          0  r[34]=NULL
-  69    SeekGT                 4  78  33                                          0  key=[33..34]
-  70    Copy                   3  34   0                                          0  r[34]=r[3]
-  71    Affinity              33   2   0                                          0  r[33..35] = A, C
-  72    IsNull                34  78   0                                          0  if (r[34]==NULL) goto 78
-  73      IdxGE                4  78  33                                          0  key=[33..34]
+  67    RowId                  5  32   0                                          0  r[32]=part.rowid
+  68    Null                   0  33   0                                          0  r[33]=NULL
+  69    SeekGT                 4  78  32                                          0  key=[32..33]
+  70    Copy                   2  33   0                                          0  r[33]=r[2]
+  71    Affinity              32   2   0                                          0  r[32..34] = A, C
+  72    IsNull                33  78   0                                          0  if (r[33]==NULL) goto 78
+  73      IdxGE                4  78  32                                          0  key=[32..33]
   74      DeferredSeek         4   3   0                                          0
-  75      Column               4   2  35                                          0  r[35]=ephemeral(ephemeral_lineitem_t1).L_EXTENDEDPRICE
-  76      AggStep              0  35  20  sum                                     0  accum=r[20] step(r[35])
+  75      Column               4   2  34                                          0  r[34]=ephemeral(ephemeral_lineitem_t1).L_EXTENDEDPRICE
+  76      AggStep              0  34  19  sum                                     0  accum=r[19] step(r[34])
   77    Next                   4  73   0                                          0
   78  Goto                     0  51   0                                          0
-  79  AggFinal                 0  20   0  sum                                     0  accum=r[20]
-  80  Copy                    20  36   0                                          0  r[36]=r[20]
-  81  Divide                  36  37  19                                          0  r[19]=r[36]/r[37]
-  82  ResultRow               19   1   0                                          0  output=r[19]
+  79  AggFinal                 0  19   0  sum                                     0  accum=r[19]
+  80  Copy                    19  35   0                                          0  r[35]=r[19]
+  81  Divide                  35  36  18                                          0  r[18]=r[35]/r[36]
+  82  ResultRow               18   1   0                                          0  output=r[18]
   83  Halt                     0   0   0                                          0
   84  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
-  85  String8                  0  24   0  Brand#52                                0  r[24]='Brand#52'
-  86  String8                  0  27   0  LG CAN                                  0  r[27]='LG CAN'
-  87  Real                     0  37   0  7.0                                     0  r[37]=7
+  85  String8                  0  23   0  Brand#52                                0  r[23]='Brand#52'
+  86  String8                  0  26   0  LG CAN                                  0  r[26]='LG CAN'
+  87  Real                     0  36   0  7.0                                     0  r[36]=7
   88  Goto                     0   1   0                                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
@@ -27,94 +27,100 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN lineitem
+|--SCAN scalar_subquery_t3
+|  |--SCAN lineitem
+|  `--USE SORTER FOR GROUP BY
 |--SEARCH part USING INTEGER PRIMARY KEY (rowid=?)
-`--SEARCH scalar_subquery_t3 USING INDEX ephemeral_subquery_t3 (correlation_key_0=?)
-   |--SCAN lineitem
-   `--USE SORTER FOR GROUP BY
+`--SEARCH lineitem USING COVERING INDEX ephemeral_lineitem_t1 (L_PARTKEY=? AND L_QUANTITY<?)
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                                     p5  comment
-   0          Init             0  78   0                                          0  Start at 78
-   1          Once            51   0   0                                          0  goto 51
-   2          OpenEphemeral    0   0   0                                          0  cursor=0 is_table=false
-   3          Null             0  11   0                                          0  r[11]=NULL
-   4          SorterOpen       1   2   0  k(1,B)                                  0  cursor=1
-   5          Integer          0   8   0                                          0  r[8]=0; clear group by abort flag
-   6          Null             0   9   0                                          0  r[9]=NULL; initialize group by comparison registers to NULL
-   7          Gosub           15  48   0                                          0  ; go to clear accumulator subroutine
-   8          OpenRead         3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   9          Rewind           3  15   0                                          0  Rewind table lineitem
-  10            Column         3   1  13                                          0  r[13]=lineitem.L_PARTKEY
-  11            Column         3   4  14                                          0  r[14]=lineitem.L_QUANTITY
-  12            MakeRecord    13   2  12                                          0  r[12]=mkrec(r[13..14])
-  13            SorterInsert   1  12   0  0                                       0  key=r[12]
-  14          Next             3  10   0                                          0
-  15          OpenPseudo       2  12   2                                          0  2 columns in r[12]
-  16          SorterSort       1  31   0                                          0
-  17            SorterData     1  12   2                                          0  r[12]=data
-  18            Column         2   0  16                                          0  r[16]=pseudo.column 0
-  19            Compare        9  16   1  k(1, Binary)                            0  r[9..9]==r[16..16]
-  20            Jump          21  25  21                                          0  ; start new group if comparison is not equal
-  21            Gosub          6  35   0                                          0  ; check if ended group had data, and output if so
-  22            Move          16   9   1                                          0  r[9..9]=r[16..16]
-  23            IfPos          8  51   0                                          0  r[8]>0 -> r[8]-=0, goto 51; check abort flag
-  24            Gosub         15  48   0                                          0  ; goto clear accumulator subroutine
-  25            Column         2   1  17                                          0  r[17]=pseudo.column 1
-  26            AggStep        0  17  11  avg                                     0  accum=r[11] step(r[17])
-  27            If             7  29   0                                          0  if r[7] goto 29; don't emit group columns if continuing existing group
-  28            Column         2   0  10                                          0  r[10]=pseudo.column 0
-  29            Integer        1   7   0                                          0  r[7]=1; indicate data in accumulator
-  30          SorterNext       1  17   0                                          0
-  31          Gosub            6  35   0                                          0  ; emit row for final group
-  32          Goto             0  51   0                                          0  ; group by finished
-  33          Integer          1   8   0                                          0  r[8]=1
-  34        Return             6   0   0                                          0
-  35        IfPos              7  37   0                                          0  r[7]>0 -> r[7]-=0, goto 37; output group by row subroutine start
-  36      Return               6   0   0                                          0
-  37      AggFinal             0  11   0  avg                                     0  accum=r[11]
-  38      Real                 0  18   0  0.2                                     0  r[18]=0.2
-  39      Copy                11  19   0                                          0  r[19]=r[11]
-  40      Multiply            18  19   4                                          0  r[4]=r[18]*r[19]
-  41      Copy                10   5   0                                          0  r[5]=r[10]
-  42      Copy                 5  21   0                                          0  r[21]=r[5]
-  43      Copy                 4  22   0                                          0  r[22]=r[4]
-  44      Sequence             0  23   0                                          0
-  45      MakeRecord          21   3  20                                          0  r[20]=mkrec(r[21..23]); for ephemeral_subquery_t3
-  46      IdxInsert            0  20   0                                          8  key=r[20]
-  47    Return                 6   0   0                                          0
-  48    Null                   0  10  11                                          0  r[10..11]=NULL; clear accumulator subroutine start
-  49    Integer                0   7   0                                          0  r[7]=0
-  50  Return                  15   0   0                                          0
-  51  Null                     0  25   0                                          0  r[25]=NULL
-  52  OpenRead                 4  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-  53  OpenRead                 5   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
-  54  Rewind                   4  73   0                                          0  Rewind table lineitem
-  55    Column                 4   1  26                                          0  r[26]=lineitem.L_PARTKEY
-  56    SeekRowid              5  26  72                                          0  if (r[26]!=cursor 5 for table part.rowid) goto 72
-  57    Column                 5   3  28                                          0  r[28]=part.P_BRAND
-  58    Ne                    28  29  72  Binary                                  0  if r[28]!=r[29] goto 72
-  59    Column                 5   6  31                                          0  r[31]=part.P_CONTAINER
-  60    Ne                    31  32  72  Binary                                  0  if r[31]!=r[32] goto 72
-  61    RowId                  5  33   0                                          0  r[33]=part.rowid
-  62    SeekGE                 0  72  33                                          0  key=[33..33]
-  63      IdxGT                0  72  33                                          0  key=[33..33]
-  64      Column               0   1   2                                          0  r[2]=ephemeral(ephemeral_subquery_t3).0.2 * avg(l_quantity)
-  65      Column               0   0   3                                          0  r[3]=ephemeral(ephemeral_subquery_t3).correlation_key_0
-  66      Column               4   4  35                                          0  r[35]=lineitem.L_QUANTITY
-  67      Column               0   1  36                                          0  r[36]=ephemeral(ephemeral_subquery_t3).0.2 * avg(l_quantity)
-  68      Ge                  35  36  71  Binary                                  0  if r[35]>=r[36] goto 71
-  69      Column               4   5  37                                          0  r[37]=lineitem.L_EXTENDEDPRICE
-  70      AggStep              0  37  25  sum                                     0  accum=r[25] step(r[37])
-  71    Next                   0  63   0                                          0
-  72  Next                     4  55   0                                          0
-  73  AggFinal                 0  25   0  sum                                     0  accum=r[25]
-  74  Copy                    25  38   0                                          0  r[38]=r[25]
-  75  Divide                  38  39  24                                          0  r[24]=r[38]/r[39]
-  76  ResultRow               24   1   0                                          0  output=r[24]
-  77  Halt                     0   0   0                                          0
-  78  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
-  79  String8                  0  29   0  Brand#52                                0  r[29]='Brand#52'
-  80  String8                  0  32   0  LG CAN                                  0  r[32]='LG CAN'
-  81  Real                     0  39   0  7.0                                     0  r[39]=7
-  82  Goto                     0   1   0                                          0
+   0          Init             0  84   0                                          0  Start at 84
+   1          InitCoroutine    2  47   2                                          0
+   2          Null             0  10   0                                          0  r[10]=NULL
+   3          SorterOpen       0   2   0  k(1,B)                                  0  cursor=0
+   4          Integer          0   7   0                                          0  r[7]=0; clear group by abort flag
+   5          Null             0   8   0                                          0  r[8]=NULL; initialize group by comparison registers to NULL
+   6          Gosub           14  43   0                                          0  ; go to clear accumulator subroutine
+   7          OpenRead         2  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+   8          Rewind           2  14   0                                          0  Rewind table lineitem
+   9            Column         2   1  12                                          0  r[12]=lineitem.L_PARTKEY
+  10            Column         2   4  13                                          0  r[13]=lineitem.L_QUANTITY
+  11            MakeRecord    12   2  11                                          0  r[11]=mkrec(r[12..13])
+  12            SorterInsert   0  11   0  0                                       0  key=r[11]
+  13          Next             2   9   0                                          0
+  14          OpenPseudo       1  11   2                                          0  2 columns in r[11]
+  15          SorterSort       0  30   0                                          0
+  16            SorterData     0  11   1                                          0  r[11]=data
+  17            Column         1   0  15                                          0  r[15]=pseudo.column 0
+  18            Compare        8  15   1  k(1, Binary)                            0  r[8..8]==r[15..15]
+  19            Jump          20  24  20                                          0  ; start new group if comparison is not equal
+  20            Gosub          5  34   0                                          0  ; check if ended group had data, and output if so
+  21            Move          15   8   1                                          0  r[8..8]=r[15..15]
+  22            IfPos          7  46   0                                          0  r[7]>0 -> r[7]-=0, goto 46; check abort flag
+  23            Gosub         14  43   0                                          0  ; goto clear accumulator subroutine
+  24            Column         1   1  16                                          0  r[16]=pseudo.column 1
+  25            AggStep        0  16  10  avg                                     0  accum=r[10] step(r[16])
+  26            If             6  28   0                                          0  if r[6] goto 28; don't emit group columns if continuing existing group
+  27            Column         1   0   9                                          0  r[9]=pseudo.column 0
+  28            Integer        1   6   0                                          0  r[6]=1; indicate data in accumulator
+  29          SorterNext       0  16   0                                          0
+  30          Gosub            5  34   0                                          0  ; emit row for final group
+  31          Goto             0  46   0                                          0  ; group by finished
+  32          Integer          1   7   0                                          0  r[7]=1
+  33        Return             5   0   0                                          0
+  34        IfPos              6  36   0                                          0  r[6]>0 -> r[6]-=0, goto 36; output group by row subroutine start
+  35      Return               5   0   0                                          0
+  36      AggFinal             0  10   0  avg                                     0  accum=r[10]
+  37      Real                 0  17   0  0.2                                     0  r[17]=0.2
+  38      Copy                10  18   0                                          0  r[18]=r[10]
+  39      Multiply            17  18   3                                          0  r[3]=r[17]*r[18]
+  40      Copy                 9   4   0                                          0  r[4]=r[9]
+  41      Yield                2   0   0                                          0
+  42    Return                 5   0   0                                          0
+  43    Null                   0   9  10                                          0  r[9..10]=NULL; clear accumulator subroutine start
+  44    Integer                0   6   0                                          0  r[6]=0
+  45  Return                  14   0   0                                          0
+  46  EndCoroutine             2   0   0                                          0
+  47  Null                     0  20   0                                          0  r[20]=NULL
+  48  OpenRead                 3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+  49  OpenRead                 5   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
+  50  InitCoroutine            2   0   2                                          0
+  51    Yield                  2  79   0                                          0
+  52    Copy                   4  21   0                                          0  r[21]=r[4]
+  53    SeekRowid              5  21  78                                          0  if (r[21]!=cursor 5 for table part.rowid) goto 78
+  54    Column                 5   3  23                                          0  r[23]=part.P_BRAND
+  55    Ne                    23  24  78  Binary                                  0  if r[23]!=r[24] goto 78
+  56    Column                 5   6  26                                          0  r[26]=part.P_CONTAINER
+  57    Ne                    26  27  78  Binary                                  0  if r[26]!=r[27] goto 78
+  58    Once                  67   0   0                                          0  goto 67
+  59    OpenAutoindex          4   0   0                                          0  cursor=4
+  60    Rewind                 3  61   0                                          0  Rewind table lineitem
+  61      Column               3   1  28                                          0  r[28]=lineitem.L_PARTKEY
+  62      ColumnRange          3   4  29  2                                       0  r[29..30]=lineitem.L_QUANTITY..L_EXTENDEDPRICE
+  63      RowId                3  31   0                                          0  r[31]=lineitem.rowid
+  64      MakeRecord          28   4  32                                          0  r[32]=mkrec(r[28..31]); for ephemeral_lineitem_t1
+  65      IdxInsert            4  32  28                                          0  key=r[32]
+  66    Next                   3  61   0                                          0
+  67    RowId                  5  33   0                                          0  r[33]=part.rowid
+  68    Null                   0  34   0                                          0  r[34]=NULL
+  69    SeekGT                 4  78  33                                          0  key=[33..34]
+  70    Copy                   3  34   0                                          0  r[34]=r[3]
+  71    Affinity              33   2   0                                          0  r[33..35] = A, C
+  72    IsNull                34  78   0                                          0  if (r[34]==NULL) goto 78
+  73      IdxGE                4  78  33                                          0  key=[33..34]
+  74      DeferredSeek         4   3   0                                          0
+  75      Column               4   2  35                                          0  r[35]=ephemeral(ephemeral_lineitem_t1).L_EXTENDEDPRICE
+  76      AggStep              0  35  20  sum                                     0  accum=r[20] step(r[35])
+  77    Next                   4  73   0                                          0
+  78  Goto                     0  51   0                                          0
+  79  AggFinal                 0  20   0  sum                                     0  accum=r[20]
+  80  Copy                    20  36   0                                          0  r[36]=r[20]
+  81  Divide                  36  37  19                                          0  r[19]=r[36]/r[37]
+  82  ResultRow               19   1   0                                          0  output=r[19]
+  83  Halt                     0   0   0                                          0
+  84  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
+  85  String8                  0  24   0  Brand#52                                0  r[24]='Brand#52'
+  86  String8                  0  27   0  LG CAN                                  0  r[27]='LG CAN'
+  87  Real                     0  37   0  7.0                                     0  r[37]=7
+  88  Goto                     0   1   0                                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
@@ -27,100 +27,105 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN scalar_subquery_t3
+|--SCAN part
+|--SEARCH scalar_subquery_t3 USING INDEX ephemeral_subquery_t3 (correlation_key_0=?)
 |  |--SCAN lineitem
 |  `--USE SORTER FOR GROUP BY
-|--SEARCH part USING INTEGER PRIMARY KEY (rowid=?)
 `--SEARCH lineitem USING COVERING INDEX ephemeral_lineitem_t1 (L_PARTKEY=? AND L_QUANTITY<?)
 
 BYTECODE
 addr  opcode                  p1  p2  p3  p4                                     p5  comment
-   0          Init             0  84   0                                          0  Start at 84
-   1          InitCoroutine    1  47   2                                          0
-   2          Null             0   9   0                                          0  r[9]=NULL
-   3          SorterOpen       0   2   0  k(1,B)                                  0  cursor=0
-   4          Integer          0   6   0                                          0  r[6]=0; clear group by abort flag
-   5          Null             0   7   0                                          0  r[7]=NULL; initialize group by comparison registers to NULL
-   6          Gosub           13  43   0                                          0  ; go to clear accumulator subroutine
-   7          OpenRead         2  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-   8          Rewind           2  14   0                                          0  Rewind table lineitem
-   9            Column         2   1  11                                          0  r[11]=lineitem.L_PARTKEY
-  10            Column         2   4  12                                          0  r[12]=lineitem.L_QUANTITY
-  11            MakeRecord    11   2  10                                          0  r[10]=mkrec(r[11..12])
-  12            SorterInsert   0  10   0  0                                       0  key=r[10]
-  13          Next             2   9   0                                          0
-  14          OpenPseudo       1  10   2                                          0  2 columns in r[10]
-  15          SorterSort       0  30   0                                          0
-  16            SorterData     0  10   1                                          0  r[10]=data
-  17            Column         1   0  14                                          0  r[14]=pseudo.column 0
-  18            Compare        7  14   1  k(1, Binary)                            0  r[7..7]==r[14..14]
-  19            Jump          20  24  20                                          0  ; start new group if comparison is not equal
-  20            Gosub          4  34   0                                          0  ; check if ended group had data, and output if so
-  21            Move          14   7   1                                          0  r[7..7]=r[14..14]
-  22            IfPos          6  46   0                                          0  r[6]>0 -> r[6]-=0, goto 46; check abort flag
-  23            Gosub         13  43   0                                          0  ; goto clear accumulator subroutine
-  24            Column         1   1  15                                          0  r[15]=pseudo.column 1
-  25            AggStep        0  15   9  avg                                     0  accum=r[9] step(r[15])
-  26            If             5  28   0                                          0  if r[5] goto 28; don't emit group columns if continuing existing group
-  27            Column         1   0   8                                          0  r[8]=pseudo.column 0
-  28            Integer        1   5   0                                          0  r[5]=1; indicate data in accumulator
-  29          SorterNext       0  16   0                                          0
-  30          Gosub            4  34   0                                          0  ; emit row for final group
-  31          Goto             0  46   0                                          0  ; group by finished
-  32          Integer          1   6   0                                          0  r[6]=1
-  33        Return             4   0   0                                          0
-  34        IfPos              5  36   0                                          0  r[5]>0 -> r[5]-=0, goto 36; output group by row subroutine start
-  35      Return               4   0   0                                          0
-  36      AggFinal             0   9   0  avg                                     0  accum=r[9]
-  37      Real                 0  16   0  0.2                                     0  r[16]=0.2
-  38      Copy                 9  17   0                                          0  r[17]=r[9]
-  39      Multiply            16  17   2                                          0  r[2]=r[16]*r[17]
-  40      Copy                 8   3   0                                          0  r[3]=r[8]
-  41      Yield                1   0   0                                          0
-  42    Return                 4   0   0                                          0
-  43    Null                   0   8   9                                          0  r[8..9]=NULL; clear accumulator subroutine start
-  44    Integer                0   5   0                                          0  r[5]=0
-  45  Return                  13   0   0                                          0
-  46  EndCoroutine             1   0   0                                          0
-  47  Null                     0  19   0                                          0  r[19]=NULL
-  48  OpenRead                 3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
-  49  OpenRead                 5   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
-  50  InitCoroutine            1   0   2                                          0
-  51    Yield                  1  79   0                                          0
-  52    Copy                   3  20   0                                          0  r[20]=r[3]
-  53    SeekRowid              5  20  78                                          0  if (r[20]!=cursor 5 for table part.rowid) goto 78
-  54    Column                 5   3  22                                          0  r[22]=part.P_BRAND
-  55    Ne                    22  23  78  Binary                                  0  if r[22]!=r[23] goto 78
-  56    Column                 5   6  25                                          0  r[25]=part.P_CONTAINER
-  57    Ne                    25  26  78  Binary                                  0  if r[25]!=r[26] goto 78
-  58    Once                  67   0   0                                          0  goto 67
-  59    OpenAutoindex          4   0   0                                          0  cursor=4
-  60    Rewind                 3  61   0                                          0  Rewind table lineitem
-  61      Column               3   1  27                                          0  r[27]=lineitem.L_PARTKEY
-  62      ColumnRange          3   4  28  2                                       0  r[28..29]=lineitem.L_QUANTITY..L_EXTENDEDPRICE
-  63      RowId                3  30   0                                          0  r[30]=lineitem.rowid
-  64      MakeRecord          27   4  31                                          0  r[31]=mkrec(r[27..30]); for ephemeral_lineitem_t1
-  65      IdxInsert            4  31  27                                          0  key=r[31]
-  66    Next                   3  61   0                                          0
-  67    RowId                  5  32   0                                          0  r[32]=part.rowid
-  68    Null                   0  33   0                                          0  r[33]=NULL
-  69    SeekGT                 4  78  32                                          0  key=[32..33]
-  70    Copy                   2  33   0                                          0  r[33]=r[2]
-  71    Affinity              32   2   0                                          0  r[32..34] = A, C
-  72    IsNull                33  78   0                                          0  if (r[33]==NULL) goto 78
-  73      IdxGE                4  78  32                                          0  key=[32..33]
-  74      DeferredSeek         4   3   0                                          0
-  75      Column               4   2  34                                          0  r[34]=ephemeral(ephemeral_lineitem_t1).L_EXTENDEDPRICE
-  76      AggStep              0  34  19  sum                                     0  accum=r[19] step(r[34])
-  77    Next                   4  73   0                                          0
-  78  Goto                     0  51   0                                          0
-  79  AggFinal                 0  19   0  sum                                     0  accum=r[19]
-  80  Copy                    19  35   0                                          0  r[35]=r[19]
-  81  Divide                  35  36  18                                          0  r[18]=r[35]/r[36]
-  82  ResultRow               18   1   0                                          0  output=r[18]
-  83  Halt                     0   0   0                                          0
-  84  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
-  85  String8                  0  23   0  Brand#52                                0  r[23]='Brand#52'
-  86  String8                  0  26   0  LG CAN                                  0  r[26]='LG CAN'
-  87  Real                     0  36   0  7.0                                     0  r[36]=7
-  88  Goto                     0   1   0                                          0
+   0          Init             0  89   0                                          0  Start at 89
+   1          Once            51   0   0                                          0  goto 51
+   2          OpenEphemeral    0   0   0                                          0  cursor=0 is_table=false
+   3          Null             0   8   0                                          0  r[8]=NULL
+   4          SorterOpen       1   2   0  k(1,B)                                  0  cursor=1
+   5          Integer          0   5   0                                          0  r[5]=0; clear group by abort flag
+   6          Null             0   6   0                                          0  r[6]=NULL; initialize group by comparison registers to NULL
+   7          Gosub           12  48   0                                          0  ; go to clear accumulator subroutine
+   8          OpenRead         3  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+   9          Rewind           3  15   0                                          0  Rewind table lineitem
+  10            Column         3   1  10                                          0  r[10]=lineitem.L_PARTKEY
+  11            Column         3   4  11                                          0  r[11]=lineitem.L_QUANTITY
+  12            MakeRecord    10   2   9                                          0  r[9]=mkrec(r[10..11])
+  13            SorterInsert   1   9   0  0                                       0  key=r[9]
+  14          Next             3  10   0                                          0
+  15          OpenPseudo       2   9   2                                          0  2 columns in r[9]
+  16          SorterSort       1  31   0                                          0
+  17            SorterData     1   9   2                                          0  r[9]=data
+  18            Column         2   0  13                                          0  r[13]=pseudo.column 0
+  19            Compare        6  13   1  k(1, Binary)                            0  r[6..6]==r[13..13]
+  20            Jump          21  25  21                                          0  ; start new group if comparison is not equal
+  21            Gosub          3  35   0                                          0  ; check if ended group had data, and output if so
+  22            Move          13   6   1                                          0  r[6..6]=r[13..13]
+  23            IfPos          5  51   0                                          0  r[5]>0 -> r[5]-=0, goto 51; check abort flag
+  24            Gosub         12  48   0                                          0  ; goto clear accumulator subroutine
+  25            Column         2   1  14                                          0  r[14]=pseudo.column 1
+  26            AggStep        0  14   8  avg                                     0  accum=r[8] step(r[14])
+  27            If             4  29   0                                          0  if r[4] goto 29; don't emit group columns if continuing existing group
+  28            Column         2   0   7                                          0  r[7]=pseudo.column 0
+  29            Integer        1   4   0                                          0  r[4]=1; indicate data in accumulator
+  30          SorterNext       1  17   0                                          0
+  31          Gosub            3  35   0                                          0  ; emit row for final group
+  32          Goto             0  51   0                                          0  ; group by finished
+  33          Integer          1   5   0                                          0  r[5]=1
+  34        Return             3   0   0                                          0
+  35        IfPos              4  37   0                                          0  r[4]>0 -> r[4]-=0, goto 37; output group by row subroutine start
+  36      Return               3   0   0                                          0
+  37      AggFinal             0   8   0  avg                                     0  accum=r[8]
+  38      Real                 0  15   0  0.2                                     0  r[15]=0.2
+  39      Copy                 8  16   0                                          0  r[16]=r[8]
+  40      Multiply            15  16   1                                          0  r[1]=r[15]*r[16]
+  41      Copy                 7   2   0                                          0  r[2]=r[7]
+  42      Copy                 2  18   0                                          0  r[18]=r[2]
+  43      Copy                 1  19   0                                          0  r[19]=r[1]
+  44      Sequence             0  20   0                                          0
+  45      MakeRecord          18   3  17                                          0  r[17]=mkrec(r[18..20]); for ephemeral_subquery_t3
+  46      IdxInsert            0  17   0                                          8  key=r[17]
+  47    Return                 3   0   0                                          0
+  48    Null                   0   7   8                                          0  r[7..8]=NULL; clear accumulator subroutine start
+  49    Integer                0   4   0                                          0  r[4]=0
+  50  Return                  12   0   0                                          0
+  51  Null                     0  22   0                                          0  r[22]=NULL
+  52  OpenRead                 4  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+  53  OpenRead                 6   4   0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
+  54  Rewind                   6  84   0                                          0  Rewind table part
+  55    Column                 6   3  24                                          0  r[24]=part.P_BRAND
+  56    Ne                    24  25  83  Binary                                  0  if r[24]!=r[25] goto 83
+  57    Column                 6   6  27                                          0  r[27]=part.P_CONTAINER
+  58    Ne                    27  28  83  Binary                                  0  if r[27]!=r[28] goto 83
+  59    RowId                  6  29   0                                          0  r[29]=part.rowid
+  60    SeekGE                 0  83  29                                          0  key=[29..29]
+  61      IdxGT                0  83  29                                          0  key=[29..29]
+  62      Once                71   0   0                                          0  goto 71
+  63      OpenAutoindex        5   0   0                                          0  cursor=5
+  64      Rewind               4  65   0                                          0  Rewind table lineitem
+  65        Column             4   1  30                                          0  r[30]=lineitem.L_PARTKEY
+  66        ColumnRange        4   4  31  2                                       0  r[31..32]=lineitem.L_QUANTITY..L_EXTENDEDPRICE
+  67        RowId              4  33   0                                          0  r[33]=lineitem.rowid
+  68        MakeRecord        30   4  34                                          0  r[34]=mkrec(r[30..33]); for ephemeral_lineitem_t1
+  69        IdxInsert          5  34  30                                          0  key=r[34]
+  70      Next                 4  65   0                                          0
+  71      RowId                6  35   0                                          0  r[35]=part.rowid
+  72      Null                 0  36   0                                          0  r[36]=NULL
+  73      SeekGT               5  82  35                                          0  key=[35..36]
+  74      Column               0   1  36                                          0  r[36]=ephemeral(ephemeral_subquery_t3).0.2 * avg(l_quantity)
+  75      Affinity            35   2   0                                          0  r[35..37] = A, C
+  76      IsNull              36  82   0                                          0  if (r[36]==NULL) goto 82
+  77        IdxGE              5  82  35                                          0  key=[35..36]
+  78        DeferredSeek       5   4   0                                          0
+  79        Column             5   2  37                                          0  r[37]=ephemeral(ephemeral_lineitem_t1).L_EXTENDEDPRICE
+  80        AggStep            0  37  22  sum                                     0  accum=r[22] step(r[37])
+  81      Next                 5  77   0                                          0
+  82    Next                   0  61   0                                          0
+  83  Next                     6  55   0                                          0
+  84  AggFinal                 0  22   0  sum                                     0  accum=r[22]
+  85  Copy                    22  38   0                                          0  r[38]=r[22]
+  86  Divide                  38  39  21                                          0  r[21]=r[38]/r[39]
+  87  ResultRow               21   1   0                                          0  output=r[21]
+  88  Halt                     0   0   0                                          0
+  89  Transaction              0   1   8                                          0  iDb=0 tx_mode=Read
+  90  String8                  0  25   0  Brand#52                                0  r[25]='Brand#52'
+  91  String8                  0  28   0  LG CAN                                  0  r[28]='LG CAN'
+  92  Real                     0  39   0  7.0                                     0  r[39]=7
+  93  Goto                     0   1   0                                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q2-minimum-cost-supplier.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q2-minimum-cost-supplier.snap
@@ -60,8 +60,8 @@ QUERY PLAN
 |--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH region USING INTEGER PRIMARY KEY (rowid=?)
-|--CORRELATED SCALAR SUBQUERY 1
-|  |--SEARCH partsupp USING INDEX sqlite_autoindex_partsupp_1 (ps_partkey=?)
+|--SEARCH scalar_subquery_t6 USING INDEX ephemeral_subquery_t6 (correlation_key_0=?)
+|  |--SCAN partsupp USING INDEX sqlite_autoindex_partsupp_1
 |  |--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
 |  |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
 |  `--SEARCH region USING INTEGER PRIMARY KEY (rowid=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q2-minimum-cost-supplier.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q2-minimum-cost-supplier.snap
@@ -60,8 +60,8 @@ QUERY PLAN
 |--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH region USING INTEGER PRIMARY KEY (rowid=?)
-|--SEARCH scalar_subquery_t6 USING INDEX ephemeral_subquery_t6 (correlation_key_0=?)
-|  |--SCAN partsupp USING INDEX sqlite_autoindex_partsupp_1
+|--CORRELATED SCALAR SUBQUERY 1
+|  |--SEARCH partsupp USING INDEX sqlite_autoindex_partsupp_1 (ps_partkey=?)
 |  |--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
 |  |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
 |  `--SEARCH region USING INTEGER PRIMARY KEY (rowid=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q20-potential-part-promotion.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q20-potential-part-promotion.snap
@@ -54,8 +54,9 @@ QUERY PLAN
 |  |--LIST SUBQUERY 2
 |  |  `--SCAN part
 |  |--SEARCH partsupp USING INDEX sqlite_autoindex_partsupp_1 (ps_partkey=?)
-|  `--CORRELATED SCALAR SUBQUERY 3
-|     `--SCAN lineitem
+|  `--SEARCH scalar_subquery_t7 USING INDEX ephemeral_subquery_t7 (correlation_key_0=? AND correlation_key_1=?)
+|     |--SCAN lineitem
+|     `--USE SORTER FOR GROUP BY
 |--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
 `--USE SORTER FOR ORDER BY

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q20-potential-part-promotion.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q20-potential-part-promotion.snap
@@ -54,9 +54,8 @@ QUERY PLAN
 |  |--LIST SUBQUERY 2
 |  |  `--SCAN part
 |  |--SEARCH partsupp USING INDEX sqlite_autoindex_partsupp_1 (ps_partkey=?)
-|  `--SEARCH scalar_subquery_t7 USING INDEX ephemeral_subquery_t7 (correlation_key_0=? AND correlation_key_1=?)
-|     |--SCAN lineitem
-|     `--USE SORTER FOR GROUP BY
+|  `--CORRELATED SCALAR SUBQUERY 3
+|     `--SCAN lineitem
 |--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
 `--USE SORTER FOR ORDER BY

--- a/sqlite/conformance/sqlite-sqltests/snapshots/cte_cardinality__small-cte-materialized-big-cte-outer.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/cte_cardinality__small-cte-materialized-big-cte-outer.snap
@@ -22,7 +22,7 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN small AS s
+|--SCAN big AS b
 |  `--SCAN items
-`--SEARCH b USING INDEX ephemeral_subquery_t4 (id=?)
+`--SEARCH s USING INDEX ephemeral_subquery_t2 (id=?)
    `--SCAN items

--- a/sqlite/conformance/sqlite-sqltests/snapshots/cte_cardinality__three-ctes-big-outer-others-materialized.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/cte_cardinality__three-ctes-big-outer-others-materialized.snap
@@ -28,9 +28,9 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SCAN tiny AS t
+|--SCAN big AS b
 |  `--SCAN items
 |--SEARCH m USING INDEX ephemeral_subquery_t4 (id=?)
 |  `--SCAN items
-`--SEARCH b USING INDEX ephemeral_subquery_t6 (id=?)
+`--SEARCH t USING INDEX ephemeral_subquery_t2 (id=?)
    `--SCAN items

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -953,6 +953,177 @@ expect pattern {
     (?s)SEARCH scalar_subquery_.*SEARCH scalar_subquery_
 }
 
+
+# Each level has one EXISTS that can be changed to a join and one EXISTS
+# that holds the next level. Preparing this query must not try every mix of
+# changed and unchanged levels.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+@backend cli
+test deep-correlated-subqueries-prepare-once {
+    CREATE TABLE deep_prepare_rows(k INTEGER);
+    CREATE TABLE deep_prepare_guards(k INTEGER);
+
+    SELECT r0.k
+        FROM deep_prepare_rows r0
+        WHERE EXISTS (
+            SELECT 1
+            FROM deep_prepare_guards g0
+            WHERE g0.k = r0.k
+        )
+          AND EXISTS (
+            SELECT r1.k
+            FROM deep_prepare_rows r1
+            WHERE r1.k = r0.k
+              AND EXISTS (
+                SELECT 1
+                FROM deep_prepare_guards g1
+                WHERE g1.k = r1.k
+            )
+              AND EXISTS (
+                SELECT r2.k
+                FROM deep_prepare_rows r2
+                WHERE r2.k = r1.k
+                  AND EXISTS (
+                    SELECT 1
+                    FROM deep_prepare_guards g2
+                    WHERE g2.k = r2.k
+                )
+                  AND EXISTS (
+                    SELECT r3.k
+                    FROM deep_prepare_rows r3
+                    WHERE r3.k = r2.k
+                      AND EXISTS (
+                        SELECT 1
+                        FROM deep_prepare_guards g3
+                        WHERE g3.k = r3.k
+                    )
+                      AND EXISTS (
+                        SELECT r4.k
+                        FROM deep_prepare_rows r4
+                        WHERE r4.k = r3.k
+                          AND EXISTS (
+                            SELECT 1
+                            FROM deep_prepare_guards g4
+                            WHERE g4.k = r4.k
+                        )
+                          AND EXISTS (
+                            SELECT r5.k
+                            FROM deep_prepare_rows r5
+                            WHERE r5.k = r4.k
+                              AND EXISTS (
+                                SELECT 1
+                                FROM deep_prepare_guards g5
+                                WHERE g5.k = r5.k
+                            )
+                              AND EXISTS (
+                                SELECT r6.k
+                                FROM deep_prepare_rows r6
+                                WHERE r6.k = r5.k
+                                  AND EXISTS (
+                                    SELECT 1
+                                    FROM deep_prepare_guards g6
+                                    WHERE g6.k = r6.k
+                                )
+                                  AND EXISTS (
+                                    SELECT r7.k
+                                    FROM deep_prepare_rows r7
+                                    WHERE r7.k = r6.k
+                                      AND EXISTS (
+                                        SELECT 1
+                                        FROM deep_prepare_guards g7
+                                        WHERE g7.k = r7.k
+                                    )
+                                      AND EXISTS (
+                                        SELECT r8.k
+                                        FROM deep_prepare_rows r8
+                                        WHERE r8.k = r7.k
+                                          AND EXISTS (
+                                            SELECT 1
+                                            FROM deep_prepare_guards g8
+                                            WHERE g8.k = r8.k
+                                        )
+                                          AND EXISTS (
+                                            SELECT r9.k
+                                            FROM deep_prepare_rows r9
+                                            WHERE r9.k = r8.k
+                                              AND EXISTS (
+                                                SELECT 1
+                                                FROM deep_prepare_guards g9
+                                                WHERE g9.k = r9.k
+                                            )
+                                              AND EXISTS (
+                                                SELECT r10.k
+                                                FROM deep_prepare_rows r10
+                                                WHERE r10.k = r9.k
+                                                  AND EXISTS (
+                                                    SELECT 1
+                                                    FROM deep_prepare_guards g10
+                                                    WHERE g10.k = r10.k
+                                                )
+                                                  AND EXISTS (
+                                                    SELECT r11.k
+                                                    FROM deep_prepare_rows r11
+                                                    WHERE r11.k = r10.k
+                                                      AND EXISTS (
+                                                        SELECT 1
+                                                        FROM deep_prepare_guards g11
+                                                        WHERE g11.k = r11.k
+                                                    )
+                                                      AND EXISTS (
+                                                        SELECT r12.k
+                                                        FROM deep_prepare_rows r12
+                                                        WHERE r12.k = r11.k
+                                                          AND EXISTS (
+                                                            SELECT 1
+                                                            FROM deep_prepare_guards g12
+                                                            WHERE g12.k = r12.k
+                                                        )
+                                                          AND EXISTS (
+                                                            SELECT r13.k
+                                                            FROM deep_prepare_rows r13
+                                                            WHERE r13.k = r12.k
+                                                              AND EXISTS (
+                                                                SELECT 1
+                                                                FROM deep_prepare_guards g13
+                                                                WHERE g13.k = r13.k
+                                                            )
+                                                              AND EXISTS (
+                                                                SELECT r14.k
+                                                                FROM deep_prepare_rows r14
+                                                                WHERE r14.k = r13.k
+                                                                  AND EXISTS (
+                                                                    SELECT 1
+                                                                    FROM deep_prepare_guards g14
+                                                                    WHERE g14.k = r14.k
+                                                                )
+                                                                  AND EXISTS (
+                                                                    SELECT r15.k
+                                                                    FROM deep_prepare_rows r15
+                                                                    WHERE r15.k = r14.k
+                                                                      AND EXISTS (
+                                                                        SELECT 1
+                                                                        FROM deep_prepare_guards g15
+                                                                        WHERE g15.k = r15.k
+                                                                    )
+                                                                )
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        );
+}
+expect {
+}
+
 setup comparison_keys {
     CREATE TABLE number_outer(id INTEGER PRIMARY KEY, key1 INTEGER);
     CREATE TABLE text_inner(key1 TEXT, amount INTEGER, group_id INTEGER);

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -892,6 +892,41 @@ expect {
     2|0|0|SEARCH i USING COVERING INDEX ephemeral_filtered_exists_inner_t3 (key1=?)
 }
 
+# With table counts from ANALYZE, one outer row should use the saved inner
+# index. All outer rows should group the inner table once.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+@skip-if mvcc "MVCC does not reload sqlite_stat1 after this test changes it"
+test indexed-average-uses-outer-row-count {
+    CREATE TABLE one_indexed_avg_outer(id INTEGER PRIMARY KEY, k INTEGER, x REAL);
+    CREATE TABLE many_indexed_avg_outer(id INTEGER PRIMARY KEY, k INTEGER, x REAL);
+    CREATE TABLE indexed_avg_inner(k INTEGER, q REAL);
+    CREATE INDEX indexed_avg_inner_k ON indexed_avg_inner(k);
+    ANALYZE;
+    DELETE FROM sqlite_stat1;
+    INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES
+        ('one_indexed_avg_outer', NULL, '1'),
+        ('many_indexed_avg_outer', NULL, '20000'),
+        ('indexed_avg_inner', 'indexed_avg_inner_k', '200000 100');
+    ANALYZE sqlite_schema;
+
+    EXPLAIN QUERY PLAN
+    SELECT count(*)
+    FROM one_indexed_avg_outer o
+    WHERE o.x < (
+              SELECT avg(i.q) FROM indexed_avg_inner i WHERE i.k = o.k
+          );
+
+    EXPLAIN QUERY PLAN
+    SELECT count(*)
+    FROM many_indexed_avg_outer o
+    WHERE o.x < (
+              SELECT avg(i.q) FROM indexed_avg_inner i WHERE i.k = o.k
+          );
+}
+expect pattern {
+    (?s)CORRELATED SCALAR SUBQUERY.*SEARCH i USING INDEX indexed_avg_inner_k.*SCAN scalar_subquery_.*SCAN indexed_avg_inner AS i USING INDEX indexed_avg_inner_k
+}
+
 setup comparison_keys {
     CREATE TABLE number_outer(id INTEGER PRIMARY KEY, key1 INTEGER);
     CREATE TABLE text_inner(key1 TEXT, amount INTEGER, group_id INTEGER);

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -924,7 +924,7 @@ test indexed-average-uses-outer-row-count {
           );
 }
 expect pattern {
-    (?s)CORRELATED SCALAR SUBQUERY.*SEARCH i USING INDEX indexed_avg_inner_k.*SCAN scalar_subquery_.*SCAN indexed_avg_inner AS i USING INDEX indexed_avg_inner_k
+    (?s)SCAN one_indexed_avg_outer AS o.*CORRELATED SCALAR SUBQUERY.*SEARCH i USING INDEX indexed_avg_inner_k.*SCAN many_indexed_avg_outer AS o.*SEARCH scalar_subquery_.*SCAN indexed_avg_inner AS i USING INDEX indexed_avg_inner_k
 }
 
 # Two copies of the same aggregate need one grouped table.

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -1,0 +1,695 @@
+@database :memory:
+
+setup correlated_rows {
+    CREATE TABLE outer_rows(
+        id INTEGER PRIMARY KEY,
+        key1 INTEGER,
+        key2 INTEGER,
+        amount INTEGER,
+        text_key TEXT
+    );
+    CREATE TABLE inner_rows(key1 INTEGER, key2 INTEGER, amount INTEGER, text_key TEXT);
+    CREATE TABLE outer_key2(id INTEGER PRIMARY KEY, key2 INTEGER);
+    INSERT INTO outer_rows VALUES
+        (1, 1, 10, 5, 'A'),
+        (2, 1, 10, 15, 'a'),
+        (3, 2, 20, 7, 'B'),
+        (4, 3, 30, 9, 'C'),
+        (5, NULL, 40, 4, NULL),
+        (6, 2, NULL, NULL, 'b');
+    INSERT INTO inner_rows VALUES
+        (1, 10, 10, 'a'),
+        (1, 10, 20, 'A'),
+        (1, 99, 100, 'x'),
+        (2, 20, 6, 'b'),
+        (2, 20, NULL, 'B'),
+        (2, NULL, 7, NULL),
+        (NULL, 40, 99, NULL);
+    INSERT INTO outer_key2 VALUES (1, 10), (3, 20), (5, 40);
+}
+
+@setup correlated_rows
+test one-value-avg-in-select-list {
+    SELECT id, (SELECT avg(i.amount) FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|43.3333333333333
+    2|43.3333333333333
+    3|6.5
+    4|
+    5|
+    6|6.5
+}
+
+@setup correlated_rows
+test one-value-count-keeps-zero-for-empty-group {
+    SELECT id, (SELECT count(*) FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|3
+    2|3
+    3|3
+    4|0
+    5|0
+    6|3
+}
+
+@setup correlated_rows
+test one-value-total-keeps-zero-for-empty-group {
+    SELECT id, (SELECT total(i.amount) FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|130.0
+    2|130.0
+    3|13.0
+    4|0.0
+    5|0.0
+    6|13.0
+}
+expect @js {
+    1|130
+    2|130
+    3|13
+    4|0
+    5|0
+    6|13
+}
+
+@setup correlated_rows
+test one-value-two-link-columns {
+    SELECT id, (SELECT min(i.amount) FROM inner_rows i
+                WHERE i.key1 = o.key1 AND i.key2 = o.key2)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|10
+    2|10
+    3|6
+    4|
+    5|
+    6|
+}
+
+@setup correlated_rows
+test one-value-link-written-outer-first {
+    SELECT id, (SELECT max(i.amount) FROM inner_rows i WHERE o.key1 = i.key1)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|100
+    2|100
+    3|7
+    4|
+    5|
+    6|7
+}
+
+@setup correlated_rows
+test one-value-inner-filter-stays-inside-grouping {
+    SELECT id, (SELECT sum(i.amount) FROM inner_rows i
+                WHERE i.key1 = o.key1 AND i.key2 = 10)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|30
+    2|30
+    3|
+    4|
+    5|
+    6|
+}
+
+@setup correlated_rows
+test one-value-aggregate-filter {
+    SELECT id, (SELECT sum(i.amount) FILTER (WHERE i.key2 = 10)
+                FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|30
+    2|30
+    3|
+    4|
+    5|
+    6|
+}
+
+@setup correlated_rows
+test one-value-group-concat {
+    SELECT id, (SELECT group_concat(i.text_key, ':')
+                FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    WHERE id IN (1, 3, 4)
+    ORDER BY id;
+}
+expect {
+    1|a:A:x
+    3|b:B
+    4|
+}
+
+@setup correlated_rows
+test one-value-distinct-aggregate {
+    SELECT id, (SELECT count(DISTINCT i.key2) FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|2
+    2|2
+    3|1
+    4|0
+    5|0
+    6|1
+}
+
+@setup correlated_rows
+test two-one-value-aggregates {
+    SELECT id,
+           (SELECT min(i.amount) FROM inner_rows i WHERE i.key1 = o.key1),
+           (SELECT max(i.amount) FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|10|100
+    2|10|100
+    3|6|7
+    4||
+    5||
+    6|6|7
+}
+
+@setup correlated_rows
+test one-value-inside-outer-aggregate {
+    SELECT key1, sum((SELECT min(i.amount) FROM inner_rows i WHERE i.key1 = o.key1))
+    FROM outer_rows o
+    WHERE key1 IS NOT NULL
+    GROUP BY key1
+    ORDER BY key1;
+}
+expect {
+    1|20
+    2|12
+    3|
+}
+
+@setup correlated_rows
+test one-value-used-in-having {
+    SELECT key1, count(*)
+    FROM outer_rows o
+    WHERE key1 IS NOT NULL
+    GROUP BY key1
+    HAVING count(*) >= (SELECT count(*) FROM inner_rows i WHERE i.key1 = o.key1)
+    ORDER BY key1;
+}
+expect {
+    3|1
+}
+
+@setup correlated_rows
+test one-value-used-for-ordering {
+    SELECT id
+    FROM outer_rows o
+    ORDER BY (SELECT max(i.amount) FROM inner_rows i WHERE i.key1 = o.key1) DESC, id;
+}
+expect {
+    1
+    2
+    3
+    6
+    4
+    5
+}
+
+@setup correlated_rows
+test one-value-math-with-null-result {
+    SELECT id
+    FROM outer_rows o
+    WHERE amount < (SELECT 0.2 * avg(i.amount) FROM inner_rows i WHERE i.key1 = o.key1)
+    ORDER BY id;
+}
+expect {
+    1
+}
+
+@setup correlated_rows
+test one-value-null-key-does-not-match-null-group {
+    SELECT id, (SELECT sum(i.amount) FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    WHERE id = 5;
+}
+expect {
+    5|
+}
+
+@setup correlated_rows
+test one-value-correlated-to-two-outer-tables {
+    SELECT o.id, (SELECT sum(i.amount) FROM inner_rows i
+                  WHERE i.key1 = o.key1 AND i.key2 = x.key2)
+    FROM outer_rows o JOIN outer_key2 x ON x.id = o.id
+    ORDER BY o.id;
+}
+expect {
+    1|30
+    3|6
+    5|
+}
+
+@setup correlated_rows
+test one-value-correlated-to-outer-table-that-may-be-null {
+    SELECT o.id, (SELECT count(*) FROM inner_rows i WHERE i.key2 = x.key2)
+    FROM outer_rows o LEFT JOIN outer_key2 x ON x.id = o.id
+    ORDER BY o.id;
+}
+expect {
+    1|2
+    2|0
+    3|2
+    4|0
+    5|1
+    6|0
+}
+
+@setup correlated_rows
+test correlated-in-basic {
+    SELECT id
+    FROM outer_rows o
+    WHERE 10 IN (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1)
+    ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+@setup correlated_rows
+test correlated-in-with-two-link-columns {
+    SELECT id
+    FROM outer_rows o
+    WHERE 6 IN (SELECT i.amount FROM inner_rows i
+                WHERE i.key1 = o.key1 AND i.key2 = o.key2)
+    ORDER BY id;
+}
+expect {
+    3
+}
+
+@setup correlated_rows
+test correlated-in-inner-filter {
+    SELECT id
+    FROM outer_rows o
+    WHERE 20 IN (SELECT i.amount FROM inner_rows i
+                 WHERE i.key1 = o.key1 AND i.text_key = 'A')
+    ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+@setup correlated_rows
+test correlated-in-null-results-do-not-match {
+    SELECT id
+    FROM outer_rows o
+    WHERE amount IN (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1)
+    ORDER BY id;
+}
+expect {
+    3
+}
+
+@setup correlated_rows
+test correlated-in-uses-left-collation {
+    SELECT id
+    FROM outer_rows o
+    WHERE text_key COLLATE NOCASE IN (
+        SELECT i.text_key FROM inner_rows i WHERE i.key1 = o.key1
+    )
+    ORDER BY id;
+}
+expect {
+    1
+    2
+    3
+    6
+}
+
+@setup correlated_rows
+test correlated-in-does-not-duplicate-outer-rows {
+    INSERT INTO inner_rows VALUES (1, 10, 10, 'a');
+    SELECT id
+    FROM outer_rows o
+    WHERE 10 IN (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1)
+    ORDER BY id;
+}
+expect {
+    1
+    2
+}
+
+@setup correlated_rows
+test correlated-in-with-outer-aggregate {
+    SELECT count(*)
+    FROM outer_rows o
+    WHERE 10 IN (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1);
+}
+expect {
+    2
+}
+
+@setup correlated_rows
+test correlated-in-through-correlated-derived-table {
+    SELECT o.id
+    FROM outer_rows o
+    WHERE o.id IN (
+        SELECT amount
+        FROM (SELECT DISTINCT amount FROM inner_rows i WHERE i.key1 = o.key1)
+    )
+    ORDER BY o.id;
+}
+expect {
+    6
+}
+
+@setup correlated_rows
+test exists-through-correlated-derived-table {
+    SELECT o.id
+    FROM outer_rows o
+    WHERE EXISTS (
+        SELECT 1
+        FROM (SELECT DISTINCT amount FROM inner_rows i WHERE i.key1 = o.key1)
+    )
+    ORDER BY o.id;
+}
+expect {
+    1
+    2
+    3
+    6
+}
+
+# These forms stay correlated because the simple join rewrites would change
+# their result. They are included here to protect the safety checks.
+
+@setup correlated_rows
+test not-in-with-null-inner-value {
+    SELECT id
+    FROM outer_rows o
+    WHERE 11 NOT IN (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1)
+    ORDER BY id;
+}
+expect {
+    1
+    2
+    4
+    5
+}
+
+@setup correlated_rows
+test in-under-or {
+    SELECT id
+    FROM outer_rows o
+    WHERE id = 4 OR 10 IN (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1)
+    ORDER BY id;
+}
+expect {
+    1
+    2
+    4
+}
+
+@setup correlated_rows
+test one-value-link-that-does-not-use-equals {
+    SELECT id, (SELECT min(i.amount) FROM inner_rows i WHERE i.key1 <= o.key1)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|10
+    2|10
+    3|6
+    4|6
+    5|
+    6|6
+}
+
+@setup correlated_rows
+test one-value-is-link-keeps-null-match {
+    SELECT id, (SELECT max(i.amount) FROM inner_rows i WHERE i.key1 IS o.key1)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|100
+    2|100
+    3|7
+    4|
+    5|99
+    6|7
+}
+
+@setup correlated_rows
+test one-value-limit-zero {
+    SELECT id, (SELECT sum(i.amount) FROM inner_rows i WHERE i.key1 = o.key1 LIMIT 0)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|
+    2|
+    3|
+    4|
+    5|
+    6|
+}
+
+@setup correlated_rows
+test one-value-outer-only-filter {
+    SELECT id, (SELECT count(*) FROM inner_rows i
+                WHERE i.key1 = o.key1 AND o.amount > 10)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|0
+    2|3
+    3|0
+    4|0
+    5|0
+    6|0
+}
+
+@setup correlated_rows
+test one-value-expression-with-non-null-empty-result {
+    SELECT id, (SELECT coalesce(sum(i.amount), 0) FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    ORDER BY id;
+}
+expect {
+    1|130
+    2|130
+    3|13
+    4|0
+    5|0
+    6|13
+}
+
+@setup correlated_rows
+test one-value-in-outer-join-condition-stays-correlated {
+    SELECT o.id, x.id
+    FROM outer_rows o LEFT JOIN outer_key2 x
+      ON x.key2 = (SELECT min(i.key2) FROM inner_rows i WHERE i.key1 = o.key1)
+    ORDER BY o.id;
+}
+expect {
+    1|1
+    2|1
+    3|3
+    4|
+    5|
+    6|3
+}
+
+setup comparison_keys {
+    CREATE TABLE number_outer(id INTEGER PRIMARY KEY, key1 INTEGER);
+    CREATE TABLE text_inner(key1 TEXT, amount INTEGER, group_id INTEGER);
+    INSERT INTO number_outer VALUES (1, 1);
+    INSERT INTO text_inner VALUES ('1', 10, 1), ('01', 20, 1);
+
+    CREATE TABLE nocase_outer(id INTEGER PRIMARY KEY, key1 TEXT COLLATE NOCASE);
+    CREATE TABLE binary_inner(key1 TEXT COLLATE BINARY, amount INTEGER);
+    CREATE TABLE nocase_inner(key1 TEXT COLLATE NOCASE, amount INTEGER);
+    INSERT INTO nocase_outer VALUES (1, 'a');
+    INSERT INTO binary_inner VALUES ('a', 10), ('A', 20);
+    INSERT INTO nocase_inner VALUES ('a', 10), ('A', 20);
+}
+
+@setup comparison_keys
+test one-value-number-and-text-stay-correlated {
+    SELECT o.id, (SELECT sum(i.amount) FROM text_inner i WHERE i.key1 = o.key1)
+    FROM number_outer o;
+}
+expect {
+    1|30
+}
+
+@setup comparison_keys
+test one-value-different-text-order-stays-correlated {
+    SELECT o.id, (SELECT sum(i.amount) FROM binary_inner i WHERE o.key1 = i.key1)
+    FROM nocase_outer o;
+}
+expect {
+    1|30
+}
+
+@setup comparison_keys
+test one-value-same-text-order-is-rewritten {
+    SELECT o.id, (SELECT sum(i.amount) FROM nocase_inner i WHERE o.key1 = i.key1)
+    FROM nocase_outer o;
+}
+expect {
+    1|30
+}
+
+@setup comparison_keys
+test correlated-in-keeps-number-to-text-comparison {
+    SELECT o.id
+    FROM number_outer o
+    WHERE o.key1 IN (SELECT i.key1 FROM text_inner i WHERE i.group_id = o.id);
+}
+expect {
+    1
+}
+
+# These cases run every generated query against Turso and SQLite. The data has
+# repeated outer keys, repeated inner keys, NULL values, missing groups, and a
+# NULL outer key.
+
+@setup correlated_rows
+@var aggregate { avg(i.amount) | sum(i.amount) | min(i.amount) | max(i.amount) | count(*) | count(i.amount) | total(i.amount) | count(DISTINCT i.key2) }
+@var link { i.key1 = o.key1 | o.key1 = i.key1 | i.key1 = o.key1 AND i.key2 = o.key2 }
+@var inner_filter { | AND i.amount IS NOT NULL | AND i.amount >= 7 }
+matrix one-value-aggregate-cases {
+    SELECT o.id, (SELECT $aggregate FROM inner_rows i WHERE $link $inner_filter)
+    FROM outer_rows o ORDER BY o.id;
+}
+
+@setup correlated_rows
+@var aggregate { avg(i.amount) | sum(i.amount) | min(i.amount) | max(i.amount) | count(*) | total(i.amount) }
+@var operator { = | <> | < | <= | > | >= }
+@var link { i.key1 = o.key1 | i.key1 = o.key1 AND i.key2 = o.key2 }
+matrix one-value-aggregate-comparisons {
+    SELECT o.id FROM outer_rows o
+    WHERE o.amount $operator (SELECT $aggregate FROM inner_rows i WHERE $link)
+    ORDER BY o.id;
+}
+
+@setup correlated_rows
+@var left { o.amount | o.key2 | 10 | NULL }
+@var link { i.key1 = o.key1 | o.key1 = i.key1 | i.key1 = o.key1 AND i.key2 = o.key2 }
+@var inner_filter { | AND i.amount IS NOT NULL | AND i.amount >= 7 }
+matrix correlated-in-cases {
+    SELECT o.id FROM outer_rows o
+    WHERE $left IN (SELECT i.amount FROM inner_rows i WHERE $link $inner_filter)
+    ORDER BY o.id;
+}
+
+@setup correlated_rows
+@var aggregate { avg(i.amount) | sum(i.amount) }
+@var link { i.key1 < o.key1 | i.key1 IS o.key1 | i.key1 = o.key1 OR i.key2 = o.key2 | i.key1 = o.key1 AND o.amount > 10 }
+@var tail { | LIMIT 0 | LIMIT 1 OFFSET 1 }
+matrix one-value-cases-that-stay-as-subqueries {
+    SELECT o.id, (SELECT $aggregate FROM inner_rows i WHERE $link $tail)
+    FROM outer_rows o ORDER BY o.id;
+}
+
+setup tpch_rows {
+    CREATE TABLE part(partkey INTEGER PRIMARY KEY, brand TEXT, container TEXT);
+    CREATE TABLE lineitem(
+        partkey INTEGER,
+        suppkey INTEGER,
+        quantity INTEGER,
+        extendedprice INTEGER,
+        shipdate TEXT
+    );
+    CREATE TABLE partsupp(partkey INTEGER, suppkey INTEGER, availqty INTEGER, supplycost INTEGER);
+    CREATE TABLE supplier(suppkey INTEGER PRIMARY KEY, region INTEGER);
+    INSERT INTO part VALUES (1, 'Brand#1', 'SM BOX'), (2, 'Brand#2', 'LG CAN');
+    INSERT INTO supplier VALUES (10, 1), (11, 1), (12, 2);
+    INSERT INTO partsupp VALUES (1, 10, 20, 5), (1, 11, 20, 7), (1, 12, 20, 1),
+                                (2, 10, 4, 8), (2, 11, 20, 3);
+    INSERT INTO lineitem VALUES
+        (1, 10, 1, 70, '1994-02-01'),
+        (1, 10, 2, 140, '1994-03-01'),
+        (1, 11, 20, 700, '1996-01-01'),
+        (2, 10, 5, 210, '1994-04-01'),
+        (2, 11, 7, 280, '1994-05-01');
+}
+
+@setup tpch_rows
+test tpch-q17-average {
+    SELECT sum(l.extendedprice) / 7.0
+    FROM lineitem l JOIN part p ON p.partkey = l.partkey
+    WHERE p.brand = 'Brand#1'
+      AND p.container = 'SM BOX'
+      AND l.quantity < (
+          SELECT 0.2 * avg(l2.quantity)
+          FROM lineitem l2
+          WHERE l2.partkey = p.partkey
+      );
+}
+expect {
+    10.0
+}
+expect @js {
+    10
+}
+
+@setup tpch_rows
+test tpch-q20-sum-with-two-keys {
+    SELECT ps.partkey, ps.suppkey
+    FROM partsupp ps
+    WHERE ps.availqty > (
+        SELECT 0.5 * sum(l.quantity)
+        FROM lineitem l
+        WHERE l.partkey = ps.partkey
+          AND l.suppkey = ps.suppkey
+          AND l.shipdate >= '1994-01-01'
+          AND l.shipdate < '1995-01-01'
+    )
+    ORDER BY ps.partkey, ps.suppkey;
+}
+expect {
+    1|10
+    2|10
+    2|11
+}
+
+@setup tpch_rows
+test tpch-q2-minimum-over-join {
+    SELECT ps.partkey, ps.suppkey
+    FROM partsupp ps JOIN supplier s ON s.suppkey = ps.suppkey
+    WHERE s.region = 1
+      AND ps.supplycost = (
+          SELECT min(ps2.supplycost)
+          FROM partsupp ps2 JOIN supplier s2 ON s2.suppkey = ps2.suppkey
+          WHERE ps2.partkey = ps.partkey
+            AND s2.region = 1
+      )
+    ORDER BY ps.partkey, ps.suppkey;
+}
+expect {
+    1|10
+    2|11
+}

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -872,6 +872,26 @@ expect {
     3|0|0|SEARCH j USING COVERING INDEX ephemeral_second_exists_inner_t5 (key2=?)
 }
 
+# A filter on the outer table must not turn the EXISTS semi join back into a
+# nested scan.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test outer-filter-keeps-exists-semi-join {
+    CREATE TABLE filtered_exists_outer(id INTEGER PRIMARY KEY, key1 INTEGER, body TEXT);
+    CREATE TABLE filtered_exists_inner(key1 INTEGER);
+
+    EXPLAIN QUERY PLAN
+    SELECT o.id
+    FROM filtered_exists_outer o
+    WHERE o.body LIKE 'apple%'
+      AND EXISTS (
+              SELECT 1 FROM filtered_exists_inner i WHERE i.key1 = o.key1
+          );
+}
+expect {
+    1|0|0|SCAN filtered_exists_outer AS o
+    2|0|0|SEARCH i USING COVERING INDEX ephemeral_filtered_exists_inner_t3 (key1=?)
+}
+
 setup comparison_keys {
     CREATE TABLE number_outer(id INTEGER PRIMARY KEY, key1 INTEGER);
     CREATE TABLE text_inner(key1 TEXT, amount INTEGER, group_id INTEGER);

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -927,17 +927,28 @@ expect pattern {
     (?s)CORRELATED SCALAR SUBQUERY.*SEARCH i USING INDEX indexed_avg_inner_k.*SCAN scalar_subquery_.*SCAN indexed_avg_inner AS i USING INDEX indexed_avg_inner_k
 }
 
-# Two useful aggregate rewrites must not make each other stay correlated.
+# Two copies of the same aggregate need one grouped table.
 @skip-if sqlite "query plan explanation output is different in sqlite"
-test two-averages-use-two-grouped-tables {
+test two-identical-averages-use-one-grouped-table {
     CREATE TABLE two_avg_outer(id INTEGER PRIMARY KEY, x REAL, k INTEGER);
     CREATE TABLE two_avg_inner(k INTEGER, q REAL);
+    INSERT INTO two_avg_outer VALUES (1, 0.5, 1);
+    INSERT INTO two_avg_inner VALUES (1, 1.0);
     ANALYZE;
     DELETE FROM sqlite_stat1;
     INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES
         ('two_avg_outer', NULL, '500'),
         ('two_avg_inner', NULL, '500');
     ANALYZE sqlite_schema;
+
+    SELECT count(*)
+    FROM two_avg_outer o
+    WHERE o.x < (
+              SELECT avg(i.q) FROM two_avg_inner i WHERE i.k = o.k
+          )
+      AND o.x > (
+              SELECT avg(i.q) FROM two_avg_inner i WHERE i.k = o.k
+          ) - 100;
 
     EXPLAIN QUERY PLAN
     SELECT count(*)
@@ -950,7 +961,7 @@ test two-averages-use-two-grouped-tables {
           ) - 100;
 }
 expect pattern {
-    (?s)SEARCH scalar_subquery_.*SEARCH scalar_subquery_
+    ^1\n[0-9]+\|0\|0\|SCAN two_avg_outer AS o\n[0-9]+\|0\|0\|SEARCH scalar_subquery_[^\n]*\n[0-9]+\|[0-9]+\|0\|SCAN two_avg_inner AS i\n[0-9]+\|[0-9]+\|0\|USE SORTER FOR GROUP BY$
 }
 
 # A grouped table search reads its result from the index when the result is
@@ -1312,6 +1323,16 @@ matrix one-value-aggregate-cases {
 matrix one-value-aggregate-comparisons {
     SELECT o.id FROM outer_rows o
     WHERE o.amount $operator (SELECT $aggregate FROM inner_rows i WHERE $link)
+    ORDER BY o.id;
+}
+
+@setup correlated_rows
+@var aggregate { avg(i.amount) | min(i.amount) | max(i.amount) | count(*) | count(i.amount) | total(i.amount) }
+matrix two-copies-of-one-aggregate {
+    SELECT o.id,
+           (SELECT $aggregate FROM inner_rows i WHERE i.key1 = o.key1),
+           (SELECT $aggregate FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
     ORDER BY o.id;
 }
 

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -672,6 +672,25 @@ expect {
     1|30
 }
 
+# A scalar subquery result does not use the text order of its result column.
+# Replacing it with a grouped-table column must keep that rule.
+test one-value-result-has-no-text-order {
+    CREATE TABLE result_order_outer(k INTEGER, v TEXT);
+    CREATE TABLE result_order_inner(k INTEGER, v TEXT COLLATE NOCASE);
+    INSERT INTO result_order_outer VALUES (1,'a'),(2,'zz');
+    INSERT INTO result_order_inner VALUES (1,'A'),(2,'q');
+
+    SELECT o.k
+    FROM result_order_outer o
+    WHERE (o.v || '') = (
+        SELECT max(i.v)
+        FROM result_order_inner i
+        WHERE i.k = o.k
+    );
+}
+expect {
+}
+
 @setup comparison_keys
 test correlated-in-keeps-number-to-text-comparison {
     SELECT o.id

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -526,6 +526,39 @@ expect {
     5
 }
 
+setup empty_not_in_rows {
+    CREATE TABLE not_in_outer(k INTEGER);
+    CREATE TABLE not_in_inner(k INTEGER, x INTEGER);
+    CREATE TABLE empty_values(a INTEGER);
+    INSERT INTO not_in_outer VALUES (1),(2);
+    INSERT INTO not_in_inner VALUES (1,10);
+}
+
+@setup empty_not_in_rows
+test one-value-not-in-empty-keeps-missing-group {
+    SELECT o.k
+    FROM not_in_outer o
+    WHERE (SELECT max(x) FROM not_in_inner i WHERE i.k = o.k)
+          NOT IN (SELECT a FROM empty_values)
+    ORDER BY o.k;
+}
+expect {
+    1
+    2
+}
+
+@setup empty_not_in_rows
+test one-value-not-in-empty-delete-removes-missing-group {
+    DELETE FROM not_in_outer
+    WHERE (SELECT max(x) FROM not_in_inner i WHERE i.k = not_in_outer.k)
+          NOT IN (SELECT a FROM empty_values);
+
+    SELECT count(*) FROM not_in_outer;
+}
+expect {
+    0
+}
+
 @setup correlated_rows
 test in-under-or {
     SELECT id

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -848,6 +848,30 @@ expect {
     2|0|0|SEARCH i USING COVERING INDEX ephemeral_limit_inner_t3 (k=? AND x=?)
 }
 
+# Each EXISTS keeps its own outer row. A second one must not make both use
+# nested scans.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test two-exists-use-two-semi-joins {
+    CREATE TABLE two_exists_outer(id INTEGER PRIMARY KEY, key1 INTEGER, key2 INTEGER);
+    CREATE TABLE first_exists_inner(key1 INTEGER);
+    CREATE TABLE second_exists_inner(key2 INTEGER);
+
+    EXPLAIN QUERY PLAN
+    SELECT o.id
+    FROM two_exists_outer o
+    WHERE EXISTS (
+              SELECT 1 FROM first_exists_inner i WHERE i.key1 = o.key1
+          )
+      AND EXISTS (
+              SELECT 1 FROM second_exists_inner j WHERE j.key2 = o.key2
+          );
+}
+expect {
+    1|0|0|SCAN two_exists_outer AS o
+    2|0|0|SEARCH i USING COVERING INDEX ephemeral_first_exists_inner_t3 (key1=?)
+    3|0|0|SEARCH j USING COVERING INDEX ephemeral_second_exists_inner_t5 (key2=?)
+}
+
 setup comparison_keys {
     CREATE TABLE number_outer(id INTEGER PRIMARY KEY, key1 INTEGER);
     CREATE TABLE text_inner(key1 TEXT, amount INTEGER, group_id INTEGER);

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -813,6 +813,41 @@ test one-value-empty-outer-does-not-sum {
 expect {
 }
 
+# LIMIT 1 can stop after the first matching row. When matches are expected to
+# be common, building an index over the whole inner table costs more.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test limit-one-keeps-correlated-in {
+    CREATE TABLE limit_outer(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+    CREATE TABLE limit_inner(k INTEGER, x INTEGER);
+
+    EXPLAIN QUERY PLAN
+    SELECT o.id
+    FROM limit_outer o
+    WHERE o.v IN (SELECT i.x FROM limit_inner i WHERE i.k = o.k)
+    LIMIT 1;
+
+    EXPLAIN QUERY PLAN
+    SELECT o.id
+    FROM limit_outer o
+    WHERE o.v IN (SELECT i.x FROM limit_inner i WHERE i.k = o.k)
+    LIMIT 100;
+
+    EXPLAIN QUERY PLAN
+    SELECT o.id
+    FROM limit_outer o
+    WHERE o.v IN (SELECT i.x FROM limit_inner i WHERE i.k = o.k);
+}
+expect {
+    1|0|0|SCAN limit_outer AS o
+    6|0|0|CORRELATED LIST SUBQUERY 1
+    8|6|0|SCAN limit_inner AS i
+    1|0|0|SCAN limit_outer AS o
+    6|0|0|CORRELATED LIST SUBQUERY 1
+    8|6|0|SCAN limit_inner AS i
+    1|0|0|SCAN limit_outer AS o
+    2|0|0|SEARCH i USING COVERING INDEX ephemeral_limit_inner_t3 (k=? AND x=?)
+}
+
 setup comparison_keys {
     CREATE TABLE number_outer(id INTEGER PRIMARY KEY, key1 INTEGER);
     CREATE TABLE text_inner(key1 TEXT, amount INTEGER, group_id INTEGER);

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -114,6 +114,78 @@ expect {
 }
 
 @setup correlated_rows
+test one-value-outer-rowid-filter {
+    SELECT o.id,
+           (SELECT count(*)
+            FROM inner_rows i
+            WHERE i.key1 = o.key1 AND o.rowid = 1)
+    FROM outer_rows o
+    ORDER BY o.id;
+}
+expect {
+    1|3
+    2|0
+    3|0
+    4|0
+    5|0
+    6|0
+}
+
+@setup correlated_rows
+test one-value-outer-rowid-link {
+    SELECT o.id,
+           (SELECT count(*)
+            FROM inner_rows i
+            WHERE i.key1 = o.key1 AND i.amount = o.rowid)
+    FROM outer_rows o
+    ORDER BY o.id;
+}
+expect {
+    1|0
+    2|0
+    3|0
+    4|0
+    5|0
+    6|1
+}
+
+@setup correlated_rows
+test one-value-outer-rowid-in-result {
+    SELECT o.id,
+           (SELECT sum(i.amount) + o.rowid
+            FROM inner_rows i
+            WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    ORDER BY o.id;
+}
+expect {
+    1|131
+    2|132
+    3|16
+    4|
+    5|
+    6|19
+}
+
+@setup correlated_rows
+test one-value-outer-rowid-in-input {
+    SELECT o.id,
+           (SELECT sum(i.amount + o.rowid)
+            FROM inner_rows i
+            WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    ORDER BY o.id;
+}
+expect {
+    1|133
+    2|136
+    3|19
+    4|
+    5|
+    6|25
+}
+
+@setup correlated_rows
 test one-value-link-written-outer-first {
     SELECT id, (SELECT max(i.amount) FROM inner_rows i WHERE o.key1 = i.key1)
     FROM outer_rows o

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -664,6 +664,68 @@ expect {
     6|3
 }
 
+# EXISTS must run after FULL JOIN has made its missing-side rows.
+test exists-after-full-join {
+    CREATE TABLE full_exists_a(id INTEGER, x INTEGER);
+    CREATE TABLE full_exists_b(id INTEGER, y INTEGER);
+    CREATE TABLE full_exists_c(id INTEGER, z INTEGER);
+    CREATE TABLE full_exists_i(k INTEGER);
+    INSERT INTO full_exists_a VALUES (1,1),(2,2);
+    INSERT INTO full_exists_b VALUES (1,1),(2,2);
+    INSERT INTO full_exists_c VALUES (2,2),(3,3);
+    INSERT INTO full_exists_i VALUES (1);
+
+    SELECT a.id, b.id, c.id
+    FROM full_exists_a a
+    JOIN full_exists_b b ON a.id = b.id
+    FULL JOIN full_exists_c c ON b.id = c.id
+    WHERE EXISTS (SELECT 1 FROM full_exists_i i WHERE i.k = a.x);
+}
+expect {
+    1|1|
+}
+
+# A link to the first table must not move before a later FULL JOIN.
+test exists-linked-past-full-join {
+    CREATE TABLE past_full_a(x INTEGER);
+    CREATE TABLE past_full_b(y INTEGER);
+    CREATE TABLE past_full_c(z INTEGER);
+    CREATE TABLE past_full_i(v INTEGER);
+    INSERT INTO past_full_a VALUES (1);
+    INSERT INTO past_full_b VALUES (1);
+    INSERT INTO past_full_c VALUES (2);
+    INSERT INTO past_full_i VALUES (1);
+
+    SELECT a.x, b.y, c.z
+    FROM past_full_a a
+    JOIN past_full_b b ON a.x = b.y
+    FULL JOIN past_full_c c ON a.x = c.z
+    WHERE EXISTS (SELECT 1 FROM past_full_i i WHERE i.v = a.x);
+}
+expect {
+    1|1|
+}
+
+# NOT EXISTS must not remove a match before FULL JOIN sees it.
+test not-exists-linked-past-full-join {
+    CREATE TABLE anti_full_a(x INTEGER);
+    CREATE TABLE anti_full_b(y INTEGER);
+    CREATE TABLE anti_full_c(z INTEGER);
+    CREATE TABLE anti_full_i(v INTEGER);
+    INSERT INTO anti_full_a VALUES (1);
+    INSERT INTO anti_full_b VALUES (1);
+    INSERT INTO anti_full_c VALUES (1);
+    INSERT INTO anti_full_i VALUES (1);
+
+    SELECT a.x, b.y, c.z
+    FROM anti_full_a a
+    JOIN anti_full_b b ON a.x = b.y
+    FULL JOIN anti_full_c c ON a.x = c.z
+    WHERE NOT EXISTS (SELECT 1 FROM anti_full_i i WHERE i.v = a.x);
+}
+expect {
+}
+
 setup comparison_keys {
     CREATE TABLE number_outer(id INTEGER PRIMARY KEY, key1 INTEGER);
     CREATE TABLE text_inner(key1 TEXT, amount INTEGER, group_id INTEGER);

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -28,6 +28,22 @@ setup correlated_rows {
     INSERT INTO outer_key2 VALUES (1, 10), (3, 20), (5, 40);
 }
 
+# A table function uses hidden columns to hold its arguments. Those checks
+# must stay inside the correlated subquery.
+test one-value-table-function-keeps-arguments {
+    CREATE TABLE outer_function_args(id INTEGER, first_value INTEGER);
+    INSERT INTO outer_function_args VALUES (1,3),(2,5);
+
+    SELECT o.id,
+           (SELECT sum(g.value) FROM generate_series(o.first_value, 6) g)
+    FROM outer_function_args o
+    ORDER BY o.id;
+}
+expect {
+    1|18
+    2|11
+}
+
 @setup correlated_rows
 test one-value-avg-in-select-list {
     SELECT id, (SELECT avg(i.amount) FROM inner_rows i WHERE i.key1 = o.key1)

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -953,6 +953,104 @@ expect pattern {
     (?s)SEARCH scalar_subquery_.*SEARCH scalar_subquery_
 }
 
+# A grouped table search reads its result from the index when the result is
+# used. It must not also copy every index column to unused registers after
+# each match.
+@skip-if sqlite "Turso uses a different grouped subquery plan"
+test grouped-seek-does-not-copy-unused-columns {
+    CREATE TABLE bytecode_outer(id INTEGER PRIMARY KEY, k INTEGER);
+    CREATE TABLE bytecode_inner(k INTEGER, x REAL);
+    ANALYZE;
+    DELETE FROM sqlite_stat1;
+    INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES
+        ('bytecode_outer', NULL, '20000'),
+        ('bytecode_inner', NULL, '200000');
+    ANALYZE sqlite_schema;
+
+    EXPLAIN
+    SELECT o.id,
+           (SELECT avg(i.x) FROM bytecode_inner i WHERE i.k = o.k)
+    FROM bytecode_outer o;
+}
+expect pattern {
+    (?m)^\d+\|SeekGE\|.*$\n^\d+\|IdxGT\|.*$\n^\d+\|Integer\|1\|.*$\n^\d+\|RowId\|.*$
+}
+
+# The IN subquery index is not used after IN becomes a semi join. Its cursor
+# number must be free for the tables and index that remain in the plan.
+@skip-if sqlite "Turso uses a different IN plan"
+test unnested-in-reuses-unused-cursor {
+    CREATE TABLE cursor_outer(id INTEGER PRIMARY KEY, k INTEGER, x INTEGER);
+    CREATE TABLE cursor_inner(k INTEGER, x INTEGER);
+    ANALYZE;
+    DELETE FROM sqlite_stat1;
+    INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES
+        ('cursor_outer', NULL, '20000'),
+        ('cursor_inner', NULL, '200000');
+    ANALYZE sqlite_schema;
+
+    EXPLAIN
+    SELECT o.id
+    FROM cursor_outer o
+    WHERE o.x IN (
+        SELECT i.x FROM cursor_inner i WHERE i.k = o.k
+    );
+}
+expect pattern {
+    (?m)^\d+\|OpenRead\|0\|.*table=cursor_outer.*$\n^\d+\|OpenRead\|1\|.*table=cursor_inner.*$(?s).*\n\d+\|OpenAutoindex\|2\|
+}
+
+# The scalar result register is not used after the aggregate becomes a grouped
+# table. The grouped table output must be able to use that register number.
+@skip-if sqlite "Turso uses a different aggregate plan"
+test grouped-aggregate-reuses-unused-result-register {
+    CREATE TABLE register_outer(id INTEGER PRIMARY KEY, k INTEGER);
+    CREATE TABLE register_inner(k INTEGER, x REAL);
+    ANALYZE;
+    DELETE FROM sqlite_stat1;
+    INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES
+        ('register_outer', NULL, '20000'),
+        ('register_inner', NULL, '200000');
+    ANALYZE sqlite_schema;
+
+    EXPLAIN
+    SELECT o.id,
+           (SELECT avg(i.x) FROM register_inner i WHERE i.k = o.k)
+    FROM register_outer o;
+}
+expect pattern {
+    (?m)^\d+\|AggFinal\|.*$\n^\d+\|Copy\|\d+\|1\|.*$\n^\d+\|Copy\|\d+\|2\|.*$
+}
+
+# A grouped value can be used while two outer hash joins build their inputs.
+# Preparing this form must keep the grouped value available in both builds.
+test grouped-value-is-available-to-two-hash-builds {
+    CREATE TABLE two_hash_sales(item_key INTEGER, sold_date_key INTEGER, discount REAL);
+    CREATE TABLE two_hash_items(item_key INTEGER, maker INTEGER);
+    CREATE TABLE two_hash_dates(date_key INTEGER, sold_on TEXT);
+    INSERT INTO two_hash_items VALUES (1,977),(2,1);
+    INSERT INTO two_hash_dates VALUES (1,'2000-02-01'),(2,'1999-01-01');
+    INSERT INTO two_hash_sales VALUES
+        (1,1,10.0),(1,1,20.0),(1,1,40.0),(2,1,100.0),(1,2,1000.0);
+
+    SELECT CAST(s.discount AS INTEGER)
+    FROM two_hash_sales s, two_hash_items i, two_hash_dates d
+    WHERE i.maker = 977
+      AND i.item_key = s.item_key
+      AND d.sold_on BETWEEN '2000-01-27' AND '2000-04-26'
+      AND d.date_key = s.sold_date_key
+      AND s.discount > (
+          SELECT 1.3 * avg(s2.discount)
+          FROM two_hash_sales s2, two_hash_dates d2
+          WHERE s2.item_key = i.item_key
+            AND d2.sold_on BETWEEN '2000-01-27' AND '2000-04-26'
+            AND d2.date_key = s2.sold_date_key
+      );
+}
+expect {
+    40
+}
+
 
 # Each level has one EXISTS that can be changed to a join and one EXISTS
 # that holds the next level. Preparing this query must not try every mix of

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -748,6 +748,71 @@ expect {
     2|
 }
 
+# A group that no outer row uses must not make sum fail.
+test one-value-does-not-sum-unused-group {
+    CREATE TABLE used_sum_key(id INTEGER, k INTEGER);
+    CREATE TABLE sum_values(k INTEGER, x INTEGER);
+    INSERT INTO used_sum_key VALUES (1,1);
+    INSERT INTO sum_values VALUES
+        (1,10),
+        (2,9223372036854775807),
+        (2,9223372036854775807);
+
+    SELECT o.id, (SELECT sum(i.x) FROM sum_values i WHERE i.k = o.k)
+    FROM used_sum_key o;
+}
+expect {
+    1|10
+}
+
+# A bad function input in an unused group must not fail the query.
+test one-value-does-not-read-unused-bad-json {
+    CREATE TABLE used_json_key(id INTEGER, k INTEGER);
+    CREATE TABLE json_values(k INTEGER, v TEXT);
+    INSERT INTO used_json_key VALUES (1,1);
+    INSERT INTO json_values VALUES (1,'{"a":1}'),(99,'not json');
+
+    SELECT o.id,
+           (SELECT sum(json_extract(i.v, '$.a'))
+            FROM json_values i
+            WHERE i.k = o.k)
+    FROM used_json_key o;
+}
+expect {
+    1|1
+}
+
+# A function in an inner filter must not run for an unused key.
+test one-value-does-not-filter-unused-bad-json {
+    CREATE TABLE used_filter_key(id INTEGER, k INTEGER);
+    CREATE TABLE filtered_json_values(k INTEGER, v TEXT);
+    INSERT INTO used_filter_key VALUES (1,1);
+    INSERT INTO filtered_json_values VALUES (1,'{"a":1}'),(99,'not json');
+
+    SELECT o.id,
+           (SELECT count(*)
+            FROM filtered_json_values i
+            WHERE i.k = o.k AND json_extract(i.v, '$.a') > 0)
+    FROM used_filter_key o;
+}
+expect {
+    1|1
+}
+
+# An empty outer table must not run sum over any inner key.
+test one-value-empty-outer-does-not-sum {
+    CREATE TABLE empty_sum_key(id INTEGER, k INTEGER);
+    CREATE TABLE unused_sum_values(k INTEGER, x INTEGER);
+    INSERT INTO unused_sum_values VALUES
+        (2,9223372036854775807),
+        (2,9223372036854775807);
+
+    SELECT o.id, (SELECT sum(i.x) FROM unused_sum_values i WHERE i.k = o.k)
+    FROM empty_sum_key o;
+}
+expect {
+}
+
 setup comparison_keys {
     CREATE TABLE number_outer(id INTEGER PRIMARY KEY, key1 INTEGER);
     CREATE TABLE text_inner(key1 TEXT, amount INTEGER, group_id INTEGER);

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -927,6 +927,32 @@ expect pattern {
     (?s)CORRELATED SCALAR SUBQUERY.*SEARCH i USING INDEX indexed_avg_inner_k.*SCAN scalar_subquery_.*SCAN indexed_avg_inner AS i USING INDEX indexed_avg_inner_k
 }
 
+# Two useful aggregate rewrites must not make each other stay correlated.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test two-averages-use-two-grouped-tables {
+    CREATE TABLE two_avg_outer(id INTEGER PRIMARY KEY, x REAL, k INTEGER);
+    CREATE TABLE two_avg_inner(k INTEGER, q REAL);
+    ANALYZE;
+    DELETE FROM sqlite_stat1;
+    INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES
+        ('two_avg_outer', NULL, '500'),
+        ('two_avg_inner', NULL, '500');
+    ANALYZE sqlite_schema;
+
+    EXPLAIN QUERY PLAN
+    SELECT count(*)
+    FROM two_avg_outer o
+    WHERE o.x < (
+              SELECT avg(i.q) FROM two_avg_inner i WHERE i.k = o.k
+          )
+      AND o.x > (
+              SELECT avg(i.q) FROM two_avg_inner i WHERE i.k = o.k
+          ) - 100;
+}
+expect pattern {
+    (?s)SEARCH scalar_subquery_.*SEARCH scalar_subquery_
+}
+
 setup comparison_keys {
     CREATE TABLE number_outer(id INTEGER PRIMARY KEY, key1 INTEGER);
     CREATE TABLE text_inner(key1 TEXT, amount INTEGER, group_id INTEGER);

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -726,6 +726,28 @@ test not-exists-linked-past-full-join {
 expect {
 }
 
+# A SELECT with no FROM has no table that can be the left side of a semi join.
+test in-under-select-with-no-from {
+    CREATE TABLE no_from_outer(k INTEGER);
+    CREATE TABLE no_from_inner(k INTEGER);
+    INSERT INTO no_from_outer VALUES (1),(2);
+    INSERT INTO no_from_inner VALUES (1),(1),(3);
+
+    SELECT o.k,
+           (SELECT 1
+            WHERE 1 IN (
+                SELECT i.k
+                FROM no_from_inner i
+                WHERE i.k = o.k
+            ))
+    FROM no_from_outer o
+    ORDER BY o.k;
+}
+expect {
+    1|1
+    2|
+}
+
 setup comparison_keys {
     CREATE TABLE number_outer(id INTEGER PRIMARY KEY, key1 INTEGER);
     CREATE TABLE text_inner(key1 TEXT, amount INTEGER, group_id INTEGER);

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -282,6 +282,28 @@ expect {
     5|
 }
 
+# Both outer tables must be ready before the grouped table reads either link
+# value. A new inner join may not move the grouped table before them.
+test one-value-two-outer-links-in-filter {
+    CREATE TABLE filter_a(id INTEGER PRIMARY KEY, k INTEGER, g INTEGER, amount INTEGER);
+    CREATE TABLE filter_b(id INTEGER PRIMARY KEY, k INTEGER, g INTEGER, amount INTEGER);
+    CREATE TABLE filter_c(id INTEGER PRIMARY KEY, k INTEGER, amount INTEGER);
+    INSERT INTO filter_a VALUES (1,1,1,10);
+    INSERT INTO filter_b VALUES (1,1,1,100);
+    INSERT INTO filter_c VALUES (1,1,50);
+
+    SELECT a.id, c.id
+    FROM filter_a a JOIN filter_c c ON a.k = c.k
+    WHERE a.amount < (
+        SELECT sum(b.amount)
+        FROM filter_b b
+        WHERE b.k = a.k AND b.g = c.k
+    );
+}
+expect {
+    1|1
+}
+
 @setup correlated_rows
 test one-value-correlated-to-outer-table-that-may-be-null {
     SELECT o.id, (SELECT count(*) FROM inner_rows i WHERE i.key2 = x.key2)

--- a/sqlite/conformance/sqlite-sqltests/update-from.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/update-from.sqltest
@@ -3100,3 +3100,27 @@ test update-from-cte-shadows-source-is-circular {
 }
 expect error {
 }
+
+# A correlated subquery in the WHERE clause must keep the index order chosen
+# when it was first planned. Planning it again after ORDER BY was removed can
+# change a backwards index scan into a forwards scan.
+@cross-check-integrity
+test update-from-correlated-subquery-keeps-order {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, v INTEGER);
+    CREATE TABLE s(id INTEGER PRIMARY KEY, k INTEGER);
+    CREATE TABLE i(k INTEGER, x INTEGER);
+    CREATE INDEX ik ON i(k, x);
+    INSERT INTO t VALUES (1,1,0),(2,2,0);
+    INSERT INTO s VALUES (10,1),(20,2);
+    INSERT INTO i VALUES (1,5),(1,9),(2,3),(2,8);
+
+    UPDATE t SET v = s.id FROM s
+    WHERE s.k = t.k
+      AND (SELECT x FROM i WHERE i.k = t.k ORDER BY x DESC LIMIT 1) = 9;
+
+    SELECT * FROM t ORDER BY id;
+}
+expect {
+    1|1|10
+    2|2|0
+}

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -816,7 +816,7 @@ set test_files {
   whereB               pass
   whereC               pass
   whereD               fail
-  whereE               fail
+  whereE               pass
   whereF               fail
   whereG               fail
   whereH               fail

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -68,7 +68,7 @@ set test_files {
   autoindex1           fail
   autoindex2           fail
   autoindex3           fail
-  autoindex4           fail
+  autoindex4           pass
   autoindex5           fail
   autovacuum           fail
   autovacuum2          fail

--- a/tests/integration/external_apis.rs
+++ b/tests/integration/external_apis.rs
@@ -925,6 +925,14 @@ fn custom_collations_cover_dotnet_create_collation_cases(
     }
     let join_sql = "SELECT count(*) FROM left_values AS l JOIN right_values AS r \
         ON l.value = r.value COLLATE dotnet_nocase";
+    let query_plan: Vec<(i64, i64, i64, String)> =
+        conn.exec_rows(&format!("EXPLAIN QUERY PLAN {join_sql}"));
+    assert!(
+        !query_plan
+            .iter()
+            .any(|(_, _, _, detail)| detail.contains("USING INDEX ephemeral_")),
+        "custom collations must not use a binary temporary index: {query_plan:?}"
+    );
     let joined: Vec<(i64,)> = conn.exec_rows(join_sql);
     assert_eq!(joined, vec![(1000,)]);
     let explain_rows = limbo_exec_rows(&conn, &format!("EXPLAIN {join_sql}"));

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -17,5 +17,6 @@ mod test_multi_thread;
 mod test_non_utf8_text;
 mod test_page1;
 mod test_schema_updated;
+mod test_subquery_unnesting;
 mod test_transactions;
 mod test_type_affinity;

--- a/tests/integration/query_processing/test_subquery_unnesting.rs
+++ b/tests/integration/query_processing/test_subquery_unnesting.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::common::TempDatabase;
+use crate::common::{ExecRows, TempDatabase};
 
 /// Return the text rows from `EXPLAIN QUERY PLAN`.
 fn explain(connection: &Arc<turso_core::Connection>, sql: &str) -> anyhow::Result<Vec<String>> {
@@ -11,6 +11,110 @@ fn explain(connection: &Arc<turso_core::Connection>, sql: &str) -> anyhow::Resul
         Ok(())
     })?;
     Ok(details)
+}
+
+/// Compute the same average once per key, not once per outer row.
+#[test]
+fn correlated_average_uses_one_grouped_table() -> anyhow::Result<()> {
+    let database =
+        TempDatabase::new_with_rusqlite("CREATE TABLE outer_rows(id INT, key1 INT, amount INT)");
+    let connection = database.connect_limbo();
+    connection.execute("CREATE TABLE inner_rows(key1 INT, amount INT)")?;
+
+    let details = explain(
+        &connection,
+        "SELECT id FROM outer_rows o
+         WHERE amount < (
+             SELECT 0.2 * avg(i.amount)
+             FROM inner_rows i
+             WHERE i.key1 = o.key1
+         )",
+    )?;
+
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail.contains("scalar_subquery")),
+        "expected a grouped subquery table, got {details:?}"
+    );
+    assert!(
+        details.iter().any(|detail| detail.contains("GROUP BY")),
+        "expected the subquery to group by its outer key, got {details:?}"
+    );
+    assert!(
+        details.iter().all(|detail| !detail.contains("CORRELATED")),
+        "expected no subquery call for each outer row, got {details:?}"
+    );
+    Ok(())
+}
+
+/// A TPC-H Q2 query should compute its minimum values once.
+#[test]
+fn minimum_over_a_join_becomes_a_joined_table() -> anyhow::Result<()> {
+    let database = TempDatabase::new_with_rusqlite(
+        "CREATE TABLE partsupp(partkey INT, suppkey INT, supplycost INT)",
+    );
+    let connection = database.connect_limbo();
+    connection.execute("CREATE TABLE supplier(suppkey INT, region INT)")?;
+
+    let details = explain(
+        &connection,
+        "SELECT ps.partkey, ps.suppkey
+         FROM partsupp ps JOIN supplier s ON s.suppkey = ps.suppkey
+         WHERE ps.supplycost = (
+             SELECT min(ps2.supplycost)
+             FROM partsupp ps2 JOIN supplier s2 ON s2.suppkey = ps2.suppkey
+             WHERE ps2.partkey = ps.partkey AND s2.region = 1
+         )",
+    )?;
+
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail.contains("scalar_subquery")),
+        "expected the minimum-cost subquery to become a joined table, got {details:?}"
+    );
+    assert!(
+        details.iter().all(|detail| !detail.contains("CORRELATED")),
+        "expected no per-row minimum-cost subquery, got {details:?}"
+    );
+    Ok(())
+}
+
+/// A grouped table can use two outer tables and a NULL outer value.
+#[test]
+fn grouped_table_can_use_two_outer_tables_and_null() -> anyhow::Result<()> {
+    let database = TempDatabase::new_with_rusqlite("CREATE TABLE outer_rows(id INT, key1 INT)");
+    let connection = database.connect_limbo();
+    connection.execute("CREATE TABLE outer_key2(id INT, key2 INT)")?;
+    connection.execute("CREATE TABLE inner_rows(key1 INT, key2 INT, amount INT)")?;
+    connection.execute("CREATE TABLE nocase_outer(key1 TEXT COLLATE NOCASE)")?;
+    connection.execute("CREATE TABLE nocase_inner(key1 TEXT COLLATE NOCASE, amount INT)")?;
+
+    let queries = [
+        "SELECT o.id, (SELECT sum(i.amount) FROM inner_rows i
+         WHERE i.key1 = o.key1 AND i.key2 = x.key2)
+         FROM outer_rows o JOIN outer_key2 x ON x.id = o.id",
+        "SELECT o.id, (SELECT count(*) FROM inner_rows i WHERE i.key2 = x.key2)
+         FROM outer_rows o LEFT JOIN outer_key2 x ON x.id = o.id",
+        "SELECT (SELECT sum(i.amount) FROM nocase_inner i WHERE o.key1 = i.key1)
+         FROM nocase_outer o",
+    ];
+
+    for query in queries {
+        let details = explain(&connection, query)?;
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail.contains("scalar_subquery")),
+            "expected a grouped subquery table: {query}; got {details:?}"
+        );
+        assert!(
+            details.iter().all(|detail| !detail.contains("CORRELATED")),
+            "expected no subquery call for each outer row: {query}; got {details:?}"
+        );
+    }
+    Ok(())
 }
 
 /// A direct positive `IN` can use the inner table as a semi-join.
@@ -70,5 +174,92 @@ fn indexed_correlated_exists_uses_a_semi_join() -> anyhow::Result<()> {
         }),
         "expected the semi-join to use the index on the linked column, got {details:?}"
     );
+    Ok(())
+}
+
+/// Cases that the rewrite does not support must stay as subqueries.
+#[test]
+fn subqueries_that_cannot_be_rewritten_stay_correlated() -> anyhow::Result<()> {
+    let database =
+        TempDatabase::new_with_rusqlite("CREATE TABLE outer_rows(id INT, key1 INT, amount INT)");
+    let connection = database.connect_limbo();
+    connection.execute("CREATE TABLE inner_rows(key1 INT, amount INT)")?;
+    connection.execute("CREATE TABLE outer_key2(id INT, key2 INT)")?;
+    connection.execute("CREATE TABLE text_inner(key1 TEXT, amount INT)")?;
+    connection.execute("CREATE TABLE nocase_outer(key1 TEXT COLLATE NOCASE)")?;
+    connection.execute("CREATE TABLE binary_inner(key1 TEXT COLLATE BINARY, amount INT)")?;
+
+    let queries = [
+        "SELECT id FROM outer_rows o WHERE amount <
+         (SELECT avg(i.amount) FROM inner_rows i WHERE i.key1 < o.key1)",
+        "SELECT id FROM outer_rows o WHERE amount =
+         (SELECT max(i.amount) FROM inner_rows i WHERE i.key1 IS o.key1)",
+        "SELECT id FROM outer_rows o WHERE amount =
+         (SELECT coalesce(sum(i.amount), 0) FROM inner_rows i WHERE i.key1 = o.key1)",
+        "SELECT id FROM outer_rows o WHERE amount NOT IN
+         (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1)",
+        "SELECT id FROM outer_rows o WHERE id = 1 OR amount IN
+         (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1)",
+        "SELECT id FROM outer_rows o WHERE amount =
+         (SELECT sum(i.amount) + random() FROM inner_rows i WHERE i.key1 = o.key1)",
+        "SELECT id FROM outer_rows o WHERE random() IN
+         (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1)",
+        "SELECT id FROM outer_rows o WHERE amount =
+         (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1)",
+        "SELECT id FROM outer_rows o WHERE amount =
+         (SELECT sum(i.amount) FROM inner_rows i WHERE i.key1 = o.key1 GROUP BY i.key1)",
+        "SELECT o.id FROM outer_rows o LEFT JOIN outer_key2 x
+         ON x.key2 = (SELECT min(i.amount) FROM inner_rows i WHERE i.key1 = o.key1)",
+        "SELECT (SELECT sum(i.amount) FROM text_inner i WHERE i.key1 = o.key1)
+         FROM outer_rows o",
+        "SELECT (SELECT sum(i.amount) FROM binary_inner i WHERE o.key1 = i.key1)
+         FROM nocase_outer o",
+    ];
+
+    for query in queries {
+        let details = explain(&connection, query)?;
+        assert!(
+            details.iter().any(|detail| detail.contains("CORRELATED")),
+            "expected this query to stay correlated: {query}; got {details:?}"
+        );
+    }
+    Ok(())
+}
+
+/// NULL values and repeated keys must give the same rows as SQLite.
+#[test]
+fn one_value_and_in_results_match_sqlite_on_nulls_and_repeated_keys() -> anyhow::Result<()> {
+    let database =
+        TempDatabase::new_with_rusqlite("CREATE TABLE outer_rows(id INT, key1 INT, amount INT)");
+    let connection = database.connect_limbo();
+    connection.execute("CREATE TABLE inner_rows(key1 INT, amount INT)")?;
+    connection
+        .execute("INSERT INTO outer_rows VALUES (1,1,10),(2,1,11),(3,2,6),(4,3,9),(5,NULL,NULL)")?;
+    connection
+        .execute("INSERT INTO inner_rows VALUES (1,10),(1,10),(1,20),(2,6),(2,NULL),(NULL,NULL)")?;
+
+    let value_rows: Vec<(i64, f64, i64)> = connection.exec_rows(
+        "SELECT id,
+                coalesce((SELECT avg(i.amount) FROM inner_rows i WHERE i.key1 = o.key1), -1.0),
+                (SELECT count(*) FROM inner_rows i WHERE i.key1 = o.key1)
+         FROM outer_rows o ORDER BY id",
+    );
+    assert_eq!(
+        value_rows,
+        vec![
+            (1, 40.0 / 3.0, 3),
+            (2, 40.0 / 3.0, 3),
+            (3, 6.0, 2),
+            (4, -1.0, 0),
+            (5, -1.0, 0),
+        ]
+    );
+
+    let in_rows: Vec<(i64,)> = connection.exec_rows(
+        "SELECT id FROM outer_rows o
+         WHERE amount IN (SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1)
+         ORDER BY id",
+    );
+    assert_eq!(in_rows, vec![(1,), (3,)]);
     Ok(())
 }

--- a/tests/integration/query_processing/test_subquery_unnesting.rs
+++ b/tests/integration/query_processing/test_subquery_unnesting.rs
@@ -128,7 +128,7 @@ fn grouped_table_can_use_null_and_text_order() -> anyhow::Result<()> {
     let queries = [
         "SELECT o.id, (SELECT count(*) FROM inner_rows i WHERE i.key2 = x.key2)
          FROM outer_rows o LEFT JOIN outer_key2 x ON x.id = o.id",
-        "SELECT (SELECT sum(i.amount) FROM nocase_inner i WHERE o.key1 = i.key1)
+        "SELECT (SELECT avg(i.amount) FROM nocase_inner i WHERE o.key1 = i.key1)
          FROM nocase_outer o",
     ];
 

--- a/tests/integration/query_processing/test_subquery_unnesting.rs
+++ b/tests/integration/query_processing/test_subquery_unnesting.rs
@@ -115,9 +115,9 @@ fn minimum_over_a_join_becomes_a_joined_table() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// A grouped table can use two outer tables and a NULL outer value.
+/// A grouped table can use a NULL outer value and a text order.
 #[test]
-fn grouped_table_can_use_two_outer_tables_and_null() -> anyhow::Result<()> {
+fn grouped_table_can_use_null_and_text_order() -> anyhow::Result<()> {
     let database = TempDatabase::new_with_rusqlite("CREATE TABLE outer_rows(id INT, key1 INT)");
     let connection = database.connect_limbo();
     connection.execute("CREATE TABLE outer_key2(id INT, key2 INT)")?;
@@ -126,9 +126,6 @@ fn grouped_table_can_use_two_outer_tables_and_null() -> anyhow::Result<()> {
     connection.execute("CREATE TABLE nocase_inner(key1 TEXT COLLATE NOCASE, amount INT)")?;
 
     let queries = [
-        "SELECT o.id, (SELECT sum(i.amount) FROM inner_rows i
-         WHERE i.key1 = o.key1 AND i.key2 = x.key2)
-         FROM outer_rows o JOIN outer_key2 x ON x.id = o.id",
         "SELECT o.id, (SELECT count(*) FROM inner_rows i WHERE i.key2 = x.key2)
          FROM outer_rows o LEFT JOIN outer_key2 x ON x.id = o.id",
         "SELECT (SELECT sum(i.amount) FROM nocase_inner i WHERE o.key1 = i.key1)

--- a/tests/integration/query_processing/test_subquery_unnesting.rs
+++ b/tests/integration/query_processing/test_subquery_unnesting.rs
@@ -48,6 +48,40 @@ fn correlated_average_uses_one_grouped_table() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Keep one index search when the outer query reads one row.
+#[test]
+fn indexed_average_for_one_outer_row_stays_a_subquery() -> anyhow::Result<()> {
+    let database = TempDatabase::new_with_rusqlite(
+        "CREATE TABLE outer_rows(id INTEGER PRIMARY KEY, amount INT)",
+    );
+    let connection = database.connect_limbo();
+    connection.execute("CREATE TABLE inner_rows(key1 INT, amount INT)")?;
+    connection.execute("CREATE INDEX inner_rows_key1 ON inner_rows(key1)")?;
+
+    let details = explain(
+        &connection,
+        "SELECT id FROM outer_rows o
+         WHERE o.id = 1
+           AND amount < (
+               SELECT avg(i.amount)
+               FROM inner_rows i
+               WHERE i.key1 = o.id
+           )",
+    )?;
+
+    assert!(
+        details.iter().any(|detail| detail.contains("CORRELATED")),
+        "expected the indexed subquery to stay as written, got {details:?}"
+    );
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail.contains("inner_rows_key1") && detail.contains("key1=?")),
+        "expected an indexed lookup for the correlated subquery, got {details:?}"
+    );
+    Ok(())
+}
+
 /// A TPC-H Q2 query should compute its minimum values once.
 #[test]
 fn minimum_over_a_join_becomes_a_joined_table() -> anyhow::Result<()> {

--- a/tests/integration/query_processing/test_subquery_unnesting.rs
+++ b/tests/integration/query_processing/test_subquery_unnesting.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use crate::common::TempDatabase;
+
+/// Return the text rows from `EXPLAIN QUERY PLAN`.
+fn explain(connection: &Arc<turso_core::Connection>, sql: &str) -> anyhow::Result<Vec<String>> {
+    let mut statement = connection.prepare(format!("EXPLAIN QUERY PLAN {sql}"))?;
+    let mut details = Vec::new();
+    statement.run_with_row_callback(|row| {
+        details.push(row.get::<String>(3)?);
+        Ok(())
+    })?;
+    Ok(details)
+}
+
+/// A direct positive `IN` can use the inner table as a semi-join.
+#[test]
+fn correlated_in_uses_a_semi_join() -> anyhow::Result<()> {
+    let database =
+        TempDatabase::new_with_rusqlite("CREATE TABLE outer_rows(id INT, key1 INT, amount INT)");
+    let connection = database.connect_limbo();
+    connection.execute("CREATE TABLE inner_rows(key1 INT, amount INT)")?;
+
+    let details = explain(
+        &connection,
+        "SELECT id FROM outer_rows o
+         WHERE amount IN (
+             SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1
+         )",
+    )?;
+
+    assert!(
+        details
+            .iter()
+            .any(|detail| detail.contains("inner_rows") && detail.contains("key1=?")),
+        "expected the inner table to be searched by the outer key, got {details:?}"
+    );
+    assert!(
+        details.iter().all(|detail| !detail.contains("CORRELATED")),
+        "expected no per-row IN subquery, got {details:?}"
+    );
+    Ok(())
+}
+
+/// An indexed `EXISTS` keeps the index search after it becomes a semi-join.
+#[test]
+fn indexed_correlated_exists_uses_a_semi_join() -> anyhow::Result<()> {
+    let database =
+        TempDatabase::new_with_rusqlite("CREATE TABLE outer_rows(id INTEGER PRIMARY KEY)");
+    let connection = database.connect_limbo();
+    connection.execute("CREATE TABLE inner_rows(outer_id INT, value INT)")?;
+    connection.execute("CREATE INDEX inner_rows_outer_id ON inner_rows(outer_id)")?;
+
+    let details = explain(
+        &connection,
+        "SELECT id FROM outer_rows o
+         WHERE EXISTS (
+             SELECT 1 FROM inner_rows i
+             WHERE i.outer_id = o.id AND i.value > 10
+         )",
+    )?;
+
+    assert!(
+        details.iter().all(|detail| !detail.contains("CORRELATED")),
+        "expected EXISTS to use a semi-join, got {details:?}"
+    );
+    assert!(
+        details.iter().any(|detail| {
+            detail.contains("inner_rows_outer_id") && detail.contains("outer_id=?")
+        }),
+        "expected the semi-join to use the index on the linked column, got {details:?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## What

Turso already changes correlated `EXISTS` and `NOT EXISTS` subqueries into joins.

This PR adds two more cases:

- A direct positive `IN` subquery can become a semi-join.
- A subquery that returns one aggregate value can become a grouped table with a left join.

These forms appear in TPC-H Q2, Q17, and Q20.

### Correlated `IN`

For example:

~~~sql
SELECT o.id
FROM outer_rows o
WHERE o.amount IN (
    SELECT i.amount
    FROM inner_rows i
    WHERE i.key1 = o.key1
);
~~~

The optimizer can turn this into a semi-join (which is a join type we already support via the `EXISTS` decorrelation work that already ...exists). In SQL, its filtering behavior is the same as:

~~~sql
SELECT o.id
FROM outer_rows o
WHERE EXISTS (
    SELECT 1
    FROM inner_rows i
    WHERE i.key1 = o.key1
      AND i.amount = o.amount
);
~~~

The semi-join keeps each outer row at most once, even when several inner rows match.

### One aggregate value

For example:

~~~sql
SELECT *
FROM lineitem l
WHERE l.quantity < (
    SELECT 0.2 * avg(l2.quantity)
    FROM lineitem l2
    WHERE l2.partkey = l.partkey
);
~~~

The new form groups `lineitem` once by `partkey`, then joins those results to the outer query:

~~~sql
SELECT l.*
FROM lineitem l
LEFT JOIN (
    SELECT
        partkey,
        0.2 * avg(quantity) AS max_quantity
    FROM lineitem
    GROUP BY partkey
) grouped_lineitem
    ON grouped_lineitem.partkey = l.partkey
WHERE l.quantity < grouped_lineitem.max_quantity;
~~~

## Why

A correlated subquery may run once for every outer row.

If `lineitem` has one million rows, the `avg` subquery above may also run one million times. Many of those calls may compute the same average for the same `partkey`.

The grouped form reads and groups the inner rows once. The outer query can then reuse the result for every row with that `partkey`.

## Plan choice

The join form is not always faster.

For example, this query reads one outer row and can use an index for one inner search:

~~~sql
SELECT o.id
FROM outer_rows o
WHERE o.id = 1
  AND o.amount < (
      SELECT avg(i.amount)
      FROM inner_rows i
      WHERE i.key1 = o.id
  );
~~~

If `inner_rows.key1` has an index, keeping the subquery may mean one cheap index search. Building a grouped table for every key could cost more.

The optimizer now:

1. Plans the query as written.
2. Makes and plans the join form when the rewrite is safe.
3. Counts how often each subquery is expected to run.
4. Includes that work in the cost.
5. Keeps the form with less expected work.
6. Uses the join form when both costs are equal.

## Safety rules

The rewrite only moves simple `=` checks between inner and outer columns. It keeps the original subquery when moving it could change the result.

### `NOT IN` is not rewritten due to its interaction with NULL

`NOT IN` has special NULL rules.

For example:

~~~sql
SELECT 5 NOT IN (1, NULL);
~~~

This does not return true. The NULL means SQL cannot know whether the missing value is equal to `5`, so the result is NULL.

A plain anti-join would only see that no row equals `5` and could return true. That would be wrong, so this PR does not rewrite `NOT IN`.

### `IN` inside `OR` is not rewritten

For example:

~~~sql
SELECT o.id
FROM outer_rows o
WHERE o.keep = 1
   OR o.amount IN (
       SELECT i.amount
       FROM inner_rows i
       WHERE i.key1 = o.key1
   );
~~~

A row with `keep = 1` must remain even when the inner query has no match.

A plain semi-join would require an inner match and could remove that row before the `OR` is checked. This form therefore stays as a subquery.

### Empty inner results

An aggregate still returns one value when no inner row matches.

For example:

~~~sql
SELECT count(*)
FROM inner_rows
WHERE key1 = 99;
~~~

This returns `0`.

A grouped table has no row for key `99`. A left join would therefore give NULL. The rewrite uses `coalesce(..., 0)` so `count` keeps returning `0`.

`total` is handled in the same way with `0.0`.

`sum`, `avg`, `min`, and `max` return NULL for an empty input, which already matches the missing side of a left join.

More complex empty-input rules stay as subqueries. For example:

~~~sql
SELECT coalesce(sum(amount), 7)
FROM inner_rows
WHERE key1 = outer_rows.key1;
~~~

This must return `7` when no row matches. The current rewrite does not try to prove that rule.

### Different collations

Grouping and joining must compare the link columns in the same way.

For example, `COLLATE BINARY` treats `a` and `A` as different values, while `COLLATE NOCASE` treats them as equal.

If the inner query groups with `BINARY` but the join uses `NOCASE`, it could make two inner groups that both match one outer row. That would copy the outer row.

The rewrite therefore requires the inner and outer columns to use the same value type and text rule.

### Limits and offsets

A limit or offset can change whether a subquery returns a row.

For example:

~~~sql
SELECT (
    SELECT sum(i.amount)
    FROM inner_rows i
    WHERE i.key1 = o.key1
    LIMIT 0
)
FROM outer_rows o;
~~~

`LIMIT 0` makes the subquery return no row. Removing it during the rewrite would change the result.

An offset can also skip the one aggregate row. These forms stay as subqueries.

### Nondeterministic functions also block rewriting

For example:

~~~sql
SELECT (
    SELECT sum(i.amount) + random()
    FROM inner_rows i
    WHERE i.key1 = o.key1
)
FROM outer_rows o;
~~~

The original query may call `random()` once for every outer row. A grouped form could call it once for every key instead.

Because those results can differ, subqueries with functions such as `random()` are not rewritten.

### Subqueries in outer join conditions are also not rewritten

For example:

~~~sql
SELECT o.id
FROM outer_rows o
LEFT JOIN other_rows x
    ON x.value = (
        SELECT min(i.amount)
        FROM inner_rows i
        WHERE i.key1 = o.key1
    );
~~~

The subquery value is needed while the left join decides whether `x` matched. Moving it into a later join could make that value available too late and change which rows get NULL values.

Subqueries used in these join conditions stay in their original form.