### PR TITLE
core/vdbe: accept i64::MIN when applying numeric affinity to text

### DIFF
--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -537,8 +537,17 @@ fn create_result_from_significand(
         }
     }
 
-    // For pure integers without exponent, try to return as integer
-    if !has_decimal && !has_exponent && exponent == 0 && significand <= i64::MAX as u64 {
+    // For pure integers without exponent, try to return as integer.
+    // The digits were accumulated as an unsigned magnitude, so the limit is
+    // sign-dependent: a negative number may reach |i64::MIN| == i64::MAX + 1.
+    // This mirrors sqlite3Atoi64, which compares against "9223372036854775807"
+    // for positives and "9223372036854775808" for negatives.
+    let magnitude_limit = if sign < 0 {
+        i64::MAX as u64 + 1
+    } else {
+        i64::MAX as u64
+    };
+    if !has_decimal && !has_exponent && exponent == 0 && significand <= magnitude_limit {
         let signed_val = (significand as i64).wrapping_mul(sign);
         return (parse_result, ParsedNumber::Integer(signed_val));
     }

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -750,4 +750,39 @@ mod tests {
             parsed.as_float().unwrap(),
         );
     }
+
+    #[test]
+    fn test_try_for_float_i64_min_is_integer() {
+        // |i64::MIN| is one past i64::MAX, so the integer range check has to be
+        // sign-dependent the way sqlite3Atoi64 is.
+        let (res, parsed) = try_for_float(b"-9223372036854775808");
+        assert_eq!(res, NumericParseResult::PureInteger);
+        assert_eq!(parsed.as_integer(), Some(i64::MIN));
+
+        let (res, parsed) = try_for_float(b"  -9223372036854775808  ");
+        assert_eq!(res, NumericParseResult::PureInteger);
+        assert_eq!(parsed.as_integer(), Some(i64::MIN));
+
+        let (res, parsed) = try_for_float(b"-009223372036854775808");
+        assert_eq!(res, NumericParseResult::PureInteger);
+        assert_eq!(parsed.as_integer(), Some(i64::MIN));
+
+        // One past the negative limit, and the positive twin, stay floats.
+        let (_, parsed) = try_for_float(b"-9223372036854775809");
+        assert_eq!(parsed.as_integer(), None);
+        let (_, parsed) = try_for_float(b"9223372036854775808");
+        assert_eq!(parsed.as_integer(), None);
+
+        // The limits that already worked must keep working.
+        let (_, parsed) = try_for_float(b"-9223372036854775807");
+        assert_eq!(parsed.as_integer(), Some(-i64::MAX));
+        let (_, parsed) = try_for_float(b"9223372036854775807");
+        assert_eq!(parsed.as_integer(), Some(i64::MAX));
+
+        // The magnitude is only integral when it is a bare integer.
+        let (_, parsed) = try_for_float(b"-9223372036854775808.0");
+        assert_eq!(parsed.as_integer(), None);
+        let (_, parsed) = try_for_float(b"-9.223372036854775808e18");
+        assert_eq!(parsed.as_integer(), None);
+    }
 }

--- a/sqlite/conformance/sqlite-sqltests/affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/affinity.sqltest
@@ -728,6 +728,7 @@ expect {
     real
 }
 
+@cross-check-integrity
 test affinity-sum-of-text-i64-min {
     SELECT typeof(sum(v)), sum(v) FROM (SELECT '-9223372036854775808' AS v);
 }

--- a/sqlite/conformance/sqlite-sqltests/affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/affinity.sqltest
@@ -668,3 +668,69 @@ expect {
     integer|0
     text|1
 }
+
+# ============================================
+# INTEGER/NUMERIC affinity at the i64 boundaries. The magnitude of i64::MIN is
+# one past i64::MAX, so the range check applied to the parsed digits has to be
+# sign-dependent.
+# ============================================
+@cross-check-integrity
+test affinity-text-i64-min-integer-column {
+    CREATE TABLE t1 (c INTEGER);
+    INSERT INTO t1 VALUES ('-9223372036854775808');
+    INSERT INTO t1 VALUES (' -9223372036854775808 ');
+    INSERT INTO t1 VALUES ('-009223372036854775808');
+    SELECT typeof(c), c FROM t1 ORDER BY rowid;
+}
+expect {
+    integer|-9223372036854775808
+    integer|-9223372036854775808
+    integer|-9223372036854775808
+}
+
+@cross-check-integrity
+test affinity-text-i64-min-numeric-column {
+    CREATE TABLE t1 (c NUMERIC);
+    INSERT INTO t1 VALUES ('-9223372036854775808');
+    SELECT typeof(c), c FROM t1;
+}
+expect {
+    integer|-9223372036854775808
+}
+
+@cross-check-integrity
+test affinity-text-i64-limits-stay-integer {
+    CREATE TABLE t1 (c INTEGER);
+    INSERT INTO t1 VALUES ('-9223372036854775807');
+    INSERT INTO t1 VALUES ('9223372036854775807');
+    INSERT INTO t1 VALUES ('+9223372036854775807');
+    SELECT typeof(c), c FROM t1 ORDER BY rowid;
+}
+expect {
+    integer|-9223372036854775807
+    integer|9223372036854775807
+    integer|9223372036854775807
+}
+
+@cross-check-integrity
+test affinity-text-past-i64-limits-become-real {
+    CREATE TABLE t1 (c INTEGER);
+    INSERT INTO t1 VALUES ('9223372036854775808');
+    INSERT INTO t1 VALUES ('-9223372036854775809');
+    INSERT INTO t1 VALUES ('-9223372036854775808.0');
+    INSERT INTO t1 VALUES ('-9.223372036854775808e18');
+    SELECT typeof(c) FROM t1 ORDER BY rowid;
+}
+expect {
+    real
+    real
+    real
+    real
+}
+
+test affinity-sum-of-text-i64-min {
+    SELECT typeof(sum(v)), sum(v) FROM (SELECT '-9223372036854775808' AS v);
+}
+expect {
+    integer|-9223372036854775808
+}


### PR DESCRIPTION
Text whose value is exactly `-9223372036854775808` was stored as a REAL under INTEGER or NUMERIC column affinity, where SQLite stores an INTEGER. `try_for_float` accumulates digits into an unsigned magnitude and applies the sign afterwards, but the integer-vs-float range check compared that magnitude against `i64::MAX`; the magnitude of `i64::MIN` is `i64::MAX + 1`, so exactly one value in the i64 range fell to the float path, and `apply_integer_affinity` refuses to convert back at the extremes.

The limit is now sign-dependent, mirroring `sqlite3Atoi64`. The existing `wrapping_mul(sign)` already produces the right bits: 2^63 as i64 is `i64::MIN`, and `i64::MIN.wrapping_mul(-1)` wraps back to `i64::MIN`. Also fixes `sum()` over the text form, which shares the conversion. The change is one-directional: it only turns a value that is today a REAL into the exact INTEGER SQLite produces.

## Tests

`sqlite/conformance/sqlite-sqltests/affinity.sqltest` boundary cases (first commit, red without the fix), all expectations taken from sqlite3 3.51.0: i64::MIN under INTEGER and NUMERIC affinity (bare, whitespace-padded, zero-padded), `sum()` over the text form, and guard rails pinning that ±i64::MAX stay INTEGER while 2^63, -(2^63)-1 and decimal/exponent spellings stay REAL. A unit test next to `try_for_float` pins the parser directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
