### PR TITLE
fix(core): correct three-valued NULL logic for row-value IN against a literal list

### DIFF
--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -61,6 +61,7 @@ pub(super) fn translate_in_list(
     let lhs_reg = program.alloc_registers(lhs_arity);
     let _ = translate_expr(program, referenced_tables, lhs, lhs_reg, resolver)?;
     let mut check_null_reg = 0;
+    let mut row_null_reg = 0;
     let label_ok = program.allocate_label();
 
     // Compute the affinity for the IN comparison based on the LHS expression
@@ -76,21 +77,30 @@ pub(super) fn translate_in_list(
             dest: check_null_reg,
         });
     }
+    if lhs_arity > 1 {
+        // Scratch register that tracks, per candidate row, whether every
+        // component compared so far was a genuine non-NULL match. Needed
+        // independently of check_null_reg: even when the caller collapses
+        // FALSE and NULL together (e.g. a plain WHERE filter), a candidate
+        // row with a NULL component that isn't otherwise disqualified must
+        // not be mistaken for a definite match.
+        row_null_reg = program.alloc_register();
+    }
 
     for (i, expr) in rhs.iter().enumerate() {
         let last_condition = i == rhs.len() - 1;
         let rhs_reg = program.alloc_registers(lhs_arity);
         let _ = translate_expr(program, referenced_tables, expr, rhs_reg, resolver)?;
 
-        if check_null_reg != 0 && expr.can_be_null() {
-            program.emit_insn(Insn::BitAnd {
-                lhs: check_null_reg,
-                rhs: rhs_reg,
-                dest: check_null_reg,
-            });
-        }
-
         if lhs_arity == 1 {
+            if check_null_reg != 0 && expr.can_be_null() {
+                program.emit_insn(Insn::BitAnd {
+                    lhs: check_null_reg,
+                    rhs: rhs_reg,
+                    dest: check_null_reg,
+                });
+            }
+
             // Scalar comparison path
             if !last_condition
                 || condition_metadata.jump_target_when_false
@@ -124,61 +134,90 @@ pub(super) fn translate_in_list(
                     target_pc: condition_metadata.jump_target_when_false,
                 });
             }
