### PR TITLE
FTS+mvcc benchmarks

### DIFF
--- a/.claude/skills/memory-benchmark/SKILL.md
+++ b/.claude/skills/memory-benchmark/SKILL.md
@@ -110,7 +110,7 @@ cargo run --release -p memory-benchmark -- --mode mvcc --workload insert-heavy -
 # All CLI options
 cargo run --release -p memory-benchmark -- \
   --mode wal|mvcc \
-  --workload insert-heavy|read-heavy|mixed|scan-heavy|recursive-cte|series-blob|update-churn \
+  --workload insert-heavy|read-heavy|mixed|scan-heavy|series-blob|recursive-cte|update-churn|fts-query-churn|fts-update-churn \
   -i <iterations> \
   -b <batch-size> \
   --connections <N> \
@@ -141,8 +141,11 @@ Every run produces a `dhat-heap.json` in the current directory. This file contai
 | `recursive-cte` | Repeated linear, priority-queue, UNION-distinct, and outer-LIMIT recursive CTE queries | No schema setup; `batch-size` is the target recursive result cardinality |
 | `series-blob` | `INSERT INTO bench(data) SELECT zeroblob(2048) FROM generate_series(1, ?)` | Creates `bench`; `batch-size` is the series length |
 | `update-churn` | Repeated UPDATEs to a fixed 10k-row set (key space partitioned per connection to avoid write-write conflicts) | Seeds 10k rows. Generates superseded versions — the MVCC GC accumulation case. |
+| `fts-query-churn` | Repeated full-text queries from one or more connections against the same immutable index | Seeds one 2k-row table and FTS index. Exposes reader/cache multiplication. |
+| `fts-update-churn` | Repeated updates of a bounded FTS document set | Seeds one 2k-row table and FTS index per connection. Separate indexes honor the single-writer-per-index contract while permitting concurrent churn. |
 
 Profiles implement the `Profile` trait in `perf/memory/src/profile/`. To add a new workload, create a new file implementing the trait and wire it into the `WorkloadProfile` enum in `main.rs`.
+The workload engine enables experimental index methods for every profile.
 
 ## Understanding the Output
 
@@ -251,8 +254,8 @@ When `--connections > 1`:
 journal modes with CodSpeed's memory instrument (eBPF-based malloc tracking:
 peak memory, total allocated, allocation count) so allocation regressions show
 up on PRs. The bench harness is the separate crate `perf/memory/codspeed/`
-(criterion benchmarks named `<mode>/<workload>/<total-ops>`, e.g.
-`mvcc/insert-heavy/2000`, with much smaller iteration counts than the CLI
+(criterion benchmarks named `<mode>/<workload>/<connections>-connections/<total-ops>`,
+e.g. `mvcc/insert-heavy/1-connections/2000`, with much smaller iteration counts than the CLI
 defaults). Each (mode, workload) pair runs at 1x/2x/4x scale — same batch
 size, more iterations — so comparing the sizes shows how memory grows with
 workload volume, plus an 8x `<ops>-checkpoint` variant that guarantees

--- a/.github/workflows/codspeed-memory.yml
+++ b/.github/workflows/codspeed-memory.yml
@@ -69,6 +69,8 @@ jobs:
           - scan-heavy
           - series-blob
           - update-churn
+          - fts-query-churn
+          - fts-update-churn
     steps:
       - uses: actions/checkout@v4
 

--- a/core/benches/fts_benchmark.rs
+++ b/core/benches/fts_benchmark.rs
@@ -23,6 +23,56 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use turso_core::{Database, DatabaseOpts, OpenFlags, PlatformIO, StepResult};
 
+#[derive(Clone, Copy)]
+enum BenchmarkMode {
+    Wal,
+    MvccDisabledCheckpoint,
+    MvccDefaultCheckpoint,
+    MvccForcedCheckpoint,
+}
+
+impl BenchmarkMode {
+    const ALL: [Self; 4] = [
+        Self::Wal,
+        Self::MvccDisabledCheckpoint,
+        Self::MvccDefaultCheckpoint,
+        Self::MvccForcedCheckpoint,
+    ];
+    const MVCC: [Self; 3] = [
+        Self::MvccDisabledCheckpoint,
+        Self::MvccDefaultCheckpoint,
+        Self::MvccForcedCheckpoint,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Wal => "wal",
+            Self::MvccDisabledCheckpoint => "mvcc_checkpoint_disabled",
+            Self::MvccDefaultCheckpoint => "mvcc_checkpoint_default",
+            Self::MvccForcedCheckpoint => "mvcc_checkpoint_forced",
+        }
+    }
+
+    fn configure(self, conn: &Arc<turso_core::Connection>) {
+        match self {
+            Self::Wal => {}
+            Self::MvccDisabledCheckpoint => {
+                conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+                conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+                    .unwrap();
+            }
+            Self::MvccDefaultCheckpoint => {
+                conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+            }
+            Self::MvccForcedCheckpoint => {
+                conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+                conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+                    .unwrap();
+            }
+        }
+    }
+}
+
 #[cfg(not(target_family = "wasm"))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -88,7 +138,11 @@ fn run_and_count_rows(
 }
 
 /// Setup a database with an FTS-indexed table populated with `row_count` rows.
