### PR TITLE
core/translate: fix REAL-affinity index seeks losing integer precision

### DIFF
--- a/core/translate/expr/affinity.rs
+++ b/core/translate/expr/affinity.rs
@@ -229,9 +229,18 @@ pub(super) fn comparison_affinity_from_info(
             Affinity::Blob
         }
     } else if lhs.has_affinity {
-        lhs.affinity
+        // A lone numeric affinity still collapses to NUMERIC.
+        if lhs.affinity.is_numeric() {
+            Affinity::Numeric
+        } else {
+            lhs.affinity
+        }
     } else if rhs.has_affinity {
-        rhs.affinity
+        if rhs.affinity.is_numeric() {
+            Affinity::Numeric
+        } else {
+            rhs.affinity
+        }
     } else {
         Affinity::Blob
     }
@@ -247,4 +256,97 @@ pub(crate) fn compare_affinity(
         other,
         get_expr_affinity_info(expr, referenced_tables, resolver),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_sides_have_affinity_numeric_wins() {
+        assert_eq!(
+            comparison_affinity_from_info(
+                ExprAffinityInfo::with_affinity(Affinity::Real),
+                ExprAffinityInfo::with_affinity(Affinity::Text),
+            ),
+            Affinity::Numeric
+        );
+    }
+
+    #[test]
+    fn both_sides_have_affinity_neither_numeric_is_blob() {
+        assert_eq!(
+            comparison_affinity_from_info(
+                ExprAffinityInfo::with_affinity(Affinity::Text),
+                ExprAffinityInfo::with_affinity(Affinity::Blob),
+            ),
+            Affinity::Blob
+        );
+    }
+
+    #[test]
+    fn only_lhs_has_real_affinity_collapses_to_numeric() {
+        assert_eq!(
+            comparison_affinity_from_info(
+                ExprAffinityInfo::with_affinity(Affinity::Real),
+                ExprAffinityInfo::no_affinity(),
+            ),
+            Affinity::Numeric
+        );
+    }
+
+    #[test]
+    fn only_lhs_has_integer_affinity_collapses_to_numeric() {
+        assert_eq!(
+            comparison_affinity_from_info(
+                ExprAffinityInfo::with_affinity(Affinity::Integer),
+                ExprAffinityInfo::no_affinity(),
+            ),
+            Affinity::Numeric
+        );
+    }
+
+    #[test]
+    fn only_rhs_has_real_affinity_collapses_to_numeric() {
+        assert_eq!(
+            comparison_affinity_from_info(
+                ExprAffinityInfo::no_affinity(),
+                ExprAffinityInfo::with_affinity(Affinity::Real),
+            ),
+            Affinity::Numeric
+        );
+    }
+
+    #[test]
+    fn only_lhs_has_text_affinity_is_preserved() {
+        assert_eq!(
+            comparison_affinity_from_info(
+                ExprAffinityInfo::with_affinity(Affinity::Text),
+                ExprAffinityInfo::no_affinity(),
+            ),
+            Affinity::Text
+        );
+    }
+
+    #[test]
+    fn only_rhs_has_text_affinity_is_preserved() {
+        assert_eq!(
+            comparison_affinity_from_info(
+                ExprAffinityInfo::no_affinity(),
+                ExprAffinityInfo::with_affinity(Affinity::Text),
+            ),
+            Affinity::Text
+        );
+    }
+
+    #[test]
+    fn neither_side_has_affinity_is_blob() {
+        assert_eq!(
+            comparison_affinity_from_info(
+                ExprAffinityInfo::no_affinity(),
+                ExprAffinityInfo::no_affinity(),
+            ),
+            Affinity::Blob
+        );
+    }
 }

--- a/sqlite/conformance/sqlite-sqltests/index_seek_comparison_affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/index_seek_comparison_affinity.sqltest
@@ -130,3 +130,36 @@ test in-literal-list-text-idx-numeric-source {
 expect {
 0
 }
+
+# #6715: an index seek against a REAL-affinity column applied REAL affinity
+# to the seek key, casting a large integer literal to f64 and losing the
+# precision needed to tell it apart from nearby integers. The comparison
+# affinity here should be NUMERIC, which leaves integer literals untouched.
+setup issue-6715-real-affinity-schema {
+    CREATE TABLE t(f REAL);
+    CREATE INDEX t_f ON t(f);
+    INSERT INTO t VALUES (-2701729208700874036);
+}
+
+@setup issue-6715-real-affinity-schema
+test issue-6715-real-affinity-seek-literal {
+    SELECT
+        (SELECT count(*) FROM t WHERE f = -2701729208700874000),
+        (SELECT count(*) FROM t WHERE f = -2701729208700874036),
+        (SELECT count(*) FROM t WHERE f = -2701729208700874240);
+}
+expect {
+0|0|1
+}
+
+# Same bug, reached through a computed seek-key expression rather than a
+# bare literal — confirms the fix isn't limited to the literal syntax shape.
+@setup issue-6715-real-affinity-schema
+test issue-6715-real-affinity-seek-computed-expr {
+    SELECT
+        (SELECT count(*) FROM t WHERE f = (-2701729208700874000 + 0)),
+        (SELECT count(*) FROM t WHERE f = (-2701729208700874240 + 0));
+}
+expect {
+0|1
+}


### PR DESCRIPTION
## Description

Fixes an index seek against a REAL-affinity column applying that
column's affinity to the seek key itself. When the seek key had no
affinity of its own (a literal, bound parameter, or computed
expression), comparison_affinity_from_info returned the REAL/INTEGER
affinity unchanged instead of downgrading to NUMERIC, so a large
integer literal got cast to f64 and lost precision past 2^53 before
the seek ever ran.

The fix mirrors SQLite's "affinity of a comparison" rule: a lone
REAL/INTEGER affinity downgrades to NUMERIC, which coerces text but
leaves an already-numeric value untouched.

## Motivation and context

Fixes #6715. SELECT count(*) FROM t WHERE f = -2701729208700874000
against a REAL-indexed column returned 1 instead of 0, because the
seek key -2701729208700874000 and the actually-stored
-2701729208700874036 both round to the same f64 once cast, so the
index seek could no longer tell them apart.

## Description of AI Usage

Used Claude Code to sketch and compare two candidate fixes, implement the one picked, and
write the unit and sqltest regressions. Checked the fix against the
vendored SQLite source and a live repro, and confirmed the new tests
fail on the pre-fix code.
