### PR TITLE
core/vdbe: only count codegen-marked steps as fullscan steps

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -703,6 +703,7 @@ fn emit_add_virtual_column_validation(
     program.emit_insn(Insn::Next {
         cursor_id,
         pc_if_next: loop_start,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(skip_label);

--- a/core/translate/analyze.rs
+++ b/core/translate/analyze.rs
@@ -318,6 +318,7 @@ pub fn translate_analyze(
             program.emit_insn(Insn::Next {
                 cursor_id: stat_cursor,
                 pc_if_next: loop_start,
+                fullscan: false,
             });
         } else {
             let rowid_reg = program.alloc_register();
@@ -333,6 +334,7 @@ pub fn translate_analyze(
             program.emit_insn(Insn::Next {
                 cursor_id: stat_cursor,
                 pc_if_next: loop_start,
+                fullscan: false,
             });
         }
 
@@ -340,6 +342,7 @@ pub fn translate_analyze(
         program.emit_insn(Insn::Next {
             cursor_id: stat_cursor,
             pc_if_next: loop_start,
+            fullscan: false,
         });
         program.preassign_label_to_next_insn(rewind_done);
 
@@ -578,6 +581,7 @@ fn emit_index_stats(
     program.emit_insn(Insn::Next {
         cursor_id: idx_cursor,
         pc_if_next: lbl_loop,
+        fullscan: false,
     });
 
     // stat_get(accum) to get the final stat string

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -630,6 +630,7 @@ fn read_deduplicated_union_or_except_rows(
     program.emit_insn(Insn::Next {
         cursor_id: dedupe_cursor_id,
         pc_if_next: label_dedupe_loop_start,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(label_close);
     program.emit_insn(Insn::Close {
@@ -703,6 +704,7 @@ fn read_intersect_rows(
     program.emit_insn(Insn::Next {
         cursor_id: left_cursor_id,
         pc_if_next: label_loop_start,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(label_close);
@@ -961,6 +963,7 @@ fn emit_compound_order_by(
     program.emit_insn(Insn::Next {
         cursor_id: collection_cursor_id,
         pc_if_next: label_sorter_loop,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(label_sorter_done);
     program.emit_insn(Insn::Close {

--- a/core/translate/expr/emission.rs
+++ b/core/translate/expr/emission.rs
@@ -253,6 +253,7 @@ pub(crate) fn emit_returning_scan_back(program: &mut ProgramBuilder, buf: &Retur
     program.emit_insn(Insn::Next {
         cursor_id: buf.cursor_id,
         pc_if_next: scan_start,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(end_label);
 }

--- a/core/translate/expr/functions.rs
+++ b/core/translate/expr/functions.rs
@@ -320,6 +320,7 @@ pub(super) fn translate_sequence_function(
         program.emit_insn(Insn::Next {
             cursor_id,
             pc_if_next: loop_label,
+            fullscan: false,
         });
         program.preassign_label_to_next_insn(empty_label);
 

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -321,6 +321,7 @@ pub fn translate_expr(
                     program.emit_insn(Insn::Next {
                         cursor_id: *cursor_id,
                         pc_if_next: label_null_checks_loop_start,
+                        fullscan: false,
                     });
                     // Loop exhausted without finding all-NULL row
                     program.emit_insn(Insn::Goto {

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -423,6 +423,7 @@ where
     program.emit_insn(Insn::Next {
         cursor_id: icur,
         pc_if_next: loop_top,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(done);
@@ -531,6 +532,7 @@ where
     program.emit_insn(Insn::Next {
         cursor_id: ccur,
         pc_if_next: loop_top,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(done);
@@ -2442,6 +2444,7 @@ pub fn emit_fk_drop_table_check(
     program.emit_insn(Insn::Next {
         cursor_id: parent_cur,
         pc_if_next: collect_loop,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(collect_done);
@@ -2588,6 +2591,7 @@ pub fn emit_fk_drop_table_check(
         program.emit_insn(Insn::Next {
             cursor_id: child_cur,
             pc_if_next: child_loop,
+            fullscan: false,
         });
 
         program.preassign_label_to_next_insn(child_done);

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -450,6 +450,7 @@ fn emit_refill_index(
         program.emit_insn(Insn::Next {
             cursor_id: table_cursor_id,
             pc_if_next: loop_start_label,
+            fullscan: false,
         });
         program.preassign_label_to_next_insn(loop_end_label);
     } else {
@@ -545,6 +546,7 @@ fn emit_refill_index(
         program.emit_insn(Insn::Next {
             cursor_id: table_cursor_id,
             pc_if_next: loop_start_label,
+            fullscan: false,
         });
         program.preassign_label_to_next_insn(loop_end_label);
 
@@ -1361,6 +1363,7 @@ pub fn translate_drop_index(
     program.emit_insn(Insn::Next {
         cursor_id: sqlite_schema_cursor_id,
         pc_if_next: loop_start_label,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(loop_end_label);

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1253,6 +1253,7 @@ fn emit_epilogue(
             program.emit_insn(Insn::Next {
                 cursor_id: temp_table_ctx.cursor_id,
                 pc_if_next: temp_table_ctx.loop_start_label,
+                fullscan: false,
             });
             program.preassign_label_to_next_insn(temp_table_ctx.loop_end_label);
 
@@ -1756,6 +1757,7 @@ fn reload_autoincrement_state(program: &mut ProgramBuilder, meta: AutoincMeta) {
     program.emit_insn(Insn::Next {
         cursor_id: seq_cursor_id,
         pc_if_next: loop_start_label,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(loop_end_label);
 }
@@ -3416,6 +3418,7 @@ fn ensure_sequence_initialized(
     program.emit_insn(Insn::Next {
         cursor_id: seq_cursor_id,
         pc_if_next: loop_start_label,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(insert_new_label);
@@ -4327,6 +4330,7 @@ pub fn emit_parent_side_fk_decrement_on_insert(
             program.emit_insn(Insn::Next {
                 cursor_id: ccur,
                 pc_if_next: loop_top,
+                fullscan: false,
             });
             program.preassign_label_to_next_insn(done);
             program.emit_insn(Insn::Close { cursor_id: ccur });

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -585,6 +585,7 @@ fn translate_integrity_check_impl(
                     program.emit_insn(Insn::Next {
                         cursor_id: bound_index.cursor_id,
                         pc_if_next: next_exists,
+                        fullscan: false,
                     });
                     program.emit_insn(Insn::Goto {
                         target_pc: unique_ok,
@@ -616,6 +617,7 @@ fn translate_integrity_check_impl(
         program.emit_insn(Insn::Next {
             cursor_id: table_cursor_id,
             pc_if_next: loop_start_label,
+            fullscan: false,
         });
         program.preassign_label_to_next_insn(table_empty_label);
 

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -84,15 +84,23 @@ impl CloseLoop {
                                     )
                                 })
                             };
+                            // An unconstrained scan is a full scan no matter
+                            // what it steps: the table, a covering index, or
+                            // the prebuilt ephemeral copy an UPDATE scans.
+                            // SQLite tags any WHERE loop without a constraint;
+                            // constrained loops go through Operation::Search.
+                            let fullscan = true;
                             if *iter_dir == IterationDirection::Backwards {
                                 program.emit_insn(Insn::Prev {
                                     cursor_id: iteration_cursor_id,
                                     pc_if_prev: loop_labels.loop_start,
+                                    fullscan,
                                 });
                             } else {
                                 program.emit_insn(Insn::Next {
                                     cursor_id: iteration_cursor_id,
                                     pc_if_next: loop_labels.loop_start,
+                                    fullscan,
                                 });
                             }
                         }
@@ -114,11 +122,13 @@ impl CloseLoop {
                                         program.emit_insn(Insn::Prev {
                                             cursor_id: *cursor_id,
                                             pc_if_prev: loop_labels.loop_start,
+                                            fullscan: false,
                                         });
                                     } else {
                                         program.emit_insn(Insn::Next {
                                             cursor_id: *cursor_id,
                                             pc_if_next: loop_labels.loop_start,
+                                            fullscan: false,
                                         });
                                     }
                                 } else {
@@ -185,11 +195,13 @@ impl CloseLoop {
                                 program.emit_insn(Insn::Prev {
                                     cursor_id: iteration_cursor_id,
                                     pc_if_prev: loop_labels.loop_start,
+                                    fullscan: false,
                                 });
                             } else {
                                 program.emit_insn(Insn::Next {
                                     cursor_id: iteration_cursor_id,
                                     pc_if_next: loop_labels.loop_start,
+                                    fullscan: false,
                                 });
                             }
                         }
@@ -210,6 +222,7 @@ impl CloseLoop {
                                 program.emit_insn(Insn::Next {
                                     cursor_id: iteration_cursor_id,
                                     pc_if_next: loop_labels.loop_start,
+                                    fullscan: false,
                                 });
                             }
 
@@ -219,6 +232,7 @@ impl CloseLoop {
                             program.emit_insn(Insn::Next {
                                 cursor_id: ephemeral_cursor_id,
                                 pc_if_next: outer_loop_start,
+                                fullscan: false,
                             });
                         }
                     }
@@ -229,6 +243,7 @@ impl CloseLoop {
                     program.emit_insn(Insn::Next {
                         cursor_id: index_cursor_id.unwrap(),
                         pc_if_next: loop_labels.loop_start,
+                        fullscan: false,
                     });
                     program.preassign_label_to_next_insn(loop_labels.loop_end);
                 }
@@ -257,6 +272,7 @@ impl CloseLoop {
                     program.emit_insn(Insn::Next {
                         cursor_id: probe_cursor_id,
                         pc_if_next: loop_labels.loop_start,
+                        fullscan: false,
                     });
                     program.preassign_label_to_next_insn(loop_labels.loop_end);
 
@@ -560,6 +576,7 @@ pub(super) fn emit_autoindex(
     program.emit_insn(Insn::Next {
         cursor_id: table_cursor_id,
         pc_if_next: label_ephemeral_build_loop_start,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(label_ephemeral_build_end);
     Ok(AutoIndexResult { use_bloom_filter })

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -526,6 +526,7 @@ impl<'a, 'plan> PreparedHashBuild<'a, 'plan> {
         planner.program.emit_insn(Insn::Next {
             cursor_id: build_iter_cursor_id,
             pc_if_next: build_loop_start,
+            fullscan: false,
         });
 
         planner.program.preassign_label_to_next_insn(build_loop_end);

--- a/core/translate/main_loop/multi_index.rs
+++ b/core/translate/main_loop/multi_index.rs
@@ -192,10 +192,12 @@ fn emit_seek_multi_index_branch(
         IterationDirection::Forwards => program.emit_insn(Insn::Next {
             cursor_id: branch_cursor_id,
             pc_if_next: branch_loop_start,
+            fullscan: false,
         }),
         IterationDirection::Backwards => program.emit_insn(Insn::Prev {
             cursor_id: branch_cursor_id,
             pc_if_prev: branch_loop_start,
+            fullscan: false,
         }),
     }
     program.preassign_label_to_next_insn(branch_loop_end);
@@ -322,6 +324,7 @@ fn emit_in_seek_multi_index_branch(
         program.emit_insn(Insn::Next {
             cursor_id: branch_cursor_id,
             pc_if_next: branch_loop_start,
+            fullscan: false,
         });
     } else {
         program.emit_insn(Insn::SeekRowid {
@@ -362,6 +365,7 @@ fn emit_in_seek_multi_index_branch(
     program.emit_insn(Insn::Next {
         cursor_id: ephemeral_cursor_id,
         pc_if_next: outer_loop_start,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(branch_loop_end);
 

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -463,6 +463,7 @@ impl EmitOrderBy {
             program.emit_insn(Insn::Next {
                 cursor_id: sort_cursor,
                 pc_if_next: sort_loop_start_label,
+                fullscan: false,
             });
         }
         program.preassign_label_to_next_insn(sort_loop_end_label);

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1944,6 +1944,7 @@ pub fn translate_drop_table(
     program.emit_insn(Insn::Next {
         cursor_id: sqlite_schema_cursor_id_0,
         pc_if_next: metadata_loop,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(end_metadata_label);
     // end of loop on schema table
@@ -2053,6 +2054,7 @@ pub fn translate_drop_table(
                 program.emit_insn(Insn::Next {
                     cursor_id: temp_cursor,
                     pc_if_next: temp_loop_label,
+                    fullscan: false,
                 });
                 program.preassign_label_to_next_insn(temp_end_label);
             }
@@ -2206,6 +2208,7 @@ pub fn translate_drop_table(
         program.emit_insn(Insn::Next {
             cursor_id: sqlite_schema_cursor_id_1,
             pc_if_next: copy_schema_to_temp_table_loop,
+            fullscan: false,
         });
         program.preassign_label_to_next_insn(copy_schema_to_temp_table_loop_end_label);
         // End loop to copy over row id's from the schema table for rows that have the same root page as the one that was moved
@@ -2272,6 +2275,7 @@ pub fn translate_drop_table(
         program.emit_insn(Insn::Next {
             cursor_id: ephemeral_cursor_id,
             pc_if_next: copy_temp_table_to_schema_loop,
+            fullscan: false,
         });
         program.preassign_label_to_next_insn(copy_temp_table_to_schema_loop_end_label);
         // End loop to copy over row id's from the ephemeral table and then re-insert into the schema table with the correct root page
@@ -2333,6 +2337,7 @@ pub fn translate_drop_table(
         program.emit_insn(Insn::Next {
             cursor_id: seq_cursor_id,
             pc_if_next: loop_start_label,
+            fullscan: false,
         });
 
         program.preassign_label_to_next_insn(end_loop_label);
@@ -2433,6 +2438,7 @@ pub fn translate_drop_table(
         program.emit_insn(Insn::Next {
             cursor_id: ver_cursor_id,
             pc_if_next: ver_loop_start_label,
+            fullscan: false,
         });
 
         program.preassign_label_to_next_insn(end_ver_loop_label);
@@ -2980,6 +2986,7 @@ pub fn translate_drop_type(
     program.emit_insn(Insn::Next {
         cursor_id: types_cursor_id,
         pc_if_next: loop_start_label,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(end_loop_label);

--- a/core/translate/sequence.rs
+++ b/core/translate/sequence.rs
@@ -632,6 +632,7 @@ pub(crate) fn emit_backing_table_compaction(
     program.emit_insn(Insn::Next {
         cursor_id,
         pc_if_next: loop_top_label,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(skip_label);
 }
@@ -706,6 +707,7 @@ pub(crate) fn emit_sqlite_sequence_sync(
     program.emit_insn(Insn::Next {
         cursor_id: sseq_cursor,
         pc_if_next: loop_top_label,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(insert_label);
 
@@ -984,6 +986,7 @@ pub(crate) fn emit_drop_sequence_cleanup(
     program.emit_insn(Insn::Next {
         cursor_id: sqlite_schema_cursor_id,
         pc_if_next: loop_start_label,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(end_loop_label);
 

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -585,6 +585,7 @@ pub fn translate_drop_trigger(
     program.emit_insn(Insn::Next {
         cursor_id: sqlite_schema_cursor_id,
         pc_if_next: search_loop_label,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(done_label);

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -160,6 +160,7 @@ pub fn translate_create_materialized_view(
     program.emit_insn(Insn::Next {
         cursor_id: view_cursor_id,
         pc_if_next: clear_loop_label,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(clear_done_label);
@@ -606,6 +607,7 @@ pub fn translate_drop_view(
     program.emit_insn(Insn::Next {
         cursor_id: sqlite_schema_cursor_id,
         pc_if_next: loop_start_label,
+        fullscan: false,
     });
 
     program.preassign_label_to_next_insn(end_loop_label);
@@ -721,6 +723,7 @@ pub fn translate_drop_view(
         program.emit_insn(Insn::Next {
             cursor_id: sqlite_schema_cursor_id,
             pc_if_next: dbsp_loop_start_label,
+            fullscan: false,
         });
 
         program.preassign_label_to_next_insn(dbsp_end_loop_label);

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -2438,6 +2438,7 @@ fn emit_window_full_scan(
     program.emit_insn(Insn::Next {
         cursor_id: scan_cursor,
         pc_if_next: label_loop,
+        fullscan: false,
     });
     program.preassign_label_to_next_insn(label_break);
     emit_window_agg_final(program, window, &registers, &minmax, true);
@@ -2932,6 +2933,7 @@ fn emit_window_op(
     program.emit_insn(Insn::Next {
         cursor_id: cursor_for_op,
         pc_if_next: label_after_next,
+        fullscan: false,
     });
     if let Some(break_target) = break_on_eof {
         program.emit_insn(Insn::Goto {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -2028,6 +2028,7 @@ impl ProgramBuilder {
         self.emit_insn(Insn::Next {
             cursor_id,
             pc_if_next: loop_start,
+            fullscan: false,
         });
         self.preassign_label_to_next_insn(loop_end);
     }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3272,6 +3272,7 @@ pub fn op_next(
         Next {
             cursor_id,
             pc_if_next,
+            fullscan,
         },
         insn
     );
@@ -3310,12 +3311,14 @@ pub fn op_next(
         state.record_rows_read(1);
         state.metrics.btree_next = state.metrics.btree_next.saturating_add(1);
         state.metrics.search_count = state.metrics.search_count.saturating_add(1);
-        // Track if this is a full table scan or index scan
+        // Only steps codegen marked as part of a full table scan count as
+        // fullscan steps, matching SQLITE_STMTSTATUS_FULLSCAN_STEP.
+        if *fullscan {
+            state.metrics.fullscan_steps = state.metrics.fullscan_steps.saturating_add(1);
+        }
         if let Some((_, cursor_type)) = program.cursor_ref.get(*cursor_id) {
             if cursor_type.is_index() {
                 state.metrics.index_steps = state.metrics.index_steps.saturating_add(1);
-            } else if matches!(cursor_type, CursorType::BTreeTable(_)) {
-                state.metrics.fullscan_steps = state.metrics.fullscan_steps.saturating_add(1);
             }
         }
         state.pc = pc_if_next.as_offset_int();
@@ -3335,6 +3338,7 @@ pub fn op_prev(
         Prev {
             cursor_id,
             pc_if_prev,
+            fullscan,
         },
         insn
     );
@@ -3358,12 +3362,14 @@ pub fn op_prev(
         state.record_rows_read(1);
         state.metrics.btree_prev = state.metrics.btree_prev.saturating_add(1);
         state.metrics.search_count = state.metrics.search_count.saturating_add(1);
-        // Track if this is a full table scan or index scan
+        // Only steps codegen marked as part of a full table scan count as
+        // fullscan steps, matching SQLITE_STMTSTATUS_FULLSCAN_STEP.
+        if *fullscan {
+            state.metrics.fullscan_steps = state.metrics.fullscan_steps.saturating_add(1);
+        }
         if let Some((_, cursor_type)) = program.cursor_ref.get(*cursor_id) {
             if cursor_type.is_index() {
                 state.metrics.index_steps = state.metrics.index_steps.saturating_add(1);
-            } else if matches!(cursor_type, CursorType::BTreeTable(_)) {
-                state.metrics.fullscan_steps = state.metrics.fullscan_steps.saturating_add(1);
             }
         }
         state.pc = pc_if_prev.as_offset_int();

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -938,13 +938,16 @@ pub fn insn_to_row(
             Insn::Next {
                 cursor_id,
                 pc_if_next,
+                fullscan,
             } => (
                 "Next",
                 *cursor_id as i64,
                 pc_if_next.as_debug_int() as i64,
                 0,
                 Value::build_text(""),
-                0,
+                // SQLite sets P5 to SQLITE_STMTSTATUS_FULLSCAN_STEP (1) on
+                // full-table-scan steps
+                *fullscan as i64,
                 "".to_string(),
             ),
             Insn::Halt {
@@ -2009,13 +2012,16 @@ pub fn insn_to_row(
             Insn::Prev {
                 cursor_id,
                 pc_if_prev,
+                fullscan,
             } => (
                 "Prev",
                 *cursor_id as i64,
                 pc_if_prev.as_debug_int() as i64,
                 0,
                 Value::build_text(""),
-                0,
+                // SQLite sets P5 to SQLITE_STMTSTATUS_FULLSCAN_STEP (1) on
+                // full-table-scan steps
+                *fullscan as i64,
                 "".to_string(),
             ),
             Insn::ShiftRight { lhs, rhs, dest } => (

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -927,11 +927,18 @@ pub enum Insn {
     Next {
         cursor_id: CursorID,
         pc_if_next: BranchOffset,
+        /// True when this step is part of a full table scan (a loop over the
+        /// whole table with no index or rowid constraint). Only these steps
+        /// count toward SQLITE_STMTSTATUS_FULLSCAN_STEP, matching SQLite,
+        /// which tags the opcode with P5 at codegen time.
+        fullscan: bool,
     },
 
     Prev {
         cursor_id: CursorID,
         pc_if_prev: BranchOffset,
+        /// See [Insn::Next::fullscan].
+        fullscan: bool,
     },
 
     /// Halt the program.

--- a/sqlite/conformance/sqlite-sqltests/fullscan_steps.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/fullscan_steps.sqltest
@@ -1,0 +1,38 @@
+# SQLITE_STMTSTATUS_FULLSCAN_STEP only counts Next/Prev steps in loops the
+# codegen tagged as full scans (P5=1 on the opcode, shown in EXPLAIN). These
+# snapshots pin the tagging: an unconstrained scan is tagged whether it steps
+# the table, a covering index, or runs in reverse; a constrained index search
+# is not tagged. This matches SQLite, which tags any WHERE loop that has no
+# constraint.
+
+@database :memory:
+
+setup fullscan_schema {
+    CREATE TABLE t (a INTEGER, b INTEGER);
+    CREATE INDEX ta ON t (a);
+    INSERT INTO t VALUES (1, 10), (2, 20), (3, 30);
+}
+
+@setup fullscan_schema
+@skip-if mvcc "MVCC uses negative root page numbers, so the bytecode snapshot differs"
+snapshot fullscan-table-scan-tags-next-p5 {
+    SELECT * FROM t;
+}
+
+@setup fullscan_schema
+@skip-if mvcc "MVCC uses negative root page numbers, so the bytecode snapshot differs"
+snapshot fullscan-covering-index-scan-tags-next-p5 {
+    SELECT a FROM t ORDER BY a;
+}
+
+@setup fullscan_schema
+@skip-if mvcc "MVCC uses negative root page numbers, so the bytecode snapshot differs"
+snapshot fullscan-reverse-table-scan-tags-prev-p5 {
+    SELECT * FROM t ORDER BY rowid DESC;
+}
+
+@setup fullscan_schema
+@skip-if mvcc "MVCC uses negative root page numbers, so the bytecode snapshot differs"
+snapshot indexed-range-search-not-tagged-fullscan {
+    SELECT * FROM t WHERE a > 5;
+}

--- a/sqlite/conformance/sqlite-sqltests/orderby/snapshots/orderby_plan__orderby_a_desc_uses_sorter.snap
+++ b/sqlite/conformance/sqlite-sqltests/orderby/snapshots/orderby_plan__orderby_a_desc_uses_sorter.snap
@@ -22,7 +22,7 @@ addr  opcode          p1  p2  p3  p4       p5  comment
    4    Column         1   0   3            0  r[3]=t.a
    5    MakeRecord     3   1   2            0  r[2]=mkrec(r[3..3])
    6    SorterInsert   0   2   0  0         0  key=r[2]
-   7  Next             1   4   0            0
+   7  Next             1   4   0            1
    8  OpenPseudo       2   2   1            0  1 columns in r[2]
    9  SorterSort       0  14   0            0
   10    SorterData     0   2   2            0  r[2]=data

--- a/sqlite/conformance/sqlite-sqltests/orderby/snapshots/orderby_plan__orderby_a_uses_sorter.snap
+++ b/sqlite/conformance/sqlite-sqltests/orderby/snapshots/orderby_plan__orderby_a_uses_sorter.snap
@@ -22,7 +22,7 @@ addr  opcode          p1  p2  p3  p4      p5  comment
    4    Column         1   0   3           0  r[3]=t.a
    5    MakeRecord     3   1   2           0  r[2]=mkrec(r[3..3])
    6    SorterInsert   0   2   0  0        0  key=r[2]
-   7  Next             1   4   0           0
+   7  Next             1   4   0           1
    8  OpenPseudo       2   2   1           0  1 columns in r[2]
    9  SorterSort       0  14   0           0
   10    SorterData     0   2   2           0  r[2]=data

--- a/sqlite/conformance/sqlite-sqltests/orderby/snapshots/orderby_plan__orderby_rowid_desc_no_sorter.snap
+++ b/sqlite/conformance/sqlite-sqltests/orderby/snapshots/orderby_plan__orderby_rowid_desc_no_sorter.snap
@@ -19,7 +19,7 @@ addr  opcode       p1  p2  p3  p4      p5  comment
    2  Last          0   6   0           0
    3    Column      0   0   1           0  r[1]=t.a
    4    ResultRow   1   1   0           0  output=r[1]
-   5  Prev          0   3   0           0
+   5  Prev          0   3   0           1
    6  Halt          0   0   0           0
    7  Transaction   0   1   1           0  iDb=0 tx_mode=Read
    8  Goto          0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__aggregation-with-join.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__aggregation-with-join.snap
@@ -59,7 +59,7 @@ addr  opcode                    p1  p2  p3  p4                p5  comment
   25            NullRow          4   0   0                     0  Set cursor 4 to a (pseudo) NULL row
   26            NullRow          5   0   0                     0  Set cursor 5 to a (pseudo) NULL row
   27            Goto             0  16   0                     0
-  28          Next               3  11   0                     0
+  28          Next               3  11   0                     1
   29          OpenPseudo         2  14   4                     0  4 columns in r[14]
   30          SorterSort         1  47   0                     0
   31            SorterData       1  14   2                     0  r[14]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__column-free-scan-covering-index.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__column-free-scan-covering-index.snap
@@ -18,7 +18,7 @@ addr  opcode       p1  p2  p3  p4      p5  comment
    1  OpenRead      0   4   0  k(2,B)   0  index=indexed_count_narrow_idx, root=4, iDb=0
    2  Rewind        0   5   0           0  Rewind index indexed_count_narrow_idx
    3    ResultRow   1   1   0           0  output=r[1]
-   4  Next          0   3   0           0
+   4  Next          0   3   0           1
    5  Halt          0   0   0           0
    6  Transaction   0   1   4           0  iDb=0 tx_mode=Read
    7  Integer       1   1   0           0  r[1]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-column.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-column.snap
@@ -20,7 +20,7 @@ addr  opcode       p1  p2  p3  p4      p5  comment
    3  Rewind        0   7   0           0  Rewind table t1
    4    Column      0   0   3           0  r[3]=t1.x
    5    AggStep     0   3   2  count    0  accum=r[2] step(r[3])
-   6  Next          0   4   0           0
+   6  Next          0   4   0           1
    7  AggFinal      0   2   0  count    0  accum=r[2]
    8  Copy          2   1   0           0  r[1]=r[2]
    9  ResultRow     1   1   0           0  output=r[1]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-distinct.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-distinct.snap
@@ -55,7 +55,7 @@ addr  opcode                          p1  p2  p3  p4                  p5  commen
   25            If                     6  27   0                       0  if r[6] goto 27; don't emit group columns if continuing existing group
   26            Column                 2   0   9                       0  r[9]=idx_sales_category.category
   27            Integer                1   6   0                       0  r[6]=1; indicate data in accumulator
-  28          Next                     2  11   0                       0
+  28          Next                     2  11   0                       1
   29          Gosub                    5  33   0                       0  ; emit row for final group
   30          Goto                     0  48   0                       0  ; group by finished
   31          Integer                  1   7   0                       0  r[7]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-star-plus-expr.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-star-plus-expr.snap
@@ -19,7 +19,7 @@ addr  opcode       p1  p2  p3  p4      p5  comment
    2  OpenRead      0   2   0  k(2,B)   0  table=t1, root=2, iDb=0
    3  Rewind        0   6   0           0  Rewind table t1
    4    AggStep     0   3   2  count    0  accum=r[2] step(r[3])
-   5  Next          0   4   0           0
+   5  Next          0   4   0           1
    6  AggFinal      0   2   0  count    0  accum=r[2]
    7  Copy          2   4   0           0  r[4]=r[2]
    8  Add           4   5   1           0  r[1]=r[4]+r[5]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__distinct-count-with-join.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__distinct-count-with-join.snap
@@ -51,7 +51,7 @@ addr  opcode                          p1  p2  p3  p4                p5  comment
   16            RowId                  4  15   0                     0  r[15]=orders.rowid
   17            MakeRecord            13   3  12                     0  r[12]=mkrec(r[13..15])
   18            SorterInsert           1  12   0  0                  0  key=r[12]
-  19          Next                     4  12   0                     0
+  19          Next                     4  12   0                     1
   20          OpenPseudo               2  12   3                     0  3 columns in r[12]
   21          SorterSort               1  39   0                     0
   22            SorterData             1  12   2                     0  r[12]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__group-by-with-having.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__group-by-with-having.snap
@@ -51,7 +51,7 @@ addr  opcode                     p1  p2  p3  p4                  p5  comment
   21            If                6  23   0                       0  if r[6] goto 23; don't emit group columns if continuing existing group
   22            Column            2   0   9                       0  r[9]=idx_sales_category.category
   23            Integer           1   6   0                       0  r[6]=1; indicate data in accumulator
-  24          Next                2   9   0                       0
+  24          Next                2   9   0                       1
   25          Gosub               5  29   0                       0  ; emit row for final group
   26          Goto                0  45   0                       0  ; group by finished
   27          Integer             1   7   0                       0  r[7]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-per-group.snap
@@ -47,7 +47,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   20            If             5  22   0                       0  if r[5] goto 22; don't emit group columns if continuing existing group
   21            Column         1   0   8                       0  r[8]=idx_sales_category.category
   22            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
-  23          Next             1   8   0                       0
+  23          Next             1   8   0                       1
   24          Gosub            4  28   0                       0  ; emit row for final group
   25          Goto             0  40   0                       0  ; group by finished
   26          Integer          1   6   0                       0  r[6]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-with-index.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__min-max-with-index.snap
@@ -27,7 +27,7 @@ addr  opcode       p1  p2  p3  p4           p5  comment
    5    AggStep     0   5   3  min(Binary)   0  accum=r[3] step(r[5])
    6    Column      0   0   6                0  r[6]=idx_sales_amount.amount
    7    AggStep     0   6   4  max(Binary)   0  accum=r[4] step(r[6])
-   8  Next          0   4   0                0
+   8  Next          0   4   0                1
    9  AggFinal      0   3   0  min           0  accum=r[3]
   10  AggFinal      0   4   0  max           0  accum=r[4]
   11  Copy          3   1   0                0  r[1]=r[3]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__multi-column-group-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__multi-column-group-by.snap
@@ -49,7 +49,7 @@ addr  opcode                  p1  p2  p3  p4                    p5  comment
   19            If             6  21   0                         0  if r[6] goto 21; don't emit group columns if continuing existing group
   20            ColumnRange    1   0  10  2                      0  r[10..11]=idx_sales_category_region.category..region
   21            Integer        1   6   0                         0  r[6]=1; indicate data in accumulator
-  22          Next             1   8   0                         0
+  22          Next             1   8   0                         1
   23          Gosub            5  27   0                         0  ; emit row for final group
   24          Goto             0  40   0                         0  ; group by finished
   25          Integer          1   7   0                         0  r[7]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__multiple-aggregates.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__multiple-aggregates.snap
@@ -56,7 +56,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   25            If             9  27   0                       0  if r[9] goto 27; don't emit group columns if continuing existing group
   26            Column         2   0  12                       0  r[12]=idx_sales_category.category
   27            Integer        1   9   0                       0  r[9]=1; indicate data in accumulator
-  28          Next             2   9   0                       0
+  28          Next             2   9   0                       1
   29          Gosub            8  33   0                       0  ; emit row for final group
   30          Goto             0  52   0                       0  ; group by finished
   31          Integer          1  10   0                       0  r[10]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__nested-aggregation.snap
@@ -51,7 +51,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   19            If             5  21   0                       0  if r[5] goto 21; don't emit group columns if continuing existing group
   20            Column         1   0   8                       0  r[8]=idx_sales_category.category
   21            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
-  22          Next             1   9   0                       0
+  22          Next             1   9   0                       1
   23          Gosub            4  27   0                       0  ; emit row for final group
   24          Goto             0  37   0                       0  ; group by finished
   25          Integer          1   6   0                       0  r[6]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__partial-index-count-star.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__partial-index-count-star.snap
@@ -21,7 +21,7 @@ addr  opcode          p1  p2  p3  p4            p5  comment
    4  Rewind           1   8   0                 0  Rewind index t2_partial_aux_idx
    5    DeferredSeek   1   0   0                 0
    6    AggStep        0   3   2  count          0  accum=r[2] step(r[3])
-   7  Next             1   5   0                 0
+   7  Next             1   5   0                 1
    8  AggFinal         0   2   0  count          0  accum=r[2]
    9  Copy             2   1   0                 0  r[1]=r[2]
   10  ResultRow        1   1   0                 0  output=r[1]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-group-by-single-column.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__simple-group-by-single-column.snap
@@ -46,7 +46,7 @@ addr  opcode                  p1  p2  p3  p4                  p5  comment
   19            If             5  21   0                       0  if r[5] goto 21; don't emit group columns if continuing existing group
   20            Column         2   0   8                       0  r[8]=idx_sales_category.category
   21            Integer        1   5   0                       0  r[5]=1; indicate data in accumulator
-  22          Next             2   9   0                       0
+  22          Next             2   9   0                       1
   23          Gosub            4  27   0                       0  ; emit row for final group
   24          Goto             0  38   0                       0  ; group by finished
   25          Integer          1   6   0                       0  r[6]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__whole-table-aggregates.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__whole-table-aggregates.snap
@@ -38,7 +38,7 @@ addr  opcode       p1  p2  p3  p4                  p5  comment
   12    AggStep     0  17  11  max(Binary)          0  accum=r[11] step(r[17])
   13    Column      0   5  18                       0  r[18]=sales.quantity
   14    AggStep     0  18  12  sum                  0  accum=r[12] step(r[18])
-  15  Next          0   4   0                       0
+  15  Next          0   4   0                       1
   16  AggFinal      0   7   0  count                0  accum=r[7]
   17  AggFinal      0   8   0  sum                  0  accum=r[8]
   18  AggFinal      0   9   0  avg                  0  accum=r[9]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__aggregate-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__aggregate-after-analyze.snap
@@ -30,7 +30,7 @@ addr  opcode                  p1  p2  p3  p4                p5  comment
    9            RealAffinity  13   0   0                     0
   10            MakeRecord    12   2  11                     0  r[11]=mkrec(r[12..13])
   11            SorterInsert   0  11   0  0                  0  key=r[11]
-  12          Next             2   8   0                     0
+  12          Next             2   8   0                     1
   13          OpenPseudo       1  11   2                     0  2 columns in r[11]
   14          SorterSort       0  30   0                     0
   15            SorterData     0  11   1                     0  r[11]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-after-analyze.snap
@@ -33,7 +33,7 @@ addr  opcode          p1  p2  p3  p4          p5  comment
    9    Column         1   2   2               0  r[2]=purchases.amount
   10    RealAffinity   2   0   0               0
   11    ResultRow      1   2   0               0  output=r[1..2]
-  12  Next             1   5   0               0
+  12  Next             1   5   0               1
   13  Halt             0   0   0               0
   14  Transaction      0   1   4               0  iDb=0 tx_mode=Read
   15  Integer          2   3   0               0  r[3]=2

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-aggregate-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__join-aggregate-after-analyze.snap
@@ -54,7 +54,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   29              MakeRecord    13   3  12                 0  r[12]=mkrec(r[13..15])
   30              SorterInsert   0  12   0  0              0  key=r[12]
   31            Next             3  23   0                 0
-  32          Next               4   9   0                 0
+  32          Next               4   9   0                 1
   33          OpenPseudo         1  12   3                 0  3 columns in r[12]
   34          SorterSort         0  50   0                 0
   35            SorterData       0  12   1                 0  r[12]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__max-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__max-after-analyze.snap
@@ -21,7 +21,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    4    Column         0   4   3                     0  r[3]=products.price
    5    RealAffinity   3   0   0                     0
    6    AggStep        0   3   2  max(Binary)        0  accum=r[2] step(r[3])
-   7  Next             0   4   0                     0
+   7  Next             0   4   0                     1
    8  AggFinal         0   2   0  max                0  accum=r[2]
    9  Copy             2   1   0                     0  r[1]=r[2]
   10  ResultRow        1   1   0                     0  output=r[1]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__min-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__min-after-analyze.snap
@@ -21,7 +21,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    4    Column         0   4   3                     0  r[3]=products.price
    5    RealAffinity   3   0   0                     0
    6    AggStep        0   3   2  min(Binary)        0  accum=r[2] step(r[3])
-   7  Next             0   4   0                     0
+   7  Next             0   4   0                     1
    8  AggFinal         0   2   0  min                0  accum=r[2]
    9  Copy             2   1   0                     0  r[1]=r[2]
   10  ResultRow        1   1   0                     0  output=r[1]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__order-by-index-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__order-by-index-after-analyze.snap
@@ -27,7 +27,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    9    Column         1   1   8                     0  r[8]=products.sku
   10    MakeRecord     6   3   4                     0  r[4]=mkrec(r[6..8])
   11    SorterInsert   0   4   0  0                  0  key=r[4]
-  12  Next             1   6   0                     0
+  12  Next             1   6   0                     1
   13  OpenPseudo       2   4   3                     0  3 columns in r[4]
   14  SorterSort       0  21   0                     0
   15    SorterData     0   4   2                     0  r[4]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-after-analyze-category.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-after-analyze-category.snap
@@ -24,7 +24,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    7    Column         0   4   3                     0  r[3]=products.price
    8    RealAffinity   3   0   0                     0
    9    ResultRow      1   3   0                     0  output=r[1..3]
-  10  Next             0   3   0                     0
+  10  Next             0   3   0                     1
   11  Halt             0   0   0                     0
   12  Transaction      0   1   5                     0  iDb=0 tx_mode=Read
   13  String8          0   6   0  Office             0  r[6]='Office'

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-after-analyze-range.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-after-analyze-range.snap
@@ -28,7 +28,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
   11    Column         0   4   3                     0  r[3]=products.price
   12    RealAffinity   3   0   0                     0
   13    ResultRow      1   3   0                     0  output=r[1..3]
-  14  Next             0   3   0                     0
+  14  Next             0   3   0                     1
   15  Halt             0   0   0                     0
   16  Transaction      0   1   5                     0  iDb=0 tx_mode=Read
   17  Real             0   6   0  20.0               0  r[6]=20

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-composite-partial-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-composite-partial-after-analyze.snap
@@ -27,7 +27,7 @@ addr  opcode           p1  p2  p3  p4              p5  comment
    7    Column          0   4   3                   0  r[3]=orders.total_amount
    8    RealAffinity    3   0   0                   0
    9    ResultRow       1   3   0                   0  output=r[1..3]
-  10  Next              0   3   0                   0
+  10  Next              0   3   0                   1
   11  Halt              0   0   0                   0
   12  Transaction       0   1   4                   0  iDb=0 tx_mode=Read
   13  Integer         100   6   0                   0  r[6]=100

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-identical-composite-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-identical-composite-after-analyze.snap
@@ -24,7 +24,7 @@ addr  opcode        p1  p2  p3  p4          p5  comment
    7    RowId        0   1   0               0  r[1]=uniform.rowid
    8    Column       0   2   2               0  r[2]=uniform.value
    9    ResultRow    1   2   0               0  output=r[1..2]
-  10  Next           0   3   0               0
+  10  Next           0   3   0               1
   11  Halt           0   0   0               0
   12  Transaction    0   1   4               0  iDb=0 tx_mode=Read
   13  String8        0   5   0  active       0  r[5]='active'

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-identical-values-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-identical-values-after-analyze.snap
@@ -22,7 +22,7 @@ addr  opcode         p1  p2  p3  p4          p5  comment
    5    RowId         0   1   0               0  r[1]=uniform.rowid
    6    ColumnRange   0   1   2  2            0  r[2..3]=uniform.status..value
    7    ResultRow     1   3   0               0  output=r[1..3]
-   8  Next            0   3   0               0
+   8  Next            0   3   0               1
    9  Halt            0   0   0               0
   10  Transaction     0   1   4               0  iDb=0 tx_mode=Read
   11  String8         0   6   0  active       0  r[6]='active'

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-three-column-first-only-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-three-column-first-only-after-analyze.snap
@@ -25,7 +25,7 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    5    RowId         0   1   0                   0  r[1]=inventory.rowid
    6    ColumnRange   0   2   2  3                0  r[2..4]=inventory.product_id..quantity
    7    ResultRow     1   4   0                   0  output=r[1..4]
-   8  Next            0   3   0                   0
+   8  Next            0   3   0                   1
    9  Halt            0   0   0                   0
   10  Transaction     0   1   3                   0  iDb=0 tx_mode=Read
   11  Integer         2   7   0                   0  r[7]=2

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-three-column-partial-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-three-column-partial-after-analyze.snap
@@ -27,7 +27,7 @@ addr  opcode          p1  p2  p3  p4              p5  comment
    7    RowId          0   1   0                   0  r[1]=inventory.rowid
    8    ColumnRange    0   3   2  2                0  r[2..3]=inventory.bin_location..quantity
    9    ResultRow      1   3   0                   0  output=r[1..3]
-  10  Next             0   3   0                   0
+  10  Next             0   3   0                   1
   11  Halt             0   0   0                   0
   12  Transaction      0   1   3                   0  iDb=0 tx_mode=Read
   13  Integer          1   6   0                   0  r[6]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-with-nulls-after-analyze.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/analyze/snapshots/analyze__query-with-nulls-after-analyze.snap
@@ -22,7 +22,7 @@ addr  opcode         p1  p2  p3  p4          p5  comment
    5    RowId         0   1   0               0  r[1]=items.rowid
    6    ColumnRange   0   1   2  2            0  r[2..3]=items.category..subcategory
    7    ResultRow     1   3   0               0  output=r[1..3]
-   8  Next            0   3   0               0
+   8  Next            0   3   0               1
    9  Halt            0   0   0               0
   10  Transaction     0   1   3               0  iDb=0 tx_mode=Read
   11  String8         0   6   0  cat1         0  r[6]='cat1'

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/expressions/snapshots/expressions__constant-parameter-hoisted-out-of-scan.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/expressions/snapshots/expressions__constant-parameter-hoisted-out-of-scan.snap
@@ -20,7 +20,7 @@ addr  opcode       p1  p2  p3  p4        p5  comment
    3  Ne            4   5   7             0  if r[4]!=r[5] goto 7
    4  Rewind        0   7   0             0  Rewind table t
    5    AggStep     0   8   2  count      0  accum=r[2] step(r[8])
-   6  Next          0   5   0             0
+   6  Next          0   5   0             1
    7  AggFinal      0   2   0  count      0  accum=r[2]
    8  Copy          2   1   0             0  r[1]=r[2]
    9  ResultRow     1   1   0             0  output=r[1]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-correlated-max-materialized-cte-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-correlated-max-materialized-cte-bytecode.snap
@@ -37,7 +37,7 @@ addr  opcode             p1  p2  p3  p4           p5  comment
    6      MakeRecord      3   1   4                0  r[4]=mkrec(r[3..3]); for
    7      NewRowid        0   5   0                0  r[5]=rowid
    8      Insert          0   4   5                4  intkey=r[5] data=r[4]
-   9    Next              1   4   0                0
+   9    Next              1   4   0                1
   10    Rewind            0  36   0                0  Rewind  ephemeral()
   11      Column          0   0   2                0  r[2]=ephemeral().price
   12      Copy            2   8   0                0  r[8]=r[2]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-bytecode.snap
@@ -22,7 +22,7 @@ addr  opcode          p1  p2  p3  p4           p5  comment
    5    RealAffinity   3   0   0                0
    6    AggStep        0   3   2  max(Binary)   0  accum=r[2] step(r[3])
    7    Goto           0   9   0                0
-   8  Prev             0   4   0                0
+   8  Prev             0   4   0                1
    9  AggFinal         0   2   0  max           0  accum=r[2]
   10  Copy             2   1   0                0  r[1]=r[2]
   11  ResultRow        1   1   0                0  output=r[1]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-bytecode.snap
@@ -29,7 +29,7 @@ addr  opcode           p1  p2  p3  p4           p5  comment
    6    MakeRecord      2   1   3                0  r[3]=mkrec(r[2..2]); for
    7    NewRowid        0   4   0                0  r[4]=rowid
    8    Insert          0   3   4                4  intkey=r[4] data=r[3]
-   9  Next              1   4   0                0
+   9  Next              1   4   0                1
   10  Null              0   6   0                0  r[6]=NULL
   11  Last              0  19   0                0
   12    Column          0   0   1                0  r[1]=ephemeral().price

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-no-where-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-max-materialized-cte-no-where-bytecode.snap
@@ -29,7 +29,7 @@ addr  opcode          p1  p2  p3  p4           p5  comment
    6    MakeRecord     2   1   3                0  r[3]=mkrec(r[2..2]); for
    7    NewRowid       0   4   0                0  r[4]=rowid
    8    Insert         0   3   4                4  intkey=r[4] data=r[3]
-   9  Next             1   4   0                0
+   9  Next             1   4   0                1
   10  Null             0   6   0                0  r[6]=NULL
   11  Last             0  17   0                0
   12    Column         0   0   1                0  r[1]=ephemeral().price

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-min-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__index-for-min-bytecode.snap
@@ -23,7 +23,7 @@ addr  opcode          p1  p2  p3  p4           p5  comment
    6    IsNull         3   9   0                0  if (r[3]==NULL) goto 9
    7    AggStep        0   3   2  min(Binary)   0  accum=r[2] step(r[3])
    8    Goto           0  10   0                0
-   9  Next             0   4   0                0
+   9  Next             0   4   0                1
   10  AggFinal         0   2   0  min           0  accum=r[2]
   11  Copy             2   1   0                0  r[1]=r[2]
   12  ResultRow        1   1   0                0  output=r[1]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-correlated-max-materialized-cte-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-correlated-max-materialized-cte-bytecode.snap
@@ -37,7 +37,7 @@ addr  opcode               p1  p2  p3  p4           p5  comment
    6      MakeRecord        3   1   4                0  r[4]=mkrec(r[3..3]); for
    7      NewRowid          0   5   0                0  r[5]=rowid
    8      Insert            0   4   5                4  intkey=r[5] data=r[4]
-   9    Next                1   4   0                0
+   9    Next                1   4   0                1
   10    Rewind              0  48   0                0  Rewind  ephemeral()
   11      Column            0   0   2                0  r[2]=ephemeral().price
   12      Copy              2   8   0                0  r[8]=r[2]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-materialized-cte-max-bytecode.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__unordered-materialized-cte-max-bytecode.snap
@@ -29,7 +29,7 @@ addr  opcode          p1  p2  p3  p4           p5  comment
    6    MakeRecord     2   1   3                0  r[3]=mkrec(r[2..2]); for
    7    NewRowid       0   4   0                0  r[4]=rowid
    8    Insert         0   3   4                4  intkey=r[4] data=r[3]
-   9  Next             1   4   0                0
+   9  Next             1   4   0                1
   10  Null             0   6   0                0  r[6]=NULL
   11  Rewind           0  16   0                0  Rewind  ephemeral()
   12    Column         0   0   1                0  r[1]=ephemeral().price

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__cross-join-explicit.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__cross-join-explicit.snap
@@ -32,8 +32,8 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    6      Column      1   1   2                   0  r[2]=products.name
    7      Column      1   3   3                   0  r[3]=products.price
    8      ResultRow   1   3   0                   0  output=r[1..3]
-   9    Next          1   5   0                   0
-  10  Next            0   4   0                   0
+   9    Next          1   5   0                   1
+  10  Next            0   4   0                   1
   11  Halt            0   0   0                   0
   12  Transaction     0   1  10                   0  iDb=0 tx_mode=Read
   13  Goto            0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__cross-join-limited.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__cross-join-limited.snap
@@ -34,8 +34,8 @@ addr  opcode            p1  p2  p3  p4              p5  comment
    8      Column         1   1   2                   0  r[2]=products.name
    9      ResultRow      1   2   0                   0  output=r[1..2]
   10      DecrJumpZero   3  13   0                   0  if (--r[3]==0) goto 13
-  11    Next             1   7   0                   0
-  12  Next               0   6   0                   0
+  11    Next             1   7   0                   1
+  12  Next               0   6   0                   1
   13  Halt               0   0   0                   0
   14  Transaction        0   1  10                   0  iDb=0 tx_mode=Read
   15  Goto               0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__cross-join-with-filter.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__cross-join-with-filter.snap
@@ -52,7 +52,7 @@ addr  opcode            p1  p2  p3  p4              p5  comment
   23      ColumnRange    2   1   2  2                0  r[2..3]=ephemeral(ephemeral_products_t2).name..price
   24      ResultRow      1   3   0                   0  output=r[1..3]
   25    Next             2  20   0                   0
-  26  Next               0   4   0                   0
+  26  Next               0   4   0                   1
   27  Halt               0   0   0                   0
   28  Transaction        0   1  10                   0  iDb=0 tx_mode=Read
   29  String8            0   6   0  Boston           0  r[6]='Boston'

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-basic.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-basic.snap
@@ -46,7 +46,7 @@ addr  opcode            p1  p2  p3  p4              p5  comment
   18    NullRow          1   0   0                   0  Set cursor 1 to a (pseudo) NULL row
   19    NullRow          2   0   0                   0  Set cursor 2 to a (pseudo) NULL row
   20    Goto             0  10   0                   0
-  21  Next               0   5   0                   0
+  21  Next               0   5   0                   1
   22  Halt               0   0   0                   0
   23  Transaction        0   1  10                   0  iDb=0 tx_mode=Read
   24  Goto               0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-chained.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-chained.snap
@@ -72,7 +72,7 @@ addr  opcode              p1  p2  p3  p4              p5  comment
   36    IfPos              5  39   0                   0  r[5]>0 -> r[5]-=0, goto 39
   37    NullRow            1   0   0                   0  Set cursor 1 to a (pseudo) NULL row
   38    Goto               0  11   0                   0
-  39  Next                 0   7   0                   0
+  39  Next                 0   7   0                   1
   40  Halt                 0   0   0                   0
   41  Transaction          0   1  10                   0  iDb=0 tx_mode=Read
   42  Goto                 0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-find-nulls.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-find-nulls.snap
@@ -44,7 +44,7 @@ addr  opcode           p1  p2  p3  p4              p5  comment
   15    IfPos           4  18   0                   0  r[4]>0 -> r[4]-=0, goto 18
   16    NullRow         1   0   0                   0  Set cursor 1 to a (pseudo) NULL row
   17    Goto            0   8   0                   0
-  18  Next              0   4   0                   0
+  18  Next              0   4   0                   1
   19  Halt              0   0   0                   0
   20  Transaction       0   1  10                   0  iDb=0 tx_mode=Read
   21  Goto              0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-with-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-with-aggregation.snap
@@ -59,7 +59,7 @@ addr  opcode                    p1  p2  p3  p4                    p5  comment
   25            NullRow          4   0   0                         0  Set cursor 4 to a (pseudo) NULL row
   26            NullRow          5   0   0                         0  Set cursor 5 to a (pseudo) NULL row
   27            Goto             0  16   0                         0
-  28          Next               3  11   0                         0
+  28          Next               3  11   0                         1
   29          OpenPseudo         2  15   4                         0  4 columns in r[15]
   30          SorterSort         1  46   0                         0
   31            SorterData       1  15   2                         0  r[15]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__self-join-category-hierarchy.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__self-join-category-hierarchy.snap
@@ -38,7 +38,7 @@ addr  opcode       p1  p2  p3  p4          p5  comment
   12    IfPos       4  15   0               0  r[4]>0 -> r[4]-=0, goto 15
   13    NullRow     1   0   0               0  Set cursor 1 to a (pseudo) NULL row
   14    Goto        0   7   0               0
-  15  Next          0   4   0               0
+  15  Next          0   4   0               1
   16  Halt          0   0   0               0
   17  Transaction   0   1  10               0  iDb=0 tx_mode=Read
   18  Goto          0   1   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__self-join-employee-manager.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__self-join-employee-manager.snap
@@ -40,7 +40,7 @@ addr  opcode       p1  p2  p3  p4              p5  comment
   13    IfPos       5  16   0                   0  r[5]>0 -> r[5]-=0, goto 16
   14    NullRow     1   0   0                   0  Set cursor 1 to a (pseudo) NULL row
   15    Goto        0   7   0                   0
-  16  Next          0   4   0                   0
+  16  Next          0   4   0                   1
   17  Halt          0   0   0                   0
   18  Transaction   0   1  10                   0  iDb=0 tx_mode=Read
   19  Goto          0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__delete-with-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__delete-with-subquery.snap
@@ -35,7 +35,7 @@ addr  opcode            p1  p2  p3  p4            p5  comment
   11    RowId            4   2   0                 0  r[2]=users.rowid
   12    MakeRecord       2   1   6                 0  r[6]=mkrec(r[2..2]); for ephemeral_index_where_sub_t2
   13    IdxInsert        0   6   0                 8  key=r[6]
-  14  Next               4   9   0                 0
+  14  Next               4   9   0                 1
   15  OpenRead           3  12   0  k(2,B)         0  index=idx_orders_user_id, root=12, iDb=0
   16  NullRow            0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
   17  Rewind             0  27   0                 0  Rewind  ephemeral(ephemeral_index_where_sub_t2)

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__delete-with-where.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__delete-with-where.snap
@@ -35,7 +35,7 @@ addr  opcode          p1  p2  p3  p4          p5  comment
   15    RowId          0  11   0               0  r[11]=orders.rowid
   16    IdxDelete      2  10   2               1
   17    Delete         0   0   0  orders       0
-  18  Next             0   5   0               0
+  18  Next             0   5   0               1
   19  Halt             0   0   0               0
   20  Transaction      0   2  10               0  iDb=0 tx_mode=Write
   21  Real             0   3   0  10.0         0  r[3]=10

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-select.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__insert-select.snap
@@ -29,7 +29,7 @@ addr  opcode            p1  p2  p3  p4                         p5  comment
    7    ColumnRange      0   1   4  4                           0  r[4..7]=orders.user_id..total_price
    8    RealAffinity     7   0   0                              0
    9    Yield            2   0   0                              0
-  10  Next               0   4   0                              0
+  10  Next               0   4   0                              1
   11  EndCoroutine       2   0   0                              0
   12  OpenWrite          1   7   0                              0  root=7; iDb=0
   13    Yield            2  37   0                              0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__update-where-self-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__update-where-self-subquery.snap
@@ -41,7 +41,7 @@ addr  opcode           p1  p2  p3  p4                 p5  comment
   15    RowId           1   2   0                      0  r[2]=products.rowid
   16    MakeRecord      2   1  11                      0  r[11]=mkrec(r[2..2]); for ephemeral_scratch
   17    Insert          0  11   2  ephemeral_scratch   6  intkey=r[2] data=r[11]
-  18  Next              1   4   0                      0
+  18  Next              1   4   0                      1
   19  OpenWrite         1   2   0                      0  root=2; iDb=0
   20  Rewind            0  34   0                      0  Rewind table ephemeral(ephemeral_scratch)
   21    RowId           0  12   0                      0  r[12]=ephemeral(ephemeral_scratch).rowid
@@ -56,7 +56,7 @@ addr  opcode           p1  p2  p3  p4                 p5  comment
   30    NotExists       1  33  12                      0
   31    Delete          1   0   0  products            0
   32    Insert          1  20  12  products           11  intkey=r[12] data=r[20]
-  33  Next              0  21   0                      0
+  33  Next              0  21   0                      1
   34  Halt              0   0   0                      0
   35  Transaction       0   2  10                      0  iDb=0 tx_mode=Write
   36  Integer           1   7   0                      0  r[7]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__update-where-unrelated-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/modifications/snapshots/modifications__update-where-unrelated-subquery.snap
@@ -38,7 +38,7 @@ addr  opcode           p1  p2  p3  p4                 p5  comment
   12    RowId           1   2   0                      0  r[2]=products.rowid
   13    MakeRecord      2   1   6                      0  r[6]=mkrec(r[2..2]); for ephemeral_scratch
   14    Insert          0   6   2  ephemeral_scratch   6  intkey=r[2] data=r[6]
-  15  Next              1   4   0                      0
+  15  Next              1   4   0                      1
   16  OpenWrite         1   2   0                      0  root=2; iDb=0
   17  Rewind            0  31   0                      0  Rewind table ephemeral(ephemeral_scratch)
   18    RowId           0   7   0                      0  r[7]=ephemeral(ephemeral_scratch).rowid
@@ -53,7 +53,7 @@ addr  opcode           p1  p2  p3  p4                 p5  comment
   27    NotExists       1  30   7                      0
   28    Delete          1   0   0  products            0
   29    Insert          1  15   7  products           11  intkey=r[7] data=r[15]
-  30  Next              0  18   0                      0
+  30  Next              0  18   0                      1
   31  Halt              0   0   0                      0
   32  Transaction       0   2  10                      0  iDb=0 tx_mode=Write
   33  Integer           1  14   0                      0  r[14]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__delete-returning-expr.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__delete-returning-expr.snap
@@ -41,7 +41,7 @@ addr  opcode          p1  p2  p3  p4      p5  comment
   23    MakeRecord    16   2  18           0  r[18]=mkrec(r[16..17])
   24    NewRowid       0  19   0           0  r[19]=rowid
   25    Insert         0  18  19           4  intkey=r[19] data=r[18]
-  26  Next             1   5   0           0
+  26  Next             1   5   0           1
   27  FkCheck          0   0   0           0
   28  Rewind           0  32   0           0  Rewind  ephemeral(t1)
   29    ColumnRange    0   0  20  2        0  r[20..21]=ephemeral(t1).id..name

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__update-returning-expr.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/returning/snapshots/returning__update-returning-expr.snap
@@ -40,7 +40,7 @@ addr  opcode          p1  p2  p3  p4        p5  comment
   22    MakeRecord    11   3  16             0  r[16]=mkrec(r[11..13])
   23    NewRowid       0  17   0             0  r[17]=rowid
   24    Insert         0  16  17             4  intkey=r[17] data=r[16]
-  25  Next             1   4   0             0
+  25  Next             1   4   0             1
   26  FkCheck          0   0   0             0
   27  Rewind           0  31   0             0  Rewind  ephemeral(t1)
   28    ColumnRange    0   0  18  3          0  r[18..20]=ephemeral(t1).id..value

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__compound-mixed-union.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__compound-mixed-union.snap
@@ -34,13 +34,13 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    4    ColumnRange   1   1   1  2                0  r[1..2]=current_employees.name..department
    5    MakeRecord    1   2   3                   0  r[3]=mkrec(r[1..2]); for compound_dedupe
    6    IdxInsert     0   3   0                   8  key=r[3]
-   7  Next            1   4   0                   0
+   7  Next            1   4   0                   1
    8  OpenRead        2   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
    9  Rewind          2  14   0                   0  Rewind table former_employees
   10    ColumnRange   2   1   4  2                0  r[4..5]=former_employees.name..department
   11    MakeRecord    4   2   6                   0  r[6]=mkrec(r[4..5]); for compound_dedupe
   12    IdxInsert     0   6   0                   8  key=r[6]
-  13  Next            2  10   0                   0
+  13  Next            2  10   0                   1
   14  Rewind          0  17   0                   0  Rewind  ephemeral(compound_dedupe)
   15    ColumnRange   0   0   7  2                0  r[7..8]=ephemeral(compound_dedupe).name..department
   16    ResultRow     7   2   0                   0  output=r[7..8]
@@ -50,7 +50,7 @@ addr  opcode         p1  p2  p3  p4              p5  comment
   20  Rewind          3  24   0                   0  Rewind table contractors
   21    ColumnRange   3   1   9  2                0  r[9..10]=contractors.name..department
   22    ResultRow     9   2   0                   0  output=r[9..10]
-  23  Next            3  21   0                   0
+  23  Next            3  21   0                   1
   24  Halt            0   0   0                   0
   25  Transaction     0   1   6                   0  iDb=0 tx_mode=Read
   26  Goto            0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__compound-union-all-three-way.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__compound-union-all-three-way.snap
@@ -32,17 +32,17 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    2  Rewind          0   6   0                   0  Rewind table current_employees
    3    ColumnRange   0   1   1  2                0  r[1..2]=current_employees.name..department
    4    ResultRow     1   2   0                   0  output=r[1..2]
-   5  Next            0   3   0                   0
+   5  Next            0   3   0                   1
    6  OpenRead        1   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
    7  Rewind          1  11   0                   0  Rewind table former_employees
    8    ColumnRange   1   1   3  2                0  r[3..4]=former_employees.name..department
    9    ResultRow     3   2   0                   0  output=r[3..4]
-  10  Next            1   8   0                   0
+  10  Next            1   8   0                   1
   11  OpenRead        2   4   0  k(4,B,B,B,B)     0  table=contractors, root=4, iDb=0
   12  Rewind          2  16   0                   0  Rewind table contractors
   13    ColumnRange   2   1   5  2                0  r[5..6]=contractors.name..department
   14    ResultRow     5   2   0                   0  output=r[5..6]
-  15  Next            2  13   0                   0
+  15  Next            2  13   0                   1
   16  Halt            0   0   0                   0
   17  Transaction     0   1   6                   0  iDb=0 tx_mode=Read
   18  Goto            0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__compound-union-except.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__compound-union-except.snap
@@ -34,18 +34,18 @@ addr  opcode         p1  p2  p3  p4      p5  comment
    4    Column        1   0   1           0  r[1]=idx_current_dept.department
    5    MakeRecord    1   1   2           0  r[2]=mkrec(r[1..1]); for compound_dedupe
    6    IdxInsert     0   2   0           8  key=r[2]
-   7  Next            1   4   0           0
+   7  Next            1   4   0           1
    8  OpenRead        2   7   0  k(2,B)   0  index=idx_contractors_dept, root=7, iDb=0
    9  Rewind          2  14   0           0  Rewind index idx_contractors_dept
   10    Column        2   0   3           0  r[3]=idx_contractors_dept.department
   11    MakeRecord    3   1   4           0  r[4]=mkrec(r[3..3]); for compound_dedupe
   12    IdxInsert     0   4   0           8  key=r[4]
-  13  Next            2  10   0           0
+  13  Next            2  10   0           1
   14  OpenRead        3   6   0  k(2,B)   0  index=idx_former_dept, root=6, iDb=0
   15  Rewind          3  19   0           0  Rewind index idx_former_dept
   16    Column        3   0   5           0  r[5]=idx_former_dept.department
   17    IdxDelete     0   5   1           0
-  18  Next            3  16   0           0
+  18  Next            3  16   0           1
   19  Rewind          0  22   0           0  Rewind  ephemeral(compound_dedupe)
   20    Column        0   0   6           0  r[6]=ephemeral(compound_dedupe).department
   21    ResultRow     6   1   0           0  output=r[6]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__compound-union-intersect.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__compound-union-intersect.snap
@@ -35,19 +35,19 @@ addr  opcode         p1  p2  p3  p4      p5  comment
    5    Column        2   0   1           0  r[1]=idx_current_dept.department
    6    MakeRecord    1   1   2           0  r[2]=mkrec(r[1..1]); for compound_dedupe
    7    IdxInsert     0   2   0           8  key=r[2]
-   8  Next            2   5   0           0
+   8  Next            2   5   0           1
    9  OpenRead        3   7   0  k(2,B)   0  index=idx_contractors_dept, root=7, iDb=0
   10  Rewind          3  15   0           0  Rewind index idx_contractors_dept
   11    Column        3   0   3           0  r[3]=idx_contractors_dept.department
   12    MakeRecord    3   1   4           0  r[4]=mkrec(r[3..3]); for compound_dedupe
   13    IdxInsert     0   4   0           8  key=r[4]
-  14  Next            3  11   0           0
+  14  Next            3  11   0           1
   15  OpenRead        4   6   0  k(2,B)   0  index=idx_former_dept, root=6, iDb=0
   16  Rewind          4  21   0           0  Rewind index idx_former_dept
   17    Column        4   0   5           0  r[5]=idx_former_dept.department
   18    MakeRecord    5   1   6           0  r[6]=mkrec(r[5..5]); for compound_dedupe
   19    IdxInsert     1   6   0           8  key=r[6]
-  20  Next            4  17   0           0
+  20  Next            4  17   0           1
   21  Rewind          0  27   0           0  Rewind  ephemeral(compound_dedupe)
   22    RowData       0   7   0           0  r[7] = data
   23    NotFound      1  26   7           0  if not found goto 26

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__except-basic.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__except-basic.snap
@@ -29,12 +29,12 @@ addr  opcode         p1  p2  p3  p4      p5  comment
    4    Column        1   0   1           0  r[1]=idx_current_dept.department
    5    MakeRecord    1   1   2           0  r[2]=mkrec(r[1..1]); for compound_dedupe
    6    IdxInsert     0   2   0           8  key=r[2]
-   7  Next            1   4   0           0
+   7  Next            1   4   0           1
    8  OpenRead        2   6   0  k(2,B)   0  index=idx_former_dept, root=6, iDb=0
    9  Rewind          2  13   0           0  Rewind index idx_former_dept
   10    Column        2   0   3           0  r[3]=idx_former_dept.department
   11    IdxDelete     0   3   1           0
-  12  Next            2  10   0           0
+  12  Next            2  10   0           1
   13  Rewind          0  16   0           0  Rewind  ephemeral(compound_dedupe)
   14    Column        0   0   4           0  r[4]=ephemeral(compound_dedupe).department
   15    ResultRow     4   1   0           0  output=r[4]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__except-multiple-columns.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__except-multiple-columns.snap
@@ -29,12 +29,12 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    4    ColumnRange   1   1   1  2                0  r[1..2]=current_employees.name..department
    5    MakeRecord    1   2   3                   0  r[3]=mkrec(r[1..2]); for compound_dedupe
    6    IdxInsert     0   3   0                   8  key=r[3]
-   7  Next            1   4   0                   0
+   7  Next            1   4   0                   1
    8  OpenRead        2   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
    9  Rewind          2  13   0                   0  Rewind table former_employees
   10    ColumnRange   2   1   4  2                0  r[4..5]=former_employees.name..department
   11    IdxDelete     0   4   2                   0
-  12  Next            2  10   0                   0
+  12  Next            2  10   0                   1
   13  Rewind          0  16   0                   0  Rewind  ephemeral(compound_dedupe)
   14    ColumnRange   0   0   6  2                0  r[6..7]=ephemeral(compound_dedupe).name..department
   15    ResultRow     6   2   0                   0  output=r[6..7]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__intersect-basic.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__intersect-basic.snap
@@ -30,13 +30,13 @@ addr  opcode         p1  p2  p3  p4      p5  comment
    5    Column        2   0   1           0  r[1]=idx_current_dept.department
    6    MakeRecord    1   1   2           0  r[2]=mkrec(r[1..1]); for compound_dedupe
    7    IdxInsert     0   2   0           8  key=r[2]
-   8  Next            2   5   0           0
+   8  Next            2   5   0           1
    9  OpenRead        3   6   0  k(2,B)   0  index=idx_former_dept, root=6, iDb=0
   10  Rewind          3  15   0           0  Rewind index idx_former_dept
   11    Column        3   0   3           0  r[3]=idx_former_dept.department
   12    MakeRecord    3   1   4           0  r[4]=mkrec(r[3..3]); for compound_dedupe
   13    IdxInsert     1   4   0           8  key=r[4]
-  14  Next            3  11   0           0
+  14  Next            3  11   0           1
   15  Rewind          0  21   0           0  Rewind  ephemeral(compound_dedupe)
   16    RowData       0   5   0           0  r[5] = data
   17    NotFound      1  20   5           0  if not found goto 20

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__intersect-multiple-columns.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__intersect-multiple-columns.snap
@@ -30,13 +30,13 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    5    ColumnRange   2   1   1  2                0  r[1..2]=current_employees.name..department
    6    MakeRecord    1   2   3                   0  r[3]=mkrec(r[1..2]); for compound_dedupe
    7    IdxInsert     0   3   0                   8  key=r[3]
-   8  Next            2   5   0                   0
+   8  Next            2   5   0                   1
    9  OpenRead        3   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
   10  Rewind          3  15   0                   0  Rewind table former_employees
   11    ColumnRange   3   1   4  2                0  r[4..5]=former_employees.name..department
   12    MakeRecord    4   2   6                   0  r[6]=mkrec(r[4..5]); for compound_dedupe
   13    IdxInsert     1   6   0                   8  key=r[6]
-  14  Next            3  11   0                   0
+  14  Next            3  11   0                   1
   15  Rewind          0  21   0                   0  Rewind  ephemeral(compound_dedupe)
   16    RowData       0   7   0                   0  r[7] = data
   17    NotFound      1  20   7                   0  if not found goto 20

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__subquery-with-union.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__subquery-with-union.snap
@@ -34,13 +34,13 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    5    ColumnRange   1   1   2  2                0  r[2..3]=current_employees.name..department
    6    MakeRecord    2   2   4                   0  r[4]=mkrec(r[2..3]); for compound_dedupe
    7    IdxInsert     0   4   0                   8  key=r[4]
-   8  Next            1   5   0                   0
+   8  Next            1   5   0                   1
    9  OpenRead        2   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
   10  Rewind          2  15   0                   0  Rewind table former_employees
   11    ColumnRange   2   1   2  2                0  r[2..3]=former_employees.name..department
   12    MakeRecord    2   2   5                   0  r[5]=mkrec(r[2..3]); for compound_dedupe
   13    IdxInsert     0   5   0                   8  key=r[5]
-  14  Next            2  11   0                   0
+  14  Next            2  11   0                   1
   15  Rewind          0  18   0                   0  Rewind  ephemeral(compound_dedupe)
   16    ColumnRange   0   0   2  2                0  r[2..3]=ephemeral(compound_dedupe).name..department
   17    Yield         1   0   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-all-basic.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-all-basic.snap
@@ -27,12 +27,12 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    2  Rewind          0   6   0                   0  Rewind table current_employees
    3    ColumnRange   0   1   1  2                0  r[1..2]=current_employees.name..department
    4    ResultRow     1   2   0                   0  output=r[1..2]
-   5  Next            0   3   0                   0
+   5  Next            0   3   0                   1
    6  OpenRead        1   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
    7  Rewind          1  11   0                   0  Rewind table former_employees
    8    ColumnRange   1   1   3  2                0  r[3..4]=former_employees.name..department
    9    ResultRow     3   2   0                   0  output=r[3..4]
-  10  Next            1   8   0                   0
+  10  Next            1   8   0                   1
   11  Halt            0   0   0                   0
   12  Transaction     0   1   6                   0  iDb=0 tx_mode=Read
   13  Goto            0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-distinct.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-distinct.snap
@@ -29,13 +29,13 @@ addr  opcode         p1  p2  p3  p4              p5  comment
    4    ColumnRange   1   1   1  2                0  r[1..2]=current_employees.name..department
    5    MakeRecord    1   2   3                   0  r[3]=mkrec(r[1..2]); for compound_dedupe
    6    IdxInsert     0   3   0                   8  key=r[3]
-   7  Next            1   4   0                   0
+   7  Next            1   4   0                   1
    8  OpenRead        2   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
    9  Rewind          2  14   0                   0  Rewind table former_employees
   10    ColumnRange   2   1   4  2                0  r[4..5]=former_employees.name..department
   11    MakeRecord    4   2   6                   0  r[6]=mkrec(r[4..5]); for compound_dedupe
   12    IdxInsert     0   6   0                   8  key=r[6]
-  13  Next            2  10   0                   0
+  13  Next            2  10   0                   1
   14  Rewind          0  17   0                   0  Rewind  ephemeral(compound_dedupe)
   15    ColumnRange   0   0   7  2                0  r[7..8]=ephemeral(compound_dedupe).name..department
   16    ResultRow     7   2   0                   0  output=r[7..8]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-explicit-distinct.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-explicit-distinct.snap
@@ -33,7 +33,7 @@ addr  opcode                  p1  p2  p3  p4      p5  comment
    6    HashDistinct  1073741824   1   1  jmp=9    0
    7    MakeRecord             1   1   2           0  r[2]=mkrec(r[1..1]); for compound_dedupe
    8    IdxInsert              0   2   0           8  key=r[2]
-   9  Next                     1   5   0           0
+   9  Next                     1   5   0           1
   10  HashClear       1073741825   0   0           0
   11  OpenRead                 2   6   0  k(2,B)   0  index=idx_former_dept, root=6, iDb=0
   12  Rewind                   2  18   0           0  Rewind index idx_former_dept
@@ -41,7 +41,7 @@ addr  opcode                  p1  p2  p3  p4      p5  comment
   14    HashDistinct  1073741825   3   1  jmp=17   0
   15    MakeRecord             3   1   4           0  r[4]=mkrec(r[3..3]); for compound_dedupe
   16    IdxInsert              0   4   0           8  key=r[4]
-  17  Next                     2  13   0           0
+  17  Next                     2  13   0           1
   18  Rewind                   0  21   0           0  Rewind  ephemeral(compound_dedupe)
   19    Column                 0   0   5           0  r[5]=ephemeral(compound_dedupe).department
   20    ResultRow              5   1   0           0  output=r[5]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-subquery-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-subquery-aggregation.snap
@@ -41,17 +41,17 @@ addr  opcode                  p1  p2  p3  p4              p5  comment
    3          Rewind           0   7   0                   0  Rewind table current_employees
    4            ColumnRange    0   1   2  2                0  r[2..3]=current_employees.name..department
    5            Yield          1   0   0                   0
-   6          Next             0   4   0                   0
+   6          Next             0   4   0                   1
    7          OpenRead         1   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
    8          Rewind           1  12   0                   0  Rewind table former_employees
    9            ColumnRange    1   1   2  2                0  r[2..3]=former_employees.name..department
   10            Yield          1   0   0                   0
-  11          Next             1   9   0                   0
+  11          Next             1   9   0                   1
   12          OpenRead         2   4   0  k(4,B,B,B,B)     0  table=contractors, root=4, iDb=0
   13          Rewind           2  17   0                   0  Rewind table contractors
   14            ColumnRange    2   1   2  2                0  r[2..3]=contractors.name..department
   15            Yield          1   0   0                   0
-  16          Next             2  14   0                   0
+  16          Next             2  14   0                   1
   17          EndCoroutine     1   0   0                   0
   18          SorterOpen       3   1   0  k(1,-B)          0  cursor=3
   19          Null             0  12   0                   0  r[12]=NULL

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-with-limit.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/setops/snapshots/setops__union-with-limit.snap
@@ -32,13 +32,13 @@ addr  opcode          p1  p2  p3  p4              p5  comment
    6    ColumnRange    1   1   2  2                0  r[2..3]=current_employees.name..department
    7    MakeRecord     2   2   4                   0  r[4]=mkrec(r[2..3]); for compound_dedupe
    8    IdxInsert      0   4   0                   8  key=r[4]
-   9  Next             1   6   0                   0
+   9  Next             1   6   0                   1
   10  OpenRead         2   3   0  k(5,B,B,B,B,B)   0  table=former_employees, root=3, iDb=0
   11  Rewind           2  16   0                   0  Rewind table former_employees
   12    ColumnRange    2   1   5  2                0  r[5..6]=former_employees.name..department
   13    MakeRecord     5   2   7                   0  r[7]=mkrec(r[5..6]); for compound_dedupe
   14    IdxInsert      0   7   0                   8  key=r[7]
-  15  Next             2  12   0                   0
+  15  Next             2  12   0                   1
   16  Rewind           0  20   0                   0  Rewind  ephemeral(compound_dedupe)
   17    ColumnRange    0   0   8  2                0  r[8..9]=ephemeral(compound_dedupe).name..department
   18    ResultRow      8   2   0                   0  output=r[8..9]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__large-offset-small-limit.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__large-offset-small-limit.snap
@@ -35,7 +35,7 @@ addr  opcode            p1  p2  p3  p4                p5  comment
   14    RealAffinity     3   0   0                     0
   15    ResultRow        1   3   0                     0  output=r[1..3]
   16    DecrJumpZero     4  18   0                     0  if (--r[4]==0) goto 18
-  17  Next               1   9   0                     0
+  17  Next               1   9   0                     1
   18  Halt               0   0   0                     0
   19  Transaction        0   1   7                     0  iDb=0 tx_mode=Read
   20  Goto               0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__limit-with-offset.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__limit-with-offset.snap
@@ -32,7 +32,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
   11    RealAffinity   3   0   0                     0
   12    ResultRow      1   3   0                     0  output=r[1..3]
   13    DecrJumpZero   4  15   0                     0  if (--r[4]==0) goto 15
-  14  Next             0   8   0                     0
+  14  Next             0   8   0                     1
   15  Halt             0   0   0                     0
   16  Transaction      0   1   7                     0  iDb=0 tx_mode=Read
   17  Goto             0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__limit-without-order.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__limit-without-order.snap
@@ -27,7 +27,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    7    RealAffinity   3   0   0                     0
    8    ResultRow      1   3   0                     0  output=r[1..3]
    9    DecrJumpZero   4  11   0                     0  if (--r[4]==0) goto 11
-  10  Next             0   5   0                     0
+  10  Next             0   5   0                     1
   11  Halt             0   0   0                     0
   12  Transaction      0   1   7                     0  iDb=0 tx_mode=Read
   13  Goto             0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__order-by-expression.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__order-by-expression.snap
@@ -32,7 +32,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
   11    Column         1   4  11                     0  r[11]=products.stock
   12    MakeRecord     7   5   6                     0  r[6]=mkrec(r[7..11])
   13    SorterInsert   0   6   0  0                  0  key=r[6]
-  14  Next             1   4   0                     0
+  14  Next             1   4   0                     1
   15  OpenPseudo       2   6   5                     0  5 columns in r[6]
   16  SorterSort       0  22   0                     0
   17    SorterData     0   6   2                     0  r[6]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__order-by-limit-one.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__order-by-limit-one.snap
@@ -31,7 +31,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
   10    RealAffinity   3   0   0                     0
   11    ResultRow      1   3   0                     0  output=r[1..3]
   12    DecrJumpZero   4  14   0                     0  if (--r[4]==0) goto 14
-  13  Next             1   6   0                     0
+  13  Next             1   6   0                     1
   14  Halt             0   0   0                     0
   15  Transaction      0   1   7                     0  iDb=0 tx_mode=Read
   16  Goto             0   1   0                     0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__order-by-mixed-direction.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__order-by-mixed-direction.snap
@@ -29,7 +29,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    8    Column         1   1   9                     0  r[9]=products.name
    9    MakeRecord     6   4   5                     0  r[5]=mkrec(r[6..9])
   10    SorterInsert   0   5   0  0                  0  key=r[5]
-  11  Next             1   4   0                     0
+  11  Next             1   4   0                     1
   12  OpenPseudo       2   5   4                     0  4 columns in r[5]
   13  SorterSort       0  19   0                     0
   14    SorterData     0   5   2                     0  r[5]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__order-by-single-column.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/sorting/snapshots/sorting__order-by-single-column.snap
@@ -28,7 +28,7 @@ addr  opcode          p1  p2  p3  p4                p5  comment
    7    RealAffinity   7   0   0                     0
    8    MakeRecord     5   3   4                     0  r[4]=mkrec(r[5..7])
    9    SorterInsert   0   4   0  0                  0  key=r[4]
-  10  Next             1   4   0                     0
+  10  Next             1   4   0                     1
   11  OpenPseudo       2   4   3                     0  3 columns in r[4]
   12  SorterSort       0  19   0                     0
   13    SorterData     0   4   2                     0  r[4]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-count.snap
@@ -44,7 +44,7 @@ addr  opcode                 p1  p2  p3  p4            p5  comment
   17            If            4  19   0                 0  if r[4] goto 19; don't emit group columns if continuing existing group
   18            Column        1   0   7                 0  r[7]=idx_order_items_order.order_id
   19            Integer       1   4   0                 0  r[4]=1; indicate data in accumulator
-  20          Next            1   9   0                 0
+  20          Next            1   9   0                 1
   21          Gosub           3  25   0                 0  ; emit row for final group
   22          Goto            0  39   0                 0  ; group by finished
   23          Integer         1   5   0                 0  r[5]=1
@@ -82,7 +82,7 @@ addr  opcode                 p1  p2  p3  p4            p5  comment
   55    IfPos                20  58   0                 0  r[20]>0 -> r[20]-=0, goto 58
   56    NullRow               0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
   57    Goto                  0  45   0                 0
-  58  Next                    2  41   0                 0
+  58  Next                    2  41   0                 1
   59  Halt                    0   0   0                 0
   60  Transaction             0   1  11                 0  iDb=0 tx_mode=Read
   61  Integer                 1  12   0                 0  r[12]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-salary.snap
@@ -38,7 +38,7 @@ addr  opcode                  p1  p2  p3  p4              p5  comment
   11            RealAffinity  11   0   0                   0
   12            MakeRecord    10   2   9                   0  r[9]=mkrec(r[10..11])
   13            SorterInsert   1   9   0  0                0  key=r[9]
-  14          Next             3  10   0                   0
+  14          Next             3  10   0                   1
   15          OpenPseudo       2   9   2                   0  2 columns in r[9]
   16          SorterSort       1  31   0                   0
   17            SorterData     1   9   2                   0  r[9]=data
@@ -89,7 +89,7 @@ addr  opcode                  p1  p2  p3  p4              p5  comment
   62      RealAffinity        22   0   0                   0
   63      ResultRow           19   4   0                   0  output=r[19..22]
   64    Next                   0  54   0                   0
-  65  Next                     4  51   0                   0
+  65  Next                     4  51   0                   1
   66  Halt                     0   0   0                   0
   67  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
   68  Goto                     0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__correlated-subquery-where.snap
@@ -47,7 +47,7 @@ addr  opcode                  p1  p2  p3  p4              p5  comment
   21            If             4  23   0                   0  if r[4] goto 23; don't emit group columns if continuing existing group
   22            Column         2   0   7                   0  r[7]=idx_products_category.category_id
   23            Integer        1   4   0                   0  r[4]=1; indicate data in accumulator
-  24          Next             2  10   0                   0
+  24          Next             2  10   0                   1
   25          Gosub            3  29   0                   0  ; emit row for final group
   26          Goto             0  43   0                   0  ; group by finished
   27          Integer          1   5   0                   0  r[5]=1
@@ -83,7 +83,7 @@ addr  opcode                  p1  p2  p3  p4              p5  comment
   57      RealAffinity        19   0   0                   0
   58      ResultRow           17   3   0                   0  output=r[17..19]
   59    Next                   0  49   0                   0
-  60  Next                     3  45   0                   0
+  60  Next                     3  45   0                   1
   61  Halt                     0   0   0                   0
   62  Transaction              0   1  11                   0  iDb=0 tx_mode=Read
   63  Goto                     0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-in-subquery-and-main.snap
@@ -58,7 +58,7 @@ addr  opcode                             p1   p2   p3  p4              p5  comme
   23                      If              7   25    0                   0  if r[7] goto 25; don't emit group columns if continuing existing group
   24                      Column          1    0   10                   0  r[10]=idx_products_category.category_id
   25                      Integer         1    7    0                   0  r[7]=1; indicate data in accumulator
-  26                    Next              1   12    0                   0
+  26                    Next              1   12    0                   1
   27                    Gosub             6   31    0                   0  ; emit row for final group
   28                    Goto              0   41    0                   0  ; group by finished
   29                    Integer           1    8    0                   0  r[8]=1
@@ -108,7 +108,7 @@ addr  opcode                             p1   p2   p3  p4              p5  comme
   73            If                       25   75    0                   0  if r[25] goto 75; don't emit group columns if continuing existing group
   74            Column                    4    0   28                   0  r[28]=idx_products_category.category_id
   75            Integer                   1   25    0                   0  r[25]=1; indicate data in accumulator
-  76          Next                        4   62    0                   0
+  76          Next                        4   62    0                   1
   77          Gosub                      24   81    0                   0  ; emit row for final group
   78          Goto                        0   93    0                   0  ; group by finished
   79          Integer                     1   26    0                   0  r[26]=1
@@ -155,7 +155,7 @@ addr  opcode                             p1   p2   p3  p4              p5  comme
  120      Column                          6    1   38                   0  r[38]=ephemeral(ephemeral_subquery_t5).avg_price
  121      ResultRow                      36    3    0                   0  output=r[36..38]
  122    Next                              6  114    0                   0
- 123  Next                                5   95    0                   0
+ 123  Next                                5   95    0                   1
  124  Halt                                0    0    0                   0
  125  Transaction                         0    1   11                   0  iDb=0 tx_mode=Read
  126  Real                                0   43    0  0.8              0  r[43]=0.8

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-multiple-independent.snap
@@ -56,7 +56,7 @@ addr  opcode            p1  p2  p3  p4            p5  comment
    9    Column           1   3   4                 0  r[4]=orders.total_amount
   10    RealAffinity     4   0   0                 0
   11    Yield            1   0   0                 0
-  12  Next               1   4   0                 0
+  12  Next               1   4   0                 1
   13  EndCoroutine       1   0   0                 0
   14  Once              50   0   0                 0  goto 50
   15  OpenEphemeral      2   0   0                 0  cursor=2 is_table=false
@@ -73,7 +73,7 @@ addr  opcode            p1  p2  p3  p4            p5  comment
   26    Column           3   3  11                 0  r[11]=orders.total_amount
   27    RealAffinity    11   0   0                 0
   28    Yield            8   0   0                 0
-  29  Next               3  21   0                 0
+  29  Next               3  21   0                 1
   30  EndCoroutine       8   0   0                 0
   31  InitCoroutine      8   0  19                 0
   32    Yield            8  37   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referenced-multiple-times.snap
@@ -63,7 +63,7 @@ addr  opcode                                       p1   p2   p3  p4            p
   23                                If              8   25    0                 0  if r[8] goto 25; don't emit group columns if continuing existing group
   24                                Column          1    0   11                 0  r[11]=idx_orders_customer.customer_id
   25                                Integer         1    8    0                 0  r[8]=1; indicate data in accumulator
-  26                              Next              1   12    0                 0
+  26                              Next              1   12    0                 1
   27                              Gosub             7   31    0                 0  ; emit row for final group
   28                              Goto              0   41    0                 0  ; group by finished
   29                              Integer           1    9    0                 0  r[9]=1
@@ -116,7 +116,7 @@ addr  opcode                                       p1   p2   p3  p4            p
   76                      If                       26   78    0                 0  if r[26] goto 78; don't emit group columns if continuing existing group
   77                      Column                    3    0   29                 0  r[29]=idx_orders_customer.customer_id
   78                      Integer                   1   26    0                 0  r[26]=1; indicate data in accumulator
-  79                    Next                        3   65    0                 0
+  79                    Next                        3   65    0                 1
   80                    Gosub                      25   84    0                 0  ; emit row for final group
   81                    Goto                        0   94    0                 0  ; group by finished
   82                    Integer                     1   27    0                 0  r[27]=1
@@ -166,7 +166,7 @@ addr  opcode                                       p1   p2   p3  p4            p
  126            If                                 44  128    0                 0  if r[44] goto 128; don't emit group columns if continuing existing group
  127            Column                              6    0   47                 0  r[47]=idx_orders_customer.customer_id
  128            Integer                             1   44    0                 0  r[44]=1; indicate data in accumulator
- 129          Next                                  6  115    0                 0
+ 129          Next                                  6  115    0                 1
  130          Gosub                                43  134    0                 0  ; emit row for final group
  131          Goto                                  0  146    0                 0  ; group by finished
  132          Integer                               1   45    0                 0  r[45]=1
@@ -205,7 +205,7 @@ addr  opcode                                       p1   p2   p3  p4            p
  165      Copy                                      2   57    0                 0  r[57]=r[2]
  166      ResultRow                                55    3    0                 0  output=r[55..57]
  167    Next                                        8  160    0                 0
- 168  Next                                          7  148    0                 0
+ 168  Next                                          7  148    0                 1
  169  Halt                                          0    0    0                 0
  170  Transaction                                   0    1   11                 0  iDb=0 tx_mode=Read
  171  Goto                                          0    1    0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referencing-previous.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-referencing-previous.snap
@@ -78,7 +78,7 @@ addr  opcode                    p1  p2  p3  p4              p5  comment
   25            If               8  27   0                   0  if r[8] goto 27; don't emit group columns if continuing existing group
   26            Column           1   0  11                   0  r[11]=idx_order_items_product.product_id
   27            Integer          1   8   0                   0  r[8]=1; indicate data in accumulator
-  28          Next               1  11   0                   0
+  28          Next               1  11   0                   1
   29          Gosub              7  33   0                   0  ; emit row for final group
   30          Goto               0  45   0                   0  ; group by finished
   31          Integer            1   9   0                   0  r[9]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__cte-with-correlated-subquery.snap
@@ -49,7 +49,7 @@ addr  opcode                      p1  p2  p3  p4              p5  comment
   15                RealAffinity  16   0   0                   0
   16                MakeRecord    15   2  14                   0  r[14]=mkrec(r[15..16])
   17                SorterInsert   2  14   0  0                0  key=r[14]
-  18              Next             4  14   0                   0
+  18              Next             4  14   0                   1
   19              OpenPseudo       3  14   2                   0  2 columns in r[14]
   20              SorterSort       2  35   0                   0
   21                SorterData     2  14   3                   0  r[14]=data
@@ -102,7 +102,7 @@ addr  opcode                      p1  p2  p3  p4              p5  comment
   68    ColumnRange                0   3   3  2                0  r[3..4]=employees.department..salary
   69    RealAffinity               4   0   0                   0
   70    ResultRow                  2   3   0                   0  output=r[2..4]
-  71  Next                         0   3   0                   0
+  71  Next                         0   3   0                   1
   72  Halt                         0   0   0                   0
   73  Transaction                  0   1  11                   0  iDb=0 tx_mode=Read
   74  Goto                         0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__delete-returning-target-selfread.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__delete-returning-target-selfread.snap
@@ -41,7 +41,7 @@ addr  opcode           p1  p2  p3  p4          p5  comment
   19      OpenRead      2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
   20      Rewind        2  23   0               0  Rewind table t
   21        AggStep     0  15  13  count        0  accum=r[13] step(r[15])
-  22      Next          2  21   0               0
+  22      Next          2  21   0               1
   23      AggFinal      0  13   0  count        0  accum=r[13]
   24      Copy         13  12   0               0  r[12]=r[13]
   25      Copy         12   1   0               0  r[1]=r[12]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-join.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-join.snap
@@ -54,7 +54,7 @@ addr  opcode                   p1  p2  p3  p4            p5  comment
   22            If              5  24   0                 0  if r[5] goto 24; don't emit group columns if continuing existing group
   23            Column          2   0   8                 0  r[8]=idx_orders_customer.customer_id
   24            Integer         1   5   0                 0  r[5]=1; indicate data in accumulator
-  25          Next              2  10   0                 0
+  25          Next              2  10   0                 1
   26          Gosub             4  30   0                 0  ; emit row for final group
   27          Goto              0  47   0                 0  ; group by finished
   28          Integer           1   6   0                 0  r[6]=1
@@ -87,7 +87,7 @@ addr  opcode                   p1  p2  p3  p4            p5  comment
   55      Column                0   1  23                 0  r[23]=ephemeral(ephemeral_subquery_t3).total_spent
   56      ResultRow            21   3   0                 0  output=r[21..23]
   57    Next                    0  52   0                 0
-  58  Next                      3  49   0                 0
+  58  Next                      3  49   0                 1
   59  Halt                      0   0   0                 0
   60  Transaction               0   1  11                 0  iDb=0 tx_mode=Read
   61  Integer                   1  15   0                 0  r[15]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__derived-table-nested.snap
@@ -57,7 +57,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   22            If               5  24   0                 0  if r[5] goto 24; don't emit group columns if continuing existing group
   23            Column           2   0   8                 0  r[8]=idx_orders_customer.customer_id
   24            Integer          1   5   0                 0  r[5]=1; indicate data in accumulator
-  25          Next               2  11   0                 0
+  25          Next               2  11   0                 1
   26          Gosub              4  30   0                 0  ; emit row for final group
   27          Goto               0  43   0                 0  ; group by finished
   28          Integer            1   6   0                 0  r[6]=1
@@ -84,7 +84,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   49      Column                 0   1  19                 0  r[19]=ephemeral(ephemeral_subquery_t3).total_spent
   50      Yield                  1   0   0                 0
   51    Next                     0  47   0                 0
-  52  Next                       3  45   0                 0
+  52  Next                       3  45   0                 1
   53  EndCoroutine               1   0   0                 0
   54  SorterOpen                 4   1   0  k(1,-B)        0  cursor=4
   55  InitCoroutine              1   0   2                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__exists-correlated.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__exists-correlated.snap
@@ -42,7 +42,7 @@ addr  opcode             p1  p2  p3  p4            p5  comment
   15      Goto            0  18   0                 0  ; semi-join: early out after first match
   16    Next              2   7   0                 0
   17    Goto              0  18   0                 0  ; semi-join: no match, skip outer row
-  18  Next                0   5   0                 0
+  18  Next                0   5   0                 1
   19  Halt                0   0   0                 0
   20  Transaction         0   1  11                 0  iDb=0 tx_mode=Read
   21  Integer           500   7   0                 0  r[7]=500

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__exists-multiple-conditions.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__exists-multiple-conditions.snap
@@ -56,7 +56,7 @@ addr  opcode              p1  p2  p3  p4              p5  comment
   25    Column             0   3   4                   0  r[4]=products.price
   26    RealAffinity       4   0   0                   0
   27    ResultRow          2   3   0                   0  output=r[2..4]
-  28  Next                 0   3   0                   0
+  28  Next                 0   3   0                   1
   29  Halt                 0   0   0                   0
   30  Transaction          0   1  11                   0  iDb=0 tx_mode=Read
   31  String8              0  12   0  2024-01-01       0  r[12]='2024-01-01'

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-having.snap
@@ -47,7 +47,7 @@ addr  opcode                          p1  p2  p3  p4            p5  comment
   20                    If             4  22   0                 0  if r[4] goto 22; don't emit group columns if continuing existing group
   21                    Column         2   0   7                 0  r[7]=idx_grouped_values_grp.grp
   22                    Integer        1   4   0                 0  r[4]=1; indicate data in accumulator
-  23                  Next             2  10   0                 0
+  23                  Next             2  10   0                 1
   24                  Gosub            3  28   0                 0  ; emit row for final group
   25                  Goto             0  42   0                 0  ; group by finished
   26                  Integer          1   5   0                 0  r[5]=1
@@ -98,7 +98,7 @@ addr  opcode                          p1  p2  p3  p4            p5  comment
   71            IfPos                 31  74   0                 0  r[31]>0 -> r[31]-=0, goto 74
   72            NullRow                0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
   73            Goto                   0  55   0                 0
-  74          Next                     4  49   0                 0
+  74          Next                     4  49   0                 1
   75          Gosub                   19  79   0                 0  ; emit row for final group
   76          Goto                     0  91   0                 0  ; group by finished
   77          Integer                  1  21   0                 0  r[21]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-correlated-subquery-order-by.snap
@@ -48,7 +48,7 @@ addr  opcode                          p1   p2  p3  p4              p5  comment
   20                    If             4   22   0                   0  if r[4] goto 22; don't emit group columns if continuing existing group
   21                    Column         2    0   7                   0  r[7]=idx_grouped_values_grp.grp
   22                    Integer        1    4   0                   0  r[4]=1; indicate data in accumulator
-  23                  Next             2   10   0                   0
+  23                  Next             2   10   0                   1
   24                  Gosub            3   28   0                   0  ; emit row for final group
   25                  Goto             0   42   0                   0  ; group by finished
   26                  Integer          1    5   0                   0  r[5]=1
@@ -100,7 +100,7 @@ addr  opcode                          p1   p2  p3  p4              p5  comment
   72            IfPos                 32   75   0                   0  r[32]>0 -> r[32]-=0, goto 75
   73            NullRow                0    0   0                   0  Set cursor 0 to a (pseudo) NULL row
   74            Goto                   0   56   0                   0
-  75          Next                     5   50   0                   0
+  75          Next                     5   50   0                   1
   76          Gosub                   20   80   0                   0  ; emit row for final group
   77          Goto                     0   93   0                   0  ; group by finished
   78          Integer                  1   22   0                   0  r[22]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-subquery-builds-once.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__grouped-subquery-builds-once.snap
@@ -49,7 +49,7 @@ addr  opcode                      p1  p2  p3  p4            p5  comment
   14                ColumnRange    4   0  13  2              0  r[13..14]=repeat_inner.k..x
   15                MakeRecord    13   2  12                 0  r[12]=mkrec(r[13..14])
   16                SorterInsert   2  12   0  0              0  key=r[12]
-  17              Next             4  14   0                 0
+  17              Next             4  14   0                 1
   18              OpenPseudo       3  12   2                 0  2 columns in r[12]
   19              SorterSort       2  34   0                 0
   20                SorterData     2  12   3                 0  r[12]=data
@@ -110,7 +110,7 @@ addr  opcode                      p1  p2  p3  p4            p5  comment
   75        Null                   0  28   0                 0  r[28]=NULL
   76        IfNot                 28  78   1                 0  if !r[28] goto 78
   77        AggStep                0  31  23  count          0  accum=r[23] step(r[31])
-  78      Next                     5  56   0                 0
+  78      Next                     5  56   0                 1
   79      AggFinal                 0  23   0  count          0  accum=r[23]
   80      Copy                    23  22   0                 0  r[22]=r[23]
   81      Copy                    22   1   0                 0  r[1]=r[22]
@@ -118,7 +118,7 @@ addr  opcode                      p1  p2  p3  p4            p5  comment
   83    Column                     1   0   2                 0  r[2]=repeat_top.t
   84    Copy                       1   3   0                 0  r[3]=r[1]
   85    ResultRow                  2   2   0                 0  output=r[2..3]
-  86  Next                         1   3   0                 0
+  86  Next                         1   3   0                 1
   87  Halt                         0   0   0                 0
   88  Transaction                  0   1   3                 0  iDb=0 tx_mode=Read
   89  Integer                      1  31   0                 0  r[31]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__in-subquery-aggregation.snap
@@ -49,7 +49,7 @@ addr  opcode                    p1  p2  p3  p4            p5  comment
   21            If               3  23   0                 0  if r[3] goto 23; don't emit group columns if continuing existing group
   22            Column           2   0   6                 0  r[6]=idx_orders_customer.customer_id
   23            Integer          1   3   0                 0  r[3]=1; indicate data in accumulator
-  24          Next               2  10   0                 0
+  24          Next               2  10   0                 1
   25          Gosub              2  29   0                 0  ; emit row for final group
   26          Goto               0  42   0                 0  ; group by finished
   27          Integer            1   4   0                 0  r[4]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-cross-table.snap
@@ -41,7 +41,7 @@ addr  opcode                 p1  p2  p3  p4            p5  comment
   17            If            4  19   0                 0  if r[4] goto 19; don't emit group columns if continuing existing group
   18            Column        1   0   7                 0  r[7]=idx_orders_customer.customer_id
   19            Integer       1   4   0                 0  r[4]=1; indicate data in accumulator
-  20          Next            1   9   0                 0
+  20          Next            1   9   0                 1
   21          Gosub           3  25   0                 0  ; emit row for final group
   22          Goto            0  39   0                 0  ; group by finished
   23          Integer         1   5   0                 0  r[5]=1
@@ -76,7 +76,7 @@ addr  opcode                 p1  p2  p3  p4            p5  comment
   52    IfPos                19  55   0                 0  r[19]>0 -> r[19]-=0, goto 55
   53    NullRow               0   0   0                 0  Set cursor 0 to a (pseudo) NULL row
   54    Goto                  0  45   0                 0
-  55  Next                    2  41   0                 0
+  55  Next                    2  41   0                 1
   56  Halt                    0   0   0                 0
   57  Transaction             0   1  11                 0  iDb=0 tx_mode=Read
   58  Integer                 1  12   0                 0  r[12]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-max-price.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__scalar-subquery-max-price.snap
@@ -34,7 +34,7 @@ addr  opcode             p1  p2  p3  p4              p5  comment
    9      Column          0   3   6                   0  r[6]=products.price
   10      RealAffinity    6   0   0                   0
   11      AggStep         0   6   4  max(Binary)      0  accum=r[4] step(r[6])
-  12    Next              0   9   0                   0
+  12    Next              0   9   0                   1
   13    AggFinal          0   4   0  max              0  accum=r[4]
   14    Copy              4   3   0                   0  r[3]=r[4]
   15    Copy              3   1   0                   0  r[1]=r[3]
@@ -49,7 +49,7 @@ addr  opcode             p1  p2  p3  p4              p5  comment
   24    RealAffinity      8   0   0                   0
   25    Copy              1   9   0                   0  r[9]=r[1]
   26    ResultRow         7   3   0                   0  output=r[7..9]
-  27  Next                1  19   0                   0
+  27  Next                1  19   0                   1
   28  Halt                0   0   0                   0
   29  Transaction         0   1  11                   0  iDb=0 tx_mode=Read
   30  Integer           100  12   0                   0  r[12]=100

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__subquery-within-cte.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__subquery-within-cte.snap
@@ -42,7 +42,7 @@ addr  opcode             p1  p2  p3  p4              p5  comment
    8    RowId             1   2   0                   0  r[2]=categories.rowid
    9    MakeRecord        2   1   4                   0  r[4]=mkrec(r[2..2]); for ephemeral_index_where_sub_t2
   10    IdxInsert         0   4   0                   8  key=r[4]
-  11  Next                1   6   0                   0
+  11  Next                1   6   0                   1
   12  OpenRead            2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
   13  OpenRead            3   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
   14  NullRow             0   0   0                   0  Set cursor 0 to a (pseudo) NULL row

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__update-returning-target-selfread.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__update-returning-target-selfread.snap
@@ -49,7 +49,7 @@ addr  opcode           p1  p2  p3  p4          p5  comment
   26        Column      2   2  19               0  r[19]=t.val
   27        Lt         19  20  29  Binary       0  if r[19]<r[20] goto 29
   28        AggStep     0  21  16  count        0  accum=r[16] step(r[21])
-  29      Next          2  26   0               0
+  29      Next          2  26   0               1
   30      AggFinal      0  16   0  count        0  accum=r[16]
   31      Copy         16  15   0               0  r[15]=r[16]
   32      Copy         15   1   0               0  r[1]=r[15]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q1-pricing-summary.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q1-pricing-summary.snap
@@ -50,7 +50,7 @@ addr  opcode                  p1  p2  p3  p4                                    
   11            ColumnRange    2   4  29  4                                       0  r[29..32]=lineitem.L_QUANTITY..L_TAX
   12            MakeRecord    27   6  26                                          0  r[26]=mkrec(r[27..32])
   13            SorterInsert   0  26   0  0                                       0  key=r[26]
-  14          Next             2   8   0                                          0
+  14          Next             2   8   0                                          1
   15          OpenPseudo       1  26   6                                          0  6 columns in r[26]
   16          SorterSort       0  49   0                                          0
   17            SorterData     0  26   1                                          0  r[26]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q11-important-stock.snap
@@ -86,7 +86,7 @@ addr  opcode                       p1   p2  p3  p4                  p5  comment
   34                MakeRecord     12    3  11                       0  r[11]=mkrec(r[12..14])
   35                SorterInsert    1   11   0  0                    0  key=r[11]
   36              Next              4   29   0                       0
-  37            Next                5   11   0                       0
+  37            Next                5   11   0                       1
   38            OpenPseudo          2   11   3                       0  3 columns in r[11]
   39            SorterSort          1   57   0                       0
   40              SorterData        1   11   2                       0  r[11]=data
@@ -147,7 +147,7 @@ addr  opcode                       p1   p2  p3  p4                  p5  comment
   95            Multiply           48   49  47                       0  r[47]=r[48]*r[49]
   96            AggStep             0   47  35  sum                  0  accum=r[35] step(r[47])
   97          Next                  8   91   0                       0
-  98        Next                    9   74   0                       0
+  98        Next                    9   74   0                       1
   99        AggFinal                0   35   0  sum                  0  accum=r[35]
  100        Copy                   35   50   0                       0  r[50]=r[35]
  101        Real                    0   51   0  0.0001               0  r[51]=0.0001

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q12-shipping-modes.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q12-shipping-modes.snap
@@ -70,7 +70,7 @@ addr  opcode                  p1  p2  p3  p4                                    
   23            Column         2   5  13                                          0  r[13]=orders.O_ORDERPRIORITY
   24            MakeRecord    12   2  11                                          0  r[11]=mkrec(r[12..13])
   25            SorterInsert   0  11   0  0                                       0  key=r[11]
-  26          Next             3   9   0                                          0
+  26          Next             3   9   0                                          1
   27          OpenPseudo       1  11   2                                          0  2 columns in r[11]
   28          SorterSort       0  74   0                                          0
   29            SorterData     0  11   1                                          0  r[11]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q14-promotion-effect.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q14-promotion-effect.snap
@@ -57,7 +57,7 @@ addr  opcode       p1  p2  p3  p4                                     p5  commen
   26    Subtract   22  23  21                                          0  r[21]=r[22]-r[23]
   27    Multiply   20  21  19                                          0  r[19]=r[20]*r[21]
   28    AggStep     0  19   3  sum                                     0  accum=r[3] step(r[19])
-  29  Next          0   5   0                                          0
+  29  Next          0   5   0                                          1
   30  AggFinal      0   2   0  sum                                     0  accum=r[2]
   31  AggFinal      0   3   0  sum                                     0  accum=r[3]
   32  Copy          2  27   0                                          0  r[27]=r[2]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q17-small-quantity-order.snap
@@ -49,7 +49,7 @@ addr  opcode                  p1  p2  p3  p4                                    
   11            Column         3   4  11                                          0  r[11]=lineitem.L_QUANTITY
   12            MakeRecord    10   2   9                                          0  r[9]=mkrec(r[10..11])
   13            SorterInsert   1   9   0  0                                       0  key=r[9]
-  14          Next             3  10   0                                          0
+  14          Next             3  10   0                                          1
   15          OpenPseudo       2   9   2                                          0  2 columns in r[9]
   16          SorterSort       1  31   0                                          0
   17            SorterData     1   9   2                                          0  r[9]=data
@@ -118,7 +118,7 @@ addr  opcode                  p1  p2  p3  p4                                    
   80        AggStep            0  37  22  sum                                     0  accum=r[22] step(r[37])
   81      Next                 5  77   0                                          0
   82    Next                   0  61   0                                          0
-  83  Next                     6  55   0                                          0
+  83  Next                     6  55   0                                          1
   84  AggFinal                 0  22   0  sum                                     0  accum=r[22]
   85  Copy                    22  38   0                                          0  r[38]=r[22]
   86  Divide                  38  39  21                                          0  r[21]=r[38]/r[39]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q19-discounted-revenue.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q19-discounted-revenue.snap
@@ -108,7 +108,7 @@ addr  opcode       p1  p2  p3  p4                                     p5  commen
   55    Subtract   72  73  71                                          0  r[71]=r[72]-r[73]
   56    Multiply   70  71  69                                          0  r[69]=r[70]*r[71]
   57    AggStep     0  69   2  sum                                     0  accum=r[2] step(r[69])
-  58  Next          0   5   0                                          0
+  58  Next          0   5   0                                          1
   59  AggFinal      0   2   0  sum                                     0  accum=r[2]
   60  Copy          2   1   0                                          0  r[1]=r[2]
   61  ResultRow     1   1   0                                          0  output=r[1]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q4-order-priority.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q4-order-priority.snap
@@ -64,7 +64,7 @@ addr  opcode                    p1  p2  p3  p4                                  
   23              Goto           0  26   0                                          0  ; semi-join: early out after first match
   24            Next             4  16   0                                          0
   25            Goto             0  26   0                                          0  ; semi-join: no match, skip outer row
-  26          Next               2  10   0                                          0
+  26          Next               2  10   0                                          1
   27          OpenPseudo         1  10   1                                          0  1 columns in r[10]
   28          SorterSort         0  42   0                                          0
   29            SorterData       0  10   1                                          0  r[10]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q6-forecasting-revenue.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q6-forecasting-revenue.snap
@@ -40,7 +40,7 @@ addr  opcode         p1  p2  p3  p4                                     p5  comm
   14    ColumnRange   0   5  23  2                                       0  r[23..24]=lineitem.L_EXTENDEDPRICE..L_DISCOUNT
   15    Multiply     23  24  22                                          0  r[22]=r[23]*r[24]
   16    AggStep       0  22   2  sum                                     0  accum=r[2] step(r[22])
-  17  Next            0   4   0                                          0
+  17  Next            0   4   0                                          1
   18  AggFinal        0   2   0  sum                                     0  accum=r[2]
   19  Copy            2   1   0                                          0  r[1]=r[2]
   20  ResultRow       1   1   0                                          0  output=r[1]

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__aggregate-windows.snap
@@ -39,7 +39,7 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
    9            Column         0    1   5                          0  r[5]=employees.name
   10            Column         0    3   6                          0  r[6]=employees.salary
   11            Yield          2    0   0                          0
-  12          Next             1    6   0                          0
+  12          Next             1    6   0                          1
   13          EndCoroutine     2    0   0                          0
   14          OpenEphemeral    2    1   0                          0  cursor=2 is_table=true
   15          OpenDup          3    2   0                          0  new_cursor=3, original_cursor=2

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__multiple-windows.snap
@@ -56,7 +56,7 @@ addr  opcode                           p1   p2   p3  p4                     p5  
   16                    RowId           0    9    0                          0  r[9]=employees.rowid
   17                    Column          0    1   10                          0  r[10]=employees.name
   18                    Yield           4    0    0                          0
-  19                  Next              2    9    0                          0
+  19                  Next              2    9    0                          1
   20                  EndCoroutine      4    0    0                          0
   21                  SorterOpen        3    1    0  k(1,B)                  0  cursor=3
   22                  OpenEphemeral     4    1    0                          0  cursor=4 is_table=true

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__percent-of-total.snap
@@ -36,7 +36,7 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
    9            Column         0    1   5                          0  r[5]=employees.name
   10            Column         0    3   6                          0  r[6]=employees.salary
   11            Yield          2    0   0                          0
-  12          Next             1    6   0                          0
+  12          Next             1    6   0                          1
   13          EndCoroutine     2    0   0                          0
   14          OpenEphemeral    2    1   0                          0  cursor=2 is_table=true
   15          OpenDup          3    2   0                          0  new_cursor=3, original_cursor=2

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__row-number-basic.snap
@@ -32,7 +32,7 @@ addr  opcode              p1  p2  p3  p4                     p5  comment
    7        IdxRowId       1   3   0                          0  r[3]=cursor 1 for index idx_employees_salary.rowid
    8        ColumnRange    0   1   4  2                       0  r[4..5]=employees.name..department
    9        Yield          1   0   0                          0
-  10      Prev             1   5   0                          0
+  10      Prev             1   5   0                          1
   11      EndCoroutine     1   0   0                          0
   12      OpenEphemeral    2   1   0                          0  cursor=2 is_table=true
   13      OpenDup          3   2   0                          0  new_cursor=3, original_cursor=2

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__running-total.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__running-total.snap
@@ -40,7 +40,7 @@ addr  opcode                   p1   p2   p3  p4                     p5  comment
    8            Column          1    3   11                          0  r[11]=sales.amount
    9            MakeRecord      8    4    7                          0  r[7]=mkrec(r[8..11])
   10            SorterInsert    0    7    0  0                       0  key=r[7]
-  11          Next              1    6    0                          0
+  11          Next              1    6    0                          1
   12          OpenPseudo        2    7    4                          0  4 columns in r[7]
   13          SorterSort        0   18    0                          0
   14            SorterData      0    7    2                          0  r[7]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-order-by.snap
@@ -35,7 +35,7 @@ addr  opcode              p1  p2  p3  p4                     p5  comment
    8        Column         1   4  12                          0  r[12]=sales.region
    9        MakeRecord     8   5   7                          0  r[7]=mkrec(r[8..12])
   10        SorterInsert   0   7   0  0                       0  key=r[7]
-  11      Next             1   5   0                          0
+  11      Next             1   5   0                          1
   12      OpenPseudo       2   7   5                          0  5 columns in r[7]
   13      SorterSort       0  18   0                          0
   14        SorterData     0   7   2                          0  r[7]=data

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-over-grouped.snap
@@ -47,7 +47,7 @@ addr  opcode                      p1  p2  p3  p4                     p5  comment
   21                If             7  23   0                          0  if r[7] goto 23; don't emit group columns if continuing existing group
   22                Column         2   0  10                          0  r[10]=idx_employees_department.department
   23                Integer        1   7   0                          0  r[7]=1; indicate data in accumulator
-  24              Next             2  10   0                          0
+  24              Next             2  10   0                          1
   25              Gosub            6  29   0                          0  ; emit row for final group
   26              Goto             0  42   0                          0  ; group by finished
   27              Integer          1   8   0                          0  r[8]=1

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/windows/snapshots/windows__window-with-subquery.snap
@@ -48,7 +48,7 @@ addr  opcode                  p1   p2  p3  p4                     p5  comment
   10            Column         0    1   6                          0  r[6]=employees.name
   11            Column         0    3   7                          0  r[7]=employees.salary
   12            Yield          3    0   0                          0
-  13          Next             1    7   0                          0
+  13          Next             1    7   0                          1
   14          EndCoroutine     3    0   0                          0
   15          OpenEphemeral    2    1   0                          0  cursor=2 is_table=true
   16          OpenDup          3    2   0                          0  new_cursor=3, original_cursor=2

--- a/sqlite/conformance/sqlite-sqltests/snapshots/fullscan_steps__fullscan-covering-index-scan-tags-next-p5.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/fullscan_steps__fullscan-covering-index-scan-tags-next-p5.snap
@@ -1,25 +1,25 @@
 ---
-source: orderby_plan.sqltest
-expression: SELECT * FROM t ORDER BY rowid;
+source: fullscan_steps.sqltest
+expression: SELECT a FROM t ORDER BY a;
 info:
   statement_type: SELECT
   tables:
   - t
   setup_blocks:
-  - orderby_plan
+  - fullscan_schema
   database: ':memory:'
 ---
 QUERY PLAN
-`--SCAN t
+`--SCAN t USING COVERING INDEX ta
 
 BYTECODE
 addr  opcode       p1  p2  p3  p4      p5  comment
    0  Init          0   7   0           0  Start at 7
-   1  OpenRead      0   2   0  k(2,B)   0  table=t, root=2, iDb=0
-   2  Rewind        0   6   0           0  Rewind table t
-   3    Column      0   0   1           0  r[1]=t.a
+   1  OpenRead      0   3   0  k(2,B)   0  index=ta, root=3, iDb=0
+   2  Rewind        0   6   0           0  Rewind index ta
+   3    Column      0   0   1           0  r[1]=ta.a
    4    ResultRow   1   1   0           0  output=r[1]
    5  Next          0   3   0           1
    6  Halt          0   0   0           0
-   7  Transaction   0   1   1           0  iDb=0 tx_mode=Read
+   7  Transaction   0   1   2           0  iDb=0 tx_mode=Read
    8  Goto          0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshots/fullscan_steps__fullscan-reverse-table-scan-tags-prev-p5.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/fullscan_steps__fullscan-reverse-table-scan-tags-prev-p5.snap
@@ -1,0 +1,25 @@
+---
+source: fullscan_steps.sqltest
+expression: SELECT * FROM t ORDER BY rowid DESC;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - fullscan_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t
+
+BYTECODE
+addr  opcode         p1  p2  p3  p4        p5  comment
+   0  Init            0   7   0             0  Start at 7
+   1  OpenRead        0   2   0  k(3,B,B)   0  table=t, root=2, iDb=0
+   2  Last            0   6   0             0
+   3    ColumnRange   0   0   1  2          0  r[1..2]=t.a..b
+   4    ResultRow     1   2   0             0  output=r[1..2]
+   5  Prev            0   3   0             1
+   6  Halt            0   0   0             0
+   7  Transaction     0   1   2             0  iDb=0 tx_mode=Read
+   8  Goto            0   1   0             0

--- a/sqlite/conformance/sqlite-sqltests/snapshots/fullscan_steps__fullscan-table-scan-tags-next-p5.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/fullscan_steps__fullscan-table-scan-tags-next-p5.snap
@@ -1,0 +1,25 @@
+---
+source: fullscan_steps.sqltest
+expression: SELECT * FROM t;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - fullscan_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t
+
+BYTECODE
+addr  opcode         p1  p2  p3  p4        p5  comment
+   0  Init            0   7   0             0  Start at 7
+   1  OpenRead        0   2   0  k(3,B,B)   0  table=t, root=2, iDb=0
+   2  Rewind          0   6   0             0  Rewind table t
+   3    ColumnRange   0   0   1  2          0  r[1..2]=t.a..b
+   4    ResultRow     1   2   0             0  output=r[1..2]
+   5  Next            0   3   0             1
+   6  Halt            0   0   0             0
+   7  Transaction     0   1   2             0  iDb=0 tx_mode=Read
+   8  Goto            0   1   0             0

--- a/sqlite/conformance/sqlite-sqltests/snapshots/fullscan_steps__indexed-range-search-not-tagged-fullscan.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/fullscan_steps__indexed-range-search-not-tagged-fullscan.snap
@@ -1,0 +1,29 @@
+---
+source: fullscan_steps.sqltest
+expression: SELECT * FROM t WHERE a > 5;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - fullscan_schema
+  database: ':memory:'
+---
+QUERY PLAN
+`--SEARCH t USING INDEX ta (a>?)
+
+BYTECODE
+addr  opcode          p1  p2  p3  p4        p5  comment
+   0  Init             0  11   0             0  Start at 11
+   1  OpenRead         0   2   0  k(3,B,B)   0  table=t, root=2, iDb=0
+   2  OpenRead         1   3   0  k(2,B)     0  index=ta, root=3, iDb=0
+   3  Integer          5   3   0             0  r[3]=5
+   4  SeekGT           1  10   3             0  key=[3..3]
+   5    DeferredSeek   1   0   0             0
+   6    Column         1   0   1             0  r[1]=ta.a
+   7    Column         0   1   2             0  r[2]=t.b
+   8    ResultRow      1   2   0             0  output=r[1..2]
+   9  Next             1   5   0             0
+  10  Halt             0   0   0             0
+  11  Transaction      0   1   2             0  iDb=0 tx_mode=Read
+  12  Goto             0   1   0             0

--- a/sqlite/conformance/sqlite-sqltests/snapshots/gencol__gencol_drop_virtual_column_no_row_rewrite.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/gencol__gencol_drop_virtual_column_no_row_rewrite.snap
@@ -27,7 +27,7 @@ addr  opcode         p1  p2  p3  p4                  p5  comment
   10    Affinity      8   5   0                       0  r[8..13] = B, B, B, D, B
   11    MakeRecord    8   5  13                       0  r[13]=mkrec(r[8..12])
   12    Insert        0  13   7  sqlite_schema        8  intkey=r[7] data=r[13]
-  13  Next            0   3   0                       0
+  13  Next            0   3   0                       1
   14  SetCookie       0   1   3                       0
   15  DropColumn      0   0   0                       0  drop_column(t, 1)
   16  Halt            0   0   0                       0


### PR DESCRIPTION
SQLITE_STMTSTATUS_FULLSCAN_STEP counted every Next/Prev on a table cursor, so index seeks and interior loops inflated the counter and it could not tell a full table scan from an indexed lookup. SQLite instead tags the Next/Prev opcode with P5 at codegen time only when the loop scans the whole table with no constraint.

Add a fullscan flag to Insn::Next and Insn::Prev, set it in the main loop epilogue when iterating a table (or the prebuilt ephemeral copy an UPDATE scans) without an index, and count only flagged steps. EXPLAIN now shows the flag in P5 like SQLite does.