-        } else {
-            // Row-valued comparison path: compare each component
-            if !last_condition
-                || condition_metadata.jump_target_when_false
-                    != condition_metadata.jump_target_when_null
-            {
-                // If all components match, jump to label_ok; otherwise skip to next RHS item
-                let skip_label = program.allocate_label();
-                for j in 0..lhs_arity {
-                    let (aff, collation) = row_component_affinity_collation(
-                        lhs,
-                        expr,
-                        j,
-                        referenced_tables,
-                        Some(resolver),
-                    )?;
-                    let flags = CmpInsFlags::default().with_affinity(aff);
-                    if j < lhs_arity - 1 {
-                        program.emit_insn(Insn::Ne {
-                            lhs: lhs_reg + j,
-                            rhs: rhs_reg + j,
-                            target_pc: skip_label,
-                            flags,
-                            collation,
-                        });
-                    } else {
-                        program.emit_insn(Insn::Eq {
-                            lhs: lhs_reg + j,
-                            rhs: rhs_reg + j,
-                            target_pc: label_ok,
-                            flags,
-                            collation,
-                        });
-                    }
-                }
-                program.preassign_label_to_next_insn(skip_label);
-            } else {
-                // Last condition, simple case: jump to false if any component doesn't match
-                for j in 0..lhs_arity {
-                    let (aff, collation) = row_component_affinity_collation(
-                        lhs,
-                        expr,
-                        j,
-                        referenced_tables,
-                        Some(resolver),
-                    )?;
-                    let flags = CmpInsFlags::default().with_affinity(aff).jump_if_null();
-                    program.emit_insn(Insn::Ne {
-                        lhs: lhs_reg + j,
+        } else if !last_condition
+            || condition_metadata.jump_target_when_false != condition_metadata.jump_target_when_null
+        {
+            // Row-valued comparison path. SQL row equality is an AND across
+            // components, so a single non-NULL mismatch definitively
+            // disqualifies the row regardless of NULLs elsewhere in it
+            // (FALSE dominates NULL/UNKNOWN in three-valued AND) -- the Ne
+            // below jumps straight to skip_label for that case, short-
+            // circuiting before any later, irrelevant NULL component is
+            // even examined. If instead every component either matches
+            // exactly or involves a NULL, row_null_reg ends up NULL iff at
+            // least one of those components was actually NULL, in which
+            // case this row's contribution is "unknown" rather than a
+            // proven match.
+            let skip_label = program.allocate_label();
+            for j in 0..lhs_arity {
+                let (aff, collation) = row_component_affinity_collation(
+                    lhs,
+                    expr,
+                    j,
+                    referenced_tables,
+                    Some(resolver),
+                )?;
+                let flags = CmpInsFlags::default().with_affinity(aff);
+                program.emit_insn(Insn::Ne {
+                    lhs: lhs_reg + j,
+                    rhs: rhs_reg + j,
+                    target_pc: skip_label,
+                    flags,
+                    collation,
+                });
+                if j == 0 {
+                    program.emit_insn(Insn::BitAnd {
+                        lhs: lhs_reg,
+                        rhs: rhs_reg,
+                        dest: row_null_reg,
+                    });
+                } else {
+                    program.emit_insn(Insn::BitAnd {
+                        lhs: row_null_reg,
+                        rhs: lhs_reg + j,
+                        dest: row_null_reg,
+                    });
+                    program.emit_insn(Insn::BitAnd {
+                        lhs: row_null_reg,
                         rhs: rhs_reg + j,
-                        target_pc: condition_metadata.jump_target_when_false,
-                        flags,
-                        collation,
+                        dest: row_null_reg,
                     });
                 }
+            }
+            // Nothing jumped to skip_label: every component matched or was
+            // NULL-involved. If row_null_reg is still non-NULL, every
+            // component was a genuine non-NULL match, so this row is a
+            // definite TRUE.
+            program.emit_insn(Insn::NotNull {
+                reg: row_null_reg,
+                target_pc: label_ok,
+            });
+            if check_null_reg != 0 {
+                program.emit_insn(Insn::BitAnd {
+                    lhs: check_null_reg,
+                    rhs: row_null_reg,
+                    dest: check_null_reg,
+                });
+            }
+            program.preassign_label_to_next_insn(skip_label);
+        } else {
+            // Last condition, simple case: jump to false if any component doesn't match
+            for j in 0..lhs_arity {
+                let (aff, collation) = row_component_affinity_collation(
+                    lhs,
+                    expr,
+                    j,
+                    referenced_tables,
+                    Some(resolver),
+                )?;
+                let flags = CmpInsFlags::default().with_affinity(aff).jump_if_null();
+                program.emit_insn(Insn::Ne {
+                    lhs: lhs_reg + j,
+                    rhs: rhs_reg + j,
+                    target_pc: condition_metadata.jump_target_when_false,
+                    flags,
+                    collation,
+                });
             }
         }
     }

--- a/sqlite/conformance/sqlite-sqltests/row-value-in.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/row-value-in.sqltest
@@ -161,3 +161,75 @@ expect {
     m5|-1
     m6|-1
 }
+
+# Regression tests for three-valued NULL handling in row-value IN/NOT IN
+# against a *literal list* (issue #8255). A NULL component that is not
+# otherwise disqualified by a definite mismatch elsewhere in the row must
+# make the comparison's result NULL, not silently coerce to TRUE/FALSE.
+
+setup null_component_schema {
+    CREATE TABLE w(a, b);
+    INSERT INTO w VALUES (NULL,1),(1,1),(2,NULL),(2,2);
+}
+
+@setup null_component_schema
+test row-value-in-literal-null-component-excludes-unknown-row {
+    SELECT a, b FROM w WHERE (a,b) IN ((1,1),(2,2)) ORDER BY 1,2;
+}
+expect {
+    1|1
+    2|2
+}
+
+@setup null_component_schema
+test row-value-not-in-literal-null-component-excludes-unknown-row {
+    SELECT a, b FROM w WHERE (a,b) NOT IN ((1,1),(2,2)) ORDER BY 1,2;
+}
+expect {
+}
+
+test row-value-in-null-component-first-position-is-null {
+    SELECT ((NULL,1) IN ((1,1))) IS NULL;
+}
+expect {
+    1
+}
+
+test row-value-in-null-component-second-position-is-null {
+    SELECT ((2,NULL) IN ((2,2))) IS NULL;
+}
+expect {
+    1
+}
+
+test row-value-not-in-null-component-is-null {
+    SELECT ((2,NULL) NOT IN ((2,2))) IS NULL;
+}
+expect {
+    1
+}
+
+test row-value-in-three-columns-middle-null-is-null {
+    SELECT ((1,NULL,3) IN ((1,2,3))) IS NULL;
+}
+expect {
+    1
+}
+
+test row-value-in-null-component-second-candidate-is-null {
+    SELECT ((NULL,1) IN ((9,9),(1,1))) IS NULL;
+}
+expect {
+    1
+}
+
+# A non-NULL component mismatch must still definitively disqualify a
+# candidate row, even when another component of the same row is NULL --
+# the result is FALSE, not NULL, because a proven mismatch dominates an
+# unrelated unknown.
+test row-value-in-null-component-already-disqualified-by-other-component {
+    SELECT (2,NULL) IN ((1,1));
+}
+expect {
+    0
+}


### PR DESCRIPTION
(a,b) IN ((...),(...)) returned TRUE or FALSE instead of NULL whenever a component of the left-hand row was NULL and no candidate proved a definite, non-NULL match. Rows were both wrongly included and wrongly excluded from WHERE filters as a result. The subquery form `(a,b) IN (SELECT ...)`, the plain comparison `(a,b) = (c,d)`, and scalar IN were all unaffected -- only the row-value-against-literal-list path skipped three-valued handling.

The per-candidate comparison loop used Eq/Ne on each component without tracking which components were NULL-involved versus genuinely equal, so a NULL component before or after a match caused it to fall through to whatever the last instruction happened to decide. Track NULL involvement per candidate row instead: a definite non-NULL mismatch in any component still short-circuits the row immediately (a proven mismatch dominates an unrelated unknown, per three-valued AND), but a row where every component is either a genuine match or NULL-involved (and none disqualify it) now correctly contributes "unknown" to the overall IN result rather than being coerced to TRUE or FALSE.

Fixes #8255