### PR TITLE
core/translate: keep left arm's implicit BINARY collation in compound…

### DIFF
--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -1,7 +1,7 @@
 use crate::alloc::TursoIteratorExt;
 use crate::schema::{Index, IndexColumn, PseudoCursorType};
 use crate::sync::Arc;
-use crate::translate::collate::get_collseq_from_expr;
+use crate::translate::collate::{CollationSeq, get_expr_collation_ctx_with_symbols};
 use crate::translate::emitter::{
     select::{emit_materialized_build_inputs, emit_query},
     LimitCtx, Resolver, TranslateCtx,
@@ -517,6 +517,35 @@ fn emit_compound_select(
     Ok(())
 }
 
+/// Resolve the collation for one result column of a compound select, per
+/// SQLite's `multiSelectCollSeq` rules: the left arm's collation wins whenever
+/// the left expression yields one at all. Crucially, a plain column reference
+/// yields its *default* BINARY collation (like `sqlite3ExprCollSeq`, which
+/// returns a non-NULL CollSeq for any column), so an implicit-BINARY column on
+/// the left must NOT defer to the right arm — only literals and function calls
+/// yield no collation and fall through rightward.
+fn compound_column_collation(
+    left_select: &SelectPlan,
+    right_select: &SelectPlan,
+    i: usize,
+) -> crate::Result<Option<CollationSeq>> {
+    let left_collation = get_expr_collation_ctx_with_symbols(
+        &left_select.result_columns[i].expr,
+        &left_select.table_references,
+        None,
+    )?
+    .map(|(collation, _)| collation);
+    if left_collation.is_some() {
+        return Ok(left_collation);
+    }
+    Ok(get_expr_collation_ctx_with_symbols(
+        &right_select.result_columns[i].expr,
+        &right_select.table_references,
+        None,
+    )?
+    .map(|(collation, _)| collation))
+}
+
 // Creates an ephemeral index that will be used to deduplicate the results of any sub-selects
 fn create_dedupe_index(
     program: &mut ProgramBuilder,
@@ -537,21 +566,7 @@ fn create_dedupe_index(
         })
         .try_collect::<crate::alloc::Vec<_>>()?;
     for (i, column) in dedupe_columns.iter_mut().enumerate() {
-        let left_collation = get_collseq_from_expr(
-            &left_select.result_columns[i].expr,
-            &left_select.table_references,
-        )?;
-        let right_collation = get_collseq_from_expr(
-            &right_select.result_columns[i].expr,
-            &right_select.table_references,
-        )?;
-        // Left precedence
-        let collation = match (left_collation, right_collation) {
-            (None, None) => None,
-            (Some(coll), None) | (None, Some(coll)) => Some(coll),
-            (Some(coll), Some(_)) => Some(coll),
-        };
-        column.collation = collation;
+        column.collation = compound_column_collation(left_select, right_select, i)?;
     }
 
     let dedupe_index = Arc::new(Index {
@@ -761,20 +776,7 @@ fn create_collection_index(
         })
         .try_collect::<crate::alloc::Vec<_>>()?;
     for (i, column) in columns.iter_mut().enumerate() {
-        let left_collation = get_collseq_from_expr(
-            &left_select.result_columns[i].expr,
-            &left_select.table_references,
-        )?;
-        let right_collation = get_collseq_from_expr(
-            &right_select.result_columns[i].expr,
-            &right_select.table_references,
-        )?;
-        let collation = match (left_collation, right_collation) {
-            (None, None) => None,
-            (Some(coll), None) | (None, Some(coll)) => Some(coll),
-            (Some(coll), Some(_)) => Some(coll),
-        };
-        column.collation = collation;
+        column.collation = compound_column_collation(left_select, right_select, i)?;
     }
 
     let index = Arc::new(Index {

--- a/sqlite/conformance/sqlite-sqltests/compound-select-implicit-binary-collation.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/compound-select-implicit-binary-collation.sqltest
@@ -1,0 +1,87 @@
+@database :memory:
+
+# A plain column with no COLLATE clause has default BINARY collation, and per
+# SQLite's multiSelectCollSeq the left arm's collation governs the compound
+# comparison whenever the left expression yields one at all. A left arm that is
+# an implicit-BINARY column must therefore NOT defer to the right arm's NOCASE;
+# only literals and function calls yield no collation and fall through
+# rightward. https://github.com/tursodatabase/turso/issues/8272
+#
+# All expected outputs verified against SQLite 3.50.
+
+setup schema {
+    CREATE TABLE q(x, y TEXT);
+    INSERT INTO q VALUES(1,'a'),(2,'B'),(NULL,'c'),('3','z');
+    CREATE TABLE p(x, y TEXT COLLATE NOCASE);
+    INSERT INTO p VALUES(1,'A'),(2,'b'),(NULL,'C'),(3,NULL),(2,'B'),(1.0,'a');
+}
+
+@setup schema
+test intersect-left-implicit-binary-governs {
+    SELECT y FROM q INTERSECT SELECT y FROM p ORDER BY 1;
+}
+expect {
+    B
+    a
+}
+
+@setup schema
+test except-left-implicit-binary-governs {
+    SELECT y FROM q EXCEPT SELECT y FROM p ORDER BY 1;
+}
+expect {
+    c
+    z
+}
+
+@setup schema
+test union-left-implicit-binary-governs {
+    SELECT y FROM q WHERE y IS NOT NULL UNION SELECT y FROM p WHERE y IS NOT NULL ORDER BY 1;
+}
+expect {
+    A
+    B
+    C
+    a
+    b
+    c
+    z
+}
+
+@setup schema
+test union-all-order-by-left-implicit-binary-governs {
+    SELECT y FROM q WHERE y IS NOT NULL UNION ALL SELECT y FROM p WHERE y IS NOT NULL ORDER BY 1;
+}
+expect {
+    A
+    B
+    B
+    C
+    a
+    a
+    b
+    c
+    z
+}
+
+# Explicit COLLATE BINARY on the left must behave identically to the implicit
+# default -- this already worked and guards against over-correction.
+@setup schema
+test intersect-left-explicit-binary-parity {
+    SELECT y COLLATE BINARY FROM q INTERSECT SELECT y FROM p ORDER BY 1;
+}
+expect {
+    B
+    a
+}
+
+# A literal on the left yields no collation, so the right arm's NOCASE governs
+# and 'a'/'A' deduplicate to a single row -- SQLite parity for the
+# defer-rightward case.
+@setup schema
+test union-left-literal-defers-to-right-nocase {
+    SELECT count(*) FROM (SELECT 'a' UNION SELECT y FROM p WHERE y = 'A');
+}
+expect {
+    1
+}


### PR DESCRIPTION
… selects

The dedupe/collection index for UNION, INTERSECT, EXCEPT and the compound ORDER BY path resolved each result column's collation with a match whose comment said "left precedence" but whose (None, Some(coll)) arm adopted the right arm's collation. It was reachable for any plain column with no COLLATE clause, because get_collseq_from_expr() returns None for implicit BINARY -- indistinguishable from "no collation at all". A 2-arm compound with an implicit-BINARY column on the left and a NOCASE column on the right therefore compared under NOCASE and returned wrong rows (INTERSECT emitted values with no BINARY match, EXCEPT dropped survivors, UNION under-deduplicated).

Resolve both arms with get_expr_collation_ctx_with_symbols(), which keeps a plain column's default BINARY collation (matching SQLite's sqlite3ExprCollSeq, where only literals and function calls yield no collation and defer rightward), and fall through to the right arm only when the left expression yields nothing at all. The two identical resolution blocks are factored into one helper.

All expected outputs in the new sqltest file were verified against SQLite 3.50, and the four affected tests fail without this change.

Fixes #8272

# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
