### PR TITLE
core/vdbe: run full post-commit bookkeeping when COMMIT resumes after I/O

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4851,11 +4851,7 @@ pub fn op_auto_commit(
             res,
             Ok(InsnFunctionStepResult::Step | InsnFunctionStepResult::Done)
         ) {
-            if !*rollback {
-                conn.index_methods_on_transaction_committed();
-            }
-            conn.clear_tx_poison();
-            conn.clear_named_savepoints();
+            finish_ended_txn(&conn, pager, mv_store.is_some(), !*rollback)?;
         }
         return res;
     }
@@ -4980,7 +4976,26 @@ pub fn op_auto_commit(
         res @ (InsnFunctionStepResult::IO(_) | InsnFunctionStepResult::Row) => return Ok(res),
     };
 
-    if mv_store.is_none() {
+    finish_ended_txn(&conn, pager, mv_store.is_some(), !*rollback)?;
+
+    // Clear deferred FK counters only after FINAL success of COMMIT/ROLLBACK.
+    if fk_on {
+        conn.clear_deferred_foreign_key_violations();
+    }
+
+    Ok(res)
+}
+
+/// Connection and pager state that must be reset once a COMMIT or ROLLBACK has
+/// finally succeeded. Both the straight-through path and the re-entry path taken
+/// after the commit yielded on IO end here, so they leave the same state behind.
+fn finish_ended_txn(
+    conn: &Arc<Connection>,
+    pager: &Arc<Pager>,
+    has_mv_store: bool,
+    is_commit: bool,
+) -> Result<()> {
+    if !has_mv_store {
         pager.clear_savepoints()?;
         // Non-main pagers (temp + attached) accumulate savepoints from the
         // mirror path; they're not cleared by the main pager's commit/
@@ -4996,20 +5011,14 @@ pub fn op_auto_commit(
         })?;
     }
 
-    // Clear deferred FK counters only after FINAL success of COMMIT/ROLLBACK.
-    if fk_on {
-        conn.clear_deferred_foreign_key_violations();
-    }
-
-    // Reset CDC transaction ID after successful COMMIT or ROLLBACK.
     conn.set_cdc_transaction_id(-1);
