### PR TITLE
core/translate: read HAVING columns during the loop for ungrouped aggregation

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -16,11 +16,112 @@ use super::{
     emitter::{OperationMode, Resolver, TranslateCtx},
     expr::{
         resolve_expr, translate_condition_expr, translate_expr, translate_expr_no_constant_opt,
-        ConditionMetadata, NoConstantOptReason,
+        walk_expr, ConditionMetadata, NoConstantOptReason, WalkControl,
     },
     plan::{Aggregate, Distinctness, SelectPlan, TableReferences},
     result_row::emit_select_result,
 };
+
+/// Calls `f` on every column reference in `expr` that is not inside an aggregate
+/// argument, i.e. the "bare" columns of an aggregate query.
+fn for_each_bare_column(
+    expr: &ast::Expr,
+    aggregates: &[Aggregate],
+    f: &mut impl FnMut(&ast::Expr),
+) -> Result<()> {
+    walk_expr(expr, &mut |e: &ast::Expr| -> Result<WalkControl> {
+        match e {
+            ast::Expr::Column { .. } | ast::Expr::RowId { .. } => {
+                f(e);
+                Ok(WalkControl::SkipChildren)
+            }
+            // Everything inside an aggregate call is read row by row during the
+            // loop, so it is not a bare column.
+            _ if aggregates.iter().any(|a| a.original_expr == *e) => Ok(WalkControl::SkipChildren),
+            _ => Ok(WalkControl::Continue),
+        }
+    })?;
+    Ok(())
+}
+
+/// Collects the bare columns of an ungrouped aggregate query that must be read
+/// during the main loop, because the expressions using them are only evaluated
+/// after the loop, when the table cursor no longer points at a row:
+///
+/// - bare columns of result columns that also contain an aggregate, e.g.
+///   `SELECT CASE WHEN sum(x) THEN a ELSE b END FROM t`
+/// - bare columns of HAVING predicates: HAVING without GROUP BY treats the
+///   whole table as one group, so the check runs after the loop
+///
+/// This is the same set as the column entries of SQLite's AggInfo.
+pub fn collect_bare_columns_read_in_loop(plan: &SelectPlan) -> Result<Vec<ast::Expr>> {
+    let mut columns: Vec<ast::Expr> = Vec::new();
+    let mut collect = |expr: &ast::Expr| {
+        if !columns.contains(expr) {
+            columns.push(expr.clone());
+        }
+    };
+    for rc in plan
+        .result_columns
+        .iter()
+        .filter(|rc| rc.contains_aggregates)
+    {
+        for_each_bare_column(&rc.expr, &plan.aggregates, &mut collect)?;
+    }
+    if let Some(having) = plan.group_by.as_ref().and_then(|gb| gb.having.as_ref()) {
+        for pred in having.iter() {
+            for_each_bare_column(pred, &plan.aggregates, &mut collect)?;
+        }
+    }
+    Ok(columns)
+}
+
+/// Allocates the registers an ungrouped aggregation writes to during the main
+/// loop and nulls them before the loop starts: one register per aggregate
+/// accumulator, plus one per bare column from
+/// [`collect_bare_columns_read_in_loop`].
+///
+/// Nulling up front matters when the same bytecode runs more than once, e.g. a
+/// correlated subquery: if the loop scans no rows this time, the registers must
+/// read as NULL instead of keeping the previous run's values. SQLite nulls the
+/// same two groups of registers here, in resetAccumulator.
+pub fn init_ungrouped_aggregation(
+    program: &mut ProgramBuilder,
+    t_ctx: &mut TranslateCtx<'_>,
+    plan: &SelectPlan,
+    bare_columns: Vec<ast::Expr>,
+) {
+    let start = program.alloc_registers_and_init_w_null(plan.aggregates.len() + bare_columns.len());
+    t_ctx.reg_agg_start = Some(start);
+    t_ctx.bare_columns_read_in_loop = bare_columns
+        .into_iter()
+        .enumerate()
+        .map(|(i, expr)| (expr, start + plan.aggregates.len() + i))
+        .collect();
+}
+
+/// Points expression translation at the registers holding the bare columns that
+/// the main loop read, so that code emitted after the loop (HAVING, result
+/// columns) uses those values instead of reading from a cursor that no longer
+/// points at a row.
+///
+/// This must only be done after the loop: inside the loop, a hash join can turn
+/// the expression cache on, and then an aggregate argument such as the `b.z` of
+/// `sum(b.z)` would read the (still unwritten) bare column register instead of
+/// the current row.
+fn cache_bare_columns_read_in_loop(t_ctx: &mut TranslateCtx<'_>, plan: &SelectPlan) -> Result<()> {
+    let bare_columns = std::mem::take(&mut t_ctx.bare_columns_read_in_loop);
+    for (expr, reg) in bare_columns.iter() {
+        t_ctx.resolver.cache_scalar_expr_reg(
+            std::borrow::Cow::Owned(expr.clone()),
+            *reg,
+            false,
+            &plan.table_references,
+        )?;
+    }
+    t_ctx.bare_columns_read_in_loop = bare_columns;
+    Ok(())
+}
 
 /// Emits the bytecode for processing an aggregate without a GROUP BY clause.
 /// This is called when the main query execution loop has finished processing,
