### PR TITLE
tests: delete temporary databases instead of leaking them

### DIFF
--- a/core/io/common.rs
+++ b/core/io/common.rs
@@ -18,10 +18,19 @@ pub mod tests {
 
         let current_exe = std::env::current_exe().expect("Failed to get current executable path");
 
+        // The child runs the whole test binary and then leaves through
+        // `process::exit`, so its destructors never run and any temp file
+        // another test had in flight is orphaned. Point it at a directory we
+        // own so those files disappear with it.
+        let child_temp_dir = tempfile::tempdir().expect("Failed to create child temp dir");
+
         // Spawn a child process and try to open the same file
         let child = Command::new(current_exe)
             .env("RUST_TEST_CHILD_PROCESS", "1")
             .env("RUST_TEST_FILE_PATH", &path)
+            .env("TMPDIR", child_temp_dir.path())
+            .env("TMP", child_temp_dir.path())
+            .env("TEMP", child_temp_dir.path())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10058,10 +10058,12 @@ mod tests {
         page
     }
 
+    /// The returned `TempDir` deletes the database directory when it drops, so
+    /// callers must hold it for as long as they use the database.
     #[allow(clippy::arc_with_non_send_sync)]
-    fn get_database() -> Arc<Database> {
-        let mut path = TempDir::new().unwrap().keep();
-        path.push("test.db");
+    fn get_database() -> (Arc<Database>, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test.db");
         {
             let connection = rusqlite::Connection::open(&path).unwrap();
             connection
@@ -10072,7 +10074,7 @@ mod tests {
         let db = Database::open_file(io.clone(), path.to_str().unwrap(), Arc::new(SqliteDialect))
             .unwrap();
 
-        db
+        (db, temp_dir)
     }
 
     /// Deterministic coverage for the allocation-failure window created by routing
@@ -10544,7 +10546,7 @@ mod tests {
 
     #[test]
     fn test_insert_cell() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
         let page = get_page(2);
 
@@ -10568,7 +10570,7 @@ mod tests {
 
     #[test]
     fn test_drop_1() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -11589,7 +11591,7 @@ mod tests {
 
     #[test]
     pub fn test_drop_odd() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12413,7 +12415,7 @@ mod tests {
 
     #[test]
     pub fn test_defragment() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12454,7 +12456,7 @@ mod tests {
 
     #[test]
     pub fn test_drop_odd_with_defragment() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12501,7 +12503,7 @@ mod tests {
 
     #[test]
     pub fn test_fuzz_drop_defragment_insert() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12585,7 +12587,7 @@ mod tests {
     pub fn test_fuzz_drop_defragment_insert_issue_1085() {
         // This test is used to demonstrate that issue at https://github.com/tursodatabase/turso/issues/1085
         // is FIXED.
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12665,7 +12667,7 @@ mod tests {
     //   +cells:
     #[test]
     pub fn test_drop_page_in_balancing_issue_1203() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let queries = vec![
@@ -12704,7 +12706,7 @@ mod tests {
     //   +cells:
     #[test]
     pub fn test_drop_page_in_balancing_issue_1203_2() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let queries = vec![
@@ -12758,7 +12760,7 @@ mod tests {
 
     #[test]
     pub fn test_free_space() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
         let page = get_page(2);
 
@@ -12775,7 +12777,7 @@ mod tests {
 
     #[test]
     pub fn test_defragment_1() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12797,7 +12799,7 @@ mod tests {
 
     #[test]
     pub fn test_insert_drop_insert() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12828,7 +12830,7 @@ mod tests {
 
     #[test]
     pub fn test_insert_drop_insert_multiple() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12861,7 +12863,7 @@ mod tests {
 
     #[test]
     pub fn test_drop_a_few_insert() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12887,7 +12889,7 @@ mod tests {
 
     #[test]
     pub fn test_fuzz_victim_1() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12919,7 +12921,7 @@ mod tests {
 
     #[test]
     pub fn test_fuzz_victim_2() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -12960,7 +12962,7 @@ mod tests {
 
     #[test]
     pub fn test_fuzz_victim_3() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);
@@ -13057,7 +13059,7 @@ mod tests {
 
     #[test]
     pub fn test_big_payload_compute_free() {
-        let db = get_database();
+        let (db, _temp_dir) = get_database();
         let conn = db.connect().unwrap();
 
         let page = get_page(2);

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -6701,9 +6701,11 @@ mod checkpoint_phase_tests {
         }
     }
 
-    fn open_checkpoint_test_database() -> (Arc<Database>, std::path::PathBuf) {
-        let dir = tempfile::tempdir().unwrap().keep();
-        let db_path = dir.join("test.db");
+    /// The returned `TempDir` deletes the database directory when it drops, so
+    /// callers must hold it for as long as they use the database.
+    fn open_checkpoint_test_database() -> (Arc<Database>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
         {
             let connection = rusqlite::Connection::open(&db_path).unwrap();
             connection
@@ -6734,7 +6736,7 @@ mod checkpoint_phase_tests {
     #[test]
     fn checkpoint_db_sync_completion_still_leaves_backfill_unpublished_until_proof_install() {
         let (db, dir) = open_checkpoint_test_database();
-        let db_path = dir.join("test.db");
+        let db_path = dir.path().join("test.db");
         let conn = db.connect().unwrap();
         conn.wal_auto_actions_disable();
         conn.execute("create table test(id integer primary key, value blob)")

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -5965,11 +5965,12 @@ pub mod test {
         }
     }
 
+    /// The returned `TempDir` deletes the database directory when it drops, so
+    /// callers must hold it for as long as they use the database.
     #[allow(clippy::arc_with_non_send_sync)]
-    pub(crate) fn get_database() -> (Arc<Database>, std::path::PathBuf) {
-        let mut path = tempfile::tempdir().unwrap().keep();
-        let dbpath = path.clone();
-        path.push("test.db");
+    pub(crate) fn get_database() -> (Arc<Database>, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("test.db");
         {
             let connection = rusqlite::Connection::open(&path).unwrap();
             connection
@@ -5987,7 +5988,7 @@ pub mod test {
         )
         .unwrap();
         // db + tmp directory
-        (db, dbpath)
+        (db, temp_dir)
     }
 
     struct DeferredReadFile {
@@ -6118,9 +6119,7 @@ pub mod test {
     #[test]
     fn test_wal_truncate_checkpoint() {
         let (db, path) = get_database();
-        let mut walpath = path.clone().into_os_string().into_string().unwrap();
-        walpath.push_str("/test.db-wal");
-        let walpath = std::path::PathBuf::from(walpath);
+        let walpath = path.path().join("test.db-wal");
 
         let conn = db.connect().unwrap();
         conn.execute("create table test (id integer primary key, value text)")
@@ -6154,7 +6153,6 @@ pub mod test {
             bytes_after, 0,
             "WAL file should be truncated to 0 bytes, but is {bytes_after} bytes",
         );
-        std::fs::remove_dir_all(path).unwrap();
     }
 
     #[test]
@@ -6164,9 +6162,7 @@ pub mod test {
     )]
     fn test_shutdown_checkpoint_truncates_after_restart() {
         let (db, path) = get_database();
-        let mut walpath = path.clone().into_os_string().into_string().unwrap();
-        walpath.push_str("/test.db-wal");
-        let walpath = std::path::PathBuf::from(walpath);
+        let walpath = path.path().join("test.db-wal");
 
         let conn = db.connect().unwrap();
         conn.execute("create table test (id integer primary key, value text)")
@@ -6190,7 +6186,6 @@ pub mod test {
             bytes_after, 0,
             "Shutdown checkpoint should truncate WAL after RESTART, but WAL is {bytes_after} bytes",
         );
-        std::fs::remove_dir_all(path).unwrap();
     }
 
     fn bulk_inserts(conn: &Arc<Connection>, n_txns: usize, rows_per_txn: usize) {
@@ -8363,7 +8358,7 @@ pub mod test {
     #[test]
     fn test_restart_checkpoint_clears_backfill_proof_and_later_replaces_it() {
         let (db, path) = get_database();
-        let wal_path = path.join("test.db-wal");
+        let wal_path = path.path().join("test.db-wal");
         let wal_path_str = wal_path.to_str().unwrap();
         let conn = db.connect().unwrap();
         conn.wal_auto_actions_disable();
@@ -8451,7 +8446,7 @@ pub mod test {
     #[test]
     fn test_truncate_checkpoint_clears_backfill_proof_and_later_replaces_it() {
         let (db, path) = get_database();
-        let wal_path = path.join("test.db-wal");
+        let wal_path = path.path().join("test.db-wal");
         let wal_path_str = wal_path.to_str().unwrap();
         let conn = db.connect().unwrap();
         conn.wal_auto_actions_disable();
@@ -9492,11 +9487,7 @@ pub mod test {
     fn restart_checkpoint_reset_wal_state_handling() {
         let (db, path) = get_database();
 
-        let walpath = {
-            let mut p = path.clone().into_os_string().into_string().unwrap();
-            p.push_str("/test.db-wal");
-            std::path::PathBuf::from(p)
-        };
+        let walpath = path.path().join("test.db-wal");
 
         let conn = db.connect().unwrap();
         conn.execute("create table test(id integer primary key, value text)")
@@ -9584,8 +9575,6 @@ pub mod test {
             .unwrap();
         let new_max = wal_shared.read().metadata.max_frame.load(Ordering::SeqCst);
         assert_eq!(new_max, 1, "first append after RESTART starts at frame 1");
-
-        std::fs::remove_dir_all(path).unwrap();
     }
 
     #[test]
@@ -9673,7 +9662,7 @@ pub mod test {
 
     #[test]
     fn test_wal_restart_blocks_readers() {
-        let (db, _) = get_database();
+        let (db, _temp_dir) = get_database();
         let conn1 = db.connect().unwrap();
         let conn2 = db.connect().unwrap();
 
@@ -10017,11 +10006,7 @@ pub mod test {
         let (db, path) = get_database();
         let conn = db.connect().unwrap();
 
-        let walpath = {
-            let mut p = path.clone().into_os_string().into_string().unwrap();
-            p.push_str("/test.db-wal");
-            std::path::PathBuf::from(p)
-        };
+        let walpath = path.path().join("test.db-wal");
 
         conn.execute("create table test(id integer primary key, value text)")
             .unwrap();
@@ -10068,7 +10053,6 @@ pub mod test {
         assert_eq!(hdr.file_format, 3007000);
         assert_eq!(hdr.page_size, 4096, "invalid page size");
         assert_eq!(hdr.checkpoint_seq, 1, "invalid checkpoint_seq");
-        std::fs::remove_dir_all(path).unwrap();
     }
 
     #[test]
@@ -10076,11 +10060,7 @@ pub mod test {
         let (db, path) = get_database();
         let conn = db.connect().unwrap();
 
-        let walpath = {
-            let mut p = path.clone().into_os_string().into_string().unwrap();
-            p.push_str("/test.db-wal");
-            std::path::PathBuf::from(p)
-        };
+        let walpath = path.path().join("test.db-wal");
 
         conn.execute("create table test(id integer primary key, value text)")
             .unwrap();
@@ -10145,7 +10125,6 @@ pub mod test {
             count, 1001,
             "we should have 1001 rows in the table all together"
         );
-        std::fs::remove_dir_all(path).unwrap();
     }
 
     fn read_wal_header(path: &std::path::Path) -> sqlite3_ondisk::WalHeader {

--- a/postgres/tests/integration/common.rs
+++ b/postgres/tests/integration/common.rs
@@ -1,9 +1,26 @@
 use rand::{rng, RngCore};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 use turso_core::{Clock, Database, IO};
 use turso_pg::Connection;
+
+/// Temp directories holding test databases, deleted when the test process exits.
+///
+/// A directory cannot be owned by the `TempDatabase` that created it: some tests
+/// clone the path, drop the database to close it, and then reopen the file to
+/// check what was written. Deleting on drop would pull the file out from under
+/// them, so the directories are parked here for the life of the process instead.
+static TEMP_DIRS: Mutex<Vec<TempDir>> = Mutex::new(Vec::new());
+
+fn delete_at_process_exit(dir: TempDir) {
+    TEMP_DIRS.lock().unwrap().push(dir);
+}
+
+#[ctor::dtor]
+fn delete_temp_dirs() {
+    TEMP_DIRS.lock().unwrap().clear();
+}
 
 pub struct TempDatabase {
     pub path: PathBuf,
@@ -152,8 +169,9 @@ impl TempDatabaseBuilder {
         let db_name = self
             .db_name
             .unwrap_or_else(|| format!("test-{}.db", rng().next_u32()));
-        let mut db_path = TempDir::new().unwrap().keep();
-        db_path.push(db_name);
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join(db_name);
+        delete_at_process_exit(temp_dir);
 
         if let Some(init_sql) = &self.init_sql {
             let connection = rusqlite::Connection::open(&db_path).unwrap();

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -25,7 +25,7 @@ mod fuzz_tests {
     use rand_chacha::ChaCha8Rng;
     use rusqlite::{params, types::Value};
     use std::{collections::HashSet, io::Write};
-    use tempfile::{NamedTempFile, TempDir};
+    use tempfile::TempDir;
 
     use super::helpers;
     use core_tester::common::{
@@ -5651,10 +5651,11 @@ mod fuzz_tests {
 
             tracing::debug!(pending_byte_pgno, pending_byte);
 
-            let db_path = tempfile::NamedTempFile::new()?;
+            let temp_dir = tempfile::tempdir()?;
+            let db_path = temp_dir.path().join("test.db");
 
             {
-                let db = builder.clone().with_db_path(db_path.path()).build();
+                let db = builder.clone().with_db_path(&db_path).build();
 
                 let prev_pending_byte = TempDatabase::get_pending_byte();
                 tracing::debug!(prev_pending_byte);
@@ -5679,7 +5680,7 @@ mod fuzz_tests {
                 conn.close()?;
             }
 
-            rusqlite_integrity_check(db_path.path())?;
+            rusqlite_integrity_check(&db_path)?;
 
             TempDatabase::reset_pending_byte();
         }
@@ -7840,13 +7841,9 @@ mod fuzz_tests {
         let (mut rng, seed) = helpers::init_fuzz_test_tracing("test_data_layout_compatibility");
         const OUTER: usize = 100;
         const INNER: usize = 10;
-        let left = NamedTempFile::new().unwrap();
-        let right = NamedTempFile::new().unwrap();
-
-        let (_left, left) = left.keep().unwrap();
-        let (_right, right) = right.keep().unwrap();
-        // let left = left.path();
-        // let right = right.path();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let left = temp_dir.path().join("left.db");
+        let right = temp_dir.path().join("right.db");
 
         tracing::info!(
             "test_data_layout_compatibility seed: {}, left_path={:?}, right_path={:?}",

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -2,10 +2,28 @@ use rand::{rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use rusqlite::params;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use turso_core::{Clock, Connection, Database, FromValueRow, Row, SqliteDialect, IO};
+
+/// Temp directories holding test databases, deleted when the test process exits.
+///
+/// A directory cannot be owned by the `TempDatabase` that created it: plenty of
+/// tests clone the path, drop the database to close it, and then reopen the file
+/// to check what was written. Deleting on drop would pull the file out from
+/// under them, so the directories are parked here for the life of the process
+/// instead.
+static TEMP_DIRS: Mutex<Vec<TempDir>> = Mutex::new(Vec::new());
+
+fn delete_at_process_exit(dir: TempDir) {
+    TEMP_DIRS.lock().unwrap().push(dir);
+}
+
+#[ctor::dtor]
+fn delete_temp_dirs() {
+    TEMP_DIRS.lock().unwrap().clear();
+}
 
 pub struct TempDatabase {
     pub path: PathBuf,
@@ -184,8 +202,9 @@ impl TempDatabaseBuilder {
                 let db_name = self
                     .db_name
                     .unwrap_or_else(|| format!("test-{}.db", rng().next_u32()));
-                let mut db_path = TempDir::new().unwrap().keep();
-                db_path.push(db_name);
+                let temp_dir = TempDir::new().unwrap();
+                let db_path = temp_dir.path().join(db_name);
+                delete_at_process_exit(temp_dir);
                 db_path
             }
         };
@@ -677,7 +696,7 @@ impl_exec_rows_for_tuple!(T0: 0, T1: 1, T2: 2, T3: 3, T4: 4, T5: 5, T6: 6, T7: 7
 #[cfg(test)]
 mod tests {
     use std::{sync::Arc, vec};
-    use tempfile::{NamedTempFile, TempDir};
+    use tempfile::TempDir;
     use turso_core::SqliteDialect;
     use turso_core::{Database, StepResult, IO};
 
@@ -725,7 +744,8 @@ mod tests {
 
     #[test]
     fn test_limbo_open_read_only() -> anyhow::Result<()> {
-        let path = TempDir::new().unwrap().keep().join("temp_read_only");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_read_only");
         {
             let db =
                 TempDatabase::new_with_existent_with_flags(&path, turso_core::OpenFlags::default());
@@ -790,7 +810,8 @@ mod tests {
 
     #[test]
     fn test_large_unique_blobs() -> anyhow::Result<()> {
-        let path = TempDir::new().unwrap().keep().join("temp_read_only");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_read_only");
         let db = TempDatabase::new_with_existent(&path);
         let conn = db.connect_limbo();
 
@@ -813,10 +834,8 @@ mod tests {
     #[test]
     /// Test that a transaction cannot read uncommitted changes of another transaction (no: READ UNCOMMITTED)
     fn test_tx_isolation_no_dirty_reads() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_transaction_isolation");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_transaction_isolation");
         let db = TempDatabase::new_with_existent(&path);
 
         // Create two separate connections
@@ -844,10 +863,8 @@ mod tests {
     #[test]
     /// Test that a transaction cannot read committed changes that were committed after the transaction started (no: READ COMMITTED)
     fn test_tx_isolation_no_read_committed() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_transaction_isolation");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_transaction_isolation");
         let db = TempDatabase::new_with_existent(&path);
 
         // Create two separate connections
@@ -881,10 +898,8 @@ mod tests {
     /// Test that a txn can write a row, flush to WAL without committing, then rollback, and finally commit a second row.
     /// Reopening database should show only the second row.
     fn test_tx_isolation_cacheflush_rollback_commit() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_transaction_isolation");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_transaction_isolation");
         let db = TempDatabase::new_with_existent(&path);
 
         let conn = db.connect_limbo();
@@ -917,10 +932,8 @@ mod tests {
     #[test]
     /// Test that a txn can write a row and flush to WAL without committing, then reopen DB and not see the row
     fn test_tx_isolation_cacheflush_reopen() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_transaction_isolation");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_transaction_isolation");
         let db = TempDatabase::new_with_existent(&path);
 
         let conn = db.connect_limbo();
@@ -948,9 +961,14 @@ mod tests {
 
     #[test]
     fn test_multi_connection_table_drop_persistence() -> Result<(), Box<dyn std::error::Error>> {
-        // Create a temporary database file
-        let temp_file = NamedTempFile::new()?;
-        let db_path = temp_file.path().to_string_lossy().to_string();
+        // Create a temporary database file. It lives inside a temp directory so
+        // the WAL sidecar the engine creates next to it is cleaned up too.
+        let temp_dir = TempDir::new()?;
+        let db_path = temp_dir
+            .path()
+            .join("test.db")
+            .to_string_lossy()
+            .to_string();
 
         // Open database
         #[allow(clippy::arc_with_non_send_sync)]
@@ -1092,10 +1110,8 @@ mod tests {
     /// (same pattern as DROP TABLE).
     #[test]
     fn test_drop_sequence_with_existing_tables() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_drop_seq_with_tables");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_drop_seq_with_tables");
         let db = TempDatabase::new_with_existent(&path);
         let conn = db.connect_limbo();
 
@@ -1122,10 +1138,8 @@ mod tests {
 
     #[test]
     fn test_currval_per_connection_isolation() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_currval_isolation");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_currval_isolation");
         let db = TempDatabase::new_with_existent(&path);
         let conn1 = db.connect_limbo();
         conn1.execute("CREATE SEQUENCE iso_seq")?;
@@ -1167,7 +1181,8 @@ mod tests {
     /// (nextval, currval, setval) work correctly on the reopened database.
     #[test]
     fn test_sequence_file_persistence() -> anyhow::Result<()> {
-        let path = TempDir::new().unwrap().keep().join("temp_seq_persist");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_seq_persist");
 
         // Phase 1: create sequences and advance them
         {
@@ -1242,7 +1257,8 @@ mod tests {
     /// watermark.
     #[test]
     fn test_sequence_nextval_persists_after_drop() -> anyhow::Result<()> {
-        let path = TempDir::new().unwrap().keep().join("temp_seq_crash");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_seq_crash");
 
         // Phase 1: create sequence, call nextval, then DROP everything (no close).
         {
@@ -1279,7 +1295,8 @@ mod tests {
     /// behavioral regression guard.
     #[test]
     fn test_setval_rollback_does_not_leak_to_nextval() -> anyhow::Result<()> {
-        let path = TempDir::new().unwrap().keep().join("temp_setval_rollback");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_setval_rollback");
         let db = TempDatabase::new_with_existent(&path);
         let conn = db.connect_limbo();
 
@@ -1307,10 +1324,8 @@ mod tests {
 
     #[test]
     fn test_sequence_cross_connection_visibility() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_sequence_cross_conn");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_sequence_cross_conn");
         let db = TempDatabase::new_with_existent(&path);
         let conn1 = db.connect_limbo();
 
@@ -1338,10 +1353,8 @@ mod tests {
     /// the same value.
     #[test]
     fn test_sequence_cross_connection_shared_counter() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_sequence_shared_counter");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_sequence_shared_counter");
         let db = TempDatabase::new_with_existent(&path);
         let conn1 = db.connect_limbo();
 
@@ -1403,10 +1416,8 @@ mod tests {
     /// to compact mid-call.
     #[test]
     fn test_mvcc_concurrent_nextval_no_conflict() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_concurrent_nextval");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_concurrent_nextval");
         let db = TempDatabase::builder()
             .with_db_path(&path)
             .with_mvcc(true)
@@ -1444,10 +1455,8 @@ mod tests {
     /// not un-burn it).
     #[test]
     fn test_mvcc_setval_persists_with_two_connections() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_setval_two_conn_mvcc");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_setval_two_conn_mvcc");
 
         {
             let db = TempDatabase::builder()
@@ -1502,10 +1511,8 @@ mod tests {
     /// durability gap in MVCC commit_txn.
     #[test]
     fn test_setval_persists_across_reopen_mvcc() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_setval_crash_mvcc");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_setval_crash_mvcc");
 
         {
             let db = TempDatabase::builder()
@@ -1550,7 +1557,8 @@ mod tests {
     /// nextval must return 51, not regress to the pre-setval watermark.
     #[test]
     fn test_setval_persists_across_reopen() -> anyhow::Result<()> {
-        let path = TempDir::new().unwrap().keep().join("temp_setval_crash");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_setval_crash");
 
         {
             let db = TempDatabase::new_with_existent(&path);
@@ -1606,10 +1614,8 @@ mod tests {
         // backing-table keys) or hit a WriteWriteConflict that surfaces as
         // the standard Busy/conflict error — the outer tx decides what to
         // do. setval inside a solo BEGIN CONCURRENT therefore succeeds.
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_setval_concurrent_ok");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_setval_concurrent_ok");
         let db = TempDatabase::builder()
             .with_db_path(&path)
             .with_mvcc(true)
@@ -1672,10 +1678,8 @@ mod tests {
     /// acceptance is sound under contention.
     #[test]
     fn test_setval_vs_nextval_concurrent_tx_mvcc_no_corruption() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_setval_vs_nextval_concurrent");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_setval_vs_nextval_concurrent");
         let db = TempDatabase::builder()
             .with_db_path(&path)
             .with_mvcc(true)
@@ -1776,10 +1780,8 @@ mod tests {
     #[cfg_attr(feature = "checksum", ignore)]
     #[test]
     fn test_descending_sequence_recovery() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_desc_seq_recovery");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_desc_seq_recovery");
 
         {
             let db = TempDatabase::new_with_existent(&path);
@@ -1835,10 +1837,8 @@ mod tests {
     /// transaction and ROLLBACK reverts the backing-table row.
     #[test]
     fn test_wal_nextval_rolled_back_re_emits_value() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_wal_nextval_rollback");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_wal_nextval_rollback");
         let db = TempDatabase::new_with_existent(&path);
         let conn = db.connect_limbo();
 
@@ -1871,10 +1871,8 @@ mod tests {
     /// this test will need to update its expectation.
     #[test]
     fn test_mvcc_nextval_rolled_back_re_emits_value_today() -> anyhow::Result<()> {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("temp_mvcc_nextval_rollback");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("temp_mvcc_nextval_rollback");
         let db = TempDatabase::builder()
             .with_db_path(&path)
             .with_mvcc(true)
@@ -1977,7 +1975,8 @@ mod tests {
         const THREADS: usize = 8;
         const PER_THREAD: usize = 50;
 
-        let path = TempDir::new().unwrap().keep().join("stress_nextval_wal");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("stress_nextval_wal");
         let db = TempDatabase::new_with_existent(&path);
         let conn = db.connect_limbo();
         conn.execute("CREATE SEQUENCE s START 1 INCREMENT 1")?;
@@ -2045,7 +2044,8 @@ mod tests {
         const THREADS: usize = 8;
         const PER_THREAD: usize = 50;
 
-        let path = TempDir::new().unwrap().keep().join("stress_nextval_mvcc");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("stress_nextval_mvcc");
         let db = TempDatabase::builder()
             .with_db_path(&path)
             .with_mvcc(true)
@@ -2111,7 +2111,8 @@ mod tests {
         const NEXTVAL_THREADS: usize = 4;
         const NEXTVAL_PER_THREAD: usize = 100;
 
-        let path = TempDir::new().unwrap().keep().join("stress_mixed_mvcc");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("stress_mixed_mvcc");
         let db = TempDatabase::builder()
             .with_db_path(&path)
             .with_mvcc(true)

--- a/tests/integration/custom_types.rs
+++ b/tests/integration/custom_types.rs
@@ -8,10 +8,8 @@ mod tests {
     /// list_types omits user-defined types.
     #[test]
     fn test_custom_types_persist_across_reopen() {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("custom_types_reopen.db");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("custom_types_reopen.db");
         let opts = turso_core::DatabaseOpts::new()
             .with_custom_types(true)
             .with_encryption(true);
@@ -60,10 +58,8 @@ mod tests {
     /// change and new tables must encode/decode correctly.
     #[test]
     fn test_custom_types_survive_schema_change_after_reopen() {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("custom_types_schema_change.db");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("custom_types_schema_change.db");
         let opts = turso_core::DatabaseOpts::new()
             .with_custom_types(true)
             .with_encryption(true);
@@ -125,10 +121,8 @@ mod tests {
     /// created by another connection, even without reopening the database file.
     #[test]
     fn test_new_connection_sees_custom_types() {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("custom_types_new_conn.db");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("custom_types_new_conn.db");
         let opts = turso_core::DatabaseOpts::new()
             .with_custom_types(true)
             .with_encryption(true);
@@ -167,10 +161,8 @@ mod tests {
     /// and that sequential UPSERTs do not progressively corrupt data.
     #[test]
     fn test_upsert_does_not_double_encode_custom_types() {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("custom_types_upsert.db");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("custom_types_upsert.db");
         let opts = turso_core::DatabaseOpts::new()
             .with_custom_types(true)
             .with_encryption(true);
@@ -257,10 +249,8 @@ mod tests {
     /// value and encoded it again, causing exponential corruption.
     #[test]
     fn test_multi_row_update_does_not_double_encode() {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("custom_types_multi_update.db");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("custom_types_multi_update.db");
         let opts = turso_core::DatabaseOpts::new()
             .with_custom_types(true)
             .with_encryption(true);
@@ -319,10 +309,8 @@ mod tests {
     /// and the vacuumed database must decode/encode correctly when reopened.
     #[test]
     fn test_vacuum_into_with_custom_types() {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("custom_types_vacuum_src.db");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("custom_types_vacuum_src.db");
         let dest_path = path.with_file_name("custom_types_vacuum_dest.db");
         let opts = turso_core::DatabaseOpts::new()
             .with_custom_types(true)
@@ -377,10 +365,8 @@ mod tests {
     /// causing a seek-key / index-key mismatch and returning no rows.
     #[test]
     fn test_self_join_on_custom_type_column() {
-        let path = TempDir::new()
-            .unwrap()
-            .keep()
-            .join("custom_types_self_join.db");
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("custom_types_self_join.db");
         let opts = turso_core::DatabaseOpts::new()
             .with_custom_types(true)
             .with_encryption(true);

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -856,9 +856,9 @@ fn test_wal_api_insert_exec_mix(db: TempDatabase) {
 // TODO: see later how this test should work with mvcc
 #[test]
 fn test_db_share_same_file() {
-    let mut path = TempDir::new().unwrap().keep();
+    let temp_dir = TempDir::new().unwrap();
     let (mut rng, _) = rng_from_time();
-    path.push(format!("test-{}.db", rng.next_u32()));
+    let path = temp_dir.path().join(format!("test-{}.db", rng.next_u32()));
 
     let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
     let db_file = io

--- a/tests/integration/query_processing/encryption.rs
+++ b/tests/integration/query_processing/encryption.rs
@@ -766,12 +766,14 @@ const CIPHER_B: &str = "aes256gcm";
 
 /// Helper: create an encrypted database file with the given cipher, hexkey, table name, and value.
 /// Returns the file path.
+/// The returned `TempDir` deletes the database directory when it drops, so
+/// callers must hold it for as long as they use the database.
 fn create_encrypted_db(
     cipher: &str,
     hexkey: &str,
     table_name: &str,
     value: &str,
-) -> anyhow::Result<std::path::PathBuf> {
+) -> anyhow::Result<(std::path::PathBuf, tempfile::TempDir)> {
     let temp_dir = tempfile::tempdir()?;
     let db_path = temp_dir
         .path()
@@ -811,9 +813,7 @@ fn create_encrypted_db(
         io.wait_for_completion(c)?;
     }
 
-    // Keep the temp dir alive by leaking it (the test process will clean up)
-    std::mem::forget(temp_dir);
-    Ok(db_path)
+    Ok((db_path, temp_dir))
 }
 
 /// Helper: open a plain (unencrypted) main database with attach + encryption enabled.
@@ -830,8 +830,8 @@ fn test_attach_encrypted_database(_tmp_db: TempDatabase) -> anyhow::Result<()> {
     let _ = env_logger::try_init();
 
     // Create two encrypted databases with different keys and ciphers
-    let path_a = create_encrypted_db(CIPHER_A, KEY_A, "secret_a", "data from A")?;
-    let path_b = create_encrypted_db(CIPHER_B, KEY_B, "secret_b", "data from B")?;
+    let (path_a, _dir_a) = create_encrypted_db(CIPHER_A, KEY_A, "secret_a", "data from A")?;
+    let (path_b, _dir_b) = create_encrypted_db(CIPHER_B, KEY_B, "secret_b", "data from B")?;
 
     // --- Test 1: Happy path — attach both with correct keys ---
     {

--- a/tests/integration/query_processing/test_alter_table_reopen.rs
+++ b/tests/integration/query_processing/test_alter_table_reopen.rs
@@ -15,9 +15,9 @@ use tempfile::TempDir;
 /// the persisted schema as AUTOINCREMENT and avoid reusing deleted rowids.
 #[test]
 fn test_alter_table_drop_column_preserves_autoincrement_reopen() {
-    let path = TempDir::new()
-        .unwrap()
-        .keep()
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir
+        .path()
         .join("alter_drop_col_autoincrement_reopen.db");
 
     {
@@ -76,10 +76,8 @@ fn test_alter_table_drop_column_preserves_autoincrement_reopen() {
 /// must succeed (no orphan autoindex) and the unique constraint must still be enforced.
 #[test]
 fn test_alter_table_add_column_preserves_unique_constraint_reopen() {
-    let path = TempDir::new()
-        .unwrap()
-        .keep()
-        .join("alter_add_col_unique_reopen.db");
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("alter_add_col_unique_reopen.db");
 
     // Session 1: create table with table-level UNIQUE, add column, close
     {
@@ -124,10 +122,8 @@ fn test_alter_table_add_column_preserves_unique_constraint_reopen() {
 /// reopen must succeed and both constraints must still be enforced.
 #[test]
 fn test_alter_table_add_column_preserves_multiple_unique_constraints_reopen() {
-    let path = TempDir::new()
-        .unwrap()
-        .keep()
-        .join("alter_add_col_multi_unique_reopen.db");
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("alter_add_col_multi_unique_reopen.db");
 
     // Session 1: create table with two table-level UNIQUEs, add column, close
     {
@@ -205,10 +201,8 @@ fn test_alter_add_generated_column_rejected_without_flag() {
 /// accepted when --experimental-generated-columns is enabled
 #[test]
 fn test_alter_add_generated_column_succeeds_with_flag() {
-    let path = TempDir::new()
-        .unwrap()
-        .keep()
-        .join("alter_add_generated_column.db");
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("alter_add_generated_column.db");
     let opts = turso_core::DatabaseOpts::new().with_generated_columns(true);
 
     {

--- a/tests/integration/query_processing/test_schema_updated.rs
+++ b/tests/integration/query_processing/test_schema_updated.rs
@@ -220,9 +220,9 @@ fn test_deferred_seeks_resize_on_reprepare(tmp_db: TempDatabase) -> Result<()> {
 /// sequence row.
 #[test]
 fn test_alter_table_alter_column_clears_autoincrement_reopen() {
-    let path = TempDir::new()
-        .unwrap()
-        .keep()
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir
+        .path()
         .join("alter_col_autoincrement_clear_reopen.db");
 
     {

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -2180,7 +2180,8 @@ fn test_mvcc_autoincrement_stress_multipage(tmp_db: TempDatabase) {
 /// high-water mark. No ID reuse is ever acceptable.
 #[test]
 fn test_autoincrement_watermark_survives_restart() {
-    let path = TempDir::new().unwrap().keep().join("p1_autoinc_restart");
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("p1_autoinc_restart");
 
     // Phase 1: create table, insert rows, close
     {
@@ -2229,7 +2230,8 @@ fn test_autoincrement_watermark_survives_restart() {
 /// nextval must return a value past the previously committed high-water mark.
 #[test]
 fn test_user_sequence_watermark_survives_restart_mvcc() {
-    let path = TempDir::new().unwrap().keep().join("p1_user_seq_restart");
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("p1_user_seq_restart");
 
     // Phase 1: create sequence, advance it, close
     {

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1153,9 +1153,10 @@ pub fn concurrent_rollback_and_insert_over_single_connection(limbo: TempDatabase
 #[test]
 fn test_unique_complex_key() {
     let _ = env_logger::try_init();
-    let db_path = tempfile::NamedTempFile::new().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("test.db");
     {
-        let connection = rusqlite::Connection::open(db_path.path()).unwrap();
+        let connection = rusqlite::Connection::open(&db_path).unwrap();
         connection
             .execute("CREATE TABLE t(a, b, c, UNIQUE (b, a));", ())
             .unwrap();
@@ -1164,7 +1165,7 @@ fn test_unique_complex_key() {
             .unwrap();
     }
 
-    let tmp_db = TempDatabase::builder().with_db_path(db_path.path()).build();
+    let tmp_db = TempDatabase::builder().with_db_path(&db_path).build();
     let conn = tmp_db.connect_limbo();
 
     let rows: Vec<(String, String, String)> = conn.exec_rows("SELECT * FROM t");
@@ -1378,8 +1379,8 @@ pub fn test_savepoint_rollback_uses_current_wal_snapshot(
 #[test]
 pub fn test_reopen_database_wal_restart() {
     let _ = env_logger::try_init();
-    let db_path = tempfile::NamedTempFile::new().unwrap();
-    let (_file, db_path) = db_path.keep().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("test.db");
     tracing::info!("path: {:?}", db_path);
     {
         let tmp_db = TempDatabase::builder().with_db_path(&db_path).build();
@@ -1422,8 +1423,8 @@ pub fn test_reopen_database_wal_restart() {
 /// Here, we simulate BusySnapshot condition when during IO in between of begin_read_tx and begin_write_tx, another connection commited some change
 pub fn test_busy_snapshot_immediate() {
     let _ = env_logger::try_init();
-    let db_path = tempfile::NamedTempFile::new().unwrap();
-    let (_file, db_path) = db_path.keep().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("test.db");
     tracing::info!("path: {:?}", db_path);
     let tmp_db = TempDatabase::builder()
         .with_db_path(&db_path)
@@ -1475,8 +1476,8 @@ pub fn test_busy_snapshot_immediate() {
 /// Here, we simulate BusySnapshot condition when transaction upgraded in the middle, but since its started another connection commited changes
 pub fn test_busy_snapshot_txn_upgrade() {
     let _ = env_logger::try_init();
-    let db_path = tempfile::NamedTempFile::new().unwrap();
-    let (_file, db_path) = db_path.keep().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("test.db");
     tracing::info!("path: {:?}", db_path);
     let tmp_db = TempDatabase::builder().with_db_path(&db_path).build();
     let conn1 = tmp_db.connect_limbo();
@@ -1512,8 +1513,8 @@ pub fn test_busy_snapshot_txn_upgrade() {
 /// The tricky part is that auto-checkpoint happens in between which can result in reuse of a page if checkpoint epoch do not properly incremented during auto-checkpoint
 pub fn test_auto_checkpoint_restart() {
     let _ = env_logger::try_init();
-    let db_path = tempfile::NamedTempFile::new().unwrap();
-    let (_file, db_path) = db_path.keep().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("test.db");
     tracing::info!("path: {:?}", db_path);
     let tmp_db = TempDatabase::builder().with_db_path(&db_path).build();
     let conn1 = tmp_db.connect_limbo();
@@ -1560,8 +1561,8 @@ pub fn test_wal_truncate_checkpoint() {
             break;
         }
         let _ = env_logger::try_init();
-        let db_path = tempfile::NamedTempFile::new().unwrap();
-        let (_file, db_path) = db_path.keep().unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("test.db");
         tracing::info!("path: {:?}", db_path);
         let tmp_db = TempDatabase::builder().with_db_path(&db_path).build();
         let conn1 = tmp_db.connect_limbo();
@@ -1612,8 +1613,8 @@ pub fn test_empty_wal_truncate_checkpoint() {
             break;
         }
         let _ = env_logger::try_init();
-        let db_path = tempfile::NamedTempFile::new().unwrap();
-        let (_file, db_path) = db_path.keep().unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("test.db");
         tracing::info!("path: {:?}", db_path);
         let tmp_db = TempDatabase::builder().with_db_path(&db_path).build();
         let conn1 = tmp_db.connect_limbo();
@@ -1656,8 +1657,8 @@ pub fn test_empty_wal_truncate_checkpoint() {
 #[test]
 pub fn test_mvcc_reader_stale_snapshot_after_schema_updated_returns_ok() {
     let _ = env_logger::try_init();
-    let db_path = tempfile::NamedTempFile::new().unwrap();
-    let (_file, db_path) = db_path.keep().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("test.db");
     tracing::info!("path: {:?}", db_path);
     let tmp_db = TempDatabase::builder()
         .with_db_path(&db_path)
@@ -1703,8 +1704,8 @@ pub fn test_mvcc_reader_stale_snapshot_after_schema_updated_returns_ok() {
 #[test]
 pub fn test_mvcc_writer_stale_snapshot_after_schema_updated() {
     let _ = env_logger::try_init();
-    let db_path = tempfile::NamedTempFile::new().unwrap();
-    let (_file, db_path) = db_path.keep().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("test.db");
     tracing::info!("path: {:?}", db_path);
     let tmp_db = TempDatabase::builder()
         .with_db_path(&db_path)
@@ -1866,8 +1867,8 @@ fn test_update_pk_on_attached_table_with_unique_index(tmp_db: TempDatabase) -> a
 #[test]
 pub fn test_mvcc_update_set_self_does_not_delete_rows() {
     let _ = env_logger::try_init();
-    let db_path = tempfile::NamedTempFile::new().unwrap();
-    let (_file, db_path) = db_path.keep().unwrap();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("test.db");
     let tmp_db = TempDatabase::builder().with_db_path(&db_path).build();
     let conn = tmp_db.connect_limbo();
 

--- a/tests/integration/statement_metadata.rs
+++ b/tests/integration/statement_metadata.rs
@@ -16,7 +16,6 @@
 #[cfg(test)]
 mod tests {
     use crate::common::{ExecRows, TempDatabase};
-    use tempfile::TempDir;
     use turso_core::{ColumnTypeInfo, ColumnTypeKind, Statement};
 
     /// Helper: open a fresh DB with custom types + STRICT support enabled.
@@ -25,9 +24,11 @@ mod tests {
     /// same opt — every test that exercises the rich type-info path uses
     /// this constructor.
     fn fresh_db_with_custom_types(name: &str) -> TempDatabase {
-        let path = TempDir::new().unwrap().keep().join(name);
         let opts = turso_core::DatabaseOpts::new().with_custom_types(true);
-        TempDatabase::new_with_existent_with_opts(&path, opts)
+        TempDatabase::builder()
+            .with_db_name(name)
+            .with_opts(opts)
+            .build()
     }
 
     /// Unwrap `Result<Option<ColumnTypeInfo>>` down to `ColumnTypeInfo`,

--- a/tests/integration/trigger.rs
+++ b/tests/integration/trigger.rs
@@ -1646,10 +1646,8 @@ fn test_after_trigger_insert_does_not_corrupt_index_cursor(db: TempDatabase) {
 /// expression-level column refs, causing "no such column: b" after DB reopen.
 #[test]
 fn test_trigger_cross_table_rename_column_persists() -> anyhow::Result<()> {
-    let path = tempfile::TempDir::new()
-        .unwrap()
-        .keep()
-        .join("trigger_rename_persist");
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("trigger_rename_persist");
     let db = TempDatabase::new_with_existent(&path);
     let conn = db.connect_limbo();
 
@@ -1688,10 +1686,8 @@ fn test_trigger_cross_table_rename_column_persists() -> anyhow::Result<()> {
 /// Cross-table trigger with qualified refs (src.b) persists after rename + reopen.
 #[test]
 fn test_trigger_cross_table_qualified_ref_persists() -> anyhow::Result<()> {
-    let path = tempfile::TempDir::new()
-        .unwrap()
-        .keep()
-        .join("trigger_qualified_persist");
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("trigger_qualified_persist");
     let db = TempDatabase::new_with_existent(&path);
     let conn = db.connect_limbo();
 
@@ -1726,10 +1722,8 @@ fn test_trigger_cross_table_qualified_ref_persists() -> anyhow::Result<()> {
 /// Cross-table trigger with UPDATE command persists after rename + reopen.
 #[test]
 fn test_trigger_cross_table_update_persists() -> anyhow::Result<()> {
-    let path = tempfile::TempDir::new()
-        .unwrap()
-        .keep()
-        .join("trigger_update_persist");
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("trigger_update_persist");
     let db = TempDatabase::new_with_existent(&path);
     let conn = db.connect_limbo();
 
@@ -1764,10 +1758,8 @@ fn test_trigger_cross_table_update_persists() -> anyhow::Result<()> {
 /// Cross-table trigger with DELETE command persists after rename + reopen.
 #[test]
 fn test_trigger_cross_table_delete_persists() -> anyhow::Result<()> {
-    let path = tempfile::TempDir::new()
-        .unwrap()
-        .keep()
-        .join("trigger_delete_persist");
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("trigger_delete_persist");
     let db = TempDatabase::new_with_existent(&path);
     let conn = db.connect_limbo();
 
@@ -1803,10 +1795,8 @@ fn test_trigger_cross_table_delete_persists() -> anyhow::Result<()> {
 /// must NOT have its SQL rewritten, and must survive reopen.
 #[test]
 fn test_trigger_no_false_rename_persists() -> anyhow::Result<()> {
-    let path = tempfile::TempDir::new()
-        .unwrap()
-        .keep()
-        .join("trigger_no_false_rename");
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("trigger_no_false_rename");
     let db = TempDatabase::new_with_existent(&path);
     let conn = db.connect_limbo();
 
@@ -1844,10 +1834,8 @@ fn test_trigger_no_false_rename_persists() -> anyhow::Result<()> {
 /// Same-table trigger (ON the table being renamed) with NEW.col refs persists.
 #[test]
 fn test_trigger_same_table_new_ref_persists() -> anyhow::Result<()> {
-    let path = tempfile::TempDir::new()
-        .unwrap()
-        .keep()
-        .join("trigger_same_table_persist");
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("trigger_same_table_persist");
     let db = TempDatabase::new_with_existent(&path);
     let conn = db.connect_limbo();
 
@@ -1879,10 +1867,8 @@ fn test_trigger_same_table_new_ref_persists() -> anyhow::Result<()> {
 /// Trigger with aggregate function (SUM) on cross-table column persists.
 #[test]
 fn test_trigger_cross_table_aggregate_persists() -> anyhow::Result<()> {
-    let path = tempfile::TempDir::new()
-        .unwrap()
-        .keep()
-        .join("trigger_agg_persist");
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("trigger_agg_persist");
     let db = TempDatabase::new_with_existent(&path);
     let conn = db.connect_limbo();
 
@@ -1918,10 +1904,8 @@ fn test_trigger_cross_table_aggregate_persists() -> anyhow::Result<()> {
 /// Multiple triggers, one cross-table and one same-table, both persist correctly.
 #[test]
 fn test_trigger_mixed_same_and_cross_table_persists() -> anyhow::Result<()> {
-    let path = tempfile::TempDir::new()
-        .unwrap()
-        .keep()
-        .join("trigger_mixed_persist");
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("trigger_mixed_persist");
     let db = TempDatabase::new_with_existent(&path);
     let conn = db.connect_limbo();
 
@@ -1967,10 +1951,8 @@ fn test_trigger_mixed_same_and_cross_table_persists() -> anyhow::Result<()> {
 /// Trigger UPSERT clauses must be rewritten in sqlite_schema so they survive reopen.
 #[test]
 fn test_trigger_upsert_clause_persists_after_rename() -> anyhow::Result<()> {
-    let path = tempfile::TempDir::new()
-        .unwrap()
-        .keep()
-        .join("trigger_upsert_persist");
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let path = temp_dir.path().join("trigger_upsert_persist");
     let db = TempDatabase::new_with_existent(&path);
     let conn = db.connect_limbo();
 


### PR DESCRIPTION
Test helpers called `TempDir::keep()`, which hands back the path and gives up the deletion guard, so every run left database files, their WAL sidecars, and the containing directories behind in the system temp directory. Tests that used `NamedTempFile` leaked the same way, since the sidecars the engine writes next to the database are not covered by the named file's guard.

Helpers now return the `TempDir` to the caller so the directory dies with the test, and databases live inside a directory rather than being a bare temp file. Two cases cannot use plain scoping:

  - `TempDatabase` callers routinely keep the path, drop the database to close it, and reopen the file to check what was written. Deleting on drop would pull the file out from under them, so those directories are parked in a process-global list that a `ctor::dtor` clears at exit.
  - The child process spawned by the file-locking test reruns the whole test binary and leaves through `process::exit`, so its destructors never run. It now gets its own TMPDIR that the parent deletes once the child is reaped.

Removing the databases through the guard also means they get cleaned up when a test panics, which the explicit `remove_dir_all` calls at the end of the WAL tests did not do.

Tests: cargo test for turso_core, core_tester (integration + fuzz), and turso_pg_tests, each with an isolated TMPDIR; nothing left behind afterwards except a lock file owned by the serial_test crate.