### PR TITLE
core: Reduce VDBE instruction memory footprint

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -7,7 +7,7 @@ use crate::{
     translate::collate::CollationSeq,
     vdbe::{
         builder::ProgramBuilder,
-        insn::{HashDistinctData, Insn},
+        insn::{AggStepData, HashDistinctData, Insn},
     },
     LimboError, Result,
 };
@@ -370,12 +370,14 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::Avg),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::Avg),
+                    comparator: None,
+                    collation: None,
+                }),
             });
             target_register
         }
@@ -384,12 +386,14 @@ pub fn translate_aggregation_step(
             let expr_reg = translate_const_arg(program, referenced_tables, resolver, &expr)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::Count0),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::Count0),
+                    comparator: None,
+                    collation: None,
+                }),
             });
             target_register
         }
@@ -400,12 +404,14 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::Count),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::Count),
+                    comparator: None,
+                    collation: None,
+                }),
             });
             target_register
         }
@@ -426,12 +432,14 @@ pub fn translate_aggregation_step(
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
 
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: delimiter_reg,
-                func: AccumulatorFunc::Agg(AggFunc::GroupConcat),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: delimiter_reg,
+                    func: AccumulatorFunc::Agg(AggFunc::GroupConcat),
+                    comparator: None,
+                    collation: None,
+                }),
             });
 
             target_register
@@ -447,12 +455,14 @@ pub fn translate_aggregation_step(
             let comparator =
                 super::order_by::custom_type_comparator(expr, referenced_tables, resolver.schema());
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::Max),
-                comparator,
-                collation: Some(arg_collation),
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::Max),
+                    comparator,
+                    collation: Some(arg_collation),
+                }),
             });
             target_register
         }
@@ -467,12 +477,14 @@ pub fn translate_aggregation_step(
             let comparator =
                 super::order_by::custom_type_comparator(expr, referenced_tables, resolver.schema());
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::Min),
-                comparator,
-                collation: Some(arg_collation),
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::Min),
+                    comparator,
+                    collation: Some(arg_collation),
+                }),
             });
             target_register
         }
@@ -486,12 +498,14 @@ pub fn translate_aggregation_step(
             let value_reg = agg_arg_source.translate(program, referenced_tables, resolver, 1)?;
 
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: value_reg,
-                func: AccumulatorFunc::Agg(AggFunc::JsonGroupObject),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: value_reg,
+                    func: AccumulatorFunc::Agg(AggFunc::JsonGroupObject),
+                    comparator: None,
+                    collation: None,
+                }),
             });
             target_register
         }
@@ -503,12 +517,14 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::JsonGroupArray),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::JsonGroupArray),
+                    comparator: None,
+                    collation: None,
+                }),
             });
             target_register
         }
@@ -522,12 +538,14 @@ pub fn translate_aggregation_step(
                 agg_arg_source.translate(program, referenced_tables, resolver, 1)?;
 
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: delimiter_reg,
-                func: AccumulatorFunc::Agg(AggFunc::StringAgg),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: delimiter_reg,
+                    func: AccumulatorFunc::Agg(AggFunc::StringAgg),
+                    comparator: None,
+                    collation: None,
+                }),
             });
 
             target_register
@@ -539,12 +557,14 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::Sum),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::Sum),
+                    comparator: None,
+                    collation: None,
+                }),
             });
             target_register
         }
@@ -555,12 +575,14 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::Total),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::Total),
+                    comparator: None,
+                    collation: None,
+                }),
             });
             target_register
         }
@@ -572,12 +594,14 @@ pub fn translate_aggregation_step(
             let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::ArrayAgg),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::ArrayAgg),
+                    comparator: None,
+                    collation: None,
+                }),
             });
             target_register
         }
@@ -591,12 +615,14 @@ pub fn translate_aggregation_step(
             let expr = &agg_arg_source.arg_at(0);
             let arg_collation = agg_arg_collation(referenced_tables, expr, resolver);
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: value_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::Mode),
-                comparator: None,
-                collation: Some(arg_collation),
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: value_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::Mode),
+                    comparator: None,
+                    collation: Some(arg_collation),
+                }),
             });
             target_register
         }
@@ -614,12 +640,14 @@ pub fn translate_aggregation_step(
             let expr = &agg_arg_source.arg_at(0);
             let arg_collation = agg_arg_collation(referenced_tables, expr, resolver);
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: value_reg,
-                delimiter: fraction_reg,
-                func: AccumulatorFunc::Agg(func.clone()),
-                comparator: None,
-                collation: Some(arg_collation),
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: value_reg,
+                    delimiter: fraction_reg,
+                    func: AccumulatorFunc::Agg(func.clone()),
+                    comparator: None,
+                    collation: Some(arg_collation),
+                }),
             });
             target_register
         }