@@ -50,6 +151,7 @@ pub fn emit_ungrouped_aggregation<'a>(
             None,
         );
     }
+    cache_bare_columns_read_in_loop(t_ctx, plan)?;
     t_ctx.resolver.enable_expr_to_reg_cache();
 
     // Allocate a label for the end (used by both HAVING and OFFSET to skip row emission)

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -996,6 +996,13 @@ pub struct TranslateCtx<'a> {
     /// evaluation: the sorter stores raw columns instead of pre-computed expressions,
     /// and full expressions are re-evaluated from the pseudo cursor during aggregation.
     pub agg_leaf_columns: Vec<Expr>,
+    /// Bare columns of an ungrouped aggregate query, paired with the register the
+    /// main loop reads them into on its first iteration. Needed because HAVING
+    /// predicates and result columns that also contain an aggregate are only
+    /// evaluated after the loop, when the cursor no longer points at a row. The
+    /// registers are nulled together with the aggregate accumulators before the
+    /// loop starts, like the column entries of SQLite's AggInfo.
+    pub bare_columns_read_in_loop: Vec<(Expr, usize)>,
     /// Cursor id for cdc table (if capture_data_changes PRAGMA is set and query can modify the data)
     pub cdc_cursor_id: Option<usize>,
     pub meta_window: Option<WindowMetadata<'a>>,
