### PR TITLE
core/incremental: give SUM and AVG SQLite's typing and NULL rules

### DIFF
--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -15,6 +15,7 @@ use crate::translate::plan::ColumnMask;
 use crate::types::{
     IOResult, ImmutableRecord, ImmutableRecordRef, SeekKey, SeekOp, SeekResult, ValueRef,
 };
+use crate::vdbe::execute::{classify_numeric_arg, NumericArg};
 use crate::{return_and_restore_if_io, return_if_io, LimboError, Result, Value};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::collections::BTreeMap;
@@ -458,15 +459,141 @@ pub struct AggregateOperator {
     is_distinct_only: bool,
 }
 
+/// Running SUM of one column, kept in the form SQLite's typing rules need.
+///
+/// SQLite's `sum()` is an INTEGER while every input is an exact integer and
+/// becomes a REAL as soon as one input is not, so the integer and the float
+/// inputs are accumulated apart and the number of float inputs still in the
+/// group decides the result type. Deleting the only float row therefore takes
+/// the group back to an INTEGER sum, which a single `f64` accumulator could
+/// never do.
+///
+/// `non_null_count` is what makes `sum()` and `avg()` over no non-NULL input
+/// NULL instead of zero.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SumAccumulator {
+    /// Sum of the inputs SQLite treats as exact integers. `i128` so that adding
+    /// and later retracting values near `i64::MAX` cannot wrap.
+    int_sum: i128,
+    /// Sum of the inputs SQLite treats as floats.
+    real_sum: f64,
+    /// How many float inputs the group currently holds.
+    real_count: i64,
+    /// How many non-NULL inputs the group currently holds.
+    non_null_count: i64,
+}
+
+impl SumAccumulator {
+    /// Add `value` `weight` times; a negative weight retracts it.
+    fn add(&mut self, value: &Value, weight: i64) {
+        match classify_numeric_arg(value) {
+            NumericArg::Null => {}
+            NumericArg::Integer(i) => {
+                self.int_sum += i as i128 * weight as i128;
+                self.non_null_count += weight;
+            }
+            NumericArg::Float(f) => {
+                self.real_sum += f * weight as f64;
+                self.real_count += weight;
+                self.non_null_count += weight;
+            }
+        }
+    }
+
+    fn total_as_float(&self) -> f64 {
+        self.int_sum as f64 + self.real_sum
+    }
+
+    /// The value `sum()` reports.
+    ///
+    /// An integer sum too large for an i64 is reported as a REAL. SQLite raises
+    /// "integer overflow" there, which this operator cannot do because the
+    /// value is produced while reading the view, not while summing.
+    fn sum_value(&self) -> Value {
+        if self.non_null_count == 0 {
+            return Value::Null;
+        }
+        if self.real_count == 0 {
+            if let Ok(exact) = i64::try_from(self.int_sum) {
+                return Value::from_i64(exact);
+            }
+        }
+        Value::from_f64(self.total_as_float())
+    }
+
+    /// The value `avg()` reports. Always a REAL, like SQLite.
+    fn avg_value(&self) -> Value {
+        if self.non_null_count == 0 {
+            return Value::Null;
+        }
+        Value::from_f64(self.total_as_float() / self.non_null_count as f64)
+    }
+
+    /// Serialized form: [int_sum high half, int_sum low half, real_sum,
+    /// real_count, non_null_count]. The i128 is split because a Value can only
+    /// hold an i64.
+    fn to_values(&self) -> Vec<Value> {
+        vec![
+            Value::from_i64((self.int_sum >> 64) as i64),
+            Value::from_i64(self.int_sum as u64 as i64),
+            Value::from_f64(self.real_sum),
+            Value::from_i64(self.real_count),
+            Value::from_i64(self.non_null_count),
+        ]
+    }
+
+    fn from_values(values: &[Value], cursor: &mut usize, what: &str) -> Result<Self> {
+        let next_int = |cursor: &mut usize| -> Result<i64> {
+            let value = values.get(*cursor).ok_or_else(|| {
+                LimboError::InternalError(format!("Aggregate state for {what} is truncated"))
+            })?;
+            let Value::Numeric(Numeric::Integer(i)) = value else {
+                return Err(LimboError::InternalError(format!(
+                    "Expected Integer in aggregate state for {what}, got {value:?}. \
+                     Materialized views written by an older version must be recreated."
+                )));
+            };
+            *cursor += 1;
+            Ok(*i)
+        };
+
+        let high = next_int(cursor)?;
+        let low = next_int(cursor)?;
+        let int_sum = ((high as i128) << 64) | (low as u64 as i128);
+
+        let real_sum = values.get(*cursor).ok_or_else(|| {
+            LimboError::InternalError(format!("Aggregate state for {what} is truncated"))
+        })?;
+        let Value::Numeric(Numeric::Float(real_sum)) = real_sum else {
+            return Err(LimboError::InternalError(format!(
+                "Expected Float in aggregate state for {what}, got {real_sum:?}. \
+                 Materialized views written by an older version must be recreated."
+            )));
+        };
+        let real_sum = f64::from(*real_sum);
+        *cursor += 1;
+
+        let real_count = next_int(cursor)?;
+        let non_null_count = next_int(cursor)?;
+
+        Ok(Self {
+            int_sum,
+            real_sum,
+            real_count,
+            non_null_count,
+        })
+    }
+}
+
 /// State for a single group's aggregates
 #[derive(Debug, Clone, Default)]
 pub struct AggregateState {
     // For COUNT: just the count
     pub count: i64,
-    // For SUM: column_index -> sum value
-    pub sums: HashMap<usize, f64>,
-    // For AVG: column_index -> (sum, count) for computing average
-    pub avgs: HashMap<usize, (f64, i64)>,
+    // For SUM: column_index -> running sum
+    pub sums: HashMap<usize, SumAccumulator>,
+    // For AVG: column_index -> running sum, divided by its non-NULL count
+    pub avgs: HashMap<usize, SumAccumulator>,
     // For MIN: column_index -> minimum value
     pub mins: HashMap<usize, Value>,
     // For MAX: column_index -> maximum value
@@ -760,8 +887,13 @@ impl AggregateState {
                     values.push(Value::from_i64(count));
                 }
                 AggregateFunction::Sum(col_idx) => {
-                    let sum = self.sums.get(col_idx).copied().unwrap_or(0.0);
-                    values.push(Value::from_f64(sum));
+                    values.extend(
+                        self.sums
+                            .get(col_idx)
+                            .cloned()
+                            .unwrap_or_default()
+                            .to_values(),
+                    );
                 }
                 AggregateFunction::SumDistinct(col_idx) => {
                     // Store both the distinct count and sum for this column
@@ -771,9 +903,13 @@ impl AggregateState {
                     values.push(Value::from_f64(sum));
                 }
                 AggregateFunction::Avg(col_idx) => {
-                    let (sum, count) = self.avgs.get(col_idx).copied().unwrap_or((0.0, 0));
-                    values.push(Value::from_f64(sum));
-                    values.push(Value::from_i64(count));
+                    values.extend(
+                        self.avgs
+                            .get(col_idx)
+                            .cloned()
+                            .unwrap_or_default()
+                            .to_values(),
+                    );
                 }
                 AggregateFunction::AvgDistinct(col_idx) => {
                     // Store both the distinct count and sum for this column
@@ -910,46 +1046,12 @@ impl AggregateState {
                     }
                 }
                 AggregateFunction::Sum(col_idx) => {
-                    let sum = values
-                        .get(cursor)
-                        .ok_or_else(|| LimboError::InternalError("Missing SUM value".into()))?;
-                    if let Value::Numeric(Numeric::Float(sum)) = sum {
-                        state.sums.insert(col_idx, f64::from(*sum));
-                        cursor += 1;
-                    } else {
-                        return Err(LimboError::InternalError(format!(
-                            "Expected Float for SUM value, got {sum:?}"
-                        )));
-                    }
+                    let sum = SumAccumulator::from_values(values, &mut cursor, "SUM")?;
+                    state.sums.insert(col_idx, sum);
                 }
                 AggregateFunction::Avg(col_idx) => {
-                    let sum = values
-                        .get(cursor)
-                        .ok_or_else(|| LimboError::InternalError("Missing AVG sum value".into()))?;
-                    let sum = match sum {
-                        Value::Numeric(Numeric::Float(f)) => f64::from(*f),
-                        _ => {
-                            return Err(LimboError::InternalError(format!(
-                                "Expected Float for AVG sum, got {sum:?}"
-                            )));
-                        }
-                    };
-                    cursor += 1;
-
-                    let count = values.get(cursor).ok_or_else(|| {
-                        LimboError::InternalError("Missing AVG count value".into())
-                    })?;
-                    let count = match count {
-                        Value::Numeric(Numeric::Integer(i)) => *i,
-                        _ => {
-                            return Err(LimboError::InternalError(format!(
-                                "Expected Integer for AVG count, got {count:?}"
-                            )));
-                        }
-                    };
-                    cursor += 1;
-
-                    state.avgs.insert(col_idx, (sum, count));
+                    let sum = SumAccumulator::from_values(values, &mut cursor, "AVG")?;
+                    state.avgs.insert(col_idx, sum);
                 }
                 AggregateFunction::Min(col_idx) => {
                     let has_value = values.get(cursor).ok_or_else(|| {
@@ -1139,24 +1241,18 @@ impl AggregateState {
                 }
                 AggregateFunction::Sum(col_idx) => {
                     if let Some(val) = values.get(*col_idx) {
-                        let num_val = match val {
-                            Value::Numeric(Numeric::Integer(i)) => *i as f64,
-                            Value::Numeric(Numeric::Float(f)) => f64::from(*f),
-                            _ => 0.0,
-                        };
-                        *self.sums.entry(*col_idx).or_insert(0.0) += num_val * weight as f64;
+                        self.sums
+                            .entry(*col_idx)
+                            .or_default()
+                            .add(val, weight as i64);
                     }
                 }
                 AggregateFunction::Avg(col_idx) => {
                     if let Some(val) = values.get(*col_idx) {
-                        let num_val = match val {
-                            Value::Numeric(Numeric::Integer(i)) => *i as f64,
-                            Value::Numeric(Numeric::Float(f)) => f64::from(*f),
-                            _ => 0.0,
-                        };
-                        let (sum, count) = self.avgs.entry(*col_idx).or_insert((0.0, 0));
-                        *sum += num_val * weight as f64;
-                        *count += weight as i64;
+                        self.avgs
+                            .entry(*col_idx)
+                            .or_default()
+                            .add(val, weight as i64);
                     }
                 }
                 AggregateFunction::Min(_col_name) | AggregateFunction::Max(_col_name) => {
@@ -1191,14 +1287,6 @@ impl AggregateState {
     }
 
     /// Convert aggregate state to output values
-    ///
-    /// Note: SQLite returns INTEGER for SUM when all inputs are integers, and REAL when any input is REAL.
-    /// However, in an incremental system like DBSP, we cannot track whether all current values are integers
-    /// after deletions. For example:
-    /// - Initial: SUM(10, 20, 30.5) = 60.5 (REAL)
-    /// - After DELETE 30.5: SUM(10, 20) = 30 (SQLite returns INTEGER, but we only know the sum is 30.0)
-    ///
-    /// Therefore, we always return REAL for SUM operations.
     pub fn to_values(&self, aggregates: &[AggregateFunction]) -> Vec<Value> {
         let mut result = Vec::new();
 
@@ -1213,8 +1301,11 @@ impl AggregateState {
                     result.push(Value::from_i64(count));
                 }
                 AggregateFunction::Sum(col_idx) => {
-                    let sum = self.sums.get(col_idx).copied().unwrap_or(0.0);
-                    result.push(Value::from_f64(sum));
+                    result.push(
+                        self.sums
+                            .get(col_idx)
+                            .map_or(Value::Null, SumAccumulator::sum_value),
+                    );
                 }
                 AggregateFunction::SumDistinct(col_idx) => {
                     // Return the computed SUM(DISTINCT)
@@ -1222,15 +1313,11 @@ impl AggregateState {
                     result.push(Value::from_f64(sum));
                 }
                 AggregateFunction::Avg(col_idx) => {
-                    if let Some((sum, count)) = self.avgs.get(col_idx) {
-                        if *count > 0 {
-                            result.push(Value::from_f64(sum / *count as f64));
-                        } else {
-                            result.push(Value::Null);
-                        }
-                    } else {
-                        result.push(Value::Null);
-                    }
+                    result.push(
+                        self.avgs
+                            .get(col_idx)
+                            .map_or(Value::Null, SumAccumulator::avg_value),
+                    );
                 }
                 AggregateFunction::AvgDistinct(col_idx) => {
                     // Compute AVG from SUM(DISTINCT) / COUNT(DISTINCT)

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -3126,14 +3126,16 @@ mod tests {
             assert_eq!(*weight, 1);
             assert_eq!(row.values.len(), 2); // name, sum
 
-            if let (Value::Text(name), Value::Numeric(Numeric::Float(sum))) =
+            if let (Value::Text(name), Value::Numeric(Numeric::Integer(sum))) =
                 (&row.values[0], &row.values[1])
             {
                 if name.as_str() == "Alice" {
-                    assert_eq!(*sum, 55.0, "Alice should have sum 55");
+                    assert_eq!(*sum, 55, "Alice should have sum 55");
                 } else if name.as_str() == "Bob" {
-                    assert_eq!(*sum, 20.0, "Bob should have sum 20");
+                    assert_eq!(*sum, 20, "Bob should have sum 20");
                 }
+            } else {
+                panic!("Unexpected value types in result");
             }
         }
     }
@@ -3331,13 +3333,12 @@ mod tests {
         let (row, _weight) = &result.changes[0];
         assert_eq!(row.values.len(), 1);
 
-        // The hex function converts the number to string first, then to hex
-        // SUM now returns Float, so 96.0 as string is "96.0", which in hex is "39362E30"
-        // (hex of ASCII '9', '6', '.', '0')
+        // The hex function converts the number to string first, then to hex,
+        // so an integer sum of 96 gives hex of ASCII '9','6'.
         assert_eq!(
             row.values[0],
-            Value::Text("39362E30".to_string().into()),
-            "HEX(SUM(age + 2)) should return '39362E30' for sum of 96.0"
+            Value::Text("3936".to_string().into()),
+            "HEX(SUM(age + 2)) should return '3936' for sum of 96"
         );
 
         // Test incremental update: add a new user
@@ -3356,22 +3357,22 @@ mod tests {
 
         let result = test_execute(&mut circuit, input_data, pager).unwrap();
 
-        // Expected: new SUM(age + 2) = 96.0 + (40+2) = 138.0
-        // HEX(138.0) = hex of "138.0" = "3133382E30"
+        // Expected: new SUM(age + 2) = 96 + (40+2) = 138
+        // HEX(138) = hex of "138" = "313338"
         assert_eq!(result.changes.len(), 2);
 
-        // First change: remove old aggregate (96.0)
+        // First change: remove old aggregate (96)
         let (row, weight) = &result.changes[0];
         assert_eq!(*weight, -1);
-        assert_eq!(row.values[0], Value::Text("39362E30".to_string().into()));
+        assert_eq!(row.values[0], Value::Text("3936".to_string().into()));
 
-        // Second change: add new aggregate (138.0)
+        // Second change: add new aggregate (138)
         let (row, weight) = &result.changes[1];
         assert_eq!(*weight, 1);
         assert_eq!(
             row.values[0],
-            Value::Text("3133382E30".to_string().into()),
-            "HEX(SUM(age + 2)) should return '3133382E30' for sum of 138.0"
+            Value::Text("313338".to_string().into()),
+            "HEX(SUM(age + 2)) should return '313338' for sum of 138"
         );
     }
 
@@ -3419,8 +3420,8 @@ mod tests {
             .unwrap();
 
         // Expected results:
-        // Alice: SUM(25*2 + 35*2) = 50 + 70 = 120.0, HEX("120.0") = "3132302E30"
-        // Bob: SUM(30*2) = 60.0, HEX("60.0") = "36302E30"
+        // Alice: SUM(25*2 + 35*2) = 50 + 70 = 120, HEX("120") = "313230"
+        // Bob: SUM(30*2) = 60, HEX("60") = "3630"
         assert_eq!(result.changes.len(), 2);
 
         let results: HashMap<String, String> = result
@@ -3441,13 +3442,13 @@ mod tests {
 
         assert_eq!(
             results.get("Alice").unwrap(),
-            "3132302E30",
-            "Alice's HEX(SUM(age * 2)) should be '3132302E30' (120.0)"
+            "313230",
+            "Alice's HEX(SUM(age * 2)) should be '313230' (120)"
         );
         assert_eq!(
             results.get("Bob").unwrap(),
-            "36302E30",
-            "Bob's HEX(SUM(age * 2)) should be '36302E30' (60.0)"
+            "3630",
+            "Bob's HEX(SUM(age * 2)) should be '3630' (60)"
         );
     }
 
@@ -4767,15 +4768,15 @@ mod tests {
         );
 
         // Check the results
-        let mut results_map: HashMap<String, f64> = HashMap::default();
+        let mut results_map: HashMap<String, i64> = HashMap::default();
         for (row, weight) in result.changes {
             assert_eq!(weight, 1);
             assert_eq!(row.values.len(), 2); // name and total_quantity
 
-            if let (Value::Text(name), Value::Numeric(Numeric::Float(total))) =
+            if let (Value::Text(name), Value::Numeric(Numeric::Integer(total))) =
                 (&row.values[0], &row.values[1])
             {
-                results_map.insert(name.to_string(), f64::from(*total));
+                results_map.insert(name.to_string(), *total);
             } else {
                 panic!("Unexpected value types in result");
             }
@@ -4783,12 +4784,12 @@ mod tests {
 
         assert_eq!(
             results_map.get("Alice"),
-            Some(&10.0),
+            Some(&10),
             "Alice should have total quantity 10"
         );
         assert_eq!(
             results_map.get("Bob"),
-            Some(&7.0),
+            Some(&7),
             "Bob should have total quantity 7"
         );
     }
@@ -4885,26 +4886,26 @@ mod tests {
         );
 
         // Check the results
-        let mut results_map: HashMap<String, f64> = HashMap::default();
+        let mut results_map: HashMap<String, i64> = HashMap::default();
         for (row, weight) in result.changes {
             assert_eq!(weight, 1);
             assert_eq!(row.values.len(), 2); // name and total
 
-            if let (Value::Text(name), Value::Numeric(Numeric::Float(total))) =
+            if let (Value::Text(name), Value::Numeric(Numeric::Integer(total))) =
                 (&row.values[0], &row.values[1])
             {
-                results_map.insert(name.to_string(), f64::from(*total));
+                results_map.insert(name.to_string(), *total);
             }
         }
 
         assert_eq!(
             results_map.get("Alice"),
-            Some(&8.0),
+            Some(&8),
             "Alice should have total 8"
         );
         assert_eq!(
             results_map.get("Charlie"),
-            Some(&7.0),
+            Some(&7),
             "Charlie should have total 7"
         );
         assert_eq!(results_map.get("Bob"), None, "Bob should be filtered out");
@@ -5046,7 +5047,7 @@ mod tests {
             if let (
                 Value::Text(name),
                 Value::Text(product),
-                Value::Numeric(Numeric::Float(total)),
+                Value::Numeric(Numeric::Integer(total)),
             ) = (&row.values[0], &row.values[1], &row.values[2])
             {
                 let key = format!("{}-{}", name.as_ref(), product.as_ref());
@@ -5054,14 +5055,14 @@ mod tests {
 
                 match key.as_str() {
                     "Alice-Widget" => {
-                        assert_eq!(*total, 9.0, "Alice should have ordered 9 Widgets total")
+                        assert_eq!(*total, 9, "Alice should have ordered 9 Widgets total")
                     }
                     "Alice-Gadget" => {
-                        assert_eq!(*total, 3.0, "Alice should have ordered 3 Gadgets")
+                        assert_eq!(*total, 3, "Alice should have ordered 3 Gadgets")
                     }
-                    "Bob-Widget" => assert_eq!(*total, 7.0, "Bob should have ordered 7 Widgets"),
+                    "Bob-Widget" => assert_eq!(*total, 7, "Bob should have ordered 7 Widgets"),
                     "Bob-Doohickey" => {
-                        assert_eq!(*total, 2.0, "Bob should have ordered 2 Doohickeys")
+                        assert_eq!(*total, 2, "Bob should have ordered 2 Doohickeys")
                     }
                     _ => panic!("Unexpected result: {key}"),
                 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8088,13 +8088,13 @@ pub fn op_agg_inverse(
 /// affinity to TEXT/BLOB. Returns the parsed pieces so callers don't
 /// re-parse, and so step and inverse agree on which path (integer or
 /// float) handles each row.
-enum NumericArg {
+pub(crate) enum NumericArg {
     Integer(i64),
     Float(f64),
     Null,
 }
 
-fn classify_numeric_arg(v: &Value) -> NumericArg {
+pub(crate) fn classify_numeric_arg(v: &Value) -> NumericArg {
     match v {
         Value::Null => NumericArg::Null,
         Value::Numeric(Numeric::Integer(i)) => NumericArg::Integer(*i),

--- a/sqlite/conformance/turso-sqltests/materialized_views.sqltest
+++ b/sqlite/conformance/turso-sqltests/materialized_views.sqltest
@@ -65,9 +65,9 @@ test matview-aggregation-population {
     SELECT * FROM daily_totals ORDER BY day;
 }
 expect {
-    1|7.0|2
-    2|2.0|2
-    3|4.0|2
+    1|7|2
+    2|2|2
+    3|4|2
 }
 
 test matview-filter-with-groupby {
@@ -81,9 +81,9 @@ test matview-filter-with-groupby {
     SELECT * FROM v ORDER BY yourb;
 }
 expect {
-    3|3.0|1
-    6|6.0|1
-    7|7.0|1
+    3|3|1
+    6|6|1
+    7|7|1
 }
 
 test matview-insert-maintenance {
@@ -101,12 +101,12 @@ test matview-insert-maintenance {
     SELECT * FROM v ORDER BY b;
 }
 expect {
-    3|3.0|1
-    6|6.0|1
-    3|7.0|2
-    6|11.0|2
-    3|7.0|2
-    6|11.0|2
+    3|3|1
+    6|6|1
+    3|7|2
+    6|11|2
+    3|7|2
+    6|11|2
 }
 
 test matview-delete-maintenance {
@@ -128,11 +128,11 @@ test matview-delete-maintenance {
     SELECT * FROM category_sums ORDER BY category;
 }
 expect {
-    A|90.0|3
-    B|60.0|2
-    A|60.0|2
-    B|60.0|2
-    A|60.0|2
+    A|90|3
+    B|60|2
+    A|60|2
+    B|60|2
+    A|60|2
 }
 
 test matview-update-maintenance {
@@ -153,12 +153,12 @@ test matview-update-maintenance {
     SELECT * FROM status_totals ORDER BY status;
 }
 expect {
-    1|400.0|2
-    2|600.0|2
-    1|450.0|2
-    2|600.0|2
-    1|150.0|1
-    2|900.0|3
+    1|400|2
+    2|600|2
+    1|450|2
+    2|600|2
+    1|150|1
+    2|900|3
 }
 
 test matview-integer-primary-key-basic {
@@ -239,12 +239,12 @@ test matview-integer-primary-key-with-aggregation {
     SELECT * FROM v ORDER BY b;
 }
 expect {
-    10|500.0|1
-    20|700.0|2
-    10|600.0|2
-    20|700.0|2
-    10|600.0|2
-    20|400.0|1
+    10|500|1
+    20|700|2
+    10|600|2
+    20|700|2
+    10|600|2
+    20|400|1
 }
 
 test matview-complex-filter-aggregation {
@@ -275,17 +275,17 @@ test matview-complex-filter-aggregation {
     SELECT * FROM account_deposits ORDER BY account;
 }
 expect {
-    100|70.0|2
-    200|100.0|1
-    300|60.0|1
-    100|95.0|3
-    200|100.0|1
-    300|60.0|1
-    100|125.0|3
-    200|100.0|1
-    300|60.0|1
-    100|125.0|3
-    300|60.0|1
+    100|70|2
+    200|100|1
+    300|60|1
+    100|95|3
+    200|100|1
+    300|60|1
+    100|125|3
+    200|100|1
+    300|60|1
+    100|125|3
+    300|60|1
 }
 
 test matview-sum-count-only {
@@ -309,12 +309,12 @@ test matview-sum-count-only {
     SELECT * FROM category_stats ORDER BY category;
 }
 expect {
-    1|80.0|3
-    2|70.0|2
-    1|85.0|4
-    2|70.0|2
-    1|85.0|4
-    2|75.0|2
+    1|80|3
+    2|70|2
+    1|85|4
+    2|70|2
+    1|85|4
+    2|75|2
 }
 
 test matview-empty-table-population {
@@ -330,8 +330,8 @@ test matview-empty-table-population {
 }
 expect {
     0
-    7|2.0|1
-    9|3.0|1
+    7|2|1
+    9|3|1
 }
 
 test matview-all-rows-filtered {
@@ -374,17 +374,17 @@ test matview-mixed-operations-sequence {
     SELECT * FROM customer_totals ORDER BY customer_id;
 }
 expect {
-    100|50.0|1
-    200|75.0|1
-    100|75.0|2
-    200|75.0|1
-    100|75.0|2
-    200|100.0|1
-    100|25.0|1
-    200|100.0|1
-    100|25.0|1
-    200|100.0|1
-    300|150.0|1
+    100|50|1
+    200|75|1
+    100|75|2
+    200|75|1
+    100|75|2
+    200|100|1
+    100|25|1
+    200|100|1
+    100|25|1
+    200|100|1
+    300|150|1
 }
 
 test matview-projections {
@@ -486,13 +486,13 @@ test matview-rollback-aggregation {
     SELECT * FROM product_totals ORDER BY product_id;
 }
 expect {
-    1|300.0|2
-    2|400.0|2
-    1|350.0|3
-    2|400.0|2
-    3|300.0|1
-    1|300.0|2
-    2|400.0|2
+    1|300|2
+    2|400|2
+    1|350|3
+    2|400|2
+    3|300|1
+    1|300|2
+    2|400|2
 }
 
 test matview-rollback-mixed-operations {
@@ -512,12 +512,12 @@ test matview-rollback-mixed-operations {
     SELECT * FROM customer_totals ORDER BY customer;
 }
 expect {
-    100|75.0|2
-    200|75.0|1
-    100|150.0|2
-    200|150.0|1
-    100|75.0|2
-    200|75.0|1
+    100|75|2
+    200|75|1
+    100|150|2
+    200|150|1
+    100|75|2
+    200|75|1
 }
 
 test matview-rollback-filtered-aggregation {
@@ -542,11 +542,11 @@ test matview-rollback-filtered-aggregation {
     SELECT * FROM deposits ORDER BY account;
 }
 expect {
-    100|50.0|1
-    200|100.0|1
-    100|135.0|2
-    100|50.0|1
-    200|100.0|1
+    100|50|1
+    200|100|1
+    100|135|2
+    100|50|1
+    200|100|1
 }
 
 test matview-rollback-empty-view {
@@ -599,8 +599,8 @@ test matview-join-with-aggregation {
     SELECT * FROM user_totals ORDER BY name;
 }
 expect {
-    Alice|250.0
-    Bob|250.0
+    Alice|250
+    Bob|250
 }
 
 test matview-three-way-join {
@@ -641,9 +641,9 @@ test matview-three-way-join-with-aggregation {
     SELECT * FROM sales_totals ORDER BY customer_name, product_name;
 }
 expect {
-    Alice|Gadget|3.0|60.0
-    Alice|Widget|9.0|90.0
-    Bob|Widget|2.0|20.0
+    Alice|Gadget|3|60
+    Alice|Widget|9|90
+    Bob|Widget|2|20
 }
 
 test matview-join-incremental-insert {
@@ -832,9 +832,9 @@ test matview-aggregation-before-join {
     SELECT * FROM customer_order_summary ORDER BY total_quantity DESC;
 }
 expect {
-    Bob|Silver|2|7.0
-    Alice|Gold|3|6.0
-    Charlie|Bronze|1|1.0
+    Bob|Silver|2|7
+    Alice|Gold|3|6
+    Charlie|Bronze|1|1
 }
 
 # Test 4: Join with aggregation AFTER the join
@@ -861,8 +861,8 @@ test matview-aggregation-after-join {
     SELECT * FROM regional_sales ORDER BY total_revenue DESC;
 }
 expect {
-    North|38.0|3150.0
-    South|18.0|1500.0
+    North|38|3150
+    South|18|1500
 }
 
 # Test 5: Modifying both tables in same transaction
@@ -1172,8 +1172,8 @@ test matview-union-with-aggregation {
     SELECT * FROM half_year_summary ORDER BY quarter;
 }
 expect {
-    Q1|68.0|16450.0
-    Q2|105.0|21750.0
+    Q1|68|16450
+    Q2|105|21750
 }
 
 test matview-union-with-join {
@@ -1601,8 +1601,8 @@ test matview-groupby-scalar-function {
     SELECT * FROM yearly_totals ORDER BY 1;
 }
 expect {
-    2020|250.0
-    2021|200.0
+    2020|250
+    2021|200
 }
 
 test matview-groupby-alias {
@@ -1617,8 +1617,8 @@ test matview-groupby-alias {
     SELECT * FROM yearly_totals ORDER BY year;
 }
 expect {
-    2020|250.0
-    2021|200.0
+    2020|250
+    2021|200
 }
 
 test matview-groupby-position {
@@ -1633,8 +1633,8 @@ test matview-groupby-position {
     SELECT * FROM national_yearly ORDER BY nation, year;
 }
 expect {
-    UK|2021|200.0
-    USA|2020|250.0
+    UK|2021|200
+    USA|2020|250
 }
 
 test matview-groupby-scalar-incremental {
@@ -1651,10 +1651,10 @@ test matview-groupby-scalar-incremental {
     SELECT * FROM yearly_totals ORDER BY year;
 }
 expect {
-    2020|100.0
-    2020|250.0
-    2020|250.0
-    2021|200.0
+    2020|100
+    2020|250
+    2020|250
+    2021|200
 }
 
 test matview-groupby-join-position {
@@ -2493,9 +2493,9 @@ test matview-recreate-after-drop {
     SELECT * FROM mv ORDER BY modified_x;
 }
 expect {
-    1|10.0
-    2|20.0
-    3|30.0
+    1|10
+    2|20
+    3|30
     3|40
     4|60
 }

--- a/sqlite/conformance/turso-sqltests/matview_sum_integer_type.sqltest
+++ b/sqlite/conformance/turso-sqltests/matview_sum_integer_type.sqltest
@@ -1,0 +1,74 @@
+@database :memory:
+@requires-file materialized_views ""
+@skip-file-if mvcc "materialized_views not supported with mvcc"
+
+# SUM() over integer input must return an INTEGER, like SQLite does.
+# All expectations below were taken from sqlite3 running the same query
+# against a plain (non-materialized) view.
+
+test matview-sum-of-integers-is-integer {
+    CREATE TABLE t(a INTEGER);
+    INSERT INTO t VALUES (3), (4), (5);
+    CREATE MATERIALIZED VIEW v AS SELECT sum(a) AS s FROM t;
+    SELECT s, typeof(s) FROM v;
+}
+expect {
+    12|integer
+}
+
+test matview-sum-of-reals-is-real {
+    CREATE TABLE t(b REAL);
+    INSERT INTO t VALUES (1.5), (2.5), (3.0);
+    CREATE MATERIALIZED VIEW v AS SELECT sum(b) AS s FROM t;
+    SELECT s, typeof(s) FROM v;
+}
+expect {
+    7.0|real
+}
+
+# One REAL input makes the whole sum REAL, and removing that row makes it
+# INTEGER again.
+test matview-sum-mixed-types-follows-current-rows {
+    CREATE TABLE t(x);
+    INSERT INTO t VALUES (1), (2), (3.5);
+    CREATE MATERIALIZED VIEW v AS SELECT sum(x) AS s FROM t;
+    SELECT s, typeof(s) FROM v;
+    DELETE FROM t WHERE x = 3.5;
+    SELECT s, typeof(s) FROM v;
+    INSERT INTO t VALUES (0.5);
+    SELECT s, typeof(s) FROM v;
+}
+expect {
+    6.5|real
+    3|integer
+    3.5|real
+}
+
+test matview-sum-per-group-is-integer {
+    CREATE TABLE g(k TEXT, v INTEGER);
+    INSERT INTO g VALUES ('a', 1), ('a', 2), ('b', 10);
+    CREATE MATERIALIZED VIEW v AS SELECT k, sum(v) AS s FROM g GROUP BY k;
+    SELECT k, s, typeof(s) FROM v ORDER BY k;
+}
+expect {
+    a|3|integer
+    b|10|integer
+}
+
+# The integer type must survive being written to and read back from the
+# persisted aggregate state, which is what a second statement reads.
+test matview-sum-integer-type-survives-more-writes {
+    CREATE TABLE t(a INTEGER);
+    INSERT INTO t VALUES (7);
+    CREATE MATERIALIZED VIEW v AS SELECT sum(a) AS s FROM t;
+    SELECT s, typeof(s) FROM v;
+    INSERT INTO t VALUES (5);
+    SELECT s, typeof(s) FROM v;
+    UPDATE t SET a = 6 WHERE a = 5;
+    SELECT s, typeof(s) FROM v;
+}
+expect {
+    7|integer
+    12|integer
+    13|integer
+}

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -8,6 +8,7 @@ mod test_in_seek;
 mod test_is_seek;
 mod test_materialized_subquery;
 mod test_multi_index_scan;
+mod test_matview_aggregate_reopen;
 mod test_read_path;
 mod test_vacuum;
 mod test_write_path;

--- a/tests/integration/query_processing/test_matview_aggregate_reopen.rs
+++ b/tests/integration/query_processing/test_matview_aggregate_reopen.rs
@@ -1,0 +1,97 @@
+//! The persisted aggregate state of a materialized view must round-trip.
+//!
+//! The DBSP aggregate state is serialized into a blob per group. Anything the
+//! serializer cannot represent is silently replaced when the blob is read back,
+//! so a view that answered correctly while its state was still in memory can
+//! start answering wrongly after the database is reopened.
+//!
+//! Expectations come from sqlite3 running the same query against a plain view.
+
+use crate::common::{limbo_exec_rows, TempDatabase};
+use rusqlite::types::Value;
+use tempfile::TempDir;
+
+fn open(path: &std::path::Path) -> TempDatabase {
+    TempDatabase::builder()
+        .with_db_path(path)
+        .with_views(true)
+        .build()
+}
+
+/// sum()/avg() over a column that only holds NULLs are NULL, and that must
+/// still be true after the aggregate state has been through the blob format.
+#[test]
+fn matview_sum_avg_over_all_null_column_stay_null_after_reopen() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("matview_agg_null_reopen.db");
+
+    {
+        let db = open(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x INTEGER)")
+            .unwrap();
+        conn.execute("INSERT INTO t VALUES (1, NULL), (2, NULL)")
+            .unwrap();
+        conn.execute(
+            "CREATE MATERIALIZED VIEW v AS
+             SELECT sum(x) AS sx, avg(x) AS ax, count(*) AS n FROM t",
+        )
+        .unwrap();
+        assert_eq!(
+            limbo_exec_rows(&conn, "SELECT sx, ax, n FROM v"),
+            vec![vec![Value::Null, Value::Null, Value::Integer(2)]],
+            "before reopen"
+        );
+        conn.close().unwrap();
+    }
+
+    {
+        let db = open(&path);
+        let conn = db.connect_limbo();
+        assert_eq!(
+            limbo_exec_rows(&conn, "SELECT sx, ax, n FROM v"),
+            vec![vec![Value::Null, Value::Null, Value::Integer(2)]],
+            "after reopen"
+        );
+    }
+}
+
+/// sum() over integer input is an INTEGER, and the blob format must not turn
+/// it into a REAL.
+#[test]
+fn matview_integer_sum_stays_integer_after_reopen() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("matview_agg_int_reopen.db");
+
+    {
+        let db = open(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(k TEXT, a INTEGER)").unwrap();
+        conn.execute("INSERT INTO t VALUES ('a', 3), ('a', 4), ('b', 5)")
+            .unwrap();
+        conn.execute("CREATE MATERIALIZED VIEW v AS SELECT k, sum(a) AS s FROM t GROUP BY k")
+            .unwrap();
+        conn.close().unwrap();
+    }
+
+    {
+        let db = open(&path);
+        let conn = db.connect_limbo();
+        assert_eq!(
+            limbo_exec_rows(&conn, "SELECT k, s FROM v ORDER BY k"),
+            vec![
+                vec![Value::Text("a".into()), Value::Integer(7)],
+                vec![Value::Text("b".into()), Value::Integer(5)],
+            ],
+            "after reopen"
+        );
+        // A write after the reopen loads the state from the blob and writes it
+        // back, so the type must survive that round trip too.
+        conn.execute("INSERT INTO t VALUES ('a', 1)").unwrap();
+        assert_eq!(
+            limbo_exec_rows(&conn, "SELECT s FROM v WHERE k = 'a'"),
+            vec![vec![Value::Integer(8)]],
+            "after a write following the reopen"
+        );
+    }
+}


### PR DESCRIPTION
SQLite's `sum()` returns an INTEGER while every input is an exact integer and a REAL as soon as one input is not, and `sum()`/`avg()` over no non-NULL value are NULL. A materialized view got neither rule: the DBSP aggregate state held each running sum in a single `f64`, so every sum came back as a REAL, and a sum with nothing in it came back as `0.0`.

```sql
CREATE TABLE t(a INTEGER, x INTEGER);
INSERT INTO t VALUES (3, NULL), (4, NULL), (5, NULL);
CREATE MATERIALIZED VIEW v AS SELECT sum(a), sum(x), avg(x) FROM t;
SELECT * FROM v;    -- returned "12.0|0.0|0.0"; SQLite returns "12||"
```

The old code documented the REAL result as unavoidable: after `SUM(10, 20, 30.5)` loses the 30.5 row, an `f64` accumulator holding `30.0` cannot tell that the group is back to integers only. That is true of one accumulator, but not of the state as a whole. `SumAccumulator` keeps the integer inputs and the float inputs apart and counts how many of each the group currently holds, so deleting the last float row takes the sum back to an INTEGER, and a group with no non-NULL input is recognisable as such.

```rust
struct SumAccumulator {
    int_sum: i128,       // exact sum of the integer inputs
    real_sum: f64,       // sum of the float inputs
    real_count: i64,     // float inputs currently in the group
    non_null_count: i64, // non-NULL inputs currently in the group
}
```

`int_sum` is an `i128` so that adding and later retracting values near `i64::MAX` cannot wrap — an incremental sum sees partial sums a one-shot sum never does. Which inputs count as integers is decided by `classify_numeric_arg`, the same helper the VDBE `sum()` uses, so a materialized view and a plain query agree on TEXT and BLOB inputs too. That helper is now `pub(crate)`; its body is unchanged.

`avg()` shares the accumulator and divides by `non_null_count`, which also fixes NULL rows inflating the divisor (`avg(x)` over one value and two NULLs used to be `3.33…` instead of `10.0`).

## Limits

An integer sum too large for an `i64` is reported as a REAL. SQLite raises `integer overflow` instead, which this operator cannot do: the value is produced while reading the view, and `AggregateState::to_values` returns `Vec<Value>`, not `Result`.

The serialized aggregate state grows from one value per SUM to five, so the blob format changes. A materialized view written by an older binary now fails to load with a message saying to recreate it, rather than being read as something it is not. Materialized views are experimental and behind `--experimental-views`.

## Tests

First commit (red without the fix): 5 cases in `sqlite/conformance/turso-sqltests/matview_sum_integer_type.sqltest` — integer sum, real sum, a mixed sum that returns to INTEGER when the only REAL row is deleted, per-group sums, and the type surviving later writes; plus 2 reopen cases in `tests/integration/query_processing/test_matview_aggregate_reopen.rs` covering the blob round trip for both the integer type and the all-NULL NULL. All expectations taken from sqlite3 3.51.0 running the same query against a plain view.

102 expected values in `materialized_views.sqltest` change from `N.0` to `N`; each one is an integer sum that sqlite3 also reports as an INTEGER. Six unit-test expectations in `core/incremental/compiler.rs` change for the same reason (`HEX(SUM(age + 2))` is now the hex of `"96"`, not of `"96.0"`).

turso-sqltests: 1544 passed / 0 failed / 341 skipped. `turso_core` lib tests: 2287 passed / 0 failed.

## Known gap (out of scope)

`sum(DISTINCT x)` keeps the old always-REAL accumulator, so it now disagrees with `sum(x)` on result type for pure-integer input. A follow-up will give the distinct path the same accumulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
