### PR TITLE
core/index-method: open backing storage through MVCC cursors

### DIFF
--- a/core/index_method/backing_btree.rs
+++ b/core/index_method/backing_btree.rs
@@ -37,7 +37,7 @@ impl IndexMethodAttachment for BackingBTreeIndexMethodAttachment {
             patterns: &[],
             backing_btree: true,
             results_materialized: false,
-            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
+            mvcc_support: super::IndexMethodMvccSupport::TransactionalBackingStore,
         }
     }
 

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -4,11 +4,12 @@ use rustc_hash::FxHashMap as HashMap;
 use turso_parser::ast;
 
 use crate::{
+    mvcc::cursor::MvccCursorType,
     schema::IndexColumn,
-    storage::btree::BTreeCursor,
+    storage::btree::{BTreeCursor, CursorTrait},
     types::{IOResult, IndexInfo, KeyInfo},
     vdbe::Register,
-    Connection, LimboError, Result, Value,
+    Connection, LimboError, MvCursor, Result, Value,
 };
 
 pub mod backing_btree;
@@ -241,30 +242,75 @@ pub trait IndexMethodCursor {
     }
 }
 
-/// helper method to open table BTree cursor in the index method implementation
+fn promote_to_mvcc_cursor(
+    connection: &Arc<Connection>,
+    database_id: usize,
+    root_page: i64,
+    cursor: Box<dyn CursorTrait>,
+    cursor_type: MvccCursorType,
+) -> Result<Box<dyn CursorTrait>> {
+    let Some(mv_store) = connection.mv_store_for_db(database_id) else {
+        return Ok(cursor);
+    };
+    let tx_id = connection.get_mv_tx_id_for_db(database_id).ok_or_else(|| {
+        LimboError::InternalError(
+            "index method opened an MVCC cursor without an active transaction".to_string(),
+        )
+    })?;
+    Ok(Box::new(MvCursor::new(
+        mv_store,
+        connection,
+        tx_id,
+        root_page,
+        cursor_type,
+        cursor,
+    )?))
+}
+
+fn btree_root_page(connection: &Connection, database_id: usize, root_page: i64) -> i64 {
+    if root_page >= 0 {
+        return root_page;
+    }
+    connection
+        .mv_store_for_db(database_id)
+        .map_or(root_page, |mv_store| mv_store.get_real_table_id(root_page))
+}
+
+/// Helper method to open a table cursor in an index method implementation.
 pub(crate) fn open_table_cursor(
-    connection: &Connection,
+    connection: &Arc<Connection>,
     database_id: usize,
     table: &str,
-) -> Result<BTreeCursor> {
+) -> Result<Box<dyn CursorTrait>> {
     let pager = connection.get_pager_from_database_index(&database_id)?;
     let Some(table) = connection.with_schema(database_id, |schema| schema.get_table(table)) else {
         return Err(LimboError::InternalError(format!(
             "table {table} not found",
         )));
     };
-    let cursor = BTreeCursor::new_table(pager, table.get_root_page()?, table.columns().len());
-    Ok(cursor)
+    let root_page = table.get_root_page()?;
+    let cursor = Box::new(BTreeCursor::new_table(
+        pager,
+        btree_root_page(connection, database_id, root_page),
+        table.columns().len(),
+    ));
+    promote_to_mvcc_cursor(
+        connection,
+        database_id,
+        root_page,
+        cursor,
+        MvccCursorType::Table,
+    )
 }
 
-/// helper method to open index BTree cursor in the index method implementation
+/// Helper method to open an index cursor in an index method implementation.
 pub(crate) fn open_index_cursor<I, E>(
-    connection: &Connection,
+    connection: &Arc<Connection>,
     database_id: usize,
     table: &str,
     index: &str,
     keys: I,
-) -> Result<BTreeCursor>
+) -> Result<Box<dyn CursorTrait>>
 where
     I: IntoIterator<Item = KeyInfo, IntoIter = E>,
     E: ExactSizeIterator<Item = KeyInfo>,
@@ -279,14 +325,20 @@ where
     };
     let keys = keys.into_iter();
     let num_cols = keys.len();
