### PR TITLE
fix: fold sign in atanh to match glibc precision

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -61,8 +61,23 @@ mod cmath {
     pub fn atan(x: f64) -> f64 {
         x.atan()
     }
+    // Mirror glibc algorithm to prevent SQLite divergence at negatives
     pub fn atanh(x: f64) -> f64 {
-        x.atanh()
+        let xa = x.abs();
+        if xa < 0.5 {
+            // 0x1p-28: below this, atanh(x) == x to double precision
+            if xa < f64::from_bits(0x3E30000000000000) {
+                return x;
+            }
+            let t = xa + xa;
+            (0.5 * (t + t * xa / (1.0 - xa)).ln_1p()).copysign(x)
+        } else if xa < 1.0 {
+            (0.5 * ((xa + xa) / (1.0 - xa)).ln_1p()).copysign(x)
+        } else if xa > 1.0 {
+            f64::NAN
+        } else {
+            x / 0.0
+        }
     }
     pub fn atan2(x: f64, y: f64) -> f64 {
         x.atan2(y)


### PR DESCRIPTION
## Description
Copes glibc's implementation of `atanh` used in SQLite on CI.

## Motivation and context
[This issue](https://github.com/tursodatabase/turso/issues/5165) is caused by a difference in implementation between glibc and Rust's std - Rust passes the value right through rather than taking the absolute value and applying the sign later, leading to more error due to log1p's asymptote at x=-1.

## Description of AI Usage
Used to compare different log1p approaches during investigation