### PR TITLE
core: Fix snapshot isolation violation for passive MVCC checkpoint

### DIFF
--- a/.github/workflows/elle.yml
+++ b/.github/workflows/elle.yml
@@ -31,13 +31,13 @@ env:
 
 jobs:
   elle-check:
-    name: Elle ${{ matrix.elle_model }} (${{ matrix.mvcc && 'MVCC' || 'default' }})
+    name: Elle ${{ matrix.elle_model }} (${{ matrix.mode }})
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        mvcc: [false, true]
+        mode: [default, mvcc, mvcc-passive]
         elle_model: [list-append, rw-register]
     steps:
       - uses: actions/checkout@v4
@@ -81,8 +81,13 @@ jobs:
           MAX_STEPS="${{ github.event.inputs.max_steps }}"
           MAX_STEPS="${MAX_STEPS:-100000}"
           MVCC_FLAG=""
-          if [ "${{ matrix.mvcc }}" = "true" ]; then
+          if [ "${{ matrix.mode }}" != "default" ]; then
             MVCC_FLAG="--enable-mvcc"
+          fi
+          if [ "${{ matrix.mode }}" = "mvcc-passive" ]; then
+            # Elle workloads write the logical log slowly; lower the checkpoint
+            # threshold so passive checkpoints actually fire during the run.
+            MVCC_FLAG="$MVCC_FLAG --enable-experimental-mvcc-passive-checkpoint --mvcc-checkpoint-threshold 1024"
           fi
           ./target/debug/turso_whopper \
             --elle ${{ matrix.elle_model }} \
@@ -125,7 +130,7 @@ jobs:
           echo "History size: $(wc -l < elle-history.edn) events"
           echo ""
           CONSISTENCY_FLAG="--consistency-models serializable"
-          if [ "${{ matrix.mvcc }}" = "true" ]; then
+          if [ "${{ matrix.mode }}" != "default" ]; then
             CONSISTENCY_FLAG="--consistency-models snapshot-isolation"
           fi
           java -jar "$ELLE_JAR" --model ${{ matrix.elle_model }} $CONSISTENCY_FLAG --verbose --directory elle-results elle-history.edn
