### PR TITLE
core/vdbe: keep the transaction alive when COMMIT's view merge yields I/O

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4831,9 +4831,10 @@ pub fn op_auto_commit(
 
     // Drive any multi-step commit/rollback that's already in progress.
     // This handles main DB commits (Committing), attached DB commits
-    // (CommittingAttached), MVCC commits (CommittingMvcc), and attached
-    // MVCC commits (CommittingAttachedMvcc) that yielded on IO and need re-entry.
-    if !matches!(state.commit_state, CommitState::Ready) {
+    // (CommittingAttached), MVCC commits (CommittingMvcc), attached
+    // MVCC commits (CommittingAttachedMvcc), and the view-delta merge that
+    // precedes all of them, any of which may have yielded on IO.
+    if state.commit_in_flight() {
         let res = program
             .commit_txn(pager.clone(), state, mv_store.as_ref(), *rollback)
             .map(Into::into);

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1143,6 +1143,19 @@ impl ProgramState {
         self.n_total_change.fetch_add(1, Ordering::SeqCst);
     }
 
+    /// Whether an explicit COMMIT/ROLLBACK that already performed its
+    /// autocommit transition is still in flight, so a fresh `op_transaction`
+    /// entry is an I/O re-entry rather than a new statement.
+    ///
+    /// `commit_state` alone does not cover this: `commit_txn` applies view
+    /// deltas first, and that phase can yield I/O while `commit_state` is
+    /// still `Ready`.
+    #[inline]
+    pub(crate) fn commit_in_flight(&self) -> bool {
+        !matches!(self.commit_state, CommitState::Ready)
+            || !matches!(self.view_delta_state, ViewDeltaCommitState::NotStarted)
+    }
+
     /// Whether this statement may finish the implicit autocommit transaction
     /// now, including re-entry while its commit is in progress.
     #[inline]

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -2022,3 +2022,129 @@ fn test_upsert_do_update_failure_preserves_indexes(tmp_db: TempDatabase) -> anyh
 
     Ok(())
 }
+
+/// A COMMIT whose commit-time materialized-view delta merge needs I/O must not
+/// destroy the transaction it is committing.
+///
+/// `Program::commit_txn` runs `apply_view_deltas` before `commit_state` ever
+/// leaves `Ready`, so an I/O yield there re-enters `op_transaction` with
+/// `auto_commit` already flipped to true and no in-flight marker set. The
+/// re-entry was then classified as a fresh COMMIT outside a transaction and
+/// rejected, silently discarding the write. The merge only yields when the
+/// view's persisted state is cold, so the view must be created by one database
+/// handle and the transaction run through another.
+#[turso_macros::test(views)]
+fn test_commit_survives_view_delta_io_yield(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER, b INTEGER)")?;
+    conn.execute("INSERT INTO t VALUES (1, 10), (1, 5), (2, 20)")?;
+    conn.execute("CREATE MATERIALIZED VIEW mv AS SELECT a, sum(b) AS s FROM t GROUP BY a")?;
+    drop(conn);
+
+    let reopened = TempDatabase::builder()
+        .with_db_path(&tmp_db.path)
+        .with_views(true)
+        .build();
+    let conn = reopened.connect_limbo();
+
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO t VALUES (3, 7)")?;
+
+    // The row is visible inside the transaction ...
+    let in_txn: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(in_txn, vec![(4,)], "row must be visible inside the txn");
+
+    // ... so COMMIT must not claim there is no transaction to commit.
+    conn.execute("COMMIT")?;
+
+    let after_commit: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(
+        after_commit,
+        vec![(4,)],
+        "committed row must survive the commit"
+    );
+    drop(conn);
+
+    // ... and must still be on disk, with the view updated to match.
+    let after = TempDatabase::builder()
+        .with_db_path(&tmp_db.path)
+        .with_views(true)
+        .build();
+    let conn = after.connect_limbo();
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows, vec![(4,)], "committed row must survive reopen");
+    let view: Vec<(i64, f64)> = conn.exec_rows("SELECT a, s FROM mv ORDER BY a");
+    assert_eq!(view, vec![(1, 15.0), (2, 20.0), (3, 7.0)]);
+
+    Ok(())
+}
+
+/// Controls for `test_commit_survives_view_delta_io_yield`: the same write must
+/// keep working on the paths whose commit-time merge never yields.
+#[turso_macros::test(views)]
+fn test_commit_with_view_controls(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER, b INTEGER)")?;
+    conn.execute("CREATE TABLE u (x INTEGER)")?;
+    conn.execute("INSERT INTO t VALUES (1, 10), (1, 5), (2, 20)")?;
+    conn.execute("CREATE MATERIALIZED VIEW mv AS SELECT a, sum(b) AS s FROM t GROUP BY a")?;
+
+    // Matview created by this same handle: txn DML commits.
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO t VALUES (3, 7)")?;
+    conn.execute("COMMIT")?;
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows, vec![(4,)]);
+
+    // Autocommit DML on a matview'd table.
+    conn.execute("INSERT INTO t VALUES (4, 1)")?;
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows, vec![(5,)]);
+
+    // Txn DML on a table no matview depends on.
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO u VALUES (9)")?;
+    conn.execute("COMMIT")?;
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM u");
+    assert_eq!(rows, vec![(1,)]);
+
+    // A read-only txn still commits cleanly.
+    conn.execute("BEGIN")?;
+    let _: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    conn.execute("COMMIT")?;
+
+    // ROLLBACK of txn DML on a matview'd table leaves both table and view intact.
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO t VALUES (5, 3)")?;
+    conn.execute("ROLLBACK")?;
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows, vec![(5,)]);
+    let view: Vec<(i64, f64)> = conn.exec_rows("SELECT a, s FROM mv ORDER BY a");
+    assert_eq!(view, vec![(1, 15.0), (2, 20.0), (3, 7.0), (4, 1.0)]);
+
+    Ok(())
+}
+
+/// The ordinary-VIEW counterpart of the reopen shape: no matview machinery is
+/// involved, so this must pass regardless.
+#[turso_macros::test(views)]
+fn test_commit_after_reopen_with_plain_view(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t (a INTEGER, b INTEGER)")?;
+    conn.execute("INSERT INTO t VALUES (1, 10)")?;
+    conn.execute("CREATE VIEW ov AS SELECT a, sum(b) AS s FROM t GROUP BY a")?;
+    drop(conn);
+
+    let reopened = TempDatabase::builder()
+        .with_db_path(&tmp_db.path)
+        .with_views(true)
+        .build();
+    let conn = reopened.connect_limbo();
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO t VALUES (3, 7)")?;
+    conn.execute("COMMIT")?;
+    let rows: Vec<(i64,)> = conn.exec_rows("SELECT count(*) FROM t");
+    assert_eq!(rows, vec![(2,)]);
+
+    Ok(())
+}


