### PR TITLE
testing/stress: stop replaying the same RNG stream after reopens

### DIFF
--- a/testing/stress/main.rs
+++ b/testing/stress/main.rs
@@ -675,16 +675,14 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         }
     };
 
+    let mut batch_idx: u64 = 0;
     while !stop && !stress_counter.all_done() {
         let mut handles = Vec::with_capacity(opts.nr_threads);
         let reopen_requested = Arc::new(AtomicBool::new(false));
         let all_threads_ready = Arc::new(Barrier::new(stress_counter.incomplete_threads()));
 
-        for (iteration_idx, ((thread_idx, thread), mut progress_bar)) in threads
-            .iter()
-            .cloned()
-            .zip(progress_bars.iter().cloned())
-            .enumerate()
+        for ((thread_idx, thread), mut progress_bar) in
+            threads.iter().cloned().zip(progress_bars.iter().cloned())
         {
             if stress_counter.done(thread_idx) {
                 continue;
@@ -704,7 +702,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
                 let mut rng = ThreadRng::new(
                     global_seed
                         .wrapping_add(thread_idx as u64)
-                        .wrapping_add(iteration_idx as u64 * 1000),
+                        .wrapping_add(batch_idx.wrapping_mul(1000)),
                 );
                 let mut iteration_count_this_batch = 0;
 
@@ -838,6 +836,7 @@ async fn async_main(opts: Opts) -> Result<(), Box<dyn std::error::Error + Send +
         // This is what triggers MVCC recovery
         db.lock().await.reset();
         clear_database_registry();
+        batch_idx += 1;
     }
 
     progress_bars


### PR DESCRIPTION
Since 9e92d5040 ("exercise MVCC recovery in turso_stress") the stress
loop periodically tears down all threads and the database to exercise
recovery, then respawns the threads in a new batch. Each respawned
thread seeds its RNG with global_seed + thread_idx + iteration_idx *
1000, where iteration_idx was meant to distinguish batches but is
actually the thread's enumerate() position in the threads vector, so
it is identical in every batch. Every reopen batch therefore replayed
each thread's random stream from position zero: the same statements,
reconnects, savepoint patterns, and checkpoint modes over and over,
so long runs had far less behavioral diversity than their iteration
count suggests.

The skew was large enough to show up in small samples: with seed 3, a
uniform 3-way checkpoint mode pick produced 0 FULL, 79 RESTART, and
36 TRUNCATE picks across a 2x800-iteration run, and 232 distinct
generated DML statements appeared more than once purely from replay.

Count batches explicitly and mix that counter into the seed instead.
Antithesis builds are unaffected because AntithesisRng ignores the
seed; plain builds now reproduce different runs for a given --seed
than before this change.
