### PR TITLE
core: match SQLite's type inference for every unary operator

### DIFF
--- a/core/statement.rs
+++ b/core/statement.rs
@@ -178,7 +178,7 @@ fn infer_expression_primitive(
     expr: &turso_parser::ast::Expr,
     referenced_tables: Option<&translate::plan::TableReferences>,
 ) -> Option<&'static str> {
-    use turso_parser::ast::{Expr, Operator};
+    use turso_parser::ast::{Expr, Operator, UnaryOperator};
 
     match expr {
         // Bare literal: read the parsed concrete value type.
@@ -195,11 +195,14 @@ fn infer_expression_primitive(
             infer_expression_primitive(exprs.first().unwrap(), referenced_tables)
         }
         Expr::Collate(inner, _) => infer_expression_primitive(inner, referenced_tables),
-        Expr::Unary(_, inner) => {
-            // Unary +/-/NOT preserve the operand's primitive (NOT on INTEGER
-            // is still INTEGER in SQLite).
-            infer_expression_primitive(inner, referenced_tables)
-        }
+        Expr::Unary(op, inner) => match op {
+            UnaryOperator::Not | UnaryOperator::BitwiseNot => Some("INTEGER"),
+            UnaryOperator::Negative => Some(combine_arithmetic_primitive(
+                Some("INTEGER"),
+                infer_expression_primitive(inner, referenced_tables),
+            )),
+            UnaryOperator::Positive => infer_expression_primitive(inner, referenced_tables),
+        },
         Expr::Binary(left, op, right) => match op {
             // Arithmetic: widen INTEGER × INTEGER to INTEGER, anything mixed
             // with REAL becomes REAL, fall through to NUMERIC otherwise.

--- a/tests/integration/statement_metadata.rs
+++ b/tests/integration/statement_metadata.rs
@@ -302,6 +302,78 @@ mod tests {
         assert_eq!(expect_info(&concat, 0).declared_name, "TEXT");
     }
 
+    /// Each unary operator, checked against what SQLite's `typeof()` actually
+    /// reports. The three behaviours are distinct and none of them is "return
+    /// the operand's type unchanged":
+    ///
+    /// * `NOT` / `~` are INTEGER for every operand — `OP_Not` and `OP_BitNot`
+    ///   unconditionally write an integer register.
+    /// * `-` is always numeric: SQLite compiles it to `0 - x` (`OP_Subtract`),
+    ///   so a TEXT operand comes back numeric, not TEXT. INTEGER and REAL
+    ///   operands keep their type; anything else is numeric but not statically
+    ///   resolvable to one or the other (`typeof(-'abc')` is `integer` while
+    ///   `typeof(-'1.5')` is `real`), so NUMERIC is the honest answer.
+    /// * `+` alone is a true no-op — `typeof(+'abc')` is `text`.
+    #[test]
+    fn type_info_for_unary_operators() {
+        let db = fresh_db_with_custom_types("type_info_unary.db");
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, label TEXT, ratio REAL) STRICT")
+            .unwrap();
+
+        // Every assertion below is `(expression, expected primitive)` with the
+        // SQLite `typeof()` it mirrors noted alongside.
+        let cases: &[(&str, &str)] = &[
+            // NOT is INTEGER regardless of operand type.
+            ("NOT ('a' || 'b')", "INTEGER"), // typeof -> integer
+            ("NOT 1.5", "INTEGER"),          // typeof -> integer
+            ("NOT id", "INTEGER"),           // typeof -> integer
+            ("NOT label", "INTEGER"),        // typeof -> integer
+            // Bitwise NOT is INTEGER regardless of operand type.
+            ("~1.5", "INTEGER"),          // typeof -> integer
+            ("~label", "INTEGER"),        // typeof -> integer
+            ("~('a' || 'b')", "INTEGER"), // typeof -> integer
+            // Unary minus is numeric, never the operand's non-numeric type.
+            ("-42", "INTEGER"),           // typeof -> integer
+            ("-1.5", "REAL"),             // typeof -> real
+            ("-id", "INTEGER"),           // typeof -> integer
+            ("-ratio", "REAL"),           // typeof -> real
+            ("-label", "NUMERIC"),        // typeof -> integer or real, by value
+            ("-('a' || 'b')", "NUMERIC"), // typeof -> integer
+            // Unary plus preserves the operand exactly.
+            ("+id", "INTEGER"),        // typeof -> integer
+            ("+1.5", "REAL"),          // typeof -> real
+            ("+label", "TEXT"),        // typeof -> text
+            ("+('a' || 'b')", "TEXT"), // typeof -> text
+            // Nesting composes the rules above.
+            ("- -1.5", "REAL"),           // typeof -> real
+            ("NOT NOT label", "INTEGER"), // typeof -> integer
+            ("-(~1.5)", "INTEGER"),       // typeof -> integer
+        ];
+
+        // Collect every mismatch rather than tripping on the first, so a
+        // regression reports the full picture in one run.
+        let mut mismatches = Vec::new();
+        for (expr, expected) in cases {
+            let stmt = conn
+                .prepare(format!("SELECT {expr} FROM t"))
+                .unwrap_or_else(|e| panic!("failed to prepare `SELECT {expr} FROM t`: {e}"));
+            let info = expect_info(&stmt, 0);
+            if info.declared_name != *expected {
+                mismatches.push(format!(
+                    "  {expr:<16} expected {expected}, got {}",
+                    info.declared_name
+                ));
+            }
+            assert_eq!(info.kind, ColumnTypeKind::Builtin, "`{expr}` kind");
+        }
+        assert!(
+            mismatches.is_empty(),
+            "unary operator inference diverges from SQLite:\n{}",
+            mismatches.join("\n")
+        );
+    }
+
     /// Expressions whose primitive can't be determined statically — function
     /// calls without a declared return affinity, BLOB literals, NULL literals
     /// — yield `Ok(None)`. Callers fall through to their own default (TEXT


### PR DESCRIPTION
## Description

`infer_expression_primitive`'s `Expr::Unary` arm discarded the operator and recursed into the operand, so `NOT (<text>)` inferred TEXT and `~<real>` inferred REAL. None of the four unary operators actually passes its operand's type through unchanged, except `+`:

| Operator | Inferred | Why |
|---|---|---|
| `NOT`, `~` | INTEGER | `OP_Not` / `OP_BitNot` write an integer register regardless of the input's type |
| `-` | INTEGER / REAL / NUMERIC | SQLite compiles `-x` to `0 - x` (`OP_Subtract`), so the result is always numeric |
| `+` | operand's type | genuine no-op |

Unary minus reuses `combine_arithmetic_primitive` against an INTEGER zero, so INTEGER and REAL operands keep their type and everything else collapses to NUMERIC. NUMERIC rather than INTEGER because integer-vs-real depends on the runtime value: `typeof(-'abc')` is `integer` but `typeof(-'1.5')` is `real`. All four arms are now spelled out instead of one falling through a wildcard.

## Motivation and context

Expected values throughout were taken from SQLite:

```
sqlite> SELECT typeof(NOT ('a' || 'b')), typeof(~1.5), typeof(-'abc'), typeof(+'abc');
integer|integer|integer|text
```

That `-x` really is compiled as a subtraction, with no negate opcode:

```
sqlite> EXPLAIN SELECT -label FROM t;
...
3     Column         0     1     3      r[3]= cursor 0 column 1
4     Subtract       3     2     1      r[1]=r[2]-r[3]
...
9     Integer        0     2     0      r[2]=0
```

The regression test lives in the existing statement-metadata integration test (`tests/integration/statement_metadata.rs`) rather than as a unit test in `core/statement.rs`, so it prepares real SQL and reads the column type back through `get_column_type_info` instead of hand-building AST nodes. It tabulates all four operators over literal, column and expression operands plus nesting, and collects every mismatch before failing so a regression reports the full picture in one run. Before this change `NOT ('a' || 'b')` inferred TEXT, `~1.5` inferred REAL, and `-label` / `-('a' || 'b')` inferred TEXT instead of NUMERIC.

One thing worth flagging for reviewers: this inference is only reachable through the statement-metadata API (`get_column_decltype` / `get_column_type_info`, used by `cli/sync_server.rs` and the bindings). Runtime `typeof()` already agreed with SQLite before the fix, so a `.sqltest` cannot cover this — it would pass on unfixed code.

## Description of AI Usage

AI was used. This bug was surfaced by slop-audit (slopaudit.org), an experimental verification tool: it locates an uncovered decision branch, has a model write one candidate test for it, compiles and runs that test in-crate, and keeps the test only if it actually fails. The reported failure was then checked by hand against SQLite's documented behavior, and the fix and regression test written and verified. An AI coding assistant (Claude Code) also helped write the test in this repo's conventions and draft this description. I have reviewed and understand the change and I am responsible for it.

