### PR TITLE
postgres: open a dedicated connection per wire client

### DIFF
--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -401,9 +401,42 @@ Upgrade is not supported.
 
 ## Transactions and Visibility
 
+The wire server opens a dedicated database connection per client, so each
+client has its own transaction and session state. Concurrency follows
+Turso's single-writer model rather than PostgreSQL's row-level locking,
+and transaction semantics currently differ in several ways:
+
+- Writers serialize on a database-wide write lock. A writer blocked by
+  another client's write transaction waits up to the busy timeout
+  (`tursopg --busy-timeout`, default 5000 ms) and then fails with SQLSTATE
+  55P03 (lock_not_available), where PostgreSQL would keep waiting on the
+  row lock.
+- A transaction reads from the snapshot taken at its first statement,
+  which behaves closest to REPEATABLE READ; PostgreSQL defaults to READ
+  COMMITTED. If another client commits after that snapshot is taken, the
+  transaction's next write fails immediately with SQLSTATE 40001
+  (serialization_failure); the client should roll back and retry the
+  transaction. (psycopg's rollback() can emit DEALLOCATE for auto-prepared
+  statements, which is not yet supported; set prepare_threshold=None until
+  it is.)
+- After a failed statement, PostgreSQL rejects everything until ROLLBACK
+  ("current transaction is aborted"); tursopg keeps executing the
+  transaction's subsequent statements, and COMMIT then commits the ones
+  that succeeded where PostgreSQL would discard the whole transaction.
+- Transaction-command no-ops error instead of warning: COMMIT or ROLLBACK
+  with no open transaction, and BEGIN inside one, are errors here where
+  PostgreSQL warns and continues.
+- A multi-statement simple-protocol message is not atomic: statements that
+  ran before an error stay applied, where PostgreSQL wraps the whole
+  message in an implicit transaction and rolls them back.
+- CREATE/DROP SCHEMA map to per-connection ATTACH state: schema files are
+  discovered when a client connects, so a schema created by one session is
+  not visible to sessions that were already connected.
+
 | Feature | Status | Notes |
 |---------|--------|-------|
 | Cursors | ❌ Not supported | DECLARE/FETCH/MOVE not translated |
+| Multiple concurrent clients | ✅ Supported | One database connection per wire client |
 | Savepoints | ✅ Supported | SAVEPOINT, RELEASE, ROLLBACK TO |
 | Serializable Snapshot Isolation | ❌ Not supported | BEGIN ISOLATION LEVEL ... accepted but the level is ignored |
 | Two-phase commit | ❌ Not supported | PREPARE TRANSACTION rejected |

--- a/postgres/cli/main.rs
+++ b/postgres/cli/main.rs
@@ -35,10 +35,10 @@ use rustyline::error::ReadlineError;
 use rustyline::history::DefaultHistory;
 use rustyline::Editor;
 use std::io::{IsTerminal, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -90,6 +90,14 @@ struct Opts {
         help = "Start PostgreSQL wire protocol server at given address (e.g. 0.0.0.0:5432)"
     )]
     server: Option<String>,
