### PR TITLE
bindings/javascript: re-step wasm statements when STEP_IO has no pending I/O

### DIFF
--- a/bindings/javascript/packages/wasm-common/index.ts
+++ b/bindings/javascript/packages/wasm-common/index.ts
@@ -48,38 +48,50 @@ function mainImports(worker: Worker, completeOpfs: (c: any, r: any) => void): Br
             return false;
         },
         write_async(handle, ptr, len, offset, c) {
+            ioNotifier.opStarted();
             writeFileAtWorker(worker, handle, ptr, len, offset)
                 .then(result => {
+                    ioNotifier.opFinished();
                     completeOpfs(c, result);
                 }, err => {
                     console.error('write_async', err);
+                    ioNotifier.opFinished();
                     completeOpfs(c, -1);
                 });
         },
         sync_async(handle, c) {
+            ioNotifier.opStarted();
             syncFileAtWorker(worker, handle)
                 .then(result => {
+                    ioNotifier.opFinished();
                     completeOpfs(c, result);
                 }, err => {
                     console.error('sync_async', err);
+                    ioNotifier.opFinished();
                     completeOpfs(c, -1);
                 });
         },
         read_async(handle, ptr, len, offset, c) {
+            ioNotifier.opStarted();
             readFileAtWorker(worker, handle, ptr, len, offset)
                 .then(result => {
+                    ioNotifier.opFinished();
                     completeOpfs(c, result);
                 }, err => {
                     console.error('read_async', err);
+                    ioNotifier.opFinished();
                     completeOpfs(c, -1);
                 });
         },
         truncate_async(handle, len, c) {
+            ioNotifier.opStarted();
             truncateFileAtWorker(worker, handle, len)
                 .then(result => {
+                    ioNotifier.opFinished();
                     completeOpfs(c, result);
                 }, err => {
                     console.error('truncate_async', err);
+                    ioNotifier.opFinished();
                     completeOpfs(c, -1);
                 });
         },
@@ -463,10 +475,32 @@ async function setupMainThread(wasmFile: ArrayBuffer, factory: () => Worker): Pr
     return __napiModule;
 }
 
+// Wakes up statements that returned STEP_IO and are waiting for OPFS I/O.
+//
+// Core can also return an I/O step result when no OPFS operation is in
+// flight and it just wants to be stepped again — for example while a busy
+// handler waits for its timeout. In that case no completion is coming, so
+// parking the caller on the waiter list would hang the statement forever
+// (https://github.com/tursodatabase/turso/issues/8171). The notifier counts
+// operations that are in flight; when there are none, waitForCompletion()
+// yields to the event loop with setTimeout(0) so the caller re-steps the
+// statement instead of parking.
 class IONotifier {
     private waiters: Array<() => void> = [];
+    private pendingOps: number = 0;
+
+    opStarted() {
+        this.pendingOps += 1;
+    }
+
+    opFinished() {
+        this.pendingOps -= 1;
+    }
 
     waitForCompletion(): Promise<void> {
+        if (this.pendingOps === 0) {
+            return new Promise(resolve => setTimeout(resolve, 0));
+        }
         return new Promise(resolve => {
             this.waiters.push(resolve);
         });

--- a/bindings/javascript/packages/wasm/busy-timeout-hang.test.ts
+++ b/bindings/javascript/packages/wasm/busy-timeout-hang.test.ts
@@ -1,0 +1,49 @@
+import { expect, test, afterAll } from 'vitest'
+import { connect } from './promise-default.js'
+import { MainWorker } from './index-default.js'
+
+afterAll(() => {
+    MainWorker?.terminate();
+})
+
+// Regression test for https://github.com/tursodatabase/turso/issues/8171
+//
+// On the wasm driver, a busy-handler retry makes stepSync() return STEP_IO
+// even though no OPFS I/O is in flight. The driver reacts to STEP_IO by
+// waiting on the shared IONotifier, and with no completion pending the
+// notifier never fires: the statement parks forever instead of failing with
+// "database is locked" after the configured busy_timeout.
+test('write on a locked database with busy_timeout errors instead of hanging', async () => {
+    const dbName = `busy-hang-8171-${Date.now()}.db`;
+
+    // Connection A takes and holds the write lock.
+    const writer = await connect(dbName);
+    await writer.exec("CREATE TABLE t (x INTEGER)");
+    await writer.exec("BEGIN IMMEDIATE");
+    await writer.exec("INSERT INTO t VALUES (1)");
+
+    // Connection B tries to write with a 200ms busy timeout. It must settle
+    // (with "database is locked") well within 10 seconds. No other OPFS I/O
+    // happens while we wait, so if the statement parks on the IONotifier
+    // nothing will ever wake it up.
+    const blocked = await connect(dbName);
+    await blocked.exec("PRAGMA busy_timeout = 200");
+
+    const STILL_PENDING = 'still pending after 10s';
+    const insert = blocked.exec("INSERT INTO t VALUES (2)").then(
+        () => 'resolved',
+        (err: Error) => `rejected: ${err.message}`,
+    );
+    const outcome = await Promise.race([
+        insert,
+        new Promise((resolve) => setTimeout(() => resolve(STILL_PENDING), 10_000)),
+    ]);
+    console.log(`INSERT outcome: ${outcome}`);
+    expect(outcome).not.toBe(STILL_PENDING);
+
+    // The writer still holds the lock, so the insert cannot have succeeded.
+    expect(outcome).toContain('rejected');
+
+    await writer.exec("ROLLBACK");
+    await writer.close();
+})


### PR DESCRIPTION
On the wasm/OPFS driver, the step loop reacts to STEP_IO by parking on the
shared IONotifier until an OPFS completion fires. But core can return an
I/O step result with no OPFS operation in flight, expecting the host to
re-poll: the busy-handler retry in core/statement.rs yields with IO while
waiting for the busy timeout, and StepResult::Yield is folded into STEP_IO
by the binding. With no completion pending, nothing ever resolves the
notifier, so the statement hangs forever while holding the connection's
exec lock; only unrelated OPFS traffic would accidentally wake it. The
native driver is unaffected because its ioStep is a no-op and the loop
re-polls.

Make the IONotifier count in-flight OPFS operations: mainImports
increments the count before dispatching each async op to the OPFS worker
and decrements it when the completion arrives. When waitForCompletion()
is called with nothing in flight, resolve on the next macrotask via
setTimeout(0) so the driver re-steps the statement instead of parking.
The count check runs synchronously in the same task as stepSync(), and
completions only arrive as worker message events, so it cannot race with
a completion being delivered.

Tests: packages/wasm busy-timeout-hang.test.ts (regression for the hang)
and promise.test.ts pass in Chromium.

Fixes #8171