### PR TITLE
bindings/dotnet: expose page codec API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ perf/mobibench/plot/uv.lock
 **/node_modules/
 
 # .NET build outputs
+examples/dotnet/bin/
 examples/dotnet/obj/
 
 # testing

--- a/bindings/dotnet/src/Turso.Data/TursoConnection.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoConnection.cs
@@ -14,6 +14,8 @@ public class TursoConnection : DbConnection
     private bool _disposed;
     private bool _readUncommitted;
     private bool _remoteTransactionActive;
+    private ITursoPageCodec? _pageCodec;
+    private byte _pageCodecReservedSpace;
 
     [AllowNull]
     public override string ConnectionString
@@ -42,6 +44,30 @@ public class TursoConnection : DbConnection
 
     protected override DbProviderFactory DbProviderFactory => TursoFactory.Instance;
 
+    public ITursoPageCodec? PageCodec
+    {
+        get => _pageCodec;
+        set
+        {
+            if (State == ConnectionState.Open)
+                throw new InvalidOperationException("PageCodec cannot be set while the connection is open.");
+
+            _pageCodec = value;
+        }
+    }
+
+    public byte PageCodecReservedSpace
+    {
+        get => _pageCodecReservedSpace;
+        set
+        {
+            if (State == ConnectionState.Open)
+                throw new InvalidOperationException("PageCodecReservedSpace cannot be set while the connection is open.");
+
+            _pageCodecReservedSpace = value;
+        }
+    }
+
     public TursoConnection() : this("")
     {
     }
@@ -68,8 +94,18 @@ public class TursoConnection : DbConnection
         var filename = _connectionOptions["Data Source"] ?? ":memory:";
         var cipher = _connectionOptions.GetEncryptionCipher();
         var hexkey = _connectionOptions["Encryption Key"];
+        var readOnly = IsReadOnlyMode(_connectionOptions["Mode"]);
 
-        if (cipher.HasValue)
+        if (_pageCodec is not null)
+        {
+            if (cipher.HasValue)
+                throw new InvalidOperationException("PageCodec cannot be combined with Encryption Cipher.");
+
+            _turso = readOnly
+                ? TursoBindings.OpenDatabaseReadOnlyWithPageCodec(filename, _pageCodec, _pageCodecReservedSpace)
+                : TursoBindings.OpenDatabaseWithPageCodec(filename, _pageCodec, _pageCodecReservedSpace);
+        }
+        else if (cipher.HasValue)
         {
             if (string.IsNullOrWhiteSpace(hexkey))
                 throw new InvalidOperationException("Encryption Key is required when Encryption Cipher is specified.");
@@ -80,6 +116,14 @@ public class TursoConnection : DbConnection
         {
             _turso = TursoBindings.OpenDatabase(filename);
         }
+    }
+
+    private static bool IsReadOnlyMode(string? mode)
+    {
+        return mode is not null
+            && (mode.Equals("ReadOnly", StringComparison.OrdinalIgnoreCase)
+                || mode.Equals("Read Only", StringComparison.OrdinalIgnoreCase)
+                || mode.Equals("ro", StringComparison.OrdinalIgnoreCase));
     }
 
     public override Task OpenAsync(CancellationToken cancellationToken)
@@ -327,6 +371,8 @@ public class TursoConnection : DbConnection
 
         if (_connectionOptions.GetEncryptionCipher().HasValue || !string.IsNullOrWhiteSpace(_connectionOptions["Encryption Key"]))
             throw new InvalidOperationException("Encryption Cipher and Encryption Key are local database options and cannot be used with remote Turso URLs.");
+        if (_pageCodec is not null)
+            throw new InvalidOperationException("PageCodec is a local database option and cannot be used with remote Turso URLs.");
 
         _remoteClient = new TursoRemoteClient(_connectionOptions.GetRemoteUri(), _connectionOptions.AuthToken);
     }

--- a/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoDatabaseHandle.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoDatabaseHandle.cs
@@ -31,7 +31,9 @@ public class TursoDatabaseHandle() : SafeHandle(IntPtr.Zero, true)
             throw new NullReferenceException("database is invalid");
     }
 
-    public static TursoDatabaseHandle FromPtrs(IntPtr database, IntPtr connection)
+    public static TursoDatabaseHandle FromPtrs(
+        IntPtr database,
+        IntPtr connection)
     {
         var handle = new TursoDatabaseHandle();
         handle._database = database;

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
@@ -301,6 +301,8 @@ public static class TursoBindings
             Vfs = IntPtr.Zero,
             EncryptionCipher = cipherString.Pointer,
             EncryptionHexKey = hexkeyString.Pointer,
+            PageCodec = IntPtr.Zero,
+            OpenFlags = 0,
         };
 
         var status = TursoInterop.DatabaseNew(ref config, out var databasePtr, out var errorPtr);

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
@@ -10,7 +10,13 @@ public static class TursoBindings
     public static TursoDatabaseHandle OpenDatabase(string path)
     {
         ArgumentNullException.ThrowIfNull(path);
-        return OpenDatabase(path, cipher: null, hexkey: null);
+        return OpenDatabase(path, cipher: null, hexkey: null, pageCodec: null, readOnly: false);
+    }
+
+    public static TursoDatabaseHandle OpenDatabaseReadOnly(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return OpenDatabase(path, cipher: null, hexkey: null, pageCodec: null, readOnly: true);
     }
 
     /// <summary>
@@ -25,7 +31,45 @@ public static class TursoBindings
         ArgumentNullException.ThrowIfNull(path);
         ArgumentNullException.ThrowIfNull(hexkey);
 
-        return OpenDatabase(path, cipher.ToRustString(), hexkey);
+        return OpenDatabase(path, cipher.ToRustString(), hexkey, pageCodec: null, readOnly: false);
+    }
+
+    private static TursoDatabaseHandle OpenDatabaseWithPageCodec(string path, TursoPageCodec pageCodec)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(pageCodec);
+
+        return OpenDatabase(path, cipher: null, hexkey: null, pageCodec, readOnly: false);
+    }
+
+    private static TursoDatabaseHandle OpenDatabaseReadOnlyWithPageCodec(string path, TursoPageCodec pageCodec)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(pageCodec);
+
+        return OpenDatabase(path, cipher: null, hexkey: null, pageCodec, readOnly: true);
+    }
+
+    public static TursoDatabaseHandle OpenDatabaseWithPageCodec(
+        string path,
+        ITursoPageCodec pageCodec,
+        byte reservedSpace = 0)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(pageCodec);
+
+        return OpenDatabaseWithPageCodec(path, new TursoPageCodec(pageCodec, reservedSpace));
+    }
+
+    public static TursoDatabaseHandle OpenDatabaseReadOnlyWithPageCodec(
+        string path,
+        ITursoPageCodec pageCodec,
+        byte reservedSpace = 0)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        ArgumentNullException.ThrowIfNull(pageCodec);
+
+        return OpenDatabaseReadOnlyWithPageCodec(path, new TursoPageCodec(pageCodec, reservedSpace));
     }
 
     public static TursoStatementHandle PrepareStatement(TursoDatabaseHandle db, string sql)
@@ -286,7 +330,12 @@ public static class TursoBindings
         }
     }
 
-    private static TursoDatabaseHandle OpenDatabase(string path, string? cipher, string? hexkey)
+    private static TursoDatabaseHandle OpenDatabase(
+        string path,
+        string? cipher,
+        string? hexkey,
+        TursoPageCodec? pageCodec,
+        bool readOnly)
     {
         using var pathString = NativeUtf8String.From(path);
         using var featuresString = NativeUtf8String.From(cipher is null ? null : "encryption");
@@ -301,16 +350,20 @@ public static class TursoBindings
             Vfs = IntPtr.Zero,
             EncryptionCipher = cipherString.Pointer,
             EncryptionHexKey = hexkeyString.Pointer,
-            PageCodec = IntPtr.Zero,
-            OpenFlags = 0,
+            PageCodec = pageCodec?.NativePointer ?? IntPtr.Zero,
+            OpenFlags = (uint)(readOnly ? TursoDatabaseOpenFlags.ReadOnly : TursoDatabaseOpenFlags.None),
         };
 
-        var status = TursoInterop.DatabaseNew(ref config, out var databasePtr, out var errorPtr);
-        ThrowIfError(status, errorPtr);
-
+        var databasePtr = IntPtr.Zero;
         var connectionPtr = IntPtr.Zero;
         try
         {
+            var status = TursoInterop.DatabaseNew(ref config, out databasePtr, out var errorPtr);
+            ThrowIfError(status, errorPtr);
+            pageCodec?.TransferNativeOwnership();
+            pageCodec?.Dispose();
+            pageCodec = null;
+
             status = TursoInterop.DatabaseOpen(databasePtr, out errorPtr);
             ThrowIfError(status, errorPtr);
 
@@ -325,6 +378,7 @@ public static class TursoBindings
                 TursoInterop.ConnectionDeinit(connectionPtr);
             if (databasePtr != IntPtr.Zero)
                 TursoInterop.DatabaseDeinit(databasePtr);
+            pageCodec?.Dispose();
             throw;
         }
     }

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoPageCodec.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoPageCodec.cs
@@ -1,0 +1,358 @@
+using System.Runtime.InteropServices;
+
+namespace Turso.Raw.Public;
+
+public enum TursoPageCodecLocation : uint
+{
+    Database = 0,
+    Wal = 1,
+}
+
+public readonly record struct TursoPageCodecHeaderInfo(uint PageSize, byte ReservedSpace);
+
+public readonly record struct TursoPageCodecId
+{
+    private readonly Guid _value;
+
+    private TursoPageCodecId(Guid value)
+    {
+        if (value == Guid.Empty)
+            throw new ArgumentException("Page codec ID must be non-zero.", nameof(value));
+
+        _value = value;
+    }
+
+    public static TursoPageCodecId FromGuid(Guid value)
+    {
+        return new TursoPageCodecId(value);
+    }
+
+    public static TursoPageCodecId FromBytes(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length != 16)
+            throw new ArgumentException("Page codec ID must be exactly 16 bytes.", nameof(bytes));
+
+        return new TursoPageCodecId(new Guid(bytes));
+    }
+
+    internal void CopyTo(Span<byte> destination)
+    {
+        if (_value == Guid.Empty)
+            throw new InvalidOperationException("Page codec ID must be non-zero.");
+
+        if (!_value.TryWriteBytes(destination))
+            throw new ArgumentException("Destination must be at least 16 bytes.", nameof(destination));
+    }
+}
+
+public interface ITursoPageCodec
+{
+    TursoPageCodecId CodecId { get; }
+
+    TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix);
+
+    void DecodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output);
+
+    void EncodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output);
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal unsafe delegate int TursoPageCodecProbeHeaderCallback(
+    IntPtr context,
+    byte* rawPage1Prefix,
+    UIntPtr rawLen,
+    TursoNativePageCodecHeaderInfo* headerInfo,
+    IntPtr* error);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal unsafe delegate int TursoPageCodecTransformCallback(
+    IntPtr context,
+    uint pageNo,
+    TursoPageCodecLocation location,
+    byte* input,
+    UIntPtr inputLen,
+    byte* output,
+    UIntPtr outputLen,
+    IntPtr* error);
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate void TursoPageCodecDestroyCallback(IntPtr context);
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TursoNativePageCodecHeaderInfo
+{
+    public uint PageSize;
+    public byte ReservedSpace;
+    public byte IsSupported;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal unsafe struct TursoNativePageCodecV1
+{
+    public uint AbiVersion;
+    public IntPtr Context;
+    public byte ReservedSpace;
+    public fixed byte CodecId[16];
+    public IntPtr Destroy;
+    public IntPtr ProbeHeader;
+    public IntPtr DecodePage;
+    public IntPtr EncodePage;
+}
+
+internal sealed unsafe class TursoPageCodec : IDisposable
+{
+    private sealed class State(ITursoPageCodec codec) : IDisposable
+    {
+        private readonly object _lock = new();
+        private readonly List<IntPtr> _errors = [];
+        private bool _disposed;
+
+        public ITursoPageCodec Codec { get; } = codec;
+
+        public IntPtr SetError(Exception exception)
+        {
+            var message = Marshal.StringToCoTaskMemUTF8(exception.Message);
+            lock (_lock)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                _errors.Add(message);
+            }
+
+            return message;
+        }
+
+        public void Dispose()
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                    return;
+
+                foreach (var error in _errors)
+                    Marshal.FreeCoTaskMem(error);
+
+                _errors.Clear();
+                _disposed = true;
+            }
+        }
+    }
+
+    private delegate void PageTransform(
+        ITursoPageCodec codec,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output);
+
+    private static readonly TursoPageCodecProbeHeaderCallback ProbeHeaderCallback = ProbeHeader;
+    private static readonly TursoPageCodecTransformCallback DecodePageCallback = DecodePage;
+    private static readonly TursoPageCodecTransformCallback EncodePageCallback = EncodePage;
+    private static readonly TursoPageCodecDestroyCallback DestroyCallback = Destroy;
+
+    private readonly IntPtr _nativeCodec;
+    private readonly GCHandle _stateHandle;
+    private bool _ownsState = true;
+    private bool _disposed;
+
+    public TursoPageCodec(ITursoPageCodec codec, byte reservedSpace)
+    {
+        ArgumentNullException.ThrowIfNull(codec);
+        Span<byte> codecId = stackalloc byte[16];
+        codec.CodecId.CopyTo(codecId);
+
+        _stateHandle = GCHandle.Alloc(new State(codec));
+
+        var nativeCodec = IntPtr.Zero;
+        try
+        {
+            var native = new TursoNativePageCodecV1
+            {
+                AbiVersion = 1,
+                Context = GCHandle.ToIntPtr(_stateHandle),
+                ReservedSpace = reservedSpace,
+                Destroy = Marshal.GetFunctionPointerForDelegate(DestroyCallback),
+                ProbeHeader = Marshal.GetFunctionPointerForDelegate(ProbeHeaderCallback),
+                DecodePage = Marshal.GetFunctionPointerForDelegate(DecodePageCallback),
+                EncodePage = Marshal.GetFunctionPointerForDelegate(EncodePageCallback),
+            };
+            codecId.CopyTo(new Span<byte>(native.CodecId, 16));
+
+            nativeCodec = Marshal.AllocHGlobal(Marshal.SizeOf<TursoNativePageCodecV1>());
+            Marshal.StructureToPtr(native, nativeCodec, false);
+            _nativeCodec = nativeCodec;
+            nativeCodec = IntPtr.Zero;
+        }
+        catch
+        {
+            if (nativeCodec != IntPtr.Zero)
+                Marshal.FreeHGlobal(nativeCodec);
+
+            Destroy(GCHandle.ToIntPtr(_stateHandle));
+            throw;
+        }
+    }
+
+    internal IntPtr NativePointer
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _nativeCodec;
+        }
+    }
+
+    public void TransferNativeOwnership()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _ownsState = false;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        Marshal.FreeHGlobal(_nativeCodec);
+        if (_ownsState)
+            Destroy(GCHandle.ToIntPtr(_stateHandle));
+
+        _disposed = true;
+    }
+
+    private static int ProbeHeader(
+        IntPtr context,
+        byte* rawPage1Prefix,
+        UIntPtr rawLen,
+        TursoNativePageCodecHeaderInfo* headerInfo,
+        IntPtr* error)
+    {
+        var state = GetState(context);
+        try
+        {
+            var raw = new ReadOnlySpan<byte>(rawPage1Prefix, checked((int)rawLen));
+            var result = state.Codec.ProbeHeader(raw);
+            if (result is null)
+            {
+                *headerInfo = default;
+            }
+            else
+            {
+                *headerInfo = new TursoNativePageCodecHeaderInfo
+                {
+                    PageSize = result.Value.PageSize,
+                    ReservedSpace = result.Value.ReservedSpace,
+                    IsSupported = 1,
+                };
+            }
+            *error = IntPtr.Zero;
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            *error = state.SetError(ex);
+            return 1;
+        }
+    }
+
+    private static int DecodePage(
+        IntPtr context,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        byte* input,
+        UIntPtr inputLen,
+        byte* output,
+        UIntPtr outputLen,
+        IntPtr* error)
+    {
+        return Transform(context, pageNo, location, input, inputLen, output, outputLen, error, DecodePage);
+    }
+
+    private static int EncodePage(
+        IntPtr context,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        byte* input,
+        UIntPtr inputLen,
+        byte* output,
+        UIntPtr outputLen,
+        IntPtr* error)
+    {
+        return Transform(context, pageNo, location, input, inputLen, output, outputLen, error, EncodePage);
+    }
+
+    private static int Transform(
+        IntPtr context,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        byte* input,
+        UIntPtr inputLen,
+        byte* output,
+        UIntPtr outputLen,
+        IntPtr* error,
+        PageTransform transform)
+    {
+        var state = GetState(context);
+        try
+        {
+            var inputSpan = new ReadOnlySpan<byte>(input, checked((int)inputLen));
+            var outputSpan = new Span<byte>(output, checked((int)outputLen));
+            transform(state.Codec, pageNo, location, inputSpan, outputSpan);
+            *error = IntPtr.Zero;
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            *error = state.SetError(ex);
+            return 1;
+        }
+    }
+
+    private static void DecodePage(
+        ITursoPageCodec codec,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        codec.DecodePage(pageNo, location, input, output);
+    }
+
+    private static void EncodePage(
+        ITursoPageCodec codec,
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        codec.EncodePage(pageNo, location, input, output);
+    }
+
+    private static State GetState(IntPtr context)
+    {
+        if (context == IntPtr.Zero)
+            throw new InvalidOperationException("Page codec context is not configured.");
+
+        return GCHandle.FromIntPtr(context).Target as State
+            ?? throw new InvalidOperationException("Page codec context is invalid.");
+    }
+
+    private static void Destroy(IntPtr context)
+    {
+        if (context == IntPtr.Zero)
+            return;
+
+        var handle = GCHandle.FromIntPtr(context);
+        if (handle.Target is State state)
+            state.Dispose();
+
+        handle.Free();
+    }
+}

