### PR TITLE
postgres: implement pg_get_expr function

### DIFF
--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -74,9 +74,11 @@ plus `pg_input_error_info`. Present but always empty: `pg_policy`,
 `pg_trigger`, `pg_statistic_ext`, `pg_inherits`, `pg_rewrite`,
 `pg_foreign_table`, `pg_partitioned_table`, `pg_collation`, `pg_description`,
 `pg_publication*`. Catalog introspection functions: `format_type`,
-`pg_get_constraintdef`, `pg_get_indexdef`, `pg_get_userbyid`,
-`pg_*_is_visible`, `pg_encoding_to_char`, `pg_input_is_valid`, `to_char`
-(numeric), `now`/`clock_timestamp`/`transaction_timestamp`/`statement_timestamp`.
+`pg_get_constraintdef`, `pg_get_indexdef`, `pg_get_expr` (returns TursoPG's
+stored SQL; relation oid and pretty printing do not change the output),
+`pg_get_userbyid`, `pg_*_is_visible`, `pg_encoding_to_char`,
+`pg_input_is_valid`, `to_char` (numeric), `now`/`clock_timestamp`/
+`transaction_timestamp`/`statement_timestamp`.
 Session information functions: `version()`, `current_database()` /
 `current_catalog`, `current_schema` (call, bare-keyword, and FROM-position
 forms), `pg_backend_pid()`, `quote_ident()`, `quote_literal()`;

