### PR TITLE
bindings/c: sqlite3_mprintf and sqlite3_snprintf via core's printf engine

### DIFF
--- a/bindings/c/include/sqlite3.h
+++ b/bindings/c/include/sqlite3.h
@@ -224,6 +224,10 @@ void *sqlite3_malloc64(int _n);
 
 void sqlite3_free(void *_ptr);
 
+char *sqlite3_mprintf(const char *fmt, ...);
+
+char *sqlite3_snprintf(int n, char *buf, const char *fmt, ...);
+
 int sqlite3_errcode(sqlite3 *_db);
 
 const char *sqlite3_errstr(int _err);

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -1517,10 +1517,130 @@ pub unsafe extern "C" fn sqlite3_interrupt(db: *mut sqlite3) {
 }
 
 extern "C" {
-    /// Variadic implementation in varargs.c; decodes the va_list and calls
-    /// turso_db_config_int below. Declared argument-less because it is only
-    /// referenced as a `sym` jump target, never called from Rust.
+    /// Variadic implementations in varargs.c; each decodes its va_list and
+    /// calls the turso_* backends below. Declared argument-less because they
+    /// are only referenced as `sym` jump targets, never called from Rust.
     fn turso_sqlite3_db_config_va();
+    fn turso_sqlite3_mprintf_va();
+    fn turso_sqlite3_snprintf_va();
+}
+
+/// Exported trampolines for the variadic sqlite3_mprintf/sqlite3_snprintf;
+/// same mechanism as sqlite3_db_config below.
+#[unsafe(naked)]
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_mprintf(_fmt: *const ffi::c_char) -> *mut ffi::c_char {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    core::arch::naked_asm!("jmp {}", sym turso_sqlite3_mprintf_va);
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    core::arch::naked_asm!("b {}", sym turso_sqlite3_mprintf_va);
+}
+
+#[unsafe(naked)]
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_snprintf(
+    _n: ffi::c_int,
+    _buf: *mut ffi::c_char,
+    _fmt: *const ffi::c_char,
+) -> *mut ffi::c_char {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    core::arch::naked_asm!("jmp {}", sym turso_sqlite3_snprintf_va);
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    core::arch::naked_asm!("b {}", sym turso_sqlite3_snprintf_va);
+}
+
+extern "C" {
+    // One-line va_arg pumps in varargs.c: only C can read a va_list, and
+    // these are the only pieces that need to.
+    fn turso_va_i32(ap: *mut ffi::c_void) -> i32;
+    fn turso_va_i64(ap: *mut ffi::c_void) -> i64;
+    fn turso_va_f64(ap: *mut ffi::c_void) -> f64;
+    fn turso_va_ptr(ap: *mut ffi::c_void) -> *mut ffi::c_void;
+}
+
+/// Formats a sqlite3_mprintf-style call through core's printf engine — the
+/// implementation backing the SQL printf()/format() functions, so the C API
+/// and SQL formatting cannot diverge. `ap` is a pointer to the caller's
+/// va_list; core's printf_c_arg_plan (derived from the engine's own
+/// specifier grammar) dictates the C type pulled for each argument slot.
+/// Returns a malloc'd NUL-terminated string for sqlite3_free, or NULL when
+/// fmt is NULL or allocation fails.
+#[no_mangle]
+#[deny(unsafe_op_in_unsafe_fn)]
+pub unsafe extern "C" fn turso_printf_va(
+    fmt: *const ffi::c_char,
+    ap: *mut ffi::c_void,
+) -> *mut ffi::c_char {
+    if fmt.is_null() || ap.is_null() {
+        return std::ptr::null_mut();
+    }
+    // SAFETY: fmt checked non-null; caller guarantees a NUL-terminated string.
+    let fmt_str = unsafe { CStr::from_ptr(fmt) };
+    let fmt_str = String::from_utf8_lossy(fmt_str.to_bytes()).into_owned();
+
+    let mut args = Vec::new();
+    for slot in turso_core::printf_c_arg_plan(&fmt_str) {
+        use turso_core::PrintfCArg;
+        // SAFETY: the plan mirrors the engine's specifier grammar, so each
+        // pump reads the C type the caller passed for that slot.
+        let value = unsafe {
+            match slot {
+                PrintfCArg::Int32 => turso_core::Value::from_i64(turso_va_i32(ap) as i64),
+                PrintfCArg::Uint32 => turso_core::Value::from_i64(turso_va_i32(ap) as u32 as i64),
+                PrintfCArg::Int64 => turso_core::Value::from_i64(turso_va_i64(ap)),
+                PrintfCArg::Double => turso_core::Value::from_f64(turso_va_f64(ap)),
+                PrintfCArg::Text | PrintfCArg::OwnedText => {
+                    let s = turso_va_ptr(ap) as *const ffi::c_char;
+                    // A NULL string pointer becomes Value::Null: the engine
+                    // renders it as (NULL) for %q, NULL for %Q, "" for %s.
+                    let value = if s.is_null() {
+                        turso_core::Value::Null
+                    } else {
+                        let text = String::from_utf8_lossy(CStr::from_ptr(s).to_bytes());
+                        turso_core::Value::build_text(text.into_owned())
+                    };
+                    if slot == PrintfCArg::OwnedText {
+                        // %z: the caller yields the pointer.
+                        libc::free(s as *mut ffi::c_void);
+                    }
+                    value
+                }
+                // %c takes a character code in the C API, converted at
+                // extraction — as SQLite's C path does before its shared
+                // engine runs; the SQL printf('%c', x) takes the first
+                // character of x's text form, from the same engine.
+                PrintfCArg::CharCode => {
+                    let c = u32::try_from(turso_va_i32(ap))
+                        .ok()
+                        .and_then(char::from_u32)
+                        .unwrap_or('\u{fffd}');
+                    turso_core::Value::build_text(c.to_string())
+                }
+            }
+        };
+        args.push(value);
+    }
+
+    let fmt_value = turso_core::Value::build_text(fmt_str);
+    let arg_refs: Vec<&turso_core::Value> = args.iter().collect();
+    let rendered = match turso_core::exec_printf_values(&fmt_value, &arg_refs) {
+        // The SQL function returns NULL for an empty format or an unknown
+        // specifier before any output; the C API returns "" there.
+        Ok(turso_core::Value::Text(t)) => t.as_str().to_string(),
+        Ok(_) => String::new(),
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let n = rendered.len();
+    // SAFETY: fresh allocation of n + 1 bytes, copied then NUL-terminated.
+    unsafe {
+        let buf = libc::malloc(n + 1) as *mut ffi::c_char;
+        if buf.is_null() {
+            return std::ptr::null_mut();
+        }
+        std::ptr::copy_nonoverlapping(rendered.as_ptr(), buf as *mut u8, n);
+        *buf.add(n) = 0;
+        buf
+    }
 }
 
 /// Exported trampoline for the variadic sqlite3_db_config. rustc exports

--- a/bindings/c/src/varargs.c
+++ b/bindings/c/src/varargs.c
@@ -13,6 +13,8 @@
 */
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
 typedef struct sqlite3 sqlite3;
 
@@ -46,4 +48,53 @@ int turso_sqlite3_db_config_va(sqlite3 *db, int op, ...) {
     p_out = va_arg(ap, int *);
     va_end(ap);
     return turso_db_config_int(db, op, value, p_out);
+}
+
+extern char *turso_printf_va(const char *fmt, void *ap);
+extern void sqlite3_free(void *p);
+
+/*
+** One-line va_arg pumps. The Rust bridge walks the format string through
+** core's specifier grammar (printf_c_arg_plan) and calls back here for
+** each argument with the C type that grammar dictates — the only work a
+** va_list requires from C.
+*/
+int turso_va_i32(void *ap) { return va_arg(*(va_list *)ap, int); }
+long long turso_va_i64(void *ap) { return va_arg(*(va_list *)ap, long long); }
+double turso_va_f64(void *ap) { return va_arg(*(va_list *)ap, double); }
+void *turso_va_ptr(void *ap) { return va_arg(*(va_list *)ap, void *); }
+
+char *turso_sqlite3_mprintf_va(const char *fmt, ...) {
+    va_list ap;
+    char *r;
+
+    va_start(ap, fmt);
+    r = turso_printf_va(fmt, &ap);
+    va_end(ap);
+    return r;
+}
+
+char *turso_sqlite3_snprintf_va(int n, char *buf, const char *fmt, ...) {
+    va_list ap;
+    char *s;
+    size_t len;
+
+    if (n <= 0 || !buf) {
+        return buf;
+    }
+    va_start(ap, fmt);
+    s = turso_printf_va(fmt, &ap);
+    va_end(ap);
+    if (!s) {
+        buf[0] = 0;
+        return buf;
+    }
+    len = strlen(s);
+    if (len >= (size_t)n) {
+        len = (size_t)n - 1;
+    }
+    memcpy(buf, s, len);
+    buf[len] = 0;
+    sqlite3_free(s);
+    return buf;
 }

--- a/bindings/c/tests/oracle.rs
+++ b/bindings/c/tests/oracle.rs
@@ -120,6 +120,8 @@ api_table! {
     sqlite3_data_count: unsafe extern "C" fn(*mut c_void) -> c_int,
     sqlite3_column_name: unsafe extern "C" fn(*mut c_void, c_int) -> *const c_char,
     sqlite3_libversion_number: unsafe extern "C" fn() -> c_int,
+    sqlite3_mprintf: unsafe extern "C" fn(*const c_char, ...) -> *mut c_char,
+    sqlite3_snprintf: unsafe extern "C" fn(c_int, *mut c_char, *const c_char, ...) -> *mut c_char,
     sqlite3_free: unsafe extern "C" fn(*mut c_void),
 }
 
@@ -432,6 +434,152 @@ unsafe fn compare_introspection(ctx: &mut Ctx, s: &mut Session, t: &mut Session,
     );
 }
 
