### PR TITLE
core/translate: Pre-filter ephemeral indexes and improve subquery unnesting tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -378,9 +378,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Each profile weights top-level statements differently so CI covers
-        # several statement mixes instead of one distribution.
-        profile: [balanced, ddl, triggers, writes]
+        # Each profile focuses a different workload so CI covers more than the
+        # default statement distribution.
+        profile: [balanced, ddl, triggers, writes, correlated-subqueries]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -410,7 +410,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        profile: [balanced, ddl, triggers, writes]
+        profile: [balanced, ddl, triggers, writes, correlated-subqueries]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -200,6 +200,18 @@ pub struct ReparseSchemaInner {
     phase: ReparsePhase,
 }
 
+/// Test-only control over correlated-subquery rewrites.
+#[cfg(feature = "simulator")]
+#[derive(Debug, AtomicEnum, Clone, Copy, PartialEq, Eq)]
+pub enum SubqueryUnnestingMode {
+    /// Let the cost model choose between the correlated and rewritten plans.
+    Auto = 0,
+    /// Keep the original correlated plan.
+    Disabled = 1,
+    /// Use the rewritten plan whenever the rewrite applies.
+    Forced = 2,
+}
+
 enum ReparsePhase {
     /// Scanning `SELECT * FROM sqlite_schema` into `fresh`.
     ParseSchema {
@@ -435,6 +447,9 @@ pub struct Connection {
     pub(super) full_column_names: AtomicBool,
     /// Deprecated pragma: when ON (default), column refs use just the column name
     pub(super) short_column_names: AtomicBool,
+    /// Simulator-only planner control used by the differential fuzzer.
+    #[cfg(feature = "simulator")]
+    pub(super) subquery_unnesting_mode: AtomicSubqueryUnnestingMode,
     /// Per-connection runtime extension loading flag.
     pub(super) enable_load_extension: AtomicBool,
     /// Cumulative count of autonomous sequence inner-tx retries (each
@@ -863,6 +878,18 @@ impl Connection {
     #[inline]
     pub(crate) fn prepare_context_generation(&self) -> u64 {
         self.prepare_context_generation.load(Ordering::Acquire)
+    }
+
+    /// Choose how correlated subqueries are planned in newly prepared statements.
+    #[cfg(feature = "simulator")]
+    pub fn set_subquery_unnesting_mode(&self, mode: SubqueryUnnestingMode) {
+        self.subquery_unnesting_mode.set(mode);
+        self.bump_prepare_context_generation();
+    }
+
+    #[cfg(feature = "simulator")]
+    pub(crate) fn subquery_unnesting_mode(&self) -> SubqueryUnnestingMode {
+        self.subquery_unnesting_mode.get()
     }
 
     /// check if connection executes nested program (so it must not do any "finalization" work as parent program will handle it)

--- a/core/database.rs
+++ b/core/database.rs
@@ -2401,6 +2401,10 @@ impl Database {
             is_mvcc_bootstrap_connection: AtomicBool::new(is_mvcc_bootstrap_connection),
             full_column_names: AtomicBool::new(false),
             short_column_names: AtomicBool::new(true),
+            #[cfg(feature = "simulator")]
+            subquery_unnesting_mode: crate::connection::AtomicSubqueryUnnestingMode::new(
+                crate::connection::SubqueryUnnestingMode::Auto,
+            ),
             enable_load_extension: AtomicBool::new(self.can_load_extensions()),
             fk_pragma: AtomicBool::new(false),
             fk_deferred_violations: AtomicIsize::new(0),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -119,6 +119,8 @@ pub use cdc::{
     CaptureDataChangesExt, CaptureDataChangesInfo, CaptureDataChangesMode, CdcVersion,
     CDC_VERSION_CURRENT,
 };
+#[cfg(feature = "simulator")]
+pub use connection::SubqueryUnnestingMode;
 pub use connection::{resolve_ext_path, Connection, PrepareOptions, Row, StepResult, SymbolTable};
 pub(crate) use connection::{AtomicTransactionState, TransactionState};
 #[cfg(feature = "simulator")]

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -178,6 +178,8 @@ pub struct Resolver<'a> {
     /// Controls whether unresolved double-quoted identifiers fall back to string
     /// literals (SQLite's DQS misfeature) in DML statements.
     pub dqs_dml: DoubleQuotedDml,
+    #[cfg(feature = "simulator")]
+    subquery_unnesting_mode: crate::SubqueryUnnestingMode,
     /// Schema dialect of the database being compiled against; used when a
     /// fresh placeholder schema must be constructed during resolution.
     pub(crate) dialect: Arc<dyn crate::dialect::Dialect>,
@@ -315,6 +317,8 @@ impl<'a> Resolver<'a> {
             enclosing_query_aggregates: RefCell::new(Vec::new()),
             enable_custom_types,
             dqs_dml,
+            #[cfg(feature = "simulator")]
+            subquery_unnesting_mode: crate::SubqueryUnnestingMode::Auto,
             dialect,
             trigger_context: None,
             has_temp_schema,
@@ -325,6 +329,16 @@ impl<'a> Resolver<'a> {
 
     pub fn schema(&self) -> &Schema {
         self.schema
+    }
+
+    #[cfg(feature = "simulator")]
+    pub(crate) fn set_subquery_unnesting_mode(&mut self, mode: crate::SubqueryUnnestingMode) {
+        self.subquery_unnesting_mode = mode;
+    }
+
+    #[cfg(feature = "simulator")]
+    pub(crate) fn subquery_unnesting_mode(&self) -> crate::SubqueryUnnestingMode {
+        self.subquery_unnesting_mode
     }
 
     pub fn has_temp_database(&self) -> bool {
@@ -348,6 +362,8 @@ impl<'a> Resolver<'a> {
             enclosing_query_aggregates: RefCell::new(Vec::new()),
             enable_custom_types: self.enable_custom_types,
             dqs_dml: self.dqs_dml,
+            #[cfg(feature = "simulator")]
+            subquery_unnesting_mode: self.subquery_unnesting_mode,
             dialect: self.dialect.clone(),
             trigger_context: self.trigger_context.clone(),
             has_temp_schema: self.has_temp_schema,
@@ -373,6 +389,8 @@ impl<'a> Resolver<'a> {
             enclosing_query_aggregates: RefCell::new(Vec::new()),
             enable_custom_types: self.enable_custom_types,
             dqs_dml: self.dqs_dml,
+            #[cfg(feature = "simulator")]
+            subquery_unnesting_mode: self.subquery_unnesting_mode,
             dialect: self.dialect.clone(),
             trigger_context: self.trigger_context.clone(),
             has_temp_schema: self.has_temp_schema,

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -111,5 +111,6 @@ pub use utils::{
 pub use vectors::expr_vector_size;
 pub use walk::{
     expr_contains_nondeterministic_scalar_function, expr_references_any_subquery,
-    expr_references_subquery_id, walk_expr, walk_expr_mut, WalkControl,
+    expr_references_outer_query, expr_references_subquery_id, expression_can_fail_on_input,
+    walk_expr, walk_expr_mut, WalkControl,
 };

--- a/core/translate/expr/walk.rs
+++ b/core/translate/expr/walk.rs
@@ -214,6 +214,60 @@ pub fn expr_references_any_subquery(expr: &ast::Expr) -> bool {
     found
 }
 
+pub fn expr_references_outer_query(expr: &ast::Expr, table_references: &TableReferences) -> bool {
+    let mut has_outer_ref = false;
+    walk_expr(expr, &mut |expr: &ast::Expr| -> Result<WalkControl> {
+        if let ast::Expr::Column { table, .. } | ast::Expr::RowId { table, .. } = expr {
+            has_outer_ref = table_references
+                .find_outer_query_ref_by_internal_id(*table)
+                .is_some();
+        }
+        Ok(if has_outer_ref {
+            WalkControl::SkipChildren
+        } else {
+            WalkControl::Continue
+        })
+    })
+    .expect("walking an expression cannot fail");
+    has_outer_ref
+}
+
+/// Return whether evaluating an expression may fail for a particular input.
+///
+/// This is deliberately conservative. Extension functions can fail, `LIKE`
+/// can call a user-defined function, and JSON or array operators can reject
+/// their input. Callers use this when an optimization would evaluate an
+/// expression for more rows than the original plan.
+pub fn expression_can_fail_on_input(expr: &ast::Expr) -> bool {
+    let mut can_fail = false;
+    walk_expr(expr, &mut |expr: &ast::Expr| -> Result<WalkControl> {
+        if matches!(
+            expr,
+            ast::Expr::FunctionCall { .. }
+                | ast::Expr::FunctionCallStar { .. }
+                | ast::Expr::Like { .. }
+                | ast::Expr::Raise(_, _)
+                | ast::Expr::Binary(
+                    _,
+                    ast::Operator::ArrowRight
+                        | ast::Operator::ArrowRightShift
+                        | ast::Operator::ArrayContains
+                        | ast::Operator::ArrayOverlap,
+                    _
+                )
+        ) {
+            can_fail = true;
+        }
+        Ok(if can_fail {
+            WalkControl::SkipChildren
+        } else {
+            WalkControl::Continue
+        })
+    })
+    .expect("walking an expression cannot fail");
+    can_fail
+}
+
 /// Returns true if this expression calls a scalar function whose result can
 /// change between calls.
 ///

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -510,6 +510,28 @@ pub(super) fn emit_autoindex(
         pc_if_empty: label_ephemeral_build_loop_start,
     });
     program.preassign_label_to_next_insn(label_ephemeral_build_loop_start);
+    let label_ephemeral_build_loop_next = program.allocate_label();
+    if let Some(filter) = &index.where_clause {
+        let filter_passed = program.allocate_label();
+        // The table's planned operation reads from the new index. While that
+        // index is being built, expressions must read the source cursor.
+        program.set_cursor_override(table_ref_id, table_cursor_id);
+        let result = translate_condition_expr(
+            program,
+            table_references,
+            filter,
+            ConditionMetadata {
+                jump_if_condition_is_true: false,
+                jump_target_when_true: filter_passed,
+                jump_target_when_false: label_ephemeral_build_loop_next,
+                jump_target_when_null: label_ephemeral_build_loop_next,
+            },
+            resolver,
+        );
+        program.clear_cursor_override(table_ref_id);
+        result?;
+        program.preassign_label_to_next_insn(filter_passed);
+    }
     // Emit all columns from source table that are needed in the ephemeral index.
     // Also reserve a register for the rowid if the source table has rowids.
     let num_regs_to_reserve = index.columns.len() + table_has_rowid as usize;
@@ -578,6 +600,7 @@ pub(super) fn emit_autoindex(
         unpacked_count: Some(num_regs_to_reserve as u32),
         flags: IdxInsertFlags::new().use_seek(false),
     });
+    program.preassign_label_to_next_insn(label_ephemeral_build_loop_next);
     program.emit_insn(Insn::Next {
         cursor_id: table_cursor_id,
         pc_if_next: label_ephemeral_build_loop_start,

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -16,25 +16,6 @@ pub(super) struct HashBuildPayloadInfo {
     pub allow_seek: bool,
 }
 
-fn expr_references_outer_query(expr: &Expr, table_references: &TableReferences) -> bool {
-    let mut has_outer_ref = false;
-    let _ = walk_expr(expr, &mut |e: &Expr| -> Result<WalkControl> {
-        match e {
-            Expr::Column { table, .. } | Expr::RowId { table, .. } => {
-                if table_references
-                    .find_outer_query_ref_by_internal_id(*table)
-                    .is_some()
-                {
-                    has_outer_ref = true;
-                }
-            }
-            _ => {}
-        }
-        Ok(WalkControl::Continue)
-    });
-    has_outer_ref
-}
-
 /// Static configuration for a fresh hash-table build.
 struct HashBuildConfig {
     payload_columns: Vec<MaterializedColumnRef>,

--- a/core/translate/main_loop/mod.rs
+++ b/core/translate/main_loop/mod.rs
@@ -7,9 +7,9 @@ use super::{
         TranslateCtx, UpdateRowSource,
     },
     expr::{
-        expr_references_subquery_id, translate_condition_expr, translate_expr,
-        translate_expr_no_constant_opt, walk_expr, ConditionMetadata, NoConstantOptReason,
-        WalkControl,
+        expr_references_outer_query, expr_references_subquery_id, translate_condition_expr,
+        translate_expr, translate_expr_no_constant_opt, walk_expr, ConditionMetadata,
+        NoConstantOptReason, WalkControl,
     },
     group_by::{group_by_agg_phase, GroupByMetadata, GroupByRowSource},
     optimizer::{constraints::BinaryExprSide, Optimizable},

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -127,6 +127,8 @@ pub fn translate(
         },
         &prepare_options.unqualified_database_search_path,
     );
+    #[cfg(feature = "simulator")]
+    resolver.set_subquery_unnesting_mode(connection.subquery_unnesting_mode());
 
     match stmt {
         // There can be no nesting with pragma, so lift it up here

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -892,6 +892,19 @@ pub fn optimize_select_plan(plan: &mut SelectPlan, resolver: &Resolver) -> Resul
     optimize_select_plan_with_cache(plan, resolver, &mut cache)
 }
 
+/// Whether the unnested form can be emitted.
+///
+/// Unnesting moves a subquery's WHERE clause into the outer query, so a term
+/// that is always false can travel with it, as in
+/// `WHERE a IN (SELECT z FROM t WHERE 'abc' AND t.z = o.b)`. The emitter skips
+/// loop setup for a query that returns no rows, and that setup is where a table
+/// the rewrite added to the FROM clause gets its result registers. Reading
+/// those registers afterwards is a bug, so run the correlated form instead. It
+/// returns the same rows.
+fn rewritten_form_is_emittable(rewritten: &SelectPlan) -> bool {
+    !rewritten.contains_constant_false_condition
+}
+
 #[turso_macros::trace_stack]
 fn optimize_select_plan_with_cache(
     plan: &mut SelectPlan,
@@ -935,6 +948,9 @@ fn optimize_select_plan_with_cache(
     if full_join_rewrite_is_complete {
         let rewritten_table_plan =
             find_select_plan_form(&mut rewritten, resolver, cache, false, None)?;
+        if !rewritten_form_is_emittable(&rewritten) {
+            return optimize_select_plan_form(plan, resolver, cache);
+        }
         *plan = rewritten;
         apply_select_table_plan(plan, rewritten_table_plan, resolver)?;
         return Ok(());
@@ -944,19 +960,30 @@ fn optimize_select_plan_with_cache(
     if resolver.subquery_unnesting_mode() == crate::SubqueryUnnestingMode::Forced {
         let rewritten_table_plan =
             find_select_plan_form(&mut rewritten, resolver, cache, false, None)?;
+        if !rewritten_form_is_emittable(&rewritten) {
+            return optimize_select_plan_form(plan, resolver, cache);
+        }
         *plan = rewritten;
         apply_select_table_plan(plan, rewritten_table_plan, resolver)?;
         return Ok(());
     }
 
     let original_table_plan = find_select_plan_form(plan, resolver, cache, true, None)?;
+    // The query already returns no rows, so a cheaper form cannot be found.
+    if plan.contains_constant_false_condition {
+        apply_select_table_plan(plan, original_table_plan, resolver)?;
+        return Ok(());
+    }
     let cost_limit = plan.estimated_cost.map(Cost);
     let rewritten_table_plan =
         find_select_plan_form(&mut rewritten, resolver, cache, false, cost_limit)?;
-    let use_rewritten = matches!(
-        (plan.estimated_cost, rewritten.estimated_cost),
-        (Some(original_cost), Some(rewritten_cost)) if rewritten_cost <= original_cost
-    );
+    // A form that returns no rows costs nothing, so it would always win the
+    // comparison below. Check that it can be emitted before comparing costs.
+    let use_rewritten = rewritten_form_is_emittable(&rewritten)
+        && matches!(
+            (plan.estimated_cost, rewritten.estimated_cost),
+            (Some(original_cost), Some(rewritten_cost)) if rewritten_cost <= original_cost
+        );
     if use_rewritten {
         // Equal work is better without one subquery call per outer row.
         *plan = rewritten;

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -906,6 +906,11 @@ fn optimize_select_plan_with_cache(
         return optimize_select_plan_form(plan, resolver, cache);
     }
 
+    #[cfg(feature = "simulator")]
+    if resolver.subquery_unnesting_mode() == crate::SubqueryUnnestingMode::Disabled {
+        return optimize_select_plan_form(plan, resolver, cache);
+    }
+
     // TODO: Let join search run a correlated subquery as soon as all columns
     // that it needs are ready. It can then compare that step with the added
     // join tables in one search. Until then, both forms need their own search.
@@ -928,6 +933,15 @@ fn optimize_select_plan_with_cache(
             .iter()
             .any(|subquery| subquery.correlated);
     if full_join_rewrite_is_complete {
+        let rewritten_table_plan =
+            find_select_plan_form(&mut rewritten, resolver, cache, false, None)?;
+        *plan = rewritten;
+        apply_select_table_plan(plan, rewritten_table_plan, resolver)?;
+        return Ok(());
+    }
+
+    #[cfg(feature = "simulator")]
+    if resolver.subquery_unnesting_mode() == crate::SubqueryUnnestingMode::Forced {
         let rewritten_table_plan =
             find_select_plan_form(&mut rewritten, resolver, cache, false, None)?;
         *plan = rewritten;

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -22,6 +22,9 @@ use crate::{
         ROWID_SENTINEL,
     },
     translate::{
+        expr::{
+            expr_references_any_subquery, expr_references_outer_query, expression_can_fail_on_input,
+        },
         insert::ROWID_COLUMN,
         optimizer::{
             access_method::{AccessMethod, AccessMethodParams},
@@ -2722,7 +2725,11 @@ fn apply_table_access_plan(
                     );
                     *index = Some(Arc::new(ephemeral_index_build(
                         &table_references.joined_tables()[table_idx],
+                        table_references,
+                        &constraints_per_table[table_idx].constraints,
                         constraint_refs,
+                        where_clause,
+                        resolver,
                     )?));
                     *build_index = false;
                 }
@@ -3622,7 +3629,11 @@ impl Optimizable for ast::Expr {
 
 fn ephemeral_index_build(
     table_reference: &JoinedTable,
+    table_references: &TableReferences,
+    constraints: &[Constraint],
     constraint_refs: &[RangeConstraintRef],
+    where_clause: &[WhereTerm],
+    resolver: &Resolver<'_>,
 ) -> Result<Index> {
     let mut ephemeral_columns: crate::alloc::Vec<IndexColumn> = table_reference
         .columns()
@@ -3674,7 +3685,15 @@ fn ephemeral_index_build(
         ephemeral: true,
         table_name: table_reference.table.get_name().to_string(),
         root_page: 0,
-        where_clause: None,
+        where_clause: autoindex_prefilter(
+            table_reference,
+            table_references,
+            constraints,
+            constraint_refs,
+            where_clause,
+            resolver,
+        )
+        .map(Box::new),
         has_rowid: table_reference
             .table
             .btree()
@@ -3684,6 +3703,98 @@ fn ephemeral_index_build(
     };
 
     Ok(ephemeral_index)
+}
+
+/// Find conditions that can filter rows while an automatic index is built.
+///
+/// For example, given:
+///
+/// ```sql
+/// SELECT *
+/// FROM accounts AS a
+/// JOIN events AS e ON e.account_id = a.id
+/// WHERE e.created_at >= '2024-01-01';
+/// ```
+///
+/// `e.account_id = a.id` needs the current account, so it is applied when the
+/// index is searched. The date condition needs only an event row and a fixed
+/// value, so rows before that date can be left out of the index entirely.
+fn autoindex_prefilter(
+    table_reference: &JoinedTable,
+    table_references: &TableReferences,
+    constraints: &[Constraint],
+    constraint_refs: &[RangeConstraintRef],
+    where_clause: &[WhereTerm],
+    resolver: &Resolver<'_>,
+) -> Option<Expr> {
+    let is_outer_join = table_reference
+        .join_info
+        .as_ref()
+        .is_some_and(JoinInfo::is_outer);
+    if table_reference
+        .join_info
+        .as_ref()
+        .is_some_and(JoinInfo::is_full_outer)
+    {
+        return None;
+    }
+
+    let mut term_positions = SmallVec::<[usize; 4]>::new();
+    for constraint_ref in constraint_refs {
+        for constraint_pos in [
+            constraint_ref.eq.as_ref().map(|eq| eq.constraint_pos),
+            constraint_ref.lower_bound,
+            constraint_ref.upper_bound,
+        ] {
+            let Some(constraint_pos) = constraint_pos else {
+                continue;
+            };
+            let constraint = &constraints[constraint_pos];
+            let Some(column_pos) = constraint.table_col_pos else {
+                continue;
+            };
+            let column = &table_reference.columns()[column_pos];
+            let depends_on_another_table = !constraint.lhs_mask.is_empty();
+            let is_virtual_column = column.is_virtual_generated();
+            let is_array = column.is_array();
+            let has_custom_type = resolver
+                .schema()
+                .get_type_def(&column.ty_str, table_reference.table.is_strict())
+                .is_some();
+            if depends_on_another_table || is_virtual_column || is_array || has_custom_type {
+                continue;
+            }
+
+            let term_pos = constraint.where_clause_pos.0;
+            let term = &where_clause[term_pos];
+            let runs_before_outer_join_condition =
+                is_outer_join && term.from_outer_join != Some(table_reference.internal_id);
+            let comes_from_another_outer_join = term
+                .from_outer_join
+                .is_some_and(|table_id| table_id != table_reference.internal_id);
+            let depends_on_outer_query = expr_references_outer_query(&term.expr, table_references);
+            let contains_subquery = expr_references_any_subquery(&term.expr);
+            // The build scans inner rows whose keys might never be searched.
+            // Do not make a possibly failing expression run for those rows.
+            let can_fail_for_unused_row = expression_can_fail_on_input(&term.expr);
+            let was_already_added = term_positions.contains(&term_pos);
+            if runs_before_outer_join_condition
+                || comes_from_another_outer_join
+                || depends_on_outer_query
+                || contains_subquery
+                || can_fail_for_unused_row
+                || was_already_added
+            {
+                continue;
+            }
+            term_positions.push(term_pos);
+        }
+    }
+
+    term_positions
+        .into_iter()
+        .map(|term_pos| where_clause[term_pos].expr.clone())
+        .reduce(|left, right| Expr::Binary(Box::new(left), ast::Operator::And, Box::new(right)))
 }
 
 /// Build a [SeekDef] for a given list of [Constraint]s

--- a/core/translate/optimizer/unnest.rs
+++ b/core/translate/optimizer/unnest.rs
@@ -131,7 +131,8 @@ use crate::translate::{
     emitter::Resolver,
     expr::{
         expr_contains_nondeterministic_scalar_function, expr_references_any_subquery,
-        expr_references_subquery_id, get_expr_affinity, walk_expr, walk_expr_mut, WalkControl,
+        expr_references_subquery_id, expression_can_fail_on_input, get_expr_affinity, walk_expr,
+        walk_expr_mut, WalkControl,
     },
     plan::{
         plan_is_correlated, Distinctness, GroupBy, JoinInfo, JoinType, JoinedTable,
@@ -1017,53 +1018,6 @@ fn aggregate_can_run_for_unused_rows(plan: &SelectPlan) -> bool {
     !aggregate_expressions
         .chain(filter_expressions)
         .any(expression_can_fail_on_input)
-}
-
-/// Return whether evaluating this expression can return an error.
-///
-/// For example, `json_extract(value, '$')` fails when `value` contains invalid
-/// JSON. This check uses these simple, strict rules:
-///
-/// - Every function call counts because an extension function can return an
-///   error, and there is no list of functions proved to be safe.
-/// - `LIKE` counts because it can call a user-defined `like` function.
-/// - `RAISE` counts because its purpose is to return an error.
-/// - JSON and array operators count because they can reject invalid input.
-///
-/// Callers use this check in two cases:
-///
-/// - An `IN` semi-join stops after its first match. It must not hide an error in
-///   a later inner row.
-/// - A grouped table computes keys that no outer row uses. It must not create
-///   an error that the original correlated subquery never created.
-fn expression_can_fail_on_input(expr: &Expr) -> bool {
-    let mut can_fail = false;
-    walk_expr(expr, &mut |expr: &Expr| -> Result<WalkControl> {
-        if matches!(
-            expr,
-            Expr::FunctionCall { .. }
-                | Expr::FunctionCallStar { .. }
-                | Expr::Like { .. }
-                | Expr::Raise(_, _)
-                | Expr::Binary(
-                    _,
-                    ast::Operator::ArrowRight
-                        | ast::Operator::ArrowRightShift
-                        | ast::Operator::ArrayContains
-                        | ast::Operator::ArrayOverlap,
-                    _
-                )
-        ) {
-            can_fail = true;
-        }
-        Ok(if can_fail {
-            WalkControl::SkipChildren
-        } else {
-            WalkControl::Continue
-        })
-    })
-    .expect("walking an expression cannot fail");
-    can_fail
 }
 
 /// Return the result for no input rows, if it is known.

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__cross-join-with-filter.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__cross-join-with-filter.snap
@@ -26,34 +26,37 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode            p1  p2  p3  p4              p5  comment
-   0  Init               0  28   0                   0  Start at 28
+   0  Init               0  30   0                   0  Start at 30
    1  OpenRead           0   2   0  k(5,B,B,B,B,B)   0  table=customers, root=2, iDb=0
    2  OpenRead           1   3   0  k(5,B,B,B,B,B)   0  table=products, root=3, iDb=0
-   3  Rewind             0  27   0                   0  Rewind table customers
+   3  Rewind             0  29   0                   0  Rewind table customers
    4    Column           0   3   5                   0  r[5]=customers.city
-   5    Ne               5   6  26  Binary           0  if r[5]!=r[6] goto 26
-   6    Once            17   0   0                   0  goto 17
+   5    Ne               5   6  28  Binary           0  if r[5]!=r[6] goto 28
+   6    Once            19   0   0                   0  goto 19
    7    OpenAutoindex    2   0   0                   0  cursor=2
    8    Rewind           1   9   0                   0  Rewind table products
-   9      Column         1   2   7                   0  r[7]=products.category
-  10      Column         1   1   8                   0  r[8]=products.name
-  11      Column         1   3   9                   0  r[9]=products.price
-  12      RowId          1  10   0                   0  r[10]=products.rowid
-  13      MakeRecord     7   4  11                   0  r[11]=mkrec(r[7..10]); for ephemeral_products_t2
-  14      FilterAdd      2   7   1                   0  bloom_filter_add(r[7..8])
-  15      IdxInsert      2  11   7                   0  key=r[11]
-  16    Next             1   9   0                   0
-  17    String8          0  12   0  Books            0  r[12]='Books'
-  18    Filter           2  26  12                   1  if !bloom_filter(r[12..13]) goto 26
-  19    SeekGE           2  26  12                   0  key=[12..12]
-  20      IdxGT          2  26  12                   0  key=[12..12]
-  21      DeferredSeek   2   1   0                   0
-  22      Column         0   1   1                   0  r[1]=customers.name
-  23      ColumnRange    2   1   2  2                0  r[2..3]=ephemeral(ephemeral_products_t2).name..price
-  24      ResultRow      1   3   0                   0  output=r[1..3]
-  25    Next             2  20   0                   0
-  26  Next               0   4   0                   1
-  27  Halt               0   0   0                   0
-  28  Transaction        0   1  10                   0  iDb=0 tx_mode=Read
-  29  String8            0   6   0  Boston           0  r[6]='Boston'
-  30  Goto               0   1   0                   0
+   9      Column         1   2   8                   0  r[8]=products.category
+  10      Ne             8   9  18  Binary           0  if r[8]!=r[9] goto 18
+  11      Column         1   2  10                   0  r[10]=products.category
+  12      Column         1   1  11                   0  r[11]=products.name
+  13      Column         1   3  12                   0  r[12]=products.price
+  14      RowId          1  13   0                   0  r[13]=products.rowid
+  15      MakeRecord    10   4  14                   0  r[14]=mkrec(r[10..13]); for ephemeral_products_t2
+  16      FilterAdd      2  10   1                   0  bloom_filter_add(r[10..11])
+  17      IdxInsert      2  14  10                   0  key=r[14]
+  18    Next             1   9   0                   0
+  19    String8          0  15   0  Books            0  r[15]='Books'
+  20    Filter           2  28  15                   1  if !bloom_filter(r[15..16]) goto 28
+  21    SeekGE           2  28  15                   0  key=[15..15]
+  22      IdxGT          2  28  15                   0  key=[15..15]
+  23      DeferredSeek   2   1   0                   0
+  24      Column         0   1   1                   0  r[1]=customers.name
+  25      ColumnRange    2   1   2  2                0  r[2..3]=ephemeral(ephemeral_products_t2).name..price
+  26      ResultRow      1   3   0                   0  output=r[1..3]
+  27    Next             2  22   0                   0
+  28  Next               0   4   0                   1
+  29  Halt               0   0   0                   0
+  30  Transaction        0   1  10                   0  iDb=0 tx_mode=Read
+  31  String8            0   6   0  Boston           0  r[6]='Boston'
+  32  String8            0   9   0  Books            0  r[9]='Books'
+  33  Goto               0   1   0                   0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q20-function-bound-stays-outside-autoindex-build.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q20-function-bound-stays-outside-autoindex-build.snap
@@ -1,0 +1,113 @@
+---
+source: tpch.sqltest
+expression: |-
+  select
+          ps_suppkey
+      from
+          partsupp
+      where
+          ps_availqty > (
+              select
+                  0.5 * sum(l_quantity)
+              from
+                  lineitem
+              where
+                  l_partkey = ps_partkey
+                  and l_suppkey = ps_suppkey
+                  and l_shipdate >= json_extract('"1994-01-01"', '$')
+                  and l_shipdate < '1995-01-01'
+          );
+info:
+  statement_type: SELECT
+  tables:
+  - lineitem
+  - partsupp
+  setup_blocks:
+  - schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN partsupp
+`--SEARCH lineitem USING COVERING INDEX ephemeral_lineitem_t3 (L_PARTKEY=? AND L_SUPPKEY=? AND L_SHIPDATE>=? AND L_SHIPDATE<?) LEFT-JOIN
+
+BYTECODE
+addr  opcode                    p1  p2  p3  p4                                     p5  comment
+   0          Init               0  76   0                                          0  Start at 76
+   1          Null               0   9   0                                          0  r[9]=NULL
+   2          Integer            0   4   0                                          0  r[4]=0; clear group by abort flag
+   3          Null               0   5   0                                          0  r[5]=NULL; initialize group by comparison registers to NULL
+   4          Gosub             15  72   0                                          0  ; go to clear accumulator subroutine
+   5          OpenRead           0   6   0  k(6,B,B,B,B,B)                          0  table=partsupp, root=6, iDb=0
+   6          OpenRead           1  10   0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+   7          Rewind             0  57   0                                          0  Rewind table partsupp
+   8            Integer          0  16   0                                          0  r[16]=0
+   9            Once            21   0   0                                          0  goto 21
+  10            OpenAutoindex    2   0   0                                          0  cursor=2
+  11            Rewind           1  12   0                                          0  Rewind table lineitem
+  12              Column         1  10  18                                          0  r[18]=lineitem.L_SHIPDATE
+  13              Ge            18  19  20  Binary                                  0  if r[18]>=r[19] goto 20
+  14              ColumnRange    1   1  20  2                                       0  r[20..21]=lineitem.L_PARTKEY..L_SUPPKEY
+  15              Column         1  10  22                                          0  r[22]=lineitem.L_SHIPDATE
+  16              Column         1   4  23                                          0  r[23]=lineitem.L_QUANTITY
+  17              RowId          1  24   0                                          0  r[24]=lineitem.rowid
+  18              MakeRecord    20   5  25                                          0  r[25]=mkrec(r[20..24]); for ephemeral_lineitem_t3
+  19              IdxInsert      2  25  20                                          0  key=r[25]
+  20            Next             1  12   0                                          0
+  21            ColumnRange      0   0  26  2                                       0  r[26..27]=partsupp.PS_PARTKEY..PS_SUPPKEY
+  22            String8          0  29   0  "1994-01-01"                            0  r[29]='"1994-01-01"'
+  23            String8          0  30   0  $                                       0  r[30]='$'
+  24            Function         0  29  28  json_extract                            0  r[28]=func(r[29..30])
+  25            IsNull          28  52   0                                          0  if (r[28]==NULL) goto 52
+  26            Affinity        26   3   0                                          0  r[26..29] = C, C, C
+  27            SeekGE           2  52  26                                          0  key=[26..28]
+  28            String8          0  28   0  1995-01-01                              0  r[28]='1995-01-01'
+  29            Affinity        26   3   0                                          0  r[26..29] = C, C, C
+  30              IdxGE          2  52  26                                          0  key=[26..28]
+  31              DeferredSeek   2   1   0                                          0
+  32              Integer        1  16   0                                          0  r[16]=1
+  33              RowId          0  11   0                                          0  r[11]=partsupp.rowid
+  34              ColumnRange    0   1  12  2                                       0  r[12..13]=partsupp.PS_SUPPKEY..PS_AVAILQTY
+  35              Column         2   3  14                                          0  r[14]=ephemeral(ephemeral_lineitem_t3).L_QUANTITY
+  36              Compare        5  11   1  k(1, Binary)                            0  r[5..5]==r[11..11]
+  37              Jump          38  42  38                                          0  ; start new group if comparison is not equal
+  38              Gosub          2  61   0                                          0  ; check if ended group had data, and output if so
+  39              Move          11   5   1                                          0  r[5..5]=r[11..11]
+  40              IfPos          4  75   0                                          0  r[4]>0 -> r[4]-=0, goto 75; check abort flag
+  41              Gosub         15  72   0                                          0  ; goto clear accumulator subroutine
+  42              IdxRowId       2  32   0                                          0  r[32]=cursor 2 for index ephemeral(ephemeral_lineitem_t3).rowid
+  43              Integer        1  31   0                                          0  r[31]=1
+  44              NotNull       32  46   0                                          0  r[32]!=NULL -> goto 46
+  45              Integer        0  31   0                                          0  r[31]=0
+  46              IfNot         31  48   1                                          0  if !r[31] goto 48
+  47              AggStep        0  14   9  sum                                     0  accum=r[9] step(r[14])
+  48              If             3  50   0                                          0  if r[3] goto 50; don't emit group columns if continuing existing group
+  49              ColumnRange    0   1   6  2                                       0  r[6..7]=partsupp.PS_SUPPKEY..PS_AVAILQTY
+  50              Integer        1   3   0                                          0  r[3]=1; indicate data in accumulator
+  51            Next             2  30   0                                          0
+  52            IfPos           16  56   0                                          0  r[16]>0 -> r[16]-=0, goto 56
+  53            NullRow          1   0   0                                          0  Set cursor 1 to a (pseudo) NULL row
+  54            NullRow          2   0   0                                          0  Set cursor 2 to a (pseudo) NULL row
+  55            Goto             0  32   0                                          0
+  56          Next               0   8   0                                          1
+  57          Gosub              2  61   0                                          0  ; emit row for final group
+  58          Goto               0  75   0                                          0  ; group by finished
+  59          Integer            1   4   0                                          0  r[4]=1
+  60        Return               2   0   0                                          0
+  61        IfPos                3  63   0                                          0  r[3]>0 -> r[3]-=0, goto 63; output group by row subroutine start
+  62      Return                 2   0   0                                          0
+  63      AggFinal               0   9   0  sum                                     0  accum=r[9]
+  64      Copy                   7  34   0                                          0  r[34]=r[7]
+  65      Real                   0  36   0  0.5                                     0  r[36]=0.5
+  66      Copy                   9  37   0                                          0  r[37]=r[9]
+  67      Multiply              36  37  35                                          0  r[35]=r[36]*r[37]
+  68      Le                    34  35  62  Binary                                  0  if r[34]<=r[35] goto 62
+  69      Copy                   6   1   0                                          0  r[1]=r[6]
+  70      ResultRow              1   1   0                                          0  output=r[1]
+  71    Return                   2   0   0                                          0
+  72    Null                     0   6   9                                          0  r[6..9]=NULL; clear accumulator subroutine start
+  73    Integer                  0   3   0                                          0  r[3]=0
+  74  Return                    15   0   0                                          0
+  75  Halt                       0   0   0                                          0
+  76  Transaction                0   1   8                                          0  iDb=0 tx_mode=Read
+  77  String8                    0  19   0  1995-01-01                              0  r[19]='1995-01-01'
+  78  Goto                       0   1   0                                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q20-potential-part-promotion.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q20-potential-part-promotion.snap
@@ -59,3 +59,142 @@ QUERY PLAN
 |--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
 `--USE SORTER FOR ORDER BY
+
+BYTECODE
+addr  opcode                       p1   p2   p3  p4                                     p5  comment
+   0          Init                  0  130    0                                          0  Start at 130
+   1          Once                107    0    0                                          0  goto 107
+   2          OpenEphemeral         1    0    0                                          0  cursor=1 is_table=false
+   3          Once                 14    0    0                                          0  goto 14
+   4          OpenEphemeral         0    0    0                                          0  cursor=0 is_table=false
+   5          OpenRead              2    4    0  k(9,B,B,B,B,B,B,B,B,B)                  0  table=part, root=4, iDb=0
+   6          Rewind                2   14    0                                          0  Rewind table part
+   7            Column              2    1    5                                          0  r[5]=part.P_NAME
+   8            Function            1    4    3  like(2)                                 0  r[3]=func(r[4..5])
+   9            IfNot               3   13    1                                          0  if !r[3] goto 13
+  10            RowId               2    2    0                                          0  r[2]=part.rowid
+  11            MakeRecord          2    1    6                                          0  r[6]=mkrec(r[2..2]); for ephemeral_index_where_sub_t5
+  12            IdxInsert           0    6    0                                          8  key=r[6]
+  13          Next                  2    7    0                                          1
+  14          Null                  0   15    0                                          0  r[15]=NULL
+  15          SorterOpen            3    5    0  k(1,B)                                  0  cursor=3
+  16          Integer               0   10    0                                          0  r[10]=0; clear group by abort flag
+  17          Null                  0   11    0                                          0  r[11]=NULL; initialize group by comparison registers to NULL
+  18          Gosub                22  104    0                                          0  ; go to clear accumulator subroutine
+  19          OpenRead              5    6    0  k(6,B,B,B,B,B)                          0  table=partsupp, root=6, iDb=0
+  20          OpenRead              6    7    0  k(3,B,B)                                0  index=sqlite_autoindex_partsupp_1, root=7, iDb=0
+  21          OpenRead              7   10    0  k(17,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B,B)   0  table=lineitem, root=10, iDb=0
+  22          NullRow               0    0    0                                          0  Set cursor 0 to a (pseudo) NULL row
+  23          Rewind                0   67    0                                          0  Rewind  ephemeral(ephemeral_index_where_sub_t5)
+  24            Column              0    0   24                                          0  r[24]=ephemeral(ephemeral_index_where_sub_t5).P_PARTKEY
+  25            IsNull             24   66    0                                          0  if (r[24]==NULL) goto 66
+  26            SeekGE              6   66   24                                          0  key=[24..24]
+  27              IdxGT             6   66   24                                          0  key=[24..24]
+  28              DeferredSeek      6    5    0                                          0
+  29              Integer           0   23    0                                          0  r[23]=0
+  30              Once             44    0    0                                          0  goto 44
+  31              OpenAutoindex     8    0    0                                          0  cursor=8
+  32              Rewind            7   33    0                                          0  Rewind table lineitem
+  33                Column          7   10   26                                          0  r[26]=lineitem.L_SHIPDATE
+  34                Lt             26   27   43  Binary                                  0  if r[26]<r[27] goto 43
+  35                Column          7   10   29                                          0  r[29]=lineitem.L_SHIPDATE
+  36                Ge             29   30   43  Binary                                  0  if r[29]>=r[30] goto 43
+  37                ColumnRange     7    1   31  2                                       0  r[31..32]=lineitem.L_PARTKEY..L_SUPPKEY
+  38                Column          7   10   33                                          0  r[33]=lineitem.L_SHIPDATE
+  39                Column          7    4   34                                          0  r[34]=lineitem.L_QUANTITY
+  40                RowId           7   35    0                                          0  r[35]=lineitem.rowid
+  41                MakeRecord     31    5   36                                          0  r[36]=mkrec(r[31..35]); for ephemeral_lineitem_t8
+  42                IdxInsert       8   36   31                                          0  key=r[36]
+  43              Next              7   33    0                                          0
+  44              ColumnRange       6    0   37  2                                       0  r[37..38]=sqlite_autoindex_partsupp_1.ps_partkey..ps_suppkey
+  45              String8           0   39    0  1994-01-01                              0  r[39]='1994-01-01'
+  46              Affinity         37    3    0                                          0  r[37..40] = C, C, C
+  47              SeekGE            8   61   37                                          0  key=[37..39]
+  48              String8           0   39    0  1995-01-01                              0  r[39]='1995-01-01'
+  49              Affinity         37    3    0                                          0  r[37..40] = C, C, C
+  50                IdxGE           8   61   37                                          0  key=[37..39]
+  51                DeferredSeek    8    7    0                                          0
+  52                Integer         1   23    0                                          0  r[23]=1
+  53                RowId           5   17    0                                          0  r[17]=partsupp.rowid
+  54                Column          6    1   18                                          0  r[18]=sqlite_autoindex_partsupp_1.ps_suppkey
+  55                Column          5    2   19                                          0  r[19]=partsupp.PS_AVAILQTY
+  56                Column          8    3   20                                          0  r[20]=ephemeral(ephemeral_lineitem_t8).L_QUANTITY
+  57                IdxRowId        8   21    0                                          0  r[21]=cursor 8 for index ephemeral(ephemeral_lineitem_t8).rowid
+  58                MakeRecord     17    5   16                                          0  r[16]=mkrec(r[17..21])
+  59                SorterInsert    3   16    0  0                                       0  key=r[16]
+  60              Next              8   50    0                                          0
+  61              IfPos            23   65    0                                          0  r[23]>0 -> r[23]-=0, goto 65
+  62              NullRow           7    0    0                                          0  Set cursor 7 to a (pseudo) NULL row
+  63              NullRow           8    0    0                                          0  Set cursor 8 to a (pseudo) NULL row
+  64              Goto              0   52    0                                          0
+  65            Next                6   27    0                                          0
+  66          Next                  0   24    0                                          0
+  67          OpenPseudo            4   16    5                                          0  5 columns in r[16]
+  68          SorterSort            3   88    0                                          0
+  69            SorterData          3   16    4                                          0  r[16]=data
+  70            Column              4    0   40                                          0  r[40]=pseudo.column 0
+  71            Compare            11   40    1  k(1, Binary)                            0  r[11..11]==r[40..40]
+  72            Jump               73   77   73                                          0  ; start new group if comparison is not equal
+  73            Gosub               8   92    0                                          0  ; check if ended group had data, and output if so
+  74            Move               40   11    1                                          0  r[11..11]=r[40..40]
+  75            IfPos              10  107    0                                          0  r[10]>0 -> r[10]-=0, goto 107; check abort flag
+  76            Gosub              22  104    0                                          0  ; goto clear accumulator subroutine
+  77            ColumnRange         4    3   41  2                                       0  r[41..42]=pseudo.column 3..column 4
+  78            Copy               42   44    0                                          0  r[44]=r[42]
+  79            Integer             1   43    0                                          0  r[43]=1
+  80            NotNull            44   82    0                                          0  r[44]!=NULL -> goto 82
+  81            Integer             0   43    0                                          0  r[43]=0
+  82            IfNot              43   84    1                                          0  if !r[43] goto 84
+  83            AggStep             0   41   15  sum                                     0  accum=r[15] step(r[41])
+  84            If                  9   86    0                                          0  if r[9] goto 86; don't emit group columns if continuing existing group
+  85            ColumnRange         4    1   12  2                                       0  r[12..13]=pseudo.column 1..column 2
+  86            Integer             1    9    0                                          0  r[9]=1; indicate data in accumulator
+  87          SorterNext            3   69    0                                          0
+  88          Gosub                 8   92    0                                          0  ; emit row for final group
+  89          Goto                  0  107    0                                          0  ; group by finished
+  90          Integer               1   10    0                                          0  r[10]=1
+  91        Return                  8    0    0                                          0
+  92        IfPos                   9   94    0                                          0  r[9]>0 -> r[9]-=0, goto 94; output group by row subroutine start
+  93      Return                    8    0    0                                          0
+  94      AggFinal                  0   15    0  sum                                     0  accum=r[15]
+  95      Copy                     13   46    0                                          0  r[46]=r[13]
+  96      Real                      0   48    0  0.5                                     0  r[48]=0.5
+  97      Copy                     15   49    0                                          0  r[49]=r[15]
+  98      Multiply                 48   49   47                                          0  r[47]=r[48]*r[49]
+  99      Le                       46   47   93  Binary                                  0  if r[46]<=r[47] goto 93
+ 100      Copy                     12    7    0                                          0  r[7]=r[12]
+ 101      MakeRecord                7    1   50                                          0  r[50]=mkrec(r[7..7]); for ephemeral_index_where_sub_t3
+ 102      IdxInsert                 1   50    0                                          8  key=r[50]
+ 103    Return                      8    0    0                                          0
+ 104    Null                        0   12   15                                          0  r[12..15]=NULL; clear accumulator subroutine start
+ 105    Integer                     0    9    0                                          0  r[9]=0
+ 106  Return                       22    0    0                                          0
+ 107  SorterOpen                    9    1    0  k(1,B)                                  0  cursor=9
+ 108  OpenRead                     10    5    0  k(7,B,B,B,B,B,B,B)                      0  table=supplier, root=5, iDb=0
+ 109  OpenRead                     11    2    0  k(4,B,B,B,B)                            0  table=nation, root=2, iDb=0
+ 110  NullRow                       1    0    0                                          0  Set cursor 1 to a (pseudo) NULL row
+ 111  Rewind                        1  123    0                                          0  Rewind  ephemeral(ephemeral_index_where_sub_t3)
+ 112    Column                      1    0   54                                          0  r[54]=ephemeral(ephemeral_index_where_sub_t3).PS_SUPPKEY
+ 113    IsNull                     54  122    0                                          0  if (r[54]==NULL) goto 122
+ 114    SeekRowid                  10   54  122                                          0  if (r[54]!=cursor 10 for table supplier.rowid) goto 122
+ 115    Column                     10    3   55                                          0  r[55]=supplier.S_NATIONKEY
+ 116    SeekRowid                  11   55  122                                          0  if (r[55]!=cursor 11 for table nation.rowid) goto 122
+ 117    Column                     11    1   57                                          0  r[57]=nation.N_NAME
+ 118    Ne                         57   58  122  Binary                                  0  if r[57]!=r[58] goto 122
+ 119    ColumnRange                10    1   59  2                                       0  r[59..60]=supplier.S_NAME..S_ADDRESS
+ 120    MakeRecord                 59    2   53                                          0  r[53]=mkrec(r[59..60])
+ 121    SorterInsert                9   53    0  0                                       0  key=r[53]
+ 122  Next                          1  112    0                                          0
+ 123  OpenPseudo                   12   53    2                                          0  2 columns in r[53]
+ 124  SorterSort                    9  129    0                                          0
+ 125    SorterData                  9   53   12                                          0  r[53]=data
+ 126    ColumnRange                12    0   51  2                                       0  r[51..52]=pseudo.column 0..column 1
+ 127    ResultRow                  51    2    0                                          0  output=r[51..52]
+ 128  SorterNext                    9  125    0                                          0
+ 129  Halt                          0    0    0                                          0
+ 130  Transaction                   0    1    8                                          0  iDb=0 tx_mode=Read
+ 131  String8                       0    4    0  frosted%                                0  r[4]='frosted%'
+ 132  String8                       0   27    0  1994-01-01                              0  r[27]='1994-01-01'
+ 133  String8                       0   30    0  1995-01-01                              0  r[30]='1995-01-01'
+ 134  String8                       0   58    0  IRAN                                    0  r[58]='IRAN'
+ 135  Goto                          0    1    0                                          0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/tpch.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/tpch.sqltest
@@ -727,7 +727,7 @@ snapshot q19-discounted-revenue {
 
 # Q20: Potential Part Promotion
 @setup schema
-snapshot-eqp q20-potential-part-promotion {
+snapshot q20-potential-part-promotion {
     select
         s_name,
         s_address
@@ -765,6 +765,27 @@ snapshot-eqp q20-potential-part-promotion {
         and n_name = 'IRAN'
     order by
         s_name;
+}
+
+# A possibly failing bound must not run while the automatic index is built.
+@setup schema
+snapshot q20-function-bound-stays-outside-autoindex-build {
+    select
+        ps_suppkey
+    from
+        partsupp
+    where
+        ps_availqty > (
+            select
+                0.5 * sum(l_quantity)
+            from
+                lineitem
+            where
+                l_partkey = ps_partkey
+                and l_suppkey = ps_suppkey
+                and l_shipdate >= json_extract('"1994-01-01"', '$')
+                and l_shipdate < '1995-01-01'
+        );
 }
 
 # Q21: Suppliers Who Kept Orders Waiting

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -399,6 +399,32 @@ expect {
     5
 }
 
+# An outer query with no input rows does not need to build or probe a grouped
+# table for its scalar subquery.
+@setup correlated_rows
+test one-value-under-false-where-stays-unused {
+    SELECT (SELECT avg(i.amount) FROM inner_rows i WHERE i.key1 = o.key1) / 2
+    FROM outer_rows o
+    WHERE 0;
+}
+expect {
+}
+
+# Unnesting the IN subquery moves its WHERE clause to the outer query, and the
+# text term there is always false. The grouped table built for the scalar
+# subquery then has nothing to read, so the outer query keeps its correlated
+# form.
+@setup correlated_rows
+test one-value-beside-in-subquery-with-false-text-term {
+    SELECT (SELECT count(i.amount) FROM inner_rows i WHERE i.key1 = o.key1)
+    FROM outer_rows o
+    WHERE o.amount IN (
+        SELECT k.key2 FROM outer_key2 k WHERE 'not a number' AND o.key1 = k.key2
+    );
+}
+expect {
+}
+
 @setup correlated_rows
 test one-value-math-with-null-result {
     SELECT id

--- a/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/unnest-correlated.sqltest
@@ -1812,6 +1812,27 @@ matrix one-value-aggregate-comparisons {
     ORDER BY o.id;
 }
 
+# Check that automatic-index prefiltering preserves results for equality and
+# range conditions, reversed operands, NULLs, and one- or two-column keys.
+@setup correlated_rows
+@var comparison { = | < | <= | > | >= }
+@var link { i.key1 = o.key1 | i.key1 = o.key1 AND i.key2 = o.key2 }
+@var inner_filter { AND i.amount = 7 | AND i.amount > 6 | AND i.amount <= 20 | AND i.amount >= 6 AND i.amount < 20 | AND 20 >= i.amount AND 6 <= i.amount | AND i.amount IS NULL }
+matrix join-first-autoindex-prefilter {
+    SELECT candidate.id
+    FROM outer_rows candidate
+    WHERE candidate.id IN (
+        SELECT o.id
+        FROM outer_rows o
+        WHERE o.amount $comparison (
+            SELECT sum(i.amount)
+            FROM inner_rows i
+            WHERE $link $inner_filter
+        )
+    )
+    ORDER BY candidate.id;
+}
+
 @setup correlated_rows
 @var aggregate { avg(i.amount) | min(i.amount) | max(i.amount) | count(*) | count(i.amount) | total(i.amount) }
 matrix two-copies-of-one-aggregate {

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -16,6 +16,9 @@ pub struct GeneratedStatement {
     pub mutates_data: bool,
     pub has_unordered_limit: bool,
     pub unordered_limit_reason: Option<String>,
+    /// The generator added an outer-column dependency to a subquery, so the
+    /// forced-rewrite and disabled-rewrite plans should return the same result.
+    pub check_unnesting_invariant: bool,
 }
 
 impl std::fmt::Display for GeneratedStatement {
@@ -34,10 +37,9 @@ pub enum GeneratorKind {
     SqlGenProp,
 }
 
-/// A named mix of top-level statement weights. Each profile stresses a
-/// different part of the engine so CI can cover several statement mixes
-/// instead of the single default distribution. Profiles are static, so a
-/// failing run reproduces from its seed once the same profile is selected.
+/// A named workload mix. Each profile stresses a different part of the engine
+/// by changing statement weights and, when needed, SELECT generation. Profiles
+/// are static, so a failing run reproduces from its seed and profile.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum WeightProfile {
     /// The general-purpose mix: mostly reads and writes, a little DDL.
@@ -49,6 +51,8 @@ pub enum WeightProfile {
     Triggers,
     /// Heavy insert/update/delete to stress constraint and conflict paths.
     Writes,
+    /// SELECT-heavy workload with every supported correlated subquery rewrite.
+    CorrelatedSubqueries,
 }
 
 impl WeightProfile {
@@ -89,6 +93,36 @@ impl WeightProfile {
             WeightProfile::Ddl => base(15, 20, 10, 10, 20, 12, 20, 15, 10, 5, 5, 3),
             WeightProfile::Triggers => base(10, 25, 25, 20, 8, 3, 3, 5, 2, 2, 30, 10),
             WeightProfile::Writes => base(10, 35, 30, 20, 5, 2, 3, 5, 2, 1, 5, 3),
+            WeightProfile::CorrelatedSubqueries => base(80, 8, 8, 4, 2, 1, 1, 1, 1, 1, 1, 1),
+        }
+    }
+
+    fn configure_policy(self, policy: &mut Policy) {
+        if self == WeightProfile::CorrelatedSubqueries {
+            let config = &mut policy.select_config;
+            config.subquery_correlation_probability = 1.0;
+            config.subquery_aggregate_probability = 1.0;
+            config.subquery_group_by_probability = 0.0;
+            config.subquery_order_by_probability = 0.0;
+            config.subquery_distinct_probability = 0.0;
+            config.cte_probability = 0.0;
+            config.compound_probability = 0.0;
+            config.expression_count_range = 1..=2;
+
+            policy.max_expr_depth = 2;
+            policy.max_subquery_depth = 1;
+            policy.max_case_branches = 1;
+            policy.max_in_list_size = 3;
+            policy.max_order_by_items = 2;
+            policy.max_group_by_items = 2;
+            policy.expr_weights.case_expr = 0;
+            policy.expr_weights.subquery = 20;
+            policy.expr_weights.in_subquery = 20;
+            policy.expr_weights.exists = 20;
+            policy.expr_config.in_subquery_negation_probability = 0.0;
+            policy.expr_config.exists_negation_probability = 0.5;
+            policy.literal_config.string_max_len = 20;
+            policy.literal_config.blob_max_size = 16;
         }
     }
 }
@@ -157,6 +191,7 @@ impl SqlGenBackend {
                 sql_gen::FunctionConfig::deterministic().disable(&["LIKELY", "UNLIKELY"]),
             );
         policy.select_config.require_order_by_with_limit = true;
+        profile.configure_policy(&mut policy);
         policy.select_config.window_function_probability = window_function_probability;
         if window_function_probability > 0.0 {
             policy.select_config.window_frame_policy = WindowFramePolicy::Exclude;
@@ -227,12 +262,14 @@ impl SqlGenerator for SqlGenBackend {
             .unordered_limit_reason()
             .or_else(|| stmt.non_unique_order_by_reason(schema))
             .map(str::to_string);
+        let check_unnesting_invariant = self.ctx.take_generated_correlated_subquery();
         Ok(GeneratedStatement {
             sql,
             is_ddl,
             mutates_data,
             has_unordered_limit,
             unordered_limit_reason,
+            check_unnesting_invariant,
         })
     }
 
@@ -327,6 +364,7 @@ impl SqlGenerator for PropTestBackend {
             mutates_data,
             has_unordered_limit,
             unordered_limit_reason: None,
+            check_unnesting_invariant: false,
         })
     }
 }
@@ -467,6 +505,7 @@ mod tests {
             WeightProfile::Ddl,
             WeightProfile::Triggers,
             WeightProfile::Writes,
+            WeightProfile::CorrelatedSubqueries,
         ] {
             let w = profile.stmt_weights();
             assert!(w.select > 0, "{profile:?} never selects");

--- a/testing/differential-oracle/fuzzer/oracle.rs
+++ b/testing/differential-oracle/fuzzer/oracle.rs
@@ -14,6 +14,7 @@ use anyhow::Result;
 use sql_gen::Schema;
 use sql_gen_prop::SqlValue;
 use sql_gen_prop::result::diff_results;
+use turso_core::SubqueryUnnestingMode;
 use turso_core::{Numeric, Value};
 
 use crate::generate::GeneratedStatement;
@@ -23,6 +24,8 @@ use crate::generate::GeneratedStatement;
 pub enum OracleResult {
     /// The oracle check passed.
     Pass,
+    /// The oracle passed after comparing distinct forced and disabled plans.
+    PassWithUnnestingInvariant,
     /// EXPLAIN failed in at least one engine, so neither engine ran the statement.
     Skipped(String),
     /// The oracle check passed but with a warning (e.g., LIMIT without ORDER BY).
@@ -33,7 +36,10 @@ pub enum OracleResult {
 
 impl OracleResult {
     pub fn is_pass(&self) -> bool {
-        matches!(self, OracleResult::Pass)
+        matches!(
+            self,
+            OracleResult::Pass | OracleResult::PassWithUnnestingInvariant
+        )
     }
 
     pub fn is_skipped(&self) -> bool {
@@ -68,7 +74,7 @@ pub trait Oracle {
 }
 
 /// Result of executing a query on a database.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum QueryResult {
     /// Query executed successfully with rows.
     Rows(Vec<Row>),
@@ -398,6 +404,83 @@ impl DifferentialOracle {
     }
 }
 
+struct RestoreAutomaticUnnesting<'a>(&'a turso_core::Connection);
+
+impl Drop for RestoreAutomaticUnnesting<'_> {
+    fn drop(&mut self) {
+        self.0
+            .set_subquery_unnesting_mode(SubqueryUnnestingMode::Auto);
+    }
+}
+
+fn format_explain_query_plan(result: &QueryResult) -> String {
+    match result {
+        QueryResult::Rows(rows) => rows
+            .iter()
+            .map(|row| match row.0.get(3) {
+                Some(SqlValue::Text(detail)) => detail.clone(),
+                _ => format!("{row:?}"),
+            })
+            .collect::<Vec<_>>()
+            .join("\n    "),
+        QueryResult::Ok => "OK".to_string(),
+        QueryResult::Error(error) => format!("ERROR: {error}"),
+    }
+}
+
+fn check_subquery_unnesting_invariant(
+    conn: &Arc<turso_core::Connection>,
+    stmt: &GeneratedStatement,
+) -> Option<OracleResult> {
+    let _restore = RestoreAutomaticUnnesting(conn);
+    let explain_sql = format!("EXPLAIN QUERY PLAN {}", stmt.sql);
+    conn.set_subquery_unnesting_mode(SubqueryUnnestingMode::Forced);
+    let rewritten_plan = DifferentialOracle::execute_turso(conn, &explain_sql);
+    conn.set_subquery_unnesting_mode(SubqueryUnnestingMode::Disabled);
+    let correlated_plan = DifferentialOracle::execute_turso(conn, &explain_sql);
+    let rewritten_plan_output = format_explain_query_plan(&rewritten_plan);
+    let correlated_plan_output = format_explain_query_plan(&correlated_plan);
+    if rewritten_plan_output == correlated_plan_output {
+        return None;
+    }
+    tracing::debug!(
+        target: "subquery_unnesting",
+        "Checking distinct subquery plans:\n  SQL: {}\n  Forced EQP:\n    {}\n  Disabled EQP:\n    {}",
+        stmt.sql,
+        rewritten_plan_output,
+        correlated_plan_output
+    );
+
+    conn.set_subquery_unnesting_mode(SubqueryUnnestingMode::Forced);
+    let rewritten = DifferentialOracle::execute_turso(conn, &stmt.sql);
+    conn.set_subquery_unnesting_mode(SubqueryUnnestingMode::Disabled);
+    let correlated = DifferentialOracle::execute_turso(conn, &stmt.sql);
+
+    Some(match (&rewritten, &correlated) {
+        (QueryResult::Rows(rewritten), QueryResult::Rows(correlated)) => {
+            let diff = diff_results(rewritten, correlated);
+            if diff.is_empty() {
+                OracleResult::Pass
+            } else {
+                OracleResult::Fail(format!(
+                    "Subquery unnesting changed the result:\n  SQL: {stmt}\n  Only with forced unnesting: {:?}\n  Only with unnesting disabled: {:?}",
+                    diff.only_in_first, diff.only_in_second
+                ))
+            }
+        }
+        (QueryResult::Ok, QueryResult::Ok) => OracleResult::Pass,
+        (QueryResult::Error(_), QueryResult::Error(_)) => OracleResult::Pass,
+        (QueryResult::Rows(rows), QueryResult::Ok) | (QueryResult::Ok, QueryResult::Rows(rows))
+            if rows.is_empty() =>
+        {
+            OracleResult::Pass
+        }
+        _ => OracleResult::Fail(format!(
+            "Subquery unnesting changed success or result shape:\n  SQL: {stmt}\n  Forced unnesting: {rewritten:?}\n  Unnesting disabled: {correlated:?}"
+        )),
+    })
+}
+
 /// Execute a statement on both databases and check the differential oracle.
 pub fn check_differential(
     turso_conn: &Arc<turso_core::Connection>,
@@ -436,7 +519,24 @@ pub fn check_differential(
 
     let oracle = DifferentialOracle;
     let direct_result = oracle.check(stmt, &turso_result, &sqlite_result);
-    if !stmt.mutates_data || !direct_result.is_pass() {
+    if !direct_result.is_pass() {
+        return direct_result;
+    }
+
+    if stmt.check_unnesting_invariant
+        && !stmt.is_ddl
+        && !stmt.mutates_data
+        && !stmt.has_unordered_limit
+    {
+        if let Some(invariant_result) = check_subquery_unnesting_invariant(turso_conn, stmt) {
+            if !invariant_result.is_pass() {
+                return invariant_result;
+            }
+            return OracleResult::PassWithUnnestingInvariant;
+        }
+    }
+
+    if !stmt.mutates_data {
         return direct_result;
     }
 
@@ -476,6 +576,7 @@ mod tests {
         assert!(!OracleResult::Pass.is_fail());
         assert!(!OracleResult::Pass.is_skipped());
         assert!(!OracleResult::Pass.is_warning());
+        assert!(OracleResult::PassWithUnnestingInvariant.is_pass());
 
         assert!(OracleResult::Skipped("test".into()).is_skipped());
         assert!(!OracleResult::Skipped("test".into()).is_pass());
@@ -499,6 +600,7 @@ mod tests {
             mutates_data: false,
             has_unordered_limit: true,
             unordered_limit_reason: Some("limit_order_by_scalar_subquery".to_string()),
+            check_unnesting_invariant: false,
         };
         let turso = QueryResult::Rows(vec![Row(vec![SqlValue::Integer(1)])]);
         let sqlite = QueryResult::Rows(vec![Row(vec![SqlValue::Integer(2)])]);
@@ -567,6 +669,7 @@ mod tests {
             mutates_data: true,
             has_unordered_limit: false,
             unordered_limit_reason: None,
+            check_unnesting_invariant: false,
         };
 
         let result = check_differential(&turso_conn, &sqlite_conn, &schema, &stmt);
@@ -616,6 +719,7 @@ mod tests {
             mutates_data: true,
             has_unordered_limit: false,
             unordered_limit_reason: None,
+            check_unnesting_invariant: false,
         };
 
         let result = check_differential(&turso_conn, &sqlite_conn, &schema, &stmt);
@@ -627,5 +731,106 @@ mod tests {
             }
             other => panic!("expected skipped statement, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn every_supported_unnesting_form_returns_the_same_rows() {
+        let io = Arc::new(MemorySimIO::new(789));
+        let turso_db = Database::open_file_with_flags(
+            io,
+            "oracle-subquery-unnesting.db",
+            turso_core::OpenFlags::default(),
+            turso_core::DatabaseOpts::new(),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let conn = turso_db.connect().unwrap();
+        for sql in [
+            "CREATE TABLE outer_rows(id INTEGER, key1 INTEGER, amount INTEGER)",
+            "CREATE TABLE inner_rows(key1 INTEGER, amount INTEGER)",
+            "INSERT INTO outer_rows VALUES (1, 1, 15), (2, 2, 5), (3, 3, NULL)",
+            "INSERT INTO inner_rows VALUES (1, 7), (1, 8), (2, NULL), (3, 2)",
+        ] {
+            assert!(matches!(
+                DifferentialOracle::execute_turso(&conn, sql),
+                QueryResult::Ok
+            ));
+        }
+        let queries = [
+            (
+                "scalar aggregate",
+                "SELECT o.id FROM outer_rows o
+                 WHERE o.amount >= (
+                     SELECT sum(i.amount) FROM inner_rows i WHERE i.key1 = o.key1
+                 )",
+            ),
+            (
+                "EXISTS",
+                "SELECT o.id FROM outer_rows o
+                 WHERE EXISTS (
+                     SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1
+                 )",
+            ),
+            (
+                "NOT EXISTS",
+                "SELECT o.id FROM outer_rows o
+                 WHERE NOT EXISTS (
+                     SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1
+                 )",
+            ),
+            (
+                "IN",
+                "SELECT o.id FROM outer_rows o
+                 WHERE o.amount IN (
+                     SELECT i.amount FROM inner_rows i WHERE i.key1 = o.key1
+                 )",
+            ),
+        ];
+
+        for (form, sql) in queries {
+            let stmt = GeneratedStatement {
+                sql: sql.to_string(),
+                is_ddl: false,
+                mutates_data: false,
+                has_unordered_limit: false,
+                unordered_limit_reason: None,
+                check_unnesting_invariant: true,
+            };
+            assert!(
+                check_subquery_unnesting_invariant(&conn, &stmt)
+                    .is_some_and(|result| result.is_pass()),
+                "expected a passing {form} invariant"
+            );
+
+            conn.set_subquery_unnesting_mode(SubqueryUnnestingMode::Forced);
+            let forced_plan =
+                DifferentialOracle::execute_turso(&conn, &format!("EXPLAIN QUERY PLAN {sql}"));
+            conn.set_subquery_unnesting_mode(SubqueryUnnestingMode::Disabled);
+            let correlated_plan =
+                DifferentialOracle::execute_turso(&conn, &format!("EXPLAIN QUERY PLAN {sql}"));
+            conn.set_subquery_unnesting_mode(SubqueryUnnestingMode::Auto);
+            let forced_plan_output = format_explain_query_plan(&forced_plan);
+            let correlated_plan_output = format_explain_query_plan(&correlated_plan);
+            assert_ne!(
+                forced_plan_output, correlated_plan_output,
+                "the {form} test must compare distinct plan forms:\n\
+                 forced:\n{forced_plan_output}\n\
+                 disabled:\n{correlated_plan_output}"
+            );
+        }
+
+        let non_equality = GeneratedStatement {
+            sql: queries[0].1.replace("i.key1 = o.key1", "i.key1 < o.key1"),
+            is_ddl: false,
+            mutates_data: false,
+            has_unordered_limit: false,
+            unordered_limit_reason: None,
+            check_unnesting_invariant: true,
+        };
+        assert!(
+            check_subquery_unnesting_invariant(&conn, &non_equality).is_none(),
+            "an unsupported correlation must not count as a rewrite invariant"
+        );
     }
 }

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -237,6 +237,8 @@ pub struct SimStats {
     pub oracle_failures: usize,
     /// Number of errors encountered.
     pub errors: usize,
+    /// Correlated SELECTs checked with unnesting forced and disabled.
+    pub unnesting_invariants_checked: usize,
 }
 
 impl SimStats {
@@ -314,6 +316,10 @@ impl SimStats {
             Cell::new(self.errors).fg(Color::Green)
         };
         table.add_row(vec![Cell::new("Errors").fg(Color::Red), errors_cell]);
+        table.add_row(vec![
+            Cell::new("Unnesting invariants").fg(Color::Blue),
+            Cell::new(self.unnesting_invariants_checked).fg(Color::Blue),
+        ]);
 
         table
     }
@@ -641,6 +647,11 @@ impl Fuzzer {
             match oracle_result {
                 OracleResult::Pass => {
                     stats.statements_executed += 1;
+                    executed_sql.push(stmt.sql.clone());
+                }
+                OracleResult::PassWithUnnestingInvariant => {
+                    stats.statements_executed += 1;
+                    stats.unnesting_invariants_checked += 1;
                     executed_sql.push(stmt.sql.clone());
                 }
                 OracleResult::Skipped(reason) => {

--- a/testing/differential-oracle/sql_gen/src/context.rs
+++ b/testing/differential-oracle/sql_gen/src/context.rs
@@ -31,6 +31,7 @@ pub struct Context {
     table_scope: Vec<Vec<ScopedTable>>,
     /// Counter for generating unique table aliases (t0, t1, t2, ...).
     alias_counter: usize,
+    generated_correlated_subquery: bool,
 }
 
 impl Context {
@@ -49,6 +50,7 @@ impl Context {
             subquery_depth: 0,
             table_scope: Vec::new(),
             alias_counter: 0,
+            generated_correlated_subquery: false,
         }
     }
 
@@ -226,6 +228,14 @@ impl Context {
         } else {
             None
         }
+    }
+
+    pub fn record_correlated_subquery(&mut self) {
+        self.generated_correlated_subquery = true;
+    }
+
+    pub fn take_generated_correlated_subquery(&mut self) -> bool {
+        std::mem::take(&mut self.generated_correlated_subquery)
     }
 
     /// Get a reference to the coverage data.

--- a/testing/differential-oracle/sql_gen/src/generate/expr.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/expr.rs
@@ -1,15 +1,15 @@
 //! Expression generation.
 
+use crate::SqlGen;
 use crate::ast::{BinOp, Expr, Literal, UnaryOp};
 use crate::capabilities::Capabilities;
 use crate::context::Context;
 use crate::error::GenError;
 use crate::functions::{FunctionCategory, FunctionDef};
 use crate::generate::literal::generate_literal;
-use crate::generate::select::{generate_select, generate_simple_select};
+use crate::generate::select::{generate_exists_select, generate_in_select, generate_simple_select};
 use crate::schema::DataType;
 use crate::trace::{ExprKind, Origin};
-use crate::{SqlGen, Stmt};
 use sql_gen_macros::trace_gen;
 
 /// Generate an expression.
@@ -634,20 +634,6 @@ fn generate_subquery_expr<C: Capabilities>(
     Ok(Expr::subquery(ctx, select))
 }
 
-/// Generate the SELECT statement for a subquery.
-#[trace_gen(Origin::Subquery)]
-fn generate_subquery_select<C: Capabilities>(
-    generator: &SqlGen<C>,
-    ctx: &mut Context,
-) -> Result<crate::ast::SelectStmt, GenError> {
-    generate_select(generator, ctx).map(|stmt| {
-        let Stmt::Select(select) = stmt else {
-            unreachable!()
-        };
-        select
-    })
-}
-
 /// Generate an IN subquery expression (expr IN (SELECT ...) or expr NOT IN (SELECT ...)).
 fn generate_in_subquery<C: Capabilities>(
     generator: &SqlGen<C>,
@@ -657,11 +643,21 @@ fn generate_in_subquery<C: Capabilities>(
     let expr_config = &generator.policy().expr_config;
     let negated = ctx.gen_bool_with_prob(expr_config.in_subquery_negation_probability);
 
-    // Generate the left-hand expression (typically a column or simple expression)
-    let expr = generate_expr(generator, ctx, depth + 1)?;
+    // Correlated IN is only unnested when its left side cannot fail. Keep the
+    // general expression mix for other profiles.
+    let expr = if generator
+        .policy()
+        .select_config
+        .subquery_correlation_probability
+        > 0.0
+    {
+        generate_column_ref(ctx)?
+    } else {
+        generate_expr(generator, ctx, depth + 1)?
+    };
 
     // IN subqueries must return exactly 1 column
-    let subquery = generate_simple_select(generator, ctx)?;
+    let subquery = generate_in_select(generator, ctx)?;
 
     Ok(Expr::in_subquery(ctx, expr, subquery, negated))
 }
@@ -674,8 +670,7 @@ fn generate_exists<C: Capabilities>(
     let expr_config = &generator.policy().expr_config;
     let negated = ctx.gen_bool_with_prob(expr_config.exists_negation_probability);
 
-    // Generate the subquery
-    let subquery = generate_subquery_select(generator, ctx)?;
+    let subquery = generate_exists_select(generator, ctx)?;
 
     Ok(Expr::exists(ctx, subquery, negated))
 }

--- a/testing/differential-oracle/sql_gen/src/generate/select.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/select.rs
@@ -71,8 +71,7 @@ pub fn generate_tableless_select<C: Capabilities>(
     })
 }
 
-/// Controls whether `generate_select_impl` produces a full SELECT or a
-/// single-column scalar subquery.
+/// Controls the SELECT shape required by its caller.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SelectMode {
     /// Normal SELECT — arbitrary columns, clauses governed by `SelectConfig`.
@@ -80,6 +79,10 @@ enum SelectMode {
     /// Scalar subquery — exactly 1 output column, LIMIT 1, no alias/offset.
     /// Probabilities come from the `subquery_*` fields in `SelectConfig`.
     Scalar,
+    /// EXISTS subquery — one table, no clauses that prevent a semi-join.
+    Exists,
+    /// IN subquery — one column and no clauses that prevent a semi-join.
+    In,
 }
 
 /// Generate correlation keys accepted by the subquery unnesting optimizer.
@@ -132,11 +135,30 @@ fn generate_supported_correlation_predicate(ctx: &mut Context) -> Option<Expr> {
 ///
 /// Always returns exactly one column. Non-aggregate forms use `LIMIT 1`;
 /// ungrouped aggregate forms already return one row.
+#[trace_gen(Origin::Subquery)]
 pub fn generate_simple_select<C: Capabilities>(
     generator: &SqlGen<C>,
     ctx: &mut Context,
 ) -> Result<SelectStmt, GenError> {
     generate_select_impl(generator, ctx, SelectMode::Scalar)
+}
+
+/// Generate the SELECT inside an EXISTS expression.
+#[trace_gen(Origin::Subquery)]
+pub fn generate_exists_select<C: Capabilities>(
+    generator: &SqlGen<C>,
+    ctx: &mut Context,
+) -> Result<SelectStmt, GenError> {
+    generate_select_impl(generator, ctx, SelectMode::Exists)
+}
+
+/// Generate the single-column SELECT inside an IN expression.
+#[trace_gen(Origin::Subquery)]
+pub fn generate_in_select<C: Capabilities>(
+    generator: &SqlGen<C>,
+    ctx: &mut Context,
+) -> Result<SelectStmt, GenError> {
+    generate_select_impl(generator, ctx, SelectMode::In)
 }
 
 /// Shared implementation for both full and scalar SELECT generation.
@@ -175,7 +197,7 @@ fn generate_select_impl<C: Capabilities>(
     };
 
     // --- Alias for primary table ---
-    let from_alias = if mode == SelectMode::Scalar
+    let from_alias = if mode != SelectMode::Full
         && !ctx.tables_in_scope().is_empty()
         && select_config.subquery_correlation_probability > 0.0
     {
@@ -241,14 +263,18 @@ fn generate_select_impl_inner<C: Capabilities>(
     let gb_prob = match mode {
         SelectMode::Full => select_config.group_by_probability,
         SelectMode::Scalar => select_config.subquery_group_by_probability,
+        SelectMode::Exists | SelectMode::In => 0.0,
     };
     let where_prob = match mode {
         SelectMode::Full => select_config.where_probability,
-        SelectMode::Scalar => select_config.subquery_where_probability,
+        SelectMode::Scalar | SelectMode::Exists | SelectMode::In => {
+            select_config.subquery_where_probability
+        }
     };
     let order_by_prob = match mode {
         SelectMode::Full => select_config.order_by_probability,
         SelectMode::Scalar => select_config.subquery_order_by_probability,
+        SelectMode::Exists | SelectMode::In => 0.0,
     };
 
     // --- GROUP BY ---
@@ -263,7 +289,7 @@ fn generate_select_impl_inner<C: Capabilities>(
                     having: None,
                 })
             }
-            _ => None,
+            SelectMode::Scalar | SelectMode::Exists | SelectMode::In => None,
         }
     } else {
         None
@@ -295,6 +321,10 @@ fn generate_select_impl_inner<C: Capabilities>(
                 }]
             }
         }
+        SelectMode::Exists | SelectMode::In => vec![SelectColumn {
+            expr: pick_scoped_column_ref(ctx)?,
+            alias: None,
+        }],
     };
 
     // When there is no GROUP BY and `restrict_mixed_aggregates` is enabled,
@@ -319,7 +349,7 @@ fn generate_select_impl_inner<C: Capabilities>(
     } else {
         None
     };
-    let correlated = (mode == SelectMode::Scalar
+    let correlated = (mode != SelectMode::Full
         && ctx.gen_bool_with_prob(select_config.subquery_correlation_probability))
     .then(|| generate_supported_correlation_predicate(ctx))
     .flatten();
@@ -340,7 +370,7 @@ fn generate_select_impl_inner<C: Capabilities>(
         // key survives is the engine's choice, so SQLite and Turso can return
         // different rows and both are allowed. No tiebreaker can help because
         // a unique column cannot be added through the deduplication.
-        SelectMode::Scalar => false,
+        SelectMode::Scalar | SelectMode::Exists | SelectMode::In => false,
     };
 
     let from = {
@@ -436,6 +466,7 @@ fn generate_select_impl_inner<C: Capabilities>(
             SelectMode::Full => generate_limit_offset(generator, ctx),
             SelectMode::Scalar if scalar_aggregate_without_group => (None, None),
             SelectMode::Scalar => (Some(1), None),
+            SelectMode::Exists | SelectMode::In => (None, None),
         };
 
         // Enforce deterministic LIMIT semantics when configured.
@@ -2884,6 +2915,45 @@ mod tests {
         );
         assert!(sql.contains("outer.key"), "expected outer reference: {sql}");
         assert!(ctx.take_generated_correlated_subquery());
+    }
+
+    #[test]
+    fn semi_join_subqueries_can_reference_an_outer_column() {
+        let policy = Policy::default().with_select_config(crate::policy::SelectConfig {
+            subquery_where_probability: 0.0,
+            subquery_correlation_probability: 1.0,
+            ..Default::default()
+        });
+        let outer = Table::new("outer_rows", vec![ColumnDef::new("key", DataType::Integer)]);
+        let schema = SchemaBuilder::new()
+            .table(outer.clone())
+            .table(Table::new(
+                "inner_rows",
+                vec![
+                    ColumnDef::new("key", DataType::Integer),
+                    ColumnDef::new("amount", DataType::Integer),
+                ],
+            ))
+            .build();
+        let generator: SqlGen<Full> = SqlGen::new(schema, policy);
+
+        for mode in [SelectMode::Exists, SelectMode::In] {
+            let mut ctx = Context::new_with_seed(7);
+            let select = ctx
+                .with_table_scope([(outer.clone(), Some("outer".to_string()))], |ctx| {
+                    generate_select_impl(&generator, ctx, mode)
+                })
+                .unwrap();
+            let sql = select.to_string();
+
+            assert_eq!(select.columns.len(), 1, "expected one result: {sql}");
+            assert!(select.limit.is_none(), "expected no LIMIT: {sql}");
+            assert!(select.group_by.is_none(), "expected no GROUP BY: {sql}");
+            assert!(select.order_by.is_empty(), "expected no ORDER BY: {sql}");
+            assert!(!select.distinct, "expected no DISTINCT: {sql}");
+            assert!(sql.contains("outer.key"), "expected outer reference: {sql}");
+            assert!(ctx.take_generated_correlated_subquery());
+        }
     }
 
     #[test]

--- a/testing/differential-oracle/sql_gen/src/generate/select.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/select.rs
@@ -82,9 +82,56 @@ enum SelectMode {
     Scalar,
 }
 
+/// Generate correlation keys accepted by the subquery unnesting optimizer.
+///
+/// Unnesting currently accepts only `=` between an inner column and an outer
+/// column. Generate one or two such keys, with either operand order. Other
+/// correlation operators cannot exercise rewritten-versus-correlated plans
+/// until the optimizer knows how to rewrite them.
+fn generate_supported_correlation_predicate(ctx: &mut Context) -> Option<Expr> {
+    let outer_tables = ctx.outer_tables()?.to_vec();
+    let inner_tables = ctx.tables_in_scope().to_vec();
+    let mut pairs = Vec::new();
+    for inner in &inner_tables {
+        for inner_column in inner.table.filterable_columns() {
+            for outer in &outer_tables {
+                for outer_column in outer.table.filterable_columns() {
+                    if inner_column.data_type == outer_column.data_type {
+                        pairs.push((
+                            inner.qualifier.clone(),
+                            inner_column.name.clone(),
+                            outer.qualifier.clone(),
+                            outer_column.name.clone(),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    let pairs = ctx.subsequence(&pairs, 1..=2);
+    let mut predicates = Vec::with_capacity(pairs.len());
+    for (inner_table, inner_column, outer_table, outer_column) in pairs {
+        let inner = Expr::column_ref(ctx, Some(inner_table), inner_column);
+        let outer = Expr::column_ref(ctx, Some(outer_table), outer_column);
+        let (left, right) = if ctx.gen_bool() {
+            (inner, outer)
+        } else {
+            (outer, inner)
+        };
+        predicates.push(Expr::binary_op(ctx, left, BinOp::Eq, right));
+    }
+    let mut predicates = predicates.into_iter();
+    let first = predicates.next()?;
+    ctx.record_correlated_subquery();
+    Some(predicates.fold(first, |left, right| {
+        Expr::binary_op(ctx, left, BinOp::And, right)
+    }))
+}
+
 /// Generate a simple single-column SELECT (for scalar subqueries).
 ///
-/// Always returns exactly 1 column with LIMIT 1.
+/// Always returns exactly one column. Non-aggregate forms use `LIMIT 1`;
+/// ungrouped aggregate forms already return one row.
 pub fn generate_simple_select<C: Capabilities>(
     generator: &SqlGen<C>,
     ctx: &mut Context,
@@ -128,7 +175,23 @@ fn generate_select_impl<C: Capabilities>(
     };
 
     // --- Alias for primary table ---
-    let from_alias = if mode == SelectMode::Full
+    let from_alias = if mode == SelectMode::Scalar
+        && !ctx.tables_in_scope().is_empty()
+        && select_config.subquery_correlation_probability > 0.0
+    {
+        let enclosing_qualifiers: Vec<String> = ctx
+            .tables_in_scope()
+            .iter()
+            .map(|table| table.qualifier.clone())
+            .collect();
+        let alias = loop {
+            let candidate = ctx.next_table_alias();
+            if !enclosing_qualifiers.contains(&candidate) {
+                break candidate;
+            }
+        };
+        Some(alias)
+    } else if mode == SelectMode::Full
         && ident_config.generate_table_aliases
         && ctx.gen_bool_with_prob(select_config.table_alias_probability)
     {
@@ -205,6 +268,9 @@ fn generate_select_impl_inner<C: Capabilities>(
     } else {
         None
     };
+    let scalar_aggregate_without_group = mode == SelectMode::Scalar
+        && group_by.is_none()
+        && ctx.gen_bool_with_prob(select_config.subquery_aggregate_probability);
 
     // --- Columns ---
     let mut columns = match mode {
@@ -216,7 +282,7 @@ fn generate_select_impl_inner<C: Capabilities>(
             }
         }
         SelectMode::Scalar => {
-            if group_by.is_some() {
+            if group_by.is_some() || scalar_aggregate_without_group {
                 // Aggregate output column
                 vec![SelectColumn {
                     expr: generate_aggregate_call(generator, ctx)?,
@@ -248,10 +314,22 @@ fn generate_select_impl_inner<C: Capabilities>(
     }
 
     // --- WHERE ---
-    let where_clause = if ctx.gen_bool_with_prob(where_prob) {
+    let generated_where = if ctx.gen_bool_with_prob(where_prob) {
         Some(generate_condition(generator, ctx)?)
     } else {
         None
+    };
+    let correlated = (mode == SelectMode::Scalar
+        && ctx.gen_bool_with_prob(select_config.subquery_correlation_probability))
+    .then(|| generate_supported_correlation_predicate(ctx))
+    .flatten();
+    let where_clause = match (generated_where, correlated) {
+        (Some(generated), Some(correlated)) => {
+            Some(Expr::binary_op(ctx, generated, BinOp::And, correlated))
+        }
+        (Some(generated), None) => Some(generated),
+        (None, Some(correlated)) => Some(correlated),
+        (None, None) => None,
     };
 
     // --- DISTINCT ---
@@ -341,7 +419,9 @@ fn generate_select_impl_inner<C: Capabilities>(
         })
     } else {
         // --- ORDER BY ---
-        let mut order_by = if ctx.gen_bool_with_prob(order_by_prob) {
+        let mut order_by = if scalar_aggregate_without_group {
+            vec![]
+        } else if ctx.gen_bool_with_prob(order_by_prob) {
             if let Some(gb) = &group_by {
                 generate_grouped_order_by(generator, ctx, &gb.exprs)?
             } else {
@@ -354,6 +434,7 @@ fn generate_select_impl_inner<C: Capabilities>(
         // --- LIMIT / OFFSET ---
         let (limit, offset) = match mode {
             SelectMode::Full => generate_limit_offset(generator, ctx),
+            SelectMode::Scalar if scalar_aggregate_without_group => (None, None),
             SelectMode::Scalar => (Some(1), None),
         };
 
@@ -371,7 +452,7 @@ fn generate_select_impl_inner<C: Capabilities>(
         // order. Grouped: order by every GROUP BY expression — groups are
         // distinct combinations of them, so that is a total order. Ungrouped:
         // append the table's primary key as a final tiebreaker.
-        if mode == SelectMode::Scalar {
+        if mode == SelectMode::Scalar && !scalar_aggregate_without_group {
             if let Some(gb) = &group_by {
                 let covered: Vec<String> = order_by.iter().map(|i| i.expr.to_string()).collect();
                 for expr in &gb.exprs {
@@ -2761,6 +2842,94 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn scalar_aggregate_subquery_can_reference_an_outer_column() {
+        let policy = Policy::default().with_select_config(crate::policy::SelectConfig {
+            subquery_where_probability: 0.0,
+            subquery_correlation_probability: 1.0,
+            subquery_aggregate_probability: 1.0,
+            subquery_group_by_probability: 0.0,
+            subquery_order_by_probability: 0.0,
+            ..Default::default()
+        });
+        let outer = Table::new("outer_rows", vec![ColumnDef::new("key", DataType::Integer)]);
+        let schema = SchemaBuilder::new()
+            .table(outer.clone())
+            .table(Table::new(
+                "inner_rows",
+                vec![
+                    ColumnDef::new("key", DataType::Integer),
+                    ColumnDef::new("amount", DataType::Integer),
+                ],
+            ))
+            .build();
+        let generator: SqlGen<Full> = SqlGen::new(schema, policy);
+        let mut ctx = Context::new_with_seed(7);
+        let select = ctx
+            .with_table_scope([(outer, Some("outer".to_string()))], |ctx| {
+                generate_select_impl(&generator, ctx, SelectMode::Scalar)
+            })
+            .unwrap();
+        let sql = select.to_string();
+
+        assert!(
+            select.limit.is_none(),
+            "one aggregate row needs no LIMIT: {sql}"
+        );
+        assert!(
+            select.columns[0].expr.contains_aggregate(),
+            "expected an aggregate result: {sql}"
+        );
+        assert!(sql.contains("outer.key"), "expected outer reference: {sql}");
+        assert!(ctx.take_generated_correlated_subquery());
+    }
+
+    #[test]
+    fn supported_correlation_keys_vary_count_and_operand_order() {
+        let outer = Table::new(
+            "outer_rows",
+            vec![
+                ColumnDef::new("key1", DataType::Integer),
+                ColumnDef::new("key2", DataType::Integer),
+            ],
+        );
+        let inner = Table::new(
+            "inner_rows",
+            vec![
+                ColumnDef::new("key1", DataType::Integer),
+                ColumnDef::new("key2", DataType::Integer),
+            ],
+        );
+        let mut saw_two_keys = false;
+        let mut saw_outer_column_on_left = false;
+        let mut saw_inner_column_on_left = false;
+
+        for seed in 0..100 {
+            let mut ctx = Context::new_with_seed(seed);
+            let predicate =
+                ctx.with_table_scope([(outer.clone(), Some("outer".to_string()))], |ctx| {
+                    ctx.with_table_scope(
+                        [(inner.clone(), Some("inner".to_string()))],
+                        generate_supported_correlation_predicate,
+                    )
+                });
+            let sql = predicate
+                .expect("matching key types should correlate")
+                .to_string();
+            saw_two_keys |= sql.matches(" = ").count() == 2;
+            for equality in sql.split(" AND ") {
+                saw_outer_column_on_left |= equality.starts_with("outer.");
+                saw_inner_column_on_left |= equality.starts_with("inner.");
+            }
+        }
+
+        assert!(saw_two_keys, "expected at least one composite correlation");
+        assert!(
+            saw_outer_column_on_left && saw_inner_column_on_left,
+            "expected both equality operand orders"
+        );
     }
 
     #[test]

--- a/testing/differential-oracle/sql_gen/src/policy.rs
+++ b/testing/differential-oracle/sql_gen/src/policy.rs
@@ -1142,6 +1142,14 @@ pub struct SelectConfig {
     /// Probability of WHERE clause in simple/subquery SELECT.
     pub subquery_where_probability: f64,
 
+    /// Probability that a subquery adds an equality to a compatible column
+    /// from its immediately enclosing SELECT.
+    pub subquery_correlation_probability: f64,
+
+    /// Probability that a scalar subquery without GROUP BY returns one
+    /// aggregate row instead of selecting one input row with LIMIT 1.
+    pub subquery_aggregate_probability: f64,
+
     /// Order direction weights.
     pub order_direction_weights: OrderDirectionWeights,
 
@@ -1233,6 +1241,8 @@ impl Default for SelectConfig {
             column_alias_probability: 0.2,
             max_offset: 100,
             subquery_where_probability: 0.5,
+            subquery_correlation_probability: 0.0,
+            subquery_aggregate_probability: 0.0,
             order_direction_weights: OrderDirectionWeights::default(),
             nulls_order_weights: NullsOrderWeights::default(),
             order_by_column_weight: 6,


### PR DESCRIPTION
## Pre-filter ephemeral indexes during build and improve subquery unnesting tests

This PR does two primary things.

## 1. Pre-filtering automatic indexes when they are built

Here's a primer on ephemeral indexes and why we might use them:

```sql
-- no index on any columns, so the naive thing is to do a cross join between the two tables,
-- joining every eligible table1 key with every table2 key
SELECT * FROM table1 JOIN table2 ON table1.key = table2.key WHERE table1.x = 1 and table2.y = 2;
```

To prevent a cross-join, we may build a temporary index keyed by `table2.key` so that we can perform point lookups on it using search keys from `table1.key` to reduce the complexity from `O(n*m)` to `(O(n log m)`.

This has a one-time build cost for the ephemeral index because... it's ephemeral, i.e. not persistent.

### The perf problem with ephemeral indexes on main, and in the example case

On `main`, we dump every `table2` row into the index. We don't actually need to put any rows from `table2` into the ephemeral index where `y != 2`, because the WHERE clause forbids those rows from being returned.

### Solution

Wherever it's safe, evaluate pre-filters like `table2.y = 2` before inserting rows into the ephemeral index and skip storing rows in the index that don't match.

### Effect

This speeds up TPC-H query 20 by roughly 10x on my machine. We don't run TPC-H in CI so it's not visible here. You can see an existing cross-join snapshot improve here by filtering out rows where `products.category != 'Books'`, and I've also changed the TPC-H q20 snapshot from an EXPLAIN QUERY PLAN snapshot to a full EXPLAIN snapshot so you can see the effect there as well.

### Why is the ephemeral index optimization above relevant to unnesting correlated subqueries?

For a primer on unnesting, see my previous PR: https://github.com/tursodatabase/turso/pull/8343

TPC-H query 20 was already optimized with a subquery unnesting pass, but it's still unnecessarily slow because of the problem explained above. Unnesting will transform a correlated subquery into a join over a derived table (= materialized uncorrelated subquery), and the derived table is represented as an ephemeral index. If we dump all the rows from that query into the index, it spends unnecessary CPU and memory, if we could've pre-filtered some - and in many cases, most - of them out.

## 2. Improve the testing of unnested correlated subqueries in the differential fuzzer

Essentially the PR adds a test-only flag that controls how we do subquery unnesting:

1. Automatic (do it when it's cheaper according to the optimizer cost estimate, OR
2. Off (don't do it at all), or
3. Forced (always do it regardless of cost)

And in the differential fuzzer, we add a profile where we heavily bias the queries towards SELECTs with correlated subqueries, and we run them with both the OFF and FORCED modes, and assert that the end result is equivalent.