### PR TITLE
core/incremental: cascade view output deltas to dependent materialized views

### DIFF
--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -327,6 +327,70 @@ impl IncrementalView {
         }
     }
 
+    /// Names a stored `CREATE MATERIALIZED VIEW` statement reads from, taken
+    /// straight from the FROM and JOIN clauses. This runs before the sources are
+    /// in the schema, so it cannot resolve them like `from_stmt` does; it only
+    /// decides the order in which views are rebuilt when a database is opened.
+    pub fn source_names_from_sql(sql: &str) -> Result<Vec<String>> {
+        let mut parser = Parser::new(sql.as_bytes());
+        let cmd = parser.next_cmd()?;
+        let cmd = cmd.expect("View is an empty statement");
+        let Cmd::Stmt(Stmt::CreateMaterializedView { select, .. }) = cmd else {
+            return Err(LimboError::ParseError(format!(
+                "View is not a CREATE MATERIALIZED VIEW statement: {sql}"
+            )));
+        };
+        let mut names = Vec::new();
+        Self::collect_source_names(&select, &HashSet::default(), &mut names);
+        Ok(names)
+    }
+
+    fn collect_source_names(
+        select: &ast::Select,
+        parent_cte_names: &HashSet<String>,
+        names: &mut Vec<String>,
+    ) {
+        let mut cte_names = parent_cte_names.clone();
+        if let Some(ref with) = select.with {
+            for cte in &with.ctes {
+                cte_names.insert(cte.tbl_name.as_str().to_string());
+            }
+            for cte in &with.ctes {
+                Self::collect_source_names(&cte.select, &cte_names, names);
+            }
+        }
+
+        Self::collect_one_select_source_names(&select.body.select, &cte_names, names);
+        for compound in &select.body.compounds {
+            Self::collect_one_select_source_names(&compound.select, &cte_names, names);
+        }
+    }
+
+    fn collect_one_select_source_names(
+        select: &ast::OneSelect,
+        cte_names: &HashSet<String>,
+        names: &mut Vec<String>,
+    ) {
+        let ast::OneSelect::Select {
+            from: Some(from), ..
+        } = select
+        else {
+            return;
+        };
+        let mut push = |table: &ast::SelectTable| {
+            if let ast::SelectTable::Table(name, _, _) = table {
+                let name = name.name.as_str();
+                if !cte_names.contains(name) {
+                    names.push(name.to_string());
+                }
+            }
+        };
+        push(from.select.as_ref());
+        for join in &from.joins {
+            push(join.table.as_ref());
+        }
+    }
+
     pub fn from_stmt(
         view_name: ast::QualifiedName,
         select: ast::Select,
@@ -1370,8 +1434,10 @@ impl IncrementalView {
         let table_name = self.referenced_tables[table_idx].name.clone();
         delta_set.insert(table_name, single_row_delta);
 
-        // Process through merge_delta
-        self.merge_delta(delta_set, pager)
+        // Process through merge_delta. Population only happens at CREATE time, so
+        // no view can be chained on top of this one yet and its delta has no reader.
+        return_if_io!(self.merge_delta(delta_set, pager));
+        Ok(IOResult::Done(()))
     }
 
     /// Extract rowid and values from a row
@@ -1400,23 +1466,25 @@ impl IncrementalView {
         }
     }
 
-    /// Merge a delta set of changes into the view's current state
+    /// Merge a delta set of changes into the view's current state, and return the
+    /// change this made to the view's own rows. Views built on top of this one
+    /// consume that as their input delta.
     pub fn merge_delta(
         &mut self,
         delta_set: DeltaSet,
         pager: Arc<crate::Pager>,
-    ) -> crate::Result<IOResult<()>> {
+    ) -> crate::Result<IOResult<Delta>> {
         // Early return if all deltas are empty
         if delta_set.is_empty() {
-            return Ok(IOResult::Done(()));
+            return Ok(IOResult::Done(Delta::new()));
         }
 
         // Use the circuit to process the deltas and write to btree
         let input_data = delta_set.into_map();
 
         // The circuit now handles all btree I/O internally with the provided pager
-        let _delta = return_if_io!(self.circuit.commit(input_data, pager));
-        Ok(IOResult::Done(()))
+        let delta = return_if_io!(self.circuit.commit(input_data, pager));
+        Ok(IOResult::Done(delta))
     }
 }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1245,6 +1245,63 @@ impl Schema {
             .unwrap_or_else(|| vec![])
     }
 
