### PR TITLE
core/window: preserve repeated cross-window expressions

### DIFF
--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -352,7 +352,7 @@ fn rewrite_terminal_expr(
                     } else {
                         // Window function referencing a different window. Push the
                         // whole expression to the subquery; it will be rewritten later.
-                        rewrite_expr_as_subquery_column(expr, ctx, false);
+                        push_new_subquery_column(expr, ctx, false);
                     }
                 }
                 Expr::RowId { .. } | Expr::Column { .. } => {

--- a/sqlite/conformance/sqlite-sqltests/window/lag_lead.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/window/lag_lead.sqltest
@@ -126,6 +126,31 @@ expect {
     5|15|
 }
 
+# Aggregate arguments to repeated lag() calls must be rewritten into the
+# window buffer even when another window aggregate has a different frame.
+setup aggregate_window_lag {
+    CREATE TABLE aggregate_window_lag(d TEXT, x INTEGER);
+    INSERT INTO aggregate_window_lag VALUES
+        ('2026-01-01', 1),
+        ('2026-02-02', 2),
+        ('2026-03-03', 3);
+}
+
+@setup aggregate_window_lag
+test lag-aggregate-arg-after-aggregate-window {
+    SELECT strftime('%Y-%m', d),
+           avg(sum(x)) OVER (ORDER BY strftime('%Y-%m', d)),
+           100.0 * (sum(x) - lag(sum(x)) OVER (ORDER BY strftime('%Y-%m', d)))
+                 / lag(sum(x)) OVER (ORDER BY strftime('%Y-%m', d))
+    FROM aggregate_window_lag
+    GROUP BY 1;
+}
+expect {
+    2026-01|1.0|
+    2026-02|1.5|100.0
+    2026-03|2.0|50.0
+}
+
 # 3-arg form: the default value can itself be an expression (here a
 # column reference computed in the source subquery).
 @setup vals


### PR DESCRIPTION
## Description

Preserve repeated window-function occurrences while rewriting different window layers.

## Motivation and context

Prevents the valid repeated `LAG(SUM(...))` query in #8336 from panicking.

Fixes #8336

## Description of AI Usage

Codex assisted with investigation, implementation, and local verification.