+/// mprintf/snprintf share core's printf engine with the SQL
+/// printf()/format() functions, so comparing them against libsqlite3 also
+/// differentially verifies that engine. Call shapes are fixed (va_arg arity
+/// is static per call site); values are randomized. %p is excluded: it
+/// renders a pointer, which legitimately differs between processes.
+type PrintfShape<'a> = &'a dyn Fn(&Api) -> *mut c_char;
+
+unsafe fn compare_printf(ctx: &mut Ctx, rng: &mut Rng, sqlite: &Api, turso: &Api) {
+    let grab = |api: &Api, f: &CStr, call: &dyn Fn(&Api) -> *mut c_char| {
+        let p = call(api);
+        let s = if p.is_null() {
+            None
+        } else {
+            Some(CStr::from_ptr(p).to_string_lossy().into_owned())
+        };
+        if !p.is_null() {
+            (api.sqlite3_free)(p as *mut c_void);
+        }
+        let _ = f;
+        s
+    };
+    for round in 0..4 {
+        let text = match random_value(rng) {
+            Val::Text(t) => t,
+            _ => "it's".to_string(),
+        };
+        let ctext = CString::new(text.clone()).unwrap_or_else(|_| CString::new("x").unwrap());
+        let tp: *const c_char = if rng.chance(15) {
+            std::ptr::null()
+        } else {
+            ctext.as_ptr()
+        };
+        // Precision counts bytes and the reference emits partial code points
+        // when it splits one; turso floors to a character boundary (Text is
+        // UTF-8). Precision shapes therefore use ASCII-only input.
+        let ascii = if text.is_ascii() {
+            text.clone()
+        } else {
+            "ab'cdef".to_string()
+        };
+        let cascii = CString::new(ascii).unwrap_or_else(|_| CString::new("x").unwrap());
+        let ap: *const c_char = if tp.is_null() { tp } else { cascii.as_ptr() };
+        let iv = rng.next() as i64;
+        let dv = [0.0f64, 3.5, -2.25, 0.1, 1e15, 12345.6789][rng.below(6)];
+        let shapes: &[(&str, PrintfShape)] = &[
+            ("%q", &|a: &Api| (a.sqlite3_mprintf)(c"%q".as_ptr(), tp)),
+            ("'%q'", &|a: &Api| (a.sqlite3_mprintf)(c"'%q'".as_ptr(), tp)),
+            ("%Q", &|a: &Api| (a.sqlite3_mprintf)(c"%Q".as_ptr(), tp)),
+            ("%w", &|a: &Api| (a.sqlite3_mprintf)(c"%w".as_ptr(), tp)),
+            ("%.3q", &|a: &Api| (a.sqlite3_mprintf)(c"%.3q".as_ptr(), ap)),
+            ("%8.3q", &|a: &Api| {
+                (a.sqlite3_mprintf)(c"%8.3q".as_ptr(), ap)
+            }),
+            ("%d|%lld", &|a: &Api| {
+                (a.sqlite3_mprintf)(c"%d|%lld".as_ptr(), iv as c_int, iv)
+            }),
+            ("%u:%x:%X:%o", &|a: &Api| {
+                (a.sqlite3_mprintf)(
+                    c"%u:%x:%X:%o".as_ptr(),
+                    iv as c_int,
+                    iv as c_int,
+                    iv as c_int,
+                    iv as c_int,
+                )
+            }),
+            ("%f/%e/%g", &|a: &Api| {
+                (a.sqlite3_mprintf)(c"%f/%e/%g".as_ptr(), dv, dv, dv)
+            }),
+            ("%08.3f", &|a: &Api| {
+                (a.sqlite3_mprintf)(c"%08.3f".as_ptr(), dv)
+            }),
+            ("%-10s|%10s|", &|a: &Api| {
+                (a.sqlite3_mprintf)(c"%-10s|%10s|".as_ptr(), tp, tp)
+            }),
+            ("%*d", &|a: &Api| {
+                (a.sqlite3_mprintf)(c"%*d".as_ptr(), (rng_width(iv)) as c_int, iv as c_int)
+            }),
+            ("%c", &|a: &Api| {
+                (a.sqlite3_mprintf)(c"%c".as_ptr(), (65 + (iv.rem_euclid(26))) as c_int)
+            }),
+            ("100%%", &|a: &Api| (a.sqlite3_mprintf)(c"100%%".as_ptr())),
+        ];
+        let (label, call) = &shapes[rng.below(shapes.len())];
+        ctx.log(format!(
+            "printf round {round}: {label} text={text:?} null={} iv={iv} dv={dv}",
+            tp.is_null()
+        ));
+        let out_s = grab(sqlite, c"", call);
+        let out_t = grab(turso, c"", call);
+        ctx.check(&format!("mprintf {label}"), out_s, out_t);
+
+        // snprintf: same engine through the bounded-buffer contract. On
+        // overflow only the contract is compared — truncation within n and
+        // NUL termination, output a prefix of the full rendering, no write
+        // past n-1 — because which truncated bytes land is an accumulator
+        // staging artifact in the reference (short conversions part-fill
+        // the remaining space, oversized ones are dropped wholesale).
+        let full = grab(sqlite, c"", &|a: &Api| {
+            (a.sqlite3_mprintf)(c"'%q'".as_ptr(), tp)
+        })
+        .unwrap_or_default();
+        let mut buf_s = [0x7fu8; 24];
+        let mut buf_t = [0x7fu8; 24];
+        let n = rng.below(24) as c_int;
+        let r_s =
+            (sqlite.sqlite3_snprintf)(n, buf_s.as_mut_ptr() as *mut c_char, c"'%q'".as_ptr(), tp);
+        let r_t =
+            (turso.sqlite3_snprintf)(n, buf_t.as_mut_ptr() as *mut c_char, c"'%q'".as_ptr(), tp);
+        ctx.check(
+            "snprintf returns buf",
+            r_s == buf_s.as_mut_ptr() as *mut c_char,
+            r_t == buf_t.as_mut_ptr() as *mut c_char,
+        );
+        if full.len() < n as usize {
+            ctx.check(&format!("snprintf n={n}"), buf_s, buf_t);
+        } else {
+            for (label, buf) in [("sqlite", &buf_s), ("turso", &buf_t)] {
+                if n > 0 {
+                    let content = &buf[..n as usize];
+                    let nul = content.iter().position(|&b| b == 0);
+                    ctx.check(
+                        &format!("snprintf overflow NUL ({label}, n={n})"),
+                        true,
+                        nul.is_some(),
+                    );
+                    let prefix = &content[..nul.unwrap_or(0)];
+                    ctx.check(
+                        &format!("snprintf overflow prefix ({label}, n={n})"),
+                        true,
+                        full.as_bytes().starts_with(prefix),
+                    );
+                }
+                ctx.check(
+                    &format!("snprintf overflow no-write-past-n ({label}, n={n})"),
+                    true,
+                    buf[n.max(0) as usize..].iter().all(|&b| b == 0x7f),
+                );
+            }
+        }
+    }
+}
+
+fn rng_width(iv: i64) -> i64 {
+    iv.rem_euclid(12)
+}
+
 unsafe fn run_scenario(ctx: &mut Ctx, rng: &mut Rng, sqlite: &Api, turso: &Api) {
     let mut s = Session::open(sqlite);
     let mut t = Session::open(turso);
@@ -615,6 +763,8 @@ unsafe fn run_scenario(ctx: &mut Ctx, rng: &mut Rng, sqlite: &Api, turso: &Api) 
             (turso.sqlite3_last_insert_rowid)(t.db),
         );
     }
