### PR TITLE
core/incremental: keep the implicit group of an ungrouped aggregate matview

### DIFF
--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -1213,13 +1213,21 @@ impl AggregateState {
                     result.push(Value::from_i64(count));
                 }
                 AggregateFunction::Sum(col_idx) => {
-                    let sum = self.sums.get(col_idx).copied().unwrap_or(0.0);
-                    result.push(Value::from_f64(sum));
+                    // SUM over zero rows is NULL, not 0.
+                    let sum = if self.count == 0 {
+                        Value::Null
+                    } else {
+                        Value::from_f64(self.sums.get(col_idx).copied().unwrap_or(0.0))
+                    };
+                    result.push(sum);
                 }
                 AggregateFunction::SumDistinct(col_idx) => {
-                    // Return the computed SUM(DISTINCT)
-                    let sum = self.distinct_sums.get(col_idx).copied().unwrap_or(0.0);
-                    result.push(Value::from_f64(sum));
+                    let sum = if self.count == 0 {
+                        Value::Null
+                    } else {
+                        Value::from_f64(self.distinct_sums.get(col_idx).copied().unwrap_or(0.0))
+                    };
+                    result.push(sum);
                 }
                 AggregateFunction::Avg(col_idx) => {
                     if let Some((sum, count)) = self.avgs.get(col_idx) {
@@ -1360,6 +1368,13 @@ impl AggregateOperator {
         // Plain DISTINCT is indicated by empty aggregates vector
         let is_distinct_only = aggregates.is_empty();
 
+        // Plain DISTINCT always groups by its projection, so it never has an implicit
+        // group. The combination would seed and persist a state that nothing can emit.
+        assert!(
+            !(is_distinct_only && group_by.is_empty()),
+            "plain DISTINCT cannot have an implicit group"
+        );
+
         // Build map of column indices to their MIN/MAX info
         let mut column_min_max = HashMap::default();
         let mut storage_indices = HashMap::default();
@@ -1438,6 +1453,28 @@ impl AggregateOperator {
         })
     }
 
+    /// An aggregate with no GROUP BY is evaluated over exactly one implicit group,
+    /// which exists for the lifetime of the view — it is read, emitted, and persisted
+    /// even when no input row maps to it.
+    fn has_implicit_group(&self) -> bool {
+        self.group_by.is_empty()
+    }
+
+    /// Key of the group described by [`Self::has_implicit_group`]: no group-by columns.
+    fn implicit_group_key() -> String {
+        Self::group_key_to_string(&[])
+    }
+
+    /// Adds the implicit group to `existing_groups` at its zero state unless it is
+    /// already there, so the delta below folds into it instead of skipping it.
+    fn seed_implicit_group(&self, existing_groups: &mut HashMap<String, AggregateState>) {
+        if self.has_implicit_group() {
+            existing_groups
+                .entry(Self::implicit_group_key())
+                .or_default();
+        }
+    }
+
     pub fn has_min_max(&self) -> bool {
         !self.column_min_max.is_empty()
     }
@@ -1463,12 +1500,15 @@ impl AggregateOperator {
                     "AggregateOperator expects right_delta to be empty"
                 );
 
-                if deltas.left.changes.is_empty() {
+                if deltas.left.changes.is_empty() && !self.has_implicit_group() {
                     *state = EvalState::Done;
                     return Ok(IOResult::Done((Delta::new(), HashMap::default())));
                 }
 
                 let mut groups_to_read = BTreeMap::new();
+                if self.has_implicit_group() {
+                    groups_to_read.insert(Self::implicit_group_key(), Vec::new());
+                }
                 for (row, _weight) in &deltas.left.changes {
                     let group_key = self.extract_group_key(&row.values);
                     let group_key_str = Self::group_key_to_string(&group_key);
@@ -1519,6 +1559,8 @@ impl AggregateOperator {
         // Track distinct value weights as we process the batch
         let mut batch_distinct_weights: HashMap<String, HashMap<(usize, HashableRow), isize>> =
             HashMap::default();
+
+        self.seed_implicit_group(existing_groups);
 
         // Process each change in the delta
         for (row, weight) in delta.changes.iter() {
@@ -1591,6 +1633,14 @@ impl AggregateOperator {
             // Always store the state for persistence (even if count=0, we need to delete it)
             final_states.insert(group_key_str.clone(), (group_key.clone(), state.clone()));
 
+            // Seeded, untouched by the delta, already materialized: nothing to emit.
+            if self.has_implicit_group()
+                && !temp_keys.contains_key(group_key_str)
+                && pre_existing_groups.contains(group_key_str)
+            {
+                continue;
+            }
+
             // Check if we only have DISTINCT (no other aggregates)
             if self.is_distinct_only {
                 // For plain DISTINCT, we output each distinct VALUE (not group)
@@ -1625,8 +1675,7 @@ impl AggregateOperator {
                     output_delta.changes.push((old_row, -1));
                 }
 
-                // Only include groups with count > 0 in the output delta
-                if state.count > 0 {
+                if state.count > 0 || self.has_implicit_group() {
                     // Build output row: group_by columns + aggregate values
                     let mut output_values = group_key.clone();
                     let aggregate_values = state.to_values(&self.aggregates);
@@ -1902,7 +1951,11 @@ impl IncrementalOperator for AggregateOperator {
                         let element_id = Hash128::new(0, 0); // Always zeros for regular aggregates
 
                         // Determine weight: 1 if exists, -1 if deleted
-                        let weight = if agg_state.count == 0 { -1 } else { 1 };
+                        let weight = if agg_state.count == 0 && !self.has_implicit_group() {
+                            -1
+                        } else {
+                            1
+                        };
 
                         // Serialize the aggregate state (only for regular aggregates, not plain DISTINCT)
                         let state_blob = agg_state.to_blob(&self.aggregates, group_key)?;

--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -38,6 +38,8 @@ pub enum PopulateState {
         /// If we're in the middle of processing a row (merge_delta returned I/O)
         pending_row: Option<(i64, Vec<Value>)>, // (rowid, values)
     },
+    /// All source rows consumed; run the circuit once with no input
+    Finalize,
     /// Population complete
     Done,
 }
@@ -74,6 +76,7 @@ impl fmt::Debug for PopulateState {
                 .field("has_pending", &pending_row.is_some())
                 .field("total_queries", &queries.len())
                 .finish(),
+            PopulateState::Finalize => write!(f, "Finalize"),
             PopulateState::Done => write!(f, "Done"),
         }
     }
@@ -1196,8 +1199,8 @@ impl IncrementalView {
                     current_idx,
                 } => {
                     if current_idx >= queries.len() {
-                        self.populate_state = PopulateState::Done;
-                        return Ok(IOResult::Done(()));
+                        self.populate_state = PopulateState::Finalize;
+                        continue 'outer;
                     }
 
                     let query = queries[current_idx].clone();
@@ -1342,6 +1345,23 @@ impl IncrementalView {
                                 let completion = crate::io::Completion::new_yield();
                                 return Ok(IOResult::IO(crate::types::IOCompletions(completion)));
                             }
+                        }
+                    }
+                }
+
+                PopulateState::Finalize => {
+                    // Materializes operators whose output does not depend on any input
+                    // row: an ungrouped aggregate yields its one row over an empty source.
+                    match self.circuit.commit(HashMap::default(), pager.clone())? {
+                        IOResult::Done(_) => {
+                            self.populate_state = PopulateState::Done;
+                            return Ok(IOResult::Done(()));
+                        }
+                        IOResult::IO(io) => {
+                            // Re-entering resumes the in-flight commit rather than starting
+                            // a second one: the input map is only read in CommitState::Init.
+                            self.populate_state = PopulateState::Finalize;
+                            return Ok(IOResult::IO(io));
                         }
                     }
                 }

--- a/sqlite/conformance/turso-sqltests/materialized_views.sqltest
+++ b/sqlite/conformance/turso-sqltests/materialized_views.sqltest
@@ -2508,3 +2508,59 @@ test matview-reserved-prefix-sqlite {
 expect error {
     object name reserved for internal use: sqlite_matview
 }
+
+# An ungrouped aggregate is evaluated over exactly one implicit group, so the
+# view holds one row even when the source table is empty.
+test matview-ungrouped-aggregate-over-empty-input {
+    CREATE TABLE t(x REAL);
+    CREATE MATERIALIZED VIEW mv AS
+    SELECT COUNT(*), SUM(x), SUM(DISTINCT x), AVG(x), MIN(x), MAX(x) FROM t;
+    SELECT * FROM mv;
+}
+expect {
+    0|||||
+}
+
+test matview-ungrouped-aggregate-fills-after-empty-create {
+    CREATE TABLE t(x REAL);
+    CREATE MATERIALIZED VIEW mv AS SELECT COUNT(*), SUM(x) FROM t;
+    SELECT * FROM mv;
+    INSERT INTO t VALUES (5.0), (7.5);
+    SELECT * FROM mv;
+}
+expect {
+    0|
+    2|12.5
+}
+
+# Emptying the source returns the view to the zero row rather than dropping it.
+test matview-ungrouped-aggregate-returns-to-zero-row {
+    CREATE TABLE t(x REAL);
+    INSERT INTO t VALUES (5.0), (7.5);
+    CREATE MATERIALIZED VIEW mv AS SELECT COUNT(*), SUM(x) FROM t;
+    SELECT * FROM mv;
+    DELETE FROM t;
+    SELECT * FROM mv;
+    INSERT INTO t VALUES (3.5);
+    SELECT * FROM mv;
+}
+expect {
+    2|12.5
+    0|
+    1|3.5
+}
+
+# Control: a grouped aggregate has no implicit group, so an empty source means
+# no rows both at creation and after all rows are deleted.
+test matview-grouped-aggregate-over-empty-input-has-no-rows {
+    CREATE TABLE t(g TEXT, x REAL);
+    CREATE MATERIALIZED VIEW mv AS SELECT g, COUNT(*), SUM(x) FROM t GROUP BY g;
+    SELECT * FROM mv;
+    INSERT INTO t VALUES ('a', 1.0);
+    DELETE FROM t;
+    SELECT * FROM mv;
+    SELECT 'end';
+}
+expect {
+    end
+}


### PR DESCRIPTION
An aggregate with no GROUP BY is evaluated over exactly one implicit group, so `SELECT count(*), sum(x) FROM t` yields one row regardless of whether `t` has any rows. The DBSP aggregate operator instead created groups only for input rows that mapped to them, so a materialized view over an ungrouped aggregate returned zero rows over an empty source table, and lost its row entirely when the last source row was deleted.

```sql
CREATE TABLE t(x REAL);
CREATE MATERIALIZED VIEW mv AS SELECT count(*), sum(x) FROM t;
SELECT * FROM mv;     -- returned nothing; SQLite returns "0|"
```

Four places assumed "a group exists iff some row maps to it": the empty-delta early return in `eval_internal`, the per-delta-row seeding of `existing_groups`, the `state.count > 0` emission guard, and the `count == 0 => weight -1` state-deletion rule. All four now special-case `group_by.is_empty()`. `SUM` over zero rows returns NULL rather than 0.

Population needed a matching change: the circuit only ran from `process_one_row`, so over an empty source table it never ran at all. `PopulateState::Finalize` runs one final `circuit.commit` with an empty input map after the source queries are exhausted, which materializes the implicit group. It is resumable, so the IO contract is intact.

An emission guard keeps the new seeding from churning a cancelling −1/+1 pair through the delta on evals that do not touch the group.

Note on existing databases: a view created by a pre-fix binary over an empty table self-heals on the first write to its source table.

## Tests

First commit (red without the fix): 4 cases in `sqlite/conformance/turso-sqltests/materialized_views.sqltest` covering creation over an empty table, filling after an empty create, returning to the zero row after DELETE and then refilling, plus a GROUP BY control that must stay empty — all expectations from sqlite3. Full turso-sqltests corpus: 1452 passed / 3 failed before, 1455 passed / 0 failed after; sqlite-sqltests and the turso_core incremental unit tests are unchanged.

## Known adjacent gap (out of scope)

Aggregates over rows that are all NULL in the aggregated column still diverge from sqlite3: `sum(x)`/`avg(x)` return `0.0` instead of NULL and `count(x)` counts the NULL rows. This predates this PR, and the persisted aggregate state flattens per-column entry absence to `0.0` on reload, so it cannot be fixed at the emit site alone. A dedicated follow-up PR covering the all-NULL family end-to-end (including state serialization) is in preparation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