+
+    #[clap(
+        long,
+        value_name = "MILLIS",
+        default_value_t = 5000,
+        help = "How long a statement waits for the database write lock before failing (server mode)"
+    )]
+    busy_timeout: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -100,7 +108,7 @@ fn open_database(
     db_path: &str,
     vfs: Option<&String>,
     readonly: bool,
-) -> anyhow::Result<(Arc<dyn turso_core::IO>, Connection)> {
+) -> anyhow::Result<(Arc<dyn turso_core::IO>, Arc<turso_core::Database>)> {
     let db_opts = DatabaseOpts::new()
         .with_views(true)
         .with_custom_types(true)
@@ -118,40 +126,7 @@ fn open_database(
 
     let (io, db) =
         turso_pg::open_database(db_path, vfs.map(|v| v.as_str()), flags, db_opts.turso_cli())?;
-    let conn = Connection::new(db.connect()?);
-    Ok((io, conn))
-}
-
-/// Discover and attach existing PG schema database files in the same directory.
-fn auto_attach_pg_schemas(conn: &Connection, db_file: &str) {
-    if db_file == ":memory:" {
-        return;
-    }
-    let dir = Path::new(db_file)
-        .parent()
-        .unwrap_or_else(|| Path::new("."));
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-    for entry in entries.flatten() {
-        let file_name = entry.file_name();
-        let Some(name) = file_name.to_str() else {
-            continue;
-        };
-        let Some(schema) = name
-            .strip_prefix("turso-postgres-schema-")
-            .and_then(|s| s.strip_suffix(".db"))
-        else {
-            continue;
-        };
-        let path = entry.path().to_string_lossy().to_string();
-        let sql = format!("ATTACH '{path}' AS \"{schema}\"");
-        tracing::info!("Auto-attaching PG schema '{}' from {}", schema, path);
-        if let Err(e) = conn.inner().execute(&sql) {
-            tracing::warn!("Failed to attach schema '{}': {}", schema, e);
-        }
-    }
+    Ok((io, db))
 }
 
 // ---------------------------------------------------------------------------
@@ -1010,7 +985,7 @@ fn main() -> anyhow::Result<()> {
         .as_ref()
         .map_or(":memory:".to_string(), |p| p.to_string_lossy().to_string());
 
-    let (io, conn) = open_database(&db_file, opts.vfs.as_ref(), opts.readonly)?;
+    let (io, db) = open_database(&db_file, opts.vfs.as_ref(), opts.readonly)?;
 
     let interrupt_count = Arc::new(AtomicUsize::new(0));
     {
@@ -1021,12 +996,21 @@ fn main() -> anyhow::Result<()> {
         .expect("Error setting Ctrl-C handler");
     }
 
-    auto_attach_pg_schemas(&conn, &db_file);
-    // Server mode: start PG wire protocol server and exit
+    // Server mode: start PG wire protocol server and exit. The server opens
+    // per-client connections; none is needed here.
     if let Some(ref address) = opts.server {
-        let server = TursoPgServer::new(address.clone(), db_file, conn, interrupt_count);
+        let server = TursoPgServer::new(
+            address.clone(),
+            db_file,
+            db,
+            Duration::from_millis(opts.busy_timeout),
+            interrupt_count,
+        );
         return server.run();
     }
+
+    let conn = Connection::new(db.connect()?);
+    turso_pg_server::auto_attach_pg_schemas(&conn, &db_file);
 
     let table_config = TableConfig::adaptive_colors();
 

--- a/postgres/cli/tests/tursopg.rs
+++ b/postgres/cli/tests/tursopg.rs
@@ -953,6 +953,14 @@ fn copy_from_file_not_found_repl() {
 /// for a free ephemeral port and verify our own child is the process that
 /// came up on it, retrying with a fresh port if the child dies on bind.
 fn start_tursopg_server() -> (Child, u16) {
+    start_tursopg_server_with_args(&[])
+}
+
+fn start_tursopg_server_with_args(extra_args: &[&str]) -> (Child, u16) {
+    start_tursopg_server_with_db_and_args(":memory:", extra_args)
+}
+
+fn start_tursopg_server_with_db_and_args(db_path: &str, extra_args: &[&str]) -> (Child, u16) {
     for _ in 0..10 {
         let port = TcpListener::bind("127.0.0.1:0")
             .unwrap()
@@ -961,9 +969,10 @@ fn start_tursopg_server() -> (Child, u16) {
             .port();
         let addr = format!("127.0.0.1:{port}");
         let mut child = Command::new(env!("CARGO_BIN_EXE_tursopg"))
-            .arg(":memory:")
+            .arg(db_path)
             .arg("--server")
             .arg(&addr)
+            .args(extra_args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -1694,4 +1703,185 @@ fn wire_end_and_abort_report_commit_and_rollback_tags() {
         assert_eq!(c.query_command_tags("ABORT"), ["ROLLBACK"]);
         assert_eq!(c.query_single_text("SELECT count(*) FROM t"), "0");
     });
+}
+
+// ---------------------------------------------------------------------------
+// Per-client connections
+// ---------------------------------------------------------------------------
+
+/// Each client gets its own transaction scope. With one shared connection,
+/// the second client's BEGIN fails with "cannot start a transaction
+/// within a transaction" (e.g. from psycopg's implicit BEGIN).
+#[test]
+fn wire_two_clients_get_independent_transactions() {
+    let (mut server, port) = start_tursopg_server();
+    let mut a = PgTestClient::connect(port);
+    let mut b = PgTestClient::connect(port);
+
+    assert_eq!(a.query_command_tags("BEGIN"), ["BEGIN"]);
+    assert_eq!(b.query_command_tags("BEGIN"), ["BEGIN"]);
+    assert_eq!(a.query_command_tags("COMMIT"), ["COMMIT"]);
+    assert_eq!(b.query_command_tags("COMMIT"), ["COMMIT"]);
+
+    server.kill().ok();
+    server.wait().ok();
+}
+
+/// Uncommitted writes are invisible to other clients until COMMIT. DDL
+/// committed in an explicit transaction must also reach other
+/// connections' schemas.
+#[test]
+fn wire_transaction_isolation_between_clients() {
+    let (mut server, port) = start_tursopg_server();
+    let mut a = PgTestClient::connect(port);
+    let mut b = PgTestClient::connect(port);
+
+    a.query_command_tags("BEGIN");
+    a.query_command_tags("CREATE TABLE t (x INTEGER)");
+    a.query_command_tags("COMMIT");
+
+    a.query_command_tags("BEGIN");
+    a.query_command_tags("INSERT INTO t VALUES (1)");
+    assert_eq!(b.query_single_text("SELECT count(*) FROM t"), "0");
+    a.query_command_tags("COMMIT");
+    assert_eq!(b.query_single_text("SELECT count(*) FROM t"), "1");
+
+    server.kill().ok();
+    server.wait().ok();
+}
+
+/// A blocked writer must proceed once the competing transaction commits.
+/// Pins query execution on the blocking pool: when run inline, the other
+/// client's COMMIT goes unprocessed and this writer times out instead.
+#[test]
+fn wire_blocked_write_succeeds_after_commit() {
+    let (mut server, port) = start_tursopg_server();
+    let mut a = PgTestClient::connect(port);
+    a.query_command_tags("CREATE TABLE t (x INTEGER)");
+    a.query_command_tags("BEGIN");
+    a.query_command_tags("INSERT INTO t VALUES (1)");
+
+    let blocked = std::thread::spawn(move || {
+        let mut b = PgTestClient::connect(port);
+        let start = std::time::Instant::now();
+        let tags = b.query_command_tags("INSERT INTO t VALUES (2)");
+        (tags, start.elapsed())
+    });
+    std::thread::sleep(std::time::Duration::from_millis(300));
+    a.query_command_tags("COMMIT");
+
+    let (tags, elapsed) = blocked.join().unwrap();
+    assert_eq!(tags, ["INSERT 0 1"]);
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "blocked write took {elapsed:?}"
+    );
+    assert_eq!(a.query_single_text("SELECT count(*) FROM t"), "2");
+
+    server.kill().ok();
+    server.wait().ok();
+}
+
+/// Busy timeout expiry while another client holds the write lock reports
+/// SQLSTATE 55P03 (lock_not_available), like PostgreSQL's lock_timeout.
+#[test]
+fn wire_write_lock_timeout_reports_lock_not_available() {
+    let (mut server, port) = start_tursopg_server_with_args(&["--busy-timeout", "100"]);
+    let mut a = PgTestClient::connect(port);
+    let mut b = PgTestClient::connect(port);
+    a.query_command_tags("CREATE TABLE t (x INTEGER)");
+    a.query_command_tags("BEGIN");
+    a.query_command_tags("INSERT INTO t VALUES (1)");
+
+    let response = b.query_raw("INSERT INTO t VALUES (2)");
+    assert_eq!(
+        extract_error_field(&response, b'C').as_deref(),
+        Some("55P03")
+    );
+    // Turso's own message is in the detail field.
+    assert!(extract_error_field(&response, b'D').is_some());
+
+    a.query_command_tags("COMMIT");
+    // The lock is free again: the same write now succeeds.
+    assert_eq!(
+        b.query_command_tags("INSERT INTO t VALUES (2)"),
+        ["INSERT 0 1"]
+    );
+
+    server.kill().ok();
+    server.wait().ok();
+}
+
+/// A write from a stale snapshot (another client committed after it was
+/// taken) fails at once with SQLSTATE 40001, the code PostgreSQL
+/// REPEATABLE READ uses for writes to concurrently-modified rows; the
+/// client rolls back and retries.
+#[test]
+fn wire_stale_snapshot_write_reports_serialization_failure() {
+    let (mut server, port) = start_tursopg_server();
+    let mut a = PgTestClient::connect(port);
+    let mut b = PgTestClient::connect(port);
+    a.query_command_tags("CREATE TABLE t (x INTEGER)");
+
+    a.query_command_tags("BEGIN");
+    assert_eq!(a.query_single_text("SELECT count(*) FROM t"), "0");
+    b.query_command_tags("INSERT INTO t VALUES (1)");
+
+    let response = a.query_raw("INSERT INTO t VALUES (2)");
+    assert_eq!(
+        extract_error_field(&response, b'C').as_deref(),
+        Some("40001")
+    );
+
+    a.query_command_tags("ROLLBACK");
+    assert_eq!(a.query_single_text("SELECT count(*) FROM t"), "1");
+
+    server.kill().ok();
+    server.wait().ok();
+}
+
+/// Disconnecting mid-transaction must not wedge the single writer: the
+/// server rolls back and releases the write lock.
+#[test]
+fn wire_disconnect_mid_transaction_releases_write_lock() {
+    let (mut server, port) = start_tursopg_server();
+    let mut a = PgTestClient::connect(port);
+    let mut b = PgTestClient::connect(port);
+    a.query_command_tags("CREATE TABLE t (x INTEGER)");
+    a.query_command_tags("BEGIN");
+    a.query_command_tags("INSERT INTO t VALUES (1)");
+
+    drop(a);
+
+    assert_eq!(
+        b.query_command_tags("INSERT INTO t VALUES (2)"),
+        ["INSERT 0 1"]
+    );
+    // The dropped client's uncommitted row was rolled back.
+    assert_eq!(b.query_single_text("SELECT count(*) FROM t"), "1");
+
+    server.kill().ok();
+    server.wait().ok();
+}
+
+/// Schema files attach at connect time: a schema created after the server
+/// started works for clients that connect later.
+#[test]
+fn wire_schema_files_attach_for_new_clients() {
+    let dir = std::env::temp_dir().join(format!("tursopg-attach-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let db_path = dir.join("main.db");
+
+    let (mut server, port) = start_tursopg_server_with_db_and_args(db_path.to_str().unwrap(), &[]);
+    let mut a = PgTestClient::connect(port);
+    a.query_command_tags("CREATE SCHEMA app");
+    a.query_command_tags("CREATE TABLE app.items (x INTEGER)");
+    a.query_command_tags("INSERT INTO app.items VALUES (1)");
+
+    let mut b = PgTestClient::connect(port);
+    assert_eq!(b.query_single_text("SELECT count(*) FROM app.items"), "1");
+
+    server.kill().ok();
+    server.wait().ok();
+    std::fs::remove_dir_all(&dir).ok();
 }

--- a/postgres/cli/tests/tursopg.rs
+++ b/postgres/cli/tests/tursopg.rs
@@ -1094,6 +1094,78 @@ impl PgTestClient {
         let response = self.read_until_ready();
         extract_first_data_row_text(&response).expect("query returned no rows")
     }
+
+    /// Send query and return the raw response bytes up to ReadyForQuery.
+    fn query_raw(&mut self, sql: &str) -> Vec<u8> {
+        self.send_query(sql);
+        self.read_until_ready()
+    }
+}
+
+/// Walk raw PG wire bytes and return the value of the given field code from
+/// the first ErrorResponse (`'E'`) message. Body layout per the PG protocol
+/// docs: repeated (field-type byte, cstring value) pairs, ended by a nul.
+/// Field `b'C'` is the SQLSTATE code.
+fn extract_error_field(data: &[u8], field: u8) -> Option<String> {
+    let mut pos = 0;
+    while pos < data.len() {
+        let tag = data[pos];
+        pos += 1;
+        if pos + 4 > data.len() {
+            break;
+        }
+        let len =
+            i32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as usize;
+        pos += 4;
+        let body_end = pos + (len - 4);
+        if body_end > data.len() {
+            break;
+        }
+        if tag == b'E' {
+            let mut f = pos;
+            while f < body_end && data[f] != 0 {
+                let code = data[f];
+                f += 1;
+                let start = f;
+                while f < body_end && data[f] != 0 {
+                    f += 1;
+                }
+                if code == field {
+                    return Some(String::from_utf8(data[start..f].to_vec()).unwrap());
+                }
+                f += 1;
+            }
+            return None;
+        }
+        pos = body_end;
+    }
+    None
+}
+
+/// Status byte of the last ReadyForQuery (`'Z'`) message: `b'I'` idle,
+/// `b'T'` in transaction, `b'E'` in failed transaction.
+fn extract_ready_status(data: &[u8]) -> Option<u8> {
+    let mut pos = 0;
+    let mut status = None;
+    while pos < data.len() {
+        let tag = data[pos];
+        pos += 1;
+        if pos + 4 > data.len() {
+            break;
+        }
+        let len =
+            i32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]) as usize;
+        pos += 4;
+        let body_end = pos + (len - 4);
+        if body_end > data.len() {
+            break;
+        }
+        if tag == b'Z' && body_end > pos {
+            status = Some(data[pos]);
+        }
+        pos = body_end;
+    }
+    status
 }
 
 /// Walk raw PG wire bytes and return the value of the first ParameterStatus
@@ -1551,4 +1623,75 @@ fn schema_sidecar_reattaches_on_reopen() {
         out.contains("persisted"),
         "expected 'persisted' in output, got: {out}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Transaction status over the wire
+// ---------------------------------------------------------------------------
+
+/// ReadyForQuery must report the real transaction status: clients that
+/// track it (e.g. psycopg3) skip sending COMMIT when the server claims
+/// idle, and the transaction's work is silently lost on disconnect.
+#[test]
+fn wire_ready_for_query_reports_transaction_status() {
+    with_pg_client(|a| {
+        assert_eq!(extract_ready_status(&a.query_raw("SELECT 1")), Some(b'I'));
+        assert_eq!(extract_ready_status(&a.query_raw("BEGIN")), Some(b'T'));
+        assert_eq!(extract_ready_status(&a.query_raw("SELECT 1")), Some(b'T'));
+        // An error inside a transaction moves it to the failed state.
+        assert_eq!(
+            extract_ready_status(&a.query_raw("SELECT x FROM missing")),
+            Some(b'E')
+        );
+        assert_eq!(extract_ready_status(&a.query_raw("ROLLBACK")), Some(b'I'));
+
+        // ROLLBACK TO SAVEPOINT stays inside the transaction.
+        assert_eq!(extract_ready_status(&a.query_raw("BEGIN")), Some(b'T'));
+        assert_eq!(
+            extract_ready_status(&a.query_raw("SAVEPOINT s1")),
+            Some(b'T')
+        );
+        assert_eq!(
+            extract_ready_status(&a.query_raw("ROLLBACK TO SAVEPOINT s1")),
+            Some(b'T')
+        );
+        assert_eq!(extract_ready_status(&a.query_raw("COMMIT")), Some(b'I'));
+    });
+}
+
+/// An error mid-message must not lose the earlier statements' tags or
+/// transaction transitions. When it did, ReadyForQuery said idle with a
+/// transaction open, and the client's next write was silently rolled
+/// back on disconnect.
+#[test]
+fn wire_error_in_multi_statement_message_keeps_transaction_state() {
+    with_pg_client(|c| {
+        c.query_command_tags("CREATE TABLE t (x INTEGER)");
+
+        let response = c.query_raw("BEGIN; INSERT INTO t VALUES (1); SELECT x FROM missing");
+        assert_eq!(extract_command_tags(&response), ["BEGIN", "INSERT 0 1"]);
+        assert!(extract_error_field(&response, b'C').is_some());
+        assert_eq!(extract_ready_status(&response), Some(b'E'));
+
+        assert_eq!(extract_ready_status(&c.query_raw("ROLLBACK")), Some(b'I'));
+        assert_eq!(c.query_single_text("SELECT count(*) FROM t"), "0");
+    });
+}
+
+/// END and ABORT are PostgreSQL aliases of COMMIT and ROLLBACK; they
+/// must report those command tags and end the transaction.
+#[test]
+fn wire_end_and_abort_report_commit_and_rollback_tags() {
+    with_pg_client(|c| {
+        c.query_command_tags("CREATE TABLE t (x INTEGER)");
+
+        assert_eq!(c.query_command_tags("BEGIN"), ["BEGIN"]);
+        assert_eq!(c.query_command_tags("END"), ["COMMIT"]);
+        assert_eq!(extract_ready_status(&c.query_raw("SELECT 1")), Some(b'I'));
+
+        assert_eq!(c.query_command_tags("BEGIN"), ["BEGIN"]);
+        c.query_command_tags("INSERT INTO t VALUES (1)");
+        assert_eq!(c.query_command_tags("ABORT"), ["ROLLBACK"]);
+        assert_eq!(c.query_single_text("SELECT count(*) FROM t"), "0");
+    });
 }

--- a/postgres/server/lib.rs
+++ b/postgres/server/lib.rs
@@ -1,15 +1,16 @@
 use std::num::NonZero;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc, Mutex,
+    Arc,
 };
+use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::stream;
 use tokio::net::TcpListener;
-use tracing::{error, info};
-use turso_core::Value;
-use turso_pg::{split_statements, Connection, PgConnection};
+use tracing::{error, info, warn};
+use turso_core::{LimboError, Value};
+use turso_pg::{split_statements, Connection};
 
 use pgwire::api::auth::StartupHandler;
 use pgwire::api::portal::{Format, Portal};
@@ -28,7 +29,8 @@ use pgwire::types::format::FormatOptions;
 pub struct TursoPgServer {
     address: String,
     db_file: String,
-    conn: Arc<Mutex<PgConnection>>,
+    db: Arc<turso_core::Database>,
+    busy_timeout: Duration,
     interrupt_count: Arc<AtomicUsize>,
 }
 
@@ -36,13 +38,15 @@ impl TursoPgServer {
     pub fn new(
         address: String,
         db_file: String,
-        conn: Connection,
+        db: Arc<turso_core::Database>,
+        busy_timeout: Duration,
         interrupt_count: Arc<AtomicUsize>,
     ) -> Self {
         Self {
             address,
             db_file,
-            conn: Arc::new(Mutex::new(conn)),
+            db,
+            busy_timeout,
             interrupt_count,
         }
     }
@@ -59,24 +63,43 @@ impl TursoPgServer {
             self.address, self.db_file
         );
 
-        let factory = Arc::new(TursoPgFactory {
-            handler: Arc::new(TursoPgHandler {
-                conn: self.conn.clone(),
-                db_file: self.db_file.clone(),
-                query_parser: Arc::new(NoopQueryParser::new()),
-            }),
-        });
-
         loop {
             tokio::select! {
                 result = listener.accept() => {
                     match result {
                         Ok((socket, addr)) => {
                             info!("PostgreSQL client connected from {}", addr);
-                            let factory_ref = factory.clone();
+                            let db = self.db.clone();
+                            let db_file = self.db_file.clone();
+                            let busy_timeout = self.busy_timeout;
                             tokio::spawn(async move {
-                                if let Err(e) = process_socket(socket, None, factory_ref).await {
+                                let minted = tokio::task::spawn_blocking({
+                                    let db_file = db_file.clone();
+                                    move || new_client_connection(&db, &db_file, busy_timeout)
+                                })
+                                .await
+                                .map_err(|e| e.to_string())
+                                .and_then(|r| r.map_err(|e| e.to_string()));
+                                let conn = match minted {
+                                    Ok(conn) => conn,
+                                    Err(e) => {
+                                        error!("Failed to open a connection for client {}: {}", addr, e);
+                                        return;
+                                    }
+                                };
+                                let factory = Arc::new(TursoPgFactory {
+                                    handler: Arc::new(TursoPgHandler {
+                                        conn: conn.clone(),
+                                        db_file,
+                                        query_parser: Arc::new(NoopQueryParser::new()),
+                                    }),
+                                });
+                                if let Err(e) = process_socket(socket, None, factory).await {
                                     error!("Error processing connection from {}: {}", addr, e);
+                                }
+                                // Rolls back any open transaction and releases its locks.
+                                if let Err(e) = conn.close() {
+                                    warn!("Error closing connection for {}: {}", addr, e);
                                 }
                             });
                         }
@@ -101,55 +124,99 @@ impl TursoPgServer {
     }
 }
 
+/// Open one client's dedicated connection; clients share no transaction or
+/// session state. Runs on the blocking pool so attaching schema files
+/// cannot stall the accept loop.
+fn new_client_connection(
+    db: &Arc<turso_core::Database>,
+    db_file: &str,
+    busy_timeout: Duration,
+) -> turso_core::Result<Connection> {
+    let conn = Connection::new(db.connect()?);
+    conn.inner().set_busy_timeout(busy_timeout);
+    auto_attach_pg_schemas(&conn, db_file);
+    Ok(conn)
+}
+
+/// Discover and attach existing PG schema database files in the same directory.
+pub fn auto_attach_pg_schemas(conn: &Connection, db_file: &str) {
+    if db_file == ":memory:" {
+        return;
+    }
+    let dir = std::path::Path::new(db_file)
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."));
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        let Some(schema) = name
+            .strip_prefix("turso-postgres-schema-")
+            .and_then(|s| s.strip_suffix(".db"))
+        else {
+            continue;
+        };
+        let path = entry.path().to_string_lossy().to_string();
+        let sql = format!("ATTACH '{path}' AS \"{schema}\"");
+        info!("Auto-attaching PG schema '{}' from {}", schema, path);
+        if let Err(e) = conn.inner().execute(&sql) {
+            warn!("Failed to attach schema '{}': {}", schema, e);
+        }
+    }
+}
+
 struct TursoPgHandler {
-    conn: Arc<Mutex<PgConnection>>,
+    conn: Connection,
     db_file: String,
     query_parser: Arc<NoopQueryParser>,
 }
 
-impl TursoPgHandler {
-    /// After a DROP SCHEMA query succeeds, delete the schema's database file.
-    /// Uses simple string matching to detect DROP SCHEMA statements.
-    fn cleanup_dropped_schema_file(&self, query: &str) {
-        if self.db_file == ":memory:" {
-            return;
+/// After a DROP SCHEMA query succeeds, delete the schema's database file.
+/// Uses simple string matching to detect DROP SCHEMA statements.
+fn cleanup_dropped_schema_file(db_file: &str, query: &str) {
+    if db_file == ":memory:" {
+        return;
+    }
+    // Simple detection: look for DROP SCHEMA pattern
+    let trimmed = query.trim().to_lowercase();
+    if !trimmed.starts_with("drop schema") {
+        return;
+    }
+    // Extract schema name: "drop schema [if exists] <name> [cascade|restrict]"
+    let rest = trimmed.strip_prefix("drop schema").unwrap().trim();
+    let rest = rest
+        .strip_prefix("if exists")
+        .map(|s| s.trim())
+        .unwrap_or(rest);
+    // Take the first word as the schema name
+    let name = rest
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .trim_matches('"');
+    if name.is_empty() || name == "public" {
+        return;
+    }
+    let parent = std::path::Path::new(db_file)
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."));
+    let schema_file = parent.join(format!("turso-postgres-schema-{name}.db"));
+    if schema_file.exists() {
+        if let Err(e) = std::fs::remove_file(&schema_file) {
+            warn!("Failed to delete schema file {:?}: {}", schema_file, e);
+        } else {
+            info!("Deleted schema file {:?}", schema_file);
         }
-        // Simple detection: look for DROP SCHEMA pattern
-        let trimmed = query.trim().to_lowercase();
-        if !trimmed.starts_with("drop schema") {
-            return;
-        }
-        // Extract schema name: "drop schema [if exists] <name> [cascade|restrict]"
-        let rest = trimmed.strip_prefix("drop schema").unwrap().trim();
-        let rest = rest
-            .strip_prefix("if exists")
-            .map(|s| s.trim())
-            .unwrap_or(rest);
-        // Take the first word as the schema name
-        let name = rest
-            .split_whitespace()
-            .next()
-            .unwrap_or("")
-            .trim_matches('"');
-        if name.is_empty() || name == "public" {
-            return;
-        }
-        let parent = std::path::Path::new(&self.db_file)
-            .parent()
-            .unwrap_or_else(|| std::path::Path::new("."));
-        let schema_file = parent.join(format!("turso-postgres-schema-{name}.db"));
-        if schema_file.exists() {
-            if let Err(e) = std::fs::remove_file(&schema_file) {
-                tracing::warn!("Failed to delete schema file {:?}: {}", schema_file, e);
-            } else {
-                tracing::info!("Deleted schema file {:?}", schema_file);
-            }
-            // Also clean up WAL and SHM files
-            let wal = schema_file.with_extension("db-wal");
-            let shm = schema_file.with_extension("db-shm");
-            let _ = std::fs::remove_file(wal);
-            let _ = std::fs::remove_file(shm);
-        }
+        // Also clean up WAL and SHM files
+        let wal = schema_file.with_extension("db-wal");
+        let shm = schema_file.with_extension("db-shm");
+        let _ = std::fs::remove_file(wal);
+        let _ = std::fs::remove_file(shm);
     }
 }
 
@@ -177,43 +244,45 @@ impl SimpleQueryHandler for TursoPgHandler {
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
-        let conn = self.conn.lock().unwrap().clone();
+        let conn = self.conn.clone();
+        let db_file = self.db_file.clone();
+        let query = query.to_string();
 
-        // Per the PostgreSQL simple query protocol, a query string may contain
-        // multiple semicolon-separated statements. Split and execute each one.
-        let statements = split_statements(query)
-            .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+        run_blocking(move || {
+            // Per the PostgreSQL simple query protocol, a query string may contain
+            // multiple semicolon-separated statements. Split and execute each one.
+            let statements = split_statements(&query).map_err(|e| limbo_error_to_pg(&e))?;
 
-        let mut responses = Vec::new();
-        for sql in &statements {
-            let result = (|| {
-                let mut stmt = conn
-                    .prepare(sql)
-                    .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+            let mut responses = Vec::new();
+            for sql in &statements {
+                let result = (|| {
+                    let mut stmt = conn.prepare(sql).map_err(|e| limbo_error_to_pg(&e))?;
 
-                self.cleanup_dropped_schema_file(sql);
+                    cleanup_dropped_schema_file(&db_file, sql);
 
-                if stmt.num_columns() == 0 || is_pg_non_query(sql) {
-                    execute_non_query(&mut stmt, sql)
-                } else {
-                    let header = Arc::new(build_field_info(&stmt, &Format::UnifiedText));
-                    execute_query(&mut stmt, header)
-                }
-            })();
-            match result {
-                Ok(response) => responses.push(response),
-                // An error ends the message. Report it as a response, not
-                // Err: pgwire drops earlier tags and transaction
-                // transitions on Err, so after a BEGIN the client would
-                // be told idle while the connection is in a transaction.
-                Err(e) => {
-                    responses.push(Response::Error(Box::new(e.into())));
-                    break;
+                    if stmt.num_columns() == 0 || is_pg_non_query(sql) {
+                        execute_non_query(&mut stmt, sql)
+                    } else {
+                        let header = Arc::new(build_field_info(&stmt, &Format::UnifiedText));
+                        execute_query(&mut stmt, header)
+                    }
+                })();
+                match result {
+                    Ok(response) => responses.push(response),
+                    // An error ends the message. Report it as a response, not
+                    // Err: pgwire drops earlier tags and transaction
+                    // transitions on Err, so after a BEGIN the client would
+                    // be told idle while the connection is in a transaction.
+                    Err(e) => {
+                        responses.push(Response::Error(Box::new(e.into())));
+                        break;
+                    }
                 }
             }
-        }
 
-        Ok(responses)
+            Ok(responses)
+        })
+        .await
     }
 }
 
@@ -235,25 +304,30 @@ impl ExtendedQueryHandler for TursoPgHandler {
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
-        let conn = self.conn.lock().unwrap().clone();
-        let query = &portal.statement.statement;
+        let conn = self.conn.clone();
+        let db_file = self.db_file.clone();
+        let query = portal.statement.statement.clone();
+        let parameters = portal.parameters.clone();
+        let parameter_types = portal.statement.parameter_types.clone();
+        let result_format = portal.result_column_format.clone();
 
-        let mut stmt = conn
-            .prepare(query)
-            .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+        run_blocking(move || {
+            let mut stmt = conn.prepare(&query).map_err(|e| limbo_error_to_pg(&e))?;
 
-        // Clean up schema file after successful DROP SCHEMA
-        self.cleanup_dropped_schema_file(query);
+            // Clean up schema file after successful DROP SCHEMA
+            cleanup_dropped_schema_file(&db_file, &query);
 
-        // Bind parameters from the portal
-        bind_portal_parameters(&mut stmt, portal)?;
+            // Bind parameters from the portal
+            bind_parameters(&mut stmt, &parameters, &parameter_types)?;
 
-        if stmt.num_columns() == 0 || is_pg_non_query(query) {
-            return execute_non_query(&mut stmt, query);
-        }
+            if stmt.num_columns() == 0 || is_pg_non_query(&query) {
+                return execute_non_query(&mut stmt, &query);
+            }
 
-        let header = Arc::new(build_field_info(&stmt, &portal.result_column_format));
-        execute_query(&mut stmt, header)
+            let header = Arc::new(build_field_info(&stmt, &result_format));
+            execute_query(&mut stmt, header)
+        })
+        .await
     }
 
     async fn do_describe_statement<C>(
@@ -264,19 +338,20 @@ impl ExtendedQueryHandler for TursoPgHandler {
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
-        let conn = self.conn.lock().unwrap().clone();
-        let stmt = conn
-            .prepare(&target.statement)
-            .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
-
+        let conn = self.conn.clone();
+        let query = target.statement.clone();
         let param_types: Vec<Type> = target
             .parameter_types
             .iter()
             .map(|t| t.clone().unwrap_or(Type::TEXT))
             .collect();
 
-        let fields = build_field_info(&stmt, &Format::UnifiedText);
-        Ok(DescribeStatementResponse::new(param_types, fields))
+        run_blocking(move || {
+            let stmt = conn.prepare(&query).map_err(|e| limbo_error_to_pg(&e))?;
+            let fields = build_field_info(&stmt, &Format::UnifiedText);
+            Ok(DescribeStatementResponse::new(param_types, fields))
+        })
+        .await
     }
 
     async fn do_describe_portal<C>(
@@ -287,13 +362,16 @@ impl ExtendedQueryHandler for TursoPgHandler {
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
-        let conn = self.conn.lock().unwrap().clone();
-        let stmt = conn
-            .prepare(&portal.statement.statement)
-            .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+        let conn = self.conn.clone();
+        let query = portal.statement.statement.clone();
+        let result_format = portal.result_column_format.clone();
 
-        let fields = build_field_info(&stmt, &portal.result_column_format);
-        Ok(DescribePortalResponse::new(fields))
+        run_blocking(move || {
+            let stmt = conn.prepare(&query).map_err(|e| limbo_error_to_pg(&e))?;
+            let fields = build_field_info(&stmt, &result_format);
+            Ok(DescribePortalResponse::new(fields))
+        })
+        .await
     }
 }
 
@@ -414,7 +492,7 @@ fn execute_query(
         rows.push(encoder.finish());
         Ok(())
     })
-    .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+    .map_err(|e| limbo_error_to_pg(&e))?;
 
     let data_stream = stream::iter(rows);
     Ok(Response::Query(QueryResponse::new(header, data_stream)))
@@ -422,8 +500,7 @@ fn execute_query(
 
 /// Execute a non-SELECT statement and build an Execution response.
 fn execute_non_query(stmt: &mut turso_core::Statement, query: &str) -> PgWireResult<Response> {
-    stmt.run_ignore_rows()
-        .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+    stmt.run_ignore_rows().map_err(|e| limbo_error_to_pg(&e))?;
 
     let affected = stmt.n_change();
     let tag = command_tag(query, affected as usize);
@@ -457,30 +534,30 @@ fn transaction_aware_response(query: &str, tag: Tag) -> Response {
     }
 }
 
-/// Extract parameters from a Portal and bind them to a prepared statement.
+/// Bind parameter values (raw bytes plus declared types) to a prepared
+/// statement.
 ///
 /// PostgreSQL parameters ($1, $2, ...) map to portal parameters 0, 1, ...
 /// The bytecode compiler may allocate internal parameter indices in a different
 /// order than the $N numbering (e.g. if $2 appears before $1 in the SQL), so we
 /// look up each parameter's internal index by name.
-fn bind_portal_parameters(
+fn bind_parameters<B: AsRef<[u8]>>(
     stmt: &mut turso_core::Statement,
-    portal: &Portal<String>,
+    parameters: &[Option<B>],
+    parameter_types: &[Option<Type>],
 ) -> PgWireResult<()> {
-    for i in 0..portal.parameter_len() {
-        let value = match &portal.parameters[i] {
+    for (i, param) in parameters.iter().enumerate() {
+        let value = match param {
             None => Value::Null,
             Some(bytes) => {
-                let pg_type = portal
-                    .statement
-                    .parameter_types
+                let pg_type = parameter_types
                     .get(i)
                     .and_then(|t| t.as_ref())
                     .unwrap_or(&Type::UNKNOWN);
-                pg_bytes_to_value(bytes, pg_type)?
+                pg_bytes_to_value(bytes.as_ref(), pg_type)?
             }
         };
-        // Portal parameter i corresponds to PostgreSQL $N where N = i + 1.
+        // Parameter i corresponds to PostgreSQL $N where N = i + 1.
         // Look up the internal index that the bytecode compiler assigned to $N.
         let pg_param_name = format!("${}", i + 1);
         let idx = stmt
@@ -797,6 +874,42 @@ fn is_create_table_as(upper: &str) -> bool {
 
 fn error_info(message: &str) -> ErrorInfo {
     ErrorInfo::new("ERROR".to_owned(), "XX000".to_owned(), message.to_owned())
+}
+
+/// Run a database operation on the blocking pool. Statements can hold a
+/// thread for seconds (busy-handler lock waits); if run on the async
+/// runtime, that blocking can leave another client's COMMIT unprocessed
+/// until the blocked statement times out.
+async fn run_blocking<T: Send + 'static>(
+    f: impl FnOnce() -> PgWireResult<T> + Send + 'static,
+) -> PgWireResult<T> {
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| PgWireError::ApiError(Box::new(e)))?
+}
+
+/// Map a turso error to a PG wire error: lock contention gets real
+/// SQLSTATEs so client retry logic works, everything else stays XX000.
+fn limbo_error_to_pg(e: &LimboError) -> PgWireError {
+    let mut info = match e {
+        // Busy timeout expired waiting for the write lock; PostgreSQL's
+        // code for a lock wait timing out is 55P03 lock_not_available.
+        LimboError::Busy => ErrorInfo::new(
+            "ERROR".to_owned(),
+            "55P03".to_owned(),
+            "canceling statement due to lock timeout".to_owned(),
+        ),
+        // Stale read snapshot: the transaction must be rolled back and
+        // retried. PostgreSQL reports this as 40001 serialization_failure.
+        LimboError::BusySnapshot => ErrorInfo::new(
+            "ERROR".to_owned(),
+            "40001".to_owned(),
+            "could not serialize access due to concurrent update".to_owned(),
+        ),
+        _ => return PgWireError::UserError(Box::new(error_info(&e.to_string()))),
+    };
+    info.detail = Some(e.to_string());
+    PgWireError::UserError(Box::new(info))
 }
 
 #[cfg(test)]

--- a/postgres/server/lib.rs
+++ b/postgres/server/lib.rs
@@ -186,17 +186,30 @@ impl SimpleQueryHandler for TursoPgHandler {
 
         let mut responses = Vec::new();
         for sql in &statements {
-            let mut stmt = conn
-                .prepare(sql)
-                .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+            let result = (|| {
+                let mut stmt = conn
+                    .prepare(sql)
+                    .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
 
-            self.cleanup_dropped_schema_file(sql);
+                self.cleanup_dropped_schema_file(sql);
 
-            if stmt.num_columns() == 0 || is_pg_non_query(sql) {
-                responses.push(execute_non_query(&mut stmt, sql)?);
-            } else {
-                let header = Arc::new(build_field_info(&stmt, &Format::UnifiedText));
-                responses.push(execute_query(&mut stmt, header)?);
+                if stmt.num_columns() == 0 || is_pg_non_query(sql) {
+                    execute_non_query(&mut stmt, sql)
+                } else {
+                    let header = Arc::new(build_field_info(&stmt, &Format::UnifiedText));
+                    execute_query(&mut stmt, header)
+                }
+            })();
+            match result {
+                Ok(response) => responses.push(response),
+                // An error ends the message. Report it as a response, not
+                // Err: pgwire drops earlier tags and transaction
+                // transitions on Err, so after a BEGIN the client would
+                // be told idle while the connection is in a transaction.
+                Err(e) => {
+                    responses.push(Response::Error(Box::new(e.into())));
+                    break;
+                }
             }
         }
 
@@ -414,7 +427,34 @@ fn execute_non_query(stmt: &mut turso_core::Statement, query: &str) -> PgWireRes
 
     let affected = stmt.n_change();
     let tag = command_tag(query, affected as usize);
-    Ok(Response::Execution(tag))
+    Ok(transaction_aware_response(query, tag))
+}
+
+/// Pick the Response variant that keeps pgwire's transaction status
+/// accurate. ReadyForQuery echoes that status, and clients that track it
+/// (e.g. psycopg3) skip sending COMMIT when it says idle; reporting BEGIN
+/// as a plain Execution would silently lose the transaction on disconnect.
+fn transaction_aware_response(query: &str, tag: Tag) -> Response {
+    let mut words = query
+        .split_whitespace()
+        .map(|w| w.trim_end_matches(';').to_ascii_uppercase());
+    let Some(first) = words.next() else {
+        return Response::Execution(tag);
+    };
+    match first.as_str() {
+        "BEGIN" | "START" => Response::TransactionStart(tag),
+        "COMMIT" | "END" | "ABORT" => Response::TransactionEnd(tag),
+        "ROLLBACK" => {
+            // ROLLBACK [WORK|TRANSACTION] TO SAVEPOINT stays inside the
+            // transaction; only a full ROLLBACK ends it.
+            if words.take(2).any(|w| w == "TO") {
+                Response::Execution(tag)
+            } else {
+                Response::TransactionEnd(tag)
+            }
+        }
+        _ => Response::Execution(tag),
+    }
 }
 
 /// Extract parameters from a Portal and bind them to a prepared statement.
@@ -680,9 +720,9 @@ fn command_tag(query: &str, affected_rows: usize) -> Tag {
         Tag::new("ALTER TABLE")
     } else if upper.starts_with("BEGIN") || upper.starts_with("START") {
         Tag::new("BEGIN")
-    } else if upper.starts_with("COMMIT") {
+    } else if upper.starts_with("COMMIT") || upper.starts_with("END") {
         Tag::new("COMMIT")
-    } else if upper.starts_with("ROLLBACK") {
+    } else if upper.starts_with("ROLLBACK") || upper.starts_with("ABORT") {
         Tag::new("ROLLBACK")
     } else if upper.starts_with("SAVEPOINT") {
         Tag::new("SAVEPOINT")
@@ -762,6 +802,28 @@ fn error_info(message: &str) -> ErrorInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_transaction_aware_response_classification() {
+        let variant = |sql: &str| match transaction_aware_response(sql, Tag::new("X")) {
+            Response::TransactionStart(_) => "start",
+            Response::TransactionEnd(_) => "end",
+            Response::Execution(_) => "execution",
+            _ => "other",
+        };
+        assert_eq!(variant("BEGIN"), "start");
+        assert_eq!(variant("begin;"), "start");
+        assert_eq!(variant("START TRANSACTION"), "start");
+        assert_eq!(variant("COMMIT"), "end");
+        assert_eq!(variant("END"), "end");
+        assert_eq!(variant("ABORT"), "end");
+        assert_eq!(variant("ROLLBACK"), "end");
+        assert_eq!(variant("ROLLBACK WORK"), "end");
+        assert_eq!(variant("ROLLBACK TO SAVEPOINT s1"), "execution");
+        assert_eq!(variant("ROLLBACK TRANSACTION TO SAVEPOINT s1"), "execution");
+        assert_eq!(variant("INSERT INTO t VALUES (1)"), "execution");
+        assert_eq!(variant("SAVEPOINT s1"), "execution");
+    }
 
     #[test]
     fn test_pg_bytes_to_value_integer() {


### PR DESCRIPTION
 ## Description

Two standalone commits:

1. `postgres/server: report transaction status in ReadyForQuery`. The server always reported idle, and clients that gate on the status (e.g. psycopg3) skip sending COMMIT, losing the transaction's work on disconnect. BEGIN / COMMIT / ROLLBACK now map to pgwire's TransactionStart/TransactionEnd (ROLLBACK TO SAVEPOINT stays in-transaction; END and ABORT report COMMIT and ROLLBACK), and a mid-message error becomes an error response so earlier statements' tags and transitions survive.

2. `postgres: open a dedicated connection per wire client`. Each accepted socket creates its own connection (schema files attach at connect time) and closes it on disconnect, rolling back abandoned transactions. Statement execution moves to the blocking pool: run inline it left a blocked writer's competing COMMIT unprocessed. Adds `--busy-timeout` (default 5000 ms).

Divergences from PostgreSQL, documented in COMPAT.md:

- Blocked writers fail with 55P03 lock_not_available after the busy timeout (database-wide write lock). PostgreSQL waits on row locks.
- Isolation is snapshot-at-first-statement, closest to REPEATABLE READ, and stale-snapshot writes fail at once with 40001. PostgreSQL defaults to READ COMMITTED.
- No aborted-transaction state: statements after an error still run and COMMIT keeps those that succeed. PostgreSQL rejects until ROLLBACK.
- CREATE/DROP SCHEMA visibility is per-connection.

Validation: wire tests (two-client isolation, blocked-writer recovery, 55P03/40001 errors, disconnect releases the write lock, status cycle, END/ABORT tags, schema attach).

## Motivation and context

The server shared one connection across all clients, so transactions did not work as expected and session state leaked between clients. This makes concurrent transactional clients work and is a base for per-session state.

## Description of AI Usage

Developed with Claude Code under my direction. I reviewed and take responsibility for the final diff.