+    /// Every materialized view that has to be brought up to date once the views in
+    /// `seeds` change, `seeds` included. A view is always listed after the views it
+    /// reads from, so maintaining the list front to back feeds each view the deltas
+    /// its sources just produced.
+    pub fn materialized_view_maintenance_order(&self, seeds: &[String]) -> Vec<String> {
+        let mut affected: HashSet<String> = HashSet::default();
+        let mut queue: VecDeque<String> = seeds.iter().map(|s| normalize_ident(s)).collect();
+        while let Some(name) = queue.pop_front() {
+            if !affected.insert(name.clone()) {
+                continue;
+            }
+            for dependent in self.get_dependent_materialized_views(&name) {
+                queue.push_back(dependent);
+            }
+        }
+
+        // Sources of each affected view, restricted to the affected set. Sorted by
+        // name so the order does not depend on hash iteration.
+        let mut names: Vec<String> = affected.iter().cloned().collect();
+        names.sort();
+        let mut pending: Vec<(String, HashSet<String>)> = names
+            .into_iter()
+            .map(|name| {
+                let sources = self
+                    .get_materialized_view(&name)
+                    .map(|view| view.lock().get_referenced_table_names())
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|source| normalize_ident(&source))
+                    .filter(|source| *source != name && affected.contains(source))
+                    .collect();
+                (name, sources)
+            })
+            .collect();
+
+        let mut order = Vec::with_capacity(pending.len());
+        while !pending.is_empty() {
+            let ready: Vec<String> = pending
+                .iter()
+                .filter(|(_, sources)| sources.is_empty())
+                .map(|(name, _)| name.clone())
+                .collect();
+            // CREATE MATERIALIZED VIEW needs its sources to exist, so the graph
+            // cannot contain a cycle.
+            turso_assert!(
+                !ready.is_empty(),
+                "materialized view dependencies must be acyclic"
+            );
+            pending.retain(|(name, _)| !ready.contains(name));
+            for (_, sources) in pending.iter_mut() {
+                sources.retain(|source| !ready.contains(source));
+            }
+            order.extend(ready);
+        }
+        order
+    }
+
     /// Add a regular (non-materialized) view
     pub fn add_view(&mut self, view: View) -> Result<()> {
         self.check_object_name_conflict(&view.name, SchemaObjectType::View)?;
@@ -1922,6 +1979,55 @@ impl Schema {
         Ok(())
     }
 
+    /// Order in which stored materialized views can be rebuilt: a view comes after
+    /// every view it selects from, because compiling it needs its sources to be in
+    /// the schema already.
+    fn materialized_view_load_order(
+        materialized_view_info: &HashMap<String, (String, i64)>,
+    ) -> Result<Vec<String>> {
+        // sqlite_schema keeps view names as written, so match sources against them
+        // case-insensitively.
+        let by_normalized_name: HashMap<String, String> = materialized_view_info
+            .keys()
+            .map(|name| (normalize_ident(name), name.clone()))
+            .collect();
+
+        let mut pending: Vec<(String, HashSet<String>)> =
+            Vec::try_with_capacity_ext(materialized_view_info.len())?;
+        for (view_name, (sql, _)) in materialized_view_info.iter() {
+            let sources = IncrementalView::source_names_from_sql(sql)?
+                .into_iter()
+                .filter_map(|source| by_normalized_name.get(&normalize_ident(&source)).cloned())
+                .filter(|source| source != view_name)
+                .collect();
+            pending
+                .push_within_capacity((view_name.clone(), sources))
+                .expect("pending vector was preallocated to the number of views");
+        }
+        // Sorted by name so a database always rebuilds its views in the same order.
+        pending.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        let mut order = Vec::try_with_capacity_ext(pending.len())?;
+        while !pending.is_empty() {
+            let ready: Vec<String> = pending
+                .iter()
+                .filter(|(_, sources)| sources.is_empty())
+                .map(|(name, _)| name.clone())
+                .collect();
+            if ready.is_empty() {
+                return Err(LimboError::InternalError(
+                    "materialized views in the schema form a dependency cycle".to_string(),
+                ));
+            }
+            pending.retain(|(name, _)| !ready.contains(name));
+            for (_, sources) in pending.iter_mut() {
+                sources.retain(|source| !ready.contains(source));
+            }
+            order.extend(ready);
+        }
+        Ok(order)
+    }
+
     /// Populate materialized views parsed from the schema.
     pub fn populate_materialized_views(
         &mut self,
@@ -1929,7 +2035,12 @@ impl Schema {
         dbsp_state_roots: HashMap<String, i64>,
         dbsp_state_index_roots: HashMap<String, i64>,
     ) -> Result<()> {
-        for (view_name, (sql, main_root)) in materialized_view_info {
+        let load_order = Self::materialized_view_load_order(&materialized_view_info)?;
+        let mut materialized_view_info = materialized_view_info;
+        for view_name in load_order {
+            let (sql, main_root) = materialized_view_info
+                .remove(&view_name)
+                .expect("load order is built from the same map");
             // Look up the DBSP state root for this view
             // If missing, it means version mismatch - skip this view
             // Check if we have a compatible DBSP state root

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -115,8 +115,14 @@ type MvccCommitStateMachine = CommitStateMachine<MvccClock, DynAllocator>;
 pub enum ViewDeltaCommitState {
     NotStarted,
     Processing {
-        views: Vec<String>, // view names (all materialized views have storage)
+        /// View names (all materialized views have storage), sources before the
+        /// views that read from them.
+        views: Vec<String>,
         current_index: usize,
+        /// Row changes the already-processed views made to themselves, keyed by
+        /// the view that made them. A view chained on top of another one reads its
+        /// source's entry the same way it reads a table delta.
+        cascade: HashMap<String, crate::incremental::dbsp::Delta>,
     },
     Done,
 }
@@ -2189,9 +2195,12 @@ impl Program {
                     // Not a rollback - proceed with processing
                     let schema = self.connection.schema.read();
 
-                    // Collect materialized views - they should all have storage
+                    // Collect materialized views - they should all have storage.
+                    // Views chained on top of these get no table delta of their
+                    // own, so pull them in and keep every view after its sources.
+                    let seeds = self.connection.view_transaction_states.get_view_names();
                     let mut views = Vec::new();
-                    for view_name in self.connection.view_transaction_states.get_view_names() {
+                    for view_name in schema.materialized_view_maintenance_order(&seeds) {
                         if let Some(view_mutex) = schema.get_materialized_view(&view_name) {
                             let view = view_mutex.lock();
                             let root_page = view.get_root_page();
@@ -2210,12 +2219,14 @@ impl Program {
                     state.view_delta_state = ViewDeltaCommitState::Processing {
                         views,
                         current_index: 0,
+                        cascade: HashMap::default(),
                     };
                 }
 
                 ViewDeltaCommitState::Processing {
                     views,
                     current_index,
+                    cascade,
                 } => {
                     // At this point we know it's not a rollback
                     if *current_index >= views.len() {
@@ -2227,36 +2238,44 @@ impl Program {
 
                     let view_name = &views[*current_index];
 
-                    let table_deltas = self
-                        .connection
-                        .view_transaction_states
-                        .get(view_name)
-                        .expect("view should have transaction state")
-                        .get_table_deltas();
-
-                    let schema = self.connection.schema.read();
-                    if let Some(view_mutex) = schema.get_materialized_view(view_name) {
-                        let mut view = view_mutex.lock();
-
-                        // Create a DeltaSet from the per-table deltas
-                        let mut delta_set = crate::incremental::compiler::DeltaSet::new();
-                        for (table_name, delta) in table_deltas {
+                    // Deltas this view can read: the ones its source tables wrote
+                    // in this transaction, plus the ones its source views just
+                    // produced. The circuit picks the names its inputs are bound
+                    // to and ignores the rest.
+                    let mut delta_set = crate::incremental::compiler::DeltaSet::new();
+                    for (source_name, delta) in cascade.iter() {
+                        delta_set.insert(source_name.clone(), delta.clone());
+                    }
+                    if let Some(tx_state) = self.connection.view_transaction_states.get(view_name) {
+                        for (table_name, delta) in tx_state.get_table_deltas() {
                             delta_set.insert(table_name, delta);
                         }
+                    }
 
-                        // Handle I/O from merge_delta - pass pager, circuit will create its own cursor
-                        match view.merge_delta(delta_set, pager.clone())? {
-                            IOResult::Done(_) => {
-                                // Move to next view
-                                state.view_delta_state = ViewDeltaCommitState::Processing {
-                                    views: views.clone(),
-                                    current_index: current_index + 1,
-                                };
+                    let schema = self.connection.schema.read();
+                    let view_mutex = schema
+                        .get_materialized_view(view_name)
+                        .expect("views were filtered to those with storage");
+                    let mut view = view_mutex.lock();
+
+                    // Handle I/O from merge_delta - pass pager, circuit will create its own cursor
+                    match view.merge_delta(delta_set, pager.clone())? {
+                        // Nothing may change before this point: an IO return
+                        // re-enters at the same index and rebuilds the input.
+                        IOResult::Done(view_delta) => {
+                            let mut cascade = cascade.clone();
+                            if !view_delta.is_empty() {
+                                cascade.insert(view_name.clone(), view_delta);
                             }
-                            IOResult::IO(io) => {
-                                // Return I/O, will resume at same index
-                                return Ok(IOResult::IO(io));
-                            }
+                            state.view_delta_state = ViewDeltaCommitState::Processing {
+                                views: views.clone(),
+                                current_index: current_index + 1,
+                                cascade,
+                            };
+                        }
+                        IOResult::IO(io) => {
+                            // Return I/O, will resume at same index
+                            return Ok(IOResult::IO(io));
                         }
                     }
                 }

--- a/sqlite/conformance/turso-sqltests/matview_chained_propagation.sqltest
+++ b/sqlite/conformance/turso-sqltests/matview_chained_propagation.sqltest
@@ -1,0 +1,97 @@
+@database :memory:
+@requires-file materialized_views ""
+@skip-file-if mvcc "materialized_views not supported with mvcc"
+
+# A materialized view whose source is another materialized view must see base
+# table changes. The maintenance cascade only walked one level out from the
+# changed table, so views chained on top of another view never got a delta.
+
+test matview-chain-depth2-insert {
+    CREATE TABLE t(a, b);
+    INSERT INTO t VALUES (1, 10), (2, 20);
+    CREATE MATERIALIZED VIEW mv1 AS SELECT a, b FROM t;
+    CREATE MATERIALIZED VIEW mv2 AS SELECT b FROM mv1;
+    INSERT INTO t VALUES (3, 30);
+    SELECT * FROM mv1 ORDER BY a;
+    SELECT * FROM mv2 ORDER BY b;
+}
+expect {
+    1|10
+    2|20
+    3|30
+    10
+    20
+    30
+}
+
+test matview-chain-depth3-insert {
+    CREATE TABLE t(a, b);
+    INSERT INTO t VALUES (1, 10), (2, 20);
+    CREATE MATERIALIZED VIEW mv1 AS SELECT a, b FROM t;
+    CREATE MATERIALIZED VIEW mv2 AS SELECT b FROM mv1;
+    CREATE MATERIALIZED VIEW mv3 AS SELECT b * 2 AS bb FROM mv2;
+    INSERT INTO t VALUES (3, 30);
+    SELECT * FROM mv2 ORDER BY b;
+    SELECT * FROM mv3 ORDER BY bb;
+}
+expect {
+    10
+    20
+    30
+    20
+    40
+    60
+}
+
+test matview-chain-delete-and-update {
+    CREATE TABLE t(a, b);
+    INSERT INTO t VALUES (1, 10), (2, 20), (3, 30);
+    CREATE MATERIALIZED VIEW mv1 AS SELECT a, b FROM t;
+    CREATE MATERIALIZED VIEW mv2 AS SELECT b FROM mv1;
+    CREATE MATERIALIZED VIEW mv3 AS SELECT b * 2 AS bb FROM mv2;
+    DELETE FROM t WHERE a = 1;
+    SELECT * FROM mv2 ORDER BY b;
+    SELECT * FROM mv3 ORDER BY bb;
+    UPDATE t SET b = 99 WHERE a = 2;
+    SELECT * FROM mv2 ORDER BY b;
+    SELECT * FROM mv3 ORDER BY bb;
+}
+expect {
+    20
+    30
+    40
+    60
+    30
+    99
+    60
+    198
+}
+
+test matview-chain-aggregate-on-view {
+    CREATE TABLE s(g TEXT, v INTEGER);
+    INSERT INTO s VALUES ('a', 1), ('a', 2), ('b', 5);
+    CREATE MATERIALIZED VIEW base AS SELECT g, v FROM s WHERE v > 0;
+    CREATE MATERIALIZED VIEW agg AS SELECT g, count(*) AS n FROM base GROUP BY g;
+    INSERT INTO s VALUES ('a', 10), ('c', 7);
+    SELECT * FROM agg ORDER BY g;
+}
+expect {
+    a|3
+    b|1
+    c|1
+}
+
+test matview-chain-insert-inside-explicit-transaction {
+    CREATE TABLE t(a, b);
+    INSERT INTO t VALUES (1, 10);
+    CREATE MATERIALIZED VIEW mv1 AS SELECT a, b FROM t;
+    CREATE MATERIALIZED VIEW mv2 AS SELECT b FROM mv1;
+    BEGIN;
+    INSERT INTO t VALUES (2, 20);
+    COMMIT;
+    SELECT * FROM mv2 ORDER BY b;
+}
+expect {
+    10
+    20
+}

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -8,6 +8,7 @@ mod test_in_seek;
 mod test_is_seek;
 mod test_materialized_subquery;
 mod test_multi_index_scan;
+mod test_matview_chain;
 mod test_read_path;
 mod test_vacuum;
 mod test_write_path;

--- a/tests/integration/query_processing/test_matview_chain.rs
+++ b/tests/integration/query_processing/test_matview_chain.rs
@@ -1,0 +1,121 @@
+//! Materialized views built on top of other materialized views.
+//!
+//! Two things must hold across a database reopen:
+//!   * a chained view keeps the rows the maintenance cascade gave it, and
+//!   * a chain of any depth can be rebuilt from the stored schema, which needs
+//!     the sources of a view to be loaded before the view itself.
+
+use crate::common::{ExecRows, TempDatabase};
+use tempfile::TempDir;
+
+fn open_with_views(path: &std::path::Path) -> TempDatabase {
+    TempDatabase::builder()
+        .with_db_path(path)
+        .with_views(true)
+        .build()
+}
+
+#[test]
+fn test_matview_chain_depth2_survives_reopen() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("matview_chain_depth2.db");
+
+    {
+        let db = open_with_views(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(a, b)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 10), (2, 20)")
+            .unwrap();
+        conn.execute("CREATE MATERIALIZED VIEW mv1 AS SELECT a, b FROM t")
+            .unwrap();
+        conn.execute("CREATE MATERIALIZED VIEW mv2 AS SELECT b FROM mv1")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (3, 30)").unwrap();
+
+        let mv2: Vec<(i64,)> = conn.exec_rows("SELECT b FROM mv2 ORDER BY b");
+        assert_eq!(mv2, vec![(10,), (20,), (30,)]);
+        conn.close().unwrap();
+    }
+
+    {
+        let db = open_with_views(&path);
+        let conn = db.connect_limbo();
+        let mv2: Vec<(i64,)> = conn.exec_rows("SELECT b FROM mv2 ORDER BY b");
+        assert_eq!(mv2, vec![(10,), (20,), (30,)]);
+        conn.close().unwrap();
+    }
+}
+
+#[test]
+fn test_matview_chain_depth3_survives_reopen() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("matview_chain_depth3.db");
+
+    {
+        let db = open_with_views(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(a, b)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 10), (2, 20)")
+            .unwrap();
+        conn.execute("CREATE MATERIALIZED VIEW mv1 AS SELECT a, b FROM t")
+            .unwrap();
+        conn.execute("CREATE MATERIALIZED VIEW mv2 AS SELECT b FROM mv1")
+            .unwrap();
+        conn.execute("CREATE MATERIALIZED VIEW mv3 AS SELECT b * 2 AS bb FROM mv2")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (3, 30)").unwrap();
+
+        let mv3: Vec<(i64,)> = conn.exec_rows("SELECT bb FROM mv3 ORDER BY bb");
+        assert_eq!(mv3, vec![(20,), (40,), (60,)]);
+        conn.close().unwrap();
+    }
+
+    {
+        let db = open_with_views(&path);
+        let conn = db.connect_limbo();
+        let mv2: Vec<(i64,)> = conn.exec_rows("SELECT b FROM mv2 ORDER BY b");
+        assert_eq!(mv2, vec![(10,), (20,), (30,)]);
+        let mv3: Vec<(i64,)> = conn.exec_rows("SELECT bb FROM mv3 ORDER BY bb");
+        assert_eq!(mv3, vec![(20,), (40,), (60,)]);
+        conn.close().unwrap();
+    }
+}
+
+/// Writes made after a reopen must keep flowing down the chain: the cascade has
+/// to be rebuilt from the stored schema, not only from the CREATE statements.
+#[test]
+fn test_matview_chain_accepts_writes_after_reopen() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("matview_chain_write_after_reopen.db");
+
+    {
+        let db = open_with_views(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(a, b)").unwrap();
+        conn.execute("INSERT INTO t VALUES (1, 10)").unwrap();
+        conn.execute("CREATE MATERIALIZED VIEW mv1 AS SELECT a, b FROM t")
+            .unwrap();
+        conn.execute("CREATE MATERIALIZED VIEW mv2 AS SELECT b FROM mv1")
+            .unwrap();
+        conn.close().unwrap();
+    }
+
+    {
+        let db = open_with_views(&path);
+        let conn = db.connect_limbo();
+        conn.execute("INSERT INTO t VALUES (2, 20)").unwrap();
+        conn.execute("DELETE FROM t WHERE a = 1").unwrap();
+
+        let mv2: Vec<(i64,)> = conn.exec_rows("SELECT b FROM mv2 ORDER BY b");
+        assert_eq!(mv2, vec![(20,)]);
+        conn.close().unwrap();
+    }
+
+    {
+        let db = open_with_views(&path);
+        let conn = db.connect_limbo();
+        let mv2: Vec<(i64,)> = conn.exec_rows("SELECT b FROM mv2 ORDER BY b");
+        assert_eq!(mv2, vec![(20,)]);
+        conn.close().unwrap();
+    }
+}


### PR DESCRIPTION
A materialized view built on top of another materialized view never received base-table changes. It was populated correctly at CREATE time and then froze: every later INSERT, UPDATE and DELETE reached the first view and stopped there.

```sql
CREATE TABLE t(a, b);
INSERT INTO t VALUES (1, 10), (2, 20);
CREATE MATERIALIZED VIEW mv1 AS SELECT a, b FROM t;
CREATE MATERIALIZED VIEW mv2 AS SELECT b FROM mv1;
INSERT INTO t VALUES (3, 30);
SELECT * FROM mv1;    -- 1|10  2|20  3|30   correct
SELECT * FROM mv2;    -- 10  20             missing 30
```

The wrong rows are written to disk and survive a reopen, and `CREATE` accepts the second view without a word.

Row changes reach a materialized view as a delta recorded per source table by `Insert`/`Delete`, and `apply_view_deltas` feeds those deltas to the views at commit. A view chained on another view has no source table of its own, so it had no delta and its circuit was never run. Its source's rows are written straight to a btree by the DBSP circuit, which does not go through `Insert`, and `IncrementalView::merge_delta` threw away the delta the circuit returned — the one thing the downstream view needed.

`merge_delta` now returns that delta. `apply_view_deltas` collects the views reached from the changed tables, keeps every view after the views it reads from, and hands each one its source views' deltas next to its table deltas. Input nodes are keyed by name, so a chained view reads its source exactly like a table. The delta is only recorded once `merge_delta` reports `Done`, so an I/O return still re-enters at the same view with the same input.

The order comes from `Schema::materialized_view_maintenance_order`: the transitive closure of the "is read by" edges the schema already tracks, topologically sorted, name-sorted at each level so the order is stable. `CREATE MATERIALIZED VIEW` requires its sources to exist, so the graph cannot have a cycle, and the sort asserts that rather than assuming it.

## A second defect: load order at open

Writing the depth-3 test uncovered a separate bug in the same area. `populate_materialized_views` iterated a `HashMap`, so it could compile a view before the view it selects from was in the schema. A three-view chain failed to open at all:

```
Error: Parse error: Table 'mv2' not found in schema
```

Two-view chains happened to survive on hash order. `Schema::materialized_view_load_order` now sorts the stored views the same way, using the FROM and JOIN names read straight out of the stored SQL — the sources are not in the schema yet at that point, so they cannot be resolved the way `from_stmt` does.

## Known gap

Reads inside an open transaction still only merge the reading view's own uncommitted deltas, so in `BEGIN; INSERT; SELECT * FROM mv2;` the chained view lags until `COMMIT`. `mv1` is up to date in the same transaction. Committed state is correct at every depth. Closing this needs the same cascade in the read path and is left for a follow-up.

## Tests

First commit, red without the fix:

* `sqlite/conformance/turso-sqltests/matview_chained_propagation.sqltest` — 5 cases: depth-2 INSERT, depth-3 INSERT, DELETE and UPDATE down a depth-3 chain, an aggregate view over another view, and an INSERT inside an explicit transaction. All expectations taken from sqlite3 with plain `CREATE VIEW`.
* `tests/integration/query_processing/test_matview_chain.rs` — 3 cases for the persistence side: depth-2 and depth-3 chains still correct after reopening the database, and writes after a reopen still flowing down the chain.

Gate numbers on this tree, same command before and after:

| | before | after |
|---|---|---|
| `tests/integration` | 1020 passed, 6 failed | 1023 passed, 3 failed |
| turso-sqltests | — | 1540 passed, 0 failed, 341 skipped |
| sqlite-sqltests | 12550 passed, 8 failed | 12550 passed, 8 failed |
| `turso_core` unit tests | — | 2287 passed, 0 failed |

The 3 remaining integration failures are the same before and after: `index_method::test_fts_field_weights`, `index_method::test_fts_flexible_query_patterns`, and the non-hermetic `test_ephemeral_temp_files_cleaned_up`. The 8 sqlite-sqltests failures are unchanged. `cargo fmt --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