--- a/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
@@ -43,6 +43,8 @@ internal struct TursoDatabaseConfig
     public IntPtr Vfs;
     public IntPtr EncryptionCipher;
     public IntPtr EncryptionHexKey;
+    public IntPtr PageCodec;
+    public uint OpenFlags;
 }
 
 internal static class TursoInterop

--- a/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
@@ -34,6 +34,13 @@ internal enum TursoNativeValueType : uint
     Null = 5,
 }
 
+[Flags]
+internal enum TursoDatabaseOpenFlags : uint
+{
+    None = 0,
+    ReadOnly = 1,
+}
+
 [StructLayout(LayoutKind.Sequential)]
 internal struct TursoDatabaseConfig
 {
@@ -53,20 +60,85 @@ internal static class TursoInterop
 
     static TursoInterop()
     {
-        if (OperatingSystem.IsIOS())
-        {
-            NativeLibrary.SetDllImportResolver(typeof(TursoInterop).Assembly, ResolveDllImport);
-        }
+        NativeLibrary.SetDllImportResolver(typeof(TursoInterop).Assembly, ResolveNativeLibrary);
     }
 
-    private static IntPtr ResolveDllImport(
+    private static IntPtr ResolveNativeLibrary(
         string libraryName,
         Assembly assembly,
         DllImportSearchPath? searchPath)
     {
-        return libraryName == DllName
-            ? NativeLibrary.Load($"Frameworks/lib{libraryName}.framework/lib{libraryName}", assembly, searchPath)
-            : IntPtr.Zero;
+        if (!string.Equals(libraryName, DllName, StringComparison.Ordinal))
+        {
+            return IntPtr.Zero;
+        }
+
+        if (OperatingSystem.IsIOS())
+        {
+            return NativeLibrary.Load($"Frameworks/lib{libraryName}.framework/lib{libraryName}", assembly, searchPath);
+        }
+
+        var rid = GetRuntimeIdentifier();
+        if (rid is null)
+        {
+            return IntPtr.Zero;
+        }
+
+        var libraryPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "runtimes",
+            rid,
+            "native",
+            GetNativeLibraryFileName());
+
+        return File.Exists(libraryPath) ? NativeLibrary.Load(libraryPath) : IntPtr.Zero;
+    }
+
+    private static string? GetRuntimeIdentifier()
+    {
+        var architecture = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            _ => null,
+        };
+
+        if (architecture is null)
+        {
+            return null;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return $"win-{architecture}";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return $"linux-{architecture}";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return $"osx-{architecture}";
+        }
+
+        return null;
+    }
+
+    private static string GetNativeLibraryFileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "turso_sdk_kit.dll";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return "libturso_sdk_kit.dylib";
+        }
+
+        return "libturso_sdk_kit.so";
     }
 
     [DllImport(DllName, EntryPoint = "turso_database_new", CallingConvention = CallingConvention.Cdecl)]

--- a/bindings/dotnet/src/Turso.Tests/Support/EncryptedDatabaseDetector.cs
+++ b/bindings/dotnet/src/Turso.Tests/Support/EncryptedDatabaseDetector.cs
@@ -1,0 +1,121 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+using Turso;
+using Turso.Raw.Public;
+
+namespace Turso.Tests.Support;
+
+internal sealed record ExternalCodecCandidate(
+    string Name,
+    Func<string, ITursoPageCodec> CreateCodec,
+    byte ReservedSpace = 0);
+
+internal sealed class DetectedEncryptedDatabase(
+    string codecName,
+    TursoConnection connection,
+    ITursoPageCodec codec) : IDisposable
+{
+    public string CodecName { get; } = codecName;
+
+    public TursoConnection Connection { get; } = connection;
+
+    public void Dispose()
+    {
+        Connection.Dispose();
+        if (codec is IDisposable disposable)
+            disposable.Dispose();
+    }
+}
+
+internal static class EncryptedDatabaseDetector
+{
+    public static IReadOnlyList<ExternalCodecCandidate> DefaultCandidates()
+    {
+        var candidates = new List<ExternalCodecCandidate>
+        {
+            new(
+                "wxSQLite3/SQLite3MC aes128cbc",
+                password => WxSQLite3Aes128CbcCodec.FromPassword(password)),
+        };
+
+        if (OperatingSystem.IsWindows())
+        {
+            candidates.Add(new(
+                "System.Data.SQLite legacy CryptoAPI RC4 (encrypted page 1)",
+                password => SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password, encryptPage1: true)));
+            candidates.Add(new(
+                "System.Data.SQLite legacy CryptoAPI RC4 (plaintext page 1 header)",
+                password => SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password, encryptPage1: false)));
+        }
+
+        return candidates;
+    }
+
+    public static DetectedEncryptedDatabase Open(
+        string path,
+        string password,
+        IEnumerable<ExternalCodecCandidate>? candidates = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(password);
+        if (!File.Exists(path))
+            throw new FileNotFoundException("Database file does not exist.", path);
+
+        var failures = new List<Exception>();
+        foreach (var candidate in candidates ?? DefaultCandidates())
+        {
+            ITursoPageCodec? codec = null;
+            TursoConnection? connection = null;
+            try
+            {
+                codec = candidate.CreateCodec(password);
+                connection = new TursoConnection(ConnectionStringFor(path))
+                {
+                    PageCodec = codec,
+                    PageCodecReservedSpace = candidate.ReservedSpace,
+                };
+                connection.Open();
+                ValidateConnection(connection);
+                return new DetectedEncryptedDatabase(candidate.Name, connection, codec);
+            }
+            catch (Exception ex) when (IsExpectedCandidateFailure(ex))
+            {
+                connection?.Dispose();
+                if (codec is IDisposable disposable)
+                    disposable.Dispose();
+
+                failures.Add(new InvalidOperationException($"{candidate.Name}: {ex.Message}", ex));
+            }
+        }
+
+        throw new AggregateException(
+            $"None of the configured external SQLite encryption codecs could open '{path}' with the supplied password.",
+            failures);
+    }
+
+    private static string ConnectionStringFor(string path)
+    {
+        return new TursoConnectionStringBuilder
+        {
+            DataSource = path,
+            Mode = "ReadOnly",
+        }.ConnectionString;
+    }
+
+    private static void ValidateConnection(TursoConnection connection)
+    {
+        using var command = new TursoCommand(connection, "SELECT count(*) FROM sqlite_schema");
+        _ = Convert.ToInt64(command.ExecuteScalar(), CultureInfo.InvariantCulture);
+    }
+
+    private static bool IsExpectedCandidateFailure(Exception exception)
+    {
+        return exception is TursoException
+            or CryptographicException
+            or PlatformNotSupportedException
+            or Win32Exception
+            or ArgumentException;
+    }
+}

--- a/bindings/dotnet/src/Turso.Tests/Support/SystemDataSQLiteLegacyCryptoApiCodec.cs
+++ b/bindings/dotnet/src/Turso.Tests/Support/SystemDataSQLiteLegacyCryptoApiCodec.cs
@@ -1,0 +1,276 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using Turso.Raw.Public;
+
+namespace Turso.Tests.Support;
+
+internal sealed class SystemDataSQLiteLegacyCryptoApiCodec : ITursoPageCodec, IDisposable
+{
+    private const uint ProvRsaFull = 1;
+    private const uint CryptVerifyContext = 0xF0000000;
+    private const uint CalgSha1 = 0x00008004;
+    private const uint CalgRc4 = 0x00006801;
+    private const string EnhancedProvider = "Microsoft Enhanced Cryptographic Provider v1.0";
+    private const string LegacyEncryptPage1Variable = "SQLite_LegacyEncryptPage1";
+    private static ReadOnlySpan<byte> SqliteHeader => "SQLite format 3\0"u8;
+
+    private readonly byte[] _password;
+    private readonly bool _encryptPage1;
+    private readonly object _lock = new();
+    private IntPtr _provider;
+    private bool _disposed;
+
+    private SystemDataSQLiteLegacyCryptoApiCodec(ReadOnlySpan<byte> password, bool? encryptPage1)
+    {
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("The legacy System.Data.SQLite codec uses Windows CryptoAPI.");
+
+        if (password.IsEmpty)
+            throw new ArgumentException("Password must not be empty.", nameof(password));
+
+        _password = password.ToArray();
+        _encryptPage1 = encryptPage1 ?? Environment.GetEnvironmentVariable(LegacyEncryptPage1Variable) is not null;
+        CodecId = CreateCodecId(_password, _encryptPage1);
+
+        if (!CryptAcquireContext(out _provider, null, EnhancedProvider, ProvRsaFull, CryptVerifyContext))
+            ThrowLastWin32Error("CryptAcquireContext");
+    }
+
+    public static SystemDataSQLiteLegacyCryptoApiCodec FromPassword(string password, bool? encryptPage1 = null)
+    {
+        ArgumentNullException.ThrowIfNull(password);
+        return new SystemDataSQLiteLegacyCryptoApiCodec(Encoding.UTF8.GetBytes(password), encryptPage1);
+    }
+
+    public static SystemDataSQLiteLegacyCryptoApiCodec FromRawPassword(
+        ReadOnlySpan<byte> password,
+        bool? encryptPage1 = null)
+    {
+        return new SystemDataSQLiteLegacyCryptoApiCodec(password, encryptPage1);
+    }
+
+    public TursoPageCodecId CodecId { get; }
+
+    public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+    {
+        if (TryReadHeader(rawPage1Prefix, out var plainHeader))
+            return plainHeader;
+
+        var decrypted = new byte[rawPage1Prefix.Length];
+        Transform(rawPage1Prefix, decrypted, decrypt: true);
+        return TryReadHeader(decrypted, out var decryptedHeader) ? decryptedHeader : null;
+    }
+
+    public void DecodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        _ = location;
+        TransformPage(pageNo, input, output, decrypt: true);
+    }
+
+    public void EncodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        _ = location;
+        TransformPage(pageNo, input, output, decrypt: false);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        CryptographicOperations.ZeroMemory(_password);
+
+        if (_provider != IntPtr.Zero)
+        {
+            CryptReleaseContext(_provider, 0);
+            _provider = IntPtr.Zero;
+        }
+
+        _disposed = true;
+    }
+
+    private static bool TryReadHeader(
+        ReadOnlySpan<byte> pagePrefix,
+        out TursoPageCodecHeaderInfo headerInfo)
+    {
+        if (pagePrefix.Length < 100 || !pagePrefix[..SqliteHeader.Length].SequenceEqual(SqliteHeader))
+        {
+            headerInfo = default;
+            return false;
+        }
+
+        var pageSizeRaw = (ushort)((pagePrefix[16] << 8) | pagePrefix[17]);
+        var pageSize = pageSizeRaw == 1 ? 65536u : pageSizeRaw;
+        if (!IsValidPageSize(pageSize) || !IsValidFileFormatVersion(pagePrefix[18]) || !IsValidFileFormatVersion(pagePrefix[19]))
+        {
+            headerInfo = default;
+            return false;
+        }
+
+        headerInfo = new TursoPageCodecHeaderInfo(pageSize, pagePrefix[20]);
+        return true;
+    }
+
+    private static TursoPageCodecId CreateCodecId(ReadOnlySpan<byte> password, bool encryptPage1)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        hash.AppendData("turso.tests.system-data-sqlite-legacy-cryptoapi"u8);
+        hash.AppendData(password);
+        hash.AppendData([(byte)(encryptPage1 ? 1 : 0)]);
+        var digest = hash.GetHashAndReset();
+        return TursoPageCodecId.FromBytes(digest.AsSpan(0, 16));
+    }
+
+    private static bool IsValidPageSize(uint pageSize)
+    {
+        return pageSize is >= 512 and <= 65536 && (pageSize & (pageSize - 1)) == 0;
+    }
+
+    private static bool IsValidFileFormatVersion(byte version)
+    {
+        return version is 1 or 2;
+    }
+
+    private void TransformPage(uint pageNo, ReadOnlySpan<byte> input, Span<byte> output, bool decrypt)
+    {
+        if (pageNo == 0)
+            throw new ArgumentOutOfRangeException(nameof(pageNo), pageNo, "SQLite page numbers are one-based.");
+
+        if (input.Length != output.Length)
+            throw new ArgumentException("Codec input and output page lengths must match.");
+
+        if (!_encryptPage1 && pageNo == 1 && input.Length >= SqliteHeader.Length && input[..SqliteHeader.Length].SequenceEqual(SqliteHeader))
+        {
+            input.CopyTo(output);
+            return;
+        }
+
+        Transform(input, output, decrypt);
+    }
+
+    private void Transform(ReadOnlySpan<byte> input, Span<byte> output, bool decrypt)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var buffer = input.ToArray();
+        lock (_lock)
+        {
+            var key = DeriveKey();
+            try
+            {
+                var dataLength = checked((uint)buffer.Length);
+                var bufferLength = dataLength;
+                var success = decrypt
+                    ? CryptDecrypt(key, IntPtr.Zero, true, 0, buffer, ref dataLength)
+                    : CryptEncrypt(key, IntPtr.Zero, true, 0, buffer, ref dataLength, bufferLength);
+
+                if (!success)
+                    ThrowLastWin32Error(decrypt ? "CryptDecrypt" : "CryptEncrypt");
+
+                if (dataLength != bufferLength)
+                    throw new InvalidOperationException("Legacy CryptoAPI page transform changed the page size.");
+            }
+            finally
+            {
+                CryptDestroyKey(key);
+            }
+        }
+
+        buffer.CopyTo(output);
+    }
+
+    private IntPtr DeriveKey()
+    {
+        if (!CryptCreateHash(_provider, CalgSha1, IntPtr.Zero, 0, out var hash))
+            ThrowLastWin32Error("CryptCreateHash");
+
+        try
+        {
+            if (!CryptHashData(hash, _password, checked((uint)_password.Length), 0))
+                ThrowLastWin32Error("CryptHashData");
+
+            if (!CryptDeriveKey(_provider, CalgRc4, hash, 0, out var key))
+                ThrowLastWin32Error("CryptDeriveKey");
+
+            return key;
+        }
+        finally
+        {
+            CryptDestroyHash(hash);
+        }
+    }
+
+    private static void ThrowLastWin32Error(string function)
+    {
+        throw new Win32Exception(Marshal.GetLastWin32Error(), function);
+    }
+
+    [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool CryptAcquireContext(
+        out IntPtr provider,
+        string? keyContainer,
+        string? providerName,
+        uint providerType,
+        uint flags);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptCreateHash(
+        IntPtr provider,
+        uint algorithmId,
+        IntPtr key,
+        uint flags,
+        out IntPtr hash);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptHashData(
+        IntPtr hash,
+        byte[] data,
+        uint dataLength,
+        uint flags);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptDeriveKey(
+        IntPtr provider,
+        uint algorithmId,
+        IntPtr baseData,
+        uint flags,
+        out IntPtr key);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptEncrypt(
+        IntPtr key,
+        IntPtr hash,
+        bool final,
+        uint flags,
+        byte[] data,
+        ref uint dataLength,
+        uint bufferLength);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptDecrypt(
+        IntPtr key,
+        IntPtr hash,
+        bool final,
+        uint flags,
+        byte[] data,
+        ref uint dataLength);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptDestroyHash(IntPtr hash);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptDestroyKey(IntPtr key);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    private static extern bool CryptReleaseContext(IntPtr provider, uint flags);
+}