### PR DESCRIPTION
A `COMMIT` on a connection whose materialized-view state is still on disk fails with `cannot commit - no transaction is active`, and the transaction's writes are silently discarded — the statements reported success and their rows were visible inside the transaction.

`op_transaction` sets `auto_commit = true` before calling `commit_txn`, and relies on `commit_state != Ready` to recognise a later re-entry as a resumption rather than a fresh `COMMIT`. But `commit_txn` applies view deltas *before* any commit-state machine is created, so when that merge has to fault the view's persisted B-tree in from disk it yields I/O while `commit_state` is still `Ready`. The re-entry is then classified as a `COMMIT` outside a transaction and rejected, leaving the connection to roll back.

The view-delta phase already records its own progress in `ProgramState::view_delta_state` so it can resume correctly; only the re-entry predicate ignored it. This PR widens that predicate to `commit_in_flight()`, which is true while either a commit-state machine or a view-delta merge is outstanding.

Reachable whenever a process opens a database containing a materialized view and writes to a table it reads inside an explicit transaction; the same statements in autocommit, or in a connection that created the view itself, are unaffected because the merge completes without I/O.

## Tests

First commit (red without the fix): `test_commit_survives_view_delta_io_yield` covers the two-handle shape and asserts the row is visible in-transaction, that `COMMIT` succeeds, and that the row and the view survive reopen; control tests pin the created-in-process, autocommit, and ordinary-`VIEW` shapes that already worked. Verified by inversion: with the one-line predicate reverted, the test reproduces the exact production error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
