### PR TITLE
core: resolve compound ORDER BY expressions

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1460,6 +1460,7 @@ fn prepare_recursive_cte_plan(
         &select.order_by,
         &initial_query,
         &recursive_query,
+        resolver,
     )?;
     let (limit, offset) = select
         .limit

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -266,7 +266,7 @@ pub(crate) fn prepare_select_plan_from_arms(
         .map(|(plan, _)| plan)
         .chain(std::iter::once(&last))
         .collect();
-    let order_by = resolve_compound_order_by(&order_by, &all_plans)?;
+    let order_by = resolve_compound_order_by(&order_by, &all_plans, resolver)?;
 
     Ok(Plan::CompoundSelect {
         left,
@@ -1255,13 +1255,11 @@ fn replace_column_number_with_copy_of_column_expr(
     Ok(())
 }
 
-/// Resolves a compound SELECT ORDER BY expression to a 0-based column index.
-/// ORDER BY in compound selects can reference columns by:
-/// 1. Numeric position (1-based): ORDER BY 1
-/// 2. Column name or alias from any constituent SELECT: ORDER BY name
+/// Resolves a compound SELECT ORDER BY term to a 0-based result column index.
 fn resolve_compound_order_by_expr(
     expr: &ast::Expr,
     all_plans: &[&SelectPlan],
+    resolver: &Resolver,
     term_number: usize,
 ) -> Result<(usize, Option<CollationSeq>)> {
     let num_result_columns = all_plans[0].result_columns.len();
@@ -1270,8 +1268,9 @@ fn resolve_compound_order_by_expr(
         // reference and carry the collation so it overrides the referenced
         // column's own collation when the compound result is sorted.
         ast::Expr::Collate(inner, collation_name) => {
-            let (col_idx, _) = resolve_compound_order_by_expr(inner, all_plans, term_number)?;
-            Ok((col_idx, Some(CollationSeq::new(collation_name.as_str())?)))
+            let (col_idx, _) =
+                resolve_compound_order_by_expr(inner, all_plans, resolver, term_number)?;
+            return Ok((col_idx, Some(CollationSeq::new(collation_name.as_str())?)));
         }
         // Case 1: Numeric column reference (e.g., ORDER BY 1). As in SQLite's
         // sqlite3ExprIsInteger, only literals that fit a 32-bit int count as
@@ -1285,55 +1284,63 @@ fn resolve_compound_order_by_expr(
                         num_result_columns
                     );
                 }
-                Ok((column_number as usize - 1, None))
-            } else {
-                crate::bail_parse_error!(
-                    "{} ORDER BY term does not match any column in the result set",
-                    ordinal(term_number)
-                );
+                return Ok((column_number as usize - 1, None));
             }
         }
-        // Case 2: Name reference (e.g., ORDER BY name or ORDER BY alias)
-        ast::Expr::Id(name) => {
-            let name_normalized = normalize_ident(name.as_str());
-            // Check aliases and column names across all constituent SELECTs
-            for plan in all_plans {
-                let result_columns = &plan.result_columns;
-                let table_references = &plan.table_references;
-                // Try matching against aliases
-                for (i, rc) in result_columns.iter().enumerate() {
-                    if let Some(alias) = &rc.alias {
-                        if normalize_ident(alias) == name_normalized {
-                            return Ok((i, None));
-                        }
-                    }
-                }
-                // Try matching against column names from the table references
-                for (i, rc) in result_columns.iter().enumerate() {
-                    if let Some(col_name) = rc.name(table_references) {
-                        if normalize_ident(col_name) == name_normalized {
-                            return Ok((i, None));
-                        }
+        _ => {}
+    }
+
+    for plan in all_plans {
+        if let ast::Expr::Id(name) = expr {
+            let normalized_name = normalize_ident(name.as_str());
+            for (index, result_column) in plan.result_columns.iter().enumerate() {
+                if let Some(alias) = &result_column.alias {
+                    if normalize_ident(alias) == normalized_name {
+                        return Ok((index, None));
                     }
                 }
             }
-            crate::bail_parse_error!(
-                "{} ORDER BY term does not match any column in the result set",
-                ordinal(term_number)
-            );
+            for (index, result_column) in plan.result_columns.iter().enumerate() {
+                if let Some(column_name) = result_column.name(&plan.table_references) {
+                    if normalize_ident(column_name) == normalized_name {
+                        return Ok((index, None));
+                    }
+                }
+            }
         }
-        _ => {
-            crate::bail_parse_error!(
-                "{} ORDER BY term does not match any column in the result set",
-                ordinal(term_number)
-            );
+
+        let mut bound_expr = expr.clone();
+        let mut table_references = plan.table_references.clone();
+        if bind_and_rewrite_expr(
+            &mut bound_expr,
+            Some(&mut table_references),
+            None,
+            resolver,
+            BindingBehavior::ResultColumnsNotAllowed,
+        )
+        .is_err()
+        {
+            continue;
+        }
+        if let Some(index) = plan
+            .result_columns
+            .iter()
+            .position(|result_column| exprs_are_equivalent(&bound_expr, &result_column.expr))
+        {
+            return Ok((index, None));
         }
     }
+
+    crate::bail_parse_error!(
+        "{} ORDER BY term does not match any column in the result set",
+        ordinal(term_number)
+    );
 }
 
 fn resolve_compound_order_by(
     order_by: &[ast::SortedColumn],
     plans: &[&SelectPlan],
+    resolver: &Resolver,
 ) -> Result<Option<Vec<super::plan::CompoundOrderByKey>>> {
     if order_by.is_empty() {
         return Ok(None);
@@ -1342,7 +1349,8 @@ fn resolve_compound_order_by(
         .iter()
         .enumerate()
         .map(|(index, term)| {
-            let (column, collation) = resolve_compound_order_by_expr(&term.expr, plans, index + 1)?;
+            let (column, collation) =
+                resolve_compound_order_by_expr(&term.expr, plans, resolver, index + 1)?;
             Ok((
                 column,
                 term.order.unwrap_or(ast::SortOrder::Asc),
@@ -1358,6 +1366,7 @@ pub(crate) fn resolve_recursive_cte_queue_order(
     order_by: &[ast::SortedColumn],
     initial_query: &Plan,
     recursive_query: &Plan,
+    resolver: &Resolver,
 ) -> Result<Option<Vec<super::plan::CompoundOrderByKey>>> {
     fn collect_selects<'a>(plan: &'a Plan, out: &mut Vec<&'a SelectPlan>) {
         match plan {
@@ -1377,7 +1386,7 @@ pub(crate) fn resolve_recursive_cte_queue_order(
     let mut plans = Vec::new();
     collect_selects(initial_query, &mut plans);
     collect_selects(recursive_query, &mut plans);
-    resolve_compound_order_by(order_by, &plans)
+    resolve_compound_order_by(order_by, &plans, resolver)
 }
 
 fn ordinal(n: usize) -> String {

--- a/sqlite/conformance/sqlite-sqltests/compound-select-orderby.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/compound-select-orderby.sqltest
@@ -615,6 +615,202 @@ expect {
     honeydew
 }
 
+# The ORDER BY term may match the output expression of any SELECT arm, not
+# just the first one.
+@setup schema
+test union-all-order-by-qualified-second-arm {
+    SELECT t1.b FROM t1
+    UNION ALL
+    SELECT t2.b FROM t2
+    ORDER BY t2.b;
+}
+expect {
+    apple
+    banana
+    banana
+    cherry
+    date
+    date
+    elderberry
+    fig
+    grape
+    honeydew
+}
+
+@setup schema
+test union-all-order-by-qualified-desc {
+    SELECT t1.a FROM t1
+    UNION ALL
+    SELECT t2.a FROM t2
+    ORDER BY t1.a DESC;
+}
+expect {
+    8
+    7
+    6
+    5
+    4
+    4
+    3
+    2
+    2
+    1
+}
+
+@setup schema
+test union-all-order-by-arithmetic-expression {
+    SELECT a + c FROM t1
+    UNION ALL
+    SELECT a + c FROM t2
+    ORDER BY a + c;
+}
+expect {
+    11
+    22
+    22
+    33
+    44
+    44
+    55
+    66
+    77
+    88
+}
+
+@setup schema
+test union-all-order-by-function-expression {
+    SELECT upper(b) FROM t1
+    UNION ALL
+    SELECT upper(b) FROM t2
+    ORDER BY upper(b);
+}
+expect {
+    APPLE
+    BANANA
+    BANANA
+    CHERRY
+    DATE
+    DATE
+    ELDERBERRY
+    FIG
+    GRAPE
+    HONEYDEW
+}
+
+@setup schema
+test union-all-order-by-qualified-collate-nocase-desc {
+    SELECT t1.b FROM t1
+    UNION ALL
+    SELECT t2.b FROM t2
+    ORDER BY t1.b COLLATE NOCASE DESC;
+}
+expect {
+    honeydew
+    grape
+    fig
+    elderberry
+    date
+    date
+    cherry
+    banana
+    banana
+    apple
+}
+
+# A qualified name matches the output expression even when the first arm
+# renames the column with an alias.
+@setup schema
+test union-all-order-by-qualified-with-alias {
+    SELECT b AS fruit FROM t1
+    UNION ALL
+    SELECT b FROM t2
+    ORDER BY t1.b;
+}
+expect {
+    apple
+    banana
+    banana
+    cherry
+    date
+    date
+    elderberry
+    fig
+    grape
+    honeydew
+}
+
+@setup schema
+test except-order-by-qualified-result-column {
+    SELECT t1.b FROM t1
+    EXCEPT
+    SELECT t2.b FROM t2
+    ORDER BY t1.b;
+}
+expect {
+    apple
+    cherry
+    elderberry
+}
+
+@setup schema
+test intersect-order-by-qualified-second-arm {
+    SELECT t1.b FROM t1
+    INTERSECT
+    SELECT t2.b FROM t2
+    ORDER BY t2.b;
+}
+expect {
+    banana
+    date
+}
+
+@setup schema
+test three-arm-compound-order-by-qualified-last-arm {
+    SELECT t1.b FROM t1
+    UNION
+    SELECT t2.b FROM t2
+    UNION ALL
+    SELECT t3.y FROM t3
+    ORDER BY t3.y;
+}
+expect {
+    alpha
+    apple
+    banana
+    cherry
+    date
+    echo
+    elderberry
+    fig
+    grape
+    honeydew
+    zulu
+}
+
+# A qualified column that is not part of the result set is still rejected.
+@setup schema
+test union-all-order-by-qualified-non-result-column-errors {
+    SELECT t1.b FROM t1
+    UNION ALL
+    SELECT t2.b FROM t2
+    ORDER BY t1.c;
+}
+expect error {
+    1st ORDER BY term does not match any column in the result set
+}
+
+# A column from a table that appears in no SELECT arm is rejected.
+@setup schema
+test union-all-order-by-unknown-table-errors {
+    SELECT t1.b FROM t1
+    UNION ALL
+    SELECT t2.b FROM t2
+    ORDER BY t3.y;
+}
+expect error {
+    1st ORDER BY term does not match any column in the result set
+}
+
 # ===== Compound with NULLs + ORDER BY =====
 
 @setup schema

--- a/sqlite/conformance/sqlite-sqltests/compound-select-orderby.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/compound-select-orderby.sqltest
@@ -595,6 +595,26 @@ expect {
     80
 }
 
+@setup schema
+test union-all-order-by-qualified-result-column {
+    SELECT t1.b FROM t1
+    UNION ALL
+    SELECT t2.b FROM t2
+    ORDER BY t1.b;
+}
+expect {
+    apple
+    banana
+    banana
+    cherry
+    date
+    date
+    elderberry
+    fig
+    grape
+    honeydew
+}
+
 # ===== Compound with NULLs + ORDER BY =====
 
 @setup schema

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -661,6 +661,40 @@ expect {
     4
 }
 
+# The queue ORDER BY may be an expression that matches the output expression
+# of the recursive term, including one that names the CTE itself.
+test recursive-cte-order-qualified-expression {
+    WITH RECURSIVE cnt(x) AS (
+        SELECT 1
+        UNION ALL
+        SELECT cnt.x + 1 FROM cnt WHERE cnt.x < 5
+        ORDER BY cnt.x + 1 DESC
+    )
+    SELECT x FROM cnt;
+}
+expect {
+    1
+    2
+    3
+    4
+    5
+}
+
+# A qualified column that matches no output expression of either term is
+# rejected, even though the CTE's own column is named that way.
+test recursive-cte-order-qualified-non-result-column-errors {
+    WITH RECURSIVE cnt(x) AS (
+        SELECT 1
+        UNION ALL
+        SELECT cnt.x + 1 FROM cnt WHERE cnt.x < 5
+        ORDER BY cnt.x DESC
+    )
+    SELECT x FROM cnt;
+}
+expect error {
+    1st ORDER BY term does not match any column in the result set
+}
+
 test recursive-cte-two-independent-producers {
     WITH RECURSIVE
       a(x) AS (VALUES(1) UNION ALL SELECT x + 1 FROM a WHERE x < 3),


### PR DESCRIPTION
## Description

This PR fixes `ORDER BY` resolution for compound SELECTs.

Turso now accepts an `ORDER BY` expression when it matches an output expression from any SELECT arm. This includes qualified columns such as `ORDER BY simple.name`.

The resolver checks each SELECT arm from left to right. It uses the existing expression binder and equivalence check. Existing behavior for integer positions, aliases, and `COLLATE` does not change.

The new sqltest covers the query that failed in Drizzle's Turso CI.

### Turso CLI output

```console
# Before
$ cargo run -q --bin tursodb -- -q -m list :memory: "CREATE TABLE simple(id INTEGER, name TEXT); INSERT INTO simple VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie'); SELECT simple.name FROM simple WHERE id <= 2 UNION ALL SELECT simple.name FROM simple WHERE id >= 2 ORDER BY simple.name;"
× Parse error: 1st ORDER BY term does not match any column in the result set

# After
$ cargo run -q --bin tursodb -- -q -m list :memory: "CREATE TABLE simple(id INTEGER, name TEXT); INSERT INTO simple VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie'); SELECT simple.name FROM simple WHERE id <= 2 UNION ALL SELECT simple.name FROM simple WHERE id >= 2 ORDER BY simple.name;"
alice
bob
bob
charlie
```

## Motivation and context

SQLite requires a non-positional `ORDER BY` term in a compound SELECT to match an output expression. Turso only resolved integer positions and bare names or aliases. It rejected a qualified name before it compared the name with the output expression.

This change removes that compatibility gap. It does not add a special case for qualified columns. An unmatched expression still returns `ORDER BY term does not match any column in the result set`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p turso_core --all-features --lib -- --deny=warnings`
- `make -C sqlite/conformance run-rust ARGS='--snapshot-filter __never__ --filter union-all-order-by-qualified-result-column'`
- Direct Turso and SQLite comparisons for names, aliases, integer positions, expressions from either SELECT arm, and unmatched expressions

## Description of AI Usage

Codex helped to reproduce the Drizzle CI failure, inspect the resolver, implement the fix, add the regression test, and run the checks. The final diff uses Turso's existing binding and expression-equivalence code. It contains no unrelated changes.