@@ -650,16 +678,18 @@ pub fn translate_aggregation_step(
                 }
             }
             program.emit_insn(Insn::AggStep {
-                acc_reg: target_register,
-                col: expr_reg,
-                delimiter: 0,
-                func: AccumulatorFunc::Agg(AggFunc::External(if registered_argc < 0 {
-                    Arc::new(func.with_aggregate_arg_count(num_args))
-                } else {
-                    func.clone()
-                })),
-                comparator: None,
-                collation: None,
+                data: Box::new(AggStepData {
+                    acc_reg: target_register,
+                    col: expr_reg,
+                    delimiter: 0,
+                    func: AccumulatorFunc::Agg(AggFunc::External(if registered_argc < 0 {
+                        Arc::new(func.with_aggregate_arg_count(num_args))
+                    } else {
+                        func.clone()
+                    })),
+                    comparator: None,
+                    collation: None,
+                }),
             });
             target_register
         }

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -28,7 +28,7 @@ use crate::{
     vdbe::{
         affinity::Affinity,
         builder::{CursorType, DmlColumnContext, ProgramBuilder},
-        insn::{to_u32, CmpInsFlags, Cookie, Insn, RegisterOrLiteral},
+        insn::{to_u32, AddColumnData, CmpInsFlags, Cookie, Insn, RegisterOrLiteral},
     },
     vtab::VirtualTable,
     LimboError, Numeric, Result, Value, ValueRef,
@@ -1543,11 +1543,13 @@ pub fn translate_alter_table(
                         p5: 0,
                     });
                     program.emit_insn(Insn::AddColumn {
-                        db: database_id,
-                        table: table_name.to_owned(),
-                        column: Box::new(column),
-                        check_constraints: btree.check_constraints.to_vec(),
-                        foreign_keys: btree.foreign_keys.to_vec(),
+                        data: Box::new(AddColumnData {
+                            db: database_id,
+                            table: table_name.to_owned(),
+                            column,
+                            check_constraints: btree.check_constraints.to_vec(),
+                            foreign_keys: btree.foreign_keys.to_vec(),
+                        }),
                     });
                 },
             )?

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -11,7 +11,7 @@ use crate::translate::order_by::{custom_type_comparator, sorter_insert};
 use crate::translate::plan::{CompoundOrderByKey, Plan, QueryDestination, SelectPlan};
 use crate::translate::result_row::emit_columns_to_destination;
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
-use crate::vdbe::insn::Insn;
+use crate::vdbe::insn::{Insn, SorterOpenData};
 use crate::{emit_explain, LimboError};
 use tracing::instrument;
 use turso_parser::ast::{CompoundOperator, Expr, Literal, SortOrder};
