### PR TITLE
fix(cli): do not stop remaining statements after a runtime error

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -565,7 +565,6 @@ impl Limbo {
 
         let conn = self.conn.clone();
         let runner = conn.query_runner(input.as_bytes());
-        let had_error_before = self.had_query_error;
         let capture_stats = self.opts.stats;
         let mut last_stmt_metrics = None;
         for mut output in runner {
@@ -574,10 +573,18 @@ impl Limbo {
                     output = Err(err);
                 }
             }
+            // Only a prepare-time failure (this statement itself is malformed,
+            // surfaced as `output: Err(..)` and propagated by `?` out of
+            // print_query_result) aborts the remaining statements sharing this
+            // input line, matching sqlite3's CLI. A runtime error while
+            // stepping a successfully-prepared statement is handled inside
+            // print_query_result (which sets had_query_error and still
+            // returns Ok(())), and must not stop the rest of the line -- e.g.
+            // a single-line `BEGIN; ...; COMMIT;` must still reach COMMIT
+            // after an earlier statement fails at runtime.
             if self
                 .print_query_result(input, &mut output, stats.as_mut())
                 .is_err()
-                || self.had_query_error != had_error_before
             {
                 self.had_query_error = true;
                 break;

--- a/cli/tests/non_interactive_exit_code.rs
+++ b/cli/tests/non_interactive_exit_code.rs
@@ -63,9 +63,11 @@ fn sql_argument_runtime_error_returns_nonzero() {
     assert_eq!(status.code(), Some(1));
 }
 
-/// A5: Fail-fast on runtime/step failure — statements after constraint violation do not execute
+/// A5: Runtime/step failure does NOT stop the rest of the line — matches
+/// sqlite3, unlike a prepare/parse failure (A3), which does.
+/// Regression test for https://github.com/tursodatabase/turso/issues/8256
 #[test]
-fn sql_argument_runtime_error_stops_execution() {
+fn sql_argument_runtime_error_does_not_stop_execution() {
     let sql = "create table t(x integer primary key); \
                insert into t values(1); \
                insert into t values(1); \
@@ -78,10 +80,83 @@ fn sql_argument_runtime_error_stops_execution() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        !stdout.contains("after"),
-        "query after runtime error should not execute"
+        stdout.contains("after"),
+        "query after a runtime error on the same line should still execute, like sqlite3, stdout: {stdout}"
+    );
+    // The run still had an error, so the exit code must still be non-zero.
+    assert_eq!(output.status.code(), Some(1));
+}
+
+/// A5b: The issue's own reproducer — an integer-overflow runtime error must
+/// not swallow the rest of the line.
+/// Regression test for https://github.com/tursodatabase/turso/issues/8256
+#[test]
+fn sql_argument_runtime_error_reproducer_from_issue_8256() {
+    let sql = "SELECT abs(-9223372036854775808); SELECT 'after';";
+    let output = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .arg(sql)
+        .output()
+        .expect("failed to run tursodb");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("after"),
+        "query after the overflow error should still execute, stdout: {stdout}"
     );
     assert_eq!(output.status.code(), Some(1));
+}
+
+/// A5c: A single-line `BEGIN; ...; COMMIT;` must still reach COMMIT after an
+/// earlier statement fails at runtime -- the concrete consequence called out
+/// in issue #8256 (losing COMMIT silently rolls the transaction back on exit).
+#[test]
+fn sql_argument_runtime_error_mid_transaction_still_reaches_commit() {
+    let sql = "create table t(x integer primary key); \
+               begin; \
+               insert into t values(1); \
+               insert into t values(1); \
+               insert into t values(2); \
+               commit;";
+    let status = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(":memory:")
+        .arg(sql)
+        .status()
+        .expect("failed to run tursodb");
+    assert_eq!(status.code(), Some(1));
+
+    // Re-open the same on-disk database and confirm the successful insert
+    // before the failed one was committed, not rolled back.
+    let db_path = std::env::temp_dir().join(format!(
+        "limbo_test_runtime_error_commit_{}.db",
+        std::process::id()
+    ));
+    std::fs::remove_file(&db_path).ok();
+
+    let setup_sql = "create table t(x integer primary key); \
+                      begin; \
+                      insert into t values(1); \
+                      insert into t values(1); \
+                      insert into t values(2); \
+                      commit;";
+    Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(&db_path)
+        .arg(setup_sql)
+        .status()
+        .expect("failed to run tursodb");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tursodb"))
+        .arg(&db_path)
+        .arg("select x from t order by x;")
+        .output()
+        .expect("failed to run tursodb");
+    std::fs::remove_file(&db_path).ok();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains('1') && stdout.contains('2'),
+        "both successful inserts must have been committed, stdout: {stdout}"
+    );
 }
 
 /// A6: Syntax error returns non-zero


### PR DESCRIPTION
A runtime error while stepping one statement in a --sql argument (or piped stdin) line caused the CLI to abort every remaining statement in that line, even though sqlite3's own CLI keeps going. This meant a single-line `BEGIN; ...; COMMIT;` could silently skip COMMIT after an earlier statement failed at runtime (e.g. a UNIQUE or overflow error), leaving a transaction open and successful inserts uncommitted.

Only a prepare-time failure (the statement itself is malformed) should abort the rest of the line; a runtime error while stepping an already- prepared statement is already surfaced to the user (had_query_error is set and stderr shows the error) and must not stop sibling statements.

Fixes #8256

# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
