### PR TITLE
Make the SQLite TCL conformance harness actually run the upstream suite

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -59,7 +59,7 @@ jobs:
 
   sqlite-tcl:
     name: SQLite TCL conformance tests
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -22,6 +22,32 @@ static SQLITE_VERSION_C_STRING: OnceLock<CString> = OnceLock::new();
 #[allow(non_upper_case_globals)]
 pub static mut sqlite3_search_count: ffi::c_int = 0;
 
+/// Test-only export of core's SQLite varint encoder for the TCL harness's
+/// btree_varint_test command (upstream test3.c). `buf` must have room for
+/// 9 bytes. Returns the number of bytes written. Not part of the sqlite3
+/// API.
+#[no_mangle]
+pub unsafe extern "C" fn turso_test_put_varint(buf: *mut u8, value: u64) -> ffi::c_int {
+    let buf = unsafe { std::slice::from_raw_parts_mut(buf, 9) };
+    turso_core::storage::sqlite3_ondisk::write_varint(buf, value) as ffi::c_int
+}
+
+/// Test-only export of core's SQLite varint decoder, the counterpart of
+/// [`turso_test_put_varint`]. `buf` must hold at least 9 readable bytes.
+/// Returns the number of bytes consumed and stores the decoded value in
+/// `*out`, or returns 0 if the bytes are not a valid varint.
+#[no_mangle]
+pub unsafe extern "C" fn turso_test_get_varint(buf: *const u8, out: *mut u64) -> ffi::c_int {
+    let buf = unsafe { std::slice::from_raw_parts(buf, 9) };
+    match turso_core::storage::sqlite3_ondisk::read_varint(buf) {
+        Ok((value, n)) => {
+            unsafe { *out = value };
+            n as ffi::c_int
+        }
+        Err(_) => 0,
+    }
+}
+
 /// Enable all experimental features for databases opened after this call.
 #[no_mangle]
 pub extern "C" fn turso_enable_experimental() {

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -1071,7 +1071,13 @@ pub unsafe extern "C" fn sqlite3_finalize(stmt: *mut sqlite3_stmt) -> ffi::c_int
 pub unsafe extern "C" fn sqlite3_step(stmt: *mut sqlite3_stmt) -> ffi::c_int {
     let stmt = &mut *stmt;
     let db = &mut *stmt.db;
-    let mut db_inner = db.inner.lock().unwrap();
+    // Do not hold the handle lock across the step. A user-defined function
+    // invoked mid-step may re-enter the C API on the same handle (SQLite
+    // allows e.g. a nested prepare/step from inside a scalar callback), and
+    // re-locking the non-reentrant mutex on the same thread deadlocks.
+    // Nothing here needs the lock while stepping: core's Connection is
+    // internally synchronized, and the statement itself was never protected
+    // by the handle lock to begin with.
     let res = stmt.stmt.run_one_step_blocking(|| Ok(()), || Ok(()));
     let rc = match res {
         Ok(Some(_)) => {
@@ -1084,7 +1090,10 @@ pub unsafe extern "C" fn sqlite3_step(stmt: *mut sqlite3_stmt) -> ffi::c_int {
         }
         Err(LimboError::Busy) => SQLITE_BUSY,
         Err(LimboError::Interrupt) => SQLITE_INTERRUPT,
-        Err(err) => set_db_err(&mut db_inner, err),
+        Err(err) => {
+            let mut db_inner = db.inner.lock().unwrap();
+            set_db_err(&mut db_inner, err)
+        }
     };
     let current = stmt.stmt.metrics().search_count;
     let delta = current - stmt.prev_search_count;

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -1255,17 +1255,27 @@ unsafe fn execute_query_with_callback(
                 // Safety: checked earlier
                 let callback = callback.unwrap();
 
-                let mut values: Vec<CString> = Vec::with_capacity(n_cols as usize);
+                let mut values: Vec<Option<CString>> = Vec::with_capacity(n_cols as usize);
                 let mut value_ptrs: Vec<*mut ffi::c_char> = Vec::with_capacity(n_cols as usize);
                 let mut col_ptrs: Vec<*mut ffi::c_char> = Vec::with_capacity(n_cols as usize);
 
                 for i in 0..n_cols {
                     let val = stmt_ref.stmt.row().unwrap().get_value(i as usize);
-                    values.push(CString::new(val.to_string().as_bytes()).unwrap());
+                    // SQL NULL is passed to the callback as a NULL pointer,
+                    // as in SQLite, not as an empty string.
+                    if matches!(val, Value::Null) {
+                        values.push(None);
+                    } else {
+                        values.push(Some(CString::new(val.to_string().as_bytes()).unwrap()));
+                    }
                 }
 
                 for value in &values {
-                    value_ptrs.push(value.as_ptr() as *mut ffi::c_char);
+                    value_ptrs.push(
+                        value
+                            .as_ref()
+                            .map_or(std::ptr::null_mut(), |v| v.as_ptr() as *mut ffi::c_char),
+                    );
                 }
                 for name in &column_names {
                     col_ptrs.push(name.as_ptr() as *mut ffi::c_char);

--- a/bindings/c/tests/sqlite3_tests.c
+++ b/bindings/c/tests/sqlite3_tests.c
@@ -26,6 +26,7 @@ void test_sqlite3_db_config();
 void test_sqlite3_extended_result_codes();
 void test_sqlite3_sql_introspection();
 void test_sqlite3_mprintf();
+void test_sqlite3_exec_null_values();
 
 int allocated = 0;
 
@@ -51,6 +52,7 @@ int main(void)
     test_sqlite3_extended_result_codes();
     test_sqlite3_sql_introspection();
     test_sqlite3_mprintf();
+    test_sqlite3_exec_null_values();
     return 0;
 }
 
@@ -1130,4 +1132,32 @@ void test_sqlite3_mprintf()
     assert(strcmp(buf, "'ab'") == 0);
 
     printf("test_sqlite3_mprintf test passed\n");
+}
+
+static int exec_null_cb(void *ctx, int argc, char **argv, char **colv)
+{
+    (void)colv;
+    assert(argc == 2);
+    /* SQL NULL arrives as a NULL pointer, like SQLite; other values as text. */
+    assert(argv[0] == NULL);
+    assert(argv[1] != NULL && strcmp(argv[1], "1") == 0);
+    *(int *)ctx += 1;
+    return 0;
+}
+
+void test_sqlite3_exec_null_values()
+{
+    sqlite3 *db;
+    int rows = 0;
+    int rc;
+
+    rc = sqlite3_open(":memory:", &db);
+    assert(rc == SQLITE_OK);
+
+    rc = sqlite3_exec(db, "SELECT NULL, 1;", exec_null_cb, &rows, NULL);
+    assert(rc == SQLITE_OK);
+    assert(rows == 1);
+
+    sqlite3_close(db);
+    printf("test_sqlite3_exec_null_values test passed\n");
 }

--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -218,6 +218,48 @@ set ptrerr [catch {sqlite3_connection_pointer nosuchdb} ptrmsg]
 assert_eq "sqlite3_connection_pointer errors on an unknown handle" 1 $ptrerr
 
 # ---------------------------------------------------------------------------
+# Probe 10: the [sqlite3_mprintf_*] / [sqlite3_snprintf_*] commands.
+# Each formats through the real sqlite3_mprintf/sqlite3_snprintf C API, so
+# these expectations (taken from upstream printf.test) exercise the engine's
+# printf implementation.
+# ---------------------------------------------------------------------------
+
+assert_eq "mprintf_int formats three ints" \
+    {This is a test 1,2,3} \
+    [sqlite3_mprintf_int {This is a test %d,%d,%d} 1 2 3]
+assert_eq "mprintf_int honors width and zero-pad flags" \
+    {abc: (000012) (00000d) (000016) :xyz} \
+    [sqlite3_mprintf_int {abc: (%06d) (%06x) (%06o) :xyz} 12 13 14]
+assert_eq "mprintf_int64 formats past 32 bits" \
+    {2147483647 2147483648 4294967296} \
+    [sqlite3_mprintf_int64 {%lld %lld %lld} 2147483647 2147483648 4294967296]
+assert_eq "mprintf_long truncates each argument to 32 bits" \
+    {2147483647 2147483648 4294967295} \
+    [sqlite3_mprintf_long {%lu %lu %lu} 0x7fffffff 0x80000000 0xffffffff]
+assert_eq "mprintf_str formats two ints and a string" \
+    {1 2 A String: (This is the string)} \
+    [sqlite3_mprintf_str {%d %d A String: (%s)} 1 2 {This is the string}]
+assert_eq "mprintf_str passes NULL when the string is omitted" \
+    {1 2 A NULL pointer in %q: '(NULL)'} \
+    [sqlite3_mprintf_str {%d %d A NULL pointer in %%q: '%q'} 1 2]
+assert_eq "mprintf_stronly quotes via %q" \
+    {Hi Y''all} [sqlite3_mprintf_stronly %q {Hi Y'all}]
+assert_eq "mprintf_double formats two ints and a double" \
+    {1 2 3.5} [sqlite3_mprintf_double {%d %d %g} 1 2 3.5]
+assert_eq "mprintf_scaled formats the product of its doubles" \
+    {A double: 1e+308} [sqlite3_mprintf_scaled {A double: %g} 1.0e307 10.0]
+assert_eq "mprintf_hexdouble decodes an IEEE-754 bit pattern" \
+    {10.00000000000000000000} [sqlite3_mprintf_hexdouble %.20f 4024000000000000]
+assert_eq "mprintf_z_test joins arguments via %z" \
+    {,one,two,three} [sqlite3_mprintf_z_test , one two three]
+assert_eq "snprintf_int truncates to SIZE-1 characters" \
+    {1234} [sqlite3_snprintf_int 5 {12345} 0]
+assert_eq "snprintf_int leaves the buffer alone when SIZE is 0" \
+    {abcdefghijklmnopqrstuvwxyz} [sqlite3_snprintf_int 0 {} 0]
+assert_eq "snprintf_str truncates to SIZE-1 characters" \
+    {x10 1} [sqlite3_snprintf_str 6 {x%d %d %s} 10 10 {This is the string}]
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -307,6 +307,24 @@ assert_eq "db func callback can run a nested statement" 42 \
     [db one {SELECT nested_probe()}]
 
 # ---------------------------------------------------------------------------
+# Probe 14: [sqlite3BitvecBuiltinTest].
+# Returns 0 when the tested bitmap matches the reference, and the index of
+# the first mismatch otherwise (opcode 5 writes only the reference, which
+# is how bitvec.test verifies deliberate errors are detected).
+# ---------------------------------------------------------------------------
+
+assert_eq "bitvec test detects a deliberate mismatch at bit 1" 1 \
+    [sqlite3BitvecBuiltinTest 400 {5 1 1 1 0}]
+assert_eq "bitvec test reports the first mismatched index" 234 \
+    [sqlite3BitvecBuiltinTest 400 {5 1 234 1 0}]
+assert_eq "bitvec test passes a linear fill" 0 \
+    [sqlite3BitvecBuiltinTest 4000 {1 4000 1 1 0}]
+assert_eq "bitvec test passes fill then clear" 0 \
+    [sqlite3BitvecBuiltinTest 4000 {1 4000 1 1 2 4000 1 1 0}]
+assert_eq "bitvec test passes random set and clear" 0 \
+    [sqlite3BitvecBuiltinTest 4000 {3 1000 4 1000 0}]
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -273,6 +273,29 @@ assert_eq "btree_varint_test round-trips 9-byte encodings" "" \
     [btree_varint_test 0x10000000 0x10000000 5000 50000000]
 
 # ---------------------------------------------------------------------------
+# Probe 12: the [sqlite3_blob_*] commands over the incremental blob C API.
+# blob_open sets VARNAME to a handle on success and raises the symbolic
+# result code on failure; read/write/bytes/close operate on the handle.
+# ---------------------------------------------------------------------------
+
+db eval {CREATE TABLE tb(x BLOB); INSERT INTO tb(rowid, x) VALUES (1, zeroblob(10));}
+
+sqlite3_blob_open db main tb x 1 1 B
+assert_eq "blob_bytes reports the blob size" 10 [sqlite3_blob_bytes $B]
+assert_eq "blob_write stores bytes" "" [sqlite3_blob_write $B 0 hello 5]
+assert_eq "blob_read returns written bytes" "hello" [sqlite3_blob_read $B 0 5]
+assert_eq "blob_read honors the offset" "ello" [sqlite3_blob_read $B 1 4]
+assert_eq "blob_close succeeds" "" [sqlite3_blob_close $B]
+assert_eq "blob_write persisted through the SQL layer" \
+    68656C6C6F0000000000 [db one {SELECT hex(x) FROM tb WHERE rowid = 1}]
+
+set boerr [catch {sqlite3_blob_open db main tb x 99 0 B2} bomsg]
+assert_eq "blob_open raises the symbolic code on a missing row" 1 $boerr
+assert_ne "blob_open error is a symbolic result code" "" $bomsg
+set brerr [catch {sqlite3_blob_read $B 0 5} brmsg]
+assert_eq "blob commands reject a closed handle" 1 $brerr
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -127,6 +127,24 @@ assert_eq "attached database is queryable" 42 [db eval {SELECT x FROM aux.t5}]
 assert_eq "DETACH is accepted" "" [db eval {DETACH aux}]
 
 # ---------------------------------------------------------------------------
+# Probe 6: TCL variable binding in [db one] and [db exists].
+# Both prepare their statement directly (bypassing the eval path), so they
+# must bind TCL variables themselves; without that, $var silently binds NULL
+# and the query returns an empty result.
+# ---------------------------------------------------------------------------
+
+db eval {CREATE TABLE tv(x);}
+db eval {INSERT INTO tv VALUES (7), (8);}
+
+set want 7
+assert_eq "db one binds \$var from the caller scope" 7 \
+    [db one {SELECT x FROM tv WHERE x = $want}]
+assert_eq "db exists binds \$var from the caller scope" 1 \
+    [db exists {SELECT 1 FROM tv WHERE x = $want}]
+assert_eq "db exists is false for a non-matching \$var" 0 \
+    [db exists {SELECT 1 FROM tv WHERE x = $want + 100}]
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -145,6 +145,47 @@ assert_eq "db exists is false for a non-matching \$var" 0 \
     [db exists {SELECT 1 FROM tv WHERE x = $want + 100}]
 
 # ---------------------------------------------------------------------------
+# Probe 7: [db transaction].
+# The script runs inside a transaction: committed on success, rolled back
+# when the script raises an error. Nested transactions use a savepoint, so
+# an inner failure undoes only the inner work.
+# ---------------------------------------------------------------------------
+
+db eval {CREATE TABLE tt(x);}
+
+db transaction {
+    db eval {INSERT INTO tt VALUES (1);}
+}
+assert_eq "transaction commits on success" 1 [db one {SELECT count(*) FROM tt}]
+
+set txerr [catch {
+    db transaction {
+        db eval {INSERT INTO tt VALUES (2);}
+        error "boom"
+    }
+} txmsg]
+assert_eq "transaction propagates the script error" 1 $txerr
+assert_eq "transaction error message survives" "boom" $txmsg
+assert_eq "transaction rolls back on error" 1 [db one {SELECT count(*) FROM tt}]
+
+db transaction immediate {
+    db eval {INSERT INTO tt VALUES (3);}
+}
+assert_eq "transaction accepts a type argument" 2 [db one {SELECT count(*) FROM tt}]
+
+db transaction {
+    db eval {INSERT INTO tt VALUES (4);}
+    catch {
+        db transaction {
+            db eval {INSERT INTO tt VALUES (5);}
+            error "inner boom"
+        }
+    }
+}
+assert_eq "inner transaction rolls back to its savepoint only" \
+    {1 3 4} [db eval {SELECT x FROM tt ORDER BY x}]
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -296,6 +296,17 @@ set brerr [catch {sqlite3_blob_read $B 0 5} brmsg]
 assert_eq "blob commands reject a closed handle" 1 $brerr
 
 # ---------------------------------------------------------------------------
+# Probe 13: re-entering the database from inside a [db func] callback.
+# SQLite allows a scalar function to run its own statements on the calling
+# connection; this used to deadlock because sqlite3_step held the handle
+# lock across the whole step.
+# ---------------------------------------------------------------------------
+
+db func nested_probe {} { db one {SELECT 40 + 2} }
+assert_eq "db func callback can run a nested statement" 42 \
+    [db one {SELECT nested_probe()}]
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -206,6 +206,18 @@ set execerr [catch {sqlite3_exec nosuchdb {SELECT 1}} execmsg]
 assert_eq "sqlite3_exec errors on an unknown handle" 1 $execerr
 
 # ---------------------------------------------------------------------------
+# Probe 9: [sqlite3_connection_pointer].
+# Returns a value that identifies the database to C-API-level harness
+# commands (here, the handle name itself), and errors on a non-database.
+# ---------------------------------------------------------------------------
+
+set DB [sqlite3_connection_pointer db]
+assert_eq "sqlite3_connection_pointer result works as a DB argument" \
+    {0 {one 1}} [sqlite3_exec $DB {SELECT 1 AS one}]
+set ptrerr [catch {sqlite3_connection_pointer nosuchdb} ptrmsg]
+assert_eq "sqlite3_connection_pointer errors on an unknown handle" 1 $ptrerr
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -260,6 +260,19 @@ assert_eq "snprintf_str truncates to SIZE-1 characters" \
     {x10 1} [sqlite3_snprintf_str 6 {x%d %d %s} 10 10 {This is the string}]
 
 # ---------------------------------------------------------------------------
+# Probe 11: [btree_varint_test].
+# Round-trips values through core's varint encoder/decoder; returns "" on
+# success. The ranges cover 1-byte, mid-size, and 9-byte encodings.
+# ---------------------------------------------------------------------------
+
+assert_eq "btree_varint_test round-trips small values" "" \
+    [btree_varint_test 0 1 5000 1]
+assert_eq "btree_varint_test round-trips large steps" "" \
+    [btree_varint_test 100 1000000 5000 50000000]
+assert_eq "btree_varint_test round-trips 9-byte encodings" "" \
+    [btree_varint_test 0x10000000 0x10000000 5000 50000000]
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/bindings/tcl/test_probes.tcl
+++ b/bindings/tcl/test_probes.tcl
@@ -186,6 +186,26 @@ assert_eq "inner transaction rolls back to its savepoint only" \
     {1 3 4} [db eval {SELECT x FROM tt ORDER BY x}]
 
 # ---------------------------------------------------------------------------
+# Probe 8: the [sqlite3_exec] test-harness command.
+# Returns {rc results} where results is column names followed by row values
+# (first row supplies the names), or {rc errmsg} on failure. %HH escapes in
+# the SQL decode to raw bytes, as in upstream test1.c.
+# ---------------------------------------------------------------------------
+
+db eval {CREATE TABLE te(a, b); INSERT INTO te VALUES (1, 2), (3, 4);}
+
+assert_eq "sqlite3_exec returns rc 0 plus names and rows" \
+    {0 {a b 1 2 3 4}} [sqlite3_exec db {SELECT * FROM te ORDER BY a}]
+assert_eq "sqlite3_exec renders NULL as the string NULL" \
+    {0 {x NULL}} [sqlite3_exec db {SELECT NULL AS x}]
+assert_eq "sqlite3_exec decodes %HH escapes" \
+    {0 {x 41}} [sqlite3_exec db {SELECT hex('%41') AS x}]
+assert_eq "sqlite3_exec reports SQL errors via rc" \
+    1 [lindex [sqlite3_exec db {SELECT * FROM no_such_table}] 0]
+set execerr [catch {sqlite3_exec nosuchdb {SELECT 1}} execmsg]
+assert_eq "sqlite3_exec errors on an unknown handle" 1 $execerr
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -605,6 +605,8 @@ static int TursoDbCmd(ClientData cd, Tcl_Interp *interp,
             return TCL_ERROR;
         }
 
+        bind_tcl_variables(interp, stmt);
+
         Tcl_Obj *result = Tcl_NewStringObj(null_str, -1);
         if (sqlite3_step(stmt) == SQLITE_ROW) {
             result = column_to_obj(stmt, 0, null_str);
@@ -629,6 +631,7 @@ static int TursoDbCmd(ClientData cd, Tcl_Interp *interp,
             Tcl_SetResult(interp, (char *)sqlite3_errmsg(tdb->db), TCL_VOLATILE);
             return TCL_ERROR;
         }
+        bind_tcl_variables(interp, stmt);
         int exists = (sqlite3_step(stmt) == SQLITE_ROW) ? 1 : 0;
         sqlite3_finalize(stmt);
         Tcl_SetObjResult(interp, Tcl_NewBooleanObj(exists));

--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -920,6 +920,34 @@ static int TursoExecCmd(ClientData cd, Tcl_Interp *interp,
     return TCL_OK;
 }
 
+/*
+ * sqlite3_connection_pointer DB
+ *
+ * Upstream test1.c returns the C-level sqlite3* for a TCL database
+ * handle so tests can hand it to C-API-level commands ("set DB
+ * [sqlite3_connection_pointer db]"). Our C-API commands resolve
+ * handles by command name, so the name itself is the pointer:
+ * validate that it names a database and return it unchanged.
+ */
+static int TursoConnectionPointerCmd(ClientData cd, Tcl_Interp *interp,
+                                     int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+
+    if (objc != 2) {
+        Tcl_WrongNumArgs(interp, 1, objv, "DB");
+        return TCL_ERROR;
+    }
+
+    const char *db_name = Tcl_GetString(objv[1]);
+    if (!find_turso_db(interp, db_name)) {
+        Tcl_AppendResult(interp, "no such database: ", db_name, NULL);
+        return TCL_ERROR;
+    }
+    Tcl_SetObjResult(interp, objv[1]);
+    return TCL_OK;
+}
+
 /* ------------------------------------------------------------------ */
 /* sqlite3 open command                                                 */
 /* ------------------------------------------------------------------ */
@@ -977,6 +1005,8 @@ int Tursotcl_Init(Tcl_Interp *interp)
 
     Tcl_CreateObjCommand(interp, "sqlite3", TursoOpenCmd, NULL, NULL);
     Tcl_CreateObjCommand(interp, "sqlite3_exec", TursoExecCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_connection_pointer",
+                         TursoConnectionPointerCmd, NULL, NULL);
 
     /* Link the global B-tree search counter so TCL tests can read/reset it. */
     Tcl_LinkVar(interp, "sqlite_search_count",

--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -15,6 +15,7 @@
  *   errmsg                      — most recent error message
  *   null ?value?                — get/set NULL representation string
  *   func name ?arg...? body     — register a Tcl-backed scalar SQL function
+ *   transaction ?type? script   — run script inside a transaction
  *   close                       — close database and delete command
  *   limit ...                   — stub returning a default value
  */
@@ -47,6 +48,7 @@ typedef struct TursoDb {
     Tcl_Obj    *null_obj;   /* replacement string for NULL values */
     CachedStmt  stmt_cache[STMT_CACHE_SIZE];
     int         cache_count;
+    int         txn_depth;  /* nesting depth of [db transaction] scripts */
 } TursoDb;
 
 /* ------------------------------------------------------------------ */
@@ -401,13 +403,13 @@ static int TursoDbCmd(ClientData cd, Tcl_Interp *interp,
     static const char *cmds[] = {
         "eval", "one", "exists", "changes", "total_changes",
         "last_insert_rowid", "errorcode", "errmsg", "null", "nullvalue",
-        "func", "function", "close", "limit",
+        "func", "function", "close", "limit", "transaction",
         NULL
     };
     enum {
         CMD_EVAL, CMD_ONE, CMD_EXISTS, CMD_CHANGES, CMD_TOTAL_CHANGES,
         CMD_LAST_INSERT_ROWID, CMD_ERRORCODE, CMD_ERRMSG, CMD_NULL, CMD_NULLVALUE,
-        CMD_FUNC, CMD_FUNCTION, CMD_CLOSE, CMD_LIMIT
+        CMD_FUNC, CMD_FUNCTION, CMD_CLOSE, CMD_LIMIT, CMD_TRANSACTION
     };
     int cmdIdx;
 
@@ -470,6 +472,79 @@ static int TursoDbCmd(ClientData cd, Tcl_Interp *interp,
     case CMD_LIMIT:
         Tcl_SetObjResult(interp, Tcl_NewIntObj(1000000));
         return TCL_OK;
+
+    /* ---- transaction ---- */
+
+    case CMD_TRANSACTION: {
+        /*
+         * db transaction ?deferred|immediate|exclusive? script
+         *
+         * Runs the script inside a transaction, committing on success and
+         * rolling back if the script raises an error. Follows upstream
+         * tclsqlite: a nested [db transaction] uses a savepoint so only the
+         * outermost level owns the real BEGIN/COMMIT.
+         */
+        static const char *types[] = {
+            "deferred", "exclusive", "immediate", NULL
+        };
+        static const char *begins[] = {
+            "BEGIN", "BEGIN EXCLUSIVE", "BEGIN IMMEDIATE"
+        };
+
+        const char *begin_sql = "BEGIN";
+        Tcl_Obj    *script;
+
+        if (objc == 3) {
+            script = objv[2];
+        } else if (objc == 4) {
+            int type_idx;
+            if (Tcl_GetIndexFromObj(interp, objv[2], types, "transaction type",
+                                    0, &type_idx) != TCL_OK) {
+                return TCL_ERROR;
+            }
+            begin_sql = begins[type_idx];
+            script = objv[3];
+        } else {
+            Tcl_WrongNumArgs(interp, 2, objv, "?TYPE? SCRIPT");
+            return TCL_ERROR;
+        }
+
+        if (tdb->txn_depth > 0) {
+            begin_sql = "SAVEPOINT _tcl_transaction";
+        }
+
+        if (sqlite3_exec(tdb->db, begin_sql, NULL, NULL, NULL) != SQLITE_OK) {
+            Tcl_SetResult(interp, (char *)sqlite3_errmsg(tdb->db), TCL_VOLATILE);
+            return TCL_ERROR;
+        }
+
+        tdb->txn_depth++;
+        int rc = Tcl_EvalObjEx(interp, script, 0);
+        tdb->txn_depth--;
+
+        const char *end_sql;
+        if (rc == TCL_ERROR) {
+            end_sql = tdb->txn_depth > 0
+                ? "ROLLBACK TO _tcl_transaction; RELEASE _tcl_transaction"
+                : "ROLLBACK";
+        } else {
+            end_sql = tdb->txn_depth > 0
+                ? "RELEASE _tcl_transaction"
+                : "COMMIT";
+        }
+
+        if (sqlite3_exec(tdb->db, end_sql, NULL, NULL, NULL) != SQLITE_OK) {
+            /* The commit (or release) itself failed: surface that error and
+             * abandon the transaction so the connection is usable again. */
+            if (rc != TCL_ERROR) {
+                Tcl_SetResult(interp, (char *)sqlite3_errmsg(tdb->db),
+                              TCL_VOLATILE);
+                rc = TCL_ERROR;
+            }
+            sqlite3_exec(tdb->db, "ROLLBACK", NULL, NULL, NULL);
+        }
+        return rc;
+    }
 
     /* ---- eval ---- */
 
@@ -756,6 +831,7 @@ static int TursoOpenCmd(ClientData cd, Tcl_Interp *interp,
     tdb->interp      = interp;
     tdb->null_obj    = NULL;
     tdb->cache_count = 0;
+    tdb->txn_depth   = 0;
 
     Tcl_CreateObjCommand(interp, handle_name, TursoDbCmd,
                          (ClientData)tdb, TursoDbFree);

--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -949,6 +949,228 @@ static int TursoConnectionPointerCmd(ClientData cd, Tcl_Interp *interp,
 }
 
 /* ------------------------------------------------------------------ */
+/* sqlite3_blob_* commands                                              */
+/* ------------------------------------------------------------------ */
+
+/* Symbolic name of a primary result code, as upstream sqlite3ErrName;
+ * the blob tests match on these (e.g. {1 SQLITE_ERROR}). */
+static const char *turso_err_name(int rc)
+{
+    switch (rc & 0xff) {
+    case 0:   return "SQLITE_OK";
+    case 1:   return "SQLITE_ERROR";
+    case 2:   return "SQLITE_INTERNAL";
+    case 3:   return "SQLITE_PERM";
+    case 4:   return "SQLITE_ABORT";
+    case 5:   return "SQLITE_BUSY";
+    case 6:   return "SQLITE_LOCKED";
+    case 7:   return "SQLITE_NOMEM";
+    case 8:   return "SQLITE_READONLY";
+    case 9:   return "SQLITE_INTERRUPT";
+    case 10:  return "SQLITE_IOERR";
+    case 11:  return "SQLITE_CORRUPT";
+    case 12:  return "SQLITE_NOTFOUND";
+    case 13:  return "SQLITE_FULL";
+    case 14:  return "SQLITE_CANTOPEN";
+    case 17:  return "SQLITE_SCHEMA";
+    case 18:  return "SQLITE_TOOBIG";
+    case 19:  return "SQLITE_CONSTRAINT";
+    case 20:  return "SQLITE_MISMATCH";
+    case 21:  return "SQLITE_MISUSE";
+    case 25:  return "SQLITE_RANGE";
+    case 100: return "SQLITE_ROW";
+    case 101: return "SQLITE_DONE";
+    default:  return "SQLITE_ERROR";
+    }
+}
+
+/* Open blob handles, keyed by a generated name so a stale or garbage
+ * handle argument is a clean TCL error instead of a wild pointer. */
+typedef struct BlobHandle {
+    void              *blob;
+    char               name[24];
+    struct BlobHandle *next;
+} BlobHandle;
+
+static BlobHandle *blob_handles      = NULL;
+static int         blob_handle_seq   = 0;
+
+static BlobHandle *find_blob_handle(Tcl_Interp *interp, Tcl_Obj *name_obj)
+{
+    const char *name = Tcl_GetString(name_obj);
+    BlobHandle *h;
+    for (h = blob_handles; h; h = h->next) {
+        if (strcmp(h->name, name) == 0) return h;
+    }
+    Tcl_AppendResult(interp, "no such blob handle: ", name, NULL);
+    return NULL;
+}
+
+/*
+ * sqlite3_blob_open DB DBNAME TABLE COLUMN ROWID FLAGS VARNAME
+ *
+ * The upstream test1.c command over the sqlite3_blob_open C API: on
+ * success VARNAME is set to a handle for the other sqlite3_blob_*
+ * commands; on failure the symbolic result code is raised as the TCL
+ * error, which is what the tests match on.
+ */
+static int TursoBlobOpenCmd(ClientData cd, Tcl_Interp *interp,
+                            int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+
+    if (objc != 8) {
+        Tcl_WrongNumArgs(interp, 1, objv,
+                         "DB DBNAME TABLE COLUMN ROWID FLAGS VARNAME");
+        return TCL_ERROR;
+    }
+
+    TursoDb *tdb = find_turso_db(interp, Tcl_GetString(objv[1]));
+    if (!tdb) {
+        /* Upstream reports a non-database first argument as misuse. */
+        Tcl_SetResult(interp, (char *)"SQLITE_MISUSE", TCL_STATIC);
+        return TCL_ERROR;
+    }
+
+    Tcl_WideInt rowid;
+    int         flags;
+    if (Tcl_GetWideIntFromObj(interp, objv[5], &rowid) != TCL_OK) return TCL_ERROR;
+    if (Tcl_GetIntFromObj(interp, objv[6], &flags) != TCL_OK) return TCL_ERROR;
+
+    void *blob = NULL;
+    int rc = sqlite3_blob_open(tdb->db, Tcl_GetString(objv[2]),
+                               Tcl_GetString(objv[3]), Tcl_GetString(objv[4]),
+                               (int64_t)rowid, flags, &blob);
+    if (rc != 0) {
+        Tcl_SetResult(interp, (char *)turso_err_name(rc), TCL_STATIC);
+        return TCL_ERROR;
+    }
+
+    BlobHandle *h = (BlobHandle *)Tcl_Alloc(sizeof(BlobHandle));
+    h->blob = blob;
+    snprintf(h->name, sizeof(h->name), "incrblob_%d", ++blob_handle_seq);
+    h->next = blob_handles;
+    blob_handles = h;
+
+    if (Tcl_SetVar2Ex(interp, Tcl_GetString(objv[7]), NULL,
+                      Tcl_NewStringObj(h->name, -1),
+                      TCL_LEAVE_ERR_MSG) == NULL) {
+        return TCL_ERROR;
+    }
+    Tcl_ResetResult(interp);
+    return TCL_OK;
+}
+
+/* sqlite3_blob_bytes HANDLE */
+static int TursoBlobBytesCmd(ClientData cd, Tcl_Interp *interp,
+                             int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    if (objc != 2) {
+        Tcl_WrongNumArgs(interp, 1, objv, "HANDLE");
+        return TCL_ERROR;
+    }
+    BlobHandle *h = find_blob_handle(interp, objv[1]);
+    if (!h) return TCL_ERROR;
+    Tcl_SetObjResult(interp, Tcl_NewIntObj(sqlite3_blob_bytes(h->blob)));
+    return TCL_OK;
+}
+
+/* sqlite3_blob_read HANDLE OFFSET N — returns N bytes as a byte array */
+static int TursoBlobReadCmd(ClientData cd, Tcl_Interp *interp,
+                            int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    if (objc != 4) {
+        Tcl_WrongNumArgs(interp, 1, objv, "HANDLE OFFSET N");
+        return TCL_ERROR;
+    }
+    BlobHandle *h = find_blob_handle(interp, objv[1]);
+    if (!h) return TCL_ERROR;
+
+    int offset, n;
+    if (Tcl_GetIntFromObj(interp, objv[2], &offset) != TCL_OK) return TCL_ERROR;
+    if (Tcl_GetIntFromObj(interp, objv[3], &n) != TCL_OK) return TCL_ERROR;
+    if (n < 0) {
+        Tcl_SetResult(interp, (char *)"SQLITE_ERROR", TCL_STATIC);
+        return TCL_ERROR;
+    }
+
+    unsigned char *buf = (unsigned char *)Tcl_Alloc(n > 0 ? n : 1);
+    int rc = sqlite3_blob_read(h->blob, buf, n, offset);
+    if (rc != 0) {
+        Tcl_Free((char *)buf);
+        Tcl_SetResult(interp, (char *)turso_err_name(rc), TCL_STATIC);
+        return TCL_ERROR;
+    }
+    Tcl_SetObjResult(interp, Tcl_NewByteArrayObj(buf, n));
+    Tcl_Free((char *)buf);
+    return TCL_OK;
+}
+
+/* sqlite3_blob_write HANDLE OFFSET DATA ?NDATA? */
+static int TursoBlobWriteCmd(ClientData cd, Tcl_Interp *interp,
+                             int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    if (objc != 4 && objc != 5) {
+        Tcl_WrongNumArgs(interp, 1, objv, "HANDLE OFFSET DATA ?NDATA?");
+        return TCL_ERROR;
+    }
+    BlobHandle *h = find_blob_handle(interp, objv[1]);
+    if (!h) return TCL_ERROR;
+
+    int offset;
+    if (Tcl_GetIntFromObj(interp, objv[2], &offset) != TCL_OK) return TCL_ERROR;
+
+    Tcl_Size        data_len;
+    unsigned char  *data = Tcl_GetByteArrayFromObj(objv[3], &data_len);
+    int             n    = (int)data_len;
+    if (objc == 5) {
+        if (Tcl_GetIntFromObj(interp, objv[4], &n) != TCL_OK) return TCL_ERROR;
+        if (n > (int)data_len) n = (int)data_len;
+    }
+
+    int rc = sqlite3_blob_write(h->blob, data, n, offset);
+    if (rc != 0) {
+        Tcl_SetResult(interp, (char *)turso_err_name(rc), TCL_STATIC);
+        return TCL_ERROR;
+    }
+    return TCL_OK;
+}
+
+/* sqlite3_blob_close HANDLE */
+static int TursoBlobCloseCmd(ClientData cd, Tcl_Interp *interp,
+                             int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    if (objc != 2) {
+        Tcl_WrongNumArgs(interp, 1, objv, "HANDLE");
+        return TCL_ERROR;
+    }
+    BlobHandle *h = find_blob_handle(interp, objv[1]);
+    if (!h) return TCL_ERROR;
+
+    int rc = sqlite3_blob_close(h->blob);
+
+    /* The handle is spent even when close reports an error. */
+    BlobHandle **pp;
+    for (pp = &blob_handles; *pp; pp = &(*pp)->next) {
+        if (*pp == h) {
+            *pp = h->next;
+            break;
+        }
+    }
+    Tcl_Free((char *)h);
+
+    if (rc != 0) {
+        Tcl_SetResult(interp, (char *)turso_err_name(rc), TCL_STATIC);
+        return TCL_ERROR;
+    }
+    return TCL_OK;
+}
+
+/* ------------------------------------------------------------------ */
 /* btree_varint_test command                                            */
 /* ------------------------------------------------------------------ */
 
@@ -1355,6 +1577,17 @@ int Tursotcl_Init(Tcl_Interp *interp)
 
     Tcl_CreateObjCommand(interp, "btree_varint_test",
                          TursoBtreeVarintTestCmd, NULL, NULL);
+
+    Tcl_CreateObjCommand(interp, "sqlite3_blob_open",
+                         TursoBlobOpenCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_blob_bytes",
+                         TursoBlobBytesCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_blob_read",
+                         TursoBlobReadCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_blob_write",
+                         TursoBlobWriteCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_blob_close",
+                         TursoBlobCloseCmd, NULL, NULL);
 
     Tcl_CreateObjCommand(interp, "sqlite3_mprintf_int",
                          TursoMprintfIntCmd, NULL, NULL);

--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -949,6 +949,77 @@ static int TursoConnectionPointerCmd(ClientData cd, Tcl_Interp *interp,
 }
 
 /* ------------------------------------------------------------------ */
+/* btree_varint_test command                                            */
+/* ------------------------------------------------------------------ */
+
+/* Test-only varint codec exports from the sqlite3 Rust crate
+ * (bindings/c/src/lib.rs); both operate on 9-byte buffers. */
+extern int turso_test_put_varint(unsigned char *buf,
+                                 unsigned long long value);
+extern int turso_test_get_varint(const unsigned char *buf,
+                                 unsigned long long *out);
+
+/*
+ * btree_varint_test START MULTIPLIER COUNT INCREMENT
+ *
+ * The upstream test3.c command: starting from START*MULTIPLIER and
+ * stepping by INCREMENT, write each value with the engine's varint
+ * encoder, read it back with the decoder, and verify byte count and
+ * value survive the round trip. Returns nothing on success and an
+ * error describing the first mismatch otherwise. Here the codec under
+ * test is core's write_varint/read_varint — the one the storage layer
+ * uses for every cell — not a harness reimplementation.
+ */
+static int TursoBtreeVarintTestCmd(ClientData cd, Tcl_Interp *interp,
+                                   int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+
+    Tcl_WideInt args[4];
+    int i;
+    if (objc != 5) {
+        Tcl_WrongNumArgs(interp, 1, objv, "START MULTIPLIER COUNT INCREMENT");
+        return TCL_ERROR;
+    }
+    for (i = 0; i < 4; i++) {
+        if (Tcl_GetWideIntFromObj(interp, objv[i + 1], &args[i]) != TCL_OK) {
+            return TCL_ERROR;
+        }
+    }
+
+    unsigned long long in   = (unsigned int)args[0];
+    unsigned long long incr = (unsigned int)args[3];
+    Tcl_WideInt        count = args[2];
+    in *= (unsigned int)args[1];
+
+    Tcl_WideInt iter;
+    for (iter = 0; iter < count; iter++) {
+        unsigned char      buf[16];
+        unsigned long long out = 0;
+
+        int n1 = turso_test_put_varint(buf, in);
+        if (n1 < 1 || n1 > 9) {
+            Tcl_SetObjResult(interp, Tcl_ObjPrintf(
+                "putVarint returned %d - should be between 1 and 9", n1));
+            return TCL_ERROR;
+        }
+        int n2 = turso_test_get_varint(buf, &out);
+        if (n1 != n2) {
+            Tcl_SetObjResult(interp, Tcl_ObjPrintf(
+                "putVarint returned %d and getVarint returned %d", n1, n2));
+            return TCL_ERROR;
+        }
+        if (in != out) {
+            Tcl_SetObjResult(interp, Tcl_ObjPrintf(
+                "Wrote 0x%016llx and got back 0x%016llx", in, out));
+            return TCL_ERROR;
+        }
+        in += incr;
+    }
+    return TCL_OK;
+}
+
+/* ------------------------------------------------------------------ */
 /* sqlite3_mprintf / sqlite3_snprintf test-harness commands             */
 /* ------------------------------------------------------------------ */
 
@@ -1281,6 +1352,9 @@ int Tursotcl_Init(Tcl_Interp *interp)
     Tcl_CreateObjCommand(interp, "sqlite3_exec", TursoExecCmd, NULL, NULL);
     Tcl_CreateObjCommand(interp, "sqlite3_connection_pointer",
                          TursoConnectionPointerCmd, NULL, NULL);
+
+    Tcl_CreateObjCommand(interp, "btree_varint_test",
+                         TursoBtreeVarintTestCmd, NULL, NULL);
 
     Tcl_CreateObjCommand(interp, "sqlite3_mprintf_int",
                          TursoMprintfIntCmd, NULL, NULL);

--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -1171,6 +1171,131 @@ static int TursoBlobCloseCmd(ClientData cd, Tcl_Interp *interp,
 }
 
 /* ------------------------------------------------------------------ */
+/* sqlite3BitvecBuiltinTest command                                     */
+/* ------------------------------------------------------------------ */
+
+#define BV_SETBIT(p, n)  ((p)[(n) >> 3] |= (unsigned char)(1 << ((n) & 7)))
+#define BV_CLEARBIT(p, n) ((p)[(n) >> 3] &= (unsigned char)~(1 << ((n) & 7)))
+#define BV_TESTBIT(p, n) (((p)[(n) >> 3] >> ((n) & 7)) & 1)
+
+/* Deterministic stand-in for sqlite3_randomness in the bitvec test
+ * program; the expected results do not depend on the values drawn. */
+static unsigned int bitvec_rand(void)
+{
+    static unsigned int state = 0x9e3779b9u;
+    state ^= state << 13;
+    state ^= state >> 17;
+    state ^= state << 5;
+    return state;
+}
+
+/*
+ * sqlite3BitvecBuiltinTest SIZE PROGRAM
+ *
+ * Faithful port of upstream sqlite3BitvecBuiltinTest (bitvec.c): runs
+ * the PROGRAM opcodes against a bitmap under test and a reference
+ * bitmap, then returns 0 if they agree or the index of the first
+ * mismatched bit. Turso has no C Bitvec object, so unlike upstream
+ * this validates the harness's program interpreter (opcode 5 writes
+ * only the reference, which is how bitvec.test checks that deliberate
+ * mismatches are detected), not an engine data structure. It exists
+ * so bitvec.test runs instead of aborting.
+ *
+ * Opcodes: 1=set linear, 2=clear linear, 3=set random, 4=clear random,
+ * 5=set reference only; each instruction is {op count start incr} for
+ * linear ops and {op count} for random ops, 0 terminates.
+ */
+static int TursoBitvecBuiltinTestCmd(ClientData cd, Tcl_Interp *interp,
+                                     int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+
+    if (objc != 3) {
+        Tcl_WrongNumArgs(interp, 1, objv, "SIZE PROGRAM");
+        return TCL_ERROR;
+    }
+
+    int sz;
+    if (Tcl_GetIntFromObj(interp, objv[1], &sz) != TCL_OK) return TCL_ERROR;
+    if (sz < 1) {
+        Tcl_AppendResult(interp, "SIZE must be at least 1", NULL);
+        return TCL_ERROR;
+    }
+
+    Tcl_Size  prog_len;
+    Tcl_Obj **prog_objs;
+    if (Tcl_ListObjGetElements(interp, objv[2],
+                               &prog_len, &prog_objs) != TCL_OK) {
+        return TCL_ERROR;
+    }
+
+    /* Mutable copy: the interpreter advances the start operand of linear
+     * instructions in place, as upstream does. Zero-padded so a program
+     * truncated mid-instruction reads harmless zeros instead of running
+     * off the end. */
+    int *ops = (int *)Tcl_Alloc((prog_len + 4) * sizeof(int));
+    memset(ops, 0, (prog_len + 4) * sizeof(int));
+    Tcl_Size k;
+    for (k = 0; k < prog_len; k++) {
+        if (Tcl_GetIntFromObj(interp, prog_objs[k], &ops[k]) != TCL_OK) {
+            Tcl_Free((char *)ops);
+            return TCL_ERROR;
+        }
+    }
+
+    size_t         nbytes = (size_t)(sz + 7) / 8 + 1;
+    unsigned char *bv     = (unsigned char *)Tcl_Alloc(nbytes);
+    unsigned char *ref    = (unsigned char *)Tcl_Alloc(nbytes);
+    memset(bv, 0, nbytes);
+    memset(ref, 0, nbytes);
+
+    int pc = 0;
+    unsigned int i = 0;
+    int op;
+    while (pc <= (int)prog_len && (op = ops[pc]) != 0) {
+        int nx;
+        switch (op) {
+        case 1:
+        case 2:
+        case 5:
+            nx = 4;
+            i = (unsigned int)(ops[pc + 2] - 1);
+            ops[pc + 2] += ops[pc + 3];
+            break;
+        default:
+            nx = 2;
+            i = bitvec_rand();
+            break;
+        }
+        if (--ops[pc + 1] > 0) nx = 0;
+        pc += nx;
+        i = (i & 0x7fffffff) % (unsigned int)sz;
+        if (op & 1) {
+            BV_SETBIT(ref, i + 1);
+            if (op != 5) BV_SETBIT(bv, i + 1);
+        } else {
+            BV_CLEARBIT(ref, i + 1);
+            BV_CLEARBIT(bv, i + 1);
+        }
+    }
+
+    int rc = 0;
+    int bit;
+    for (bit = 1; bit <= sz; bit++) {
+        if (BV_TESTBIT(ref, bit) != BV_TESTBIT(bv, bit)) {
+            rc = bit;
+            break;
+        }
+    }
+
+    Tcl_Free((char *)ops);
+    Tcl_Free((char *)bv);
+    Tcl_Free((char *)ref);
+    Tcl_SetObjResult(interp, Tcl_NewIntObj(rc));
+    return TCL_OK;
+}
+
+/* ------------------------------------------------------------------ */
 /* btree_varint_test command                                            */
 /* ------------------------------------------------------------------ */
 
@@ -1577,6 +1702,8 @@ int Tursotcl_Init(Tcl_Interp *interp)
 
     Tcl_CreateObjCommand(interp, "btree_varint_test",
                          TursoBtreeVarintTestCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3BitvecBuiltinTest",
+                         TursoBitvecBuiltinTestCmd, NULL, NULL);
 
     Tcl_CreateObjCommand(interp, "sqlite3_blob_open",
                          TursoBlobOpenCmd, NULL, NULL);

--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -800,6 +800,127 @@ static int TursoDbCmd(ClientData cd, Tcl_Interp *interp,
 }
 
 /* ------------------------------------------------------------------ */
+/* sqlite3_exec command                                                 */
+/* ------------------------------------------------------------------ */
+
+/* Resolve a database handle name (e.g. "db") to its TursoDb state, or
+ * NULL if the name is not a database command created by [sqlite3]. */
+static TursoDb *find_turso_db(Tcl_Interp *interp, const char *name)
+{
+    Tcl_CmdInfo info;
+    if (!Tcl_GetCommandInfo(interp, name, &info)) return NULL;
+    if (info.objProc != TursoDbCmd) return NULL;
+    return (TursoDb *)info.objClientData;
+}
+
+static int hex_to_int(int c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+/* Row callback for TursoExecCmd: mirrors upstream test1.c exec_printf_cb.
+ * The first row appends the column names, then every row appends its
+ * values, with NULL rendered as the string "NULL". */
+typedef struct ExecCbState {
+    Tcl_Interp *interp;
+    Tcl_Obj    *list;
+    int         seen_row;
+} ExecCbState;
+
+static int exec_collect_cb(void *ctx, int argc, char **argv, char **colv)
+{
+    ExecCbState *s = (ExecCbState *)ctx;
+    int i;
+    if (!s->seen_row) {
+        for (i = 0; i < argc; i++) {
+            Tcl_ListObjAppendElement(s->interp, s->list,
+                Tcl_NewStringObj(colv[i] ? colv[i] : "", -1));
+        }
+        s->seen_row = 1;
+    }
+    for (i = 0; i < argc; i++) {
+        Tcl_ListObjAppendElement(s->interp, s->list,
+            Tcl_NewStringObj(argv[i] ? argv[i] : "NULL", -1));
+    }
+    return 0;
+}
+
+/*
+ * sqlite3_exec DB SQL
+ *
+ * The upstream test-harness command from test1.c: runs SQL through the
+ * sqlite3_exec C API and returns a two-element list {rc results}, where
+ * results is column names followed by row values on success, or the error
+ * message on failure. "%HH" sequences in the SQL are decoded to raw bytes
+ * first, which is how upstream tests inject invalid UTF-8 into statements.
+ */
+static int TursoExecCmd(ClientData cd, Tcl_Interp *interp,
+                        int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+
+    if (objc != 3) {
+        Tcl_WrongNumArgs(interp, 1, objv, "DB SQL");
+        return TCL_ERROR;
+    }
+
+    const char *db_name = Tcl_GetString(objv[1]);
+    TursoDb *tdb = find_turso_db(interp, db_name);
+    if (!tdb) {
+        Tcl_AppendResult(interp, "no such database: ", db_name, NULL);
+        return TCL_ERROR;
+    }
+
+    /* Copy the SQL, decoding %HH escapes. Unlike upstream, only decode
+     * when two hex digits follow, so a stray '%' (e.g. a LIKE pattern)
+     * passes through unchanged. */
+    Tcl_Size    in_len;
+    const char *in  = Tcl_GetStringFromObj(objv[2], &in_len);
+    char       *sql = Tcl_Alloc(in_len + 1);
+    Tcl_Size    i, j;
+    for (i = j = 0; i < in_len;) {
+        if (in[i] == '%' && i + 2 < in_len &&
+            hex_to_int(in[i + 1]) >= 0 && hex_to_int(in[i + 2]) >= 0) {
+            sql[j++] = (char)((hex_to_int(in[i + 1]) << 4)
+                              | hex_to_int(in[i + 2]));
+            i += 3;
+        } else {
+            sql[j++] = in[i++];
+        }
+    }
+    sql[j] = '\0';
+
+    ExecCbState st;
+    st.interp   = interp;
+    st.list     = Tcl_NewListObj(0, NULL);
+    st.seen_row = 0;
+    Tcl_IncrRefCount(st.list);
+
+    char *zerr = NULL;
+    int rc = sqlite3_exec(tdb->db, sql, exec_collect_cb, &st, &zerr);
+    Tcl_Free(sql);
+
+    Tcl_Obj *result = Tcl_NewListObj(0, NULL);
+    Tcl_ListObjAppendElement(interp, result, Tcl_NewIntObj(rc));
+    if (rc == 0) {
+        Tcl_ListObjAppendElement(interp, result, st.list);
+    } else {
+        Tcl_ListObjAppendElement(interp, result,
+            Tcl_NewStringObj(zerr ? zerr : sqlite3_errmsg(tdb->db), -1));
+    }
+    Tcl_DecrRefCount(st.list);
+    if (zerr) sqlite3_free(zerr);
+
+    /* Like upstream, an SQL error is reported through the returned rc, not
+     * as a TCL error, so tests can match on {1 {error message}}. */
+    Tcl_SetObjResult(interp, result);
+    return TCL_OK;
+}
+
+/* ------------------------------------------------------------------ */
 /* sqlite3 open command                                                 */
 /* ------------------------------------------------------------------ */
 
@@ -855,6 +976,7 @@ int Tursotcl_Init(Tcl_Interp *interp)
     turso_enable_experimental();
 
     Tcl_CreateObjCommand(interp, "sqlite3", TursoOpenCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_exec", TursoExecCmd, NULL, NULL);
 
     /* Link the global B-tree search counter so TCL tests can read/reset it. */
     Tcl_LinkVar(interp, "sqlite_search_count",

--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -949,6 +949,280 @@ static int TursoConnectionPointerCmd(ClientData cd, Tcl_Interp *interp,
 }
 
 /* ------------------------------------------------------------------ */
+/* sqlite3_mprintf / sqlite3_snprintf test-harness commands             */
+/* ------------------------------------------------------------------ */
+
+/* The upstream test1.c printf commands: each formats through the real
+ * sqlite3_mprintf/sqlite3_snprintf C API (backed by core's printf
+ * engine), so the printf.test expectations exercise turso's formatter
+ * rather than a reimplementation. */
+
+static void mprintf_result(Tcl_Interp *interp, char *z)
+{
+    Tcl_SetObjResult(interp, Tcl_NewStringObj(z ? z : "", -1));
+    if (z) sqlite3_free(z);
+}
+
+/* Parse a TCL integer that may exceed 32 bits (e.g. 0xffffffff),
+ * wrapping to the C type at the call site like upstream's Tcl_GetInt. */
+static int get_wide(Tcl_Interp *interp, Tcl_Obj *obj, Tcl_WideInt *out)
+{
+    return Tcl_GetWideIntFromObj(interp, obj, out);
+}
+
+/* sqlite3_mprintf_int FORMAT INT INT INT */
+static int TursoMprintfIntCmd(ClientData cd, Tcl_Interp *interp,
+                              int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    Tcl_WideInt a[3];
+    int i;
+    if (objc != 5) {
+        Tcl_WrongNumArgs(interp, 1, objv, "FORMAT INT INT INT");
+        return TCL_ERROR;
+    }
+    for (i = 0; i < 3; i++) {
+        if (get_wide(interp, objv[i + 2], &a[i]) != TCL_OK) return TCL_ERROR;
+    }
+    mprintf_result(interp, sqlite3_mprintf(Tcl_GetString(objv[1]),
+        (int)a[0], (int)a[1], (int)a[2]));
+    return TCL_OK;
+}
+
+/* sqlite3_mprintf_int64 FORMAT INT INT INT */
+static int TursoMprintfInt64Cmd(ClientData cd, Tcl_Interp *interp,
+                                int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    Tcl_WideInt a[3];
+    int i;
+    if (objc != 5) {
+        Tcl_WrongNumArgs(interp, 1, objv, "FORMAT INT INT INT");
+        return TCL_ERROR;
+    }
+    for (i = 0; i < 3; i++) {
+        if (get_wide(interp, objv[i + 2], &a[i]) != TCL_OK) return TCL_ERROR;
+    }
+    mprintf_result(interp, sqlite3_mprintf(Tcl_GetString(objv[1]),
+        (long long)a[0], (long long)a[1], (long long)a[2]));
+    return TCL_OK;
+}
+
+/* sqlite3_mprintf_long FORMAT INT INT INT
+ * As in upstream, each argument is truncated to 32 bits before being
+ * passed as a C long, so 0xffffffff formats as 4294967295 via %lu. */
+static int TursoMprintfLongCmd(ClientData cd, Tcl_Interp *interp,
+                               int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    Tcl_WideInt a[3];
+    long v[3];
+    int i;
+    if (objc != 5) {
+        Tcl_WrongNumArgs(interp, 1, objv, "FORMAT INT INT INT");
+        return TCL_ERROR;
+    }
+    for (i = 0; i < 3; i++) {
+        if (get_wide(interp, objv[i + 2], &a[i]) != TCL_OK) return TCL_ERROR;
+        v[i] = (long)(a[i] & 0xffffffffLL);
+    }
+    mprintf_result(interp, sqlite3_mprintf(Tcl_GetString(objv[1]),
+        v[0], v[1], v[2]));
+    return TCL_OK;
+}
+
+/* sqlite3_mprintf_str FORMAT INT INT ?STRING? */
+static int TursoMprintfStrCmd(ClientData cd, Tcl_Interp *interp,
+                              int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    Tcl_WideInt a[2];
+    int i;
+    if (objc != 4 && objc != 5) {
+        Tcl_WrongNumArgs(interp, 1, objv, "FORMAT INT INT ?STRING?");
+        return TCL_ERROR;
+    }
+    for (i = 0; i < 2; i++) {
+        if (get_wide(interp, objv[i + 2], &a[i]) != TCL_OK) return TCL_ERROR;
+    }
+    mprintf_result(interp, sqlite3_mprintf(Tcl_GetString(objv[1]),
+        (int)a[0], (int)a[1], objc == 5 ? Tcl_GetString(objv[4]) : NULL));
+    return TCL_OK;
+}
+
+/* sqlite3_mprintf_stronly FORMAT STRING */
+static int TursoMprintfStronlyCmd(ClientData cd, Tcl_Interp *interp,
+                                  int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    if (objc != 3) {
+        Tcl_WrongNumArgs(interp, 1, objv, "FORMAT STRING");
+        return TCL_ERROR;
+    }
+    mprintf_result(interp,
+        sqlite3_mprintf(Tcl_GetString(objv[1]), Tcl_GetString(objv[2])));
+    return TCL_OK;
+}
+
+/* sqlite3_mprintf_double FORMAT INT INT DOUBLE */
+static int TursoMprintfDoubleCmd(ClientData cd, Tcl_Interp *interp,
+                                 int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    Tcl_WideInt a[2];
+    double r;
+    int i;
+    if (objc != 5) {
+        Tcl_WrongNumArgs(interp, 1, objv, "FORMAT INT INT DOUBLE");
+        return TCL_ERROR;
+    }
+    for (i = 0; i < 2; i++) {
+        if (get_wide(interp, objv[i + 2], &a[i]) != TCL_OK) return TCL_ERROR;
+    }
+    if (Tcl_GetDoubleFromObj(interp, objv[4], &r) != TCL_OK) return TCL_ERROR;
+    mprintf_result(interp, sqlite3_mprintf(Tcl_GetString(objv[1]),
+        (int)a[0], (int)a[1], r));
+    return TCL_OK;
+}
+
+/* sqlite3_mprintf_scaled FORMAT DOUBLE DOUBLE
+ * Formats the product of the two doubles; the tests use this to reach
+ * magnitudes (e.g. 1e308) that TCL literals cannot spell exactly. */
+static int TursoMprintfScaledCmd(ClientData cd, Tcl_Interp *interp,
+                                 int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    double r[2];
+    int i;
+    if (objc != 4) {
+        Tcl_WrongNumArgs(interp, 1, objv, "FORMAT DOUBLE DOUBLE");
+        return TCL_ERROR;
+    }
+    for (i = 0; i < 2; i++) {
+        if (Tcl_GetDoubleFromObj(interp, objv[i + 2], &r[i]) != TCL_OK) {
+            return TCL_ERROR;
+        }
+    }
+    mprintf_result(interp,
+        sqlite3_mprintf(Tcl_GetString(objv[1]), r[0] * r[1]));
+    return TCL_OK;
+}
+
+/* sqlite3_mprintf_hexdouble FORMAT HEX
+ * HEX is the 16-hex-digit IEEE-754 bit pattern of the double to format,
+ * so tests can name exact values like Inf and denormals. */
+static int TursoMprintfHexdoubleCmd(ClientData cd, Tcl_Interp *interp,
+                                    int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    if (objc != 3) {
+        Tcl_WrongNumArgs(interp, 1, objv, "FORMAT HEX");
+        return TCL_ERROR;
+    }
+    const char *hex = Tcl_GetString(objv[2]);
+    unsigned long long bits = 0;
+    int i;
+    for (i = 0; hex[i]; i++) {
+        int d = hex_to_int(hex[i]);
+        if (d < 0 || i >= 16) {
+            Tcl_AppendResult(interp, "invalid hex double: ", hex, NULL);
+            return TCL_ERROR;
+        }
+        bits = (bits << 4) | (unsigned)d;
+    }
+    double r;
+    memcpy(&r, &bits, sizeof(r));
+    mprintf_result(interp, sqlite3_mprintf(Tcl_GetString(objv[1]), r));
+    return TCL_OK;
+}
+
+/* sqlite3_mprintf_z_test SEPARATOR ARG0 ARG1 ...
+ * Joins the arguments with the separator by repeatedly growing the
+ * result through the %z (format-and-free) specifier. */
+static int TursoMprintfZCmd(ClientData cd, Tcl_Interp *interp,
+                            int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    char *result = NULL;
+    int i;
+    if (objc < 2) {
+        Tcl_WrongNumArgs(interp, 1, objv, "SEPARATOR ?ARG...?");
+        return TCL_ERROR;
+    }
+    for (i = 2; i < objc && (i == 2 || result); i++) {
+        result = sqlite3_mprintf("%z%s%s", result,
+            Tcl_GetString(objv[1]), Tcl_GetString(objv[i]));
+    }
+    mprintf_result(interp, result);
+    return TCL_OK;
+}
+
+/* sqlite3_mprintf_n_test STRING
+ * Returns the character count that a trailing %n reports. */
+static int TursoMprintfNCmd(ClientData cd, Tcl_Interp *interp,
+                            int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    int n = 0;
+    if (objc != 2) {
+        Tcl_WrongNumArgs(interp, 1, objv, "STRING");
+        return TCL_ERROR;
+    }
+    char *z = sqlite3_mprintf("%s%n", Tcl_GetString(objv[1]), &n);
+    if (z) sqlite3_free(z);
+    Tcl_SetObjResult(interp, Tcl_NewIntObj(n));
+    return TCL_OK;
+}
+
+/* sqlite3_snprintf_int SIZE FORMAT INT
+ * The buffer is pre-filled with the alphabet so tests can verify that
+ * SIZE 0 leaves the buffer untouched. */
+static int TursoSnprintfIntCmd(ClientData cd, Tcl_Interp *interp,
+                               int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    char buf[100];
+    int n, x;
+    if (objc != 4) {
+        Tcl_WrongNumArgs(interp, 1, objv, "SIZE FORMAT INT");
+        return TCL_ERROR;
+    }
+    if (Tcl_GetIntFromObj(interp, objv[1], &n) != TCL_OK) return TCL_ERROR;
+    if (Tcl_GetIntFromObj(interp, objv[3], &x) != TCL_OK) return TCL_ERROR;
+    if (n > (int)sizeof(buf)) n = (int)sizeof(buf);
+    strcpy(buf, "abcdefghijklmnopqrstuvwxyz");
+    sqlite3_snprintf(n, buf, Tcl_GetString(objv[2]), x);
+    Tcl_SetObjResult(interp, Tcl_NewStringObj(buf, -1));
+    return TCL_OK;
+}
+
+/* sqlite3_snprintf_str SIZE FORMAT INT INT STRING */
+static int TursoSnprintfStrCmd(ClientData cd, Tcl_Interp *interp,
+                               int objc, Tcl_Obj *const objv[])
+{
+    (void)cd;
+    char buf[100];
+    int n, a0, a1;
+    if (objc != 6) {
+        Tcl_WrongNumArgs(interp, 1, objv, "SIZE FORMAT INT INT STRING");
+        return TCL_ERROR;
+    }
+    if (Tcl_GetIntFromObj(interp, objv[1], &n) != TCL_OK) return TCL_ERROR;
+    if (n < 0) {
+        Tcl_AppendResult(interp, "SIZE must be non-negative", NULL);
+        return TCL_ERROR;
+    }
+    if (Tcl_GetIntFromObj(interp, objv[3], &a0) != TCL_OK) return TCL_ERROR;
+    if (Tcl_GetIntFromObj(interp, objv[4], &a1) != TCL_OK) return TCL_ERROR;
+    if (n > (int)sizeof(buf)) n = (int)sizeof(buf);
+    buf[0] = '\0';
+    sqlite3_snprintf(n, buf, Tcl_GetString(objv[2]), a0, a1,
+                     Tcl_GetString(objv[5]));
+    Tcl_SetObjResult(interp, Tcl_NewStringObj(buf, -1));
+    return TCL_OK;
+}
+
+/* ------------------------------------------------------------------ */
 /* sqlite3 open command                                                 */
 /* ------------------------------------------------------------------ */
 
@@ -1007,6 +1281,31 @@ int Tursotcl_Init(Tcl_Interp *interp)
     Tcl_CreateObjCommand(interp, "sqlite3_exec", TursoExecCmd, NULL, NULL);
     Tcl_CreateObjCommand(interp, "sqlite3_connection_pointer",
                          TursoConnectionPointerCmd, NULL, NULL);
+
+    Tcl_CreateObjCommand(interp, "sqlite3_mprintf_int",
+                         TursoMprintfIntCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_mprintf_int64",
+                         TursoMprintfInt64Cmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_mprintf_long",
+                         TursoMprintfLongCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_mprintf_str",
+                         TursoMprintfStrCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_mprintf_stronly",
+                         TursoMprintfStronlyCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_mprintf_double",
+                         TursoMprintfDoubleCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_mprintf_scaled",
+                         TursoMprintfScaledCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_mprintf_hexdouble",
+                         TursoMprintfHexdoubleCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_mprintf_z_test",
+                         TursoMprintfZCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_mprintf_n_test",
+                         TursoMprintfNCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_snprintf_int",
+                         TursoSnprintfIntCmd, NULL, NULL);
+    Tcl_CreateObjCommand(interp, "sqlite3_snprintf_str",
+                         TursoSnprintfStrCmd, NULL, NULL);
 
     /* Link the global B-tree search counter so TCL tests can read/reset it. */
     Tcl_LinkVar(interp, "sqlite_search_count",

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -193,7 +193,7 @@ set test_files {
   distinct             fail
   distinct2            fail
   distinctagg          fail
-  e_blobbytes          fail
+  e_blobbytes          pass
   e_blobclose          fail
   e_blobopen           fail
   e_blobwrite          fail
@@ -229,7 +229,7 @@ set test_files {
   eval                 fail
   exclusive            fail
   exclusive2           fail
-  exec                 fail
+  exec                 pass
   exists               fail
   expr                 fail
   expr2                pass
@@ -767,7 +767,7 @@ set test_files {
   vacuum6              fail
   vacuummem            fail
   values               fail
-  varint               fail
+  varint               pass
   veryquick            fail
   view                 fail
   view2                pass

--- a/sqlite/conformance/upstream/tester.tcl
+++ b/sqlite/conformance/upstream/tester.tcl
@@ -75,6 +75,15 @@ if {![info exists ::tcl_precision]} {
 proc breakpoint {} {}
 proc do_not_use_codec {} {}
 
+# Name of the current test permutation, as in upstream tester.tcl. We only
+# run the default configuration, so this is "" unless a permutation script
+# sets G(perm:name).
+proc permutation {} {
+  set perm ""
+  catch {set perm $::G(perm:name)}
+  set perm
+}
+
 # Modern SQLite builds default to schema file format 4; upstream tests
 # read this to decide format-dependent expectations.
 if {![info exists ::SQLITE_DEFAULT_FILE_FORMAT]} {

--- a/sqlite/conformance/upstream/tester.tcl
+++ b/sqlite/conformance/upstream/tester.tcl
@@ -155,7 +155,12 @@ proc catchsql {sql {db db}} {
 # (15 significant digits vs shortest round-trip), so two renderings of one
 # value can differ in their last digits at any magnitude.
 proc floats_equal {a b} {
-  expr {abs($a - $b) <= 1e-12 * (abs($a) + abs($b) + 1.0)}
+  # NaN passes [string is double] but throws in expr arithmetic; treat any
+  # non-computable comparison as unequal instead of aborting the test file.
+  if {[catch {expr {abs($a - $b) <= 1e-12 * (abs($a) + abs($b) + 1.0)}} eq]} {
+    return 0
+  }
+  return $eq
 }
 
 # Main test execution function
@@ -352,6 +357,10 @@ set SQLITE_MAX_ATTACHED 10
 set SQLITE_MAX_VARIABLE_NUMBER 999
 set SQLITE_MAX_COLUMN 2000
 set SQLITE_MAX_SQL_LENGTH 1000000
+# Turso does not enforce SQLite's default 1e9 string-length limit, so
+# report the practical 32-bit cap; tests guarded on a smaller limit
+# (e.g. printf.test's 2e9-width allocation probe) skip themselves.
+set SQLITE_MAX_LENGTH 2147483647
 set SQLITE_MAX_EXPR_DEPTH 1000
 set SQLITE_MAX_LIKE_PATTERN_LENGTH 50000
 set SQLITE_MAX_TRIGGER_DEPTH 1000


### PR DESCRIPTION
## What this is

The upstream SQLite TCL suite was largely dead weight: around 400 of the imported files aborted on their first missing test-harness command and contributed nothing, and thousands of assertions in the files that did run compared garbage against garbage because the TCL bindings could not bind variables into SQL. This series fixes the harness layer end to end so the suite now executes ~170k real assertions per run: **162,018 / 170,065 passing (95.3%)**, with five files newly fully green and blessed.

## Variable binding and db subcommands

- `sqlite/parser`: accept namespace-qualified (`$::var`, `$ns::var`) and array-element (`$arr(elem)`) parameter names, matching sqlite3's tokenizer. This alone unblocks ~3,000 assertions (essentially all of `in2.test` and `date5.test`).
- `bindings/tcl`: bind TCL variables in `db one` and `db exists` — previously `db one {SELECT datetime($d1)}` silently bound NULL, so tests like `timediff1.test` compared empty strings on both sides (1,465 junk failures; the file now runs 1,520 real assertions with 113 honest failures).
- `bindings/tcl`: add the `db transaction` subcommand with upstream's savepoint-based nesting semantics.

## Missing test-harness commands

Ports of the upstream `test1.c`/`test3.c`/`bitvec.c` commands the imported files call, each wired to the real C API where one exists:

- `sqlite3_exec` (with `%HH` decoding) and `sqlite3_connection_pointer`
- the `sqlite3_mprintf_*`/`sqlite3_snprintf_*` family (12 commands), backed by the real `sqlite3_mprintf` and therefore core's printf engine — `printf.test` runs 1,374 assertions against the actual formatter instead of dying at line 65
- `btree_varint_test`, backed by test-only exports of core's `write_varint`/`read_varint`, so `varint.test`'s 160 round-trip cases exercise the codec the storage layer uses for every cell
- `sqlite3_blob_{open,read,write,bytes,close}` over the real incremental-blob C API
- `sqlite3BitvecBuiltinTest`, a faithful port of upstream's opcode interpreter (turso has no C Bitvec object, so this one validates the interpreter itself; it exists so `bitvec.test` runs its 43 cases instead of aborting)
- `permutation` and tester.tcl robustness fixes (`floats_equal` no longer aborts a whole file when a result is NaN; `SQLITE_MAX_LENGTH` is defined)

## A real deadlock fix in bindings/c

`sqlite3_step` held the handle's non-reentrant mutex across the whole step, so a scalar function that re-enters the C API on the same handle — which SQLite explicitly allows, and `e_blobclose.test` does — deadlocked the process. The lock protected nothing during the step (core's `Connection` is internally synchronized and the statement was never behind that lock), so it is now taken only on the error path.

## Newly blessed files

`date5` (874 tests), `e_blobbytes` (22), `exec` (3), `varint` (160) and `tkt-38cb5df375` (293) are now fully green and promoted to `pass` in `all.test` so they are guarded against regression. The CI timeout for the suite rises to 60 minutes since it now does two orders of magnitude more work.

## Engine bugs surfaced

Running the suite for real immediately paid off: `in2.test` — written for exactly this bug class in SQLite — now reaches a reproducible engine panic in `balance_non_root` (`core/storage/btree.rs:5024`, "corrupted database, cells were not balanced properly") when an ephemeral IN-subquery b-tree contains a zero-length text cell. Filed with a minimal deterministic repro as #8312. Known engine gaps also now surface as honest test failures instead of being masked (printf `%n` reports 0, NaN formats as `0.0`, `PRAGMA lock_status` unsupported).