@@ -880,10 +880,12 @@ fn emit_compound_order_by(
         .chain(std::iter::once(None))
         .try_collect()?;
     program.emit_insn(Insn::SorterOpen {
-        cursor_id: sort_cursor,
-        columns: order_collations_nulls.len(),
-        order_collations_nulls,
-        comparators,
+        data: Box::new(SorterOpenData {
+            cursor_id: sort_cursor,
+            columns: order_collations_nulls.len(),
+            order_collations_nulls,
+            comparators,
+        }),
     });
 
     // Read from collection index and insert into Sorter

--- a/core/translate/expr/arrays.rs
+++ b/core/translate/expr/arrays.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::vdbe::insn::ArrayEncodeData;
 
 /// Maximum number of array elements supported in the per-element transform loop.
 /// Limited by the fixed register block allocated at compile time.
@@ -135,11 +136,13 @@ pub(super) fn emit_array_encode(
         if let Some(encode_expr) = type_def.encode() {
             // Normalize input (text or blob) to blob with ANY affinity first
             program.emit_insn(Insn::ArrayEncode {
-                reg,
-                element_affinity: Affinity::Blob,
-                element_type: "ANY".into(),
-                table_name: table_name.into(),
-                col_name: col.name.as_deref().unwrap_or("").into(),
+                data: Box::new(ArrayEncodeData {
+                    reg,
+                    element_affinity: Affinity::Blob,
+                    element_type: "ANY".into(),
+                    table_name: table_name.into(),
+                    col_name: col.name.as_deref().unwrap_or("").into(),
+                }),
             });
 
             emit_array_element_loop(program, reg, encode_expr, col, type_def, resolver)?;
@@ -164,11 +167,13 @@ pub(super) fn emit_array_encode(
         col.ty_str.to_uppercase().into()
     };
     program.emit_insn(Insn::ArrayEncode {
-        reg,
-        element_affinity,
-        element_type,
-        table_name: table_name.into(),
-        col_name: col_name.into(),
+        data: Box::new(ArrayEncodeData {
+            reg,
+            element_affinity,
+            element_type,
+            table_name: table_name.into(),
+            col_name: col_name.into(),
+        }),
     });
     Ok(())
 }

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -26,7 +26,7 @@ use crate::{
     util::exprs_are_equivalent,
     vdbe::{
         builder::{CursorType, ProgramBuilder},
-        insn::Insn,
+        insn::{Insn, SorterOpenData},
         BranchOffset,
     },
     Result,
@@ -189,10 +189,12 @@ impl EmitGroupBy {
                 .try_collect()?;
 
             program.emit_insn(Insn::SorterOpen {
-                cursor_id: sort_cursor,
-                columns: column_count,
-                order_collations_nulls,
-                comparators,
+                data: Box::new(SorterOpenData {
+                    cursor_id: sort_cursor,
+                    columns: column_count,
+                    order_collations_nulls,
+                    comparators,
+                }),
             });
             emit_explain!(program, false, "USE SORTER FOR GROUP BY".to_owned());
             let pseudo_cursor = group_by_create_pseudo_table(program, column_count);

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -30,7 +30,7 @@ use crate::{
     util::{escape_sql_string_literal, normalize_ident, PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX},
     vdbe::{
         builder::{CursorType, ProgramBuilder},
-        insn::{IdxInsertFlags, Insn, RegisterOrLiteral},
+        insn::{IdxInsertFlags, Insn, RegisterOrLiteral, SorterOpenData},
     },
 };
 use rustc_hash::FxHashMap as HashMap;
@@ -459,10 +459,12 @@ fn emit_refill_index(
             .map(|c| (c.order, c.collation, c.nulls_order))
             .try_collect()?;
         program.emit_insn(Insn::SorterOpen {
-            cursor_id: sorter_cursor_id,
-            columns: columns.len(),
-            order_collations_nulls,
-            comparators: crate::alloc::vec![],
+            data: Box::new(SorterOpenData {
+                cursor_id: sorter_cursor_id,
+                columns: columns.len(),
+                order_collations_nulls,
+                comparators: crate::alloc::vec![],
+            }),
         });
         // SorterData moves each sorted record into the pseudo cursor's
         // content register; the two must name the same register.

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     vdbe::{
         builder::{CursorKey, CursorType, ProgramBuilder},
-        insn::{CmpInsFlags, Insn},
+        insn::{CmpInsFlags, Insn, IntegrityCkData},
     },
     HashSet,
 };
@@ -218,11 +218,13 @@ fn translate_integrity_check_impl(
     let scratch_reg = program.alloc_register();
 
     program.emit_insn(Insn::IntegrityCk {
-        db: database_id,
-        max_errors,
-        roots: root_pages,
-        dropped_roots,
-        message_register: message_reg,
+        data: Box::new(IntegrityCkData {
+            db: database_id,
+            max_errors,
+            roots: root_pages,
+            dropped_roots,
+            message_register: message_reg,
+        }),
     });
 
     let no_structural_error_label = program.allocate_label();

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -4,6 +4,7 @@ use crate::translate::{
     order_by::{custom_type_comparator, EmitOrderBy},
     window::EmitWindow,
 };
+use crate::vdbe::insn::AggStepData;
 
 use super::*;
 
@@ -259,12 +260,14 @@ fn emit_loop_source<'a>(
                     t_ctx.resolver.schema(),
                 );
                 program.emit_insn(Insn::AggStep {
-                    acc_reg: start_reg,
-                    col: expr_reg,
-                    delimiter: 0,
-                    func: crate::function::AccumulatorFunc::Agg(min_max.func.clone()),
-                    comparator,
-                    collation: Some(arg_collation),
+                    data: Box::new(AggStepData {
+                        acc_reg: start_reg,
+                        col: expr_reg,
+                        delimiter: 0,
+                        func: crate::function::AccumulatorFunc::Agg(min_max.func.clone()),
+                        comparator,
+                        collation: Some(arg_collation),
+                    }),
                 });
                 program.emit_insn(Insn::Goto {
                     target_pc: loop_end,

--- a/core/translate/main_loop/seek.rs
+++ b/core/translate/main_loop/seek.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::translate::plan::BitSet;
+use crate::vdbe::insn::NullMatchingMask;
 use turso_parser::ast::NullsOrder;
 
 fn index_seek_affinities(seek_def: &SeekDef, seek_key: &SeekKey) -> String {
@@ -200,12 +201,13 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
         // Which key components match NULL rather than comparing with `=`; the
         // seek and the bloom-filter probe keep their "NULL key cannot match"
         // shortcut for the rest.
-        let mut null_matching_mask = BitSet::default();
+        let mut null_matching_bits = BitSet::default();
         for i in 0..num_regs {
             if self.seek_def.is_null_matching_key_component(i) {
-                null_matching_mask.set(i)?;
+                null_matching_bits.set(i)?;
             }
         }
+        let null_matching_mask = NullMatchingMask::from(null_matching_bits);
 
         if let Some(idx) = self.seek_index {
             encode_seek_keys_for_custom_types(

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -14,7 +14,7 @@ use crate::{
     util::exprs_are_equivalent,
     vdbe::{
         builder::{CursorType, ProgramBuilder},
-        insn::{to_u32, IdxInsertFlags, Insn},
+        insn::{to_u32, IdxInsertFlags, Insn, SorterOpenData},
     },
     Result,
 };
@@ -312,10 +312,12 @@ impl EmitOrderBy {
             let key_len = order_collations_nulls.len();
 
             program.emit_insn(Insn::SorterOpen {
-                cursor_id: sort_cursor,
-                columns: key_len,
-                order_collations_nulls,
-                comparators,
+                data: Box::new(SorterOpenData {
+                    cursor_id: sort_cursor,
+                    columns: key_len,
+                    order_collations_nulls,
+                    comparators,
+                }),
             });
         }
         Ok(())

--- a/core/translate/sequence.rs
+++ b/core/translate/sequence.rs
@@ -23,7 +23,9 @@ use crate::translate::emitter::Resolver;
 use crate::translate::schema::{emit_schema_entry, SchemaEntryType, SQLITE_TABLEID};
 use crate::util::{escape_sql_string_literal, normalize_ident};
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
-use crate::vdbe::insn::{to_u32, CmpInsFlags, Cookie, InsertFlags, Insn, RegisterOrLiteral};
+use crate::vdbe::insn::{
+    to_u32, AddSequenceData, CmpInsFlags, Cookie, InsertFlags, Insn, RegisterOrLiteral,
+};
 use crate::Result;
 use turso_parser::ast;
 
@@ -878,13 +880,15 @@ pub fn translate_create_sequence(
 
     // Add the fully-configured Sequence to the in-memory schema
     program.emit_insn(Insn::AddSequence {
-        db: database_id,
-        name: normalized_name,
-        start: seq.start_value,
-        increment: seq.increment_by,
-        min_value: seq.min_value,
-        max_value: seq.max_value,
-        cycle: seq.cycle,
+        data: Box::new(AddSequenceData {
+            db: database_id,
+            name: normalized_name,
+            start: seq.start_value,
+            increment: seq.increment_by,
+            min_value: seq.min_value,
+            max_value: seq.max_value,
+            cycle: seq.cycle,
+        }),
     });
 
     // Bump schema version so other connections detect the change

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -21,7 +21,7 @@ use crate::types::KeyInfo;
 use crate::util::exprs_are_equivalent;
 use crate::vdbe::builder::{CursorType, ProgramBuilder};
 use crate::vdbe::insn::{
-    to_u32, {IdxInsertFlags, InsertFlags, Insn},
+    to_u32, AggStepData, {IdxInsertFlags, InsertFlags, Insn},
 };
 use crate::vdbe::{BranchOffset, CursorID};
 use crate::Connection;
@@ -3243,12 +3243,14 @@ fn emit_function_step(
                 // 0-ary window funcs (row_number) ignore `col`; the runtime
                 // only reads `state.registers[col + i]` for i in 0..arity.
                 program.emit_insn(Insn::AggStep {
-                    acc_reg,
-                    col: arg_load_start.unwrap_or(0),
-                    delimiter: 0,
-                    func: AccumulatorFunc::Window(win_func.clone()),
-                    comparator: None,
-                    collation: None,
+                    data: Box::new(AggStepData {
+                        acc_reg,
+                        col: arg_load_start.unwrap_or(0),
+                        delimiter: 0,
+                        func: AccumulatorFunc::Window(win_func.clone()),
+                        comparator: None,
+                        collation: None,
+                    }),
                 });
             }
         }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -16172,23 +16172,14 @@ pub fn op_add_column(
     insn: &Insn,
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
-    load_insn!(
-        AddColumn {
-            db,
-            table,
-            column,
-            check_constraints,
-            foreign_keys
-        },
-        insn
-    );
+    load_insn!(AddColumn { data }, insn);
 
     let conn = program.connection.clone();
-    let normalized_table_name = normalize_ident(table.as_str());
-    let new_check_constraints = check_constraints.try_to_vec()?;
-    let new_foreign_keys = foreign_keys.try_to_vec()?;
+    let normalized_table_name = normalize_ident(data.table.as_str());
+    let new_check_constraints = data.check_constraints.try_to_vec()?;
+    let new_foreign_keys = data.foreign_keys.try_to_vec()?;
 
-    conn.with_database_schema_mut(*db, |schema| -> Result<()> {
+    conn.with_database_schema_mut(data.db, |schema| -> Result<()> {
         let table_ref = schema
             .tables
             .get_mut(&normalized_table_name)
@@ -16201,7 +16192,7 @@ pub fn op_add_column(
         };
 
         let btree = Arc::make_mut(btree);
-        btree.columns_mut().try_push((**column).clone())?;
+        btree.columns_mut().try_push(data.column.clone())?;
         // Update CHECK constraints to include any constraints from the new column
         btree.check_constraints = new_check_constraints;
         // Update foreign keys to include any FK constraints from the new column

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -129,7 +129,10 @@ use super::{
         exec_array_slice, exec_array_to_string, exec_string_to_array, make_array_from_registers,
         parse_text_array, serialize_array_from_blob, values_to_record_blob,
     },
-    insn::{Cookie, RegisterOrLiteral, SortComparatorType},
+    insn::{
+        AddSequenceData, ArrayEncodeData, Cookie, IntegrityCkData, RegisterOrLiteral,
+        SortComparatorType, SorterOpenData,
+    },
     CommitState,
 };
 use crate::sync::{Mutex, RwLock};
@@ -2395,16 +2398,14 @@ pub fn op_array_encode(
     insn: &Insn,
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
-    load_insn!(
-        ArrayEncode {
-            reg,
-            element_affinity,
-            element_type,
-            table_name,
-            col_name,
-        },
-        insn
-    );
+    load_insn!(ArrayEncode { data }, insn);
+    let ArrayEncodeData {
+        reg,
+        element_affinity,
+        element_type,
+        table_name,
+        col_name,
+    } = data.as_ref();
 
     let val = state.registers[*reg].get_value();
     if matches!(val, Value::Null) {
@@ -8383,15 +8384,13 @@ pub fn op_sorter_open(
     insn: &Insn,
     pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
-    load_insn!(
-        SorterOpen {
-            cursor_id,
-            columns: _,
-            order_collations_nulls,
-            comparators,
-        },
-        insn
-    );
+    load_insn!(SorterOpen { data }, insn);
+    let SorterOpenData {
+        cursor_id,
+        columns: _,
+        order_collations_nulls,
+        comparators,
+    } = data.as_ref();
     // be careful here - we must not use any async operations after pager.with_header because this op-code has no proper state-machine
     let page_size = match pager.with_header(|header| header.page_size) {
         Ok(IOResult::Done(page_size)) => page_size,
@@ -13338,18 +13337,16 @@ pub fn op_add_sequence(
     insn: &Insn,
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
-    load_insn!(
-        AddSequence {
-            db,
-            name,
-            start,
-            increment,
-            min_value,
-            max_value,
-            cycle,
-        },
-        insn
-    );
+    load_insn!(AddSequence { data }, insn);
+    let AddSequenceData {
+        db,
+        name,
+        start,
+        increment,
+        min_value,
+        max_value,
+        cycle,
+    } = data.as_ref();
     let seq = crate::schema::Sequence::new(
         name.clone(),
         Some(*start),
@@ -15537,16 +15534,14 @@ pub fn op_integrity_check(
     insn: &Insn,
     pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
-    load_insn!(
-        IntegrityCk {
-            db,
-            max_errors,
-            roots,
-            dropped_roots,
-            message_register,
-        },
-        insn
-    );
+    load_insn!(IntegrityCk { data }, insn);
+    let IntegrityCkData {
+        db,
+        max_errors,
+        roots,
+        dropped_roots,
+        message_register,
+    } = data.as_ref();
 
     let mv_store = program.connection.mv_store_for_db(*db);
     // Use the correct pager for the target database (main or attached)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -130,7 +130,7 @@ use super::{
         parse_text_array, serialize_array_from_blob, values_to_record_blob,
     },
     insn::{
-        AddSequenceData, ArrayEncodeData, Cookie, IntegrityCkData, RegisterOrLiteral,
+        AddSequenceData, AggStepData, ArrayEncodeData, Cookie, IntegrityCkData, RegisterOrLiteral,
         SortComparatorType, SorterOpenData,
     },
     CommitState,
@@ -8111,17 +8111,15 @@ pub fn op_agg_step(
     insn: &Insn,
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
-    load_insn!(
-        AggStep {
-            acc_reg,
-            col,
-            delimiter,
-            func,
-            comparator,
-            collation,
-        },
-        insn
-    );
+    load_insn!(AggStep { data }, insn);
+    let AggStepData {
+        acc_reg,
+        col,
+        delimiter,
+        func,
+        comparator,
+        collation,
+    } = data.as_ref();
 
     if let AccumulatorFunc::Window(win_func) = func {
         return op_window_step(state, *acc_reg, *col, win_func);

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1304,24 +1304,17 @@ pub fn insn_to_row(
                 0,
                 format!("if (--r[{}]==0) goto {}", reg, target_pc.as_debug_int()),
             ),
-            Insn::AggStep {
-                func,
-                acc_reg,
-                delimiter: _,
-                col,
-                comparator: _,
-                collation,
-            } => (
+            Insn::AggStep { data } => (
                 "AggStep",
                 0,
-                *col as i64,
-                *acc_reg as i64,
-                Value::build_text(match collation {
-                    Some(collation) => format!("{}({collation})", func.as_str()),
-                    None => func.as_str().to_string(),
+                data.col as i64,
+                data.acc_reg as i64,
+                Value::build_text(match &data.collation {
+                    Some(collation) => format!("{}({collation})", data.func.as_str()),
+                    None => data.func.as_str().to_string(),
                 }),
                 0,
-                format!("accum=r[{}] step(r[{}])", *acc_reg, *col),
+                format!("accum=r[{}] step(r[{}])", data.acc_reg, data.col),
             ),
             Insn::AggInverse {
                 func,

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -2385,14 +2385,14 @@ pub fn insn_to_row(
                 0,
                 format!("drop_column({table}, {column_index})"),
             ),
-            Insn::AddColumn { db: _, table, column, .. } => (
+            Insn::AddColumn { data } => (
                 "AddColumn",
                 0,
                 0,
                 0,
                 Value::build_text(""),
                 0,
-                format!("add_column({table}, {column:?})"),
+                format!("add_column({}, {:?})", data.table, data.column),
             ),
             Insn::AlterColumn { db: _, table, column_index, definition: column, rename } => (
                 "AlterColumn",

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1,4 +1,7 @@
-use crate::vdbe::{builder::CursorType, insn::RegisterOrLiteral};
+use crate::vdbe::{
+    builder::CursorType,
+    insn::{IntegrityCkData, RegisterOrLiteral, SorterOpenData},
+};
 use crate::HashSet;
 use turso_parser::ast::{ResolveType, SortOrder};
 
@@ -681,20 +684,17 @@ pub fn insn_to_row(
                 0,
                 String::from(""),
             ),
-            Insn::ArrayEncode {
-                reg,
-                element_type,
-                table_name,
-                col_name,
-                ..
-            } => (
+            Insn::ArrayEncode { data } => (
                 "ArrayEncode",
-                *reg as i64,
+                data.reg as i64,
                 0,
                 0,
                 Value::build_text(""),
                 0,
-                format!("{table_name}.{col_name} ({element_type})"),
+                format!(
+                    "{}.{} ({})",
+                    data.table_name, data.col_name, data.element_type
+                ),
             ),
             Insn::ArrayDecode { reg } => (
                 "ArrayDecode",
@@ -1360,12 +1360,13 @@ pub fn insn_to_row(
                 0,
                 format!("accum=r[{}] dest=r[{}]", *acc_reg, *dest_reg),
             ),
-            Insn::SorterOpen {
-                cursor_id,
-                columns,
-                order_collations_nulls,
-                ..
-            } => {
+            Insn::SorterOpen { data } => {
+                let SorterOpenData {
+                    cursor_id,
+                    columns,
+                    order_collations_nulls,
+                    ..
+                } = data.as_ref();
                 let to_print: Vec<String> = order_collations_nulls
                     .iter()
                     .map(|(order, collation, nulls)| {
@@ -1826,14 +1827,14 @@ pub fn insn_to_row(
                 0,
                 format!("DROP TYPE {type_name}"),
             ),
-            Insn::AddSequence { db, name, .. } => (
+            Insn::AddSequence { data } => (
                 "AddSequence",
-                *db as i64,
+                data.db as i64,
                 0,
                 0,
-                Value::build_text(name.clone()),
+                Value::build_text(data.name.clone()),
                 0,
-                format!("ADD SEQUENCE {name}"),
+                format!("ADD SEQUENCE {}", data.name),
             ),
             Insn::DropSequence { db, seq_name } => (
                 "DropSequence",
@@ -2334,21 +2335,24 @@ pub fn insn_to_row(
                 0,
                 format!("r[{}]={}", *out_reg, *value),
             ),
-            Insn::IntegrityCk {
-                db,
-                max_errors,
-                roots,
-                dropped_roots,
-                message_register,
-            } => (
-                "IntegrityCk",
-                *max_errors as i64,
-                0,
-                0,
-                Value::build_text(""),
-                0,
-                format!("db={db} roots={roots:?} dropped_roots={dropped_roots:?} message_register={message_register}"),
-            ),
+            Insn::IntegrityCk { data } => {
+                let IntegrityCkData {
+                    db,
+                    max_errors,
+                    roots,
+                    dropped_roots,
+                    message_register,
+                } = data.as_ref();
+                (
+                    "IntegrityCk",
+                    *max_errors as i64,
+                    0,
+                    0,
+                    Value::build_text(""),
+                    0,
+                    format!("db={db} roots={roots:?} dropped_roots={dropped_roots:?} message_register={message_register}"),
+                )
+            }
             Insn::RowData { cursor_id, dest } => (
                 "RowData",
                 *cursor_id as i64,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -345,6 +345,20 @@ pub struct SorterOpenData {
     pub comparators: crate::alloc::Vec<Option<SortComparatorType>>,
 }
 
+/// Data for AggStep instruction (boxed to keep Insn small).
+#[derive(Debug, Clone)]
+pub struct AggStepData {
+    pub acc_reg: usize,
+    pub col: usize,
+    pub delimiter: usize,
+    pub func: AccumulatorFunc,
+    /// Optional custom type comparator for MIN/MAX aggregates.
+    pub comparator: Option<SortComparatorType>,
+    /// Collation for comparison-based aggregates (MIN/MAX), resolved at
+    /// translation time from the argument expression.
+    pub collation: Option<CollationSeq>,
+}
+
 /// Data for ArrayEncode instruction (boxed to keep Insn small).
 #[derive(Debug, Clone)]
 pub struct ArrayEncodeData {
@@ -1178,15 +1192,7 @@ pub enum Insn {
     },
 
     AggStep {
-        acc_reg: usize,
-        col: usize,
-        delimiter: usize,
-        func: AccumulatorFunc,
-        /// Optional custom type comparator for MIN/MAX aggregates.
-        comparator: Option<SortComparatorType>,
-        /// Collation for comparison-based aggregates (MIN/MAX), resolved at
-        /// translation time from the argument expression.
-        collation: Option<CollationSeq>,
+        data: Box<AggStepData>,
     },
 
     /// Mirror-image of AggStep: fires when a row crosses the frame-start

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -270,6 +270,16 @@ pub struct HashBuildData {
     pub track_matched: bool,
 }
 
+/// Data for AddColumn instruction (boxed to keep Insn small).
+#[derive(Debug, Clone)]
+pub struct AddColumnData {
+    pub db: usize,
+    pub table: String,
+    pub column: Column,
+    pub check_constraints: Vec<CheckConstraint>,
+    pub foreign_keys: Vec<Arc<ForeignKey>>,
+}
+
 /// Data for HashDistinct instruction (boxed to keep Insn small).
 #[derive(Debug, Clone)]
 pub struct HashDistinctData {
@@ -1797,11 +1807,7 @@ pub enum Insn {
         column_index: usize,
     },
     AddColumn {
-        db: usize,
-        table: String,
-        column: Box<Column>,
-        check_constraints: Vec<CheckConstraint>,
-        foreign_keys: Vec<Arc<ForeignKey>>,
+        data: Box<AddColumnData>,
     },
     AlterColumn {
         db: usize,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -270,6 +270,33 @@ pub struct HashBuildData {
     pub track_matched: bool,
 }
 
+/// Key columns of a seek that use `IS` instead of `=`, so NULL may match in
+/// them. Most seeks have no such columns, so the empty mask is a null pointer
+/// and only IS-seeks allocate (boxed to keep Insn small).
+///
+/// Build it from a [`BitSet`] via `From`; that keeps the invariant that the
+/// inner option is `None` exactly when the mask is empty.
+#[derive(Debug, Clone, Default)]
+pub struct NullMatchingMask(Option<Box<BitSet>>);
+
+impl NullMatchingMask {
+    /// Returns true if key column `idx` uses `IS`, so NULL may match in it.
+    pub fn get(&self, idx: usize) -> bool {
+        self.0.as_ref().is_some_and(|mask| mask.get(idx))
+    }
+
+    /// Returns true if no key column uses `IS`.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
+impl From<BitSet> for NullMatchingMask {
+    fn from(mask: BitSet) -> Self {
+        Self((!mask.is_empty()).then(|| Box::new(mask)))
+    }
+}
+
 /// Data for AddColumn instruction (boxed to keep Insn small).
 #[derive(Debug, Clone)]
 pub struct AddColumnData {
@@ -1010,7 +1037,7 @@ pub enum Insn {
         eq_only: bool,
         /// Key columns that use `IS` instead of `=`. NULL may match in these
         /// columns, so the seek must not stop when their key value is NULL.
-        null_matching_mask: BitSet,
+        null_matching_mask: NullMatchingMask,
     },
 
     /// If cursor_id refers to an SQL table (B-Tree that uses integer keys), use the value in start_reg as the key.
@@ -1050,7 +1077,7 @@ pub enum Insn {
         eq_only: bool,
         /// Key columns that use `IS` instead of `=`. NULL may match in these
         /// columns, so the seek must not stop when their key value is NULL.
-        null_matching_mask: BitSet,
+        null_matching_mask: NullMatchingMask,
     },
 
     // If cursor_id refers to an SQL table (B-Tree that uses integer keys), use the value in start_reg as the key.

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -307,6 +307,54 @@ pub struct AddColumnData {
     pub foreign_keys: Vec<Arc<ForeignKey>>,
 }
 
+/// Data for IntegrityCk instruction (boxed to keep Insn small).
+#[derive(Debug, Clone)]
+pub struct IntegrityCkData {
+    pub db: usize,
+    pub max_errors: usize,
+    pub roots: Vec<i64>,
+    pub dropped_roots: Vec<i64>,
+    pub message_register: usize,
+}
+
+/// Data for AddSequence instruction (boxed to keep Insn small).
+#[derive(Debug, Clone)]
+pub struct AddSequenceData {
+    pub db: usize,
+    pub name: String,
+    pub start: i64,
+    pub increment: i64,
+    pub min_value: i64,
+    pub max_value: i64,
+    pub cycle: bool,
+}
+
+/// Data for SorterOpen instruction (boxed to keep Insn small).
+#[derive(Debug, Clone)]
+pub struct SorterOpenData {
+    pub cursor_id: CursorID, // P1
+    pub columns: usize,      // P2
+    /// Combined order, collation, and nulls ordering per column.
+    pub order_collations_nulls: crate::alloc::Vec<(
+        SortOrder,
+        Option<CollationSeq>,
+        Option<turso_parser::ast::NullsOrder>,
+    )>,
+    /// Per-column custom type comparators for ORDER BY sorting.
+    /// When present, the comparator is used instead of standard value comparison.
+    pub comparators: crate::alloc::Vec<Option<SortComparatorType>>,
+}
+
+/// Data for ArrayEncode instruction (boxed to keep Insn small).
+#[derive(Debug, Clone)]
+pub struct ArrayEncodeData {
+    pub reg: usize,
+    pub element_affinity: Affinity,
+    pub element_type: Arc<str>,
+    pub table_name: Arc<str>,
+    pub col_name: Arc<str>,
+}
+
 /// Data for HashDistinct instruction (boxed to keep Insn small).
 #[derive(Debug, Clone)]
 pub struct HashDistinctData {
@@ -698,11 +746,7 @@ pub enum Insn {
     /// Input: reg = JSON text like '[1,2,3]'. Output: reg = record-format BLOB.
     /// Raises SQLITE_CONSTRAINT on type mismatch.
     ArrayEncode {
-        reg: usize,
-        element_affinity: Affinity,
-        element_type: Arc<str>,
-        table_name: Arc<str>,
-        col_name: Arc<str>,
+        data: Box<ArrayEncodeData>,
     },
 
     /// Convert a native record-format BLOB back to PostgreSQL-style array text for display.
@@ -1173,17 +1217,7 @@ pub enum Insn {
 
     /// Open a sorter.
     SorterOpen {
-        cursor_id: CursorID, // P1
-        columns: usize,      // P2
-        /// Combined order, collation, and nulls ordering per column.
-        order_collations_nulls: crate::alloc::Vec<(
-            SortOrder,
-            Option<CollationSeq>,
-            Option<turso_parser::ast::NullsOrder>,
-        )>,
-        /// Per-column custom type comparators for ORDER BY sorting.
-        /// When present, the comparator is used instead of standard value comparison.
-        comparators: crate::alloc::Vec<Option<SortComparatorType>>,
+        data: Box<SorterOpenData>,
     },
 
     /// Insert a row into the sorter.
@@ -1480,13 +1514,7 @@ pub enum Insn {
     /// Add a fully-configured sequence to the in-memory schema.
     /// Emitted by CREATE SEQUENCE after ParseSchema has added the backing table.
     AddSequence {
-        db: usize,
-        name: String,
-        start: i64,
-        increment: i64,
-        min_value: i64,
-        max_value: i64,
-        cycle: bool,
+        data: Box<AddSequenceData>,
     },
     /// Drop a sequence from the in-memory schema
     DropSequence {
@@ -1817,11 +1845,7 @@ pub enum Insn {
     /// In passive MVCC mode, `dropped_roots` lists checkpointed objects dropped before the next
     /// checkpoint; execute walks them after live roots and skips pages already accounted for.
     IntegrityCk {
-        db: usize,
-        max_errors: usize,
-        roots: Vec<i64>,
-        dropped_roots: Vec<i64>,
-        message_register: usize,
+        data: Box<IntegrityCkData>,
     },
     RenameTable {
         db: usize,


### PR DESCRIPTION
This reduces VDBE instruction memory footprint from 96 bytes to 64. It's still much higher than SQLite's 24 bytes, but at least fits a CPU cache line now.