### PR TITLE
core: optimize varint decoding with whole-word operations

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -245,6 +245,10 @@ name = "write_perf_benchmark"
 harness = false
 
 [[bench]]
+name = "varint_benchmark"
+harness = false
+
+[[bench]]
 name = "create_index_benchmark"
 harness = false
 

--- a/core/benches/varint_benchmark.rs
+++ b/core/benches/varint_benchmark.rs
@@ -1,0 +1,260 @@
+//! Microbenchmarks for SQLite-format varint decoding.
+//!
+//! Varints show up in three hot shapes in the engine, and each gets a benchmark:
+//!  - single-varint decode at each encoded length (predictable branch pattern)
+//!  - a shuffled mixed-length stream (unpredictable lengths, like parsing many
+//!    b-tree cells where payload sizes and rowids vary)
+//!  - record-header runs: decoding every serial type of a record header, and the
+//!    Column-opcode pattern of skipping k serial types to reach one column
+//!
+//! Run: cargo bench -p turso_core --bench varint_benchmark
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
+};
+#[cfg(not(feature = "codspeed"))]
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+use turso_core::storage::sqlite3_ondisk::{read_varint, write_varint};
+use turso_core::types::ValueIterator;
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+/// Deterministic RNG (xorshift64*) so every run benches identical byte streams.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545F4914F6CDD1D)
+    }
+
+    /// Random value in [0, n).
+    fn below(&mut self, n: u64) -> u64 {
+        self.next() % n
+    }
+}
+
+/// Smallest and largest value for each encoded varint length 1..=9.
+fn value_range_for_len(len: usize) -> (u64, u64) {
+    match len {
+        1 => (0, 0x7f),
+        2..=8 => (1u64 << (7 * (len - 1)), (1u64 << (7 * len)) - 1),
+        9 => (1u64 << 56, u64::MAX),
+        _ => unreachable!(),
+    }
+}
+
+/// A byte stream of `count` varints plus the values they encode.
+struct VarintStream {
+    bytes: Vec<u8>,
+    values: Vec<u64>,
+}
+
+fn build_stream(count: usize, mut pick_value: impl FnMut() -> u64) -> VarintStream {
+    let mut bytes = Vec::new();
+    let mut values = Vec::with_capacity(count);
+    let mut buf = [0u8; 9];
+    for _ in 0..count {
+        let v = pick_value();
+        let n = write_varint(&mut buf, v);
+        bytes.extend_from_slice(&buf[..n]);
+        values.push(v);
+    }
+    // Padding so decoding the final varint still sees a full-size read window,
+    // like a varint in the middle of a page. Zero bytes never extend a varint.
+    bytes.extend_from_slice(&[0u8; 16]);
+    VarintStream { bytes, values }
+}
+
+/// Decode the whole stream front to back, folding the values so the decode
+/// cannot be optimized away. Panics on any decode error: benchmarked streams
+/// are always valid.
+fn decode_stream(bytes: &[u8], count: usize) -> u64 {
+    let mut pos = 0;
+    let mut acc = 0u64;
+    for _ in 0..count {
+        let (v, n) = read_varint(&bytes[pos..]).unwrap();
+        acc = acc.wrapping_add(v);
+        pos += n;
+    }
+    acc
+}
+
+const STREAM_COUNT: usize = 8_192;
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_varint_single_lengths(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("varint_decode_fixed_len");
+    for len in 1..=9usize {
+        let (lo, hi) = value_range_for_len(len);
+        let mut rng = Rng(0x9E3779B97F4A7C15);
+        let stream = build_stream(STREAM_COUNT, || lo + rng.below(hi - lo + 1));
+        let expected: u64 = stream.values.iter().fold(0u64, |a, &v| a.wrapping_add(v));
+        group.throughput(Throughput::Elements(STREAM_COUNT as u64));
+        group.bench_with_input(BenchmarkId::new("len", len), &stream, |b, s| {
+            b.iter(|| {
+                let acc = decode_stream(black_box(&s.bytes), STREAM_COUNT);
+                assert_eq!(acc, expected);
+                acc
+            })
+        });
+    }
+    group.finish();
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_varint_mixed_stream(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("varint_decode_mixed");
+
+    // Length mix modeled on b-tree traffic: mostly tiny values (serial types,
+    // small rowids), a solid share of 2-byte (payload sizes, medium rowids),
+    // and a tail of larger ones. Order is shuffled, so the length of each
+    // varint is unpredictable to the branch predictor.
+    let mut rng = Rng(0xDEADBEEFCAFED00D);
+    let stream = build_stream(STREAM_COUNT, || {
+        let (lo, hi) = match rng.below(100) {
+            0..=59 => value_range_for_len(1),
+            60..=84 => value_range_for_len(2),
+            85..=94 => value_range_for_len(3),
+            95..=98 => value_range_for_len(5),
+            _ => value_range_for_len(9),
+        };
+        lo + rng.below((hi - lo).wrapping_add(1).max(1))
+    });
+    let expected: u64 = stream.values.iter().fold(0u64, |a, &v| a.wrapping_add(v));
+
+    group.throughput(Throughput::Elements(STREAM_COUNT as u64));
+    group.bench_function("shuffled_lengths", |b| {
+        b.iter(|| {
+            let acc = decode_stream(black_box(&stream.bytes), STREAM_COUNT);
+            assert_eq!(acc, expected);
+            acc
+        })
+    });
+    group.finish();
+}
+
+/// Build one record payload: header-size varint, serial-type varints, then data
+/// bytes sized to match. Values are filler; the interesting part is the header.
+fn build_record(serial_types: &[u64]) -> Vec<u8> {
+    fn serial_type_data_size(st: u64) -> usize {
+        match st {
+            0 | 8 | 9 => 0,
+            1 => 1,
+            2 => 2,
+            3 => 3,
+            4 => 4,
+            5 => 6,
+            6 | 7 => 8,
+            n if n >= 12 => ((n - 12) / 2) as usize,
+            _ => unreachable!("reserved serial type"),
+        }
+    }
+
+    let mut buf = [0u8; 9];
+    let mut header_body = Vec::new();
+    for &st in serial_types {
+        let n = write_varint(&mut buf, st);
+        header_body.extend_from_slice(&buf[..n]);
+    }
+    // Header size includes its own varint. One byte is always enough here:
+    // benchmark headers stay far below 128 bytes.
+    let header_size = header_body.len() + 1;
+    assert!(header_size <= 0x7f);
+
+    let mut payload = Vec::new();
+    payload.push(header_size as u8);
+    payload.extend_from_slice(&header_body);
+    for &st in serial_types {
+        let size = serial_type_data_size(st);
+        // 0x41 = 'A': valid UTF-8 so text serial types decode cleanly.
+        payload.extend(std::iter::repeat_n(0x41u8, size));
+    }
+    payload
+}
+
+/// Serial types for text of the given byte length.
+fn text_st(len: usize) -> u64 {
+    (len as u64) * 2 + 13
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_record_header_runs(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("varint_decode_header_run");
+
+    // (label, serial types): three realistic table shapes.
+    // narrow: small ints and short text, 1-byte serial types only.
+    // wide: 32 columns, 1-byte serial types only.
+    // text_heavy: large text columns force 2-byte serial-type varints.
+    let narrow: Vec<u64> = vec![1, 4, text_st(20), 8];
+    let wide: Vec<u64> = (0..32)
+        .map(|i| match i % 4 {
+            0 => 1,
+            1 => 4,
+            2 => text_st(24),
+            _ => 6,
+        })
+        .collect();
+    let text_heavy: Vec<u64> = (0..8)
+        .map(|i| if i % 2 == 0 { text_st(100) } else { 2 })
+        .collect();
+
+    for (label, serial_types) in [
+        ("narrow_4col", &narrow),
+        ("wide_32col", &wide),
+        ("text_heavy_8col", &text_heavy),
+    ] {
+        let payload = build_record(serial_types);
+        let cols = serial_types.len();
+
+        // Full iteration: decode every value of the record, like SELECT *.
+        group.throughput(Throughput::Elements(cols as u64));
+        group.bench_with_input(
+            BenchmarkId::new("iterate_all", label),
+            &payload,
+            |b, payload| {
+                b.iter(|| {
+                    let iter = ValueIterator::new(black_box(payload.as_slice())).unwrap();
+                    let mut n = 0usize;
+                    for v in iter {
+                        black_box(v.unwrap());
+                        n += 1;
+                    }
+                    assert_eq!(n, cols);
+                })
+            },
+        );
+
+        // Column-opcode pattern: skip to the last column, decode just it.
+        // Skipping is pure serial-type varint decoding plus size accumulation.
+        group.throughput(Throughput::Elements(cols as u64));
+        group.bench_with_input(
+            BenchmarkId::new("skip_to_last", label),
+            &payload,
+            |b, payload| {
+                b.iter(|| {
+                    let mut iter = ValueIterator::new(black_box(payload.as_slice())).unwrap();
+                    let v = iter.nth(cols - 1).unwrap().unwrap();
+                    black_box(v);
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_varint_single_lengths,
+    bench_varint_mixed_stream,
+    bench_record_header_runs
+);
+criterion_main!(benches);

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -48,7 +48,7 @@ use crate::{
     types::{IOCompletions, IOResult},
     util::IOExt as _,
 };
-use branches::{mark_unlikely, unlikely};
+use branches::{likely, mark_unlikely, unlikely};
 use bytemuck::{Pod, Zeroable};
 use pack1::{I32BE, U16BE, U32BE};
 use tracing::{instrument, Level};
@@ -1310,65 +1310,108 @@ pub fn read_integer(buf: &[u8], serial_type: u8) -> Result<i64> {
     }
 }
 
+/// The high bit of each varint byte except the ninth says "more bytes follow";
+/// the other 7 bits carry the value. These masks split a whole 8-byte word
+/// into those two parts.
+pub(crate) const VARINT_CONT_BITS: u64 = 0x8080_8080_8080_8080;
+const VARINT_PAYLOAD_BITS: u64 = 0x7f7f_7f7f_7f7f_7f7f;
+
+/// Gather the low 7 bits of every byte of `x` into one 56-bit integer, keeping
+/// byte significance: the most significant byte contributes the highest 7 bits.
+/// Works by merging adjacent digits in three halving steps (7-bit digits into
+/// 14-bit, then 28-bit, then one 56-bit value), a dozen cheap ALU ops with no
+/// branches.
+#[inline(always)]
+fn varint_gather_payload_bits(x: u64) -> u64 {
+    let m = x & VARINT_PAYLOAD_BITS;
+    let m = (m & 0x007f_007f_007f_007f) | ((m & 0x7f00_7f00_7f00_7f00) >> 1);
+    let m = (m & 0x0000_3fff_0000_3fff) | ((m & 0x3fff_0000_3fff_0000) >> 2);
+    (m & 0x0000_0000_0fff_ffff) | ((m & 0x0fff_ffff_0000_0000) >> 4)
+}
+
 /// Reads varint integer from the buffer.
-/// This function is similar to `sqlite3GetVarint32`
+///
+/// 1- and 2-byte varints (nearly all serial types, rowids and payload sizes)
+/// return through two direct checks. Longer ones decode from a single 8-byte
+/// load without a per-byte loop, so the varint length adds no unpredictable
+/// branches.
 #[inline(always)]
 pub fn read_varint(buf: &[u8]) -> Result<(u64, usize)> {
-    let mut v: u64 = 0;
-    for i in 0..8 {
-        match buf.get(i) {
-            Some(c) => {
-                v = (v << 7) + (c & 0x7f) as u64;
-                if (c & 0x80) == 0 {
-                    return Ok((v, i + 1));
-                }
-            }
-            None => {
-                mark_unlikely();
-                crate::bail_corrupt_error!("Invalid varint");
-            }
-        }
+    let Some(&b0) = buf.first() else {
+        mark_unlikely();
+        bail_corrupt_error!("Invalid varint");
+    };
+    if likely(b0 < 0x80) {
+        return Ok((b0 as u64, 1));
     }
-    match buf.get(8) {
-        Some(&c) => {
-            // Values requiring 9 bytes must have non-zero in the top 8 bits (value >= 1<<56).
-            // Since the final value is `(v<<8) + c`, the top 8 bits (v >> 48) must not be 0.
-            // If those are zero, this should be treated as corrupt.
-            // Perf? the comparison + branching happens only in parsing 9-byte varint which is rare.
-            if unlikely((v >> 48) == 0) {
-                bail_corrupt_error!("Invalid varint");
-            }
-            v = (v << 8) + c as u64;
-            Ok((v, 9))
+    let Some(&b1) = buf.get(1) else {
+        mark_unlikely();
+        bail_corrupt_error!("Invalid varint");
+    };
+    if b1 < 0x80 {
+        return Ok(((((b0 & 0x7f) as u64) << 7) | b1 as u64, 2));
+    }
+    read_varint_long(buf)
+}
+
+/// Decode a varint of any length wholesale from an 8-byte word. Split out of
+/// [read_varint] so the common short cases stay small at every call site.
+fn read_varint_long(buf: &[u8]) -> Result<(u64, usize)> {
+    if let Some(chunk) = buf.first_chunk::<8>() {
+        let x = u64::from_be_bytes(*chunk);
+        let stops = !x & VARINT_CONT_BITS;
+        if likely(stops != 0) {
+            // The most significant stop bit sits in the first byte with a
+            // clear high bit: the last byte of the varint.
+            let n = (stops.leading_zeros() >> 3) as usize + 1;
+            // Gathering all 8 bytes leaves the digits past the stop byte in
+            // the bits below the wanted value; the shift drops them.
+            let v = varint_gather_payload_bits(x) >> (7 * (8 - n));
+            return Ok((v, n));
         }
-        None => {
+        // All 8 bytes continue: a 9-byte varint, whose last byte contributes
+        // a full 8 bits with no continuation flag.
+        let Some(&b8) = buf.get(8) else {
             mark_unlikely();
             bail_corrupt_error!("Invalid varint");
+        };
+        let v = varint_gather_payload_bits(x);
+        // Values requiring 9 bytes must have non-zero in the top 8 bits (value >= 1<<56).
+        // Since the final value is `(v<<8) + b8`, the top 8 bits (v >> 48) must not be 0.
+        // If those are zero, this should be treated as corrupt.
+        if unlikely((v >> 48) == 0) {
+            bail_corrupt_error!("Invalid varint");
+        }
+        return Ok(((v << 8) + b8 as u64, 9));
+    }
+    // Fewer than 8 bytes left in the buffer: any valid varint fits in what
+    // remains, so a short byte loop covers it.
+    let mut v: u64 = 0;
+    for (i, &c) in buf.iter().enumerate() {
+        v = (v << 7) + (c & 0x7f) as u64;
+        if (c & 0x80) == 0 {
+            return Ok((v, i + 1));
         }
     }
+    mark_unlikely();
+    bail_corrupt_error!("Invalid varint");
 }
 
 #[inline(always)]
 /// Reads a varint from the buffer, returning None if more data is needed.
 pub fn read_varint_partial(buf: &[u8]) -> Result<Option<(u64, usize)>> {
+    if likely(buf.len() >= 9) {
+        // A varint is at most 9 bytes, so it cannot need more data than this.
+        return read_varint(buf).map(Some);
+    }
     let mut v: u64 = 0;
-    for i in 0..8 {
-        let Some(&c) = buf.get(i) else {
-            return Ok(None);
-        };
+    for (i, &c) in buf.iter().enumerate() {
         v = (v << 7) + (c & 0x7f) as u64;
         if (c & 0x80) == 0 {
             return Ok(Some((v, i + 1)));
         }
     }
-    let Some(&c) = buf.get(8) else {
-        return Ok(None);
-    };
-    if unlikely((v >> 48) == 0) {
-        bail_corrupt_error!("Invalid varint");
-    }
-    v = (v << 8) + c as u64;
-    Ok(Some((v, 9)))
+    Ok(None)
 }
 
 /// Compute the length of a varint encoding for a given u64 value.
@@ -2517,5 +2560,132 @@ mod tests {
         let mut buf = [0u8; 9];
         let written = write_varint(&mut buf, value);
         varint_len(value) == written
+    }
+
+    /// Byte-at-a-time varint decoder, the shape [read_varint] had before the
+    /// whole-word decode. Kept as the oracle the optimized decoder must match
+    /// on every input, valid or not.
+    fn read_varint_reference(buf: &[u8]) -> Result<(u64, usize)> {
+        let mut v: u64 = 0;
+        for i in 0..8 {
+            match buf.get(i) {
+                Some(c) => {
+                    v = (v << 7) + (c & 0x7f) as u64;
+                    if (c & 0x80) == 0 {
+                        return Ok((v, i + 1));
+                    }
+                }
+                None => bail_corrupt_error!("Invalid varint"),
+            }
+        }
+        match buf.get(8) {
+            Some(&c) => {
+                if (v >> 48) == 0 {
+                    bail_corrupt_error!("Invalid varint");
+                }
+                Ok(((v << 8) + c as u64, 9))
+            }
+            None => bail_corrupt_error!("Invalid varint"),
+        }
+    }
+
+    fn read_varint_partial_reference(buf: &[u8]) -> Result<Option<(u64, usize)>> {
+        let mut v: u64 = 0;
+        for i in 0..8 {
+            let Some(&c) = buf.get(i) else {
+                return Ok(None);
+            };
+            v = (v << 7) + (c & 0x7f) as u64;
+            if (c & 0x80) == 0 {
+                return Ok(Some((v, i + 1)));
+            }
+        }
+        let Some(&c) = buf.get(8) else {
+            return Ok(None);
+        };
+        if (v >> 48) == 0 {
+            bail_corrupt_error!("Invalid varint");
+        }
+        Ok(Some(((v << 8) + c as u64, 9)))
+    }
+
+    fn assert_matches_reference(buf: &[u8]) {
+        let expected = read_varint_reference(buf);
+        let actual = read_varint(buf);
+        match (&expected, &actual) {
+            (Ok(a), Ok(b)) => assert_eq!(a, b, "decode mismatch on {buf:02x?}"),
+            (Err(_), Err(_)) => {}
+            _ => panic!("outcome mismatch on {buf:02x?}: expected {expected:?}, got {actual:?}"),
+        }
+        let expected = read_varint_partial_reference(buf);
+        let actual = read_varint_partial(buf);
+        match (&expected, &actual) {
+            (Ok(a), Ok(b)) => assert_eq!(a, b, "partial decode mismatch on {buf:02x?}"),
+            (Err(_), Err(_)) => {}
+            _ => panic!(
+                "partial outcome mismatch on {buf:02x?}: expected {expected:?}, got {actual:?}"
+            ),
+        }
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn read_varint_matches_reference_on_arbitrary_bytes(buf: Vec<u8>) -> bool {
+        // Every window of the buffer, so varints land both flush against the
+        // end (short-tail path) and with plenty of room (whole-word path).
+        for start in 0..=buf.len().min(16) {
+            assert_matches_reference(&buf[start..]);
+        }
+        true
+    }
+
+    #[test]
+    fn read_varint_roundtrips_boundary_values_at_any_offset_from_buffer_end() {
+        let mut values: Vec<u64> = vec![0, 1, u64::MAX];
+        for bits in 1..=63 {
+            let v = 1u64 << bits;
+            values.extend_from_slice(&[v - 1, v, v + 1]);
+        }
+        for &value in &values {
+            let mut enc = [0u8; 32];
+            let n = write_varint(&mut enc, value);
+            // Decode with 0..=16 bytes of slack after the varint, then from
+            // every truncation of the varint itself.
+            for end in n..=32 {
+                let (decoded, len) = read_varint(&enc[..end]).unwrap();
+                assert_eq!((decoded, len), (value, n), "value {value} end {end}");
+            }
+            for cut in 0..n {
+                assert_matches_reference(&enc[..cut]);
+            }
+        }
+    }
+
+    #[rstest]
+    // Non-canonical encodings (leading 0x80 padding) decode like the loop
+    // decoder always decoded them: 2..=8 byte encodings of small values are
+    // accepted.
+    #[case(&[0x80, 0x00], (0, 2))]
+    #[case(&[0x80, 0x7f], (0x7f, 2))]
+    #[case(&[0x80, 0x80, 0x01], (1, 3))]
+    #[case(&[0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01], (1, 8))]
+    // Largest 8-byte varint.
+    #[case(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f], ((1 << 56) - 1, 8))]
+    // Smallest valid 9-byte varint: 1 << 56.
+    #[case(&[0x80, 0xC0, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00], (1 << 56, 9))]
+    // Largest varint: u64::MAX.
+    #[case(&[0xff; 9], (u64::MAX, 9))]
+    fn test_read_varint_exact_encodings(#[case] buf: &[u8], #[case] expected: (u64, usize)) {
+        assert_eq!(read_varint(buf).unwrap(), expected);
+        assert_eq!(read_varint_partial(buf).unwrap(), Some(expected));
+    }
+
+    /// A 9-byte varint whose value would fit in 8 bytes is rejected, even when
+    /// the buffer extends past it.
+    #[test]
+    fn test_read_varint_rejects_noncanonical_9_byte() {
+        let mut buf = [0x80u8; 16];
+        buf[8] = 0x01;
+        assert!(read_varint(&buf).is_err());
+        assert!(read_varint_partial(&buf).is_err());
     }
 }

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1366,6 +1366,11 @@ pub fn read_varint(buf: &[u8]) -> Result<(u64, usize)> {
 /// digits, shift. That trades the old per-byte loop for a handful of
 /// branch-free ALU ops, which wins precisely where lengths are too scattered
 /// to predict.
+///
+/// Kept inline: an outlined call serializes the caller's decode loop on the
+/// call's argument and result flow, which measures slower than the decode
+/// itself.
+#[inline(always)]
 fn read_varint_long(buf: &[u8]) -> Result<(u64, usize)> {
     let Some(&b2) = buf.get(2) else {
         mark_unlikely();

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1332,9 +1332,10 @@ fn varint_gather_payload_bits(x: u64) -> u64 {
 /// Reads varint integer from the buffer.
 ///
 /// 1- and 2-byte varints (nearly all serial types, rowids and payload sizes)
-/// return through two direct checks. Longer ones decode from a single 8-byte
-/// load without a per-byte loop, so the varint length adds no unpredictable
-/// branches.
+/// return through two direct checks inlined at the call site; everything
+/// longer goes through one outlined call. The byte-by-byte accumulator loop
+/// is gone from every path, so no decode carries a loop-carried data
+/// dependency per byte.
 #[inline(always)]
 pub fn read_varint(buf: &[u8]) -> Result<(u64, usize)> {
     let Some(&b0) = buf.first() else {
@@ -1354,47 +1355,74 @@ pub fn read_varint(buf: &[u8]) -> Result<(u64, usize)> {
     read_varint_long(buf)
 }
 
-/// Decode a varint of any length wholesale from an 8-byte word. Split out of
-/// [read_varint] so the common short cases stay small at every call site.
+/// Decode a varint of 3 or more bytes; `buf[0]` and `buf[1]` are known to
+/// carry continuation bits.
+///
+/// 3- and 4-byte varints take direct checks: their length is usually stable
+/// within a scan (rowids and payload sizes of neighboring rows are alike), and
+/// the branch predictor then hides the checks entirely. 5 bytes and up
+/// (values >= 1<<28, rare) decode wholesale from one 8-byte load: locate the
+/// terminating byte through the continuation-bit mask, gather the 7-bit
+/// digits, shift. That trades the old per-byte loop for a handful of
+/// branch-free ALU ops, which wins precisely where lengths are too scattered
+/// to predict.
 fn read_varint_long(buf: &[u8]) -> Result<(u64, usize)> {
-    if let Some(chunk) = buf.first_chunk::<8>() {
-        let x = u64::from_be_bytes(*chunk);
-        let stops = !x & VARINT_CONT_BITS;
-        if likely(stops != 0) {
-            // The most significant stop bit sits in the first byte with a
-            // clear high bit: the last byte of the varint.
-            let n = (stops.leading_zeros() >> 3) as usize + 1;
-            // Gathering all 8 bytes leaves the digits past the stop byte in
-            // the bits below the wanted value; the shift drops them.
-            let v = varint_gather_payload_bits(x) >> (7 * (8 - n));
-            return Ok((v, n));
-        }
-        // All 8 bytes continue: a 9-byte varint, whose last byte contributes
-        // a full 8 bits with no continuation flag.
-        let Some(&b8) = buf.get(8) else {
-            mark_unlikely();
-            bail_corrupt_error!("Invalid varint");
-        };
-        let v = varint_gather_payload_bits(x);
-        // Values requiring 9 bytes must have non-zero in the top 8 bits (value >= 1<<56).
-        // Since the final value is `(v<<8) + b8`, the top 8 bits (v >> 48) must not be 0.
-        // If those are zero, this should be treated as corrupt.
-        if unlikely((v >> 48) == 0) {
-            bail_corrupt_error!("Invalid varint");
-        }
-        return Ok(((v << 8) + b8 as u64, 9));
+    let Some(&b2) = buf.get(2) else {
+        mark_unlikely();
+        bail_corrupt_error!("Invalid varint");
+    };
+    let v2 =
+        (((buf[0] & 0x7f) as u64) << 14) | (((buf[1] & 0x7f) as u64) << 7) | (b2 & 0x7f) as u64;
+    if b2 < 0x80 {
+        return Ok((v2, 3));
     }
-    // Fewer than 8 bytes left in the buffer: any valid varint fits in what
-    // remains, so a short byte loop covers it.
-    let mut v: u64 = 0;
-    for (i, &c) in buf.iter().enumerate() {
-        v = (v << 7) + (c & 0x7f) as u64;
-        if (c & 0x80) == 0 {
-            return Ok((v, i + 1));
-        }
+    let Some(&b3) = buf.get(3) else {
+        mark_unlikely();
+        bail_corrupt_error!("Invalid varint");
+    };
+    if b3 < 0x80 {
+        return Ok(((v2 << 7) | b3 as u64, 4));
     }
-    mark_unlikely();
-    bail_corrupt_error!("Invalid varint");
+
+    let Some(chunk) = buf.first_chunk::<8>() else {
+        // Fewer than 8 bytes left in the buffer: any valid varint fits in
+        // what remains, so a short byte loop covers it.
+        let mut v: u64 = 0;
+        for (i, &c) in buf.iter().enumerate() {
+            v = (v << 7) + (c & 0x7f) as u64;
+            if (c & 0x80) == 0 {
+                return Ok((v, i + 1));
+            }
+        }
+        mark_unlikely();
+        bail_corrupt_error!("Invalid varint");
+    };
+    let x = u64::from_be_bytes(*chunk);
+    let stops = !x & VARINT_CONT_BITS;
+    if likely(stops != 0) {
+        // The most significant stop bit sits in the first byte with a
+        // clear high bit: the last byte of the varint.
+        let n = (stops.leading_zeros() >> 3) as usize + 1;
+        // Gathering all 8 bytes leaves the digits past the stop byte in
+        // the bits below the wanted value; the shift drops them.
+        let v = varint_gather_payload_bits(x) >> (7 * (8 - n));
+        return Ok((v, n));
+    }
+    // All 8 bytes continue: a 9-byte varint (value >= 1<<56, e.g. a negative
+    // rowid), whose last byte contributes a full 8 bits with no continuation
+    // flag.
+    let Some(&b8) = buf.get(8) else {
+        mark_unlikely();
+        bail_corrupt_error!("Invalid varint");
+    };
+    let v = varint_gather_payload_bits(x);
+    // Values requiring 9 bytes must have non-zero in the top 8 bits (value >= 1<<56).
+    // Since the final value is `(v<<8) + b8`, the top 8 bits (v >> 48) must not be 0.
+    // If those are zero, this should be treated as corrupt.
+    if unlikely((v >> 48) == 0) {
+        bail_corrupt_error!("Invalid varint");
+    }
+    Ok(((v << 8) + b8 as u64, 9))
 }
 
 #[inline(always)]

--- a/core/types.rs
+++ b/core/types.rs
@@ -3762,8 +3762,14 @@ mod tests {
         }
     }
 
+    // `std::vec::Vec` spelled out on purpose: this module glob-imports
+    // `crate::alloc`, whose `Vec` carries our allocator under `--cfg nightly`,
+    // and quickcheck only generates the plain global-allocator `Vec`.
     #[quickcheck_macros::quickcheck]
-    fn skip_serial_types_matches_reference_on_arbitrary_headers(header: Vec<u8>, n: usize) -> bool {
+    fn skip_serial_types_matches_reference_on_arbitrary_headers(
+        header: std::vec::Vec<u8>,
+        n: usize,
+    ) -> bool {
         // Cap n a little above the byte count: enough to exhaust any header.
         let n = n % (header.len() + 4);
         assert_skip_matches_reference(&header, n);

--- a/core/types.rs
+++ b/core/types.rs
@@ -2878,23 +2878,22 @@ where
 
     // Skip over `skip` number of fields
     let mut skipped = 0;
-    while skipped < skip {
-        // Whole-word step: 8 one-byte serial types at once. Null and the
-        // constant int types add 0 there, matching the kind check below.
-        if skip - skipped >= 8 && header_end.saturating_sub(header_pos) >= 8 {
-            if let Some(chunk) = payload
-                .get(header_pos..)
-                .and_then(|rest| rest.first_chunk::<8>())
-            {
-                if let Some(size) = small_serial_type_run_size(chunk) {
-                    header_pos += 8;
-                    data_pos += size;
-                    skipped += 8;
-                    continue;
-                }
-            }
-        }
-
+    // Leading run of one-byte serial types, 8 header bytes per step. Null and
+    // the constant int types add 0 to data_pos there, matching the kind check
+    // in the one-at-a-time loop below.
+    while skip - skipped >= 8 && header_end.saturating_sub(header_pos) >= 8 {
+        let Some(size) = payload
+            .get(header_pos..)
+            .and_then(|rest| rest.first_chunk::<8>())
+            .and_then(small_serial_type_run_size)
+        else {
+            break;
+        };
+        header_pos += 8;
+        data_pos += size;
+        skipped += 8;
+    }
+    for _ in skipped..skip {
         if header_pos >= header_end {
             break;
         }
@@ -2909,7 +2908,6 @@ where
         ) {
             data_pos += serial_type.size();
         }
-        skipped += 1;
     }
 
     let mut field_idx = skip;
@@ -3178,33 +3176,39 @@ pub(crate) fn small_serial_type_run_size(chunk: &[u8; 8]) -> Option<usize> {
 
 /// Skip `n` serial-type varints from the front of `header`, totalling their
 /// data sizes. Behaves exactly like `n` sequential [read_varint] +
-/// [get_serial_type_size] calls (same values, same errors), but consumes runs
-/// of one-byte serial types 8 header bytes per step.
+/// [get_serial_type_size] calls (same values, same errors), but consumes the
+/// leading run of one-byte serial types 8 header bytes per step. Once the run
+/// ends the remainder goes one at a time; a header where the run never starts
+/// costs the same as the plain loop.
 ///
 /// Returns the remaining header and the summed data size, or `Ok(None)` when
 /// the header runs out before `n` serial types were read.
-#[inline]
+///
+/// Kept inline: the callers (Column opcode, [ValueIterator::nth]) previously
+/// ran this loop in their own bodies, and an outlined call costs more than
+/// skipping a few one-byte serial types.
+#[inline(always)]
 pub(crate) fn skip_serial_types(mut header: &[u8], n: usize) -> Result<Option<(&[u8], usize)>> {
     let mut data_sum = 0;
     let mut left = n;
-    while left > 0 {
-        if left >= 8 {
-            if let Some(chunk) = header.first_chunk::<8>() {
-                if let Some(size) = small_serial_type_run_size(chunk) {
-                    data_sum += size;
-                    header = &header[8..];
-                    left -= 8;
-                    continue;
-                }
-            }
-        }
+    while left >= 8 {
+        let Some(size) = header
+            .first_chunk::<8>()
+            .and_then(small_serial_type_run_size)
+        else {
+            break;
+        };
+        data_sum += size;
+        header = &header[8..];
+        left -= 8;
+    }
+    for _ in 0..left {
         if unlikely(header.is_empty()) {
             return Ok(None);
         }
         let (serial_type, bytes_read) = read_varint(header)?;
         header = &header[bytes_read..];
         data_sum += get_serial_type_size(serial_type)?;
-        left -= 1;
     }
     Ok(Some((header, data_sum)))
 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -2069,29 +2069,17 @@ impl<'a> Iterator for ValueIterator<'a> {
         let mut header = self.header_section.get();
         let mut data = self.data_section.get();
 
-        let mut data_sum = 0;
-        for _ in 0..n {
-            if unlikely(header.is_empty()) {
-                return None;
+        let data_sum = match skip_serial_types(header, n) {
+            Ok(Some((rest, data_sum))) => {
+                header = rest;
+                data_sum
             }
-
-            let (serial_type, bytes_read) = match read_varint(header) {
-                Ok(v) => v,
-                Err(e) => {
-                    mark_unlikely();
-                    return Some(Err(e));
-                }
-            };
-            header = &header[bytes_read..];
-
-            data_sum += match get_serial_type_size(serial_type) {
-                Ok(size) => size,
-                Err(e) => {
-                    mark_unlikely();
-                    return Some(Err(e));
-                }
-            };
-        }
+            Ok(None) => return None,
+            Err(e) => {
+                mark_unlikely();
+                return Some(Err(e));
+            }
+        };
 
         if unlikely(data_sum > data.len()) {
             return Some(Err(LimboError::Corrupt(
@@ -2889,7 +2877,24 @@ where
     let mut data_pos = header_size as usize;
 
     // Skip over `skip` number of fields
-    for _ in 0..skip {
+    let mut skipped = 0;
+    while skipped < skip {
+        // Whole-word step: 8 one-byte serial types at once. Null and the
+        // constant int types add 0 there, matching the kind check below.
+        if skip - skipped >= 8 && header_end.saturating_sub(header_pos) >= 8 {
+            if let Some(chunk) = payload
+                .get(header_pos..)
+                .and_then(|rest| rest.first_chunk::<8>())
+            {
+                if let Some(size) = small_serial_type_run_size(chunk) {
+                    header_pos += 8;
+                    data_pos += size;
+                    skipped += 8;
+                    continue;
+                }
+            }
+        }
+
         if header_pos >= header_end {
             break;
         }
@@ -2904,6 +2909,7 @@ where
         ) {
             data_pos += serial_type.size();
         }
+        skipped += 1;
     }
 
     let mut field_idx = skip;
@@ -3120,6 +3126,87 @@ pub fn get_serial_type_size(serial: u64) -> Result<usize> {
             )))
         }
     }
+}
+
+/// Sentinel in [SMALL_SERIAL_TYPE_SIZES] for the reserved serial types 10 and
+/// 11. Larger than any sum of 8 real one-byte-type sizes (at most 8 * 57), so
+/// one reserved entry pushes a whole-word sum past it.
+const RESERVED_SERIAL_TYPE_SIZE: u16 = 0x8000;
+
+/// Data size of each serial type that fits in one header byte (0..=127),
+/// mirroring [get_serial_type_size]. The reserved types 10 and 11 hold
+/// [RESERVED_SERIAL_TYPE_SIZE] so sums that include them are detectable.
+static SMALL_SERIAL_TYPE_SIZES: [u16; 128] = {
+    let mut table = [0u16; 128];
+    let mut serial_type = 0;
+    while serial_type < 128 {
+        table[serial_type] = match serial_type {
+            0 | 8 | 9 => 0,
+            1 => 1,
+            2 => 2,
+            3 => 3,
+            4 => 4,
+            5 => 6,
+            6 | 7 => 8,
+            10 | 11 => RESERVED_SERIAL_TYPE_SIZE,
+            _ => ((serial_type - 12) >> 1) as u16,
+        };
+        serial_type += 1;
+    }
+    table
+};
+
+/// Combined data size of the next 8 serial types when the next 8 header bytes
+/// are all one-byte, non-reserved serial types; None when any of them needs
+/// the caller's one-at-a-time path (a multi-byte varint or reserved type
+/// 10/11). Null and the constant int types count as 0 bytes of data.
+#[inline(always)]
+pub(crate) fn small_serial_type_run_size(chunk: &[u8; 8]) -> Option<usize> {
+    let word = u64::from_ne_bytes(*chunk);
+    if word & crate::storage::sqlite3_ondisk::VARINT_CONT_BITS != 0 {
+        return None;
+    }
+    let mut sum = 0u32;
+    for &serial_type in chunk {
+        sum += SMALL_SERIAL_TYPE_SIZES[serial_type as usize] as u32;
+    }
+    if unlikely(sum >= RESERVED_SERIAL_TYPE_SIZE as u32) {
+        return None;
+    }
+    Some(sum as usize)
+}
+
+/// Skip `n` serial-type varints from the front of `header`, totalling their
+/// data sizes. Behaves exactly like `n` sequential [read_varint] +
+/// [get_serial_type_size] calls (same values, same errors), but consumes runs
+/// of one-byte serial types 8 header bytes per step.
+///
+/// Returns the remaining header and the summed data size, or `Ok(None)` when
+/// the header runs out before `n` serial types were read.
+#[inline]
+pub(crate) fn skip_serial_types(mut header: &[u8], n: usize) -> Result<Option<(&[u8], usize)>> {
+    let mut data_sum = 0;
+    let mut left = n;
+    while left > 0 {
+        if left >= 8 {
+            if let Some(chunk) = header.first_chunk::<8>() {
+                if let Some(size) = small_serial_type_run_size(chunk) {
+                    data_sum += size;
+                    header = &header[8..];
+                    left -= 8;
+                    continue;
+                }
+            }
+        }
+        if unlikely(header.is_empty()) {
+            return Ok(None);
+        }
+        let (serial_type, bytes_read) = read_varint(header)?;
+        header = &header[bytes_read..];
+        data_sum += get_serial_type_size(serial_type)?;
+        left -= 1;
+    }
+    Ok(Some((header, data_sum)))
 }
 
 impl<T: AsValueRef> From<T> for SerialType {
@@ -3642,6 +3729,119 @@ mod tests {
     use super::*;
     use crate::alloc::vec;
     use crate::translate::collate::CollationSeq;
+
+    /// One-at-a-time version of [skip_serial_types]: the loop the callers ran
+    /// before whole-word skipping. The optimized helper must behave the same
+    /// on every input.
+    fn skip_serial_types_reference(mut header: &[u8], n: usize) -> Result<Option<(&[u8], usize)>> {
+        let mut data_sum = 0;
+        for _ in 0..n {
+            if header.is_empty() {
+                return Ok(None);
+            }
+            let (serial_type, bytes_read) = read_varint(header)?;
+            header = &header[bytes_read..];
+            data_sum += get_serial_type_size(serial_type)?;
+        }
+        Ok(Some((header, data_sum)))
+    }
+
+    fn assert_skip_matches_reference(header: &[u8], n: usize) {
+        let expected = skip_serial_types_reference(header, n);
+        let actual = skip_serial_types(header, n);
+        match (&expected, &actual) {
+            (Ok(a), Ok(b)) => assert_eq!(a, b, "skip mismatch on {header:02x?} n={n}"),
+            (Err(_), Err(_)) => {}
+            _ => panic!(
+                "skip outcome mismatch on {header:02x?} n={n}: expected {expected:?}, got {actual:?}"
+            ),
+        }
+    }
+
+    #[quickcheck_macros::quickcheck]
+    fn skip_serial_types_matches_reference_on_arbitrary_headers(header: Vec<u8>, n: usize) -> bool {
+        // Cap n a little above the byte count: enough to exhaust any header.
+        let n = n % (header.len() + 4);
+        assert_skip_matches_reference(&header, n);
+        true
+    }
+
+    #[test]
+    fn skip_serial_types_matches_reference_on_targeted_headers() {
+        // 16 one-byte types exercising every size class, including the
+        // zero-size ones (NULL and the constant ints).
+        let plain: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 64, 65, 126, 127];
+        // Reserved type 10 hiding at each position of a word-sized run.
+        for reserved_at in 0..8 {
+            let mut header = plain.clone();
+            header[reserved_at] = 10;
+            for n in 0..=header.len() + 1 {
+                assert_skip_matches_reference(&header, n);
+            }
+        }
+        // A multi-byte serial type (a large text) at each position.
+        for multi_at in 0..8 {
+            let mut header = Vec::new();
+            for (i, &st) in plain.iter().enumerate() {
+                if i == multi_at {
+                    crate::storage::sqlite3_ondisk::write_varint_to_vec(
+                        (1 << 20) + 13,
+                        &mut header,
+                    );
+                }
+                header.push(st);
+            }
+            for n in 0..=plain.len() + 2 {
+                assert_skip_matches_reference(&header, n);
+            }
+        }
+        // Truncated multi-byte varint at the end of the header.
+        let mut truncated = plain.clone();
+        truncated.push(0x81);
+        for n in 0..=truncated.len() + 1 {
+            assert_skip_matches_reference(&truncated, n);
+        }
+        for n in 0..=plain.len() + 1 {
+            assert_skip_matches_reference(&plain, n);
+        }
+    }
+
+    #[test]
+    fn small_serial_type_run_size_matches_serial_type_sizes() {
+        // Any word with a continuation bit is rejected.
+        assert_eq!(
+            small_serial_type_run_size(&[0x80, 0, 0, 0, 0, 0, 0, 0]),
+            None
+        );
+        assert_eq!(
+            small_serial_type_run_size(&[0, 0, 0, 0, 0, 0, 0, 0xff]),
+            None
+        );
+        // Reserved types are rejected wherever they sit.
+        for pos in 0..8 {
+            for reserved in [10u8, 11] {
+                let mut chunk = [1u8; 8];
+                chunk[pos] = reserved;
+                assert_eq!(small_serial_type_run_size(&chunk), None);
+            }
+        }
+        // Otherwise the sum matches get_serial_type_size byte for byte.
+        for st in 0u8..128 {
+            if st == 10 || st == 11 {
+                continue;
+            }
+            let chunk = [st, 0, 1, 127, 12, 13, 9, st];
+            let expected: usize = chunk
+                .iter()
+                .map(|&b| get_serial_type_size(b as u64).unwrap())
+                .sum();
+            assert_eq!(
+                small_serial_type_run_size(&chunk),
+                Some(expected),
+                "st {st}"
+            );
+        }
+    }
 
     fn assert_integer_conversions<T>(in_range: &[(i64, T)], out_of_range: &[i64])
     where

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3127,29 +3127,20 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
     #[inline(always)]
     fn nth_into_register(&mut self, n: usize, dest: &mut Register) -> Option<Result<()>> {
         use crate::storage::sqlite3_ondisk::read_varint;
-        use crate::types::{get_serial_type_size, Extendable, Text};
+        use crate::types::{skip_serial_types, Extendable, Text};
 
         let mut header = self.header_section_ref();
         let mut data = self.data_section_ref();
 
         // Skip n elements
-        let mut data_sum = 0;
-        for _ in 0..n {
-            if header.is_empty() {
-                return None;
+        let data_sum = match skip_serial_types(header, n) {
+            Ok(Some((rest, data_sum))) => {
+                header = rest;
+                data_sum
             }
-
-            let (serial_type, bytes_read) = match read_varint(header) {
-                Ok(v) => v,
-                Err(e) => return Some(Err(e)),
-            };
-            header = &header[bytes_read..];
-
-            data_sum += match get_serial_type_size(serial_type) {
-                Ok(size) => size,
-                Err(e) => return Some(Err(e)),
-            };
-        }
+            Ok(None) => return None,
+            Err(e) => return Some(Err(e)),
+        };
 
         if data_sum > data.len() {
             return Some(Err(LimboError::Corrupt(


### PR DESCRIPTION
## Description

Rewrites SQLite varint decoding to eliminate the byte-by-byte loop that carried a loop-carried data dependency per byte. The new implementation:

1. **Fast path for 1-2 byte varints** (most common): Direct checks inlined at call sites, no function call overhead
2. **Whole-word decode for 3+ bytes**: Loads 8 bytes at once, uses bit manipulation to locate the terminating byte and gather the 7-bit payload digits in parallel, then shifts to the final value
3. **Fallback for short buffers**: Byte-by-byte loop only when fewer than 8 bytes remain

The optimization trades the old per-byte loop (which stalls on each byte's continuation bit) for a handful of branch-free ALU operations. This is particularly effective for:
- Mixed-length varint streams where branch prediction fails (e.g., parsing b-tree cells with varying rowid/payload sizes)
- Record header iteration where serial types are mostly 1-byte but lengths are unpredictable
- Bulk decoding where the per-byte stall dominates

Also optimizes serial-type skipping in `ValueIterator::nth` and the Column opcode by decoding 8 one-byte serial types per step using the same whole-word technique, with a fallback to one-at-a-time for reserved types or multi-byte varints.

## Motivation and context

Varint decoding is a hot path in the storage layer: every record header, every rowid, every payload size goes through it. The byte-by-byte loop with its per-byte data dependency (each byte's continuation bit gates the next iteration) creates a stall on modern CPUs. Whole-word operations eliminate that dependency chain while keeping the code branch-free and predictable.

Includes comprehensive property-based tests (quickcheck) and targeted unit tests to verify the optimized decoder matches the reference implementation on all inputs, plus a new benchmark suite (`varint_benchmark.rs`) covering single-length streams, mixed-length streams, and record header iteration patterns.

## Tests

- Added `read_varint_matches_reference_on_arbitrary_bytes` (quickcheck) to verify optimized decoder matches reference on arbitrary byte streams
- Added `read_varint_roundtrips_boundary_values_at_any_offset_from_buffer_end` to test all power-of-2 boundaries and truncations
- Added `test_read_varint_exact_encodings` (rstest) for canonical and non-canonical edge cases
- Added `test_read_varint_rejects_noncanonical_9_byte` to verify corruption detection
- Added `skip_serial_types_matches_reference_on_arbitrary_headers` (quickcheck) for serial-type skipping
- Added `skip_serial_types_matches_reference_on_targeted_headers` for reserved types and multi-byte varints
- Added `small_serial_type_run_size_matches_serial_type_sizes` to verify whole-word serial-type summation
- New benchmark suite in `core/benches/varint_benchmark.rs` with three scenarios: fixed-length streams, shuffled mixed-length streams, and record header iteration patterns

All existing tests pass; no behavior changes to the public API.

https://claude.ai/code/session_012bVgcCoNWqBgW4iskX56dk