### PR TITLE
cli: interrupt the running statement on Ctrl-C

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -28,7 +28,7 @@ use std::{
     path::PathBuf,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, Mutex,
     },
     time::{Duration, Instant},
 };
@@ -126,6 +126,9 @@ pub struct Limbo {
     io: Arc<dyn turso_core::IO>,
     writer: Option<Box<dyn Write>>,
     conn: Arc<turso_core::Connection>,
+    /// The connection the Ctrl-C handler interrupts. Shared with the handler thread and
+    /// retargeted by `.open`, which replaces `conn`.
+    interrupt_target: Arc<Mutex<Arc<turso_core::Connection>>>,
     pub interrupt_count: Arc<AtomicUsize>,
     input_buff: ManuallyDrop<String>,
     pub(crate) opts: Settings,
@@ -286,11 +289,17 @@ impl Limbo {
             conn._free_extension_ctx(ext_api);
         }
         let interrupt_count = Arc::new(AtomicUsize::new(0));
+        let interrupt_target = Arc::new(Mutex::new(conn.clone()));
         {
             let interrupt_count: Arc<AtomicUsize> = Arc::clone(&interrupt_count);
+            let interrupt_target = Arc::clone(&interrupt_target);
             ctrlc::set_handler(move || {
                 // Increment the interrupt count on Ctrl-C
                 interrupt_count.fetch_add(1, Ordering::Release);
+                // Installing this handler suppresses the default SIGINT kill, so a statement
+                // that is already running can only be abandoned by asking the VDBE to stop.
+                // The request is a no-op when no statement is active, as in sqlite3_interrupt.
+                interrupt_target.lock().unwrap().interrupt();
             })
             .expect("Error setting Ctrl-C handler");
         }
@@ -303,6 +312,7 @@ impl Limbo {
             io,
             writer: Some(get_writer(&opts.output)),
             conn,
+            interrupt_target,
             interrupt_count,
             input_buff: ManuallyDrop::new(sql.unwrap_or_default()),
             read_state: ReadState::default(),
@@ -494,6 +504,7 @@ impl Limbo {
         };
         self.io = io;
         self.conn = db.connect()?;
+        *self.interrupt_target.lock().unwrap() = self.conn.clone();
         self.opts.db_file = path.to_string();
         Ok(())
     }

--- a/testing/cli_tests/cli_test_cases.py
+++ b/testing/cli_tests/cli_test_cases.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -521,6 +522,54 @@ def test_blob_bytes_are_printed_raw_in_list_mode():
     )
 
 
