### PR TITLE
core/functions: anchor negative timediff on the later date

### DIFF
--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -1112,62 +1112,86 @@ where
     d1.compute_ymd_hms();
     d2.compute_ymd_hms();
 
+    // Month arithmetic is not symmetric: adding a month clamps a day-of-month
+    // overflow forward, so subtracting a month is not the inverse of adding
+    // one. To keep datetime(B, timediff(A, B)) == datetime(A), the Y/M shift
+    // must be applied to the second argument (d2) in the same direction that
+    // the resulting modifier will be applied, exactly as SQLite does.
     let sign: char;
+    let mut y: i32;
+    let mut m: i32;
+    let diff_ms: i64;
     if d1.i_jd >= d2.i_jd {
         sign = '+';
+        y = d1.y - d2.y;
+        if y != 0 {
+            d2.y = d1.y;
+            d2.valid_jd = false;
+            d2.compute_jd();
+        }
+        m = d1.m - d2.m;
+        if m < 0 {
+            y -= 1;
+            m += 12;
+        }
+        if m != 0 {
+            d2.m = d1.m;
+            d2.valid_jd = false;
+            d2.compute_jd();
+        }
+        // If shifting d2 forward by Y years and M months overshot d1, back
+        // off one month at a time.
+        while d1.i_jd < d2.i_jd {
+            m -= 1;
+            if m < 0 {
+                m = 11;
+                y -= 1;
+            }
+            d2.m -= 1;
+            if d2.m < 1 {
+                d2.m = 12;
+                d2.y -= 1;
+            }
+            d2.valid_jd = false;
+            d2.compute_jd();
+        }
+        diff_ms = d1.i_jd - d2.i_jd;
     } else {
         sign = '-';
-        std::mem::swap(&mut d1, &mut d2);
-    }
-
-    let mut y = d1.y - d2.y;
-    let mut m = d1.m - d2.m;
-
-    if m < 0 {
-        y -= 1;
-        m += 12;
-    }
-
-    let mut temp = d2;
-    temp.y += y;
-    temp.m += m;
-
-    // Normalize months
-    while temp.m > 12 {
-        temp.m -= 12;
-        temp.y += 1;
-    }
-    while temp.m < 1 {
-        temp.m += 12;
-        temp.y -= 1;
-    }
-
-    temp.valid_jd = false;
-    temp.compute_jd();
-
-    // Adjust if the Y/M shift overshot d1
-    while temp.i_jd > d1.i_jd {
-        m -= 1;
+        y = d2.y - d1.y;
+        if y != 0 {
+            d2.y = d1.y;
+            d2.valid_jd = false;
+            d2.compute_jd();
+        }
+        m = d2.m - d1.m;
         if m < 0 {
-            m = 11;
             y -= 1;
+            m += 12;
         }
-        temp = d2;
-        temp.y += y;
-        temp.m += m;
-        while temp.m > 12 {
-            temp.m -= 12;
-            temp.y += 1;
+        if m != 0 {
+            d2.m = d1.m;
+            d2.valid_jd = false;
+            d2.compute_jd();
         }
-        while temp.m < 1 {
-            temp.m += 12;
-            temp.y -= 1;
+        // If shifting d2 backward by Y years and M months overshot d1, move
+        // forward one month at a time.
+        while d1.i_jd > d2.i_jd {
+            m -= 1;
+            if m < 0 {
+                m = 11;
+                y -= 1;
+            }
+            d2.m += 1;
+            if d2.m > 12 {
+                d2.m = 1;
+                d2.y += 1;
+            }
+            d2.valid_jd = false;
+            d2.compute_jd();
         }
-        temp.valid_jd = false;
-        temp.compute_jd();
+        diff_ms = d2.i_jd - d1.i_jd;
     }
-
-    let diff_ms = d1.i_jd - temp.i_jd;
     let days = diff_ms / 86400000;
     let rem_ms = diff_ms % 86400000;
     let hours = rem_ms / 3600000;

--- a/sqlite/conformance/sqlite-sqltests/timediff-negative-month-roundtrip.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/timediff-negative-month-roundtrip.sqltest
@@ -1,0 +1,96 @@
+# Regression coverage for issue #8242.
+#
+# timediff(A, B) must produce a modifier that turns B into A, i.e.
+# datetime(B, timediff(A, B)) = datetime(A). SQLite month arithmetic is not
+# symmetric: adding a month clamps a day-of-month overflow forward, so
+# subtracting a month is not the inverse of adding one. A negative timediff
+# result therefore has to be anchored on the later date and walked backwards,
+# which can give a different month/day split than the positive direction.
+
+@database :default:
+
+test timediff-negative-month-overflow {
+    SELECT timediff('2000-01-31', '2000-03-02');
+}
+expect {
+    -0000-01-02 00:00:00.000
+}
+
+test timediff-negative-month-overflow-roundtrip {
+    SELECT datetime('2000-03-02', timediff('2000-01-31', '2000-03-02'));
+}
+expect {
+    2000-01-31 00:00:00
+}
+
+test timediff-negative-month-overflow-across-years {
+    SELECT timediff('1999-01-31', '2000-03-02');
+}
+expect {
+    -0001-01-02 00:00:00.000
+}
+
+test timediff-negative-month-overflow-across-years-roundtrip {
+    SELECT datetime('2000-03-02', timediff('1999-01-31', '2000-03-02'));
+}
+expect {
+    1999-01-31 00:00:00
+}
+
+test timediff-negative-short-february {
+    SELECT timediff('2000-01-02', '2000-03-01');
+}
+expect {
+    -0000-01-30 00:00:00.000
+}
+
+test timediff-negative-short-february-roundtrip {
+    SELECT datetime('2000-03-01', timediff('2000-01-02', '2000-03-01'));
+}
+expect {
+    2000-01-02 00:00:00
+}
+
+test timediff-negative-two-months-back {
+    SELECT timediff('1999-12-31', '2000-03-01');
+}
+expect {
+    -0000-02-01 00:00:00.000
+}
+
+test timediff-negative-two-months-back-roundtrip {
+    SELECT datetime('2000-03-01', timediff('1999-12-31', '2000-03-01'));
+}
+expect {
+    1999-12-31 00:00:00
+}
+
+# The positive direction already matches SQLite and must keep doing so:
+# adding one month to 2000-01-31 overflows February and lands on 2000-03-02.
+test timediff-positive-month-overflow {
+    SELECT timediff('2000-03-02', '2000-01-31');
+}
+expect {
+    +0000-01-00 00:00:00.000
+}
+
+test timediff-positive-month-overflow-roundtrip {
+    SELECT datetime('2000-01-31', timediff('2000-03-02', '2000-01-31'));
+}
+expect {
+    2000-03-02 00:00:00
+}
+
+test timediff-equal-dates {
+    SELECT timediff('2000-01-01', '2000-01-01');
+}
+expect {
+    +0000-00-00 00:00:00.000
+}
+
+test timediff-positive-with-time-of-day {
+    SELECT timediff('2000-02-29 12:34:56', '2000-01-30 01:02:03');
+}
+expect {
+    +0000-00-30 11:32:53.000
+}


### PR DESCRIPTION
timediff(A, B) must return a modifier that turns B into A, i.e.
datetime(B, timediff(A, B)) == datetime(A). The old code swapped the two
dates when the result was negative and always walked the earlier date
forward, so timediff(A, B) and timediff(B, A) always had the same
year/month/day magnitude. Month arithmetic is not symmetric: adding a
month clamps a day-of-month overflow forward (Feb 31 becomes Mar 2), so
subtracting a month is not the inverse of adding one, and the swap broke
the round trip for about 15% of date pairs.

Rewrite the year/month shift to match SQLite's timediffFunc: handle the
two directions separately and shift the second argument (the one the
modifier will be applied to) in place toward the first, in the same
direction the modifier will move it. For a negative result that means
anchoring on the later date and walking backward, which can give a
different month/day split than the positive direction.

Tests: sqlite-sqltests/timediff-negative-month-roundtrip.sqltest passes;
upstream timediff1.test cases timediff-3.2 and timediff-3.4 now pass;
the 3648-pair round-trip grid from the issue drops from 556 failures to
zero; output matches sqlite3 exactly on all 7296 grid queries in both
argument orders.

Fixes #8242