### PR TITLE
core: implement PRAGMA count_changes

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -401,6 +401,9 @@ pub struct Connection {
     pub(super) vdbe_trace: AtomicBool,
     /// If enabled, the UPDATE/DELETE statements must have a WHERE clause
     pub(super) dml_require_where: AtomicBool,
+    /// PRAGMA count_changes: when ON, each INSERT, UPDATE and DELETE returns
+    /// one row with the number of rows it changed.
+    pub(super) count_changes: AtomicBool,
     /// SQLite DQS misfeature: when ON (default), unresolved double-quoted identifiers
     /// in DML statements fall back to string literals instead of raising an error.
     pub(super) dqs_dml: AtomicBool,
@@ -3822,6 +3825,14 @@ impl Connection {
 
     pub fn set_dml_require_where(&self, value: bool) {
         self.dml_require_where.store(value, Ordering::SeqCst);
+    }
+
+    pub fn get_count_changes(&self) -> bool {
+        self.count_changes.load(Ordering::SeqCst)
+    }
+
+    pub fn set_count_changes(&self, value: bool) {
+        self.count_changes.store(value, Ordering::SeqCst);
     }
 
     pub fn get_dqs_dml(&self) -> bool {

--- a/core/database.rs
+++ b/core/database.rs
@@ -2305,6 +2305,7 @@ impl Database {
             query_only: AtomicBool::new(false),
             vdbe_trace: AtomicBool::new(false),
             dml_require_where: AtomicBool::new(false),
+            count_changes: AtomicBool::new(false),
             dqs_dml: AtomicBool::new(true),
             sequence_inner_retries: AtomicU64::new(0),
             mv_tx: RwLock::new(None),

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -46,6 +46,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
                 | PragmaFlags::NoColumns1,
             &["cache_size"],
         ),
+        CountChanges => Pragma::new(
+            PragmaFlags::Result0 | PragmaFlags::NoColumns1,
+            &["count_changes"],
+        ),
         DataSyncRetry => Pragma::new(
             PragmaFlags::Result0 | PragmaFlags::NoColumns1,
             &["data_sync_retry"],

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -198,6 +198,23 @@ pub fn translate_inner(
         ast::Stmt::Delete { .. } | ast::Stmt::Insert { .. } | ast::Stmt::Update { .. }
     );
 
+    // PRAGMA count_changes: top-level INSERT/UPDATE/DELETE statements return one row
+    // with the number of rows they changed. Trigger bodies, foreign key actions and
+    // engine-internal nested statements never return count rows, matching SQLite.
+    let count_changes_column = if connection.get_count_changes()
+        && !connection.is_nested_stmt()
+        && !program.flags.is_subprogram()
+    {
+        match &stmt {
+            ast::Stmt::Insert { .. } => Some("rows inserted"),
+            ast::Stmt::Update { .. } => Some("rows updated"),
+            ast::Stmt::Delete { .. } => Some("rows deleted"),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
     match stmt {
         ast::Stmt::AlterTable(alter) => {
             translate_alter_table(alter, resolver, program, connection, input)?;
@@ -487,6 +504,17 @@ pub fn translate_inner(
     // Indicate read operations so that in the epilogue we can emit the correct type of transaction
     if is_select && !program.table_references.is_empty() {
         program.begin_read_operation()?;
+    }
+
+    // A statement with RETURNING already produces rows, so it never also returns
+    // a count row (same as SQLite).
+    if let Some(column_name) = count_changes_column {
+        if program.result_columns.is_empty() {
+            let reg = program.alloc_register();
+            program.emit_insn(crate::vdbe::insn::Insn::ChangeCount { dest: reg });
+            program.emit_result_row(reg, 1);
+            program.add_pragma_result_column(column_name.to_string());
+        }
     }
 
     Ok(())

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -708,6 +708,11 @@ fn update_pragma(
             connection.set_dml_require_where(enabled);
             Ok(TransactionMode::None)
         }
+        PragmaName::CountChanges => {
+            let enabled = parse_pragma_enabled(&value);
+            connection.set_count_changes(enabled);
+            Ok(TransactionMode::None)
+        }
         PragmaName::IgnoreCheckConstraints => {
             let enabled = parse_pragma_enabled(&value);
             connection.set_check_constraints_ignored(enabled);
@@ -1638,6 +1643,14 @@ fn query_pragma(
         PragmaName::IAmADummy | PragmaName::RequireWhere => {
             let register = program.alloc_register();
             let enabled = connection.get_dml_require_where();
+            program.emit_int(enabled as i64, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::CountChanges => {
+            let register = program.alloc_register();
+            let enabled = connection.get_count_changes();
             program.emit_int(enabled as i64, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4916,6 +4916,19 @@ pub fn op_reset_count(
     Ok(InsnFunctionStepResult::Step)
 }
 
+pub fn op_change_count(
+    _program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> Result<InsnFunctionStepResult> {
+    load_insn!(ChangeCount { dest }, insn);
+    let nchange = state.n_change.load(Ordering::SeqCst);
+    state.registers[*dest].set_int(nchange);
+    state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
 /// Execute a subprogram (Program opcode).
 /// Used for both triggers and FK actions (CASCADE, SET NULL, etc.)
 pub fn op_program(

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1032,6 +1032,15 @@ pub fn insn_to_row(
                 0,
                 "".to_string(),
             ),
+            Insn::ChangeCount { dest } => (
+                "ChangeCount",
+                0,
+                *dest as i64,
+                0,
+                Value::build_text(""),
+                0,
+                format!("r[{dest}]=changes"),
+            ),
             Insn::Real { value, dest } => (
                 "Real",
                 0,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -908,6 +908,13 @@ pub enum Insn {
     /// `total_changes()` observe the just-completed statement without leaking into the next one.
     ResetCount,
 
+    /// Write the number of rows the current statement has changed so far into a register.
+    /// Emitted at the end of INSERT/UPDATE/DELETE programs when PRAGMA count_changes is on,
+    /// followed by a ResultRow that returns the count to the caller.
+    ChangeCount {
+        dest: usize,
+    },
+
     /// Write an integer value into a register.
     Integer {
         value: i64,
@@ -2099,6 +2106,7 @@ impl InsnVariants {
             InsnVariants::Integer => execute::op_integer,
             InsnVariants::Program => execute::op_program,
             InsnVariants::ResetCount => execute::op_reset_count,
+            InsnVariants::ChangeCount => execute::op_change_count,
             InsnVariants::Real => execute::op_real,
             InsnVariants::RealAffinity => execute::op_real_affinity,
             InsnVariants::String8 => execute::op_string8,

--- a/sqlite/conformance/sqlite-sqltests/pragma-count-changes.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma-count-changes.sqltest
@@ -1,0 +1,38 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/8203
+# With PRAGMA count_changes = on, each INSERT, UPDATE, and DELETE must
+# return one row with the number of rows it changed.
+
+test pragma-count-changes-insert {
+    CREATE TABLE t1 (x);
+    PRAGMA count_changes = on;
+    INSERT INTO t1 VALUES (1), (2);
+}
+expect {
+    2
+}
+
+test pragma-count-changes-update-delete {
+    CREATE TABLE t1 (x);
+    PRAGMA count_changes = on;
+    INSERT INTO t1 VALUES (1), (2), (3);
+    UPDATE t1 SET x = x + 1 WHERE x >= 2;
+    DELETE FROM t1;
+}
+expect {
+    3
+    2
+    3
+}
+
+test pragma-count-changes-off-is-silent {
+    CREATE TABLE t1 (x);
+    PRAGMA count_changes = on;
+    PRAGMA count_changes = off;
+    INSERT INTO t1 VALUES (1), (2);
+    SELECT count(*) FROM t1;
+}
+expect {
+    2
+}

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -40,7 +40,7 @@ set test_files {
   selectH  fail
 
   insert   fail
-  insert2  fail
+  insert2  pass
   insert3  fail
   insert4  fail
   insert5  pass

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1802,6 +1802,9 @@ pub enum PragmaName {
     CacheSize,
     /// set the cache spill behavior
     CacheSpill,
+    /// When ON, each INSERT, UPDATE and DELETE returns one row with the
+    /// number of rows it changed.
+    CountChanges,
     /// encryption cipher algorithm name for encrypted databases
     #[strum(serialize = "cipher")]
     #[cfg_attr(feature = "serde", serde(rename = "cipher"))]


### PR DESCRIPTION
PRAGMA count_changes was not recognized at all, so it silently did
nothing. In SQLite, with this pragma on, each INSERT, UPDATE and DELETE
returns one row with the number of rows it changed.

Add a CountChanges pragma name and a per-connection flag, and a new
ChangeCount opcode that writes the number of rows the current statement
has changed into a register. When the pragma is on, top-level
INSERT/UPDATE/DELETE programs end with ChangeCount + ResultRow, using
SQLite's column names ("rows inserted"/"rows updated"/"rows deleted").
The count comes from the VM's per-statement change counter, which
already excludes trigger and foreign-key-action changes because those
run in subprograms, so the returned value matches changes(). Trigger
bodies, FK actions, nested statements and statements with RETURNING
never return count rows, matching SQLite.

This was the last gap in the upstream insert2.test conformance file, so
enable it in sqlite/conformance/upstream/all.test (29/29 tests pass).

Tests: sqlite/conformance/sqlite-sqltests/pragma-count-changes.sqltest,
upstream insert2.test via tclsh all.test, and differential checks
against sqlite3 covering INSERT..SELECT, OR IGNORE, zero-row UPDATE,
full-table DELETE, triggers, RETURNING and FK cascades.

Fixes #8203