+
+    compare_printf(ctx, rng, sqlite, turso);
 
     // Read everything back in lockstep and compare types and values. The
     // SELECT is sometimes prepared from a multi-statement buffer with an

--- a/bindings/c/tests/sqlite3_tests.c
+++ b/bindings/c/tests/sqlite3_tests.c
@@ -25,6 +25,7 @@ void test_sqlite3_set_authorizer();
 void test_sqlite3_db_config();
 void test_sqlite3_extended_result_codes();
 void test_sqlite3_sql_introspection();
+void test_sqlite3_mprintf();
 
 int allocated = 0;
 
@@ -49,6 +50,7 @@ int main(void)
     test_sqlite3_db_config();
     test_sqlite3_extended_result_codes();
     test_sqlite3_sql_introspection();
+    test_sqlite3_mprintf();
     return 0;
 }
 
@@ -1066,4 +1068,66 @@ void test_sqlite3_sql_introspection()
 
     sqlite3_close(db);
     printf("test_sqlite3_sql_introspection test passed\n");
+}
+
+/*
+** sqlite3_mprintf / sqlite3_snprintf: the SQL-quoting specifiers backing
+** SQLite3::escapeString (%q) and PDO::quote ('%q'), plus the standard
+** conversions, width/precision, %z, and snprintf's bounded contract
+** (returns buf, truncates at n-1 with NUL, writes nothing when n <= 0).
+*/
+void test_sqlite3_mprintf()
+{
+    char *p;
+    char buf[8];
+
+    p = sqlite3_mprintf("%q", "it's");
+    assert(strcmp(p, "it''s") == 0);
+    sqlite3_free(p);
+
+    p = sqlite3_mprintf("%q", (const char *)0);
+    assert(strcmp(p, "(NULL)") == 0);
+    sqlite3_free(p);
+
+    p = sqlite3_mprintf("%Q", "it's");
+    assert(strcmp(p, "'it''s'") == 0);
+    sqlite3_free(p);
+
+    p = sqlite3_mprintf("%Q", (const char *)0);
+    assert(strcmp(p, "NULL") == 0);
+    sqlite3_free(p);
+
+    p = sqlite3_mprintf("%w", "a\"b");
+    assert(strcmp(p, "a\"\"b") == 0);
+    sqlite3_free(p);
+
+    /* Precision truncates the input before escaping; width pads after. */
+    p = sqlite3_mprintf("%8.3q", "ab'cdef");
+    assert(strcmp(p, "    ab''") == 0);
+    sqlite3_free(p);
+
+    p = sqlite3_mprintf("%d|%05d|%x|%.2f|%e|%lld", 42, 7, 255, 3.14159,
+                        12345.678, (long long)9223372036854775807LL);
+    assert(strcmp(p, "42|00007|ff|3.14|1.234568e+04|9223372036854775807") == 0);
+    sqlite3_free(p);
+
+    p = sqlite3_mprintf("%s|%10s|%-10s|100%%|%c%c", "hi", "hi", "hi", 'A', 'B');
+    assert(strcmp(p, "hi|        hi|hi        |100%|AB") == 0);
+    sqlite3_free(p);
+
+    /* %z consumes and frees its argument. */
+    p = sqlite3_mprintf("dup-%z-end", sqlite3_mprintf("inner"));
+    assert(strcmp(p, "dup-inner-end") == 0);
+    sqlite3_free(p);
+
+    assert(sqlite3_snprintf(sizeof buf, buf, "'%q'", "abcdefghij") == buf);
+    assert(strcmp(buf, "'abcdef") == 0);
+
+    sqlite3_snprintf(0, buf, "%d", 5);
+    assert(strcmp(buf, "'abcdef") == 0);
+
+    sqlite3_snprintf(sizeof buf, buf, "'%q'", "ab");
+    assert(strcmp(buf, "'ab'") == 0);
+
+    printf("test_sqlite3_mprintf test passed\n");
 }

