### PR TITLE
core/storage: clear connection tx state before post-commit auto-checkpoint

### DIFF
--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3138,8 +3138,6 @@ impl Pager {
 
                     wal.end_write_tx();
                     wal.end_read_tx();
-                    // we do not set TransactionState::None here - because caller can decide that nothing should be done for this connection
-                    // and skip next calls of the commit_tx methods after IO
 
                     tracing::debug!("commit_tx: schema_did_change={schema_did_change}");
                     if schema_did_change {
@@ -3151,6 +3149,16 @@ impl Pager {
                         complete_commit();
                         self.clear_savepoints()?;
                         return Ok(IOResult::Done(()));
+                    }
+
+                    // The commit is durable and the WAL locks are released; only
+                    // the auto-checkpoint remains. Clear the transaction state now
+                    // so an abort during the checkpoint does not try to roll back
+                    // the committed transaction. Savepoints stay until the
+                    // checkpoint finishes: a re-entered RELEASE must still find
+                    // them (see release_named_savepoint).
+                    if update_transaction_state {
+                        connection.set_tx_state(TransactionState::None);
                     }
                 }
             }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2194,9 +2194,18 @@ impl Program {
             tx_state,
         );
         if matches!(program_state.commit_state, CommitState::Committing) {
-            let TransactionState::Write { .. } = tx_state else {
-                unreachable!("invalid state for write commit step")
-            };
+            // Normally a resumed commit still has an open write transaction.
+            // The exception is the post-commit auto-checkpoint: commit_tx has
+            // already committed the WAL, released the locks and cleared the
+            // transaction state, and only the checkpoint is still in flight,
+            // so the state is None.
+            turso_assert!(
+                matches!(
+                    tx_state,
+                    TransactionState::Write { .. } | TransactionState::None
+                ),
+                "invalid state for write commit step: {tx_state:?}"
+            );
             self.step_end_write_txn(&pager, &connection, program_state, rollback)
         } else if matches!(program_state.commit_state, CommitState::CommittingAttached) {
             // Re-entry after IO yield from attached pager commit.

--- a/tests/integration/abandoned_statement_pager.rs
+++ b/tests/integration/abandoned_statement_pager.rs
@@ -347,3 +347,106 @@ fn test_abandoned_insert_does_not_poison_next_insert() {
         );
     }
 }