+def test_ctrl_c_interrupts_a_running_query():
+    # A non-terminating query must be abandonable from the keyboard, the way it is in the
+    # sqlite3 shell. tursodb installs a SIGINT handler, which suppresses the default kill, so
+    # if that handler does not reach the running statement the shell becomes unrecoverable.
+    exec_name = os.environ.get("SQLITE_EXEC", "./scripts/limbo-sqlite3")
+
+    console.test("Running test: ctrl-c-interrupts-a-running-query")
+    # SQLITE_EXEC may be the tursodb binary or the scripts/limbo-sqlite3 wrapper, which runs
+    # tursodb as a bash child. Give the whole thing its own process group and signal the group,
+    # so the interrupt reaches tursodb under either invocation, and so a regression can be
+    # cleaned up wholesale instead of leaving the runaway query spinning.
+    proc = subprocess.Popen(
+        [exec_name, ":memory:"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=0,
+        start_new_session=True,
+    )
+    pgid = os.getpgid(proc.pid)
+    try:
+        try:
+            proc.stdin.write(
+                b"WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM c) SELECT count(*) FROM c;\n"
+            )
+            proc.stdin.flush()
+            # Let the statement get well inside the recursive fixed point before signalling.
+            time.sleep(1.0)
+            os.killpg(pgid, signal.SIGINT)
+
+            # The shell must be back at the prompt and able to run the next statement.
+            proc.stdin.write(b"SELECT 42;\n.quit\n")
+            proc.stdin.flush()
+            stdout, _ = proc.communicate(timeout=15)
+        except (subprocess.TimeoutExpired, BrokenPipeError) as exc:
+            raise AssertionError(
+                f"SIGINT did not interrupt the running query; the shell never returned to the prompt ({exc!r})"
+            ) from exc
+    finally:
+        # Nothing bounds the recursion, so on any failure the query is still burning a core.
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.communicate()
+    assert b"42" in stdout, f"expected the shell to answer after the interrupt, got {stdout!r}"
+
+
 def main():
     console.info("Running all turso CLI tests...")
     test_read_command()
@@ -549,6 +598,7 @@ def main():
     test_tables_with_attached_db()
     test_dbtotxt()
     test_blob_bytes_are_printed_raw_in_list_mode()
+    test_ctrl_c_interrupts_a_running_query()
     console.info("All tests have passed")
 
 

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -18,6 +18,7 @@ mod pragma;
 mod query_processing;
 mod query_timeout;
 mod queued_io;
+mod recursive_cte_runaway;
 mod reindex;
 mod statement_metadata;
 mod statement_reset;

--- a/tests/integration/recursive_cte_runaway.rs
+++ b/tests/integration/recursive_cte_runaway.rs
@@ -1,0 +1,89 @@
+use crate::common::TempDatabase;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use turso_core::vdbe::StepResult;
+
+/// The classic non-terminating recursive CTE. It has no I/O and no natural bound, so it is the
+/// worst case for every bounded-execution mechanism the engine offers.
+const RUNAWAY: &str =
+    "WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM c) SELECT count(*) FROM c;";
+
+fn run_until_terminal(stmt: &mut turso_core::Statement) -> turso_core::Result<StepResult> {
+    loop {
+        match stmt.step()? {
+            StepResult::IO => stmt._io().step()?,
+            StepResult::Row | StepResult::Yield => continue,
+            result => return Ok(result),
+        }
+    }
+}
+
+/// A runaway recursive CTE must be bounded by the generic query deadline. The recursive fixed
+/// point is ordinary bytecode with a back-edge, so it re-enters the step loop on every opcode and
+/// the deadline check fires exactly as it does for a runaway cross join.
+#[turso_macros::test]
+fn runaway_recursive_cte_is_bounded_by_query_timeout(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    conn.set_query_timeout(Duration::from_millis(50));
+
+    let mut stmt = conn.prepare(RUNAWAY)?;
+    let result = run_until_terminal(&mut stmt)?;
+    assert!(
+        matches!(result, StepResult::Interrupt),
+        "expected the query deadline to interrupt the runaway recursion, got {result:?}"
+    );
+    Ok(())
+}
+
+/// A runaway recursive CTE must be interruptible from another thread, which is the contract
+/// `sqlite3_interrupt` provides and the only thing a CLI Ctrl-C handler can rely on.
+#[turso_macros::test]
+fn runaway_recursive_cte_is_interruptible_from_another_thread(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    let stepping_finished = Arc::new(AtomicBool::new(false));
+
+    let interrupter = {
+        let conn = conn.clone();
+        let stepping_finished = stepping_finished.clone();
+        std::thread::spawn(move || {
+            // The request is dropped unless a root statement is active, so keep asking until
+            // the stepping thread reports that it is done.
+            while !stepping_finished.load(Ordering::SeqCst) {
+                conn.interrupt();
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        })
+    };
+
+    let mut stmt = conn.prepare(RUNAWAY)?;
+    let result = run_until_terminal(&mut stmt)?;
+    stepping_finished.store(true, Ordering::SeqCst);
+    interrupter.join().unwrap();
+
+    assert!(
+        matches!(result, StepResult::Interrupt),
+        "expected interrupt, got {result:?}"
+    );
+    Ok(())
+}
+
+/// Legitimately deep recursion must keep working. SQLite completes this query, so bounding
+/// recursion by a low iteration count would be a compatibility regression rather than a fix.
+#[turso_macros::test]
+fn deep_recursive_cte_still_completes(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    let mut stmt = conn.prepare(
+        "WITH RECURSIVE seq(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM seq WHERE x < 100000)
+         SELECT count(*) FROM seq;",
+    )?;
+    let mut count = None;
+    stmt.run_with_row_callback(|row| {
+        count = Some(row.get::<i64>(0).unwrap());
+        Ok(())
+    })?;
+    assert_eq!(count, Some(100000));
+    Ok(())
+}


### PR DESCRIPTION
A query that does not terminate cannot be abandoned from the tursodb shell. Ctrl-C is recorded and then ignored, and because installing a SIGINT handler also suppresses the default kill, the process cannot be stopped from the keyboard at all. The canonical reproducer is a non-converging recursive CTE:

```sql
WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM c) SELECT count(*) FROM c;
```

which pins a core at 100% indefinitely. The sqlite3 shell returns to the prompt on Ctrl-C for the same query.

The engine side of this already works. `Program::step` checks `Connection::is_interrupted()` on every opcode, a recursive CTE is ordinary bytecode with a back-edge rather than one long-running opcode, and `Statement::step` already maps `StepResult::Interrupt` to `LimboError::Interrupt`, which `print_query_result` already handles silently. The only missing piece is that the Ctrl-C handler never calls `Connection::interrupt()`; it only bumps a counter that nothing in the query path reads.

This wires the handler to the connection. The request is dropped when no root statement is active, matching `sqlite3_interrupt`, so behavior at the prompt is unchanged. Because `.open` replaces the connection, the handler holds the target behind a shared cell rather than capturing it, so Ctrl-C keeps working after reconnecting.

**On not adding a recursion limit.** The obvious alternative is to cap recursive-CTE iterations and error when the cap is hit. I did not do that, for two reasons. SQLite imposes no such cap and completes `WHERE x < 1000000`, so any default-on limit turns working queries into errors, and a cap only bounds one query shape while leaving every other runaway (a large cross join, say) equally unrecoverable. Interruption is the mechanism SQLite itself relies on here, and Turso already implements it — it just was not reachable from the shell.

Note that `Connection::set_query_timeout` and `Connection::set_progress_handler` already bound runaway execution for embedders, and a test here confirms the deadline stops this exact query. Neither is reachable from SQL; exposing the deadline as a pragma would be a reasonable follow-up and would cover all query shapes rather than recursive CTEs specifically.

## Tests

First commit (red without the fix): a CLI test that spawns the shell, starts the runaway CTE, and delivers SIGINT to the process group — so it reaches tursodb both directly and through `scripts/limbo-sqlite3`'s bash wrapper — asserting the query stops and the shell answers the next statement; the group is killed on the way out so a regression cannot leak a runaway process into CI. Integration tests pin the engine half that already worked: the per-opcode interrupt check and `set_query_timeout` both stop the same query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
