### PR TITLE
core/translate: don't push WHERE filters into FULL OUTER hash build

### DIFF
--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -345,7 +345,16 @@ impl<'a, 'plan> PreparedHashBuild<'a, 'plan> {
             });
         }
 
-        if !config.use_materialized_keys {
+        // Pre-filtering build rows with WHERE terms is a pure optimization: the
+        // same terms are still evaluated in the probe loop. It is safe for INNER
+        // and LEFT OUTER joins because the build side is never null-extended, so
+        // a build row rejected here can never appear in the output. For FULL
+        // OUTER joins it is wrong: a build row removed from the hash table makes
+        // the probe rows that matched it look unmatched, so they would be
+        // emitted as spurious null-extended rows.
+        let push_where_filters_to_build = !config.use_materialized_keys
+            && planner.hash_join_op.join_type != HashJoinType::FullOuter;
+        if push_where_filters_to_build {
             let build_only_mask: TableMask = [planner.hash_join_op.build_table_idx]
                 .into_iter()
                 .try_collect()?;

--- a/sqlite/conformance/sqlite-sqltests/full-join-where-filters-matched-row.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/full-join-where-filters-matched-row.sqltest
@@ -1,0 +1,15 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/8202
+# A FULL JOIN where every left row matches must not emit a spurious
+# all-NULL row when the WHERE clause filters out the matched rows.
+
+test full-join-where-filters-matched-row {
+    CREATE TABLE t1 (a INT);
+    CREATE TABLE t2 (b INT);
+    INSERT INTO t1 VALUES (1);
+    INSERT INTO t2 VALUES (NULL);
+    SELECT a, b FROM t1 FULL JOIN t2 ON true WHERE a IS NULL ORDER BY coalesce(a, b, 3);
+}
+expect {
+}

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -58,7 +58,7 @@ set test_files {
   joinB    fail
   joinC    fail
   joinD    fail
-  joinE    fail
+  joinE    pass
   joinF    fail
   joinH    fail
 


### PR DESCRIPTION
The hash-build loop pre-filters build rows with WHERE terms that
reference only the build table. That is a pure optimization for INNER
and LEFT OUTER joins (the terms are re-evaluated in the probe loop, and
a rejected build row can never appear in the output because the build
side is never null-extended). For FULL OUTER joins it is wrong: a build
row removed from the hash table makes the probe rows that matched it
look unmatched, so they were emitted as spurious null-extended rows.
For example, `SELECT a, b FROM t1 FULL JOIN t2 ON true WHERE a IS NULL`
returned an all-NULL row even though every probe row had a match.

Skip the pushdown when the join type is FullOuter. The WHERE terms are
still evaluated on every output path of the probe loop (matched rows,
unmatched-probe null-extension, and the unmatched-build scan), so this
only disables the pre-filter optimization. The change is a no-op for
Inner and LeftOuter hash joins.

Also enable upstream joinE.test in sqlite/conformance/upstream/all.test
now that its last failure (joinE-37) is fixed.

Tests: new sqltest full-join-where-filters-matched-row; full .sqltest
conformance run; upstream TCL all.test (557 tests, joinE enabled);
cargo test join/hash_join/translate; clippy clean.

Fixes #8202