### PR TITLE
core: fix affinity loss for FROM-subquery/CTE/view columns with no real type

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -5240,10 +5240,13 @@ const TYPE_MASK: u32 = 0b111 << TYPE_SHIFT;
 const COLL_SHIFT: u32 = TYPE_SHIFT + 3;
 const COLL_MASK: u32 = 0b1111_1111_1111 << COLL_SHIFT;
 
-// Bits 20-22: base type affinity override for custom type columns.
-// 0 = not set (use ty_str-based affinity), 1-5 = Affinity value + 1
+// Bits 20-22: base type affinity override.
+// 0 = not set (use ty_str-based affinity), 1-5 = Affinity value + 1,
+// 6 = no declared affinity at all (e.g. a FROM-subquery/CTE/view column
+// backed by a literal or computed expression, not a real declared type)
 const BASE_AFF_SHIFT: u32 = COLL_SHIFT + 12;
 const BASE_AFF_MASK: u32 = 0b111 << BASE_AFF_SHIFT;
+const BASE_AFF_NO_DECLARED: u32 = 6;
 
 // Bits 23-25: array dimensions (0 = scalar, 1-7 = number of [] dimensions)
 const ARRAY_DIM_SHIFT: u32 = BASE_AFF_SHIFT + 3;
@@ -5253,13 +5256,13 @@ impl Column {
     pub fn affinity(&self) -> Affinity {
         let v = ((self.raw & BASE_AFF_MASK) >> BASE_AFF_SHIFT) as u8;
         if v > 0 {
-            // Custom type column: use the base type's affinity
             match v {
                 1 => Affinity::Integer,
                 2 => Affinity::Text,
                 3 => Affinity::Blob,
                 4 => Affinity::Real,
-                _ => Affinity::Numeric,
+                5 => Affinity::Numeric,
+                _ => Affinity::Blob,
             }
         } else {
             Affinity::affinity(&self.ty_str)
@@ -5278,6 +5281,18 @@ impl Column {
             Affinity::Numeric => 5,
         };
         self.raw = (self.raw & !BASE_AFF_MASK) | ((v << BASE_AFF_SHIFT) & BASE_AFF_MASK);
+    }
+
+    /// Mark this column as backed by an expression with no real declared type
+    /// (e.g. a literal column in a FROM-subquery, CTE, or view).
+    pub fn set_no_declared_affinity(&mut self) {
+        self.raw = (self.raw & !BASE_AFF_MASK)
+            | ((BASE_AFF_NO_DECLARED << BASE_AFF_SHIFT) & BASE_AFF_MASK);
+    }
+
+    /// Whether this column has a real declared type. Always `true` for table columns.
+    pub fn has_declared_affinity(&self) -> bool {
+        ((self.raw & BASE_AFF_MASK) >> BASE_AFF_SHIFT) != BASE_AFF_NO_DECLARED
     }
     pub fn affinity_with_strict(&self, is_strict: bool) -> Affinity {
         if is_strict && self.ty_str.eq_ignore_ascii_case("ANY") {
@@ -7391,5 +7406,50 @@ mod tests {
             !schema.sequences.contains_key("broken_seq"),
             "rejected descriptor must not land in the sequences map",
         );
+    }
+
+    fn new_blob_column() -> Column {
+        Column::new(
+            Some("x".to_string()),
+            "BLOB".to_string(),
+            None,
+            None,
+            Type::Blob,
+            None,
+            ColDef::default(),
+        )
+    }
+
+    #[test]
+    fn column_has_declared_affinity_by_default() {
+        let col = new_blob_column();
+        assert!(col.has_declared_affinity());
+        assert_eq!(col.affinity(), Affinity::Blob);
+    }
+
+    #[test]
+    fn column_set_no_declared_affinity_reports_no_affinity() {
+        let mut col = new_blob_column();
+        col.set_no_declared_affinity();
+        assert!(!col.has_declared_affinity());
+        // Still resolves to BLOB at the runtime-conversion level.
+        assert_eq!(col.affinity(), Affinity::Blob);
+    }
+
+    #[test]
+    fn column_set_base_affinity_still_has_declared_affinity() {
+        let mut col = new_blob_column();
+        col.set_base_affinity(Affinity::Real);
+        assert!(col.has_declared_affinity());
+        assert_eq!(col.affinity(), Affinity::Real);
+    }
+
+    #[test]
+    fn column_no_declared_affinity_can_be_overwritten_by_base_affinity() {
+        let mut col = new_blob_column();
+        col.set_no_declared_affinity();
+        col.set_base_affinity(Affinity::Integer);
+        assert!(col.has_declared_affinity());
+        assert_eq!(col.affinity(), Affinity::Integer);
     }
 }

--- a/core/translate/expr/affinity.rs
+++ b/core/translate/expr/affinity.rs
@@ -51,18 +51,26 @@ pub(crate) struct ExprAffinityInfo {
 }
 
 impl ExprAffinityInfo {
-    const fn with_affinity(affinity: Affinity) -> Self {
+    pub(crate) const fn with_affinity(affinity: Affinity) -> Self {
         Self {
             affinity,
             has_affinity: true,
         }
     }
 
-    const fn no_affinity() -> Self {
+    pub(crate) const fn no_affinity() -> Self {
         Self {
             affinity: Affinity::Blob,
             has_affinity: false,
         }
+    }
+
+    pub(crate) const fn affinity(&self) -> Affinity {
+        self.affinity
+    }
+
+    pub(crate) const fn has_affinity(&self) -> bool {
+        self.has_affinity
     }
 }
 
@@ -83,6 +91,9 @@ pub(crate) fn get_expr_affinity_info(
             if let Some(tables) = referenced_tables {
                 if let Some((_, table_ref)) = tables.find_table_by_internal_id(*table) {
                     if let Some(col) = table_ref.get_column_at(*column) {
+                        if !col.has_declared_affinity() {
+                            return ExprAffinityInfo::no_affinity();
+                        }
                         if let Some(btree) = table_ref.btree() {
                             return ExprAffinityInfo::with_affinity(
                                 col.affinity_with_strict(btree.is_strict),

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -3,12 +3,15 @@ use crate::{
     function::{AccumulatorFunc, AggFunc},
     schema::{
         BTreeTable, ColDef, Column, FromClauseSubquery, Index, PseudoCursorType, RecursiveCteInput,
-        Schema, Table, Type, ROWID_SENTINEL,
+        Schema, Table, ROWID_SENTINEL,
     },
     translate::{
         collate::{get_collseq_from_expr, CollationSeq},
         emitter::UpdateRowSource,
-        expr::{as_binary_components, expr_data_type, get_expr_affinity, StorageClassMask},
+        expr::{
+            as_binary_components, expr_data_type, get_expr_affinity, get_expr_affinity_info,
+            ExprAffinityInfo, StorageClassMask,
+        },
         expression_index::{normalize_expr_for_index_matching, single_table_column_usage},
         optimizer::constraints::{BinaryExprSide, SeekRangeConstraint},
         planner::determine_where_to_eval_term,
@@ -34,18 +37,18 @@ use turso_parser::ast::TableInternalId;
 
 use super::emitter::OperationMode;
 
-/// Infer the Type from an expression's affinity.
+/// Infer the affinity of a subquery result column from its expression.
 ///
 /// Used for subquery result columns. SQLite derives column affinity from:
 /// - Column references: the declared column type
 /// - CAST expressions: the cast target type
 /// - Subqueries: recursively from the subquery's result expression
-/// - Literals: BLOB affinity (no affinity)
+/// - Literals, function calls, and other computed expressions: no affinity
 ///
-/// The affinity determines comparison behavior in IN expressions, etc.
-fn infer_type_from_expr(expr: &ast::Expr, tables: Option<&TableReferences>) -> Type {
-    let affinity = get_expr_affinity(expr, tables, None);
-    affinity.to_type()
+/// The affinity (and whether it's a real declared one) determines comparison
+/// behavior in IN expressions, etc.
+fn infer_type_from_expr(expr: &ast::Expr, tables: Option<&TableReferences>) -> ExprAffinityInfo {
+    get_expr_affinity_info(expr, tables, None)
 }
 
 /// Computes the affinity of column `i` of a compound (UNION/INTERSECT/EXCEPT)
@@ -58,15 +61,15 @@ fn infer_type_from_expr(expr: &ast::Expr, tables: Option<&TableReferences>) -> T
 /// (TEXT affinity + a numeric arm, or numeric affinity + a text arm), in which
 /// case it is downgraded to BLOB (none) so the column is compared by storage
 /// class.
-fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> Affinity {
+fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> ExprAffinityInfo {
     if arms.is_empty() {
-        return Affinity::Blob;
+        return ExprAffinityInfo::no_affinity();
     }
-    let col_affinity = |arm: &SelectPlan| {
+    let col_info = |arm: &SelectPlan| {
         arm.result_columns
             .get(i)
-            .map(|rc| get_expr_affinity(&rc.expr, Some(&arm.table_references), None))
-            .unwrap_or(Affinity::Blob)
+            .map(|rc| get_expr_affinity_info(&rc.expr, Some(&arm.table_references), None))
+            .unwrap_or_else(ExprAffinityInfo::no_affinity)
     };
     let col_data_type = |arm: &SelectPlan| {
         arm.result_columns
@@ -75,26 +78,30 @@ fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> Affinity {
             .unwrap_or(StorageClassMask::from_null())
     };
 
-    let mut affinity = col_affinity(arms[0]);
+    let mut info = col_info(arms[0]);
     let mut data_types = StorageClassMask::from_null();
     let mut idx = 0;
     // Skip leading arms with no affinity, adopting the next arm's affinity.
-    while matches!(affinity, Affinity::Blob) && idx + 1 < arms.len() {
+    while !info.has_affinity() && idx + 1 < arms.len() {
         data_types |= col_data_type(arms[idx]);
         idx += 1;
-        affinity = col_affinity(arms[idx]);
+        info = col_info(arms[idx]);
     }
-    if matches!(affinity, Affinity::Blob) {
-        return Affinity::Blob;
+    if !info.has_affinity() {
+        return ExprAffinityInfo::no_affinity();
     }
-    // `affinity` is TEXT or numeric here; accumulate the remaining arms' classes.
+    // `info` has TEXT or numeric affinity here; accumulate the remaining arms' classes.
     for &arm in &arms[idx + 1..] {
         data_types |= col_data_type(arm);
     }
-    match affinity {
-        Affinity::Text if data_types.has_numeric() => Affinity::Blob,
-        a if a.is_numeric() && data_types.has_text() => Affinity::Blob,
-        a => a,
+    match info.affinity() {
+        Affinity::Text if data_types.has_numeric() => {
+            ExprAffinityInfo::with_affinity(Affinity::Blob)
+        }
+        a if a.is_numeric() && data_types.has_text() => {
+            ExprAffinityInfo::with_affinity(Affinity::Blob)
+        }
+        _ => info,
     }
 }
 
@@ -2447,13 +2454,14 @@ fn query_output_columns(
             let name = explicit_columns
                 .and_then(|names| names.get(column_index).cloned())
                 .or_else(|| result_column.name(table_references).map(String::from));
-            let column_type = compound_arms
+            let affinity_info = compound_arms
                 .as_ref()
-                .map(|arms| compound_column_affinity(arms, column_index).to_type())
+                .map(|arms| compound_column_affinity(arms, column_index))
                 .unwrap_or_else(|| {
                     infer_type_from_expr(&result_column.expr, Some(table_references))
                 });
-            Column::new(
+            let column_type = affinity_info.affinity().to_type();
+            let mut column = Column::new(
                 name,
                 column_type.to_string(),
                 None,
@@ -2461,7 +2469,11 @@ fn query_output_columns(
                 column_type,
                 None,
                 ColDef::default(),
-            )
+            );
+            if !affinity_info.has_affinity() {
+                column.set_no_declared_affinity();
+            }
+            column
         })
         .try_collect::<alloc::Vec<_>>()?;
 
@@ -2507,17 +2519,21 @@ impl JoinedTable {
             .result_columns
             .iter()
             .map(|rc| {
-                let col_type = infer_type_from_expr(&rc.expr, Some(&plan.table_references));
-                let type_name = col_type.to_string();
-                Column::new(
+                let affinity_info = infer_type_from_expr(&rc.expr, Some(&plan.table_references));
+                let col_type = affinity_info.affinity().to_type();
+                let mut column = Column::new(
                     rc.name(&plan.table_references).map(String::from),
-                    type_name,
+                    col_type.to_string(),
                     None,
                     None,
                     col_type,
                     None,
                     ColDef::default(),
-                )
+                );
+                if !affinity_info.has_affinity() {
+                    column.set_no_declared_affinity();
+                }
+                column
             })
             .try_collect::<alloc::Vec<_>>()?;
 

--- a/sqlite/conformance/sqlite-sqltests/from-subquery-affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/from-subquery-affinity.sqltest
@@ -76,6 +76,30 @@ expect {
 1
 }
 
+@setup text-column-derived-table-schema
+test derived-table-literal-column-join-on-converts-reversed-operands {
+    SELECT t1.a FROM t1 JOIN (SELECT 1 AS x) d ON d.x = t1.a;
+}
+expect {
+1
+}
+
+@setup text-column-derived-table-schema
+test derived-table-literal-column-scalar-equality-converts {
+    SELECT a FROM t1 WHERE a = (SELECT x FROM (SELECT 1 AS x));
+}
+expect {
+1
+}
+
+@setup text-column-derived-table-schema
+test derived-table-literal-column-range-comparison-converts {
+    SELECT a FROM t1 WHERE a < (SELECT x FROM (SELECT 2 AS x)) ORDER BY a;
+}
+expect {
+1
+}
+
 # Same bug, reached through a UNION where every arm is a bare literal.
 @setup text-column-derived-table-schema
 test derived-table-compound-select-all-literal-arms-converts {
@@ -102,4 +126,19 @@ test derived-table-real-column-keeps-declared-affinity {
 }
 expect {
 1
+}
+
+setup blob-and-text-tables-schema {
+    CREATE TABLE blobcol(x BLOB);
+    INSERT INTO blobcol VALUES(3);
+    CREATE TABLE t4(a TEXT);
+    INSERT INTO t4 VALUES('3');
+}
+
+@setup blob-and-text-tables-schema
+test derived-table-compound-select-real-blob-leading-arm-not-skipped {
+    WITH u(x) AS (SELECT x FROM blobcol UNION ALL SELECT 'unused_arm')
+    SELECT a FROM t4 WHERE a IN (SELECT x FROM u);
+}
+expect {
 }

--- a/sqlite/conformance/sqlite-sqltests/from-subquery-affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/from-subquery-affinity.sqltest
@@ -1,0 +1,105 @@
+@database :memory:
+
+# A column from a derived table, CTE, or view that comes from a literal or
+# computed expression has no real declared type. Comparing it against a TEXT
+# column should convert it to TEXT first, same as SQLite does. Turso was
+# skipping that conversion, treating the column as if it had a real BLOB
+# type instead, so these comparisons quietly returned the wrong rows.
+# Regression tests for https://github.com/tursodatabase/turso/issues/8317
+
+setup orders-status-cte-schema {
+    CREATE TABLE orders(order_id INTEGER, status_code TEXT);
+    INSERT INTO orders VALUES (1, '1'), (2, '2'), (3, '3');
+}
+
+@setup orders-status-cte-schema
+test cte-literal-column-join-converts-status-code {
+    WITH status_labels(code, label) AS (
+        SELECT 1, 'Active'
+        UNION ALL SELECT 2, 'Cancelled'
+        UNION ALL SELECT 3, 'Pending'
+    )
+    SELECT o.order_id, sl.label
+    FROM orders o
+    JOIN status_labels sl ON o.status_code = sl.code
+    ORDER BY o.order_id;
+}
+expect {
+1|Active
+2|Cancelled
+3|Pending
+}
+
+setup phone-normalization-view-schema {
+    CREATE TABLE contacts(phone TEXT);
+    INSERT INTO contacts VALUES ('4155551234');
+    CREATE TABLE call_log(raw_number INTEGER);
+    INSERT INTO call_log VALUES (14155551234);
+    CREATE VIEW normalized_calls AS SELECT raw_number - 10000000000 AS phone FROM call_log;
+}
+
+@setup phone-normalization-view-schema
+test view-computed-column-in-subquery-converts-phone {
+    SELECT phone FROM contacts WHERE phone IN (SELECT phone FROM normalized_calls);
+}
+expect {
+4155551234
+}
+
+setup text-column-derived-table-schema {
+    CREATE TABLE t1(a TEXT);
+    INSERT INTO t1 VALUES('1'),('2'),('3');
+}
+
+@setup text-column-derived-table-schema
+test derived-table-literal-column-in-matches {
+    SELECT a FROM t1 WHERE a IN (SELECT x FROM (SELECT 1 AS x));
+}
+expect {
+1
+}
+
+@setup text-column-derived-table-schema
+test derived-table-literal-column-not-in-excludes-match {
+    SELECT a FROM t1 WHERE a NOT IN (SELECT x FROM (SELECT 1 AS x)) ORDER BY a;
+}
+expect {
+2
+3
+}
+
+@setup text-column-derived-table-schema
+test derived-table-literal-column-join-on-converts {
+    SELECT t1.a FROM t1 JOIN (SELECT 1 AS x) d ON t1.a = d.x;
+}
+expect {
+1
+}
+
+# Same bug, reached through a UNION where every arm is a bare literal.
+@setup text-column-derived-table-schema
+test derived-table-compound-select-all-literal-arms-converts {
+    SELECT a FROM t1
+    WHERE a IN (SELECT x FROM (SELECT 1 AS x UNION ALL SELECT 2 AS x))
+    ORDER BY a;
+}
+expect {
+1
+2
+}
+
+# Control: a derived table wrapping a real column must still convert.
+setup text-and-integer-tables-schema {
+    CREATE TABLE t1(a TEXT);
+    INSERT INTO t1 VALUES('1'),('2'),('3');
+    CREATE TABLE t3(x INTEGER);
+    INSERT INTO t3 VALUES(1);
+}
+
+@setup text-and-integer-tables-schema
+test derived-table-real-column-keeps-declared-affinity {
+    SELECT a FROM t1 WHERE a IN (SELECT x FROM (SELECT x FROM t3));
+}
+expect {
+1
+}


### PR DESCRIPTION
## Description

Fixes affinity handling for columns coming from a FROM-clause
subquery, CTE, or view when the underlying expression has no real
declared type, such as a literal, a computed expression, or a
function call.

Example:

    CREATE TABLE t1(a TEXT);
    INSERT INTO t1 VALUES('1');
    SELECT a FROM t1 WHERE a IN (SELECT x FROM (SELECT 1 AS x));

SQLite returns 1. Turso returned nothing, because the TEXT
conversion on the right side got skipped.

The fix adds a new value to Column's existing BASE_AFF override
bitfield to mark a column with no real declared affinity, and
threads that information through the two places that build synthetic
columns for derived tables, infer_type_from_expr and
compound_column_affinity, instead of throwing it away like before.

## Motivation and context

Tracked as issue #8317 . It affects any query that filters or joins
through a derived table, CTE, or view column with no real declared
type, quietly returning the wrong rows instead of crashing, so it's
easy to miss without dedicated test coverage.

## Description of AI Usage

Used Claude Code to help me find the root cause, write the fix, and add
tests. Verified manually against SQLite's affinity rules and by
comparing EXPLAIN bytecode before and after the fix. Confirmed all
new tests fail before the fix and pass after.