### PR TITLE
core/schema: preserve COLLATE when reconstructing CREATE TABLE DDL

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3620,6 +3620,24 @@ impl BTreeTable {
                     sql.push_str("[]");
                 }
             }
+            // Only an explicit `COLLATE` in the column definition sets this
+            // (absence means the type's default collation applies), so this
+            // reconstructs exactly the clauses the user wrote -- never
+            // synthesizes a redundant "COLLATE BINARY" for a plain column.
+            // Custom collations can't reach here: they're rejected during
+            // CREATE TABLE parsing ("custom collations are not supported in
+            // schema definitions"), so only the three built-in sequences and
+            // locale collations are possible.
+            if let Some(collation) = column.collation_opt() {
+                let collation_name = match collation {
+                    CollationSeq::Binary => "BINARY".to_string(),
+                    CollationSeq::NoCase => "NOCASE".to_string(),
+                    CollationSeq::Rtrim => "RTRIM".to_string(),
+                    _ => collation.name(),
+                };
+                sql.push_str(" COLLATE ");
+                sql.push_str(&collation_name);
+            }
             if column.notnull()
                 && (column.explicit_notnull() || !self.is_without_rowid_inline_pk(column))
             {

--- a/sqlite/conformance/sqlite-sqltests/alter-add-column-preserves-collate.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter-add-column-preserves-collate.sqltest
@@ -1,0 +1,52 @@
+# Regression test for https://github.com/tursodatabase/turso/issues/8254
+#
+# ALTER TABLE ... ADD COLUMN reconstructs the stored CREATE TABLE text from
+# the parsed schema, and the reconstruction dropped an explicit COLLATE from
+# existing columns -- CHECK, NOT NULL, DEFAULT, UNIQUE, PRIMARY KEY and
+# REFERENCES all already survived it. A column that loses its COLLATE
+# silently reverts to BINARY comparisons for every connection that opens the
+# database afterwards.
+#
+# Expected outputs verified against SQLite 3.50.
+
+@database :memory:
+
+test alter-add-column-preserves-collate-in-schema {
+    CREATE TABLE tbl(col1 TEXT COLLATE NOCASE);
+    ALTER TABLE tbl ADD COLUMN extra TEXT;
+    SELECT count(*) FROM sqlite_master WHERE name = 'tbl' AND sql LIKE '%col1 TEXT COLLATE NOCASE%';
+}
+expect {
+    1
+}
+
+test alter-add-column-collate-nocase-still-compares-case-insensitively {
+    CREATE TABLE tbl(col1 TEXT COLLATE NOCASE);
+    INSERT INTO tbl VALUES ('ABC');
+    ALTER TABLE tbl ADD COLUMN extra TEXT;
+    SELECT count(*) FROM tbl WHERE col1 = 'abc';
+}
+expect {
+    1
+}
+
+# Guard against over-correction: a column with no explicit COLLATE must not
+# gain a synthesized "COLLATE BINARY" after the rewrite.
+test alter-add-column-does-not-synthesize-collate-for-plain-column {
+    CREATE TABLE tbl(col1 TEXT);
+    ALTER TABLE tbl ADD COLUMN extra TEXT;
+    SELECT count(*) FROM sqlite_master WHERE name = 'tbl' AND sql LIKE '%COLLATE%';
+}
+expect {
+    0
+}
+
+# RTRIM collation alongside another column-level constraint, matching SQLite.
+test alter-add-column-preserves-collate-alongside-not-null {
+    CREATE TABLE t2(x TEXT COLLATE RTRIM NOT NULL, y INTEGER PRIMARY KEY);
+    ALTER TABLE t2 ADD COLUMN z TEXT DEFAULT 'd';
+    SELECT count(*) FROM sqlite_master WHERE name = 't2' AND sql LIKE '%x TEXT COLLATE RTRIM NOT NULL%';
+}
+expect {
+    1
+}


### PR DESCRIPTION
BTreeTable::to_sql() reconstructs the stored CREATE TABLE text field-by-field from the parsed schema (used by ALTER TABLE ADD COLUMN, which rewrites the whole DDL rather than editing the original). It already emits NOT NULL, UNIQUE, PRIMARY KEY, DEFAULT, generated-column and CHECK constraints, but never emitted a column's explicit COLLATE. After ADD COLUMN, the stored schema silently lost it, and every connection that reopens the database (or otherwise re-parses sqlite_master) sees that column as BINARY instead of its declared collation.

Emit " COLLATE <name>" when Column::collation_opt() is Some -- which is only set from an explicit COLLATE clause in the original column definition, never synthesized for the default case, so a plain column does not gain a redundant "COLLATE BINARY". Custom collations can't reach this path: they're rejected during CREATE TABLE parsing.

All expected outputs in the new sqltest file were verified against SQLite 3.50, and the two schema-text assertions fail without this change (the case-insensitive-comparison assertion does not, by design: in a single session the in-memory Column already carries the right collation regardless of what gets persisted, so only inspecting the stored DDL text -- what a future connection would re-parse -- proves the fix).

Fixes #8254

# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
