### PR TITLE
core: fix MVCC+CDC panic on empty COMMIT after a failed captured write

### DIFF
--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1749,6 +1749,13 @@ pub fn emit_cdc_explicit_commit_insns(
         collation: None,
     });
 
+    // The CDC record write needs a transaction; joins the open one (keeping its mode) if any.
+    program.emit_insn(Insn::Transaction {
+        db: crate::MAIN_DB_ID,
+        tx_mode: TransactionMode::Write,
+        schema_cookie: schema.schema_version,
+    });
+
     // A COMMIT record has no associated table, so pass `None` (no self-exclusion check).
     if let Some((cdc_cursor_id, _)) = prepare_cdc_if_necessary(program, schema, None)? {
         emit_cdc_commit_insns(program, resolver, cdc_cursor_id)?;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12529,6 +12529,10 @@ pub fn op_open_write(
                     mv_cursor_type,
                     btree_cursor,
                 )?))
+            } else if mv_store.is_some() {
+                Err(LimboError::InternalError(
+                    "OpenWrite requires an active MVCC transaction".to_string(),
+                ))
             } else {
                 Ok(btree_cursor)
             }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2921,6 +2921,7 @@ impl Program {
 
     fn rollback_current_txn(&self, pager: &Arc<Pager>) {
         self.connection.rollback_current_txn_state(pager, true);
+        self.connection.set_cdc_transaction_id(-1);
     }
 
     /// MVCC sequence operations run in a separate inner tx, which temporarily

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -1675,6 +1675,32 @@ fn test_cdc_v2_txn_id_reset_after_commit(db: TempDatabase) {
     assert_ne!(rows[0][0], rows[1][0]);
 }
 
+#[turso_macros::test]
+fn test_cdc_mvcc_failed_insert_then_empty_commit(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.execute("PRAGMA capture_data_changes_conn('full')")
+        .unwrap();
+    conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 10)").unwrap();
+    limbo_exec_rows_fallible(&db, &conn, "INSERT INTO t VALUES (3, 30), (4, 30)")
+        .expect_err("second row must violate the UNIQUE constraint");
+
+    let rows_before = limbo_exec_rows(&conn, "SELECT change_type FROM turso_cdc");
+    conn.execute("BEGIN DEFERRED").unwrap();
+    conn.execute("COMMIT").unwrap();
+    let rows_after_empty_commit = limbo_exec_rows(&conn, "SELECT change_type FROM turso_cdc");
+    assert_eq!(rows_after_empty_commit, rows_before);
+
+    conn.execute("INSERT INTO t VALUES (2, 20)").unwrap();
+    let rows = limbo_exec_rows(&conn, "SELECT change_type FROM turso_cdc");
+    assert_eq!(
+        &rows[rows.len() - 2..],
+        &[vec![Value::Integer(1)], vec![Value::Integer(2)],]
+    );
+}
+
 /// Regression test for https://github.com/tursodatabase/turso/issues/7677.
 ///
 /// With CDC v2 enabled, an explicit COMMIT emits a CDC commit record. For a transaction that


### PR DESCRIPTION
## What

Fixes a panic (`self.current_page >= 0` in `btree.rs`) when a COMMIT emits a CDC commit record under MVCC without an active transaction.

Reproducer:

```sql
PRAGMA journal_mode = 'mvcc';
PRAGMA capture_data_changes_conn('full');
CREATE TABLE t (x INTEGER PRIMARY KEY, y UNIQUE);
INSERT INTO t VALUES (1, 10);
INSERT INTO t VALUES (3, 30), (4, 30);   -- row 1 captured into CDC, row 2 fails UNIQUE
BEGIN DEFERRED;
COMMIT;                                   -- panics
```

## Why

Three defects compose:

1. **`Program::abort` never reset `cdc_transaction_id`.** The failed multi-row INSERT captured its first row into `turso_cdc` (setting the id via `ConnTxnId`) before the second row's unique violation aborted the statement. The reset to `-1` only happened on the halt paths, so the stale id leaked into the next transaction.
2. **`translate_tx_commit` emitted the CDC commit-record instructions with no `Transaction` instruction before them.** The write is guarded by a runtime "skip when nothing was captured" check, but the stale id from (1) defeated the guard — and for an *empty* `BEGIN DEFERRED` transaction nothing ever opened a transaction, so the CDC `OpenWrite` ran with no MVCC transaction.
3. **`op_open_write` silently fell back to an unwrapped physical `BTreeCursor`** when there was no MVCC transaction — handing a btree cursor a negative (MVCC placeholder) root page, which tripped the assert.

## The fix

- **`core/vdbe/mod.rs`**: reset `cdc_transaction_id` in `Program::rollback_current_txn`, i.e. only when the *transaction* is rolled back — a statement that fails inside a live explicit transaction (`BEGIN; INSERT ok; INSERT fails; INSERT ok; COMMIT`) still keeps its id so its captured rows stay grouped.
- **`core/translate/emitter/mod.rs`**: emit a `Transaction` instruction after the "nothing captured" skip and before the CDC commit-record write. An empty COMMIT still skips everything; when the record *is* written it joins the open transaction and keeps its mode (concurrent transactions stay concurrent), so `op_open_write` wraps the cursor in an `MvCursor`.
- **`core/vdbe/execute.rs`**: when an MVCC store exists but `OpenWrite` has no active transaction, return an internal error instead of silently using an unwrapped cursor — converting this class of bug from a corruption-shaped panic into an immediate diagnostic.

## Test

Adds a regression test mirroring the reproducer, which also asserts the empty COMMIT writes no spurious commit record and that CDC keeps working afterwards.

## Verification

- Reproducer runs to completion (no panic).
- `cargo test -p core_tester --test integration_tests test_cdc` — pass.
- `cargo test -p core_tester --test integration_tests test_vacuum` — pass (guards the `OpenWrite` change).
- `cargo test -p turso_core --lib` — pass.
- `cargo fmt`, focused clippy on the touched crates — clean.

Fixes #8187

---

*Disclosure: this fix was investigated, written, and submitted by Claude (an AI assistant) acting on behalf of Glauber Costa (@glommer).*
