### PR TITLE
core: report one SQLite version everywhere

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -6,6 +6,7 @@ use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use tracing::trace;
+use turso_core::dialect::sqlite::{SQLITE_VERSION, SQLITE_VERSION_NUMBER};
 use turso_core::SqliteDialect;
 use turso_core::{CheckpointMode, DatabaseOpts, LimboError, Value};
 use turso_ext::ScalarFunction;
@@ -13,6 +14,7 @@ use turso_ext::Value as ExtValue;
 
 /// Global flag: when set, all subsequently opened databases enable experimental features.
 static EXPERIMENTAL_ENABLED: AtomicBool = AtomicBool::new(false);
+static SQLITE_VERSION_C_STRING: OnceLock<CString> = OnceLock::new();
 
 /// Global B-tree search counter exposed to the TCL test harness as
 /// `sqlite_search_count`.
@@ -2780,12 +2782,16 @@ pub unsafe extern "C" fn sqlite3_threadsafe() -> ffi::c_int {
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_libversion() -> *const ffi::c_char {
-    c"3.42.0".as_ptr()
+    SQLITE_VERSION_C_STRING
+        .get_or_init(|| {
+            CString::new(SQLITE_VERSION).expect("SQLITE_VERSION must not contain a NUL byte")
+        })
+        .as_ptr()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_libversion_number() -> ffi::c_int {
-    3042000
+    SQLITE_VERSION_NUMBER
 }
 
 fn sqlite3_errstr_impl(rc: i32) -> *const ffi::c_char {

--- a/bindings/c/tests/compat/mod.rs
+++ b/bindings/c/tests/compat/mod.rs
@@ -213,6 +213,8 @@ mod tests {
         unsafe {
             let version = sqlite3_libversion();
             assert!(!version.is_null());
+            #[cfg(not(feature = "sqlite3"))]
+            assert_eq!(std::ffi::CStr::from_ptr(version), c"3.50.4");
         }
     }
 
@@ -220,7 +222,10 @@ mod tests {
     fn test_libversion_number() {
         unsafe {
             let version_num = sqlite3_libversion_number();
-            assert!(version_num >= 3042000);
+            #[cfg(feature = "sqlite3")]
+            assert!(version_num > 0);
+            #[cfg(not(feature = "sqlite3"))]
+            assert_eq!(version_num, 3050004);
         }
     }
 

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -13,6 +13,12 @@ use crate::sync::Arc;
 use crate::vtab::{VirtualTable, VirtualTableType};
 use turso_ext::VTabKind;
 
+/// SQLite version reported by compatibility APIs.
+pub const SQLITE_VERSION: &str = "3.50.4";
+
+/// Integer form of [`SQLITE_VERSION`] used by `sqlite3_libversion_number()`.
+pub const SQLITE_VERSION_NUMBER: i32 = 3_050_004;
+
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
 use crate::function::FtsFunc;
 #[cfg(feature = "json")]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -17272,7 +17272,7 @@ fn parse_test_uint(reg: &Register) -> Result<Option<u64>> {
 
 // Compat for applications that test for SQLite.
 fn execute_sqlite_version() -> String {
-    "3.50.4".to_string()
+    crate::dialect::sqlite::SQLITE_VERSION.to_string()
 }
 
 fn execute_turso_version(version_integer: i64) -> String {
@@ -18760,6 +18760,14 @@ mod tests {
 
     #[test]
     fn test_execute_sqlite_version() {
+        assert_eq!(
+            execute_sqlite_version(),
+            crate::dialect::sqlite::SQLITE_VERSION
+        );
+    }
+
+    #[test]
+    fn test_execute_turso_version() {
         let version_integer = 3046001;
         let expected = "3.46.1";
         assert_eq!(execute_turso_version(version_integer), expected);


### PR DESCRIPTION
The C API and the sqlite_version() SQL function each carried their own
hardcoded version string, and they disagreed: sqlite3_libversion()
returned 3.42.0 while sqlite_version() returned 3.50.4. Applications
that probe for feature support through the C API therefore saw a
different SQLite than the one the query engine claims to be.

Put the version in a single place, SQLITE_VERSION in
core/dialect/sqlite.rs, together with the integer form
sqlite3_libversion_number() needs, and have both callers read from it.
The C string is built once into a OnceLock so the pointer handed to C
stays valid for the process lifetime.

Tests: the compat tests now pin the exact version instead of asserting
a lower bound, so the two spellings cannot drift apart again; skipped
when the sqlite3 feature links the real library.