--- a/bindings/dotnet/src/Turso.Tests/Support/WxSQLite3Aes128CbcCodec.cs
+++ b/bindings/dotnet/src/Turso.Tests/Support/WxSQLite3Aes128CbcCodec.cs
@@ -1,0 +1,351 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using Turso.Raw.Public;
+
+namespace Turso.Tests.Support;
+
+internal sealed class WxSQLite3Aes128CbcCodec : ITursoPageCodec, IDisposable
+{
+    private static ReadOnlySpan<byte> SqliteHeader => "SQLite format 3\0"u8;
+    private static ReadOnlySpan<byte> PageKeySalt => "sAlT"u8;
+    private static ReadOnlySpan<byte> PasswordPadding =>
+    [
+        0x28, 0xBF, 0x4E, 0x5E, 0x4E, 0x75, 0x8A, 0x41,
+        0x64, 0x00, 0x4E, 0x56, 0xFF, 0xFA, 0x01, 0x08,
+        0x2E, 0x2E, 0x00, 0xB6, 0xD0, 0x68, 0x3E, 0x80,
+        0x2F, 0x0C, 0xA9, 0xFE, 0x64, 0x53, 0x69, 0x7A
+    ];
+
+    private readonly byte[] _masterKey;
+    private bool _disposed;
+
+    private WxSQLite3Aes128CbcCodec(ReadOnlySpan<byte> password)
+    {
+        if (password.IsEmpty)
+            throw new ArgumentException("Password must not be empty.", nameof(password));
+
+        _masterKey = DeriveMasterKey(password);
+        CodecId = CreateCodecId(_masterKey);
+    }
+
+    public static WxSQLite3Aes128CbcCodec FromPassword(string password)
+    {
+        ArgumentNullException.ThrowIfNull(password);
+
+        var passwordBytes = Encoding.UTF8.GetBytes(password);
+        try
+        {
+            return new WxSQLite3Aes128CbcCodec(passwordBytes);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(passwordBytes);
+        }
+    }
+
+    public static WxSQLite3Aes128CbcCodec FromRawPassword(ReadOnlySpan<byte> password)
+    {
+        return new WxSQLite3Aes128CbcCodec(password);
+    }
+
+    public TursoPageCodecId CodecId { get; }
+
+    public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+    {
+        if (TryReadSqliteHeader(rawPage1Prefix, out var plainHeader))
+            return plainHeader;
+
+        if (TryReadModernAesHeader(rawPage1Prefix, out var encryptedHeader))
+            return encryptedHeader;
+
+        return null;
+    }
+
+    public void DecodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        _ = location;
+        TransformPage(pageNo, input, output, encrypt: false);
+    }
+
+    public void EncodePage(
+        uint pageNo,
+        TursoPageCodecLocation location,
+        ReadOnlySpan<byte> input,
+        Span<byte> output)
+    {
+        _ = location;
+        TransformPage(pageNo, input, output, encrypt: true);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        CryptographicOperations.ZeroMemory(_masterKey);
+        _disposed = true;
+    }
+
+    private static bool TryReadSqliteHeader(
+        ReadOnlySpan<byte> pagePrefix,
+        out TursoPageCodecHeaderInfo headerInfo)
+    {
+        if (pagePrefix.Length < 100 || !pagePrefix[..SqliteHeader.Length].SequenceEqual(SqliteHeader))
+        {
+            headerInfo = default;
+            return false;
+        }
+
+        return TryReadHeaderFields(pagePrefix, out headerInfo);
+    }
+
+    private static bool TryReadModernAesHeader(
+        ReadOnlySpan<byte> pagePrefix,
+        out TursoPageCodecHeaderInfo headerInfo)
+    {
+        if (pagePrefix.Length < 24 || pagePrefix[..SqliteHeader.Length].SequenceEqual(SqliteHeader))
+        {
+            headerInfo = default;
+            return false;
+        }
+
+        return TryReadHeaderFields(pagePrefix, out headerInfo);
+    }
+
+    private static bool TryReadHeaderFields(
+        ReadOnlySpan<byte> pagePrefix,
+        out TursoPageCodecHeaderInfo headerInfo)
+    {
+        var pageSizeRaw = (ushort)((pagePrefix[16] << 8) | pagePrefix[17]);
+        var pageSize = pageSizeRaw == 1 ? 65536u : pageSizeRaw;
+        if (!IsValidPageSize(pageSize)
+            || !IsValidFileFormatVersion(pagePrefix[18])
+            || !IsValidFileFormatVersion(pagePrefix[19])
+            || pagePrefix[21] != 64
+            || pagePrefix[22] != 32
+            || pagePrefix[23] != 32)
+        {
+            headerInfo = default;
+            return false;
+        }
+
+        headerInfo = new TursoPageCodecHeaderInfo(pageSize, pagePrefix[20]);
+        return true;
+    }
+
+    private static TursoPageCodecId CreateCodecId(ReadOnlySpan<byte> masterKey)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        hash.AppendData("turso.tests.wxsqlite3-aes128-cbc"u8);
+        hash.AppendData(masterKey);
+        var digest = hash.GetHashAndReset();
+        return TursoPageCodecId.FromBytes(digest.AsSpan(0, 16));
+    }
+
+    private static bool IsValidPageSize(uint pageSize)
+    {
+        return pageSize is >= 512 and <= 65536 && (pageSize & (pageSize - 1)) == 0;
+    }
+
+    private static bool IsValidFileFormatVersion(byte version)
+    {
+        return version is 1 or 2;
+    }
+
+    private void TransformPage(uint pageNo, ReadOnlySpan<byte> input, Span<byte> output, bool encrypt)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (pageNo == 0)
+            throw new ArgumentOutOfRangeException(nameof(pageNo), pageNo, "SQLite page numbers are one-based.");
+
+        if (input.Length != output.Length)
+            throw new ArgumentException("Codec input and output page lengths must match.");
+
+        if (input.Length < 512 || input.Length % 16 != 0)
+            throw new ArgumentException("wxSQLite3 AES-128-CBC pages must be at least 512 bytes and block aligned.");
+
+        var buffer = input.ToArray();
+        if (encrypt)
+            EncryptPage(checked((int)pageNo), buffer);
+        else
+            DecryptPage(checked((int)pageNo), buffer);
+
+        buffer.CopyTo(output);
+    }
+
+    private void EncryptPage(int pageNo, Span<byte> data)
+    {
+        if (pageNo != 1)
+        {
+            TransformAes(pageNo, data, data, encrypt: true);
+            return;
+        }
+
+        Span<byte> dbHeader = stackalloc byte[8];
+        data[16..24].CopyTo(dbHeader);
+
+        TransformAes(pageNo, data[..16], data[..16], encrypt: true);
+        TransformAes(pageNo, data[16..], data[16..], encrypt: true);
+
+        data[16..24].CopyTo(data[8..16]);
+        dbHeader.CopyTo(data[16..24]);
+    }
+
+    private void DecryptPage(int pageNo, Span<byte> data)
+    {
+        if (pageNo != 1)
+        {
+            TransformAes(pageNo, data, data, encrypt: false);
+            return;
+        }
+
+        Span<byte> dbHeader = stackalloc byte[8];
+        data[16..24].CopyTo(dbHeader);
+
+        var offset = 0;
+        if (IsModernPageOneHeader(dbHeader))
+        {
+            data[8..16].CopyTo(data[16..24]);
+            offset = 16;
+        }
+
+        TransformAes(pageNo, data[offset..], data[offset..], encrypt: false);
+        if (offset != 0 && data[16..24].SequenceEqual(dbHeader))
+            SqliteHeader.CopyTo(data);
+    }
+
+    private static bool IsModernPageOneHeader(ReadOnlySpan<byte> dbHeader)
+    {
+        var dbPageSize = (dbHeader[0] << 8) | (dbHeader[1] << 16);
+        return IsValidPageSize((uint)dbPageSize)
+            && dbHeader[5] == 0x40
+            && dbHeader[6] == 0x20
+            && dbHeader[7] == 0x20;
+    }
+
+    private void TransformAes(int pageNo, ReadOnlySpan<byte> input, Span<byte> output, bool encrypt)
+    {
+        if (input.Length % 16 != 0)
+            throw new ArgumentException("AES-CBC input length must be block aligned.");
+
+        Span<byte> pageKey = stackalloc byte[16];
+        DerivePageKey(pageNo, pageKey);
+
+        Span<byte> iv = stackalloc byte[16];
+        GenerateInitialVector(pageNo, iv);
+
+        using var aes = Aes.Create();
+        aes.Mode = CipherMode.CBC;
+        aes.Padding = PaddingMode.None;
+        aes.Key = pageKey.ToArray();
+        aes.IV = iv.ToArray();
+
+        using var transform = encrypt ? aes.CreateEncryptor() : aes.CreateDecryptor();
+        var transformed = transform.TransformFinalBlock(input.ToArray(), 0, input.Length);
+        transformed.CopyTo(output);
+    }
+
+    private void DerivePageKey(int pageNo, Span<byte> pageKey)
+    {
+        Span<byte> keyMaterial = stackalloc byte[24];
+        _masterKey.CopyTo(keyMaterial);
+        BinaryPrimitives.WriteInt32LittleEndian(keyMaterial[16..20], pageNo);
+        PageKeySalt.CopyTo(keyMaterial[20..24]);
+        MD5.HashData(keyMaterial, pageKey);
+    }
+
+    private static void GenerateInitialVector(int pageNo, Span<byte> iv)
+    {
+        Span<byte> initKey = stackalloc byte[16];
+        var z = (long)pageNo + 1;
+        for (var j = 0; j < 4; j++)
+        {
+            var q = z / 52774;
+            z = 40692 * (z - 52774 * q) - 3791 * q;
+            if (z < 0)
+                z += 2147483399L;
+
+            BinaryPrimitives.WriteInt32LittleEndian(initKey[(4 * j)..(4 * j + 4)], (int)z);
+        }
+
+        MD5.HashData(initKey, iv);
+    }
+
+    private static byte[] DeriveMasterKey(ReadOnlySpan<byte> password)
+    {
+        var userPad = PadPassword(password);
+        var ownerPad = PadPassword([]);
+
+        var digest = MD5.HashData(ownerPad);
+        for (var k = 0; k < 50; k++)
+            digest = MD5.HashData(digest);
+
+        var ownerKey = userPad.ToArray();
+        Span<byte> rc4Key = stackalloc byte[16];
+        for (var i = 0; i < 20; i++)
+        {
+            for (var j = 0; j < rc4Key.Length; j++)
+                rc4Key[j] = (byte)(digest[j] ^ i);
+
+            Rc4(rc4Key, ownerKey, ownerKey);
+        }
+
+        var encryptionKeyMaterial = new byte[64];
+        userPad.CopyTo(encryptionKeyMaterial);
+        ownerKey.CopyTo(encryptionKeyMaterial.AsSpan(32));
+
+        digest = MD5.HashData(encryptionKeyMaterial);
+        for (var k = 0; k < 50; k++)
+            digest = MD5.HashData(digest);
+
+        CryptographicOperations.ZeroMemory(userPad);
+        CryptographicOperations.ZeroMemory(ownerPad);
+        CryptographicOperations.ZeroMemory(ownerKey);
+        CryptographicOperations.ZeroMemory(encryptionKeyMaterial);
+        return digest;
+    }
+
+    private static byte[] PadPassword(ReadOnlySpan<byte> password)
+    {
+        var padded = new byte[32];
+        var passwordLength = Math.Min(password.Length, padded.Length);
+        password[..passwordLength].CopyTo(padded);
+        PasswordPadding[..(padded.Length - passwordLength)].CopyTo(padded.AsSpan(passwordLength));
+        return padded;
+    }
+
+    private static void Rc4(ReadOnlySpan<byte> key, ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        Span<byte> state = stackalloc byte[256];
+        for (var i = 0; i < state.Length; i++)
+            state[i] = (byte)i;
+
+        var j = 0;
+        for (var i = 0; i < state.Length; i++)
+        {
+            var value = state[i];
+            j = (j + value + key[i % key.Length]) & 0xFF;
+            state[i] = state[j];
+            state[j] = value;
+        }
+
+        var a = 0;
+        var b = 0;
+        for (var i = 0; i < input.Length; i++)
+        {
+            a = (a + 1) & 0xFF;
+            var value = state[a];
+            b = (b + value) & 0xFF;
+            state[a] = state[b];
+            state[b] = value;
+            var k = state[(state[a] + state[b]) & 0xFF];
+            output[i] = (byte)(input[i] ^ k);
+        }
+    }
+}