@@ -134,7 +139,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: elle-results-${{ matrix.elle_model }}-${{ matrix.mvcc && 'mvcc' || 'default' }}
+          name: elle-results-${{ matrix.elle_model }}-${{ matrix.mode }}
           path: |
             elle-history.edn
             elle-results/

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -5331,11 +5331,16 @@ impl WalFile {
     /// MVCC helper: check if WAL state changed and refresh local snapshot without starting a read tx.
     /// FIXME: this isn't TOCTOU safe because we're not taking WAL read locks.
     ///
-    /// This is only used to invalidate page cache, so false positives are sort of acceptable since
-    /// MVCC reads currently don't read from WAL frames ever.
-    /// FIXME: MVCC should start using pager read transactions anyway so that we can get rid of
-    /// the stop-the-world MVCC checkpoint that blocks all reads.
+    /// No-op while this connection holds a read guard: an active read tx pinned the
+    /// connection's WAL view, and an MVCC transaction's `read_mark` was captured from it.
+    /// Advancing `max_frame` here would let the transaction's B-tree reads see pages a
+    /// passive checkpoint materialized after its snapshot, leaking later commits into it.
+    /// The guard also keeps everything at-or-below the pinned view immutable, so the page
+    /// cache stays valid and needs no invalidation.
     pub fn mvcc_refresh_if_db_changed(&self) -> bool {
+        if self.max_frame_read_lock_index.load(Ordering::Acquire) != NO_LOCK_HELD {
+            return false;
+        }
         let snapshot = self.load_coordination_snapshot();
         let local_state = self.connection_state();
         let changed = self.db_changed_against(snapshot, local_state);
@@ -7181,7 +7186,7 @@ pub mod test {
     }
 
     #[test]
-    fn test_mvcc_refresh_updates_snapshot_without_changing_read_guard() {
+    fn test_mvcc_refresh_updates_snapshot_only_when_no_read_guard_is_held() {
         let (shared, wal) = make_test_wal();
         let initial = WalSnapshot {
             max_frame: 4,
@@ -7207,13 +7212,23 @@ pub mod test {
         };
         set_shared_snapshot(&shared, updated);
 
-        assert!(wal.mvcc_refresh_if_db_changed());
+        // A held read guard pins this connection's WAL view; the refresh must not
+        // advance it past the snapshot an active transaction captured.
+        assert!(!wal.mvcc_refresh_if_db_changed());
         assert_eq!(
             wal.connection_state(),
             WalConnectionState::new(
-                updated,
+                initial,
                 ReadGuardKind::ReadMark(NonZeroUsize::new(2).unwrap())
             )
+        );
+
+        // With no read guard held the refresh picks up the new shared snapshot.
+        wal.install_connection_state(WalConnectionState::new(initial, ReadGuardKind::None));
+        assert!(wal.mvcc_refresh_if_db_changed());
+        assert_eq!(
+            wal.connection_state(),
+            WalConnectionState::new(updated, ReadGuardKind::None)
         );
     }
 

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -297,6 +297,10 @@ pub struct WhopperOpts {
     /// If true, MVCC's auto-checkpoint is disabled on the Database immediately after open.
     /// Recovery bugs need uncheckpointed schema rows to remain in the logical log to exercise recovery.
     pub disable_mvcc_auto_checkpoint: bool,
+    /// If set, overrides the MVCC auto-checkpoint threshold (bytes of logical log) on the
+    /// Database immediately after open. A small value makes checkpoints fire often enough for
+    /// short runs to exercise them. Ignored when `disable_mvcc_auto_checkpoint` is true.
+    pub mvcc_checkpoint_threshold: Option<i64>,
     /// If false, don't close connections before dropping them
     pub close_connections_gracefully: bool,
     /// Probabilty of a reopen fault.
@@ -348,6 +352,7 @@ impl Default for WhopperOpts {
             chaotic_profiles: vec![],
             schema_bias: SchemaBias::default(),
             disable_mvcc_auto_checkpoint: false,
+            mvcc_checkpoint_threshold: None,
             close_connections_gracefully: true,
             reopen_probability: 0.0,
             allocation_fault_probability: 0.0,
@@ -463,6 +468,11 @@ impl WhopperOpts {
 
     pub fn with_experimental_mvcc_passive_checkpoint(mut self, enable: bool) -> Self {
         self.experimental_mvcc_passive_checkpoint = enable;
+        self
+    }
+
+    pub fn with_mvcc_checkpoint_threshold(mut self, threshold: Option<i64>) -> Self {
+        self.mvcc_checkpoint_threshold = threshold;
         self
     }
 
@@ -649,6 +659,8 @@ pub struct Whopper {
     chaotic_profiles: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)>,
     /// Setting this to true sets `pramga mvcc_checkpoint_threshold = -1` (disabled).
     disable_mvcc_auto_checkpoint: bool,
+    /// If set, overrides the MVCC auto-checkpoint threshold (bytes of logical log) after open.
+    mvcc_checkpoint_threshold: Option<i64>,
     /// Open databases with the experimental non-blocking (passive) MVCC checkpoint enabled.
     experimental_mvcc_passive_checkpoint: bool,
     /// If false, drop fiber connections without first closing them.
@@ -809,6 +821,7 @@ impl Whopper {
             stats: Stats::default(),
             chaotic_profiles: opts.chaotic_profiles,
             disable_mvcc_auto_checkpoint: opts.disable_mvcc_auto_checkpoint,
+            mvcc_checkpoint_threshold: opts.mvcc_checkpoint_threshold,
             experimental_mvcc_passive_checkpoint: opts.experimental_mvcc_passive_checkpoint,
             close_connections_gracefully: opts.close_connections_gracefully,
             allocation_fault_injector,
@@ -1536,6 +1549,10 @@ impl Whopper {
         if self.disable_mvcc_auto_checkpoint {
             if let Some(mv_store) = db.get_mv_store().as_ref() {
                 mv_store.set_checkpoint_threshold(-1);
+            }
+        } else if let Some(threshold) = self.mvcc_checkpoint_threshold {
+            if let Some(mv_store) = db.get_mv_store().as_ref() {
+                mv_store.set_checkpoint_threshold(threshold);
             }
         }
 

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -64,6 +64,11 @@ struct Args {
     /// Enable the experimental non-blocking (passive) MVCC checkpoint (requires --enable-mvcc)
     #[arg(long)]
     enable_experimental_mvcc_passive_checkpoint: bool,
+    /// Override the MVCC auto-checkpoint threshold in bytes of logical log (requires --enable-mvcc).
+    /// Elle runs write the logical log slowly, so a small value here makes checkpoints actually
+    /// fire during the run.
+    #[arg(long)]
+    mvcc_checkpoint_threshold: Option<i64>,
     /// Enable database encryption
     #[arg(long)]
     enable_encryption: bool,
@@ -150,6 +155,12 @@ fn main() -> anyhow::Result<()> {
     if args.enable_experimental_mvcc_passive_checkpoint && !args.enable_mvcc {
         return Err(anyhow::anyhow!(
             "--enable-experimental-mvcc-passive-checkpoint requires --enable-mvcc"
+        ));
+    }
+
+    if args.mvcc_checkpoint_threshold.is_some() && !args.enable_mvcc {
+        return Err(anyhow::anyhow!(
+            "--mvcc-checkpoint-threshold requires --enable-mvcc"
         ));
     }
 
@@ -507,6 +518,7 @@ fn build_inprocess_opts(args: &Args, seed: u64) -> anyhow::Result<WhopperOpts> {
         .with_keep_files(args.keep)
         .with_enable_mvcc(args.enable_mvcc || is_schema_clone_fault_mode(&args.mode))
         .with_experimental_mvcc_passive_checkpoint(args.enable_experimental_mvcc_passive_checkpoint)
+        .with_mvcc_checkpoint_threshold(args.mvcc_checkpoint_threshold)
         .with_enable_encryption(args.enable_encryption)
         .with_elle_tables(elle_tables)
         .with_workloads(workloads)

--- a/tests/integration/mvcc.rs
+++ b/tests/integration/mvcc.rs
@@ -1628,3 +1628,40 @@ fn test_issue_7638_gc_after_abandoned_checkpoint_does_not_resurrect_row() {
     assert_eq!(index_rows, Vec::<Vec<turso_core::Value>>::new());
     assert_eq!(integrity, vec![vec![turso_core::Value::build_text("ok")]]);
 }
+
+#[test]
+fn mvcc_passive_checkpoint_must_not_leak_commits_into_pinned_snapshot() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(DatabaseOpts::new().with_experimental_mvcc_passive_checkpoint(true))
+        .with_mvcc(true)
+        .build();
+    let setup = tmp_db.connect_limbo();
+    setup
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, content TEXT)")
+        .unwrap();
+    setup
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    setup
+        .execute("INSERT INTO docs VALUES (2, 'first')")
+        .unwrap();
+
+    let writer = tmp_db.connect_limbo();
+    let pinned = tmp_db.connect_limbo();
+
+    pinned.execute("BEGIN CONCURRENT").unwrap();
+    let before: Vec<(i64,)> = pinned.exec_rows("SELECT id FROM docs ORDER BY id");
+    assert_eq!(before, vec![(2,)]);
+
+    // Commits and is immediately checkpointed (threshold 0, passive mode).
+    writer
+        .execute("INSERT INTO docs VALUES (13, 'second')")
+        .unwrap();
+
+    let after: Vec<(i64,)> = pinned.exec_rows("SELECT id FROM docs ORDER BY id");
+    assert_eq!(
+        after,
+        vec![(2,)],
+        "a pinned BEGIN CONCURRENT snapshot must not see a commit that happened after it"
+    );
+}


### PR DESCRIPTION
A connection inside `BEGIN CONCURRENT` freezes its snapshot two ways: a logical begin timestamp, and a physical WAL read mark captured at begin. The physical mark is what keeps the B-tree scan from seeing rows a passive checkpoint materializes later: the version-store shadow check deliberately does not invalidate a B-tree row whose insert is invisible to the snapshot, because such a row is never supposed to be physically reachable.
But `WalFile::mvcc_refresh_if_db_changed` runs on every statement's Transaction opcode and unconditionally bumped the connection's local max_frame to the latest shared WAL position.