### PR TITLE
core: match numbered parameters in index method patterns

### DIFF
--- a/core/util.rs
+++ b/core/util.rs
@@ -533,7 +533,7 @@ pub fn try_substitute_parameters(
             }))
         }
         Expr::Variable(var) => {
-            if var.name.is_some() {
+            if !var.is_positional() {
                 return None;
             }
             let Ok(var) = i32::try_from(var.index.get()) else {
@@ -591,7 +591,7 @@ pub fn try_capture_parameters(pattern: &Expr, query: &Expr) -> Option<HashMap<i3
             Some(captured)
         }
         (Expr::Variable(var), expr) => {
-            if var.name.is_some() {
+            if !var.is_positional() {
                 return None;
             }
             let Ok(var) = i32::try_from(var.index.get()) else {

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -652,6 +652,14 @@ impl Variable {
             col_type: None,
         }
     }
+
+    /// True for the `?` and `?N` markers, which are bound by position.
+    /// `:name`, `@name` and `$name` markers are bound by name instead.
+    pub fn is_positional(&self) -> bool {
+        self.name
+            .as_deref()
+            .is_none_or(|name| name.starts_with('?'))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -5431,6 +5431,39 @@ mod tests {
     }
 
     #[test]
+    fn only_colon_at_and_dollar_markers_are_bound_by_name() {
+        for sql in ["SELECT ?", "SELECT ?1"] {
+            assert!(
+                parse_one_variable(sql).is_positional(),
+                "{sql} should be bound by position"
+            );
+        }
+        for sql in ["SELECT :a", "SELECT @a", "SELECT $a"] {
+            assert!(
+                !parse_one_variable(sql).is_positional(),
+                "{sql} should be bound by name"
+            );
+        }
+    }
+
+    fn parse_one_variable(sql: &str) -> Variable {
+        let mut p = Parser::new(sql.as_bytes());
+        let Some(Cmd::Stmt(Stmt::Select(select))) = p.next_cmd().unwrap() else {
+            panic!("expected a SELECT for {sql}");
+        };
+        let OneSelect::Select { columns, .. } = &select.body.select else {
+            panic!("expected a simple SELECT for {sql}");
+        };
+        let [ResultColumn::Expr(expr, _)] = columns.as_slice() else {
+            panic!("expected one result column for {sql}");
+        };
+        let Expr::Variable(variable) = expr.as_ref() else {
+            panic!("expected a variable for {sql}");
+        };
+        variable.clone()
+    }
+
+    #[test]
     fn test_expect_fail() {
         let testcases = vec![
             "ALTER TABLE my_table ADD COLUMN my_column PRIMARY KEY",


### PR DESCRIPTION
Index method query patterns use `?1` to bind one value into several places, as the FTS patterns do to share a query string between `fts_score` and `fts_match`. Since `?N` started parsing as a named variable, the pattern matcher rejected those patterns because it treated any named variable as non-substitutable, so combined score and match queries stopped picking the FTS plan and returned zero scores in arbitrary order.

Match on whether a marker is bound by position rather than on whether it carries a name: `?` and `?N` are positional, `:a`, `@a` and `$a` are not.

Tests: index_method integration tests test_fts_field_weights and test_fts_flexible_query_patterns fail without this change.