+
+/// Regression test for issue #8291.
+///
+/// A single big INSERT pushes the WAL past the 1000-frame auto-checkpoint
+/// threshold, so its commit runs a checkpoint that yields for I/O after the
+/// WAL commit is durable and the WAL locks are released. Resetting the
+/// statement at one of those yields used to panic: the connection's
+/// transaction state was still `Write`, so the abort path called
+/// `wal.end_write_tx()` for locks that were already released, tripping the
+/// "write lock not held" assertion in wal.rs. This sweeps every I/O boundary
+/// of the INSERT, resets the statement there, and asserts the reset does not
+/// panic and leaves the connection usable.
+#[test]
+fn test_reset_during_post_commit_auto_checkpoint() {
+    // ~1200 overflow pages at page_size 512, so one commit crosses the
+    // 1000-frame auto-checkpoint threshold.
+    const INSERT: &str = "INSERT INTO t VALUES (1, zeroblob(600000))";
+
+    fn setup(io: &Arc<MemoryYieldIO>, path: &str) -> Arc<Connection> {
+        let conn = open_conn(io.clone(), path);
+        conn.execute("PRAGMA page_size=512").unwrap();
+        conn.execute("PRAGMA journal_mode = 'wal'").unwrap();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB)")
+            .unwrap();
+        conn
+    }
+
+    // Dry run: count the INSERT's I/O yields so the sweep below can visit
+    // every boundary, including the ones inside the auto-checkpoint at the
+    // end.
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let total_ios = {
+        let io = Arc::new(MemoryYieldIO::new());
+        let path = temp_dir.path().join("dry-run.db");
+        let conn = setup(&io, path.to_str().unwrap());
+        let mut stmt = conn.prepare(INSERT).unwrap();
+        let mut count = 0usize;
+        loop {
+            match stmt.step().unwrap() {
+                StepResult::IO => {
+                    count += 1;
+                    io.step().unwrap();
+                }
+                StepResult::Done => break,
+                StepResult::Yield => {}
+                other => panic!("unexpected step result in dry run: {other:?}"),
+            }
+        }
+        count
+    };
+    assert!(
+        total_ios > 2,
+        "INSERT must yield for I/O several times for the sweep to mean anything"
+    );
+
+    for target_io in 1..=total_ios {
+        let io = Arc::new(MemoryYieldIO::new());
+        let path = temp_dir.path().join(format!("reset-at-{target_io}.db"));
+        let conn = setup(&io, path.to_str().unwrap());
+
+        let mut stmt = conn.prepare(INSERT).unwrap();
+        let mut io_count = 0usize;
+        loop {
+            match stmt.step().unwrap() {
+                StepResult::IO => {
+                    io_count += 1;
+                    io.step().unwrap();
+                    if io_count == target_io {
+                        break;
+                    }
+                }
+                StepResult::Done => {
+                    panic!("target_io={target_io}: INSERT finished before the target boundary")
+                }
+                StepResult::Yield => {}
+                other => panic!("unexpected step result: {other:?}"),
+            }
+        }
+
+        // Before the fix this panicked with "end_write_tx called while write
+        // lock not held according to connection state" when target_io landed
+        // inside the post-commit auto-checkpoint.
+        stmt.reset()
+            .unwrap_or_else(|e| panic!("target_io={target_io}: reset failed: {e}"));
+        drop(stmt);
+
+        // The reset either rolled the INSERT back (mid-write) or interrupted
+        // only the checkpoint of an already-committed INSERT, so the row
+        // count is 0 or 1 and the connection must stay fully usable.
+        let count = ids(&conn, "SELECT count(*) FROM t")[0];
+        assert!(
+            (0..=1).contains(&count),
+            "target_io={target_io}: unexpected row count {count}"
+        );
+        conn.execute("INSERT INTO t VALUES (2, zeroblob(1000))")
+            .unwrap();
+        assert_eq!(
+            integrity_check(&conn),
+            vec!["ok"],
+            "target_io={target_io}: reset during commit corrupted the database"
+        );
+    }
+}


### PR DESCRIPTION
commit_tx releases the WAL write and read locks as soon as the WAL
commit finishes, then runs the post-commit auto-checkpoint, which can
yield for IO. The connection's transaction state stayed Write across
that yield, so if the statement was aborted mid-checkpoint (for example
by being dropped or reset), the abort path saw a write transaction and
called wal.end_write_tx() for locks that were already released,
tripping the write_lock_held assertion in wal.rs.

Clear the connection's transaction state as soon as the WAL commit is
durable and the locks are released, before starting the auto-checkpoint.
An abort during the checkpoint then takes the read-transaction cleanup
path. commit_wal_end() is deliberately not called at that point because
commit_tx resumes the checkpoint on re-entry by reading
commit_info.state == AutoCheckpoint. Savepoints are also kept until the
checkpoint completes: a RELEASE that commits the transaction re-executes
from the top after every IO yield and must still find its savepoint.

The vdbe commit resume path asserted the transaction state is still
Write when re-entering a commit; TransactionState::None is now a legal
resume state while only the auto-checkpoint is in flight, so the
assertion accepts both.

Tests: new integration test sweeps every IO boundary of an INSERT whose
commit triggers the auto-checkpoint and resets the statement there;
without the fix it panics with the exact #8291 assertion. Run with:
cargo test -p core_tester --features io_memory_yield --test
integration_tests abandoned_statement_pager::test_reset_during_post_commit_auto_checkpoint

Fixes #8291