--- a/bindings/dotnet/src/Turso.Tests/TursoPageCodecTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/TursoPageCodecTests.cs
@@ -1,0 +1,1520 @@
+using AwesomeAssertions;
+using System.Data.Common;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using Turso.Raw.Public;
+using Turso.Raw.Public.Handles;
+using Turso.Tests.Support;
+
+namespace Turso.Tests;
+
+public class TursoPageCodecTests
+{
+    private const string LegacyPassword = "legacy-password";
+    private const string WxSQLitePassword = "wxsqlite-password";
+    private const string TursoEncryptionKey = "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
+
+    [Test]
+    public void ManagedPageCodecRoundTripsDatabaseFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5)))
+            {
+                Execute(db, "CREATE TABLE data(value TEXT)");
+                Execute(db, "INSERT INTO data VALUES ('encrypted')");
+            }
+
+            Assert.Throws<TursoException>(() => TursoBindings.OpenDatabase(path));
+
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5)))
+            {
+                ScalarText(db, "SELECT value FROM data").Should().Be("encrypted");
+                Execute(db, "INSERT INTO data VALUES ('written-through-codec')");
+            }
+
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5)))
+            {
+                ScalarLong(db, "SELECT COUNT(*) FROM data").Should().Be(2);
+            }
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void RawPageCodecApiRejectsNullArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() => TursoBindings.OpenDatabaseWithPageCodec(null!, new XorPageCodec(0xA5)));
+        Assert.Throws<ArgumentNullException>(() => TursoBindings.OpenDatabaseWithPageCodec(":memory:", null!));
+    }
+
+    [Test]
+    public void RawPageCodecApiRejectsEmptyCodecId()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            TursoBindings.OpenDatabaseWithPageCodec(":memory:", new EmptyCodecIdCodec()));
+    }
+
+    [Test]
+    public void ReadOnlyRawOpenDoesNotCreateMissingDatabaseFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-readonly-missing-{Guid.NewGuid():N}.db");
+        try
+        {
+            Assert.Throws<TursoException>(() => TursoBindings.OpenDatabaseReadOnly(path));
+            File.Exists(path).Should().BeFalse();
+
+            Assert.Throws<TursoException>(() =>
+                TursoBindings.OpenDatabaseReadOnlyWithPageCodec(path, new XorPageCodec(0xA5)));
+            File.Exists(path).Should().BeFalse();
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void ManagedPageCodecCallbackErrorsPropagate()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-codec-error-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5)))
+            {
+                Execute(db, "CREATE TABLE data(value TEXT)");
+            }
+
+            var exception = Assert.Throws<TursoException>(() =>
+                TursoBindings.OpenDatabaseWithPageCodec(path, new ThrowingProbeCodec()));
+            exception!.Message.Should().Contain("probe failed");
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void ManagedPageCodecEncodeErrorsPropagate()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-codec-encode-error-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var db = TursoBindings.OpenDatabaseWithPageCodec(path, new ThrowingEncodeCodec());
+            var exception = Assert.Throws<TursoException>(() => Execute(db, "CREATE TABLE data(value TEXT)"));
+            exception!.Message.Should().Contain("encode failed");
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void ManagedPageCodecAllowsOverlappingCachedDatabaseOpen()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-codec-cache-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var db = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5));
+            Execute(db, "CREATE TABLE data(value TEXT)");
+            Execute(db, "INSERT INTO data VALUES ('first-connection')");
+
+            using var second = TursoBindings.OpenDatabaseWithPageCodec(path, new XorPageCodec(0xA5));
+            ScalarText(second, "SELECT value FROM data").Should().Be("first-connection");
+            Execute(second, "INSERT INTO data VALUES ('second-connection')");
+
+            ScalarLong(db, "SELECT count(*) FROM data").Should().Be(2);
+            Assert.Throws<TursoException>(() => TursoBindings.OpenDatabase(path));
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void ManagedPageCodecNativeLifetimeKeepsCodecAliveUntilDatabaseDispose()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-codec-lifetime-{Guid.NewGuid():N}.db");
+        try
+        {
+            var (db, codecReference) = OpenDatabaseWithTrackedCodec(path);
+            using (db)
+            {
+                ForceFullCollection();
+                codecReference.IsAlive.Should().BeTrue();
+                Execute(db, "CREATE TABLE data(value TEXT)");
+                Execute(db, "INSERT INTO data VALUES ('callback-still-alive')");
+                ScalarText(db, "SELECT value FROM data").Should().Be("callback-still-alive");
+            }
+
+            ForceFullCollection();
+            codecReference.IsAlive.Should().BeFalse();
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    public void TursoConnectionPageCodecRoundTripsDatabaseFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-connection-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var connection = new TursoConnection($"Data Source={path}"))
+            {
+                connection.PageCodec = new XorPageCodec(0xA5);
+                connection.Open();
+                connection.ExecuteNonQuery("CREATE TABLE data(value TEXT)");
+                connection.ExecuteNonQuery("INSERT INTO data VALUES ('connection-codec')");
+            }
+
+            Assert.Throws<TursoException>(() =>
+            {
+                using var connection = new TursoConnection($"Data Source={path}");
+                connection.Open();
+                ScalarText(connection, "SELECT value FROM data");
+            });
+
+            using (var connection = new TursoConnection($"Data Source={path}"))
+            {
+                connection.PageCodec = new XorPageCodec(0xA5);
+                connection.Open();
+                ScalarText(connection, "SELECT value FROM data").Should().Be("connection-codec");
+            }
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+        }
+    }
+
+    [Test]
+    public void TursoConnectionPageCodecPropertiesCannotChangeWhileOpen()
+    {
+        using var connection = new TursoConnection("Data Source=:memory:");
+        connection.PageCodec = new XorPageCodec(0xA5);
+        connection.Open();
+
+        Assert.Throws<InvalidOperationException>(() => connection.PageCodec = new XorPageCodec(0x5A));
+        Assert.Throws<InvalidOperationException>(() => connection.PageCodecReservedSpace = 4);
+    }
+
+    [Test]
+    public void TursoConnectionPageCodecCannotBeCombinedWithBuiltInEncryption()
+    {
+        using var connection = new TursoConnection(
+            "Data Source=:memory:;Encryption Cipher=aegis256;Encryption Key=b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327");
+        connection.PageCodec = new XorPageCodec(0xA5);
+
+        Assert.Throws<InvalidOperationException>(connection.Open);
+    }
+
+    [Test]
+    public void TursoConnectionPageCodecReservedSpaceIsWrittenToDatabaseHeader()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-connection-codec-reserved-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var connection = new TursoConnection($"Data Source={path}"))
+            {
+                connection.PageCodec = new XorPageCodec(0xA5);
+                connection.PageCodecReservedSpace = 4;
+                connection.Open();
+                connection.ExecuteNonQuery("PRAGMA journal_mode=DELETE");
+                connection.ExecuteNonQuery("CREATE TABLE data(value TEXT)");
+            }
+
+            ReadDecodedHeader(path, 0xA5)[20].Should().Be(4);
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+            TryDelete($"{path}-journal");
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void MigratesLegacyExternalCryptoToTursoEncryption()
+    {
+        var legacyPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-legacy-source-{Guid.NewGuid():N}.db");
+        var tursoPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-turso-target-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var legacyCodec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(LegacyPassword, encryptPage1: true))
+            using (var legacySource = new TursoConnection($"Data Source={legacyPath}"))
+            {
+                legacySource.PageCodec = legacyCodec;
+                legacySource.Open();
+                CreateSampleData(legacySource);
+            }
+
+            using (var legacyCodec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(LegacyPassword, encryptPage1: true))
+            using (var legacySource = new TursoConnection($"Data Source={legacyPath}"))
+            using (var tursoTarget = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                legacySource.PageCodec = legacyCodec;
+                legacySource.Open();
+                tursoTarget.Open();
+                CopySampleData(legacySource, tursoTarget);
+            }
+
+            AssertPlainConnectionCannotRead(tursoPath);
+
+            using (var tursoTarget = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                tursoTarget.Open();
+                ReadSampleData(tursoTarget).Should().Equal(ExpectedSampleRows());
+            }
+
+            Assert.That(() =>
+            {
+                using var legacyCodec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(LegacyPassword, encryptPage1: true);
+                using var legacyConnection = new TursoConnection($"Data Source={tursoPath}");
+                legacyConnection.PageCodec = legacyCodec;
+                legacyConnection.Open();
+                ReadSampleData(legacyConnection);
+            }, Throws.Exception);
+        }
+        finally
+        {
+            DeleteDatabaseFiles(legacyPath);
+            DeleteDatabaseFiles(tursoPath);
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void MigratesTursoEncryptionToLegacyExternalCrypto()
+    {
+        var tursoPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-turso-source-{Guid.NewGuid():N}.db");
+        var legacyPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-legacy-target-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var tursoSource = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                tursoSource.Open();
+                CreateSampleData(tursoSource);
+            }
+
+            using (var tursoSource = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            using (var legacyCodec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(LegacyPassword, encryptPage1: true))
+            using (var legacyTarget = new TursoConnection($"Data Source={legacyPath}"))
+            {
+                legacyTarget.PageCodec = legacyCodec;
+                tursoSource.Open();
+                legacyTarget.Open();
+                CopySampleData(tursoSource, legacyTarget);
+            }
+
+            AssertPlainConnectionCannotRead(legacyPath);
+
+            using (var legacyCodec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(LegacyPassword, encryptPage1: true))
+            using (var legacyTarget = new TursoConnection($"Data Source={legacyPath}"))
+            {
+                legacyTarget.PageCodec = legacyCodec;
+                legacyTarget.Open();
+                ReadSampleData(legacyTarget).Should().Equal(ExpectedSampleRows());
+            }
+
+            Assert.That(() =>
+            {
+                using var tursoConnection = new TursoConnection(TursoEncryptedConnectionString(legacyPath));
+                tursoConnection.Open();
+                ReadSampleData(tursoConnection);
+            }, Throws.Exception);
+        }
+        finally
+        {
+            DeleteDatabaseFiles(tursoPath);
+            DeleteDatabaseFiles(legacyPath);
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void SystemDataSQLiteLegacyCryptoApiCodecRoundTripsDatabaseFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-legacy-system-data-sqlite-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            const string password = "legacy-password";
+            using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                Execute(db, "CREATE TABLE data(value TEXT)");
+                Execute(db, "INSERT INTO data VALUES ('legacy-cryptoapi')");
+            }
+
+            AssertPlainTursoCannotReadLegacyEncryptedData(path);
+
+            using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarText(db, "SELECT value FROM data").Should().Be("legacy-cryptoapi");
+                Execute(db, "INSERT INTO data VALUES ('written-through-codec')");
+            }
+
+            using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarLong(db, "SELECT COUNT(*) FROM data").Should().Be(2);
+            }
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+            TryDelete($"{path}-journal");
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void SystemDataSQLiteLegacyCryptoApiCodecMatchesPageOneRules()
+    {
+        var page = CreateSqliteHeaderPage();
+        Span<byte> encoded = stackalloc byte[page.Length];
+        Span<byte> decoded = stackalloc byte[page.Length];
+
+        using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword("legacy-password", encryptPage1: false))
+        {
+            codec.ProbeHeader(page).Should().Be(new TursoPageCodecHeaderInfo(512, 0));
+            codec.EncodePage(1, TursoPageCodecLocation.Database, page, encoded);
+            encoded.SequenceEqual(page).Should().BeTrue();
+        }
+
+        using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword("legacy-password", encryptPage1: true))
+        {
+            codec.EncodePage(1, TursoPageCodecLocation.Database, page, encoded);
+            encoded[..16].SequenceEqual("SQLite format 3\0"u8).Should().BeFalse();
+        }
+
+        using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword("legacy-password", encryptPage1: false))
+        {
+            codec.ProbeHeader(encoded).Should().Be(new TursoPageCodecHeaderInfo(512, 0));
+            codec.DecodePage(1, TursoPageCodecLocation.Database, encoded, decoded);
+            decoded.SequenceEqual(page).Should().BeTrue();
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void SystemDataSQLiteLegacyCryptoApiDatabaseRoundTripsWithManagedCodec()
+    {
+        using var fixture = SystemDataSQLiteFixture.TryLoad();
+        var path = Path.Combine(Path.GetTempPath(), $"turso-system-data-sqlite-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            const string password = "legacy-password";
+            fixture.ExecuteWithPassword(
+                path,
+                password,
+                "PRAGMA journal_mode=DELETE",
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('system-data-sqlite')");
+            var encryptPage1 = IsPageOneEncrypted(path);
+
+            AssertPlainTursoCannotReadLegacyEncryptedData(path);
+
+            using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(password, encryptPage1))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarText(db, "SELECT value FROM data").Should().Be("system-data-sqlite");
+                Execute(db, "INSERT INTO data VALUES ('written-through-turso')");
+            }
+
+            fixture.ScalarLongWithPassword(path, password, "SELECT COUNT(*) FROM data").Should().Be(2);
+            fixture.ScalarTextWithPassword(
+                    path,
+                    password,
+                    "SELECT value FROM data ORDER BY rowid DESC LIMIT 1")
+                .Should()
+                .Be("written-through-turso");
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+            TryDelete($"{path}-journal");
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void SystemDataSQLiteLegacyCryptoApiWrongPasswordFails()
+    {
+        using var fixture = SystemDataSQLiteFixture.TryLoad();
+        var path = Path.Combine(Path.GetTempPath(), $"turso-system-data-sqlite-codec-wrong-password-{Guid.NewGuid():N}.db");
+        try
+        {
+            const string password = "legacy-password";
+            fixture.ExecuteWithPassword(
+                path,
+                password,
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('system-data-sqlite')");
+            var encryptPage1 = IsPageOneEncrypted(path);
+
+            Assert.Throws<TursoException>(() =>
+            {
+                using var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword("wrong-password", encryptPage1);
+                using var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec);
+                ScalarText(db, "SELECT value FROM data");
+            });
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+            TryDelete($"{path}-journal");
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void SystemDataSQLiteLegacyCryptoApiRekeyAndClearPassword()
+    {
+        using var fixture = SystemDataSQLiteFixture.TryLoad();
+        var path = Path.Combine(Path.GetTempPath(), $"turso-system-data-sqlite-codec-rekey-{Guid.NewGuid():N}.db");
+        try
+        {
+            const string oldPassword = "legacy-password";
+            const string newPassword = "new-legacy-password";
+            fixture.ExecuteWithPassword(
+                path,
+                oldPassword,
+                "PRAGMA journal_mode=DELETE",
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('system-data-sqlite')");
+            var encryptPage1 = IsPageOneEncrypted(path);
+
+            fixture.ChangePassword(path, oldPassword, newPassword);
+
+            Assert.Throws<TursoException>(() =>
+            {
+                using var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(oldPassword, encryptPage1);
+                using var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec);
+                ScalarText(db, "SELECT value FROM data");
+            });
+
+            using (var codec = SystemDataSQLiteLegacyCryptoApiCodec.FromPassword(newPassword, encryptPage1))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                ScalarText(db, "SELECT value FROM data").Should().Be("system-data-sqlite");
+            }
+
+            fixture.ChangePassword(path, newPassword, string.Empty);
+
+            using (var db = TursoBindings.OpenDatabase(path))
+            {
+                ScalarText(db, "SELECT value FROM data").Should().Be("system-data-sqlite");
+            }
+        }
+        finally
+        {
+            TryDelete(path);
+            TryDelete($"{path}-wal");
+            TryDelete($"{path}-shm");
+            TryDelete($"{path}-journal");
+        }
+    }
+
+    [Test]
+    public void WxSQLite3Aes128CbcCodecMatchesModernPageOneRules()
+    {
+        var page = CreateSqliteHeaderPage(pageSize: 4096);
+        Span<byte> encoded = stackalloc byte[page.Length];
+        Span<byte> decoded = stackalloc byte[page.Length];
+
+        using var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword);
+        codec.ProbeHeader(page).Should().Be(new TursoPageCodecHeaderInfo(4096, 0));
+        codec.EncodePage(1, TursoPageCodecLocation.Database, page, encoded);
+
+        encoded[..16].SequenceEqual("SQLite format 3\0"u8).Should().BeFalse();
+        encoded[16..24].SequenceEqual(page.AsSpan(16, 8)).Should().BeTrue();
+        codec.ProbeHeader(encoded).Should().Be(new TursoPageCodecHeaderInfo(4096, 0));
+
+        codec.DecodePage(1, TursoPageCodecLocation.Database, encoded, decoded);
+        decoded.SequenceEqual(page).Should().BeTrue();
+    }
+
+    [Test]
+    public void WxSQLite3Aes128CbcCodecRoundTripsDatabaseFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-wxsqlite3-aes128-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                Execute(db, "CREATE TABLE data(value TEXT)");
+                Execute(db, "INSERT INTO data VALUES ('wxsqlite3-aes128cbc')");
+            }
+
+            AssertPlainTursoCannotReadLegacyEncryptedData(path);
+
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarText(db, "SELECT value FROM data").Should().Be("wxsqlite3-aes128cbc");
+                Execute(db, "INSERT INTO data VALUES ('written-through-codec')");
+            }
+
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarLong(db, "SELECT COUNT(*) FROM data").Should().Be(2);
+            }
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    public void DetectsWxSQLite3Aes128CbcCodecAfterEarlierCandidateFails()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-detect-wxsqlite3-aes128-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                Execute(db, "CREATE TABLE data(value TEXT)");
+                Execute(db, "INSERT INTO data VALUES ('detected-wxsqlite3')");
+            }
+
+            var candidates = new[]
+            {
+                new ExternalCodecCandidate("wrong xor codec", _ => new XorPageCodec(0x5A)),
+                new ExternalCodecCandidate(
+                    "wxSQLite3/SQLite3MC aes128cbc",
+                    password => WxSQLite3Aes128CbcCodec.FromPassword(password)),
+            };
+
+            using var detected = EncryptedDatabaseDetector.Open(path, WxSQLitePassword, candidates);
+            detected.CodecName.Should().Be("wxSQLite3/SQLite3MC aes128cbc");
+            ScalarText(detected.Connection, "SELECT value FROM data").Should().Be("detected-wxsqlite3");
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    public void DetectingEncryptedDatabaseReportsCandidateFailures()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-detect-failure-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                Execute(db, "CREATE TABLE data(value TEXT)");
+            }
+
+            var candidates = new[]
+            {
+                new ExternalCodecCandidate("wrong xor codec", _ => new XorPageCodec(0x5A)),
+            };
+
+            var exception = Assert.Throws<AggregateException>(() =>
+                EncryptedDatabaseDetector.Open(path, WxSQLitePassword, candidates));
+            exception!.Message.Should().Contain("None of the configured external SQLite encryption codecs");
+            exception.InnerExceptions.Should().ContainSingle()
+                .Which.Message.Should().Contain("wrong xor codec");
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    public void DetectingEncryptedDatabaseRejectsMissingFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"turso-detect-missing-{Guid.NewGuid():N}.db");
+        var candidates = new[]
+        {
+            new ExternalCodecCandidate("would create if attempted", _ => new XorPageCodec(0xA5)),
+        };
+
+        Assert.Throws<FileNotFoundException>(() =>
+            EncryptedDatabaseDetector.Open(path, WxSQLitePassword, candidates));
+        File.Exists(path).Should().BeFalse();
+    }
+
+    [Test]
+    public void MigratesWxSQLite3Aes128CbcExternalCryptoToTursoEncryption()
+    {
+        var wxPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-wxsqlite3-source-{Guid.NewGuid():N}.db");
+        var tursoPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-wxsqlite3-turso-target-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var wxCodec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var wxSource = new TursoConnection($"Data Source={wxPath}"))
+            {
+                wxSource.PageCodec = wxCodec;
+                wxSource.Open();
+                CreateSampleData(wxSource);
+            }
+
+            using (var wxCodec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var wxSource = new TursoConnection($"Data Source={wxPath}"))
+            using (var tursoTarget = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                wxSource.PageCodec = wxCodec;
+                wxSource.Open();
+                tursoTarget.Open();
+                CopySampleData(wxSource, tursoTarget);
+            }
+
+            AssertPlainConnectionCannotRead(tursoPath);
+
+            using (var tursoTarget = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                tursoTarget.Open();
+                ReadSampleData(tursoTarget).Should().Equal(ExpectedSampleRows());
+            }
+        }
+        finally
+        {
+            DeleteDatabaseFiles(wxPath);
+            DeleteDatabaseFiles(tursoPath);
+        }
+    }
+
+    [Test]
+    public void MigratesTursoEncryptionToWxSQLite3Aes128CbcExternalCrypto()
+    {
+        var tursoPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-turso-wxsqlite3-source-{Guid.NewGuid():N}.db");
+        var wxPath = Path.Combine(Path.GetTempPath(), $"turso-migrate-wxsqlite3-target-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var tursoSource = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            {
+                tursoSource.Open();
+                CreateSampleData(tursoSource);
+            }
+
+            using (var tursoSource = new TursoConnection(TursoEncryptedConnectionString(tursoPath)))
+            using (var wxCodec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var wxTarget = new TursoConnection($"Data Source={wxPath}"))
+            {
+                wxTarget.PageCodec = wxCodec;
+                tursoSource.Open();
+                wxTarget.Open();
+                CopySampleData(tursoSource, wxTarget);
+            }
+
+            AssertPlainConnectionCannotRead(wxPath);
+
+            using (var wxCodec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var wxTarget = new TursoConnection($"Data Source={wxPath}"))
+            {
+                wxTarget.PageCodec = wxCodec;
+                wxTarget.Open();
+                ReadSampleData(wxTarget).Should().Equal(ExpectedSampleRows());
+            }
+        }
+        finally
+        {
+            DeleteDatabaseFiles(tursoPath);
+            DeleteDatabaseFiles(wxPath);
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void Sqlite3SecureAes128CbcDatabaseRoundTripsWithManagedCodec()
+    {
+        using var fixture = Sqlite3SecureFixture.TryLoad();
+        fixture.DefaultCipherName.Should().Be("aes128cbc");
+
+        var path = Path.Combine(Path.GetTempPath(), $"turso-sqlite3secure-aes128-codec-{Guid.NewGuid():N}.db");
+        try
+        {
+            fixture.ExecuteWithPassword(
+                path,
+                WxSQLitePassword,
+                "PRAGMA journal_mode=DELETE",
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('sqlite3secure')");
+
+            AssertPlainTursoCannotReadLegacyEncryptedData(path);
+
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec))
+            {
+                Execute(db, "PRAGMA journal_mode=DELETE");
+                ScalarText(db, "SELECT value FROM data").Should().Be("sqlite3secure");
+                Execute(db, "INSERT INTO data VALUES ('written-through-turso')");
+            }
+
+            fixture.ScalarLongWithPassword(path, WxSQLitePassword, "SELECT COUNT(*) FROM data").Should().Be(2);
+            fixture.ScalarTextWithPassword(
+                    path,
+                    WxSQLitePassword,
+                    "SELECT value FROM data ORDER BY rowid DESC LIMIT 1")
+                .Should()
+                .Be("written-through-turso");
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void Sqlite3SecureAes128CbcWrongPasswordFails()
+    {
+        using var fixture = Sqlite3SecureFixture.TryLoad();
+        fixture.DefaultCipherName.Should().Be("aes128cbc");
+
+        var path = Path.Combine(Path.GetTempPath(), $"turso-sqlite3secure-aes128-wrong-password-{Guid.NewGuid():N}.db");
+        try
+        {
+            fixture.ExecuteWithPassword(
+                path,
+                WxSQLitePassword,
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('sqlite3secure')");
+
+            Assert.Throws<TursoException>(() =>
+            {
+                using var codec = WxSQLite3Aes128CbcCodec.FromPassword("wrong-password");
+                using var db = TursoBindings.OpenDatabaseWithPageCodec(path, codec);
+                ScalarText(db, "SELECT value FROM data");
+            });
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    [Test]
+    [Platform(Include = "Win")]
+    public void Sqlite3SecureAes128CbcWalCheckpointRoundTripsWithManagedCodec()
+    {
+        using var fixture = Sqlite3SecureFixture.TryLoad();
+        fixture.DefaultCipherName.Should().Be("aes128cbc");
+
+        var path = Path.Combine(Path.GetTempPath(), $"turso-sqlite3secure-aes128-wal-{Guid.NewGuid():N}.db");
+        try
+        {
+            fixture.ExecuteWithPassword(
+                path,
+                WxSQLitePassword,
+                "PRAGMA journal_mode=WAL",
+                "CREATE TABLE data(value TEXT)",
+                "INSERT INTO data VALUES ('from-sqlite3secure')");
+
+            using (var codec = WxSQLite3Aes128CbcCodec.FromPassword(WxSQLitePassword))
+            using (var connection = new TursoConnection($"Data Source={path}"))
+            {
+                connection.PageCodec = codec;
+                connection.Open();
+                connection.ExecuteNonQuery("PRAGMA journal_mode=WAL");
+                ScalarText(connection, "SELECT value FROM data ORDER BY rowid LIMIT 1").Should().Be("from-sqlite3secure");
+                connection.ExecuteNonQuery("INSERT INTO data VALUES ('from-turso-wal')");
+                connection.ExecuteNonQuery("PRAGMA wal_checkpoint(FULL)");
+            }
+
+            fixture.ScalarLongWithPassword(path, WxSQLitePassword, "SELECT COUNT(*) FROM data").Should().Be(2);
+            fixture.ScalarTextWithPassword(
+                    path,
+                    WxSQLitePassword,
+                    "SELECT value FROM data ORDER BY rowid DESC LIMIT 1")
+                .Should()
+                .Be("from-turso-wal");
+        }
+        finally
+        {
+            DeleteDatabaseFiles(path);
+        }
+    }
+
+    private static byte[] CreateSqliteHeaderPage(int pageSize = 512)
+    {
+        if (pageSize is < 512 or > 65536 || (pageSize & (pageSize - 1)) != 0)
+            throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "SQLite page size must be a power of two between 512 and 65536.");
+
+        var page = new byte[pageSize];
+        "SQLite format 3\0"u8.CopyTo(page);
+        if (pageSize == 65536)
+        {
+            page[16] = 0x00;
+            page[17] = 0x01;
+        }
+        else
+        {
+            page[16] = (byte)(pageSize >> 8);
+            page[17] = (byte)pageSize;
+        }
+
+        page[18] = 1;
+        page[19] = 1;
+        page[20] = 0;
+        page[21] = 64;
+        page[22] = 32;
+        page[23] = 32;
+        page[100] = 13;
+        return page;
+    }
+
+    private static bool IsPageOneEncrypted(string path)
+    {
+        Span<byte> header = stackalloc byte[16];
+        using var file = File.OpenRead(path);
+        file.ReadExactly(header);
+        return !header.SequenceEqual("SQLite format 3\0"u8);
+    }
+
+    private static byte[] ReadDecodedHeader(string path, byte key)
+    {
+        var header = new byte[100];
+        using var file = File.OpenRead(path);
+        file.ReadExactly(header);
+        for (var i = 0; i < header.Length; i++)
+            header[i] ^= key;
+
+        return header;
+    }
+
+    private static string TursoEncryptedConnectionString(string path)
+    {
+        return $"Data Source={path};Encryption Cipher=aegis256;Encryption Key={TursoEncryptionKey}";
+    }
+
+    private static (long Id, string Value)[] ExpectedSampleRows()
+    {
+        return [(1, "alpha"), (2, "bravo"), (3, "charlie")];
+    }
+
+    private static void CreateSampleData(TursoConnection connection)
+    {
+        connection.ExecuteNonQuery("PRAGMA journal_mode=DELETE");
+        connection.ExecuteNonQuery("CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+        foreach (var row in ExpectedSampleRows())
+        {
+            using var command = new TursoCommand(connection, "INSERT INTO data(id, value) VALUES (?, ?)");
+            command.Parameters.Add(row.Id);
+            command.Parameters.Add(row.Value);
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private static void CopySampleData(TursoConnection source, TursoConnection target)
+    {
+        target.ExecuteNonQuery("PRAGMA journal_mode=DELETE");
+        target.ExecuteNonQuery("CREATE TABLE data(id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+        foreach (var row in ReadSampleData(source))
+        {
+            using var command = new TursoCommand(target, "INSERT INTO data(id, value) VALUES (?, ?)");
+            command.Parameters.Add(row.Id);
+            command.Parameters.Add(row.Value);
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private static List<(long Id, string Value)> ReadSampleData(TursoConnection connection)
+    {
+        using var command = new TursoCommand(connection, "SELECT id, value FROM data ORDER BY id");
+        using var reader = command.ExecuteReader();
+        var rows = new List<(long Id, string Value)>();
+        while (reader.Read())
+            rows.Add((reader.GetInt64(0), reader.GetString(1)));
+
+        return rows;
+    }
+
+    private static void AssertPlainConnectionCannotRead(string path)
+    {
+        Assert.That(() =>
+        {
+            using var connection = new TursoConnection($"Data Source={path}");
+            connection.Open();
+            ReadSampleData(connection);
+        }, Throws.Exception);
+    }
+
+    private static void DeleteDatabaseFiles(string path)
+    {
+        TryDelete(path);
+        TryDelete($"{path}-wal");
+        TryDelete($"{path}-shm");
+        TryDelete($"{path}-journal");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (TursoDatabaseHandle Database, WeakReference CodecReference) OpenDatabaseWithTrackedCodec(string path)
+    {
+        var codec = new XorPageCodec(0xA5);
+        return (TursoBindings.OpenDatabaseWithPageCodec(path, codec), new WeakReference(codec));
+    }
+
+    private static void ForceFullCollection()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+
+    private static void Execute(TursoDatabaseHandle db, string sql)
+    {
+        using var statement = TursoBindings.PrepareStatement(db, sql);
+        while (TursoBindings.Read(statement))
+        {
+        }
+    }
+
+    private static string ScalarText(TursoDatabaseHandle db, string sql)
+    {
+        using var statement = TursoBindings.PrepareStatement(db, sql);
+        TursoBindings.Read(statement).Should().BeTrue();
+        var value = TursoBindings.GetValue(statement, 0);
+        return value.StringValue;
+    }
+
+    private static long ScalarLong(TursoDatabaseHandle db, string sql)
+    {
+        using var statement = TursoBindings.PrepareStatement(db, sql);
+        TursoBindings.Read(statement).Should().BeTrue();
+        var value = TursoBindings.GetValue(statement, 0);
+        return value.IntValue;
+    }
+
+    private static string ScalarText(TursoConnection connection, string sql)
+    {
+        using var command = new TursoCommand(connection, sql);
+        using var reader = command.ExecuteReader();
+        reader.Read().Should().BeTrue();
+        return reader.GetString(0);
+    }
+
+    private static void AssertPlainTursoCannotReadLegacyEncryptedData(string path)
+    {
+        Assert.Throws<TursoException>(() =>
+        {
+            using var db = TursoBindings.OpenDatabase(path);
+            ScalarText(db, "SELECT value FROM data");
+        });
+    }
+
+    private static void TryDelete(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    private sealed class XorPageCodec(byte key) : ITursoPageCodec
+    {
+        public TursoPageCodecId CodecId { get; } = CreateCodecId($"turso.tests.xor-page-codec:{key:X2}");
+
+        public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+        {
+            Span<byte> header = stackalloc byte[100];
+            for (var i = 0; i < header.Length; i++)
+                header[i] = (byte)(rawPage1Prefix[i] ^ key);
+
+            if (!header[..16].SequenceEqual("SQLite format 3\0"u8))
+                return null;
+
+            var pageSizeRaw = (ushort)((header[16] << 8) | header[17]);
+            var pageSize = pageSizeRaw == 1 ? 65536u : pageSizeRaw;
+            return new TursoPageCodecHeaderInfo(pageSize, header[20]);
+        }
+
+        public void DecodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            Transform(input, output);
+        }
+
+        public void EncodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            Transform(input, output);
+        }
+
+        private void Transform(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            input.Length.Should().Be(output.Length);
+            for (var i = 0; i < input.Length; i++)
+                output[i] = (byte)(input[i] ^ key);
+        }
+    }
+
+    private sealed class ThrowingProbeCodec : ITursoPageCodec
+    {
+        public TursoPageCodecId CodecId { get; } = TursoPageCodecId.FromGuid(
+            new Guid("f80b61b9-e06f-48c6-ae3a-704b8a935adc"));
+
+        public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+        {
+            throw new InvalidOperationException("probe failed");
+        }
+
+        public void DecodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            input.CopyTo(output);
+        }
+
+        public void EncodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            input.CopyTo(output);
+        }
+    }
+
+    private sealed class ThrowingEncodeCodec : ITursoPageCodec
+    {
+        public TursoPageCodecId CodecId { get; } = TursoPageCodecId.FromGuid(
+            new Guid("8331f2f8-3cc1-48e9-bdb4-c494f1db6553"));
+
+        public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+        {
+            return null;
+        }
+
+        public void DecodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            input.CopyTo(output);
+        }
+
+        public void EncodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            throw new InvalidOperationException("encode failed");
+        }
+    }
+
+    private sealed class EmptyCodecIdCodec : ITursoPageCodec
+    {
+        public TursoPageCodecId CodecId => default;
+
+        public TursoPageCodecHeaderInfo? ProbeHeader(ReadOnlySpan<byte> rawPage1Prefix)
+        {
+            return null;
+        }
+
+        public void DecodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            input.CopyTo(output);
+        }
+
+        public void EncodePage(
+            uint pageNo,
+            TursoPageCodecLocation location,
+            ReadOnlySpan<byte> input,
+            Span<byte> output)
+        {
+            input.CopyTo(output);
+        }
+    }
+
+    private static TursoPageCodecId CreateCodecId(string value)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return TursoPageCodecId.FromBytes(hash.AsSpan(0, 16));
+    }
+
+    private sealed class SystemDataSQLiteFixture : IDisposable
+    {
+        private const string AssemblyPathVariable = "TURSO_TEST_SYSTEM_DATA_SQLITE_DLL";
+        private const string InteropPathVariable = "TURSO_TEST_SQLITE_INTEROP_DLL";
+        private readonly Type _connectionType;
+        private readonly IntPtr _interopHandle;
+
+        private SystemDataSQLiteFixture(Type connectionType, IntPtr interopHandle)
+        {
+            _connectionType = connectionType;
+            _interopHandle = interopHandle;
+        }
+
+        public static SystemDataSQLiteFixture TryLoad()
+        {
+            var assemblyPath = Environment.GetEnvironmentVariable(AssemblyPathVariable);
+            if (string.IsNullOrWhiteSpace(assemblyPath))
+                Assert.Ignore($"{AssemblyPathVariable} must point at a codec-enabled System.Data.SQLite.dll.");
+
+            if (!File.Exists(assemblyPath))
+                Assert.Ignore($"{AssemblyPathVariable} does not exist: {assemblyPath}");
+
+            var interopPath = Environment.GetEnvironmentVariable(InteropPathVariable);
+            var interopHandle = IntPtr.Zero;
+            if (!string.IsNullOrWhiteSpace(interopPath))
+            {
+                if (!File.Exists(interopPath))
+                    Assert.Ignore($"{InteropPathVariable} does not exist: {interopPath}");
+
+                interopHandle = NativeLibrary.Load(interopPath);
+            }
+
+            var assembly = Assembly.LoadFrom(assemblyPath);
+            var connectionType = assembly.GetType("System.Data.SQLite.SQLiteConnection", throwOnError: true)!;
+            return new SystemDataSQLiteFixture(connectionType, interopHandle);
+        }
+
+        public void ExecuteWithPassword(string path, string password, params string[] statements)
+        {
+            using var connection = CreateConnection(path, password);
+            connection.Open();
+            foreach (var statement in statements)
+            {
+                using var command = connection.CreateCommand();
+                command.CommandText = statement;
+                command.ExecuteNonQuery();
+            }
+        }
+
+        public string ScalarTextWithPassword(string path, string password, string sql)
+        {
+            var value = ExecuteScalarWithPassword(path, password, sql);
+            return value.Should().BeOfType<string>().Subject;
+        }
+
+        public long ScalarLongWithPassword(string path, string password, string sql)
+        {
+            var value = ExecuteScalarWithPassword(path, password, sql);
+            return Convert.ToInt64(value);
+        }
+
+        public void ChangePassword(string path, string password, string newPassword)
+        {
+            using var connection = CreateConnection(path, password);
+            connection.Open();
+
+            var method = _connectionType.GetMethod(
+                "ChangePassword",
+                BindingFlags.Instance | BindingFlags.Public,
+                binder: null,
+                types: [typeof(string)],
+                modifiers: null);
+
+            if (method is null)
+                throw new MissingMethodException(_connectionType.FullName, "ChangePassword");
+
+            method.Invoke(connection, [newPassword]);
+        }
+
+        public void Dispose()
+        {
+            if (_interopHandle != IntPtr.Zero)
+                NativeLibrary.Free(_interopHandle);
+        }
+
+        private object? ExecuteScalarWithPassword(string path, string password, string sql)
+        {
+            using var connection = CreateConnection(path, password);
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = sql;
+            return command.ExecuteScalar();
+        }
+
+        private DbConnection CreateConnection(string path, string password)
+        {
+            var connectionString = $"Data Source={path};Password={password};Pooling=False";
+            var connection = Activator.CreateInstance(_connectionType, connectionString);
+            return connection.Should().BeAssignableTo<DbConnection>().Subject;
+        }
+    }
+
+    private sealed class Sqlite3SecureFixture : IDisposable
+    {
+        private const string LibraryPathVariable = "TURSO_TEST_SQLITE3SECURE_DLL";
+        private readonly IntPtr _libraryHandle;
+        private readonly Sqlite3Open _open;
+        private readonly Sqlite3Close _close;
+        private readonly Sqlite3Key _key;
+        private readonly Sqlite3Exec _exec;
+        private readonly Sqlite3ErrMsg _errmsg;
+        private readonly Sqlite3Free _free;
+        private readonly WxSqlite3Config _config;
+
+        private Sqlite3SecureFixture(IntPtr libraryHandle)
+        {
+            _libraryHandle = libraryHandle;
+            _open = GetExport<Sqlite3Open>(libraryHandle, "sqlite3_open");
+            _close = GetExport<Sqlite3Close>(libraryHandle, "sqlite3_close");
+            _key = GetExport<Sqlite3Key>(libraryHandle, "sqlite3_key");
+            _exec = GetExport<Sqlite3Exec>(libraryHandle, "sqlite3_exec");
+            _errmsg = GetExport<Sqlite3ErrMsg>(libraryHandle, "sqlite3_errmsg");
+            _free = GetExport<Sqlite3Free>(libraryHandle, "sqlite3_free");
+            _config = GetExport<WxSqlite3Config>(libraryHandle, "wxsqlite3_config");
+        }
+
+        public string DefaultCipherName
+        {
+            get
+            {
+                using var parameterName = new NativeUtf8String("default:cipher");
+                return CipherName(_config(IntPtr.Zero, parameterName.Pointer, -1));
+            }
+        }
+
+        public static Sqlite3SecureFixture TryLoad()
+        {
+            var libraryPath = Environment.GetEnvironmentVariable(LibraryPathVariable);
+            if (string.IsNullOrWhiteSpace(libraryPath))
+                Assert.Ignore($"{LibraryPathVariable} must point at sqlite3secure.dll from Devolutions.Sqlite3secure.");
+
+            if (!File.Exists(libraryPath))
+                Assert.Ignore($"{LibraryPathVariable} does not exist: {libraryPath}");
+
+            var handle = NativeLibrary.Load(libraryPath);
+            try
+            {
+                return new Sqlite3SecureFixture(handle);
+            }
+            catch
+            {
+                NativeLibrary.Free(handle);
+                throw;
+            }
+        }
+
+        public void ExecuteWithPassword(string path, string password, params string[] statements)
+        {
+            var db = OpenWithPassword(path, password);
+            try
+            {
+                foreach (var statement in statements)
+                    Execute(db, statement);
+            }
+            finally
+            {
+                _close(db);
+            }
+        }
+
+        public string ScalarTextWithPassword(string path, string password, string sql)
+        {
+            return ExecuteScalarWithPassword(path, password, sql).Should().NotBeNull().And.BeOfType<string>().Subject;
+        }
+
+        public long ScalarLongWithPassword(string path, string password, string sql)
+        {
+            return long.Parse(ScalarTextWithPassword(path, password, sql));
+        }
+
+        public void Dispose()
+        {
+            NativeLibrary.Free(_libraryHandle);
+        }
+
+        private static T GetExport<T>(IntPtr libraryHandle, string name)
+            where T : Delegate
+        {
+            var function = NativeLibrary.GetExport(libraryHandle, name);
+            return Marshal.GetDelegateForFunctionPointer<T>(function);
+        }
+
+        private static string CipherName(int cipherIndex)
+        {
+            return cipherIndex switch
+            {
+                1 => "aes128cbc",
+                2 => "aes256cbc",
+                3 => "chacha20",
+                4 => "sqlcipher",
+                _ => $"unknown:{cipherIndex}"
+            };
+        }
+
+        private IntPtr OpenWithPassword(string path, string password)
+        {
+            using var pathUtf8 = new NativeUtf8String(path);
+            var rc = _open(pathUtf8.Pointer, out var db);
+            if (rc != 0)
+                throw new InvalidOperationException($"sqlite3_open failed: rc={rc}");
+
+            try
+            {
+                var passwordBytes = Encoding.UTF8.GetBytes(password);
+                try
+                {
+                    rc = _key(db, passwordBytes, passwordBytes.Length);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(passwordBytes);
+                }
+
+                if (rc != 0)
+                    throw new InvalidOperationException($"sqlite3_key failed: rc={rc}, message={ErrorMessage(db)}");
+
+                return db;
+            }
+            catch
+            {
+                _close(db);
+                throw;
+            }
+        }
+
+        private object? ExecuteScalarWithPassword(string path, string password, string sql)
+        {
+            var db = OpenWithPassword(path, password);
+            try
+            {
+                object? result = null;
+                var callback = new Sqlite3ExecCallback((_, columns, values, _) =>
+                {
+                    if (columns > 0 && result is null)
+                    {
+                        var value = Marshal.ReadIntPtr(values);
+                        result = value == IntPtr.Zero ? null : Marshal.PtrToStringUTF8(value);
+                    }
+
+                    return 0;
+                });
+                Execute(db, sql, callback);
+                GC.KeepAlive(callback);
+                return result;
+            }
+            finally
+            {
+                _close(db);
+            }
+        }
+
+        private void Execute(IntPtr db, string sql, Sqlite3ExecCallback? callback = null)
+        {
+            callback ??= (_, _, _, _) => 0;
+
+            using var sqlUtf8 = new NativeUtf8String(sql);
+            var rc = _exec(db, sqlUtf8.Pointer, callback, IntPtr.Zero, out var error);
+            GC.KeepAlive(callback);
+            if (rc == 0)
+                return;
+
+            var message = error == IntPtr.Zero ? ErrorMessage(db) : Marshal.PtrToStringUTF8(error);
+            if (error != IntPtr.Zero)
+                _free(error);
+
+            throw new InvalidOperationException($"sqlite3_exec failed: rc={rc}, message={message}");
+        }
+
+        private string ErrorMessage(IntPtr db)
+        {
+            return Marshal.PtrToStringUTF8(_errmsg(db)) ?? string.Empty;
+        }
+
+        private sealed class NativeUtf8String : IDisposable
+        {
+            public NativeUtf8String(string value)
+            {
+                Pointer = Marshal.StringToCoTaskMemUTF8(value);
+            }
+
+            public IntPtr Pointer { get; private set; }
+
+            public void Dispose()
+            {
+                if (Pointer == IntPtr.Zero)
+                    return;
+
+                Marshal.FreeCoTaskMem(Pointer);
+                Pointer = IntPtr.Zero;
+            }
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int Sqlite3Open(IntPtr filename, out IntPtr db);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int Sqlite3Close(IntPtr db);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int Sqlite3Key(IntPtr db, byte[] key, int keyLength);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int Sqlite3Exec(
+            IntPtr db,
+            IntPtr sql,
+            Sqlite3ExecCallback callback,
+            IntPtr arg,
+            out IntPtr errorMessage);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int Sqlite3ExecCallback(IntPtr arg, int columns, IntPtr values, IntPtr names);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate IntPtr Sqlite3ErrMsg(IntPtr db);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void Sqlite3Free(IntPtr value);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int WxSqlite3Config(IntPtr db, IntPtr paramName, int newValue);
+    }
+}

--- a/bindings/dotnet/src/Turso.Tests/TursoTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/TursoTests.cs
@@ -235,9 +235,13 @@ public class TursoTests
 
         using var command = new TursoCommand(connection, "SELECT ?");
 
-        command.Invoking(x => x.ExecuteScalar())
+        var exception = command.Invoking(x => x.ExecuteScalar())
             .Should().Throw<InvalidOperationException>()
-            .WithMessage("Missing value for parameter ?1.");
+            .Which;
+
+        exception.Message.Should().BeOneOf(
+            "Missing value for parameter ?1.",
+            "Missing value for parameter at position 1.");
     }
 
     [Test]

--- a/bindings/go/bindings_db.go
+++ b/bindings/go/bindings_db.go
@@ -145,6 +145,8 @@ type turso_database_config_t struct {
 	vfs                   uintptr // const char* or null
 	encryption_cipher     uintptr // const char* or null
 	encryption_hexkey     uintptr // const char* or null
+	page_codec            uintptr // const turso_page_codec_v1_t* or null
+	open_flags            uint32
 }
 
 // C extern method types

--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -211,6 +211,8 @@ pub fn py_turso_database_open(config: &PyTursoDatabaseConfig) -> PyResult<PyTurs
         vfs: config.vfs.clone(),
         io: None,
         db_file: None,
+        page_codec: None,
+        open_flags: Default::default(),
     });
     let result = database.open().map_err(turso_error_to_py_err)?;
     // async_io is false - so db.open() will return result immediately

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -182,6 +182,8 @@ pub fn py_turso_sync_new(
         vfs: IoBackend::Default,
         io: None,
         db_file: None,
+        page_codec: None,
+        open_flags: Default::default(),
     };
     // calculate and set reserved_bytes from cipher if necessary
     let reserved_bytes = sync_config

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -303,6 +303,8 @@ impl Builder {
                 vfs: self.vfs,
                 io: self.io,
                 db_file: None,
+                page_codec: None,
+                open_flags: Default::default(),
             });
         while let Some(io_c) = db.open()?.io() {
             // At this point IO must already be created

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -360,6 +360,8 @@ impl Builder {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: Default::default(),
         };
 
         let url = if let Some(remote_url) = &self.remote_url {

--- a/examples/dotnet/Encryption.cs
+++ b/examples/dotnet/Encryption.cs
@@ -4,135 +4,120 @@
  * This example demonstrates how to use local database encryption
  * with the Turso .NET SDK.
  *
- * Supported ciphers:
- *   - Aes128Gcm
- *   - Aes256Gcm
- *   - Aegis256
- *   - Aegis256x2
- *   - Aegis128l
- *   - Aegis128x2
- *   - Aegis128x4
+ * Supported ciphers include:
+ *   - aes128gcm
+ *   - aes256gcm
+ *   - aegis256
+ *   - aegis256x2
+ *   - aegis128l
+ *   - aegis128x2
+ *   - aegis128x4
  */
 
-using System;
-using System.IO;
 using System.Text;
 using Turso;
 
-class EncryptionExample
+const string DatabasePath = "encrypted.db";
+
+// 32-byte hex key for aegis256 (256 bits = 32 bytes = 64 hex chars).
+const string EncryptionKey =
+    "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
+
+Console.WriteLine("=== Turso Local Encryption Example ===");
+
+DeleteDatabaseFiles(DatabasePath);
+
+Console.WriteLine("\n1. Creating encrypted database...");
+using (var connection = OpenEncryptedConnection(DatabasePath, EncryptionKey))
 {
-    private const string DB_PATH = "encrypted.db";
-    // 32-byte hex key for aegis256 (256 bits = 32 bytes = 64 hex chars)
-    private const string ENCRYPTION_KEY =
-        "b1bbfda4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327";
-
-    public static void Main(string[] args)
+    using (var create = new TursoCommand(
+        connection,
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, ssn TEXT NOT NULL)"))
     {
-        Console.WriteLine("=== Turso Local Encryption Example ===\n");
-
-        // Create an encrypted database
-        Console.WriteLine("1. Creating encrypted database...");
-        using (var connection = new TursoConnection(
-            $"Data Source={DB_PATH};Encryption Cipher=aegis256;Encryption Key={ENCRYPTION_KEY}"))
-        {
-            connection.Open();
-
-            // Create a table and insert sensitive data
-            Console.WriteLine("2. Creating table and inserting data...");
-            using (var create = new TursoCommand(connection,
-                "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, ssn TEXT)"))
-            {
-                create.ExecuteNonQuery();
-            }
-
-            using (var insert = new TursoCommand(connection,
-                "INSERT INTO users (name, ssn) VALUES ('Alice', '123-45-6789')"))
-            {
-                insert.ExecuteNonQuery();
-            }
-
-            using (var insert = new TursoCommand(connection,
-                "INSERT INTO users (name, ssn) VALUES ('Bob', '987-65-4321')"))
-            {
-                insert.ExecuteNonQuery();
-            }
-
-            // Checkpoint to flush data to disk
-            using (var checkpoint = new TursoCommand(connection,
-                "PRAGMA wal_checkpoint(truncate)"))
-            {
-                checkpoint.ExecuteNonQuery();
-            }
-
-            // Query the data
-            Console.WriteLine("3. Querying data...");
-            using (var select = new TursoCommand(connection, "SELECT * FROM users"))
-            using (var reader = select.ExecuteReader())
-            {
-                while (reader.Read())
-                {
-                    Console.WriteLine($"   User: id={reader.GetInt64(0)}, name={reader.GetString(1)}, ssn={reader.GetString(2)}");
-                }
-            }
-        }
-
-        // Verify the data is encrypted on disk
-        Console.WriteLine("\n4. Verifying encryption...");
-        var rawContent = File.ReadAllBytes(DB_PATH);
-        var contentStr = Encoding.UTF8.GetString(rawContent);
-        var containsPlaintext = contentStr.Contains("Alice") || contentStr.Contains("123-45-6789");
-
-        if (containsPlaintext)
-        {
-            Console.WriteLine("   WARNING: Data appears to be unencrypted!");
-        }
-        else
-        {
-            Console.WriteLine("   Data is encrypted on disk (plaintext not found)");
-        }
-
-        // Reopen with the same key
-        Console.WriteLine("\n5. Reopening database with correct key...");
-        using (var connection2 = new TursoConnection(
-            $"Data Source={DB_PATH};Encryption Cipher=aegis256;Encryption Key={ENCRYPTION_KEY}"))
-        {
-            connection2.Open();
-            using (var select = new TursoCommand(connection2, "SELECT name FROM users"))
-            using (var reader = select.ExecuteReader())
-            {
-                Console.Write("   Successfully read users: ");
-                var names = new System.Collections.Generic.List<string>();
-                while (reader.Read())
-                {
-                    names.Add(reader.GetString(0));
-                }
-                Console.WriteLine(string.Join(", ", names));
-            }
-        }
-
-        // Demonstrate that wrong key fails
-        Console.WriteLine("\n6. Attempting to open with wrong key (should fail)...");
-        try
-        {
-            using (var connection3 = new TursoConnection(
-                $"Data Source={DB_PATH};Encryption Cipher=aegis256;Encryption Key=aaaaaaa4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327"))
-            {
-                connection3.Open();
-                using (var select = new TursoCommand(connection3, "SELECT * FROM users"))
-                using (var reader = select.ExecuteReader())
-                {
-                    reader.Read();
-                    Console.WriteLine("   ERROR: Should have failed with wrong key!");
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine($"   Correctly failed: {e.Message}");
-        }
-
-        // Cleanup
-        File.Delete(DB_PATH);
-        Console.WriteLine("\n=== Example completed successfully ===");
+        create.ExecuteNonQuery();
     }
+
+    using (var insert = new TursoCommand(
+        connection,
+        "INSERT INTO users (name, ssn) VALUES ('Alice', '123-45-6789'), ('Bob', '987-65-4321')"))
+    {
+        insert.ExecuteNonQuery();
+    }
+
+    using (var checkpoint = new TursoCommand(connection, "PRAGMA wal_checkpoint(truncate)"))
+    {
+        checkpoint.ExecuteNonQuery();
+    }
+
+    Console.WriteLine("2. Querying encrypted database...");
+    using (var select = new TursoCommand(connection, "SELECT id, name, ssn FROM users ORDER BY id"))
+    using (var reader = select.ExecuteReader())
+    {
+        while (reader.Read())
+        {
+            Console.WriteLine(
+                $"   User: id={reader.GetInt64(0)}, name={reader.GetString(1)}, ssn={reader.GetString(2)}");
+        }
+    }
+}
+
+Console.WriteLine("\n3. Verifying encryption on disk...");
+var rawContent = File.ReadAllBytes(DatabasePath);
+var content = Encoding.UTF8.GetString(rawContent);
+if (content.Contains("Alice", StringComparison.Ordinal) ||
+    content.Contains("123-45-6789", StringComparison.Ordinal))
+{
+    throw new InvalidOperationException("Plaintext data was found in the encrypted database file.");
+}
+
+Console.WriteLine("   Plaintext values were not found in the database file.");
+
+Console.WriteLine("\n4. Reopening database with the correct key...");
+using (var connection = OpenEncryptedConnection(DatabasePath, EncryptionKey))
+using (var select = new TursoCommand(connection, "SELECT group_concat(name, ', ') FROM users"))
+using (var reader = select.ExecuteReader())
+{
+    reader.Read();
+    Console.WriteLine($"   Successfully read users: {reader.GetString(0)}");
+}
+
+Console.WriteLine("\n5. Attempting to read with the wrong key...");
+var wrongKeySucceeded = false;
+try
+{
+    using var connection = OpenEncryptedConnection(
+        DatabasePath,
+        "aaaaaaa4f589dc9daaf004fe21111e00dc00c98237102f5c7002a5669fc76327");
+    using var select = new TursoCommand(connection, "SELECT count(*) FROM users");
+    select.ExecuteScalar();
+
+    wrongKeySucceeded = true;
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"   Correctly failed: {ex.Message}");
+}
+
+if (wrongKeySucceeded)
+{
+    throw new InvalidOperationException("Reading with the wrong encryption key unexpectedly succeeded.");
+}
+
+DeleteDatabaseFiles(DatabasePath);
+
+Console.WriteLine("\n=== Example completed successfully ===");
+
+static TursoConnection OpenEncryptedConnection(string path, string key)
+{
+    var connection = new TursoConnection(
+        $"Data Source={path};Encryption Cipher=aegis256;Encryption Key={key}");
+    connection.Open();
+    return connection;
+}
+
+static void DeleteDatabaseFiles(string path)
+{
+    File.Delete(path);
+    File.Delete(path + "-wal");
+    File.Delete(path + "-shm");
 }

--- a/examples/dotnet/EncryptionExample.csproj
+++ b/examples/dotnet/EncryptionExample.csproj
@@ -2,26 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>EncryptionExample</RootNamespace>
+    <RootNamespace>Turso.EncryptionExample</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../bindings/dotnet/src/Turso.Data/Turso.Data.csproj" />
-  </ItemGroup>
-
-  <!-- Copy native library to output directory -->
-  <ItemGroup>
-    <None Include="../../target/release/libturso_dotnet.dylib" Condition="Exists('../../target/release/libturso_dotnet.dylib')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>libturso_dotnet.dylib</Link>
-    </None>
-    <None Include="../../target/debug/libturso_dotnet.dylib" Condition="Exists('../../target/debug/libturso_dotnet.dylib') And !Exists('../../target/release/libturso_dotnet.dylib')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>libturso_dotnet.dylib</Link>
-    </None>
+    <ProjectReference Include="..\..\bindings\dotnet\src\Turso.Data\Turso.Data.csproj" />
   </ItemGroup>
 
 </Project>

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -1,19 +1,21 @@
 # .NET Examples
 
-## Prerequisites
+## Local encryption
 
-1. .NET 9.0 SDK
-2. Build the native library:
-   ```bash
-   cd /path/to/limbo
-   cargo build --release -p turso-dotnet
-   ```
+This example demonstrates local database encryption with the Turso .NET SDK.
 
-## Encryption
+Build the native SDK library first so the project reference can copy the runtime asset:
 
-This example demonstrates how to use local database encryption with the Turso .NET SDK.
-
-```bash
-cd examples/dotnet
-dotnet run
+```powershell
+cargo build -p turso_sdk_kit --target-dir bindings\dotnet\rs_compiled --target x86_64-pc-windows-msvc
 ```
+
+Then run the example from the repository root:
+
+```powershell
+dotnet run --project examples\dotnet\EncryptionExample.csproj
+```
+
+## External page codecs
+
+The managed wxSQLite3/SQLite3MC AES-128-CBC, System.Data.SQLite legacy CryptoAPI, and ordered detector reference code lives in `bindings\dotnet\src\Turso.Tests\Support`, with coverage in `bindings\dotnet\src\Turso.Tests\TursoPageCodecTests.cs`. Keeping that code test-owned avoids duplicating compatibility crypto in the sample app.

--- a/sdk-kit/README.md
+++ b/sdk-kit/README.md
@@ -9,8 +9,25 @@ Key ideas:
 - Clear status codes: Done/Row/Io/Error/etc. No hidden blocking or exceptions.
 - Minimal surface: open database, connect, prepare, bind, step/execute, read rows, finalize.
 - Ownership model and lifetimes are explicit for C consumers.
+- Optional page codecs: callers can provide a synchronous page transform callback table to decode/encode legacy encrypted database pages without linking that crypto into Turso core.
 
 Note: turso.h is the single C header exported by the crate and can be translated to bindings.rs with rust-bindgen.
+
+## External page codecs
+
+`turso_database_config_t.page_codec` accepts a versioned `turso_page_codec_v1_t` callback table. The callbacks transform complete page images between on-disk bytes and plaintext SQLite pages. They are intended for compatibility layers such as legacy SQLite codec formats where the application supplies the crypto implementation.
+
+Codec rules:
+
+- callbacks are synchronous and must not perform Turso I/O or re-enter the same database;
+- `probe_header` may inspect the raw first 512 bytes and report page size/reserved bytes before Turso parses page 1;
+- `decode_page` and `encode_page` receive a page number and location (`DATABASE` or `WAL`) and must write exactly one page to the output buffer;
+- `codec_id` must be a stable, non-secret identifier for the codec configuration and must change whenever the page transform could produce different bytes;
+- the callback context and function pointers must remain valid until `turso_database_deinit`;
+- callback failures are surfaced as database open/read/write errors.
+
+Language bindings can expose this generic surface by wrapping `turso_page_codec_v1_t`
+with binding-specific lifetime management for the callback context.
 
 ## Rust example
 

--- a/sdk-kit/README.md
+++ b/sdk-kit/README.md
@@ -23,7 +23,7 @@ Codec rules:
 - `probe_header` may inspect the raw first 512 bytes and report page size/reserved bytes before Turso parses page 1;
 - `decode_page` and `encode_page` receive a page number and location (`DATABASE` or `WAL`) and must write exactly one page to the output buffer;
 - `codec_id` must be a stable, non-secret identifier for the codec configuration and must change whenever the page transform could produce different bytes;
-- the callback context and function pointers must remain valid until `turso_database_deinit`;
+- the callback context and function pointers must remain valid until the codec `destroy` callback is invoked;
 - callback failures are surfaced as database open/read/write errors.
 
 Language bindings can expose this generic surface by wrapping `turso_page_codec_v1_t`

--- a/sdk-kit/src/bindings.rs
+++ b/sdk-kit/src/bindings.rs
@@ -307,6 +307,64 @@ impl Default for turso_config_t {
         }
     }
 }
+pub const turso_codec_location_t_TURSO_CODEC_LOCATION_DATABASE: turso_codec_location_t = 0;
+pub const turso_codec_location_t_TURSO_CODEC_LOCATION_WAL: turso_codec_location_t = 1;
+pub type turso_codec_location_t = ::std::os::raw::c_uint;
+pub const turso_database_open_flags_t_TURSO_DATABASE_OPEN_DEFAULT: turso_database_open_flags_t = 0;
+pub const turso_database_open_flags_t_TURSO_DATABASE_OPEN_READONLY: turso_database_open_flags_t = 1;
+pub type turso_database_open_flags_t = ::std::os::raw::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct turso_page_codec_header_info_t {
+    pub page_size: u32,
+    pub reserved_space: u8,
+    pub is_supported: u8,
+}
+pub type turso_page_codec_probe_header_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        ctx: *mut ::std::os::raw::c_void,
+        raw_page1_prefix: *const u8,
+        raw_len: usize,
+        out: *mut turso_page_codec_header_info_t,
+        error: *mut *const ::std::os::raw::c_char,
+    ) -> i32,
+>;
+pub type turso_page_codec_transform_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        ctx: *mut ::std::os::raw::c_void,
+        page_no: u32,
+        location: turso_codec_location_t,
+        input: *const u8,
+        input_len: usize,
+        output: *mut u8,
+        output_len: usize,
+        error: *mut *const ::std::os::raw::c_char,
+    ) -> i32,
+>;
+pub type turso_page_codec_destroy_t =
+    ::std::option::Option<unsafe extern "C" fn(ctx: *mut ::std::os::raw::c_void)>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct turso_page_codec_v1_t {
+    pub abi_version: u32,
+    pub ctx: *mut ::std::os::raw::c_void,
+    pub reserved_space: u8,
+    #[doc = " Stable, non-secret identifier for this codec configuration. Must change whenever encoded bytes could differ."]
+    pub codec_id: [u8; 16usize],
+    pub destroy: turso_page_codec_destroy_t,
+    pub probe_header: turso_page_codec_probe_header_t,
+    pub decode_page: turso_page_codec_transform_t,
+    pub encode_page: turso_page_codec_transform_t,
+}
+impl Default for turso_page_codec_v1_t {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
 #[doc = " Database description."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -323,6 +381,10 @@ pub struct turso_database_config_t {
     pub encryption_cipher: *const ::std::os::raw::c_char,
     #[doc = " optional encryption hexkey\n as encryption is experimental - experimental_features must have \"encryption\" in the list"]
     pub encryption_hexkey: *const ::std::os::raw::c_char,
+    #[doc = " optional external page codec; callback context must remain valid and thread-safe until destroy is called"]
+    pub page_codec: *const turso_page_codec_v1_t,
+    #[doc = " optional bitmask of turso_database_open_flags_t values"]
+    pub open_flags: u32,
 }
 impl Default for turso_database_config_t {
     fn default() -> Self {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    ffi::CString,
+    ffi::{CStr, CString},
     fmt::Display,
     ops::Deref,
     sync::{
@@ -10,8 +10,6 @@ use std::{
     task::Waker,
     time::Duration,
 };
-use turso_core::SqliteDialect;
-
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
     fmt::{self, format::Writer},
@@ -22,7 +20,8 @@ use tracing_subscriber::{
 use turso_core::{
     storage::database::DatabaseFile, types::AsValueRef, Connection, Database, DatabaseOpts,
     DatabaseStorage, EncryptionKey, IOResult, LimboError, OpenDbAsyncState, OpenFlags, OpenOptions,
-    QueryMode, Statement, StepResult, IO,
+    PageCodec, PageCodecContext, PageCodecHeaderInfo, PageCodecId, PageLocation, QueryMode,
+    SqliteDialect, Statement, StepResult, IO,
 };
 
 use crate::{
@@ -180,6 +179,191 @@ pub struct TursoDatabaseConfig {
     /// optional custom DatabaseStorage provided by the caller
     /// if provided, caller must guarantee that IO used by the TursoDatabase will be consistent with underlying DatabaseStorage IO
     pub db_file: Option<Arc<dyn DatabaseStorage>>,
+
+    /// optional external page codec provided by the caller
+    pub page_codec: Option<Arc<dyn PageCodec>>,
+
+    /// database open flags
+    pub open_flags: OpenFlags,
+}
+
+#[derive(Clone)]
+struct CApiPageCodec {
+    inner: Arc<CApiPageCodecInner>,
+}
+
+struct CApiPageCodecInner {
+    raw: c::turso_page_codec_v1_t,
+}
+
+// SAFETY: external page codecs are an FFI contract. Callers that install a codec must keep the
+// context and callbacks valid and thread-safe for the database lifetime.
+unsafe impl Send for CApiPageCodecInner {}
+// SAFETY: see the Send impl; Turso may read/write pages through shared database state.
+unsafe impl Sync for CApiPageCodecInner {}
+
+impl std::fmt::Debug for CApiPageCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CApiPageCodec")
+            .field("abi_version", &self.inner.raw.abi_version)
+            .field("ctx", &"<opaque>")
+            .finish()
+    }
+}
+
+impl Drop for CApiPageCodecInner {
+    fn drop(&mut self) {
+        if let Some(destroy) = self.raw.destroy {
+            unsafe { destroy(self.raw.ctx) };
+        }
+    }
+}
+
+impl CApiPageCodec {
+    unsafe fn from_capi(codec: *const c::turso_page_codec_v1_t) -> Result<Self, TursoError> {
+        if codec.is_null() {
+            return Err(TursoError::Misuse(
+                "page codec pointer must be not null".to_string(),
+            ));
+        }
+        let raw = unsafe { *codec };
+        if raw.abi_version != 1 {
+            return Err(TursoError::Misuse(format!(
+                "unsupported page codec ABI version {}",
+                raw.abi_version
+            )));
+        }
+        if raw.decode_page.is_none() || raw.encode_page.is_none() {
+            return Err(TursoError::Misuse(
+                "page codec decode_page and encode_page callbacks are required".to_string(),
+            ));
+        }
+        if raw.codec_id == [0; 16] {
+            return Err(TursoError::Misuse(
+                "page codec codec_id must be a stable non-zero identifier".to_string(),
+            ));
+        }
+        Ok(Self {
+            inner: Arc::new(CApiPageCodecInner { raw }),
+        })
+    }
+
+    fn callback_error(error: *const std::ffi::c_char, operation: &str) -> LimboError {
+        if error.is_null() {
+            return LimboError::InvalidArgument(format!("page codec {operation} failed"));
+        }
+        let message = unsafe { CStr::from_ptr(error) }.to_string_lossy();
+        LimboError::InvalidArgument(format!("page codec {operation} failed: {message}"))
+    }
+
+    fn location_to_c(location: PageLocation) -> c::turso_codec_location_t {
+        match location {
+            PageLocation::Database => c::turso_codec_location_t_TURSO_CODEC_LOCATION_DATABASE,
+            PageLocation::Wal => c::turso_codec_location_t_TURSO_CODEC_LOCATION_WAL,
+        }
+    }
+
+    fn transform(
+        &self,
+        operation: &str,
+        callback: c::turso_page_codec_transform_t,
+        context: PageCodecContext,
+        page: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), LimboError> {
+        let Some(callback) = callback else {
+            return Err(LimboError::InvalidArgument(format!(
+                "page codec {operation} callback is not configured"
+            )));
+        };
+        let mut error = std::ptr::null();
+        let status = unsafe {
+            callback(
+                self.inner.raw.ctx,
+                context.page_no,
+                Self::location_to_c(context.location),
+                page.as_ptr(),
+                page.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                &mut error,
+            )
+        };
+        if status != 0 {
+            return Err(Self::callback_error(error, operation));
+        }
+        Ok(())
+    }
+}
+
+impl PageCodec for CApiPageCodec {
+    fn codec_id(&self) -> PageCodecId {
+        PageCodecId::new(self.inner.raw.codec_id)
+    }
+
+    fn bootstrap_page_info(
+        &self,
+        raw_page1_prefix: &[u8],
+    ) -> Result<PageCodecHeaderInfo, LimboError> {
+        let Some(probe_header) = self.inner.raw.probe_header else {
+            return PageCodecHeaderInfo::from_visible_sqlite_header(raw_page1_prefix);
+        };
+        let mut out = c::turso_page_codec_header_info_t::default();
+        let mut error = std::ptr::null();
+        let status = unsafe {
+            probe_header(
+                self.inner.raw.ctx,
+                raw_page1_prefix.as_ptr(),
+                raw_page1_prefix.len(),
+                &mut out,
+                &mut error,
+            )
+        };
+        if status != 0 {
+            return Err(Self::callback_error(error, "probe_header"));
+        }
+        if out.is_supported == 0 {
+            return Err(LimboError::NotADB);
+        }
+        Ok(PageCodecHeaderInfo {
+            page_size: out.page_size as usize,
+            reserved_space: out.reserved_space,
+        })
+    }
+
+    fn required_reserved_bytes(&self) -> u8 {
+        self.inner.raw.reserved_space
+    }
+
+    fn encode_page(
+        &self,
+        context: PageCodecContext,
+        page: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), LimboError> {
+        self.transform(
+            "encode_page",
+            self.inner.raw.encode_page,
+            context,
+            page,
+            output,
+        )
+    }
+
+    fn decode_page(
+        &self,
+        context: PageCodecContext,
+        page: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), LimboError> {
+        self.transform(
+            "decode_page",
+            self.inner.raw.decode_page,
+            context,
+            page,
+            output,
+        )
+    }
 }
 
 impl TursoDatabaseConfig {
@@ -335,6 +519,12 @@ impl TursoDatabaseConfig {
                 "either both encryption cipher and key must be set or no".to_string(),
             ));
         }
+        if encryption_cipher.is_some() && !config.page_codec.is_null() {
+            return Err(TursoError::Misuse(
+                "built-in encryption cannot be combined with an external page codec".to_string(),
+            ));
+        }
+        let open_flags = open_flags_from_capi(config.open_flags)?;
         Ok(Self {
             path: str_from_c_str(config.path)?.to_string(),
             experimental_features: if !config.experimental_features.is_null() {
@@ -354,7 +544,28 @@ impl TursoDatabaseConfig {
             },
             io: None,
             db_file: None,
+            page_codec: if !config.page_codec.is_null() {
+                Some(Arc::new(CApiPageCodec::from_capi(config.page_codec)?))
+            } else {
+                None
+            },
+            open_flags,
         })
+    }
+}
+
+fn open_flags_from_capi(flags: u32) -> Result<OpenFlags, TursoError> {
+    const READONLY: u32 = c::turso_database_open_flags_t_TURSO_DATABASE_OPEN_READONLY;
+    if flags & !READONLY != 0 {
+        return Err(TursoError::Misuse(format!(
+            "unknown database open flags: 0x{flags:x}"
+        )));
+    }
+
+    if flags & READONLY != 0 {
+        Ok(OpenFlags::ReadOnly)
+    } else {
+        Ok(OpenFlags::default())
     }
 }
 
@@ -758,8 +969,14 @@ impl TursoDatabase {
                             "encryption is experimental and must be explicitly enabled through experimental features list".to_string(),
                         ));
                     }
+                    if self.config.encryption.is_some() && self.config.page_codec.is_some() {
+                        return Err(TursoError::Misuse(
+                            "built-in encryption cannot be combined with an external page codec"
+                                .to_string(),
+                        ));
+                    }
 
-                    let mut open_flags = OpenFlags::default();
+                    let mut open_flags = self.config.open_flags;
                     if opts.enable_multiprocess_wal {
                         open_flags |= OpenFlags::NoLock;
                     }
@@ -795,7 +1012,8 @@ impl TursoDatabase {
                         .storage(db_file)
                         .flags(open_flags)
                         .db_opts(opts)
-                        .encryption(self.config.encryption.clone());
+                        .encryption(self.config.encryption.clone())
+                        .page_codec(self.config.page_codec.clone());
                     match Database::open_async(
                         &mut state.open_db_state,
                         io.clone(),
@@ -835,17 +1053,18 @@ impl TursoDatabase {
             ));
         };
 
-        // Parse encryption key if configured - needed for connect_with_encryption
-        // which sets up encryption context before reading pages
-        let encryption_key = if let Some(ref encryption_opts) = self.config.encryption {
-            Some(EncryptionKey::from_hex_string(&encryption_opts.hexkey)?)
+        let connection = if let Some(page_codec) = &self.config.page_codec {
+            db.connect_with_page_codec(page_codec.clone())?
         } else {
-            None
+            // Parse encryption key if configured - needed for connect_with_encryption
+            // which sets up encryption context before reading pages.
+            let encryption_key = if let Some(ref encryption_opts) = self.config.encryption {
+                Some(EncryptionKey::from_hex_string(&encryption_opts.hexkey)?)
+            } else {
+                None
+            };
+            db.connect_with_encryption(encryption_key)?
         };
-
-        // Use connect_with_encryption to properly set up encryption context
-        // before the pager reads page 1. This is required for encrypted databases.
-        let connection = db.connect_with_encryption(encryption_key)?;
 
         Ok(TursoConnection::new(&self.config, connection))
     }
@@ -1583,10 +1802,16 @@ impl TursoStatement {
 #[cfg(test)]
 mod tests {
     use crate::{
-        rsapi::{TursoDatabase, TursoDatabaseConfig, TursoError, TursoStatusCode, FINALIZED_ERR},
+        rsapi::{
+            OpenFlags, TursoDatabase, TursoDatabaseConfig, TursoError, TursoStatusCode,
+            FINALIZED_ERR,
+        },
         IoBackend,
     };
-    use turso_core::Value;
+    use std::sync::Arc;
+    use turso_core::{
+        LimboError, PageCodec, PageCodecContext, PageCodecHeaderInfo, PageCodecId, Value,
+    };
 
     fn config_with_features(features: Option<&str>) -> TursoDatabaseConfig {
         TursoDatabaseConfig {
@@ -1597,7 +1822,99 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         }
+    }
+
+    #[derive(Debug)]
+    struct XorPageCodec {
+        mask: u8,
+        reserved_bytes: u8,
+    }
+
+    impl XorPageCodec {
+        fn transform(&self, page: &[u8], output: &mut [u8]) {
+            for (input, output) in page.iter().zip(output.iter_mut()) {
+                *output = *input ^ self.mask;
+            }
+        }
+    }
+
+    impl PageCodec for XorPageCodec {
+        fn codec_id(&self) -> PageCodecId {
+            let mut id = *b"sdk-xor-codec---";
+            id[15] = self.mask;
+            PageCodecId::new(id)
+        }
+
+        fn bootstrap_page_info(
+            &self,
+            raw_page1_prefix: &[u8],
+        ) -> turso_core::Result<PageCodecHeaderInfo> {
+            if raw_page1_prefix.len() < 21 {
+                return Err(LimboError::NotADB);
+            }
+
+            let decoded_magic = raw_page1_prefix[..16]
+                .iter()
+                .map(|byte| byte ^ self.mask)
+                .collect::<Vec<_>>();
+            if decoded_magic.as_slice() != b"SQLite format 3\0" {
+                return Err(LimboError::NotADB);
+            }
+
+            let ps_raw = u16::from_be_bytes([
+                raw_page1_prefix[16] ^ self.mask,
+                raw_page1_prefix[17] ^ self.mask,
+            ]);
+            let page_size = if ps_raw == 1 { 65536 } else { ps_raw as usize };
+            Ok(PageCodecHeaderInfo {
+                page_size,
+                reserved_space: raw_page1_prefix[20] ^ self.mask,
+            })
+        }
+
+        fn required_reserved_bytes(&self) -> u8 {
+            self.reserved_bytes
+        }
+
+        fn encode_page(
+            &self,
+            _context: PageCodecContext,
+            page: &[u8],
+            output: &mut [u8],
+        ) -> turso_core::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+
+        fn decode_page(
+            &self,
+            _context: PageCodecContext,
+            page: &[u8],
+            output: &mut [u8],
+        ) -> turso_core::Result<()> {
+            self.transform(page, output);
+            Ok(())
+        }
+    }
+
+    fn open_database_with_page_codec(path: &str, codec: Arc<dyn PageCodec>) -> Arc<TursoDatabase> {
+        let db = TursoDatabase::new(TursoDatabaseConfig {
+            path: path.to_string(),
+            experimental_features: None,
+            async_io: false,
+            encryption: None,
+            vfs: IoBackend::Default,
+            io: None,
+            db_file: None,
+            page_codec: Some(codec),
+            open_flags: OpenFlags::default(),
+        });
+        let result = db.open().unwrap();
+        assert!(!result.is_io());
+        db
     }
 
     #[test]
@@ -1634,6 +1951,77 @@ mod tests {
     }
 
     #[test]
+    pub fn page_codec_is_applied_to_sdk_connections() {
+        let temp_file = tempfile::NamedTempFile::new().unwrap();
+        let db_path = temp_file.path().to_str().unwrap();
+        let codec: Arc<dyn PageCodec> = Arc::new(XorPageCodec {
+            mask: 0xa5,
+            reserved_bytes: 1,
+        });
+
+        {
+            let db = open_database_with_page_codec(db_path, codec.clone());
+            let conn = db.connect().unwrap();
+
+            let mut stmt = conn
+                .prepare_single("CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)")
+                .unwrap();
+            assert_eq!(stmt.execute(None).unwrap().status, TursoStatusCode::Done);
+
+            let mut stmt = conn
+                .prepare_single("INSERT INTO test (id, value) VALUES (1, 'secret_data')")
+                .unwrap();
+            assert_eq!(stmt.execute(None).unwrap().status, TursoStatusCode::Done);
+
+            let mut stmt = conn
+                .prepare_single("PRAGMA wal_checkpoint(TRUNCATE)")
+                .unwrap();
+            assert_eq!(stmt.execute(None).unwrap().status, TursoStatusCode::Done);
+        }
+
+        let raw_database = std::fs::read(db_path).unwrap();
+        assert_ne!(&raw_database[..16], b"SQLite format 3\0");
+
+        {
+            let db = open_database_with_page_codec(db_path, codec);
+            let conn = db.connect().unwrap();
+
+            let mut stmt = conn
+                .prepare_single("SELECT value FROM test WHERE id = 1")
+                .unwrap();
+            assert_eq!(stmt.step(None).unwrap(), TursoStatusCode::Row);
+            assert_eq!(stmt.row_value(0).unwrap().to_text(), Some("secret_data"));
+        }
+    }
+
+    #[test]
+    pub fn page_codec_rejects_multiprocess_wal_through_sdk_open() {
+        let db = TursoDatabase::new(TursoDatabaseConfig {
+            path: ":memory:".to_string(),
+            experimental_features: Some("multiprocess_wal".to_string()),
+            async_io: false,
+            encryption: None,
+            vfs: IoBackend::Default,
+            io: None,
+            db_file: None,
+            page_codec: Some(Arc::new(XorPageCodec {
+                mask: 0xa5,
+                reserved_bytes: 1,
+            })),
+            open_flags: OpenFlags::default(),
+        });
+
+        let error = db.open().unwrap_err();
+        match error {
+            TursoError::Error(message) => assert_eq!(
+                message,
+                "Invalid argument supplied: external page codecs are not supported with experimental multiprocess WAL"
+            ),
+            error => panic!("expected multiprocess WAL rejection, got {error:?}"),
+        }
+    }
+
+    #[test]
     pub fn test_db_concurrent_use() {
         use std::sync::{Arc, Barrier};
 
@@ -1647,6 +2035,8 @@ mod tests {
                 vfs: IoBackend::Default,
                 io: None,
                 db_file: None,
+                page_codec: None,
+                open_flags: OpenFlags::default(),
             });
             let result = db.open().unwrap();
             assert!(!result.is_io());
@@ -1708,6 +2098,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1728,6 +2120,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1758,6 +2152,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1781,6 +2177,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1831,6 +2229,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1890,6 +2290,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1922,6 +2324,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1951,6 +2355,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -1976,6 +2382,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -2002,6 +2410,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -2052,6 +2462,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -2140,6 +2552,8 @@ mod tests {
                     vfs: IoBackend::Default,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 let result = db.open().unwrap();
                 assert!(!result.is_io());
@@ -2180,6 +2594,8 @@ mod tests {
                     vfs: IoBackend::Default,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 let result = db.open().unwrap();
                 assert!(!result.is_io());
@@ -2206,6 +2622,8 @@ mod tests {
                     vfs: IoBackend::Default,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 assert!(db.open().is_err(), "Opening with wrong key should fail");
             }
@@ -2220,6 +2638,8 @@ mod tests {
                     vfs: IoBackend::Default,
                     io: None,
                     db_file: None,
+                    page_codec: None,
+                    open_flags: OpenFlags::default(),
                 });
                 let result = db.open();
                 println!("result: {result:?}");
@@ -2255,6 +2675,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let _ = db_a.open().unwrap();
         let conn_a = db_a.connect().unwrap();
@@ -2292,6 +2714,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let _ = db_a2.open().unwrap();
         let conn_a2 = db_a2.connect().unwrap();
@@ -2326,6 +2750,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());
@@ -2360,6 +2786,8 @@ mod tests {
             vfs: IoBackend::Default,
             io: None,
             db_file: None,
+            page_codec: None,
+            open_flags: OpenFlags::default(),
         });
         let result = db.open().unwrap();
         assert!(!result.is_io());

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -1839,13 +1839,41 @@ mod tests {
                 *output = *input ^ self.mask;
             }
         }
+
+        fn stable_config_fingerprint(&self) -> [u8; 16] {
+            fn mix(mut hash: u64, byte: u8) -> u64 {
+                hash ^= byte as u64;
+                hash.wrapping_mul(0x0000_0100_0000_01b3)
+            }
+
+            let mut hash1 = 0xcbf2_9ce4_8422_2325;
+            for byte in b"turso-sdk-xor-page-codec-v1" {
+                hash1 = mix(hash1, *byte);
+            }
+            hash1 = mix(hash1, b'm');
+            hash1 = mix(hash1, self.mask);
+            hash1 = mix(hash1, b'r');
+            hash1 = mix(hash1, self.reserved_bytes);
+
+            let mut hash2 = 0x9ae1_6a3b_2f90_404f;
+            for byte in b"turso-sdk-xor-page-codec-v1".iter().rev() {
+                hash2 = mix(hash2, *byte);
+            }
+            hash2 = mix(hash2, b'r');
+            hash2 = mix(hash2, self.reserved_bytes);
+            hash2 = mix(hash2, b'm');
+            hash2 = mix(hash2, self.mask);
+
+            let mut id = [0; 16];
+            id[..8].copy_from_slice(&hash1.to_le_bytes());
+            id[8..].copy_from_slice(&hash2.to_le_bytes());
+            id
+        }
     }
 
     impl PageCodec for XorPageCodec {
         fn codec_id(&self) -> PageCodecId {
-            let mut id = *b"sdk-xor-codec---";
-            id[15] = self.mask;
-            PageCodecId::new(id)
+            PageCodecId::new(self.stable_config_fingerprint())
         }
 
         fn bootstrap_page_info(
@@ -1898,6 +1926,28 @@ mod tests {
             self.transform(page, output);
             Ok(())
         }
+    }
+
+    #[test]
+    pub fn page_codec_id_tracks_full_test_codec_configuration() {
+        let base = XorPageCodec {
+            mask: 0xa5,
+            reserved_bytes: 1,
+        }
+        .codec_id();
+        let different_mask = XorPageCodec {
+            mask: 0x5a,
+            reserved_bytes: 1,
+        }
+        .codec_id();
+        let different_reserved_bytes = XorPageCodec {
+            mask: 0xa5,
+            reserved_bytes: 2,
+        }
+        .codec_id();
+
+        assert_ne!(base, different_mask);
+        assert_ne!(base, different_reserved_bytes);
     }
 
     fn open_database_with_page_codec(path: &str, codec: Arc<dyn PageCodec>) -> Arc<TursoDatabase> {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -226,7 +226,18 @@ impl CApiPageCodec {
                 "page codec pointer must be not null".to_string(),
             ));
         }
-        let raw = unsafe { *codec };
+        let raw = unsafe {
+            c::turso_page_codec_v1_t {
+                abi_version: (*codec).abi_version,
+                ctx: (*codec).ctx,
+                reserved_space: (*codec).reserved_space,
+                codec_id: (*codec).codec_id,
+                destroy: (*codec).destroy,
+                probe_header: (*codec).probe_header,
+                decode_page: (*codec).decode_page,
+                encode_page: (*codec).encode_page,
+            }
+        };
         if raw.abi_version != 1 {
             return Err(TursoError::Misuse(format!(
                 "unsupported page codec ABI version {}",
@@ -1801,6 +1812,7 @@ impl TursoStatement {
 
 #[cfg(test)]
 mod tests {
+    use super::{c, CApiPageCodec};
     use crate::{
         rsapi::{
             OpenFlags, TursoDatabase, TursoDatabaseConfig, TursoError, TursoStatusCode,
@@ -1808,7 +1820,11 @@ mod tests {
         },
         IoBackend,
     };
-    use std::sync::Arc;
+    use std::{
+        ffi::{c_char, c_void},
+        mem::MaybeUninit,
+        sync::Arc,
+    };
     use turso_core::{
         LimboError, PageCodec, PageCodecContext, PageCodecHeaderInfo, PageCodecId, Value,
     };
@@ -1824,6 +1840,39 @@ mod tests {
             db_file: None,
             page_codec: None,
             open_flags: OpenFlags::default(),
+        }
+    }
+
+    #[test]
+    fn capi_page_codec_does_not_read_c_struct_padding() {
+        unsafe extern "C" fn transform(
+            _ctx: *mut c_void,
+            _page_no: u32,
+            _location: c::turso_codec_location_t,
+            _input: *const u8,
+            _input_len: usize,
+            _output: *mut u8,
+            _output_len: usize,
+            _error: *mut *const c_char,
+        ) -> i32 {
+            0
+        }
+
+        let mut codec = MaybeUninit::<c::turso_page_codec_v1_t>::uninit();
+        let codec = codec.as_mut_ptr();
+        unsafe {
+            std::ptr::addr_of_mut!((*codec).abi_version).write(1);
+            std::ptr::addr_of_mut!((*codec).ctx).write(std::ptr::null_mut());
+            std::ptr::addr_of_mut!((*codec).reserved_space).write(16);
+            std::ptr::addr_of_mut!((*codec).codec_id).write([1; 16]);
+            std::ptr::addr_of_mut!((*codec).destroy).write(None);
+            std::ptr::addr_of_mut!((*codec).probe_header).write(None);
+            std::ptr::addr_of_mut!((*codec).decode_page).write(Some(transform));
+            std::ptr::addr_of_mut!((*codec).encode_page).write(Some(transform));
+
+            let codec = CApiPageCodec::from_capi(codec).unwrap();
+            assert_eq!(codec.inner.raw.codec_id, [1; 16]);
+            assert_eq!(codec.inner.raw.reserved_space, 16);
         }
     }
 

--- a/sdk-kit/turso.h
+++ b/sdk-kit/turso.h
@@ -196,6 +196,57 @@ typedef struct
     const char *log_level;
 } turso_config_t;
 
+typedef enum
+{
+    TURSO_CODEC_LOCATION_DATABASE = 0,
+    TURSO_CODEC_LOCATION_WAL = 1,
+} turso_codec_location_t;
+
+typedef enum
+{
+    TURSO_DATABASE_OPEN_DEFAULT = 0,
+    TURSO_DATABASE_OPEN_READONLY = 1,
+} turso_database_open_flags_t;
+
+typedef struct
+{
+    uint32_t page_size;
+    uint8_t reserved_space;
+    uint8_t is_supported;
+} turso_page_codec_header_info_t;
+
+typedef int32_t (*turso_page_codec_probe_header_t)(
+    void *ctx,
+    const uint8_t *raw_page1_prefix,
+    size_t raw_len,
+    turso_page_codec_header_info_t *out,
+    const char **error);
+
+typedef int32_t (*turso_page_codec_transform_t)(
+    void *ctx,
+    uint32_t page_no,
+    turso_codec_location_t location,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_len,
+    const char **error);
+
+typedef void (*turso_page_codec_destroy_t)(void *ctx);
+
+typedef struct
+{
+    uint32_t abi_version;
+    void *ctx;
+    uint8_t reserved_space;
+    /** Stable, non-secret identifier for this codec configuration. Must change whenever encoded bytes could differ. */
+    uint8_t codec_id[16];
+    turso_page_codec_destroy_t destroy;
+    turso_page_codec_probe_header_t probe_header;
+    turso_page_codec_transform_t decode_page;
+    turso_page_codec_transform_t encode_page;
+} turso_page_codec_v1_t;
+
 /**
  * Database description.
  */
@@ -227,6 +278,10 @@ typedef struct
      * as encryption is experimental - experimental_features must have "encryption" in the list
      */
     const char *encryption_hexkey;
+    /** optional external page codec; callback context must remain valid and thread-safe until destroy is called */
+    const turso_page_codec_v1_t *page_codec;
+    /** optional bitmask of turso_database_open_flags_t values */
+    uint32_t open_flags;
 } turso_database_config_t;
 
 /** Setup global database info */

--- a/sync/sdk-kit/bindgen.sh
+++ b/sync/sdk-kit/bindgen.sh
@@ -19,6 +19,9 @@ bindgen turso_sync.h -o src/bindings.rs \
     --blocklist-type "turso_connection_t" \
     --blocklist-type "turso_status_t" \
     --blocklist-type "turso_slice_ref_t" \
+    --blocklist-type "turso_codec_location_t" \
+    --blocklist-type "turso_database_open_flags_t" \
+    --blocklist-type "turso_page_codec_.*_t" \
     --rustified-enum "turso_sync_io_request_type_t" \
     --rustified-enum "turso_sync_database_io_request_type_t" \
     --rustified-enum "turso_sync_operation_result_type_t" \

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -98,6 +98,8 @@ fn test_sdk_close_finalizes_leaked_statements() {
         vfs: IoBackend::Default,
         io: None,
         db_file: None,
+        page_codec: None,
+        open_flags: OpenFlags::default(),
     });
     let _ = db_a.open().unwrap();
     let conn_a = db_a.connect().unwrap();


### PR DESCRIPTION
# NOTICE:

## Description

Adds the .NET/C# page-codec layer on top of the SDK C ABI from https://github.com/tursodatabase/turso/pull/8183:

- exposes managed page-codec IDs and callbacks through `Turso.Raw`
- wires page-codec support into `Turso.Data`
- adds compatibility tests and support codecs for encrypted databases
- updates the .NET encryption example and docs

This PR depends on https://github.com/tursodatabase/turso/pull/8183 and must be merged after https://github.com/tursodatabase/turso/pull/8183 is merged first.

## Motivation and context

This completes the .NET binding surface for external page codecs after the SDK-kit C ABI support in https://github.com/tursodatabase/turso/pull/8183. The codec ID is caller-provided as a stable, non-secret, configuration-specific 16-byte identifier and managed tests cover all-zero/default ID rejection.

## Description of AI Usage

GitHub Copilot CLI was used to split and rebase the stacked .NET page-codec changes, resolve rebase conflicts, and run validation.
