### PR TITLE
Fixes for MVCC sync issues found by fuzzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ custom-types-fuzzer-output/
 CLAUDE.md
 bindings/python/dev.py
 bindings/python/implementation-test/
+bindings/javascript/wasi-sdk-*
 dhat-heap.json
 
 # Aristo runtime, cache, and per-user state: never commit these.

--- a/sync/engine/src/database_replay_generator.rs
+++ b/sync/engine/src/database_replay_generator.rs
@@ -38,6 +38,44 @@ fn quote_ident(name: &str) -> String {
     format!("\"{}\"", name.replace('"', "\"\""))
 }
 
+/// Identity predicate for one primary-key column.
+///
+/// `IS` instead of `=` because rowid tables allow NULL in PRIMARY KEY columns
+/// (only a rowid-alias INTEGER PRIMARY KEY is implicitly NOT NULL), and
+/// `NULL = NULL` is not true: an `=` predicate silently matches no row, so a
+/// replayed DELETE or UPDATE of such a row applies nowhere. `IS` is NULL-safe
+/// and, like SQLite, still seeks the index.
+fn identity_predicate(column_name: &str) -> String {
+    format!("{} IS ?", quote_ident(column_name))
+}
+
+/// The aliases SQLite accepts for a rowid table's implicit rowid, in the order
+/// the replay generator prefers them.
+const IMPLICIT_ROWID_ALIASES: [&str; 3] = ["rowid", "_rowid_", "oid"];
+
+/// Resolve the identifier that names the implicit rowid of `table_name`.
+///
+/// A user column may shadow any of the three aliases, in which case that
+/// identifier resolves to the user column and a rowid-based replay statement
+/// would match nothing (or write the wrong column). Pick the first alias the
+/// table does not shadow; if it shadows all three the implicit rowid is
+/// unreachable from SQL, so refuse the replay instead of corrupting the row.
+fn implicit_rowid_alias(table_name: &str, column_names: &[String]) -> Result<&'static str> {
+    IMPLICIT_ROWID_ALIASES
+        .into_iter()
+        .find(|alias| {
+            !column_names
+                .iter()
+                .any(|name| name.eq_ignore_ascii_case(alias))
+        })
+        .ok_or_else(|| {
+            Error::DatabaseTapeError(format!(
+                "table '{table_name}' has user columns shadowing every implicit rowid alias ({}); refusing rowid-based replay",
+                IMPLICIT_ROWID_ALIASES.join(", ")
+            ))
+        })
+}
+
 impl DatabaseReplayGenerator {
     pub fn new(conn: Arc<turso_core::Connection>, opts: DatabaseReplaySessionOpts) -> Self {
         Self { conn, opts }
@@ -120,14 +158,23 @@ impl DatabaseReplayGenerator {
         }
         row
     }
+    /// Bind values for an INSERT/UPSERT/UPDATE replay statement.
+    ///
+    /// `record` is the row's after image. `before` is the row's before image and
+    /// is only used for UPDATE: the WHERE clause pins the row by the primary key
+    /// it had *before* the change, so an update that moves a key still finds its
+    /// row. Binding the after image there makes a key-changing UPDATE match zero
+    /// rows — silently, since affecting no rows is not an error.
     pub fn replay_values(
         &self,
         info: &ReplayInfo,
         change: DatabaseChangeType,
         id: i64,
-        mut record: crate::alloc::Vec<turso_core::Value>,
+        record: crate::alloc::Vec<turso_core::Value>,
         updates: Option<crate::alloc::Vec<turso_core::Value>>,
+        before: Option<crate::alloc::Vec<turso_core::Value>>,
     ) -> crate::alloc::Vec<turso_core::Value> {
+        let mut record = record;
         if info.is_ddl_replay {
             return <crate::alloc::Vec<turso_core::Value> as TursoAllocExt>::new();
         }
@@ -171,11 +218,15 @@ impl DatabaseReplayGenerator {
                     values.push(value);
                 }
                 if let Some(pk_column_indices) = &info.pk_column_indices {
+                    // Identity predicates are emitted in `pk_column_indices`
+                    // order by `update_query`, so the binds follow that order.
+                    // They come from the before image: see `replay_values`.
+                    let mut identity = before.unwrap_or(record);
                     for pk in pk_column_indices {
                         let value = if info.rowid_alias_pk_column_index == Some(*pk) {
                             turso_core::Value::from_i64(id)
                         } else {
-                            std::mem::replace(&mut record[*pk], turso_core::Value::Null)
+                            std::mem::replace(&mut identity[*pk], turso_core::Value::Null)
                         };
                         values.push(value);
                     }
@@ -237,6 +288,28 @@ impl DatabaseReplayGenerator {
             values.push(value);
         }
         Ok(values)
+    }
+
+    /// Whether an upsert replay of `record` needs a NULL-safe pre-delete.
+    ///
+    /// `INSERT ... ON CONFLICT(pk) DO UPDATE` resolves nothing when a key
+    /// component is NULL: NULLs are distinct in a unique index, so no conflict
+    /// is raised and the upsert appends a duplicate row instead of updating the
+    /// existing one. Such a row must be deleted through the NULL-safe identity
+    /// predicates first, after which the insert lands cleanly.
+    pub(crate) fn upsert_needs_null_safe_predelete(
+        &self,
+        info: &ReplayInfo,
+        record: &[turso_core::Value],
+    ) -> bool {
+        let Some(pk_column_indices) = info.pk_column_indices.as_ref() else {
+            return false;
+        };
+        pk_column_indices.iter().any(|&pk| {
+            // A rowid-alias primary key is the implicit rowid: never NULL.
+            info.rowid_alias_pk_column_index != Some(pk)
+                && matches!(record.get(pk), Some(turso_core::Value::Null))
+        })
     }
 
     /// Whether a DELETE replay must fall back to the implicit rowid: only when
@@ -401,7 +474,7 @@ impl DatabaseReplayGenerator {
                     idx, record_columns.len(), table_name
                 )));
             }
