### PR TITLE
fix: fold sign in atanh to match fdlibm algorithm

### DIFF
--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -65,8 +65,8 @@ mod cmath {
     pub fn atanh(x: f64) -> f64 {
         let xa = x.abs();
         if xa < 0.5 {
-            // 0x1p-28: below this, atanh(x) == x to double precision
-            if xa < f64::from_bits(0x3E30000000000000) {
+            // 2^-28: below this, atanh(x) == x to double precision
+            if xa < 1.0 / 268_435_456.0 {
                 return x;
             }
             let t = xa + xa;

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -61,8 +61,23 @@ mod cmath {
     pub fn atan(x: f64) -> f64 {
         x.atan()
     }
+    // Mirror glibc algorithm to prevent SQLite divergence at negatives
     pub fn atanh(x: f64) -> f64 {
-        x.atanh()
+        let xa = x.abs();
+        if xa < 0.5 {
+            // 0x1p-28: below this, atanh(x) == x to double precision
+            if xa < f64::from_bits(0x3E30000000000000) {
+                return x;
+            }
+            let t = xa + xa;
+            (0.5 * (t + t * xa / (1.0 - xa)).ln_1p()).copysign(x)
+        } else if xa < 1.0 {
+            (0.5 * ((xa + xa) / (1.0 - xa)).ln_1p()).copysign(x)
+        } else if xa > 1.0 {
+            f64::NAN
+        } else {
+            x / 0.0
+        }
     }
     pub fn atan2(x: f64, y: f64) -> f64 {
         x.atan2(y)

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -4213,6 +4213,8 @@ mod fuzz_tests {
     /// compute log(X)/log(B) exactly like SQLite's logFunc instead of
     /// special-casing bases 2 and 10. mod() with a huge dividend amplifies any
     /// 1-ulp difference in the modulus far beyond fuzzer tolerance.
+    /// atanh() folds the sign before applying log1p rather than passing negative
+    /// values, since Rust's std diverges from glibc near log1p's asymptote at x=-1.
     #[turso_macros::test(mvcc)]
     pub fn math_ex(db: TempDatabase) {
         let _ = env_logger::try_init();
@@ -4228,6 +4230,10 @@ mod fuzz_tests {
             "SELECT log(0.5, 3.0)",
             "SELECT log(1.0, 3.0)",
             "SELECT mod(cosh(-2.0 - (0.5) * (-2.0 / 2.0 + (0.5) - degrees(1.0))), log10(2.0))",
+            "SELECT trunc(atanh(tanh(-2.0)))",
+            "SELECT atanh(-0.25)",
+            "SELECT atanh(0.25)",
+            "SELECT atanh(-0.9999)",
         ] {
             helpers::assert_differential(&limbo_conn, &sqlite_conn, query, "");
         }


### PR DESCRIPTION
## Description
Reimplements `atanh` using the fdlibm algorithm that SQLite gets from libm, instead of Rust's `f64::atanh`.

## Motivation and context
[This issue](https://github.com/tursodatabase/turso/issues/5165) is caused by a difference in implementation between glibc and Rust's std - Rust passes the value right through rather than taking the absolute value and applying the sign later, leading to more error due to log1p's asymptote at x=-1.

## Description of AI Usage
Used to compare different log1p approaches during investigation