### PR TITLE
postgres/server: emit real SQLSTATEs for constraint failures

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -3621,7 +3621,12 @@ fn limbo_err_code(err: &LimboError) -> i32 {
     match err {
         LimboError::Corrupt(..) => SQLITE_CORRUPT,
         LimboError::NotADB => SQLITE_NOTADB,
-        LimboError::Constraint(_) | LimboError::ForeignKeyConstraint(_) => SQLITE_CONSTRAINT,
+        LimboError::Constraint(_)
+        | LimboError::UniqueConstraint(_)
+        | LimboError::CheckConstraint(_)
+        | LimboError::NotNullConstraint(_)
+        | LimboError::ForeignKeyConstraint(_)
+        | LimboError::ConstraintRaise(..) => SQLITE_CONSTRAINT,
         LimboError::DatabaseFull(_) => SQLITE_FULL,
         LimboError::TableLocked => SQLITE_LOCKED,
         LimboError::ReadOnly => SQLITE_READONLY,

--- a/core/error.rs
+++ b/core/error.rs
@@ -49,11 +49,30 @@ pub enum LimboError {
     InvalidArgument(String),
     #[error("Invalid formatter supplied: {0}")]
     InvalidFormatter(String),
+    /// A constraint failure that has no narrower variant: trigger `RAISE`,
+    /// JSON/blob/type-validation errors surfaced as SQLITE_CONSTRAINT, and the
+    /// undocumented-halt catch-all.
     #[error("{0}")]
     Constraint(String),
+    /// A UNIQUE or PRIMARY KEY violation. SQLite backs primary keys with a
+    /// unique index, so both surface as "UNIQUE constraint failed" and share
+    /// this variant (and PostgreSQL's 23505).
     #[error("{0}")]
-    /// We need to specify for ROLLBACK|FAIL resolve types when to roll the tx back
-    /// so instead of matching on the string, we introduce a specific ForeignKeyConstraint error
+    UniqueConstraint(String),
+    #[error("{0}")]
+    CheckConstraint(String),
+    #[error("{0}")]
+    NotNullConstraint(String),
+    /// A constraint failure raised under ON CONFLICT FAIL/ROLLBACK, where the
+    /// resolve type is embedded (like `Raise`) so `abort()` knows whether to
+    /// roll back, but the constraint kind survives so the pgwire layer can map
+    /// the SQLSTATE.
+    #[error("{2}")]
+    ConstraintRaise(turso_parser::ast::ResolveType, ConstraintKind, String),
+    /// Split out from `Constraint` because ON CONFLICT never applies to a
+    /// foreign-key violation, so instead of matching on the message string we
+    /// give it its own variant. The pgwire layer maps it to 23503.
+    #[error("{0}")]
     ForeignKeyConstraint(String),
     #[error("{1}")]
     Raise(turso_parser::ast::ResolveType, String),
@@ -130,7 +149,13 @@ impl LimboError {
     /// shell appends after a runtime error message ("... (19)").
     pub fn sqlite_result_code(&self) -> i32 {
         match self {
-            Self::Constraint(_) | Self::ForeignKeyConstraint(_) | Self::Raise(..) => 19,
+            Self::Constraint(_)
+            | Self::UniqueConstraint(_)
+            | Self::CheckConstraint(_)
+            | Self::NotNullConstraint(_)
+            | Self::ForeignKeyConstraint(_)
+            | Self::ConstraintRaise(..)
+            | Self::Raise(..) => 19,
             Self::Busy | Self::BusySnapshot | Self::StatementsInProgress(_) => 5,
             Self::TableLocked => 6,
             Self::ReadOnly => 8,
@@ -144,6 +169,16 @@ impl LimboError {
             _ => 1,
         }
     }
+}
+
+/// The kind of a column-constraint violation. Carried by the typed constraint
+/// variants and by [`LimboError::ConstraintRaise`] so callers can map a
+/// violation to its SQLSTATE without parsing the VDBE message text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConstraintKind {
+    Unique,
+    Check,
+    NotNull,
 }
 
 impl From<crate::alloc::AllocError> for LimboError {

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -126,7 +126,7 @@ pub use database::{
 #[cfg(test)]
 pub(crate) use database::{DatabaseKey, RegistryEntry, DATABASE_MANAGER};
 pub use dialect::{Dialect, SqliteDialect};
-pub use error::{io_error, CompletionError, LimboError};
+pub use error::{io_error, CompletionError, ConstraintKind, LimboError};
 pub use function::ContextCollationFunction;
 #[cfg(feature = "io_memory_yield")]
 pub use io::MemoryYieldIO;

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -17522,7 +17522,13 @@ fn test_snapshot_stability_full() {
                         };
                         match conn.execute(&sql) {
                             Ok(_) => {}
-                            Err(LimboError::Constraint(_)) => {}
+                            Err(
+                                LimboError::Constraint(_)
+                                | LimboError::UniqueConstraint(_)
+                                | LimboError::CheckConstraint(_)
+                                | LimboError::NotNullConstraint(_)
+                                | LimboError::ForeignKeyConstraint(_),
+                            ) => {}
                             Err(LimboError::WriteWriteConflict)
                             | Err(LimboError::Busy)
                             | Err(LimboError::TxTerminated) => {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -73,9 +73,9 @@ use crate::{
 };
 use crate::{
     error::{
-        LimboError, SQLITE_CONSTRAINT, SQLITE_CONSTRAINT_CHECK, SQLITE_CONSTRAINT_FOREIGNKEY,
-        SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY, SQLITE_CONSTRAINT_TRIGGER,
-        SQLITE_ERROR, SQLITE_FULL,
+        ConstraintKind, LimboError, SQLITE_CONSTRAINT, SQLITE_CONSTRAINT_CHECK,
+        SQLITE_CONSTRAINT_FOREIGNKEY, SQLITE_CONSTRAINT_NOTNULL, SQLITE_CONSTRAINT_PRIMARYKEY,
+        SQLITE_CONSTRAINT_TRIGGER, SQLITE_ERROR, SQLITE_FULL,
     },
     function::{AggFunc, ExtFunc, MathFunc, MathFuncArity, ScalarFunc, VectorFunc},
     functions::{
@@ -2344,12 +2344,12 @@ pub fn op_type_check(
             // INT PRIMARY KEY is not row_id_alias so we throw error if this col is NULL
             if !col.is_rowid_alias() && col.primary_key() && matches!(reg.get_value(), Value::Null)
             {
-                bail_constraint_error!(
+                return crate::error::cold_return(Err(LimboError::NotNullConstraint(format!(
                     "NOT NULL constraint failed: {}.{} ({})",
                     &table_reference.name,
                     col.name.as_deref().unwrap_or(""),
                     SQLITE_CONSTRAINT
-                )
+                ))));
             } else if col.is_rowid_alias() && matches!(reg.get_value(), Value::Null) {
                 // Handle INTEGER PRIMARY KEY for null as usual (Rowid will be auto-assigned)
                 return Ok(());
@@ -3372,6 +3372,16 @@ pub fn op_prev(
     }
     Ok(InsnFunctionStepResult::Step)
 }
+/// Map a `SQLITE_CONSTRAINT_*` halt code to its constraint kind, or `None` for
+/// codes that are not a column constraint (foreign-key, trigger `RAISE`).
+fn constraint_kind_from_err_code(err_code: usize) -> Option<ConstraintKind> {
+    match err_code {
+        SQLITE_CONSTRAINT_PRIMARYKEY | SQLITE_CONSTRAINT_UNIQUE => Some(ConstraintKind::Unique),
+        SQLITE_CONSTRAINT_CHECK => Some(ConstraintKind::Check),
+        SQLITE_CONSTRAINT_NOTNULL => Some(ConstraintKind::NotNull),
+        _ => None,
+    }
+}
 
 pub fn halt(
     program: &Program,
@@ -3411,7 +3421,12 @@ pub fn halt(
         if err_code > 0 {
             let error = match resolve_type {
                 ResolveType::Abort | ResolveType::Rollback | ResolveType::Fail => {
-                    LimboError::Raise(resolve_type, description.to_string())
+                    match constraint_kind_from_err_code(err_code) {
+                        Some(kind) => {
+                            LimboError::ConstraintRaise(resolve_type, kind, description.to_string())
+                        }
+                        None => LimboError::Raise(resolve_type, description.to_string()),
+                    }
                 }
                 ResolveType::Ignore => unreachable!("handled above"),
                 ResolveType::Replace => unreachable!("Replace not valid for RAISE"),
@@ -3430,16 +3445,16 @@ pub fn halt(
     // Determine the constraint error (if any) based on error code
     let constraint_error = match err_code {
         0 => None,
-        SQLITE_CONSTRAINT_PRIMARYKEY => Some(LimboError::Constraint(format!(
+        SQLITE_CONSTRAINT_PRIMARYKEY => Some(LimboError::UniqueConstraint(format!(
             "UNIQUE constraint failed: {description}"
         ))),
-        SQLITE_CONSTRAINT_CHECK => Some(LimboError::Constraint(format!(
+        SQLITE_CONSTRAINT_CHECK => Some(LimboError::CheckConstraint(format!(
             "CHECK constraint failed: {description}"
         ))),
-        SQLITE_CONSTRAINT_NOTNULL => Some(LimboError::Constraint(format!(
+        SQLITE_CONSTRAINT_NOTNULL => Some(LimboError::NotNullConstraint(format!(
             "NOT NULL constraint failed: {description}"
         ))),
-        SQLITE_CONSTRAINT_UNIQUE => Some(LimboError::Constraint(format!(
+        SQLITE_CONSTRAINT_UNIQUE => Some(LimboError::UniqueConstraint(format!(
             "UNIQUE constraint failed: {description}"
         ))),
         SQLITE_CONSTRAINT_FOREIGNKEY => {
@@ -3493,11 +3508,21 @@ pub fn halt(
         // before the error. Re-tag the constraint as a FAIL raise so the outer
         // program's abort() preserves and commits them instead of rolling the
         // statement back. FK errors do not respect ON CONFLICT, so leave them
-        // as-is.
         if program.resolve_type == ResolveType::Fail {
-            if let LimboError::Constraint(msg) = error {
-                return Err(LimboError::Raise(ResolveType::Fail, msg));
-            }
+            let raised = match error {
+                LimboError::UniqueConstraint(msg) => {
+                    LimboError::ConstraintRaise(ResolveType::Fail, ConstraintKind::Unique, msg)
+                }
+                LimboError::CheckConstraint(msg) => {
+                    LimboError::ConstraintRaise(ResolveType::Fail, ConstraintKind::Check, msg)
+                }
+                LimboError::NotNullConstraint(msg) => {
+                    LimboError::ConstraintRaise(ResolveType::Fail, ConstraintKind::NotNull, msg)
+                }
+                LimboError::Constraint(msg) => LimboError::Raise(ResolveType::Fail, msg),
+                other => return Err(other),
+            };
+            return Err(raised);
         }
 
         // For non-FAIL modes (or non-autocommit), just return the error.
@@ -5275,7 +5300,12 @@ pub fn op_program(
                                 return Err(LimboError::Busy);
                             }
                         },
-                        Err(LimboError::Constraint(constraint_err)) => {
+                        Err(
+                            e @ (LimboError::Constraint(_)
+                            | LimboError::UniqueConstraint(_)
+                            | LimboError::CheckConstraint(_)
+                            | LimboError::NotNullConstraint(_)),
+                        ) => {
                             if program.resolve_type != ResolveType::Ignore {
                                 subprogram_aborted = true;
                                 finish_subprogram(
@@ -5286,7 +5316,7 @@ pub fn op_program(
                                     saved_last_insert_rowid,
                                     saved_last_changes_value,
                                 );
-                                return Err(LimboError::Constraint(constraint_err));
+                                return Err(e);
                             }
                             subprogram_aborted = true;
                             break;
@@ -12184,7 +12214,7 @@ pub fn op_idx_insert(
                     if flags.has(IdxInsertFlags::NO_OP_DUPLICATE) {
                         break 'i true;
                     }
-                    return Err(LimboError::Constraint(
+                    return Err(LimboError::UniqueConstraint(
                         "UNIQUE constraint failed: duplicate key".into(),
                     ));
                 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2729,9 +2729,22 @@ impl Program {
                 // For ON CONFLICT FAIL, do NOT rollback the statement savepoint —
                 // changes made before the error should persist.
                 // For all other resolve types (ABORT, ROLLBACK, etc.), rollback the statement.
-                let is_fail_constraint = (matches!(err, Some(LimboError::Constraint(_)))
-                    && self.resolve_type == ResolveType::Fail)
-                    || matches!(err, Some(LimboError::Raise(ResolveType::Fail, _)));
+                let is_fail_constraint = (matches!(
+                    err,
+                    Some(
+                        LimboError::Constraint(_)
+                            | LimboError::UniqueConstraint(_)
+                            | LimboError::CheckConstraint(_)
+                            | LimboError::NotNullConstraint(_)
+                    )
+                ) && self.resolve_type == ResolveType::Fail)
+                    || matches!(
+                        err,
+                        Some(
+                            LimboError::Raise(ResolveType::Fail, _)
+                                | LimboError::ConstraintRaise(ResolveType::Fail, _, _)
+                        )
+                    );
                 if !is_fail_constraint {
                     if let Err(end_stmt_err) = state.end_statement(
                         &self.connection,
@@ -2796,9 +2809,17 @@ impl Program {
                 // - ROLLBACK: rollback the entire transaction regardless of autocommit mode
                 // - FAIL: don't rollback anything - changes persist, transaction stays active
                 // - ABORT (default): rollback statement, rollback txn if autocommit
-                Some(LimboError::Constraint(_)) | Some(LimboError::Raise(_, _)) => {
+                Some(
+                    LimboError::Constraint(_)
+                    | LimboError::UniqueConstraint(_)
+                    | LimboError::CheckConstraint(_)
+                    | LimboError::NotNullConstraint(_),
+                )
+                | Some(LimboError::Raise(_, _))
+                | Some(LimboError::ConstraintRaise(_, _, _)) => {
                     let effective_resolve = match err {
-                        Some(LimboError::Raise(rt, _)) => *rt,
+                        Some(LimboError::Raise(rt, _))
+                        | Some(LimboError::ConstraintRaise(rt, _, _)) => *rt,
                         _ => self.resolve_type,
                     };
                     match effective_resolve {

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -893,7 +893,7 @@ fn test_first_writer_without_statement_savepoint_error_rolls_back_joined_writer(
         .step()
         .expect_err("resumed INSERT SELECT should hit duplicate primary key");
     assert!(
-        matches!(err, LimboError::Constraint(_)),
+        matches!(err, LimboError::UniqueConstraint(_)),
         "expected duplicate-key constraint error, got {err:?}"
     );
     drop(insert_select);
@@ -1389,7 +1389,7 @@ fn test_mvcc_completed_writer_changes_lost_when_joining_writer_errors() {
         .execute("INSERT INTO rows SELECT id, v FROM src")
         .expect_err("second insert should hit duplicate primary key");
     assert!(
-        matches!(err, LimboError::Constraint(_)),
+        matches!(err, LimboError::UniqueConstraint(_)),
         "expected duplicate-key constraint error, got {err:?}"
     );
 

--- a/postgres/server/lib.rs
+++ b/postgres/server/lib.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use futures::stream;
 use tokio::net::TcpListener;
 use tracing::{error, info};
-use turso_core::Value;
+use turso_core::{ConstraintKind, LimboError, Value};
 use turso_pg::{split_statements, Connection, PgConnection};
 
 use pgwire::api::auth::StartupHandler;
@@ -188,7 +188,7 @@ impl SimpleQueryHandler for TursoPgHandler {
         for sql in &statements {
             let mut stmt = conn
                 .prepare(sql)
-                .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+                .map_err(|e| PgWireError::UserError(Box::new(error_info_from_core(&e))))?;
 
             self.cleanup_dropped_schema_file(sql);
 
@@ -227,7 +227,7 @@ impl ExtendedQueryHandler for TursoPgHandler {
 
         let mut stmt = conn
             .prepare(query)
-            .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+            .map_err(|e| PgWireError::UserError(Box::new(error_info_from_core(&e))))?;
 
         // Clean up schema file after successful DROP SCHEMA
         self.cleanup_dropped_schema_file(query);
@@ -254,7 +254,7 @@ impl ExtendedQueryHandler for TursoPgHandler {
         let conn = self.conn.lock().unwrap().clone();
         let stmt = conn
             .prepare(&target.statement)
-            .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+            .map_err(|e| PgWireError::UserError(Box::new(error_info_from_core(&e))))?;
 
         let param_types: Vec<Type> = target
             .parameter_types
@@ -277,7 +277,7 @@ impl ExtendedQueryHandler for TursoPgHandler {
         let conn = self.conn.lock().unwrap().clone();
         let stmt = conn
             .prepare(&portal.statement.statement)
-            .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+            .map_err(|e| PgWireError::UserError(Box::new(error_info_from_core(&e))))?;
 
         let fields = build_field_info(&stmt, &portal.result_column_format);
         Ok(DescribePortalResponse::new(fields))
@@ -401,7 +401,7 @@ fn execute_query(
         rows.push(encoder.finish());
         Ok(())
     })
-    .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+    .map_err(|e| PgWireError::UserError(Box::new(error_info_from_core(&e))))?;
 
     let data_stream = stream::iter(rows);
     Ok(Response::Query(QueryResponse::new(header, data_stream)))
@@ -410,7 +410,7 @@ fn execute_query(
 /// Execute a non-SELECT statement and build an Execution response.
 fn execute_non_query(stmt: &mut turso_core::Statement, query: &str) -> PgWireResult<Response> {
     stmt.run_ignore_rows()
-        .map_err(|e| PgWireError::UserError(Box::new(error_info(&e.to_string()))))?;
+        .map_err(|e| PgWireError::UserError(Box::new(error_info_from_core(&e))))?;
 
     let affected = stmt.n_change();
     let tag = command_tag(query, affected as usize);
@@ -755,6 +755,38 @@ fn is_create_table_as(upper: &str) -> bool {
     matches!(tokens.next(), Some(t) if t == "AS" || t.starts_with("AS("))
 }
 
+/// The PostgreSQL SQLSTATE that best describes a core error. Constraint
+/// failures get their real class-23 codes so drivers (node-postgres ->
+/// db-result) can tell unique / foreign-key / check / not-null apart. The
+/// engine distinguishes each with its own `LimboError` variant, so the mapping
+/// is structural. Everything else stays XX000 until the engine grows richer
+/// error typing.
+fn sqlstate_for_error(e: &LimboError) -> &'static str {
+    match e {
+        LimboError::ForeignKeyConstraint(_) => "23503",
+        LimboError::UniqueConstraint(_)
+        | LimboError::ConstraintRaise(_, ConstraintKind::Unique, _) => "23505",
+        LimboError::CheckConstraint(_)
+        | LimboError::ConstraintRaise(_, ConstraintKind::Check, _) => "23514",
+        LimboError::NotNullConstraint(_)
+        | LimboError::ConstraintRaise(_, ConstraintKind::NotNull, _) => "23502",
+        _ => "XX000",
+    }
+}
+
+/// Build the wire `ErrorInfo` for a core error: a real SQLSTATE when the
+/// engine distinguished the constraint, the engine's message verbatim either
+/// way.
+fn error_info_from_core(e: &LimboError) -> ErrorInfo {
+    ErrorInfo::new(
+        "ERROR".to_owned(),
+        sqlstate_for_error(e).to_owned(),
+        e.to_string(),
+    )
+}
+
+/// Build the wire `ErrorInfo` for a non-core error (statement splitting,
+/// parameter decoding) that has only a message.
 fn error_info(message: &str) -> ErrorInfo {
     ErrorInfo::new("ERROR".to_owned(), "XX000".to_owned(), message.to_owned())
 }
@@ -762,6 +794,44 @@ fn error_info(message: &str) -> ErrorInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_sqlstate_for_error_constraint_mapping() {
+        // The four constraint families the wire protocol must distinguish.
+        assert_eq!(
+            sqlstate_for_error(&LimboError::ForeignKeyConstraint("orphan".to_owned())),
+            "23503"
+        );
+        assert_eq!(
+            sqlstate_for_error(&LimboError::UniqueConstraint(
+                "UNIQUE constraint failed: post.slug".to_owned()
+            )),
+            "23505"
+        );
+        assert_eq!(
+            sqlstate_for_error(&LimboError::CheckConstraint(
+                "CHECK constraint failed: locale IN ('is', 'en')".to_owned()
+            )),
+            "23514"
+        );
+        assert_eq!(
+            sqlstate_for_error(&LimboError::NotNullConstraint(
+                "NOT NULL constraint failed: post.title".to_owned()
+            )),
+            "23502"
+        );
+        // Anything else stays the generic code.
+        assert_eq!(
+            sqlstate_for_error(&LimboError::Constraint(
+                "JSON cannot hold BLOB values".to_owned()
+            )),
+            "XX000"
+        );
+        assert_eq!(
+            sqlstate_for_error(&LimboError::ParseError("bad SQL".to_owned())),
+            "XX000"
+        );
+    }
 
     #[test]
     fn test_pg_bytes_to_value_integer() {

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -728,9 +728,12 @@ pub fn c_string_to_str(ptr: *const std::ffi::c_char) -> std::ffi::CString {
 impl From<LimboError> for TursoError {
     fn from(value: LimboError) -> Self {
         match value {
-            LimboError::ForeignKeyConstraint(e) | LimboError::Constraint(e) => {
-                TursoError::Constraint(e)
-            }
+            LimboError::ForeignKeyConstraint(e)
+            | LimboError::UniqueConstraint(e)
+            | LimboError::CheckConstraint(e)
+            | LimboError::NotNullConstraint(e)
+            | LimboError::ConstraintRaise(_, _, e)
+            | LimboError::Constraint(e) => TursoError::Constraint(e),
             LimboError::Corrupt(e) => TursoError::Corrupt(e),
             LimboError::NotADB => TursoError::NotAdb("file is not a database".to_string()),
             LimboError::DatabaseFull(e) => TursoError::DatabaseFull(e),

--- a/testing/concurrent-simulator/protocol.rs
+++ b/testing/concurrent-simulator/protocol.rs
@@ -119,6 +119,10 @@ pub fn limbo_error_to_message(err: &LimboError) -> String {
         | LimboError::TxError(s)
         | LimboError::InvalidArgument(s)
         | LimboError::Constraint(s)
+        | LimboError::UniqueConstraint(s)
+        | LimboError::CheckConstraint(s)
+        | LimboError::NotNullConstraint(s)
+        | LimboError::ConstraintRaise(_, _, s)
         | LimboError::Conflict(s)
         | LimboError::CheckpointFailed(s) => s.clone(),
         other => other.to_string(),
@@ -136,7 +140,11 @@ pub fn limbo_error_to_kind(err: &LimboError) -> &'static str {
         LimboError::SchemaConflict => "SchemaConflict",
         LimboError::TableLocked => "TableLocked",
         LimboError::InvalidArgument(_) => "InvalidArgument",
-        LimboError::Constraint(_) => "Constraint",
+        LimboError::Constraint(_)
+        | LimboError::UniqueConstraint(_)
+        | LimboError::CheckConstraint(_)
+        | LimboError::NotNullConstraint(_)
+        | LimboError::ConstraintRaise(_, _, _) => "Constraint",
         LimboError::Corrupt(_) => "Corrupt",
         LimboError::ReadOnly => "ReadOnly",
         LimboError::Interrupt => "Interrupt",

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -249,7 +249,11 @@ pub fn execute_interaction_turso(
                         }
                         ExecutionContinuation::NextInteractionOutsideThisProperty
                     }
-                    LimboError::Constraint(_) => {
+                    LimboError::Constraint(_)
+                    | LimboError::UniqueConstraint(_)
+                    | LimboError::CheckConstraint(_)
+                    | LimboError::NotNullConstraint(_)
+                    | LimboError::ConstraintRaise(_, _, _) => {
                         let shadow_result =
                             interaction.shadow(&mut env.get_conn_tables_mut(connection_index));
                         if shadow_result.is_ok() {

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -244,7 +244,7 @@ fn test_constraint_error_aborts_only_stmt_not_entire_transaction(tmp_db: TempDat
 
     // Second insert fails due to UNIQUE constraint
     let result = conn.execute("INSERT INTO t VALUES (2),(3)");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Third insert is valid again
     conn.execute("INSERT INTO t VALUES (4)").unwrap();
@@ -1636,7 +1636,7 @@ fn test_wal_savepoint_rollback_on_constraint_violation() {
     let result =
         conn.execute("UPDATE t SET val = 'modified', u = CASE WHEN id = 1000 THEN 1 ELSE u END");
     assert!(
-        matches!(result, Err(LimboError::Constraint(_))),
+        matches!(result, Err(LimboError::UniqueConstraint(_))),
         "Expected UNIQUE constraint violation, got: {result:?}"
     );
 
@@ -1785,7 +1785,7 @@ fn test_insert_or_fail_keeps_prior_changes(tmp_db: TempDatabase) {
 
     // INSERT OR FAIL with multiple rows - (3, 'third') succeeds, then (1, 'conflict') fails
     let result = conn.execute("INSERT OR FAIL INTO t VALUES (3, 'third'), (1, 'conflict')");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Verify that row 3 was inserted (FAIL keeps prior changes)
     let stmt = conn.query("SELECT id FROM t ORDER BY id").unwrap().unwrap();
@@ -1813,7 +1813,7 @@ fn test_insert_or_abort_rolls_back_statement(tmp_db: TempDatabase) {
     // INSERT OR ABORT with multiple rows - (3, 'third') would succeed, but (1, 'conflict') fails
     // and rolls back the entire statement
     let result = conn.execute("INSERT OR ABORT INTO t VALUES (3, 'third'), (1, 'conflict')");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Verify that row 3 was NOT inserted (ABORT rolls back statement)
     let stmt = conn.query("SELECT id FROM t ORDER BY id").unwrap().unwrap();
@@ -1843,7 +1843,7 @@ fn test_insert_or_rollback_rolls_back_transaction(tmp_db: TempDatabase) {
 
     // INSERT OR ROLLBACK causes the entire transaction to roll back
     let result = conn.execute("INSERT OR ROLLBACK INTO t VALUES (1, 'conflict')");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Verify that row 2 was rolled back (ROLLBACK affects entire transaction)
     let stmt = conn.query("SELECT id FROM t ORDER BY id").unwrap().unwrap();
@@ -1874,7 +1874,7 @@ fn test_insert_or_rollback_unique_constraint_in_transaction(tmp_db: TempDatabase
 
     // INSERT OR ROLLBACK with unique constraint violation
     let result = conn.execute("INSERT OR ROLLBACK INTO t VALUES (3, 'alice')");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Verify that row 2 (bob) was rolled back
     let stmt = conn
@@ -1899,7 +1899,7 @@ fn test_insert_or_rollback_in_autocommit(tmp_db: TempDatabase) {
 
     // INSERT OR ROLLBACK in autocommit mode
     let result = conn.execute("INSERT OR ROLLBACK INTO t VALUES (1, 'conflict')");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Verify the original row is still there
     let stmt = conn
@@ -1922,7 +1922,7 @@ fn test_insert_or_fail_unique_constraint(tmp_db: TempDatabase) {
 
     // INSERT OR FAIL - (3, 'charlie') succeeds, then (4, 'alice') fails
     let result = conn.execute("INSERT OR FAIL INTO t VALUES (3, 'charlie'), (4, 'alice')");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Verify charlie was inserted (FAIL keeps prior changes)
     let stmt = conn
@@ -1953,7 +1953,7 @@ fn test_update_or_fail_keeps_prior_changes(tmp_db: TempDatabase) {
 
     // UPDATE OR FAIL - try to set val=20 which conflicts with id=2
     let result = conn.execute("UPDATE OR FAIL t SET val = 20 WHERE id = 1");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Verify original values (single row update, so nothing before the error to keep)
     let stmt = conn
@@ -1982,7 +1982,7 @@ fn test_update_or_abort_rolls_back_statement(tmp_db: TempDatabase) {
 
     // UPDATE OR ABORT - try to set val=20 which conflicts with id=2
     let result = conn.execute("UPDATE OR ABORT t SET val = 20 WHERE id = 1");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Verify original values (ABORT rolls back statement)
     let stmt = conn
@@ -2015,7 +2015,7 @@ fn test_update_or_rollback_rolls_back_transaction(tmp_db: TempDatabase) {
 
     // UPDATE OR ROLLBACK causes the entire transaction to roll back
     let result = conn.execute("UPDATE OR ROLLBACK t SET val = 30 WHERE id = 2");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Verify that all changes were rolled back (including the first UPDATE)
     let stmt = conn
@@ -2048,7 +2048,7 @@ fn test_update_or_rollback_in_autocommit(tmp_db: TempDatabase) {
 
     // UPDATE OR ROLLBACK in autocommit mode
     let result = conn.execute("UPDATE OR ROLLBACK t SET val = 20 WHERE id = 1");
-    assert!(matches!(result, Err(LimboError::Constraint(_))));
+    assert!(matches!(result, Err(LimboError::UniqueConstraint(_))));
 
     // Verify original values
     let stmt = conn

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1203,7 +1203,7 @@ pub fn test_conflict_autocommit(limbo: TempDatabase) {
     conn1.execute("INSERT INTO t VALUES (1, 10)").unwrap();
     assert!(matches!(
         conn1.execute("INSERT INTO t VALUES (1, 0)").unwrap_err(),
-        LimboError::Constraint(_)
+        LimboError::UniqueConstraint(_)
     ));
     conn2.execute("INSERT INTO t VALUES (2, 20)").unwrap();
     assert_eq!(
@@ -1247,7 +1247,7 @@ pub fn test_conflict_multi_insert_autocommit(limbo: TempDatabase) {
         conn1
             .execute("INSERT INTO t VALUES (2, 20), (1, 0), (3, 30)")
             .unwrap_err(),
-        LimboError::Constraint(_)
+        LimboError::UniqueConstraint(_)
     ));
     conn2.execute("INSERT INTO t VALUES (4, 40)").unwrap();
     assert_eq!(
@@ -1291,7 +1291,7 @@ pub fn test_conflict_inside_txn(limbo: TempDatabase) {
     conn1.execute("INSERT INTO t VALUES (2, 20)").unwrap();
     assert!(matches!(
         conn1.execute("INSERT INTO t VALUES (1, 0)").unwrap_err(),
-        LimboError::Constraint(_)
+        LimboError::UniqueConstraint(_)
     ));
     conn1.execute("INSERT INTO t VALUES (3, 30)").unwrap();
     conn1.execute("COMMIT").unwrap();
@@ -1364,7 +1364,7 @@ pub fn test_savepoint_rollback_uses_current_wal_snapshot(
         conn1.execute(format!(
             "UPDATE t SET payload = '{payload}', u2 = CASE WHEN u2 = 20 THEN 1 ELSE u2 END WHERE TRUE"
         )),
-        Err(LimboError::Constraint(_))
+        Err(LimboError::UniqueConstraint(_))
     ));
     conn1.execute("ROLLBACK TO sp")?;
     conn1.execute("RELEASE sp")?;
@@ -2019,6 +2019,25 @@ fn test_upsert_do_update_failure_preserves_indexes(tmp_db: TempDatabase) -> anyh
 
     let ic = run_integrity_check(&conn);
     assert_eq!(ic, "ok", "integrity_check after commit: {ic}");
+
+    Ok(())
+}
+#[turso_macros::test]
+fn test_strict_non_rowid_pk_null_is_not_null_constraint(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
+    let conn = tmp_db.connect_limbo();
+
+    // A PostgreSQL-created STRICT table with a non-rowid TEXT primary key.
+    // Inserting NULL into the PK must surface as a NOT NULL constraint, not
+    // the generic Constraint catch-all.
+    conn.execute("CREATE TABLE t (id TEXT PRIMARY KEY, v INT) STRICT")?;
+    let err = conn.execute("INSERT INTO t VALUES (NULL, 1)").unwrap_err();
+    assert!(
+        matches!(err, LimboError::NotNullConstraint(_)),
+        "expected NotNullConstraint for NULL into STRICT non-rowid PK, got: {err:?}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

The pgwire layer mapped every core error to SQLSTATE `XX000`, so drivers that classify on SQLSTATE (node-postgres → `db-result`) can't tell a unique violation from a foreign-key or not-null violation — all constraint failures land in the generic error path.

## Approach

Split the constraint subtype out of the message string and into dedicated `LimboError` variants, mirroring the existing `ForeignKeyConstraint`:

- `UniqueConstraint(String)` — PRIMARY KEY + UNIQUE → `23505`
- `CheckConstraint(String)` → `23514`
- `NotNullConstraint(String)` → `23502`
- `ForeignKeyConstraint(String)` → `23503` (existing)
- `Constraint(String)` — stays generic (trigger `RAISE`, JSON/type-validation, unknown halt)

A new `ConstraintKind` enum tags constraint failures raised under `ON CONFLICT FAIL/ROLLBACK` (`ConstraintRaise(ResolveType, ConstraintKind, String)`), so the kind survives the resolve-type wrapper that `Raise` previously erased. The pgwire layer maps these structurally instead of parsing VDBE text.

## Scope / behavior

SQLite-observable behavior is unchanged: message text, `sqlite_result_code()` (19), the C API `SQLITE_CONSTRAINT` code, and the SDK `TursoError::Constraint` class are all preserved. The subtype split is additive and only the pgwire layer consumes it today.

Trigger `RAISE(...)` and non-constraint errors still report `XX000`.

## Tests

- Unit test for the SQLSTATE mapping (all four families + `XX000` fallback).
- STRICT non-rowid `TEXT PRIMARY KEY` NULL now classifies as `NotNullConstraint` (was the generic `Constraint` catch-all).
- Updated unique-violation assertions across core, bindings, simulator, and integration tests to the precise `UniqueConstraint`.

`cargo check --workspace` passes (one pre-existing, unrelated `memory-benchmark` global-allocator conflict); `cargo test -p turso_pg_server` (15), ON CONFLICT (`or_` 88, `conflict` 117), and NOT NULL (18) suites all green.