@@ -1037,6 +1044,7 @@ impl<'a> TranslateCtx<'a> {
             resolver,
             non_aggregate_expressions: Vec::new(),
             agg_leaf_columns: Vec::new(),
+            bare_columns_read_in_loop: Vec::new(),
             cdc_cursor_id: None,
             meta_window: None,
             meta_in_seeks: (0..table_count).map(|_| None).collect(),

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -4,7 +4,10 @@ use crate::{
     schema::{BTreeCharacteristics, BTreeTable},
     sync::Arc,
     translate::{
-        aggregation::emit_ungrouped_aggregation,
+        aggregation::{
+            collect_bare_columns_read_in_loop, emit_ungrouped_aggregation,
+            init_ungrouped_aggregation,
+        },
         emitter::{
             build_rowid_column, init_exists_result_regs, init_limit, Column, CursorID, CursorType,
             MaterializedBuildInput, MaterializedBuildInputMode, MaterializedColumnRef,
@@ -112,12 +115,31 @@ pub fn emit_query<'a>(
     // Emit FROM clause subqueries first so the results can be read in the main query loop.
     emit_from_clause_subqueries(program, t_ctx, &mut plan.table_references, &plan.join_order)?;
 
+    // HAVING without GROUP BY sets group_by to Some with an empty exprs list. That
+    // is still ungrouped aggregation, so key the ungrouped paths below off the
+    // GROUP BY expressions rather than off group_by being None.
+    let has_group_by_exprs = plan
+        .group_by
+        .as_ref()
+        .is_some_and(|gb| !gb.exprs.is_empty());
+    let is_ungrouped_aggregation = !plan.aggregates.is_empty() && !has_group_by_exprs;
+
+    // Bare columns that the loop must read for the code emitted after it (HAVING
+    // predicates, result columns that also contain an aggregate).
+    let bare_columns_read_in_loop = if is_ungrouped_aggregation {
+        collect_bare_columns_read_in_loop(plan)?
+    } else {
+        Vec::new()
+    };
+
     // For non-grouped aggregation queries that also have non-aggregate columns,
     // we need to ensure non-aggregate columns are only emitted once.
     // This flag helps track whether we've already emitted these columns.
-    let has_ungrouped_nonagg_cols = !plan.aggregates.is_empty()
-        && plan.group_by.is_none()
-        && plan.result_columns.iter().any(|c| !c.contains_aggregates);
+    // The bare columns above are read under the same flag, so that they hold the
+    // first row's values like SQLite, instead of the last row's.
+    let has_ungrouped_nonagg_cols = is_ungrouped_aggregation
+        && (plan.result_columns.iter().any(|c| !c.contains_aggregates)
+            || !bare_columns_read_in_loop.is_empty());
 
     if has_ungrouped_nonagg_cols {
         let flag = program.alloc_register();
@@ -143,11 +165,6 @@ pub fn emit_query<'a>(
             }
         }
     }
-
-    let has_group_by_exprs = plan
-        .group_by
-        .as_ref()
-        .is_some_and(|gb| !gb.exprs.is_empty());
 
     // Initialize cursors and other resources needed for query execution
     if !plan.order_by.is_empty() {
@@ -175,10 +192,10 @@ pub fn emit_query<'a>(
             )?;
         }
     } else if !plan.aggregates.is_empty() {
-        // Handle aggregation without GROUP BY (or HAVING without GROUP BY)
-        // Aggregate registers need to be NULLed at the start because the same registers might be reused on another invocation of a subquery,
-        // and if they are not NULLed, the 2nd invocation of the same subquery will have values left over from the first invocation.
-        t_ctx.reg_agg_start = Some(program.alloc_registers_and_init_w_null(plan.aggregates.len()));
+        // Handle aggregation without GROUP BY (or HAVING without GROUP BY):
+        // null the aggregate accumulators and the registers for bare columns
+        // read during the loop, before the loop starts.
+        init_ungrouped_aggregation(program, t_ctx, plan, bare_columns_read_in_loop);
     } else if let Some(window) = &plan.window {
         EmitWindow::init(
             program,

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -361,44 +361,27 @@ fn emit_loop_source<'a>(
                 )?;
             }
 
