### PR TITLE
SQLite-compatible error messages

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -3618,6 +3618,44 @@ mod tests {
     use super::*;
     use std::ptr;
 
+    /// sqlite3_errmsg must return the bare message SQLite produces — no
+    /// "Runtime error:" prefix and no "(19)" suffix; those are sqlite3
+    /// shell decoration, not part of the message.
+    #[test]
+    fn test_sqlite3_errmsg_constraint_failure_matches_sqlite() {
+        unsafe {
+            let mut db = ptr::null_mut();
+            assert_eq!(sqlite3_open(c":memory:".as_ptr(), &mut db), SQLITE_OK);
+            assert_eq!(
+                sqlite3_exec(
+                    db,
+                    c"CREATE TABLE u(a UNIQUE); INSERT INTO u VALUES (1);".as_ptr(),
+                    None,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+
+            let mut stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"INSERT INTO u VALUES (1)".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_CONSTRAINT);
+            let msg = CStr::from_ptr(sqlite3_errmsg(db)).to_str().unwrap();
+            assert_eq!(msg, "UNIQUE constraint failed: u.a");
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+        }
+    }
+
     #[test]
     fn test_sqlite3_stmt_status_rows_read_written() {
         unsafe {

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1936,33 +1936,33 @@ async fn test_typed_numeric_row_conversions() {
     assert!(matches!(
         row.get::<i32>(0),
         Err(Error::ConversionFailure(message))
-            if message == "Runtime error: integer overflow"
+            if message == "integer overflow"
     ));
     assert_eq!(row.get::<i32>(1).unwrap(), i32::MIN);
     assert_eq!(row.get::<i32>(2).unwrap(), i32::MAX);
     assert!(matches!(
         row.get::<i32>(3),
         Err(Error::ConversionFailure(message))
-            if message == "Runtime error: integer overflow"
+            if message == "integer overflow"
     ));
 
     assert!(matches!(
         row.get::<u32>(4),
         Err(Error::ConversionFailure(message))
-            if message == "Runtime error: integer overflow"
+            if message == "integer overflow"
     ));
     assert_eq!(row.get::<u32>(5).unwrap(), 0);
     assert_eq!(row.get::<u32>(6).unwrap(), u32::MAX);
     assert!(matches!(
         row.get::<u32>(7),
         Err(Error::ConversionFailure(message))
-            if message == "Runtime error: integer overflow"
+            if message == "integer overflow"
     ));
 
     assert!(matches!(
         row.get::<u64>(4),
         Err(Error::ConversionFailure(message))
-            if message == "Runtime error: integer overflow"
+            if message == "integer overflow"
     ));
     assert_eq!(row.get::<u64>(8).unwrap(), i64::MAX as u64);
 

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1367,7 +1367,13 @@ impl Limbo {
                 let _ = self.writeln("database is busy");
             }
             _ => {
-                let _ = self.writeln_fmt(format_args!("Error: {err}"));
+                // Mirror the sqlite3 shell: the bare sqlite3_errmsg text plus
+                // the result code, e.g.
+                // "Runtime error: UNIQUE constraint failed: t.a (19)".
+                let _ = self.writeln_fmt(format_args!(
+                    "Runtime error: {err} ({})",
+                    err.sqlite_result_code()
+                ));
             }
         }
     }

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1370,10 +1370,13 @@ impl Limbo {
                 // Mirror the sqlite3 shell: the bare sqlite3_errmsg text plus
                 // the result code, e.g.
                 // "Runtime error: UNIQUE constraint failed: t.a (19)".
-                let _ = self.writeln_fmt(format_args!(
-                    "Runtime error: {err} ({})",
-                    err.sqlite_result_code()
-                ));
+                // The shell omits the code for plain SQLITE_ERROR (1).
+                let code = err.sqlite_result_code();
+                if code == 1 {
+                    let _ = self.writeln_fmt(format_args!("Runtime error: {err}"));
+                } else {
+                    let _ = self.writeln_fmt(format_args!("Runtime error: {err} ({code})"));
+                }
             }
         }
     }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -5328,7 +5328,7 @@ mod tests {
             .to_string();
         assert_eq!(
             err,
-            "Invalid argument supplied: cannot attach database 'aux': reserved space 0 is smaller than attached database minimum 8"
+            "cannot attach database 'aux': reserved space 0 is smaller than attached database minimum 8"
         );
     }
 

--- a/core/error.rs
+++ b/core/error.rs
@@ -39,7 +39,7 @@ pub enum LimboError {
     InvalidTime(String),
     #[error("Modifier parsing error: {0}")]
     InvalidModifier(String),
-    #[error("Invalid argument supplied: {0}")]
+    #[error("{0}")]
     InvalidArgument(String),
     #[error("Invalid formatter supplied: {0}")]
     InvalidFormatter(String),

--- a/core/error.rs
+++ b/core/error.rs
@@ -10,6 +10,12 @@ pub enum LimboError {
     NotADB,
     #[error("Internal error: {0}")]
     InternalError(String),
+    /// An error raised by emitted bytecode (`Insn::Halt` with SQLITE_ERROR),
+    /// e.g. ALTER TABLE validation or window-function argument checks.
+    /// Displayed bare, like sqlite3_errmsg. Kept distinct from `Constraint`
+    /// so `abort()` does not apply ON CONFLICT resolution to it.
+    #[error("{0}")]
+    SqlError(String),
     #[error(transparent)]
     CacheError(#[from] CacheError),
     #[error("Database is full: {0}")]

--- a/core/error.rs
+++ b/core/error.rs
@@ -43,23 +43,23 @@ pub enum LimboError {
     InvalidArgument(String),
     #[error("Invalid formatter supplied: {0}")]
     InvalidFormatter(String),
-    #[error("Runtime error: {0}")]
+    #[error("{0}")]
     Constraint(String),
-    #[error("Runtime error: {0}")]
+    #[error("{0}")]
     /// We need to specify for ROLLBACK|FAIL resolve types when to roll the tx back
     /// so instead of matching on the string, we introduce a specific ForeignKeyConstraint error
     ForeignKeyConstraint(String),
-    #[error("Runtime error: {1}")]
+    #[error("{1}")]
     Raise(turso_parser::ast::ResolveType, String),
     #[error("RaiseIgnore")]
     RaiseIgnore,
     #[error("Extension error: {0}")]
     ExtensionError(String),
-    #[error("Runtime error: integer overflow")]
+    #[error("integer overflow")]
     IntegerOverflow,
-    #[error("Runtime error: string or blob too big")]
+    #[error("string or blob too big")]
     TooBig,
-    #[error("Runtime error: database table is locked")]
+    #[error("database table is locked")]
     TableLocked,
     #[error("Error: Resource is read-only")]
     ReadOnly,
@@ -107,7 +107,7 @@ pub enum LimboError {
     /// (or its table) was modified after the handle was opened. Mirrors SQLite's
     /// expired blob handles: every subsequent read/write must fail with
     /// SQLITE_ABORT until the handle is closed.
-    #[error("Runtime error: blob handle expired")]
+    #[error("blob handle expired")]
     BlobHandleExpired,
     #[error("Planning error: {0}")]
     PlanningError(String),
@@ -117,6 +117,27 @@ pub enum LimboError {
     UnsupportedEncoding(String),
     #[error("Out of memory")]
     OutOfMemory,
+}
+
+impl LimboError {
+    /// The primary SQLite result code for this error, e.g. what the sqlite3
+    /// shell appends after a runtime error message ("... (19)").
+    pub fn sqlite_result_code(&self) -> i32 {
+        match self {
+            Self::Constraint(_) | Self::ForeignKeyConstraint(_) | Self::Raise(..) => 19,
+            Self::Busy | Self::BusySnapshot | Self::StatementsInProgress(_) => 5,
+            Self::TableLocked => 6,
+            Self::ReadOnly => 8,
+            Self::Interrupt => 9,
+            Self::Corrupt(_) => 11,
+            Self::DatabaseFull(_) => 13,
+            Self::SchemaUpdated | Self::SchemaConflict => 17,
+            Self::TooBig => 18,
+            Self::NotADB => 26,
+            Self::BlobHandleExpired => 4,
+            _ => 1,
+        }
+    }
 }
 
 impl From<crate::alloc::AllocError> for LimboError {

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3160,23 +3160,42 @@ pub struct CheckConstraint {
     pub name: Option<String>,
     /// CHECK expression
     pub expr: ast::Expr,
+    /// The expression's source text exactly as the user wrote it between the
+    /// CHECK parens (whitespace-trimmed). SQLite reports an unnamed failed
+    /// constraint with this text, not a re-rendering of the expression.
+    pub source: Option<String>,
     /// Column name if this is a column-level CHECK constraint (defined inline with the column).
     /// None if this is a table-level CHECK constraint.
     pub column: Option<String>,
 }
 
 impl CheckConstraint {
-    pub fn new(name: Option<&ast::Name>, expr: &ast::Expr, column: Option<&str>) -> Self {
+    pub fn new(
+        name: Option<&ast::Name>,
+        expr: &ast::Expr,
+        source: Option<&str>,
+        column: Option<&str>,
+    ) -> Self {
         Self {
             name: name.map(|n| n.as_str().to_string()),
             expr: expr.clone(),
+            source: source.map(|s| s.to_string()),
             column: column.map(|s| s.to_string()),
         }
     }
 
     /// Returns the SQL representation of this CHECK constraint (e.g. `CHECK(x > 0)`).
     pub fn sql(&self) -> String {
-        format!("CHECK({})", self.expr)
+        match &self.source {
+            // Keep the user's spelling when rebuilding SQL. Put the closing
+            // paren on a new line when a line comment might otherwise swallow
+            // it. Closed block comments are safe as-is.
+            Some(source) if !source.is_empty() => {
+                let newline = if source.contains("--") { "\n" } else { "" };
+                format!("CHECK({source}{newline})")
+            }
+            _ => format!("CHECK({})", self.expr),
+        }
     }
 }
 
@@ -3533,6 +3552,7 @@ impl BTreeTable {
                     new_checks.try_push(CheckConstraint {
                         name: Some(name),
                         expr: *rewritten,
+                        source: None,
                         column: Some(col_name.clone()),
                     })?;
                 }
@@ -4600,10 +4620,11 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     };
                     foreign_keys.try_push(Arc::new(fk))?;
                     table_fk_order += 1;
-                } else if let ast::TableConstraint::Check(expr) = &c.constraint {
+                } else if let ast::TableConstraint::Check { expr, source } = &c.constraint {
                     check_constraints.try_push(CheckConstraint::new(
                         c.name.as_ref(),
                         expr,
+                        source.as_deref(),
                         None,
                     ))?;
                 }
@@ -4669,10 +4690,11 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                 let mut collation = None;
                 for c_def in constraints {
                     match &c_def.constraint {
-                        ast::ColumnConstraint::Check(expr) => {
+                        ast::ColumnConstraint::Check { expr, source } => {
                             check_constraints.try_push(CheckConstraint::new(
                                 c_def.name.as_ref(),
                                 expr,
+                                source.as_deref(),
                                 Some(&name),
                             ))?;
                         }
@@ -6472,6 +6494,30 @@ mod tests {
         let expected = r#"CREATE TABLE sqlite_schema (type TEXT, name TEXT, tbl_name TEXT, rootpage INT, sql TEXT)"#;
         let actual = sqlite_schema_table()?.to_sql();
         assert_eq!(expected, actual);
+        Ok(())
+    }
+
+    #[test]
+    fn check_constraint_comments_survive_table_reconstruction() -> Result<()> {
+        for (sql, comment) in [
+            (
+                "CREATE TABLE t (x CHECK(x /* block comment */ > 0))",
+                "/* block comment */",
+            ),
+            (
+                "CREATE TABLE t (x CHECK(x > 0 -- line comment\n))",
+                "-- line comment",
+            ),
+        ] {
+            let reconstructed = BTreeTable::from_sql(sql, 0)?.to_sql();
+
+            assert!(
+                reconstructed.contains(comment),
+                "reconstructed SQL: {reconstructed}"
+            );
+            BTreeTable::from_sql(&reconstructed, 0)?;
+        }
+
         Ok(())
     }
 

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1246,7 +1246,7 @@ impl Schema {
 
     /// Add a regular (non-materialized) view
     pub fn add_view(&mut self, view: View) -> Result<()> {
-        self.check_object_name_conflict(&view.name)?;
+        self.check_object_name_conflict(&view.name, SchemaObjectType::View)?;
         let name = normalize_ident(&view.name);
         self.views.insert(name, Arc::new(view));
         Ok(())
@@ -1379,7 +1379,7 @@ impl Schema {
     }
 
     pub fn add_btree_table(&mut self, table: Arc<BTreeTable>) -> Result<()> {
-        self.check_object_name_conflict(&table.name)?;
+        self.check_object_name_conflict(&table.name, SchemaObjectType::Table)?;
         let name = normalize_ident(&table.name);
         #[cfg(feature = "conn_raw_api")]
         self.table_names_by_root_page
@@ -1389,7 +1389,7 @@ impl Schema {
     }
 
     pub fn add_virtual_table(&mut self, table: Arc<VirtualTable>) -> Result<()> {
-        self.check_object_name_conflict(&table.name)?;
+        self.check_object_name_conflict(&table.name, SchemaObjectType::Table)?;
         let name = normalize_ident(&table.name);
         self.tables.insert(name, Table::Virtual(table).into());
         Ok(())
@@ -1453,7 +1453,7 @@ impl Schema {
     }
 
     pub fn add_index(&mut self, index: Arc<Index>) -> Result<()> {
-        self.check_object_name_conflict(&index.name)?;
+        self.check_object_name_conflict(&index.name, SchemaObjectType::Index)?;
         let table_name = normalize_ident(&index.table_name);
         // We must add the new index to the front of the deque, because SQLite stores index definitions as a linked list
         // where the newest parsed index entry is at the head of list. If we would add it to the back of a regular Vec for example,
@@ -2592,16 +2592,23 @@ impl Schema {
             .is_some_and(|t| !t.foreign_keys.is_empty())
     }
 
-    fn check_object_name_conflict(&self, name: &str) -> Result<()> {
-        if let Some(object_type) = self.get_object_type(name) {
-            let type_str = match object_type {
-                SchemaObjectType::Table => "table",
-                SchemaObjectType::View => "view",
-                SchemaObjectType::Index => "index",
+    fn check_object_name_conflict(&self, name: &str, creating: SchemaObjectType) -> Result<()> {
+        if let Some(existing) = self.get_object_type(name) {
+            // Match SQLite's message shapes: indexes and tables/views live in
+            // different namespaces, so a cross-namespace clash names the other
+            // side ("there is already a ...") instead of "already exists".
+            let msg = match (creating, existing) {
+                (SchemaObjectType::Index, SchemaObjectType::Index) => {
+                    format!("index {name} already exists")
+                }
+                (SchemaObjectType::Index, _) => format!("there is already a table named {name}"),
+                (_, SchemaObjectType::Index) => {
+                    format!("there is already an index named {name}")
+                }
+                (_, SchemaObjectType::Table) => format!("table {name} already exists"),
+                (_, SchemaObjectType::View) => format!("view {name} already exists"),
             };
-            return Err(crate::LimboError::ParseError(format!(
-                "{type_str} \"{name}\" already exists"
-            )));
+            return Err(crate::LimboError::ParseError(msg));
         }
         Ok(())
     }

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -578,10 +578,11 @@ fn emit_add_virtual_column_validation(
     let check_constraints: Vec<CheckConstraint> = constraints
         .iter()
         .filter_map(|c| {
-            if let ast::ColumnConstraint::Check(expr) = &c.constraint {
+            if let ast::ColumnConstraint::Check { expr, source } = &c.constraint {
                 Some(CheckConstraint::new(
                     c.name.as_ref(),
                     expr,
+                    source.as_deref(),
                     column.name.as_deref(),
                 ))
             } else {
@@ -736,12 +737,13 @@ fn emit_add_column_check_validation(
 
     // Collect CHECK constraints from column-level constraints + domain CHECKs.
     // Domain CHECKs use `value` as placeholder which must be rewritten to the column name.
-    let mut all_checks: Vec<(Option<String>, Box<ast::Expr>)> = constraints
+    let mut all_checks: Vec<(Option<String>, Option<String>, Box<ast::Expr>)> = constraints
         .iter()
         .filter_map(|c| {
-            if let ast::ColumnConstraint::Check(expr) = &c.constraint {
+            if let ast::ColumnConstraint::Check { expr, source } = &c.constraint {
                 Some((
                     c.name.as_ref().map(|n| n.as_str().to_string()),
+                    source.clone(),
                     expr.clone(),
                 ))
             } else {
@@ -759,7 +761,7 @@ fn emit_add_column_check_validation(
                 for dc in &td.domain_checks {
                     let rewritten =
                         crate::schema::rewrite_value_to_column(&dc.check, new_column_name);
-                    all_checks.push((dc.name.clone(), rewritten));
+                    all_checks.push((dc.name.clone(), None, rewritten));
                 }
             }
         }
@@ -787,7 +789,7 @@ fn emit_add_column_check_validation(
     });
 
     // Table has rows -- evaluate each CHECK constraint with the default value substituted.
-    for (constraint_name, check_expr) in &all_checks {
+    for (constraint_name, check_source, check_expr) in &all_checks {
         let mut substituted = *check_expr.clone();
 
         // Replace references to the new column with the default value expression.
@@ -828,10 +830,12 @@ fn emit_add_column_check_validation(
             jump_if_null: false,
         });
 
-        // CHECK failed -- halt with constraint error.
-        let name = match constraint_name {
-            Some(name) => name.clone(),
-            None => format!("{check_expr}"),
+        // CHECK failed -- halt with constraint error. SQLite reports the
+        // constraint name, or the expression's source text as written.
+        let name = match (constraint_name, check_source) {
+            (Some(name), _) => name.clone(),
+            (None, Some(source)) => crate::util::check_source_for_error(source),
+            (None, None) => format!("{check_expr}"),
         };
         program.emit_insn(Insn::Halt {
             err_code: SQLITE_CONSTRAINT_CHECK,
@@ -1395,7 +1399,7 @@ pub fn translate_alter_table(
                         };
                         btree.foreign_keys.push(Arc::new(fk));
                     }
-                    ast::ColumnConstraint::Check(expr) => {
+                    ast::ColumnConstraint::Check { expr, source } => {
                         let column_names: Vec<&str> = btree
                             .columns()
                             .iter()
@@ -1405,6 +1409,7 @@ pub fn translate_alter_table(
                         btree.check_constraints.push(CheckConstraint::new(
                             constraint.name.as_ref(),
                             expr,
+                            source.as_deref(),
                             Some(&new_column_name),
                         ));
                     }

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -875,7 +875,8 @@ pub fn translate_alter_table(
 
     let Some(table) = resolver.with_schema(database_id, |s| s.get_table(table_name)) else {
         return Err(LimboError::ParseError(format!(
-            "no such table: {table_name}"
+            "no such table: {}",
+            crate::util::table_name_for_error(&qualified_name)
         )));
     };
     if let Some(tbl) = table.virtual_table() {

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -25,6 +25,7 @@ use super::plan::{ColumnUsedMask, JoinedTable, TableReferences, WhereTerm};
 fn validate_delete(
     resolver: &Resolver,
     tbl_name: &str,
+    qualified_name: &QualifiedName,
     database_id: usize,
     program: &mut ProgramBuilder,
     connection: &Arc<crate::Connection>,
@@ -38,7 +39,10 @@ fn validate_delete(
     }
     let table = match resolver.with_schema(database_id, |s| s.get_table(tbl_name)) {
         Some(table) => table,
-        None => crate::bail_parse_error!("no such table: {}", tbl_name),
+        None => crate::bail_parse_error!(
+            "no such table: {}",
+            crate::util::table_name_for_error(qualified_name)
+        ),
     };
     if program.trigger.is_some() && table.virtual_table().is_some() {
         crate::bail_parse_error!("unsafe use of virtual table \"{}\"", tbl_name);
@@ -85,6 +89,7 @@ pub fn translate_delete(
     let table = validate_delete(
         resolver,
         &normalized_table_name,
+        tbl_name,
         database_id,
         program,
         connection,

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -2221,9 +2221,12 @@ fn emit_check_constraint_bytecode(
             jump_if_null: false,
         });
 
-        let constraint_name = match &check_constraint.name {
-            Some(name) => name.clone(),
-            None => format!("{}", check_constraint.expr),
+        // SQLite reports a failed CHECK by its constraint name, or by the
+        // expression's source text exactly as the user wrote it.
+        let constraint_name = match (&check_constraint.name, &check_constraint.source) {
+            (Some(name), _) => name.clone(),
+            (None, Some(source)) => crate::util::check_source_for_error(source),
+            (None, None) => format!("{}", check_constraint.expr),
         };
 
         match or_conflict {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -134,7 +134,7 @@ pub fn translate_create_index(
         if if_not_exists {
             return Ok(());
         }
-        crate::bail_parse_error!("Error: index with name '{idx_name}' already exists.");
+        crate::bail_parse_error!("index {} already exists", original_idx_name.name.as_str());
     }
     let table = resolver.with_schema(database_id, |s| s.get_table(&tbl_name));
     let Some(table) = table else {

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -104,13 +104,14 @@ pub fn translate_create_index(
     };
 
     let original_idx_name = idx_name;
+    let original_tbl_name = tbl_name;
     let database_id = if original_idx_name.db_name.is_some() {
         resolver.resolve_database_id(&original_idx_name)?
     } else {
-        resolver.resolve_existing_table_database_id(tbl_name.as_str())?
+        resolver.resolve_existing_table_database_id(original_tbl_name.as_str())?
     };
     let idx_name = normalize_ident(original_idx_name.name.as_str());
-    let tbl_name = normalize_ident(tbl_name.as_str());
+    let tbl_name = normalize_ident(original_tbl_name.as_str());
 
     validate(
         &tbl_name,
@@ -138,10 +139,20 @@ pub fn translate_create_index(
     }
     let table = resolver.with_schema(database_id, |s| s.get_table(&tbl_name));
     let Some(table) = table else {
-        crate::bail_parse_error!("Error: table '{tbl_name}' does not exist.");
+        if resolver.with_schema(database_id, |s| {
+            s.get_view(&tbl_name).is_some() || s.is_materialized_view(&tbl_name)
+        }) {
+            crate::bail_parse_error!("views may not be indexed");
+        }
+        // The index's target table always lives in the index's own database,
+        // so SQLite qualifies the missing table with that database name.
+        let db_name = resolver
+            .get_database_name_by_index(database_id)
+            .unwrap_or_else(|| "main".to_string());
+        crate::bail_parse_error!("no such table: {}.{}", db_name, original_tbl_name.as_str());
     };
     let Some(tbl) = table.btree() else {
-        crate::bail_parse_error!("Error: table '{tbl_name}' is not a b-tree table.");
+        crate::bail_parse_error!("virtual tables may not be indexed");
     };
     if !tbl.has_rowid {
         bail_parse_error!("CREATE INDEX on WITHOUT ROWID tables is not supported");

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -267,7 +267,10 @@ pub fn translate_insert(
     let table_name = &tbl_name.name;
     let table = match resolver.with_schema(database_id, |s| s.get_table(table_name.as_str())) {
         Some(table) => table,
-        None => crate::bail_parse_error!("no such table: {}", table_name),
+        None => crate::bail_parse_error!(
+            "no such table: {}",
+            crate::util::table_name_for_error(&tbl_name)
+        ),
     };
     if program.trigger.is_some() && table.virtual_table().is_some() {
         crate::bail_parse_error!("unsafe use of virtual table \"{}\"", tbl_name.name.as_str());
@@ -295,7 +298,10 @@ pub fn translate_insert(
     }
 
     let Some(btree_table) = table.btree() else {
-        crate::bail_parse_error!("no such table: {}", table_name);
+        crate::bail_parse_error!(
+            "no such table: {}",
+            crate::util::table_name_for_error(&tbl_name)
+        );
     };
 
     let BoundInsertResult {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -3494,7 +3494,7 @@ pub(crate) fn halt_desc_and_on_error(
     }
     match effective {
         ResolveType::Fail | ResolveType::Rollback => (
-            format!("UNIQUE constraint failed: {raw_desc} (19)"),
+            format!("UNIQUE constraint failed: {raw_desc}"),
             Some(effective),
         ),
         _ => (raw_desc.to_string(), None),

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -602,7 +602,7 @@ pub fn resolve_window_and_aggregate_functions(
                                 distinctness,
                             )?;
                         } else {
-                            crate::bail_parse_error!("misuse of window function: {}()", f);
+                            crate::bail_parse_error!("misuse of window function {}()", f);
                         }
                         return Ok(WalkControl::SkipChildren);
                     }
@@ -689,7 +689,7 @@ pub fn resolve_window_and_aggregate_functions(
                                 Distinctness::NonDistinct,
                             )?;
                         } else {
-                            crate::bail_parse_error!("misuse of window function: {}()", f);
+                            crate::bail_parse_error!("misuse of window function {}()", f);
                         }
                         return Ok(WalkControl::SkipChildren);
                     }
@@ -864,7 +864,7 @@ fn link_with_window(
             AccumulatorFunc::Agg(f) => f.as_str().to_string(),
             AccumulatorFunc::Window(f) => f.to_string(),
         };
-        crate::bail_parse_error!("misuse of window function: {}()", func_name);
+        crate::bail_parse_error!("misuse of window function {}()", func_name);
     }
     Ok(())
 }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -2030,7 +2030,10 @@ fn parse_table(
         );
     }
 
-    crate::bail_parse_error!("no such table: {}", normalized_qualified_name);
+    crate::bail_parse_error!(
+        "no such table: {}",
+        crate::util::table_name_for_error(qualified_name)
+    );
 }
 
 fn transform_args_into_where_terms(

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -738,7 +738,7 @@ fn validate(
             let col_i = &columns[i];
             for constraint in &col_i.constraints {
                 match &constraint.constraint {
-                    ast::ColumnConstraint::Check(expr) => {
+                    ast::ColumnConstraint::Check { expr, .. } => {
                         validate_check_expr(expr, table_name, &column_names, resolver)?;
                     }
                     ast::ColumnConstraint::Generated { .. }
@@ -775,7 +775,7 @@ fn validate(
             }
         }
         for constraint in constraints {
-            if let ast::TableConstraint::Check(ref expr) = constraint.constraint {
+            if let ast::TableConstraint::Check { ref expr, .. } = constraint.constraint {
                 validate_check_expr(expr, table_name, &column_names, resolver)?;
             }
         }
@@ -860,13 +860,13 @@ fn validate(
             let col_refs: Vec<&ast::ColumnDefinition> = columns.iter().collect();
             for col in columns {
                 for constraint in &col.constraints {
-                    if let ast::ColumnConstraint::Check(expr) = &constraint.constraint {
+                    if let ast::ColumnConstraint::Check { expr, .. } = &constraint.constraint {
                         validate_check_types_in_expr(expr, &col_refs, resolver)?;
                     }
                 }
             }
             for constraint in constraints {
-                if let ast::TableConstraint::Check(ref expr) = constraint.constraint {
+                if let ast::TableConstraint::Check { ref expr, .. } = constraint.constraint {
                     validate_check_types_in_expr(expr, &col_refs, resolver)?;
                 }
             }

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1819,7 +1819,10 @@ pub fn translate_drop_table(
         if if_exists {
             return Ok(());
         }
-        bail_parse_error!("No such table: {name}");
+        bail_parse_error!(
+            "no such table: {}",
+            crate::util::table_name_for_error(&tbl_name)
+        );
     };
     validate_drop_table(resolver, database_id, name, connection)?;
     // Check if foreign keys are enabled and if this table is referenced by foreign keys

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1186,12 +1186,22 @@ pub fn translate_create_table(
                 return Ok(());
             }
             _ => {
-                let type_str = match object_type {
-                    SchemaObjectType::Table => "table",
-                    SchemaObjectType::View => "view",
-                    SchemaObjectType::Index => "index",
-                };
-                bail_parse_error!("{} {} already exists", type_str, normalized_tbl_name);
+                // SQLite echoes the new table's name token as written
+                // (`table "t" already exists`), except when the name clashes
+                // with an index, which gets its own message shape.
+                let token = crate::util::identifier_token_for_error(&tbl_name.name);
+                match object_type {
+                    SchemaObjectType::Table => {
+                        bail_parse_error!("table {} already exists", token)
+                    }
+                    SchemaObjectType::View => {
+                        bail_parse_error!("view {} already exists", token)
+                    }
+                    SchemaObjectType::Index => bail_parse_error!(
+                        "there is already an index named {}",
+                        tbl_name.name.as_str()
+                    ),
+                }
             }
         }
     }
@@ -1703,7 +1713,10 @@ pub fn translate_create_virtual_table(
         if *if_not_exists {
             return Ok(());
         }
-        bail_parse_error!("Table {} already exists", tbl_name);
+        bail_parse_error!(
+            "table {} already exists",
+            crate::util::identifier_token_for_error(&tbl_name.name)
+        );
     }
 
     let opts = ProgramBuilderOpts::new(2, 40, 2);

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -151,7 +151,10 @@ pub fn translate_create_trigger(
         if if_not_exists {
             return Ok(());
         }
-        bail_parse_error!("Trigger {} already exists", normalized_trigger_name);
+        bail_parse_error!(
+            "trigger {} already exists",
+            crate::util::identifier_token_for_error(&trigger_name.name)
+        );
     }
 
     // Verify the table exists (use the table's database, not the trigger's).

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -159,7 +159,19 @@ pub fn translate_create_trigger(
         s.get_table(&normalized_table_name)
     });
     let Some(table) = table else {
-        bail_parse_error!("no such table: {}", normalized_table_name);
+        // SQLite qualifies a non-temp trigger's missing target table with its
+        // database ("no such table: main.t1"); temp triggers report the name
+        // as the user wrote it.
+        if temporary {
+            bail_parse_error!(
+                "no such table: {}",
+                crate::util::table_name_for_error(&tbl_name)
+            );
+        }
+        let db_name = resolver
+            .get_database_name_by_index(target_table_database_id)
+            .unwrap_or_else(|| "main".to_string());
+        bail_parse_error!("no such table: {}.{}", db_name, tbl_name.name.as_str());
     };
     if table.virtual_table().is_some() {
         bail_parse_error!("cannot create triggers on virtual tables");

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -246,7 +246,10 @@ fn prepare_update_plan(
     let target_name = &body.tbl_name.name;
     let table = match resolver.with_schema(database_id, |s| s.get_table(target_name.as_str())) {
         Some(table) => table,
-        None => bail_parse_error!("Parse error: no such table: {}", target_name),
+        None => bail_parse_error!(
+            "no such table: {}",
+            crate::util::table_name_for_error(&body.tbl_name)
+        ),
     };
     if program.trigger.is_some() && table.virtual_table().is_some() {
         bail_parse_error!(

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -283,6 +283,7 @@ fn create_materialized_view_to_str(view_name: &str, select_stmt: &ast::Select) -
 fn validate_create_view(
     resolver: &Resolver,
     database_id: usize,
+    view_name: &ast::Name,
     normalized_view_name: &str,
 ) -> Result<()> {
     // Check if view already exists. A broken view (unparseable sqlite_schema
@@ -294,7 +295,8 @@ fn validate_create_view(
             || s.broken_views.contains(normalized_view_name)
     }) {
         return Err(crate::LimboError::ParseError(format!(
-            "View {normalized_view_name} already exists"
+            "view {} already exists",
+            crate::util::identifier_token_for_error(view_name)
         )));
     }
     if RESERVED_TABLE_PREFIXES
@@ -336,7 +338,12 @@ pub fn translate_create_view(
         return Ok(());
     }
 
-    validate_create_view(resolver, database_id, &normalized_view_name)?;
+    validate_create_view(
+        resolver,
+        database_id,
+        &view_name.name,
+        &normalized_view_name,
+    )?;
 
     // Check for name conflicts with existing schema objects
     if let Some(object_type) =
@@ -352,14 +359,17 @@ pub fn translate_create_view(
         {
             return Ok(());
         }
-        let type_str = match object_type {
-            SchemaObjectType::Table => "table",
-            SchemaObjectType::View => "view",
-            SchemaObjectType::Index => "index",
-        };
-        return Err(crate::LimboError::ParseError(format!(
-            "{type_str} {normalized_view_name} already exists"
-        )));
+        // SQLite echoes the new view's name token as written, except when the
+        // name clashes with an index, which gets its own message shape.
+        let token = crate::util::identifier_token_for_error(&view_name.name);
+        return Err(crate::LimboError::ParseError(match object_type {
+            SchemaObjectType::Table => format!("table {token} already exists"),
+            SchemaObjectType::View => format!("view {token} already exists"),
+            SchemaObjectType::Index => format!(
+                "there is already an index named {}",
+                view_name.name.as_str()
+            ),
+        }));
     }
 
     crate::util::validate_select_for_views(select_stmt, view_name.db_name.as_ref())?;

--- a/core/util.rs
+++ b/core/util.rs
@@ -130,6 +130,17 @@ pub fn escape_sql_string_literal(literal: &str) -> String {
     literal.replace('\'', "''")
 }
 
+/// Format an identifier for error messages the way SQLite's `%T` does: the
+/// token exactly as the user wrote it, keeping the original quote characters.
+/// `CREATE TABLE "t"` reports an existing table as `table "t" already exists`.
+pub fn identifier_token_for_error(name: &turso_parser::ast::Name) -> String {
+    if name.quoted() {
+        name.as_ident()
+    } else {
+        name.as_str().to_owned()
+    }
+}
+
 /// Format a table reference for error messages the way SQLite does: the name
 /// as the user wrote it with quotes stripped, keeping any database prefix.
 /// `SELECT * FROM main."T1"` reports the missing table as `main.T1`.

--- a/core/util.rs
+++ b/core/util.rs
@@ -130,6 +130,16 @@ pub fn escape_sql_string_literal(literal: &str) -> String {
     literal.replace('\'', "''")
 }
 
+/// Format a table reference for error messages the way SQLite does: the name
+/// as the user wrote it with quotes stripped, keeping any database prefix.
+/// `SELECT * FROM main."T1"` reports the missing table as `main.T1`.
+pub fn table_name_for_error(name: &turso_parser::ast::QualifiedName) -> String {
+    match &name.db_name {
+        Some(db) => format!("{}.{}", db.as_str(), name.name.as_str()),
+        None => name.name.as_str().to_owned(),
+    }
+}
+
 /// Quote a SQL identifier with double quotes when necessary.
 /// Always safe to call — returns the bare name when no quoting is needed.
 pub fn quote_identifier(name: &str) -> String {

--- a/core/util.rs
+++ b/core/util.rs
@@ -141,6 +141,38 @@ pub fn identifier_token_for_error(name: &turso_parser::ast::Name) -> String {
     }
 }
 
+/// Format a CHECK constraint's captured source text for an error message the
+/// way SQLite does. SQLite dequotes the text: when it starts with a quote
+/// character, only the first quoted token survives, so `"x" < +5` is
+/// reported as just `x`.
+pub fn check_source_for_error(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let close = match bytes.first() {
+        Some(&c @ (b'"' | b'\'' | b'`')) => c,
+        Some(b'[') => b']',
+        _ => return source.to_string(),
+    };
+    let mut i = 1;
+    while i < bytes.len() {
+        if bytes[i] == close {
+            // A doubled quote is an escaped quote, not the end.
+            if close != b']' && bytes.get(i + 1) == Some(&close) {
+                i += 2;
+                continue;
+            }
+            break;
+        }
+        i += 1;
+    }
+    let inner = &source[1..i.min(source.len())];
+    if close == b']' {
+        inner.to_string()
+    } else {
+        let quote = (close as char).to_string();
+        inner.replace(&format!("{quote}{quote}"), &quote)
+    }
+}
+
 /// Format a table reference for error messages the way SQLite does: the name
 /// as the user wrote it with quotes stripped, keeping any database prefix.
 /// `SELECT * FROM main."T1"` reports the missing table as `main.T1`.
@@ -3503,8 +3535,11 @@ pub fn rewrite_column_references_if_needed(
             ast::ColumnConstraint::ForeignKey { clause, .. } => {
                 rewrite_fk_parent_cols_if_self_ref(clause, table, from, to);
             }
-            ast::ColumnConstraint::Check(expr) => {
+            ast::ColumnConstraint::Check { expr, source } => {
                 rename_identifiers(expr, from, to);
+                // The captured source text no longer matches the rewritten
+                // expression.
+                *source = None;
             }
             ast::ColumnConstraint::Generated { expr, .. } => {
                 rename_identifiers(expr, from, to);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10683,26 +10683,34 @@ pub fn op_function(
                                 // (e.g. t1.a > 0 → t2.a > 0)
                                 if this_table == rename_from {
                                     for c in &mut constraints {
-                                        if let ast::TableConstraint::Check(ref mut expr) =
-                                            c.constraint
+                                        if let ast::TableConstraint::Check {
+                                            ref mut expr,
+                                            ref mut source,
+                                        } = c.constraint
                                         {
                                             rewrite_check_expr_table_refs(
                                                 expr,
                                                 &rename_from,
                                                 &rename_to,
                                             );
+                                            // The captured source text no longer
+                                            // matches the rewritten expression.
+                                            *source = None;
                                         }
                                     }
                                     for col in &mut columns {
                                         for cc in &mut col.constraints {
-                                            if let ast::ColumnConstraint::Check(ref mut expr) =
-                                                cc.constraint
+                                            if let ast::ColumnConstraint::Check {
+                                                ref mut expr,
+                                                ref mut source,
+                                            } = cc.constraint
                                             {
                                                 rewrite_check_expr_table_refs(
                                                     expr,
                                                     &rename_from,
                                                     &rename_to,
                                                 );
+                                                *source = None;
                                             }
                                         }
                                     }
@@ -11033,12 +11041,16 @@ pub fn op_function(
                                                     column_def.col_name.as_str(),
                                                 );
                                             }
-                                            ast::TableConstraint::Check(ref mut expr) => {
+                                            ast::TableConstraint::Check {
+                                                ref mut expr,
+                                                ref mut source,
+                                            } => {
                                                 rename_identifiers(
                                                     expr,
                                                     &rename_from,
                                                     column_def.col_name.as_str(),
                                                 );
+                                                *source = None;
                                             }
                                         }
                                     }
@@ -15879,6 +15891,9 @@ pub fn op_rename_table(
                         &normalized_from,
                         &normalized_to,
                     );
+                    // The captured source text no longer matches the
+                    // rewritten expression.
+                    check.source = None;
                 }
 
                 normalized_to.clone_into(&mut btree.name);
@@ -16375,6 +16390,9 @@ pub fn op_alter_column(
         let old_col_normalized = normalize_ident(&old_column_name);
         for check in &mut btree.check_constraints {
             rename_identifiers(&mut check.expr, &old_col_normalized, &new_name);
+            // The captured source text no longer matches the rewritten
+            // expression.
+            check.source = None;
             if let Some(ref mut col) = check.column {
                 if col.eq_ignore_ascii_case(&old_column_name) {
                     col.clone_from(&new_name);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3440,8 +3440,9 @@ pub fn halt(
         SQLITE_CONSTRAINT_TRIGGER => Some(LimboError::Constraint(description.to_string())),
         SQLITE_FULL => Some(LimboError::DatabaseFull(description.to_string())),
         // SQLITE_ERROR is a generic error (e.g. ALTER TABLE validation), not a constraint.
-        // Use InternalError so abort() doesn't apply ON CONFLICT resolution to it.
-        SQLITE_ERROR => Some(LimboError::InternalError(description.to_string())),
+        // SqlError displays bare like sqlite3_errmsg and abort() doesn't apply
+        // ON CONFLICT resolution to it.
+        SQLITE_ERROR => Some(LimboError::SqlError(description.to_string())),
         _ => Some(LimboError::Constraint(format!(
             "undocumented halt error code {description}"
         ))),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3423,16 +3423,16 @@ pub fn halt(
     let constraint_error = match err_code {
         0 => None,
         SQLITE_CONSTRAINT_PRIMARYKEY => Some(LimboError::Constraint(format!(
-            "UNIQUE constraint failed: {description} (19)"
+            "UNIQUE constraint failed: {description}"
         ))),
         SQLITE_CONSTRAINT_CHECK => Some(LimboError::Constraint(format!(
-            "CHECK constraint failed: {description} (19)"
+            "CHECK constraint failed: {description}"
         ))),
         SQLITE_CONSTRAINT_NOTNULL => Some(LimboError::Constraint(format!(
-            "NOT NULL constraint failed: {description} (19)"
+            "NOT NULL constraint failed: {description}"
         ))),
         SQLITE_CONSTRAINT_UNIQUE => Some(LimboError::Constraint(format!(
-            "UNIQUE constraint failed: {description} (19)"
+            "UNIQUE constraint failed: {description}"
         ))),
         SQLITE_CONSTRAINT_FOREIGNKEY => {
             Some(LimboError::ForeignKeyConstraint(description.to_string()))

--- a/postgres/parser/parser.rs
+++ b/postgres/parser/parser.rs
@@ -1946,7 +1946,7 @@ impl<'a> Parser<'a> {
                 self.expect(TokenType::LeftParen)?;
                 let expr = self.parse_expression()?;
                 self.expect(TokenType::RightParen)?;
-                Ok(ColumnConstraint::Check(expr))
+                Ok(ColumnConstraint::Check { expr, source: None })
             }
             TokenType::Default => {
                 self.advance()?;
@@ -2004,7 +2004,7 @@ impl<'a> Parser<'a> {
                 self.expect(TokenType::LeftParen)?;
                 let expr = self.parse_expression()?;
                 self.expect(TokenType::RightParen)?;
-                Ok(TableConstraint::Check(expr))
+                Ok(TableConstraint::Check { expr, source: None })
             }
             _ => Err(Error::SyntaxError(format!(
                 "Unexpected table constraint: {:?}",

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -311,7 +311,10 @@ impl PostgreSQLTranslator {
                                 let expr = self.translate_expr(raw_expr)?;
                                 table_constraints.push(ast::NamedTableConstraint {
                                     name: None,
-                                    constraint: ast::TableConstraint::Check(Box::new(expr)),
+                                    constraint: ast::TableConstraint::Check {
+                                        expr: Box::new(expr),
+                                        source: None,
+                                    },
                                 });
                             }
                         }
@@ -417,9 +420,10 @@ impl PostgreSQLTranslator {
                             } else {
                                 Some(ast::Name::from_string(constraint.conname.clone()))
                             },
-                            constraint: ast::ColumnConstraint::Check(Box::new(
-                                self.translate_expr(raw_expr)?,
-                            )),
+                            constraint: ast::ColumnConstraint::Check {
+                                expr: Box::new(self.translate_expr(raw_expr)?),
+                                source: None,
+                            },
                         });
                     }
                 }

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -2114,7 +2114,7 @@ mod tests {
         match error {
             TursoError::Error(message) => assert_eq!(
                 message,
-                "Invalid argument supplied: external page codecs are not supported with experimental multiprocess WAL"
+                "external page codecs are not supported with experimental multiprocess WAL"
             ),
             error => panic!("expected multiprocess WAL rejection, got {error:?}"),
         }

--- a/sqlite/conformance/sqlite-sqltests/already-exists-error-message.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/already-exists-error-message.sqltest
@@ -1,0 +1,115 @@
+@database :memory:
+
+# SQLite reports a name collision on CREATE TABLE/VIEW/TRIGGER by echoing the
+# new object's name token exactly as the user wrote it, quotes included:
+# `CREATE TABLE "t2"` fails with `table "t2" already exists`. Index names are
+# reported without quotes, and a clash between the index and table namespaces
+# uses "there is already a[n] ..." instead of "already exists". Turso used to
+# strip quotes everywhere and had its own spellings ("Trigger t already
+# exists", "Error: index with name 't' already exists.").
+
+setup base-table {
+    CREATE TABLE test2 (a);
+}
+
+@setup base-table
+test create-table-duplicate-plain-name {
+    CREATE TABLE test2 (a);
+}
+expect error {
+    table test2 already exists
+}
+
+@setup base-table
+test create-table-duplicate-double-quoted-name {
+    CREATE TABLE "test2" (a);
+}
+expect error {
+    table "test2" already exists
+}
+
+@setup base-table
+test create-table-duplicate-bracket-quoted-name {
+    CREATE TABLE [test2] (a);
+}
+expect error {
+    table \[test2\] already exists
+}
+
+@setup base-table
+test create-table-duplicate-backtick-quoted-name {
+    CREATE TABLE `test2` (a);
+}
+expect error {
+    table `test2` already exists
+}
+
+@setup base-table
+test create-table-duplicate-escaped-quote-name {
+    CREATE TABLE "te""st" (a);
+    CREATE TABLE "te""st" (a);
+}
+expect error {
+    table "te""st" already exists
+}
+
+@setup base-table
+test create-view-duplicate-quoted-name {
+    CREATE VIEW v AS SELECT 1;
+    CREATE VIEW "v" AS SELECT 1;
+}
+expect error {
+    view "v" already exists
+}
+
+@setup base-table
+test create-table-over-existing-view {
+    CREATE VIEW v AS SELECT 1;
+    CREATE TABLE v (a);
+}
+expect error {
+    view v already exists
+}
+
+@setup base-table
+test create-view-over-existing-table {
+    CREATE VIEW test2 AS SELECT 1;
+}
+expect error {
+    table test2 already exists
+}
+
+@setup base-table
+test create-trigger-duplicate-quoted-name {
+    CREATE TRIGGER trg AFTER INSERT ON test2 BEGIN SELECT 1; END;
+    CREATE TRIGGER "trg" AFTER INSERT ON test2 BEGIN SELECT 1; END;
+}
+expect error {
+    trigger "trg" already exists
+}
+
+@setup base-table
+test create-index-duplicate-name-reported-without-quotes {
+    CREATE INDEX "idx1" ON test2 (a);
+    CREATE INDEX "idx1" ON test2 (a);
+}
+expect error {
+    index idx1 already exists
+}
+
+@setup base-table
+test create-table-over-existing-index {
+    CREATE INDEX idx1 ON test2 (a);
+    CREATE TABLE idx1 (a);
+}
+expect error {
+    there is already an index named idx1
+}
+
+@setup base-table
+test create-index-over-existing-table-name {
+    CREATE INDEX test2 ON test2 (a);
+}
+expect error {
+    there is already a table named test2
+}

--- a/sqlite/conformance/sqlite-sqltests/check_constraint.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/check_constraint.sqltest
@@ -1963,3 +1963,14 @@ test check_constraint_error_dequotes_leading_quoted_token {
 expect error {
     CHECK constraint failed: xy
 }
+
+# sqlite3_errmsg carries no result-code suffix; the "(19)" the sqlite3 shell
+# shows is added by the shell. Turso used to bake " (19)" into the message.
+@cross-check-integrity
+test check_constraint_error_has_no_result_code_suffix {
+    CREATE TABLE t(x INT CHECK(x<5));
+    INSERT INTO t VALUES (10);
+}
+expect error {
+    ^CHECK constraint failed: x<5$
+}

--- a/sqlite/conformance/sqlite-sqltests/check_constraint.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/check_constraint.sqltest
@@ -1908,3 +1908,58 @@ test check_constraint_integer_affinity_coercion_violation {
 expect error {
     CHECK constraint failed: val > 5
 }
+
+# SQLite reports an unnamed failed CHECK with the expression's source text
+# exactly as the user wrote it between the parens (whitespace-trimmed), not a
+# re-rendering of the parsed expression: CHECK(x<5) fails with `CHECK
+# constraint failed: x<5`, never `x < 5`. Turso used to pretty-print the
+# expression.
+
+@cross-check-integrity
+test check_constraint_error_reports_verbatim_source_text {
+    CREATE TABLE t(x INT CHECK(x<5));
+    INSERT INTO t VALUES (10);
+}
+expect error {
+    CHECK constraint failed: x<5
+}
+
+@cross-check-integrity
+test check_constraint_error_verbatim_text_table_level {
+    CREATE TABLE t(x INT, CHECK(x<5 AND x>0));
+    INSERT INTO t VALUES (10);
+}
+expect error {
+    CHECK constraint failed: x<5 AND x>0
+}
+
+@cross-check-integrity
+test check_constraint_error_verbatim_text_survives_reopen {
+    CREATE TABLE t(x INT CHECK(x<5));
+    INSERT INTO t VALUES (1);
+    INSERT INTO t VALUES (10);
+}
+expect error {
+    CHECK constraint failed: x<5
+}
+
+# Named constraints are reported by name, not by expression text.
+@cross-check-integrity
+test check_constraint_error_reports_constraint_name {
+    CREATE TABLE t(x INT CONSTRAINT xsmall CHECK(x  <  5));
+    INSERT INTO t VALUES (10);
+}
+expect error {
+    CHECK constraint failed: xsmall
+}
+
+# SQLite dequotes the captured text: when it starts with a quote character,
+# only the first quoted token survives in the message.
+@cross-check-integrity
+test check_constraint_error_dequotes_leading_quoted_token {
+    CREATE TABLE t(xy INT CHECK("xy" < +5));
+    INSERT INTO t VALUES (10);
+}
+expect error {
+    CHECK constraint failed: xy
+}

--- a/sqlite/conformance/sqlite-sqltests/constraint-error-message-suffix.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/constraint-error-message-suffix.sqltest
@@ -1,0 +1,31 @@
+@database :memory:
+
+# sqlite3_errmsg reports constraint failures without a result-code suffix;
+# the "(19)" the sqlite3 shell prints is shell decoration. Turso used to bake
+# " (19)" into UNIQUE, NOT NULL, and PRIMARY KEY failure messages.
+
+test unique-constraint-error-has-no-result-code-suffix {
+    CREATE TABLE u (a UNIQUE);
+    INSERT INTO u VALUES (1);
+    INSERT INTO u VALUES (1);
+}
+expect error {
+    ^UNIQUE constraint failed: u\.a$
+}
+
+test not-null-constraint-error-has-no-result-code-suffix {
+    CREATE TABLE nn (a NOT NULL);
+    INSERT INTO nn VALUES (NULL);
+}
+expect error {
+    ^NOT NULL constraint failed: nn\.a$
+}
+
+test primary-key-constraint-error-has-no-result-code-suffix {
+    CREATE TABLE pk (a INTEGER PRIMARY KEY);
+    INSERT INTO pk VALUES (1);
+    INSERT INTO pk VALUES (1);
+}
+expect error {
+    ^UNIQUE constraint failed: pk\.a$
+}

--- a/sqlite/conformance/sqlite-sqltests/create-index-error-message.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/create-index-error-message.sqltest
@@ -1,0 +1,29 @@
+@database :memory:
+
+# SQLite's CREATE INDEX errors: a missing target table is reported with the
+# database qualifier (`no such table: main.nosuch`) because an index always
+# lives in its table's database, and indexing a view or virtual table gets a
+# dedicated message. Turso used its own spellings ("Error: table 'nosuch'
+# does not exist.", "Error: table 'v' is not a b-tree table.").
+
+test create-index-missing-table-reports-qualified-name {
+    CREATE INDEX idx1 ON nosuch (a);
+}
+expect error {
+    no such table: main.nosuch
+}
+
+test create-index-missing-table-keeps-name-case {
+    CREATE INDEX idx1 ON NoSuch (a);
+}
+expect error {
+    no such table: main.NoSuch
+}
+
+test create-index-on-view {
+    CREATE VIEW v AS SELECT 1 AS x;
+    CREATE INDEX idx1 ON v (x);
+}
+expect error {
+    views may not be indexed
+}

--- a/sqlite/conformance/sqlite-sqltests/insert.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/insert.sqltest
@@ -917,7 +917,7 @@ test uniq_constraint {
     insert into test values (1);
 }
 expect error {
-    UNIQUE constraint failed: test.id \(19\)
+    UNIQUE constraint failed: test\.id
 }
 
 @cross-check-integrity
@@ -927,7 +927,7 @@ test insert-explicit-rowid-conflict {
     insert into t(rowid, x) values (1, 2);
 }
 expect error {
-    UNIQUE constraint failed: t.rowid \(19\)
+    UNIQUE constraint failed: t\.rowid
 }
 
 # RETURNING clause tests

--- a/sqlite/conformance/sqlite-sqltests/no-such-table-error-message.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/no-such-table-error-message.sqltest
@@ -1,0 +1,81 @@
+@database :memory:
+
+# SQLite reports a missing table using the name the user wrote, with quotes
+# stripped but any database qualifier kept: `SELECT * FROM main."t1"` fails
+# with `no such table: main.t1`. Turso used to report the normalized bare
+# name (`no such table: t1`) for every statement kind.
+
+test select-missing-table-plain-name {
+    SELECT * FROM nosuch;
+}
+expect error {
+    no such table: nosuch
+}
+
+test select-missing-table-qualified-name {
+    SELECT * FROM main.nosuch;
+}
+expect error {
+    no such table: main.nosuch
+}
+
+test select-missing-table-quoted-qualified-name {
+    SELECT * FROM main."nosuch";
+}
+expect error {
+    no such table: main.nosuch
+}
+
+test drop-missing-table-qualified-name {
+    DROP TABLE main.nosuch;
+}
+expect error {
+    no such table: main.nosuch
+}
+
+test delete-missing-table-qualified-name {
+    DELETE FROM main.nosuch;
+}
+expect error {
+    no such table: main.nosuch
+}
+
+test update-missing-table-qualified-name {
+    UPDATE main.nosuch SET x = 1;
+}
+expect error {
+    no such table: main.nosuch
+}
+
+test insert-missing-table-qualified-name {
+    INSERT INTO main.nosuch VALUES (1);
+}
+expect error {
+    no such table: main.nosuch
+}
+
+test alter-missing-table-qualified-name {
+    ALTER TABLE main.nosuch RENAME TO other;
+}
+expect error {
+    no such table: main.nosuch
+}
+
+# A trigger's target table lives in the same database as the trigger, so
+# SQLite qualifies the missing table with that database name even when the
+# user wrote it bare.
+test create-trigger-missing-table-reports-qualified-name {
+    CREATE TRIGGER trg AFTER INSERT ON nosuch BEGIN SELECT 1; END;
+}
+expect error {
+    no such table: main.nosuch
+}
+
+# A temp trigger searches every database for its target, so the error keeps
+# the name exactly as the user wrote it.
+test create-temp-trigger-missing-table-reports-plain-name {
+    CREATE TEMP TRIGGER trg AFTER INSERT ON nosuch BEGIN SELECT 1; END;
+}
+expect error {
+    no such table: nosuch
+}

--- a/sqlite/conformance/sqlite-sqltests/sql-error-message-prefix.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/sql-error-message-prefix.sqltest
@@ -1,0 +1,15 @@
+@database :memory:
+
+# Errors raised by emitted bytecode with the generic SQLITE_ERROR code must
+# read exactly like sqlite3_errmsg. Turso used to route them through its
+# internal-error type, which stamped an "Internal error: " prefix on
+# messages real SQLite reports bare.
+
+test sql-error-has-no-internal-error-prefix {
+    CREATE TABLE w (x);
+    INSERT INTO w VALUES (1), (2);
+    SELECT nth_value(x, 0) OVER (ORDER BY x) FROM w;
+}
+expect error {
+    ^second argument to nth_value must be a positive integer$
+}

--- a/sqlite/conformance/sqlite-sqltests/window/default.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/default.sqltest
@@ -416,7 +416,14 @@ test window-function-without-over {
     SELECT row_number() FROM products;
 }
 expect error {
-    misuse of window function
+    misuse of window function row_number\(\)$
+}
+
+test window-function-star-without-over {
+    SELECT row_number(*) FROM products;
+}
+expect error {
+    misuse of window function row_number\(\)$
 }
 
 test window-scalar-function-star {

--- a/sqlite/conformance/turso-sqltests/invalid-argument-error-message.sqltest
+++ b/sqlite/conformance/turso-sqltests/invalid-argument-error-message.sqltest
@@ -1,0 +1,12 @@
+@database :memory:
+
+# Turso used to prefix every InvalidArgument error with "Invalid argument
+# supplied: ", a spelling SQLite never produces (sqlite3_errmsg is bare).
+# The anchored pattern proves the prefix is gone.
+
+test invalid-argument-error-has-no-prefix {
+    PRAGMA auto_vacuum = 1;
+}
+expect error {
+    ^Autovacuum is not enabled\. Use --experimental-autovacuum flag to enable it\.$
+}

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -354,7 +354,7 @@ set test_files {
   like                 fail
   like2                pass
   like3                fail
-  limit                fail
+  limit                pass
   limit2               fail
   literal              fail
   literal2             pass
@@ -578,7 +578,7 @@ set test_files {
   tkt-3998683a16       pass
   tkt-3a77c9714e       pass
   tkt-3fe897352e       fail
-  tkt-4a03edc4c8       fail
+  tkt-4a03edc4c8       pass
   tkt-4c86b126f2       pass
   tkt-4dd95f6943       pass
   tkt-4ef7e3cfca       fail
@@ -638,7 +638,7 @@ set test_files {
   tkt1567              fail
   tkt1644              fail
   tkt1667              fail
-  tkt1873              fail
+  tkt1873              pass
   tkt2141              pass
   tkt2192              pass
   tkt2213              fail

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1512,7 +1512,17 @@ pub enum ColumnConstraint {
     /// `UNIQUE`
     Unique(Option<ResolveType>),
     /// `CHECK`
-    Check(Box<Expr>),
+    Check {
+        /// constraint expression
+        expr: Box<Expr>,
+        /// The text between the CHECK parens exactly as the user wrote it,
+        /// whitespace-trimmed. SQLite reports an unnamed failed constraint
+        /// with this text. `None` when the constraint did not come from this
+        /// parser — the PostgreSQL frontend's translator builds these nodes
+        /// from its own AST — or after an ALTER TABLE rewrite changed the
+        /// expression out from under the captured text.
+        source: Option<String>,
+    },
     /// `DEFAULT`
     Default(Box<Expr>),
     /// `COLLATE`
@@ -1579,7 +1589,17 @@ pub enum TableConstraint {
         conflict_clause: Option<ResolveType>,
     },
     /// `CHECK`
-    Check(Box<Expr>),
+    Check {
+        /// constraint expression
+        expr: Box<Expr>,
+        /// The text between the CHECK parens exactly as the user wrote it,
+        /// whitespace-trimmed. SQLite reports an unnamed failed constraint
+        /// with this text. `None` when the constraint did not come from this
+        /// parser — the PostgreSQL frontend's translator builds these nodes
+        /// from its own AST — or after an ALTER TABLE rewrite changed the
+        /// expression out from under the captured text.
+        source: Option<String>,
+    },
     /// `FOREIGN KEY`
     ForeignKey {
         /// columns

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1217,6 +1217,14 @@ impl Name {
             quote: None,
         }
     }
+    /// Create a name parsed from a bracket-quoted identifier (`[name]`),
+    /// remembering the bracket quoting so the name renders back as written.
+    pub const fn bracketed(s: String) -> Self {
+        Self {
+            value: s,
+            quote: Some('['),
+        }
+    }
     /// Parse name from the string (e.g. handle quoting and handle escaped quotes)
     pub fn from_string(s: impl AsRef<str>) -> Self {
         let s = s.as_ref();
@@ -1242,7 +1250,7 @@ impl Name {
         } else if bytes[0] == b'[' {
             assert!(s.len() >= 2);
             assert!(bytes[bytes.len() - 1] == b']');
-            Name::exact(s[1..s.len() - 1].to_string())
+            Name::bracketed(s[1..s.len() - 1].to_string())
         } else {
             Name::exact(s.to_string())
         }
@@ -1262,6 +1270,14 @@ impl Name {
     pub fn as_ident(&self) -> String {
         // let's keep original quotes if they were set
         // (parser.rs tests validates that behaviour)
+        if self.quote == Some('[') {
+            // A `]` cannot be escaped inside a bracket-quoted identifier, so
+            // fall back to double quotes when the name contains one.
+            if !self.value.contains(']') {
+                return format!("[{}]", self.value);
+            }
+            return format!("\"{}\"", self.value.replace('"', "\"\""));
+        }
         if let Some(quote) = self.quote {
             let single = quote.to_string();
             let double = single.clone() + &single;

--- a/sqlite/parser/src/ast/fmt.rs
+++ b/sqlite/parser/src/ast/fmt.rs
@@ -1804,10 +1804,23 @@ impl ToTokens for ColumnConstraint {
                 }
                 Ok(())
             }
-            Self::Check(expr) => {
+            Self::Check { expr, source } => {
                 s.append(TK_CHECK, None)?;
                 s.append(TK_LP, None)?;
-                expr.to_tokens(s, context)?;
+                match source {
+                    // Emit the expression exactly as the user wrote it so the
+                    // spelling survives the canonical re-render (SQLite
+                    // reports failed CHECKs with this text). Put the closing
+                    // paren on a new line when a line comment might otherwise
+                    // swallow it. Closed block comments are safe as-is.
+                    Some(src) if !src.is_empty() => {
+                        s.append(TK_ID, Some(src))?;
+                        if src.contains("--") {
+                            s.append(TK_ID, Some("\n"))?;
+                        }
+                    }
+                    _ => expr.to_tokens(s, context)?,
+                }
                 s.append(TK_RP, None)
             }
             Self::Default(expr) => {
@@ -1904,10 +1917,23 @@ impl ToTokens for TableConstraint {
                 }
                 Ok(())
             }
-            Self::Check(expr) => {
+            Self::Check { expr, source } => {
                 s.append(TK_CHECK, None)?;
                 s.append(TK_LP, None)?;
-                expr.to_tokens(s, context)?;
+                match source {
+                    // Emit the expression exactly as the user wrote it so the
+                    // spelling survives the canonical re-render (SQLite
+                    // reports failed CHECKs with this text). Put the closing
+                    // paren on a new line when a line comment might otherwise
+                    // swallow it. Closed block comments are safe as-is.
+                    Some(src) if !src.is_empty() => {
+                        s.append(TK_ID, Some(src))?;
+                        if src.contains("--") {
+                            s.append(TK_ID, Some("\n"))?;
+                        }
+                    }
+                    _ => expr.to_tokens(s, context)?,
+                }
                 s.append(TK_RP, None)
             }
             Self::ForeignKey {

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -764,7 +764,7 @@ impl<'a> Parser<'a> {
         let name = String::from_utf8_lossy(raw).into_owned();
         // Advance lexer past the closing `]`
         self.lexer.offset = start + end_pos + 1;
-        Ok(Name::exact(name))
+        Ok(Name::bracketed(name))
     }
 
     fn parse_transopt(&mut self) -> Result<Option<Name>> {

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -3393,9 +3393,26 @@ impl<'a> Parser<'a> {
     fn parse_check_table_constraint(&mut self) -> Result<TableConstraint> {
         eat_assert!(self, TK_CHECK);
         eat_expect!(self, TK_LP);
+        let start = self.offset();
         let expr = self.parse_expr(0)?;
+        let source = self.check_constraint_source(start);
         eat_expect!(self, TK_RP);
-        Ok(TableConstraint::Check(expr))
+        Ok(TableConstraint::Check { expr, source })
+    }
+
+    /// The text between a CHECK constraint's parens exactly as the user wrote
+    /// it, whitespace-trimmed, the way SQLite keeps it for constraint error
+    /// messages. `start` is the offset right after the opening paren; the
+    /// expression must already be parsed so the closing paren is the peeked
+    /// token.
+    fn check_constraint_source(&self, start: usize) -> Option<String> {
+        let end = self.offset();
+        let raw = self.lexer.input.get(start..end)?;
+        let text = std::str::from_utf8(raw).ok()?;
+        Some(
+            text.trim_matches(|c: char| c.is_ascii_whitespace())
+                .to_owned(),
+        )
     }
 
     fn parse_foreign_key_table_constraint(&mut self) -> Result<TableConstraint> {
@@ -3931,9 +3948,11 @@ impl<'a> Parser<'a> {
     fn parse_check_column_constraint(&mut self) -> Result<ColumnConstraint> {
         eat_assert!(self, TK_CHECK);
         eat_expect!(self, TK_LP);
+        let start = self.offset();
         let expr = self.parse_expr(0)?;
+        let source = self.check_constraint_source(start);
         eat_expect!(self, TK_RP);
-        Ok(ColumnConstraint::Check(expr))
+        Ok(ColumnConstraint::Check { expr, source })
     }
 
     fn parse_ref_act(&mut self) -> Result<RefAct> {
@@ -5397,6 +5416,26 @@ mod tests {
         p.next_cmd().unwrap();
         let third = p.offset();
         assert_eq!(&s[second..third], "SELECT * FROM test;");
+    }
+
+    #[test]
+    fn check_constraint_comments_survive_formatting() {
+        for (sql, comment) in [
+            (
+                "CREATE TABLE t (x CHECK(x /* column comment */ > 0))",
+                "/* column comment */",
+            ),
+            (
+                "CREATE TABLE t (x, CHECK(x -- table comment\n > 0))",
+                "-- table comment",
+            ),
+        ] {
+            let command = Parser::new(sql.as_bytes()).next().unwrap().unwrap();
+            let formatted = command.to_string();
+
+            assert!(formatted.contains(comment), "formatted SQL: {formatted}");
+            Parser::new(formatted.as_bytes()).next().unwrap().unwrap();
+        }
     }
 
     #[test]
@@ -10904,9 +10943,10 @@ mod tests {
                         constraints: vec![
                             NamedColumnConstraint {
                                 name: None,
-                                constraint: ColumnConstraint::Check(
-                                    Box::new(Expr::Literal(Literal::Numeric("1".to_owned()))),
-                                ),
+                                constraint: ColumnConstraint::Check {
+                                    expr: Box::new(Expr::Literal(Literal::Numeric("1".to_owned()))),
+                                    source: Some("1".to_owned()),
+                                },
                             },
                         ],
                     }),
@@ -10926,9 +10966,10 @@ mod tests {
                         constraints: vec![
                             NamedColumnConstraint {
                                 name: None,
-                                constraint: ColumnConstraint::Check(
-                                    Box::new(Expr::Literal(Literal::Numeric("1".to_owned()))),
-                                ),
+                                constraint: ColumnConstraint::Check {
+                                    expr: Box::new(Expr::Literal(Literal::Numeric("1".to_owned()))),
+                                    source: Some("1".to_owned()),
+                                },
                             },
                         ],
                     }),
@@ -11750,9 +11791,10 @@ mod tests {
                         constraints: vec![
                             NamedTableConstraint {
                                 name: None,
-                                constraint: TableConstraint::Check(Box::new(
-                                    Expr::Literal(Literal::Numeric("1".to_owned()))
-                                )),
+                                constraint: TableConstraint::Check {
+                                    expr: Box::new(Expr::Literal(Literal::Numeric("1".to_owned()))),
+                                    source: Some("1".to_owned()),
+                                },
                             },
                         ],
                         options: TableOptions::empty(),
@@ -11813,9 +11855,10 @@ mod tests {
                             },
                             NamedTableConstraint {
                                 name: None,
-                                constraint: TableConstraint::Check(Box::new(
-                                    Expr::Literal(Literal::Numeric("1".to_owned()))
-                                )),
+                                constraint: TableConstraint::Check {
+                                    expr: Box::new(Expr::Literal(Literal::Numeric("1".to_owned()))),
+                                    source: Some("1".to_owned()),
+                                },
                             },
                         ],
                         options: TableOptions::empty(),

--- a/testing/sqltest/src/backends/cli.rs
+++ b/testing/sqltest/src/backends/cli.rs
@@ -342,7 +342,7 @@ impl CliDatabaseInstance {
             } else {
                 format!("command exited with status {}", output.status)
             };
-            return Ok(QueryResult::error(error_msg));
+            return Ok(QueryResult::error(normalize_cli_error(&error_msg)));
         }
 
         if is_sqlite_dot_command {
@@ -415,9 +415,72 @@ impl DatabaseInstance for CliDatabaseInstance {
     }
 }
 
+/// Normalize shell-decorated error output to the message `sqlite3_errmsg`
+/// would report, matching what the rust backend surfaces: parse errors read
+/// `Parse error: <message>`, runtime errors are the bare message.
+///
+/// The sqlite3 shell prints `Parse error near line N: <message>` followed by
+/// source-context lines, and `Runtime error near line N: <message> (<code>)`.
+/// The tursodb shell prints `Runtime error: <message> (<code>)` and renders
+/// prepare-time errors through miette as `× <message>` with `│` continuation
+/// lines when the message wraps.
+fn normalize_cli_error(raw: &str) -> String {
+    let lines: Vec<&str> = raw.lines().collect();
+    for (idx, line) in lines.iter().enumerate() {
+        let line = line.trim_start();
+        // Older tursodb shells wrapped everything in a generic "Error: ".
+        let line = line.strip_prefix("Error: ").unwrap_or(line);
+        if let Some(message) = strip_shell_error_prefix(line, "Parse error") {
+            return format!("Parse error: {message}");
+        }
+        if let Some(message) = strip_shell_error_prefix(line, "Runtime error") {
+            return strip_result_code(message).to_string();
+        }
+        if let Some(message) = line.strip_prefix("× ") {
+            // miette wraps long messages onto `│` continuation lines.
+            let mut message = message.trim().to_string();
+            for continuation in &lines[idx + 1..] {
+                let Some(continuation) = continuation.trim_start().strip_prefix("│ ") else {
+                    break;
+                };
+                message.push(' ');
+                message.push_str(continuation.trim());
+            }
+            return message;
+        }
+    }
+    raw.trim().to_string()
+}
+
+/// Strip `<kind>: ` or `<kind> near line N: ` from the start of a shell
+/// error line, returning the message that follows.
+fn strip_shell_error_prefix<'a>(line: &'a str, kind: &str) -> Option<&'a str> {
+    let rest = line.strip_prefix(kind)?.trim_start();
+    let rest = if let Some(rest) = rest.strip_prefix("near line") {
+        rest.trim_start()
+            .trim_start_matches(|c: char| c.is_ascii_digit())
+    } else {
+        rest
+    };
+    Some(rest.strip_prefix(':')?.trim_start())
+}
+
+/// Strip a trailing ` (<code>)` result code the sqlite3 and tursodb shells
+/// append after runtime error messages.
+fn strip_result_code(message: &str) -> &str {
+    if let Some(open) = message.rfind(" (") {
+        if let Some(code) = message[open + 2..].strip_suffix(')') {
+            if !code.is_empty() && code.bytes().all(|b| b.is_ascii_digit()) {
+                return &message[..open];
+            }
+        }
+    }
+    message
+}
+
 #[cfg(test)]
 mod tests {
-    use super::CliDatabaseInstance;
+    use super::{CliDatabaseInstance, normalize_cli_error};
 
     #[test]
     fn final_supported_sqlite_dot_command_detects_last_line() {
@@ -459,6 +522,75 @@ mod tests {
                 vec!["CREATE TABLE t1 (a CHECK(abs(a) > 0));".to_string()],
                 vec!["CREATE TRIGGER trg AFTER INSERT ON t1 BEGIN SELECT 1; END;".to_string()]
             ]
+        );
+    }
+
+    #[test]
+    fn normalize_sqlite3_runtime_error_strips_line_and_code() {
+        assert_eq!(
+            normalize_cli_error("Runtime error near line 3: UNIQUE constraint failed: u.a (19)"),
+            "UNIQUE constraint failed: u.a"
+        );
+    }
+
+    #[test]
+    fn normalize_sqlite3_runtime_error_without_code() {
+        assert_eq!(
+            normalize_cli_error(
+                "Runtime error near line 3: second argument to nth_value must be a positive integer"
+            ),
+            "second argument to nth_value must be a positive integer"
+        );
+    }
+
+    #[test]
+    fn normalize_sqlite3_parse_error_drops_context_lines() {
+        assert_eq!(
+            normalize_cli_error(
+                "Parse error near line 4: no such table: nosuch\n  CREATE TABLE...\n     ^--- error here"
+            ),
+            "Parse error: no such table: nosuch"
+        );
+    }
+
+    #[test]
+    fn normalize_tursodb_runtime_error() {
+        assert_eq!(
+            normalize_cli_error("Runtime error: CHECK constraint failed: x<5 (19)"),
+            "CHECK constraint failed: x<5"
+        );
+    }
+
+    #[test]
+    fn normalize_tursodb_miette_error_joins_wrapped_lines() {
+        assert_eq!(
+            normalize_cli_error(
+                "  × Autovacuum is not enabled. Use --experimental-autovacuum flag to enable\n  │ it."
+            ),
+            "Autovacuum is not enabled. Use --experimental-autovacuum flag to enable it."
+        );
+    }
+
+    #[test]
+    fn normalize_tursodb_miette_parse_error_keeps_parse_prefix() {
+        assert_eq!(
+            normalize_cli_error("  × Parse error: no such table: main.nosuch"),
+            "Parse error: no such table: main.nosuch"
+        );
+    }
+
+    #[test]
+    fn normalize_leaves_undecorated_text_alone() {
+        assert_eq!(normalize_cli_error("plain message\n"), "plain message");
+    }
+
+    #[test]
+    fn normalize_skips_leading_result_rows() {
+        assert_eq!(
+            normalize_cli_error(
+                "1|2\nRuntime error near line 9: NOT NULL constraint failed: nn.a (19)"
+            ),
+            "NOT NULL constraint failed: nn.a"
         );
     }
 }

--- a/testing/sqltest/src/backends/js.rs
+++ b/testing/sqltest/src/backends/js.rs
@@ -183,12 +183,12 @@ impl JsDatabaseInstance {
 
         // Check for errors in stderr
         if !stderr.is_empty() && (stderr.contains("Error") || stderr.contains("error")) {
-            return Ok(QueryResult::error(stderr.trim().to_string()));
+            return Ok(QueryResult::error(normalize_js_error(stderr.trim())));
         }
 
         // Check for errors in stdout (the runner outputs "Error: ...")
         if stdout.starts_with("Error:") || stdout.contains("\nError:") {
-            return Ok(QueryResult::error(stdout.trim().to_string()));
+            return Ok(QueryResult::error(normalize_js_error(stdout.trim())));
         }
 
         if !output.status.success() {
@@ -266,6 +266,22 @@ impl DatabaseInstance for JsDatabaseInstance {
     }
 }
 
+/// Normalize the JS runner's error output to the message the rust backend
+/// surfaces. The runner prints `Error: <js error>`, and the JS binding wraps
+/// the engine message in an operation context, e.g. `step failed: UNIQUE
+/// constraint failed: u.a`. Strip both layers so one error expectation works
+/// on every backend.
+fn normalize_js_error(raw: &str) -> String {
+    const BINDING_CONTEXTS: &[&str] = &["step failed: ", "prepare failed: ", "reset failed: "];
+    let message = raw.strip_prefix("Error: ").unwrap_or(raw);
+    for context in BINDING_CONTEXTS {
+        if let Some(message) = message.strip_prefix(context) {
+            return message.to_string();
+        }
+    }
+    message.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -275,5 +291,26 @@ mod tests {
         let backend = JsBackend::new("node", "bindings/javascript/turso-sql-runner.mjs");
         let capabilities = backend.capabilities();
         assert!(capabilities.contains(&Capability::Trigger));
+    }
+
+    #[test]
+    fn normalize_js_error_strips_runner_and_binding_wrappers() {
+        assert_eq!(
+            normalize_js_error("Error: step failed: CHECK constraint failed: x<5"),
+            "CHECK constraint failed: x<5"
+        );
+    }
+
+    #[test]
+    fn normalize_js_error_keeps_parse_errors_intact() {
+        assert_eq!(
+            normalize_js_error("Error: prepare failed: Parse error: no such table: t"),
+            "Parse error: no such table: t"
+        );
+    }
+
+    #[test]
+    fn normalize_js_error_leaves_plain_messages_alone() {
+        assert_eq!(normalize_js_error("some other error"), "some other error");
     }
 }

--- a/testing/system/vtab.test
+++ b/testing/system/vtab.test
@@ -23,17 +23,17 @@ load_extension test_ext
 do_execsql_test_in_memory_error_content create-virtual-table-duplicate-name-1 {
     CREATE VIRTUAL TABLE t1 USING kv_store;
     CREATE VIRTUAL TABLE t1 USING kv_store;
-} {Table t1 already exists}
+} {table t1 already exists}
 
 do_execsql_test_in_memory_error_content create-virtual-table-duplicate-name-2 {
     CREATE TABLE t2 (col INTEGER);
     CREATE VIRTUAL TABLE t2 USING kv_store;
-} {Table t2 already exists}
+} {table t2 already exists}
 
 do_execsql_test_in_memory_error_content create-virtual-table-duplicate-name-3 {
     CREATE VIRTUAL TABLE t3 USING kv_store;
     CREATE TABLE t3 (col INTEGER);
-} {Table t3 already exists}
+} {table t3 already exists}
 
 do_execsql_test_on_specific_db {:memory:} create-virtual-table-if-not-exists-1 {
     CREATE TABLE t2 (col INTEGER);

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -236,7 +236,7 @@ fn test_attach_rejects_initialized_page_size_mismatch(_tmp_db: TempDatabase) -> 
     assert_eq!(
         err,
         format!(
-            "Invalid argument supplied: cannot attach database 'aux': page size mismatch (main={:?}, attached={:?})",
+            "cannot attach database 'aux': page size mismatch (main={:?}, attached={:?})",
             turso_core::storage::sqlite3_ondisk::PageSize::new(8192).unwrap(),
             turso_core::storage::sqlite3_ondisk::PageSize::new(4096).unwrap(),
         )
@@ -262,7 +262,7 @@ fn test_attach_rejects_fresh_read_only_database(_tmp_db: TempDatabase) -> anyhow
         .to_string();
     assert_eq!(
         err,
-        "Invalid argument supplied: cannot attach database 'aux': fresh read-only databases cannot be initialized during attach"
+        "cannot attach database 'aux': fresh read-only databases cannot be initialized during attach"
     );
 
     Ok(())
@@ -358,7 +358,7 @@ fn test_fresh_mvcc_attach_rejects_custom_durable_storage_without_attached_backen
         .to_string();
     assert_eq!(
         err,
-        "Invalid argument supplied: cannot attach database 'aux': fresh MVCC attach does not support inheriting custom durable storage"
+        "cannot attach database 'aux': fresh MVCC attach does not support inheriting custom durable storage"
     );
 
     Ok(())


### PR DESCRIPTION
This series aligns Turso's error messages with what `sqlite3_errmsg` actually produces, fixing the ~200 error-message mismatches found in the TCL conformance run. Each mismatch category is a separate commit with a regression test that fails without the fix.

## What changed

- **Missing tables** are reported with the name the user wrote, keeping any database qualifier: `SELECT * FROM main."t1"` now fails with `no such table: main.t1`. A non-temp `CREATE TRIGGER` qualifies its missing target with the trigger's database, like SQLite; a temp trigger reports the name as written. `CREATE INDEX` on a missing table also qualifies (`no such table: main.nosuch`), and indexing a view says `views may not be indexed`.
- **Name collisions on CREATE** echo the new object's name token exactly as written, quotes included: `CREATE TABLE "t2"` fails with `table "t2" already exists`. Duplicate indexes print the dequoted name, and clashes across the index/table namespaces use SQLite's `there is already a[n] index/table named x` shapes. The parser now remembers `[bracket]` quoting in `ast::Name` so any quoted token can be reproduced as written.
- **CHECK constraint failures** report the expression's source text verbatim (`CHECK constraint failed: x<5`, never `x < 5`), including SQLite's dequoting of a leading quoted token. The parser captures the between-parens text; because Turso stores canonically re-rendered SQL in `sqlite_schema`, the renderer re-embeds the captured text so the spelling survives reopen, and ALTER rewrites clear it.
- **Shell decoration removed from the API surface**: the `Runtime error:` / `Invalid argument supplied:` prefixes and the `(19)` suffix are sqlite3 *shell* output, not part of `sqlite3_errmsg`. Core messages are now bare, and the tursodb shell adds `Runtime error: <message> (<code>)` itself, matching the sqlite3 shell (including omitting the code for plain `SQLITE_ERROR`).
- **Generic `SQLITE_ERROR` halts** (e.g. `nth_value(x, 0)` argument validation) no longer gain an `Internal error:` prefix; a new bare-display `LimboError::SqlError` keeps the same abort semantics.

## Validation

Every commit passed `cargo fmt`, workspace clippy with `--deny=warnings`, both sqltest conformance suites (12,260 + 1,550 passing), and the turso_core unit tests. The series was additionally validated with the parser tests, Rust-binding and attach integration tests, the CLI constraint Python tests, and the full TCL compat suite. New coverage: five `.sqltest` files plus extensions to `check_constraint.sqltest` and a C API test pinning `sqlite3_errmsg` to SQLite's exact text; each was verified to fail on the pre-fix build.