### PR TITLE
bindings/tcl: enable ATTACH for the upstream TCL harness

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -33,7 +33,8 @@ fn default_db_opts() -> DatabaseOpts {
         opts = opts
             .with_generated_columns(true)
             .with_vacuum(true)
-            .with_without_rowid(true);
+            .with_without_rowid(true)
+            .with_attach(true);
     }
     opts
 }

--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -1,9 +1,11 @@
 # Probe tests for the native Turso TCL extension (bindings/tcl/turso_tcl.c).
 #
-# Validates the three capabilities that the subprocess shim cannot provide:
+# Validates the capabilities that the subprocess shim cannot provide:
 #   1. Real engine error codes via [db errorcode].
 #   2. Accurate DML change counters via [db changes] / [db total_changes].
 #   3. In-process Tcl function registration via [db func].
+#   4. Rows from every statement of a multi-statement [db eval].
+#   5. ATTACH / DETACH, which the engine gates behind its experimental flag.
 #
 # Run via:
 #   LD_LIBRARY_PATH=target/debug tclsh bindings/tcl/test_probes.tcl
@@ -109,6 +111,20 @@ set multi_sql {
 }
 assert_eq "multi-statement db eval keeps rows from every statement" \
     {1 one 2 two 2} [db eval $multi_sql]
+
+# ---------------------------------------------------------------------------
+# Probe 5: ATTACH and DETACH.
+# The engine refuses ATTACH unless the database was opened with the attach
+# option, which the tursodb CLI spells --experimental-attach. The module turns
+# that option on for every database it opens, so the upstream attach*.test
+# files get a working ATTACH instead of an immediate "experimental feature"
+# error.
+# ---------------------------------------------------------------------------
+
+assert_eq "ATTACH is accepted" "" [db eval {ATTACH ':memory:' AS aux}]
+db eval {CREATE TABLE aux.t5(x); INSERT INTO aux.t5 VALUES (42);}
+assert_eq "attached database is queryable" 42 [db eval {SELECT x FROM aux.t5}]
+assert_eq "DETACH is accepted" "" [db eval {DETACH aux}]
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
The upstream TCL harness loads libturso_tcl, which opens databases
through the turso_sqlite3 C API rather than the tursodb CLI. The module
already turns on experimental features, but that set covered only
generated columns, vacuum, and WITHOUT ROWID, so enable_attach stayed
false and every ATTACH failed with the "experimental feature" error.
That killed attach.test mid-file and left attach3.test failing 43 of 45
tests.

Add attach to the experimental set. This matches the legacy harness,
where scripts/limbo-sqlite3 already passes --experimental-attach.

Tests: attach.test now runs all 112 tests (45 failing) instead of dying
at line 534; attach3.test drops from 43 failures to 16. A full
sqlite/conformance/upstream/all.test sweep stays green at 158399/168599
(94.0%) with no blessed file regressing and no known-bad file needing
to be blessed. New probe 5 in bindings/tcl/test_probes.tcl covers
ATTACH, a write and read through the attached database, and DETACH.