-    if matches!(tx_op, TxOp::Commit) {
+    if is_commit {
         conn.index_methods_on_transaction_committed();
     }
     conn.clear_tx_poison();
     conn.clear_named_savepoints();
 
-    Ok(res)
+    Ok(())
 }
 
 pub fn op_savepoint(

--- a/tests/integration/statement_reset.rs
+++ b/tests/integration/statement_reset.rs
@@ -438,3 +438,95 @@ fn returning_read_all_rows_commits(tmp_db: TempDatabase) -> anyhow::Result<()> {
     assert_eq!(count, 3);
     Ok(())
 }
+
+/// Steps a COMMIT to completion and reports how many times it yielded on IO.
+/// A non-zero count means `op_auto_commit` took its re-entry branch.
+fn step_commit_counting_io(stmt: &mut turso_core::Statement) -> turso_core::Result<usize> {
+    let mut io_yields = 0;
+    loop {
+        match stmt.step()? {
+            StepResult::IO => {
+                io_yields += 1;
+                stmt._io().step()?;
+            }
+            StepResult::Yield => continue,
+            StepResult::Done => return Ok(io_yields),
+            other => panic!("unexpected {other:?} from COMMIT"),
+        }
+    }
+}
+
+#[test]
+fn commit_resumed_after_io_starts_a_new_cdc_transaction() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let db = Database::open_file(io, "queued-commit-reentry-cdc.db", Arc::new(SqliteDialect))?;
+    let conn = db.connect()?;
+
+    conn.execute("CREATE TABLE t(x INTEGER PRIMARY KEY)")?;
+    conn.execute("PRAGMA capture_data_changes_conn('id')")?;
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO t VALUES (1)")?;
+
+    let io_yields = {
+        let mut commit = conn.prepare("COMMIT")?;
+        step_commit_counting_io(&mut commit)?
+    };
+    assert!(
+        io_yields > 0,
+        "COMMIT must yield on IO for this test to cover the re-entry path"
+    );
+
+    conn.execute("INSERT INTO t VALUES (2)")?;
+
+    // Each transaction owns a CDC transaction id. If the resumed COMMIT keeps
+    // the first id, the second transaction's rows are filed under it.
+    let rows = limbo_exec_rows(&conn, "SELECT COUNT(DISTINCT change_txn_id) FROM turso_cdc");
+    assert_eq!(rows[0][0], rusqlite::types::Value::Integer(2));
+    Ok(())
+}
+
+#[test]
+fn commit_resumed_after_io_clears_savepoints() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let db = Database::open_file_with_flags(
+        io,
+        "queued-commit-reentry-savepoint.db",
+        turso_core::OpenFlags::default(),
+        turso_core::DatabaseOpts::new().with_attach(true),
+        None,
+        Arc::new(SqliteDialect),
+    )?;
+    let conn = db.connect()?;
+
+    conn.execute("ATTACH 'queued-commit-reentry-savepoint-aux.db' AS aux1")?;
+    conn.execute("CREATE TABLE m(x INTEGER PRIMARY KEY)")?;
+    conn.execute("CREATE TABLE aux1.t(x INTEGER PRIMARY KEY)")?;
+
+    // The savepoint is opened on the main pager, but the transaction writes
+    // only to the attached database. The main pager therefore never commits a
+    // write transaction, so nothing along its own commit path clears the
+    // savepoint — only the post-commit bookkeeping does.
+    conn.execute("BEGIN")?;
+    conn.execute("SAVEPOINT sp")?;
+    conn.execute("INSERT INTO aux1.t VALUES (1)")?;
+
+    let io_yields = {
+        let mut commit = conn.prepare("COMMIT")?;
+        step_commit_counting_io(&mut commit)?
+    };
+    assert!(
+        io_yields > 0,
+        "COMMIT must yield on IO for this test to cover the re-entry path"
+    );
+
+    // This must be the next statement: any write in between would clear the
+    // stale savepoint through its own commit path and hide the bug.
+    let err = conn
+        .execute("ROLLBACK TO sp")
+        .expect_err("the committed transaction took its savepoint with it");
+    assert!(
+        err.to_string().contains("no such savepoint"),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
A `COMMIT` that yields on IO is finished by re-entering `op_auto_commit`. That re-entry branch returns early, before the post-commit bookkeeping the straight-through path performs at the bottom of the function. Two pieces were missing: `pager.clear_savepoints()` (main plus every attached/temp pager) and `conn.set_cdc_transaction_id(-1)`.

Both are user-visible, in two different ways.

**A savepoint outlives the transaction that owned it.** `COMMIT` destroys every savepoint, so the name must stop resolving. It keeps resolving when the transaction wrote only to an attached database: `SAVEPOINT` always opens a frame on the main pager, but with no main-DB write the main pager never commits a write transaction, so nothing on its own commit path clears that frame — only the skipped `clear_savepoints()` would have. `ROLLBACK TO` and `RELEASE` resolve names against the main pager, so they find the dead frame and return success where SQLite errors.

```sql
ATTACH 'aux.db' AS aux1;
CREATE TABLE aux1.t(x INTEGER PRIMARY KEY);
BEGIN;
SAVEPOINT sp;
INSERT INTO aux1.t VALUES (1);   -- nothing is written to the main database
COMMIT;                          -- yields on IO, resumes through the re-entry branch
ROLLBACK TO sp;                  -- returned OK; must be "no such savepoint: sp"
```

The window is narrow: any write after the COMMIT clears the stale frame through its own commit path, so only the statement immediately following the COMMIT sees it. No data was damaged in this scenario — the symptom is a wrong result, a dead savepoint name that still resolves, not corruption.

**CDC merges two transactions into one.** `conn_txn_id` has get-or-set semantics: the first captured change of a transaction stores the transaction id, and every later change reuses it until the id is reset to `-1` at commit. When the commit yielded on IO the reset never happened, so the *next* transaction's rows were filed under the previous transaction's id — a consumer reading `turso_cdc` sees the second transaction's changes attributed to a transaction that already emitted its COMMIT record.

```sql
BEGIN;
INSERT INTO t VALUES (1);
COMMIT;                     -- yields on IO, resumes through the re-entry branch
INSERT INTO t VALUES (2);   -- autocommit: its own transaction
SELECT COUNT(DISTINCT change_txn_id) FROM turso_cdc;  -- returned 1, must be 2
```

The two paths now end in one shared `finish_ended_txn`, so there is no second place to keep in sync.

Deferred foreign-key clearing stays where it was at each site: the re-entry branch clears only after a non-rollback COMMIT, the straight path clears after both. That difference predates this change and is left alone.

## Tests

Two tests in `tests/integration/statement_reset.rs`, one per symptom:

- `commit_resumed_after_io_clears_savepoints` — the attached-database savepoint case above.
- `commit_resumed_after_io_starts_a_new_cdc_transaction` — the CDC transaction-id case above.

Both drive the COMMIT over the existing `QueuedIo` harness, which makes it yield deterministically, and both assert the commit really did yield before checking anything else — so neither can pass by silently missing the re-entry branch.

Red without the fix (`ROLLBACK TO sp` returns Ok; `COUNT(DISTINCT change_txn_id)` is 1), green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
