### PR TITLE
core/vdbe: fill NULLs when ColumnRange reads a never-opened cursor

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2168,10 +2168,7 @@ fn op_column_range_fetch(
                 let cursor_ref =
                     must_be_btree_cursor!(cursor_id, program.cursor_ref, state, "ColumnRange");
                 if matches!(cursor_ref, Cursor::NullRow) {
-                    // The cursor slot holds the NullRow placeholder for a
-                    // never-opened cursor: every column reads as NULL, and
-                    // defaults must not apply (a null row is not a short record).
-                    tracing::trace!("op_column_range(null_row placeholder)");
+                    tracing::trace!("op_column_range(null_row)");
                     for reg in &mut state.registers[dest..dest + count] {
                         reg.set_null();
                     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2167,6 +2167,16 @@ fn op_column_range_fetch(
             let filled = {
                 let cursor_ref =
                     must_be_btree_cursor!(cursor_id, program.cursor_ref, state, "ColumnRange");
+                if matches!(cursor_ref, Cursor::NullRow) {
+                    // The cursor slot holds the NullRow placeholder for a
+                    // never-opened cursor: every column reads as NULL, and
+                    // defaults must not apply (a null row is not a short record).
+                    tracing::trace!("op_column_range(null_row placeholder)");
+                    for reg in &mut state.registers[dest..dest + count] {
+                        reg.set_null();
+                    }
+                    return Ok(InsnFunctionStepResult::Step);
+                }
                 let cursor = cursor_ref.as_btree_mut();
 
                 if cursor.get_null_flag() {

--- a/sqlite/conformance/sqlite-sqltests/join-empty-table-ungrouped-aggregate.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/join-empty-table-ungrouped-aggregate.sqltest
@@ -34,8 +34,7 @@ setup empty-table-with-default {
     ALTER TABLE t ADD COLUMN y DEFAULT 99;
 }
 
-# Adjacent column reads are fused into ColumnRange. An unopened cursor's NULL
-# row must override column defaults just as it does for separate Column opcodes.
+# This fails if ColumnRange doesn't check for NullRow.
 @setup empty-table-with-default
 test inner-join-empty-table-ungrouped-aggregate-column-range {
     SELECT b.x, b.y, COUNT(*) FROM t a JOIN t b ON a.x=b.x;

--- a/sqlite/conformance/sqlite-sqltests/join-empty-table-ungrouped-aggregate.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/join-empty-table-ungrouped-aggregate.sqltest
@@ -29,6 +29,21 @@ expect {
     |0
 }
 
+setup empty-table-with-default {
+    CREATE TABLE t(x);
+    ALTER TABLE t ADD COLUMN y DEFAULT 99;
+}
+
+# Adjacent column reads are fused into ColumnRange. An unopened cursor's NULL
+# row must override column defaults just as it does for separate Column opcodes.
+@setup empty-table-with-default
+test inner-join-empty-table-ungrouped-aggregate-column-range {
+    SELECT b.x, b.y, COUNT(*) FROM t a JOIN t b ON a.x=b.x;
+}
+expect {
+    ||0
+}
+
 # RowId (not just Column) must also read NULL from the never-opened cursor.
 @setup empty-table
 test inner-join-empty-table-ungrouped-aggregate-rowid {


### PR DESCRIPTION
## Note:
 this was found while asking claude to walk me through `columnrange` pr and asking bunch of questions
 
 initial suggestion from claude for  this fix was following sqlite(turso has two ways on storing nullrow depending on whether cursor is open or not) sqlite has only one way - maybe that is a better long term fix but doing it touches lot more code, so this is a minimal fix.
## Description

Fix a bug where the `ColumnRange` opcode did not properly handle never-opened cursors (represented by the `NullRow` placeholder). When a cursor is never opened, all column reads should return NULL, and column defaults must not apply—just as they don't for individual `Column` opcodes.

The fix adds an explicit check in `op_column_range_fetch` to detect the `NullRow` case and set all destination registers to NULL before returning, bypassing the normal column fetch logic that would incorrectly apply defaults.

## Motivation and context

When adjacent column reads are fused into a `ColumnRange` opcode for optimization, the behavior must remain identical to separate `Column` opcodes. A never-opened cursor's NULL row is a special case: it represents no actual record, so defaults stored in the table schema should not be applied.

This manifests in queries like `SELECT b.x, b.y, COUNT(*) FROM t a JOIN t b ON a.x=b.x` where table `t` has a column with a default value. If the join produces no rows, the ungrouped aggregate still executes once with a NULL row from the unopened cursor `b`, and all columns from `b` must read as NULL, not as their defaults.

## Test Plan

Added a new test case `inner-join-empty-table-ungrouped-aggregate-column-range` in `sqlite/conformance/sqlite-sqltests/join-empty-table-ungrouped-aggregate.sqltest` that verifies the fix. The test creates a table with a column that has a default value, performs an inner join that produces no rows, and asserts that the ungrouped aggregate returns NULL columns (not the defaults).

Existing tests continue to pass.

## Description of AI Usage

claude did this