--- a/core/functions/printf.rs
+++ b/core/functions/printf.rs
@@ -90,7 +90,7 @@ const MAX_WIDTH: usize = 1_000_000;
 /// May consume arguments from `values` for `*` width/precision.
 fn parse_format_spec(
     chars: &mut Peekable<Chars>,
-    values: &[Register],
+    values: &[&Value],
     args_index: &mut usize,
 ) -> FormatSpec {
     let mut flags = parse_flags(chars);
@@ -150,11 +150,11 @@ fn parse_format_spec(
 // ── Coercion helpers ────────────────────────────────────────────
 
 /// Get the next argument as i64 (for * width/precision), advancing args_index.
-fn get_arg_i64(values: &[Register], args_index: &mut usize) -> i64 {
-    if *args_index >= values.len() {
+fn get_arg_i64(args: &[&Value], args_index: &mut usize) -> i64 {
+    if *args_index >= args.len() {
         return 0;
     }
-    let val = coerce_to_i64(values[*args_index].get_value());
+    let val = coerce_to_i64(args[*args_index]);
     *args_index += 1;
     val
 }
@@ -233,8 +233,16 @@ fn apply_width(
     flags: &FormatFlags,
     zero_overrides_left: bool,
 ) {
-    // Use character count, not byte count, for width — SQLite counts characters.
-    let total_len = sign_prefix.chars().count() + content.chars().count();
+    // Width counts bytes by default and characters with the ! flag, as
+    // SQLite measures it.
+    let measure = |t: &str| {
+        if flags.alt_form_2 {
+            t.chars().count()
+        } else {
+            t.len()
+        }
+    };
+    let total_len = measure(sign_prefix) + measure(content);
     let w = width.unwrap_or(0);
     if total_len >= w {
         output.push_str(sign_prefix);
@@ -1051,18 +1059,7 @@ fn format_string(output: &mut String, value: &Value, spec: &FormatSpec) {
         }
         _ => coerce_to_string(value),
     };
-    let truncated = if let Some(prec) = spec.precision {
-        // Truncate by character count (not bytes). SQLite uses bytes by default
-        // and chars with !, but since blobs are already lossy-converted to UTF-8,
-        // character-based truncation avoids mid-char splits.
-        if let Some((byte_idx, _)) = s.char_indices().nth(prec) {
-            &s[..byte_idx]
-        } else {
-            &s
-        }
-    } else {
-        &s
-    };
+    let truncated = truncate_to_precision(&s, spec.precision, &spec.flags);
 
     // Zero-pad flag is ignored for string specifiers
     let mut flags = spec.flags.clone();
@@ -1117,12 +1114,12 @@ fn format_sql_quote(output: &mut String, value: &Value, spec: &FormatSpec) {
     flags.zero_pad = false;
     match value {
         Value::Null => {
-            let truncated = truncate_to_precision("(NULL)", spec.precision);
+            let truncated = truncate_to_precision("(NULL)", spec.precision, &spec.flags);
             apply_width(output, "", truncated, spec.width, &flags, false);
         }
         _ => {
             let s = coerce_to_string(value);
-            let truncated = truncate_to_precision(&s, spec.precision);
+            let truncated = truncate_to_precision(&s, spec.precision, &spec.flags);
             let mut escaped = truncated.replace('\'', "''");
             if spec.flags.alternate {
                 escaped = escape_control_chars(&escaped);
@@ -1139,12 +1136,12 @@ fn format_sql_quote_wrap(output: &mut String, value: &Value, spec: &FormatSpec) 
     flags.zero_pad = false;
     match value {
         Value::Null => {
-            let truncated = truncate_to_precision("NULL", spec.precision);
+            let truncated = truncate_to_precision("NULL", spec.precision, &spec.flags);
             apply_width(output, "", truncated, spec.width, &flags, false);
         }
         _ => {
             let s = coerce_to_string(value);
-            let truncated = truncate_to_precision(&s, spec.precision);
+            let truncated = truncate_to_precision(&s, spec.precision, &spec.flags);
             let mut escaped = truncated.replace('\'', "''");
             // %#Q: escape control chars and wrap with unistr('...') if any are present.
             let use_unistr = if spec.flags.alternate {
@@ -1181,12 +1178,12 @@ fn format_sql_identifier(output: &mut String, value: &Value, spec: &FormatSpec) 
     flags.zero_pad = false;
     match value {
         Value::Null => {
-            let truncated = truncate_to_precision("(NULL)", spec.precision);
+            let truncated = truncate_to_precision("(NULL)", spec.precision, &spec.flags);
             apply_width(output, "", truncated, spec.width, &flags, false);
         }
         _ => {
             let s = coerce_to_string(value);
-            let truncated = truncate_to_precision(&s, spec.precision);
+            let truncated = truncate_to_precision(&s, spec.precision, &spec.flags);
             let escaped = truncated.replace('"', "\"\"");
             apply_width(output, "", &escaped, spec.width, &flags, false);
         }
@@ -1227,20 +1224,29 @@ fn format_ordinal(output: &mut String, value: &Value, spec: &FormatSpec) {
     }
 }
 
-/// Truncate a string to at most `precision` characters.
-fn truncate_to_precision(s: &str, precision: Option<usize>) -> &str {
-    match precision {
-        Some(prec) => {
-            // Truncate by character count. SQLite uses byte count by default
-            // and character count with the ! flag, but since Turso is UTF-8 only,
-            // character-based truncation is always correct for our strings.
-            if let Some((byte_idx, _)) = s.char_indices().nth(prec) {
-                &s[..byte_idx]
-            } else {
-                s
-            }
+/// Truncate a string to at most `precision` units: bytes by default,
+/// characters with the ! flag, as SQLite counts them. Byte truncation
+/// floors to a character boundary — Text values are UTF-8 strings, so the
+/// partial code point SQLite emits when precision splits one cannot be
+/// represented.
+fn truncate_to_precision<'a>(s: &'a str, precision: Option<usize>, flags: &FormatFlags) -> &'a str {
+    let Some(prec) = precision else {
+        return s;
+    };
+    if flags.alt_form_2 {
+        if let Some((byte_idx, _)) = s.char_indices().nth(prec) {
+            &s[..byte_idx]
+        } else {
+            s
         }
-        _ => s,
+    } else if prec >= s.len() {
+        s
+    } else {
+        let mut end = prec;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
     }
 }
 
@@ -1250,11 +1256,97 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
     if values.is_empty() {
         return Ok(Value::Null);
     }
+    let args: Vec<&Value> = values[1..].iter().map(|r| r.get_value()).collect();
+    exec_printf_values(values[0].get_value(), &args)
+}
 
+/// The C type a sqlite3_mprintf-style caller passes for one argument slot,
+/// in order. Derived from the same specifier grammar the engine formats
+/// with, so the C API's va_list walk cannot drift from the formatter:
+/// varargs.c pulls exactly these types and the bridge feeds the values back
+/// into exec_printf_values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrintfCArg {
+    Int32,
+    /// u/o/x/X without a length modifier: an unsigned int, zero-extended.
+    Uint32,
+    Int64,
+    Double,
+    Text,
+    /// %z: text whose pointer the caller yields; freed after use.
+    OwnedText,
+    /// %c: a character code in the C API, rendered as that character.
+    CharCode,
+}
+
+/// The sequence of C argument types `format` consumes: for each conversion,
+/// an Int32 for a `*` width, an Int32 for a `.*` precision, then the
+/// conversion's own argument. Stops at an unknown conversion, where the
+/// engine stops formatting too.
+pub fn printf_c_arg_plan(format: &str) -> Vec<PrintfCArg> {
+    let mut plan = Vec::new();
+    let mut chars = format.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '%' {
+            continue;
+        }
+        if chars.peek() == Some(&'%') {
+            chars.next();
+            continue;
+        }
+        parse_flags(&mut chars);
+        if chars.peek() == Some(&'*') {
+            chars.next();
+            plan.push(PrintfCArg::Int32);
+        } else {
+            parse_number(&mut chars);
+        }
+        if chars.peek() == Some(&'.') {
+            chars.next();
+            if chars.peek() == Some(&'*') {
+                chars.next();
+                plan.push(PrintfCArg::Int32);
+            } else {
+                parse_number(&mut chars);
+            }
+        }
+        let mut longs = 0;
+        while matches!(chars.peek(), Some(&'l') | Some(&'h')) {
+            if chars.peek() == Some(&'l') {
+                longs += 1;
+            }
+            chars.next();
+        }
+        match chars.next() {
+            Some('d' | 'i' | 'r') => plan.push(if longs >= 1 {
+                PrintfCArg::Int64
+            } else {
+                PrintfCArg::Int32
+            }),
+            Some('u' | 'o' | 'x' | 'X') => plan.push(if longs >= 1 {
+                PrintfCArg::Int64
+            } else {
+                PrintfCArg::Uint32
+            }),
+            Some('f' | 'e' | 'E' | 'g' | 'G') => plan.push(PrintfCArg::Double),
+            Some('s' | 'q' | 'Q' | 'w') => plan.push(PrintfCArg::Text),
+            Some('z') => plan.push(PrintfCArg::OwnedText),
+            Some('c') => plan.push(PrintfCArg::CharCode),
+            Some('p') => plan.push(PrintfCArg::Int64),
+            Some('n') | None => {}
+            _ => break,
+        }
+    }
+    plan
+}
+
+/// Value-level entry point, shared by the SQL printf()/format() functions
+/// and the C API's sqlite3_mprintf/sqlite3_snprintf bridge so there is a
+/// single formatting implementation.
+pub fn exec_printf_values(format: &Value, args: &[&Value]) -> crate::Result<Value> {
     // SQLite converts the format argument to text if not already text.
-    let format_value = values[0].get_value();
     let fmt_owned: String;
-    let format_str = match &format_value {
+    let format_str = match format {
         Value::Text(t) => t.as_str(),
         Value::Null => return Ok(Value::Null),
         Value::Numeric(Numeric::Integer(i)) => {
@@ -1272,7 +1364,7 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
     };
 
     let mut result = String::new();
-    let mut args_index = 1;
+    let mut args_index = 0;
     let mut chars = format_str.chars().peekable();
     if format_str.is_empty() {
         return Ok(Value::Null);
@@ -1307,14 +1399,14 @@ pub fn exec_printf(values: &[Register]) -> crate::Result<Value> {
         }
 
         // Parse the full format specifier
-        let spec = parse_format_spec(&mut chars, values, &mut args_index);
+        let spec = parse_format_spec(&mut chars, args, &mut args_index);
 
         // Get the argument value (or use NULL if missing)
         let needs_arg = !matches!(spec.spec_type, 'n' | '\0');
         let null_val = Value::Null;
         let arg = if needs_arg {
-            if args_index < values.len() {
-                let v = values[args_index].get_value();
+            if args_index < args.len() {
+                let v = args[args_index];
                 args_index += 1;
                 v
             } else {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -90,6 +90,10 @@ mod vtab;
 pub use function::Func;
 #[cfg(any(feature = "fuzz", feature = "bench"))]
 pub use function::MathFunc;
+/// The printf engine backing the SQL printf()/format() functions, also used
+/// by the C API's sqlite3_mprintf/sqlite3_snprintf so both share one
+/// formatting implementation.
+pub use functions::printf::{exec_printf_values, printf_c_arg_plan, PrintfCArg};
 
 use crate::{
     busy::{BusyHandler, BusyHandlerCallback},


### PR DESCRIPTION
Implements `sqlite3_mprintf` and `sqlite3_snprintf`, backing `SQLite3::escapeString` (`%q`) and `PDO::quote` (`'%q'`) in PHP.

Formatting runs through core's printf engine — the implementation behind the SQL `printf()`/`format()` functions — via a new Value-level entry point, `exec_printf_values`, so the C API and SQL formatting share one implementation, as they do in SQLite. The C side (`varargs.c`) only walks the format string to pull each `va_list` argument with the type its conversion implies, handles `%z` (argument freed after use) and `%c` (a character code in the C API, converted at extraction; the SQL function takes the first character of the text form — both behaviors from the same engine), and pushes the values to the Rust bridge. `mprintf` results are released with `sqlite3_free`; `snprintf` writes at most n-1 bytes, always NUL-terminates, and returns the buffer.

Width and precision for string conversions count bytes, or characters with the `!` flag, as SQLite measures them. Byte-counted precision floors to a character boundary: Text values are UTF-8 strings, so the partial code point SQLite emits when precision splits one cannot be represented.

The oracle gains a printf stage comparing both entry points against libsqlite3 across randomized values and specifier shapes — and since the engine is shared, it differentially verifies the SQL `printf()` as well. On `snprintf` overflow only the contract is compared (truncation within n, NUL termination, output a prefix of the full rendering, no write past n-1); which truncated bytes land is an accumulator staging artifact in the reference. Directed tests pin `%q`/`%Q`/`%w`, NULL arguments, width/precision, `%z`, and the `snprintf` bounds against both libraries.

Based on #8259 (uses its oracle harness); retargets to main and rebases to a single commit when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
