### PR TITLE
sqlite/parser: match SQLite error for ORDER BY before compound operator

### DIFF
--- a/sqlite/conformance/sqlite-sqltests/compound-select-order-by-before-operator-error.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/compound-select-order-by-before-operator-error.sqltest
@@ -1,0 +1,29 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/8201
+#
+# When an ORDER BY clause appears before a compound operator, SQLite rejects
+# the statement with the message "ORDER BY clause should come after EXCEPT
+# not before". Turso must report the same message instead of a generic
+# syntax error.
+
+test order-by-before-except-error-message {
+    SELECT 1 EXCEPT SELECT 2 ORDER BY 1 COLLATE nocase EXCEPT SELECT 3;
+}
+expect error {
+    ORDER BY clause should come after EXCEPT not before
+}
+
+test order-by-before-union-error-message {
+    SELECT 1 UNION SELECT 2 ORDER BY 1 UNION SELECT 3;
+}
+expect error {
+    ORDER BY clause should come after UNION not before
+}
+
+test order-by-before-intersect-error-message {
+    SELECT 1 INTERSECT SELECT 2 ORDER BY 1 INTERSECT SELECT 3;
+}
+expect error {
+    ORDER BY clause should come after INTERSECT not before
+}

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -506,7 +506,7 @@ set test_files {
   selectB              fail
   selectC              pass
   selectD              fail
-  selectE              fail
+  selectE              pass
   selectF              pass
   selectG              skip {hangs on an INSERT with a 100,000-entry VALUES clause}
   selectH              fail
@@ -543,7 +543,7 @@ set test_files {
   strict2              fail
   subjournal           fail
   subquery             fail
-  subquery2            fail
+  subquery2            pass
   subselect            fail
   substr               fail
   subtype1             fail

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -3277,6 +3277,32 @@ impl<'a> Parser<'a> {
         let body = self.parse_select_body()?;
         let order_by = self.parse_order_by()?;
         let limit = self.parse_limit()?;
+        if !order_by.is_empty() || limit.is_some() {
+            if let Some(tok) = self.peek()? {
+                let op_name = match tok.token_type {
+                    TK_UNION => {
+                        eat_assert!(self, TK_UNION);
+                        match self.peek()? {
+                            Some(tok) if tok.token_type == TK_ALL => "UNION ALL",
+                            _ => "UNION",
+                        }
+                    }
+                    TK_EXCEPT => "EXCEPT",
+                    TK_INTERSECT => "INTERSECT",
+                    _ => "",
+                };
+                if !op_name.is_empty() {
+                    let clause = if order_by.is_empty() {
+                        "LIMIT"
+                    } else {
+                        "ORDER BY"
+                    };
+                    return Err(Error::Custom(format!(
+                        "{clause} clause should come after {op_name} not before"
+                    )));
+                }
+            }
+        }
         Ok(Select {
             with,
             body,


### PR DESCRIPTION
When an ORDER BY or LIMIT clause appears before a compound operator,
as in `SELECT 1 ORDER BY 1 UNION SELECT 2`, the parser stopped the
compound-select loop at the clause and then failed on the leftover
operator token with a generic `near "UNION": syntax error`. SQLite
instead reports `ORDER BY clause should come after UNION not before`,
so error-message compatibility tests failed.

After parsing a select's ORDER BY and LIMIT clauses, peek at the next
token: a compound operator there can only mean one of those clauses cut
the compound-select loop short, so report SQLite's message instead.
As in SQLite, ORDER BY takes precedence over LIMIT when both are
present and UNION ALL is named in full.

This removed the last failures in the upstream conformance files
selectE.test and subquery2.test, so promote both from "fail" to "pass"
in sqlite/conformance/upstream/all.test.

Tests: sqlite-sqltests/compound-select-order-by-before-operator-error.sqltest,
tclsh sqlite/conformance/upstream/all.test (selectE and subquery2 now
blessed), cargo test in sqlite/parser, full sqltest corpus via
make -C sqlite/conformance run-rust.

Fixes #8201