-fn setup_fts_db(temp_dir: &TempDir, row_count: usize) -> Arc<Database> {
+fn setup_fts_db(
+    temp_dir: &TempDir,
+    row_count: usize,
+    benchmark_mode: BenchmarkMode,
+) -> Arc<Database> {
     let db_path = temp_dir.path().join("fts_bench.db");
     #[allow(clippy::arc_with_non_send_sync)]
     let io = Arc::new(PlatformIO::new().unwrap());
@@ -103,6 +157,7 @@ fn setup_fts_db(temp_dir: &TempDir, row_count: usize) -> Arc<Database> {
     )
     .unwrap();
     let conn = db.connect().unwrap();
+    benchmark_mode.configure(&conn);
 
     // Create table and FTS index
     conn.execute("CREATE TABLE docs (id INTEGER PRIMARY KEY, title TEXT, body TEXT)")
@@ -147,8 +202,12 @@ fn setup_fts_db(temp_dir: &TempDir, row_count: usize) -> Arc<Database> {
 }
 
 /// Setup an index with one FTS commit per row to exercise segment churn.
-fn setup_fts_churn_db(temp_dir: &TempDir, commit_count: usize) -> Arc<Database> {
-    let db = setup_fts_db(temp_dir, 0);
+fn setup_fts_churn_db(
+    temp_dir: &TempDir,
+    commit_count: usize,
+    benchmark_mode: BenchmarkMode,
+) -> Arc<Database> {
+    let db = setup_fts_db(temp_dir, 0, benchmark_mode);
     let conn = db.connect().unwrap();
 
     for id in 0..commit_count {
@@ -175,32 +234,37 @@ fn bench_fts_cold_query(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Cold Query");
     group.sample_size(20); // Cold queries are slow; reduce samples
 
-    for row_count in [1000, 5000, 10000] {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let db = setup_fts_db(&temp_dir, row_count);
+    for benchmark_mode in BenchmarkMode::ALL {
+        for row_count in [1000, 5000, 10000] {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let db = setup_fts_db(&temp_dir, row_count, benchmark_mode);
 
-        group.bench_function(
-            BenchmarkId::new("cold_query", format!("{row_count}_rows")),
-            |b| {
-                iter_custom_or_iter!(b, |iters| {
-                    let mut total = std::time::Duration::ZERO;
-                    for _ in 0..iters {
-                        // Fresh connection = no cached directory
-                        let conn = db.connect().unwrap();
-                        let start = std::time::Instant::now();
-                        let mut stmt = conn
-                            .query(
-                                "SELECT id, title FROM docs WHERE (title, body) MATCH 'database'",
-                            )
-                            .unwrap()
-                            .unwrap();
-                        let _rows = run_and_count_rows(&mut stmt, &db).unwrap();
-                        total += start.elapsed();
-                    }
-                    total
-                });
-            },
-        );
+            group.bench_function(
+                BenchmarkId::new(
+                    "cold_query",
+                    format!("{}_{}_rows", benchmark_mode.label(), row_count),
+                ),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iters {
+                            // Fresh connection = no cached directory
+                            let conn = db.connect().unwrap();
+                            let start = std::time::Instant::now();
+                            let mut stmt = conn
+                                .query(
+                                    "SELECT id, title FROM docs WHERE (title, body) MATCH 'database'",
+                                )
+                                .unwrap()
+                                .unwrap();
+                            let _rows = run_and_count_rows(&mut stmt, &db).unwrap();
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
+        }
     }
 
     group.finish();
@@ -216,38 +280,43 @@ fn bench_fts_cold_query(criterion: &mut Criterion) {
 fn bench_fts_warm_query(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Warm Query");
 
-    for row_count in [1000, 5000, 10000] {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let db = setup_fts_db(&temp_dir, row_count);
-        let conn = db.connect().unwrap();
+    for benchmark_mode in BenchmarkMode::ALL {
+        for row_count in [1000, 5000, 10000] {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let db = setup_fts_db(&temp_dir, row_count, benchmark_mode);
+            let conn = db.connect().unwrap();
 
-        // Warm up: run one query to populate the directory cache
-        let mut stmt = conn
-            .query("SELECT id FROM docs WHERE (title, body) MATCH 'database'")
-            .unwrap()
-            .unwrap();
-        run_to_completion(&mut stmt, &db).unwrap();
+            // Warm up: run one query to populate the directory cache
+            let mut stmt = conn
+                .query("SELECT id FROM docs WHERE (title, body) MATCH 'database'")
+                .unwrap()
+                .unwrap();
+            run_to_completion(&mut stmt, &db).unwrap();
 
-        group.bench_function(
-            BenchmarkId::new("warm_query", format!("{row_count}_rows")),
-            |b| {
-                iter_custom_or_iter!(b, |iters| {
-                    let mut total = std::time::Duration::ZERO;
-                    for _ in 0..iters {
-                        let start = std::time::Instant::now();
-                        let mut stmt = conn
-                            .query(
-                                "SELECT id, title FROM docs WHERE (title, body) MATCH 'database'",
-                            )
-                            .unwrap()
-                            .unwrap();
-                        let _rows = run_and_count_rows(&mut stmt, &db).unwrap();
-                        total += start.elapsed();
-                    }
-                    total
-                });
-            },
-        );
+            group.bench_function(
+                BenchmarkId::new(
+                    "warm_query",
+                    format!("{}_{}_rows", benchmark_mode.label(), row_count),
+                ),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iters {
+                            let start = std::time::Instant::now();
+                            let mut stmt = conn
+                                .query(
+                                    "SELECT id, title FROM docs WHERE (title, body) MATCH 'database'",
+                                )
+                                .unwrap()
+                                .unwrap();
+                            let _rows = run_and_count_rows(&mut stmt, &db).unwrap();
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
+        }
     }
 
     group.finish();
@@ -261,43 +330,52 @@ fn bench_fts_warm_query(criterion: &mut Criterion) {
 #[turso_macros::codspeed_criterion_benchmark]
 fn bench_fts_connection_pool_query(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Connection Pool Query");
-    let temp_dir = tempfile::tempdir().unwrap();
-    let db = setup_fts_db(&temp_dir, 5_000);
+    for benchmark_mode in BenchmarkMode::ALL {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = setup_fts_db(&temp_dir, 5_000, benchmark_mode);
 
-    for connection_count in [1, 2, 4] {
-        let connections = (0..connection_count)
-            .map(|_| db.connect().unwrap())
-            .collect::<Vec<_>>();
-        for conn in &connections {
-            let mut stmt = conn
-                .query("SELECT id FROM docs WHERE (title, body) MATCH 'database'")
-                .unwrap()
-                .unwrap();
-            run_to_completion(&mut stmt, &db).unwrap();
+        for connection_count in [1, 2, 4] {
+            let connections = (0..connection_count)
+                .map(|_| db.connect().unwrap())
+                .collect::<Vec<_>>();
+            for conn in &connections {
+                let mut stmt = conn
+                    .query("SELECT id FROM docs WHERE (title, body) MATCH 'database'")
+                    .unwrap()
+                    .unwrap();
+                run_to_completion(&mut stmt, &db).unwrap();
+            }
+
+            group.bench_function(
+                BenchmarkId::new(
+                    "alternating_warm_query",
+                    format!(
+                        "{}_{}_connections",
+                        benchmark_mode.label(),
+                        connection_count
+                    ),
+                ),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for iteration in 0..iters {
+                            let conn = &connections[iteration as usize % connections.len()];
+                            let start = std::time::Instant::now();
+                            let mut stmt = conn
+                                .query(
+                                    "SELECT id, title FROM docs \
+                                     WHERE (title, body) MATCH 'database'",
+                                )
+                                .unwrap()
+                                .unwrap();
+                            let _rows = run_and_count_rows(&mut stmt, &db).unwrap();
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
         }
-
-        group.bench_function(
-            BenchmarkId::new("alternating_warm_query", connection_count),
-            |b| {
-                iter_custom_or_iter!(b, |iters| {
-                    let mut total = std::time::Duration::ZERO;
-                    for iteration in 0..iters {
-                        let conn = &connections[iteration as usize % connections.len()];
-                        let start = std::time::Instant::now();
-                        let mut stmt = conn
-                            .query(
-                                "SELECT id, title FROM docs \
-                                 WHERE (title, body) MATCH 'database'",
-                            )
-                            .unwrap()
-                            .unwrap();
-                        let _rows = run_and_count_rows(&mut stmt, &db).unwrap();
-                        total += start.elapsed();
-                    }
-                    total
-                });
-            },
-        );
     }
 
     group.finish();
@@ -312,18 +390,6 @@ fn bench_fts_connection_pool_query(criterion: &mut Criterion) {
 fn bench_fts_query_selectivity(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Query Selectivity");
 
-    let row_count = 10000;
-    let temp_dir = tempfile::tempdir().unwrap();
-    let db = setup_fts_db(&temp_dir, row_count);
-    let conn = db.connect().unwrap();
-
-    // Warm up
-    let mut stmt = conn
-        .query("SELECT id FROM docs WHERE (title, body) MATCH 'database'")
-        .unwrap()
-        .unwrap();
-    run_to_completion(&mut stmt, &db).unwrap();
-
     let queries = [
         ("single_common_term", "database"),
         ("single_uncommon_term", "optimization"),
@@ -331,21 +397,39 @@ fn bench_fts_query_selectivity(criterion: &mut Criterion) {
         ("phrase_query", "\"database document\""),
     ];
 
-    for (name, query_term) in queries {
-        let sql = format!("SELECT id, title FROM docs WHERE (title, body) MATCH '{query_term}'");
+    for benchmark_mode in BenchmarkMode::ALL {
+        let row_count = 10000;
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db = setup_fts_db(&temp_dir, row_count, benchmark_mode);
+        let conn = db.connect().unwrap();
 
-        group.bench_function(BenchmarkId::new("selectivity", name), |b| {
-            iter_custom_or_iter!(b, |iters| {
-                let mut total = std::time::Duration::ZERO;
-                for _ in 0..iters {
-                    let start = std::time::Instant::now();
-                    let mut stmt = conn.query(&sql).unwrap().unwrap();
-                    let _rows = run_and_count_rows(&mut stmt, &db).unwrap();
-                    total += start.elapsed();
-                }
-                total
-            });
-        });
+        // Warm up
+        let mut stmt = conn
+            .query("SELECT id FROM docs WHERE (title, body) MATCH 'database'")
+            .unwrap()
+            .unwrap();
+        run_to_completion(&mut stmt, &db).unwrap();
+
+        for (name, query_term) in queries {
+            let sql =
+                format!("SELECT id, title FROM docs WHERE (title, body) MATCH '{query_term}'");
+
+            group.bench_function(
+                BenchmarkId::new("selectivity", format!("{}_{name}", benchmark_mode.label())),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iters {
+                            let start = std::time::Instant::now();
+                            let mut stmt = conn.query(&sql).unwrap().unwrap();
+                            let _rows = run_and_count_rows(&mut stmt, &db).unwrap();
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
+        }
     }
 
     group.finish();
@@ -361,52 +445,58 @@ fn bench_fts_insert_then_query(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Insert+Query Lifecycle");
     group.sample_size(20);
 
-    for row_count in [1000, 5000] {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let db = setup_fts_db(&temp_dir, row_count);
-        let conn = db.connect().unwrap();
+    for benchmark_mode in BenchmarkMode::ALL {
+        for row_count in [1000, 5000] {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let db = setup_fts_db(&temp_dir, row_count, benchmark_mode);
+            let conn = db.connect().unwrap();
 
-        // Use a shared counter that persists across warmup + sampling invocations
-        let counter = std::cell::Cell::new(row_count + 1_000_000);
+            // Use a shared counter that persists across warmup + sampling invocations
+            let counter = std::cell::Cell::new(row_count + 1_000_000);
 
-        group.bench_function(
-            BenchmarkId::new("insert_query", format!("{row_count}_rows")),
-            |b| {
-                iter_custom_or_iter!(b, |iters| {
-                    let mut total = std::time::Duration::ZERO;
-                    for _ in 0..iters {
-                        let start = std::time::Instant::now();
+            group.bench_function(
+                BenchmarkId::new(
+                    "insert_query",
+                    format!("{}_{}_rows", benchmark_mode.label(), row_count),
+                ),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iters {
+                            let start = std::time::Instant::now();
 
-                        // Insert 10 new rows (use rowid=NULL to auto-assign)
-                        let c = counter.get();
-                        let mut sql = String::from("INSERT INTO docs (id, title, body) VALUES ");
-                        for j in 0..10 {
-                            if j > 0 {
-                                sql.push(',');
+                            // Insert 10 new rows (use rowid=NULL to auto-assign)
+                            let c = counter.get();
+                            let mut sql =
+                                String::from("INSERT INTO docs (id, title, body) VALUES ");
+                            for j in 0..10 {
+                                if j > 0 {
+                                    sql.push(',');
+                                }
+                                let id = c + j;
+                                sql.push_str(&format!(
+                                    "({id}, 'new document {id}', 'freshly inserted content about database systems')"
+                                ));
                             }
-                            let id = c + j;
-                            sql.push_str(&format!(
-                                "({id}, 'new document {id}', 'freshly inserted content about database systems')"
-                            ));
+                            counter.set(c + 10);
+                            conn.execute(&sql).unwrap();
+
+                            // Query (exercises cache invalidation + re-query)
+                            let mut stmt = conn
+                                .query(
+                                    "SELECT id, title FROM docs WHERE (title, body) MATCH 'database'",
+                                )
+                                .unwrap()
+                                .unwrap();
+                            let _rows = run_and_count_rows(&mut stmt, &db).unwrap();
+
+                            total += start.elapsed();
                         }
-                        counter.set(c + 10);
-                        conn.execute(&sql).unwrap();
-
-                        // Query (exercises cache invalidation + re-query)
-                        let mut stmt = conn
-                            .query(
-                                "SELECT id, title FROM docs WHERE (title, body) MATCH 'database'",
-                            )
-                            .unwrap()
-                            .unwrap();
-                        let _rows = run_and_count_rows(&mut stmt, &db).unwrap();
-
-                        total += start.elapsed();
-                    }
-                    total
-                });
-            },
-        );
+                        total
+                    });
+                },
+            );
+        }
     }
 
     group.finish();
@@ -421,54 +511,62 @@ fn bench_fts_segment_churn_query(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Segment Churn");
     group.sample_size(20);
 
-    for commit_count in [64, 256, 1024] {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let db = setup_fts_churn_db(&temp_dir, commit_count);
-        let conn = db.connect().unwrap();
-        let dense_sql = "SELECT fts_score(body, 'common') AS score, id \
-                         FROM docs \
-                         WHERE fts_match(body, 'common') \
-                         ORDER BY score DESC LIMIT 10";
-        let sparse_sql = "SELECT fts_score(body, 'needle') AS score, id \
-                          FROM docs \
-                          WHERE fts_match(body, 'needle') \
-                          ORDER BY score DESC LIMIT 10";
+    for benchmark_mode in BenchmarkMode::ALL {
+        for commit_count in [64, 256, 1024] {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let db = setup_fts_churn_db(&temp_dir, commit_count, benchmark_mode);
+            let conn = db.connect().unwrap();
+            let dense_sql = "SELECT fts_score(body, 'common') AS score, id \
+                             FROM docs \
+                             WHERE fts_match(body, 'common') \
+                             ORDER BY score DESC LIMIT 10";
+            let sparse_sql = "SELECT fts_score(body, 'needle') AS score, id \
+                              FROM docs \
+                              WHERE fts_match(body, 'needle') \
+                              ORDER BY score DESC LIMIT 10";
 
-        let mut stmt = conn.query(dense_sql).unwrap().unwrap();
-        assert_eq!(run_and_count_rows(&mut stmt, &db).unwrap(), 10);
-        let mut stmt = conn.query(sparse_sql).unwrap().unwrap();
-        assert_eq!(run_and_count_rows(&mut stmt, &db).unwrap(), 1);
+            let mut stmt = conn.query(dense_sql).unwrap().unwrap();
+            assert_eq!(run_and_count_rows(&mut stmt, &db).unwrap(), 10);
+            let mut stmt = conn.query(sparse_sql).unwrap().unwrap();
+            assert_eq!(run_and_count_rows(&mut stmt, &db).unwrap(), 1);
 
-        group.bench_function(
-            BenchmarkId::new("top_10_query", format!("{commit_count}_commits")),
-            |b| {
-                iter_custom_or_iter!(b, |iters| {
-                    let mut total = std::time::Duration::ZERO;
-                    for _ in 0..iters {
-                        let start = std::time::Instant::now();
-                        let mut stmt = conn.query(dense_sql).unwrap().unwrap();
-                        assert_eq!(run_and_count_rows(&mut stmt, &db).unwrap(), 10);
-                        total += start.elapsed();
-                    }
-                    total
-                });
-            },
-        );
-        group.bench_function(
-            BenchmarkId::new("sparse_top_10_query", format!("{commit_count}_commits")),
-            |b| {
-                iter_custom_or_iter!(b, |iters| {
-                    let mut total = std::time::Duration::ZERO;
-                    for _ in 0..iters {
-                        let start = std::time::Instant::now();
-                        let mut stmt = conn.query(sparse_sql).unwrap().unwrap();
-                        assert_eq!(run_and_count_rows(&mut stmt, &db).unwrap(), 1);
-                        total += start.elapsed();
-                    }
-                    total
-                });
-            },
-        );
+            group.bench_function(
+                BenchmarkId::new(
+                    "top_10_query",
+                    format!("{}_{}_commits", benchmark_mode.label(), commit_count),
+                ),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iters {
+                            let start = std::time::Instant::now();
+                            let mut stmt = conn.query(dense_sql).unwrap().unwrap();
+                            assert_eq!(run_and_count_rows(&mut stmt, &db).unwrap(), 10);
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
+            group.bench_function(
+                BenchmarkId::new(
+                    "sparse_top_10_query",
+                    format!("{}_{}_commits", benchmark_mode.label(), commit_count),
+                ),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iters {
+                            let start = std::time::Instant::now();
+                            let mut stmt = conn.query(sparse_sql).unwrap().unwrap();
+                            assert_eq!(run_and_count_rows(&mut stmt, &db).unwrap(), 1);
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
+        }
     }
 
     group.finish();
@@ -484,29 +582,37 @@ fn bench_fts_single_row_commit_churn(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Single Row Commit Churn");
     group.sample_size(10);
 
-    for commit_count in [64, 256] {
-        group.bench_function(BenchmarkId::new("committed_rows", commit_count), |b| {
-            iter_custom_or_iter!(b, |iters| {
-                let mut total = std::time::Duration::ZERO;
-                for repetition in 0..iters {
-                    let temp_dir = tempfile::tempdir().unwrap();
-                    let db = setup_fts_db(&temp_dir, 0);
-                    let conn = db.connect().unwrap();
-                    let start = std::time::Instant::now();
-                    for id in 0..commit_count {
-                        let id = id as u64 + repetition * commit_count as u64;
-                        conn.execute(format!(
-                            "INSERT INTO docs (id, title, body) VALUES \
-                                 ({id}, 'commit {id}', \
-                                 'independently committed database document {id}')"
-                        ))
-                        .unwrap();
-                    }
-                    total += start.elapsed();
-                }
-                total
-            });
-        });
+    for benchmark_mode in BenchmarkMode::ALL {
+        for commit_count in [64, 256] {
+            group.bench_function(
+                BenchmarkId::new(
+                    "committed_rows",
+                    format!("{}_{}", benchmark_mode.label(), commit_count),
+                ),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for repetition in 0..iters {
+                            let temp_dir = tempfile::tempdir().unwrap();
+                            let db = setup_fts_db(&temp_dir, 0, benchmark_mode);
+                            let conn = db.connect().unwrap();
+                            let start = std::time::Instant::now();
+                            for id in 0..commit_count {
+                                let id = id as u64 + repetition * commit_count as u64;
+                                conn.execute(format!(
+                                    "INSERT INTO docs (id, title, body) VALUES \
+                                     ({id}, 'commit {id}', \
+                                     'independently committed database document {id}')"
+                                ))
+                                .unwrap();
+                            }
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
+        }
     }
 
     group.finish();
@@ -522,43 +628,171 @@ fn bench_fts_large_merge_boundary(criterion: &mut Criterion) {
     group.sample_size(10);
     let rows_per_commit = 1_000;
 
-    for commit_count in [7, 8] {
-        group.bench_function(BenchmarkId::new("1000_row_commits", commit_count), |b| {
-            iter_custom_or_iter!(b, |iters| {
-                let mut total = std::time::Duration::ZERO;
-                for repetition in 0..iters {
-                    let temp_dir = tempfile::tempdir().unwrap();
-                    let db = setup_fts_db(&temp_dir, 0);
-                    let conn = db.connect().unwrap();
-                    let statements = (0..commit_count)
-                        .map(|commit| {
-                            let first_id =
-                                (repetition as usize * commit_count + commit) * rows_per_commit;
-                            let mut sql =
-                                String::from("INSERT INTO docs (id, title, body) VALUES ");
-                            for offset in 0..rows_per_commit {
-                                if offset > 0 {
-                                    sql.push(',');
-                                }
-                                let id = first_id + offset;
-                                sql.push_str(&format!(
-                                    "({id}, 'document {id}', \
-                                         'database content for merged document {id}')"
+    for benchmark_mode in BenchmarkMode::ALL {
+        for commit_count in [7, 8] {
+            group.bench_function(
+                BenchmarkId::new(
+                    "1000_row_commits",
+                    format!("{}_{}", benchmark_mode.label(), commit_count),
+                ),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for repetition in 0..iters {
+                            let temp_dir = tempfile::tempdir().unwrap();
+                            let db = setup_fts_db(&temp_dir, 0, benchmark_mode);
+                            let conn = db.connect().unwrap();
+                            let statements = (0..commit_count)
+                                .map(|commit| {
+                                    let first_id = (repetition as usize * commit_count + commit)
+                                        * rows_per_commit;
+                                    let mut sql =
+                                        String::from("INSERT INTO docs (id, title, body) VALUES ");
+                                    for offset in 0..rows_per_commit {
+                                        if offset > 0 {
+                                            sql.push(',');
+                                        }
+                                        let id = first_id + offset;
+                                        sql.push_str(&format!(
+                                            "({id}, 'document {id}', \
+                                             'database content for merged document {id}')"
+                                        ));
+                                    }
+                                    sql
+                                })
+                                .collect::<Vec<_>>();
+
+                            let start = std::time::Instant::now();
+                            for sql in statements {
+                                conn.execute(sql).unwrap();
+                            }
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+/// Benchmark transaction-level writer scaling under the supported lease model.
+///
+/// Independent indexes should all make progress. Writers targeting one index
+/// intentionally exercise the eager conflict path: one transaction commits and
+/// every contender is rejected before constructing a Tantivy writer.
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_fts_mvcc_writer_scaling(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("FTS MVCC Writer Scaling");
+    group.sample_size(10);
+
+    for benchmark_mode in BenchmarkMode::MVCC {
+        for writer_count in [1usize, 2, 4, 8] {
+            group.bench_function(
+                BenchmarkId::new(
+                    "independent_indexes",
+                    format!("{}_{}_writers", benchmark_mode.label(), writer_count),
+                ),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iters {
+                            let temp_dir = tempfile::tempdir().unwrap();
+                            let db = setup_fts_db(&temp_dir, 0, benchmark_mode);
+                            let setup = db.connect().unwrap();
+                            for index in 1..writer_count {
+                                setup
+                                    .execute(format!(
+                                        "CREATE TABLE docs_{index} \
+                                         (id INTEGER PRIMARY KEY, title TEXT, body TEXT)"
+                                    ))
+                                    .unwrap();
+                                setup
+                                    .execute(format!(
+                                        "CREATE INDEX docs_{index}_fts ON docs_{index} \
+                                         USING fts(title, body)"
+                                    ))
+                                    .unwrap();
+                            }
+                            let connections = (0..writer_count)
+                                .map(|_| db.connect().unwrap())
+                                .collect::<Vec<_>>();
+                            for connection in &connections {
+                                connection.execute("BEGIN CONCURRENT").unwrap();
+                            }
+
+                            let start = std::time::Instant::now();
+                            for (index, connection) in connections.iter().enumerate() {
+                                let table = if index == 0 {
+                                    "docs".to_string()
+                                } else {
+                                    format!("docs_{index}")
+                                };
+                                connection
+                                    .execute(format!(
+                                        "INSERT INTO {table} VALUES \
+                                         (1, 'writer {index}', 'independent index writer {index}')"
+                                    ))
+                                    .unwrap();
+                            }
+                            for connection in &connections {
+                                connection.execute("COMMIT").unwrap();
+                            }
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
+
+            group.bench_function(
+                BenchmarkId::new(
+                    "same_index_contention",
+                    format!("{}_{}_writers", benchmark_mode.label(), writer_count),
+                ),
+                |b| {
+                    iter_custom_or_iter!(b, |iters| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iters {
+                            let temp_dir = tempfile::tempdir().unwrap();
+                            let db = setup_fts_db(&temp_dir, 0, benchmark_mode);
+                            let connections = (0..writer_count)
+                                .map(|_| db.connect().unwrap())
+                                .collect::<Vec<_>>();
+                            for connection in &connections {
+                                connection.execute("BEGIN CONCURRENT").unwrap();
+                            }
+
+                            let start = std::time::Instant::now();
+                            connections[0]
+                                .execute(
+                                    "INSERT INTO docs VALUES \
+                                     (1, 'lease winner', 'same index lease winner')",
+                                )
+                                .unwrap();
+                            for (contender, connection) in connections.iter().enumerate().skip(1) {
+                                let error = connection
+                                    .execute(format!(
+                                        "INSERT INTO docs VALUES \
+                                         ({}, 'lease loser', 'same index contender')",
+                                        contender + 1
+                                    ))
+                                    .unwrap_err();
+                                assert!(matches!(
+                                    error,
+                                    turso_core::LimboError::WriteWriteConflict
                                 ));
                             }
-                            sql
-                        })
-                        .collect::<Vec<_>>();
-
-                    let start = std::time::Instant::now();
-                    for sql in statements {
-                        conn.execute(sql).unwrap();
-                    }
-                    total += start.elapsed();
-                }
-                total
-            });
-        });
+                            connections[0].execute("COMMIT").unwrap();
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
+        }
     }
 
     group.finish();
@@ -570,14 +804,14 @@ criterion_group! {
     config = Criterion::default()
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)))
         .sample_size(50);
-    targets = bench_fts_cold_query, bench_fts_warm_query, bench_fts_connection_pool_query, bench_fts_query_selectivity, bench_fts_insert_then_query, bench_fts_segment_churn_query, bench_fts_single_row_commit_churn, bench_fts_large_merge_boundary
+    targets = bench_fts_cold_query, bench_fts_warm_query, bench_fts_connection_pool_query, bench_fts_query_selectivity, bench_fts_insert_then_query, bench_fts_segment_churn_query, bench_fts_single_row_commit_churn, bench_fts_large_merge_boundary, bench_fts_mvcc_writer_scaling
 }
 
 #[cfg(feature = "codspeed")]
 criterion_group! {
     name = fts_benches;
     config = Criterion::default().sample_size(50);
-    targets = bench_fts_cold_query, bench_fts_warm_query, bench_fts_connection_pool_query, bench_fts_query_selectivity, bench_fts_insert_then_query, bench_fts_segment_churn_query, bench_fts_single_row_commit_churn, bench_fts_large_merge_boundary
+    targets = bench_fts_cold_query, bench_fts_warm_query, bench_fts_connection_pool_query, bench_fts_query_selectivity, bench_fts_insert_then_query, bench_fts_segment_churn_query, bench_fts_single_row_commit_churn, bench_fts_large_merge_boundary, bench_fts_mvcc_writer_scaling
 }
 
 criterion_main!(fts_benches);

--- a/core/benches/fts_comparison_benchmark.rs
+++ b/core/benches/fts_comparison_benchmark.rs
@@ -37,6 +37,51 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use turso_core::{Database, DatabaseOpts, OpenFlags, PlatformIO, StepResult};
 
+#[derive(Clone, Copy)]
+enum TursoBenchmarkMode {
+    Wal,
+    MvccDisabledCheckpoint,
+    MvccDefaultCheckpoint,
+    MvccForcedCheckpoint,
+}
+
+impl TursoBenchmarkMode {
+    const ALL: [Self; 4] = [
+        Self::Wal,
+        Self::MvccDisabledCheckpoint,
+        Self::MvccDefaultCheckpoint,
+        Self::MvccForcedCheckpoint,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Wal => "turso_wal",
+            Self::MvccDisabledCheckpoint => "turso_mvcc_checkpoint_disabled",
+            Self::MvccDefaultCheckpoint => "turso_mvcc_checkpoint_default",
+            Self::MvccForcedCheckpoint => "turso_mvcc_checkpoint_forced",
+        }
+    }
+
+    fn configure(self, conn: &Arc<turso_core::Connection>) {
+        match self {
+            Self::Wal => {}
+            Self::MvccDisabledCheckpoint => {
+                conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+                conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+                    .unwrap();
+            }
+            Self::MvccDefaultCheckpoint => {
+                conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+            }
+            Self::MvccForcedCheckpoint => {
+                conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+                conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+                    .unwrap();
+            }
+        }
+    }
+}
+
 #[cfg(not(target_family = "wasm"))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -160,7 +205,7 @@ fn query_sqlite(conn: &rusqlite::Connection, sql: &str) -> usize {
     row_count
 }
 
-fn open_turso() -> TursoDatabase {
+fn open_turso(benchmark_mode: TursoBenchmarkMode) -> TursoDatabase {
     let temp_dir = tempfile::tempdir().unwrap();
     let db_path = temp_dir.path().join("turso_fts.db");
     #[allow(clippy::arc_with_non_send_sync)]
@@ -176,6 +221,7 @@ fn open_turso() -> TursoDatabase {
     )
     .unwrap();
     let conn = db.connect().unwrap();
+    benchmark_mode.configure(&conn);
     execute_turso(
         &db,
         &conn,
@@ -332,18 +378,23 @@ fn bench_bulk_ingest(criterion: &mut Criterion) {
     group.sampling_mode(SamplingMode::Flat);
     group.throughput(Throughput::Elements(INGEST_ROW_COUNT as u64));
 
-    group.bench_function(BenchmarkId::new("turso", INGEST_ROW_COUNT), |bencher| {
-        iter_custom_or_iter!(bencher, |iterations| {
-            let mut total = std::time::Duration::ZERO;
-            for _ in 0..iterations {
-                let database = open_turso();
-                let start = std::time::Instant::now();
-                populate_turso(&database, &batches);
-                total += start.elapsed();
-            }
-            total
-        });
-    });
+    for benchmark_mode in TursoBenchmarkMode::ALL {
+        group.bench_function(
+            BenchmarkId::new(benchmark_mode.label(), INGEST_ROW_COUNT),
+            |bencher| {
+                iter_custom_or_iter!(bencher, |iterations| {
+                    let mut total = std::time::Duration::ZERO;
+                    for _ in 0..iterations {
+                        let database = open_turso(benchmark_mode);
+                        let start = std::time::Instant::now();
+                        populate_turso(&database, &batches);
+                        total += start.elapsed();
+                    }
+                    total
+                });
+            },
+        );
+    }
 
     if !cfg!(feature = "codspeed") {
         group.bench_function(
@@ -369,27 +420,35 @@ fn bench_bulk_ingest(criterion: &mut Criterion) {
 #[turso_macros::codspeed_criterion_benchmark]
 fn bench_queries(criterion: &mut Criterion) {
     let batches = insert_batches(QUERY_ROW_COUNT);
-    let turso = open_turso();
     let sqlite = open_sqlite();
-    populate_turso(&turso, &batches);
     populate_sqlite(&sqlite, &batches);
-    assert_workload_parity(&turso, &sqlite);
 
     let mut group = criterion.benchmark_group("FTS comparison - warm queries");
-    for workload in QUERY_WORKLOADS {
-        group.bench_function(BenchmarkId::new(workload.name, "turso"), |bencher| {
-            iter_custom_or_iter!(bencher, |iterations| {
-                let mut total = std::time::Duration::ZERO;
-                for _ in 0..iterations {
-                    let start = std::time::Instant::now();
-                    let row_count = query_turso(&turso.db, &turso.conn, workload.turso_sql);
-                    std::hint::black_box(row_count);
-                    total += start.elapsed();
-                }
-                total
-            });
-        });
+    for benchmark_mode in TursoBenchmarkMode::ALL {
+        let turso = open_turso(benchmark_mode);
+        populate_turso(&turso, &batches);
+        assert_workload_parity(&turso, &sqlite);
 
+        for workload in QUERY_WORKLOADS {
+            group.bench_function(
+                BenchmarkId::new(workload.name, benchmark_mode.label()),
+                |bencher| {
+                    iter_custom_or_iter!(bencher, |iterations| {
+                        let mut total = std::time::Duration::ZERO;
+                        for _ in 0..iterations {
+                            let start = std::time::Instant::now();
+                            let row_count = query_turso(&turso.db, &turso.conn, workload.turso_sql);
+                            std::hint::black_box(row_count);
+                            total += start.elapsed();
+                        }
+                        total
+                    });
+                },
+            );
+        }
+    }
+
+    for workload in QUERY_WORKLOADS {
         if !cfg!(feature = "codspeed") {
             group.bench_function(BenchmarkId::new(workload.name, "sqlite_fts5"), |bencher| {
                 iter_custom_or_iter!(bencher, |iterations| {

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -8,7 +8,7 @@ use crate::sync::{
     atomic::{
         AtomicBool, AtomicI32, AtomicI64, AtomicIsize, AtomicU16, AtomicU64, AtomicU8, Ordering,
     },
-    Arc, RwLock,
+    Arc, Mutex, RwLock,
 };
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
@@ -487,6 +487,11 @@ pub struct Connection {
     pub(super) check_constraints_pragma: AtomicBool,
     /// Track when each virtual table instance is currently in transaction.
     pub(crate) vtab_txn_states: RwLock<HashSet<u64>>,
+    /// One prepared cursor per index-method attachment touched by the active
+    /// database transaction. Statement reset transfers cursors here so the
+    /// eventual transaction outcome is delivered exactly once per attachment.
+    pub(crate) index_method_tx_cursors:
+        Mutex<Vec<crate::index_method::TransactionIndexMethodCursor>>,
     /// Connection-level named savepoint stack used to mirror savepoint state
     /// onto temp/attached databases that start participating after SAVEPOINT.
     pub(crate) named_savepoints: RwLock<Vec<NamedSavepointFrame>>,
@@ -2356,6 +2361,7 @@ impl Connection {
                 self.set_tx_state(TransactionState::None);
             }
         }
+        self.index_methods_transaction_rolled_back();
         self.clear_mvcc_log_meta();
 
         let is_memory_db = is_memory_like(&self.db.path);
@@ -4886,6 +4892,86 @@ impl Connection {
         self.named_savepoints.write().clear();
     }
 
+    pub(crate) fn register_index_method_transaction_cursor(
+        &self,
+        mut entry: crate::index_method::TransactionIndexMethodCursor,
+    ) {
+        entry.cursor.statement_committed(&entry.context);
+        let mut entries = self.index_method_tx_cursors.lock();
+        let previous = if let Some(position) = entries
+            .iter()
+            .position(|existing| existing.same_attachment(&entry.context))
+        {
+            Some(std::mem::replace(&mut entries[position], entry))
+        } else {
+            entries.push(entry);
+            None
+        };
+        drop(entries);
+
+        if let Some(mut previous) = previous {
+            previous.cursor.close(&previous.context);
+        }
+    }
+
+    fn take_index_method_transaction_cursors(
+        &self,
+    ) -> Vec<crate::index_method::TransactionIndexMethodCursor> {
+        let mut entries = std::mem::take(&mut *self.index_method_tx_cursors.lock());
+        entries.sort_by(|left, right| {
+            (
+                left.context.database().id,
+                left.context.index().method_name.as_str(),
+                left.context.index().table_name.as_str(),
+                left.context.index().index_name.as_str(),
+                left.context.index().runtime_id,
+            )
+                .cmp(&(
+                    right.context.database().id,
+                    right.context.index().method_name.as_str(),
+                    right.context.index().table_name.as_str(),
+                    right.context.index().index_name.as_str(),
+                    right.context.index().runtime_id,
+                ))
+        });
+        entries
+    }
+
+    pub(crate) fn index_methods_transaction_committed(&self) {
+        let entries = self.take_index_method_transaction_cursors();
+        tracing::trace!(
+            attachments = entries.len(),
+            "publishing transaction-scoped index-method state"
+        );
+        for mut entry in entries {
+            entry.cursor.transaction_committed(&entry.context);
+            entry.cursor.close(&entry.context);
+        }
+    }
+
+    pub(crate) fn index_methods_transaction_rolled_back(&self) {
+        let entries = self.take_index_method_transaction_cursors();
+        tracing::trace!(
+            attachments = entries.len(),
+            "invalidating transaction-scoped index-method state"
+        );
+        for mut entry in entries {
+            entry.cursor.transaction_rolled_back(&entry.context);
+            entry.cursor.close(&entry.context);
+        }
+    }
+
+    pub(crate) fn index_methods_savepoint_rolled_back(&self) {
+        let mut entries = self.index_method_tx_cursors.lock();
+        tracing::trace!(
+            attachments = entries.len(),
+            "invalidating index-method state after savepoint rollback"
+        );
+        for entry in entries.iter_mut() {
+            entry.cursor.savepoint_rolled_back(&entry.context);
+        }
+    }
+
     /// Roll back the current main-db transaction state and any attached-db
     /// transaction state on this connection.
     pub(crate) fn rollback_current_txn_state(
@@ -4909,6 +4995,7 @@ impl Connection {
             self.auto_commit.store(true, Ordering::SeqCst);
         }
         self.rollback_attached_wal_txns();
+        self.index_methods_transaction_rolled_back();
         self.set_tx_state(TransactionState::None);
         self.clear_tx_poison();
     }
@@ -4936,6 +5023,7 @@ impl Connection {
                 self.rollback_attached_mvcc_txs(clear_attached_schemas);
             }
             self.rollback_attached_wal_txns();
+            self.index_methods_transaction_rolled_back();
             self.set_tx_state(TransactionState::None);
             self.auto_commit.store(true, Ordering::SeqCst);
         }

--- a/core/database.rs
+++ b/core/database.rs
@@ -2340,6 +2340,7 @@ impl Database {
             n_active_root_statements: AtomicI32::new(0),
             check_constraints_pragma: AtomicBool::new(false),
             vtab_txn_states: RwLock::new(HashSet::default()),
+            index_method_tx_cursors: crate::sync::Mutex::new(Vec::new()),
             named_savepoints: RwLock::new(Vec::new()),
             schema_reparse_in_progress: AtomicBool::new(false),
             prepare_context_generation: AtomicU64::new(0),

--- a/core/index_method/backing_btree.rs
+++ b/core/index_method/backing_btree.rs
@@ -37,6 +37,7 @@ impl IndexMethodAttachment for BackingBTreeIndexMethodAttachment {
             patterns: &[],
             backing_btree: true,
             results_materialized: false,
+            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
         }
     }
 

--- a/core/index_method/backing_btree.rs
+++ b/core/index_method/backing_btree.rs
@@ -16,16 +16,20 @@ use crate::{
 pub struct BackingBtreeIndexMethod;
 
 #[derive(Debug)]
-pub struct BackingBTreeIndexMethodAttachment(String);
+pub struct BackingBTreeIndexMethodAttachment {
+    table_name: String,
+    index_name: String,
+}
 
 impl IndexMethod for BackingBtreeIndexMethod {
     fn attach(
         &self,
         configuration: &IndexMethodConfiguration,
     ) -> Result<Arc<dyn IndexMethodAttachment>> {
-        Ok(Arc::new(BackingBTreeIndexMethodAttachment(
-            configuration.index_name.clone(),
-        )))
+        Ok(Arc::new(BackingBTreeIndexMethodAttachment {
+            table_name: configuration.table_name.clone(),
+            index_name: configuration.index_name.clone(),
+        }))
     }
 }
 
@@ -33,7 +37,8 @@ impl IndexMethodAttachment for BackingBTreeIndexMethodAttachment {
     fn definition<'a>(&'a self) -> IndexMethodDefinition<'a> {
         IndexMethodDefinition {
             method_name: BACKING_BTREE_INDEX_METHOD_NAME,
-            index_name: &self.0,
+            table_name: &self.table_name,
+            index_name: &self.index_name,
             patterns: &[],
             backing_btree: true,
             results_materialized: false,

--- a/core/index_method/backing_btree.rs
+++ b/core/index_method/backing_btree.rs
@@ -37,7 +37,7 @@ impl IndexMethodAttachment for BackingBTreeIndexMethodAttachment {
             patterns: &[],
             backing_btree: true,
             results_materialized: false,
-            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
+            mvcc_support: super::IndexMethodMvccSupport::TransactionalBackingStore,
         }
     }
 

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1773,6 +1773,7 @@ impl IndexMethodAttachment for FtsIndexAttachment {
             // Unordered match queries stream directly from Tantivy scorers.
             // UPDATE/DELETE must therefore collect stable rowids before writes.
             results_materialized: false,
+            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
         }
     }
 

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1,20 +1,18 @@
-use crate::alloc::ALLOC_ERR_MSG;
 use crate::sync::{Arc, Weak};
-use crate::turso_assert;
-use crate::turso_debug_assert;
 use crate::{
     index_method::{
-        parse_patterns, IndexMethod, IndexMethodAttachment, IndexMethodConfiguration,
-        IndexMethodCursor, IndexMethodDefinition,
+        open_index_cursor, parse_patterns, IndexMethod, IndexMethodAttachment,
+        IndexMethodConfiguration, IndexMethodContext, IndexMethodCursor, IndexMethodDefinition,
     },
     return_if_io,
     schema::IndexColumn,
     storage::{
-        btree::{BTreeCursor, BTreeKey, CursorTrait},
+        btree::{BTreeKey, CursorTrait},
         pager::Pager,
     },
     translate::collate::CollationSeq,
-    types::{IOResult, ImmutableRecord, IndexInfo, KeyInfo, SeekKey, SeekOp, SeekResult, Text},
+    turso_assert,
+    types::{IOResult, ImmutableRecord, KeyInfo, SeekKey, SeekOp, SeekResult, Text},
     util::quote_identifier,
     vdbe::Register,
     Connection, LimboError, Result, Value,
@@ -24,7 +22,10 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::io::{BufWriter, Write};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::{cell::RefCell, sync::atomic::Ordering};
+use std::{
+    cell::RefCell,
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+};
 use tantivy::{
     directory::{
         error::{DeleteError, OpenReadError, OpenWriteError},
@@ -50,7 +51,7 @@ pub const FTS_INDEX_METHOD_NAME: &str = "fts";
 /// Controls how much memory Tantivy uses for in-memory indexing before flushing to disk.
 pub const DEFAULT_MEMORY_BUDGET_BYTES: usize = 64 * 1024 * 1024;
 
-/// Default chunk size (152KB) for splitting large files when storing in BTree.
+/// Default chunk size (512 KiB) for splitting large files when storing in BTree.
 /// Files larger than this are split into multiple chunks for efficient storage and retrieval.
 pub const DEFAULT_CHUNK_SIZE: usize = 512 * 1024;
 
@@ -89,6 +90,38 @@ const FTS_MAX_CACHED_CONNECTIONS: usize = 4;
 
 /// Aggregate resident file-cache budget across retained connection snapshots.
 const FTS_MAX_RETAINED_CACHE_BYTES: usize = DEFAULT_HOT_CACHE_BYTES + DEFAULT_CHUNK_CACHE_BYTES;
+
+#[cfg(feature = "test_helper")]
+crate::thread::thread_local! {
+    static FTS_RETAINED_CACHE_BYTES_OVERRIDE: core::cell::Cell<Option<usize>> =
+        const { core::cell::Cell::new(None) };
+}
+
+/// Override the retained-cache budget for tests on the current thread, so
+/// budget-admission rejection is reachable without multi-hundred-MiB indexes.
+/// Pass `None` to restore the default.
+#[cfg(feature = "test_helper")]
+pub fn set_fts_retained_cache_bytes_for_test(bytes: Option<usize>) {
+    FTS_RETAINED_CACHE_BYTES_OVERRIDE.with(|cell| cell.set(bytes));
+}
+
+fn fts_max_retained_cache_bytes() -> usize {
+    #[cfg(feature = "test_helper")]
+    if let Some(bytes) = FTS_RETAINED_CACHE_BYTES_OVERRIDE.with(|cell| cell.get()) {
+        return bytes;
+    }
+    FTS_MAX_RETAINED_CACHE_BYTES
+}
+
+const FTS_CONTROL_PATH: &str = "__turso_fts_control_v1";
+const FTS_CONTROL_MAGIC: &[u8; 8] = b"TFTSCTL1";
+const FTS_CONTROL_FORMAT_VERSION: u32 = 1;
+/// Placeholder incarnation for an index with no persisted control record yet
+/// (an empty catalog). Deterministic, so every connection opening a
+/// never-written index agrees on it; the real incarnation is minted when the
+/// first control record is staged and is never this value.
+const FTS_EMPTY_INDEX_INCARNATION: u64 = 0;
+static NEXT_FTS_INDEX_INCARNATION: AtomicU64 = AtomicU64::new(1);
 
 const ROWID_FIELD: &str = "rowid";
 
@@ -218,83 +251,224 @@ pub fn fts_match(text: &str, query: &str) -> bool {
     })
 }
 
-/// File classification for hybrid caching strategy.
-/// Determines which files are kept hot in memory vs lazy-loaded on demand.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FileCategory {
-    /// Always in memory: meta.json, .managed.json, .lock (typically < 64KB)
-    Metadata,
-    /// Hot files: .term dictionaries - loaded on first access, kept in LRU
-    TermDictionary,
-    /// Fast fields and field norms - small, frequently accessed
-    FastFields,
-    /// Cold files: .idx, .pos, .store - lazy-loaded on demand
-    SegmentData,
-}
-
-impl FileCategory {
-    const METADATA_FILES: [&'static str; 3] = [TANTIVY_META_FILE, ".managed.json", ".lock"];
-    /// Classify a file based on its path/extension.
-    /// https://fulmicoton.gitbooks.io/tantivy-doc/content/index-files.html
-    fn from_path(path: &Path) -> Self {
-        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-
-        // Check for known Tantivy metadata files first
-        if Self::METADATA_FILES.contains(&name) {
-            return FileCategory::Metadata;
-        }
-
-        match ext {
-            // Term dictionary - hot for queries
-            "term" => FileCategory::TermDictionary,
-            // Fast fields and field norms - small, frequently accessed
-            "fast" | "fieldnorm" => FileCategory::FastFields,
-            // Segment data - large, lazy-loaded
-            "idx" | "pos" | "store" => FileCategory::SegmentData,
-            "lock" | "info" => FileCategory::Metadata,
-            // Default to segment data (lazy-loaded)
-            _ => FileCategory::SegmentData,
-        }
-    }
-
-    /// Returns true if files in this category should be preloaded at startup.
-    const fn should_preload(&self) -> bool {
-        matches!(self, FileCategory::Metadata)
-    }
-
-    /// Returns true if files in this category should be kept in the hot cache.
-    const fn is_hot(&self) -> bool {
-        matches!(
-            self,
-            FileCategory::Metadata | FileCategory::TermDictionary | FileCategory::FastFields
-        )
-    }
-}
-
 /// Metadata about a file stored in the FTS directory.
-/// Used for catalog-first loading where we build file metadata without loading content.
+/// Used for merge-budget accounting.
 #[derive(Debug, Clone)]
 struct FileMetadata {
     /// Total file size in bytes
     size: usize,
-    /// Number of chunks this file is split into
-    num_chunks: usize,
-    /// File category for caching decisions
-    category: FileCategory,
+    chunks: u64,
 }
 
 impl FileMetadata {
-    fn new(path: &Path, size: usize, num_chunks: usize) -> Self {
+    fn new(_path: &Path, size: usize, num_chunks: usize) -> Self {
         Self {
             size,
-            num_chunks,
-            category: FileCategory::from_path(path),
+            chunks: num_chunks as u64,
         }
     }
 }
 
-type ChunkKey = (PathBuf, i64);
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FtsManifestFile {
+    size: u64,
+    chunks: u64,
+}
+
+#[derive(Debug, Clone)]
+struct FtsControlRecord {
+    index_incarnation: u64,
+    manifest_generation: u64,
+    files: HashMap<PathBuf, FtsManifestFile>,
+}
+
+impl FtsControlRecord {
+    fn new(index_incarnation: u64) -> Self {
+        Self {
+            index_incarnation,
+            manifest_generation: 0,
+            files: HashMap::default(),
+        }
+    }
+
+    fn from_catalog(
+        previous: Option<&Self>,
+        index_incarnation: u64,
+        catalog: &Catalog,
+    ) -> Result<Self> {
+        let manifest_generation = match previous {
+            Some(control) => control.manifest_generation.checked_add(1).ok_or_else(|| {
+                LimboError::InternalError("FTS manifest generation is exhausted".to_string())
+            })?,
+            None => 1,
+        };
+        let mut files = HashMap::default();
+        for (path, metadata) in catalog {
+            let path_text = path.to_str().ok_or_else(|| {
+                LimboError::InternalError(format!(
+                    "FTS manifest path is not valid UTF-8: {}",
+                    path.display()
+                ))
+            })?;
+            let _ = path_text;
+            files.insert(
+                path.clone(),
+                FtsManifestFile {
+                    size: metadata.size as u64,
+                    chunks: metadata.chunks,
+                },
+            );
+        }
+        Ok(Self {
+            index_incarnation,
+            manifest_generation,
+            files,
+        })
+    }
+
+    fn encode(&self) -> Result<Vec<u8>> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(FTS_CONTROL_MAGIC);
+        bytes.extend_from_slice(&FTS_CONTROL_FORMAT_VERSION.to_le_bytes());
+        bytes.extend_from_slice(&self.index_incarnation.to_le_bytes());
+        bytes.extend_from_slice(&self.manifest_generation.to_le_bytes());
+        let mut files = self.files.iter().collect::<Vec<_>>();
+        files.sort_by(|(left, _), (right, _)| left.cmp(right));
+        let file_count = u32::try_from(files.len())
+            .map_err(|_| LimboError::InternalError("FTS manifest has too many files".into()))?;
+        bytes.extend_from_slice(&file_count.to_le_bytes());
+        for (path, metadata) in files {
+            let path = path.to_str().ok_or_else(|| {
+                LimboError::InternalError(format!(
+                    "FTS manifest path is not valid UTF-8: {}",
+                    path.display()
+                ))
+            })?;
+            let path_len = u32::try_from(path.len())
+                .map_err(|_| LimboError::InternalError("FTS manifest path is too long".into()))?;
+            bytes.extend_from_slice(&path_len.to_le_bytes());
+            bytes.extend_from_slice(path.as_bytes());
+            bytes.extend_from_slice(&metadata.size.to_le_bytes());
+            bytes.extend_from_slice(&metadata.chunks.to_le_bytes());
+        }
+        let checksum = fts_control_checksum(&bytes);
+        bytes.extend_from_slice(&checksum.to_le_bytes());
+        Ok(bytes)
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self> {
+        fn take<const N: usize>(bytes: &[u8], offset: &mut usize) -> Result<[u8; N]> {
+            let end = offset
+                .checked_add(N)
+                .ok_or_else(|| LimboError::Corrupt("FTS control record offset overflow".into()))?;
+            let value = bytes
+                .get(*offset..end)
+                .ok_or_else(|| LimboError::Corrupt("truncated FTS control record".into()))?;
+            *offset = end;
+            Ok(value.try_into().expect("slice length checked"))
+        }
+
+        if bytes.len() < FTS_CONTROL_MAGIC.len() + 4 + 8 + 8 + 4 + 8 {
+            return Err(LimboError::Corrupt("truncated FTS control record".into()));
+        }
+        let payload_len = bytes.len() - 8;
+        let expected_checksum = u64::from_le_bytes(
+            bytes[payload_len..]
+                .try_into()
+                .expect("checksum length checked"),
+        );
+        if fts_control_checksum(&bytes[..payload_len]) != expected_checksum {
+            return Err(LimboError::Corrupt(
+                "FTS control record checksum mismatch".into(),
+            ));
+        }
+
+        let mut offset = 0;
+        if take::<8>(bytes, &mut offset)? != *FTS_CONTROL_MAGIC {
+            return Err(LimboError::Corrupt(
+                "unrecognized FTS control record".into(),
+            ));
+        }
+        let version = u32::from_le_bytes(take(bytes, &mut offset)?);
+        if version != FTS_CONTROL_FORMAT_VERSION {
+            return Err(LimboError::Corrupt(format!(
+                "unsupported FTS control format version {version}"
+            )));
+        }
+        let index_incarnation = u64::from_le_bytes(take(bytes, &mut offset)?);
+        let manifest_generation = u64::from_le_bytes(take(bytes, &mut offset)?);
+        let file_count = u32::from_le_bytes(take(bytes, &mut offset)?) as usize;
+        let mut files = HashMap::default();
+        for _ in 0..file_count {
+            let path_len = u32::from_le_bytes(take(bytes, &mut offset)?) as usize;
+            let path_end = offset
+                .checked_add(path_len)
+                .ok_or_else(|| LimboError::Corrupt("FTS manifest path offset overflow".into()))?;
+            let path_bytes = bytes
+                .get(offset..path_end)
+                .ok_or_else(|| LimboError::Corrupt("truncated FTS manifest path".into()))?;
+            offset = path_end;
+            let path = std::str::from_utf8(path_bytes)
+                .map_err(|_| LimboError::Corrupt("FTS manifest path is not UTF-8".into()))?;
+            let size = u64::from_le_bytes(take(bytes, &mut offset)?);
+            let chunks = u64::from_le_bytes(take(bytes, &mut offset)?);
+            if chunks == 0 {
+                return Err(LimboError::Corrupt(format!(
+                    "FTS manifest file {path} has zero chunks"
+                )));
+            }
+            if files
+                .insert(PathBuf::from(path), FtsManifestFile { size, chunks })
+                .is_some()
+            {
+                return Err(LimboError::Corrupt(format!(
+                    "duplicate FTS manifest entry for {path}"
+                )));
+            }
+        }
+        if offset != payload_len {
+            return Err(LimboError::Corrupt(
+                "FTS control record has trailing payload bytes".into(),
+            ));
+        }
+        Ok(Self {
+            index_incarnation,
+            manifest_generation,
+            files,
+        })
+    }
+
+    fn validate_catalog(&self, catalog: &Catalog) -> Result<()> {
+        if self.files.len() != catalog.len() {
+            return Err(LimboError::Corrupt(format!(
+                "FTS manifest contains {} files but storage contains {}",
+                self.files.len(),
+                catalog.len()
+            )));
+        }
+        for (path, metadata) in catalog {
+            let manifest = self.files.get(path).ok_or_else(|| {
+                LimboError::Corrupt(format!(
+                    "FTS storage file {} is absent from the manifest",
+                    path.display()
+                ))
+            })?;
+            if manifest.size != metadata.size as u64 || manifest.chunks != metadata.chunks {
+                return Err(LimboError::Corrupt(format!(
+                    "FTS manifest metadata mismatch for {}",
+                    path.display()
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn fts_control_checksum(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf2_9ce4_8422_2325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100_0000_01b3)
+    })
+}
 
 /// Eviction samples per put
 const EVICTION_SAMPLES: usize = 8;
@@ -330,18 +504,6 @@ impl<K: std::fmt::Debug> std::fmt::Debug for LruCache<K> {
 }
 
 impl<K: Eq + std::hash::Hash + Clone> LruCache<K> {
-    /// Creates a new empty cache with the specified capacity in bytes.
-    fn new(capacity: usize) -> Self {
-        Self {
-            capacity,
-            inner: RwLock::new(LruCacheInner {
-                current_size: 0,
-                clock: 0,
-                entries: HashMap::default(),
-            }),
-        }
-    }
-
     /// Lookup entry, updating access timestamp. Returns Arc-cloned data.
     fn get<Q>(&self, key: &Q) -> Option<Arc<[u8]>>
     where
@@ -447,30 +609,10 @@ impl<K: Eq + std::hash::Hash + Clone> LruCache<K> {
     }
 }
 
-/// Specialized methods for ChunkKey (PathBuf, i64) caches.
-impl LruCache<ChunkKey> {
-    /// Invalidate all chunks for a file path.
-    /// Called when a file is deleted or overwritten.
-    fn invalidate(&self, path: &Path) {
-        let mut inner = self.inner.write();
-        let mut freed = 0usize;
-        inner.entries.retain(|(p, _), e| {
-            if p == path {
-                freed += e.data.len();
-                false
-            } else {
-                true
-            }
-        });
-        inner.current_size -= freed;
-    }
-}
-
 /// Specialized methods for PathBuf caches (hot files).
 impl LruCache<PathBuf> {
-    /// Create from preloaded files (used during initialization).
-    fn with_preloaded(capacity: usize, files: HashMap<PathBuf, Vec<u8>>) -> Self {
-        let current_size: usize = files.values().map(|v| v.len()).sum();
+    fn with_preloaded_arcs(capacity: usize, files: HashMap<PathBuf, Arc<[u8]>>) -> Self {
+        let current_size: usize = files.values().map(|data| data.len()).sum();
         let entries: HashMap<PathBuf, LruCacheEntry> = files
             .into_iter()
             .enumerate()
@@ -478,7 +620,7 @@ impl LruCache<PathBuf> {
                 (
                     path,
                     LruCacheEntry {
-                        data: Arc::from(data),
+                        data,
                         accessed: i as u64,
                     },
                 )
@@ -493,6 +635,15 @@ impl LruCache<PathBuf> {
                 entries,
             }),
         }
+    }
+
+    fn arc_snapshot(&self) -> HashMap<PathBuf, Arc<[u8]>> {
+        self.inner
+            .read()
+            .entries
+            .iter()
+            .map(|(path, entry)| (path.clone(), Arc::clone(&entry.data)))
+            .collect()
     }
 }
 
@@ -532,35 +683,21 @@ impl PendingFileMutations {
     }
 }
 
-/// Tantivy Directory implementation backed by Turso's BTree storage.
+/// Tantivy Directory implementation backed by a complete in-memory snapshot.
 ///
 /// Tantivy stores its index as a collection of files (segments, metadata, term dictionaries, etc.).
-/// The `Directory` trait is Tantivy's storage abstraction for reading, writing, and managing
-/// these files. Tantivy's Directory methods are synchronous, so we must do blocking IO to back
-/// these operations and cache data in memory for performance.
+/// The `Directory` trait is synchronous, while Turso storage is asynchronous. The FTS cursor
+/// therefore loads the complete directory through its resumable state machine before constructing
+/// Tantivy objects. Directory callbacks only read this snapshot or cursor-local pending writes;
+/// they must never open a B-tree cursor or drive the pager.
 ///
 /// FTS index files are stored in a BTree with the schema `(path TEXT, chunk_no INTEGER, bytes BLOB)`.
-/// Large files are split into chunks of `DEFAULT_CHUNK_SIZE` (1MB) to enable efficient
+/// Large files are split into chunks of `DEFAULT_CHUNK_SIZE` (512 KiB) to enable efficient
 /// partial reads and bounded memory usage during loading.
-///
-/// We use a two-tier caching strategy to optimize for Tantivy's access patterns:
-///
-/// 1. `hot_cache` (keyed by `PathBuf`): Caches entire files for small,
-///    frequently-accessed files that benefit from being fully resident in memory:
-///    - Metadata files (meta.json, .managed.json, .lock)
-///    - Term dictionaries (.term) - critical for query performance
-///    - Fast fields and field norms (.fast, .fieldnorm)
-///
-/// 2. `chunk_cache` (keyed by `(PathBuf, chunk_no)`): Caches individual 1MB chunks
-///    of large segment files. Large files like posting lists (.idx), positions (.pos),
-///    and document store (.store) are split into 1MB chunks when stored in the BTree.
-///    When Tantivy reads a byte range, we load only the chunks covering that range,
-///    allowing partial file access without loading entire multi-MB files into memory.
 ///
 /// File mutations are buffered in memory and flushed to the BTree when:
 /// - A Tantivy commit occurs (via `commit_and_flush`)
-/// - The cursor is dropped with pending documents
-/// - The transaction is about to commit (via `pre_commit`)
+/// - The statement is finalized (via `prepare_statement_commit`)
 ///
 /// During flush, writes are moved to `flushing_writes` so they remain readable while
 /// the async BTree write completes.
@@ -569,12 +706,15 @@ struct HybridBTreeDirectory {
     /// File catalog: path -> metadata (always in memory, no content)
     catalog: Arc<RwLock<Catalog>>,
 
-    /// Hot cache: LRU cache for frequently accessed files (metadata, term dictionaries)
-    /// Bounded to DEFAULT_HOT_CACHE_BYTES (64MB) to prevent unbounded memory growth
+    /// Complete file snapshot loaded before Tantivy is invoked.
+    ///
+    /// The capacity is deliberately unbounded: eviction would turn a synchronous Tantivy
+    /// callback into a storage read. Connection-level cache pruning bounds retained snapshots.
     hot_cache: Arc<LruCache<PathBuf>>,
 
-    /// Chunk cache: LRU cache for lazy-loaded segment chunks
-    chunk_cache: Arc<LruCache<ChunkKey>>,
+    /// Storage view at cursor checkout, kept separate from Tantivy's mutable
+    /// in-memory view so unchanged rewrites can be elided.
+    base_files: Arc<RwLock<HashMap<PathBuf, Arc<[u8]>>>>,
 
     /// Latest pending mutation for each path.
     pending_mutations: Arc<RwLock<PendingFileMutations>>,
@@ -596,7 +736,6 @@ impl std::fmt::Debug for HybridBTreeDirectory {
             .field("catalog_size", &self.catalog.read().len())
             .field("hot_cache_size", &self.hot_cache.len())
             .field("hot_cache_bytes", &self.hot_cache.size())
-            .field("chunk_cache_size", &self.chunk_cache.size())
             .field("btree_root_page", &self.btree_root_page)
             .finish()
     }
@@ -609,10 +748,14 @@ impl HybridBTreeDirectory {
     /// This prevents the bug where writes from one cursor affect the Drop behavior
     /// of another cursor.
     fn clone_with_fresh_pending(&self) -> Self {
+        let files = self.hot_cache.arc_snapshot();
         Self {
-            catalog: Arc::clone(&self.catalog),
-            hot_cache: Arc::clone(&self.hot_cache),
-            chunk_cache: Arc::clone(&self.chunk_cache),
+            catalog: Arc::new(RwLock::new(self.catalog.read().clone())),
+            hot_cache: Arc::new(LruCache::<PathBuf>::with_preloaded_arcs(
+                usize::MAX,
+                files.clone(),
+            )),
+            base_files: Arc::new(RwLock::new(files)),
             // Fresh pending state - not shared with cache
             pending_mutations: Arc::new(RwLock::new(PendingFileMutations::default())),
             flushing_writes: Arc::new(RwLock::new(HashMap::default())),
@@ -622,27 +765,25 @@ impl HybridBTreeDirectory {
     }
 }
 
-fn io_not_found<M: Into<Box<dyn std::error::Error + Send + Sync>>>(msg: M) -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::NotFound, msg)
-}
-
 impl HybridBTreeDirectory {
-    /// Create from preloaded catalog and hot cache files.
+    /// Create from a complete, asynchronously preloaded snapshot.
     fn with_preloaded(
         pager: Arc<Pager>,
         btree_root_page: i64,
         catalog: HashMap<PathBuf, FileMetadata>,
-        hot_files: HashMap<PathBuf, Vec<u8>>,
-        hot_cache_capacity: usize,
-        chunk_cache_capacity: usize,
+        files: HashMap<PathBuf, Vec<u8>>,
     ) -> Self {
+        let base_files = files
+            .into_iter()
+            .map(|(path, data)| (path, Arc::<[u8]>::from(data)))
+            .collect::<HashMap<_, _>>();
         Self {
             catalog: Arc::new(RwLock::new(catalog)),
-            hot_cache: Arc::new(LruCache::<PathBuf>::with_preloaded(
-                hot_cache_capacity,
-                hot_files,
+            hot_cache: Arc::new(LruCache::<PathBuf>::with_preloaded_arcs(
+                usize::MAX,
+                base_files.clone(),
             )),
-            chunk_cache: Arc::new(LruCache::<ChunkKey>::new(chunk_cache_capacity)),
+            base_files: Arc::new(RwLock::new(base_files)),
             pending_mutations: Arc::new(RwLock::new(PendingFileMutations::default())),
             flushing_writes: Arc::new(RwLock::new(HashMap::default())),
             pager,
@@ -664,7 +805,20 @@ impl HybridBTreeDirectory {
     /// while the resumable BTree flush is in progress. `None` is an explicit
     /// delete; `Some(Vec::new())` is an empty file.
     fn take_pending_flushes(&self) -> PendingFlushes {
-        let flushes = self.pending_mutations.write().take_flushes();
+        let base_files = self.base_files.read();
+        let flushes = self
+            .pending_mutations
+            .write()
+            .take_flushes()
+            .into_iter()
+            .filter(|(path, data)| match data {
+                Some(data) => base_files
+                    .get(path)
+                    .is_none_or(|base| base.as_ref() != data.as_slice()),
+                None => base_files.contains_key(path),
+            })
+            .collect::<Vec<_>>();
+        drop(base_files);
 
         {
             let mut flushing = self.flushing_writes.write();
@@ -688,6 +842,7 @@ impl HybridBTreeDirectory {
             flushing.len()
         );
         flushing.clear();
+        *self.base_files.write() = self.hot_cache.arc_snapshot();
     }
 
     /// Find file data in pending or flushing writes.
@@ -710,352 +865,6 @@ impl HybridBTreeDirectory {
         }
 
         None
-    }
-
-    const CHUNK_LEN: usize = 3;
-
-    /// Blocking read of a range of chunks from BTree using a single cursor.
-    /// Efficient for both single and multiple chunk reads, as it only seeks once
-    /// and advances sequentially.
-    fn get_chunks_range_blocking(
-        &self,
-        path: &Path,
-        start_chunk: usize,
-        end_chunk: usize,
-    ) -> std::io::Result<Vec<Arc<[u8]>>> {
-        if start_chunk > end_chunk {
-            return Ok(Vec::new());
-        }
-
-        let mut chunks = Vec::with_capacity(end_chunk - start_chunk + 1);
-        let path_str = path.to_string_lossy().to_string();
-
-        // Check cache for all requested chunks first
-        let mut uncached_start = None;
-        for chunk_no in start_chunk..=end_chunk {
-            let cache_key = (path.to_path_buf(), chunk_no as i64);
-            if let Some(chunk) = self.chunk_cache.get(&cache_key) {
-                chunks.push(chunk);
-            } else {
-                // Found first uncached chunk
-                uncached_start = Some(chunk_no);
-                break;
-            }
-        }
-
-        // If all chunks were cached, return them
-        if uncached_start.is_none() {
-            return Ok(chunks);
-        }
-
-        let uncached_start = uncached_start.unwrap();
-
-        // Create cursor and seek to first uncached chunk
-        let mut cursor =
-            BTreeCursor::new(self.pager.clone(), self.btree_root_page, Self::CHUNK_LEN);
-        cursor.index_info = Some(Arc::new(
-            IndexInfo::new(
-                [key_info(), key_info(), key_info()],
-                false,
-                Self::CHUNK_LEN,
-                false,
-            )
-            .expect(ALLOC_ERR_MSG),
-        ));
-
-        let seek_key = ImmutableRecord::from_values(
-            &[
-                Value::Text(Text::new(path_str.clone())),
-                Value::from_i64(uncached_start as i64),
-                Value::Blob(crate::alloc::vec![]),
-            ],
-            Self::CHUNK_LEN,
-        )
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-
-        // Blocking seek to first chunk
-        loop {
-            match cursor.seek(
-                SeekKey::IndexKey(seek_key.as_record_ref()),
-                SeekOp::GE { eq_only: false },
-            ) {
-                Ok(IOResult::Done(SeekResult::Found)) => break,
-                Ok(IOResult::Done(SeekResult::TryAdvance)) => {
-                    loop {
-                        match cursor.next() {
-                            Ok(IOResult::Done(_)) => {
-                                if !cursor.has_record() {
-                                    return Err(io_not_found(format!(
-                                        "chunk {}:{} not found",
-                                        path.display(),
-                                        uncached_start
-                                    )));
-                                }
-                                break;
-                            }
-                            Ok(IOResult::IO(_)) => {
-                                self.pager
-                                    .io
-                                    .step()
-                                    .map_err(|e| std::io::Error::other(e.to_string()))?;
-                            }
-                            Err(e) => return Err(std::io::Error::other(e.to_string())),
-                        }
-                    }
-                    break;
-                }
-                Ok(IOResult::Done(SeekResult::NotFound)) => {
-                    return Err(io_not_found(format!(
-                        "chunk {}:{} not found",
-                        path.display(),
-                        uncached_start
-                    )));
-                }
-                Ok(IOResult::IO(_)) => {
-                    self.pager
-                        .io
-                        .step()
-                        .map_err(|e| std::io::Error::other(e.to_string()))?;
-                }
-                Err(e) => return Err(std::io::Error::other(e.to_string())),
-            }
-        }
-
-        // Read remaining chunks sequentially
-        for expected_chunk_no in uncached_start..=end_chunk {
-            // Check if cursor has a record
-            if !cursor.has_record() {
-                return Err(io_not_found(format!(
-                    "chunk {}:{} not found (cursor exhausted)",
-                    path.display(),
-                    expected_chunk_no
-                )));
-            }
-
-            // Read current record
-            let record = loop {
-                match cursor.record() {
-                    Ok(IOResult::Done(r)) => break r,
-                    Ok(IOResult::IO(_)) => {
-                        self.pager
-                            .io
-                            .step()
-                            .map_err(|e| std::io::Error::other(e.to_string()))?;
-                    }
-                    Err(e) => return Err(std::io::Error::other(e.to_string())),
-                }
-            };
-
-            let record = record.ok_or_else(|| io_not_found("no record at cursor"))?;
-
-            // Extract and validate
-            let found_path = record.get_value_opt(0).and_then(|v| match v {
-                crate::types::ValueRef::Text(t) => Some(t.value.to_string()),
-                _ => None,
-            });
-            let found_chunk = record.get_value_opt(1).and_then(|v| match v {
-                crate::types::ValueRef::Numeric(crate::numeric::Numeric::Integer(i)) => Some(i),
-                _ => None,
-            });
-            let bytes = record.get_value_opt(2).and_then(|v| match v {
-                crate::types::ValueRef::Blob(b) => Some(b.to_vec()),
-                _ => None,
-            });
-
-            let (found_path_str, found_chunk_no, bytes) = match (found_path, found_chunk, bytes) {
-                (Some(p), Some(c), Some(b)) => (p, c, b),
-                _ => {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "malformed chunk record",
-                    ));
-                }
-            };
-
-            if found_path_str != path_str || found_chunk_no != expected_chunk_no as i64 {
-                return Err(io_not_found(format!(
-                    "wrong chunk: expected {path_str}:{expected_chunk_no}, got {found_path_str}:{found_chunk_no}",
-                )));
-            }
-
-            // Cache and collect the chunk
-            if can_cache_chunks(path) {
-                let cache_key = (path.to_path_buf(), expected_chunk_no as i64);
-                self.chunk_cache.put(cache_key, bytes.clone());
-            }
-            chunks.push(Arc::from(bytes));
-
-            // Advance cursor to next record (unless this is the last chunk we need)
-            if expected_chunk_no < end_chunk {
-                loop {
-                    match cursor.next() {
-                        Ok(IOResult::Done(_)) => break,
-                        Ok(IOResult::IO(_)) => {
-                            self.pager
-                                .io
-                                .step()
-                                .map_err(|e| std::io::Error::other(e.to_string()))?;
-                        }
-                        Err(e) => return Err(std::io::Error::other(e.to_string())),
-                    }
-                }
-            }
-        }
-
-        Ok(chunks)
-    }
-
-    /// Load an entire file by concatenating all its chunks (blocking).
-    /// Uses efficient bulk read with a single cursor seek.
-    fn load_file_blocking(&self, path: &Path) -> std::io::Result<Vec<u8>> {
-        let catalog = self.catalog.read();
-        let metadata = catalog
-            .get(path)
-            .ok_or_else(|| io_not_found(format!("file not in catalog: {}", path.display())))?;
-
-        if metadata.num_chunks == 0 {
-            return Ok(Vec::new());
-        }
-
-        let chunks =
-            self.get_chunks_range_blocking(path, 0, metadata.num_chunks.saturating_sub(1))?;
-
-        let mut result = Vec::with_capacity(metadata.size);
-        for chunk in chunks {
-            result.extend_from_slice(&chunk);
-        }
-
-        Ok(result)
-    }
-
-    /// Read a file's full contents straight from the BTree, bypassing the
-    /// catalog and every cache layer. Returns `None` when the BTree holds no
-    /// rows for the path. Used to validate cached read state.
-    /// against durable state at cursor checkout.
-    fn read_file_from_btree_uncached(&self, path: &Path) -> std::io::Result<Option<Vec<u8>>> {
-        let path_str = path.to_string_lossy().to_string();
-        let mut cursor =
-            BTreeCursor::new(self.pager.clone(), self.btree_root_page, Self::CHUNK_LEN);
-        cursor.index_info = Some(Arc::new(
-            IndexInfo::new(
-                [key_info(), key_info(), key_info()],
-                false,
-                Self::CHUNK_LEN,
-                false,
-            )
-            .expect(ALLOC_ERR_MSG),
-        ));
-
-        let seek_key = ImmutableRecord::from_values(
-            &[
-                Value::Text(Text::new(path_str.clone())),
-                Value::from_i64(0),
-                Value::Blob(crate::alloc::vec![]),
-            ],
-            Self::CHUNK_LEN,
-        )
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-
-        loop {
-            match cursor.seek(
-                SeekKey::IndexKey(seek_key.as_record_ref()),
-                SeekOp::GE { eq_only: false },
-            ) {
-                Ok(IOResult::Done(SeekResult::Found)) => break,
-                Ok(IOResult::Done(SeekResult::TryAdvance)) => {
-                    loop {
-                        match cursor.next() {
-                            Ok(IOResult::Done(_)) => break,
-                            Ok(IOResult::IO(_)) => {
-                                self.pager
-                                    .io
-                                    .step()
-                                    .map_err(|e| std::io::Error::other(e.to_string()))?;
-                            }
-                            Err(e) => return Err(std::io::Error::other(e.to_string())),
-                        }
-                    }
-                    break;
-                }
-                Ok(IOResult::Done(SeekResult::NotFound)) => return Ok(None),
-                Ok(IOResult::IO(_)) => {
-                    self.pager
-                        .io
-                        .step()
-                        .map_err(|e| std::io::Error::other(e.to_string()))?;
-                }
-                Err(e) => return Err(std::io::Error::other(e.to_string())),
-            }
-        }
-
-        let mut result: Option<Vec<u8>> = None;
-        loop {
-            if !cursor.has_record() {
-                return Ok(result);
-            }
-            let record = loop {
-                match cursor.record() {
-                    Ok(IOResult::Done(r)) => break r,
-                    Ok(IOResult::IO(_)) => {
-                        self.pager
-                            .io
-                            .step()
-                            .map_err(|e| std::io::Error::other(e.to_string()))?;
-                    }
-                    Err(e) => return Err(std::io::Error::other(e.to_string())),
-                }
-            };
-            let Some(record) = record else {
-                return Ok(result);
-            };
-            let matches_path = record.get_value_opt(0).is_some_and(|v| match v {
-                crate::types::ValueRef::Text(t) => t.value == path_str.as_str(),
-                _ => false,
-            });
-            if !matches_path {
-                return Ok(result);
-            }
-            let bytes = record.get_value_opt(2).and_then(|v| match v {
-                crate::types::ValueRef::Blob(b) => Some(b.to_vec()),
-                _ => None,
-            });
-            let Some(bytes) = bytes else {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "malformed chunk record",
-                ));
-            };
-            result
-                .get_or_insert_with(Vec::new)
-                .extend_from_slice(&bytes);
-            loop {
-                match cursor.next() {
-                    Ok(IOResult::Done(_)) => break,
-                    Ok(IOResult::IO(_)) => {
-                        self.pager
-                            .io
-                            .step()
-                            .map_err(|e| std::io::Error::other(e.to_string()))?;
-                    }
-                    Err(e) => return Err(std::io::Error::other(e.to_string())),
-                }
-            }
-        }
-    }
-
-    /// True when this directory's in-memory view of the Tantivy metadata file
-    /// matches what the BTree currently holds. Cached read state can
-    /// go stale without any notification — a rolled-back transaction (or
-    /// savepoint) reverts the BTree while the cache keeps the state published
-    /// mid-transaction (issue 7522) — so cursors verify before trusting it.
-    fn is_consistent_with_btree(&self) -> std::io::Result<bool> {
-        let meta_path = Path::new(TANTIVY_META_FILE);
-        let Some(cached_meta) = self.hot_cache.get(meta_path) else {
-            // No in-memory metadata to compare — cannot vouch for the cache.
-            return Ok(false);
-        };
-        let btree_meta = self.read_file_from_btree_uncached(meta_path)?;
-        Ok(btree_meta.as_deref() == Some(&cached_meta[..]))
     }
 
     /// Add a file to the hot cache.
@@ -1105,99 +914,6 @@ impl FileHandle for InMemoryFileHandle {
     }
 }
 
-/// Lazy file handle that fetches chunks on demand.
-struct LazyFileHandle {
-    path: PathBuf,
-    size: usize,
-    directory: HybridBTreeDirectory,
-}
-
-impl std::fmt::Debug for LazyFileHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LazyFileHandle")
-            .field("path", &self.path)
-            .field("size", &self.size)
-            .finish()
-    }
-}
-
-impl HasLen for LazyFileHandle {
-    fn len(&self) -> usize {
-        self.size
-    }
-}
-
-impl FileHandle for LazyFileHandle {
-    fn read_bytes(&self, range: Range<usize>) -> std::io::Result<OwnedBytes> {
-        if range.end > self.size {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                format!(
-                    "range {:?} exceeds file size {} for {}",
-                    range,
-                    self.size,
-                    self.path.display()
-                ),
-            ));
-        }
-        if range.start >= range.end {
-            return Ok(OwnedBytes::new(Vec::new()));
-        }
-
-        // Check hot cache first
-        if let Some(data) = self.directory.hot_cache.get(&self.path) {
-            return Ok(OwnedBytes::new(data).slice(range));
-        }
-
-        // Check pending/flushing writes (data not yet persisted to BTree)
-        if let Some(data) = self.directory.find_in_pending_writes(&self.path) {
-            return Ok(OwnedBytes::new(data[range].to_vec()));
-        }
-
-        // Calculate required chunks
-        let chunk_size = DEFAULT_CHUNK_SIZE;
-        let start_chunk = range.start / chunk_size;
-        let end_chunk = range.end.saturating_sub(1) / chunk_size;
-
-        // Use efficient bulk read when multiple chunks are needed
-        let chunks =
-            self.directory
-                .get_chunks_range_blocking(&self.path, start_chunk, end_chunk)?;
-
-        // Collect result from chunks
-        let mut result = Vec::with_capacity(range.len());
-        for (i, chunk) in chunks.into_iter().enumerate() {
-            let chunk_no = start_chunk + i;
-            let chunk_start = chunk_no * chunk_size;
-
-            // Calculate slice within this chunk
-            let local_start = if chunk_no == start_chunk {
-                range.start - chunk_start
-            } else {
-                0
-            };
-            let local_end = if chunk_no == end_chunk {
-                range.end - chunk_start
-            } else {
-                chunk.len()
-            };
-
-            // Defensive bounds check - should not be needed if logic is correct
-            turso_debug_assert!(
-                local_start <= chunk.len() && local_end <= chunk.len(),
-                "chunk slice out of bounds",
-                { "local_start": local_start, "local_end": local_end, "chunk_len": chunk.len() }
-            );
-            let local_end = local_end.min(chunk.len());
-            let local_start = local_start.min(local_end);
-
-            result.extend_from_slice(&chunk[local_start..local_end]);
-        }
-
-        Ok(OwnedBytes::new(result))
-    }
-}
-
 /// In-memory writer for HybridBTreeDirectory.
 struct HybridWriter {
     path: PathBuf,
@@ -1224,14 +940,10 @@ impl Drop for HybridWriter {
             // Update catalog
             let num_chunks = data.len().div_ceil(DEFAULT_CHUNK_SIZE);
             let metadata = FileMetadata::new(&self.path, data.len(), num_chunks);
-            self.directory
-                .update_catalog(self.path.clone(), metadata.clone());
+            self.directory.update_catalog(self.path.clone(), metadata);
 
-            // If it's a hot file category, add to hot cache
-            if metadata.category.is_hot() {
-                self.directory
-                    .add_to_hot_cache(self.path.clone(), data.clone());
-            }
+            self.directory
+                .add_to_hot_cache(self.path.clone(), data.clone());
 
             self.directory.queue_write(self.path.clone(), data);
         }
@@ -1246,14 +958,10 @@ impl TerminatingWrite for HybridWriter {
 
         // Update catalog - even empty files should exist in the catalog
         let metadata = FileMetadata::new(&self.path, data.len(), num_chunks);
-        self.directory
-            .update_catalog(self.path.clone(), metadata.clone());
+        self.directory.update_catalog(self.path.clone(), metadata);
 
-        // If it's a hot file category, add to hot cache (even if empty)
-        if metadata.category.is_hot() {
-            self.directory
-                .add_to_hot_cache(self.path.clone(), data.clone());
-        }
+        self.directory
+            .add_to_hot_cache(self.path.clone(), data.clone());
 
         self.directory.queue_write(self.path.clone(), data);
         Ok(())
@@ -1277,17 +985,17 @@ impl Directory for HybridBTreeDirectory {
             }));
         }
 
-        // Check catalog for file metadata
-        let catalog = self.catalog.read();
-        let metadata = catalog
-            .get(path)
-            .ok_or_else(|| OpenReadError::FileDoesNotExist(path.to_path_buf()))?;
+        if !self.catalog.read().contains_key(path) {
+            return Err(OpenReadError::FileDoesNotExist(path.to_path_buf()));
+        }
 
-        Ok(Arc::new(LazyFileHandle {
-            path: path.to_path_buf(),
-            size: metadata.size,
-            directory: self.clone(),
-        }))
+        Err(OpenReadError::IoError {
+            io_error: Arc::new(std::io::Error::other(format!(
+                "FTS snapshot invariant violated: {} is cataloged but was not preloaded",
+                path.display()
+            ))),
+            filepath: path.to_path_buf(),
+        })
     }
 
     fn exists(&self, path: &Path) -> std::result::Result<bool, OpenReadError> {
@@ -1308,10 +1016,6 @@ impl Directory for HybridBTreeDirectory {
             let mut catalog = self.catalog.write();
             catalog.remove(path);
         }
-        if can_cache_chunks(path) {
-            // Invalidate chunk cache
-            self.chunk_cache.invalidate(path);
-        }
         self.queue_delete(path.to_path_buf());
         Ok(())
     }
@@ -1329,12 +1033,11 @@ impl Directory for HybridBTreeDirectory {
         // existing file first. The error is ignored because:
         // 1. If the file doesn't exist, delete() succeeds (no-op on missing files)
         // 2. Our delete() implementation always returns Ok(()) - it only removes entries
-        //    from in-memory structures (hot_cache, catalog, chunk_cache) and queues the
+        //    from in-memory structures and queues the
         //    BTree deletion, none of which can fail.
         //
         // Skip delete for the meta lock file: Tantivy calls open_write on it for every
-        // search query, but it's never cached (can_cache_chunks returns false), never in
-        // hot_cache, and doesn't need BTree deletion, so delete() is pure overhead.
+        // search query and it does not need BTree deletion.
         if path != Path::new(TANTIVY_META_LOCK_FILE) {
             let _ = self.delete(path);
         }
@@ -1365,24 +1068,22 @@ impl Directory for HybridBTreeDirectory {
             }
         }
 
-        // Load file blocking from BTree
-        self.load_file_blocking(path)
-            .map_err(|e| OpenReadError::IoError {
-                io_error: Arc::new(e),
-                filepath: path.to_path_buf(),
-            })
+        Err(OpenReadError::IoError {
+            io_error: Arc::new(std::io::Error::other(format!(
+                "FTS snapshot invariant violated: {} is cataloged but was not preloaded",
+                path.display()
+            ))),
+            filepath: path.to_path_buf(),
+        })
     }
 
     fn atomic_write(&self, path: &Path, data: &[u8]) -> std::io::Result<()> {
         // Update catalog
         let num_chunks = data.len().div_ceil(DEFAULT_CHUNK_SIZE).max(1);
         let metadata = FileMetadata::new(path, data.len(), num_chunks);
-        self.update_catalog(path.to_path_buf(), metadata.clone());
+        self.update_catalog(path.to_path_buf(), metadata);
 
-        // If it's a hot file category, add to hot cache
-        if metadata.category.is_hot() {
-            self.add_to_hot_cache(path.to_path_buf(), data.to_vec());
-        }
+        self.add_to_hot_cache(path.to_path_buf(), data.to_vec());
 
         self.queue_write(path.to_path_buf(), data.to_vec());
         Ok(())
@@ -1488,11 +1189,14 @@ impl IndexMethod for FtsIndexMethod {
 /// pending-write state.
 pub struct CachedFtsState {
     connection: Weak<Connection>,
+    /// MVCC transaction that owns this snapshot. `None` denotes a WAL entry.
+    transaction_id: Option<u64>,
     /// WAL snapshot at which the cached Tantivy metadata was loaded.
     ///
     /// `None` means the pager has no WAL identity and requires the slower
     /// metadata-byte comparison before reuse.
     snapshot_wal_pos: Option<(u32, u64)>,
+    control: FtsControlRecord,
     directory: HybridBTreeDirectory,
     index: Index,
     reader: IndexReader,
@@ -1507,6 +1211,11 @@ pub struct CachedFtsState {
 /// stale Tantivy segments.
 struct CachedFtsWriter {
     connection: Weak<Connection>,
+    /// MVCC transaction that exclusively owns this writer. `None` denotes a
+    /// WAL writer whose visibility remains connection-local until commit.
+    transaction_id: Option<u64>,
+    snapshot_wal_pos: Option<(u32, u64)>,
+    control: FtsControlRecord,
     directory: HybridBTreeDirectory,
     index: Index,
     writer: IndexWriter,
@@ -1528,10 +1237,7 @@ struct CachedFtsStates {
 
 impl CachedFtsState {
     fn resident_cache_bytes(&self) -> usize {
-        self.directory
-            .hot_cache
-            .size()
-            .saturating_add(self.directory.chunk_cache.size())
+        self.directory.hot_cache.size()
     }
 }
 
@@ -1547,7 +1253,7 @@ impl CachedFtsStates {
             .retain(|cached| cached.connection.strong_count() > 0);
         while self.entries.len() > FTS_MAX_CACHED_CONNECTIONS
             || (self.entries.len() > 1
-                && self.resident_cache_bytes() > FTS_MAX_RETAINED_CACHE_BYTES)
+                && self.resident_cache_bytes() > fts_max_retained_cache_bytes())
         {
             self.entries.remove(0);
         }
@@ -1568,11 +1274,18 @@ impl CachedFtsStates {
         }
     }
 
-    fn insert(&mut self, state: CachedFtsState) {
+    fn insert(&mut self, state: CachedFtsState, byte_budget: usize) -> bool {
         self.entries
             .retain(|cached| !Weak::ptr_eq(&cached.connection, &state.connection));
+        if state.resident_cache_bytes() > byte_budget {
+            return false;
+        }
         self.entries.push(state);
         self.prune();
+        while self.entries.len() > 1 && self.resident_cache_bytes() > byte_budget {
+            self.entries.remove(0);
+        }
+        true
     }
 
     fn clear(&mut self) {
@@ -1616,6 +1329,26 @@ pub struct FtsIndexAttachment {
     /// `Mutex` provides exclusive access without requiring `IndexWriter` to be
     /// `Sync`; SQLite transaction rules already serialize writers.
     cached_writer: Arc<Mutex<Option<CachedFtsWriter>>>,
+    runtime_stats: Arc<FtsRuntimeStats>,
+}
+
+#[derive(Debug, Default)]
+struct FtsRuntimeStats {
+    tantivy_writer_constructions: AtomicUsize,
+    writer_cache_lookups: AtomicUsize,
+    writer_cache_hits: AtomicUsize,
+    writer_cache_validation_failures: AtomicUsize,
+    writer_cache_rollback_discards: AtomicUsize,
+    writer_cache_misses: AtomicUsize,
+    read_cache_lookups: AtomicUsize,
+    read_cache_hits: AtomicUsize,
+    read_cache_misses: AtomicUsize,
+    cache_admission_rejections: AtomicUsize,
+    full_snapshot_loads: AtomicUsize,
+    manifest_validation_hits: AtomicUsize,
+    manifest_validation_misses: AtomicUsize,
+    write_lease_acquisitions: AtomicUsize,
+    write_lease_rejections: AtomicUsize,
 }
 
 /// Supported tokenizer names for FTS indexes
@@ -1759,6 +1492,7 @@ impl FtsIndexAttachment {
             field_weights,
             cached_state: Arc::new(RwLock::new(CachedFtsStates::default())),
             cached_writer: Arc::new(Mutex::new(None)),
+            runtime_stats: Arc::new(FtsRuntimeStats::default()),
         })
     }
 }
@@ -1767,26 +1501,19 @@ impl IndexMethodAttachment for FtsIndexAttachment {
     fn definition<'a>(&'a self) -> IndexMethodDefinition<'a> {
         IndexMethodDefinition {
             method_name: FTS_INDEX_METHOD_NAME,
+            table_name: &self.cfg.table_name,
             index_name: &self.cfg.index_name,
             patterns: &self.patterns,
             backing_btree: false,
             // Unordered match queries stream directly from Tantivy scorers.
             // UPDATE/DELETE must therefore collect stable rowids before writes.
             results_materialized: false,
-            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
+            mvcc_support: super::IndexMethodMvccSupport::TransactionalBackingStore,
         }
     }
 
     fn init(&self) -> Result<Box<dyn IndexMethodCursor>> {
-        Ok(Box::new(FtsCursor::new(
-            &self.cfg,
-            self.schema.clone(),
-            self.rowid_field,
-            self.text_fields.clone(),
-            self.field_weights.clone(),
-            self.cached_state.clone(),
-            self.cached_writer.clone(),
-        )))
+        Ok(Box::new(FtsCursor::new(self)))
     }
 }
 
@@ -1862,17 +1589,41 @@ fn bounded_query_limit(limit: Option<i64>, live_docs: u64) -> usize {
     }
 }
 
-/// Check if a file's chunks should be cached.
-///
-/// The meta lock file is excluded because Tantivy calls `open_write` on it for every search query.
-/// Since `open_write` calls `delete` first, caching the lock file would trigger a full chunk cache
-/// scan on every query, causing significant overhead.
-fn can_cache_chunks(path: &Path) -> bool {
-    path.as_os_str().to_str() != Some(TANTIVY_META_LOCK_FILE)
-}
-
 /// Accumulated file metadata: path -> (chunk_no -> (blob_size, Option<blob_data>))
 type CatalogBuilder = HashMap<i64, (usize, Option<Vec<u8>>)>;
+type CachedFtsCheckout = (
+    HybridBTreeDirectory,
+    Index,
+    IndexReader,
+    Arc<tantivy::query::QueryParser>,
+    FtsControlRecord,
+);
+
+fn assemble_catalog_file(path: &Path, chunks: &CatalogBuilder) -> Result<Vec<u8>> {
+    let max_chunk =
+        chunks.keys().max().copied().ok_or_else(|| {
+            LimboError::Corrupt(format!("FTS file {} has no chunks", path.display()))
+        })?;
+    if max_chunk < 0 {
+        return Err(LimboError::Corrupt(format!(
+            "FTS file {} has a negative chunk number",
+            path.display()
+        )));
+    }
+    let total_size = chunks.values().map(|(size, _)| size).sum();
+    let mut assembled = Vec::with_capacity(total_size);
+    for chunk_no in 0..=max_chunk {
+        let Some((_, Some(data))) = chunks.get(&chunk_no) else {
+            return Err(LimboError::Corrupt(format!(
+                "FTS directory file {} is missing chunk {}",
+                path.display(),
+                chunk_no
+            )));
+        };
+        assembled.extend_from_slice(data);
+    }
+    Ok(assembled)
+}
 
 /// State machine for FTS cursor async operations
 #[derive(Debug)]
@@ -1881,23 +1632,24 @@ enum FtsState {
     Init,
     /// Rewinding cursor to start
     Rewinding,
+    /// Seeking the small control record for cross-transaction cache validation.
+    SeekingControl,
+    /// Advancing after the control-record seek returned `TryAdvance`.
+    AdvancingToControl,
+    /// Reading the control record's chunks without scanning directory files.
+    LoadingControl {
+        chunks: CatalogBuilder,
+        advance_pending: bool,
+    },
     /// Loading file catalog from BTree (metadata only, not content)
     /// This is the new catalog-first approach for HybridBTreeDirectory
     LoadingCatalog {
-        /// Hot files capture blob data during scan to avoid a second pass.
         catalog_builder: HashMap<PathBuf, CatalogBuilder>,
+        control_builder: CatalogBuilder,
         current_path: Option<PathBuf>,
-    },
-    /// Preloading essential files (meta.json and other hot files)
-    PreloadingEssentials {
-        /// Files that need to be preloaded
-        files_to_load: Vec<PathBuf>,
-        /// Files already loaded
-        loaded_files: HashMap<PathBuf, Vec<u8>>,
-        /// Current file being loaded
-        current_loading: Option<PathBuf>,
-        /// Current chunks being accumulated for the file being loaded
-        current_chunks: Vec<(i64, Vec<u8>)>,
+        /// The current record was captured and `cursor.next()` must finish
+        /// before it can be observed again.
+        advance_pending: bool,
     },
     /// Creating/opening Tantivy index
     CreatingIndex,
@@ -1923,12 +1675,6 @@ enum FtsState {
     },
     /// Performing the actual delete of a chunk
     DeletingChunk {
-        writes: PendingFlushes,
-        write_idx: usize,
-        path_str: String,
-    },
-    /// Advancing cursor after delete to check next record
-    AdvancingAfterDelete {
         writes: PendingFlushes,
         write_idx: usize,
         path_str: String,
@@ -1965,7 +1711,6 @@ impl FtsState {
                 | Self::AdvancingAfterSeek { .. }
                 | Self::CheckingChunkPath { .. }
                 | Self::DeletingChunk { .. }
-                | Self::AdvancingAfterDelete { .. }
                 | Self::SeekingWrite { .. }
                 | Self::InsertingWrite { .. }
         )
@@ -2044,8 +1789,9 @@ pub struct FtsCursor {
     shared_writer: Arc<Mutex<Option<CachedFtsWriter>>>,
     connection: Option<Arc<Connection>>,
     database_id: Option<usize>,
-    fts_dir_cursor: Option<BTreeCursor>,
+    fts_dir_cursor: Option<Box<dyn CursorTrait>>,
     btree_root_page: Option<i64>,
+    control: Option<FtsControlRecord>,
     hybrid_directory: Option<HybridBTreeDirectory>,
     index: Option<Index>,
     reader: Option<IndexReader>,
@@ -2060,43 +1806,43 @@ pub struct FtsCursor {
     /// True while `open_write` is driving the shared open state machine.
     /// Read state is never published or reused in this mode.
     opening_for_write: bool,
+    runtime_stats: Arc<FtsRuntimeStats>,
 }
 
 impl FtsCursor {
     /// Creates a new FTS cursor with the given configuration.
-    fn new(
-        cfg: &IndexMethodConfiguration,
-        schema: Schema,
-        rowid_field: Field,
-        text_fields: Vec<(IndexColumn, Field)>,
-        field_weights: HashMap<String, f32>,
-        shared_cache: Arc<RwLock<CachedFtsStates>>,
-        shared_writer: Arc<Mutex<Option<CachedFtsWriter>>>,
-    ) -> Self {
+    fn new(attachment: &FtsIndexAttachment) -> Self {
         let dir_table_name = format!(
             "{}fts_dir_{}",
             crate::schema::TURSO_INTERNAL_PREFIX,
-            cfg.index_name
+            attachment.cfg.index_name
         );
+        let text_fields = attachment.text_fields.clone();
         let default_fields: Vec<Field> = text_fields.iter().map(|(_, f)| *f).collect();
         let field_boosts: Vec<(Field, f32)> = text_fields
             .iter()
-            .filter_map(|(col, field)| field_weights.get(&col.name).map(|&boost| (*field, boost)))
+            .filter_map(|(col, field)| {
+                attachment
+                    .field_weights
+                    .get(&col.name)
+                    .map(|&boost| (*field, boost))
+            })
             .collect();
         Self {
-            schema,
-            rowid_field,
+            schema: attachment.schema.clone(),
+            rowid_field: attachment.rowid_field,
             text_fields,
             dir_table_name,
             default_fields,
             field_boosts,
             cached_parser: None,
-            shared_cache,
-            shared_writer,
+            shared_cache: Arc::clone(&attachment.cached_state),
+            shared_writer: Arc::clone(&attachment.cached_writer),
             connection: None,
             database_id: None,
             fts_dir_cursor: None,
             btree_root_page: None,
+            control: None,
             hybrid_directory: None,
             index: None,
             reader: None,
@@ -2109,6 +1855,7 @@ impl FtsCursor {
             hit_pos: 0,
             current_pattern: FTS_PATTERN_SCORE,
             opening_for_write: false,
+            runtime_stats: Arc::clone(&attachment.runtime_stats),
         }
     }
 
@@ -2123,7 +1870,6 @@ impl FtsCursor {
         let index_name = format!("{}_key", self.dir_table_name);
 
         // Get root page for HybridBTreeDirectory
-        let pager = conn.get_pager_from_database_index(&database_id)?;
         let scratch = conn
             .with_schema(database_id, |schema| {
                 schema.get_index(&self.dir_table_name, &index_name).cloned()
@@ -2138,14 +1884,13 @@ impl FtsCursor {
 
         self.btree_root_page = Some(root_page);
 
-        let mut cursor = BTreeCursor::new(pager, root_page, 3);
-        cursor.index_info = Some(Arc::new(IndexInfo::new(
+        self.fts_dir_cursor = Some(open_index_cursor(
+            conn,
+            database_id,
+            &self.dir_table_name,
+            &index_name,
             [key_info(), key_info(), key_info()],
-            false,
-            3,
-            false,
-        )?));
-        self.fts_dir_cursor = Some(cursor);
+        )?);
         Ok(())
     }
 
@@ -2177,11 +1922,84 @@ impl FtsCursor {
         Arc::new(parser)
     }
 
+    fn checkout_cached_state(
+        &self,
+        context: &IndexMethodContext,
+        visible_control: Option<&FtsControlRecord>,
+    ) -> Option<CachedFtsCheckout> {
+        let conn = context.connection();
+        if conn.is_in_write_tx() {
+            return None;
+        }
+        let mut cache = self.shared_cache.write();
+        cache.prune();
+        let position = cache.connection_position(conn)?;
+        let cached = &cache.entries[position];
+        let same_snapshot = match (context.transaction_id(), cached.transaction_id) {
+            (Some(current), Some(cached)) => current == cached,
+            (None, None) => cached.snapshot_wal_pos.is_some_and(|snapshot_wal_pos| {
+                cached.directory.pager.wal_pos() == snapshot_wal_pos
+            }),
+            _ => false,
+        };
+        let same_manifest = visible_control.is_some_and(|control| {
+            control.index_incarnation == cached.control.index_incarnation
+                && control.manifest_generation == cached.control.manifest_generation
+        });
+        if !same_snapshot && !same_manifest {
+            if visible_control.is_some() {
+                cache.entries.remove(position);
+            }
+            return None;
+        }
+
+        let cached = cache.entries.remove(position);
+        let checkout = (
+            cached.directory.clone_with_fresh_pending(),
+            cached.index.clone(),
+            cached.reader.clone(),
+            Arc::clone(&cached.query_parser),
+            cached.control.clone(),
+        );
+        cache.entries.push(cached);
+        Some(checkout)
+    }
+
+    fn has_cached_state(&self, context: &IndexMethodContext) -> bool {
+        let conn = context.connection();
+        !conn.is_in_write_tx() && self.shared_cache.read().connection_position(conn).is_some()
+    }
+
+    fn install_cached_checkout(&mut self, checkout: CachedFtsCheckout) {
+        let (directory, index, reader, query_parser, control) = checkout;
+        self.runtime_stats
+            .read_cache_hits
+            .fetch_add(1, Ordering::Relaxed);
+        tracing::debug!("FTS open_read: using cached state (skipping catalog load)");
+        self.hybrid_directory = Some(directory);
+        self.control = Some(control);
+        self.index = Some(index);
+        self.searcher = Some(reader.searcher());
+        self.reader = Some(reader);
+        self.cached_parser = Some(query_parser);
+        self.state = FtsState::Ready;
+    }
+
     /// Restore a writer retained by the previous statement when its committed
     /// metadata still matches this transaction's backing B-tree view.
-    fn restore_cached_writer(&mut self, conn: &Arc<Connection>) -> Result<bool> {
-        let cached = self.shared_writer.lock().take();
-        let Some(cached) = cached else {
+    fn restore_cached_writer(&mut self, context: &IndexMethodContext) -> Result<bool> {
+        let conn = context.connection();
+        self.runtime_stats
+            .writer_cache_lookups
+            .fetch_add(1, Ordering::Relaxed);
+        let database_id = self.database_id.ok_or_else(|| {
+            LimboError::InternalError("FTS database id is not initialized".to_string())
+        })?;
+        let mut cached_writer = self.shared_writer.lock();
+        let Some(cached) = cached_writer.as_ref() else {
+            self.runtime_stats
+                .writer_cache_misses
+                .fetch_add(1, Ordering::Relaxed);
             return Ok(false);
         };
 
@@ -2189,15 +2007,54 @@ impl FtsCursor {
             .connection
             .upgrade()
             .is_some_and(|owner| Arc::ptr_eq(&owner, conn));
-        let metadata_matches = same_connection
-            && cached.directory.is_consistent_with_btree().map_err(|e| {
-                LimboError::InternalError(format!("FTS writer cache validation failed: {e}"))
-            })?;
+        let metadata_matches = if conn.mv_store_for_db(database_id).is_some() {
+            same_connection
+                && context.transaction_id().is_some()
+                && context.transaction_id() == cached.transaction_id
+        } else {
+            same_connection
+                && cached.transaction_id.is_none()
+                && cached
+                    .snapshot_wal_pos
+                    .is_some_and(|position| cached.directory.pager.wal_pos() == position)
+        };
         if !metadata_matches {
+            // A committed MVCC writer is retained until its small control
+            // record can be validated asynchronously by open_read().
+            if conn.mv_store_for_db(database_id).is_some()
+                && same_connection
+                && cached.transaction_id.is_none()
+            {
+                return Ok(false);
+            }
+            // The slot is shared by every connection. Only remove an entry
+            // this connection owns, or one whose owner is gone; a live writer
+            // owned by another connection stays cached for its owner.
+            let stale = if same_connection || cached.connection.strong_count() == 0 {
+                cached_writer.take()
+            } else {
+                None
+            };
+            drop(cached_writer);
+            self.runtime_stats
+                .writer_cache_validation_failures
+                .fetch_add(1, Ordering::Relaxed);
+            self.runtime_stats
+                .writer_cache_misses
+                .fetch_add(1, Ordering::Relaxed);
+            drop(stale);
             return Ok(false);
         }
 
+        let cached = cached_writer
+            .take()
+            .expect("validated cached writer must still be present");
+        drop(cached_writer);
+        self.runtime_stats
+            .writer_cache_hits
+            .fetch_add(1, Ordering::Relaxed);
         tracing::debug!("FTS open_write: reusing committed writer state");
+        self.control = Some(cached.control);
         self.hybrid_directory = Some(cached.directory);
         self.index = Some(cached.index);
         self.writer = Some(cached.writer);
@@ -2208,25 +2065,150 @@ impl FtsCursor {
         Ok(true)
     }
 
+    fn has_deferred_cached_writer(&self, context: &IndexMethodContext) -> bool {
+        let conn = context.connection();
+        self.shared_writer.lock().as_ref().is_some_and(|cached| {
+            cached.transaction_id.is_none()
+                && cached
+                    .connection
+                    .upgrade()
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, conn))
+        })
+    }
+
+    fn checkout_validated_cached_writer(
+        &mut self,
+        context: &IndexMethodContext,
+        visible_control: &FtsControlRecord,
+    ) -> bool {
+        let conn = context.connection();
+        let mut cached_writer = self.shared_writer.lock();
+        let Some(cached) = cached_writer.as_ref() else {
+            return false;
+        };
+        let owner = cached.connection.upgrade();
+        let same_connection = owner.as_ref().is_some_and(|owner| Arc::ptr_eq(owner, conn));
+        let deferred = cached.transaction_id.is_none();
+        let matches_control = cached.control.index_incarnation == visible_control.index_incarnation
+            && cached.control.manifest_generation == visible_control.manifest_generation;
+        if !(same_connection && deferred && matches_control) {
+            // A dead owner, or a committed writer the committed control record
+            // has moved past, can never be reused by anyone: remove it. A live
+            // writer owned by another connection stays cached for its owner.
+            let stale = if owner.is_none() || (deferred && !matches_control) {
+                cached_writer.take()
+            } else {
+                None
+            };
+            drop(cached_writer);
+            self.runtime_stats
+                .writer_cache_validation_failures
+                .fetch_add(1, Ordering::Relaxed);
+            self.runtime_stats
+                .writer_cache_misses
+                .fetch_add(1, Ordering::Relaxed);
+            drop(stale);
+            return false;
+        }
+
+        let cached = cached_writer
+            .take()
+            .expect("validated cached writer must still be present");
+        drop(cached_writer);
+        self.runtime_stats
+            .writer_cache_hits
+            .fetch_add(1, Ordering::Relaxed);
+        self.control = Some(cached.control);
+        self.hybrid_directory = Some(cached.directory);
+        self.index = Some(cached.index);
+        self.writer = Some(cached.writer);
+        self.reader = None;
+        self.searcher = None;
+        self.cached_parser = None;
+        self.state = FtsState::Ready;
+        true
+    }
+
+    fn discard_deferred_cached_writer(&self, context: &IndexMethodContext) {
+        let conn = context.connection();
+        let mut cached_writer = self.shared_writer.lock();
+        // A missing control record proves this connection's deferred writer is
+        // stale. The slot is shared by every connection, so a live writer
+        // owned by another connection stays cached for its owner.
+        let discard =
+            cached_writer
+                .as_ref()
+                .is_some_and(|cached| match cached.connection.upgrade() {
+                    None => true,
+                    Some(owner) => Arc::ptr_eq(&owner, conn) && cached.transaction_id.is_none(),
+                });
+        if !discard {
+            return;
+        }
+        let stale = cached_writer.take();
+        drop(cached_writer);
+        self.runtime_stats
+            .writer_cache_validation_failures
+            .fetch_add(1, Ordering::Relaxed);
+        self.runtime_stats
+            .writer_cache_misses
+            .fetch_add(1, Ordering::Relaxed);
+        drop(stale);
+    }
+
     /// Retain a fully flushed writer for the next statement on this connection.
-    fn cache_writer(&mut self, conn: &Arc<Connection>) {
+    fn cache_writer(&mut self, context: &IndexMethodContext) {
+        let conn = context.connection();
         if self.pending_docs_count != 0 || !matches!(self.state, FtsState::Ready) {
+            tracing::trace!(
+                pending_documents = self.pending_docs_count,
+                state = ?self.state,
+                "FTS writer cache: cursor is not fully prepared"
+            );
             return;
         }
         let Some(directory) = self.hybrid_directory.as_ref() else {
+            tracing::trace!("FTS writer cache: directory is not initialized");
             return;
         };
+        let retained_read_bytes = self.shared_cache.read().resident_cache_bytes();
+        if directory
+            .hot_cache
+            .size()
+            .saturating_add(retained_read_bytes)
+            > fts_max_retained_cache_bytes()
+        {
+            self.runtime_stats
+                .cache_admission_rejections
+                .fetch_add(1, Ordering::Relaxed);
+            tracing::debug!(
+                resident_bytes = directory.hot_cache.size(),
+                budget_bytes = fts_max_retained_cache_bytes(),
+                "FTS writer cache: snapshot exceeds retention budget"
+            );
+            return;
+        }
         // Index creation and failed statements can close a cursor before all
         // directory mutations enter the normal document flush state machine.
         // Such a writer is not reusable.
         if !directory.pending_mutations.read().by_path.is_empty()
             || !directory.flushing_writes.read().is_empty()
         {
+            tracing::trace!("FTS writer cache: directory still has pending mutations");
             return;
         }
-        let Some(writer) = self.writer.take() else {
+        if self.writer.is_none() {
+            tracing::trace!("FTS writer cache: cursor has no writer");
+            return;
+        }
+        // Keep `self.control` set: `transaction_committed` compares it against
+        // the cached writer's control record before re-stamping the WAL
+        // position.
+        let Some(control) = self.control.clone() else {
+            tracing::error!("FTS writer cache: control record is not initialized");
             return;
         };
+        let writer = self.writer.take().expect("writer checked above");
         let index = self
             .index
             .take()
@@ -2235,9 +2217,14 @@ impl FtsCursor {
             .hybrid_directory
             .take()
             .expect("FTS writer must have an initialized directory");
+        let wal_pos = directory.pager.wal_pos();
+        let snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
 
         let previous = self.shared_writer.lock().replace(CachedFtsWriter {
             connection: Arc::downgrade(conn),
+            transaction_id: context.transaction_id(),
+            snapshot_wal_pos,
+            control,
             directory,
             index,
             writer,
@@ -2481,41 +2468,18 @@ impl FtsCursor {
                     // Perform the delete - if IO is needed, we'll come back to this state
                     return_if_io!(cursor.delete());
 
-                    // Delete completed, advance cursor to next record before checking again
-                    self.state = FtsState::AdvancingAfterDelete {
+                    // Re-seek from the logical prefix after every delete.
+                    // B-tree deletion may retreat, preserve, or advance the
+                    // physical cursor depending on balancing; calling next()
+                    // can therefore skip a sibling value for the same
+                    // (path, chunk_no) prefix. Re-seeking is unambiguous and
+                    // enforces one logical value even though bytes remain a
+                    // physical key column.
+                    self.state = FtsState::SeekingOldChunks {
                         writes: std::mem::take(writes),
                         write_idx: *write_idx,
                         path_str: std::mem::take(path_str),
                     };
-                }
-                FtsState::AdvancingAfterDelete {
-                    writes,
-                    write_idx,
-                    path_str,
-                } => {
-                    let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
-                        LimboError::InternalError("cursor not initialized".into())
-                    })?;
-
-                    // Advance cursor to next record after delete
-                    return_if_io!(cursor.next());
-                    let has_next = cursor.has_record();
-
-                    if has_next {
-                        // Check the next record in CheckingChunkPath state
-                        self.state = FtsState::CheckingChunkPath {
-                            writes: std::mem::take(writes),
-                            write_idx: *write_idx,
-                            path_str: std::mem::take(path_str),
-                        };
-                    } else {
-                        // No more records, start writing
-                        self.state = FtsState::FlushingWrites {
-                            writes: std::mem::take(writes),
-                            write_idx: *write_idx,
-                            chunk_idx: None, // Ready to start from chunk 0
-                        };
-                    }
                 }
                 FtsState::SeekingWrite {
                     writes,
@@ -2555,18 +2519,58 @@ impl FtsCursor {
 
                     // Seek to find the correct position using GE (not eq_only)
                     // This positions the cursor at or after where the record should be inserted
-                    let _result = return_if_io!(cursor.seek(
+                    let seek_result = return_if_io!(cursor.seek(
                         SeekKey::IndexKey(record.as_record_ref()),
                         SeekOp::GE { eq_only: false },
                     ));
 
-                    // don't do insert in same state to avoid re-seeking on IO
-                    self.state = FtsState::InsertingWrite {
-                        writes: std::mem::take(writes),
-                        write_idx: *write_idx,
-                        chunk_idx: actual_chunk_idx,
-                        record,
-                    };
+                    let exact_key_exists =
+                        if matches!(seek_result, SeekResult::Found) && cursor.has_record() {
+                            return_if_io!(cursor.record()).is_some_and(|existing| {
+                                let existing_path =
+                                    existing.get_value_opt(0).and_then(|value| match value {
+                                        crate::types::ValueRef::Text(text) => Some(text.value),
+                                        _ => None,
+                                    });
+                                let existing_chunk =
+                                    existing.get_value_opt(1).and_then(|value| match value {
+                                        crate::types::ValueRef::Numeric(
+                                            crate::numeric::Numeric::Integer(value),
+                                        ) => Some(value),
+                                        _ => None,
+                                    });
+                                let existing_bytes =
+                                    existing.get_value_opt(2).and_then(|value| match value {
+                                        crate::types::ValueRef::Blob(bytes) => Some(bytes),
+                                        _ => None,
+                                    });
+                                existing_path == Some(path_str.as_str())
+                                    && existing_chunk == Some(actual_chunk_idx as i64)
+                                    && existing_bytes == Some(chunk_data)
+                            })
+                        } else {
+                            false
+                        };
+
+                    if exact_key_exists {
+                        // Resumption or a previously duplicated physical row
+                        // may leave the exact full key present. Treat the
+                        // logical write as idempotent instead of inserting a
+                        // second identical `(path, chunk_no, bytes)` key.
+                        self.state = FtsState::FlushingWrites {
+                            writes: std::mem::take(writes),
+                            write_idx: *write_idx,
+                            chunk_idx: Some(actual_chunk_idx + 1),
+                        };
+                    } else {
+                        // Don't do insert in the same state to avoid re-seeking on I/O.
+                        self.state = FtsState::InsertingWrite {
+                            writes: std::mem::take(writes),
+                            write_idx: *write_idx,
+                            chunk_idx: actual_chunk_idx,
+                            record,
+                        };
+                    }
                 }
                 FtsState::InsertingWrite {
                     writes,
@@ -2613,6 +2617,7 @@ impl FtsCursor {
         }
 
         // Commit Tantivy to make documents visible
+        let mut committed_writer = false;
         if let Some(ref mut writer) = self.writer {
             tracing::debug!(
                 "FTS commit_and_flush: committing {} documents",
@@ -2625,6 +2630,7 @@ impl FtsCursor {
                 LimboError::InternalError("FTS directory not initialized".to_string())
             })?;
             Self::commit_writer_with_maintenance(index, writer, directory)?;
+            committed_writer = true;
 
             // The cached reader belongs to the previous index snapshot.
             if let Some(conn) = &self.connection {
@@ -2634,6 +2640,9 @@ impl FtsCursor {
                     cache.remove_connection(conn);
                 }
             }
+        }
+        if committed_writer {
+            self.stage_control_record()?;
         }
         if let Some(ref reader) = self.reader {
             reader
@@ -2816,161 +2825,71 @@ impl FtsCursor {
             .map_err(|e| LimboError::InternalError(format!("FTS maintenance merge commit: {e}")))?;
         Ok(())
     }
+
+    fn stage_control_record(&mut self) -> Result<()> {
+        let directory = self.hybrid_directory.as_ref().ok_or_else(|| {
+            LimboError::InternalError("FTS directory not initialized".to_string())
+        })?;
+        let index_incarnation = self
+            .control
+            .as_ref()
+            .map(|control| control.index_incarnation)
+            // A never-written index carries the placeholder incarnation; the
+            // first staged control record mints the real one.
+            .filter(|&incarnation| incarnation != FTS_EMPTY_INDEX_INCARNATION)
+            .or_else(|| {
+                self.btree_root_page.map(|root_page| {
+                    let nonce = NEXT_FTS_INDEX_INCARNATION.fetch_add(1, Ordering::Relaxed);
+                    // The placeholder value marks "never written": never mint it.
+                    ((root_page as u64).rotate_left(32) ^ nonce).max(1)
+                })
+            })
+            .ok_or_else(|| {
+                LimboError::InternalError("FTS backing root is not initialized".to_string())
+            })?;
+        let control = FtsControlRecord::from_catalog(
+            self.control.as_ref(),
+            index_incarnation,
+            &directory.catalog.read(),
+        )?;
+        directory.queue_write(PathBuf::from(FTS_CONTROL_PATH), control.encode()?);
+        self.control = Some(control);
+        Ok(())
+    }
 }
 
 impl Drop for FtsCursor {
     fn drop(&mut self) {
-        // Skip cleanup if we're already panicking
-        if crate::thread::panicking() {
-            return;
-        }
-
-        // Get connection reference for transaction check and pager access
-        let conn = match &self.connection {
-            Some(conn) => conn.clone(),
-            None => {
-                if self.pending_docs_count > 0 {
-                    tracing::warn!(
-                        "FTS Drop: {} pending documents lost (no connection)",
-                        self.pending_docs_count
-                    );
-                }
-                return;
-            }
-        };
-
-        let pager = conn.pager.load().clone();
-
-        // Check if we're already in a flushing state (from commit_and_flush)
-        // This can happen when commit_and_flush started a flush but yielded for IO
-        // and the cursor is being dropped before the flush completed
-        if self.state.is_flushing() {
-            turso_assert!(
-                conn.is_in_write_tx(),
-                "FTS Drop: in-progress flush abandoned (transaction already committed). pre_commit should have completed the flush."
+        let is_flushing = self.state.is_flushing();
+        if self.pending_docs_count != 0 || is_flushing {
+            tracing::error!(
+                pending_documents = self.pending_docs_count,
+                is_flushing,
+                "FTS cursor dropped before explicit statement finalization"
             );
-
-            tracing::debug!("FTS Drop: completing in-progress flush");
-            loop {
-                match self.flush_writes_internal() {
-                    Ok(IOResult::Done(())) => {
-                        self.cache_writer(&conn);
-                        break;
-                    }
-                    Ok(IOResult::IO(_)) => {
-                        if let Err(e) = pager.io.step() {
-                            tracing::error!("FTS Drop: IO error during flush: {}", e);
-                            return;
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!("FTS Drop: error during flush: {}", e);
-                        return;
-                    }
-                }
-            }
-            return;
-        }
-
-        // Only flush new pending documents if we have any
-        if self.pending_docs_count == 0 {
-            self.cache_writer(&conn);
-            // Query execution may have populated file caches after checkout.
-            // Enforce the aggregate retention budget when the cursor releases
-            // its snapshot.
-            self.shared_cache.write().prune();
-            return;
-        }
-
-        // If the transaction has already committed (auto-commit), flushing to BTree
-        // would create dirty pages outside of any transaction, causing the
-        // "dirty pages must be empty for read txn" panic on the next read.
-        turso_assert!(
-            conn.is_in_write_tx(),
-            "FTS Drop: transaction already committed, cannot flush",
-            { "pending_docs_count": self.pending_docs_count }
-        );
-
-        // Commit any pending writes to Tantivy
-        if let Some(ref mut writer) = self.writer {
-            let Some(ref index) = self.index else {
-                tracing::error!("FTS Drop: index not initialized");
-                return;
-            };
-            let Some(ref directory) = self.hybrid_directory else {
-                tracing::error!("FTS Drop: directory not initialized");
-                return;
-            };
-            if let Err(e) = Self::commit_writer_with_maintenance(index, writer, directory) {
-                tracing::error!("FTS Drop: failed to commit writer: {}", e);
-                return;
-            }
-
-            // Invalidate the read state for the previous index snapshot.
-            // This MUST happen after commit but before we check for pending writes
-            // to ensure the next cursor loads fresh data from BTree
-            {
-                let mut cache = self.shared_cache.write();
-                if cache.connection_position(&conn).is_some() {
-                    tracing::debug!("FTS Drop: invalidating cached read state");
-                    cache.remove_connection(&conn);
-                }
-            }
-        }
-
-        let Some(ref dir) = self.hybrid_directory else {
-            return;
-        };
-        let writes = dir.take_pending_flushes();
-
-        if writes.is_empty() {
-            return;
-        }
-
-        tracing::debug!(
-            "FTS Drop: blocking flush of {} files to BTree",
-            writes.len()
-        );
-
-        // Set up flush state machine
-        self.state = FtsState::FlushingWrites {
-            writes,
-            write_idx: 0,
-            chunk_idx: Some(0),
-        };
-
-        // Run blocking flush
-        loop {
-            match self.flush_writes_internal() {
-                Ok(IOResult::Done(())) => {
-                    self.cache_writer(&conn);
-                    break;
-                }
-                Ok(IOResult::IO(_)) => {
-                    if let Err(e) = pager.io.step() {
-                        tracing::error!("FTS Drop: IO error during flush: {}", e);
-                        return;
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("FTS Drop: error during flush: {}", e);
-                    return;
-                }
-            }
+            debug_assert!(
+                crate::thread::panicking(),
+                "FTS cursor dropped with pending persistence work"
+            );
         }
     }
 }
 
 impl IndexMethodCursor for FtsCursor {
     /// Creates the FTS index storage (internal BTree table for Tantivy files).
-    fn create(&mut self, conn: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>> {
+    fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let conn = context.connection();
+        let database_id = context.database().id;
         self.database_id = Some(database_id);
         initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
-        Ok(IOResult::Done(()))
+        return_if_io!(self.open_write(context));
+        self.commit_and_flush_inner(true)
     }
 
     /// Destroys the FTS index, dropping all storage and clearing caches.
-    fn destroy(&mut self, conn: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>> {
+    fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let conn = context.connection();
+        let database_id = context.database().id;
         self.database_id = Some(database_id);
         tracing::debug!(
             "FTS destroy: dropping internal storage {}",
@@ -2984,6 +2903,7 @@ impl IndexMethodCursor for FtsCursor {
         self.index = None;
         self.hybrid_directory = None;
         self.fts_dir_cursor = None;
+        self.control = None;
 
         // Invalidate cached read state.
         {
@@ -3023,90 +2943,198 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Opens the index for reading, loading the catalog and creating a searcher.
     /// Uses async state machine for non-blocking IO during catalog/file loading.
-    fn open_read(&mut self, conn: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>> {
+    fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let conn = context.connection();
+        let database_id = context.database().id;
         self.database_id = Some(database_id);
         loop {
             match &mut self.state {
                 FtsState::Init => {
+                    if !self.opening_for_write {
+                        self.runtime_stats
+                            .read_cache_lookups
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
                     self.connection = Some(conn.clone());
                     // Ensure storage table exists
                     initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
                     // Open BTree cursor (needed for btree_root_page)
                     self.open_cursor(conn, database_id)?;
 
-                    // Check for cached read state. Caches are never published
-                    // or consumed during a write transaction, so rollback and
-                    // savepoint rollback cannot leave uncommitted Tantivy
-                    // state reusable. For committed snapshots, the pager's WAL
-                    // position is an O(1) cache identity. Pagers without a WAL
-                    // identity fall back to comparing meta.json bytes.
-                    let cached_hit = {
-                        let mut cache = self.shared_cache.write();
-                        cache.prune();
-                        if let Some(position) = cache.connection_position(conn) {
-                            if conn.is_in_write_tx() {
-                                tracing::debug!(
-                                    "FTS open_read: bypassing shared cache in write transaction"
-                                );
-                                None
-                            } else {
-                                let cached = &cache.entries[position];
-                                let snapshot_matches = if let Some(snapshot_wal_pos) =
-                                    cached.snapshot_wal_pos
-                                {
-                                    cached.directory.pager.wal_pos() == snapshot_wal_pos
-                                } else {
-                                    cached.directory.is_consistent_with_btree().map_err(|e| {
-                                        LimboError::InternalError(format!(
-                                            "FTS cache validation failed: {e}"
-                                        ))
-                                    })?
-                                };
-                                if snapshot_matches {
-                                    let cached = cache.entries.remove(position);
-                                    let hit = (
-                                        cached.directory.clone_with_fresh_pending(),
-                                        cached.index.clone(),
-                                        cached.reader.clone(),
-                                        Arc::clone(&cached.query_parser),
-                                    );
-                                    // Move the successful checkout to the MRU end.
-                                    cache.entries.push(cached);
-                                    Some(hit)
-                                } else {
-                                    tracing::debug!(
-                                    "FTS open_read: cached directory is stale (snapshot diverged), reloading"
-                                );
-                                    cache.entries.remove(position);
-                                    None
-                                }
-                            }
-                        } else {
-                            None
-                        }
-                    };
-                    if let Some((directory, index, reader, query_parser)) = cached_hit {
-                        tracing::debug!(
-                            "FTS open_read: using cached state (skipping catalog load)"
-                        );
-                        self.hybrid_directory = Some(directory);
-                        if self.opening_for_write {
-                            // A writer needs an Index whose Directory owns
-                            // cursor-local pending state.
-                            self.state = FtsState::CreatingIndex;
-                            continue;
-                        }
-
-                        self.index = Some(index);
-                        self.searcher = Some(reader.searcher());
-                        self.reader = Some(reader);
-                        self.cached_parser = Some(query_parser);
-                        self.state = FtsState::Ready;
+                    // A cache entry from the exact same snapshot can be used
+                    // immediately. A cache from an older snapshot is retained
+                    // until the small transactional control record has been
+                    // read asynchronously and its identity validated.
+                    if let Some(checkout) = self.checkout_cached_state(context, None) {
+                        self.install_cached_checkout(checkout);
                         return Ok(IOResult::Done(()));
                     }
 
-                    // No cache available, proceed with full catalog loading
-                    self.state = FtsState::Rewinding;
+                    self.state = if self.has_cached_state(context)
+                        || (self.opening_for_write && self.has_deferred_cached_writer(context))
+                    {
+                        FtsState::SeekingControl
+                    } else {
+                        if !self.opening_for_write {
+                            self.runtime_stats
+                                .read_cache_misses
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
+                        FtsState::Rewinding
+                    };
+                }
+                FtsState::SeekingControl => {
+                    let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
+                        LimboError::InternalError("cursor not initialized".into())
+                    })?;
+                    let seek_key = ImmutableRecord::from_values(
+                        &[
+                            Value::Text(Text::new(FTS_CONTROL_PATH.to_string())),
+                            Value::from_i64(0),
+                            Value::Blob(crate::alloc::vec![]),
+                        ],
+                        3,
+                    )?;
+                    let seek_result = return_if_io!(cursor.seek(
+                        SeekKey::IndexKey(seek_key.as_record_ref()),
+                        SeekOp::GE { eq_only: false },
+                    ));
+                    self.state = match seek_result {
+                        SeekResult::NotFound => {
+                            if self.opening_for_write {
+                                self.discard_deferred_cached_writer(context);
+                            }
+                            FtsState::Rewinding
+                        }
+                        SeekResult::TryAdvance => FtsState::AdvancingToControl,
+                        SeekResult::Found => FtsState::LoadingControl {
+                            chunks: HashMap::default(),
+                            advance_pending: false,
+                        },
+                    };
+                }
+                FtsState::AdvancingToControl => {
+                    let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
+                        LimboError::InternalError("cursor not initialized".into())
+                    })?;
+                    return_if_io!(cursor.next());
+                    self.state = if cursor.has_record() {
+                        FtsState::LoadingControl {
+                            chunks: HashMap::default(),
+                            advance_pending: false,
+                        }
+                    } else {
+                        if self.opening_for_write {
+                            self.discard_deferred_cached_writer(context);
+                        }
+                        FtsState::Rewinding
+                    };
+                }
+                FtsState::LoadingControl {
+                    chunks,
+                    advance_pending,
+                } => {
+                    let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
+                        LimboError::InternalError("cursor not initialized".into())
+                    })?;
+                    if *advance_pending {
+                        return_if_io!(cursor.next());
+                        *advance_pending = false;
+                        continue;
+                    }
+
+                    let mut finished = !cursor.has_record();
+                    if !finished {
+                        let record = return_if_io!(cursor.record()).ok_or_else(|| {
+                            LimboError::Corrupt("FTS cursor has no record payload".into())
+                        })?;
+                        let path = record
+                            .get_value_opt(0)
+                            .and_then(|value| match value {
+                                crate::types::ValueRef::Text(text) => Some(text.value),
+                                _ => None,
+                            })
+                            .ok_or_else(|| {
+                                LimboError::Corrupt("FTS chunk path is not text".into())
+                            })?;
+                        finished = path != FTS_CONTROL_PATH;
+                        if !finished {
+                            let chunk_no = record
+                                .get_value_opt(1)
+                                .and_then(|value| match value {
+                                    crate::types::ValueRef::Numeric(
+                                        crate::numeric::Numeric::Integer(value),
+                                    ) => Some(value),
+                                    _ => None,
+                                })
+                                .ok_or_else(|| {
+                                    LimboError::Corrupt(
+                                        "FTS control chunk number is not an integer".into(),
+                                    )
+                                })?;
+                            let blob = record
+                                .get_value_opt(2)
+                                .and_then(|value| match value {
+                                    crate::types::ValueRef::Blob(blob) => Some(blob.to_vec()),
+                                    _ => None,
+                                })
+                                .ok_or_else(|| {
+                                    LimboError::Corrupt(
+                                        "FTS control chunk payload is not a blob".into(),
+                                    )
+                                })?;
+                            if chunks.insert(chunk_no, (blob.len(), Some(blob))).is_some() {
+                                return Err(LimboError::Corrupt(format!(
+                                    "duplicate FTS control chunk {chunk_no}"
+                                )));
+                            }
+                            *advance_pending = true;
+                        }
+                    }
+
+                    if finished {
+                        if chunks.is_empty() {
+                            if self.opening_for_write {
+                                self.discard_deferred_cached_writer(context);
+                            }
+                            self.runtime_stats
+                                .manifest_validation_misses
+                                .fetch_add(1, Ordering::Relaxed);
+                            if !self.opening_for_write {
+                                self.runtime_stats
+                                    .read_cache_misses
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                            self.state = FtsState::Rewinding;
+                            continue;
+                        }
+                        let control_chunks = std::mem::take(chunks);
+                        let control_bytes =
+                            assemble_catalog_file(Path::new(FTS_CONTROL_PATH), &control_chunks)?;
+                        let control = FtsControlRecord::decode(&control_bytes)?;
+                        if self.opening_for_write
+                            && self.checkout_validated_cached_writer(context, &control)
+                        {
+                            return Ok(IOResult::Done(()));
+                        }
+                        if let Some(checkout) = self.checkout_cached_state(context, Some(&control))
+                        {
+                            self.runtime_stats
+                                .manifest_validation_hits
+                                .fetch_add(1, Ordering::Relaxed);
+                            self.install_cached_checkout(checkout);
+                            return Ok(IOResult::Done(()));
+                        }
+                        self.runtime_stats
+                            .manifest_validation_misses
+                            .fetch_add(1, Ordering::Relaxed);
+                        if !self.opening_for_write {
+                            self.runtime_stats
+                                .read_cache_misses
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
+                        self.state = FtsState::Rewinding;
+                    }
                 }
                 FtsState::Rewinding => {
                     let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
@@ -3116,225 +3144,150 @@ impl IndexMethodCursor for FtsCursor {
                     // Use catalog-first loading for HybridBTreeDirectory
                     self.state = FtsState::LoadingCatalog {
                         catalog_builder: HashMap::default(),
+                        control_builder: HashMap::default(),
                         current_path: None,
+                        advance_pending: false,
                     };
                 }
                 FtsState::LoadingCatalog {
                     catalog_builder,
+                    control_builder,
                     current_path,
+                    advance_pending,
                 } => {
                     let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
                         LimboError::InternalError("cursor not initialized".into())
                     })?;
 
+                    if *advance_pending {
+                        return_if_io!(cursor.next());
+                        *advance_pending = false;
+                        continue;
+                    }
+
                     if !cursor.has_record() {
-                        // Done scanning: build catalog and assemble hot files in single pass
+                        self.runtime_stats
+                            .full_snapshot_loads
+                            .fetch_add(1, Ordering::Relaxed);
+                        // Done scanning: build a complete file snapshot before Tantivy can run.
                         let mut catalog = HashMap::default();
-                        let mut hot_files: HashMap<PathBuf, Vec<u8>> = HashMap::default();
-                        let mut files_to_load = Vec::new();
+                        let mut files: HashMap<PathBuf, Vec<u8>> = HashMap::default();
 
                         for (path, chunks) in catalog_builder.drain() {
-                            let max_chunk = chunks.keys().max().copied().unwrap_or(0);
+                            let max_chunk = chunks
+                                .keys()
+                                .max()
+                                .copied()
+                                .expect("catalog builder entries have chunks");
                             let total_size: usize = chunks.values().map(|(size, _)| size).sum();
                             let num_chunks = (max_chunk + 1) as usize;
                             let metadata = FileMetadata::new(&path, total_size, num_chunks);
-
-                            if metadata.category.is_hot() {
-                                // Try to assemble from captured blob data
-                                let mut all_captured = true;
-                                let mut assembled = Vec::with_capacity(total_size);
-                                for chunk_no in 0..=(max_chunk) {
-                                    if let Some((_, Some(data))) = chunks.get(&chunk_no) {
-                                        assembled.extend_from_slice(data);
-                                    } else {
-                                        all_captured = false;
-                                        break;
-                                    }
-                                }
-                                if all_captured {
-                                    hot_files.insert(path.clone(), assembled);
-                                } else {
-                                    files_to_load.push(path.clone());
-                                }
-                            } else if metadata.category.should_preload() {
-                                files_to_load.push(path.clone());
-                            }
-
+                            let assembled = assemble_catalog_file(&path, &chunks)?;
+                            files.insert(path.clone(), assembled);
                             catalog.insert(path, metadata);
                         }
 
+                        let control = if control_builder.is_empty() {
+                            if catalog.is_empty() {
+                                Some(FtsControlRecord::new(FTS_EMPTY_INDEX_INCARNATION))
+                            } else {
+                                return Err(LimboError::Corrupt(
+                                    "FTS storage predates control-record format v1; rebuild the index"
+                                        .into(),
+                                ));
+                            }
+                        } else {
+                            let control_bytes = assemble_catalog_file(
+                                Path::new(FTS_CONTROL_PATH),
+                                control_builder,
+                            )?;
+                            let control = FtsControlRecord::decode(&control_bytes)?;
+                            control.validate_catalog(&catalog)?;
+                            Some(control)
+                        };
+                        self.control = control;
+
                         tracing::debug!(
-                            "FTS LoadingCatalog: found {} files, {} hot assembled, {} to preload",
+                            "FTS LoadingCatalog: preloaded {} files ({} bytes)",
                             catalog.len(),
-                            hot_files.len(),
-                            files_to_load.len()
+                            files.values().map(Vec::len).sum::<usize>()
                         );
 
-                        // Create HybridBTreeDirectory with catalog and pre-assembled hot files
                         let pager = conn.get_pager_from_database_index(&database_id)?;
                         let root_page = self.btree_root_page.ok_or_else(|| {
                             LimboError::InternalError("btree_root_page not set".into())
                         })?;
 
-                        let hybrid_dir = HybridBTreeDirectory::with_preloaded(
-                            pager,
-                            root_page,
-                            catalog,
-                            hot_files,
-                            DEFAULT_HOT_CACHE_BYTES,
-                            DEFAULT_CHUNK_CACHE_BYTES,
-                        );
+                        let hybrid_dir =
+                            HybridBTreeDirectory::with_preloaded(pager, root_page, catalog, files);
                         self.hybrid_directory = Some(hybrid_dir);
-
-                        if files_to_load.is_empty() {
-                            // All hot files assembled in single pass, skip PreloadingEssentials
-                            self.state = FtsState::CreatingIndex;
-                        } else {
-                            self.state = FtsState::PreloadingEssentials {
-                                files_to_load,
-                                loaded_files: HashMap::default(),
-                                current_loading: None,
-                                current_chunks: Vec::new(),
-                            };
-                        }
+                        self.state = FtsState::CreatingIndex;
                         continue;
                     }
 
-                    // Read record metadata and capture hot file blobs in single pass
+                    // Capture every blob while storage I/O is under the cursor state machine.
                     let record = return_if_io!(cursor.record());
-                    if let Some(record) = record {
-                        let path_str = record.get_value_opt(0).and_then(|v| match v {
+                    let record = record.ok_or_else(|| {
+                        LimboError::Corrupt("FTS cursor has no record payload".into())
+                    })?;
+                    let path_str = record
+                        .get_value_opt(0)
+                        .and_then(|v| match v {
                             crate::types::ValueRef::Text(t) => Some(t.value.to_string()),
                             _ => None,
-                        });
-                        let chunk_no = record.get_value_opt(1).and_then(|v| match v {
+                        })
+                        .ok_or_else(|| LimboError::Corrupt("FTS chunk path is not text".into()))?;
+                    let chunk_no = record
+                        .get_value_opt(1)
+                        .and_then(|v| match v {
                             crate::types::ValueRef::Numeric(crate::numeric::Numeric::Integer(
                                 i,
                             )) => Some(i),
                             _ => None,
-                        });
+                        })
+                        .ok_or_else(|| {
+                            LimboError::Corrupt("FTS chunk number is not an integer".into())
+                        })?;
+                    let blob = record
+                        .get_value_opt(2)
+                        .and_then(|v| match v {
+                            crate::types::ValueRef::Blob(blob) => Some(blob.to_vec()),
+                            _ => None,
+                        })
+                        .ok_or_else(|| {
+                            LimboError::Corrupt("FTS chunk payload is not a blob".into())
+                        })?;
 
-                        if let (Some(path_str), Some(chunk_no)) = (path_str, chunk_no) {
-                            // Reuse PathBuf when path hasn't changed (records are BTree-ordered)
-                            let path_buf = if current_path.as_ref().map(|p| p.as_os_str().to_str())
-                                == Some(Some(&path_str))
-                            {
-                                current_path.clone().unwrap()
-                            } else {
-                                let p = PathBuf::from(&path_str);
-                                *current_path = Some(p.clone());
-                                p
-                            };
+                    // Reuse PathBuf when path hasn't changed (records are BTree-ordered).
+                    let path_buf = if current_path.as_ref().map(|p| p.as_os_str().to_str())
+                        == Some(Some(&path_str))
+                    {
+                        current_path.clone().unwrap()
+                    } else {
+                        let path = PathBuf::from(&path_str);
+                        *current_path = Some(path.clone());
+                        path
+                    };
 
-                            // Classify file to decide whether to capture blob data
-                            let category = FileCategory::from_path(&path_buf);
-                            let (blob_size, blob_data) = record
-                                .get_value_opt(2)
-                                .map(|v| match v {
-                                    crate::types::ValueRef::Blob(b) => {
-                                        let size = b.len();
-                                        if category.is_hot() {
-                                            (size, Some(b.to_vec()))
-                                        } else {
-                                            (size, None)
-                                        }
-                                    }
-                                    _ => (0, None),
-                                })
-                                .unwrap_or((0, None));
-
-                            let chunks = catalog_builder.entry(path_buf).or_default();
-                            chunks.insert(chunk_no, (blob_size, blob_data));
-                        }
+                    let chunks = if path_buf == Path::new(FTS_CONTROL_PATH) {
+                        control_builder
+                    } else {
+                        catalog_builder.entry(path_buf.clone()).or_default()
+                    };
+                    if let Some((existing_size, existing_blob)) =
+                        chunks.insert(chunk_no, (blob.len(), Some(blob.clone())))
+                    {
+                        return Err(LimboError::Corrupt(format!(
+                            "duplicate FTS chunk {}:{} (existing_size={}, new_size={}, equal={})",
+                            path_buf.display(),
+                            chunk_no,
+                            existing_size,
+                            blob.len(),
+                            existing_blob.as_deref() == Some(blob.as_slice())
+                        )));
                     }
 
-                    return_if_io!(cursor.next());
-                }
-                FtsState::PreloadingEssentials {
-                    files_to_load,
-                    loaded_files,
-                    current_loading,
-                    current_chunks,
-                } => {
-                    // Use blocking file load from HybridBTreeDirectory
-                    let hybrid_dir = self.hybrid_directory.as_ref().ok_or_else(|| {
-                        LimboError::InternalError("hybrid_directory not initialized".into())
-                    })?;
-
-                    // If we're loading a file, continue with it
-                    if let Some(path) = current_loading.take() {
-                        // We loaded chunks, finalize the file
-                        if !current_chunks.is_empty() {
-                            current_chunks.sort_by_key(|(chunk_no, _)| *chunk_no);
-
-                            // Deduplicate
-                            let mut deduped: Vec<(i64, Vec<u8>)> = Vec::new();
-                            for (chunk_no, bytes) in current_chunks.drain(..) {
-                                if let Some(last) = deduped.last_mut() {
-                                    if last.0 == chunk_no {
-                                        *last = (chunk_no, bytes);
-                                    } else {
-                                        deduped.push((chunk_no, bytes));
-                                    }
-                                } else {
-                                    deduped.push((chunk_no, bytes));
-                                }
-                            }
-
-                            let data: Vec<u8> =
-                                deduped.iter().flat_map(|(_, b)| b.clone()).collect();
-                            loaded_files.insert(path.clone(), data.clone());
-
-                            // Add to hot cache
-                            hybrid_dir.add_to_hot_cache(path, data);
-                        }
-                    }
-
-                    // Check if we have more files to load
-                    if let Some(next_path) = files_to_load.pop() {
-                        // Load this file using blocking IO
-                        match hybrid_dir.load_file_blocking(&next_path) {
-                            Ok(data) => {
-                                loaded_files.insert(next_path.clone(), data.clone());
-                                hybrid_dir.add_to_hot_cache(next_path, data);
-                            }
-                            Err(e) => {
-                                let category = FileCategory::from_path(&next_path);
-                                // NotFound is expected for new empty indexes
-                                if e.kind() == std::io::ErrorKind::NotFound {
-                                    // Expected for new index, just log at debug level
-                                    tracing::debug!(
-                                        "FTS: preload skipped (not found): {}",
-                                        next_path.display()
-                                    );
-                                } else if category == FileCategory::Metadata {
-                                    // Metadata files are critical - propagate error
-                                    return Err(LimboError::InternalError(format!(
-                                        "FTS: failed to preload metadata file {}: {}",
-                                        next_path.display(),
-                                        e
-                                    )));
-                                } else {
-                                    // Non-critical file, warn but continue
-                                    tracing::warn!(
-                                        "FTS: could not preload {} ({:?}): {}",
-                                        next_path.display(),
-                                        category,
-                                        e
-                                    );
-                                }
-                            }
-                        }
-                        continue;
-                    }
-
-                    // All files loaded
-                    tracing::debug!(
-                        "FTS PreloadingEssentials: loaded {} files into hot cache",
-                        loaded_files.len()
-                    );
-                    self.state = FtsState::CreatingIndex;
-                    continue;
+                    *advance_pending = true;
                 }
                 FtsState::CreatingIndex => {
                     // Log loaded files for debugging
@@ -3373,15 +3326,36 @@ impl IndexMethodCursor for FtsCursor {
                         let snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
 
                         let mut cache = self.shared_cache.write();
-                        cache.insert(CachedFtsState {
-                            connection: Arc::downgrade(conn),
-                            snapshot_wal_pos,
-                            directory: dir.clone(),
-                            index: index.clone(),
-                            reader: reader.clone(),
-                            query_parser,
-                        });
+                        let control = self.control.clone().ok_or_else(|| {
+                            LimboError::InternalError("FTS control record not initialized".into())
+                        })?;
+                        let writer_bytes = self
+                            .shared_writer
+                            .lock()
+                            .as_ref()
+                            .map_or(0, |cached| cached.directory.hot_cache.size());
+                        let cache_budget =
+                            fts_max_retained_cache_bytes().saturating_sub(writer_bytes);
+                        let retained = cache.insert(
+                            CachedFtsState {
+                                connection: Arc::downgrade(conn),
+                                transaction_id: context.transaction_id(),
+                                snapshot_wal_pos,
+                                control,
+                                directory: dir.clone(),
+                                index: index.clone(),
+                                reader: reader.clone(),
+                                query_parser,
+                            },
+                            cache_budget,
+                        );
+                        if !retained {
+                            self.runtime_stats
+                                .cache_admission_rejections
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
                         tracing::debug!(
+                            retained,
                             cached_connections = cache.entries.len(),
                             "FTS CreatingIndex: cached read state for future queries"
                         );
@@ -3404,7 +3378,9 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Opens the index for writing, creating the IndexWriter.
     /// Calls `open_read` first if not already initialized.
-    fn open_write(&mut self, conn: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>> {
+    fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let conn = context.connection();
+        let database_id = context.database().id;
         self.database_id = Some(database_id);
         self.opening_for_write = true;
         if self.connection.is_none() {
@@ -3418,7 +3394,33 @@ impl IndexMethodCursor for FtsCursor {
 
         initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
         self.open_cursor(conn, database_id)?;
-        if self.restore_cached_writer(conn)? {
+        if let Some(mv_store) = conn.mv_store_for_db(database_id) {
+            let tx_id = conn.get_mv_tx_id_for_db(database_id).ok_or_else(|| {
+                LimboError::InternalError(
+                    "FTS write opened without an active MVCC transaction".to_string(),
+                )
+            })?;
+            let root_page = self.btree_root_page.ok_or_else(|| {
+                LimboError::InternalError("FTS backing root is not initialized".to_string())
+            })?;
+            let snapshot_ts = mv_store.read_snapshot_ts(tx_id);
+            let index_id = mv_store.get_table_id_from_root_page_at(root_page, snapshot_ts);
+            match mv_store.acquire_index_method_write_lease(tx_id, index_id) {
+                Ok(()) => {
+                    self.runtime_stats
+                        .write_lease_acquisitions
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                Err(err @ LimboError::WriteWriteConflict) => {
+                    self.runtime_stats
+                        .write_lease_rejections
+                        .fetch_add(1, Ordering::Relaxed);
+                    return Err(err);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        if self.restore_cached_writer(context)? {
             self.opening_for_write = false;
             return Ok(IOResult::Done(()));
         }
@@ -3427,11 +3429,15 @@ impl IndexMethodCursor for FtsCursor {
         match &self.state {
             FtsState::Ready => {}
             _ => {
-                let result = self.open_read(conn, database_id)?;
+                let result = self.open_read(context)?;
                 if let IOResult::IO(io) = result {
                     return Ok(IOResult::IO(io));
                 }
             }
+        }
+        if self.writer.is_some() {
+            self.opening_for_write = false;
+            return Ok(IOResult::Done(()));
         }
 
         let index = self
@@ -3439,6 +3445,9 @@ impl IndexMethodCursor for FtsCursor {
             .as_ref()
             .ok_or_else(|| LimboError::InternalError("FTS index not initialized".into()))?;
         // Use single-threaded mode to avoid concurrent access.
+        self.runtime_stats
+            .tantivy_writer_constructions
+            .fetch_add(1, Ordering::Relaxed);
         let writer = index
             .writer_with_num_threads(1, DEFAULT_MEMORY_BUDGET_BYTES)
             .map_err(|e| LimboError::InternalError(e.to_string()))?;
@@ -3787,7 +3796,7 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Flushes pending writes before transaction commit.
     /// This ensures FTS writes are persisted as part of the transaction.
-    fn pre_commit(&mut self) -> Result<IOResult<()>> {
+    fn prepare_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         // First, check if we're in the middle of a flush operation that needs to continue
         // This handles the case where commit_and_flush() returned IOResult::IO and we need
         // to continue the flush after IO completes
@@ -3805,13 +3814,139 @@ impl IndexMethodCursor for FtsCursor {
         Ok(IOResult::Done(()))
     }
 
+    fn abort_statement(&mut self, context: &IndexMethodContext) {
+        self.pending_docs_count = 0;
+        self.writer = None;
+        self.reader = None;
+        self.searcher = None;
+        self.index = None;
+        self.hybrid_directory = None;
+        self.fts_dir_cursor = None;
+        self.control = None;
+        self.cached_parser = None;
+        self.current_hits.clear();
+        self.streaming_hits = None;
+        self.shared_cache
+            .write()
+            .remove_connection(context.connection());
+        // The slot is shared by every connection: a failed statement here
+        // (e.g. the losing side of a lease conflict) must not evict another
+        // connection's writer. Only remove what this connection's failed
+        // statement could have produced: its own writer tagged with this
+        // transaction (both `None` in WAL mode). An MVCC deferred writer
+        // (`transaction_id == None`) predates this transaction, so it stays
+        // valid across this rollback. Entries with a dead owner are removed
+        // opportunistically.
+        let mut cached_writer = self.shared_writer.lock();
+        let (dead_owner, owned) = match cached_writer.as_ref() {
+            None => (false, false),
+            Some(cached) => match cached.connection.upgrade() {
+                None => (true, false),
+                Some(owner) => (
+                    false,
+                    Arc::ptr_eq(&owner, context.connection())
+                        && cached.transaction_id == context.transaction_id(),
+                ),
+            },
+        };
+        let stale = if dead_owner || owned {
+            cached_writer.take()
+        } else {
+            None
+        };
+        drop(cached_writer);
+        if owned {
+            self.runtime_stats
+                .writer_cache_rollback_discards
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        drop(stale);
+        self.state = FtsState::Init;
+    }
+
+    fn statement_committed(&mut self, context: &IndexMethodContext) {
+        self.cache_writer(context);
+    }
+
+    fn transaction_committed(&mut self, context: &IndexMethodContext) {
+        tracing::trace!(
+            index = context.index().index_name,
+            pending_documents = self.pending_docs_count,
+            state = ?self.state,
+            has_writer = self.writer.is_some(),
+            "FTS transaction outcome: committed"
+        );
+        self.cache_writer(context);
+        if let Some(transaction_id) = context.transaction_id() {
+            // The backing transaction is now committed, so its private writer
+            // may be considered by a future transaction only after validating
+            // the transactional control record.
+            if let Some(cached) = self.shared_writer.lock().as_mut() {
+                let same_connection = cached
+                    .connection
+                    .upgrade()
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, context.connection()));
+                if same_connection && cached.transaction_id == Some(transaction_id) {
+                    cached.transaction_id = None;
+                    cached.snapshot_wal_pos = None;
+                }
+            }
+        } else if let Some(cached) = self.shared_writer.lock().as_mut() {
+            // This hook also runs for read-only FTS cursors, and the shared
+            // slot can still hold an older writer (e.g. one a later statement
+            // failed to replace under the retention budget). Re-stamping a
+            // writer this commit did not produce or validate would make its
+            // stale segments pass WAL-position validation, losing documents
+            // committed since. Stamp only when this connection owns the writer
+            // and this cursor's control record matches it.
+            let same_connection = cached
+                .connection
+                .upgrade()
+                .is_some_and(|owner| Arc::ptr_eq(&owner, context.connection()));
+            let matches_cursor_control = self.control.as_ref().is_some_and(|control| {
+                control.index_incarnation == cached.control.index_incarnation
+                    && control.manifest_generation == cached.control.manifest_generation
+            });
+            if same_connection && matches_cursor_control {
+                let wal_pos = cached.directory.pager.wal_pos();
+                cached.snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
+            }
+        }
+        self.shared_cache.write().prune();
+    }
+
+    fn transaction_rolled_back(&mut self, context: &IndexMethodContext) {
+        self.abort_statement(context);
+    }
+
+    fn savepoint_rolled_back(&mut self, context: &IndexMethodContext) {
+        self.abort_statement(context);
+    }
+
+    fn close(&mut self, context: &IndexMethodContext) {
+        if self.pending_docs_count != 0 {
+            tracing::error!(
+                pending_documents = self.pending_docs_count,
+                "closing FTS cursor with unprepared writes"
+            );
+        }
+        self.writer = None;
+        self.reader = None;
+        self.searcher = None;
+        self.index = None;
+        self.hybrid_directory = None;
+        self.fts_dir_cursor = None;
+        self.cached_parser = None;
+        self.current_hits.clear();
+        self.streaming_hits = None;
+        let _ = context;
+        self.shared_cache.write().prune();
+    }
+
     /// Optimizes the FTS index by merging all segments into one.
     /// Call via `OPTIMIZE INDEX idx_name` SQL command.
-    fn optimize(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>> {
+    fn optimize(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let database_id = context.database().id;
         self.database_id = Some(database_id);
         // First ensure any pending documents are flushed
         if self.pending_docs_count > 0 {
@@ -3824,7 +3959,7 @@ impl IndexMethodCursor for FtsCursor {
 
         // If we're not open for writing, open it
         if self.writer.is_none() {
-            return_if_io!(self.open_write(connection, database_id));
+            return_if_io!(self.open_write(context));
         }
 
         let index = self
@@ -3990,12 +4125,91 @@ impl IndexMethodCursor for FtsCursor {
             .len();
 
         let cache = self.shared_cache.read();
+        let cached_writer_bytes = self
+            .shared_writer
+            .lock()
+            .as_ref()
+            .map_or(0, |cached| cached.directory.hot_cache.size());
+        let control = self.control.as_ref().ok_or_else(|| {
+            LimboError::InternalError("FTS control record not initialized".to_string())
+        })?;
         Ok(Some(super::IndexMethodTestStats {
+            storage_format_version: Some(FTS_CONTROL_FORMAT_VERSION),
+            index_incarnation: Some(control.index_incarnation),
+            manifest_generation: Some(control.manifest_generation),
+            manifest_file_count: Some(control.files.len()),
             storage_file_count: directory.catalog.read().len(),
             segment_count: Some(segment_count),
             cached_connection_count: Some(cache.entries.len()),
-            cached_bytes: Some(cache.resident_cache_bytes()),
+            cached_bytes: Some(
+                cache
+                    .resident_cache_bytes()
+                    .saturating_add(cached_writer_bytes),
+            ),
+            cache_admission_rejections: Some(
+                self.runtime_stats
+                    .cache_admission_rejections
+                    .load(Ordering::Relaxed),
+            ),
             cached_writer: Some(self.shared_writer.lock().is_some()),
+            tantivy_writer_constructions: Some(
+                self.runtime_stats
+                    .tantivy_writer_constructions
+                    .load(Ordering::Relaxed),
+            ),
+            writer_cache_lookups: Some(
+                self.runtime_stats
+                    .writer_cache_lookups
+                    .load(Ordering::Relaxed),
+            ),
+            writer_cache_hits: Some(self.runtime_stats.writer_cache_hits.load(Ordering::Relaxed)),
+            writer_cache_validation_failures: Some(
+                self.runtime_stats
+                    .writer_cache_validation_failures
+                    .load(Ordering::Relaxed),
+            ),
+            writer_cache_rollback_discards: Some(
+                self.runtime_stats
+                    .writer_cache_rollback_discards
+                    .load(Ordering::Relaxed),
+            ),
+            writer_cache_misses: Some(
+                self.runtime_stats
+                    .writer_cache_misses
+                    .load(Ordering::Relaxed),
+            ),
+            read_cache_lookups: Some(
+                self.runtime_stats
+                    .read_cache_lookups
+                    .load(Ordering::Relaxed),
+            ),
+            read_cache_hits: Some(self.runtime_stats.read_cache_hits.load(Ordering::Relaxed)),
+            read_cache_misses: Some(self.runtime_stats.read_cache_misses.load(Ordering::Relaxed)),
+            full_snapshot_loads: Some(
+                self.runtime_stats
+                    .full_snapshot_loads
+                    .load(Ordering::Relaxed),
+            ),
+            manifest_validation_hits: Some(
+                self.runtime_stats
+                    .manifest_validation_hits
+                    .load(Ordering::Relaxed),
+            ),
+            manifest_validation_misses: Some(
+                self.runtime_stats
+                    .manifest_validation_misses
+                    .load(Ordering::Relaxed),
+            ),
+            write_lease_acquisitions: Some(
+                self.runtime_stats
+                    .write_lease_acquisitions
+                    .load(Ordering::Relaxed),
+            ),
+            write_lease_rejections: Some(
+                self.runtime_stats
+                    .write_lease_rejections
+                    .load(Ordering::Relaxed),
+            ),
         }))
     }
 }
@@ -4003,8 +4217,8 @@ impl IndexMethodCursor for FtsCursor {
 #[cfg(test)]
 mod tests {
     use super::{
-        FtsCursor, FtsIndexAttachment, PendingFileMutations, DEFAULT_MEMORY_BUDGET_BYTES,
-        FTS_PATTERN_MATCH, FTS_PATTERN_MATCH_LIMIT, FTS_PATTERN_SCORE,
+        FtsControlRecord, FtsCursor, FtsIndexAttachment, FtsManifestFile, PendingFileMutations,
+        DEFAULT_MEMORY_BUDGET_BYTES, FTS_PATTERN_MATCH, FTS_PATTERN_MATCH_LIMIT, FTS_PATTERN_SCORE,
     };
     use crate::{
         index_method::{
@@ -4027,6 +4241,50 @@ mod tests {
         let flushes = mutations.take_flushes();
         assert_eq!(flushes.len(), 1);
         flushes.into_iter().next().unwrap()
+    }
+
+    #[test]
+    fn control_record_round_trips_and_detects_corruption() {
+        let mut files = FxHashMap::default();
+        files.insert(
+            PathBuf::from("segment.idx"),
+            FtsManifestFile {
+                size: 42,
+                chunks: 2,
+            },
+        );
+        let control = FtsControlRecord {
+            index_incarnation: 17,
+            manifest_generation: 9,
+            files,
+        };
+
+        let encoded = control.encode().unwrap();
+        let decoded = FtsControlRecord::decode(&encoded).unwrap();
+        assert_eq!(decoded.index_incarnation, 17);
+        assert_eq!(decoded.manifest_generation, 9);
+        assert_eq!(decoded.files, control.files);
+
+        let mut corrupt = encoded;
+        corrupt[8] ^= 1;
+        assert!(matches!(
+            FtsControlRecord::decode(&corrupt),
+            Err(crate::LimboError::Corrupt(message))
+                if message.contains("checksum mismatch")
+        ));
+
+        let exhausted = FtsControlRecord {
+            index_incarnation: 17,
+            manifest_generation: u64::MAX,
+            files: FxHashMap::default(),
+        };
+        let error = FtsControlRecord::from_catalog(
+            Some(&exhausted),
+            exhausted.index_incarnation,
+            &FxHashMap::default(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("generation is exhausted"));
     }
 
     #[test]

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -48,6 +48,19 @@ pub trait IndexMethodAttachment: std::fmt::Debug + Send + Sync {
     fn init(&self) -> Result<Box<dyn IndexMethodCursor>>;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexMethodMvccSupport {
+    /// The method cannot be opened while MVCC is active.
+    Unsupported,
+    /// The method may query MVCC snapshots but has no transactional write path.
+    ReadOnly,
+    /// Persistent state is stored exclusively through core-provided,
+    /// MVCC-aware backing storage.
+    TransactionalBackingStore,
+    /// Persistent state is external and implements transaction outcome hooks.
+    ExternalTransactional,
+}
+
 #[derive(Debug)]
 pub struct IndexMethodDefinition<'a> {
     /// index method name
@@ -65,6 +78,30 @@ pub struct IndexMethodDefinition<'a> {
     /// a live data structure that writes could invalidate.
     /// When `false`, the emitter will collect rowids into a RowSet/ephemeral table before writing.
     pub results_materialized: bool,
+    /// Declares how this method participates in MVCC transactions.
+    pub mvcc_support: IndexMethodMvccSupport,
+}
+
+pub(crate) fn ensure_mvcc_support(
+    definition: &IndexMethodDefinition<'_>,
+    write: bool,
+) -> Result<()> {
+    match (definition.mvcc_support, write) {
+        (IndexMethodMvccSupport::Unsupported, _) => Err(LimboError::ParseError(format!(
+            "index method '{}' does not support MVCC",
+            definition.method_name
+        ))),
+        (IndexMethodMvccSupport::ReadOnly, true) => Err(LimboError::ParseError(format!(
+            "index method '{}' is read-only in MVCC",
+            definition.method_name
+        ))),
+        (
+            IndexMethodMvccSupport::ReadOnly
+            | IndexMethodMvccSupport::TransactionalBackingStore
+            | IndexMethodMvccSupport::ExternalTransactional,
+            _,
+        ) => Ok(()),
+    }
 }
 
 /// Cost estimate returned by custom index methods for optimizer integration.
@@ -271,4 +308,35 @@ pub(crate) fn parse_patterns(patterns: &[&str]) -> Result<Vec<ast::Select>> {
         parsed.push(select);
     }
     Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_mvcc_support, IndexMethodDefinition, IndexMethodMvccSupport};
+
+    fn definition(support: IndexMethodMvccSupport) -> IndexMethodDefinition<'static> {
+        IndexMethodDefinition {
+            method_name: "test_method",
+            index_name: "test_index",
+            patterns: &[],
+            backing_btree: false,
+            results_materialized: true,
+            mvcc_support: support,
+        }
+    }
+
+    #[test]
+    fn mvcc_support_declaration_rejects_unsupported_access() {
+        let error = ensure_mvcc_support(&definition(IndexMethodMvccSupport::Unsupported), false)
+            .unwrap_err();
+        assert!(matches!(error, crate::LimboError::ParseError(_)));
+
+        ensure_mvcc_support(&definition(IndexMethodMvccSupport::ReadOnly), false).unwrap();
+        assert!(ensure_mvcc_support(&definition(IndexMethodMvccSupport::ReadOnly), true).is_err());
+        ensure_mvcc_support(
+            &definition(IndexMethodMvccSupport::TransactionalBackingStore),
+            true,
+        )
+        .unwrap();
+    }
 }

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -4,11 +4,12 @@ use rustc_hash::FxHashMap as HashMap;
 use turso_parser::ast;
 
 use crate::{
+    mvcc::cursor::MvccCursorType,
     schema::IndexColumn,
-    storage::btree::BTreeCursor,
+    storage::btree::{BTreeCursor, CursorTrait},
     types::{IOResult, IndexInfo, KeyInfo},
     vdbe::Register,
-    Connection, LimboError, Result, Value,
+    Connection, LimboError, MvCursor, Result, Value,
 };
 
 pub mod backing_btree;
@@ -241,30 +242,75 @@ pub trait IndexMethodCursor {
     }
 }
 
-/// helper method to open table BTree cursor in the index method implementation
+fn promote_to_mvcc_cursor(
+    connection: &Arc<Connection>,
+    database_id: usize,
+    root_page: i64,
+    cursor: Box<dyn CursorTrait>,
+    cursor_type: MvccCursorType,
+) -> Result<Box<dyn CursorTrait>> {
+    let Some(mv_store) = connection.mv_store_for_db(database_id) else {
+        return Ok(cursor);
+    };
+    let tx_id = connection.get_mv_tx_id_for_db(database_id).ok_or_else(|| {
+        LimboError::InternalError(
+            "index method opened an MVCC cursor without an active transaction".to_string(),
+        )
+    })?;
+    Ok(Box::new(MvCursor::new(
+        mv_store,
+        connection,
+        tx_id,
+        root_page,
+        cursor_type,
+        cursor,
+    )?))
+}
+
+fn btree_root_page(connection: &Connection, database_id: usize, root_page: i64) -> i64 {
+    if root_page >= 0 {
+        return root_page;
+    }
+    connection
+        .mv_store_for_db(database_id)
+        .map_or(root_page, |mv_store| mv_store.get_real_table_id(root_page))
+}
+
+/// Helper method to open a table cursor in an index method implementation.
 pub(crate) fn open_table_cursor(
-    connection: &Connection,
+    connection: &Arc<Connection>,
     database_id: usize,
     table: &str,
-) -> Result<BTreeCursor> {
+) -> Result<Box<dyn CursorTrait>> {
     let pager = connection.get_pager_from_database_index(&database_id)?;
     let Some(table) = connection.with_schema(database_id, |schema| schema.get_table(table)) else {
         return Err(LimboError::InternalError(format!(
             "table {table} not found",
         )));
     };
-    let cursor = BTreeCursor::new_table(pager, table.get_root_page()?, table.columns().len());
-    Ok(cursor)
+    let root_page = table.get_root_page()?;
+    let cursor = Box::new(BTreeCursor::new_table(
+        pager,
+        btree_root_page(connection, database_id, root_page),
+        table.columns().len(),
+    ));
+    promote_to_mvcc_cursor(
+        connection,
+        database_id,
+        root_page,
+        cursor,
+        MvccCursorType::Table,
+    )
 }
 
-/// helper method to open index BTree cursor in the index method implementation
+/// Helper method to open an index cursor in an index method implementation.
 pub(crate) fn open_index_cursor<I, E>(
-    connection: &Connection,
+    connection: &Arc<Connection>,
     database_id: usize,
     table: &str,
     index: &str,
     keys: I,
-) -> Result<BTreeCursor>
+) -> Result<Box<dyn CursorTrait>>
 where
     I: IntoIterator<Item = KeyInfo, IntoIter = E>,
     E: ExactSizeIterator<Item = KeyInfo>,
@@ -279,14 +325,20 @@ where
     };
     let keys = keys.into_iter();
     let num_cols = keys.len();
-    let mut cursor = BTreeCursor::new(pager, scratch.root_page, num_cols);
-    cursor.index_info = Some(Arc::new(IndexInfo::new(
-        keys,
-        false,
+    let index_info = Arc::new(IndexInfo::new(keys, false, num_cols, scratch.unique)?);
+    let mut cursor = BTreeCursor::new(
+        pager,
+        btree_root_page(connection, database_id, scratch.root_page),
         num_cols,
-        scratch.unique,
-    )?));
-    Ok(cursor)
+    );
+    cursor.index_info = Some(index_info.clone());
+    promote_to_mvcc_cursor(
+        connection,
+        database_id,
+        scratch.root_page,
+        Box::new(cursor),
+        MvccCursorType::Index(index_info),
+    )
 }
 
 /// helper method to parse select patterns for [IndexMethodAttachment::definition] call

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -1,12 +1,18 @@
 use std::sync::Arc;
 
 use rustc_hash::FxHashMap as HashMap;
+#[cfg(any(test, injected_yields))]
+use strum::EnumCount;
 use turso_parser::ast;
 
 use crate::{
     mvcc::cursor::MvccCursorType,
     schema::IndexColumn,
-    storage::btree::{BTreeCursor, CursorTrait},
+    storage::{
+        btree::{BTreeCursor, CursorTrait},
+        journal_mode::JournalMode,
+    },
+    translate::emitter::TransactionMode,
     types::{IOResult, IndexInfo, KeyInfo},
     vdbe::Register,
     Connection, LimboError, MvCursor, Result, Value,
@@ -66,6 +72,8 @@ pub enum IndexMethodMvccSupport {
 pub struct IndexMethodDefinition<'a> {
     /// index method name
     pub method_name: &'a str,
+    /// table to which the index is attached
+    pub table_name: &'a str,
     /// index name
     pub index_name: &'a str,
     /// SELECT patterns where index method can be used
@@ -81,6 +89,299 @@ pub struct IndexMethodDefinition<'a> {
     pub results_materialized: bool,
     /// Declares how this method participates in MVCC transactions.
     pub mvcc_support: IndexMethodMvccSupport,
+}
+
+/// Transaction mode exposed to index methods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexMethodTransactionMode {
+    Read,
+    Write,
+    Concurrent,
+}
+
+/// Stable coordinates for the snapshot visible to an index method operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexMethodSnapshotIdentity {
+    /// WAL readers are pinned to a checkpoint sequence and maximum frame.
+    Wal {
+        checkpoint_sequence: u32,
+        max_frame: u64,
+    },
+    /// MVCC readers are pinned to the transaction's begin timestamp.
+    Mvcc { begin_timestamp: u64 },
+}
+
+/// Append-only synthetic-yield markers for index-method lifecycle boundaries.
+///
+/// Ordinals are consumed by deterministic simulator plans; never reorder or
+/// reuse an existing value.
+#[cfg(any(test, injected_yields))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::EnumCount)]
+#[repr(u8)]
+pub(crate) enum IndexMethodYieldPoint {
+    BeforePrepareStatement = 0,
+    AfterPrepareStatement = 1,
+}
+
+#[cfg(any(test, injected_yields))]
+impl crate::mvcc::yield_hooks::YieldPointMarker for IndexMethodYieldPoint {
+    const POINT_COUNT: u8 = Self::COUNT as u8;
+
+    fn ordinal(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IndexMethodDatabaseIdentity {
+    /// Connection-local slot used to address the database.
+    pub id: usize,
+    pub name: String,
+    /// Runtime identity of the shared `Database` object. Unlike `id` and
+    /// `name`, this distinguishes detach/reattach and close/reopen lifetimes.
+    pub incarnation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IndexMethodIdentity {
+    pub method_name: String,
+    pub table_name: String,
+    pub index_name: String,
+    /// Runtime-stable identity for this schema incarnation. Drop/recreate and
+    /// attach/detach cannot compare equal even when names are reused.
+    pub runtime_id: u64,
+    /// Schema root assigned to the logical definition. Custom index methods
+    /// must keep this at zero; physical ownership belongs to backing objects.
+    pub schema_root: i64,
+}
+
+fn index_method_runtime_id(
+    database_incarnation: u64,
+    schema_generation: u64,
+    definition: &IndexMethodDefinition<'_>,
+) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64 ^ database_incarnation;
+    hash = (hash ^ schema_generation).wrapping_mul(0x100_0000_01b3);
+    for byte in definition
+        .method_name
+        .bytes()
+        .chain(definition.table_name.bytes())
+        .chain(definition.index_name.bytes())
+    {
+        hash = (hash ^ u64::from(byte)).wrapping_mul(0x100_0000_01b3);
+    }
+    hash
+}
+
+/// Read-only execution and storage context for an index method operation.
+///
+/// Persistent cursors can only be created through this context, ensuring they
+/// are promoted to snapshot-aware MVCC cursors whenever MVCC is active.
+#[derive(Clone)]
+pub struct IndexMethodContext {
+    connection: Arc<Connection>,
+    database: IndexMethodDatabaseIdentity,
+    journal_mode: JournalMode,
+    transaction_mode: IndexMethodTransactionMode,
+    transaction_id: Option<u64>,
+    snapshot: IndexMethodSnapshotIdentity,
+    schema_generation: u64,
+    index: IndexMethodIdentity,
+    #[cfg(any(test, injected_yields))]
+    yield_instance_id: u64,
+}
+
+impl std::fmt::Debug for IndexMethodContext {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("IndexMethodContext")
+            .field("database", &self.database)
+            .field("journal_mode", &self.journal_mode)
+            .field("transaction_mode", &self.transaction_mode)
+            .field("transaction_id", &self.transaction_id)
+            .field("snapshot", &self.snapshot)
+            .field("schema_generation", &self.schema_generation)
+            .field("index", &self.index)
+            .finish_non_exhaustive()
+    }
+}
+
+impl IndexMethodContext {
+    pub(crate) fn new(
+        connection: &Arc<Connection>,
+        database_id: usize,
+        definition: &IndexMethodDefinition<'_>,
+    ) -> Result<Self> {
+        let pager = connection.get_pager_from_database_index(&database_id)?;
+        let schema_root = connection.with_schema(database_id, |schema| {
+            schema
+                .get_index(definition.table_name, definition.index_name)
+                .map_or(0, |index| index.root_page)
+        });
+        if !definition.backing_btree && schema_root != 0 {
+            return Err(LimboError::Corrupt(format!(
+                "logical index-method definition '{}.{}' owns physical root {schema_root}",
+                definition.table_name, definition.index_name
+            )));
+        }
+
+        let (journal_mode, transaction_mode, transaction_id, snapshot, schema_generation) =
+            if let Some(mv_store) = connection.mv_store_for_db(database_id) {
+                let (tx_id, mode) = connection.get_mv_tx_for_db(database_id).ok_or_else(|| {
+                    LimboError::InternalError(format!(
+                        "index method '{}' opened MVCC storage without an active transaction",
+                        definition.method_name
+                    ))
+                })?;
+                let transaction_mode = match mode {
+                    TransactionMode::None | TransactionMode::Read => {
+                        IndexMethodTransactionMode::Read
+                    }
+                    TransactionMode::Write => IndexMethodTransactionMode::Write,
+                    TransactionMode::Concurrent => IndexMethodTransactionMode::Concurrent,
+                };
+                (
+                    JournalMode::Mvcc,
+                    transaction_mode,
+                    Some(tx_id),
+                    IndexMethodSnapshotIdentity::Mvcc {
+                        begin_timestamp: mv_store.read_snapshot_ts(tx_id),
+                    },
+                    mv_store.schema_generation(),
+                )
+            } else {
+                let (checkpoint_sequence, max_frame) = pager.wal_pos();
+                (
+                    JournalMode::Wal,
+                    if connection.is_in_write_tx() {
+                        IndexMethodTransactionMode::Write
+                    } else {
+                        IndexMethodTransactionMode::Read
+                    },
+                    None,
+                    IndexMethodSnapshotIdentity::Wal {
+                        checkpoint_sequence,
+                        max_frame,
+                    },
+                    pager.get_schema_cookie_cached().unwrap_or_default() as u64,
+                )
+            };
+
+        let source_database = connection.get_source_database(database_id);
+        let database_incarnation = Arc::as_ptr(&source_database) as usize as u64;
+        let runtime_id =
+            index_method_runtime_id(database_incarnation, schema_generation, definition);
+
+        Ok(Self {
+            connection: Arc::clone(connection),
+            database: IndexMethodDatabaseIdentity {
+                id: database_id,
+                name: connection
+                    .get_database_name_by_index(database_id)
+                    .unwrap_or_else(|| format!("database-{database_id}")),
+                incarnation: database_incarnation,
+            },
+            journal_mode,
+            transaction_mode,
+            transaction_id,
+            snapshot,
+            schema_generation,
+            index: IndexMethodIdentity {
+                method_name: definition.method_name.to_string(),
+                table_name: definition.table_name.to_string(),
+                index_name: definition.index_name.to_string(),
+                runtime_id,
+                schema_root,
+            },
+            #[cfg(any(test, injected_yields))]
+            yield_instance_id: connection.next_yield_instance_id(),
+        })
+    }
+
+    /// Build the same core-owned context for raw index-method integration
+    /// tests. Production callers receive contexts only from the VDBE.
+    #[cfg(any(feature = "test_helper", feature = "conn_raw_api"))]
+    #[doc(hidden)]
+    pub fn for_test(
+        connection: &Arc<Connection>,
+        database_id: usize,
+        attachment: &dyn IndexMethodAttachment,
+    ) -> Result<Self> {
+        Self::new(connection, database_id, &attachment.definition())
+    }
+
+    pub fn connection(&self) -> &Arc<Connection> {
+        &self.connection
+    }
+
+    pub fn database(&self) -> &IndexMethodDatabaseIdentity {
+        &self.database
+    }
+
+    pub fn journal_mode(&self) -> JournalMode {
+        self.journal_mode
+    }
+
+    pub fn transaction_mode(&self) -> IndexMethodTransactionMode {
+        self.transaction_mode
+    }
+
+    pub fn transaction_id(&self) -> Option<u64> {
+        self.transaction_id
+    }
+
+    pub fn snapshot(&self) -> IndexMethodSnapshotIdentity {
+        self.snapshot
+    }
+
+    pub fn schema_generation(&self) -> u64 {
+        self.schema_generation
+    }
+
+    pub fn index(&self) -> &IndexMethodIdentity {
+        &self.index
+    }
+
+    pub fn open_table_cursor(&self, table: &str) -> Result<Box<dyn CursorTrait>> {
+        open_table_cursor(&self.connection, self.database.id, table)
+    }
+
+    pub fn open_index_cursor<I, E>(
+        &self,
+        table: &str,
+        index: &str,
+        keys: I,
+    ) -> Result<Box<dyn CursorTrait>>
+    where
+        I: IntoIterator<Item = KeyInfo, IntoIter = E>,
+        E: ExactSizeIterator<Item = KeyInfo>,
+    {
+        open_index_cursor(&self.connection, self.database.id, table, index, keys)
+    }
+}
+
+#[cfg(any(test, injected_yields))]
+impl crate::mvcc::yield_hooks::ProvidesYieldContext for IndexMethodContext {
+    fn yield_context(&self) -> crate::mvcc::yield_hooks::YieldContext {
+        let mut selection_key = 0x494e_4458_4d45_5448u64;
+        selection_key ^= self.database.id as u64;
+        selection_key = selection_key.rotate_left(17) ^ self.schema_generation;
+        selection_key = selection_key.rotate_left(17) ^ self.index.schema_root as u64;
+        for byte in self
+            .index
+            .method_name
+            .bytes()
+            .chain(self.index.index_name.bytes())
+        {
+            selection_key = selection_key.wrapping_mul(0x100_0000_01b3) ^ u64::from(byte);
+        }
+        crate::mvcc::yield_hooks::YieldContext::new(
+            self.connection.yield_injector(),
+            self.connection.failure_injector(),
+            self.yield_instance_id,
+            selection_key,
+        )
+    }
 }
 
 pub(crate) fn ensure_mvcc_support(
@@ -132,6 +433,14 @@ pub struct IndexMethodCostContext<'a> {
 #[cfg(feature = "test_helper")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IndexMethodTestStats {
+    /// Persistent index-method storage format version.
+    pub storage_format_version: Option<u32>,
+    /// Persistent logical incarnation from the control record.
+    pub index_incarnation: Option<u64>,
+    /// Transactional manifest generation visible to this cursor.
+    pub manifest_generation: Option<u64>,
+    /// Files referenced by the visible manifest.
+    pub manifest_file_count: Option<usize>,
     /// Number of physical files visible in the index method's storage.
     pub storage_file_count: usize,
     /// Number of searchable engine segments, when the method is segmented.
@@ -140,30 +449,53 @@ pub struct IndexMethodTestStats {
     pub cached_connection_count: Option<usize>,
     /// Resident bytes held by retained read-snapshot file caches.
     pub cached_bytes: Option<usize>,
+    /// Complete snapshots rejected from retention because they exceed the
+    /// aggregate cache budget by themselves.
+    pub cache_admission_rejections: Option<usize>,
     /// Whether the method retained a committed writer for statement reuse.
     pub cached_writer: Option<bool>,
+    /// Number of Tantivy writers constructed by this attachment.
+    pub tantivy_writer_constructions: Option<usize>,
+    /// Retained-writer cache lookups.
+    pub writer_cache_lookups: Option<usize>,
+    /// Retained-writer cache hits.
+    pub writer_cache_hits: Option<usize>,
+    /// Retained writers rejected because their owner or snapshot diverged.
+    pub writer_cache_validation_failures: Option<usize>,
+    /// Transaction-private retained writers discarded by rollback.
+    pub writer_cache_rollback_discards: Option<usize>,
+    /// Retained-writer cache lookups with no reusable entry.
+    pub writer_cache_misses: Option<usize>,
+    /// Read-snapshot cache lookups.
+    pub read_cache_lookups: Option<usize>,
+    /// Snapshot cache checkouts that avoided a backing-directory scan.
+    pub read_cache_hits: Option<usize>,
+    /// Read-snapshot cache lookups that required a full snapshot load.
+    pub read_cache_misses: Option<usize>,
+    /// Complete backing-directory snapshots loaded by the async scan.
+    pub full_snapshot_loads: Option<usize>,
+    /// Cross-snapshot control-record validations that reused a cached manifest.
+    pub manifest_validation_hits: Option<usize>,
+    /// Cross-snapshot control-record validations that rejected a stale cache.
+    pub manifest_validation_misses: Option<usize>,
+    /// Number of successful MVCC writer-lease acquisitions, including
+    /// reentrant acquisition by the owning transaction.
+    pub write_lease_acquisitions: Option<usize>,
+    /// Number of writer-lease acquisitions rejected due to contention.
+    pub write_lease_rejections: Option<usize>,
 }
 
 /// cursor opened for index method and capable of executing DML/DDL/DQL queries for the index method over fixed table
-pub trait IndexMethodCursor {
+pub trait IndexMethodCursor: Send {
     /// create necessary components for index method (usually, this is a bunch of btree-s)
-    fn create(&mut self, connection: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>>;
+    fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
     /// destroy components created in the create(...) call for index method
-    fn destroy(&mut self, connection: &Arc<Connection>, database_id: usize)
-        -> Result<IOResult<()>>;
+    fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
 
     /// open necessary components for reading the index
-    fn open_read(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>>;
+    fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
     /// open necessary components for writing the index
-    fn open_write(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>>;
+    fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
 
     /// handle insert action
     /// "values" argument contains registers with values for index columns followed by rowid Integer register
@@ -208,18 +540,37 @@ pub trait IndexMethodCursor {
     /// returned from query_rowid(...) method
     fn query_rowid(&mut self) -> Result<IOResult<Option<i64>>>;
 
-    /// Called before transaction commit to flush any pending writes.
-    /// This ensures index method writes are persisted as part of the transaction.
-    fn pre_commit(&mut self) -> Result<IOResult<()>> {
+    /// Stage all pending index changes before the statement savepoint is
+    /// released. Any fallible work or I/O belongs in this phase.
+    fn prepare_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         Ok(IOResult::Done(()))
     }
 
+    /// Discard statement-owned in-memory work. This hook must not perform I/O.
+    fn abort_statement(&mut self, _context: &IndexMethodContext) {}
+
+    /// Publish transaction-private in-memory state after the statement
+    /// savepoint has been released successfully. This hook is infallible and
+    /// must not make uncommitted state visible to another transaction.
+    fn statement_committed(&mut self, _context: &IndexMethodContext) {}
+
+    /// Publish in-memory state after the database transaction commits.
+    /// This hook is infallible and must not perform I/O.
+    fn transaction_committed(&mut self, _context: &IndexMethodContext) {}
+
+    /// Invalidate transaction-owned in-memory state after rollback.
+    /// This hook is infallible and must not perform I/O.
+    fn transaction_rolled_back(&mut self, _context: &IndexMethodContext) {}
+
+    /// Invalidate state newer than a rolled-back savepoint.
+    /// This hook is infallible and must not perform I/O.
+    fn savepoint_rolled_back(&mut self, _context: &IndexMethodContext) {}
+
+    /// Release resources without performing I/O or persistent writes.
+    fn close(&mut self, _context: &IndexMethodContext) {}
+
     /// Optimize the index by merging segments or performing other maintenance.
-    fn optimize(
-        &mut self,
-        _connection: &Arc<Connection>,
-        _database_id: usize,
-    ) -> Result<IOResult<()>> {
+    fn optimize(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         Ok(IOResult::Done(()))
     }
 
@@ -239,6 +590,17 @@ pub trait IndexMethodCursor {
     #[cfg(feature = "test_helper")]
     fn test_stats(&self) -> Result<Option<IndexMethodTestStats>> {
         Ok(None)
+    }
+}
+
+pub(crate) struct TransactionIndexMethodCursor {
+    pub(crate) cursor: Box<dyn IndexMethodCursor>,
+    pub(crate) context: IndexMethodContext,
+}
+
+impl TransactionIndexMethodCursor {
+    pub(crate) fn same_attachment(&self, context: &IndexMethodContext) -> bool {
+        self.context.database == context.database && self.context.index == context.index
     }
 }
 
@@ -369,6 +731,7 @@ mod tests {
     fn definition(support: IndexMethodMvccSupport) -> IndexMethodDefinition<'static> {
         IndexMethodDefinition {
             method_name: "test_method",
+            table_name: "test_table",
             index_name: "test_index",
             patterns: &[],
             backing_btree: false,

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -345,6 +345,7 @@ impl IndexMethodAttachment for VectorSparseInvertedIndexMethodAttachment {
             patterns: self.patterns.as_slice(),
             backing_btree: false,
             results_materialized: true,
+            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
         }
     }
     fn init(&self) -> Result<Box<dyn IndexMethodCursor>> {

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -9,8 +9,8 @@ use crate::numeric::Numeric;
 use crate::util::quote_identifier;
 use crate::{
     index_method::{
-        open_index_cursor, open_table_cursor, parse_patterns, IndexMethod, IndexMethodAttachment,
-        IndexMethodConfiguration, IndexMethodCursor, IndexMethodDefinition,
+        parse_patterns, IndexMethod, IndexMethodAttachment, IndexMethodConfiguration,
+        IndexMethodContext, IndexMethodCursor, IndexMethodDefinition,
         BACKING_BTREE_INDEX_METHOD_NAME, TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME,
     },
     return_if_io,
@@ -23,7 +23,7 @@ use crate::{
         operations,
         vector_types::{Vector, VectorType},
     },
-    Connection, LimboError, Result, Value, ValueRef,
+    LimboError, Result, Value, ValueRef,
 };
 
 /// Simple inverted index for sparse vectors
@@ -341,6 +341,7 @@ impl IndexMethodAttachment for VectorSparseInvertedIndexMethodAttachment {
     fn definition<'a>(&'a self) -> IndexMethodDefinition<'a> {
         IndexMethodDefinition {
             method_name: TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME,
+            table_name: &self.configuration.table_name,
             index_name: &self.configuration.index_name,
             patterns: self.patterns.as_slice(),
             backing_btree: false,
@@ -403,8 +404,10 @@ fn key_info() -> KeyInfo {
 }
 
 impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
-    fn create(&mut self, connection: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>> {
+    fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
         // we need to properly track subprograms and propagate result to the root program to make this execution async
+        let connection = context.connection();
+        let database_id = context.database().id;
 
         let columns = &self.configuration.columns;
         let columns = columns.iter().map(|x| x.name.as_str()).collect::<Vec<_>>();
@@ -447,11 +450,9 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         Ok(IOResult::Done(()))
     }
 
-    fn destroy(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>> {
+    fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let connection = context.connection();
+        let database_id = context.database().id;
         let db_prefix = connection
             .get_database_name_by_index(database_id)
             .filter(|name| name != "main")
@@ -476,57 +477,55 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         Ok(IOResult::Done(()))
     }
 
-    fn open_read(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>> {
-        self.inverted_index_cursor = Some(open_index_cursor(
-            connection,
-            database_id,
+    fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        self.inverted_index_cursor = Some(context.open_index_cursor(
             &self.configuration.table_name,
             &self.inverted_index_btree,
             // component, length, rowid
             [key_info(), key_info(), key_info()],
         )?);
-        self.stats_cursor = Some(open_index_cursor(
-            connection,
-            database_id,
+        self.stats_cursor = Some(context.open_index_cursor(
             &self.configuration.table_name,
             &self.stats_btree,
             // component
             [key_info()],
         )?);
-        self.main_btree = Some(open_table_cursor(
-            connection,
-            database_id,
+        self.main_btree = Some(context.open_table_cursor(&self.configuration.table_name)?);
+        Ok(IOResult::Done(()))
+    }
+
+    fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        self.inverted_index_cursor = Some(context.open_index_cursor(
             &self.configuration.table_name,
+            &self.inverted_index_btree,
+            // component, length, rowid
+            [key_info(), key_info(), key_info()],
+        )?);
+        self.stats_cursor = Some(context.open_index_cursor(
+            &self.configuration.table_name,
+            &self.stats_btree,
+            // component
+            [key_info()],
         )?);
         Ok(IOResult::Done(()))
     }
 
-    fn open_write(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>> {
-        self.inverted_index_cursor = Some(open_index_cursor(
-            connection,
-            database_id,
-            &self.configuration.table_name,
-            &self.inverted_index_btree,
-            // component, length, rowid
-            [key_info(), key_info(), key_info()],
-        )?);
-        self.stats_cursor = Some(open_index_cursor(
-            connection,
-            database_id,
-            &self.configuration.table_name,
-            &self.stats_btree,
-            // component
-            [key_info()],
-        )?);
+    fn prepare_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         Ok(IOResult::Done(()))
+    }
+
+    fn abort_statement(&mut self, _context: &IndexMethodContext) {}
+
+    fn transaction_committed(&mut self, _context: &IndexMethodContext) {}
+
+    fn transaction_rolled_back(&mut self, _context: &IndexMethodContext) {}
+
+    fn savepoint_rolled_back(&mut self, _context: &IndexMethodContext) {}
+
+    fn close(&mut self, _context: &IndexMethodContext) {
+        self.inverted_index_cursor = None;
+        self.stats_cursor = None;
+        self.main_btree = None;
     }
 
     fn insert(&mut self, values: &[Register]) -> Result<IOResult<()>> {

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -14,7 +14,7 @@ use crate::{
         BACKING_BTREE_INDEX_METHOD_NAME, TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME,
     },
     return_if_io,
-    storage::btree::{BTreeCursor, BTreeKey, CursorTrait},
+    storage::btree::{BTreeKey, CursorTrait},
     sync::Arc,
     translate::collate::CollationSeq,
     types::{IOResult, ImmutableRecord, KeyInfo, SeekKey, SeekOp, SeekResult},
@@ -307,10 +307,10 @@ pub struct VectorSparseInvertedIndexMethodCursor {
     scan_portion: f64,
     scan_order: ScanOrder,
     inverted_index_btree: String,
-    inverted_index_cursor: Option<BTreeCursor>,
+    inverted_index_cursor: Option<Box<dyn CursorTrait>>,
     stats_btree: String,
-    stats_cursor: Option<BTreeCursor>,
-    main_btree: Option<BTreeCursor>,
+    stats_cursor: Option<Box<dyn CursorTrait>>,
+    main_btree: Option<Box<dyn CursorTrait>>,
     insert_state: VectorSparseInvertedIndexInsertState,
     delete_state: VectorSparseInvertedIndexDeleteState,
     search_state: VectorSparseInvertedIndexSearchState,
@@ -345,7 +345,7 @@ impl IndexMethodAttachment for VectorSparseInvertedIndexMethodAttachment {
             patterns: self.patterns.as_slice(),
             backing_btree: false,
             results_materialized: true,
-            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
+            mvcc_support: super::IndexMethodMvccSupport::TransactionalBackingStore,
         }
     }
     fn init(&self) -> Result<Box<dyn IndexMethodCursor>> {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -703,6 +703,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             .indexes
             .values()
             .flatten()
+            .filter(|index| index.is_btree_backed())
             .map(|index| {
                 turso_assert!(index.root_page != 0, "index root_page must be non-zero");
                 (
@@ -761,6 +762,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 .indexes
                 .values()
                 .flatten()
+                .filter(|index| index.is_btree_backed())
                 .map(|index| {
                     turso_assert!(index.root_page != 0, "index root_page must be non-zero");
                     (
@@ -2058,7 +2060,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                             .indexes
                             .values()
                             .flatten()
+                            .filter(|index| index.is_btree_backed())
                             .filter_map(|index| {
+                                turso_assert!(
+                                    index.root_page != 0,
+                                    "index root_page must be non-zero"
+                                );
                                 self.mvstore
                                     .try_get_table_id_from_root_page_at(
                                         index.root_page,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4018,6 +4018,10 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     ///
     /// If there is no exclusive transaction, the field is set to `NO_EXCLUSIVE_TX`.
     exclusive_tx: AtomicU64,
+    /// Active custom-index writer leases keyed by the backing object's stable
+    /// MVCC table ID. Leases reject contention instead of waiting, so acquiring
+    /// several leases cannot deadlock.
+    index_method_write_leases: Mutex<HashMap<MVTableId, TxID>>,
     commit_coordinator: Arc<CommitCoordinator>,
     global_header: Arc<RwLock<Option<DatabaseHeader>>>,
     /// Held by checkpoints only during the brief in-memory publish phase; the I/O-heavy
@@ -4225,6 +4229,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             clock,
             storage,
             exclusive_tx: AtomicU64::new(NO_EXCLUSIVE_TX),
+            index_method_write_leases: Mutex::new(HashMap::default()),
             commit_coordinator: Arc::new(CommitCoordinator::new()),
             global_header: Arc::new(RwLock::new(None)),
             backfill_floor: Arc::new(RwLock::new(WalPos::ORIGIN)),
@@ -6172,6 +6177,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     }
 
     pub fn remove_tx(&self, tx_id: TxID) -> Result<(), TryReserveError> {
+        self.release_index_method_write_leases(tx_id);
         self.remove_sequence_allocations(tx_id);
         if let Some(entry) = self.txs.get(&tx_id) {
             let tx = entry.value();
@@ -6202,6 +6208,37 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         }
         self.txs.remove(&tx_id);
         Ok(())
+    }
+
+    /// Acquire a transaction-scoped custom-index writer lease.
+    ///
+    /// Acquisition is reentrant for the owning transaction. Contention is an
+    /// eager write conflict so expensive index construction never starts for a
+    /// transaction that cannot publish its work.
+    pub(crate) fn acquire_index_method_write_lease(
+        &self,
+        tx_id: TxID,
+        index_id: MVTableId,
+    ) -> Result<()> {
+        if !self.is_tx_rollbackable(tx_id) {
+            return Err(LimboError::NoSuchTransactionID(tx_id.to_string()));
+        }
+
+        let mut leases = self.index_method_write_leases.lock();
+        match leases.get(&index_id) {
+            Some(owner) if *owner == tx_id => Ok(()),
+            Some(_) => Err(LimboError::WriteWriteConflict),
+            None => {
+                leases.insert(index_id, tx_id);
+                Ok(())
+            }
+        }
+    }
+
+    fn release_index_method_write_leases(&self, tx_id: TxID) {
+        self.index_method_write_leases
+            .lock()
+            .retain(|_, owner| *owner != tx_id);
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::FinalizedTxStateInsert)]

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4526,6 +4526,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     .indexes
                     .values()
                     .flatten()
+                    .filter(|index| index.is_btree_backed())
                     .map(|index| index.root_page),
             )
             .collect::<Vec<_>>();
@@ -4927,6 +4928,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         .indexes
                         .values()
                         .flatten()
+                        .filter(|index| index.is_btree_backed())
                         .map(|index| index.root_page),
                 )
         };
@@ -9128,7 +9130,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 let is_virtual_table = row_type == "table"
                                     && sql.is_some_and(crate::util::sql_is_create_virtual_table);
                                 let has_btree = match row_type {
-                                    "index" => true,
+                                    "index" => root_page != 0,
                                     "table" => !is_virtual_table,
                                     _ => false,
                                 };

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -5860,6 +5860,11 @@ impl Index {
             .is_some_and(|x| x.definition().backing_btree)
     }
 
+    /// Whether this schema index owns a B-tree root page.
+    pub fn is_btree_backed(&self) -> bool {
+        self.index_method.is_none() || self.is_backing_btree_index()
+    }
+
     pub fn automatic_from_primary_key(
         table: &BTreeTable,
         auto_index: (String, i64), // name, root_page

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1804,11 +1804,6 @@ impl Schema {
                 unparsed_sql_from_index.root_page,
                 table.as_ref(),
             )?;
-            if mvcc_enabled {
-                if let Some(index_method) = index.index_method.as_ref() {
-                    crate::index_method::ensure_mvcc_support(&index_method.definition(), false)?;
-                }
-            }
             self.add_index(Arc::new(index))?;
         }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1804,8 +1804,10 @@ impl Schema {
                 unparsed_sql_from_index.root_page,
                 table.as_ref(),
             )?;
-            if mvcc_enabled && index.index_method.is_some() {
-                crate::bail_parse_error!("Custom index modules are not supported with MVCC");
+            if mvcc_enabled {
+                if let Some(index_method) = index.index_method.as_ref() {
+                    crate::index_method::ensure_mvcc_support(&index_method.definition(), false)?;
+                }
             }
             self.add_index(Arc::new(index))?;
         }

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -22,8 +22,8 @@ use crate::{
         self,
         explain::{EXPLAIN_COLUMNS_TYPE, EXPLAIN_QUERY_PLAN_COLUMNS_TYPE},
     },
-    LimboError, MvStore, Pager, QueryMode, Result, TransactionState, Value, EXPLAIN_COLUMNS,
-    EXPLAIN_QUERY_PLAN_COLUMNS,
+    Connection, LimboError, MvStore, Pager, QueryMode, Result, TransactionState, Value,
+    EXPLAIN_COLUMNS, EXPLAIN_QUERY_PLAN_COLUMNS,
 };
 
 type ProgramExecutionState = vdbe::ProgramExecutionState;
@@ -324,6 +324,25 @@ impl std::fmt::Debug for Statement {
 }
 
 impl Statement {
+    pub(crate) fn prepare_index_methods(&mut self) -> Result<crate::IOResult<()>> {
+        crate::vdbe::execute::index_method_prepare_statement_all(&mut self.state)
+    }
+
+    pub(crate) fn abort_index_methods(&mut self) {
+        crate::vdbe::execute::index_method_abort_statement_all(&mut self.state);
+    }
+
+    pub(crate) fn commit_index_methods(&mut self) {
+        crate::vdbe::execute::index_method_transaction_committed_all(
+            &mut self.state,
+            &self.program.connection,
+        );
+    }
+
+    pub(crate) fn register_index_methods(&mut self, connection: &Connection) -> Result<()> {
+        crate::vdbe::execute::index_method_register_transaction_all(&mut self.state, connection)
+    }
+
     pub fn new(
         program: vdbe::Program,
         pager: Arc<Pager>,

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1,7 +1,7 @@
 use crate::alloc::{TryClone, TursoIteratorExt, TursoVecExt};
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::Func;
-use crate::index_method::IndexMethodConfiguration;
+use crate::index_method::{ensure_mvcc_support, IndexMethodConfiguration};
 use crate::numeric::Numeric;
 use crate::schema::{Column, GeneratedType, Table, EXPR_INDEX_SENTINEL, RESERVED_TABLE_PREFIXES};
 use crate::sync::Arc;
@@ -65,9 +65,6 @@ fn validate(
         bail_parse_error!(
             "index method is an experimental feature. Enable with --experimental-index-method flag"
         )
-    }
-    if connection.mvcc_enabled() && using.is_some() {
-        bail_parse_error!("Custom index modules are not supported in MVCC mode");
     }
     if tbl_name.eq_ignore_ascii_case("sqlite_sequence") {
         crate::bail_parse_error!("table sqlite_sequence may not be indexed");
@@ -196,12 +193,16 @@ pub fn translate_create_index(
         }
         if let Some(index_module) = index_module {
             let parameters = resolve_index_method_parameters(with_clause)?;
-            index_method = Some(index_module.attach(&IndexMethodConfiguration {
+            let attachment = index_module.attach(&IndexMethodConfiguration {
                 table_name: tbl.name.clone(),
                 index_name: idx_name.clone(),
                 columns: columns.try_clone()?,
                 parameters,
-            })?);
+            })?;
+            if connection.mvcc_enabled() {
+                ensure_mvcc_support(&attachment.definition(), true)?;
+            }
+            index_method = Some(attachment);
         }
     }
     let idx = Arc::new(Index {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1,7 +1,7 @@
 use crate::alloc::{TryClone, TursoIteratorExt, TursoVecExt};
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::Func;
-use crate::index_method::{ensure_mvcc_support, IndexMethodConfiguration};
+use crate::index_method::IndexMethodConfiguration;
 use crate::numeric::Numeric;
 use crate::schema::{Column, GeneratedType, Table, EXPR_INDEX_SENTINEL, RESERVED_TABLE_PREFIXES};
 use crate::sync::Arc;
@@ -193,16 +193,12 @@ pub fn translate_create_index(
         }
         if let Some(index_module) = index_module {
             let parameters = resolve_index_method_parameters(with_clause)?;
-            let attachment = index_module.attach(&IndexMethodConfiguration {
+            index_method = Some(index_module.attach(&IndexMethodConfiguration {
                 table_name: tbl.name.clone(),
                 index_name: idx_name.clone(),
                 columns: columns.try_clone()?,
                 parameters,
-            })?;
-            if connection.mvcc_enabled() {
-                ensure_mvcc_support(&attachment.definition(), true)?;
-            }
-            index_method = Some(attachment);
+            })?);
         }
     }
     let idx = Arc::new(Index {

--- a/core/types.rs
+++ b/core/types.rs
@@ -2421,6 +2421,9 @@ impl IndexInfo {
         index: &Index,
         alloc: A,
     ) -> Result<Self, TryReserveError> {
+        // A backing_btree stores the index method's complete opaque key. Unlike
+        // an ordinary secondary index, it must not append the base-table rowid.
+        let has_rowid = index.has_rowid && !index.is_backing_btree_index();
         let key_info = index
             .columns
             .iter()
@@ -2429,15 +2432,15 @@ impl IndexInfo {
                 collation: c.collation.unwrap_or_default(),
                 nulls_order: c.nulls_order,
             })
-            .chain(index.has_rowid.then_some(KeyInfo {
+            .chain(has_rowid.then_some(KeyInfo {
                 sort_order: SortOrder::Asc,
                 collation: CollationSeq::Binary,
                 nulls_order: None,
             }));
         Self::new_in(
             key_info,
-            index.has_rowid,
-            index.columns.len() + (index.has_rowid as usize),
+            has_rowid,
+            index.columns.len() + (has_rowid as usize),
             index.unique,
             alloc,
         )

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1165,6 +1165,26 @@ pub fn op_if_not(
     Ok(InsnFunctionStepResult::Step)
 }
 
+fn ensure_index_method_context(
+    program: &Program,
+    state: &mut ProgramState,
+    cursor_id: usize,
+    database_id: usize,
+    attachment: &dyn crate::index_method::IndexMethodAttachment,
+) -> Result<crate::index_method::IndexMethodContext> {
+    if let Some(context) = state.index_method_contexts[cursor_id].as_ref() {
+        return Ok(context.clone());
+    }
+    let definition = attachment.definition();
+    let context = crate::index_method::IndexMethodContext::new(
+        &program.connection,
+        database_id,
+        &definition,
+    )?;
+    state.index_method_contexts[cursor_id] = Some(context.clone());
+    Ok(context)
+}
+
 pub fn op_open_read(
     program: &Program,
     state: &mut ProgramState,
@@ -1186,6 +1206,11 @@ pub fn op_open_read(
     let mv_store = program.connection.mv_store_for_db(*db);
 
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
+        if mv_store.is_some() {
+            crate::index_method::ensure_mvcc_support(&module.definition(), false)?;
+        }
+        let context =
+            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
             let cursor_ref = &mut state.cursors[*cursor_id];
@@ -1196,7 +1221,7 @@ pub fn op_open_read(
             .as_mut()
             .expect("cursor should exist after initialization");
         let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.open_read(&program.connection, *db));
+        return_if_io!(cursor.open_read(&context));
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
@@ -3382,7 +3407,10 @@ pub fn halt(
     // for FAIL mode and need to continue the commit, then return the stored error.
     if let Some(pending_error) = state.pending_fail_error.take() {
         match program.commit_txn(pager.clone(), state, mv_store.as_ref(), false)? {
-            IOResult::Done(_) => return Err(pending_error),
+            IOResult::Done(_) => {
+                index_method_transaction_committed_all(state, &program.connection);
+                return Err(pending_error);
+            }
             IOResult::IO(io) => {
                 state.pending_fail_error = Some(pending_error); // put it back and wait
                 return Ok(InsnFunctionStepResult::IO(io));
@@ -3462,14 +3490,18 @@ pub fn halt(
                 ));
             }
 
-            // Release savepoint to preserve partial changes, then commit
-            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
+            // Prepare every custom index before releasing the statement
+            // savepoint, then commit the partial FAIL changes.
             vtab_commit_all(&program.connection)?;
-            index_method_pre_commit_all(state, pager)?;
+            return_if_io!(index_method_prepare_statement_all(state));
+            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
 
             // Commit the transaction with partial changes
             match program.commit_txn(pager.clone(), state, mv_store.as_ref(), false)? {
-                IOResult::Done(_) => return Err(error),
+                IOResult::Done(_) => {
+                    index_method_transaction_committed_all(state, &program.connection);
+                    return Err(error);
+                }
                 IOResult::IO(io) => {
                     // store the error for reentrancy
                     state.pending_fail_error = Some(error);
@@ -3513,6 +3545,11 @@ pub fn halt(
     }
 
     if program.is_trigger_subprogram() {
+        // Trigger statements are cached and reset before the next firing.
+        // Stage their index-method writes now so reset cannot drop pending
+        // work from an earlier row in the parent statement. The parent still
+        // owns the statement savepoint and the final transaction outcome.
+        return_if_io!(index_method_prepare_statement_all(state));
         return Ok(InsnFunctionStepResult::Done);
     }
 
@@ -3540,10 +3577,10 @@ pub fn halt(
                 ));
             }
         }
-        state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
         if can_autocommit_now {
             vtab_commit_all(&program.connection)?;
-            index_method_pre_commit_all(state, pager)?;
+            return_if_io!(index_method_prepare_statement_all(state));
+            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
             // Sequence backing-table compaction and sqlite_sequence sync
             // are emitted as straight-line bytecode inside the
             // nextval / advance_past / setval translators
@@ -3558,6 +3595,7 @@ pub fn halt(
                 .map(Into::into);
             // Apply deferred CDC state and reset CDC txn ID after successful commit
             if matches!(result, Ok(InsnFunctionStepResult::Done)) {
+                index_method_transaction_committed_all(state, &program.connection);
                 if let Some(cdc_info) = state.pending_cdc_info.take() {
                     program.connection.set_capture_data_changes_info(cdc_info);
                 }
@@ -3565,6 +3603,7 @@ pub fn halt(
             }
             result
         } else {
+            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
             // Another root statement may own the implicit autocommit
             // transaction. This statement can finish, but must not commit or
             // roll back connection-level state it did not start.
@@ -3608,8 +3647,9 @@ pub fn halt(
         // Otherwise the cursor's Drop fallback performs these writes after
         // statement success, where an I/O error can no longer be returned to
         // the caller or rolled back at statement scope.
-        index_method_pre_commit_all(state, pager)?;
+        return_if_io!(index_method_prepare_statement_all(state));
         state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
+        index_method_register_transaction_all(state, &program.connection)?;
         // Apply deferred CDC state after successful statement completion
         if let Some(cdc_info) = state.pending_cdc_info.take() {
             program.connection.set_capture_data_changes_info(cdc_info);
@@ -3643,27 +3683,174 @@ pub(crate) fn vtab_commit_all(conn: &Connection) -> crate::Result<()> {
     Ok(())
 }
 
-/// Flush pending writes on all index method cursors before transaction commit.
-/// This ensures index method writes are persisted as part of the transaction.
-pub(crate) fn index_method_pre_commit_all(
+/// Stage pending writes on every index-method cursor before releasing the
+/// statement savepoint. Cursor order is bytecode cursor order, which is stable
+/// across resumptions and avoids attachment-order ambiguity.
+pub(crate) fn index_method_prepare_statement_all(
     state: &mut ProgramState,
-    pager: &Arc<Pager>,
-) -> crate::Result<()> {
-    for cursor_opt in state.cursors.iter_mut().flatten() {
-        let Cursor::IndexMethod(cursor) = cursor_opt else {
-            continue;
-        };
-        loop {
-            match cursor.pre_commit()? {
-                IOResult::Done(()) => break,
-                IOResult::IO(io) => {
-                    while !io.finished() {
-                        pager.io.step()?;
-                    }
-                }
+) -> crate::Result<IOResult<()>> {
+    if state.index_methods_finalized {
+        return Ok(IOResult::Done(()));
+    }
+
+    while state.index_method_finalize_cursor < state.cursors.len() {
+        let cursor_id = state.index_method_finalize_cursor;
+        if matches!(
+            state.cursors[cursor_id].as_ref(),
+            Some(Cursor::IndexMethod(_))
+        ) {
+            let Some(context) = state.index_method_contexts[cursor_id].clone() else {
+                return Err(LimboError::InternalError(format!(
+                    "index-method cursor {cursor_id} has no execution context"
+                )));
+            };
+            crate::mvcc::yield_points::inject_io_yield!(
+                context,
+                crate::index_method::IndexMethodYieldPoint::BeforePrepareStatement
+            );
+            let Some(Cursor::IndexMethod(cursor)) = state.cursors[cursor_id].as_mut() else {
+                unreachable!("cursor kind checked above")
+            };
+            match cursor.prepare_statement_commit(&context)? {
+                IOResult::Done(()) => {}
+                IOResult::IO(io) => return Ok(IOResult::IO(io)),
             }
+            state.index_method_finalize_cursor += 1;
+            crate::mvcc::yield_points::inject_io_yield!(
+                context,
+                crate::index_method::IndexMethodYieldPoint::AfterPrepareStatement
+            );
+            continue;
+        }
+        state.index_method_finalize_cursor += 1;
+    }
+
+    let subprogram_keys = state
+        .index_method_finalize_subprogram_keys
+        .get_or_insert_with(|| {
+            let mut keys = state
+                .subprogram_stmt_cache
+                .keys()
+                .copied()
+                .collect::<Vec<_>>();
+            keys.sort_unstable();
+            keys
+        });
+    while state.index_method_finalize_subprogram < subprogram_keys.len() {
+        let key = subprogram_keys[state.index_method_finalize_subprogram];
+        let statement = state
+            .subprogram_stmt_cache
+            .get_mut(&key)
+            .expect("finalization key must reference a cached subprogram");
+        match statement.prepare_index_methods()? {
+            IOResult::Done(()) => state.index_method_finalize_subprogram += 1,
+            IOResult::IO(io) => return Ok(IOResult::IO(io)),
         }
     }
+
+    state.index_methods_finalized = true;
+    Ok(IOResult::Done(()))
+}
+
+/// Discard statement-owned index-method work before a statement savepoint or
+/// transaction is rolled back. Hooks are deliberately infallible and may not
+/// perform I/O.
+pub(crate) fn index_method_abort_statement_all(state: &mut ProgramState) {
+    for (cursor_id, cursor_opt) in state.cursors.iter_mut().enumerate() {
+        let Some(Cursor::IndexMethod(cursor)) = cursor_opt else {
+            continue;
+        };
+        let Some(context) = state.index_method_contexts[cursor_id].as_ref() else {
+            continue;
+        };
+        cursor.abort_statement(context);
+    }
+    for (cursor, context) in &mut state.closed_index_method_cursors {
+        cursor.abort_statement(context);
+    }
+    for statement in state.subprogram_stmt_cache.values_mut() {
+        statement.abort_index_methods();
+    }
+    state.index_method_finalize_cursor = 0;
+    state.index_method_finalize_subprogram_keys = None;
+    state.index_method_finalize_subprogram = 0;
+    state.index_methods_finalized = false;
+}
+
+/// Publish safe in-memory state after a durable autocommit outcome.
+pub(crate) fn index_method_transaction_committed_all(
+    state: &mut ProgramState,
+    connection: &Connection,
+) {
+    tracing::trace!(
+        open_cursors = state
+            .cursors
+            .iter()
+            .filter(|cursor| matches!(cursor, Some(Cursor::IndexMethod(_))))
+            .count(),
+        closed_cursors = state.closed_index_method_cursors.len(),
+        subprograms = state.subprogram_stmt_cache.len(),
+        "publishing committed index-method state"
+    );
+    for (cursor_id, cursor_opt) in state.cursors.iter_mut().enumerate() {
+        let Some(Cursor::IndexMethod(cursor)) = cursor_opt else {
+            continue;
+        };
+        let Some(context) = state.index_method_contexts[cursor_id].as_ref() else {
+            continue;
+        };
+        cursor.transaction_committed(context);
+    }
+    for (cursor, context) in &mut state.closed_index_method_cursors {
+        cursor.transaction_committed(context);
+    }
+    for statement in state.subprogram_stmt_cache.values_mut() {
+        statement.commit_index_methods();
+    }
+    connection.index_methods_transaction_committed();
+}
+
+/// Transfer the final prepared cursor for every attachment touched by this
+/// statement into connection-level transaction ownership. Replacing an older
+/// cursor for the same attachment keeps outcome delivery exactly once while
+/// retaining the newest in-transaction view.
+pub(crate) fn index_method_register_transaction_all(
+    state: &mut ProgramState,
+    connection: &Connection,
+) -> crate::Result<()> {
+    let mut registered = 0usize;
+    for cursor_id in 0..state.cursors.len() {
+        if !matches!(state.cursors[cursor_id], Some(Cursor::IndexMethod(_))) {
+            continue;
+        }
+        let Some(Cursor::IndexMethod(cursor)) = state.cursors[cursor_id].take() else {
+            unreachable!("cursor kind checked above")
+        };
+        let context = state.index_method_contexts[cursor_id]
+            .take()
+            .ok_or_else(|| {
+                LimboError::InternalError(format!(
+                    "index-method cursor {cursor_id} has no execution context"
+                ))
+            })?;
+        connection.register_index_method_transaction_cursor(
+            crate::index_method::TransactionIndexMethodCursor { cursor, context },
+        );
+        registered += 1;
+    }
+    for (cursor, context) in state.closed_index_method_cursors.drain(..) {
+        connection.register_index_method_transaction_cursor(
+            crate::index_method::TransactionIndexMethodCursor { cursor, context },
+        );
+        registered += 1;
+    }
+    for statement in state.subprogram_stmt_cache.values_mut() {
+        statement.register_index_methods(connection)?;
+    }
+    tracing::trace!(
+        registered,
+        "retained statement index-method cursors for transaction outcome"
+    );
     Ok(())
 }
 
@@ -4593,6 +4780,9 @@ pub fn op_auto_commit(
             res,
             Ok(InsnFunctionStepResult::Step | InsnFunctionStepResult::Done)
         ) {
+            if !*rollback {
+                conn.index_methods_transaction_committed();
+            }
             conn.clear_tx_poison();
             conn.clear_named_savepoints();
         }
@@ -4653,6 +4843,7 @@ pub fn op_auto_commit(
                 }
                 conn.rollback_attached_wal_txns();
                 conn.rollback_temp_schema();
+                conn.index_methods_transaction_rolled_back();
                 conn.set_tx_state(TransactionState::None);
                 conn.auto_commit.store(true, Ordering::SeqCst);
                 conn.set_cdc_transaction_id(-1);
@@ -4706,7 +4897,7 @@ pub fn op_auto_commit(
     // so they are part of the same transaction. Sequence flush no longer
     // belongs here — see the long-form comment in `op_halt` above.
     if matches!(tx_op, TxOp::Commit) {
-        index_method_pre_commit_all(state, pager)?;
+        return_if_io!(index_method_prepare_statement_all(state));
     }
 
     let res = match program
@@ -4740,6 +4931,9 @@ pub fn op_auto_commit(
 
     // Reset CDC transaction ID after successful COMMIT or ROLLBACK.
     conn.set_cdc_transaction_id(-1);
+    if matches!(tx_op, TxOp::Commit) {
+        conn.index_methods_transaction_committed();
+    }
     conn.clear_tx_poison();
     conn.clear_named_savepoints();
 
@@ -4980,6 +5174,7 @@ pub fn op_savepoint(
                 }
             });
             pager.set_schema_cookie(None);
+            conn.index_methods_savepoint_rolled_back();
 
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
@@ -12698,6 +12893,11 @@ pub fn op_open_write(
     let mv_store = program.connection.mv_store_for_db(*db);
 
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
+        if mv_store.is_some() {
+            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
+        }
+        let context =
+            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
             let cursor_ref = &mut state.cursors[*cursor_id];
@@ -12708,7 +12908,7 @@ pub fn op_open_write(
             .as_mut()
             .expect("cursor should exist");
         let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.open_write(&program.connection, *db));
+        return_if_io!(cursor.open_write(&context));
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
@@ -12940,17 +13140,22 @@ pub fn op_index_method_create(
         return Err(LimboError::ReadOnly);
     }
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
+        if program.connection.mv_store_for_db(*db).is_some() {
+            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
+        }
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
             let cursor_ref = &mut state.cursors[*cursor_id];
             *cursor_ref = Some(Cursor::IndexMethod(cursor));
         }
+        let context =
+            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+        let cursor = state.cursors[*cursor_id]
+            .as_mut()
+            .expect("cursor should exist");
+        let cursor = cursor.as_index_method_mut();
+        return_if_io!(cursor.create(&context));
     }
-    let cursor = state.cursors[*cursor_id]
-        .as_mut()
-        .expect("cursor should exist");
-    let cursor = cursor.as_index_method_mut();
-    return_if_io!(cursor.create(&program.connection, *db));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -12967,17 +13172,22 @@ pub fn op_index_method_destroy(
         return Err(LimboError::ReadOnly);
     }
     if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
+        if program.connection.mv_store_for_db(*db).is_some() {
+            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
+        }
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
             let cursor_ref = &mut state.cursors[*cursor_id];
             *cursor_ref = Some(Cursor::IndexMethod(cursor));
         }
+        let context =
+            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+        let cursor = state.cursors[*cursor_id]
+            .as_mut()
+            .expect("cursor should exist");
+        let cursor = cursor.as_index_method_mut();
+        return_if_io!(cursor.destroy(&context));
     }
-    let cursor = state.cursors[*cursor_id]
-        .as_mut()
-        .expect("cursor should exist");
-    let cursor = cursor.as_index_method_mut();
-    return_if_io!(cursor.destroy(&program.connection, *db));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -12994,17 +13204,22 @@ pub fn op_index_method_optimize(
         return Err(LimboError::ReadOnly);
     }
     if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
+        if program.connection.mv_store_for_db(*db).is_some() {
+            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
+        }
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
             let cursor_ref = &mut state.cursors[*cursor_id];
             *cursor_ref = Some(Cursor::IndexMethod(cursor));
         }
+        let context =
+            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+        let cursor = state.cursors[*cursor_id]
+            .as_mut()
+            .expect("cursor should exist");
+        let cursor = cursor.as_index_method_mut();
+        return_if_io!(cursor.optimize(&context));
     }
-    let cursor = state.cursors[*cursor_id]
-        .as_mut()
-        .expect("cursor should exist");
-    let cursor = cursor.as_index_method_mut();
-    return_if_io!(cursor.optimize(&program.connection, *db));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13985,6 +14200,24 @@ pub fn op_close(
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Close { cursor_id }, insn);
+    if let Some(Cursor::IndexMethod(cursor)) = state.cursors[*cursor_id].as_mut() {
+        let context = state.index_method_contexts[*cursor_id]
+            .as_ref()
+            .ok_or_else(|| {
+                LimboError::InternalError(format!(
+                    "index-method cursor {cursor_id} closed without an execution context"
+                ))
+            })?
+            .clone();
+        return_if_io!(cursor.prepare_statement_commit(&context));
+        let Some(Cursor::IndexMethod(cursor)) = state.cursors[*cursor_id].take() else {
+            unreachable!("cursor variant checked above");
+        };
+        let context = state.index_method_contexts[*cursor_id]
+            .take()
+            .expect("index-method context checked above");
+        state.closed_index_method_cursors.push((cursor, context));
+    }
     let cursors = &mut state.cursors;
     cursors
         .get_mut(*cursor_id)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12939,10 +12939,6 @@ pub fn op_index_method_create(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    let mv_store = program.connection.mv_store_for_db(*db);
-    if let Some(_mv_store) = mv_store.as_ref() {
-        todo!("MVCC is not supported yet");
-    }
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
@@ -12969,10 +12965,6 @@ pub fn op_index_method_destroy(
     load_insn!(IndexMethodDestroy { db, cursor_id }, insn);
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
-    }
-    let mv_store = program.connection.mv_store_for_db(*db);
-    if let Some(_mv_store) = mv_store.as_ref() {
-        todo!("MVCC is not supported yet");
     }
     if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
         if state.cursors[*cursor_id].is_none() {
@@ -13001,10 +12993,6 @@ pub fn op_index_method_optimize(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    let mv_store = program.connection.mv_store_for_db(*db);
-    if let Some(_mv_store) = mv_store.as_ref() {
-        todo!("MVCC is not supported yet");
-    }
     if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
@@ -13023,7 +13011,7 @@ pub fn op_index_method_optimize(
 }
 
 pub fn op_index_method_query(
-    program: &Program,
+    _program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
@@ -13038,10 +13026,6 @@ pub fn op_index_method_query(
         },
         insn
     );
-    let mv_store = program.connection.mv_store();
-    if let Some(_mv_store) = mv_store.as_ref() {
-        todo!("MVCC is not supported yet");
-    }
     let cursor = state.cursors[*cursor_id]
         .as_mut()
         .expect("cursor should exist");

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -252,6 +252,7 @@ impl CommitState {
         connection.rollback_attached_mvcc_txs(true);
         connection.rollback_attached_wal_txns();
         connection.rollback_temp_schema();
+        connection.index_methods_transaction_rolled_back();
     }
 }
 
@@ -770,6 +771,21 @@ pub struct ProgramState {
     pub io_completions: Option<IOCompletions>,
     pub pc: InsnReference,
     pub(crate) cursors: Vec<Option<Cursor>>,
+    /// Immutable execution/storage context captured when each index-method
+    /// cursor is first opened for this statement.
+    pub(crate) index_method_contexts: Vec<Option<crate::index_method::IndexMethodContext>>,
+    /// Index-method cursors explicitly closed by bytecode after their
+    /// statement work was prepared. Retain them until commit/rollback decides
+    /// whether prepared in-memory state may be published.
+    pub(crate) closed_index_method_cursors: Vec<(
+        Box<dyn crate::index_method::IndexMethodCursor>,
+        crate::index_method::IndexMethodContext,
+    )>,
+    /// Resumption coordinates for statement-level index-method finalization.
+    pub(crate) index_method_finalize_cursor: usize,
+    pub(crate) index_method_finalize_subprogram_keys: Option<Vec<usize>>,
+    pub(crate) index_method_finalize_subprogram: usize,
+    pub(crate) index_methods_finalized: bool,
     cursor_seqs: Vec<i64>,
     registers: Box<[Register]>,
     /// Trace state: register snapshot for diffing.
@@ -838,6 +854,10 @@ pub struct ProgramState {
     /// When a constraint error occurs with FAIL resolve type in autocommit mode,
     /// we need to commit partial changes before returning the error.
     pub(crate) pending_fail_error: Option<LimboError>,
+    /// FAIL can escape a trigger before the parent reaches its Halt opcode.
+    /// Keep the error here while index-method writes from earlier rows finish
+    /// through the normal resumable I/O path.
+    pending_fail_prepare_error: Option<LimboError>,
     /// Pending CDC info to apply after the program completes successfully.
     /// Set by InitCdcVersion opcode, applied at Halt/Done so that if the
     /// transaction rolls back, the connection's CDC state remains unchanged.
@@ -893,6 +913,12 @@ impl ProgramState {
             io_completions: None,
             pc: 0,
             cursors,
+            index_method_contexts: vec![None; max_cursors],
+            closed_index_method_cursors: Vec::new(),
+            index_method_finalize_cursor: 0,
+            index_method_finalize_subprogram_keys: None,
+            index_method_finalize_subprogram: 0,
+            index_methods_finalized: false,
             cursor_seqs,
             registers,
             pre_op_registers: None,
@@ -931,6 +957,7 @@ impl ProgramState {
             n_total_change: AtomicI64::new(0),
             explain_state: RwLock::new(ExplainState::default()),
             pending_fail_error: None,
+            pending_fail_prepare_error: None,
             pending_cdc_info: None,
             subprogram_stmt_cache: HashMap::default(),
         }
@@ -996,6 +1023,7 @@ impl ProgramState {
 
         if let Some(max_cursors) = max_cursors {
             self.cursors.resize_with(max_cursors, || None);
+            self.index_method_contexts.resize_with(max_cursors, || None);
             self.cursor_seqs.resize(max_cursors, 0);
             self.deferred_seeks.resize(max_cursors, None);
         }
@@ -1008,9 +1036,26 @@ impl ProgramState {
             self.registers = registers.into_boxed_slice();
         }
         // reset cursors as they can have cached information which will be no longer relevant on next program execution
-        self.cursors.iter_mut().for_each(|c| {
-            let _ = c.take();
-        });
+        for (cursor, context) in self
+            .cursors
+            .iter_mut()
+            .zip(self.index_method_contexts.iter_mut())
+        {
+            if let (Some(Cursor::IndexMethod(cursor)), Some(context)) =
+                (cursor.as_mut(), context.as_ref())
+            {
+                cursor.close(context);
+            }
+            let _ = cursor.take();
+            *context = None;
+        }
+        for (mut cursor, context) in self.closed_index_method_cursors.drain(..) {
+            cursor.close(&context);
+        }
+        self.index_method_finalize_cursor = 0;
+        self.index_method_finalize_subprogram_keys = None;
+        self.index_method_finalize_subprogram = 0;
+        self.index_methods_finalized = false;
         for r in self.registers.iter_mut() {
             match r {
                 Register::Value(v) => *v = Value::Null,
@@ -1060,6 +1105,7 @@ impl ProgramState {
         self.n_total_change.store(0, Ordering::SeqCst);
         *self.explain_state.write() = ExplainState::default();
         self.pending_fail_error = None;
+        self.pending_fail_prepare_error = None;
         self.pending_cdc_info = None;
         self.subprogram_stmt_cache.clear();
     }
@@ -1882,6 +1928,54 @@ impl Program {
                     self.abort(pager, None, state)?;
                     return Ok(StepResult::Interrupt);
                 }
+
+                // A trigger can return FAIL before the parent program reaches
+                // Halt. FAIL keeps changes made by earlier rows, so their
+                // index-method writes must finish before abort() releases the
+                // statement savepoint and commits those partial changes.
+                if let Some(fail_error) = state.pending_fail_prepare_error.take() {
+                    match execute::index_method_prepare_statement_all(state) {
+                        Ok(IOResult::Done(())) => {
+                            if let Err(abort_err) = self.abort(pager, Some(&fail_error), state) {
+                                tracing::error!(
+                                    "Abort failed after preparing FAIL index methods: {abort_err}"
+                                );
+                            }
+                            return Err(fail_error);
+                        }
+                        Ok(IOResult::IO(io)) => {
+                            state.pending_fail_prepare_error = Some(fail_error);
+                            io.set_waker(waker);
+                            if io.is_explicit_yield() {
+                                return Ok(StepResult::Yield);
+                            }
+                            let finished = io.finished();
+                            state.io_completions = Some(io);
+                            if !finished {
+                                return Ok(StepResult::IO);
+                            }
+                            continue 'io_check;
+                        }
+                        Err(prepare_error) => {
+                            // FAIL may keep earlier base-table rows only when every
+                            // matching index-method write was staged successfully.
+                            // Once preparation fails, committing those rows would
+                            // leave the table and index out of sync, so roll back the
+                            // whole transaction while returning the real preparation
+                            // error to the caller.
+                            let rollback_error =
+                                LimboError::Raise(ResolveType::Rollback, prepare_error.to_string());
+                            if let Err(abort_err) = self.abort(pager, Some(&rollback_error), state)
+                            {
+                                tracing::error!(
+                                    "Abort also failed after FAIL index-method preparation: \
+                                     {abort_err}"
+                                );
+                            }
+                            return Err(prepare_error);
+                        }
+                    }
+                }
                 let (insn, _) = &self.insns[state.pc as usize];
                 let insn_function = insn.to_function();
                 if enable_tracing {
@@ -1980,6 +2074,13 @@ impl Program {
                         // However, for auto-commits or BEGIN IMMEDIATE, failing to promote to write transaction means it was rolled
                         // back, so auto-retrying can be useful.
                         return Ok(StepResult::Busy);
+                    }
+                    Err(err)
+                        if (matches!(err, LimboError::Constraint(_))
+                            && self.resolve_type == ResolveType::Fail)
+                            || matches!(err, LimboError::Raise(ResolveType::Fail, _)) =>
+                    {
+                        state.pending_fail_prepare_error = Some(err);
                     }
                     Err(err) => {
                         if let Err(abort_err) = self.abort(pager, Some(&err), state) {
@@ -2632,6 +2733,9 @@ impl Program {
         // nested helper statements whose drop releases nested guards. Drop
         // them before the `is_nested_stmt()` check below for the same reason.
         state.close_virtual_table_cursors();
+        if err.is_some() || state.execution_state.is_running() {
+            execute::index_method_abort_statement_all(state);
+        }
 
         // Only end trigger execution if the subprogram was actually running.
         // Cached (pooled) statements may be dropped after their trigger execution
@@ -2817,12 +2921,27 @@ impl Program {
                                         "vtab_commit_all failed during FAIL abort",
                                     );
                                 }
-                                if let Err(e) = execute::index_method_pre_commit_all(state, pager) {
-                                    capture_abort_error(
-                                        &mut abort_error,
-                                        e,
-                                        "index_method_pre_commit_all failed during FAIL abort",
-                                    );
+                                match execute::index_method_prepare_statement_all(state) {
+                                    Ok(IOResult::Done(())) => {}
+                                    Ok(IOResult::IO(io)) => {
+                                        io.abort();
+                                        capture_abort_error(
+                                            &mut abort_error,
+                                            LimboError::InternalError(
+                                                "FAIL cleanup reached asynchronous index-method \
+                                                 finalization outside the resumable Halt path"
+                                                    .to_string(),
+                                            ),
+                                            "index-method finalization yielded during FAIL abort",
+                                        );
+                                    }
+                                    Err(e) => {
+                                        capture_abort_error(
+                                            &mut abort_error,
+                                            e,
+                                            "index-method finalization failed during FAIL abort",
+                                        );
+                                    }
                                 }
                                 loop {
                                     match self.commit_txn(

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -6,7 +6,123 @@ use crate::mvcc::cursor::CursorYieldPoint;
 use crate::mvcc::yield_hooks::YieldPointMarker;
 use crate::mvcc::yield_points::{YieldInjector, YieldPoint};
 use crate::sync::{Arc, Mutex};
+#[cfg(feature = "fts")]
+use crate::StepResult;
 use crate::{Connection, Database, DatabaseOpts, LimboError, OpenFlags, Result, Value};
+
+#[derive(Debug)]
+struct FailingPrepareIndexMethod;
+
+#[derive(Debug)]
+struct FailingPrepareAttachment {
+    table_name: String,
+    index_name: String,
+}
+
+#[derive(Debug, Default)]
+struct FailingPrepareCursor {
+    dirty: bool,
+}
+
+impl crate::index_method::IndexMethod for FailingPrepareIndexMethod {
+    fn attach(
+        &self,
+        configuration: &crate::index_method::IndexMethodConfiguration,
+    ) -> Result<Arc<dyn crate::index_method::IndexMethodAttachment>> {
+        Ok(Arc::new(FailingPrepareAttachment {
+            table_name: configuration.table_name.clone(),
+            index_name: configuration.index_name.clone(),
+        }))
+    }
+}
+
+impl crate::index_method::IndexMethodAttachment for FailingPrepareAttachment {
+    fn definition<'a>(&'a self) -> crate::index_method::IndexMethodDefinition<'a> {
+        crate::index_method::IndexMethodDefinition {
+            method_name: "failing_prepare",
+            table_name: &self.table_name,
+            index_name: &self.index_name,
+            patterns: &[],
+            backing_btree: false,
+            results_materialized: true,
+            mvcc_support: crate::index_method::IndexMethodMvccSupport::ExternalTransactional,
+        }
+    }
+
+    fn init(&self) -> Result<Box<dyn crate::index_method::IndexMethodCursor>> {
+        Ok(Box::new(FailingPrepareCursor::default()))
+    }
+}
+
+impl crate::index_method::IndexMethodCursor for FailingPrepareCursor {
+    fn create(
+        &mut self,
+        _context: &crate::index_method::IndexMethodContext,
+    ) -> Result<crate::IOResult<()>> {
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn destroy(
+        &mut self,
+        _context: &crate::index_method::IndexMethodContext,
+    ) -> Result<crate::IOResult<()>> {
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn open_read(
+        &mut self,
+        _context: &crate::index_method::IndexMethodContext,
+    ) -> Result<crate::IOResult<()>> {
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn open_write(
+        &mut self,
+        _context: &crate::index_method::IndexMethodContext,
+    ) -> Result<crate::IOResult<()>> {
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn insert(&mut self, _values: &[crate::vdbe::Register]) -> Result<crate::IOResult<()>> {
+        self.dirty = true;
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn delete(&mut self, _values: &[crate::vdbe::Register]) -> Result<crate::IOResult<()>> {
+        self.dirty = true;
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn query_start(&mut self, _values: &[crate::vdbe::Register]) -> Result<crate::IOResult<bool>> {
+        Ok(crate::IOResult::Done(false))
+    }
+
+    fn query_next(&mut self) -> Result<crate::IOResult<bool>> {
+        Ok(crate::IOResult::Done(false))
+    }
+
+    fn query_column(&mut self, _idx: usize) -> Result<crate::IOResult<Value>> {
+        Err(LimboError::InternalError(
+            "failing_prepare has no query rows".to_string(),
+        ))
+    }
+
+    fn query_rowid(&mut self) -> Result<crate::IOResult<Option<i64>>> {
+        Ok(crate::IOResult::Done(None))
+    }
+
+    fn prepare_statement_commit(
+        &mut self,
+        _context: &crate::index_method::IndexMethodContext,
+    ) -> Result<crate::IOResult<()>> {
+        if self.dirty {
+            return Err(LimboError::InternalError(
+                "forced index-method preparation failure".to_string(),
+            ));
+        }
+        Ok(crate::IOResult::Done(()))
+    }
+}
 
 #[derive(Debug)]
 struct FixedYieldInjector {
@@ -47,6 +163,103 @@ fn get_rows(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
     })
     .unwrap();
     rows
+}
+
+#[test]
+fn fail_rolls_back_base_rows_when_index_method_preparation_fails() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io,
+        ":memory:index-method-failing-prepare",
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    db.builtin_syms.write().index_methods.insert(
+        "failing_prepare".to_string(),
+        Arc::new(FailingPrepareIndexMethod),
+    );
+    let conn = db.connect().unwrap();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fail ON docs USING failing_prepare(body)")
+        .unwrap();
+    conn.execute(
+        "CREATE TRIGGER fail_second BEFORE INSERT ON docs WHEN NEW.id = 2 BEGIN \
+         SELECT RAISE(FAIL, 'stop'); END",
+    )
+    .unwrap();
+
+    let error = conn
+        .execute("INSERT INTO docs VALUES (1, 'first'), (2, 'second')")
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("forced index-method preparation failure"),
+        "unexpected error: {error}"
+    );
+    assert!(get_rows(&conn, "SELECT id FROM docs").is_empty());
+}
+
+#[cfg(feature = "fts")]
+#[test]
+fn abandoning_after_index_method_prepare_rolls_back_without_drop_io() {
+    use crate::index_method::IndexMethodYieldPoint;
+
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        ":memory:index-method-finalize-abandon",
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.set_yield_injector(Some(FixedYieldInjector::new([
+        IndexMethodYieldPoint::AfterPrepareStatement.point(),
+    ])));
+    let mut insert = conn
+        .prepare("INSERT INTO docs VALUES (1, 'abandoned after prepare')")
+        .unwrap();
+    loop {
+        match insert.step().unwrap() {
+            StepResult::IO => io.step().unwrap(),
+            StepResult::Yield => break,
+            StepResult::Done => panic!("INSERT completed before the injected finalization yield"),
+            other => panic!("unexpected INSERT result: {other:?}"),
+        }
+    }
+    drop(insert);
+    conn.set_yield_injector(None);
+
+    assert!(get_rows(&conn, "SELECT id FROM docs").is_empty());
+    assert!(get_rows(
+        &conn,
+        "SELECT id FROM docs WHERE fts_match(body, 'abandoned')"
+    )
+    .is_empty());
+
+    conn.execute("INSERT INTO docs VALUES (2, 'surviving retry')")
+        .unwrap();
+    assert_eq!(
+        get_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'surviving')"
+        ),
+        vec![vec![Value::from_i64(2)]]
+    );
 }
 
 fn open_mvcc_database_with_opts(path: &str, opts: DatabaseOpts) -> Arc<Database> {

--- a/perf/memory/Cargo.toml
+++ b/perf/memory/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/stack_report.rs"
 stacker = ["turso/stacker"]
 
 [dependencies]
-turso = { path = "../../bindings/rust", default-features = false }
+turso = { path = "../../bindings/rust", default-features = false, features = ["fts"] }
 turso_parser = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, default-features = true, features = ["full"] }

--- a/perf/memory/codspeed/benches/memory_profiles.rs
+++ b/perf/memory/codspeed/benches/memory_profiles.rs
@@ -28,7 +28,7 @@ use memory_benchmark::workload::{
 
 const MODES: [JournalMode; 2] = [JournalMode::Wal, JournalMode::Mvcc];
 
-const WORKLOADS: [WorkloadProfile; 7] = [
+const WORKLOADS: [WorkloadProfile; 9] = [
     WorkloadProfile::InsertHeavy,
     WorkloadProfile::ReadHeavy,
     WorkloadProfile::Mixed,
@@ -36,6 +36,8 @@ const WORKLOADS: [WorkloadProfile; 7] = [
     WorkloadProfile::RecursiveCte,
     WorkloadProfile::SeriesBlob,
     WorkloadProfile::UpdateChurn,
+    WorkloadProfile::FtsQueryChurn,
+    WorkloadProfile::FtsUpdateChurn,
 ];
 
 /// Workload scale series: the base iteration count is multiplied by each of
@@ -61,6 +63,7 @@ fn base_workload_size(workload: WorkloadProfile) -> (usize, usize) {
     match workload {
         WorkloadProfile::ScanHeavy => (5, 2),
         WorkloadProfile::RecursiveCte => (2, 100),
+        WorkloadProfile::FtsQueryChurn | WorkloadProfile::FtsUpdateChurn => (5, 10),
         _ => (10, 50),
     }
 }
@@ -72,22 +75,26 @@ fn bench_memory_profiles(c: &mut Criterion) {
 
     for mode in MODES {
         for workload in WORKLOADS {
-            for multiplier in SIZE_MULTIPLIERS {
-                bench_workload(c, &work_dir, mode, workload, multiplier, false);
+            let connection_counts: &[usize] = match workload {
+                WorkloadProfile::FtsQueryChurn | WorkloadProfile::FtsUpdateChurn => &[1, 4],
+                _ => &[1],
+            };
+            for &connections in connection_counts {
+                for multiplier in SIZE_MULTIPLIERS {
+                    bench_workload(c, &work_dir, mode, workload, connections, multiplier, false);
+                }
+                // Bigger checkpointed variant: low MVCC auto-checkpoint
+                // threshold plus a final explicit checkpoint.
+                bench_workload(
+                    c,
+                    &work_dir,
+                    mode,
+                    workload,
+                    connections,
+                    CHECKPOINT_SIZE_MULTIPLIER,
+                    true,
+                );
             }
-            // Bigger checkpointed variant: low MVCC auto-checkpoint threshold
-            // plus a final explicit `PRAGMA wal_checkpoint(TRUNCATE)` (the
-            // only guaranteed checkpoint in WAL mode, whose 1000-frame
-            // auto-checkpoint threshold is not configurable), so checkpoint
-            // memory behavior is part of the measurement.
-            bench_workload(
-                c,
-                &work_dir,
-                mode,
-                workload,
-                CHECKPOINT_SIZE_MULTIPLIER,
-                true,
-            );
         }
     }
 }
@@ -98,6 +105,7 @@ fn bench_workload(
     work_dir: &std::path::Path,
     mode: JournalMode,
     workload: WorkloadProfile,
+    connections: usize,
     multiplier: usize,
     checkpoint: bool,
 ) {
@@ -110,7 +118,7 @@ fn bench_workload(
         workload,
         iterations,
         batch_size,
-        connections: 1,
+        connections,
         timeout: Duration::from_millis(30_000),
         cache_size: None,
         checkpoint,
@@ -119,22 +127,27 @@ fn bench_workload(
         mvcc_gc_threshold: (matches!(mode, JournalMode::Mvcc)).then_some(16384i64),
     };
     let db_path = work_dir
-        .join(format!("{mode}_{workload}_{total_ops}{suffix}.db"))
+        .join(format!(
+            "{mode}_{workload}_{connections}-connections_{total_ops}{suffix}.db"
+        ))
         .to_string_lossy()
         .into_owned();
 
     let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(1)
+        .worker_threads(connections)
         .build()
         .expect("failed to build tokio runtime");
 
-    c.bench_function(&format!("{mode}/{workload}/{total_ops}{suffix}"), |b| {
-        b.iter(|| {
-            clean_db_files(&db_path);
-            rt.block_on(run_workload(&db_path, &cfg, &mut ()))
-                .expect("workload failed");
-        });
-    });
+    c.bench_function(
+        &format!("{mode}/{workload}/{connections}-connections/{total_ops}{suffix}"),
+        |b| {
+            b.iter(|| {
+                clean_db_files(&db_path);
+                rt.block_on(run_workload(&db_path, &cfg, &mut ()))
+                    .expect("workload failed");
+            });
+        },
+    );
 
     clean_db_files(&db_path);
 }

--- a/perf/memory/src/profile/fts_query_churn.rs
+++ b/perf/memory/src/profile/fts_query_churn.rs
@@ -1,0 +1,146 @@
+use super::{Phase, Profile, WorkItem};
+
+const SEED_ROWS: usize = 2_000;
+const QUERY_TERMS: [&str; 8] = [
+    "database",
+    "transaction",
+    "storage",
+    "index",
+    "replication",
+    "search",
+    "rust",
+    "sqlite",
+];
+
+/// Repeated full-text queries over a fixed FTS index.
+///
+/// Multiple connections intentionally query the same index. This makes the
+/// profile sensitive to snapshot reader and immutable index cache
+/// multiplication without introducing writer conflicts.
+pub struct FtsQueryChurn {
+    iterations: usize,
+    batch_size: usize,
+    current_iteration: usize,
+    phase: InternalPhase,
+    seed_offset: usize,
+}
+
+enum InternalPhase {
+    CreateSchema,
+    Seed,
+    Run,
+}
+
+impl FtsQueryChurn {
+    pub fn new(iterations: usize, batch_size: usize) -> Self {
+        Self {
+            iterations,
+            batch_size,
+            current_iteration: 0,
+            phase: InternalPhase::CreateSchema,
+            seed_offset: 0,
+        }
+    }
+}
+
+impl Profile for FtsQueryChurn {
+    fn name(&self) -> &str {
+        "fts-query-churn"
+    }
+
+    fn next_batch(&mut self, connections: usize) -> (Phase, Vec<Vec<WorkItem>>) {
+        match self.phase {
+            InternalPhase::CreateSchema => {
+                self.phase = InternalPhase::Seed;
+                (
+                    Phase::Setup,
+                    vec![vec![
+                        WorkItem {
+                            sql: "CREATE TABLE fts_query_docs (id INTEGER PRIMARY KEY, title TEXT NOT NULL, body TEXT NOT NULL)".to_string(),
+                            params: vec![],
+                        },
+                        WorkItem {
+                            sql: "CREATE INDEX fts_query_docs_idx ON fts_query_docs USING fts (title, body)".to_string(),
+                            params: vec![],
+                        },
+                    ]],
+                )
+            }
+            InternalPhase::Seed => {
+                let remaining = SEED_ROWS - self.seed_offset;
+                let batch = remaining.min(500);
+                let mut items = Vec::with_capacity(batch);
+                for i in 0..batch {
+                    let id = self.seed_offset + i;
+                    let primary_term = QUERY_TERMS[id % QUERY_TERMS.len()];
+                    let secondary_term = QUERY_TERMS[(id * 5 + 3) % QUERY_TERMS.len()];
+                    items.push(WorkItem {
+                        sql: "INSERT INTO fts_query_docs (id, title, body) VALUES (?, ?, ?)"
+                            .to_string(),
+                        params: vec![
+                            turso::Value::Integer(id as i64),
+                            turso::Value::Text(format!("{primary_term} document {id}")),
+                            turso::Value::Text(format!(
+                                "{primary_term} {secondary_term} benchmark payload {id}"
+                            )),
+                        ],
+                    });
+                }
+                self.seed_offset += batch;
+                if self.seed_offset >= SEED_ROWS {
+                    self.phase = InternalPhase::Run;
+                }
+                (Phase::Setup, vec![items])
+            }
+            InternalPhase::Run => {
+                if self.current_iteration >= self.iterations {
+                    return (Phase::Done, vec![]);
+                }
+
+                let connection_count = connections.max(1);
+                let mut batches = Vec::with_capacity(connection_count);
+                for connection in 0..connection_count {
+                    let mut items = Vec::with_capacity(self.batch_size);
+                    for item in 0..self.batch_size {
+                        let term =
+                            QUERY_TERMS[(self.current_iteration + connection * 3 + item * 5)
+                                % QUERY_TERMS.len()];
+                        items.push(WorkItem {
+                            sql: format!(
+                                "SELECT id FROM fts_query_docs WHERE fts_match(title, body, '{term}') ORDER BY id LIMIT 50"
+                            ),
+                            params: vec![],
+                        });
+                    }
+                    batches.push(items);
+                }
+
+                self.current_iteration += 1;
+                (Phase::Run, batches)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn four_connections_query_the_same_index() {
+        let mut profile = FtsQueryChurn::new(1, 3);
+
+        loop {
+            let (phase, batches) = profile.next_batch(4);
+            if phase == Phase::Run {
+                assert_eq!(batches.len(), 4);
+                assert!(batches.iter().all(|batch| batch.len() == 3));
+                assert!(batches.iter().flatten().all(|item| {
+                    item.sql.contains("FROM fts_query_docs")
+                        && item.sql.contains("fts_match(title, body")
+                }));
+                break;
+            }
+        }
+    }
+}

--- a/perf/memory/src/profile/fts_update_churn.rs
+++ b/perf/memory/src/profile/fts_update_churn.rs
@@ -1,0 +1,174 @@
+use super::{Phase, Profile, WorkItem};
+
+const SEED_ROWS_PER_INDEX: usize = 2_000;
+const SEED_BATCH_SIZE: usize = 500;
+const TERMS: [&str; 8] = [
+    "database",
+    "transaction",
+    "storage",
+    "index",
+    "replication",
+    "search",
+    "rust",
+    "sqlite",
+];
+
+/// Repeated updates to fixed-size, full-text-indexed tables.
+///
+/// The FTS MVCC contract permits one active writer per index. To measure four
+/// concurrent writers without turning expected same-index conflicts into
+/// benchmark failures, each connection owns a separate table and index. Every
+/// table retains a bounded live document set while accumulating FTS and MVCC
+/// update churn.
+pub struct FtsUpdateChurn {
+    iterations: usize,
+    batch_size: usize,
+    current_iteration: usize,
+    phase: InternalPhase,
+    configured_connections: usize,
+    seed_connection: usize,
+    seed_offset: usize,
+}
+
+enum InternalPhase {
+    CreateSchema,
+    Seed,
+    Run,
+}
+
+impl FtsUpdateChurn {
+    pub fn new(iterations: usize, batch_size: usize) -> Self {
+        Self {
+            iterations,
+            batch_size,
+            current_iteration: 0,
+            phase: InternalPhase::CreateSchema,
+            configured_connections: 0,
+            seed_connection: 0,
+            seed_offset: 0,
+        }
+    }
+}
+
+impl Profile for FtsUpdateChurn {
+    fn name(&self) -> &str {
+        "fts-update-churn"
+    }
+
+    fn next_batch(&mut self, connections: usize) -> (Phase, Vec<Vec<WorkItem>>) {
+        match self.phase {
+            InternalPhase::CreateSchema => {
+                self.configured_connections = connections.max(1);
+                self.phase = InternalPhase::Seed;
+
+                let mut items = Vec::with_capacity(self.configured_connections * 2);
+                for connection in 0..self.configured_connections {
+                    items.push(WorkItem {
+                        sql: format!(
+                            "CREATE TABLE fts_update_docs_{connection} (id INTEGER PRIMARY KEY, body TEXT NOT NULL)"
+                        ),
+                        params: vec![],
+                    });
+                    items.push(WorkItem {
+                        sql: format!(
+                            "CREATE INDEX fts_update_docs_{connection}_idx ON fts_update_docs_{connection} USING fts (body)"
+                        ),
+                        params: vec![],
+                    });
+                }
+                (Phase::Setup, vec![items])
+            }
+            InternalPhase::Seed => {
+                let remaining = SEED_ROWS_PER_INDEX - self.seed_offset;
+                let batch = remaining.min(SEED_BATCH_SIZE);
+                let mut items = Vec::with_capacity(batch);
+                for i in 0..batch {
+                    let id = self.seed_offset + i;
+                    let term = TERMS[(id + self.seed_connection * 3) % TERMS.len()];
+                    items.push(WorkItem {
+                        sql: format!(
+                            "INSERT INTO fts_update_docs_{} (id, body) VALUES (?, ?)",
+                            self.seed_connection
+                        ),
+                        params: vec![
+                            turso::Value::Integer(id as i64),
+                            turso::Value::Text(format!("{term} initial document {id}")),
+                        ],
+                    });
+                }
+
+                self.seed_offset += batch;
+                if self.seed_offset >= SEED_ROWS_PER_INDEX {
+                    self.seed_connection += 1;
+                    self.seed_offset = 0;
+                    if self.seed_connection >= self.configured_connections {
+                        self.phase = InternalPhase::Run;
+                    }
+                }
+                (Phase::Setup, vec![items])
+            }
+            InternalPhase::Run => {
+                if self.current_iteration >= self.iterations {
+                    return (Phase::Done, vec![]);
+                }
+
+                let mut batches = Vec::with_capacity(self.configured_connections);
+                for connection in 0..self.configured_connections {
+                    let mut items = Vec::with_capacity(self.batch_size);
+                    for item in 0..self.batch_size {
+                        let id = (self.current_iteration * self.batch_size
+                            + item * 31
+                            + connection * 17)
+                            % SEED_ROWS_PER_INDEX;
+                        let term =
+                            TERMS[(self.current_iteration + item + connection) % TERMS.len()];
+                        items.push(WorkItem {
+                            sql: format!(
+                                "UPDATE fts_update_docs_{connection} SET body = ? WHERE id = ?"
+                            ),
+                            params: vec![
+                                turso::Value::Text(format!(
+                                    "{term} updated generation {} document {id}",
+                                    self.current_iteration
+                                )),
+                                turso::Value::Integer(id as i64),
+                            ],
+                        });
+                    }
+                    batches.push(items);
+                }
+
+                self.current_iteration += 1;
+                (Phase::Run, batches)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn four_connections_update_distinct_indexes() {
+        let mut profile = FtsUpdateChurn::new(1, 3);
+        let (phase, schema_batches) = profile.next_batch(4);
+        assert_eq!(phase, Phase::Setup);
+        assert_eq!(schema_batches[0].len(), 8);
+
+        loop {
+            let (phase, batches) = profile.next_batch(4);
+            if phase == Phase::Run {
+                assert_eq!(batches.len(), 4);
+                for (connection, batch) in batches.iter().enumerate() {
+                    assert_eq!(batch.len(), 3);
+                    assert!(batch.iter().all(|item| {
+                        item.sql
+                            .starts_with(&format!("UPDATE fts_update_docs_{connection} "))
+                    }));
+                }
+                break;
+            }
+        }
+    }
+}

--- a/perf/memory/src/profile/mod.rs
+++ b/perf/memory/src/profile/mod.rs
@@ -1,4 +1,6 @@
 pub mod checkpoint;
+pub mod fts_query_churn;
+pub mod fts_update_churn;
 pub mod insert;
 pub mod mixed;
 pub mod read;

--- a/perf/memory/src/workload.rs
+++ b/perf/memory/src/workload.rs
@@ -6,8 +6,9 @@ use turso::Connection;
 use turso::params::Params;
 
 use super::profile::{
-    Phase, Profile, WorkItem, checkpoint::Checkpoint, insert::InsertHeavy, mixed::Mixed,
-    read::ReadHeavy, recursive_cte::RecursiveCte, scan::ScanHeavy, series_blob::SeriesBlob,
+    Phase, Profile, WorkItem, checkpoint::Checkpoint, fts_query_churn::FtsQueryChurn,
+    fts_update_churn::FtsUpdateChurn, insert::InsertHeavy, mixed::Mixed, read::ReadHeavy,
+    recursive_cte::RecursiveCte, scan::ScanHeavy, series_blob::SeriesBlob,
     update_churn::UpdateChurn,
 };
 
@@ -35,6 +36,8 @@ pub enum WorkloadProfile {
     RecursiveCte,
     SeriesBlob,
     UpdateChurn,
+    FtsQueryChurn,
+    FtsUpdateChurn,
 }
 
 impl std::fmt::Display for WorkloadProfile {
@@ -47,6 +50,8 @@ impl std::fmt::Display for WorkloadProfile {
             WorkloadProfile::RecursiveCte => write!(f, "recursive-cte"),
             WorkloadProfile::SeriesBlob => write!(f, "series-blob"),
             WorkloadProfile::UpdateChurn => write!(f, "update-churn"),
+            WorkloadProfile::FtsQueryChurn => write!(f, "fts-query-churn"),
+            WorkloadProfile::FtsUpdateChurn => write!(f, "fts-update-churn"),
         }
     }
 }
@@ -97,6 +102,8 @@ pub fn create_profile(
         WorkloadProfile::RecursiveCte => Box::new(RecursiveCte::new(iterations, batch_size)),
         WorkloadProfile::SeriesBlob => Box::new(SeriesBlob::new(iterations, batch_size)),
         WorkloadProfile::UpdateChurn => Box::new(UpdateChurn::new(iterations, batch_size)),
+        WorkloadProfile::FtsQueryChurn => Box::new(FtsQueryChurn::new(iterations, batch_size)),
+        WorkloadProfile::FtsUpdateChurn => Box::new(FtsUpdateChurn::new(iterations, batch_size)),
     };
 
     if checkpoint {
@@ -116,7 +123,10 @@ pub async fn run_workload(
     let mut profile = create_profile(cfg.workload, cfg.iterations, cfg.batch_size, cfg.checkpoint);
     let workload_name = profile.name().to_string();
 
-    let db = turso::Builder::new_local(db_path).build().await?;
+    let db = turso::Builder::new_local(db_path)
+        .experimental_index_method(true)
+        .build()
+        .await?;
 
     // Setup connection for schema/seeding and journal mode
     let setup_conn = db.connect()?;

--- a/tests/fuzz/fts.rs
+++ b/tests/fuzz/fts.rs
@@ -89,18 +89,20 @@ mod tests {
         history.push(sql);
     }
 
-    /// Model-based FTS churn fuzzing.
+    /// Model-based FTS churn fuzzing shared by WAL and MVCC.
     ///
-    /// The vocabulary and queries are deliberately simple so the oracle does not
-    /// duplicate Tantivy's query parser. The generated operation stream stresses
-    /// index maintenance, transaction/savepoint rollback, cache invalidation,
-    /// explicit optimization, and visibility across connections.
-    #[test]
-    fn fts_index_maintenance_model_fuzz() {
-        let (mut rng, seed) = helpers::init_fuzz_test_tracing("fts_index_maintenance_model_fuzz");
-        let db = TempDatabase::builder()
-            .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
-            .build();
+    /// The vocabulary and queries are deliberately simple so the oracle does
+    /// not duplicate Tantivy's query parser. The generated operation stream
+    /// stresses index maintenance, transaction/savepoint rollback, cache
+    /// validation, explicit optimization, and visibility across connections.
+    fn run_fts_index_maintenance_model_fuzz(test_name: &str, mvcc: bool) {
+        let (mut rng, seed) = helpers::init_fuzz_test_tracing(test_name);
+        let mut builder = TempDatabase::builder()
+            .with_opts(turso_core::DatabaseOpts::new().with_index_method(true));
+        if mvcc {
+            builder = builder.with_mvcc(true);
+        }
+        let db = builder.build();
         let writer = db.connect_limbo();
         let observer = db.connect_limbo();
 
@@ -116,22 +118,23 @@ mod tests {
         let mut in_transaction = false;
         let mut next_id = 1i64;
         let mut history = vec![
+            format!("journal_mode={}", if mvcc { "mvcc" } else { "wal" }),
             "CREATE TABLE docs(id INTEGER PRIMARY KEY, content TEXT)".to_string(),
             "CREATE INDEX docs_fts ON docs USING fts(content)".to_string(),
         ];
 
         let iterations = helpers::fuzz_iterations(300);
         for iteration in 0..iterations {
-            helpers::log_progress(
-                "fts_index_maintenance_model_fuzz",
-                iteration,
-                iterations,
-                20,
-            );
+            helpers::log_progress(test_name, iteration, iterations, 20);
 
             match rng.random_range(0..100) {
                 0..=7 if !in_transaction => {
-                    execute(&writer, "BEGIN".to_string(), &mut history);
+                    let begin = if mvcc && rng.random_bool(0.5) {
+                        "BEGIN CONCURRENT"
+                    } else {
+                        "BEGIN"
+                    };
+                    execute(&writer, begin.to_string(), &mut history);
                     in_transaction = true;
                 }
                 0..=3 if in_transaction => {
@@ -273,6 +276,103 @@ mod tests {
         for token in TOKENS {
             assert_matches_model(&writer, &visible, token, seed, &history, "writer");
             assert_matches_model(&observer, &visible, token, seed, &history, "observer");
+        }
+    }
+
+    #[test]
+    fn fts_index_maintenance_model_fuzz_wal() {
+        run_fts_index_maintenance_model_fuzz("fts_index_maintenance_model_fuzz_wal", false);
+    }
+
+    #[test]
+    fn fts_index_maintenance_model_fuzz_mvcc() {
+        run_fts_index_maintenance_model_fuzz("fts_index_maintenance_model_fuzz_mvcc", true);
+    }
+
+    #[test]
+    fn fts_same_index_writer_lease_model_fuzz_mvcc() {
+        let (mut rng, seed) =
+            helpers::init_fuzz_test_tracing("fts_same_index_writer_lease_model_fuzz_mvcc");
+        let db = TempDatabase::builder()
+            .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+            .with_mvcc(true)
+            .build();
+        let connections = [db.connect_limbo(), db.connect_limbo()];
+        connections[0]
+            .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, content TEXT)")
+            .unwrap();
+        connections[0]
+            .execute("CREATE INDEX docs_fts ON docs USING fts(content)")
+            .unwrap();
+
+        let mut committed = Model::new();
+        let mut history = vec![
+            "journal_mode=mvcc".to_string(),
+            "CREATE TABLE docs(id INTEGER PRIMARY KEY, content TEXT)".to_string(),
+            "CREATE INDEX docs_fts ON docs USING fts(content)".to_string(),
+        ];
+        let iterations = helpers::fuzz_iterations(100);
+        for iteration in 0..iterations {
+            helpers::log_progress(
+                "fts_same_index_writer_lease_model_fuzz_mvcc",
+                iteration,
+                iterations,
+                20,
+            );
+            let owner = rng.random_range(0..connections.len());
+            let contender = 1 - owner;
+            execute(
+                &connections[owner],
+                "BEGIN CONCURRENT".to_string(),
+                &mut history,
+            );
+            execute(
+                &connections[contender],
+                "BEGIN CONCURRENT".to_string(),
+                &mut history,
+            );
+
+            let committed_id = iteration as i64 * 2 + 1;
+            let rejected_id = committed_id + 1;
+            let token = TOKENS.choose(&mut rng).unwrap();
+            let content = Some((*token).to_string());
+            execute(
+                &connections[owner],
+                format!(
+                    "INSERT INTO docs VALUES ({committed_id}, {})",
+                    sql_text(&content)
+                ),
+                &mut history,
+            );
+            let contender_sql =
+                format!("INSERT INTO docs VALUES ({rejected_id}, 'should_not_commit')");
+            let conflict = connections[contender].execute(&contender_sql).unwrap_err();
+            history.push(format!("{contender_sql} -> {conflict}"));
+            assert!(
+                matches!(conflict, turso_core::LimboError::WriteWriteConflict),
+                "same-index contender returned {conflict}; seed={seed}\n{}",
+                helpers::history_tail(&history, 40)
+            );
+
+            execute(&connections[owner], "COMMIT".to_string(), &mut history);
+            committed.insert(committed_id, content);
+            assert_matches_model(
+                &connections[contender],
+                &committed,
+                token,
+                seed,
+                &history,
+                "contender",
+            );
+            assert!(
+                limbo_exec_rows(
+                    &connections[contender],
+                    &format!("SELECT id FROM docs WHERE id = {rejected_id}")
+                )
+                .is_empty(),
+                "lease loser published its base row; seed={seed}\n{}",
+                helpers::history_tail(&history, 40)
+            );
         }
     }
 }

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -387,6 +387,40 @@ fn test_attach_inherits_index_method_flag_on_reattach(_tmp_db: TempDatabase) -> 
     Ok(())
 }
 
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test]
+fn test_attached_mvcc_fts_uses_attached_store(_tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let db = attach_enabled_db(DatabaseOpts::new().with_index_method(true));
+    let conn = db.connect_limbo();
+    let aux_path = db.path.with_extension("attached_mvcc_fts.db");
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("PRAGMA aux.journal_mode = 'experimental_mvcc'")?;
+    conn.execute("CREATE TABLE aux.docs(id INTEGER PRIMARY KEY, content TEXT)")?;
+    conn.execute("CREATE INDEX aux.docs_fts ON docs USING fts(content)")?;
+
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO aux.docs VALUES (1, 'attached committed')")?;
+    conn.execute("COMMIT")?;
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO aux.docs VALUES (2, 'attached rolledback')")?;
+    conn.execute("ROLLBACK")?;
+
+    let committed: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'committed')");
+    assert_eq!(committed, vec![(1,)]);
+    let rolled_back: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'rolledback')");
+    assert!(rolled_back.is_empty());
+
+    conn.execute("DETACH aux")?;
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    let recovered: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'attached')");
+    assert_eq!(recovered, vec![(1,)]);
+    Ok(())
+}
+
 #[test]
 fn test_attach_create_stores_canonical_schema_sql() -> anyhow::Result<()> {
     let aux_db = TempDatabase::builder().build();

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -82,6 +82,25 @@ fn sparse_vector(v: &str) -> Value {
     vector::operations::serialize::vector_serialize(vector).expect(turso_core::alloc::ALLOC_ERR_MSG)
 }
 
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test]
+fn fts_mvcc_capability_is_checked_before_create(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+
+    let error = conn
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("index method 'fts' does not support MVCC"),
+        "unexpected error: {error}"
+    );
+}
+
 // TODO: cannot use MVCC as we use indexes here
 #[turso_macros::test(init_sql = "CREATE TABLE t(name, embedding)")]
 fn test_vector_sparse_ivf_create_destroy(tmp_db: TempDatabase) {

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -304,6 +304,55 @@ fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
     assert!(!run(&tmp_db, || reader.query_next()).unwrap());
 }
 
+#[turso_macros::test(mvcc)]
+fn test_vector_sparse_ivf_mvcc_sql(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE vectors(id INTEGER PRIMARY KEY, embedding)")
+        .unwrap();
+    conn.execute("CREATE INDEX vectors_idx ON vectors USING toy_vector_sparse_ivf (embedding)")
+        .unwrap();
+    conn.execute(
+        "INSERT INTO vectors VALUES \
+         (1, vector32_sparse('[1, 0, 0]')), \
+         (2, vector32_sparse('[0, 1, 0]'))",
+    )
+    .unwrap();
+
+    let nearest = |vector: &str| {
+        limbo_exec_rows(
+            &conn,
+            &format!(
+                "SELECT id FROM vectors \
+                 ORDER BY vector_distance_jaccard(embedding, vector32_sparse('{vector}')) \
+                 LIMIT 1"
+            ),
+        )
+    };
+    assert_eq!(
+        nearest("[1, 0, 0]"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("UPDATE vectors SET embedding = vector32_sparse('[0, 0, 1]') WHERE id = 1")
+        .unwrap();
+    assert_eq!(
+        nearest("[0, 0, 1]"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    conn.execute("ROLLBACK").unwrap();
+    assert_eq!(
+        nearest("[1, 0, 0]"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    assert_eq!(
+        nearest("[0, 1, 0]"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
 // TODO: cannot use MVCC as we use indexes here
 #[turso_macros::test]
 fn test_vector_sparse_ivf_fuzz(tmp_db: TempDatabase) {

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
 use std::sync::Arc;
 
 use core_tester::common::rng_from_time_or_env;
@@ -9,8 +8,8 @@ use rand_chacha::ChaCha8Rng;
 use turso_core::index_method::fts::FtsIndexMethod;
 use turso_core::{
     index_method::{
-        toy_vector_sparse_ivf::VectorSparseInvertedIndexMethod, IndexMethod,
-        IndexMethodConfiguration,
+        toy_vector_sparse_ivf::VectorSparseInvertedIndexMethod, IndexMethod, IndexMethodAttachment,
+        IndexMethodConfiguration, IndexMethodContext,
     },
     schema::IndexColumn,
     types::IOResult,
@@ -33,6 +32,13 @@ fn run<T>(db: &TempDatabase, mut f: impl FnMut() -> Result<IOResult<T>>) -> Resu
     }
 }
 
+fn index_method_context(
+    connection: &Arc<turso_core::Connection>,
+    attachment: &dyn IndexMethodAttachment,
+) -> IndexMethodContext {
+    IndexMethodContext::for_test(connection, MAIN_DB_ID, attachment).unwrap()
+}
+
 #[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
 fn fts_test_stats(
     db: &TempDatabase,
@@ -53,7 +59,10 @@ fn fts_test_stats(
         })
         .unwrap();
     let mut cursor = attachment.init().unwrap();
-    run(db, || cursor.open_read(conn, MAIN_DB_ID)).unwrap();
+    run(db, || {
+        cursor.open_read(&index_method_context(conn, attachment.as_ref()))
+    })
+    .unwrap();
     cursor.test_stats().unwrap().unwrap()
 }
 
@@ -73,7 +82,10 @@ fn fts_attachment_test_stats(
         .unwrap()
         .expect("FTS attachment must exist in the connection schema");
     let mut cursor = attachment.init().unwrap();
-    run(db, || cursor.open_read(conn, MAIN_DB_ID)).unwrap();
+    run(db, || {
+        cursor.open_read(&index_method_context(conn, attachment.as_ref()))
+    })
+    .unwrap();
     cursor.test_stats().unwrap().unwrap()
 }
 
@@ -82,26 +94,7 @@ fn sparse_vector(v: &str) -> Value {
     vector::operations::serialize::vector_serialize(vector).expect(turso_core::alloc::ALLOC_ERR_MSG)
 }
 
-#[cfg(all(feature = "fts", not(target_family = "wasm")))]
-#[turso_macros::test]
-fn fts_mvcc_capability_is_checked_before_create(tmp_db: TempDatabase) {
-    let conn = tmp_db.connect_limbo();
-    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
-    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
-        .unwrap();
-
-    let error = conn
-        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
-        .unwrap_err();
-    assert!(
-        error
-            .to_string()
-            .contains("index method 'fts' does not support MVCC"),
-        "unexpected error: {error}"
-    );
-}
-
-// TODO: cannot use MVCC as we use indexes here
+// This raw-cursor test manually opens pager write transactions.
 #[turso_macros::test(init_sql = "CREATE TABLE t(name, embedding)")]
 fn test_vector_sparse_ivf_create_destroy(tmp_db: TempDatabase) {
     let _ = env_logger::try_init();
@@ -132,7 +125,10 @@ fn test_vector_sparse_ivf_create_destroy(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.create(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.create(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
     assert_eq!(
@@ -143,13 +139,16 @@ fn test_vector_sparse_ivf_create_destroy(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.destroy(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.destroy(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
     assert_eq!(schema_rows(), vec!["t"]);
 }
 
-// TODO: cannot use MVCC as we use indexes here
+// This raw-cursor test manually opens pager write transactions.
 #[turso_macros::test(init_sql = "CREATE TABLE t(name, embedding)")]
 fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
     let _ = env_logger::try_init();
@@ -168,7 +167,10 @@ fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.create(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.create(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
 
@@ -182,7 +184,10 @@ fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
     .enumerate()
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.open_write(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.open_write(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
 
         let values = [
             Register::Value(sparse_vector(vector_str)),
@@ -206,7 +211,10 @@ fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
         ),
     ] {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.open_read(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.open_read(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
 
         let values = [
             Register::Value(Value::from_i64(0)),
@@ -232,7 +240,7 @@ fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
     }
 }
 
-// TODO: cannot use MVCC as we use indexes here
+// This raw-cursor test manually opens pager write transactions.
 #[turso_macros::test(init_sql = "CREATE TABLE t(name, embedding)")]
 fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
     let _ = env_logger::try_init();
@@ -251,12 +259,18 @@ fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.create(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.create(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
 
     let mut writer = attached.init().unwrap();
-    run(&tmp_db, || writer.open_write(&conn, MAIN_DB_ID)).unwrap();
+    run(&tmp_db, || {
+        writer.open_write(&index_method_context(&conn, attached.as_ref()))
+    })
+    .unwrap();
 
     let v0_str = "[0, 1, 0, 0]";
     let v1_str = "[1, 0, 0, 1]";
@@ -283,7 +297,10 @@ fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
     .unwrap();
 
     let mut reader = attached.init().unwrap();
-    run(&tmp_db, || reader.open_read(&conn, MAIN_DB_ID)).unwrap();
+    run(&tmp_db, || {
+        reader.open_read(&index_method_context(&conn, attached.as_ref()))
+    })
+    .unwrap();
     assert!(!run(&tmp_db, || reader.query_start(&query_values)).unwrap());
 
     conn.execute(format!(
@@ -294,7 +311,10 @@ fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
     run(&tmp_db, || writer.insert(&insert1_values)).unwrap();
 
     let mut reader = attached.init().unwrap();
-    run(&tmp_db, || reader.open_read(&conn, MAIN_DB_ID)).unwrap();
+    run(&tmp_db, || {
+        reader.open_read(&index_method_context(&conn, attached.as_ref()))
+    })
+    .unwrap();
     assert!(run(&tmp_db, || reader.query_start(&query_values)).unwrap());
     assert_eq!(1, run(&tmp_db, || reader.query_rowid()).unwrap().unwrap());
     assert_eq!(
@@ -353,7 +373,7 @@ fn test_vector_sparse_ivf_mvcc_sql(tmp_db: TempDatabase) {
     );
 }
 
-// TODO: cannot use MVCC as we use indexes here
+// This differential harness disables automatic WAL actions on both databases.
 #[turso_macros::test]
 fn test_vector_sparse_ivf_fuzz(tmp_db: TempDatabase) {
     let _ = env_logger::try_init();
@@ -513,7 +533,10 @@ fn test_fts_create_destroy(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.create(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.create(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
 
@@ -526,7 +549,10 @@ fn test_fts_create_destroy(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.destroy(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.destroy(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
 
@@ -555,7 +581,10 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.create(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.create(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
 
@@ -581,7 +610,10 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
 
     for (id, title, body) in docs {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.open_write(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.open_write(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
 
         let values = [
             Register::Value(Value::Text(turso_core::types::Text::from(title))),
@@ -590,8 +622,11 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
         ];
         run(&tmp_db, || cursor.insert(&values)).unwrap();
         // Flush FTS data before executing SQL (which auto-commits the transaction)
-        // This mimics what VDBE does via index_method_pre_commit_all()
-        run(&tmp_db, || cursor.pre_commit()).unwrap();
+        // This mimics the VDBE's explicit statement-finalization phase.
+        run(&tmp_db, || {
+            cursor.prepare_statement_commit(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
         conn.execute(format!(
             "INSERT INTO docs VALUES ({id}, '{title}', '{body}')"
         ))
@@ -601,7 +636,10 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
     // Query for "Rust" - should match docs 1 and 3
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.open_read(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.open_read(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
 
         // Pattern 0 = fts_score pattern with ORDER BY DESC LIMIT
         let values = [
@@ -635,7 +673,10 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
     // Query for "Python" - should match doc 2
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.open_read(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.open_read(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
 
         let values = [
             Register::Value(Value::from_i64(0)),
@@ -1794,6 +1835,803 @@ fn test_fts_with_explicit_transactions(tmp_db: TempDatabase) {
 }
 
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn test_fts_mvcc_lifecycle(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'committed alpha'), (2, 'committed beta')")
+        .unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'committed') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("UPDATE docs SET body = 'ephemeral update' WHERE id = 1")
+        .unwrap();
+    conn.execute("DELETE FROM docs WHERE id = 2").unwrap();
+    conn.execute("INSERT INTO docs VALUES (3, 'ephemeral insert')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'ephemeral') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+    conn.execute("ROLLBACK").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'committed') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+    assert!(limbo_exec_rows(
+        &conn,
+        "SELECT id FROM docs WHERE fts_match(body, 'ephemeral')"
+    )
+    .is_empty());
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("UPDATE docs SET body = 'durable update' WHERE id = 1")
+        .unwrap();
+    conn.execute("DELETE FROM docs WHERE id = 2").unwrap();
+    conn.execute("INSERT INTO docs VALUES (3, 'durable insert')")
+        .unwrap();
+    conn.execute("COMMIT").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'durable') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+
+    conn.execute("OPTIMIZE INDEX docs_fts").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'durable') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+
+    conn.execute("DROP INDEX docs_fts").unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'durable') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_trigger_writes_survive_repeated_subprogram_runs(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("CREATE TABLE source(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute(
+        "CREATE TRIGGER copy_docs AFTER INSERT ON source BEGIN \
+         INSERT INTO docs VALUES(NEW.id, NEW.body); END",
+    )
+    .unwrap();
+
+    conn.execute("INSERT INTO source VALUES (1, 'first trigger'), (2, 'second trigger')")
+        .unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'trigger') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_raise_fail_keeps_base_rows_and_index_in_sync(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute(
+        "CREATE TRIGGER fail_second BEFORE INSERT ON docs WHEN NEW.id = 2 BEGIN \
+         SELECT RAISE(FAIL, 'stop'); END",
+    )
+    .unwrap();
+
+    assert!(conn
+        .execute("INSERT INTO docs VALUES (1, 'first kept row'), (2, 'second rejected row')")
+        .is_err());
+
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs ORDER BY id"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'kept') ORDER BY id"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    conn.execute("BEGIN").unwrap();
+    assert!(conn
+        .execute("INSERT INTO docs VALUES (3, 'transaction kept row'), (2, 'still rejected')")
+        .is_err());
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'kept') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+    conn.execute("COMMIT").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'kept') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+
+    conn.execute("CREATE TABLE source(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute(
+        "CREATE TRIGGER copy_then_fail AFTER INSERT ON source BEGIN \
+         INSERT INTO docs VALUES(NEW.id, NEW.body); \
+         SELECT RAISE(FAIL, 'after copy'); END",
+    )
+    .unwrap();
+    assert!(conn
+        .execute("INSERT INTO source VALUES (4, 'trigger kept row')")
+        .is_err());
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'kept') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+            vec![rusqlite::types::Value::Integer(4)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn test_fts_mvcc_connection_isolation(tmp_db: TempDatabase) {
+    let writer = tmp_db.connect_limbo();
+    let observer = tmp_db.connect_limbo();
+
+    writer
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    writer
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    writer
+        .execute("INSERT INTO docs VALUES (1, 'committed token')")
+        .unwrap();
+
+    writer.execute("BEGIN").unwrap();
+    writer
+        .execute("UPDATE docs SET body = 'uncommitted token' WHERE id = 1")
+        .unwrap();
+    writer
+        .execute("INSERT INTO docs VALUES (2, 'uncommitted token')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &writer,
+            "SELECT id FROM docs WHERE fts_match(body, 'uncommitted') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+    assert!(limbo_exec_rows(
+        &observer,
+        "SELECT id FROM docs WHERE fts_match(body, 'uncommitted')"
+    )
+    .is_empty());
+    assert_eq!(
+        limbo_exec_rows(
+            &observer,
+            "SELECT id FROM docs WHERE fts_match(body, 'committed')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    writer.execute("COMMIT").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &observer,
+            "SELECT id FROM docs WHERE fts_match(body, 'uncommitted') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_same_index_writer_conflicts_before_tantivy_work() {
+    let tmp_db = TempDatabase::builder()
+        .with_db_name("fts-same-index-writer-conflict.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    first
+        .execute("INSERT INTO docs VALUES (1, 'writer one')")
+        .unwrap();
+    let stats_before_conflict = fts_attachment_test_stats(&tmp_db, &first, "docs", "docs_fts");
+
+    let conflict = second
+        .execute("INSERT INTO docs VALUES (2, 'writer two')")
+        .unwrap_err();
+    assert!(matches!(
+        conflict,
+        turso_core::LimboError::WriteWriteConflict
+    ));
+    let stats_after_conflict = fts_attachment_test_stats(&tmp_db, &first, "docs", "docs_fts");
+    assert_eq!(
+        stats_after_conflict.tantivy_writer_constructions,
+        stats_before_conflict.tantivy_writer_constructions,
+        "the losing transaction must not construct a Tantivy writer"
+    );
+    assert_eq!(
+        stats_after_conflict.write_lease_rejections,
+        stats_before_conflict
+            .write_lease_rejections
+            .map(|count| count + 1)
+    );
+
+    first.execute("COMMIT").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    second
+        .execute("INSERT INTO docs VALUES (2, 'writer two retry')")
+        .unwrap();
+    second.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(&first, "SELECT id FROM docs ORDER BY id"),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &first,
+            "SELECT id FROM docs WHERE fts_match(body, 'writer') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_different_index_writers_do_not_conflict() {
+    let tmp_db = TempDatabase::builder()
+        .with_db_name("fts-different-index-writers.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("CREATE TABLE first_docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX first_fts ON first_docs USING fts(body)")
+        .unwrap();
+    first
+        .execute("CREATE TABLE second_docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX second_fts ON second_docs USING fts(body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    first
+        .execute("INSERT INTO first_docs VALUES (1, 'first writer')")
+        .unwrap();
+    second
+        .execute("INSERT INTO second_docs VALUES (2, 'second writer')")
+        .unwrap();
+    first.execute("COMMIT").unwrap();
+    second.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &first,
+            "SELECT id FROM first_docs WHERE fts_match(body, 'writer')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &first,
+            "SELECT id FROM second_docs WHERE fts_match(body, 'writer')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_opposite_index_order_rejects_without_deadlock() {
+    let tmp_db = TempDatabase::builder()
+        .with_db_name("fts-opposite-index-order.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("CREATE TABLE a(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX a_fts ON a USING fts(body)")
+        .unwrap();
+    first
+        .execute("CREATE TABLE b(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX b_fts ON b USING fts(body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    first
+        .execute("INSERT INTO a VALUES (1, 'rolled back')")
+        .unwrap();
+    second
+        .execute("INSERT INTO b VALUES (2, 'survives')")
+        .unwrap();
+
+    let conflict = first
+        .execute("INSERT INTO b VALUES (1, 'rolled back')")
+        .unwrap_err();
+    assert!(matches!(
+        conflict,
+        turso_core::LimboError::WriteWriteConflict
+    ));
+
+    second
+        .execute("INSERT INTO a VALUES (2, 'survives')")
+        .unwrap();
+    second.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(&second, "SELECT id FROM a"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(&second, "SELECT id FROM b"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &second,
+            "SELECT id FROM a WHERE fts_match(body, 'survives')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &second,
+            "SELECT id FROM b WHERE fts_match(body, 'survives')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_savepoint_rollback_keeps_transaction_lease() {
+    let tmp_db = TempDatabase::builder()
+        .with_db_name("fts-savepoint-writer-lease.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    first.execute("SAVEPOINT pending_write").unwrap();
+    first
+        .execute("INSERT INTO docs VALUES (1, 'rolled back savepoint')")
+        .unwrap();
+    first.execute("ROLLBACK TO pending_write").unwrap();
+
+    second.execute("BEGIN CONCURRENT").unwrap();
+    let conflict = second
+        .execute("INSERT INTO docs VALUES (2, 'blocked writer')")
+        .unwrap_err();
+    assert!(matches!(
+        conflict,
+        turso_core::LimboError::WriteWriteConflict
+    ));
+
+    first.execute("ROLLBACK").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    second
+        .execute("INSERT INTO docs VALUES (2, 'successful retry')")
+        .unwrap();
+    second.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(&second, "SELECT id FROM docs"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &second,
+            "SELECT id FROM docs WHERE fts_match(body, 'retry')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_connection_close_releases_writer_lease() {
+    let tmp_db = TempDatabase::builder()
+        .with_db_name("fts-close-writer-lease.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    first
+        .execute("INSERT INTO docs VALUES (1, 'abandoned writer')")
+        .unwrap();
+    first.close().unwrap();
+
+    second.execute("BEGIN CONCURRENT").unwrap();
+    second
+        .execute("INSERT INTO docs VALUES (2, 'replacement writer')")
+        .unwrap();
+    second.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(&second, "SELECT id FROM docs"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &second,
+            "SELECT id FROM docs WHERE fts_match(body, 'replacement')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn test_fts_mvcc_recovery(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'logical recovery'), (2, 'logical recovery')")
+        .unwrap();
+
+    let path = tmp_db.path.clone();
+    let io = tmp_db.io.clone();
+    let opts = tmp_db.db_opts;
+    let flags = tmp_db.db_flags;
+    conn.close().unwrap();
+    drop(conn);
+    drop(tmp_db);
+
+    let db = turso_core::Database::open_file_with_flags(
+        io.clone(),
+        path.to_str().unwrap(),
+        flags,
+        opts,
+        None,
+        std::sync::Arc::new(turso_core::SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'recovery') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    conn.close().unwrap();
+    drop(conn);
+    drop(db);
+
+    let db = turso_core::Database::open_file_with_flags(
+        io,
+        path.to_str().unwrap(),
+        flags,
+        opts,
+        None,
+        std::sync::Arc::new(turso_core::SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'recovery') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_checkpoint_modes_preserve_manifest() {
+    for mvcc in [false, true] {
+        let opts = turso_core::DatabaseOpts::new()
+            .with_index_method(true)
+            .with_experimental_mvcc_passive_checkpoint(true);
+        let mut builder = TempDatabase::builder().with_opts(opts);
+        if mvcc {
+            builder = builder.with_mvcc(true);
+        }
+        let tmp_db = builder.build();
+        let conn = tmp_db.connect_limbo();
+        conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+            .unwrap();
+        conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+            .unwrap();
+
+        let cases = [
+            ("PASSIVE", "checkpointalpha"),
+            ("FULL", "checkpointbravo"),
+            ("RESTART", "checkpointcharlie"),
+            ("TRUNCATE", "checkpointdelta"),
+        ];
+        for (id, (mode, token)) in cases.into_iter().enumerate() {
+            let id = id as i64 + 1;
+            conn.execute(format!("INSERT INTO docs VALUES ({id}, '{token}')"))
+                .unwrap();
+            conn.execute(format!("PRAGMA wal_checkpoint({mode})"))
+                .unwrap();
+
+            for (visible_id, (_, visible_token)) in cases.iter().take(id as usize).enumerate() {
+                let visible_id = visible_id as i64 + 1;
+                assert_eq!(
+                    limbo_exec_rows(
+                        &conn,
+                        &format!("SELECT id FROM docs WHERE fts_match(body, '{visible_token}')")
+                    ),
+                    vec![vec![rusqlite::types::Value::Integer(visible_id)]],
+                    "{mode} checkpoint lost FTS generation {visible_id}"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_passive_checkpoint_preserves_pinned_reader() {
+    for mvcc in [false, true] {
+        let opts = turso_core::DatabaseOpts::new()
+            .with_index_method(true)
+            .with_experimental_mvcc_passive_checkpoint(true);
+        let mut builder = TempDatabase::builder().with_opts(opts);
+        if mvcc {
+            builder = builder.with_mvcc(true);
+        }
+        let tmp_db = builder.build();
+        let writer = tmp_db.connect_limbo();
+        let reader = tmp_db.connect_limbo();
+        writer
+            .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+            .unwrap();
+        writer
+            .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+            .unwrap();
+        writer
+            .execute("INSERT INTO docs VALUES (1, 'pinned generation')")
+            .unwrap();
+
+        reader.execute("BEGIN").unwrap();
+        assert_eq!(
+            limbo_exec_rows(
+                &reader,
+                "SELECT id FROM docs WHERE fts_match(body, 'pinned')"
+            ),
+            vec![vec![rusqlite::types::Value::Integer(1)]]
+        );
+
+        writer
+            .execute("INSERT INTO docs VALUES (2, 'new generation')")
+            .unwrap();
+        if let Err(error) = writer.execute("PRAGMA wal_checkpoint(PASSIVE)") {
+            assert!(
+                matches!(error, turso_core::LimboError::Busy),
+                "passive checkpoint returned unexpected error in {} mode: {error}",
+                if mvcc { "MVCC" } else { "WAL" }
+            );
+        }
+        assert!(
+            limbo_exec_rows(&reader, "SELECT id FROM docs WHERE fts_match(body, 'new')").is_empty(),
+            "a checkpoint must not move a pinned reader to the new FTS manifest"
+        );
+        reader.execute("COMMIT").unwrap();
+
+        assert_eq!(
+            limbo_exec_rows(&reader, "SELECT id FROM docs WHERE fts_match(body, 'new')"),
+            vec![vec![rusqlite::types::Value::Integer(2)]],
+            "the next transaction must observe the post-checkpoint manifest"
+        );
+    }
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test]
+fn test_fts_switch_to_mvcc(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'before switch')")
+        .unwrap();
+
+    conn.pragma_update("journal_mode", "'mvcc'").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'switch')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    conn.execute("UPDATE docs SET body = 'updated after transition' WHERE id = 1")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (2, 'inserted after transition')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'transition') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+    assert!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'switch')").is_empty()
+    );
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'transition') ORDER BY id"
+        )
+        .len(),
+        2
+    );
+
+    conn.pragma_update("journal_mode", "'wal'").unwrap();
+    conn.execute("UPDATE docs SET body = 'returned to wal' WHERE id = 1")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (3, 'created in wal')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'wal') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ],
+        "FTS state must survive the MVCC-to-WAL transition"
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
 #[turso_macros::test(init_sql = "CREATE TABLE docs(id INTEGER PRIMARY KEY, title TEXT, body TEXT)")]
 fn test_fts_optimize_index(tmp_db: TempDatabase) {
     let _ = env_logger::try_init();
@@ -2550,6 +3388,7 @@ fn fts_reuses_committed_writer_across_insert_statements() {
         .len(),
         2
     );
+    let before_drop = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
 
     // Destroying an index must release the retained Tantivy writer and its
     // directory lock so an index with the same name can be created immediately.
@@ -2563,6 +3402,683 @@ fn fts_reuses_committed_writer_across_insert_statements() {
         )
         .len(),
         2
+    );
+    let after_recreate = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_ne!(
+        after_recreate.index_incarnation, before_drop.index_incarnation,
+        "drop/recreate must allocate a distinct persistent index incarnation"
+    );
+}
+
+/// A cursor prepared by a statement inside BEGIN must survive statement reset
+/// until the later COMMIT delivers the transaction outcome. The committed
+/// writer should then be reusable by the next transaction.
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_explicit_commit_publishes_transaction_scoped_writer() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'explicit transaction writer')")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (2, 'newest transaction cursor')")
+        .unwrap();
+    assert_eq!(
+        fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts").cached_writer,
+        Some(true),
+        "statement success must retain transaction-private writer state"
+    );
+    conn.execute("COMMIT").unwrap();
+
+    let committed = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(committed.cached_writer, Some(true));
+    let constructions = committed.tantivy_writer_constructions;
+
+    conn.execute("INSERT INTO docs VALUES (3, 'reused explicit writer')")
+        .unwrap();
+    assert_eq!(
+        fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts").tantivy_writer_constructions,
+        constructions,
+        "the post-COMMIT statement should restore the transaction-published writer"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'transaction') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)]
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_reuses_writer_within_explicit_transaction() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    let before = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("INSERT INTO docs VALUES (1, 'first retained writer')")
+        .unwrap();
+    let after_first = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(after_first.cached_writer, Some(true));
+    assert!(
+        after_first.tantivy_writer_constructions > before.tantivy_writer_constructions,
+        "the first write must construct one Tantivy writer"
+    );
+
+    conn.execute("INSERT INTO docs VALUES (2, 'second retained writer')")
+        .unwrap();
+    let after_second = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(
+        after_second.tantivy_writer_constructions, after_first.tantivy_writer_constructions,
+        "the next statement in the same MVCC transaction must reuse the lease-owned writer"
+    );
+    assert!(
+        after_second.writer_cache_hits > after_first.writer_cache_hits,
+        "writer-cache telemetry must record the transaction-private reuse"
+    );
+    conn.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'retained') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)]
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_reuses_validated_writer_across_transactions() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'first transaction')")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'first')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let after_first = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("COMMIT").unwrap();
+
+    conn.execute("INSERT INTO docs VALUES (2, 'second transaction')")
+        .unwrap();
+    conn.execute("BEGIN").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'second')"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    let after_second = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        after_second.tantivy_writer_constructions, after_first.tantivy_writer_constructions,
+        "an unchanged committed manifest must reuse the asynchronously validated MVCC writer"
+    );
+    assert!(
+        after_second.writer_cache_hits > after_first.writer_cache_hits,
+        "writer-cache telemetry must record cross-transaction validation reuse"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'transaction') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)]
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_savepoint_rollback_invalidates_transaction_scoped_writer() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("SAVEPOINT before_fts").unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'rolled back writer state')")
+        .unwrap();
+    conn.execute("ROLLBACK TO before_fts").unwrap();
+    conn.execute("COMMIT").unwrap();
+
+    let after_rollback = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(
+        after_rollback.cached_writer,
+        Some(false),
+        "ROLLBACK TO must invalidate the retained transaction cursor before COMMIT"
+    );
+    assert!(
+        after_rollback.writer_cache_rollback_discards > Some(0),
+        "rollback telemetry must record the discarded transaction-private writer"
+    );
+    assert!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'rolled')").is_empty()
+    );
+
+    conn.execute("INSERT INTO docs VALUES (2, 'surviving writer state')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'surviving')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_loser_rollback_keeps_winner_cached_writer() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let winner = tmp_db.connect_limbo();
+    let loser = tmp_db.connect_limbo();
+
+    winner
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    winner
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    winner.execute("BEGIN CONCURRENT").unwrap();
+    loser.execute("BEGIN CONCURRENT").unwrap();
+    winner
+        .execute("INSERT INTO docs VALUES (1, 'winner writer')")
+        .unwrap();
+    let before_conflict = fts_attachment_test_stats(&tmp_db, &winner, "docs", "docs_fts");
+    assert_eq!(
+        before_conflict.cached_writer,
+        Some(true),
+        "the winner's statement must retain its transaction-tagged writer"
+    );
+
+    let conflict = loser
+        .execute("INSERT INTO docs VALUES (2, 'loser writer')")
+        .unwrap_err();
+    assert!(matches!(
+        conflict,
+        turso_core::LimboError::WriteWriteConflict
+    ));
+
+    let after_conflict = fts_attachment_test_stats(&tmp_db, &winner, "docs", "docs_fts");
+    assert_eq!(
+        after_conflict.cached_writer,
+        Some(true),
+        "the loser's rollback must not evict the winner's cached writer"
+    );
+    assert_eq!(
+        after_conflict.writer_cache_rollback_discards,
+        before_conflict.writer_cache_rollback_discards,
+        "the loser's rollback must not count a discard of a writer it does not own"
+    );
+
+    winner
+        .execute("INSERT INTO docs VALUES (3, 'winner reuses writer')")
+        .unwrap();
+    let after_reuse = fts_attachment_test_stats(&tmp_db, &winner, "docs", "docs_fts");
+    assert_eq!(
+        after_reuse.tantivy_writer_constructions, after_conflict.tantivy_writer_constructions,
+        "the winner's next statement must reuse its writer instead of rebuilding it"
+    );
+    assert!(
+        after_reuse.writer_cache_hits > after_conflict.writer_cache_hits,
+        "writer-cache telemetry must record the winner's reuse after the conflict"
+    );
+    winner.execute("COMMIT").unwrap();
+
+    // The conflict rolled back the loser's whole transaction; a retry from a
+    // fresh transaction succeeds.
+    loser.execute("BEGIN CONCURRENT").unwrap();
+    loser
+        .execute("INSERT INTO docs VALUES (2, 'loser retry writer')")
+        .unwrap();
+    loser.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &winner,
+            "SELECT id FROM docs WHERE fts_match(body, 'writer') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_wal_other_connection_commit_does_not_revalidate_writer() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let writer_conn = tmp_db.connect_limbo();
+    let other = tmp_db.connect_limbo();
+
+    writer_conn
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    writer_conn
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    writer_conn
+        .execute("CREATE TABLE plain(x INTEGER)")
+        .unwrap();
+    writer_conn
+        .execute("INSERT INTO docs VALUES (1, 'alpha document')")
+        .unwrap();
+
+    let before = fts_attachment_test_stats(&tmp_db, &writer_conn, "docs", "docs_fts");
+    assert_eq!(before.cached_writer, Some(true));
+
+    // Another connection's transaction reads the FTS index and commits an
+    // unrelated write. Its commit hook must not re-stamp the first
+    // connection's cached writer to the post-commit WAL position: that would
+    // revalidate a writer whose WAL snapshot has moved.
+    other.execute("BEGIN").unwrap();
+    other.execute("INSERT INTO plain VALUES (1)").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&other, "SELECT id FROM docs WHERE fts_match(body, 'alpha')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    other.execute("COMMIT").unwrap();
+
+    writer_conn
+        .execute("INSERT INTO docs VALUES (2, 'beta document')")
+        .unwrap();
+    let after = fts_attachment_test_stats(&tmp_db, &writer_conn, "docs", "docs_fts");
+    assert!(
+        after.tantivy_writer_constructions > before.tantivy_writer_constructions,
+        "a WAL-position change committed by another connection must invalidate the \
+         cached writer, not revalidate it"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &writer_conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'document') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_wal_commit_must_not_revalidate_stale_budget_rejected_writer() {
+    use turso_core::index_method::fts::set_fts_retained_cache_bytes_for_test;
+
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn_a = tmp_db.connect_limbo();
+    let conn_b = tmp_db.connect_limbo();
+
+    conn_a
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn_a
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn_a
+        .execute("INSERT INTO docs VALUES (1, 'alpha stays visible')")
+        .unwrap();
+    // Connection A's committed writer sits in the shared slot, stamped at A's
+    // post-commit WAL position.
+    assert_eq!(
+        fts_attachment_test_stats(&tmp_db, &conn_a, "docs", "docs_fts").cached_writer,
+        Some(true)
+    );
+
+    // Shrink the retention budget: B's newer writer now fails cache admission,
+    // so A's stale writer stays in the slot while the index moves past it.
+    set_fts_retained_cache_bytes_for_test(Some(1));
+    conn_b
+        .execute("INSERT INTO docs VALUES (2, 'bravo must survive')")
+        .unwrap();
+
+    // A read-only FTS statement on connection A commits with A's WAL mark
+    // advanced past B's commit. Its commit hook must not re-stamp the stale
+    // writer to that mark: the writer's segments predate B's document, and
+    // reusing it would drop the document from the index.
+    assert_eq!(
+        limbo_exec_rows(
+            &conn_a,
+            "SELECT id FROM docs WHERE fts_match(body, 'bravo')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+
+    let before = fts_attachment_test_stats(&tmp_db, &conn_a, "docs", "docs_fts");
+    conn_a
+        .execute("INSERT INTO docs VALUES (3, 'charlie added later')")
+        .unwrap();
+    let after = fts_attachment_test_stats(&tmp_db, &conn_a, "docs", "docs_fts");
+    set_fts_retained_cache_bytes_for_test(None);
+
+    assert!(
+        after.tantivy_writer_constructions > before.tantivy_writer_constructions,
+        "connection A must rebuild its writer: the cached one predates B's committed document"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn_a,
+            "SELECT id FROM docs WHERE fts_match(body, 'bravo') OR fts_match(body, 'charlie') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(2)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ],
+        "every committed document must stay searchable after the writer churn"
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_create_persists_real_index_incarnation() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    // A never-written index uses the deterministic placeholder incarnation 0;
+    // staging the first control record (which CREATE INDEX does) must mint a
+    // real incarnation so cache validation can distinguish incarnations.
+    let stats = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_ne!(
+        stats.index_incarnation,
+        Some(0),
+        "the persisted control record must never carry the empty-index placeholder incarnation"
+    );
+    assert_eq!(stats.manifest_generation, Some(1));
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_manifest_generation_is_transactional() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    let created = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(created.storage_format_version, Some(1));
+    assert_eq!(created.manifest_generation, Some(1));
+    assert_eq!(
+        created.storage_file_count,
+        created.manifest_file_count.unwrap()
+    );
+
+    conn.execute("INSERT INTO docs VALUES (1, 'committed generation')")
+        .unwrap();
+    let committed = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert!(
+        committed.manifest_generation > created.manifest_generation,
+        "committed write must advance the manifest"
+    );
+    assert_eq!(committed.index_incarnation, created.index_incarnation);
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO docs VALUES (2, 'rolled back generation')")
+        .unwrap();
+    conn.execute("ROLLBACK").unwrap();
+    let rolled_back = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(
+        rolled_back.manifest_generation, committed.manifest_generation,
+        "rollback must restore the prior control record"
+    );
+    assert_eq!(rolled_back.index_incarnation, created.index_incarnation);
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_reuses_snapshot_within_one_read_transaction() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'same snapshot cache')")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'snapshot')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let after_first = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'snapshot')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let after_second = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        after_second.full_snapshot_loads, after_first.full_snapshot_loads,
+        "the second read in one MVCC transaction must not rescan the directory"
+    );
+    assert!(
+        after_second.read_cache_hits > after_first.read_cache_hits,
+        "the second read must use the transaction-bound snapshot cache"
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_wal_reuses_manifest_after_unrelated_commit() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE TABLE unrelated(value TEXT)").unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'stable manifest')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'stable')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let before = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+
+    conn.execute("INSERT INTO unrelated VALUES ('changes the WAL position')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'stable')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let after = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+
+    assert_eq!(
+        after.full_snapshot_loads, before.full_snapshot_loads,
+        "an unrelated commit must validate the FTS manifest without reloading its files"
+    );
+    assert!(
+        after.manifest_validation_hits > before.manifest_validation_hits,
+        "the changed WAL snapshot must be accepted through control-record validation"
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_reuses_manifest_across_read_transactions() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'autocommit manifest')")
+        .unwrap();
+    conn.execute("BEGIN").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'autocommit')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let before = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("COMMIT").unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'autocommit')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let after = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        after.full_snapshot_loads, before.full_snapshot_loads,
+        "a new MVCC read transaction must not reload an unchanged FTS manifest"
+    );
+    assert!(
+        after.manifest_validation_hits > before.manifest_validation_hits,
+        "the new MVCC snapshot must validate the cached manifest by its control record"
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_manifest_generation_invalidates_stale_snapshot_once() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let writer = tmp_db.connect_limbo();
+    let reader = tmp_db.connect_limbo();
+
+    writer
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    writer
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    writer
+        .execute("INSERT INTO docs VALUES (1, 'first generation')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &reader,
+            "SELECT id FROM docs WHERE fts_match(body, 'first')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let before_write = fts_attachment_test_stats(&tmp_db, &reader, "docs", "docs_fts");
+
+    writer
+        .execute("INSERT INTO docs VALUES (2, 'second generation')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &reader,
+            "SELECT id FROM docs WHERE fts_match(body, 'second')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]],
+        "the observer must reject its stale snapshot after the writer commits"
+    );
+    let after_write = fts_attachment_test_stats(&tmp_db, &reader, "docs", "docs_fts");
+    assert!(
+        after_write.manifest_validation_misses > before_write.manifest_validation_misses,
+        "an advanced manifest generation must reject the stale read snapshot"
+    );
+    assert!(
+        after_write.full_snapshot_loads > before_write.full_snapshot_loads,
+        "the first reader of a new generation must load its directory snapshot"
+    );
+
+    assert_eq!(
+        limbo_exec_rows(
+            &reader,
+            "SELECT id FROM docs WHERE fts_match(body, 'second')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    let after_reuse = fts_attachment_test_stats(&tmp_db, &reader, "docs", "docs_fts");
+    assert_eq!(
+        after_reuse.full_snapshot_loads, after_write.full_snapshot_loads,
+        "the newly loaded generation must be reusable without another full scan"
     );
 }
 
@@ -2686,7 +4202,10 @@ fn fts_read_cache_is_connection_local_and_bounded() {
     {
         let mut cursor = attachment.init().unwrap();
         run(&tmp_db, || {
-            cursor.open_read(&readers[reader_index], MAIN_DB_ID)
+            cursor.open_read(&index_method_context(
+                &readers[reader_index],
+                attachment.as_ref(),
+            ))
         })
         .unwrap();
         let stats = cursor.test_stats().unwrap().unwrap();


### PR DESCRIPTION
This is PR 5 of 6 in the IndexMethod/FTS MVCC stack.

Add controlled performance and memory coverage for the FTS MVCC contract.

### Criterion benchmarks

- Label WAL and MVCC results separately.
- Exercise disabled, default, and forced checkpoint policies.
- Measure cold reads, warm reads, and alternating pooled-connection reads.
- Measure query selectivity, insert/query cycles, commit churn, segment churn,
  and merge boundaries.
- Measure 1/2/4/8 MVCC writers targeting independent indexes.
- Measure the eager conflict path for 1/2/4/8 writers targeting the same
  index.

### Memory profiles and CI

- Add `fts-query-churn`, where one or four connections repeatedly query the
  same immutable FTS index.
- Add `fts-update-churn`, where each of one or four connections updates a
  separate fixed-size FTS index. Separate indexes avoid turning the supported
  lease conflict into benchmark noise.
- Run both profiles under WAL and MVCC in the CodSpeed memory matrix.
- Include normal size scaling and a larger checkpointed variant.
- Include the connection count in benchmark names and database paths.

## Context: 

MVCC FTS trades a cold full-directory snapshot for snapshot-safe Tantivy
access, then relies on bounded read and writer caches to make repeated work
cheap. Those choices need measurements that distinguish journal mode,
checkpoint policy, cache reuse, connection count, and supported versus
contended writer layouts.


Stack:

1. https://github.com/tursodatabase/turso/pull/8265
2. https://github.com/tursodatabase/turso/pull/8268
3. https://github.com/tursodatabase/turso/pull/8269
4. https://github.com/tursodatabase/turso/pull/8271
5. *This PR*
6. FTS MVCC documentation and tooling