-            pk_predicates.push(format!("{} = ?", quote_ident(&record_columns[idx])));
+            pk_predicates.push(identity_predicate(&record_columns[idx]));
         }
         for (idx, name) in record_columns.iter().enumerate() {
             if columns[idx] {
@@ -410,10 +483,12 @@ impl DatabaseReplayGenerator {
         }
         let quoted_table_name = quote_ident(table_name);
         let (query, pk_column_indices) = if pk_column_indices.is_empty() {
+            let rowid_alias = implicit_rowid_alias(table_name, &column_names)?;
             (
                 format!(
-                    "UPDATE {quoted_table_name} SET {} WHERE rowid = ?",
-                    column_updates.join(", ")
+                    "UPDATE {quoted_table_name} SET {} WHERE {} = ?",
+                    column_updates.join(", "),
+                    quote_ident(rowid_alias)
                 ),
                 None,
             )
@@ -498,7 +573,11 @@ impl DatabaseReplayGenerator {
         };
         let mut insert_columns = record_columns.to_vec();
         let original_column_names = insert_columns.clone();
-        insert_columns.push("rowid".to_string());
+        // Rowid preservation names the implicit rowid explicitly in the column
+        // list, so it must use an alias the table does not shadow with a user
+        // column of the same name.
+        let rowid_alias = implicit_rowid_alias(table_name, &column_names)?;
+        insert_columns.push(rowid_alias.to_string());
 
         let placeholders = ["?"].repeat(columns + 1).join(",");
         let col_list = insert_columns
@@ -533,7 +612,7 @@ impl DatabaseReplayGenerator {
             self.table_columns_info(coro, table_name).await?;
         let mut pk_predicates = Vec::with_capacity(1);
         for &idx in &pk_column_indices {
-            pk_predicates.push(format!("{} = ?", quote_ident(&column_names[idx])));
+            pk_predicates.push(identity_predicate(&column_names[idx]));
         }
         let use_implicit_rowid = self.opts.use_implicit_rowid;
         let quoted_table_name = quote_ident(table_name);
@@ -551,7 +630,11 @@ impl DatabaseReplayGenerator {
                     "DELETE for table '{table_name}' has no primary-key projection and no before image, but its PRIMARY KEY is not the rowid; refusing rowid-based replay"
                 )));
             }
-            let query = format!("DELETE FROM {quoted_table_name} WHERE rowid = ?");
+            let rowid_alias = implicit_rowid_alias(table_name, &column_names)?;
+            let query = format!(
+                "DELETE FROM {quoted_table_name} WHERE {} = ?",
+                quote_ident(rowid_alias)
+            );
             tracing::trace!("delete_query: table_name={table_name}, query={query}, use_implicit_rowid={use_implicit_rowid}");
             return Ok(ReplayInfo {
                 change_type: DatabaseChangeType::Delete,
@@ -761,5 +844,240 @@ impl DatabaseReplayGenerator {
             None
         };
         Ok((column_names, pk_column_indices, rowid_alias_pk_column_index))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database_tape::DatabaseReplaySessionOpts;
+    use std::sync::Arc;
+    use tempfile::NamedTempFile;
+    use turso_core::SqliteDialect;
+
+    enum QueryKind {
+        Delete { use_rowid: bool },
+        Update(Vec<bool>),
+        Upsert(usize),
+    }
+
+    fn replay_info_for(
+        ddl: &[&str],
+        table: &str,
+        kind: QueryKind,
+        use_implicit_rowid: bool,
+    ) -> Result<ReplayInfo> {
+        let temp_file = NamedTempFile::new().unwrap();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = turso_core::Database::open_file(
+            io.clone(),
+            temp_file.path().to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        for stmt in ddl {
+            conn.execute(stmt).unwrap();
+        }
+        let generator =
+            DatabaseReplayGenerator::new(conn, DatabaseReplaySessionOpts { use_implicit_rowid });
+        let table = table.to_string();
+        let mut gen = genawaiter::sync::Gen::new(|coro| async move {
+            let coro: Coro<()> = coro.into();
+            match kind {
+                QueryKind::Delete { use_rowid } => {
+                    generator.delete_query(&coro, &table, use_rowid).await
+                }
+                QueryKind::Update(columns) => generator.update_query(&coro, &table, &columns).await,
+                QueryKind::Upsert(columns) => generator.upsert_query(&coro, &table, columns).await,
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        }
+    }
+
+    #[test]
+    fn test_identity_predicates_are_null_safe() {
+        // Rowid tables allow NULL in PRIMARY KEY columns, and `NULL = NULL` is
+        // not true: `=` predicates make replay of such a row a silent no-op.
+        let ddl = &["CREATE TABLE t (a, b, c, PRIMARY KEY (a, c))"];
+        let delete =
+            replay_info_for(ddl, "t", QueryKind::Delete { use_rowid: false }, false).unwrap();
+        assert_eq!(
+            delete.query,
+            r#"DELETE FROM "t" WHERE "a" IS ? AND "c" IS ?"#
+        );
+
+        let update =
+            replay_info_for(ddl, "t", QueryKind::Update(vec![false, true, false]), false).unwrap();
+        assert_eq!(
+            update.query,
+            r#"UPDATE "t" SET "b" = ? WHERE "a" IS ? AND "c" IS ?"#
+        );
+    }
+
+    #[test]
+    fn test_identity_predicates_follow_primary_key_ordinal_order() {
+        // `PRIMARY KEY (c, a)`: predicates and binds are both ordered by PK
+        // ordinal, not by column declaration order.
+        let ddl = &["CREATE TABLE t (a, b, c, PRIMARY KEY (c, a))"];
+        let update =
+            replay_info_for(ddl, "t", QueryKind::Update(vec![false, true, false]), false).unwrap();
+        assert_eq!(
+            update.query,
+            r#"UPDATE "t" SET "b" = ? WHERE "c" IS ? AND "a" IS ?"#
+        );
+        assert_eq!(update.pk_column_indices, Some(vec![2, 0]));
+    }
+
+    #[test]
+    fn test_rowid_replay_avoids_user_columns_shadowing_rowid_aliases() {
+        // A user column named `rowid` hijacks `WHERE rowid = ?`: the predicate
+        // resolves to the user column, so the integer row-id bind matches
+        // nothing and the replayed delete is a silent no-op.
+        let shadow_rowid = &["CREATE TABLE t (rowid, v)"];
+        let delete = replay_info_for(
+            shadow_rowid,
+            "t",
+            QueryKind::Delete { use_rowid: true },
+            true,
+        )
+        .unwrap();
+        assert_eq!(delete.query, r#"DELETE FROM "t" WHERE "_rowid_" = ?"#);
+        let update = replay_info_for(
+            shadow_rowid,
+            "t",
+            QueryKind::Update(vec![false, true]),
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            update.query,
+            r#"UPDATE "t" SET "v" = ? WHERE "_rowid_" = ?"#
+        );
+        let upsert = replay_info_for(shadow_rowid, "t", QueryKind::Upsert(2), true).unwrap();
+        assert_eq!(
+            upsert.query,
+            r#"INSERT OR REPLACE INTO "t"("rowid", "v", "_rowid_") VALUES (?,?,?)"#
+        );
+
+        let shadow_two = &["CREATE TABLE t (rowid, _rowid_, v)"];
+        let delete =
+            replay_info_for(shadow_two, "t", QueryKind::Delete { use_rowid: true }, true).unwrap();
+        assert_eq!(delete.query, r#"DELETE FROM "t" WHERE "oid" = ?"#);
+
+        // Shadowing all three aliases is legal SQLite, but then the implicit
+        // rowid is unreachable from SQL: refuse instead of writing the wrong row.
+        let shadow_all = &["CREATE TABLE t (rowid, _rowid_, oid, v)"];
+        let err = replay_info_for(shadow_all, "t", QueryKind::Delete { use_rowid: true }, true)
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("shadowing every implicit rowid alias"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_update_identity_values_come_from_before_image() {
+        // A key-changing UPDATE must be identified by the key it had *before*
+        // the change: binding the after image matches zero rows, silently.
+        let ddl = &["CREATE TABLE t (a, b, c, PRIMARY KEY (c, a))"];
+        let info =
+            replay_info_for(ddl, "t", QueryKind::Update(vec![false, false, true]), false).unwrap();
+        assert_eq!(
+            info.query,
+            r#"UPDATE "t" SET "c" = ? WHERE "c" IS ? AND "a" IS ?"#
+        );
+
+        let temp_file = NamedTempFile::new().unwrap();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = turso_core::Database::open_file(
+            io,
+            temp_file.path().to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let generator = DatabaseReplayGenerator::new(
+            db.connect().unwrap(),
+            DatabaseReplaySessionOpts {
+                use_implicit_rowid: false,
+            },
+        );
+
+        let text = |value: &str| turso_core::Value::from_text(value.to_string());
+        // changes mask: only column `c` was updated; second half holds new values.
+        let updates = turso_core::alloc::vec![
+            turso_core::Value::from_i64(0),
+            turso_core::Value::from_i64(0),
+            turso_core::Value::from_i64(1),
+            text("a1"),
+            text("b1"),
+            text("c9"),
+        ];
+        let before = turso_core::alloc::vec![text("a1"), text("b1"), text("c1")];
+        let after = turso_core::alloc::vec![text("a1"), text("b1"), text("c9")];
+
+        let values = generator.replay_values(
+            &info,
+            DatabaseChangeType::Update,
+            0,
+            after,
+            Some(updates),
+            Some(before),
+        );
+
+        // SET c = 'c9', then identity in PK ordinal order: c (before), a.
+        assert_eq!(values.to_vec(), vec![text("c9"), text("c1"), text("a1")]);
+    }
+
+    #[test]
+    fn test_upsert_predelete_only_for_null_key_components() {
+        let ddl = &["CREATE TABLE t (a, b, c, PRIMARY KEY (a, c))"];
+        let info = replay_info_for(ddl, "t", QueryKind::Upsert(3), false).unwrap();
+        let temp_file = NamedTempFile::new().unwrap();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db = turso_core::Database::open_file(
+            io,
+            temp_file.path().to_str().unwrap(),
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let generator = DatabaseReplayGenerator::new(
+            db.connect().unwrap(),
+            DatabaseReplaySessionOpts {
+                use_implicit_rowid: false,
+            },
+        );
+        let text = |value: &str| turso_core::Value::from_text(value.to_string());
+
+        assert!(!generator
+            .upsert_needs_null_safe_predelete(&info, &[text("a1"), text("b1"), text("c1")]));
+        // NULL in a key column: ON CONFLICT cannot fire, so the row must be
+        // pre-deleted or the upsert duplicates it.
+        assert!(generator.upsert_needs_null_safe_predelete(
+            &info,
+            &[text("a1"), text("b1"), turso_core::Value::Null]
+        ));
+        // NULL in a non-key column is irrelevant.
+        assert!(!generator.upsert_needs_null_safe_predelete(
+            &info,
+            &[text("a1"), turso_core::Value::Null, text("c1")]
+        ));
+
+        // A rowid-alias primary key is the implicit rowid: never NULL.
+        let rowid_alias = replay_info_for(
+            &["CREATE TABLE r (id INTEGER PRIMARY KEY, v)"],
+            "r",
+            QueryKind::Upsert(2),
+            false,
+        )
+        .unwrap();
+        assert!(!generator
+            .upsert_needs_null_safe_predelete(&rowid_alias, &[turso_core::Value::Null, text("v")]));
     }
 }

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -1427,7 +1427,26 @@ fn decode_recovery_ops_to_logical_txn(
 
     let mut ops = header_ops;
     append_schema_ops(schema_deltas, &mut ops)?;
-    ops.extend(row_ops);
+    // Every row delete in a transaction is applied before every row upsert.
+    //
+    // MVCC coalesces a transaction to one final version per rowid, and a row
+    // whose primary key changed arrives as a delete of its old key followed by
+    // an upsert of its new image. Applying those pairs row by row breaks as soon
+    // as two rows exchange keys inside one transaction: the second row's delete
+    // targets the key the first row's upsert just took, so it removes the row
+    // that was just written and the replica silently ends up one row short.
+    //
+    // Draining the deletes first applies the transaction as a set difference,
+    // which is also what lets both upserts land without tripping the unique
+    // index on an intermediate state — the remote needed a temporary key to make
+    // the same swap statement by statement. A rowid appears at most once per
+    // coalesced transaction, so no upsert can depend on a delete of its own row
+    // running later.
+    let (row_deletes, row_upserts): (Vec<_>, Vec<_>) = row_ops
+        .into_iter()
+        .partition(|op| op.op_type == LogicalOpType::DeleteRow as i32);
+    ops.extend(row_deletes);
+    ops.extend(row_upserts);
 
     Ok(LogicalTxnData {
         end_offset: portable_txn.end_offset,
@@ -3047,20 +3066,39 @@ async fn send_push_batch<IO: SyncEngineIo, Ctx>(
                             .push(step(replay_info.query.clone(), convert_to_args(values)))
                     }
                     DatabaseTapeRowChangeType::Insert { after } => {
+                        if generator.upsert_needs_null_safe_predelete(&replay_info, after) {
+                            // ON CONFLICT cannot resolve a key with a NULL
+                            // component, so remove the remote row by its
+                            // NULL-safe identity before inserting the new image.
+                            let delete_info = generator
+                                .delete_query(ctx.coro, &change.table_name, false)
+                                .await?;
+                            let delete_values = generator.replay_delete_values(
+                                &delete_info,
+                                change.id,
+                                after.clone(),
+                                None,
+                            )?;
+                            sql_over_http_requests.push(step(
+                                delete_info.query.clone(),
+                                convert_to_args(delete_values),
+                            ));
+                        }
                         let values = generator.replay_values(
                             &replay_info,
                             replay_info.change_type,
                             change.id,
                             after.clone(),
                             None,
+                            None,
                         );
                         sql_over_http_requests
                             .push(step(replay_info.query.clone(), convert_to_args(values)));
                     }
                     DatabaseTapeRowChangeType::Update {
+                        before,
                         after,
                         updates: Some(updates),
-                        ..
                     } => {
                         let values = generator.replay_values(
                             &replay_info,
@@ -3068,6 +3106,7 @@ async fn send_push_batch<IO: SyncEngineIo, Ctx>(
                             change.id,
                             after.clone(),
                             Some(updates.clone()),
+                            Some(before.clone()),
                         );
                         sql_over_http_requests
                             .push(step(replay_info.query.clone(), convert_to_args(values)));
@@ -3082,6 +3121,7 @@ async fn send_push_batch<IO: SyncEngineIo, Ctx>(
                             replay_info.change_type,
                             change.id,
                             after.clone(),
+                            None,
                             None,
                         );
                         sql_over_http_requests
@@ -4544,14 +4584,106 @@ mod tests {
         assert_eq!(txns[0].ops[0].op_type, LogicalOpType::Schema as i32);
         assert_eq!(txns[0].ops[0].schema_name, "t");
         assert_eq!(txns[0].ops[0].stable_table_id, 0);
-        assert_eq!(txns[0].ops[1].op_type, LogicalOpType::UpsertRow as i32);
+        // Row deletes are drained before row upserts, so the frame's
+        // upsert-then-delete order is inverted here on purpose.
+        assert_eq!(txns[0].ops[1].op_type, LogicalOpType::DeleteRow as i32);
         assert_eq!(txns[0].ops[1].table_name, "t");
         assert_eq!(txns[0].ops[1].rowid, 1);
-        assert_eq!(txns[0].ops[1].record, row_record);
-        assert_eq!(txns[0].ops[2].op_type, LogicalOpType::DeleteRow as i32);
+        assert_eq!(txns[0].ops[1].record, primary_key_record);
+        assert_eq!(txns[0].ops[2].op_type, LogicalOpType::UpsertRow as i32);
         assert_eq!(txns[0].ops[2].table_name, "t");
         assert_eq!(txns[0].ops[2].rowid, 1);
-        assert_eq!(txns[0].ops[2].record, primary_key_record);
+        assert_eq!(txns[0].ops[2].record, row_record);
+    }
+
+    /// A transaction that swaps the primary keys of two rows arrives as
+    /// interleaved (delete old key, upsert new image) pairs. Replaying it in that
+    /// order lets the second row's delete remove the row the first row's upsert
+    /// just wrote, so the decoder has to group all deletes ahead of all upserts.
+    #[test]
+    fn raw_mvcc_log_decoder_orders_row_deletes_before_upserts() {
+        let table_id = -42;
+        let text = turso_core::Value::build_text;
+        let first_new_image = record(&[text("b"), text("2"), text("left")]);
+        let second_new_image = record(&[text("a"), text("1"), text("right")]);
+        let first_old_key = record(&[text("a"), text("1")]);
+        let second_old_key = record(&[text("b"), text("2")]);
+
+        let portable_txn = super::PortableLogicalTxn {
+            end_offset: 104,
+            commit_ts: 77,
+            string_table: vec![Bytes::from_static(b"t")],
+            object_map: vec![super::PortableObjectMap {
+                mv_table_id: table_id,
+                name_ref: 0,
+            }],
+            meta: vec![],
+        };
+        let portable_payload = portable_txn.encode_length_delimited_to_vec();
+
+        // Exactly what the MVCC writer emits for
+        //   BEGIN;
+        //     UPDATE t SET x='tmp' WHERE x='a' AND y='1';
+        //     UPDATE t SET x='a', y='1' WHERE x='b' AND y='2';
+        //     UPDATE t SET x='b', y='2' WHERE x='tmp';
+        //   COMMIT;
+        // on `CREATE TABLE t(x, y, z, PRIMARY KEY (x, y))`: one delete+upsert
+        // pair per rowid, coalesced to the transaction's final image.
+        let mut recovery_payload = Vec::new();
+        append_test_table_delete(&mut recovery_payload, table_id, 1, &first_old_key);
+        append_test_table_upsert(&mut recovery_payload, table_id, 1, &first_new_image);
+        append_test_table_delete(&mut recovery_payload, table_id, 2, &second_old_key);
+        append_test_table_upsert(&mut recovery_payload, table_id, 2, &second_new_image);
+
+        let salt = 0x0123_4567_89ab_cdefu64;
+        let log_header = raw_mvcc_log_header(salt);
+        let initial_crc = crc32c::crc32c(&salt.to_le_bytes());
+        let (frame, _) =
+            raw_mvcc_log_frame_with_crc(77, &portable_payload, &recovery_payload, 4, initial_crc);
+        let end_offset = (log_header.len() + frame.len()) as u64;
+        let header = PullUpdatesRespProtoBody {
+            protocol: 0,
+            server_revision: format!("g1:o{end_offset}"),
+            db_size: 0,
+            raw_encoding: None,
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: Some(server_proto::MvccLogicalLogMetadataProto {
+                format: "lml3".to_string(),
+                checkpoint_transition: false,
+                ranges: vec![server_proto::MvccLogicalLogRangeProto {
+                    generation: 1,
+                    start_offset: 0,
+                    end_offset,
+                    starts_with_header: true,
+                    crc_seed: None,
+                }],
+            }),
+        };
+        let mut body = log_header;
+        body.extend_from_slice(&frame);
+
+        let txns = decode_raw_mvcc_log_for_test(header, body).unwrap();
+        assert_eq!(txns.len(), 1);
+        let ops = &txns[0].ops;
+        assert_eq!(ops.len(), 4);
+        let kinds = ops.iter().map(|op| op.op_type).collect::<Vec<_>>();
+        assert_eq!(
+            kinds,
+            vec![
+                LogicalOpType::DeleteRow as i32,
+                LogicalOpType::DeleteRow as i32,
+                LogicalOpType::UpsertRow as i32,
+                LogicalOpType::UpsertRow as i32,
+            ],
+            "row deletes must precede row upserts"
+        );
+        // Order within each group is the frame's order.
+        assert_eq!(ops[0].record, first_old_key);
+        assert_eq!(ops[1].record, second_old_key);
+        assert_eq!(ops[2].record, first_new_image);
+        assert_eq!(ops[3].record, second_new_image);
     }
 
     #[test]

--- a/sync/engine/src/database_tape.rs
+++ b/sync/engine/src/database_tape.rs
@@ -730,6 +730,27 @@ impl DatabaseReplaySession {
                                 "ready to use prepared insert statement for replay: key={:?}",
                                 key
                             );
+                            let needs_predelete = {
+                                let cached = self.cached_insert_stmt.get(&key).unwrap();
+                                self.generator
+                                    .upsert_needs_null_safe_predelete(&cached.info, &after)
+                            };
+                            if needs_predelete {
+                                // ON CONFLICT cannot resolve a key with a NULL
+                                // component, so remove the row by its NULL-safe
+                                // identity before inserting the new image.
+                                let delete_key =
+                                    self.populate_delete_stmt(coro, table, false).await?;
+                                let cached = self.cached_delete_stmt.get_mut(&delete_key).unwrap();
+                                cached.stmt.reset()?;
+                                let values = self.generator.replay_delete_values(
+                                    &cached.info,
+                                    change.id,
+                                    after.clone(),
+                                    None,
+                                )?;
+                                replay_stmt(coro, &mut cached.stmt, values).await?;
+                            }
                             let cached = self.cached_insert_stmt.get_mut(&key).unwrap();
                             cached.stmt.reset()?;
                             let values = self.generator.replay_values(
@@ -738,13 +759,14 @@ impl DatabaseReplaySession {
                                 change.id,
                                 after,
                                 None,
+                                None,
                             );
                             replay_stmt(coro, &mut cached.stmt, values).await?;
                         }
                         DatabaseTapeRowChangeType::Update {
+                            before,
                             after,
                             updates: Some(updates),
-                            ..
                         } => {
                             assert!(updates.len() % 2 == 0);
                             let columns_cnt = updates.len() / 2;
@@ -768,6 +790,7 @@ impl DatabaseReplaySession {
                                 change.id,
                                 after,
                                 Some(updates),
+                                Some(before),
                             );
                             replay_stmt(coro, &mut cached.stmt, values).await?;
                         }
@@ -804,6 +827,7 @@ impl DatabaseReplaySession {
                                 DatabaseChangeType::Insert,
                                 change.id,
                                 after,
+                                None,
                                 None,
                             );
                             replay_stmt(coro, &mut cached.stmt, values).await?;
@@ -3271,5 +3295,118 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// End state of a primary-key swap replayed as one logical transaction.
+    ///
+    /// The remote needed three statements and a temporary key to swap the keys of
+    /// two rows; the logical stream carries the coalesced result as a delete of
+    /// each row's old key plus an upsert of its new image. Replaying every delete
+    /// before every upsert is what keeps both rows: interleaved per-row order
+    /// would have the second delete remove the row the first upsert wrote.
+    #[test]
+    pub fn test_pk_swap_in_one_txn_replays_both_rows() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_str().unwrap();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let db =
+            turso_core::Database::open_file(io.clone(), db_path, Arc::new(SqliteDialect)).unwrap();
+        let db = Arc::new(DatabaseTape::new(db));
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let db = db.clone();
+            |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let conn = db.connect(&coro).await.unwrap();
+                conn.execute("CREATE TABLE t(x, y, z, PRIMARY KEY (x, y))")
+                    .unwrap();
+                conn.execute("INSERT INTO t VALUES ('a', '1', 'left'), ('b', '2', 'right')")
+                    .unwrap();
+
+                fn text(value: &str) -> turso_core::Value {
+                    turso_core::Value::Text(turso_core::types::Text::new(value.to_string()))
+                }
+                let key = |x: &str, y: &str| Some(turso_core::alloc::vec![text(x), text(y)]);
+                let image =
+                    |x: &str, y: &str, z: &str| turso_core::alloc::vec![text(x), text(y), text(z)];
+                let change = |id: i64, change: DatabaseTapeRowChangeType| DatabaseTapeRowChange {
+                    change_id: 0,
+                    change_time: 0,
+                    change,
+                    table_name: "t".to_string(),
+                    id,
+                };
+
+                {
+                    let opts = DatabaseReplaySessionOpts {
+                        use_implicit_rowid: true,
+                    };
+                    let mut session = db.start_replay_session(&coro, opts).await.unwrap();
+                    // Deletes first, then upserts — the order the decoder emits.
+                    for operation in [
+                        change(
+                            1,
+                            DatabaseTapeRowChangeType::Delete {
+                                before: turso_core::alloc::vec![],
+                                key: key("a", "1"),
+                            },
+                        ),
+                        change(
+                            2,
+                            DatabaseTapeRowChangeType::Delete {
+                                before: turso_core::alloc::vec![],
+                                key: key("b", "2"),
+                            },
+                        ),
+                        change(
+                            1,
+                            DatabaseTapeRowChangeType::Insert {
+                                after: image("b", "2", "left"),
+                            },
+                        ),
+                        change(
+                            2,
+                            DatabaseTapeRowChangeType::Insert {
+                                after: image("a", "1", "right"),
+                            },
+                        ),
+                    ] {
+                        session
+                            .replay(&coro, DatabaseTapeOperation::RowChange(operation))
+                            .await
+                            .unwrap();
+                    }
+                    session
+                        .replay(&coro, DatabaseTapeOperation::Commit)
+                        .await
+                        .unwrap();
+                }
+
+                let mut stmt = conn.prepare("SELECT x, y, z FROM t ORDER BY x, y").unwrap();
+                let mut rows = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await.unwrap() {
+                    rows.push(
+                        row.get_values()
+                            .map(|value| format!("{value}"))
+                            .collect::<Vec<_>>()
+                            .join("|"),
+                    );
+                }
+                rows
+            }
+        });
+        let rows = loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result,
+            }
+        };
+
+        assert_eq!(
+            rows,
+            vec!["a|1|right".to_string(), "b|2|left".to_string()],
+            "the swap must keep both rows"
+        );
     }
 }


### PR DESCRIPTION
### sync: fix replay of NULL primary keys, rowid-shadowed tables, key swaps and key-changing updates

Four bugs in the sync engine's replay path, found by a scripted `sync-fuzzer` sweep
against a our server,

All four live in the SQL the replay generator builds, so each one affects both
directions: pull replay applies it locally, and `send_push_batch` sends the same
statements to the remote. Three of the four fail *silently* — a DELETE or UPDATE
that matches zero rows is not an error — so the replica or the remote diverges
with nothing logged anywhere. Worse, a pushed transaction whose user statements
all no-op leaves only internal bookkeeping ops in the commit, which is what used
to wedge MVCC bootstrap entirely (fixed separately, see *Related*).

## 1. NULL components in a composite primary key

`CREATE TABLE t(a, b, c, PRIMARY KEY (a, c))` is a rowid table, and only a
rowid-alias `INTEGER PRIMARY KEY` is implicitly `NOT NULL` — so a row may hold
NULL in a key column, and the server accepts it. Identity predicates were built
as `{col} = ?`, and `NULL = NULL` is not true, so replaying a DELETE or UPDATE of
such a row matched nothing: remote deletes never landed on the replica, and
remote updates arrived as inserts that duplicated the row.

Identity predicates are now `{col} IS ?` (`identity_predicate()`), which is
NULL-safe and, like SQLite, still uses an index seek.

The duplicate-row half needed a second fix. Update replay goes through
`INSERT ... ON CONFLICT(pk) DO UPDATE`, and a NULL key component raises no
conflict at all — NULLs are distinct in a unique index — so the upsert appended a
row instead of updating the existing one. `upsert_needs_null_safe_predelete()`
detects that shape, and both replay paths emit a NULL-safe DELETE first, after
which the insert lands cleanly.

## 2. A user column shadowing `rowid`

Replay for a table with no usable primary key falls back to the implicit rowid:
`DELETE FROM t WHERE rowid = ?`. When the table declares its own column named
`rowid`, that identifier resolves to the user column, so the integer row-id bind
matched nothing — deletes no-oped and updates duplicated rows. The
rowid-preserving upsert had the same hazard from the other side: it names the
rowid in its column list, so it wrote the user column instead of the row id.

`implicit_rowid_alias()` picks the first alias the table does not shadow, in the
order `rowid`, `_rowid_`, `oid`, and the delete, update and upsert fallbacks all
use it. Shadowing all three is legal SQLite, but then the implicit rowid is
unreachable from SQL, so replay refuses with an error naming the table rather
than writing the wrong column.

## 3. A primary-key swap inside one transaction

Two rows exchanging composite primary keys in one remote transaction left the
replica one row short.

MVCC coalesces a transaction to one final version per rowid and emits, per row, a
delete of the old key followed by an upsert of the new image — interleaved row by
row:

```
DELETE rowid=1  identity=('a','1')
UPSERT rowid=1  values=('b','2','left')
DELETE rowid=2  identity=('b','2')
UPSERT rowid=2  values=('a','1','right')
```

Applied in that order against a replica holding `(a,1,left)`, `(b,2,right)`: the
first delete removes `(a,1)`; the first upsert conflicts on `(b,2)` and updates
that row; **the second delete then removes the row the upsert just wrote**; the
second upsert inserts. One row survives.

`decode_recovery_ops_to_logical_txn` now drains all row deletes before all row
upserts, stable within each group, applying the transaction as a set difference.
That also removes the need for the intermediate key the remote used to make the
same swap statement by statement: once both deletes are applied, both upserts
land without tripping the unique index. A rowid appears at most once per coalesced
transaction, so no upsert can depend on a delete of its own row running later.

## 4. A key-changing UPDATE identified by its after image

`UPDATE t SET c='c9' WHERE a='a1' AND c='c1'` pushed without error but left the
remote unchanged. `replay_values` projected the WHERE-clause identity binds from
the row's *after* image, so a key-changing UPDATE bound the key it was moving
*to* — `... WHERE c=? AND a=?` bound `('c9','a1')` and matched nothing.

`replay_values` now takes the before image and projects UPDATE identity binds
from it; both call sites (tape replay and `send_push_batch`) pass it, and it is
always present when `updates` is. Note this is not a bind-*ordering* bug:
predicates and binds were already both emitted in `pk_column_indices` order.



## ~depends on: #8151

Fix 1 changes the shape of every identity lookup replay issues, and `= ?` and
`IS ?` differ in more than NULL semantics on today's turso. In SQLite the two are
the same *kind* of operator to the planner — both are index-usable equalities, so
`WHERE a IS ? AND c IS ?` seeks a composite-PK index exactly as `WHERE a = ? AND
c = ?` does. Turso extracted `Is` constraints but never admitted them as seek
keys, so the predicate that planned as `SEARCH t USING INDEX ... (a=? AND c=?)`
before this PR plans as `SCAN t` after it. That costs more than a plan-shape
regression, because replay is per-row: a pull or push applies one DELETE/UPDATE
statement per changed row, so an apply that was proportional to the number of
changes becomes proportional to changes × table size — a full table scan for
every row in the batch. Small fuzzer tables would never surface it; a real
database would feel it on every sync. The alternative was to keep `=` and add a
NULL-safe arm (`c = ? OR (c IS NULL AND ? IS NULL)`), which doubles the binds per
key column, still does not restore the single clean seek, and leaves turso
diverging from SQLite on an operator it already parses and extracts. Fixing the
planner was the smaller and more correct change, which is why it went out
separately as #8151. This PR is safe either way, but #8151 should merge first, or
alongside, so there is no window in which sync replay scans.
 