### PR TITLE
core: report plain column names from RETURNING like SELECT does

### DIFF
--- a/core/translate/expr/emission.rs
+++ b/core/translate/expr/emission.rs
@@ -140,8 +140,6 @@ pub fn process_returning_clause(
 ) -> Result<Vec<ResultSetColumn>> {
     let mut result_columns = Vec::with_capacity(returning.len());
 
-    let alias_to_string = |alias: &ast::As| alias.name().as_str().to_string();
-
     for rc in returning.iter_mut() {
         match rc {
             ast::ResultColumn::Expr(expr, alias) => {
@@ -161,10 +159,24 @@ pub fn process_returning_clause(
                     );
                 }
 
+                // An implicit column name is the verbatim SQL text of the
+                // expression, not a user-written alias. Keeping the two apart
+                // lets a plain column reference report its own name, so
+                // RETURNING "t"."id" is named `id` just like SELECT is.
+                let (alias, implicit_column_name) = match alias.as_ref() {
+                    Some(ast::As::As(name)) | Some(ast::As::Elided(name)) => {
+                        (Some(name.as_str().to_string()), None)
+                    }
+                    Some(ast::As::ImplicitColumnName(name)) => {
+                        (None, Some(name.as_str().to_string()))
+                    }
+                    None => (None, None),
+                };
+
                 result_columns.push(ResultSetColumn {
                     expr: expr.as_ref().clone(),
-                    alias: alias.as_ref().map(alias_to_string),
-                    implicit_column_name: None,
+                    alias,
+                    implicit_column_name,
                     contains_aggregates: false,
                 });
             }

--- a/sqlite/conformance/sqlite-sqltests/returning.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/returning.sqltest
@@ -2468,3 +2468,64 @@ expect {
     3|10|3
     4|20|1
 }
+
+# The column names reported for a RETURNING clause should be the plain column
+# name, the same as SELECT, no matter how the column is written in the query.
+@backend cli
+@cross-check-integrity
+test insert-returning-column-names-are-unqualified {
+    .headers on
+    CREATE TABLE t (id INTEGER, name TEXT);
+    INSERT INTO t VALUES (1, 'test') RETURNING id, "id", t.id, "t"."id";
+}
+expect {
+    id|id|id|id
+    1|1|1|1
+}
+
+# UPDATE and DELETE share process_returning_clause with INSERT, so they name
+# their RETURNING columns the same way. `.headers on` needs the CLI backend,
+# so these tests can only run there.
+@backend cli
+@cross-check-integrity
+test update-returning-column-names-are-unqualified {
+    .headers on
+    CREATE TABLE t (id INTEGER, name TEXT);
+    INSERT INTO t VALUES (1, 'test');
+    UPDATE t SET name = 'other' RETURNING id, "id", t.id, "t"."id", id AS foo, id  +  1;
+}
+expect {
+    id|id|id|id|foo|id  +  1
+    1|1|1|1|1|2
+}
+
+@backend cli
+@cross-check-integrity
+test delete-returning-column-names-are-unqualified {
+    .headers on
+    CREATE TABLE t (id INTEGER, name TEXT);
+    INSERT INTO t VALUES (1, 'test');
+    DELETE FROM t RETURNING id, "id", t.id, "t"."id", id AS foo, id  +  1;
+}
+expect {
+    id|id|id|id|foo|id  +  1
+    1|1|1|1|1|2
+}
+
+# A rowid reference in RETURNING is named like SELECT names it: the rowid
+# alias column's name when the table has one, "rowid" otherwise.
+@backend cli
+@cross-check-integrity
+test returning-rowid-column-names-default-pragmas {
+    .headers on
+    CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER);
+    CREATE TABLE n (a INTEGER);
+    INSERT INTO t VALUES (1, 10) RETURNING rowid, oid, _rowid_;
+    INSERT INTO n VALUES (1) RETURNING rowid;
+}
+expect {
+    id|id|id
+    1|1|1
+    rowid
+    1
+}


### PR DESCRIPTION
## Description

RETURNING stored the parser's verbatim expression text as the column alias, so `INSERT ... RETURNING "users"."id"` reported the column name `"users"."id"` where SQLite reports `id`.

`ResultSetColumn.implicit_column_name` already exists and allows `SELECT` to apply naming, which aligns with SQLite.

https://github.com/tursodatabase/turso/blob/f43edb3fb629715533387fe0e531961c688b655b/core/translate/select.rs#L600-L608

This change implements a similar solution, which splits the user-written alias from the implicit column name when building the result columns, so the naming ladder in `Statement::get_column_name` applies to `RETURNING` the same way it applies to `SELECT`.

This also names `RETURNING rowid` after the rowid alias column, which is consistent with SQLite.

Tests: sqlite/conformance returning.sqltest; all four new expect blocks reproduce on sqlite3 3.51

| Query | Before | After / SQLite |
|---|---|---|
| `RETURNING "id"` | `"id"` | `id` |
| `RETURNING users.id` | `users.id` | `id` |
| `RETURNING "users"."id"` | `"users"."id"` | `id` |
| `RETURNING rowid` | `rowid` | `id` (rowid alias column) |


## Motivation and context

Fixes #7115

I was working on an adapter for Drizzle when I ran into this issue, and fixing it would make my life easier and allow ORMs written for Turso to be more robust. ORMs often quote and qualify all identifiers for correctness (reserved words, case-sensitive column names), so bare unquoted RETURNING isn't viable for these use cases.

## Description of AI Usage

I write very little Rust, so a large portion of this was having an agent translate Rust into pseudocode/TS for me.

I started with red tests because I knew the failing cases up front. I first dispatched an agent to investigate where the issue may be. After isolating it, I had the agent explain what it thought the bug was and propose a solution. I ran through it in pseudocode to better understand the specifics of the solution before investigating the syntax to ensure I clearly understood the implementation's outcome. The patterns were generally recognisable: destructuring, pattern matching. It was an interesting exercise to understand both this and why this bug cropped up in the first place.

I believe this change represents the narrowest possible solution and aligns with the codebase's conventions and standards. This change ends up populating a field that the rest of the naming machinery already handles successfully, rather than introducing any new mechanisms.

I have read the relevant sections of the CONTRIBUTING.md and understand that opening an MR does not entitle me to a review or a merge, but if anyone does end up reading this far, thank you for your time and consideration!