-            // For result columns that contain aggregates but also reference
-            // non-aggregate columns (e.g. CASE WHEN SUM(1) THEN a ELSE b END),
-            // pre-read those column references while the cursor is still valid.
-            // They are cached in expr_to_reg_cache so that when the full
-            // expression is evaluated after AggFinal, translate_expr finds
-            // the cached values instead of reading from the exhausted cursor.
-            for rc in plan
-                .result_columns
-                .iter()
-                .filter(|rc| rc.contains_aggregates)
-            {
-                walk_expr(&rc.expr, &mut |expr: &Expr| -> Result<WalkControl> {
-                    match expr {
-                        Expr::Column { .. } | Expr::RowId { .. } => {
-                            let reg = program.alloc_register();
-                            translate_expr(
-                                program,
-                                Some(&plan.table_references),
-                                expr,
-                                reg,
-                                &t_ctx.resolver,
-                            )?;
-                            t_ctx.resolver.cache_scalar_expr_reg(
-                                Cow::Owned(expr.clone()),
-                                reg,
-                                false,
-                                &plan.table_references,
-                            )?;
-                            Ok(WalkControl::SkipChildren)
-                        }
-                        _ => {
-                            if plan.aggregates.iter().any(|a| a.original_expr == *expr) {
-                                return Ok(WalkControl::SkipChildren);
-                            }
-                            Ok(WalkControl::Continue)
-                        }
-                    }
-                })?;
+            // Read the bare columns needed after the loop (in HAVING predicates,
+            // or in result columns that also contain an aggregate such as
+            // CASE WHEN sum(1) THEN a ELSE b END) into the registers allocated for
+            // them, while the cursor still points at a row. The whole table is one
+            // group here, so like SQLite we take the first row's values, which is
+            // what the once-flag guard above gives us.
+            // emit_ungrouped_aggregation then points post-loop translation at
+            // these registers.
+            turso_assert!(
+                t_ctx.bare_columns_read_in_loop.is_empty()
+                    || label_emit_nonagg_only_once.is_some(),
+                "bare columns must be read under the once flag, or they end up holding the last row's values instead of the first row's"
+            );
+            for (expr, reg) in t_ctx.bare_columns_read_in_loop.iter() {
+                translate_expr(
+                    program,
+                    Some(&plan.table_references),
+                    expr,
+                    *reg,
+                    &t_ctx.resolver,
+                )?;
             }
 
             if let Some(label) = label_emit_nonagg_only_once {

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1686,6 +1686,7 @@ pub fn emit_from_clause_subquery(
                     resolver: t_ctx.resolver.fork(),
                     non_aggregate_expressions: Vec::new(),
                     agg_leaf_columns: Vec::new(),
+                    bare_columns_read_in_loop: Vec::new(),
                     cdc_cursor_id: None,
                     meta_window: None,
                     meta_in_seeks: (0..select_plan.joined_tables().len())
@@ -1776,6 +1777,7 @@ fn emit_indexed_materialized_subquery(
                 resolver: t_ctx.resolver.fork(),
                 non_aggregate_expressions: Vec::new(),
                 agg_leaf_columns: Vec::new(),
+                bare_columns_read_in_loop: Vec::new(),
                 cdc_cursor_id: None,
                 meta_window: None,
                 meta_in_seeks: (0..select_plan.joined_tables().len())
@@ -1873,6 +1875,7 @@ fn emit_materialized_subquery_table(
                 resolver: t_ctx.resolver.fork(),
                 non_aggregate_expressions: Vec::new(),
                 agg_leaf_columns: Vec::new(),
+                bare_columns_read_in_loop: Vec::new(),
                 cdc_cursor_id: None,
                 meta_window: None,
                 meta_in_seeks: (0..select_plan.joined_tables().len())

--- a/sqlite/conformance/sqlite-sqltests/having-without-group-by.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/having-without-group-by.sqltest
@@ -1,0 +1,118 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/8200
+#
+# An aggregate query with a HAVING clause but no GROUP BY must treat the
+# whole table as a single group. When the HAVING clause references a bare
+# table column, Turso returned no rows while SQLite returns the aggregate
+# row (upstream select3-3.3).
+
+setup logs {
+    CREATE TABLE t1 (log int);
+    INSERT INTO t1 VALUES (1), (2), (3);
+}
+
+@setup logs
+test having-bare-column-true {
+    SELECT count(*) FROM t1 HAVING log != 400;
+}
+expect {
+    3
+}
+
+@setup logs
+test having-bare-column-false {
+    SELECT count(*) FROM t1 HAVING log = 400;
+}
+expect {
+}
+
+@setup logs
+test having-aggregate-no-group-by {
+    SELECT max(log) FROM t1 HAVING count(*) > 2;
+}
+expect {
+    3
+}
+
+@setup logs
+test having-aggregate-on-column {
+    SELECT count(*) FROM t1 HAVING min(log) > 0;
+}
+expect {
+    3
+}
+
+@setup logs
+test having-bare-column-and-non-aggregate-result-column {
+    SELECT log, count(*) FROM t1 HAVING log < 2;
+}
+expect {
+    1|3
+}
+
+@setup logs
+test having-bare-column-with-where-filter {
+    SELECT count(*) FROM t1 WHERE log > 1 HAVING log = 2;
+}
+expect {
+    2
+}
+
+# A hash join turns the expression-to-register cache on while emitting the loop
+# body. The registers for the bare columns must not be visible in that cache
+# yet, or the aggregate arguments read them instead of the current row: sum()
+# would then add up NULLs and every one of these queries would return no row.
+setup join {
+    CREATE TABLE a (x int, y int);
+    INSERT INTO a VALUES (1, 10), (2, 20), (3, 30);
+    CREATE TABLE b (x int, z int);
+    INSERT INTO b VALUES (1, 100), (2, 200), (3, 300);
+}
+
+@setup join
+test having-bare-column-of-joined-table {
+    SELECT sum(b.z) FROM a JOIN b ON a.x = b.x HAVING b.z != 400;
+}
+expect {
+    600
+}
+
+@setup join
+test having-bare-column-of-other-joined-table {
+    SELECT count(*), sum(a.y) FROM a JOIN b ON a.x = b.x HAVING b.z != 400;
+}
+expect {
+    3|60
+}
+
+@setup join
+test joined-bare-column-inside-aggregate-result-column {
+    SELECT CASE WHEN sum(b.z) THEN b.z ELSE 0 END FROM a JOIN b ON a.x = b.x;
+}
+expect {
+    100
+}
+
+# A correlated subquery reuses the same bytecode for every outer row. The
+# column pre-read for HAVING happens on the first loop iteration, so when a
+# later outer row filters out every inner row, the pre-read registers must be
+# nulled instead of keeping the previous outer row's values. Here a=1 leaves
+# y=500 behind; for a=2 the subquery scans no rows, so HAVING must see y as
+# NULL and return no row (NULL), not reuse 500 and return 0.
+setup correlated {
+    CREATE TABLE outer_t (a int);
+    INSERT INTO outer_t VALUES (1), (2);
+    CREATE TABLE inner_t (x int, y int);
+    INSERT INTO inner_t VALUES (1, 500);
+}
+
+@setup correlated
+test having-correlated-subquery-no-stale-columns {
+    SELECT a, (SELECT count(*) FROM inner_t WHERE x = a HAVING y != 400)
+    FROM outer_t ORDER BY a;
+}
+expect {
+    1|1
+    2|
+}

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -495,7 +495,7 @@ set test_files {
   seekscan1            pass
   select1              pass
   select2              pass
-  select3              fail
+  select3              pass
   select4              fail
   select5              pass
   select6              fail


### PR DESCRIPTION
An aggregate query with HAVING but no GROUP BY treats the whole table as
one group, so the HAVING check runs after the main loop, when the table
cursor no longer points at a row. Bare column references in HAVING (e.g.
SELECT count(*) FROM t1 HAVING log != 400) read NULL there, so the
condition never passed and the aggregate row was dropped. Result columns
that mix an aggregate with a bare column had a related problem: the
mechanism that reads such columns once per loop was only enabled when
group_by was None, and HAVING without GROUP BY sets group_by to Some with
an empty expression list.

Follow SQLite's AggInfo model. The bare columns of HAVING predicates and
of aggregate-containing result columns each get a register next to the
aggregate accumulators, and all of them are nulled in one range before
the loop starts, the way SQLite's resetAccumulator does. The loop reads
them on its first iteration (the existing once-flag, so they hold the
first row's values like SQLite), and code emitted after the loop finds
them through the expression-to-register cache.

The cache entries are added after the loop, not when the registers are
allocated. Inside the loop a hash join turns the expression cache on, and
an entry visible there makes aggregate arguments such as the b.z of
"SELECT sum(b.z) FROM a JOIN b ON a.x = b.x HAVING b.z != 400" read the
still-unwritten bare column register instead of the current row, so sum()
adds up NULLs.

Nulling before the loop means that when the same bytecode runs again with
no rows to scan, e.g. a correlated subquery whose WHERE clause filters
everything out, the registers read as NULL instead of keeping the
previous run's values.

Bare columns still come from the first row even when the query's only
aggregate is min() or max(), where SQLite takes them from the extreme
row. Turso ignores that rule everywhere today, e.g. in
"SELECT max(log), log FROM t1", so it is left for separate work.

Also promote upstream select3.test from "fail" to "pass" in all.test,
since this was its only remaining failure.

Tests: sqlite-sqltests/having-without-group-by.sqltest (bare columns in
HAVING, the hash join cases, and a correlated subquery that must not
reuse stale registers), upstream select3.test (90/90), full upstream
all.test, full sqltest conformance, cargo test.

Fixes #8200