--- a/postgres/cli/TODO.md
+++ b/postgres/cli/TODO.md
@@ -7,7 +7,7 @@ Sorted by implementation difficulty.
 1. ~~**COMMENT ON**~~ — DONE (accepted as a no-op; comments are not persisted)
 2. **PREPARE / EXECUTE / DEALLOCATE** — wire protocol already handles this; just need the SQL syntax to not error
 3. **GRANT/REVOKE** — parse + ignore (single-user system, just don't error)
-4. **More PG system functions** — still missing: `current_setting`, `current_schemas(bool)`, ~~a real `pg_get_expr` (currently a NULL stub)~~, and the regexp functions (`extensions/regexp` is not linked into tursopg); session information functions and the `string_agg` family already resolve
+4. **More PG system functions** — still missing: `current_setting`, `current_schemas(bool)`, and the regexp functions (`extensions/regexp` is not linked into tursopg); session information functions and the `string_agg` family already resolve
 5. ~~**SET search_path**~~ — intercept in try_prepare_pg, store on connection, use in table resolution
 ∑
 ## Easy (a day or two)

--- a/postgres/cli/TODO.md
+++ b/postgres/cli/TODO.md
@@ -7,7 +7,7 @@ Sorted by implementation difficulty.
 1. ~~**COMMENT ON**~~ — DONE (accepted as a no-op; comments are not persisted)
 2. **PREPARE / EXECUTE / DEALLOCATE** — wire protocol already handles this; just need the SQL syntax to not error
 3. **GRANT/REVOKE** — parse + ignore (single-user system, just don't error)
-4. **More PG system functions** — still missing: `current_setting`, `current_schemas(bool)`, a real `pg_get_expr` (currently a NULL stub), and the regexp functions (`extensions/regexp` is not linked into tursopg); session information functions and the `string_agg` family already resolve
+4. **More PG system functions** — still missing: `current_setting`, `current_schemas(bool)`, ~~a real `pg_get_expr` (currently a NULL stub)~~, and the regexp functions (`extensions/regexp` is not linked into tursopg); session information functions and the `string_agg` family already resolve
 5. ~~**SET search_path**~~ — intercept in try_prepare_pg, store on connection, use in table resolution
 ∑
 ## Easy (a day or two)

--- a/postgres/conformance/pg-sqltests/functions.sqltest
+++ b/postgres/conformance/pg-sqltests/functions.sqltest
@@ -197,3 +197,16 @@ test pg-get-expr-non-text-expression-errors {
     SELECT pg_get_expr(42, 1::oid) FROM pg_attrdef;
 }
 expect error {}
+
+test pg-get-expr-null-oid-does-not-hide-invalid-expression {
+    SELECT pg_get_expr(42, NULL::oid);
+}
+expect error {}
+
+test pg-get-expr-check-constraint {
+    CREATE TABLE checked (val int CHECK (val > 0));
+    SELECT pg_get_expr(conbin, conrelid) FROM pg_constraint WHERE contype = 'c';
+}
+expect {
+    val > 0
+}

--- a/postgres/conformance/pg-sqltests/functions.sqltest
+++ b/postgres/conformance/pg-sqltests/functions.sqltest
@@ -168,3 +168,18 @@ test quote-ident-wrong-arity-errors {
     SELECT quote_ident();
 }
 expect error {}
+
+test pg-get-expr-  {
+    DROP TABLE IF EXISTS demo;
+    CREATE TABLE demo (id int DEFAULT 7, label text);
+    SELECT pg_get_expr(adbin, adrelid) FROM pg_attrdef;
+}
+expect {
+    7
+}
+
+test pg-get-expr-null-expressions-is-null {
+    SELECT pg_get_expr(NULL, 1);
+}
+expect {
+}

--- a/postgres/conformance/pg-sqltests/functions.sqltest
+++ b/postgres/conformance/pg-sqltests/functions.sqltest
@@ -169,8 +169,7 @@ test quote-ident-wrong-arity-errors {
 }
 expect error {}
 
-test pg-get-expr-  {
-    DROP TABLE IF EXISTS demo;
+test pg-get-expr-default-two-args {
     CREATE TABLE demo (id int DEFAULT 7, label text);
     SELECT pg_get_expr(adbin, adrelid) FROM pg_attrdef;
 }
@@ -178,8 +177,23 @@ expect {
     7
 }
 
-test pg-get-expr-null-expressions-is-null {
-    SELECT pg_get_expr(NULL, 1);
+test pg-get-expr-default-three-args {
+    CREATE TABLE demo (id int DEFAULT 7, label text);
+    SELECT pg_get_expr(adbin, adrelid, true) FROM pg_attrdef;
+}
+expect {
+    7
+}
+
+test pg-get-expr-null-oid-is-null {
+    CREATE TABLE demo (id int DEFAULT 7, label text);
+    SELECT pg_get_expr(adbin, NULL, true) FROM pg_attrdef;
 }
 expect {
 }
+
+test pg-get-expr-non-text-expression-errors {
+    CREATE TABLE demo (id int DEFAULT 7, label text);
+    SELECT pg_get_expr(42, 1::oid) FROM pg_attrdef;
+}
+expect error {}

--- a/postgres/frontend/functions.rs
+++ b/postgres/frontend/functions.rs
@@ -71,7 +71,7 @@ pub(crate) fn exec_scalar(conn: &Connection, name: &str, args: &[Value]) -> Resu
             ))),
         },
         "quote_literal" => Ok(exec_quote_literal(args.first().unwrap_or(&Value::Null))),
-        "pg_get_expr" => Ok(exec_pg_get_expr(args)),
+        "pg_get_expr" => exec_pg_get_expr(args),
         // Catalog introspection stubs: accepted for compatibility, no output.
         // obj_description/col_description are NULL because COMMENT ON is not persisted.
         "pg_get_statisticsobjdef_columns"
@@ -234,11 +234,18 @@ fn exec_pg_input_is_valid(input: &Value, type_name: &str) -> Value {
     Value::from_i64(if valid { 1 } else { 0 })
 }
 
