### PR TITLE
show covering indexes in EXPLAIN QUERY PLAN

### DIFF
--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -311,9 +311,14 @@ impl Display for SelectPlan {
                             seek_def,
                         } => {
                             let constraints = seek_constraint_annotation(index, seek_def);
+                            let covering = if reference.utilizes_covering_index() {
+                                "COVERING "
+                            } else {
+                                ""
+                            };
                             writeln!(
                                 f,
-                                "{indent}SEARCH {} USING INDEX {}{constraints}{left_join_suffix}",
+                                "{indent}SEARCH {} USING {covering}INDEX {}{constraints}{left_join_suffix}",
                                 reference.identifier, index.name
                             )?;
                         }
@@ -325,9 +330,14 @@ impl Display for SelectPlan {
                             } else {
                                 String::new()
                             };
+                            let covering = if reference.utilizes_covering_index() {
+                                "COVERING "
+                            } else {
+                                ""
+                            };
                             writeln!(
                                 f,
-                                "{indent}SEARCH {} USING INDEX {}{constraint}{left_join_suffix}",
+                                "{indent}SEARCH {} USING {covering}INDEX {}{constraint}{left_join_suffix}",
                                 reference.identifier, index.name
                             )?;
                         }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1451,8 +1451,13 @@ pub fn emit_from_clause_subqueries(
                     } => {
                         let constraints =
                             super::display::seek_constraint_annotation(index, seek_def);
+                        let covering = if table_reference.utilizes_covering_index() {
+                            "COVERING "
+                        } else {
+                            ""
+                        };
                         format!(
-                            "SEARCH {} USING INDEX {}{constraints}{left_join_suffix}",
+                            "SEARCH {} USING {covering}INDEX {}{constraints}{left_join_suffix}",
                             table_reference.identifier, index.name
                         )
                     }
@@ -1464,8 +1469,13 @@ pub fn emit_from_clause_subqueries(
                         } else {
                             String::new()
                         };
+                        let covering = if table_reference.utilizes_covering_index() {
+                            "COVERING "
+                        } else {
+                            ""
+                        };
                         format!(
-                            "SEARCH {} USING INDEX {}{constraint}{left_join_suffix}",
+                            "SEARCH {} USING {covering}INDEX {}{constraint}{left_join_suffix}",
                             table_reference.identifier, index.name
                         )
                     }

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-after-analyze.snap
@@ -17,7 +17,7 @@ info:
 ---
 QUERY PLAN
 |--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
-`--SEARCH p USING INDEX ephemeral_purchases_t2 (customer_id=?)
+`--SEARCH p USING COVERING INDEX ephemeral_purchases_t2 (customer_id=?)
 
 BYTECODE
 addr  opcode          p1  p2  p3  p4          p5  comment

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-aggregate-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-aggregate-after-analyze.snap
@@ -17,7 +17,7 @@ info:
 ---
 QUERY PLAN
 |--SCAN customers AS c
