### PR TITLE
core: skip transaction setup for unused temp database

### DIFF
--- a/core/translate/transaction.rs
+++ b/core/translate/transaction.rs
@@ -28,10 +28,8 @@ pub fn translate_tx_begin(
             });
         }
         TransactionType::Immediate | TransactionType::Exclusive => {
-            // SQLite emits Transaction for every open database (main, temp, each attached)
-            // on BEGIN IMMEDIATE / EXCLUSIVE. We match that exactly. For temp, this may
-            // trigger lazy initialization via `ensure_temp_database` in op_transaction:
-            // an acceptable one-time cost that keeps the opcode sequence identical to SQLite.
+            // SQLite emits Transaction for every database slot (main, temp, each attached)
+            // but skips the temp opcode at execution when temp storage is not open.
             program.emit_insn(Insn::Transaction {
                 db: crate::MAIN_DB_ID,
                 tx_mode: TransactionMode::Write,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3972,6 +3972,14 @@ pub fn op_transaction_inner(
             "Transaction instruction should not be used in trigger subprograms"
         );
     }
+    let is_unused_temp_database = *db == crate::TEMP_DB_ID
+        && program.connection.temp.database.read().is_none()
+        && !program.read_databases.get(*db)
+        && !program.write_databases.get(*db);
+    if is_unused_temp_database {
+        state.pc += 1;
+        return Ok(InsnFunctionStepResult::Step);
+    }
     if *db == crate::TEMP_DB_ID {
         program.connection.ensure_temp_database()?;
     }

--- a/sqlite/conformance/sqlite-sqltests/transactions.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/transactions.sqltest
@@ -18,6 +18,38 @@ test basic-tx-3 {
 expect {
 }
 
+test begin-immediate-does-not-initialize-temp {
+    BEGIN IMMEDIATE;
+    PRAGMA database_list;
+    ROLLBACK;
+}
+expect {
+    0|main|
+}
+
+test begin-exclusive-does-not-initialize-temp {
+    BEGIN EXCLUSIVE;
+    PRAGMA database_list;
+    ROLLBACK;
+}
+expect {
+    0|main|
+}
+
+test temp-used-after-begin-participates-in-commit-and-rollback {
+    BEGIN IMMEDIATE;
+    CREATE TEMP TABLE used_temp(v INTEGER);
+    INSERT INTO used_temp VALUES(1);
+    COMMIT;
+    BEGIN EXCLUSIVE;
+    INSERT INTO used_temp VALUES(2);
+    ROLLBACK;
+    SELECT * FROM used_temp;
+}
+expect {
+    1
+}
+
 test temp-table-in-immediate-tx {
     BEGIN IMMEDIATE;
     CREATE TEMP TABLE t1(x);


### PR DESCRIPTION
## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

Currently on main, BEGIN IMMEDIATE transactions follow a code path which always attempt to init a temp database, even if one is not required. This PR introduces a guard to skip the init of the database if it is unused. We also introduce tests for both the used and unused paths.


## Motivation and context

This temp database init is an issue for the `wasm32-unknown-unknown` target because the downstream code path makes a call to `std::time::Intant::now()` which hangs in this environment. Introducing this guard allows callers who wish to embed turso core directly in a wasm bundle (instead of the npm package) to correctly use BEGIN IMMEDIATE as long as their query does not require a temp db.

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

The bug was discovered manually by me, AI assisted with the implementation, all output code was read and verified by me. All PR description and comments are written by hand
