### PR TITLE
core/index-method: declare MVCC capabilities

### DIFF
--- a/core/index_method/backing_btree.rs
+++ b/core/index_method/backing_btree.rs
@@ -37,6 +37,7 @@ impl IndexMethodAttachment for BackingBTreeIndexMethodAttachment {
             patterns: &[],
             backing_btree: true,
             results_materialized: false,
+            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
         }
     }
 

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1773,6 +1773,7 @@ impl IndexMethodAttachment for FtsIndexAttachment {
             // Unordered match queries stream directly from Tantivy scorers.
             // UPDATE/DELETE must therefore collect stable rowids before writes.
             results_materialized: false,
+            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
         }
     }
 

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -48,6 +48,19 @@ pub trait IndexMethodAttachment: std::fmt::Debug + Send + Sync {
     fn init(&self) -> Result<Box<dyn IndexMethodCursor>>;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexMethodMvccSupport {
+    /// The method cannot be opened while MVCC is active.
+    Unsupported,
+    /// The method may query MVCC snapshots but has no transactional write path.
+    ReadOnly,
+    /// Persistent state is stored exclusively through core-provided,
+    /// MVCC-aware backing storage.
+    TransactionalBackingStore,
+    /// Persistent state is external and implements transaction outcome hooks.
+    ExternalTransactional,
+}
+
 #[derive(Debug)]
 pub struct IndexMethodDefinition<'a> {
     /// index method name
@@ -65,6 +78,30 @@ pub struct IndexMethodDefinition<'a> {
     /// a live data structure that writes could invalidate.
     /// When `false`, the emitter will collect rowids into a RowSet/ephemeral table before writing.
     pub results_materialized: bool,
+    /// Declares how this method participates in MVCC transactions.
+    pub mvcc_support: IndexMethodMvccSupport,
+}
+
+pub(crate) fn ensure_mvcc_support(
+    definition: &IndexMethodDefinition<'_>,
+    write: bool,
+) -> Result<()> {
+    match (definition.mvcc_support, write) {
+        (IndexMethodMvccSupport::Unsupported, _) => Err(LimboError::ParseError(format!(
+            "index method '{}' does not support MVCC",
+            definition.method_name
+        ))),
+        (IndexMethodMvccSupport::ReadOnly, true) => Err(LimboError::ParseError(format!(
+            "index method '{}' is read-only in MVCC",
+            definition.method_name
+        ))),
+        (
+            IndexMethodMvccSupport::ReadOnly
+            | IndexMethodMvccSupport::TransactionalBackingStore
+            | IndexMethodMvccSupport::ExternalTransactional,
+            _,
+        ) => Ok(()),
+    }
 }
 
 /// Cost estimate returned by custom index methods for optimizer integration.
@@ -271,4 +308,35 @@ pub(crate) fn parse_patterns(patterns: &[&str]) -> Result<Vec<ast::Select>> {
         parsed.push(select);
     }
     Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_mvcc_support, IndexMethodDefinition, IndexMethodMvccSupport};
+
+    fn definition(support: IndexMethodMvccSupport) -> IndexMethodDefinition<'static> {
+        IndexMethodDefinition {
+            method_name: "test_method",
+            index_name: "test_index",
+            patterns: &[],
+            backing_btree: false,
+            results_materialized: true,
+            mvcc_support: support,
+        }
+    }
+
+    #[test]
+    fn mvcc_support_declaration_rejects_unsupported_access() {
+        let error = ensure_mvcc_support(&definition(IndexMethodMvccSupport::Unsupported), false)
+            .unwrap_err();
+        assert!(matches!(error, crate::LimboError::ParseError(_)));
+
+        ensure_mvcc_support(&definition(IndexMethodMvccSupport::ReadOnly), false).unwrap();
+        assert!(ensure_mvcc_support(&definition(IndexMethodMvccSupport::ReadOnly), true).is_err());
+        ensure_mvcc_support(
+            &definition(IndexMethodMvccSupport::TransactionalBackingStore),
+            true,
+        )
+        .unwrap();
+    }
 }

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -345,6 +345,7 @@ impl IndexMethodAttachment for VectorSparseInvertedIndexMethodAttachment {
             patterns: self.patterns.as_slice(),
             backing_btree: false,
             results_materialized: true,
+            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
         }
     }
     fn init(&self) -> Result<Box<dyn IndexMethodCursor>> {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1804,8 +1804,10 @@ impl Schema {
                 unparsed_sql_from_index.root_page,
                 table.as_ref(),
             )?;
-            if mvcc_enabled && index.index_method.is_some() {
-                crate::bail_parse_error!("Custom index modules are not supported with MVCC");
+            if mvcc_enabled {
+                if let Some(index_method) = index.index_method.as_ref() {
+                    crate::index_method::ensure_mvcc_support(&index_method.definition(), false)?;
+                }
             }
             self.add_index(Arc::new(index))?;
         }

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1,7 +1,7 @@
 use crate::alloc::{TryClone, TursoIteratorExt, TursoVecExt};
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::Func;
-use crate::index_method::IndexMethodConfiguration;
+use crate::index_method::{ensure_mvcc_support, IndexMethodConfiguration};
 use crate::numeric::Numeric;
 use crate::schema::{Column, GeneratedType, Table, EXPR_INDEX_SENTINEL, RESERVED_TABLE_PREFIXES};
 use crate::sync::Arc;
@@ -65,9 +65,6 @@ fn validate(
         bail_parse_error!(
             "index method is an experimental feature. Enable with --experimental-index-method flag"
         )
-    }
-    if connection.mvcc_enabled() && using.is_some() {
-        bail_parse_error!("Custom index modules are not supported in MVCC mode");
     }
     if tbl_name.eq_ignore_ascii_case("sqlite_sequence") {
         crate::bail_parse_error!("table sqlite_sequence may not be indexed");
@@ -196,12 +193,16 @@ pub fn translate_create_index(
         }
         if let Some(index_module) = index_module {
             let parameters = resolve_index_method_parameters(with_clause)?;
-            index_method = Some(index_module.attach(&IndexMethodConfiguration {
+            let attachment = index_module.attach(&IndexMethodConfiguration {
                 table_name: tbl.name.clone(),
                 index_name: idx_name.clone(),
                 columns: columns.try_clone()?,
                 parameters,
-            })?);
+            })?;
+            if connection.mvcc_enabled() {
+                ensure_mvcc_support(&attachment.definition(), true)?;
+            }
+            index_method = Some(attachment);
         }
     }
     let idx = Arc::new(Index {

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -82,6 +82,25 @@ fn sparse_vector(v: &str) -> Value {
     vector::operations::serialize::vector_serialize(vector).expect(turso_core::alloc::ALLOC_ERR_MSG)
 }
 
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test]
+fn fts_mvcc_capability_is_checked_before_create(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+
+    let error = conn
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("index method 'fts' does not support MVCC"),
+        "unexpected error: {error}"
+    );
+}
+
 // TODO: cannot use MVCC as we use indexes here
 #[turso_macros::test(init_sql = "CREATE TABLE t(name, embedding)")]
 fn test_vector_sparse_ivf_create_destroy(tmp_db: TempDatabase) {


### PR DESCRIPTION
Replace the global custom-index MVCC ban with an explicit capability on each `IndexMethod` definition. Built-in methods remain unsupported in this commit, so behavior does not change until their storage and lifecycle support lands.