-    let mut cursor = BTreeCursor::new(pager, scratch.root_page, num_cols);
-    cursor.index_info = Some(Arc::new(IndexInfo::new(
-        keys,
-        false,
+    let index_info = Arc::new(IndexInfo::new(keys, false, num_cols, scratch.unique)?);
+    let mut cursor = BTreeCursor::new(
+        pager,
+        btree_root_page(connection, database_id, scratch.root_page),
         num_cols,
-        scratch.unique,
-    )?));
-    Ok(cursor)
+    );
+    cursor.index_info = Some(index_info.clone());
+    promote_to_mvcc_cursor(
+        connection,
+        database_id,
+        scratch.root_page,
+        Box::new(cursor),
+        MvccCursorType::Index(index_info),
+    )
 }
 
 /// helper method to parse select patterns for [IndexMethodAttachment::definition] call

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -14,7 +14,7 @@ use crate::{
         BACKING_BTREE_INDEX_METHOD_NAME, TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME,
     },
     return_if_io,
-    storage::btree::{BTreeCursor, BTreeKey, CursorTrait},
+    storage::btree::{BTreeKey, CursorTrait},
     sync::Arc,
     translate::collate::CollationSeq,
     types::{IOResult, ImmutableRecord, KeyInfo, SeekKey, SeekOp, SeekResult},
