### PR TITLE
fts: fix duplicate rowids when index build flushes full batches

### DIFF
--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1955,6 +1955,22 @@ enum FtsState {
     },
 }
 
+impl FtsState {
+    fn is_flushing(&self) -> bool {
+        matches!(
+            self,
+            Self::FlushingWrites { .. }
+                | Self::SeekingOldChunks { .. }
+                | Self::AdvancingAfterSeek { .. }
+                | Self::CheckingChunkPath { .. }
+                | Self::DeletingChunk { .. }
+                | Self::AdvancingAfterDelete { .. }
+                | Self::SeekingWrite { .. }
+                | Self::InsertingWrite { .. }
+        )
+    }
+}
+
 struct FtsStreamingSegment {
     scorer: Box<dyn Scorer>,
     rowids: Column<i64>,
@@ -2587,18 +2603,8 @@ impl FtsCursor {
     /// If `force_flush` is true, flushes directory writes even when no pending docs.
     fn commit_and_flush_inner(&mut self, force_flush: bool) -> Result<IOResult<()>> {
         // Handle flush state machine if already in progress
-        match &self.state {
-            FtsState::FlushingWrites { .. }
-            | FtsState::SeekingOldChunks { .. }
-            | FtsState::AdvancingAfterSeek { .. }
-            | FtsState::CheckingChunkPath { .. }
-            | FtsState::DeletingChunk { .. }
-            | FtsState::AdvancingAfterDelete { .. }
-            | FtsState::SeekingWrite { .. }
-            | FtsState::InsertingWrite { .. } => {
-                return self.flush_writes_internal();
-            }
-            _ => {}
+        if self.state.is_flushing() {
+            return self.flush_writes_internal();
         }
 
         if self.pending_docs_count == 0 && !force_flush {
@@ -2663,6 +2669,29 @@ impl FtsCursor {
     /// Commit pending documents to Tantivy and flush to BTree.
     pub fn commit_and_flush(&mut self) -> Result<IOResult<()>> {
         self.commit_and_flush_inner(false)
+    }
+
+    // The VDBE retries the current instruction when an operation returns
+    // `IOResult::IO`, so complete such work before mutating Tantivy.
+    fn flush_full_batch_before_mutation(&mut self) -> Result<IOResult<()>> {
+        if self.state.is_flushing() {
+            return_if_io!(self.flush_writes_internal());
+        }
+
+        turso_assert!(
+            self.pending_docs_count <= BATCH_COMMIT_SIZE,
+            "FTS pending operation count exceeded its batch size",
+            {
+                "pending_docs_count": self.pending_docs_count,
+                "batch_size": BATCH_COMMIT_SIZE
+            }
+        );
+
+        if self.pending_docs_count == BATCH_COMMIT_SIZE {
+            return_if_io!(self.commit_and_flush());
+        }
+
+        Ok(IOResult::Done(()))
     }
 
     /// Build the tiered policy used to identify automatic merge candidates.
@@ -2814,19 +2843,7 @@ impl Drop for FtsCursor {
         // Check if we're already in a flushing state (from commit_and_flush)
         // This can happen when commit_and_flush started a flush but yielded for IO
         // and the cursor is being dropped before the flush completed
-        let is_flushing = matches!(
-            &self.state,
-            FtsState::FlushingWrites { .. }
-                | FtsState::SeekingOldChunks { .. }
-                | FtsState::AdvancingAfterSeek { .. }
-                | FtsState::CheckingChunkPath { .. }
-                | FtsState::DeletingChunk { .. }
-                | FtsState::AdvancingAfterDelete { .. }
-                | FtsState::SeekingWrite { .. }
-                | FtsState::InsertingWrite { .. }
-        );
-
-        if is_flushing {
+        if self.state.is_flushing() {
             turso_assert!(
                 conn.is_in_write_tx(),
                 "FTS Drop: in-progress flush abandoned (transaction already committed). pre_commit should have completed the flush."
@@ -3434,22 +3451,7 @@ impl IndexMethodCursor for FtsCursor {
     /// Inserts a document into the FTS index.
     /// Values are text columns followed by rowid. Batches commits for efficiency.
     fn insert(&mut self, values: &[Register]) -> Result<IOResult<()>> {
-        // Handle flush state machine if in progress
-        while matches!(
-            &self.state,
-            FtsState::FlushingWrites { .. }
-                | FtsState::SeekingOldChunks { .. }
-                | FtsState::AdvancingAfterSeek { .. }
-                | FtsState::CheckingChunkPath { .. }
-                | FtsState::DeletingChunk { .. }
-                | FtsState::AdvancingAfterDelete { .. }
-                | FtsState::SeekingWrite { .. }
-                | FtsState::InsertingWrite { .. }
-        ) {
-            if let IOResult::IO(io) = self.flush_writes_internal()? {
-                return Ok(IOResult::IO(io));
-            }
-        }
+        return_if_io!(self.flush_full_batch_before_mutation());
 
         let Some(ref mut writer) = self.writer else {
             return Err(LimboError::InternalError(
@@ -3489,17 +3491,13 @@ impl IndexMethodCursor for FtsCursor {
 
         self.pending_docs_count += 1;
 
-        // Batch commits: only commit every BATCH_COMMIT_SIZE documents
-        // This dramatically improves bulk insert performance for CREATE INDEX
-        if self.pending_docs_count >= BATCH_COMMIT_SIZE {
-            return self.commit_and_flush();
-        }
-
         Ok(IOResult::Done(()))
     }
 
     /// Deletes a document from the FTS index by rowid.
     fn delete(&mut self, values: &[Register]) -> Result<IOResult<()>> {
+        return_if_io!(self.flush_full_batch_before_mutation());
+
         let Some(ref mut writer) = self.writer else {
             return Err(LimboError::InternalError(
                 "FTS writer not initialized - call open_write first".into(),
@@ -3524,9 +3522,6 @@ impl IndexMethodCursor for FtsCursor {
         // Track delete as a pending operation so commit_and_flush() will run
         // and invalidate cached read state.
         self.pending_docs_count += 1;
-        if self.pending_docs_count >= BATCH_COMMIT_SIZE {
-            return self.commit_and_flush();
-        }
 
         Ok(IOResult::Done(()))
     }
@@ -3795,18 +3790,8 @@ impl IndexMethodCursor for FtsCursor {
         // First, check if we're in the middle of a flush operation that needs to continue
         // This handles the case where commit_and_flush() returned IOResult::IO and we need
         // to continue the flush after IO completes
-        match &self.state {
-            FtsState::FlushingWrites { .. }
-            | FtsState::SeekingOldChunks { .. }
-            | FtsState::AdvancingAfterSeek { .. }
-            | FtsState::CheckingChunkPath { .. }
-            | FtsState::DeletingChunk { .. }
-            | FtsState::AdvancingAfterDelete { .. }
-            | FtsState::SeekingWrite { .. }
-            | FtsState::InsertingWrite { .. } => {
-                return self.flush_writes_internal();
-            }
-            _ => {}
+        if self.state.is_flushing() {
+            return self.flush_writes_internal();
         }
 
         if self.pending_docs_count > 0 {

--- a/sqlite/conformance/turso-sqltests/fts.sqltest
+++ b/sqlite/conformance/turso-sqltests/fts.sqltest
@@ -960,3 +960,24 @@ expect {
     alice|hello world
 }
 
+@backend cli
+test fts-create-index-batch-flush-returns-each-rowid-once {
+    CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT);
+    WITH RECURSIVE seq(id) AS (
+        VALUES (1)
+        UNION ALL
+        SELECT id + 1 FROM seq WHERE id < 20000
+    )
+    INSERT INTO docs
+    SELECT id, 'needle document ' || id FROM seq;
+    CREATE INDEX docs_fts ON docs USING fts (body);
+    SELECT
+        (SELECT count(*) FROM docs),
+        count(*),
+        count(DISTINCT id)
+    FROM docs
+    WHERE fts_match(body, 'needle');
+}
+expect {
+    20000|20000|20000
+}


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

 This fixes FTS returning the same rowid more than once when building an index large enough to flush one or more 1,000-document batches.

  During `CREATE INDEX`, Turso turns each table row into a Tantivy document. The text is indexed for search, and the rowid is kept as a fast field so a search result can be mapped back to the table row. FTS collects these documents in batches of 1,000.

  Before this change, 
  - when an insert filled a batch, the document was added to Tantivy first.  Tantivy then commits the batch, and FTS flushed the resulting files to the backing B-tree as part of the same operation.

  A page rebalance here can possibly cause an insertion into the backing B-tree to yield while restoring its cursor position. This yield propagates as `IOResult::IO`, so the VDBE retries the same `IdxInsert` with the same row. On retry, FTS finishes the flush and adds the same row again. That extra copy is committed with a later batch. Both Tantivy documents carry the same rowid, so an FTS query returns that rowid twice.

  
 This change flushes a full batch before applying the next mutation. 
 - If the flush yields, the current row has not been added yet, so retrying the insertion is safe. Once the flush finishes, the row is added exactly once. The same ordering is used for inserts and deletes, while pre_commit continues to flush the final batch.


## Description of AI Usage

used claude for reviewing, it suggested making a `is_flushing` function which made sense to me so i did it.
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
