### PR TITLE
bindings/c: statement introspection, column conversions, and a C API oracle

### DIFF
--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -40,5 +40,9 @@ name = "sqlite3.h"
 name = "compat"
 path = "tests/compat/mod.rs"
 
+[[test]]
+name = "oracle"
+path = "tests/oracle.rs"
+
 [build-dependencies]
 cc = "1"

--- a/bindings/c/include/sqlite3.h
+++ b/bindings/c/include/sqlite3.h
@@ -151,6 +151,8 @@ int sqlite3_exec(sqlite3 *db, const char *sql, exec_callback _callback, void *_c
 
 int sqlite3_reset(sqlite3_stmt *stmt);
 
+int sqlite3_clear_bindings(sqlite3_stmt *stmt);
+
 int sqlite3_changes(sqlite3 *_db);
 
 int64_t sqlite3_changes64(sqlite3 *_db);
@@ -238,7 +240,9 @@ int sqlite3_backup_pagecount(void *_backup);
 
 int sqlite3_backup_finish(void *_backup);
 
-char *sqlite3_expanded_sql(sqlite3_stmt *_stmt);
+const char *sqlite3_sql(sqlite3_stmt *stmt);
+
+char *sqlite3_expanded_sql(sqlite3_stmt *stmt);
 
 int sqlite3_data_count(sqlite3_stmt *stmt);
 

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -214,6 +214,12 @@ impl sqlite3 {
 pub struct sqlite3_stmt {
     pub(crate) db: *mut sqlite3,
     pub(crate) stmt: turso_core::Statement,
+    /// NUL-terminated copy of the statement's SQL, backing sqlite3_sql():
+    /// the returned pointer must stay valid until finalize.
+    pub(crate) sql: CString,
+    /// Parameter names handed out by sqlite3_bind_parameter_name, which
+    /// must stay valid until finalize.
+    pub(crate) param_name_cache: Vec<(ffi::c_int, CString)>,
     pub(crate) destructors: Vec<(
         usize,
         Option<unsafe extern "C" fn(*mut ffi::c_void)>,
@@ -232,9 +238,12 @@ pub struct sqlite3_stmt {
 impl sqlite3_stmt {
     pub fn new(db: *mut sqlite3, stmt: turso_core::Statement) -> Self {
         let n_cols = stmt.num_columns();
+        let sql = CString::new(stmt.get_sql()).unwrap_or_default();
         Self {
             db,
             stmt,
+            sql,
+            param_name_cache: Vec::new(),
             destructors: Vec::new(),
             next: std::ptr::null_mut(),
             text_cache: vec![vec![]; n_cols],
@@ -933,7 +942,21 @@ pub unsafe extern "C" fn sqlite3_prepare_v2(
         }
     };
     if !tail.is_null() {
-        *tail = sql.add(stmt.tail_offset());
+        // The parser's consumed-bytes position includes whitespace it lexed
+        // past, but the C contract points the tail at the first byte past
+        // the end of the statement: just after the terminating ';'. When
+        // the statement ends without a semicolon, the consumed position is
+        // already the answer, so only step back over whitespace that
+        // follows a ';'.
+        let mut off = stmt.tail_offset();
+        let mut p = off;
+        while p > 0 && (*(sql.add(p - 1) as *const u8)).is_ascii_whitespace() {
+            p -= 1;
+        }
+        if p > 0 && *(sql.add(p - 1) as *const u8) == b';' {
+            off = p;
+        }
+        *tail = sql.add(off);
     }
     let new_stmt = Box::leak(Box::new(sqlite3_stmt::new(raw_db, stmt)));
 
@@ -1364,9 +1387,14 @@ pub unsafe extern "C" fn sqlite3_stmt_readonly(stmt: *mut sqlite3_stmt) -> ffi::
     }
 }
 
+/// True if the statement has been stepped but has neither returned
+/// SQLITE_DONE nor been reset.
 #[no_mangle]
-pub unsafe extern "C" fn sqlite3_stmt_busy(_stmt: *mut sqlite3_stmt) -> ffi::c_int {
-    stub!();
+pub unsafe extern "C" fn sqlite3_stmt_busy(stmt: *mut sqlite3_stmt) -> ffi::c_int {
+    if stmt.is_null() {
+        return 0;
+    }
+    (*stmt).stmt.is_busy() as ffi::c_int
 }
 
 #[no_mangle]
@@ -1466,10 +1494,10 @@ pub unsafe extern "C" fn sqlite3_total_changes(db: *mut sqlite3) -> ffi::c_int {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sqlite3_last_insert_rowid(db: *mut sqlite3) -> ffi::c_int {
+pub unsafe extern "C" fn sqlite3_last_insert_rowid(db: *mut sqlite3) -> i64 {
     let db: &mut sqlite3 = &mut *db;
     let inner = db.inner.lock().unwrap();
-    inner.conn.last_insert_rowid() as ffi::c_int
+    inner.conn.last_insert_rowid()
 }
 
 #[no_mangle]
@@ -1678,16 +1706,55 @@ pub unsafe extern "C" fn sqlite3_backup_finish(_backup: *mut ffi::c_void) -> ffi
     stub!();
 }
 
+/// Returns the statement's original SQL text. The pointer is owned by the
+/// statement and stays valid until sqlite3_finalize.
 #[no_mangle]
-pub unsafe extern "C" fn sqlite3_expanded_sql(_stmt: *mut sqlite3_stmt) -> *mut ffi::c_char {
-    stub!();
+pub unsafe extern "C" fn sqlite3_sql(stmt: *mut sqlite3_stmt) -> *const ffi::c_char {
+    if stmt.is_null() {
+        return std::ptr::null();
+    }
+    (*stmt).sql.as_ptr()
 }
 
+/// Returns the SQL text with bound parameters expanded into literals,
+/// rendered by Statement::expanded_sql in turso_core. The returned buffer is
+/// allocated with sqlite3_malloc and must be released by the caller with
+/// sqlite3_free.
+#[no_mangle]
+#[deny(unsafe_op_in_unsafe_fn)]
+pub unsafe extern "C" fn sqlite3_expanded_sql(stmt: *mut sqlite3_stmt) -> *mut ffi::c_char {
+    if stmt.is_null() {
+        return std::ptr::null_mut();
+    }
+    // SAFETY: stmt checked non-null just above; caller guarantees it points
+    // to a live sqlite3_stmt for the duration of the call.
+    let stmt: &sqlite3_stmt = unsafe { &*stmt };
+    let expanded = stmt.stmt.expanded_sql();
+    let n = expanded.len();
+    let buf = unsafe { libc::malloc(n + 1) } as *mut ffi::c_char;
+    if buf.is_null() {
+        return std::ptr::null_mut();
+    }
+    // SAFETY: buf is a fresh allocation of n + 1 bytes; expanded is n bytes.
+    unsafe {
+        std::ptr::copy_nonoverlapping(expanded.as_ptr(), buf as *mut u8, n);
+        *buf.add(n) = 0;
+    }
+    buf
+}
+
+/// Number of columns in the current row, or 0 when no row is available
+/// (before the first step, after SQLITE_DONE, or after a reset).
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_data_count(stmt: *mut sqlite3_stmt) -> ffi::c_int {
+    if stmt.is_null() {
+        return 0;
+    }
     let stmt = &*stmt;
-    let row = stmt.stmt.row().unwrap();
-    row.len() as ffi::c_int
+    match stmt.stmt.row() {
+        Some(row) => row.len() as ffi::c_int,
+        None => 0,
+    }
 }
 
 #[no_mangle]
@@ -1721,21 +1788,33 @@ unsafe fn sqlite3_bind_result(
     }
 }
 
+/// The returned pointer is owned by the statement and stays valid until
+/// finalize, as documented; names are cached on the statement rather than
+/// leaked per call.
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_bind_parameter_name(
     stmt: *mut sqlite3_stmt,
     idx: ffi::c_int,
 ) -> *const ffi::c_char {
-    let stmt = &*stmt;
+    let stmt = &mut *stmt;
     let Some(index) = sqlite3_bind_index_in_range(stmt, idx) else {
         return std::ptr::null();
     };
 
-    if let Some(val) = stmt.stmt.parameters().name(index) {
-        let c_string = CString::new(val).expect("CString::new failed");
-        c_string.into_raw()
-    } else {
-        std::ptr::null()
+    if let Some(cached) = stmt.param_name_cache.iter().find(|(i, _)| *i == idx) {
+        return cached.1.as_ptr();
+    }
+    match stmt
+        .stmt
+        .parameters()
+        .name(index)
+        .and_then(|n| CString::new(n).ok())
+    {
+        Some(c_string) => {
+            stmt.param_name_cache.push((idx, c_string));
+            stmt.param_name_cache.last().unwrap().1.as_ptr()
+        }
+        None => std::ptr::null(),
     }
 }
 
@@ -2030,16 +2109,32 @@ pub unsafe extern "C" fn sqlite3_column_table_name(
     c_string.into_raw()
 }
 
+/// Returns the value at column `idx` of the current row, or None when there
+/// is no current row or the index is out of range.
+unsafe fn column_value(stmt: *mut sqlite3_stmt, idx: ffi::c_int) -> Option<&'static Value> {
+    if stmt.is_null() || idx < 0 {
+        return None;
+    }
+    let stmt = &mut *stmt;
+    let row = stmt.stmt.row()?;
+    row.get::<&Value>(idx as usize).ok()
+}
+
+/// The sqlite3_column_* accessors apply SQLite's documented conversions
+/// when the requested representation differs from the stored type (a text
+/// column read through column_int64 parses like CAST, an integer read
+/// through column_text renders as its decimal text, and so on); they never
+/// fail on a legal call.
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_column_int64(stmt: *mut sqlite3_stmt, idx: ffi::c_int) -> i64 {
-    // Attempt to convert idx to usize
-    let idx = idx.try_into().unwrap();
-    let stmt = &mut *stmt;
-    let row = stmt
-        .stmt
-        .row()
-        .expect("Function should only be called after `SQLITE_ROW`");
-    row.get(idx).unwrap()
+    match column_value(stmt, idx) {
+        Some(Value::Numeric(turso_core::Numeric::Integer(i))) => *i,
+        Some(v) => match v.exec_cast("INTEGER") {
+            Ok(Value::Numeric(turso_core::Numeric::Integer(i))) => i,
+            _ => 0,
+        },
+        None => 0,
+    }
 }
 
 #[no_mangle]
@@ -2052,13 +2147,40 @@ pub unsafe extern "C" fn sqlite3_column_int(
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_column_double(stmt: *mut sqlite3_stmt, idx: ffi::c_int) -> f64 {
-    let idx = idx.try_into().unwrap();
+    match column_value(stmt, idx) {
+        Some(Value::Numeric(turso_core::Numeric::Float(f))) => f64::from(*f),
+        Some(v) => match v.exec_cast("REAL") {
+            Ok(Value::Numeric(n)) => match n {
+                turso_core::Numeric::Float(f) => f64::from(f),
+                turso_core::Numeric::Integer(i) => i as f64,
+            },
+            _ => 0.0,
+        },
+        None => 0.0,
+    }
+}
+
+/// Fills (when not yet done for this row) and returns the per-column cache
+/// holding the column's text conversion, NUL-terminated: text bytes as-is,
+/// raw blob bytes, or the decimal rendering of a number. None for NULL.
+unsafe fn column_text_cache(stmt: *mut sqlite3_stmt, idx: ffi::c_int) -> Option<&'static Vec<u8>> {
+    let value = column_value(stmt, idx)?;
     let stmt = &mut *stmt;
-    let row = stmt
-        .stmt
-        .row()
-        .expect("Function should only be called after `SQLITE_ROW`");
-    row.get(idx).unwrap()
+    let i = idx as usize;
+    if i >= stmt.text_cache.len() {
+        return None;
+    }
+    if stmt.text_cache[i].is_empty() {
+        let buf = &mut stmt.text_cache[i];
+        match value {
+            Value::Null => return None,
+            Value::Text(t) => buf.extend(t.as_str().as_bytes()),
+            Value::Blob(b) => buf.extend(b.iter()),
+            numeric => buf.extend(numeric.to_string().as_bytes()),
+        }
+        buf.push(0);
+    }
+    Some(&stmt.text_cache[i])
 }
 
 #[no_mangle]
@@ -2066,14 +2188,13 @@ pub unsafe extern "C" fn sqlite3_column_blob(
     stmt: *mut sqlite3_stmt,
     idx: ffi::c_int,
 ) -> *const ffi::c_void {
-    let stmt = &mut *stmt;
-    let row = stmt.stmt.row();
-    let row = match row.as_ref() {
-        Some(row) => row,
-        None => return std::ptr::null(),
-    };
-    match row.get::<&Value>(idx as usize) {
-        Ok(turso_core::Value::Blob(blob)) => blob.as_ptr() as *const ffi::c_void,
+    if matches!(column_value(stmt, idx), Some(Value::Null) | None) {
+        return std::ptr::null();
+    }
+    match column_text_cache(stmt, idx) {
+        // A zero-length result (only the cache's NUL) reports NULL, as
+        // sqlite3_column_blob does for zero-length blobs.
+        Some(cache) if cache.len() > 1 => cache.as_ptr() as *const ffi::c_void,
         _ => std::ptr::null(),
     }
 }
@@ -2083,16 +2204,9 @@ pub unsafe extern "C" fn sqlite3_column_bytes(
     stmt: *mut sqlite3_stmt,
     idx: ffi::c_int,
 ) -> ffi::c_int {
-    let stmt = &mut *stmt;
-    let row = stmt.stmt.row();
-    let row = match row.as_ref() {
-        Some(row) => row,
-        None => return 0,
-    };
-    match row.get::<&Value>(idx as usize) {
-        Ok(turso_core::Value::Text(text)) => text.as_str().len() as ffi::c_int,
-        Ok(turso_core::Value::Blob(blob)) => blob.len() as ffi::c_int,
-        _ => 0,
+    match column_text_cache(stmt, idx) {
+        Some(cache) => (cache.len() - 1) as ffi::c_int,
+        None => 0,
     }
 }
 
@@ -2213,31 +2327,9 @@ pub unsafe extern "C" fn sqlite3_column_text(
     stmt: *mut sqlite3_stmt,
     idx: ffi::c_int,
 ) -> *const ffi::c_uchar {
-    if stmt.is_null() || idx < 0 {
-        return std::ptr::null();
-    }
-    let stmt = &mut *stmt;
-    let row = stmt.stmt.row();
-    let row = match row.as_ref() {
-        Some(row) => row,
-        None => return std::ptr::null(),
-    };
-    let i = idx as usize;
-    if i >= stmt.text_cache.len() {
-        return std::ptr::null();
-    }
-    if !stmt.text_cache[i].is_empty() {
-        // we have already cached this value
-        return stmt.text_cache[i].as_ptr() as *const ffi::c_uchar;
-    }
-    match row.get::<&Value>(i) {
-        Ok(turso_core::Value::Text(text)) => {
-            let buf = &mut stmt.text_cache[i];
-            buf.extend(text.as_str().as_bytes());
-            buf.push(0);
-            buf.as_ptr() as *const ffi::c_uchar
-        }
-        _ => std::ptr::null(),
+    match column_text_cache(stmt, idx) {
+        Some(cache) => cache.as_ptr() as *const ffi::c_uchar,
+        None => std::ptr::null(),
     }
 }
 

--- a/bindings/c/tests/oracle.rs
+++ b/bindings/c/tests/oracle.rs
@@ -1,0 +1,702 @@
+//! Randomized differential oracle for the C API.
+//!
+//! Loads the system libsqlite3 and the freshly built libturso_sqlite3 into
+//! the same process with dlopen (RTLD_LOCAL keeps their symbol tables
+//! apart), resolves the same set of entry points from each, and drives both
+//! through identical randomized call sequences — schemas, inserts with
+//! every parameter-marker style, binds in random order with adversarial
+//! values, interleaved introspection (sqlite3_sql, sqlite3_expanded_sql,
+//! sqlite3_stmt_busy), resets, clear_bindings, and full row readback —
+//! comparing every observable in lockstep. Any divergence aborts with the
+//! scenario seed and the operation trace.
+//!
+//! Going through dlopen/dlsym also verifies the dynamic export table of the
+//! cdylib itself: a symbol missing from the library fails resolution here
+//! before any C consumer trips over it.
+//!
+//! Reproduce a failure with TURSO_ORACLE_SEED=<seed>; raise the scenario
+//! count with TURSO_ORACLE_ITERS=<n> for longer local fuzzing sessions.
+//!
+//! The turso side is the cdylib in target/debug, which `cargo test` does
+//! not relink on its own: run `cargo build -p turso_sqlite3 --features
+//! capi` first (CI's c-compat workflow already does) or the oracle tests a
+//! stale library.
+
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
+
+const SQLITE_OK: c_int = 0;
+const SQLITE_ROW: c_int = 100;
+const SQLITE_DONE: c_int = 101;
+
+/// The destructor slot of sqlite3_bind_text/blob is a function pointer in
+/// the C API; SQLITE_TRANSIENT is the all-ones sentinel value of that type.
+type BindDestructor = Option<unsafe extern "C" fn(*mut c_void)>;
+#[allow(clippy::useless_transmute)]
+fn sqlite_transient() -> BindDestructor {
+    // SAFETY: reproduces C's ((sqlite3_destructor_type)-1) sentinel; it is
+    // never called, only compared against by the library.
+    unsafe { std::mem::transmute(-1isize) }
+}
+
+macro_rules! api_table {
+    ($( $name:ident : $ty:ty ),+ $(,)?) => {
+        struct Api {
+            label: &'static str,
+            $( $name: $ty, )+
+        }
+
+        impl Api {
+            /// # Safety
+            /// `path` must name a library exporting the sqlite3 C API with
+            /// the standard signatures.
+            unsafe fn load(label: &'static str, path: &str) -> Api {
+                let cpath = CString::new(path).unwrap();
+                let handle = libc::dlopen(cpath.as_ptr(), libc::RTLD_NOW | libc::RTLD_LOCAL);
+                assert!(!handle.is_null(), "dlopen({path}) failed");
+                #[allow(unused_assignments)]
+                let mut sym: *mut c_void = std::ptr::null_mut();
+                $(
+                    let cname = CString::new(stringify!($name)).unwrap();
+                    sym = libc::dlsym(handle, cname.as_ptr());
+                    assert!(
+                        !sym.is_null(),
+                        "{label}: symbol {} not exported by {path}",
+                        stringify!($name)
+                    );
+                    let $name: $ty = std::mem::transmute(sym);
+                )+
+                Api { label, $( $name, )+ }
+            }
+        }
+    };
+}
+
+api_table! {
+    sqlite3_open: unsafe extern "C" fn(*const c_char, *mut *mut c_void) -> c_int,
+    sqlite3_close: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_exec: unsafe extern "C" fn(*mut c_void, *const c_char, *mut c_void, *mut c_void, *mut *mut c_char) -> c_int,
+    sqlite3_prepare_v2: unsafe extern "C" fn(*mut c_void, *const c_char, c_int, *mut *mut c_void, *mut *const c_char) -> c_int,
+    sqlite3_step: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_reset: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_clear_bindings: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_finalize: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_bind_null: unsafe extern "C" fn(*mut c_void, c_int) -> c_int,
+    sqlite3_bind_int64: unsafe extern "C" fn(*mut c_void, c_int, i64) -> c_int,
+    sqlite3_bind_double: unsafe extern "C" fn(*mut c_void, c_int, f64) -> c_int,
+    sqlite3_bind_text: unsafe extern "C" fn(*mut c_void, c_int, *const c_char, c_int, BindDestructor) -> c_int,
+    sqlite3_bind_blob: unsafe extern "C" fn(*mut c_void, c_int, *const c_void, c_int, BindDestructor) -> c_int,
+    sqlite3_bind_parameter_count: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_bind_parameter_index: unsafe extern "C" fn(*mut c_void, *const c_char) -> c_int,
+    sqlite3_bind_parameter_name: unsafe extern "C" fn(*mut c_void, c_int) -> *const c_char,
+    sqlite3_column_count: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_column_type: unsafe extern "C" fn(*mut c_void, c_int) -> c_int,
+    sqlite3_column_int64: unsafe extern "C" fn(*mut c_void, c_int) -> i64,
+    sqlite3_column_double: unsafe extern "C" fn(*mut c_void, c_int) -> f64,
+    sqlite3_column_text: unsafe extern "C" fn(*mut c_void, c_int) -> *const u8,
+    sqlite3_column_blob: unsafe extern "C" fn(*mut c_void, c_int) -> *const c_void,
+    sqlite3_column_bytes: unsafe extern "C" fn(*mut c_void, c_int) -> c_int,
+    sqlite3_sql: unsafe extern "C" fn(*mut c_void) -> *const c_char,
+    sqlite3_expanded_sql: unsafe extern "C" fn(*mut c_void) -> *mut c_char,
+    sqlite3_stmt_busy: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_changes: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_total_changes: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_last_insert_rowid: unsafe extern "C" fn(*mut c_void) -> i64,
+    sqlite3_errcode: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_get_autocommit: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_data_count: unsafe extern "C" fn(*mut c_void) -> c_int,
+    sqlite3_column_name: unsafe extern "C" fn(*mut c_void, c_int) -> *const c_char,
+    sqlite3_libversion_number: unsafe extern "C" fn() -> c_int,
+    sqlite3_free: unsafe extern "C" fn(*mut c_void),
+}
+
+fn system_sqlite_path() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "/usr/lib/libsqlite3.dylib"
+    } else {
+        "libsqlite3.so.0"
+    }
+}
+
+fn turso_sqlite_path() -> String {
+    // current_exe is target/debug/deps/oracle-<hash>; the cdylib sits two
+    // levels up in target/debug.
+    let exe = std::env::current_exe().unwrap();
+    let dir = exe.parent().unwrap().parent().unwrap();
+    let name = if cfg!(target_os = "macos") {
+        "libturso_sqlite3.dylib"
+    } else {
+        "libturso_sqlite3.so"
+    };
+    dir.join(name).to_str().unwrap().to_string()
+}
+
+/// SplitMix64: tiny deterministic PRNG, no dependencies.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e3779b97f4a7c15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
+        z ^ (z >> 31)
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+    fn chance(&mut self, percent: u64) -> bool {
+        self.next() % 100 < percent
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum Val {
+    Null,
+    Int(i64),
+    Float(f64),
+    Text(String),
+    Blob(Vec<u8>),
+}
+
+/// Everything observable about one result column, read through every
+/// accessor. Text and blob keep raw bytes and pointer-nullness.
+#[derive(Debug, PartialEq)]
+struct ColObs {
+    declared_type: c_int,
+    as_int: i64,
+    as_double: f64,
+    as_text: Option<Vec<u8>>,
+    as_blob: Option<Vec<u8>>,
+}
+
+fn random_value(rng: &mut Rng) -> Val {
+    match rng.below(5) {
+        0 => Val::Null,
+        1 => {
+            let pool = [
+                0i64,
+                1,
+                -1,
+                42,
+                i64::MAX,
+                i64::MIN,
+                1 << 40,
+                i32::MAX as i64,
+                i32::MIN as i64,
+                i32::MAX as i64 + 1,
+                i32::MIN as i64 - 1,
+            ];
+            Val::Int(pool[rng.below(pool.len())])
+        }
+        2 => {
+            // NaN and infinities are deliberately excluded until core's
+            // policy for them matches SQLite (bind_double(NaN) stores NULL).
+            let pool = [0.0f64, -0.0, 3.5, -2.25, 0.1, 1e15, -1.5e-8, 12345.6789];
+            Val::Float(pool[rng.below(pool.len())])
+        }
+        3 => {
+            let pool = [
+                "",
+                "a",
+                "it's",
+                "two''quotes",
+                "h\u{e9}llo w\u{f6}rld \u{1F680}",
+                "line\nbreak\ttab",
+                "SELECT ?1 -- not a param",
+                "12345",
+                "-3.25",
+            ];
+            let mut s = pool[rng.below(pool.len())].to_string();
+            if rng.chance(20) {
+                // Stay under SQLITE_TRACE_SIZE_LIMIT territory: reference
+                // builds compiled with it (e.g. Apple's) truncate long
+                // values in expanded SQL with a "/*+N bytes*/" marker,
+                // while stock builds and turso render them in full.
+                let max_repeat = (900 / s.len().max(1)).max(1);
+                s = s.repeat(rng.below(max_repeat) + 1);
+            }
+            Val::Text(s)
+        }
+        _ => {
+            let mut b = vec![0u8; rng.below(48)];
+            for byte in b.iter_mut() {
+                *byte = rng.next() as u8;
+            }
+            Val::Blob(b)
+        }
+    }
+}
+
+/// The random whitespace/comment filler exercises the marker scanner.
+fn random_filler(rng: &mut Rng) -> &'static str {
+    [" ", " ", " ", "\n", "\t", " /* c? */ ", " -- ?x\n"][rng.below(7)]
+}
+
+/// One randomly chosen parameter marker. Duplicated names and explicit
+/// index gaps are legal and exercise the numbering rules.
+fn random_marker(rng: &mut Rng, k: usize, names: &mut Vec<String>) -> String {
+    match rng.below(5) {
+        0 => "?".to_string(),
+        1 => format!("?{}", k + 1 + rng.below(3)),
+        2 | 3 => {
+            let name = format!(":p{}", rng.below(4));
+            names.push(name.clone());
+            name
+        }
+        _ => {
+            let sig = ["@", "$"][rng.below(2)];
+            let name = format!("{sig}q{}", rng.below(4));
+            names.push(name.clone());
+            name
+        }
+    }
+}
+
+struct Ctx {
+    seed: u64,
+    trace: Vec<String>,
+}
+
+impl Ctx {
+    fn log(&mut self, line: String) {
+        self.trace.push(line);
+    }
+    fn check<T: PartialEq + std::fmt::Debug>(&mut self, what: &str, sqlite: T, turso: T) {
+        if sqlite != turso {
+            panic!(
+                "[oracle] seed={} DIVERGENCE at {what}:\n  sqlite: {sqlite:?}\n  turso:  {turso:?}\ntrace:\n  {}",
+                self.seed,
+                self.trace.join("\n  ")
+            );
+        }
+    }
+}
+
+struct Session<'a> {
+    api: &'a Api,
+    db: *mut c_void,
+    stmt: *mut c_void,
+}
+
+impl<'a> Session<'a> {
+    unsafe fn open(api: &'a Api) -> Session<'a> {
+        let mut db = std::ptr::null_mut();
+        let path = CString::new(":memory:").unwrap();
+        let rc = (api.sqlite3_open)(path.as_ptr(), &mut db);
+        assert_eq!(rc, SQLITE_OK, "{}: open :memory:", api.label);
+        Session {
+            api,
+            db,
+            stmt: std::ptr::null_mut(),
+        }
+    }
+
+    unsafe fn exec(&mut self, sql: &CString) -> c_int {
+        (self.api.sqlite3_exec)(
+            self.db,
+            sql.as_ptr(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    }
+
+    unsafe fn prepare(&mut self, sql: &CString) -> c_int {
+        self.finalize();
+        (self.api.sqlite3_prepare_v2)(
+            self.db,
+            sql.as_ptr(),
+            -1,
+            &mut self.stmt,
+            std::ptr::null_mut(),
+        )
+    }
+
+    unsafe fn finalize(&mut self) {
+        if !self.stmt.is_null() {
+            (self.api.sqlite3_finalize)(self.stmt);
+            self.stmt = std::ptr::null_mut();
+        }
+    }
+
+    unsafe fn bind(&mut self, idx: c_int, v: &Val) -> c_int {
+        let api = self.api;
+        match v {
+            Val::Null => (api.sqlite3_bind_null)(self.stmt, idx),
+            Val::Int(i) => (api.sqlite3_bind_int64)(self.stmt, idx, *i),
+            Val::Float(f) => (api.sqlite3_bind_double)(self.stmt, idx, *f),
+            Val::Text(s) => (api.sqlite3_bind_text)(
+                self.stmt,
+                idx,
+                s.as_ptr() as *const c_char,
+                s.len() as c_int,
+                sqlite_transient(),
+            ),
+            Val::Blob(b) => (api.sqlite3_bind_blob)(
+                self.stmt,
+                idx,
+                b.as_ptr() as *const c_void,
+                b.len() as c_int,
+                sqlite_transient(),
+            ),
+        }
+    }
+
+    unsafe fn expanded_sql(&mut self) -> Option<String> {
+        let p = (self.api.sqlite3_expanded_sql)(self.stmt);
+        if p.is_null() {
+            return None;
+        }
+        let s = CStr::from_ptr(p).to_string_lossy().into_owned();
+        (self.api.sqlite3_free)(p as *mut c_void);
+        Some(s)
+    }
+
+    unsafe fn sql(&mut self) -> String {
+        let p = (self.api.sqlite3_sql)(self.stmt);
+        assert!(!p.is_null());
+        CStr::from_ptr(p).to_string_lossy().into_owned()
+    }
+
+    /// Reads column `i` through every accessor, not just the one matching
+    /// the declared type: SQLite defines conversions for mismatched
+    /// accessors (column_text on an integer renders it, column_int64 on
+    /// text parses it), and those paths are exactly where a compat layer
+    /// diverges. Accessors are invoked in a fixed order on both libraries;
+    /// SQLite documents that conversions may mutate the stored value, so
+    /// the identical call order keeps the comparison fair. NULL pointers
+    /// are observed as None rather than folded into empty buffers.
+    unsafe fn column(&mut self, i: c_int) -> ColObs {
+        let api = self.api;
+        let declared_type = (api.sqlite3_column_type)(self.stmt, i);
+        let as_int = (api.sqlite3_column_int64)(self.stmt, i);
+        let as_double = (api.sqlite3_column_double)(self.stmt, i);
+        let text_ptr = (api.sqlite3_column_text)(self.stmt, i);
+        let text_bytes = (api.sqlite3_column_bytes)(self.stmt, i) as usize;
+        let as_text = if text_ptr.is_null() {
+            None
+        } else {
+            Some(std::slice::from_raw_parts(text_ptr, text_bytes).to_vec())
+        };
+        let blob_ptr = (api.sqlite3_column_blob)(self.stmt, i);
+        let blob_bytes = (api.sqlite3_column_bytes)(self.stmt, i) as usize;
+        let as_blob = if blob_ptr.is_null() {
+            None
+        } else {
+            Some(std::slice::from_raw_parts(blob_ptr as *const u8, blob_bytes).to_vec())
+        };
+        ColObs {
+            declared_type,
+            as_int,
+            as_double,
+            as_text,
+            as_blob,
+        }
+    }
+}
+
+impl Drop for Session<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            self.finalize();
+            (self.api.sqlite3_close)(self.db);
+        }
+    }
+}
+
+unsafe fn compare_introspection(ctx: &mut Ctx, s: &mut Session, t: &mut Session, when: &str) {
+    ctx.check(&format!("sql ({when})"), s.sql(), t.sql());
+    ctx.check(
+        &format!("expanded_sql ({when})"),
+        s.expanded_sql(),
+        t.expanded_sql(),
+    );
+    ctx.check(
+        &format!("stmt_busy ({when})"),
+        (s.api.sqlite3_stmt_busy)(s.stmt),
+        (t.api.sqlite3_stmt_busy)(t.stmt),
+    );
+}
+
+unsafe fn run_scenario(ctx: &mut Ctx, rng: &mut Rng, sqlite: &Api, turso: &Api) {
+    let mut s = Session::open(sqlite);
+    let mut t = Session::open(turso);
+
+    let create = CString::new("CREATE TABLE t(a,b,c,d,e)").unwrap();
+    ctx.check("exec CREATE", s.exec(&create), t.exec(&create));
+
+    for round in 0..4 {
+        // Build an INSERT whose five values are a random mix of parameter
+        // markers (all styles) and the occasional literal, separated by
+        // random whitespace and comments.
+        let mut names = Vec::new();
+        let mut sql = String::from("INSERT INTO t VALUES(");
+        for k in 0..5 {
+            if k > 0 {
+                sql.push(',');
+            }
+            sql.push_str(random_filler(rng));
+            if rng.chance(20) {
+                sql.push_str(["7", "'lit''x'", "x'ff00'", "NULL", "1.5"][rng.below(5)]);
+            } else {
+                sql.push_str(&random_marker(rng, k, &mut names));
+            }
+            sql.push_str(random_filler(rng));
+        }
+        sql.push(')');
+        ctx.log(format!("round {round}: {sql:?}"));
+        let csql = CString::new(sql).unwrap();
+
+        let rc_s = s.prepare(&csql);
+        let rc_t = t.prepare(&csql);
+        ctx.check("prepare INSERT rc", rc_s, rc_t);
+        if rc_s != SQLITE_OK {
+            continue;
+        }
+
+        let count = (sqlite.sqlite3_bind_parameter_count)(s.stmt);
+        ctx.check(
+            "bind_parameter_count",
+            count,
+            (turso.sqlite3_bind_parameter_count)(t.stmt),
+        );
+
+        // Every index reports the same parameter name (None for positional
+        // slots and gaps), including one index past the end.
+        for i in 0..=count + 1 {
+            let name_s = (sqlite.sqlite3_bind_parameter_name)(s.stmt, i);
+            let name_t = (turso.sqlite3_bind_parameter_name)(t.stmt, i);
+            let name_s = (!name_s.is_null()).then(|| CStr::from_ptr(name_s).to_owned());
+            let name_t = (!name_t.is_null()).then(|| CStr::from_ptr(name_t).to_owned());
+            ctx.check(&format!("bind_parameter_name({i})"), name_s, name_t);
+        }
+
+        compare_introspection(ctx, &mut s, &mut t, "before binds");
+
+        // Bind by name: each library resolves the name with its own
+        // bind_parameter_index, so numbering rules are compared too.
+        for name in &names {
+            if !rng.chance(80) {
+                continue;
+            }
+            let cname = CString::new(name.as_str()).unwrap();
+            let idx_s = (sqlite.sqlite3_bind_parameter_index)(s.stmt, cname.as_ptr());
+            let idx_t = (turso.sqlite3_bind_parameter_index)(t.stmt, cname.as_ptr());
+            ctx.check(&format!("parameter_index({name})"), idx_s, idx_t);
+            if idx_s == 0 {
+                continue;
+            }
+            let v = random_value(rng);
+            ctx.log(format!("bind {name} (idx {idx_s}) = {v:?}"));
+            ctx.check(
+                &format!("bind rc ({name})"),
+                s.bind(idx_s, &v),
+                t.bind(idx_t, &v),
+            );
+        }
+
+        // Bind a random subset of positional indices, sometimes out of
+        // range on purpose: both sides must fail identically.
+        for _ in 0..rng.below(6) {
+            let idx = if rng.chance(15) {
+                [0, count + 1, count + 7][rng.below(3)]
+            } else if count > 0 {
+                (rng.below(count as usize) + 1) as c_int
+            } else {
+                continue;
+            };
+            let v = random_value(rng);
+            ctx.log(format!("bind idx {idx} = {v:?}"));
+            ctx.check(
+                &format!("bind rc (idx {idx})"),
+                s.bind(idx, &v),
+                t.bind(idx, &v),
+            );
+        }
+
+        compare_introspection(ctx, &mut s, &mut t, "after binds");
+
+        let rc_s = (sqlite.sqlite3_step)(s.stmt);
+        let rc_t = (turso.sqlite3_step)(t.stmt);
+        ctx.check("step INSERT rc", rc_s, rc_t);
+        compare_introspection(ctx, &mut s, &mut t, "after step");
+        if rc_s == SQLITE_DONE {
+            ctx.check(
+                "changes",
+                (sqlite.sqlite3_changes)(s.db),
+                (turso.sqlite3_changes)(t.db),
+            );
+            ctx.check(
+                "total_changes",
+                (sqlite.sqlite3_total_changes)(s.db),
+                (turso.sqlite3_total_changes)(t.db),
+            );
+            ctx.check(
+                "last_insert_rowid",
+                (sqlite.sqlite3_last_insert_rowid)(s.db),
+                (turso.sqlite3_last_insert_rowid)(t.db),
+            );
+        } else {
+            ctx.check(
+                "errcode after failed step",
+                (sqlite.sqlite3_errcode)(s.db),
+                (turso.sqlite3_errcode)(t.db),
+            );
+        }
+        ctx.check(
+            "get_autocommit",
+            (sqlite.sqlite3_get_autocommit)(s.db),
+            (turso.sqlite3_get_autocommit)(t.db),
+        );
+
+        // Lifecycle chaos: double reset and re-binding after reset are
+        // legal call orders with defined behavior. Stepping again after
+        // SQLITE_DONE is deliberately NOT exercised: stock SQLite
+        // auto-resets and re-runs, builds with SQLITE_OMIT_AUTORESET (e.g.
+        // Apple's) return SQLITE_MISUSE, and turso returns SQLITE_DONE
+        // without re-running — the oracle found this three-way divergence;
+        // auto-reset support in core is tracked as follow-up work.
+        ctx.check(
+            "reset rc",
+            (sqlite.sqlite3_reset)(s.stmt),
+            (turso.sqlite3_reset)(t.stmt),
+        );
+        compare_introspection(ctx, &mut s, &mut t, "after reset");
+        if rng.chance(20) {
+            ctx.log("chaos: double reset".into());
+            ctx.check(
+                "second reset rc",
+                (sqlite.sqlite3_reset)(s.stmt),
+                (turso.sqlite3_reset)(t.stmt),
+            );
+        }
+        if rng.chance(20) && count > 0 {
+            let idx = (rng.below(count as usize) + 1) as c_int;
+            let v = random_value(rng);
+            ctx.log(format!("chaos: re-bind idx {idx} = {v:?} after reset"));
+            ctx.check("re-bind after reset rc", s.bind(idx, &v), t.bind(idx, &v));
+            compare_introspection(ctx, &mut s, &mut t, "after re-bind");
+        }
+        if rng.chance(50) {
+            ctx.check(
+                "clear_bindings rc",
+                (sqlite.sqlite3_clear_bindings)(s.stmt),
+                (turso.sqlite3_clear_bindings)(t.stmt),
+            );
+            compare_introspection(ctx, &mut s, &mut t, "after clear_bindings");
+        }
+    }
+
+    // An explicit rowid far above i32 keeps last_insert_rowid honest as a
+    // 64-bit value across the ABI.
+    if rng.chance(40) {
+        let rowid = 5_000_000_000i64 + rng.below(1_000_000) as i64;
+        let ins = format!("INSERT INTO t(rowid,a,b,c,d,e) VALUES({rowid},1,2,3,4,5)");
+        ctx.log(format!("large rowid insert: {ins}"));
+        let cins = CString::new(ins).unwrap();
+        ctx.check("exec large-rowid INSERT", s.exec(&cins), t.exec(&cins));
+        ctx.check(
+            "last_insert_rowid (large)",
+            (sqlite.sqlite3_last_insert_rowid)(s.db),
+            (turso.sqlite3_last_insert_rowid)(t.db),
+        );
+    }
+
+    // Read everything back in lockstep and compare types and values. The
+    // SELECT is sometimes prepared from a multi-statement buffer with an
+    // explicit byte length, comparing the reported tail offset.
+    let select_text = "SELECT a,b,c,d,e FROM t ORDER BY rowid";
+    if rng.chance(30) {
+        let multi = format!("{select_text}; SELECT 2 /* tail */");
+        ctx.log(format!("prepare with tail: {multi:?}"));
+        let cmulti = CString::new(multi).unwrap();
+        let mut tail_s: *const c_char = std::ptr::null();
+        let mut tail_t: *const c_char = std::ptr::null();
+        s.finalize();
+        t.finalize();
+        let rc_s = (sqlite.sqlite3_prepare_v2)(s.db, cmulti.as_ptr(), -1, &mut s.stmt, &mut tail_s);
+        let rc_t = (turso.sqlite3_prepare_v2)(t.db, cmulti.as_ptr(), -1, &mut t.stmt, &mut tail_t);
+        ctx.check("prepare multi rc", rc_s, rc_t);
+        let off = |tail: *const c_char| {
+            if tail.is_null() {
+                -1
+            } else {
+                tail as isize - cmulti.as_ptr() as isize
+            }
+        };
+        ctx.check("tail offset", off(tail_s), off(tail_t));
+    } else {
+        let cselect = CString::new(select_text).unwrap();
+        ctx.check(
+            "prepare SELECT rc",
+            s.prepare(&cselect),
+            t.prepare(&cselect),
+        );
+    }
+    ctx.check(
+        "column_count",
+        (sqlite.sqlite3_column_count)(s.stmt),
+        (turso.sqlite3_column_count)(t.stmt),
+    );
+    for i in 0..5 {
+        let name_s = (sqlite.sqlite3_column_name)(s.stmt, i);
+        let name_t = (turso.sqlite3_column_name)(t.stmt, i);
+        let name_s = (!name_s.is_null()).then(|| CStr::from_ptr(name_s).to_owned());
+        let name_t = (!name_t.is_null()).then(|| CStr::from_ptr(name_t).to_owned());
+        ctx.check(&format!("column_name({i})"), name_s, name_t);
+    }
+    let mut row = 0;
+    loop {
+        let rc_s = (sqlite.sqlite3_step)(s.stmt);
+        let rc_t = (turso.sqlite3_step)(t.stmt);
+        ctx.check(&format!("step SELECT rc (row {row})"), rc_s, rc_t);
+        ctx.check(
+            &format!("data_count (row {row})"),
+            (sqlite.sqlite3_data_count)(s.stmt),
+            (turso.sqlite3_data_count)(t.stmt),
+        );
+        if rc_s != SQLITE_ROW {
+            break;
+        }
+        for i in 0..5 {
+            ctx.check(&format!("row {row} col {i}"), s.column(i), t.column(i));
+        }
+        if rng.chance(25) {
+            compare_introspection(ctx, &mut s, &mut t, "mid-select");
+        }
+        row += 1;
+    }
+}
+
+#[test]
+fn oracle_differential() {
+    let seed_base: u64 = std::env::var("TURSO_ORACLE_SEED")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0xDEC0DE);
+    let iters: u64 = std::env::var("TURSO_ORACLE_ITERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(64);
+
+    unsafe {
+        let sqlite = Api::load("sqlite", system_sqlite_path());
+        let turso = Api::load("turso", &turso_sqlite_path());
+        println!(
+            "oracle: sqlite {} ({}) vs turso {} ({}), seed_base={seed_base}, iters={iters}",
+            (sqlite.sqlite3_libversion_number)(),
+            system_sqlite_path(),
+            (turso.sqlite3_libversion_number)(),
+            turso_sqlite_path(),
+        );
+        for i in 0..iters {
+            let seed = seed_base.wrapping_add(i);
+            let mut rng = Rng(seed);
+            let mut ctx = Ctx {
+                seed,
+                trace: Vec::new(),
+            };
+            run_scenario(&mut ctx, &mut rng, &sqlite, &turso);
+        }
+    }
+}

--- a/bindings/c/tests/sqlite3_tests.c
+++ b/bindings/c/tests/sqlite3_tests.c
@@ -24,6 +24,7 @@ void test_sqlite3_insert_returning();
 void test_sqlite3_set_authorizer();
 void test_sqlite3_db_config();
 void test_sqlite3_extended_result_codes();
+void test_sqlite3_sql_introspection();
 
 int allocated = 0;
 
@@ -47,6 +48,7 @@ int main(void)
     test_sqlite3_set_authorizer();
     test_sqlite3_db_config();
     test_sqlite3_extended_result_codes();
+    test_sqlite3_sql_introspection();
     return 0;
 }
 
@@ -967,4 +969,101 @@ void test_sqlite3_extended_result_codes()
 
     sqlite3_close(db);
     printf("test_sqlite3_extended_result_codes test passed\n");
+}
+
+/*
+** sqlite3_sql / sqlite3_expanded_sql / sqlite3_stmt_busy.
+** sqlite3_sql returns the original text, owned by the statement.
+** sqlite3_expanded_sql renders current bindings as SQL literals (NULL when
+** unbound), does not treat markers inside strings or comments as
+** parameters, and its buffer is released with sqlite3_free. Bindings
+** survive reset; clear_bindings reverts parameters to NULL.
+** sqlite3_stmt_busy is true after a step that returned a row, false before
+** any step, after SQLITE_DONE, and after reset.
+*/
+void test_sqlite3_sql_introspection()
+{
+    sqlite3 *db;
+    sqlite3_stmt *stmt;
+    char *expanded;
+    int rc;
+
+    rc = sqlite3_open(":memory:", &db);
+    assert(rc == SQLITE_OK);
+
+    const char *text = "SELECT ?1, :nm, ':nm' /* ? */, -- ?\n?";
+    rc = sqlite3_prepare_v2(db, text, -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+
+    assert(strcmp(sqlite3_sql(stmt), text) == 0);
+
+    /* Nothing bound yet: every parameter renders as NULL. */
+    expanded = sqlite3_expanded_sql(stmt);
+    assert(expanded != NULL);
+    assert(strcmp(expanded, "SELECT NULL, NULL, ':nm' /* ? */, -- ?\nNULL") == 0);
+    sqlite3_free(expanded);
+
+    rc = sqlite3_bind_int64(stmt, 1, 42);
+    assert(rc == SQLITE_OK);
+    rc = sqlite3_bind_text(stmt, sqlite3_bind_parameter_index(stmt, ":nm"),
+                           "it's", -1, SQLITE_TRANSIENT);
+    assert(rc == SQLITE_OK);
+    rc = sqlite3_bind_double(stmt, 3, 3.5);
+    assert(rc == SQLITE_OK);
+
+    expanded = sqlite3_expanded_sql(stmt);
+    assert(expanded != NULL);
+    assert(strcmp(expanded, "SELECT 42, 'it''s', ':nm' /* ? */, -- ?\n3.5") == 0);
+    sqlite3_free(expanded);
+
+    /* Busy transitions around stepping. */
+    assert(sqlite3_stmt_busy(stmt) == 0);
+    rc = sqlite3_step(stmt);
+    assert(rc == SQLITE_ROW);
+    assert(sqlite3_stmt_busy(stmt) == 1);
+    rc = sqlite3_step(stmt);
+    assert(rc == SQLITE_DONE);
+    assert(sqlite3_stmt_busy(stmt) == 0);
+
+    /* Bindings survive reset... */
+    rc = sqlite3_reset(stmt);
+    assert(rc == SQLITE_OK);
+    assert(sqlite3_stmt_busy(stmt) == 0);
+    expanded = sqlite3_expanded_sql(stmt);
+    assert(expanded != NULL);
+    assert(strcmp(expanded, "SELECT 42, 'it''s', ':nm' /* ? */, -- ?\n3.5") == 0);
+    sqlite3_free(expanded);
+
+    /* ...and clear_bindings reverts them to NULL. */
+    rc = sqlite3_clear_bindings(stmt);
+    assert(rc == SQLITE_OK);
+    expanded = sqlite3_expanded_sql(stmt);
+    assert(expanded != NULL);
+    assert(strcmp(expanded, "SELECT NULL, NULL, ':nm' /* ? */, -- ?\nNULL") == 0);
+    sqlite3_free(expanded);
+    sqlite3_finalize(stmt);
+
+    /* Blob rendering, and busy after a reset taken mid-rows. */
+    rc = sqlite3_exec(db, "CREATE TABLE sq_t(a); INSERT INTO sq_t VALUES (1), (2)",
+                      NULL, NULL, NULL);
+    assert(rc == SQLITE_OK);
+    rc = sqlite3_prepare_v2(db, "SELECT a FROM sq_t WHERE ? IS x'0102'", -1, &stmt, NULL);
+    assert(rc == SQLITE_OK);
+    rc = sqlite3_bind_blob(stmt, 1, "\x01\x02", 2, SQLITE_TRANSIENT);
+    assert(rc == SQLITE_OK);
+    expanded = sqlite3_expanded_sql(stmt);
+    assert(expanded != NULL);
+    assert(strcmp(expanded, "SELECT a FROM sq_t WHERE x'0102' IS x'0102'") == 0);
+    sqlite3_free(expanded);
+
+    rc = sqlite3_step(stmt);
+    assert(rc == SQLITE_ROW);
+    assert(sqlite3_stmt_busy(stmt) == 1);
+    rc = sqlite3_reset(stmt);
+    assert(rc == SQLITE_OK);
+    assert(sqlite3_stmt_busy(stmt) == 0);
+    sqlite3_finalize(stmt);
+
+    sqlite3_close(db);
+    printf("test_sqlite3_sql_introspection test passed\n");
 }

--- a/core/parameters.rs
+++ b/core/parameters.rs
@@ -71,14 +71,11 @@ impl Parameters {
         self.present.contains(&index) && !self.index_to_name.contains_key(&index)
     }
 
+    /// The name of the parameter at `index`: the ":name"/"@name"/"$name"
+    /// text for named parameters, "?N" for explicit numbered ones, and None
+    /// for anonymous `?` slots, matching sqlite3_bind_parameter_name.
     pub fn name(&self, index: NonZero<usize>) -> Option<String> {
-        if let Some(name) = self.index_to_name.get(&index) {
-            Some(name.clone())
-        } else if self.present.contains(&index) {
-            Some(format!("?{index}"))
-        } else {
-            None
-        }
+        self.index_to_name.get(&index).cloned()
     }
 
     pub fn index(&self, name: impl AsRef<str>) -> Option<NonZero<usize>> {

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -1265,6 +1265,51 @@ impl Statement {
         Ok(())
     }
 
+    /// Returns the SQL text with every parameter marker replaced by the
+    /// literal of its currently bound value (NULL when unbound), following
+    /// SQLite's sqlite3_expanded_sql rendering. The text is re-tokenized
+    /// with the lexer — whose token stream partitions the input, emitting
+    /// whitespace and comments as TK_NONE tokens carrying their bytes — so
+    /// string literals, quoted identifiers and comments are never mistaken
+    /// for markers. Each TK_VARIABLE token resolves to its bind index from
+    /// its own text: `?N` carries the number, named markers are looked up
+    /// in the parameter table (the same marker can occur several times),
+    /// and a bare `?` takes one more than the largest number assigned so
+    /// far, which is SQLite's numbering rule.
+    pub fn expanded_sql(&self) -> String {
+        let sql = self.get_sql();
+        let params = &self.program.parameters;
+        let mut out = String::with_capacity(sql.len());
+        let mut max_index = 0usize;
+        for token in turso_parser::lexer::Lexer::new(sql.as_bytes()) {
+            let Ok(token) = token else {
+                // The statement already parsed once, so re-lexing its text
+                // cannot fail; return the unexpanded SQL if it somehow does.
+                return sql.to_string();
+            };
+            if token.token_type == turso_parser::token::TokenType::TK_VARIABLE {
+                let text = String::from_utf8_lossy(token.value);
+                let index = if let Some(digits) = text.strip_prefix('?') {
+                    if digits.is_empty() {
+                        max_index + 1
+                    } else {
+                        digits.parse().unwrap_or(0)
+                    }
+                } else {
+                    params.index(text.as_ref()).map_or(0, |i| i.get())
+                };
+                max_index = max_index.max(index);
+                let value = NonZero::new(index)
+                    .map(|i| self.state.get_parameter(i))
+                    .unwrap_or(Value::Null);
+                append_expanded_literal(&mut out, &value);
+            } else {
+                out.push_str(&String::from_utf8_lossy(token.value));
+            }
+        }
+        out
+    }
+
     pub fn clear_bindings(&mut self) {
         self.state.clear_bindings();
     }
@@ -1506,6 +1551,40 @@ impl Statement {
     }
 }
 
+/// Appends `value` to `out` as a SQL literal, the way SQLite renders bound
+/// parameters into expanded SQL: NULL, decimal integers, floats, single-quoted
+/// text with embedded quotes doubled, and x'..' hex blobs.
+///
+/// This deliberately does not reuse Value::exec_quote: SQLite's quote() and
+/// its expanded-SQL rendering differ (quote() emits X'..' uppercase blobs and
+/// truncates text at an embedded NUL; expanded SQL emits x'..' lowercase).
+fn append_expanded_literal(out: &mut String, value: &Value) {
+    use std::fmt::Write;
+    match value {
+        Value::Null => out.push_str("NULL"),
+        Value::Text(t) => {
+            out.push('\'');
+            for ch in t.as_str().chars() {
+                if ch == '\'' {
+                    out.push('\'');
+                }
+                out.push(ch);
+            }
+            out.push('\'');
+        }
+        Value::Blob(b) => {
+            out.push_str("x'");
+            for byte in b.iter() {
+                let _ = write!(out, "{byte:02x}");
+            }
+            out.push('\'');
+        }
+        other => {
+            let _ = write!(out, "{other}");
+        }
+    }
+}
+
 impl Drop for Statement {
     fn drop(&mut self) {
         // Keep helper statements nested while drop-time reset/abort cleanup runs.
@@ -1537,6 +1616,55 @@ mod tests {
             Arc::new(SqliteDialect),
         )?;
         db.connect()
+    }
+
+    #[test]
+    fn test_expanded_sql() {
+        let conn = open_test_connection().unwrap();
+        let mut stmt = conn
+            .prepare("SELECT ?1, :nm, ':nm' /* ? */, -- ?\n?")
+            .unwrap();
+
+        // Unbound parameters render as NULL; markers inside string
+        // literals and comments are untouched.
+        assert_eq!(
+            stmt.expanded_sql(),
+            "SELECT NULL, NULL, ':nm' /* ? */, -- ?\nNULL"
+        );
+
+        stmt.bind_at(1.try_into().unwrap(), Value::from_i64(42))
+            .unwrap();
+        let nm = stmt.parameter_index(":nm").unwrap();
+        stmt.bind_at(nm, Value::build_text("it's")).unwrap();
+        stmt.bind_at(3.try_into().unwrap(), Value::from_blob(vec![1, 2]))
+            .unwrap();
+        assert_eq!(
+            stmt.expanded_sql(),
+            "SELECT 42, 'it''s', ':nm' /* ? */, -- ?\nx'0102'"
+        );
+
+        // Bindings survive reset; clear_bindings reverts them to NULL.
+        stmt.reset().unwrap();
+        assert_eq!(
+            stmt.expanded_sql(),
+            "SELECT 42, 'it''s', ':nm' /* ? */, -- ?\nx'0102'"
+        );
+        stmt.clear_bindings();
+        assert_eq!(
+            stmt.expanded_sql(),
+            "SELECT NULL, NULL, ':nm' /* ? */, -- ?\nNULL"
+        );
+
+        // A marker can occur several times and renders its value at every
+        // occurrence; a bare ? after ?2 takes index 3.
+        let mut stmt = conn.prepare("SELECT ?2, :a, ?2, ?").unwrap();
+        stmt.bind_at(2.try_into().unwrap(), Value::from_i64(7))
+            .unwrap();
+        stmt.bind_at(3.try_into().unwrap(), Value::build_text("x"))
+            .unwrap();
+        stmt.bind_at(4.try_into().unwrap(), Value::from_i64(9))
+            .unwrap();
+        assert_eq!(stmt.expanded_sql(), "SELECT 7, 'x', 7, 9");
     }
 
     #[test]

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -241,7 +241,13 @@ impl<'a> Parser<'a> {
             }
             self.last_variable_id = self.last_variable_id.max(variable_id);
             let index = NonZeroU32::new(variable_id).unwrap();
-            Ok(Expr::Variable(Variable::indexed(index)))
+            // An explicit ?N carries "?N" as its name (sqlite3_bind_parameter_name
+            // returns it and bind_parameter_index resolves it); only a bare ? is
+            // anonymous.
+            Ok(Expr::Variable(Variable::named(
+                from_bytes_as_str(token),
+                index,
+            )))
         } else {
             debug_assert!(matches!(token[0], b':' | b'@' | b'$'));
             let index = if let Some(index) = self.named_variables.get(token).copied() {


### PR DESCRIPTION
Implements `sqlite3_sql`, `sqlite3_expanded_sql` and `sqlite3_stmt_busy` (backing `SQLite3Stmt::getSQL()` and `busy()` in PHP's ext/sqlite3), SQLite conversion semantics for the column accessors, and a randomized differential oracle for the C API.

## Statement introspection

- `sqlite3_sql`: original text, retained on the statement, valid until finalize.
- `sqlite3_expanded_sql`: SQL with each parameter marker replaced by its bound value's literal (NULL when unbound). Implemented in core as `Statement::expanded_sql()` so any binding can expose it; the text is re-tokenized with the lexer, and each `TK_VARIABLE` resolves its index from its own text (`?N` carries the number, names are looked up, bare `?` is largest-so-far + 1). Does not reuse `Value::exec_quote`: SQLite renders `quote()` and expanded SQL differently (`X'..'` vs `x'..'` blobs).
- `sqlite3_stmt_busy`: delegates to the statement's busy state in core.

## Column accessors

`column_int64/int/double/text/blob/bytes` apply SQLite's conversion table when the requested representation differs from the stored type, via `Value::exec_cast` and the SQLite-compatible text rendering. Converted results are cached per column for pointer stability; `column_blob` returns NULL for zero-length results.

## C API semantics

- `sqlite3_last_insert_rowid` returns `int64` per its prototype.
- `sqlite3_bind_parameter_name` returns NULL for anonymous `?` and `"?N"` for numbered markers; the parser records `"?N"` as the parameter's name, which also makes `bind_parameter_index("?N")` resolve. Returned names are cached on the statement (valid until finalize).
- The prepare tail points at the first byte past the terminating `;`.
- `sqlite3_data_count` returns 0 when no row is available.

## Differential oracle

`tests/oracle.rs` dlopens the system libsqlite3 and the built cdylib side by side (verifying the export table via dlsym), and drives both through identical seeded scenarios, comparing every observable in lockstep: all marker styles with gaps and repeats, random-order binds with adversarial values, parameter/column-name sweeps, tail offsets, lifecycle sequences, readback through every accessor, and changes/total_changes/last_insert_rowid/get_autocommit/data_count. Failures abort with seed + operation trace; `TURSO_ORACLE_SEED`/`TURSO_ORACLE_ITERS` reproduce and extend. Runs under `cargo test` with a deterministic seed.

Not exercised (reference behavior is build-dependent, noted in the oracle): step after `SQLITE_DONE` (auto-reset vs `SQLITE_OMIT_AUTORESET`; core auto-reset is follow-up work) and long values in expanded SQL (`SQLITE_TRACE_SIZE_LIMIT`).

Directed tests in `sqlite3_tests.c` pin the introspection contracts byte-for-byte against both libraries; a core unit test covers `expanded_sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
