### PR TITLE
core/optimizer: use index for ORDER BY/GROUP BY on virtual generated columns

### DIFF
--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -759,7 +759,7 @@ fn target_matches_index_column(
         return false;
     }
     match (&target_col.target, &idx_col.expr) {
-        (ColumnTarget::Column(col_no), None) => idx_col.pos_in_table == *col_no,
+        (ColumnTarget::Column(col_no), _) => idx_col.pos_in_table == *col_no,
         (ColumnTarget::Expr(expr), Some(idx_expr)) => {
             let target_expr = unsafe { &**expr };
             if exprs_are_equivalent(target_expr, idx_expr) {

--- a/sqlite/conformance/sqlite-sqltests/gencol.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/gencol.sqltest
@@ -2273,6 +2273,79 @@ expect {
     5|10
 }
 
+# --- ORDER BY / GROUP BY on an indexed VIRTUAL column ---
+
+@cross-check-integrity
+@skip-if mvcc "Expression indexes are not supported with MVCC"
+test gencol_index_virtual_order_by_nulls_first_limit {
+    CREATE TABLE t1(a INTEGER, b INTEGER, v AS (a*2+b));
+    CREATE INDEX idx_v ON t1(v);
+    INSERT INTO t1(a,b) VALUES (1,1),(NULL,5),(2,0),(NULL,NULL),(4,4);
+    SELECT ifnull(v,'N') FROM t1 ORDER BY v LIMIT 3;
+}
+expect {
+    N
+    N
+    3
+}
+
+@cross-check-integrity
+@skip-if mvcc "Expression indexes are not supported with MVCC"
+test gencol_index_virtual_order_by_desc_nulls_last {
+    CREATE TABLE t1(a INTEGER, b INTEGER, v AS (a*2+b));
+    CREATE INDEX idx_v ON t1(v);
+    INSERT INTO t1(a,b) VALUES (1,1),(NULL,5),(2,0),(NULL,NULL),(4,4);
+    SELECT ifnull(v,'N') FROM t1 ORDER BY v DESC;
+}
+expect {
+    12
+    4
+    3
+    N
+    N
+}
+
+@cross-check-integrity
+@skip-if mvcc "Expression indexes are not supported with MVCC"
+test gencol_index_virtual_group_by_null_group {
+    CREATE TABLE t1(a INTEGER, b INTEGER, v AS (a*2+b));
+    CREATE INDEX idx_v ON t1(v);
+    INSERT INTO t1(a,b) VALUES (1,1),(NULL,5),(2,0),(NULL,NULL),(4,4);
+    SELECT ifnull(v,'N'), count(*) FROM t1 GROUP BY v;
+}
+expect {
+    N|2
+    3|1
+    4|1
+    12|1
+}
+
+@cross-check-integrity
+@skip-if mvcc "Expression indexes are not supported with MVCC"
+test gencol_index_virtual_min_max {
+    CREATE TABLE t1(a INTEGER, b INTEGER, v AS (a*2+b));
+    CREATE INDEX idx_v ON t1(v);
+    INSERT INTO t1(a,b) VALUES (1,1),(NULL,5),(2,0),(NULL,NULL),(4,4);
+    SELECT max(v), min(v) FROM t1;
+}
+expect {
+    12|3
+}
+
+@cross-check-integrity
+@skip-if mvcc "Expression indexes are not supported with MVCC"
+test gencol_index_virtual_eq_prefix_order_by {
+    CREATE TABLE t1(a INTEGER, b INTEGER, v AS (a*2+b));
+    CREATE INDEX idx_av ON t1(a, v);
+    INSERT INTO t1(a,b) VALUES (1,9),(1,1),(1,4),(2,0),(2,7);
+    SELECT v FROM t1 WHERE a = 1 ORDER BY v;
+}
+expect {
+    3
+    6
+    11
+}
+
 # --- Index UPDATE and integrity ---
 
 @cross-check-integrity

--- a/sqlite/conformance/turso-sqltests/gencol-index-order.sqltest
+++ b/sqlite/conformance/turso-sqltests/gencol-index-order.sqltest
@@ -1,0 +1,108 @@
+@database :memory:
+
+# Regression tests for https://github.com/tursodatabase/turso/issues/8245:
+# an index on a VIRTUAL generated column must satisfy ORDER BY / GROUP BY
+# with an ordered index scan instead of a full table scan plus sorter.
+
+test eqp-order-by-virtual-column-uses-index {
+    CREATE TABLE t(a INT, b INT, v INT GENERATED ALWAYS AS (a*2+b) VIRTUAL);
+    CREATE INDEX tv ON t(v);
+    EXPLAIN QUERY PLAN SELECT v FROM t ORDER BY v LIMIT 10;
+}
+expect {
+    1|0|0|SCAN t USING INDEX tv
+}
+
+test eqp-order-by-desc-virtual-column-uses-index {
+    CREATE TABLE t(a INT, b INT, v INT GENERATED ALWAYS AS (a*2+b) VIRTUAL);
+    CREATE INDEX tv ON t(v);
+    EXPLAIN QUERY PLAN SELECT v FROM t ORDER BY v DESC;
+}
+expect {
+    1|0|0|SCAN t USING INDEX tv
+}
+
+test eqp-order-by-virtual-column-uses-desc-index {
+    CREATE TABLE t(a INT, b INT, v INT GENERATED ALWAYS AS (a*2+b) VIRTUAL);
+    CREATE INDEX tvd ON t(v DESC);
+    EXPLAIN QUERY PLAN SELECT v FROM t ORDER BY v DESC;
+}
+expect {
+    1|0|0|SCAN t USING INDEX tvd
+}
+
+test eqp-group-by-virtual-column-uses-index {
+    CREATE TABLE t(a INT, b INT, v INT GENERATED ALWAYS AS (a*2+b) VIRTUAL);
+    CREATE INDEX tv ON t(v);
+    EXPLAIN QUERY PLAN SELECT v, count(*) FROM t GROUP BY v;
+}
+expect {
+    1|0|0|SCAN t USING INDEX tv
+}
+
+test eqp-max-virtual-column-uses-index {
+    CREATE TABLE t(a INT, b INT, v INT GENERATED ALWAYS AS (a*2+b) VIRTUAL);
+    CREATE INDEX tv ON t(v);
+    EXPLAIN QUERY PLAN SELECT max(v) FROM t;
+}
+expect {
+    1|0|0|SCAN t USING INDEX tv
+}
+
+test eqp-eq-prefix-order-by-virtual-column-uses-index {
+    CREATE TABLE t(a INT, b INT, v INT GENERATED ALWAYS AS (a*2+b) VIRTUAL);
+    CREATE INDEX tav ON t(a, v);
+    EXPLAIN QUERY PLAN SELECT v FROM t WHERE a = 1 ORDER BY v;
+}
+expect {
+    1|0|0|SEARCH t USING INDEX tav (a=?)
+}
+
+test eqp-order-by-virtual-column-and-unindexed-column-still-sorts {
+    CREATE TABLE t(a INT, b INT, v INT GENERATED ALWAYS AS (a*2+b) VIRTUAL);
+    CREATE INDEX tv ON t(v);
+    EXPLAIN QUERY PLAN SELECT v FROM t ORDER BY v, b;
+}
+expect {
+    1|0|0|SCAN t
+    14|0|0|USE SORTER FOR ORDER BY
+}
+
+test order-by-virtual-column-index-scan-nulls-first-limit {
+    CREATE TABLE t(a INT, b INT, v INT GENERATED ALWAYS AS (a*2+b) VIRTUAL);
+    CREATE INDEX tv ON t(v);
+    INSERT INTO t(a,b) VALUES (1,1),(NULL,5),(2,0),(NULL,NULL),(4,4);
+    SELECT ifnull(v,'N') FROM t ORDER BY v LIMIT 3;
+}
+expect {
+    N
+    N
+    3
+}
+
+test order-by-desc-virtual-column-index-scan-nulls-last {
+    CREATE TABLE t(a INT, b INT, v INT GENERATED ALWAYS AS (a*2+b) VIRTUAL);
+    CREATE INDEX tv ON t(v);
+    INSERT INTO t(a,b) VALUES (1,1),(NULL,5),(2,0),(NULL,NULL),(4,4);
+    SELECT ifnull(v,'N') FROM t ORDER BY v DESC;
+}
+expect {
+    12
+    4
+    3
+    N
+    N
+}
+
+test group-by-virtual-column-index-scan-includes-null-group {
+    CREATE TABLE t(a INT, b INT, v INT GENERATED ALWAYS AS (a*2+b) VIRTUAL);
+    CREATE INDEX tv ON t(v);
+    INSERT INTO t(a,b) VALUES (1,1),(NULL,5),(2,0),(NULL,NULL),(4,4);
+    SELECT ifnull(v,'N'), count(*) FROM t GROUP BY v;
+}
+expect {
+    N|2
+    3|1
+    4|1
+    12|1
+}


### PR DESCRIPTION
## Description

Use virtual columns for `ORDER BY/GROUP BY`.