### PR TITLE
sqlite/conformance: update gencol EQP expectations for covering SEARCH

### DIFF
--- a/sqlite/conformance/sqlite-sqltests/gencol.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/gencol.sqltest
@@ -2540,7 +2540,7 @@ test gencol_index_on_virtual_is_covering_query_plan {
 }
 expect {
     1|0|0|SCAN t1 USING COVERING INDEX idx_v
-    1|0|0|SEARCH t1 USING INDEX idx_v (v>?)
+    1|0|0|SEARCH t1 USING COVERING INDEX idx_v (v>?)
 }
 
 @skip-if sqlite "sqlite doesn't use covering indexes with virtual columns"
@@ -2550,7 +2550,7 @@ test gencol_composite_index_with_virtual_is_covering_query_plan {
     EXPLAIN QUERY PLAN SELECT v, a FROM t1 WHERE v > 5;
 }
 expect {
-    1|0|0|SEARCH t1 USING INDEX idx_va (v>?)
+    1|0|0|SEARCH t1 USING COVERING INDEX idx_va (v>?)
 }
 
 @cross-check-integrity

--- a/sqlite/conformance/turso-sqltests/gencol-index-order.sqltest
+++ b/sqlite/conformance/turso-sqltests/gencol-index-order.sqltest
@@ -10,7 +10,7 @@ test eqp-order-by-virtual-column-uses-index {
     EXPLAIN QUERY PLAN SELECT v FROM t ORDER BY v LIMIT 10;
 }
 expect {
-    1|0|0|SCAN t USING INDEX tv
+    1|0|0|SCAN t USING COVERING INDEX tv
 }
 
 test eqp-order-by-desc-virtual-column-uses-index {
@@ -19,7 +19,7 @@ test eqp-order-by-desc-virtual-column-uses-index {
     EXPLAIN QUERY PLAN SELECT v FROM t ORDER BY v DESC;
 }
 expect {
-    1|0|0|SCAN t USING INDEX tv
+    1|0|0|SCAN t USING COVERING INDEX tv
 }
 
 test eqp-order-by-virtual-column-uses-desc-index {
@@ -28,7 +28,7 @@ test eqp-order-by-virtual-column-uses-desc-index {
     EXPLAIN QUERY PLAN SELECT v FROM t ORDER BY v DESC;
 }
 expect {
-    1|0|0|SCAN t USING INDEX tvd
+    1|0|0|SCAN t USING COVERING INDEX tvd
 }
 
 test eqp-group-by-virtual-column-uses-index {
@@ -37,7 +37,7 @@ test eqp-group-by-virtual-column-uses-index {
     EXPLAIN QUERY PLAN SELECT v, count(*) FROM t GROUP BY v;
 }
 expect {
-    1|0|0|SCAN t USING INDEX tv
+    1|0|0|SCAN t USING COVERING INDEX tv
 }
 
 test eqp-max-virtual-column-uses-index {
@@ -46,7 +46,7 @@ test eqp-max-virtual-column-uses-index {
     EXPLAIN QUERY PLAN SELECT max(v) FROM t;
 }
 expect {
-    1|0|0|SCAN t USING INDEX tv
+    1|0|0|SCAN t USING COVERING INDEX tv
 }
 
 test eqp-eq-prefix-order-by-virtual-column-uses-index {
@@ -55,7 +55,7 @@ test eqp-eq-prefix-order-by-virtual-column-uses-index {
     EXPLAIN QUERY PLAN SELECT v FROM t WHERE a = 1 ORDER BY v;
 }
 expect {
-    1|0|0|SEARCH t USING INDEX tav (a=?)
+    1|0|0|SEARCH t USING COVERING INDEX tav (a=?)
 }
 
 test eqp-order-by-virtual-column-and-unindexed-column-still-sorts {


### PR DESCRIPTION
Main broke after 791632495 ("Merge 'Support virtual columns in
covering indexes' from Mikaël Francoeur") landed: two EXPLAIN QUERY
PLAN tests in gencol.sqltest expect `SEARCH t1 USING INDEX ...` but
main now prints `SEARCH t1 USING COVERING INDEX ...`.

Nothing in that PR is wrong; this is a semantic conflict between two
independently green branches. The covering-virtual-columns branch
forked from main before a400334ca ("Merge 'show covering indexes in
EXPLAIN QUERY PLAN' from Mikaël Francoeur"), which added the
"COVERING " tag to SEARCH lines (SCAN lines already had it). On the
PR branch a covering index search still printed plain "USING INDEX",
so the test expectations were recorded that way and passed there.
Once both branches were on main, indexes on virtual columns became
covering and SEARCH lines started saying COVERING, so the recorded
expectations went stale and the Rust CI job failed.

The engine output is correct: the tests are named
"...is_covering_query_plan" precisely because these indexes should
cover the queries. Update the expected plans instead of the code.

Tests: cargo run -p sqltest -- run
sqlite/conformance/sqlite-sqltests/gencol.sqltest (448 passed,
including the two previously failing tests)
