### PR TITLE
postgres: support file COPY TO and CSV options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,14 +1559,14 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7458,6 +7458,7 @@ name = "turso_pg"
 version = "0.8.0-pre.2"
 dependencies = [
  "chrono",
+ "csv",
  "parking_lot",
  "rustc-hash 2.1.1",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ similar-asserts = { version = "1.7.0" }
 bitmaps = { version = "3.2.1", default-features = false }
 console-subscriber = { version = "0.4.1" }
 either = { version = "1.15" }
+csv = "1.3.1"
 
 # Multi threading testing
 loom = { version = "0.7" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,7 @@ cfg-if = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 clap_complete = { version = "=4.5.47", features = ["unstable-dynamic"] }
 comfy-table = "7.1.4"
-csv = "1.3.1"
+csv = { workspace = true }
 ctrlc = "3.4.4"
 crc32c = "0.6.8"
 dirs = "5.0.1"

--- a/extensions/csv/Cargo.toml
+++ b/extensions/csv/Cargo.toml
@@ -15,7 +15,7 @@ static = ["turso_ext/static"]
 
 [dependencies]
 turso_ext = { workspace = true, features = ["static"] }
-csv = "1.3.1"
+csv = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/postgres/cli/TODO.md
+++ b/postgres/cli/TODO.md
@@ -8,14 +8,14 @@ Sorted by implementation difficulty.
 2. **PREPARE / EXECUTE / DEALLOCATE** — wire protocol already handles this; just need the SQL syntax to not error
 3. **GRANT/REVOKE** — parse + ignore (single-user system, just don't error)
 4. **More PG system functions** — still missing: `current_setting`, `current_schemas(bool)`, a real `pg_get_expr` (currently a NULL stub), and the regexp functions (`extensions/regexp` is not linked into tursopg); session information functions and the `string_agg` family already resolve
-5. ~~**SET search_path**~~ — intercept in try_prepare_pg, store on connection, use in table resolution
+5. ~~**SET search_path**~~ — DONE intercept in try_prepare_pg, store on connection, use in table resolution
 ∑
 ## Easy (a day or two)
 
-6. **CREATE TABLE AS / SELECT INTO** — translate to `CREATE TABLE ... AS SELECT` which Turso already supports
+6. ~~**CREATE TABLE AS / SELECT INTO**~~ — DONE (translates to `CREATE TABLE ... AS SELECT`; WITH NO DATA supported, explicit column list rejected)
 7. **ALTER COLUMN SET/DROP DEFAULT, SET/DROP NOT NULL** — Turso's ALTER TABLE is limited but these map to SQLite operations
 8. **CONCURRENTLY on CREATE INDEX** — just ignore the keyword (SQLite doesn't do concurrent DDL anyway)
-9. **COPY ... FROM/TO with simple CSV** — implement as INSERT loop or SELECT output (not the wire protocol COPY)
+9. ~~**COPY ... FROM/TO with simple CSV**~~ — DONE implement as INSERT loop or SELECT output (not the wire protocol COPY)
 
 ## Medium (a few days)
 

--- a/postgres/frontend/Cargo.toml
+++ b/postgres/frontend/Cargo.toml
@@ -21,6 +21,7 @@ turso_core = { workspace = true, default-features = true, features = [
 turso_parser = { workspace = true }
 turso_ext = { workspace = true, features = ["core_only"] }
 turso_pg_parser = { workspace = true }
+csv = { workspace = true }
 
 [lints]
 workspace = true

--- a/postgres/frontend/copy.rs
+++ b/postgres/frontend/copy.rs
@@ -1,39 +1,253 @@
-//! COPY FROM text format parser.
+//! COPY FROM/TO format parser and writer.
 //!
-//! Implements PostgreSQL's default COPY text format:
+//! Text format:
 //! - One row per line (`\n`)
 //! - Columns separated by tab (`\t`) by default
-//! - `\N` = NULL
+//! - `\N` = NULL; empty field = empty string
 //! - Backslash escapes: `\\` = `\`, `\t` = tab, `\n` = newline, `\r` = CR
-//! - Empty field = empty string (not NULL)
 //! - Lines starting with `\.` = end of data
+//!
+//! CSV format:
+//! - Comma delimiter, double-quote quoting, and an empty default NULL marker
+
+use turso_pg_parser::translator::{
+    PgCopyCsvOptions, PgCopyFromFormat, PgCopyTextOptions, PgCopyToFormat,
+};
 
 use crate::{LimboError, Result};
+use std::io::{BufWriter, Write};
 
-/// A parsed row from COPY text format: each element is None for NULL, Some for a value.
+/// A parsed row from COPY format: each element is None for NULL, Some for a value.
 type CopyRow = Vec<Option<String>>;
 
-/// Parse COPY text format data into rows of column values.
-pub fn parse_copy_text_format(
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum CopyToWriter<'a, W: Write> {
+    Text {
+        writer: BufWriter<W>,
+        options: &'a PgCopyTextOptions,
+    },
+    Csv {
+        writer: csv::Writer<W>,
+        options: &'a PgCopyCsvOptions,
+    },
+}
+
+impl<'a, W: Write> CopyToWriter<'a, W> {
+    pub(crate) fn new(writer: W, format: &'a PgCopyToFormat) -> Self {
+        match format {
+            PgCopyToFormat::Text(options) => Self::Text {
+                writer: BufWriter::new(writer),
+                options,
+            },
+            PgCopyToFormat::Csv(options) => Self::Csv {
+                writer: new_csv_writer(writer, options),
+                options,
+            },
+        }
+    }
+
+    pub(crate) fn write_header(&mut self, columns: &[String]) -> Result<()> {
+        match self {
+            Self::Text { writer, options } if options.header => {
+                let fields: Vec<Option<String>> = columns.iter().map(|c| Some(c.clone())).collect();
+                write_text_record(writer, &fields, options)
+            }
+            Self::Csv { writer, options } if options.header => writer
+                .write_record(columns)
+                .map_err(|e| LimboError::Conflict(e.to_string())),
+            _ => Ok(()),
+        }
+    }
+
+    pub(crate) fn write_record(&mut self, fields: &[Option<String>]) -> Result<()> {
+        match self {
+            Self::Text { writer, options } => write_text_record(writer, fields, options),
+            Self::Csv { writer, options } => write_csv_record(writer, fields, options),
+        }
+    }
+
+    pub(crate) fn finish(mut self) -> Result<()> {
+        match &mut self {
+            Self::Text { writer, .. } => writer
+                .flush()
+                .map_err(|e| LimboError::Conflict(e.to_string())),
+            Self::Csv { writer, .. } => writer
+                .flush()
+                .map_err(|e| LimboError::Conflict(e.to_string())),
+        }
+    }
+}
+
+/// Parse COPY FROM input, dispatching to text or CSV based on `format`.
+pub(crate) fn parse_copy_format(
     data: &str,
-    delimiter: char,
-    null_string: &str,
+    format: &PgCopyFromFormat,
     num_columns: usize,
 ) -> Result<Vec<CopyRow>> {
-    let mut rows = Vec::new();
+    match format {
+        PgCopyFromFormat::Text(t) => parse_copy_text_format(data, num_columns, t),
+        PgCopyFromFormat::Csv(c) => parse_copy_csv_format(data, num_columns, c),
+    }
+}
 
+fn new_csv_writer<W: Write>(w: W, options: &PgCopyCsvOptions) -> csv::Writer<W> {
+    let delimiter = options
+        .delimiter
+        .as_ref()
+        .and_then(|d| d.chars().next())
+        .unwrap_or(',');
+    let quote = options
+        .quote
+        .as_ref()
+        .and_then(|d| d.chars().next())
+        .unwrap_or('"');
+    let escape = options
+        .escape
+        .as_ref()
+        .and_then(|d| d.chars().next())
+        .unwrap_or(quote);
+
+    let mut builder = csv::WriterBuilder::new();
+    builder.delimiter(delimiter as u8);
+    builder.quote(quote as u8);
+    if escape != quote {
+        builder.double_quote(false);
+        builder.escape(escape as u8);
+    }
+    builder.from_writer(w)
+}
+
+fn write_text_record<W: Write>(
+    writer: &mut W,
+    fields: &[Option<String>],
+    options: &PgCopyTextOptions,
+) -> Result<()> {
+    let delimiter = options
+        .delimiter
+        .as_ref()
+        .and_then(|d| d.chars().next())
+        .unwrap_or('\t');
+    let null_string = options.null_string.as_deref().unwrap_or("\\N");
+
+    for (i, field) in fields.iter().enumerate() {
+        if i > 0 {
+            write!(writer, "{delimiter}").map_err(|e| LimboError::Conflict(e.to_string()))?;
+        }
+        match field {
+            None => {
+                write!(writer, "{null_string}").map_err(|e| LimboError::Conflict(e.to_string()))?
+            }
+            Some(value) => {
+                let escaped = escape_copy_text_field(value, delimiter);
+                write!(writer, "{escaped}").map_err(|e| LimboError::Conflict(e.to_string()))?;
+            }
+        }
+    }
+    writeln!(writer).map_err(|e| LimboError::Conflict(e.to_string()))
+}
+
+fn write_csv_record<W: Write>(
+    writer: &mut csv::Writer<W>,
+    fields: &[Option<String>],
+    options: &PgCopyCsvOptions,
+) -> Result<()> {
+    let null_string = options.null_string.as_deref().unwrap_or("");
+    writer
+        .write_record(
+            fields
+                .iter()
+                .map(|field| field.as_deref().unwrap_or(null_string)),
+        )
+        .map_err(|e| LimboError::Conflict(e.to_string()))
+}
+
+fn parse_copy_csv_format(
+    data: &str,
+    num_columns: usize,
+    options: &PgCopyCsvOptions,
+) -> Result<Vec<CopyRow>> {
+    let delimiter = options
+        .delimiter
+        .as_ref()
+        .and_then(|d| d.chars().next())
+        .unwrap_or(',');
+    let quote = options
+        .quote
+        .as_ref()
+        .and_then(|d| d.chars().next())
+        .unwrap_or('"');
+    let escape = options
+        .escape
+        .as_ref()
+        .and_then(|d| d.chars().next())
+        .unwrap_or(quote);
+    let null_string = options.null_string.as_deref().unwrap_or("");
+
+    // has_headers(false): header skipping is handled manually below
+    let mut reader = csv::ReaderBuilder::new()
+        .delimiter(delimiter as u8)
+        .quote(quote as u8)
+        .has_headers(false)
+        .escape(u8::try_from(escape).ok())
+        .from_reader(data.as_bytes());
+
+    let mut rows = Vec::new();
+    let skip = usize::from(options.header);
+    for (line_num, record) in reader.records().enumerate().skip(skip) {
+        match record {
+            Ok(record) => {
+                if record.len() != num_columns {
+                    return Err(LimboError::ParseError(format!(
+                        "COPY: line {}: expected {} columns, got {}",
+                        line_num + 1,
+                        num_columns,
+                        record.len()
+                    )));
+                }
+                let row: CopyRow = record
+                    .iter()
+                    .map(|field| {
+                        if field == null_string {
+                            None
+                        } else {
+                            Some(field.to_string())
+                        }
+                    })
+                    .collect();
+                rows.push(row);
+            }
+            Err(e) => return Err(LimboError::ParseError(format!("COPY: got err: {e}"))),
+        }
+    }
+    Ok(rows)
+}
+
+fn parse_copy_text_format(
+    data: &str,
+    num_columns: usize,
+    options: &PgCopyTextOptions,
+) -> Result<Vec<CopyRow>> {
+    let delimiter = options
+        .delimiter
+        .as_ref()
+        .and_then(|d| d.chars().next())
+        .unwrap_or('\t');
+    let null_string = options.null_string.as_deref().unwrap_or("\\N");
+    let mut rows = Vec::new();
+    let mut header_skipped = false;
+
+    // `str::lines()` keeps a lone empty line but skips the extra row after a trailing newline.
     for (line_num, line) in data.lines().enumerate() {
         // End-of-data marker (used in STDIN mode, but handle it for files too)
         if line == "\\." {
             break;
         }
-
-        // Skip empty lines at the end of file
-        if line.is_empty() {
+        if options.header && !header_skipped {
+            header_skipped = true;
             continue;
         }
 
-        let fields: Vec<&str> = line.split(delimiter).collect();
+        let fields: Vec<&str> = split_copy_text_line(line, delimiter);
         if fields.len() != num_columns {
             return Err(LimboError::ParseError(format!(
                 "COPY: line {}: expected {} columns, got {}",
@@ -53,10 +267,8 @@ pub fn parse_copy_text_format(
                 }
             })
             .collect();
-
         rows.push(row);
     }
-
     Ok(rows)
 }
 
@@ -75,29 +287,88 @@ fn unescape_copy_field(field: &str) -> String {
                 Some('b') => result.push('\x08'),
                 Some('f') => result.push('\x0C'),
                 Some('v') => result.push('\x0B'),
-                Some(other) => {
-                    result.push(other);
-                }
-                None => {
-                    result.push('\\');
-                }
+                Some(other) => result.push(other),
+                None => result.push('\\'),
             }
         } else {
             result.push(c);
         }
     }
+    result
+}
 
+/// Split a COPY text line into raw field slices, treating the delimiter as a field
+/// separator only when it is not preceded by a backslash.
+/// Each returned slice still contains backslash escape sequences; the caller must
+/// pass them through `unescape_copy_field` to get the final value.
+fn split_copy_text_line(line: &str, delimiter: char) -> Vec<&str> {
+    let mut fields = Vec::new();
+    let mut field_start = 0;
+    let mut chars = line.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if c == '\\' {
+            chars.next();
+        } else if c == delimiter {
+            fields.push(&line[field_start..i]);
+            field_start = i + delimiter.len_utf8();
+        }
+    }
+    fields.push(&line[field_start..]);
+    fields
+}
+
+/// Escape special characters for COPY text output.
+/// Backslash, tab, newline, and carriage return are always escaped.
+/// If the delimiter appears in the value it is also escaped so round-trips parse cleanly.
+fn escape_copy_text_field(value: &str, delimiter: char) -> String {
+    let mut result = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\\' => result.push_str("\\\\"),
+            '\t' => result.push_str("\\t"),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            c if c == delimiter => {
+                result.push('\\');
+                result.push(c);
+            }
+            c => result.push(c),
+        }
+    }
     result
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use turso_pg_parser::translator::{PgCopyCsvOptions, PgCopyFromFormat, PgCopyTextOptions};
+
+    fn text_format(delimiter: Option<&str>, null_string: Option<&str>) -> PgCopyFromFormat {
+        PgCopyFromFormat::Text(PgCopyTextOptions {
+            delimiter: delimiter.map(str::to_owned),
+            null_string: null_string.map(str::to_owned),
+            header: false,
+        })
+    }
+
+    fn csv_format(opts: PgCopyCsvOptions) -> PgCopyFromFormat {
+        PgCopyFromFormat::Csv(opts)
+    }
+
+    fn default_csv() -> PgCopyCsvOptions {
+        PgCopyCsvOptions::default()
+    }
+
+    fn default_text_opts() -> PgCopyTextOptions {
+        PgCopyTextOptions::default()
+    }
+
+    // --- text FROM tests ---
 
     #[test]
     fn test_basic_tsv() {
         let data = "1\thello\n2\tworld\n";
-        let rows = parse_copy_text_format(data, '\t', "\\N", 2).unwrap();
+        let rows = parse_copy_format(data, &text_format(None, None), 2).unwrap();
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0], vec![Some("1".into()), Some("hello".into())]);
         assert_eq!(rows[1], vec![Some("2".into()), Some("world".into())]);
@@ -106,7 +377,7 @@ mod tests {
     #[test]
     fn test_null_values() {
         let data = "1\t\\N\n\\N\thello\n";
-        let rows = parse_copy_text_format(data, '\t', "\\N", 2).unwrap();
+        let rows = parse_copy_format(data, &text_format(None, None), 2).unwrap();
         assert_eq!(rows[0], vec![Some("1".into()), None]);
         assert_eq!(rows[1], vec![None, Some("hello".into())]);
     }
@@ -114,14 +385,31 @@ mod tests {
     #[test]
     fn test_empty_string() {
         let data = "1\t\n";
-        let rows = parse_copy_text_format(data, '\t', "\\N", 2).unwrap();
+        let rows = parse_copy_format(data, &text_format(None, None), 2).unwrap();
         assert_eq!(rows[0], vec![Some("1".into()), Some(String::new())]);
+    }
+
+    #[test]
+    fn test_empty_line_single_column_is_empty_string() {
+        // A bare newline is one row whose single field is an empty string.
+        let data = "\n";
+        let rows = parse_copy_format(data, &text_format(None, None), 1).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0], vec![Some(String::new())]);
+    }
+
+    #[test]
+    fn test_empty_line_multi_column_is_error() {
+        // A bare newline with a 2-column table is a column-count mismatch, not a skip.
+        let data = "\n";
+        let result = parse_copy_format(data, &text_format(None, None), 2);
+        assert!(result.is_err());
     }
 
     #[test]
     fn test_backslash_escapes() {
         let data = "hello\\\\world\tline1\\nline2\n";
-        let rows = parse_copy_text_format(data, '\t', "\\N", 2).unwrap();
+        let rows = parse_copy_format(data, &text_format(None, None), 2).unwrap();
         assert_eq!(
             rows[0],
             vec![Some("hello\\world".into()), Some("line1\nline2".into())]
@@ -131,7 +419,7 @@ mod tests {
     #[test]
     fn test_end_of_data_marker() {
         let data = "1\thello\n\\.\n2\tworld\n";
-        let rows = parse_copy_text_format(data, '\t', "\\N", 2).unwrap();
+        let rows = parse_copy_format(data, &text_format(None, None), 2).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0], vec![Some("1".into()), Some("hello".into())]);
     }
@@ -139,28 +427,174 @@ mod tests {
     #[test]
     fn test_wrong_column_count() {
         let data = "1\t2\t3\n";
-        let result = parse_copy_text_format(data, '\t', "\\N", 2);
+        let result = parse_copy_format(data, &text_format(None, None), 2);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_custom_delimiter() {
         let data = "1,hello\n2,world\n";
-        let rows = parse_copy_text_format(data, ',', "\\N", 2).unwrap();
+        let rows = parse_copy_format(data, &text_format(Some(","), None), 2).unwrap();
         assert_eq!(rows[0], vec![Some("1".into()), Some("hello".into())]);
     }
 
     #[test]
     fn test_custom_null_string() {
         let data = "1\tNULL\n";
-        let rows = parse_copy_text_format(data, '\t', "NULL", 2).unwrap();
+        let rows = parse_copy_format(data, &text_format(None, Some("NULL")), 2).unwrap();
+        assert_eq!(rows[0], vec![Some("1".into()), None]);
+    }
+
+    // --- text TO tests ---
+
+    #[test]
+    fn test_write_text_record_basic() {
+        let mut out = Vec::new();
+        let fields = vec![Some("1".to_owned()), Some("hello".to_owned())];
+        write_text_record(&mut out, &fields, &default_text_opts()).unwrap();
+        assert_eq!(out, b"1\thello\n");
+    }
+
+    #[test]
+    fn test_write_text_record_null() {
+        let mut out = Vec::new();
+        let fields = vec![Some("1".to_owned()), None];
+        write_text_record(&mut out, &fields, &default_text_opts()).unwrap();
+        assert_eq!(out, b"1\t\\N\n");
+    }
+
+    #[test]
+    fn test_write_text_record_escapes_special_chars() {
+        let mut out = Vec::new();
+        let fields = vec![Some("a\tb".to_owned()), Some("c\nd".to_owned())];
+        write_text_record(&mut out, &fields, &default_text_opts()).unwrap();
+        assert_eq!(out, b"a\\tb\tc\\nd\n");
+    }
+
+    #[test]
+    fn test_write_text_record_roundtrip() {
+        let original = vec![
+            Some("hello\\world".to_owned()),
+            Some("line1\nline2".to_owned()),
+        ];
+        let mut out = Vec::new();
+        write_text_record(&mut out, &original, &default_text_opts()).unwrap();
+        let written = String::from_utf8(out).unwrap();
+        let parsed = parse_copy_format(&written, &text_format(None, None), 2).unwrap();
+        assert_eq!(parsed[0], original);
+    }
+
+    #[test]
+    fn test_custom_delimiter_with_escaped_delimiter_in_value() {
+        // A value that contains the delimiter character must roundtrip correctly.
+        // write_text_record escapes it as \,; split_copy_text_line must not split on it.
+        let delimiter = Some(",");
+        let original = vec![
+            Some("a,b".to_owned()), // comma inside value
+            Some("plain".to_owned()),
+        ];
+        let opts = PgCopyTextOptions {
+            delimiter: Some(",".to_owned()),
+            ..Default::default()
+        };
+        let mut out = Vec::new();
+        write_text_record(&mut out, &original, &opts).unwrap();
+        // written form: "a\,b,plain\n"
+        let written = String::from_utf8(out).unwrap();
+        let parsed = parse_copy_format(&written, &text_format(delimiter, None), 2).unwrap();
+        assert_eq!(parsed[0], original);
+    }
+
+    // --- CSV FROM tests ---
+
+    #[test]
+    fn test_csv_basic() {
+        let data = "1,hello\n2,world\n";
+        let rows = parse_copy_format(data, &csv_format(default_csv()), 2).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], vec![Some("1".into()), Some("hello".into())]);
+        assert_eq!(rows[1], vec![Some("2".into()), Some("world".into())]);
+    }
+
+    #[test]
+    fn test_csv_quoted_comma() {
+        let data = "\"hello, world\",42\n";
+        let rows = parse_copy_format(data, &csv_format(default_csv()), 2).unwrap();
+        assert_eq!(
+            rows[0],
+            vec![Some("hello, world".into()), Some("42".into())]
+        );
+    }
+
+    #[test]
+    fn test_csv_escaped_quote() {
+        let data = "\"say \"\"hi\"\"\",42\n";
+        let rows = parse_copy_format(data, &csv_format(default_csv()), 2).unwrap();
+        assert_eq!(rows[0], vec![Some("say \"hi\"".into()), Some("42".into())]);
+    }
+
+    #[test]
+    fn test_csv_header_skipped() {
+        let data = "id,name\n1,alice\n";
+        let opts = PgCopyCsvOptions {
+            header: true,
+            ..Default::default()
+        };
+        let rows = parse_copy_format(data, &csv_format(opts), 2).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0], vec![Some("1".into()), Some("alice".into())]);
+    }
+
+    #[test]
+    fn test_csv_empty_field_is_null() {
+        let data = "1,\n";
+        let rows = parse_copy_format(data, &csv_format(default_csv()), 2).unwrap();
         assert_eq!(rows[0], vec![Some("1".into()), None]);
     }
 
     #[test]
-    fn test_header_skip() {
-        let data = "id\tname\n1\thello\n";
-        let rows = parse_copy_text_format(data, '\t', "\\N", 2).unwrap();
-        assert_eq!(rows.len(), 2);
+    fn test_csv_custom_null_string() {
+        let data = "1,NULL\n";
+        let opts = PgCopyCsvOptions {
+            null_string: Some("NULL".to_owned()),
+            ..Default::default()
+        };
+        let rows = parse_copy_format(data, &csv_format(opts), 2).unwrap();
+        assert_eq!(rows[0], vec![Some("1".into()), None]);
+    }
+
+    // --- CSV TO tests ---
+
+    #[test]
+    fn test_write_csv_record_basic() {
+        let mut out = Vec::new();
+        let fields = vec![Some("1".to_owned()), Some("hello".to_owned())];
+        let mut w = new_csv_writer(&mut out, &default_csv());
+        write_csv_record(&mut w, &fields, &default_csv()).unwrap();
+        w.flush().unwrap();
+        drop(w);
+        assert_eq!(out, b"1,hello\n");
+    }
+
+    #[test]
+    fn test_write_csv_record_null() {
+        let mut out = Vec::new();
+        let fields = vec![Some("1".to_owned()), None];
+        let mut w = new_csv_writer(&mut out, &default_csv());
+        write_csv_record(&mut w, &fields, &default_csv()).unwrap();
+        w.flush().unwrap();
+        drop(w);
+        assert_eq!(out, b"1,\n");
+    }
+
+    #[test]
+    fn test_write_csv_record_quoted_comma() {
+        let mut out = Vec::new();
+        let fields = vec![Some("hello, world".to_owned()), Some("42".to_owned())];
+        let mut w = new_csv_writer(&mut out, &default_csv());
+        write_csv_record(&mut w, &fields, &default_csv()).unwrap();
+        w.flush().unwrap();
+        drop(w);
+        assert_eq!(out, b"\"hello, world\",42\n");
     }
 }

--- a/postgres/frontend/session.rs
+++ b/postgres/frontend/session.rs
@@ -1,4 +1,5 @@
 use std::num::NonZero;
+use std::path::Path;
 use std::str;
 use std::sync::{Arc, Mutex};
 
@@ -7,12 +8,12 @@ use crate::catalog::{self, PostgresDialect};
 use turso_core::{Connection, LimboError, PrepareOptions, Result, Statement, Value};
 use turso_parser::ast::{self};
 use turso_pg_parser::translator::{
-    is_comment_on, is_refresh_matview, try_extract_copy_from, try_extract_create_schema,
-    try_extract_drop_schema, try_extract_set, try_extract_show, PgCopyFromStmt, PgCreateSchemaStmt,
-    PgDropSchemaStmt, PgSetStmt, PostgreSQLTranslator,
+    is_comment_on, is_refresh_matview, try_extract_copy, try_extract_create_schema,
+    try_extract_drop_schema, try_extract_set, try_extract_show, PgCopyFromStmt, PgCopyStmt,
+    PgCopyToStmt, PgCreateSchemaStmt, PgDropSchemaStmt, PgSetStmt, PostgreSQLTranslator,
 };
 
-use crate::copy::parse_copy_text_format;
+use crate::copy::{parse_copy_format, CopyToWriter};
 
 #[derive(Clone)]
 pub struct PgConnection {
@@ -281,11 +282,21 @@ fn try_prepare_special(pg_conn: &Arc<PgConnectionInner>, sql: &str) -> Result<Op
         return Ok(Some(noop_statement(&pg_conn.conn)?));
     }
 
-    if let Some(stmt) = try_extract_copy_from(&parse_result) {
-        let rows_inserted = handle_pg_copy_from(&pg_conn.conn, &stmt)?;
-        let stmt = noop_statement(&pg_conn.conn)?;
-        stmt.set_n_change(rows_inserted as i64);
-        return Ok(Some(stmt));
+    if let Some(stmt) = try_extract_copy(&parse_result) {
+        match stmt {
+            PgCopyStmt::From(from) => {
+                let rows_inserted = handle_pg_copy_from(&pg_conn.conn, &from)?;
+                let stmt = noop_statement(&pg_conn.conn)?;
+                stmt.set_n_change(rows_inserted as i64);
+                return Ok(Some(stmt));
+            }
+            PgCopyStmt::To(to) => {
+                let rows_copied = handle_copy_pg_to(pg_conn, &to)?;
+                let stmt = noop_statement(&pg_conn.conn)?;
+                stmt.set_n_change(rows_copied as i64);
+                return Ok(Some(stmt));
+            }
+        }
     }
 
     Ok(None)
@@ -405,9 +416,70 @@ fn drop_all_tables_in_schema(conn: &Arc<Connection>, schema_name: &str) -> Resul
     Ok(())
 }
 
+fn handle_copy_pg_to(pg_conn: &Arc<PgConnectionInner>, stmt: &PgCopyToStmt) -> Result<usize> {
+    let conn = &pg_conn.conn;
+    let table_name = match &stmt.schema_name {
+        Some(schema) => format!("\"{schema}\".\"{}\"", stmt.table_name),
+        None => format!("\"{}\"", stmt.table_name),
+    };
+    let column_names = get_table_columns(conn, &stmt.table_name, stmt.schema_name.as_deref())?;
+    if column_names.is_empty() {
+        return Err(LimboError::ParseError(format!(
+            "COPY TO: table '{}' not found or has no columns",
+            stmt.table_name
+        )));
+    }
+
+    let columns: &Vec<String> = stmt.columns.as_ref().unwrap_or(&column_names);
+    let col_list = columns
+        .iter()
+        .map(|c| format!("\"{c}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let select_sql = format!("SELECT {col_list} FROM {table_name}");
+
+    let mut select_stmt = prepare_statement(pg_conn, &select_sql)?;
+
+    let target = Path::new(&stmt.file_path);
+    let parent = copy_to_temp_parent(target);
+
+    let mut count = 0;
+    // Write beside the target first so a failed COPY TO leaves the old file intact.
+    let mut tmp =
+        tempfile::NamedTempFile::new_in(parent).map_err(|e| LimboError::Conflict(e.to_string()))?;
+    {
+        let mut writer = CopyToWriter::new(tmp.as_file_mut(), &stmt.format);
+        writer.write_header(columns)?;
+
+        select_stmt.run_with_row_callback(|row| {
+            let fields: Vec<Option<String>> = row
+                .get_values()
+                .map(|value| match value {
+                    Value::Null => None,
+                    _ => Some(value.to_string()),
+                })
+                .collect();
+
+            writer.write_record(&fields)?;
+            count += 1;
+
+            Ok(())
+        })?;
+
+        writer.finish()?;
+    }
+    tmp.persist(target)
+        .map_err(|e| LimboError::Conflict(e.to_string()))?;
+
+    Ok(count)
+}
+
 fn handle_pg_copy_from(conn: &Arc<Connection>, stmt: &PgCopyFromStmt) -> Result<usize> {
-    let data = std::fs::read_to_string(&stmt.filename).map_err(|e| {
-        LimboError::ParseError(format!("COPY FROM: cannot read '{}': {}", stmt.filename, e))
+    let data = std::fs::read_to_string(&stmt.file_path).map_err(|e| {
+        LimboError::ParseError(format!(
+            "COPY FROM: cannot read '{}': {}",
+            stmt.file_path, e
+        ))
     })?;
 
     let table_name = match &stmt.schema_name {
@@ -437,17 +509,7 @@ fn handle_pg_copy_from(conn: &Arc<Connection>, stmt: &PgCopyFromStmt) -> Result<
     let placeholders = (0..num_columns).map(|_| "?").collect::<Vec<_>>().join(", ");
     let insert_sql = format!("INSERT INTO {table_name}{insert_cols} VALUES ({placeholders})");
 
-    let delimiter = stmt
-        .delimiter
-        .as_ref()
-        .and_then(|d| d.chars().next())
-        .unwrap_or('\t');
-    let null_string = stmt.null_string.as_deref().unwrap_or("\\N");
-
-    let mut rows = parse_copy_text_format(&data, delimiter, null_string, num_columns)?;
-    if stmt.header && !rows.is_empty() {
-        rows.remove(0);
-    }
+    let rows = parse_copy_format(&data, &stmt.format, num_columns)?;
 
     let rows_inserted = rows.len();
     let mut begin = conn.prepare_sqlite("BEGIN")?;
@@ -527,4 +589,40 @@ fn schema_exists(conn: &Arc<Connection>, schema_name: &str) -> Result<bool> {
     let mut stmt = conn.prepare_internal(&sql)?;
     let rows = stmt.run_collect_rows()?;
     Ok(!rows.is_empty())
+}
+
+/// Return the directory in which a temp file should be created for atomic COPY TO.
+/// `Path::new("output.csv").parent()` is `Some("")`, not `None`, so we filter out
+/// the empty string and fall back to `"."` for bare filenames.
+fn copy_to_temp_parent(target: &Path) -> &Path {
+    target
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_copy_to_temp_parent_bare_filename() {
+        assert_eq!(copy_to_temp_parent(Path::new("output.csv")), Path::new("."));
+    }
+
+    #[test]
+    fn test_copy_to_temp_parent_relative_dir() {
+        assert_eq!(
+            copy_to_temp_parent(Path::new("dir/output.csv")),
+            Path::new("dir")
+        );
+    }
+
+    #[test]
+    fn test_copy_to_temp_parent_absolute() {
+        assert_eq!(
+            copy_to_temp_parent(Path::new("/tmp/output.csv")),
+            Path::new("/tmp")
+        );
+    }
 }

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -3,6 +3,8 @@
 // This module translates pg_query's PostgreSQL AST into Turso's SQL AST
 // representation, handling the semantic differences between PostgreSQL and SQLite.
 
+use std::str::FromStr;
+
 use crate::ParseError;
 use pg_query::protobuf::JoinType as PgJoinType;
 use pg_query::{NodeRef, ParseResult};
@@ -4661,21 +4663,179 @@ pub fn is_comment_on(parse_result: &ParseResult) -> bool {
     matches!(&nodes[0].0, NodeRef::CommentStmt(_))
 }
 
-/// Extracted COPY FROM statement info for use by the connection layer.
+#[derive(Debug, Clone)]
+pub enum PgCopyStmt {
+    From(PgCopyFromStmt),
+    To(PgCopyToStmt),
+}
+
 #[derive(Debug, Clone)]
 pub struct PgCopyFromStmt {
     pub table_name: String,
     pub schema_name: Option<String>,
     pub columns: Option<Vec<String>>,
-    pub filename: String,
+    pub file_path: String,
+    pub format: PgCopyFromFormat,
+}
+
+#[derive(Debug, Clone)]
+pub struct PgCopyToStmt {
+    pub table_name: String,
+    pub schema_name: Option<String>,
+    pub columns: Option<Vec<String>>,
+    pub file_path: String,
+    pub format: PgCopyToFormat,
+}
+
+#[derive(Debug, Clone)]
+pub enum PgCopyFromFormat {
+    Text(PgCopyTextOptions),
+    Csv(PgCopyCsvOptions),
+}
+
+#[derive(Debug, Clone)]
+pub enum PgCopyToFormat {
+    Text(PgCopyTextOptions),
+    Csv(PgCopyCsvOptions),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PgCopyTextOptions {
+    pub delimiter: Option<String>,
+    pub null_string: Option<String>,
+    pub header: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PgCopyCsvOptions {
     pub delimiter: Option<String>,
     pub header: bool,
     pub null_string: Option<String>,
+    pub quote: Option<String>,
+    pub escape: Option<String>,
 }
 
-/// Try to extract a COPY FROM file statement from pg_query parse output.
-/// Returns None if the statement is not a COPY FROM with a filename.
-pub fn try_extract_copy_from(parse_result: &ParseResult) -> Option<PgCopyFromStmt> {
+#[derive(Debug)]
+enum PgCopyDirection {
+    From,
+    To,
+}
+
+#[derive(Debug)]
+enum PgCopyFormatName {
+    Text,
+    Csv,
+}
+
+impl std::str::FromStr for PgCopyFormatName {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "text" => Ok(Self::Text),
+            "csv" => Ok(Self::Csv),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RawCopyOptions {
+    direction: PgCopyDirection,
+    file_path: String,
+    table_name: String,
+    schema_name: Option<String>,
+    columns: Option<Vec<String>>,
+    format: PgCopyFormatName,
+    delimiter: Option<String>,
+    header: bool,
+    null_string: Option<String>,
+    quote: Option<String>,
+    escape: Option<String>,
+}
+
+impl RawCopyOptions {
+    fn new(
+        direction: PgCopyDirection,
+        file_path: String,
+        table_name: String,
+        schema_name: Option<String>,
+        columns: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            direction,
+            file_path,
+            table_name,
+            schema_name,
+            columns,
+            format: PgCopyFormatName::Text,
+            delimiter: None,
+            header: false,
+            null_string: None,
+            quote: None,
+            escape: None,
+        }
+    }
+
+    fn build(self) -> PgCopyStmt {
+        match self.direction {
+            PgCopyDirection::From => PgCopyStmt::From(self.build_from()),
+            PgCopyDirection::To => PgCopyStmt::To(self.build_to()),
+        }
+    }
+
+    fn build_from(self) -> PgCopyFromStmt {
+        let format = match self.format {
+            PgCopyFormatName::Text => PgCopyFromFormat::Text(PgCopyTextOptions {
+                delimiter: self.delimiter,
+                null_string: self.null_string,
+                header: self.header,
+            }),
+            PgCopyFormatName::Csv => PgCopyFromFormat::Csv(PgCopyCsvOptions {
+                delimiter: self.delimiter,
+                header: self.header,
+                null_string: self.null_string,
+                quote: self.quote,
+                escape: self.escape,
+            }),
+        };
+        PgCopyFromStmt {
+            table_name: self.table_name,
+            schema_name: self.schema_name,
+            columns: self.columns,
+            file_path: self.file_path,
+            format,
+        }
+    }
+
+    fn build_to(self) -> PgCopyToStmt {
+        let format = match self.format {
+            PgCopyFormatName::Text => PgCopyToFormat::Text(PgCopyTextOptions {
+                delimiter: self.delimiter,
+                null_string: self.null_string,
+                header: self.header,
+            }),
+            PgCopyFormatName::Csv => PgCopyToFormat::Csv(PgCopyCsvOptions {
+                delimiter: self.delimiter,
+                header: self.header,
+                null_string: self.null_string,
+                quote: self.quote,
+                escape: self.escape,
+            }),
+        };
+        PgCopyToStmt {
+            table_name: self.table_name,
+            schema_name: self.schema_name,
+            columns: self.columns,
+            file_path: self.file_path,
+            format,
+        }
+    }
+}
+
+/// Try to extract a file-based COPY FROM or COPY TO statement from pg_query parse output.
+/// Returns None if the statement is not a file COPY (STDIN/STDOUT and PROGRAM are rejected).
+pub fn try_extract_copy(parse_result: &ParseResult) -> Option<PgCopyStmt> {
     use pg_query::NodeRef;
 
     let nodes = parse_result.protobuf.nodes();
@@ -4686,8 +4846,7 @@ pub fn try_extract_copy_from(parse_result: &ParseResult) -> Option<PgCopyFromStm
         return None;
     };
 
-    // Only handle COPY FROM with a file path (not STDIN, not COPY TO)
-    if !copy.is_from || copy.filename.is_empty() || copy.is_program {
+    if copy.filename.is_empty() || copy.is_program {
         return None;
     }
 
@@ -4717,9 +4876,19 @@ pub fn try_extract_copy_from(parse_result: &ParseResult) -> Option<PgCopyFromStm
         Some(cols)
     };
 
-    let mut delimiter = None;
-    let mut header = false;
-    let mut null_string = None;
+    let direction = if copy.is_from {
+        PgCopyDirection::From
+    } else {
+        PgCopyDirection::To
+    };
+
+    let mut opts = RawCopyOptions::new(
+        direction,
+        copy.filename.clone(),
+        table_name,
+        schema_name,
+        columns,
+    );
 
     for opt in &copy.options {
         let Some(pg_query::protobuf::node::Node::DefElem(def)) = &opt.node else {
@@ -4727,29 +4896,20 @@ pub fn try_extract_copy_from(parse_result: &ParseResult) -> Option<PgCopyFromStm
         };
         match def.defname.as_str() {
             "format" => {
-                // Only support text format for now
                 if let Some(val) = def_elem_string_val(def) {
-                    if val.to_lowercase() != "text" {
-                        return None; // unsupported format
-                    }
+                    opts.format = PgCopyFormatName::from_str(&val.to_lowercase()).ok()?;
                 }
             }
-            "delimiter" => delimiter = def_elem_string_val(def),
-            "header" => header = def_elem_bool_val(def).unwrap_or(true),
-            "null" => null_string = def_elem_string_val(def),
-            _ => {}
+            "delimiter" => opts.delimiter = def_elem_string_val(def),
+            "header" => opts.header = def_elem_bool_val(def).unwrap_or(true),
+            "null" => opts.null_string = def_elem_string_val(def),
+            "quote" => opts.quote = def_elem_string_val(def),
+            "escape" => opts.escape = def_elem_string_val(def),
+            _ => return None,
         }
     }
 
-    Some(PgCopyFromStmt {
-        table_name,
-        schema_name,
-        columns,
-        filename: copy.filename.clone(),
-        delimiter,
-        header,
-        null_string,
-    })
+    Some(opts.build())
 }
 
 /// Parse a SQL referential action string to an AST RefAct.
@@ -7216,34 +7376,56 @@ mod tests {
     #[test]
     fn test_try_extract_copy_from() {
         let parsed = crate::parse("COPY users FROM '/tmp/data.tsv'").unwrap();
-        let copy = try_extract_copy_from(&parsed).unwrap();
-        assert_eq!(copy.table_name, "users");
-        assert!(copy.schema_name.is_none());
-        assert!(copy.columns.is_none());
-        assert_eq!(copy.filename, "/tmp/data.tsv");
-        assert!(!copy.header);
-        assert!(copy.delimiter.is_none());
-        assert!(copy.null_string.is_none());
+        let copy = try_extract_copy(&parsed).unwrap();
+        let PgCopyStmt::From(stmt) = copy else {
+            panic!("expected COPY FROM")
+        };
+        assert_eq!(stmt.table_name, "users");
+        assert!(stmt.schema_name.is_none());
+        assert!(stmt.columns.is_none());
+        assert_eq!(stmt.file_path, "/tmp/data.tsv");
+        let PgCopyFromFormat::Text(opts) = stmt.format else {
+            panic!("expected text format")
+        };
+        assert!(opts.delimiter.is_none());
+        assert!(opts.null_string.is_none());
     }
 
     #[test]
     fn test_try_extract_copy_from_not_to() {
         let parsed = crate::parse("COPY users TO '/tmp/out.tsv'").unwrap();
-        assert!(try_extract_copy_from(&parsed).is_none());
+        assert!(matches!(try_extract_copy(&parsed), Some(PgCopyStmt::To(_))));
     }
 
     #[test]
     fn test_try_extract_copy_from_not_stdin() {
         let parsed = crate::parse("COPY users FROM STDIN").unwrap();
-        assert!(try_extract_copy_from(&parsed).is_none());
+        assert!(try_extract_copy(&parsed).is_none());
     }
 
     #[test]
     fn test_try_extract_copy_from_with_columns() {
         let parsed = crate::parse("COPY users (id, name) FROM '/tmp/data.tsv'").unwrap();
-        let copy = try_extract_copy_from(&parsed).unwrap();
-        let cols = copy.columns.unwrap();
+        let copy = try_extract_copy(&parsed).unwrap();
+        let PgCopyStmt::From(stmt) = copy else {
+            panic!("expected COPY FROM")
+        };
+        let cols = stmt.columns.unwrap();
         assert_eq!(cols, vec!["id", "name"]);
+    }
+
+    #[test]
+    fn test_try_extract_copy_unsupported_option_returns_none() {
+        // FORCE_NULL is a valid PostgreSQL COPY option but not handled here.
+        // try_extract_copy must return None so the statement falls through to
+        // the normal translator path and produces a meaningful error.
+        let parsed =
+            crate::parse("COPY users FROM '/tmp/data.csv' WITH (FORMAT csv, FORCE_NULL (id))")
+                .unwrap();
+        assert!(
+            try_extract_copy(&parsed).is_none(),
+            "unsupported COPY option should return None"
+        );
     }
 
     #[test]

--- a/postgres/tests/integration/postgres/copy.rs
+++ b/postgres/tests/integration/postgres/copy.rs
@@ -439,17 +439,25 @@ fn test_copy_from_combined_options(db: TempDatabase) {
 }
 
 // ---------------------------------------------------------------------------
-// COPY TO should produce a clear error (unsupported)
+// COPY TO text format
 // ---------------------------------------------------------------------------
 
 #[turso_macros::test(mvcc)]
-fn test_copy_to_unsupported(db: TempDatabase) {
+fn test_copy_to_text(db: TempDatabase) {
     let conn = db.connect_postgres();
 
-    conn.execute("CREATE TABLE t (a INTEGER)").unwrap();
+    conn.execute("CREATE TABLE t (id INTEGER, name TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 'Alice')").unwrap();
+    conn.execute("INSERT INTO t VALUES (2, 'Bob')").unwrap();
 
-    let result = conn.execute("COPY t TO '/tmp/out.tsv'");
-    assert!(result.is_err());
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("copy_to_text.tsv");
+    let sql = format!("COPY t TO '{}'", out_path.display());
+    conn.execute(&sql).unwrap();
+
+    let content = std::fs::read_to_string(&out_path).unwrap();
+    assert_eq!(content, "1\tAlice\n2\tBob\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -623,23 +631,25 @@ fn test_copy_from_nonexistent_column(db: TempDatabase) {
 }
 
 // ---------------------------------------------------------------------------
-// CSV format rejection — we only support text format
+// CSV format FROM
 // ---------------------------------------------------------------------------
 
 #[turso_macros::test(mvcc)]
-fn test_copy_from_csv_format_unsupported(db: TempDatabase) {
+fn test_copy_from_csv_format(db: TempDatabase) {
     let conn = db.connect_postgres();
 
     conn.execute("CREATE TABLE t (a INTEGER, b TEXT)").unwrap();
 
-    let csv = write_temp_file("1,hello\n");
+    let csv = write_temp_file("1,hello\n2,world\n");
     let sql = format!("COPY t FROM '{}' WITH (FORMAT csv)", csv.path().display());
-    let result = conn.execute(&sql);
-    // Should fail: CSV format is not supported
-    assert!(
-        result.is_err(),
-        "CSV format should not be silently accepted"
-    );
+    conn.execute(&sql).unwrap();
+
+    let rows = query_all(&conn, "SELECT a, b FROM t ORDER BY a");
+    assert_eq!(rows.len(), 2);
+    assert_int(&rows[0][0], 1);
+    assert_text(&rows[0][1], "hello");
+    assert_int(&rows[1][0], 2);
+    assert_text(&rows[1][1], "world");
 }
 
 // ---------------------------------------------------------------------------
@@ -756,4 +766,53 @@ fn test_copy_from_stdin_unsupported(db: TempDatabase) {
     let result = conn.execute("COPY t FROM STDIN");
     // STDIN is not supported — should produce an error
     assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// COPY TO CSV format
+// ---------------------------------------------------------------------------
+
+#[turso_macros::test(mvcc)]
+fn test_copy_to_csv(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    conn.execute("CREATE TABLE t (id INTEGER, name TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 'Alice')").unwrap();
+    conn.execute("INSERT INTO t VALUES (2, 'Bob, Jr.')")
+        .unwrap();
+
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("copy_to_csv.csv");
+    let sql = format!("COPY t TO '{}' WITH (FORMAT csv)", out_path.display());
+    conn.execute(&sql).unwrap();
+
+    let content = std::fs::read_to_string(&out_path).unwrap();
+    // comma with a value that contains a comma must be quoted
+    assert_eq!(content, "1,Alice\n2,\"Bob, Jr.\"\n");
+}
+
+// ---------------------------------------------------------------------------
+// COPY TO: target file is not modified when the copy fails
+// ---------------------------------------------------------------------------
+
+#[turso_macros::test(mvcc)]
+fn test_copy_to_does_not_overwrite_on_failure(db: TempDatabase) {
+    let conn = db.connect_postgres();
+
+    conn.execute("CREATE TABLE t (id INTEGER)").unwrap();
+
+    // Keep the target path closed so COPY TO can replace it.
+    let out_dir = tempfile::tempdir().unwrap();
+    let out_path = out_dir.path().join("copy_to_failure.tsv");
+    std::fs::write(&out_path, b"keep me\n").unwrap();
+
+    // COPY with a non-existent column fails during SELECT preparation,
+    // before writing anything to the output file.
+    let sql = format!("COPY t (missing_col) TO '{}'", out_path.display());
+    assert!(conn.execute(&sql).is_err());
+
+    // The original content must still be intact.
+    let content = std::fs::read_to_string(&out_path).unwrap();
+    assert_eq!(content, "keep me\n");
 }


### PR DESCRIPTION
## Description

Adds file-based `COPY TO` support for the PostgreSQL frontend and extends simple `COPY FROM/TO` handling for text and CSV formats.

This includes:
- `COPY TO 'file'` export support using `SELECT` output
- CSV/text writer support for `COPY TO`
- CSV option parsing for delimiter, header, null, quote, and escape
- safer `COPY TO` writes through a sibling temp file before replacing the target

## Motivation and context

`postgres/cli/todo.md` lists simple file-based COPY FROM/TO support as missing.

The pg frontend already had partial COPY FROM support, but did not support COPY TO, and several text and CSV options were not handled consistently.

One pg csv edge case is intentionally left for follow-up. pg distinguishes an unquoted field matching the null marker from the same value in quotes. With the default options, an unquoted empty field represents NULL, while "" represents an empty string.

The current implementation uses the decoded field value exposed by the csv crate and therefore treats any field matching the configured null marker as NULL, regardless of whether it was quoted.

## Description of AI Usage

I used AI for codebase navigation, debugging guidance, and review of the implementation approach and tests. The implementation itself was written and reviewed by me