### PR TITLE
core/storage/wal: return error instead of panicking on out-of-range WAL watermark

### DIFF
--- a/.github/workflows/elle.yml
+++ b/.github/workflows/elle.yml
@@ -110,7 +110,19 @@ jobs:
           fi
           cd /tmp/elle-cli
           if [ ! -f target/*-standalone.jar ]; then
-            /tmp/lein/lein uberjar
+            # Retry: the build downloads Maven dependencies and transient
+            # network errors otherwise fail the whole job.
+            for attempt in 1 2 3; do
+              if /tmp/lein/lein uberjar; then
+                break
+              fi
+              if [ "$attempt" = 3 ]; then
+                echo "lein uberjar failed after 3 attempts"
+                exit 1
+              fi
+              echo "lein uberjar failed (attempt $attempt), retrying in 30s..."
+              sleep 30
+            done
           fi
 
       - name: Install Graphviz

--- a/bindings/javascript/packages/native/promise.test.ts
+++ b/bindings/javascript/packages/native/promise.test.ts
@@ -4,7 +4,10 @@ import { Database, connect, Transaction } from './promise.js'
 import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 
-test('drizzle-orm', async () => {
+// 1234 blob inserts can take well over vitest's default 5s timeout on slow
+// Windows CI runners, so give this test the same generous budget as the other
+// bulk-insert tests in the JS bindings.
+test('drizzle-orm', { timeout: 60_000 }, async () => {
     const path = `test-${(Math.random() * 10000) | 0}.db`;
     try {
         const conn = await connect(path);

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -652,7 +652,8 @@ pub trait Wal: Debug + Send + Sync {
     /// Find the latest frame containing a page.
     ///
     /// optional frame_watermark parameter can be passed to force WAL to find frame not larger than watermark value
-    /// caller must guarantee, that frame_watermark must be greater than last checkpointed frame, otherwise method will panic
+    /// frame_watermark must be within [last checkpointed frame, max_frame], otherwise method returns an error
+    /// (frames below the checkpointed prefix are already in the DB file, so the WAL cannot serve that position)
     fn find_frame(&self, page_id: u64, frame_watermark: Option<u64>) -> Result<Option<u64>>;
 
     /// Read a frame from the WAL.
@@ -3485,21 +3486,26 @@ impl Wal for WalFile {
             "unexpected use of frame_watermark optional argument"
         );
 
-        turso_assert!(
-            frame_watermark.unwrap_or(0) <= self.max_frame.load(Ordering::Acquire),
-            "frame_watermark must be <= than current WAL max_frame value"
-        );
+        // frame_watermark comes from the caller (raw connection API), so treat
+        // an out-of-range value as bad input, not a broken internal invariant.
+        let max_frame = self.max_frame.load(Ordering::Acquire);
+        if frame_watermark.unwrap_or(0) > max_frame {
+            return Err(LimboError::InvalidArgument(format!(
+                "frame_watermark {frame_watermark:?} is beyond the current WAL max_frame {max_frame}"
+            )));
+        }
 
         // we can guarantee correctness of the method, only if frame_watermark is strictly after the current checkpointed prefix
         //
         // if it's not, than pages from WAL range [frame_watermark..nBackfill] are already in the DB file,
-        // and in case if page first occurrence in WAL was after frame_watermark - we will be unable to read proper previous version of the page
+        // and in case if page first occurrence in WAL was after frame_watermark - we will be unable to read proper previous version of the page:
+        // the DB file may already hold a newer version of the page than the watermark allows
         let nbackfills = self.load_coordination_snapshot().nbackfills;
-        turso_assert!(
-            frame_watermark.is_none() || frame_watermark.unwrap() >= nbackfills,
-            "frame_watermark must be >= than current WAL backfill amount",
-            { "frame_watermark": frame_watermark, "nbackfills": nbackfills }
-        );
+        if frame_watermark.is_some_and(|watermark| watermark < nbackfills) {
+            return Err(LimboError::InvalidArgument(format!(
+                "frame_watermark {frame_watermark:?} is below the WAL backfill amount {nbackfills}: those frames were checkpointed into the DB file and can no longer be read at this position"
+            )));
+        }
 
         // if we are holding read_lock 0 and didn't write anything to the WAL, skip and read right from db file.
         //

--- a/tests/integration/functions/test_wal_api.rs
+++ b/tests/integration/functions/test_wal_api.rs
@@ -975,3 +975,39 @@ fn test_wal_api_simulate_spilled_frames(db: TempDatabase) {
             .unwrap();
     }
 }
+
+/// Regression test for https://github.com/tursodatabase/turso/issues/8195
+///
+/// A WAL page lookup with a watermark below the checkpoint backfill floor is a
+/// normal reader state: the reader pinned its snapshot before a passive
+/// checkpoint copied those frames into the main database file. The lookup must
+/// answer "not in the WAL" (or a clean error), never abort the process.
+/// Before the fix, `find_frame` hit
+/// `turso_assert!(frame_watermark >= nbackfills)` and panicked.
+#[turso_macros::test()]
+fn wal_watermark_below_backfill_floor_does_not_panic(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("create table t(x integer primary key, y)")
+        .unwrap();
+    for i in 0..50 {
+        conn.execute(format!("insert into t values ({i}, {i})").as_str())
+            .unwrap();
+    }
+    let max_frame = conn.wal_state().unwrap().max_frame;
+    assert!(
+        max_frame > 30,
+        "expected more than 30 WAL frames, got {max_frame}"
+    );
+
+    // A passive checkpoint moves the backfill floor up to the WAL tip.
+    conn.checkpoint(CheckpointMode::Passive {
+        upper_bound_inclusive: None,
+    })
+    .unwrap();
+
+    // Probe page 1 with a watermark below the floor, like a reader whose
+    // snapshot predates the checkpoint. The lookup must complete: found,
+    // not found, or a clean error are all acceptable; a panic is not.
+    let mut page = vec![0u8; 4096];
+    let _ = conn.try_wal_watermark_read_page(1, &mut page, Some(30));
+}


### PR DESCRIPTION
find_frame aborted the whole process with turso_assert when handed a
frame watermark below the checkpoint backfill floor (or above the WAL
tip). A below-floor watermark is a routine caller state: a reader that
pinned its snapshot before a passive checkpoint advanced nbackfills.
One stale read position could take down every connection in the
process.

The watermark only arrives through the raw connection API (internal
readers always pass None, enforced by the existing cfg assert), so an
out-of-range value is bad caller input, not a broken internal
invariant. Convert both guards into clean InvalidArgument errors. The
below-floor case returns an error rather than "not found" because
routing the reader to the DB file could silently hand back a page
version newer than its snapshot: the checkpointed frames above the
watermark are already merged into the DB file. Also update the
Wal::find_frame trait doc, which promised a panic.

Also give the JS bindings drizzle-orm test an explicit 60s vitest
timeout: its 1234 blob inserts can exceed the default 5s budget on
slow Windows CI runners, which flaked on this PR. And make the Elle
workflow's elle-cli build retry lein uberjar up to 3 times, because a
transient Maven Central download failure in that step failed the Elle
list-append (MVCC) check on this PR even though the simulation itself
passed.

Tests: cargo test -p core_tester --test integration_tests
wal_watermark_below_backfill_floor_does_not_panic, plus turso_core WAL
unit tests, WAL integration tests, and turso_sync_engine tests.

Fixes #8195