### PR TITLE
core/vdbe: label physical column offsets with logical names

### DIFF
--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -583,8 +583,12 @@ pub fn insn_to_row(
                 let cursor_type = &program.cursor_ref[*cursor_id].1;
                 let column_name: Option<&String> = match cursor_type {
                     CursorType::BTreeTable(table) => {
-                        let name = table.columns().get(*column).and_then(|v| v.name.as_ref());
-                        name
+                        table
+                            .logical_to_physical_map
+                            .iter()
+                            .position(|physical| physical == column)
+                            .and_then(|logical| table.columns().get(logical))
+                            .and_then(|column| column.name.as_ref())
                     }
                     CursorType::BTreeIndex(index) => {
                         let name = index.columns.get(*column).map(|c| &c.name);
@@ -628,7 +632,11 @@ pub fn insn_to_row(
                 let column_name = |column: usize| -> String {
                     let name: Option<&String> = match cursor_type {
                         CursorType::BTreeTable(table) => {
-                            table.columns().get(column).and_then(|v| v.name.as_ref())
+                            table.logical_to_physical_map
+                                .iter()
+                                .position(|&physical| physical == column)
+                                .and_then(|logical| table.columns().get(logical))
+                                .and_then(|column| column.name.as_ref())
                         }
                         CursorType::BTreeIndex(index) => index.columns.get(column).map(|c| &c.name),
                         _ => {

--- a/sqlite/conformance/sqlite-sqltests/gencol.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/gencol.sqltest
@@ -5064,3 +5064,17 @@ test update-or-virtual-deferred-seek-no-panic-explicit-index {
 expect error {
     UNIQUE constraint failed
 }
+
+setup gencol_explain_physical_columns {
+    CREATE TABLE t(a INT, b INT, v INT AS (a + b) VIRTUAL, c INT);
+}
+
+@setup gencol_explain_physical_columns
+snapshot gencol_explain_column_after_virtual {
+    SELECT c FROM t;
+}
+
+@setup gencol_explain_physical_columns
+snapshot gencol_explain_column_range_across_virtual {
+    SELECT b, c FROM t;
+}

--- a/sqlite/conformance/sqlite-sqltests/gencol.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/gencol.sqltest
@@ -5067,6 +5067,7 @@ expect error {
 
 setup gencol_explain_physical_columns {
     CREATE TABLE t(a INT, b INT, v INT AS (a + b) VIRTUAL, c INT);
+    PRAGMA wal_checkpoint(TRUNCATE);
 }
 
 @setup gencol_explain_physical_columns

--- a/sqlite/conformance/sqlite-sqltests/snapshots/gencol__gencol_explain_column_after_virtual.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/gencol__gencol_explain_column_after_virtual.snap
@@ -1,0 +1,25 @@
+---
+source: gencol.sqltest
+expression: SELECT c FROM t;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - gencol_explain_physical_columns
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4            p5  comment
+   0  Init          0   7   0                 0  Start at 7
+   1  OpenRead      0   2   0  k(5,B,B,B,B)   0  table=t, root=2, iDb=0
+   2  Rewind        0   6   0                 0  Rewind table t
+   3    Column      0   2   1                 0  r[1]=t.c
+   4    ResultRow   1   1   0                 0  output=r[1]
+   5  Next          0   3   0                 0
+   6  Halt          0   0   0                 0
+   7  Transaction   0   1   1                 0  iDb=0 tx_mode=Read
+   8  Goto          0   1   0                 0

--- a/sqlite/conformance/sqlite-sqltests/snapshots/gencol__gencol_explain_column_range_across_virtual.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/gencol__gencol_explain_column_range_across_virtual.snap
@@ -1,0 +1,25 @@
+---
+source: gencol.sqltest
+expression: SELECT b, c FROM t;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - gencol_explain_physical_columns
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t
+
+BYTECODE
+addr  opcode         p1  p2  p3  p4            p5  comment
+   0  Init            0   7   0                 0  Start at 7
+   1  OpenRead        0   2   0  k(5,B,B,B,B)   0  table=t, root=2, iDb=0
+   2  Rewind          0   6   0                 0  Rewind table t
+   3    ColumnRange   0   1   1  2              0  r[1..2]=t.b..c
+   4    ResultRow     1   2   0                 0  output=r[1..2]
+   5  Next            0   3   0                 0
+   6  Halt            0   0   0                 0
+   7  Transaction     0   1   1                 0  iDb=0 tx_mode=Read
+   8  Goto            0   1   0                 0

--- a/testing/sqltest/src/backends/rust.rs
+++ b/testing/sqltest/src/backends/rust.rs
@@ -218,9 +218,7 @@ impl RustDatabaseInstance {
 #[async_trait]
 impl DatabaseInstance for RustDatabaseInstance {
     async fn execute_setup(&mut self, sql: &str) -> Result<(), BackendError> {
-        // Use execute_batch for setup SQL (may contain multiple statements)
-        self.conn
-            .execute_batch(sql)
+        self.execute_query(sql)
             .await
             .map_err(|e| BackendError::Execute(e.to_string()))?;
         Ok(())
@@ -436,6 +434,24 @@ mod tests {
             .unwrap();
         assert!(!result.is_error());
         assert_eq!(result.rows, vec![vec!["1"], vec!["2"]]);
+    }
+
+    #[tokio::test]
+    async fn test_setup_ignores_rows_returned_by_pragma() {
+        let backend = RustBackend::new();
+        let config = DatabaseConfig {
+            location: DatabaseLocation::Memory,
+            readonly: false,
+        };
+        let mut instance = backend.create_database(&config).await.unwrap();
+
+        instance
+            .execute_setup("CREATE TABLE t(x INTEGER); PRAGMA wal_checkpoint(TRUNCATE);")
+            .await
+            .unwrap();
+
+        let result = instance.execute("SELECT count(*) FROM t").await.unwrap();
+        assert_eq!(result.rows, vec![vec!["0"]]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Fix `EXPLAIN` comments for tables with virtual generated columns.

`Column` and `ColumnRange` operands use physical record offsets, while table columns use logical schema order. Map physical
offsets back to logical columns before rendering their names.

Add snapshot coverage for single-column and column-range cases.

Fixes #8248

## Motivation and context

Virtual generated columns are not stored in records, so physical and logical column positions can differ. This previously
caused `EXPLAIN` to show `t.v` instead of `t.c`:

```sql
CREATE TABLE t(
    a INT,
    b INT,
    v INT GENERATED ALWAYS AS (a * 2 + b) VIRTUAL,
    c TEXT
);

EXPLAIN SELECT a, c FROM t;
```

## Description of AI Usage
I  used Codex to inspect the relevant code and tests, verify the fix, run targeted tests, and help draft this description. 