-`--SEARCH p USING INDEX ephemeral_purchases_t2 (customer_id=?)
+`--SEARCH p USING COVERING INDEX ephemeral_purchases_t2 (customer_id=?)
 
 BYTECODE
 addr  opcode                    p1  p2  p3  p4            p5  comment

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-for-nulls-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-for-nulls-after-analyze.snap
@@ -10,7 +10,7 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SEARCH items USING INDEX idx_items_cat (category=?)
+`--SEARCH items USING COVERING INDEX idx_items_cat (category=?)
 
 BYTECODE
 addr  opcode         p1  p2  p3  p4        p5  comment

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__covering-index-all-columns.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__covering-index-all-columns.snap
@@ -13,4 +13,4 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SEARCH inventory USING INDEX idx_inventory_covering (warehouse_id=? AND product_id=?)
+`--SEARCH inventory USING COVERING INDEX idx_inventory_covering (warehouse_id=? AND product_id=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__covering-index-subset.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__covering-index-subset.snap
@@ -13,4 +13,4 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SEARCH inventory USING INDEX idx_inventory_covering (warehouse_id=?)
+`--SEARCH inventory USING COVERING INDEX idx_inventory_covering (warehouse_id=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__covering-index-with-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__covering-index-with-aggregation.snap
@@ -14,4 +14,4 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SEARCH inventory USING INDEX idx_inventory_covering (warehouse_id=?)
+`--SEARCH inventory USING COVERING INDEX idx_inventory_covering (warehouse_id=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__in-list-composite-prefix.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__in-list-composite-prefix.snap
@@ -13,4 +13,4 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SEARCH orders USING INDEX idx_orders_customer_date (customer_id=?)
+`--SEARCH orders USING COVERING INDEX idx_orders_customer_date (customer_id=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__indexed-by-join-both.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__indexed-by-join-both.snap
@@ -18,4 +18,4 @@ info:
 ---
 QUERY PLAN
 |--SEARCH p USING INDEX idx_products_sku (sku=?)
-`--SEARCH o USING INDEX idx_orders_customer_date (customer_id=?)
+`--SEARCH o USING COVERING INDEX idx_orders_customer_date (customer_id=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__indexed-by-join-one-side.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__indexed-by-join-one-side.snap
@@ -16,5 +16,5 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SEARCH o USING INDEX idx_orders_customer_date (customer_id=?)
+|--SEARCH o USING COVERING INDEX idx_orders_customer_date (customer_id=?)
 `--SEARCH p USING INTEGER PRIMARY KEY (rowid=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__max-with-equality-prefix-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__max-with-equality-prefix-bytecode.snap
@@ -10,7 +10,7 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SEARCH measurements USING INDEX idx_measurements_category_value (category=?)
+`--SEARCH measurements USING COVERING INDEX idx_measurements_category_value (category=?)
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4           p5  comment

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__subquery-with-index.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__subquery-with-index.snap
@@ -15,5 +15,5 @@ info:
 ---
 QUERY PLAN
 |--LIST SUBQUERY 1
-|  `--SEARCH inventory USING INDEX idx_inventory_covering (warehouse_id=?)
+|  `--SEARCH inventory USING COVERING INDEX idx_inventory_covering (warehouse_id=?)
 `--SEARCH products USING INTEGER PRIMARY KEY (rowid=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__cross-join-with-filter.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__cross-join-with-filter.snap
@@ -22,7 +22,7 @@ info:
 ---
 QUERY PLAN
 |--SCAN customers AS c
-`--SEARCH p USING INDEX ephemeral_products_t2 (category=?)
+`--SEARCH p USING COVERING INDEX ephemeral_products_t2 (category=?)
 
 BYTECODE
 addr  opcode            p1  p2  p3  p4              p5  comment

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__index-assisted-join-range-scan.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__index-assisted-join-range-scan.snap
@@ -23,5 +23,5 @@ info:
 ---
 QUERY PLAN
 |--SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
-|--SEARCH o USING INDEX idx_orders_customer_id (customer_id=?)
+|--SEARCH o USING COVERING INDEX idx_orders_customer_id (customer_id=?)
 `--USE SORTER FOR GROUP BY

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-chained.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-chained.snap
@@ -27,7 +27,7 @@ info:
 ---
 QUERY PLAN
 |--SCAN customers AS c
-|--SEARCH o USING INDEX idx_orders_customer_id (customer_id=?) LEFT-JOIN
+|--SEARCH o USING COVERING INDEX idx_orders_customer_id (customer_id=?) LEFT-JOIN
 |--SEARCH oi USING INDEX idx_order_items_order_id (order_id=?) LEFT-JOIN
 `--SEARCH p USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN
 

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-find-nulls.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-find-nulls.snap
@@ -22,7 +22,7 @@ info:
 ---
 QUERY PLAN
 |--SCAN customers AS c
-`--SEARCH o USING INDEX idx_orders_customer_id (customer_id=?) LEFT-JOIN
+`--SEARCH o USING COVERING INDEX idx_orders_customer_id (customer_id=?) LEFT-JOIN
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4              p5  comment

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__delete-with-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__delete-with-subquery.snap
@@ -17,7 +17,7 @@ info:
 QUERY PLAN
 |--LIST SUBQUERY 1
 |  `--SCAN users
-`--SEARCH orders USING INDEX idx_orders_user_id (user_id=?)
+`--SEARCH orders USING COVERING INDEX idx_orders_user_id (user_id=?)
 
 BYTECODE
 addr  opcode            p1  p2  p3  p4            p5  comment

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__sort-elim-left-join-outer-rowid-suffix.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__sort-elim-left-join-outer-rowid-suffix.snap
@@ -18,5 +18,5 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-|--SEARCH o USING INDEX idx_lhs_customer (customer_id=?)
+|--SEARCH o USING COVERING INDEX idx_lhs_customer (customer_id=?)
 `--SEARCH i USING INDEX idx_rhs_product_qty (product=?) LEFT-JOIN

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
@@ -20,7 +20,7 @@ info:
 QUERY PLAN
 |--SCAN orders AS o
 `--CORRELATED SCALAR SUBQUERY 1
-   `--SEARCH oi USING INDEX idx_order_items_order (order_id=?)
+   `--SEARCH oi USING COVERING INDEX idx_order_items_order (order_id=?)
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4            p5  comment

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__not-exists-never-ordered.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__not-exists-never-ordered.snap
@@ -19,4 +19,4 @@ info:
 ---
 QUERY PLAN
 |--SCAN products AS p
-`--SEARCH oi USING INDEX idx_order_items_product (product_id=?)
+`--SEARCH oi USING COVERING INDEX idx_order_items_product (product_id=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__not-exists-no-orders.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__not-exists-no-orders.snap
@@ -19,4 +19,4 @@ info:
 ---
 QUERY PLAN
 |--SCAN customers AS c
-`--SEARCH o USING INDEX idx_orders_customer (customer_id=?)
+`--SEARCH o USING COVERING INDEX idx_orders_customer (customer_id=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
@@ -17,7 +17,7 @@ info:
 QUERY PLAN
 |--SCAN customers AS c
 `--CORRELATED SCALAR SUBQUERY 1
-   `--SEARCH orders USING INDEX idx_orders_customer (customer_id=?)
+   `--SEARCH orders USING COVERING INDEX idx_orders_customer (customer_id=?)
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4            p5  comment

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q16-parts-supplier.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q16-parts-supplier.snap
@@ -44,7 +44,7 @@ QUERY PLAN
 |--LIST SUBQUERY 1
 |  `--SCAN supplier
 |--SCAN part
-|--SEARCH partsupp USING INDEX sqlite_autoindex_partsupp_1 (ps_partkey=?)
+|--SEARCH partsupp USING COVERING INDEX sqlite_autoindex_partsupp_1 (ps_partkey=?)
 |--USE SORTER FOR GROUP BY
 |--USE HASH TABLE FOR count(DISTINCT)
 `--USE SORTER FOR ORDER BY

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q22-global-sales-opportunity.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q22-global-sales-opportunity.snap
@@ -52,5 +52,5 @@ QUERY PLAN
 |  |--SCALAR SUBQUERY 1
 |  |  `--SCAN customer
 |  |--SCAN customer
-|  `--SEARCH orders USING INDEX ephemeral_orders_t5 (O_CUSTKEY=?)
+|  `--SEARCH orders USING COVERING INDEX ephemeral_orders_t5 (O_CUSTKEY=?)
 `--USE SORTER FOR GROUP BY

--- a/sqlite/conformance/sqlite-sqltests/snapshots/graph_traversal_text_pk__cte-neighbor-traversal-text-pk.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/graph_traversal_text_pk__cte-neighbor-traversal-text-pk.snap
@@ -27,6 +27,6 @@ info:
 ---
 QUERY PLAN
 |--SCAN seed_articles AS s
-|  `--SEARCH a USING INDEX sqlite_autoindex_article_1 (id=?)
+|  `--SEARCH a USING COVERING INDEX sqlite_autoindex_article_1 (id=?)
 |--MULTI-INDEX OR l (idx_link_source, idx_link_target)
 `--MULTI-INDEX OR a (sqlite_autoindex_article_1, sqlite_autoindex_article_1)

--- a/sqlite/conformance/sqlite-sqltests/snapshots/multi_index_intersection__composite-index-preferred-over-intersection-eqp.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/multi_index_intersection__composite-index-preferred-over-intersection-eqp.snap
@@ -10,4 +10,4 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SEARCH t USING INDEX idx_ab (a=? AND b=?)
+`--SEARCH t USING COVERING INDEX idx_ab (a=? AND b=?)

--- a/sqlite/conformance/turso-sqltests/create-index-nulls-first-last.sqltest
+++ b/sqlite/conformance/turso-sqltests/create-index-nulls-first-last.sqltest
@@ -257,7 +257,7 @@ test eqp-elide-composite-eq-prefix-trailing-nulls-last {
     EXPLAIN QUERY PLAN SELECT b FROM t WHERE a = 1 ORDER BY b NULLS LAST;
 }
 expect {
-    1|0|0|SEARCH t USING INDEX idx (a=?)
+    1|0|0|SEARCH t USING COVERING INDEX idx (a=?)
 }
 
 @setup single_data
@@ -451,7 +451,7 @@ test eqp-range-seek-on-nulls-last-index {
     EXPLAIN QUERY PLAN SELECT id FROM t WHERE a > 1;
 }
 expect {
-    1|0|0|SEARCH t USING INDEX idx (a>?)
+    1|0|0|SEARCH t USING COVERING INDEX idx (a>?)
 }
 
 @setup single_data
@@ -460,7 +460,7 @@ test eqp-upper-range-seek-on-nulls-last-index {
     EXPLAIN QUERY PLAN SELECT id FROM t WHERE a < 3;
 }
 expect {
-    1|0|0|SEARCH t USING INDEX idx (a<?)
+    1|0|0|SEARCH t USING COVERING INDEX idx (a<?)
 }
 
 @setup single_data

--- a/tests/fuzz/test_join_optimizer.rs
+++ b/tests/fuzz/test_join_optimizer.rs
@@ -82,7 +82,9 @@ fn has_index_search_on_table(eqp_rows: &[Vec<rusqlite::types::Value>], table_nam
     for row in eqp_rows {
         assert!(row.len() >= 4);
         if let rusqlite::types::Value::Text(detail) = &row[3] {
-            if detail.contains(&format!("SEARCH {table_name} USING INDEX")) {
+            if detail.contains(&format!("SEARCH {table_name} USING INDEX"))
+                || detail.contains(&format!("SEARCH {table_name} USING COVERING INDEX"))
+            {
                 return true;
             }
         }
@@ -222,7 +224,9 @@ fn test_chain_join_fuzz() {
                     let Value::Text(detail) = &row[3] else {
                         panic!("Expected TEXT value for detail in EXPLAIN QUERY PLAN");
                     };
-                    detail.contains("SEARCH") && detail.contains("USING INDEX")
+                    detail.contains("SEARCH")
+                        && (detail.contains("USING INDEX")
+                            || detail.contains("USING COVERING INDEX"))
                 })
                 .count();
             assert_eq!(

--- a/tests/integration/query_processing/test_in_seek.rs
+++ b/tests/integration/query_processing/test_in_seek.rs
@@ -39,7 +39,7 @@ fn large_indexed_in_list_uses_seek_loop() {
         .collect::<Vec<_>>()
         .join("\n");
     assert!(
-        plan.contains("SEARCH t USING INDEX t_x (x=?)"),
+        plan.contains("SEARCH t USING COVERING INDEX t_x (x=?)"),
         "expected IN-list to drive indexed seeks, got:\n{plan}"
     );
     assert!(

--- a/tests/integration/query_processing/test_is_seek.rs
+++ b/tests/integration/query_processing/test_is_seek.rs
@@ -70,7 +70,7 @@ fn is_true_and_false_do_not_use_equality_seeks() {
     ] {
         let plan = query_plan(&conn, query);
         assert!(
-            plan.contains("SEARCH t USING INDEX ti (x=?)"),
+            plan.contains("SEARCH t USING COVERING INDEX ti (x=?)"),
             "expected an index seek for `{query}`, got:\n{plan}"
         );
     }


### PR DESCRIPTION
## Description

EQP didn't say `COVERING` when using a covering index search. Now it does.