@@ -307,10 +307,10 @@ pub struct VectorSparseInvertedIndexMethodCursor {
     scan_portion: f64,
     scan_order: ScanOrder,
     inverted_index_btree: String,
-    inverted_index_cursor: Option<BTreeCursor>,
+    inverted_index_cursor: Option<Box<dyn CursorTrait>>,
     stats_btree: String,
-    stats_cursor: Option<BTreeCursor>,
-    main_btree: Option<BTreeCursor>,
+    stats_cursor: Option<Box<dyn CursorTrait>>,
+    main_btree: Option<Box<dyn CursorTrait>>,
     insert_state: VectorSparseInvertedIndexInsertState,
     delete_state: VectorSparseInvertedIndexDeleteState,
     search_state: VectorSparseInvertedIndexSearchState,
@@ -345,7 +345,7 @@ impl IndexMethodAttachment for VectorSparseInvertedIndexMethodAttachment {
             patterns: self.patterns.as_slice(),
             backing_btree: false,
             results_materialized: true,
-            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
+            mvcc_support: super::IndexMethodMvccSupport::TransactionalBackingStore,
         }
     }
     fn init(&self) -> Result<Box<dyn IndexMethodCursor>> {

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -703,6 +703,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             .indexes
             .values()
             .flatten()
+            .filter(|index| index.is_btree_backed())
             .map(|index| {
                 turso_assert!(index.root_page != 0, "index root_page must be non-zero");
                 (
@@ -761,6 +762,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 .indexes
                 .values()
                 .flatten()
+                .filter(|index| index.is_btree_backed())
                 .map(|index| {
                     turso_assert!(index.root_page != 0, "index root_page must be non-zero");
                     (
@@ -2058,7 +2060,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                             .indexes
                             .values()
                             .flatten()
+                            .filter(|index| index.is_btree_backed())
                             .filter_map(|index| {
+                                turso_assert!(
+                                    index.root_page != 0,
+                                    "index root_page must be non-zero"
+                                );
                                 self.mvstore
                                     .try_get_table_id_from_root_page_at(
                                         index.root_page,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4526,6 +4526,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     .indexes
                     .values()
                     .flatten()
+                    .filter(|index| index.is_btree_backed())
                     .map(|index| index.root_page),
             )
             .collect::<Vec<_>>();
@@ -4927,6 +4928,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         .indexes
                         .values()
                         .flatten()
+                        .filter(|index| index.is_btree_backed())
                         .map(|index| index.root_page),
                 )
         };
@@ -9126,7 +9128,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     _ => None,
                                 };
                                 let has_btree = match row_type {
-                                    "index" => true,
+                                    "index" => root_page != 0,
                                     "table" => {
                                         !sql.is_some_and(crate::util::sql_is_create_virtual_table)
                                     }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -5890,6 +5890,11 @@ impl Index {
             .is_some_and(|x| x.definition().backing_btree)
     }
 
+    /// Whether this schema index owns a B-tree root page.
+    pub fn is_btree_backed(&self) -> bool {
+        self.index_method.is_none() || self.is_backing_btree_index()
+    }
+
     pub fn automatic_from_primary_key(
         table: &BTreeTable,
         auto_index: (String, i64), // name, root_page

--- a/core/types.rs
+++ b/core/types.rs
@@ -2421,6 +2421,9 @@ impl IndexInfo {
         index: &Index,
         alloc: A,
     ) -> Result<Self, TryReserveError> {
+        // A backing_btree stores the index method's complete opaque key. Unlike
+        // an ordinary secondary index, it must not append the base-table rowid.
+        let has_rowid = index.has_rowid && !index.is_backing_btree_index();
         let key_info = index
             .columns
             .iter()
@@ -2429,15 +2432,15 @@ impl IndexInfo {
                 collation: c.collation.unwrap_or_default(),
                 nulls_order: c.nulls_order,
             })
-            .chain(index.has_rowid.then_some(KeyInfo {
+            .chain(has_rowid.then_some(KeyInfo {
                 sort_order: SortOrder::Asc,
                 collation: CollationSeq::Binary,
                 nulls_order: None,
             }));
         Self::new_in(
             key_info,
-            index.has_rowid,
-            index.columns.len() + (index.has_rowid as usize),
+            has_rowid,
+            index.columns.len() + (has_rowid as usize),
             index.unique,
             alloc,
         )

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12967,10 +12967,6 @@ pub fn op_index_method_create(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    let mv_store = program.connection.mv_store_for_db(*db);
-    if let Some(_mv_store) = mv_store.as_ref() {
-        todo!("MVCC is not supported yet");
-    }
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
@@ -12997,10 +12993,6 @@ pub fn op_index_method_destroy(
     load_insn!(IndexMethodDestroy { db, cursor_id }, insn);
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
-    }
-    let mv_store = program.connection.mv_store_for_db(*db);
-    if let Some(_mv_store) = mv_store.as_ref() {
-        todo!("MVCC is not supported yet");
     }
     if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
         if state.cursors[*cursor_id].is_none() {
@@ -13029,10 +13021,6 @@ pub fn op_index_method_optimize(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    let mv_store = program.connection.mv_store_for_db(*db);
-    if let Some(_mv_store) = mv_store.as_ref() {
-        todo!("MVCC is not supported yet");
-    }
     if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
@@ -13051,7 +13039,7 @@ pub fn op_index_method_optimize(
 }
 
 pub fn op_index_method_query(
-    program: &Program,
+    _program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
@@ -13066,10 +13054,6 @@ pub fn op_index_method_query(
         },
         insn
     );
-    let mv_store = program.connection.mv_store();
-    if let Some(_mv_store) = mv_store.as_ref() {
-        todo!("MVCC is not supported yet");
-    }
     let cursor = state.cursors[*cursor_id]
         .as_mut()
         .expect("cursor should exist");

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -304,6 +304,55 @@ fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
     assert!(!run(&tmp_db, || reader.query_next()).unwrap());
 }
 
+#[turso_macros::test(mvcc)]
+fn test_vector_sparse_ivf_mvcc_sql(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE vectors(id INTEGER PRIMARY KEY, embedding)")
+        .unwrap();
+    conn.execute("CREATE INDEX vectors_idx ON vectors USING toy_vector_sparse_ivf (embedding)")
+        .unwrap();
+    conn.execute(
+        "INSERT INTO vectors VALUES \
+         (1, vector32_sparse('[1, 0, 0]')), \
+         (2, vector32_sparse('[0, 1, 0]'))",
+    )
+    .unwrap();
+
+    let nearest = |vector: &str| {
+        limbo_exec_rows(
+            &conn,
+            &format!(
+                "SELECT id FROM vectors \
+                 ORDER BY vector_distance_jaccard(embedding, vector32_sparse('{vector}')) \
+                 LIMIT 1"
+            ),
+        )
+    };
+    assert_eq!(
+        nearest("[1, 0, 0]"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("UPDATE vectors SET embedding = vector32_sparse('[0, 0, 1]') WHERE id = 1")
+        .unwrap();
+    assert_eq!(
+        nearest("[0, 0, 1]"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    conn.execute("ROLLBACK").unwrap();
+    assert_eq!(
+        nearest("[1, 0, 0]"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    assert_eq!(
+        nearest("[0, 1, 0]"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
 // TODO: cannot use MVCC as we use indexes here
 #[turso_macros::test]
 fn test_vector_sparse_ivf_fuzz(tmp_db: TempDatabase) {


### PR DESCRIPTION
Custom indexes have a logical schema entry without their own B-tree root, while their backing indexes must participate in MVCC checkpointing and row versioning. Teach cursor helpers and root-page maps to distinguish those cases.

Enable the toy vector method as the first `TransactionalBackingStore` implementation. FTS remains unsupported until its statement lifecycle is explicit.