### PR TITLE
Apply comparison affinity to CASE base-expression comparisons

### DIFF
--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -456,16 +456,12 @@ pub fn translate_expr(
             // Only allocate a reg to hold the base expression if one was provided.
             // And base_reg then becomes the flag we check to see which sort of
             // case statement we're processing.
-            let base_reg = base.as_ref().map(|_| program.alloc_register());
+            let base_reg = base
+                .as_ref()
+                .map(|base_expr| (base_expr.as_ref(), program.alloc_register()));
             let expr_reg = program.alloc_register();
-            if let Some(base_expr) = base {
-                translate_expr(
-                    program,
-                    referenced_tables,
-                    base_expr,
-                    base_reg.unwrap(),
-                    resolver,
-                )?;
+            if let Some((base_expr, base_reg)) = base_reg {
+                translate_expr(program, referenced_tables, base_expr, base_reg, resolver)?;
             };
             for (when_expr, then_expr) in when_then_pairs {
                 translate_expr_no_constant_opt(
@@ -478,12 +474,21 @@ pub fn translate_expr(
                 )?;
                 match base_reg {
                     // CASE 1 WHEN 0 THEN 0 ELSE 1 becomes 1==0, Ne branch to next clause
-                    Some(base_reg) => program.emit_insn(Insn::Ne {
+                    Some((base_expr, base_reg)) => program.emit_insn(Insn::Ne {
                         lhs: base_reg,
                         rhs: expr_reg,
                         target_pc: next_case_label,
                         // A NULL result is considered untrue when evaluating WHEN terms.
-                        flags: CmpInsFlags::default().jump_if_null(),
+                        // The base value is compared against each WHEN term with the same
+                        // affinity a plain `base = when` comparison would use.
+                        flags: CmpInsFlags::default().jump_if_null().with_affinity(
+                            comparison_affinity(
+                                base_expr,
+                                when_expr,
+                                referenced_tables,
+                                Some(resolver),
+                            ),
+                        ),
                         collation: program.curr_collation(),
                     }),
                     // CASE WHEN 0 THEN 0 ELSE 1 becomes ifnot 0 branch to next clause

--- a/sqlite/conformance/sqlite-sqltests/affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/affinity.sqltest
@@ -735,3 +735,59 @@ test affinity-sum-of-text-i64-min {
 expect {
     integer|-9223372036854775808
 }
+
+# ============================================
+# CASE x WHEN y: the base value is compared against each WHEN term with the
+# same affinity a plain `x = y` comparison would use
+# ============================================
+@cross-check-integrity
+test affinity-case-base-vs-when-term {
+    CREATE TABLE o (t TEXT, n INTEGER, r REAL);
+    INSERT INTO o VALUES ('5', 5, 5.0);
+    SELECT CASE o.t WHEN 5 THEN 'y' ELSE 'n' END FROM o;
+    SELECT CASE o.n WHEN '5' THEN 'y' ELSE 'n' END FROM o;
+    SELECT CASE o.r WHEN '5' THEN 'y' ELSE 'n' END FROM o;
+    SELECT CASE 5 WHEN o.t THEN 'y' ELSE 'n' END FROM o;
+}
+expect {
+    y
+    y
+    y
+    y
+}
+
+@cross-check-integrity
+test affinity-case-base-text-affinity-is-not-a-blind-coercion {
+    CREATE TABLE o (t TEXT);
+    INSERT INTO o VALUES ('5');
+    SELECT CASE o.t WHEN 5.0 THEN 'y' ELSE 'n' END FROM o;
+    SELECT CASE o.t WHEN 'x' THEN 'y' ELSE 'n' END FROM o;
+}
+expect {
+    n
+    n
+}
+
+@cross-check-integrity
+test affinity-case-base-picks-the-matching-when-branch {
+    CREATE TABLE o (t TEXT);
+    INSERT INTO o VALUES ('5');
+    SELECT CASE o.t WHEN 4 THEN 'four' WHEN 5 THEN 'five' ELSE 'none' END FROM o;
+    SELECT CASE o.t WHEN NULL THEN 'null' WHEN 5 THEN 'five' ELSE 'none' END FROM o;
+}
+expect {
+    five
+    five
+}
+
+@cross-check-integrity
+test affinity-case-base-no-affinity-on-either-side {
+    CREATE TABLE o (b BLOB);
+    INSERT INTO o VALUES ('5');
+    SELECT CASE o.b WHEN 5 THEN 'y' ELSE 'n' END FROM o;
+    SELECT CASE o.b WHEN '5' THEN 'y' ELSE 'n' END FROM o;
+}
+expect {
+    n
+    y
+}


### PR DESCRIPTION
## Description

`CASE x WHEN y THEN ...` compares the base value against each WHEN term with an
`Ne` instruction whose `CmpInsFlags` carry `jump_if_null` and a collation, but no
affinity. Without it a TEXT column value never matches a numeric literal (and
vice versa), so the wrong branch is taken:

```sql
CREATE TABLE o(t TEXT, n INTEGER, r REAL);
INSERT INTO o VALUES ('5', 5, 5.0);

SELECT CASE o.t WHEN 5   THEN 'y' ELSE 'n' END FROM o;   -- SQLite: y      before: n
SELECT CASE o.n WHEN '5' THEN 'y' ELSE 'n' END FROM o;   -- SQLite: y      before: n
SELECT CASE o.r WHEN '5' THEN 'y' ELSE 'n' END FROM o;   -- SQLite: y      before: n
SELECT CASE 5   WHEN o.t THEN 'y' ELSE 'n' END FROM o;   -- SQLite: y      before: n

SELECT CASE o.t WHEN 4 THEN 'four' WHEN 5 THEN 'five' ELSE 'none' END FROM o;
-- SQLite: five   before: none
```

The predicate form `CASE WHEN o.t = 5 THEN ...` was always correct, because it
goes through `emit_binary_insn` in `core/translate/expr/binary.rs`, which
computes `comparison_affinity(...)` and passes it via
`CmpInsFlags::with_affinity`. The `CASE x WHEN y` arm in
`core/translate/expr/translator.rs` never called that helper.

SQLite compiles `CASE x WHEN y` into a real `TK_EQ` comparison (`opCompare.op =
TK_EQ` in `sqlite3ExprCodeTarget`), which then runs through `codeCompare` /
`binaryCompareP5` and picks up the usual comparison affinity, so this is the
same comparison the `x = y` form performs.

## Motivation and context

Fixes #8225.

The affinity is computed per WHEN term rather than once for the whole CASE,
because it depends on both sides — the same reason SQLite recomputes it each
time it reuses `opCompare` with a new `pRight`.

This is deliberately not a blind coercion. The affinity rules still say `CASE
o.t WHEN 5.0` is `n` for a TEXT `'5'` (TEXT affinity turns `5.0` into `'5.0'`),
and a column with no affinity still compares without conversion. Both are
covered by the new tests, and both of those tests already passed before this
change — they are here to keep the fix honest.

## Tests

Added four cases to `sqlite/conformance/sqlite-sqltests/affinity.sqltest`, so
they are asserted against real SQLite as well as against Turso. Expected values
were taken from SQLite 3.51.2.

Before the fix:

```
Failures:

── affinity-case-base-picks-the-matching-when-branch (sqlite-sqltests/affinity.sqltest) - :memory:
   --- expected
   +++ actual
   -five
   -five
   +none
   +none

── affinity-case-base-vs-when-term (sqlite-sqltests/affinity.sqltest) - :memory:
   --- expected
   +++ actual
   -y
   -y
   -y
   -y
   +n
   +n
   +n
   +n

Summary:
  56 passed, 2 failed
```

After the fix `affinity.sqltest` is 58 passed, 0 failed.

Wider runs on this branch:

* `sqlite-sqltests` (CLI backend): 10455 passed, 1 failed, 6 skipped. The single
  failure is `expr_depth_or_chain_at_limit`, which overflows the stack in a debug
  build on a clean checkout of the base commit too (it is what #8097 is about).
* `turso-sqltests` (CLI backend): 1955 passed, 0 failed.
* `cargo test -p turso_core --lib`: 2293 passed, 0 failed, 17 ignored.
* `cargo fmt --check` clean; `cargo clippy -p turso_core --all-features
  --all-targets -- --deny=warnings` clean.

## Not changed

* The collation for the CASE comparison still comes from
  `program.curr_collation()` rather than `comparison_collation(base, when)`.
  That is a separate question from affinity and is left alone here.
* The logical-plan CASE path used by incremental/materialized views
  (`core/translate/logical.rs`) is untouched.
