### PR TITLE
core/wal: refuse stale nbackfills after concurrent WAL reset

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -149,6 +149,8 @@ pub use io::{
 };
 pub use numeric::{nonnan::NonNan, Numeric};
 pub use statement::{ColumnTypeInfo, ColumnTypeKind, Statement, StatementStatusCounter};
+#[cfg(any(test, feature = "test_helper"))]
+pub use storage::wal::set_checkpoint_start_before_lock_hook;
 pub use storage::{
     buffer_pool::BufferPool,
     database::{DatabaseStorage, IOContext},
@@ -157,8 +159,6 @@ pub use storage::{
     pager::{Page, PageRef, Pager},
     wal::{CheckpointMode, CheckpointResult, Wal, WalAutoActions, WalFile, WalFileShared},
 };
-#[cfg(any(test, feature = "test_helper"))]
-pub use storage::wal::set_checkpoint_start_before_lock_hook;
 pub use translate::expr::{walk_expr_mut, WalkControl};
 pub use turso_ext::ContextDestructor;
 pub use turso_macros::{

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -157,6 +157,8 @@ pub use storage::{
     pager::{Page, PageRef, Pager},
     wal::{CheckpointMode, CheckpointResult, Wal, WalAutoActions, WalFile, WalFileShared},
 };
+#[cfg(any(test, feature = "test_helper"))]
+pub use storage::wal::set_checkpoint_start_before_lock_hook;
 pub use translate::expr::{walk_expr_mut, WalkControl};
 pub use turso_ext::ContextDestructor;
 pub use turso_macros::{

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -1478,25 +1478,28 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
     /// Publish `nbackfills` after Passive backfill + DB sync. Skip Truncate/Restart.
     /// Leaves the checkpoint guard held until Finalize (same as the pager).
-    fn publish_wal_backfill_if_needed(&mut self) {
+    fn publish_wal_backfill_if_needed(&mut self) -> Result<()> {
         if self.mode.should_restart_log() {
-            return;
+            return Ok(());
         }
         let Some(result) = self.checkpoint_result.as_ref() else {
-            return;
+            return Ok(());
         };
         if result.wal_checkpoint_backfilled == 0 {
-            return;
+            return Ok(());
         }
         let max_frame = result.wal_total_backfilled;
+        let expected_checkpoint_seq = result.checkpoint_seq;
         turso_assert!(self.pager.wal.is_some(), "No WAL to publish backfill");
         let wal = self.pager.wal.as_ref().unwrap();
         tracing::debug!(
             max_frame,
             backfilled = result.wal_checkpoint_backfilled,
+            expected_checkpoint_seq,
             "publishing WAL backfill after MVCC checkpoint"
         );
-        wal.publish_backfill(max_frame);
+        wal.publish_backfill(max_frame, expected_checkpoint_seq)?;
+        Ok(())
     }
 
     fn has_unpublished_schema_changes(&self) -> bool {
@@ -2878,7 +2881,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 // Crash after truncate but before fsync would lose checkpointed data.
                 if self.sync_mode == SyncMode::Off {
                     tracing::debug!("Skipping fsync of database file (synchronous=off)");
-                    self.publish_wal_backfill_if_needed();
+                    self.publish_wal_backfill_if_needed()?;
                     self.state = CheckpointState::TruncateLogicalLog;
                     return Ok(TransitionResult::Continue);
                 }
@@ -2896,7 +2899,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
 
                 // Check if we already sent the sync
                 if checkpoint_result.db_sync_sent {
-                    self.publish_wal_backfill_if_needed();
+                    self.publish_wal_backfill_if_needed()?;
                     self.state = CheckpointState::TruncateLogicalLog;
                     return Ok(TransitionResult::Continue);
                 }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -4956,7 +4956,16 @@ impl Pager {
                             }
                         );
                     }
-                    wal.publish_backfill(max_frame);
+                    let expected_checkpoint_seq = {
+                        let state = self.checkpoint_state.read();
+                        state
+                            .result
+                            .as_ref()
+                            .expect("result should be set")
+                            .checkpoint_seq
+                    };
+                    // Refuse cross-generation publish (SQLite WAL-reset bug class).
+                    wal.publish_backfill(max_frame, expected_checkpoint_seq)?;
                     let next_phase = {
                         let state = self.checkpoint_state.read();
                         if matches!(state.mode, Some(CheckpointMode::Truncate { .. })) {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -801,6 +801,10 @@ pub trait Wal: Debug + Send + Sync {
     /// `expected_checkpoint_seq` must match the current WAL generation; a mismatch
     /// means the WAL was reset under this checkpoint and publishing would poison
     /// the new generation (SQLite WAL-reset bug).
+    ///
+    /// This generation check is defense-in-depth only. The load-bearing fix is
+    /// re-sampling `nbackfills` under the checkpoint lock before fixing
+    /// `min_frame`. Callers must hold the checkpoint guard through publish.
     fn publish_backfill(&self, max_frame: u64, expected_checkpoint_seq: u32) -> Result<()>;
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion>;
     fn is_syncing(&self) -> bool;
@@ -993,6 +997,12 @@ impl WalCoordination for InProcessWalCoordination {
     }
 
     fn publish_backfill(&self, max_frame: u64, expected_checkpoint_seq: u32) -> Result<()> {
+        // Defense-in-depth only. The load-bearing WAL-reset fix is re-sampling
+        // nbackfills under the checkpoint lock before fixing min_frame: if the
+        // checkpointer already observed the *new* generation's checkpoint_seq but
+        // kept a stale pre-lock min_frame, this seq check still passes and would
+        // publish a poisoned watermark. Callers must hold the checkpoint guard for
+        // the whole backfill→publish window so restart cannot race this store.
         let snapshot = self.load_snapshot();
         if snapshot.checkpoint_seq != expected_checkpoint_seq {
             tracing::warn!(
@@ -2017,6 +2027,8 @@ impl WalCoordination for ShmWalCoordination {
     }
 
     fn publish_backfill(&self, max_frame: u64, expected_checkpoint_seq: u32) -> Result<()> {
+        // Defense-in-depth only — see InProcessWalCoordination::publish_backfill.
+        // Load-bearing fix remains post-lock nbackfills re-sample before min_frame.
         let snapshot = self.load_snapshot();
         if snapshot.checkpoint_seq != expected_checkpoint_seq {
             tracing::warn!(

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -49,6 +49,33 @@ use crate::{
     Result, SyncMode,
 };
 
+// Test-only hook between pre-lock checkpoint snapshot and lock acquisition.
+// Thread-local so the hook may capture non-Send Connection handles and run
+// nested work on the same thread as the checkpoint under test (WAL-reset race).
+#[cfg(any(test, feature = "test_helper"))]
+std::thread_local! {
+    static CHECKPOINT_START_BEFORE_LOCK_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Install a one-shot hook that runs after a checkpoint decides it has work
+/// but before it acquires the checkpoint lock. Passing `None` clears any hook.
+/// Used to force the SQLite WAL-reset interleaving in regression tests.
+#[cfg(any(test, feature = "test_helper"))]
+pub fn set_checkpoint_start_before_lock_hook(hook: Option<Box<dyn FnOnce()>>) {
+    CHECKPOINT_START_BEFORE_LOCK_HOOK.with(|slot| {
+        *slot.borrow_mut() = hook;
+    });
+}
+
+#[cfg(any(test, feature = "test_helper"))]
+fn run_checkpoint_start_before_lock_hook() {
+    let hook = CHECKPOINT_START_BEFORE_LOCK_HOOK.with(|slot| slot.borrow_mut().take());
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 /// this contains the frame to rollback to and its associated checksum.
 #[derive(Debug, Clone)]
 pub struct RollbackTo {
@@ -68,6 +95,10 @@ pub struct CheckpointResult {
     pub wal_total_backfilled: u64,
     /// amount of new frames backfilled to the DB file during this checkpoint procedure
     pub wal_checkpoint_backfilled: u64,
+    /// WAL generation (`checkpoint_seq`) observed when this checkpoint fixed its frame range.
+    /// `publish_backfill` must refuse to advance `nbackfills` if the WAL was reset to a
+    /// different generation (SQLite WAL-reset / Tailscale bug class).
+    pub checkpoint_seq: u32,
     /// In the case of everything backfilled, we need to hold the locks until the db
     /// file is truncated.
     maybe_guard: Option<CheckpointLocks>,
@@ -91,10 +122,20 @@ impl CheckpointResult {
         wal_total_backfilled: u64,
         wal_checkpoint_backfilled: u64,
     ) -> Self {
+        Self::with_checkpoint_seq(wal_max_frame, wal_total_backfilled, wal_checkpoint_backfilled, 0)
+    }
+
+    pub fn with_checkpoint_seq(
+        wal_max_frame: u64,
+        wal_total_backfilled: u64,
+        wal_checkpoint_backfilled: u64,
+        checkpoint_seq: u32,
+    ) -> Self {
         Self {
             wal_max_frame,
             wal_total_backfilled,
             wal_checkpoint_backfilled,
+            checkpoint_seq,
             maybe_guard: None,
             db_sync_sent: false,
             db_truncate_sent: false,
@@ -498,7 +539,11 @@ trait WalCoordination: Debug + Send + Sync {
     fn publish_commit(&self, commit: WalCommitState);
 
     /// Publish the highest frame durably backfilled during checkpoint.
-    fn publish_backfill(&self, max_frame: u64);
+    ///
+    /// `expected_checkpoint_seq` is the WAL generation observed when the checkpointer
+    /// fixed its frame range. If the WAL was restarted to a new generation since then,
+    /// this must refuse to update `nbackfills` (SQLite WAL-reset bug class).
+    fn publish_backfill(&self, max_frame: u64, expected_checkpoint_seq: u32) -> Result<()>;
 
     /// Install any backend-specific durable proof before publishing backfill.
     /// Returns an optional completion that must finish before `publish_backfill`.
@@ -751,7 +796,12 @@ pub trait Wal: Debug + Send + Sync {
         db_header_crc32c: u32,
         sync_type: FileSyncType,
     ) -> Result<Option<Completion>>;
-    fn publish_backfill(&self, max_frame: u64);
+    /// Publish durable backfill progress for `max_frame`.
+    ///
+    /// `expected_checkpoint_seq` must match the current WAL generation; a mismatch
+    /// means the WAL was reset under this checkpoint and publishing would poison
+    /// the new generation (SQLite WAL-reset bug).
+    fn publish_backfill(&self, max_frame: u64, expected_checkpoint_seq: u32) -> Result<()>;
     fn sync(&self, sync_type: FileSyncType) -> Result<Completion>;
     fn is_syncing(&self) -> bool;
     /// Whether the WAL file is dirty: frames were appended that no successful
@@ -942,12 +992,32 @@ impl WalCoordination for InProcessWalCoordination {
             .store(commit.transaction_count, Ordering::Release);
     }
 
-    fn publish_backfill(&self, max_frame: u64) {
+    fn publish_backfill(&self, max_frame: u64, expected_checkpoint_seq: u32) -> Result<()> {
+        let snapshot = self.load_snapshot();
+        if snapshot.checkpoint_seq != expected_checkpoint_seq {
+            tracing::warn!(
+                expected = expected_checkpoint_seq,
+                actual = snapshot.checkpoint_seq,
+                max_frame,
+                "refusing publish_backfill after WAL generation change (WAL-reset race)"
+            );
+            return Err(LimboError::Busy);
+        }
+        turso_assert!(
+            (snapshot.nbackfills..=snapshot.max_frame).contains(&max_frame),
+            "published backfill must stay within the current WAL generation",
+            {
+                "publish_backfill": max_frame,
+                "current_nbackfills": snapshot.nbackfills,
+                "current_max_frame": snapshot.max_frame
+            }
+        );
         self.shared
             .write()
             .metadata
             .nbackfills
             .store(max_frame, Ordering::Release);
+        Ok(())
     }
 
     fn install_durable_backfill_proof(
@@ -1946,13 +2016,33 @@ impl WalCoordination for ShmWalCoordination {
         }
     }
 
-    fn publish_backfill(&self, max_frame: u64) {
+    fn publish_backfill(&self, max_frame: u64, expected_checkpoint_seq: u32) -> Result<()> {
+        let snapshot = self.load_snapshot();
+        if snapshot.checkpoint_seq != expected_checkpoint_seq {
+            tracing::warn!(
+                expected = expected_checkpoint_seq,
+                actual = snapshot.checkpoint_seq,
+                max_frame,
+                "refusing publish_backfill after WAL generation change (WAL-reset race)"
+            );
+            return Err(LimboError::Busy);
+        }
+        turso_assert!(
+            (snapshot.nbackfills..=snapshot.max_frame).contains(&max_frame),
+            "published backfill must stay within the current WAL generation",
+            {
+                "publish_backfill": max_frame,
+                "current_nbackfills": snapshot.nbackfills,
+                "current_max_frame": snapshot.max_frame
+            }
+        );
         self.shared
             .write()
             .metadata
             .nbackfills
             .store(max_frame, Ordering::Release);
         self.authority.publish_backfill(max_frame);
+        Ok(())
     }
 
     fn install_durable_backfill_proof(
@@ -2543,6 +2633,9 @@ struct OngoingCheckpoint {
     min_frame: u64,
     /// maximum safe frame number that will be backfilled by this checkpoint operation.
     max_frame: u64,
+    /// WAL generation (`checkpoint_seq`) when `min_frame`/`max_frame` were fixed under lock.
+    /// Used so `publish_backfill` can refuse a cross-generation watermark (WAL-reset race).
+    checkpoint_seq: u32,
     /// cursor used to iterate through all the pages that might have a frame in the safe range
     current_page: u64,
     /// State of the checkpoint
@@ -2566,6 +2659,7 @@ impl OngoingCheckpoint {
     fn reset(&mut self) {
         self.min_frame = 0;
         self.max_frame = 0;
+        self.checkpoint_seq = 0;
         self.current_page = 0;
         self.pages_to_checkpoint.clear();
         self.pending_writes.clear();
@@ -2671,6 +2765,7 @@ impl fmt::Debug for OngoingCheckpoint {
             .field("state", &self.state)
             .field("min_frame", &self.min_frame)
             .field("max_frame", &self.max_frame)
+            .field("checkpoint_seq", &self.checkpoint_seq)
             .field("current_page", &self.current_page)
             .finish()
     }
@@ -4004,18 +4099,9 @@ impl Wal for WalFile {
         )
     }
 
-    fn publish_backfill(&self, max_frame: u64) {
-        let snapshot = self.load_coordination_snapshot();
-        turso_assert!(
-            (snapshot.nbackfills..=snapshot.max_frame).contains(&max_frame),
-            "published backfill must stay within the current WAL generation",
-            {
-                "publish_backfill": max_frame,
-                "current_nbackfills": snapshot.nbackfills,
-                "current_max_frame": snapshot.max_frame
-            }
-        );
-        self.coordination.publish_backfill(max_frame);
+    fn publish_backfill(&self, max_frame: u64, expected_checkpoint_seq: u32) -> Result<()> {
+        self.coordination
+            .publish_backfill(max_frame, expected_checkpoint_seq)
     }
 
     #[instrument(err, skip_all, level = Level::DEBUG)]
@@ -4692,6 +4778,7 @@ impl WalFile {
                 state: CheckpointState::Start,
                 min_frame: 0,
                 max_frame: 0,
+                checkpoint_seq: 0,
                 current_page: 0,
                 pages_to_checkpoint: Vec::new(),
                 inflight_reads: Vec::with_capacity(MAX_INFLIGHT_READS),
@@ -4792,6 +4879,11 @@ impl WalFile {
                 // so no other checkpointer can run. fsync WAL if there are unapplied frames.
                 // Decide the largest frame we are allowed to back‑fill.
                 CheckpointState::Start => {
+                    // Pre-lock snapshot is only a fast path for "nothing to do".
+                    // Never use pre-lock nbackfills as min_frame: another connection can
+                    // finish a checkpoint and a writer can restart the WAL in that window
+                    // (SQLite WAL-reset / Tailscale bug class). Frame range is fixed only
+                    // after acquire_proper_checkpoint_guard below.
                     let snapshot = self.load_coordination_snapshot();
                     let max_frame = snapshot.max_frame;
                     let nbackfills = snapshot.nbackfills;
@@ -4807,12 +4899,22 @@ impl WalFile {
                     if !needs_backfill && !mode.should_restart_log() {
                         // there are no frames to copy over and we don't need to reset
                         // the log so we can return early success.
-                        return Ok(IOResult::Done(CheckpointResult::new(
-                            max_frame, nbackfills, 0,
+                        return Ok(IOResult::Done(CheckpointResult::with_checkpoint_seq(
+                            max_frame,
+                            nbackfills,
+                            0,
+                            snapshot.checkpoint_seq,
                         )));
                     }
+                    // Test-only: run work that must interleave after the pre-lock sample
+                    // and before the checkpoint lock (WAL-reset race regression).
+                    #[cfg(any(test, feature = "test_helper"))]
+                    run_checkpoint_start_before_lock_hook();
                     // acquire the appropriate exclusive locks depending on the checkpoint mode
                     self.acquire_proper_checkpoint_guard(mode, lock_source)?;
+                    // Re-sample under lock so min_frame and max_frame belong to one generation.
+                    let locked_snapshot = self.load_coordination_snapshot();
+                    let nbackfills = locked_snapshot.nbackfills;
                     let mut max_frame = self.determine_max_safe_checkpoint_frame();
 
                     if let CheckpointMode::Truncate {
@@ -4833,10 +4935,24 @@ impl WalFile {
                         max_frame = max_frame.min(upper_bound);
                     }
 
+                    // Another connection may have finished the work (and/or a writer
+                    // restarted the WAL) while we waited for locks.
+                    if max_frame <= nbackfills && !mode.should_restart_log() {
+                        let _ = self.checkpoint_guard.write().take();
+                        return Ok(IOResult::Done(CheckpointResult::with_checkpoint_seq(
+                            locked_snapshot.max_frame,
+                            nbackfills,
+                            0,
+                            locked_snapshot.checkpoint_seq,
+                        )));
+                    }
+
                     {
                         let mut oc = self.ongoing_checkpoint.write();
                         oc.max_frame = max_frame;
+                        // Always from post-lock nbackfills — never the pre-lock sample.
                         oc.min_frame = nbackfills + 1;
+                        oc.checkpoint_seq = locked_snapshot.checkpoint_seq;
                     }
                     let (oc_min_frame, oc_max_frame) = {
                         let oc = self.ongoing_checkpoint.read();
@@ -5005,6 +5121,7 @@ impl WalFile {
                     );
                     let wal_max_frame = self.load_coordination_snapshot().max_frame;
                     let wal_total_backfilled = ongoing_chkpt.max_frame;
+                    let checkpoint_seq = ongoing_chkpt.checkpoint_seq;
                     // Record two num pages fields to return as checkpoint result to caller.
                     // Ref: pnLog, pnCkpt on https://www.sqlite.org/c3ref/wal_checkpoint_v2.html
 
@@ -5012,10 +5129,11 @@ impl WalFile {
                     let wal_checkpoint_backfilled =
                         wal_total_backfilled.saturating_sub(ongoing_chkpt.min_frame - 1);
 
-                    let checkpoint_result = CheckpointResult::new(
+                    let checkpoint_result = CheckpointResult::with_checkpoint_seq(
                         wal_max_frame,
                         wal_total_backfilled,
                         wal_checkpoint_backfilled,
+                        checkpoint_seq,
                     );
                     tracing::debug!("checkpoint_result={:?}, mode={:?}", checkpoint_result, mode);
                     if mode.require_all_backfilled() && !checkpoint_result.everything_backfilled() {
@@ -7286,7 +7404,9 @@ pub mod test {
                 .extend([(1, vec![1, 4, 8]), (2, vec![2, 6])]);
         }
 
-        coordination.publish_backfill(8);
+        coordination
+            .publish_backfill(8, snapshot.checkpoint_seq)
+            .unwrap();
         assert_eq!(coordination.load_snapshot().nbackfills, 8);
         assert_eq!(coordination.bump_checkpoint_epoch(), 5);
         assert_eq!(coordination.checkpoint_epoch(), 6);
@@ -7310,6 +7430,38 @@ pub mod test {
         }
         assert!(guard.runtime.frame_cache.lock().is_empty());
         assert!(!guard.metadata.initialized.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn test_publish_backfill_refuses_checkpoint_seq_mismatch() {
+        let (shared, _wal) = make_test_wal();
+        let coordination = make_test_coordination(&shared);
+        let snapshot = WalSnapshot {
+            max_frame: 9,
+            nbackfills: 3,
+            last_checksum: (1, 2),
+            checkpoint_seq: 7,
+            transaction_count: 4,
+        };
+        set_shared_snapshot(&shared, snapshot);
+
+        let err = coordination
+            .publish_backfill(8, snapshot.checkpoint_seq.wrapping_sub(1))
+            .expect_err("mismatched generation must refuse publish");
+        assert!(
+            matches!(err, LimboError::Busy),
+            "expected Busy on generation mismatch, got {err:?}"
+        );
+        assert_eq!(
+            coordination.load_snapshot().nbackfills,
+            3,
+            "nbackfills must stay unchanged after refused publish"
+        );
+
+        coordination
+            .publish_backfill(8, snapshot.checkpoint_seq)
+            .expect("matching generation must publish");
+        assert_eq!(coordination.load_snapshot().nbackfills, 8);
     }
 
     #[test]

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -122,7 +122,12 @@ impl CheckpointResult {
         wal_total_backfilled: u64,
         wal_checkpoint_backfilled: u64,
     ) -> Self {
-        Self::with_checkpoint_seq(wal_max_frame, wal_total_backfilled, wal_checkpoint_backfilled, 0)
+        Self::with_checkpoint_seq(
+            wal_max_frame,
+            wal_total_backfilled,
+            wal_checkpoint_backfilled,
+            0,
+        )
     }
 
     pub fn with_checkpoint_seq(

--- a/tests/integration/wal/mod.rs
+++ b/tests/integration/wal/mod.rs
@@ -1,3 +1,4 @@
 mod test_power_loss_before_first_checkpoint;
 mod test_wal;
 mod test_wal_publish_backfill_race;
+mod test_wal_reset_stale_nbackfills;

--- a/tests/integration/wal/test_wal_reset_stale_nbackfills.rs
+++ b/tests/integration/wal/test_wal_reset_stale_nbackfills.rs
@@ -67,6 +67,14 @@ fn assert_integrity_ok(conn: &Arc<Connection>, context: &str) {
 
 /// Without post-lock re-sample of `nbackfills`, checkpoint A can publish a
 /// watermark that skips low frames of a restarted WAL generation.
+///
+/// Proof shape (must fail without the Start-path re-sample):
+/// - Partial backfill leaves stale floor `P = nbackfills > 0`.
+/// - Hook restarts WAL and writes a new generation with frame count `N > P`.
+/// - Stale `min_frame = P+1` would skip frames `[1, P]` of the new gen and can
+///   still publish `nbackfills = N` (seq check alone does not catch this once
+///   the post-lock snapshot is already the new generation).
+/// - With the fix, range is rebased to `[1, N']` and no rows are lost.
 #[test]
 fn wal_reset_stale_prelock_nbackfills_does_not_lose_frames() {
     let tmp = TempDatabase::new("wal-reset-stale-nbackfills.db");
@@ -80,7 +88,6 @@ fn wal_reset_stale_prelock_nbackfills_does_not_lose_frames() {
     // Batch 1: enough pages that a pinned reader leaves a partial backfill window.
     const BATCH1: i64 = 80;
     const BATCH2: i64 = 120;
-    const NEW_GEN: i64 = 200;
 
     exec(&a, "BEGIN").unwrap();
     for i in 0..BATCH1 {
@@ -109,7 +116,7 @@ fn wal_reset_stale_prelock_nbackfills_does_not_lose_frames() {
     }
     exec(&a, "COMMIT").unwrap();
 
-    // Partial backfill under the pinned reader.
+    // Partial backfill under the pinned reader. `ckpt_frames` is the stale floor P.
     let partial = exec_ints(&c, "PRAGMA wal_checkpoint(PASSIVE)").unwrap();
     assert_eq!(partial.first().copied(), Some(0), "partial checkpoint busy flag: {partial:?}");
     let log_frames = partial.get(1).copied().unwrap_or(0);
@@ -117,6 +124,14 @@ fn wal_reset_stale_prelock_nbackfills_does_not_lose_frames() {
     assert!(
         ckpt_frames > 0 && ckpt_frames < log_frames,
         "need partial backfill for stale-nbackfills race: log={log_frames} ckpt={ckpt_frames} raw={partial:?}"
+    );
+
+    // New-gen frame count must exceed stale floor P. With ~1 page/row, rows = P + margin
+    // ensures a poisoned min_frame=P+1 still has frames to "checkpoint" and can hide data.
+    let new_gen_rows = ckpt_frames + 80;
+    assert!(
+        new_gen_rows > ckpt_frames,
+        "new generation must outgrow stale floor P={ckpt_frames}"
     );
 
     let hook_ran = Arc::new(AtomicBool::new(false));
@@ -135,9 +150,11 @@ fn wal_reset_stale_prelock_nbackfills_does_not_lose_frames() {
             "RESTART checkpoint must succeed inside hook: {full:?}"
         );
 
-        // New generation with enough frames that a stale min_frame would skip early ones.
+        // New generation large enough that stale min_frame=P+1 would skip early frames.
+        // Do not checkpoint here: that would backfill the new gen before A takes the lock
+        // and collapse the race window.
         exec(&writer, "BEGIN").unwrap();
-        for i in 0..NEW_GEN {
+        for i in 0..new_gen_rows {
             let id = 1_000_000 + i;
             exec(
                 &writer,
@@ -164,24 +181,48 @@ fn wal_reset_stale_prelock_nbackfills_does_not_lose_frames() {
         "checkpoint A must not fail after re-basing on the new generation: {after:?}"
     );
 
-    let expected_total = BATCH1 + BATCH2 + NEW_GEN;
+    // Checkpoint result is (busy, log, checkpointed). After a correct re-base onto the
+    // new generation, checkpointed is a prefix of that generation's log — never larger.
+    let after_log = after.get(1).copied().unwrap_or(0);
+    let after_ckpt = after.get(2).copied().unwrap_or(0);
+    assert!(
+        after_ckpt <= after_log,
+        "watermark cannot exceed WAL log: log={after_log} ckpt={after_ckpt} P={ckpt_frames} raw={after:?}"
+    );
+    // With ~1 frame per large blob row, new-gen log should exceed stale floor P. If the
+    // log shrank below P the stale min_frame path does no work and the test can false-pass.
+    assert!(
+        after_log > ckpt_frames,
+        "post-race WAL log ({after_log}) must exceed stale floor P={ckpt_frames} so a poisoned \
+         min_frame=P+1 would still attempt a partial new-gen backfill: {after:?}"
+    );
+
+    let expected_total = BATCH1 + BATCH2 + new_gen_rows;
     let count = exec_ints(&a, "SELECT count(*) FROM t").unwrap();
     assert_eq!(
         count,
         vec![expected_total],
-        "all committed rows must survive the WAL-reset race"
+        "all committed rows must survive the WAL-reset race (P={ckpt_frames}, new_gen={new_gen_rows}, \
+         after={after:?})"
     );
 
     let new_gen_count = exec_ints(
         &a,
-        "SELECT count(*) FROM t WHERE id >= 1000000 AND id < 1000000 + 100000",
+        &format!(
+            "SELECT count(*) FROM t WHERE id >= 1000000 AND id < {}",
+            1_000_000 + new_gen_rows
+        ),
     )
     .unwrap();
     assert_eq!(
         new_gen_count,
-        vec![NEW_GEN],
+        vec![new_gen_rows],
         "new-generation rows must all be visible"
     );
+
+    // Pre-reset rows were fully checkpointed by RESTART inside the hook.
+    let low_id = exec_ints(&a, "SELECT count(*) FROM t WHERE id < 1000000").unwrap();
+    assert_eq!(low_id, vec![BATCH1 + BATCH2], "pre-reset rows must remain");
 
     assert_integrity_ok(&a, "after WAL-reset stale-nbackfills race");
 

--- a/tests/integration/wal/test_wal_reset_stale_nbackfills.rs
+++ b/tests/integration/wal/test_wal_reset_stale_nbackfills.rs
@@ -62,7 +62,11 @@ fn assert_integrity_ok(conn: &Arc<Connection>, context: &str) {
             r => panic!("unexpected integrity_check step: {r:?}"),
         }
     }
-    assert_eq!(rows, vec!["ok".to_string()], "integrity_check failed {context}");
+    assert_eq!(
+        rows,
+        vec!["ok".to_string()],
+        "integrity_check failed {context}"
+    );
 }
 
 /// Without post-lock re-sample of `nbackfills`, checkpoint A can publish a
@@ -118,7 +122,11 @@ fn wal_reset_stale_prelock_nbackfills_does_not_lose_frames() {
 
     // Partial backfill under the pinned reader. `ckpt_frames` is the stale floor P.
     let partial = exec_ints(&c, "PRAGMA wal_checkpoint(PASSIVE)").unwrap();
-    assert_eq!(partial.first().copied(), Some(0), "partial checkpoint busy flag: {partial:?}");
+    assert_eq!(
+        partial.first().copied(),
+        Some(0),
+        "partial checkpoint busy flag: {partial:?}"
+    );
     let log_frames = partial.get(1).copied().unwrap_or(0);
     let ckpt_frames = partial.get(2).copied().unwrap_or(0);
     assert!(
@@ -143,7 +151,8 @@ fn wal_reset_stale_prelock_nbackfills_does_not_lose_frames() {
         // Release the pin so RESTART can finish a full checkpoint and reset the WAL.
         drop(parked_reader.take());
 
-        let full = exec_ints(&writer, "PRAGMA wal_checkpoint(RESTART)").expect("restart checkpoint");
+        let full =
+            exec_ints(&writer, "PRAGMA wal_checkpoint(RESTART)").expect("restart checkpoint");
         assert_eq!(
             full.first().copied(),
             Some(0),

--- a/tests/integration/wal/test_wal_reset_stale_nbackfills.rs
+++ b/tests/integration/wal/test_wal_reset_stale_nbackfills.rs
@@ -1,0 +1,200 @@
+//! Regression for the SQLite WAL-reset / Tailscale bug class:
+//! a checkpointer must not use pre-lock `nbackfills` as `min_frame` after a
+//! concurrent full checkpoint + WAL restart rewrites the generation.
+
+use crate::common::TempDatabase;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use turso_core::vdbe::StepResult;
+use turso_core::{set_checkpoint_start_before_lock_hook, Connection, Result};
+
+fn step_blocking(stmt: &mut turso_core::Statement) -> Result<StepResult> {
+    loop {
+        match stmt.step()? {
+            StepResult::IO => stmt._io().step()?,
+            StepResult::Yield => continue,
+            other => return Ok(other),
+        }
+    }
+}
+
+fn exec(conn: &Arc<Connection>, sql: &str) -> Result<()> {
+    let mut stmt = conn.prepare(sql)?;
+    match step_blocking(&mut stmt)? {
+        StepResult::Done | StepResult::Row => Ok(()),
+        r => panic!("unexpected step result for `{sql}`: {r:?}"),
+    }
+}
+
+fn exec_ints(conn: &Arc<Connection>, sql: &str) -> Result<Vec<i64>> {
+    let mut stmt = conn.prepare(sql)?;
+    let mut out = Vec::new();
+    loop {
+        match stmt.step()? {
+            StepResult::IO => stmt._io().step()?,
+            StepResult::Yield => continue,
+            StepResult::Row => {
+                let row = stmt.row().unwrap();
+                for value in row.get_values() {
+                    if let turso_core::Value::Numeric(turso_core::Numeric::Integer(i)) = value {
+                        out.push(*i);
+                    }
+                }
+            }
+            StepResult::Done => break,
+            r => panic!("unexpected step result: {r:?}"),
+        }
+    }
+    Ok(out)
+}
+
+fn assert_integrity_ok(conn: &Arc<Connection>, context: &str) {
+    let mut stmt = conn.prepare("PRAGMA integrity_check").unwrap();
+    let mut rows = Vec::new();
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::IO => stmt._io().step().unwrap(),
+            StepResult::Yield => continue,
+            StepResult::Row => {
+                rows.push(stmt.row().unwrap().get::<String>(0).unwrap());
+            }
+            StepResult::Done => break,
+            r => panic!("unexpected integrity_check step: {r:?}"),
+        }
+    }
+    assert_eq!(rows, vec!["ok".to_string()], "integrity_check failed {context}");
+}
+
+/// Without post-lock re-sample of `nbackfills`, checkpoint A can publish a
+/// watermark that skips low frames of a restarted WAL generation.
+#[test]
+fn wal_reset_stale_prelock_nbackfills_does_not_lose_frames() {
+    let tmp = TempDatabase::new("wal-reset-stale-nbackfills.db");
+    let a = tmp.connect_limbo();
+    let b = tmp.connect_limbo();
+    let c = tmp.connect_limbo();
+
+    exec(&a, "PRAGMA journal_mode=WAL").unwrap();
+    exec(&a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB)").unwrap();
+
+    // Batch 1: enough pages that a pinned reader leaves a partial backfill window.
+    const BATCH1: i64 = 80;
+    const BATCH2: i64 = 120;
+    const NEW_GEN: i64 = 200;
+
+    exec(&a, "BEGIN").unwrap();
+    for i in 0..BATCH1 {
+        exec(&a, &format!("INSERT INTO t VALUES ({i}, zeroblob(3000))")).unwrap();
+    }
+    exec(&a, "COMMIT").unwrap();
+
+    // Pin a read mark so a passive checkpoint cannot backfill everything.
+    let mut reader = b.prepare("SELECT id FROM t").unwrap();
+    loop {
+        match reader.step().unwrap() {
+            StepResult::IO => reader._io().step().unwrap(),
+            StepResult::Yield => continue,
+            StepResult::Row => break,
+            r => panic!("unexpected while parking reader: {r:?}"),
+        }
+    }
+
+    exec(&a, "BEGIN").unwrap();
+    for i in 0..BATCH2 {
+        exec(
+            &a,
+            &format!("INSERT INTO t VALUES ({}, zeroblob(3000))", BATCH1 + i),
+        )
+        .unwrap();
+    }
+    exec(&a, "COMMIT").unwrap();
+
+    // Partial backfill under the pinned reader.
+    let partial = exec_ints(&c, "PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+    assert_eq!(partial.first().copied(), Some(0), "partial checkpoint busy flag: {partial:?}");
+    let log_frames = partial.get(1).copied().unwrap_or(0);
+    let ckpt_frames = partial.get(2).copied().unwrap_or(0);
+    assert!(
+        ckpt_frames > 0 && ckpt_frames < log_frames,
+        "need partial backfill for stale-nbackfills race: log={log_frames} ckpt={ckpt_frames} raw={partial:?}"
+    );
+
+    let hook_ran = Arc::new(AtomicBool::new(false));
+    let hook_ran_flag = hook_ran.clone();
+    let writer = c.clone();
+    let mut parked_reader = Some(reader);
+
+    set_checkpoint_start_before_lock_hook(Some(Box::new(move || {
+        // Release the pin so RESTART can finish a full checkpoint and reset the WAL.
+        drop(parked_reader.take());
+
+        let full = exec_ints(&writer, "PRAGMA wal_checkpoint(RESTART)").expect("restart checkpoint");
+        assert_eq!(
+            full.first().copied(),
+            Some(0),
+            "RESTART checkpoint must succeed inside hook: {full:?}"
+        );
+
+        // New generation with enough frames that a stale min_frame would skip early ones.
+        exec(&writer, "BEGIN").unwrap();
+        for i in 0..NEW_GEN {
+            let id = 1_000_000 + i;
+            exec(
+                &writer,
+                &format!("INSERT INTO t VALUES ({id}, zeroblob(3000))"),
+            )
+            .unwrap();
+        }
+        exec(&writer, "COMMIT").unwrap();
+        hook_ran_flag.store(true, Ordering::Release);
+    })));
+
+    // Checkpoint A samples the partial snapshot, then the hook restarts the WAL.
+    let after = exec_ints(&a, "PRAGMA wal_checkpoint(PASSIVE)");
+    set_checkpoint_start_before_lock_hook(None);
+
+    assert!(
+        hook_ran.load(Ordering::Acquire),
+        "pre-lock hook must run (checkpoint A should have seen work before the race window)"
+    );
+    let after = after.expect("checkpoint A after WAL-reset race");
+    assert_eq!(
+        after.first().copied(),
+        Some(0),
+        "checkpoint A must not fail after re-basing on the new generation: {after:?}"
+    );
+
+    let expected_total = BATCH1 + BATCH2 + NEW_GEN;
+    let count = exec_ints(&a, "SELECT count(*) FROM t").unwrap();
+    assert_eq!(
+        count,
+        vec![expected_total],
+        "all committed rows must survive the WAL-reset race"
+    );
+
+    let new_gen_count = exec_ints(
+        &a,
+        "SELECT count(*) FROM t WHERE id >= 1000000 AND id < 1000000 + 100000",
+    )
+    .unwrap();
+    assert_eq!(
+        new_gen_count,
+        vec![NEW_GEN],
+        "new-generation rows must all be visible"
+    );
+
+    assert_integrity_ok(&a, "after WAL-reset stale-nbackfills race");
+
+    // Force recovery path: close and reopen.
+    drop(a);
+    drop(b);
+    drop(c);
+    let a2 = tmp.connect_limbo();
+    let count2 = exec_ints(&a2, "SELECT count(*) FROM t").unwrap();
+    assert_eq!(
+        count2,
+        vec![expected_total],
+        "row count must survive reopen/recovery"
+    );
+    assert_integrity_ok(&a2, "after reopen following WAL-reset race");
+}


### PR DESCRIPTION
## Summary

Fixes the SQLite WAL-reset bug class described by Tailscale:

https://tailscale.com/blog/sqlite-wal-reset-bug

In SQLite, a checkpointer could publish a stale `nBackfill` after another connection restarted the WAL, which could skip frames in the new generation and silently lose committed data. SQLite fixed this in 3.51.3 by detecting the reset.

Turso already holds the checkpoint guard through DB sync + `publish_backfill` (so the exact in-flight C race is largely blocked), but it still had a similar hole:

1. Checkpoint A samples `nbackfills` **before** taking the checkpoint lock and uses that sample as `min_frame`
2. Concurrently, checkpoint B finishes a full backfill and a writer restarts the WAL (new `checkpoint_seq`, `nbackfills = 0`, new frames)
3. Checkpoint A resumes with a stale floor into the new generation, skips low frames, and can later publish a watermark that hides committed work

## Fix

- Treat the pre-lock snapshot as a no-work fast path only
- After acquiring the checkpoint lock, re-sample `nbackfills` and `checkpoint_seq`
- Set `min_frame = nbackfills + 1` only from the post-lock sample
- Carry `checkpoint_seq` on `CheckpointResult`
- Make `publish_backfill(max_frame, expected_checkpoint_seq)` refuse cross-generation publishes with `Busy` and leave `nbackfills` unchanged
- Wire pager + MVCC publish paths through the generation-aware API

## Tests

- Unit: `publish_backfill` refuses mismatched `checkpoint_seq` and does not advance `nbackfills`
- Integration: one-shot hook between pre-lock sample and lock acquisition runs `RESTART` + new-generation writes, then asserts full row survival, integrity, and reopen recovery
- Confirmed the integration test fails without the Start-path re-sample (200 vs 400 rows) and passes with it
- Existing `wal_stale_publish_backfill_*` regressions still pass

## Validation

```text
cargo test -p turso_core --lib test_publish_backfill_refuses
cargo test -p turso_core --lib test_in_process_coordination_publishes
cargo test -p core_tester --test integration_tests wal_reset
cargo test -p core_tester --test integration_tests wal_stale_publish
```