-fn exec_pg_get_expr(args: &[Value]) -> Value {
+fn exec_pg_get_expr(args: &[Value]) -> Result<Value> {
     if args.iter().any(|arg| matches!(arg, Value::Null)) {
-        return Value::Null;
+        return Ok(Value::Null);
     }
-    args.first().cloned().unwrap_or(Value::Null)
+
+    // TursoPG already stores adbin and conbin as rendered SQL rather than pg_node_tree, so the relation OID and pretty flag do not affect the output
+    match args.first() {
+        Some(Value::Text(expression)) => Ok(Value::Text(expression.clone())),
+        Some(_) | None => Err(LimboError::ConversionError(
+            "Expected text value".to_string(),
+        )),
+    }
 }
 
 fn user_tables_sorted(schema: &Schema) -> Vec<(&String, &Arc<Table>)> {

--- a/postgres/frontend/functions.rs
+++ b/postgres/frontend/functions.rs
@@ -71,10 +71,10 @@ pub(crate) fn exec_scalar(conn: &Connection, name: &str, args: &[Value]) -> Resu
             ))),
         },
         "quote_literal" => Ok(exec_quote_literal(args.first().unwrap_or(&Value::Null))),
+        "pg_get_expr" => Ok(exec_pg_get_expr(args)),
         // Catalog introspection stubs: accepted for compatibility, no output.
         // obj_description/col_description are NULL because COMMENT ON is not persisted.
-        "pg_get_expr"
-        | "pg_get_statisticsobjdef_columns"
+        "pg_get_statisticsobjdef_columns"
         | "pg_relation_is_publishable"
         | "pg_get_function_result"
         | "pg_get_function_arguments"
@@ -232,6 +232,13 @@ fn exec_pg_input_is_valid(input: &Value, type_name: &str) -> Value {
     };
     let valid = validate_pg_input(&s, type_name).is_none();
     Value::from_i64(if valid { 1 } else { 0 })
+}
+
+fn exec_pg_get_expr(args: &[Value]) -> Value {
+    if args.iter().any(|arg| matches!(arg, Value::Null)) {
+        return Value::Null;
+    }
+    args.first().cloned().unwrap_or(Value::Null)
 }
 
 fn user_tables_sorted(schema: &Schema) -> Vec<(&String, &Arc<Table>)> {

--- a/postgres/frontend/functions.rs
+++ b/postgres/frontend/functions.rs
@@ -235,13 +235,16 @@ fn exec_pg_input_is_valid(input: &Value, type_name: &str) -> Value {
 }
 
 fn exec_pg_get_expr(args: &[Value]) -> Result<Value> {
-    if args.iter().any(|arg| matches!(arg, Value::Null)) {
-        return Ok(Value::Null);
-    }
-
-    // TursoPG already stores adbin and conbin as rendered SQL rather than pg_node_tree, so the relation OID and pretty flag do not affect the output
     match args.first() {
-        Some(Value::Text(expression)) => Ok(Value::Text(expression.clone())),
+        Some(Value::Text(expression)) => {
+            if args[1..].iter().any(|arg| matches!(arg, Value::Null)) {
+                return Ok(Value::Null);
+            }
+
+            // TursoPG stores adbin and conbin as rendered SQL, so the relation OID and pretty flag do not change the output.
+            Ok(Value::Text(expression.clone()))
+        }
+        Some(Value::Null) => Ok(Value::Null),
         Some(_) | None => Err(LimboError::ConversionError(
             "Expected text value".to_string(),
         )),


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->
Implements the `pg_get_expr` function in Tursopg. Previously, the `pg_get_expr` scalar function returned NULL instead of the expression in a readable format. The implementation supports two and three argument forms, preserves Postgres's NULL behavior, and rejects non-text inputs for the expression.

Fixes #8198 that I created that describes the discrepancy more in-depth.

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Tursopg already registered `pg_get_expr` as a valid function but always returned NULL. Unlike Postgres, Turso exposes these expressions as rendered SQL rather than `pg_node_tree` values. This makes the implementation for `pg_get_expr` fairly trivial. We can just return Tursopg's existing rendered expression text (adbin or conbin).

The actual benefit that this function provides is that it is useful for tools such as `pg_dump` that call this function to extract column default values and check constraints.

Reference: https://pgpedia.info/p/pg_get_expr.html
## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

Used GPT 5.6 sol to understand `pg_get_expr` function itself, `postgres/frontend/functions.rs`, and the conformance tests better. Most of the implementation was guided by AI but written by me so that I could learn.
