### PR TITLE
testing/stress: exercise WAL checkpoints in the stress loop

### DIFF
--- a/testing/stress/checkpoint.rs
+++ b/testing/stress/checkpoint.rs
@@ -1,0 +1,119 @@
+//! WAL checkpoint action for the stress loop: pick a checkpoint mode and
+//! run PRAGMA wal_checkpoint, sanity-checking the result.
+
+use rand::Rng;
+use turso::Value;
+use turso_stress::ThreadId;
+
+use crate::conn::StressConn;
+use crate::opts::TxMode;
+use crate::sql_logging::SqlLogger;
+use crate::ThreadRng;
+
+/// Pick a checkpoint mode: PASSIVE-heavy with occasional
+/// RESTART/TRUNCATE/FULL in SQLite mode. PASSIVE checkpoints in MVCC mode
+/// need the experimental passive-checkpoint flag, which this binary does
+/// not enable, so pick from the other modes there.
+pub fn pick_mode(rng: &mut ThreadRng, tx_mode: TxMode) -> &'static str {
+    match tx_mode {
+        TxMode::SQLite => {
+            let pick: u32 = rng.random_range(0..100);
+            if pick < 70 {
+                "PASSIVE"
+            } else if pick < 85 {
+                "RESTART"
+            } else if pick < 95 {
+                "TRUNCATE"
+            } else {
+                "FULL"
+            }
+        }
+        TxMode::Concurrent => match rng.random_range(0..3) {
+            0 => "FULL",
+            1 => "RESTART",
+            _ => "TRUNCATE",
+        },
+    }
+}
+
+/// Run a WAL checkpoint and sanity-check the (busy, log, checkpointed)
+/// result row. Lock contention is logged and skipped; corruption fails the
+/// run. A checkpoint that could not run reports busy=1 with NULL counters.
+pub async fn run_wal_checkpoint(
+    conn: &StressConn,
+    sql_logger: &SqlLogger,
+    thread: &ThreadId,
+    mode: &str,
+    tx_mode: TxMode,
+) {
+    let sql = format!("PRAGMA wal_checkpoint({mode})");
+    let mut rows = match conn.query(&sql, ()).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            match e {
+                turso::Error::Busy(_) | turso::Error::BusySnapshot(_) => {
+                    sql_logger.log(thread, &sql, "SKIPPED: database busy");
+                }
+                turso::Error::Corrupt(e) => {
+                    turso_macros::turso_assert_unreachable!("corrupt error running checkpoint", { "thread": thread, "mode": mode, "error": e });
+                }
+                e => {
+                    sql_logger.log(thread, &sql, &format!("ERROR: {e}"));
+                }
+            }
+            return;
+        }
+    };
+    match rows.next().await {
+        Ok(Some(row)) => {
+            let int_at = |idx: usize| match row.get_value(idx) {
+                Ok(Value::Integer(v)) => Some(v),
+                _ => None,
+            };
+            let (Some(busy), Some(log), Some(checkpointed)) = (int_at(0), int_at(1), int_at(2))
+            else {
+                // A checkpoint that fails inside the engine (e.g. lock
+                // contention) reports busy=1 and leaves the counters NULL.
+                sql_logger.log(thread, &sql, "SKIPPED: checkpoint busy");
+                return;
+            };
+            sql_logger.log(
+                thread,
+                &sql,
+                &format!("busy={busy} log={log} checkpointed={checkpointed}"),
+            );
+            turso_macros::turso_assert!(
+                checkpointed <= log,
+                "checkpoint never reports more frames copied than the WAL holds",
+                { "thread": thread, "mode": mode, "busy": busy, "log": log, "checkpointed": checkpointed }
+            );
+            // In concurrent mode commits go through the MVCC logical log, so
+            // the physical WAL stays empty and these counters are always
+            // zero. Only expect checkpoint progress in SQLite mode.
+            if tx_mode == TxMode::SQLite {
+                turso_macros::turso_assert_sometimes!(
+                    checkpointed > 0,
+                    "a checkpoint copied frames into the database file",
+                    { "mode": mode }
+                );
+                turso_macros::turso_assert_sometimes!(
+                    log > 0 && checkpointed == log,
+                    "a checkpoint drained the entire WAL",
+                    { "mode": mode }
+                );
+            }
+        }
+        Ok(None) => {
+            turso_macros::turso_assert_unreachable!("wal_checkpoint returned no rows", { "thread": thread, "mode": mode });
+        }
+        Err(turso::Error::Busy(_) | turso::Error::BusySnapshot(_)) => {
+            sql_logger.log(thread, &sql, "SKIPPED: database busy");
+        }
+        Err(turso::Error::Corrupt(e)) => {
+            turso_macros::turso_assert_unreachable!("corrupt error reading checkpoint result", { "thread": thread, "mode": mode, "error": e });
+        }
+        Err(e) => {
+            sql_logger.log(thread, &sql, &format!("ERROR: {e}"));
+        }
+    }
+}

--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+mod checkpoint;
 mod conn;
 mod counter;
 mod logging;
@@ -763,6 +764,21 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                     if tx.is_some() {
                         let end_tx = *rng.choose(&["COMMIT;", "ROLLBACK;"]);
                         let _ = conn.execute(end_tx, ()).await;
+                    }
+
+                    // Occasionally checkpoint the WAL so backfills, full
+                    // drains, and WAL restarts race the other threads'
+                    // commits instead of only happening on autocheckpoint.
+                    if rng.random_ratio(1, 20) {
+                        let mode = checkpoint::pick_mode(&mut rng, opts.tx_mode);
+                        checkpoint::run_wal_checkpoint(
+                            &conn,
+                            &sql_logger,
+                            &thread,
+                            mode,
+                            opts.tx_mode,
+                        )
+                        .await;
                     }
 
                     const INTEGRITY_CHECK_INTERVAL: usize = 100;


### PR DESCRIPTION
turso_stress never issued PRAGMA wal_checkpoint, so checkpoint
backfills, full WAL drains, and WAL restarts only ever raced the
writer threads implicitly through autocheckpoint. The checkpoint
machinery is where the WAL-reset bug class lives (issues #7722 and
#7744), so the Antithesis stress templates should put explicit
checkpoint pressure on it.

Run a checkpoint on roughly 1 in 20 iterations per thread, once the
iteration's transaction has ended: PASSIVE-heavy with occasional
RESTART/TRUNCATE/FULL in SQLite mode, and FULL/RESTART/TRUNCATE in
MVCC mode, where PASSIVE requires the experimental passive-checkpoint
flag this binary does not enable.

Check the (busy, log, checkpointed) result row: a checkpoint must
never report more frames copied than the WAL holds, and in SQLite
mode sometimes assertions record that checkpoints actually backfill
frames and drain the WAL, so Antithesis can steer toward those
states. The progress assertions are SQLite-only because MVCC commits
go through the logical log: the physical WAL stays empty, the
counters are always zero, and the assertions would report unreachable
coverage in the MVCC campaigns. Lock contention is logged and
skipped; a corruption error fails the run. A checkpoint that fails
inside the engine reports busy=1 with NULL counters, which is treated
as contention.

Tests: cargo build/check under both cfgs (plain and --cfg antithesis);
2x1500-iteration local runs in both tx modes: SQLite mode logs sane
checkpoint triples in all four modes including full WAL drains, MVCC
mode reports (0,0,0) rows throughout with no errors.
