### PR TITLE
core/mvcc: optimize cursor record caching and index key comparison

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -13,8 +13,8 @@ use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
 use crate::sync::Arc;
 use crate::translate::plan::IterationDirection;
 use crate::types::{
-    compare_immutable, IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekKey, SeekOp,
-    SeekResult, Value,
+    compare_serialized_records, IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekKey,
+    SeekOp, SeekResult, Value,
 };
 use crate::vdbe::Register;
 use crate::{return_if_io, Completion, Connection, LimboError, Pager, Result};
@@ -241,13 +241,14 @@ fn current_pos_matches_seek_key(
             let MvccCursorType::Index(index_info) = mv_cursor_type else {
                 return Ok(false);
             };
-            let key_info: Vec<_> = index_info
-                .key_info
-                .iter()
-                .take(target.column_count())
-                .cloned()
-                .collect();
-            compare_immutable(target.get_values()?, current.key.get_values()?, &key_info).is_eq()
+            let num_cols = target.column_count().min(index_info.key_info.len());
+            compare_serialized_records(
+                target.get_payload(),
+                current.key.get_payload(),
+                &index_info.key_info,
+                num_cols,
+            )?
+            .is_eq()
         }
         _ => false,
     })
@@ -610,6 +611,13 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator 
     /// (`invalidate_record`); a store epoch bump covers writes made through
     /// other cursors of the same transaction (e.g. triggers).
     record_serialized_at: Option<u64>,
+    /// Metadata for the most recent seek probe key with fewer columns than
+    /// the index (a prefix seek). Probe metadata only differs from the
+    /// cursor's own [`MvccCursorType::Index`] metadata in `num_cols`, and a
+    /// scan loop seeks with the same probe width every iteration, so caching
+    /// one truncated `IndexInfo` avoids rebuilding it (and re-copying its
+    /// key_info) on every seek.
+    probe_index_info: Option<Arc<IndexInfo>>,
     btree_cursor: Box<dyn CursorTrait>,
     null_flag: bool,
     creating_new_rowid: bool,
@@ -690,6 +698,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
             reusable_immutable_record: None,
             eq_seek_memo: None,
             record_serialized_at: None,
+            probe_index_info: None,
             btree_cursor,
             null_flag: false,
             creating_new_rowid: false,
@@ -913,6 +922,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
         let res = if allocator.is_uninitialized() {
             NextRowidResult::Uninitialized
         } else if let Some((next_rowid, prev_max_rowid)) = allocator.get_next_rowid() {
+            self.remember_fresh_rowid(next_rowid);
             NextRowidResult::Next {
                 new_rowid: next_rowid,
                 prev_rowid: prev_max_rowid,
@@ -921,6 +931,20 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
             NextRowidResult::FindRandom
         };
         Ok(IOResult::Done(res))
+    }
+
+    /// Record that `rowid` was just handed out by the allocator. The allocator
+    /// counter is bumped by every version insert and seeded from the B-tree
+    /// max, so an allocated rowid is strictly greater than every rowid this
+    /// transaction can see (rows committed by others after our snapshot are
+    /// invisible). An eq probe on it would find nothing; remember that so
+    /// `insert` skips the probe.
+    fn remember_fresh_rowid(&mut self, rowid: i64) {
+        self.eq_seek_memo = Some(EqSeekMemo {
+            key: RowID::new(self.table_id, RowKey::Int(rowid)),
+            mvcc_found: false,
+            epoch: self.db.version_mutation_epoch(),
+        });
     }
 
     pub fn initialize_max_rowid(&mut self, max_rowid: Option<i64>) -> Result<()> {
@@ -935,9 +959,13 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
 
     /// Allocate the next rowid from the (already initialized) allocator.
     /// Must be called while holding the allocator lock.
-    pub fn allocate_next_rowid(&self) -> Option<(i64, Option<i64>)> {
+    pub fn allocate_next_rowid(&mut self) -> Option<(i64, Option<i64>)> {
         let allocator = self.db.get_rowid_allocator(&self.table_id);
-        allocator.get_next_rowid()
+        let allocated = allocator.get_next_rowid();
+        if let Some((next_rowid, _)) = allocated {
+            self.remember_fresh_rowid(next_rowid);
+        }
+        allocated
     }
 
     pub fn end_new_rowid(&mut self) {
@@ -1846,13 +1874,28 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                                 let MvccCursorType::Index(index_info) = &self.mv_cursor_type else {
                                     panic!("SeekKey::IndexKey requires Index cursor type");
                                 };
-                                Arc::new(IndexInfo::new_in(
-                                    index_info.key_info.iter().cloned(),
-                                    index_info.has_rowid,
-                                    index_key.column_count(),
-                                    index_info.is_unique,
-                                    self.db.allocator(),
-                                )?)
+                                let probe_cols = index_key.column_count();
+                                if probe_cols == index_info.num_cols {
+                                    // Full-width probe: the cursor's own metadata
+                                    // describes it exactly.
+                                    index_info.clone()
+                                } else if let Some(cached) = self
+                                    .probe_index_info
+                                    .as_ref()
+                                    .filter(|cached| cached.num_cols == probe_cols)
+                                {
+                                    cached.clone()
+                                } else {
+                                    let built = Arc::new(IndexInfo::new_in(
+                                        index_info.key_info.iter().cloned(),
+                                        index_info.has_rowid,
+                                        probe_cols,
+                                        index_info.is_unique,
+                                        self.db.allocator(),
+                                    )?);
+                                    self.probe_index_info = Some(built.clone());
+                                    built
+                                }
                             };
                             let sortable_key = SortableIndexKey::new_from_payload_in(
                                 index_key,
@@ -1943,18 +1986,15 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                                     else {
                                         panic!("Index cursor expected");
                                     };
-                                    let key_info: Vec<_> = index_info
-                                        .key_info
-                                        .iter()
-                                        .take(index_key.column_count())
-                                        .cloned()
-                                        .collect();
-                                    let cmp = compare_immutable(
-                                        index_key.get_values()?,
-                                        found_key.key.get_values()?,
-                                        &key_info,
-                                    );
-                                    cmp.is_eq()
+                                    let num_cols =
+                                        index_key.column_count().min(index_info.key_info.len());
+                                    compare_serialized_records(
+                                        index_key.get_payload(),
+                                        found_key.key.get_payload(),
+                                        &index_info.key_info,
+                                        num_cols,
+                                    )?
+                                    .is_eq()
                                 }
                             };
                             if found {

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -618,6 +618,14 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator 
     /// one truncated `IndexInfo` avoids rebuilding it (and re-copying its
     /// key_info) on every seek.
     probe_index_info: Option<Arc<IndexInfo>>,
+    /// The transaction's `begin_ts`, captured at cursor construction. A
+    /// transaction's snapshot timestamp never changes, and a cursor is bound
+    /// to one transaction for its whole life, so this replaces a
+    /// transactions-map lookup on every B-tree-readability check.
+    snapshot_ts: u64,
+    /// The transaction's frozen WAL read mark; immutable per transaction,
+    /// cached for the same reason as `snapshot_ts`.
+    read_mark: crate::mvcc::database::WalPos,
     btree_cursor: Box<dyn CursorTrait>,
     null_flag: bool,
     creating_new_rowid: bool,
@@ -683,6 +691,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
         } else {
             db.get_table_id_from_root_page_at(root_page_or_table_id, snapshot_ts)
         };
+        let read_mark = db.read_tx_mark(tx_id);
         Ok(Self {
             db,
             #[cfg(any(test, injected_yields))]
@@ -699,6 +708,8 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
             eq_seek_memo: None,
             record_serialized_at: None,
             probe_index_info: None,
+            snapshot_ts,
+            read_mark,
             btree_cursor,
             null_flag: false,
             creating_new_rowid: false,
@@ -1001,10 +1012,10 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
         // (`visible_from <= observed_boundary`). A cursor that opened before checkpoint publish
         // materialization therefore stays version-store-only for its whole life and never seeks
         // the page its read mark can't see. See `MvStore::is_btree_readable_at`.
-        let begin_ts = self.db.read_snapshot_ts(self.tx_id);
-        let read_mark = self.db.read_tx_mark(self.tx_id);
+        // `snapshot_ts` and `read_mark` are immutable per transaction and
+        // cached at cursor construction.
         self.db
-            .is_btree_readable_at(&self.table_id, begin_ts, read_mark)
+            .is_btree_readable_at(&self.table_id, self.snapshot_ts, self.read_mark)
     }
 
     fn query_btree_version_is_valid(&self, key: &RowKey) -> bool {

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -24,6 +24,69 @@ use std::ops::Bound;
 #[cfg(any(test, injected_yields))]
 use strum::EnumCount;
 
+/// The visible row a scan or seek resolved while it already held the version
+/// chain's read lock, plus the [`MvStore::version_mutation_epoch`] observed
+/// *before* resolving. While the store's epoch still equals `epoch`, no write
+/// that could change visibility has happened, so `current_row` can serialize
+/// the row's payload without re-locking the chain, re-checking visibility, or
+/// looking up the transaction.
+///
+/// `row` is `Some` for table rows (their payload lives in the row's shared
+/// data buffer; the clone is a refcount bump on a line the resolution just
+/// touched). It is `None` for index rows: an index row's payload *is* its
+/// key, which the cursor position already carries, so cloning a `Row` for it
+/// would only add refcount traffic.
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedRow {
+    row: Option<Row>,
+    epoch: u64,
+}
+
+/// Outcome of the most recent eq-only seek (or rowid existence probe) on this
+/// cursor: whether MvStore held a visible version for `key` as of `epoch`.
+/// [`MvccLazyCursor::insert`] runs right after such a probe on the same key
+/// and needs exactly this fact to pick insert-vs-update, so while the store's
+/// [`MvStore::version_mutation_epoch`] still equals `epoch` the memo replaces
+/// a full skiplist lookup. Never invalidated by cursor movement — it is a
+/// statement about the store, not about the cursor position — only
+/// overwritten by the next probe or bypassed when the epoch moved.
+struct EqSeekMemo {
+    key: RowID,
+    /// True when MvStore had a visible version for `key` (B-tree-only
+    /// presence does not count; `insert` distinguishes those separately).
+    mvcc_found: bool,
+    epoch: u64,
+}
+
+impl EqSeekMemo {
+    /// The memo's answer for `id`, if it is about the same key. For record
+    /// keys the probe must also cover the same number of columns: a prefix
+    /// probe (e.g. a unique-index NoConflict without the rowid) proves
+    /// nothing about one exact full key when it *found* a prefix match.
+    fn mvcc_found_for(&self, id: &RowID, store_epoch: u64) -> Option<bool> {
+        if self.epoch != store_epoch || self.key.table_id != id.table_id {
+            return None;
+        }
+        match (&self.key.row_id, &id.row_id) {
+            (RowKey::Int(a), RowKey::Int(b)) => (a == b).then_some(self.mvcc_found),
+            (RowKey::Record(a), RowKey::Record(b)) => {
+                if a.metadata.num_cols != b.metadata.num_cols {
+                    // A shorter probe that found nothing proves every longer
+                    // key with that prefix absent; a prefix hit says nothing
+                    // about one exact longer key. (`SortableIndexKey` equality
+                    // compares the shared prefix.)
+                    return (!self.mvcc_found
+                        && a.metadata.num_cols < b.metadata.num_cols
+                        && a == b)
+                        .then_some(false);
+                }
+                (a == b).then_some(self.mvcc_found)
+            }
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone)]
 enum CursorPosition<A: ConcurrentAllocator = TursoAllocator> {
     /// We haven't loaded any row yet.
@@ -35,9 +98,12 @@ enum CursorPosition<A: ConcurrentAllocator = TursoAllocator> {
         in_btree: bool,
         /// Resolved MVCC version chain for this row, captured from the range
         /// iterator so `read_mvcc_current_row` can skip a second `self.rows.get`.
-        /// `Some` only for MVCC table rows reached via the scan path; `None`
-        /// (btree rows, index rows, seek/insert positions) falls back to a lookup.
+        /// `Some` only for MVCC rows reached via the scan or seek paths; `None`
+        /// (btree rows, insert positions) falls back to a lookup.
         versions: Option<RowVersions<A>>,
+        /// The visible row resolved when this position was created; see
+        /// [`ResolvedRow`]. `None` for btree rows and insert positions.
+        resolved: Option<ResolvedRow>,
     },
     /// We have reached the end of the table.
     End,
@@ -220,53 +286,84 @@ impl<A: ConcurrentAllocator> Default for DualCursorPeek<A> {
     }
 }
 
+/// The winner of one sorted-merge step over the dual peeks; the raw material
+/// for a [`CursorPosition::Loaded`].
+struct MergeWinner<A: ConcurrentAllocator> {
+    key: RowKey,
+    in_btree: bool,
+    versions: Option<RowVersions<A>>,
+    resolved: Option<ResolvedRow>,
+}
+
 impl<A: ConcurrentAllocator> DualCursorPeek<A> {
     /// Returns the next row key, whether the row is from the BTree, and (for
-    /// MVCC winners) the resolved version chain captured during iteration.
-    fn get_next(&self, dir: IterationDirection) -> Option<(RowKey, bool, Option<RowVersions<A>>)> {
+    /// MVCC winners) the resolved version chain and row captured during
+    /// iteration. The resolved row is moved out of the winning peek (it is
+    /// only consumed by the position built from this result); the peek's key
+    /// and version chain stay for the sorted-merge bookkeeping.
+    fn get_next(&mut self, dir: IterationDirection) -> Option<MergeWinner<A>> {
         tracing::trace!(
             "get_next: mvcc_key: {:?}, btree_key: {:?}",
             self.mvcc_peek.get_row_key(),
             self.btree_peek.get_row_key()
         );
-        match (self.mvcc_peek.get_row_key(), self.btree_peek.get_row_key()) {
+        let mvcc_wins = match (self.mvcc_peek.get_row_key(), self.btree_peek.get_row_key()) {
             (Some(mvcc_key), Some(btree_key)) => {
                 if dir == IterationDirection::Forwards {
                     // In forwards iteration we want the smaller of the two keys
-                    if mvcc_key <= btree_key {
-                        Some((mvcc_key.clone(), false, self.mvcc_peek.get_versions()))
-                    } else {
-                        Some((btree_key.clone(), true, None))
-                    }
-                // In backwards iteration we want the larger of the two keys
-                } else if mvcc_key >= btree_key {
-                    Some((mvcc_key.clone(), false, self.mvcc_peek.get_versions()))
+                    mvcc_key <= btree_key
                 } else {
-                    Some((btree_key.clone(), true, None))
+                    // In backwards iteration we want the larger of the two keys
+                    mvcc_key >= btree_key
                 }
             }
-            (Some(mvcc_key), None) => {
-                Some((mvcc_key.clone(), false, self.mvcc_peek.get_versions()))
-            }
-            (None, Some(btree_key)) => Some((btree_key.clone(), true, None)),
-            (None, None) => None,
+            (Some(_), None) => true,
+            (None, Some(_)) => false,
+            (None, None) => return None,
+        };
+        if mvcc_wins {
+            let CursorPeek::Row {
+                key,
+                versions,
+                resolved,
+            } = &mut self.mvcc_peek
+            else {
+                unreachable!("mvcc peek holds a row when it wins");
+            };
+            Some(MergeWinner {
+                key: key.clone(),
+                in_btree: false,
+                versions: versions.clone(),
+                resolved: resolved.take(),
+            })
+        } else {
+            let CursorPeek::Row { key, .. } = &self.btree_peek else {
+                unreachable!("btree peek holds a row when it wins");
+            };
+            Some(MergeWinner {
+                key: key.clone(),
+                in_btree: true,
+                versions: None,
+                resolved: None,
+            })
         }
     }
 
     /// Returns a new [CursorPosition] based on the next row key
     pub fn cursor_position_from_next(
-        &self,
+        &mut self,
         table_id: MVTableId,
         dir: IterationDirection,
     ) -> CursorPosition<A> {
         match self.get_next(dir) {
-            Some((row_key, in_btree, versions)) => CursorPosition::Loaded {
+            Some(winner) => CursorPosition::Loaded {
                 row_id: RowID {
                     table_id,
-                    row_id: row_key,
+                    row_id: winner.key,
                 },
-                in_btree,
-                versions,
+                in_btree: winner.in_btree,
+                versions: winner.versions,
+                resolved: winner.resolved,
             },
             None => match dir {
                 IterationDirection::Forwards => CursorPosition::End,
@@ -297,9 +394,13 @@ enum CursorPeek<A: ConcurrentAllocator = TursoAllocator> {
     Uninitialized,
     Row {
         key: RowKey,
-        /// Resolved MVCC version chain, set when this peek came from the MVCC
-        /// table iterator. `None` for btree peeks and index peeks.
+        /// Resolved MVCC version chain, set when this peek came from an MVCC
+        /// iterator. `None` for btree peeks.
         versions: Option<RowVersions<A>>,
+        /// The visible row resolved when this peek was produced; see
+        /// [`ResolvedRow`]. `None` for btree peeks. Moved into the cursor
+        /// position when this peek wins the sorted merge.
+        resolved: Option<ResolvedRow>,
     },
     Exhausted,
 }
@@ -314,13 +415,6 @@ impl<A: ConcurrentAllocator> CursorPeek<A> {
     pub fn get_row_key(&self) -> Option<&RowKey> {
         match self {
             CursorPeek::Row { key, .. } => Some(key),
-            _ => None,
-        }
-    }
-
-    pub fn get_versions(&self) -> Option<RowVersions<A>> {
-        match self {
-            CursorPeek::Row { versions, .. } => versions.clone(),
             _ => None,
         }
     }
@@ -505,6 +599,17 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator 
     tx_id: u64,
     /// Reusable immutable record, used to allow better allocation strategy.
     reusable_immutable_record: Option<ImmutableRecord>,
+    /// Latest eq-only probe outcome; see [`EqSeekMemo`].
+    eq_seek_memo: Option<EqSeekMemo>,
+    /// [`MvStore::version_mutation_epoch`] snapshot taken when
+    /// `reusable_immutable_record` was serialized for the current MVCC
+    /// position. While it matches the store's current epoch, `current_row`
+    /// returns the already-serialized record instead of re-resolving the
+    /// visible version, so a row read column-by-column pays for one
+    /// resolution instead of one per column. Cleared on any reposition
+    /// (`invalidate_record`); a store epoch bump covers writes made through
+    /// other cursors of the same transaction (e.g. triggers).
+    record_serialized_at: Option<u64>,
     btree_cursor: Box<dyn CursorTrait>,
     null_flag: bool,
     creating_new_rowid: bool,
@@ -583,6 +688,8 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
             current_pos: CursorPosition::BeforeFirst,
             table_id,
             reusable_immutable_record: None,
+            eq_seek_memo: None,
+            record_serialized_at: None,
             btree_cursor,
             null_flag: false,
             creating_new_rowid: false,
@@ -638,6 +745,62 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
             CursorPosition::Loaded {
                 in_btree: false, ..
             } => {
+                // Memo fast path: the reusable record already holds this
+                // position's row and no visibility-changing write happened
+                // since it was serialized (every reposition clears
+                // `record_serialized_at`, and any write bumps the epoch).
+                let store_epoch = self.db.version_mutation_epoch();
+                if self.record_serialized_at == Some(store_epoch) {
+                    let record_ref = self.reusable_immutable_record.as_ref().ok_or_else(|| {
+                        LimboError::InternalError("immutable record not initialized".to_string())
+                    })?;
+                    return Ok(IOResult::Done(Some(record_ref)));
+                }
+                self.record_serialized_at = None;
+
+                // Resolved fast path: the scan/seek that produced this
+                // position already found the visible row, and no write has
+                // happened since (epoch match), so serialize its payload
+                // without re-locking the chain or re-checking visibility.
+                // `current_pos` and the reusable record are disjoint fields,
+                // so the payload is copied without an intermediate clone.
+                if self.reusable_immutable_record.is_none() {
+                    self.reusable_immutable_record = Some(ImmutableRecord::new(1024)?);
+                }
+                if let CursorPosition::Loaded {
+                    resolved: Some(resolved),
+                    row_id,
+                    ..
+                } = &self.current_pos
+                {
+                    if resolved.epoch == store_epoch {
+                        let payload: &[u8] = match &resolved.row {
+                            Some(row) => row.payload(),
+                            // Index row: the payload is the position's key.
+                            None => match &row_id.row_id {
+                                RowKey::Record(key) => key.key.get_payload(),
+                                RowKey::Int(_) => {
+                                    unreachable!("resolved.row is None only for index rows")
+                                }
+                            },
+                        };
+                        let record = self
+                            .reusable_immutable_record
+                            .as_mut()
+                            .expect("created above");
+                        record.invalidate();
+                        record.start_serialization(payload)?;
+                        self.record_serialized_at = Some(store_epoch);
+                        let record_ref =
+                            self.reusable_immutable_record.as_ref().ok_or_else(|| {
+                                LimboError::InternalError(
+                                    "immutable record not initialized".to_string(),
+                                )
+                            })?;
+                        return Ok(IOResult::Done(Some(record_ref)));
+                    }
+                }
+
                 // Lightweight handle clone (refcount bump) so we can drop the
                 // borrow of `current_pos` and mutably borrow the reusable record.
                 let versions = match &self.current_pos {
@@ -683,6 +846,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                 if !found {
                     return Ok(IOResult::Done(None));
                 }
+                self.record_serialized_at = Some(store_epoch);
                 let record_ref = self.reusable_immutable_record.as_ref().ok_or_else(|| {
                     LimboError::InternalError("immutable record not initialized".to_string())
                 })?;
@@ -697,16 +861,29 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     }
 
     pub fn read_mvcc_current_row(&self) -> Result<Option<Row>> {
-        let (row_id, versions) = match &self.current_pos {
+        let (row_id, versions, resolved) = match &self.current_pos {
             CursorPosition::Loaded {
                 row_id,
                 in_btree,
                 versions,
-            } if !in_btree => (row_id, versions),
+                resolved,
+            } if !in_btree => (row_id, versions, resolved),
             _ => panic!("invalid position to read current mvcc row"),
         };
-        // Scan path: the range iterator already resolved this row's version
-        // chain, so read it directly instead of a second skiplist lookup.
+        // Scan/seek path: visibility was already resolved when this position
+        // was created, and no write has happened since (epoch match), so hand
+        // out the resolved row without re-locking the chain.
+        if let Some(ResolvedRow {
+            row: Some(row),
+            epoch,
+        }) = resolved
+        {
+            if *epoch == self.db.version_mutation_epoch() {
+                return Ok(Some(row.clone()));
+            }
+        }
+        // The range iterator already resolved this row's version chain, so
+        // read it directly instead of a second skiplist lookup.
         if let Some(versions) = versions {
             return self.db.read_visible_from_versions(self.tx_id, versions);
         }
@@ -809,15 +986,23 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
 
     /// Advance MVCC iterator and return next visible row key in the direction that the iterator was initialized in.
     fn advance_mvcc_iterator(&mut self) {
+        // Read the epoch before resolving visibility: a write that lands after
+        // this load fails the equality check in `current_row` and forces a
+        // re-read there.
+        let epoch = self.db.version_mutation_epoch();
         let new_peek_state = match &self.mv_cursor_type {
             MvccCursorType::Table => match self.db.advance_cursor_and_get_row_id_for_table(
                 self.table_id,
                 &mut self.table_iterator,
                 self.tx_id,
             ) {
-                Some((row_id, versions)) => CursorPeek::Row {
-                    key: row_id.row_id,
+                Some((row, versions)) => CursorPeek::Row {
+                    key: row.id.row_id.clone(),
                     versions: Some(versions),
+                    resolved: Some(ResolvedRow {
+                        row: Some(row),
+                        epoch,
+                    }),
                 },
                 None => CursorPeek::Exhausted,
             },
@@ -825,9 +1010,10 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                 .db
                 .advance_cursor_and_get_row_id_for_index(&mut self.index_iterator, self.tx_id)
             {
-                Some(row_id) => CursorPeek::Row {
-                    key: row_id.row_id,
-                    versions: None,
+                Some((key, versions)) => CursorPeek::Row {
+                    key: RowKey::Record(key),
+                    versions: Some(versions),
+                    resolved: Some(ResolvedRow { row: None, epoch }),
                 },
                 None => CursorPeek::Exhausted,
             },
@@ -871,6 +1057,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                             self.dual_peek.btree_peek = CursorPeek::Row {
                                 key: k,
                                 versions: None,
+                                resolved: None,
                             };
                             self.btree_advance_state = None;
                             return Ok(IOResult::Done(()));
@@ -905,6 +1092,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                             self.dual_peek.btree_peek = CursorPeek::Row {
                                 key,
                                 versions: None,
+                                resolved: None,
                             };
                             self.btree_advance_state = None;
                             return Ok(IOResult::Done(()));
@@ -959,6 +1147,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                             self.dual_peek.btree_peek = CursorPeek::Row {
                                 key: k,
                                 versions: None,
+                                resolved: None,
                             };
                             self.btree_advance_state = None;
                             return Ok(IOResult::Done(()));
@@ -993,6 +1182,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                             self.dual_peek.btree_peek = CursorPeek::Row {
                                 key: k,
                                 versions: None,
+                                resolved: None,
                             };
                             self.btree_advance_state = None;
                             return Ok(IOResult::Done(()));
@@ -1137,6 +1327,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                             self.dual_peek.btree_peek = CursorPeek::Row {
                                 key: k,
                                 versions: None,
+                                resolved: None,
                             };
                             return Ok(IOResult::Done(()));
                         }
@@ -1230,6 +1421,9 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         self.invalidate_record();
         self.current_pos = CursorPosition::End;
 
+        // Read the epoch before the MVCC-last resolution; see
+        // `advance_mvcc_iterator`.
+        let epoch = self.db.version_mutation_epoch();
         // Initialize MVCC iterator to last position
         match &self.mv_cursor_type {
             MvccCursorType::Table => match self.db.get_last_table_rowid(
@@ -1237,11 +1431,15 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 &mut self.table_iterator,
                 self.tx_id,
             ) {
-                Some(k) => {
-                    tracing::trace!("last: mvcc_key: {:?}", k);
+                Some((row, versions)) => {
+                    tracing::trace!("last: mvcc_key: {:?}", row.id);
                     self.dual_peek.mvcc_peek = CursorPeek::Row {
-                        key: k,
-                        versions: None,
+                        key: row.id.row_id.clone(),
+                        versions: Some(versions),
+                        resolved: Some(ResolvedRow {
+                            row: Some(row),
+                            epoch,
+                        }),
                     };
                 }
                 None => {
@@ -1253,10 +1451,11 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 self.tx_id,
                 &mut self.index_iterator,
             )? {
-                Some(k) => {
+                Some((key, versions)) => {
                     self.dual_peek.mvcc_peek = CursorPeek::Row {
-                        key: k,
-                        versions: None,
+                        key: RowKey::Record(key),
+                        versions: Some(versions),
+                        resolved: Some(ResolvedRow { row: None, epoch }),
                     };
                 }
                 None => {
@@ -1278,8 +1477,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     fn next(&mut self) -> Result<IOResult<()>> {
         if self.state.is_none() {
             // If BeforeFirst and peek not initialized, initialize the iterators and peek values
-            let current_pos = self.get_current_pos();
-            if matches!(current_pos, CursorPosition::BeforeFirst) {
+            if matches!(self.current_pos, CursorPosition::BeforeFirst) {
                 let uninitialized = self.dual_peek.both_uninitialized();
                 if uninitialized {
                     // Initialize MVCC iterator and get first peek
@@ -1313,8 +1511,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
             MvccLazyCursorState::Next(NextState::CheckNeedsAdvance)
         ) {
             // Determine which cursor(s) need to be advanced based on current position
-            let current_pos = self.get_current_pos();
-            let (need_advance_mvcc, need_advance_btree) = match &current_pos {
+            let (need_advance_mvcc, need_advance_btree) = match &self.current_pos {
                 CursorPosition::BeforeFirst => {
                     // First call after rewind - peek values should already be populated
                     // Just need to pick the smaller one
@@ -1374,8 +1571,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     fn prev(&mut self) -> Result<IOResult<()>> {
         if self.state.is_none() {
             // If End and peek not initialized, initialize via last()
-            let current_pos = self.get_current_pos();
-            if matches!(current_pos, CursorPosition::End) {
+            if matches!(self.current_pos, CursorPosition::End) {
                 let uninitialized = self.dual_peek.both_uninitialized();
                 if uninitialized {
                     self.state
@@ -1405,8 +1601,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
             MvccLazyCursorState::Prev(PrevState::CheckNeedsAdvance)
         ) {
             // Determine which cursor(s) need to be advanced based on current position
-            let current_pos = self.get_current_pos();
-            let (need_advance_mvcc, need_advance_btree) = match &current_pos {
+            let (need_advance_mvcc, need_advance_btree) = match &self.current_pos {
                 CursorPosition::End => {
                     // First call after last() - peek values should already be populated
                     (false, false)
@@ -1550,6 +1745,9 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                         MvccCursorType::Index(_) => Some(self.table_id),
                         MvccCursorType::Table => None,
                     };
+                    // Epoch for the memo below, read before the probe; see
+                    // `advance_mvcc_iterator`.
+                    let epoch = self.db.version_mutation_epoch();
                     // The current row is visible either because MvStore has a visible version
                     // for it, or because it is a b-tree-resident row that is not shadowed by
                     // any MVCC version. Both cases must short-circuit: otherwise a b-tree-only
@@ -1557,10 +1755,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                     // iterators and marks the MVCC peek exhausted, skipping MvStore-resident
                     // rows that the enclosing range scan (see the comment above) still needs
                     // to visit.
-                    let visible = self
+                    let mvcc_found = self
                         .db
                         .read_from_table_or_index(self.tx_id, row_id, maybe_index_id)?
-                        .is_some()
+                        .is_some();
+                    self.eq_seek_memo = Some(EqSeekMemo {
+                        key: row_id.clone(),
+                        mvcc_found,
+                        epoch,
+                    });
+                    let visible = mvcc_found
                         || (*in_btree && self.query_btree_version_is_valid(&row_id.row_id));
                     if visible {
                         // We need to clear the null flag for the table cursor before seeking,
@@ -1590,6 +1794,10 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                     let direction = op.iteration_direction();
                     let inclusive = matches!(op, SeekOp::GE { .. } | SeekOp::LE { .. });
 
+                    // Read the epoch before the MVCC seek resolves visibility;
+                    // see `advance_mvcc_iterator`.
+                    let epoch = self.db.version_mutation_epoch();
+
                     match &seek_key {
                         SeekKey::TableRowId(row_id) => {
                             let rowid = RowID {
@@ -1607,12 +1815,27 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                                 &mut self.table_iterator,
                             );
 
+                            // An eq-only seek's range is bounded to the probe
+                            // key, so a hit means exactly "visible version at
+                            // this key"; remember that for `insert`.
+                            if op.eq_only() {
+                                self.eq_seek_memo = Some(EqSeekMemo {
+                                    key: rowid,
+                                    mvcc_found: mvcc_rowid.is_some(),
+                                    epoch,
+                                });
+                            }
+
                             // Set MVCC peek
                             {
-                                self.dual_peek.mvcc_peek = match &mvcc_rowid {
-                                    Some(rid) => CursorPeek::Row {
-                                        key: rid.row_id.clone(),
-                                        versions: None,
+                                self.dual_peek.mvcc_peek = match mvcc_rowid {
+                                    Some((row, versions)) => CursorPeek::Row {
+                                        key: row.id.row_id.clone(),
+                                        versions: Some(versions),
+                                        resolved: Some(ResolvedRow {
+                                            row: Some(row),
+                                            epoch,
+                                        }),
                                     },
                                     None => CursorPeek::Exhausted,
                                 };
@@ -1648,12 +1871,26 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                                 &mut self.index_iterator,
                             )?;
 
+                            // See the TableRowId arm: eq-only hit == visible
+                            // version at the probe key.
+                            if op.eq_only() {
+                                self.eq_seek_memo = Some(EqSeekMemo {
+                                    key: RowID {
+                                        table_id: self.table_id,
+                                        row_id: RowKey::Record(Arc::new(sortable_key.clone())),
+                                    },
+                                    mvcc_found: mvcc_rowid.is_some(),
+                                    epoch,
+                                });
+                            }
+
                             // Set MVCC peek
                             {
-                                self.dual_peek.mvcc_peek = match &mvcc_rowid {
-                                    Some(rid) => CursorPeek::Row {
-                                        key: rid.row_id.clone(),
-                                        versions: None,
+                                self.dual_peek.mvcc_peek = match mvcc_rowid {
+                                    Some((key, versions)) => CursorPeek::Row {
+                                        key: RowKey::Record(key),
+                                        versions: Some(versions),
+                                        resolved: Some(ResolvedRow { row: None, epoch }),
                                     },
                                     None => CursorPeek::Exhausted,
                                 };
@@ -1682,14 +1919,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                     // Clear seek state
                     self.state = None;
 
-                    if let Some((winner_key, in_btree, winner_versions)) = winner {
+                    if let Some(winner) = winner {
+                        let winner_key = winner.key.clone();
                         self.current_pos = CursorPosition::Loaded {
                             row_id: RowID {
                                 table_id: self.table_id,
-                                row_id: winner_key.clone(),
+                                row_id: winner.key,
                             },
-                            in_btree,
-                            versions: winner_versions,
+                            in_btree: winner.in_btree,
+                            versions: winner.versions,
+                            resolved: winner.resolved,
                         };
 
                         if op.eq_only() {
@@ -1808,17 +2047,29 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
             row_id: row.id.clone(),
             in_btree: was_btree_resident,
             versions: None,
+            resolved: None,
         };
         let maybe_index_id = match &self.mv_cursor_type {
             MvccCursorType::Index(_) => Some(self.table_id),
             MvccCursorType::Table => None,
         };
-        // FIXME: set btree to somewhere close to this rowid?
-        if self
-            .db
-            .read_from_table_or_index(self.tx_id, &row.id, maybe_index_id)?
-            .is_some()
+        // Inserts run right after an eq probe of the same key (NotExists,
+        // NoConflict, or IdxInsert's own seek); reuse that probe's outcome
+        // instead of a second skiplist lookup when it is still current.
+        let store_epoch = self.db.version_mutation_epoch();
+        let mvcc_exists = match self
+            .eq_seek_memo
+            .as_ref()
+            .and_then(|memo| memo.mvcc_found_for(&row.id, store_epoch))
         {
+            Some(found) => found,
+            None => self
+                .db
+                .read_from_table_or_index(self.tx_id, &row.id, maybe_index_id)?
+                .is_some(),
+        };
+        // FIXME: set btree to somewhere close to this rowid?
+        if mvcc_exists {
             self.db
                 .update_to_table_or_index(self.tx_id, row, maybe_index_id)
                 .inspect_err(|_| {
@@ -1932,6 +2183,9 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
             // Check MVCC first. This is a point existence probe, so it is
             // eq-only: bound the skiplist walk to the single rowid instead of
             // scanning forward over invisible concurrent rows.
+            // Read the epoch before the seek resolves visibility; see
+            // `advance_mvcc_iterator`.
+            let epoch = self.db.version_mutation_epoch();
             let rowid = self.db.seek_rowid(
                 RowID {
                     table_id: self.table_id,
@@ -1944,24 +2198,35 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 &mut self.table_iterator,
             );
 
-            let mvcc_exists = if let Some(rowid) = &rowid {
-                let RowKey::Int(rowid) = rowid.row_id else {
-                    panic!("Rowid is not an integer in mvcc table cursor");
-                };
-                rowid == *int_key
-            } else {
-                false
+            let mvcc_found = match rowid {
+                Some((row, versions)) => {
+                    let RowKey::Int(rowid) = row.id.row_id else {
+                        panic!("Rowid is not an integer in mvcc table cursor");
+                    };
+                    (rowid == *int_key).then_some((row, versions))
+                }
+                None => None,
             };
+            self.eq_seek_memo = Some(EqSeekMemo {
+                key: RowID {
+                    table_id: self.table_id,
+                    row_id: RowKey::Int(*int_key),
+                },
+                mvcc_found: mvcc_found.is_some(),
+                epoch,
+            });
 
             tracing::trace!(
-                "MVCC exists check: mvcc_exists={mvcc_exists} find={int_key} got={rowid:?}"
+                "MVCC exists check: mvcc_exists={} find={int_key}",
+                mvcc_found.is_some()
             );
 
             // If found in MVCC, update dual_peek and return true
-            if mvcc_exists {
+            if let Some((row, versions)) = mvcc_found {
                 self.dual_peek.mvcc_peek = CursorPeek::Row {
                     key: RowKey::Int(*int_key),
-                    versions: None,
+                    versions: Some(versions.clone()),
+                    resolved: None,
                 };
                 self.current_pos = CursorPosition::Loaded {
                     row_id: RowID {
@@ -1969,7 +2234,11 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                         row_id: RowKey::Int(*int_key),
                     },
                     in_btree: false,
-                    versions: None,
+                    versions: Some(versions),
+                    resolved: Some(ResolvedRow {
+                        row: Some(row),
+                        epoch,
+                    }),
                 };
                 self.state = None;
                 return Ok(IOResult::Done(true));
@@ -2022,6 +2291,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 self.dual_peek.btree_peek = CursorPeek::Row {
                     key: row_key.clone(),
                     versions: None,
+                    resolved: None,
                 };
                 self.current_pos = CursorPosition::Loaded {
                     row_id: RowID {
@@ -2030,6 +2300,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                     },
                     in_btree: true,
                     versions: None,
+                    resolved: None,
                 };
                 self.state = None;
                 Ok(IOResult::Done(true))
@@ -2212,6 +2483,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     }
 
     fn invalidate_record(&mut self) {
+        self.record_serialized_at = None;
         if let Some(record) = self.reusable_immutable_record.as_mut() {
             record.invalidate();
         }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -26,7 +26,9 @@ use crate::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use crate::sync::Arc;
 use crate::sync::{Mutex, RwLock};
 use crate::translate::plan::IterationDirection;
-use crate::types::compare_immutable;
+use crate::types::compare_serialized_records;
+use crate::types::serialized_record_has_null_in_first_cols;
+use crate::types::serialized_record_prefixes_equal;
 use crate::types::IOCompletions;
 use crate::types::IOResult;
 use crate::types::ImmutableRecord;
@@ -201,72 +203,31 @@ impl SortableIndexKey {
         // We sometimes need to compare a shorter key to a longer one,
         // for example when seeking with an index key that is a prefix of the full key.
         let num_cols = self.metadata.num_cols.min(other.metadata.num_cols);
-
-        let mut lhs = self.key.iter()?;
-        let mut rhs = other.key.iter()?;
-
-        for i in 0..num_cols {
-            let lhs_value = lhs.next().expect("we already checked length")?;
-            let rhs_value = rhs.next().expect("we already checked length")?;
-
-            let cmp = compare_immutable(
-                std::iter::once(&lhs_value),
-                std::iter::once(&rhs_value),
-                &self.metadata.key_info[i..i + 1],
-            );
-
-            if cmp != std::cmp::Ordering::Equal {
-                return Ok(cmp);
-            }
-        }
-
-        Ok(std::cmp::Ordering::Equal)
+        compare_serialized_records(
+            self.key.get_payload(),
+            other.key.get_payload(),
+            &self.metadata.key_info,
+            num_cols,
+        )
     }
 
     /// Check if the index key contains any NULL values (excluding the rowid column).
     /// In SQLite, NULLs don't violate UNIQUE constraints, so we skip conflict checks for NULL keys.
     pub fn contains_null(&self, num_indexed_cols: usize) -> Result<bool> {
-        let mut iter = self.key.iter()?;
         // Only check the indexed columns, not the rowid at the end
-        for _ in 0..num_indexed_cols {
-            if let Some(value) = iter.next() {
-                if matches!(value?, crate::types::ValueRef::Null) {
-                    return Ok(true);
-                }
-            }
-        }
-        Ok(false)
+        serialized_record_has_null_in_first_cols(self.key.get_payload(), num_indexed_cols)
     }
 
     /// Check if the first `num_cols` columns of this key match another key.
     /// Used for UNIQUE index conflict detection where we need to compare only
     /// the indexed columns, not the rowid suffix.
     pub fn matches_prefix(&self, other: &Self, num_cols: usize) -> Result<bool> {
-        let mut lhs = self.key.iter()?;
-        let mut rhs = other.key.iter()?;
-
-        for i in 0..num_cols {
-            let lhs_value = match lhs.next() {
-                Some(v) => v?,
-                None => return Ok(false),
-            };
-            let rhs_value = match rhs.next() {
-                Some(v) => v?,
-                None => return Ok(false),
-            };
-
-            let cmp = compare_immutable(
-                std::iter::once(&lhs_value),
-                std::iter::once(&rhs_value),
-                &self.metadata.key_info[i..i + 1],
-            );
-
-            if cmp != std::cmp::Ordering::Equal {
-                return Ok(false);
-            }
-        }
-
-        Ok(true)
+        serialized_record_prefixes_equal(
+            self.key.get_payload(),
+            other.key.get_payload(),
+            &self.metadata.key_info,
+            num_cols,
+        )
     }
 }
 
@@ -1463,7 +1424,10 @@ pub enum CommitState<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocato
     Checkpoint {
         // TODO: if and when we transform this code to async we won't be needing this explicit state machine nor
         // the mutex
-        state_machine: Mutex<StateMachine<CheckpointStateMachine<Clock, A>>>,
+        // Boxed so this rarely-entered variant doesn't inflate every
+        // `CommitStateMachine` (one is built per commit) to the checkpoint
+        // machine's size.
+        state_machine: Box<Mutex<StateMachine<CheckpointStateMachine<Clock, A>>>>,
     },
     CommitEnd {
         end_ts: u64,
@@ -2157,18 +2121,32 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         // a table's in-memory table_id (e.g. -53) may differ from -(root_page)
         // (e.g. -58). On recovery, bootstrap reconstructs the map using
         // -(root_page), so log records must use that canonical form to be found.
+        //
+        // A commit logs many versions but usually touches one table plus a few
+        // indexes, so memoize the rootpage lookup per table id: a hash probe
+        // per version instead of a skiplist search. The memo lives for one
+        // chunk of this step; the rootpage binding cannot change mid-commit
+        // (checkpoints serialize behind the commit lock this tx holds).
+        let canonical_table_ids: std::cell::RefCell<HashMap<MVTableId, MVTableId>> =
+            std::cell::RefCell::new(HashMap::default());
         let canonicalize_table_id = |version: &mut RowVersion| {
             let table_id = version.row.id.table_id;
             if table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {
                 return;
             }
-            if let Some(entry) = mvcc_store.table_id_to_rootpage.get(&table_id) {
-                if let Some(root_page) = entry.value().root_page {
-                    let canonical = MVTableId::from(-(root_page as i64));
-                    if canonical != table_id {
-                        version.row.id.table_id = canonical;
-                    }
-                }
+            let canonical = *canonical_table_ids
+                .borrow_mut()
+                .entry(table_id)
+                .or_insert_with(|| {
+                    mvcc_store
+                        .table_id_to_rootpage
+                        .get(&table_id)
+                        .and_then(|entry| entry.value().root_page)
+                        .map(|root_page| MVTableId::from(-(root_page as i64)))
+                        .unwrap_or(table_id)
+                });
+            if canonical != table_id {
+                version.row.id.table_id = canonical;
             }
         };
 
@@ -3353,7 +3331,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                         self.db_id,
                         auto_checkpoint_mode,
                     ));
-                    let state_machine = Mutex::new(state_machine);
+                    let state_machine = Box::new(Mutex::new(state_machine));
                     self.state = CommitState::Checkpoint { state_machine };
                     return Ok(TransitionResult::Continue);
                 }
@@ -5245,6 +5223,15 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     ) -> Result<bool> {
         tracing::trace!("delete(tx_id={}, id={:?})", tx_id, id);
         self.bump_version_mutation_epoch();
+        // One transaction lookup for the whole call. The entry stays valid
+        // across the version loop: only this connection can finish the
+        // transaction, and it is busy running this delete.
+        let tx = self
+            .txs
+            .get(&tx_id)
+            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
+        let tx = tx.value();
+        turso_assert_eq!(tx.state, TransactionState::Active);
         match maybe_index_id {
             Some(index_id) => {
                 let rows = self.get_or_create_index_rows(index_id)?;
@@ -5257,12 +5244,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     let arc_key = row_versions_entry.key().clone();
                     let row_versions = row_versions_entry.value().clone();
                     for rv in row_versions.write().iter_mut().rev() {
-                        let tx = self
-                            .txs
-                            .get(&tx_id)
-                            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-                        let tx = tx.value();
-                        turso_assert_eq!(tx.state, TransactionState::Active);
                         // A transaction cannot delete a version that it cannot see,
                         // nor can it conflict with it.
                         if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
@@ -5275,11 +5256,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
                         let version_id = rv.id;
                         rv.set_end(Some(TxTimestampOrID::TxID(tx.tx_id)));
-                        let tx = self
-                            .txs
-                            .get(&tx_id)
-                            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-                        let tx = tx.value();
                         tx.insert_to_write_set(id, row_versions.clone());
                         tx.record_deleted_index_version((index_id, arc_key), version_id);
                         return Ok(true);
@@ -5293,12 +5269,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     let row_versions = row_versions_entry.value().clone();
                     let mut locked_row_versions = row_versions.write();
                     for rv in locked_row_versions.iter_mut().rev() {
-                        let tx = self
-                            .txs
-                            .get(&tx_id)
-                            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-                        let tx = tx.value();
-                        turso_assert_eq!(tx.state, TransactionState::Active);
                         // A transaction cannot delete a version that it cannot see,
                         // nor can it conflict with it.
                         if !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
@@ -5313,11 +5283,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         rv.set_end(Some(TxTimestampOrID::TxID(tx.tx_id)));
                         drop(locked_row_versions);
                         drop(row_versions_opt);
-                        let tx = self
-                            .txs
-                            .get(&tx_id)
-                            .ok_or_else(|| LimboError::NoSuchTransactionID(tx_id.to_string()))?;
-                        let tx = tx.value();
                         tx.insert_to_write_set(id.clone(), row_versions.clone());
                         tx.record_deleted_table_version(id.clone(), version_id);
                         return Ok(true);
@@ -8033,9 +7998,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         // which performs a binary search for the insertion point.
         versions.try_reserve(1)?;
         let mut position = 0_usize;
+        let new_begin = self.resolve_begin_timestamp(&row_version.begin());
         for (i, v) in versions.iter().enumerate().rev() {
             let existing_begin = self.resolve_begin_timestamp(&v.begin());
-            let new_begin = self.resolve_begin_timestamp(&row_version.begin());
             if existing_begin <= new_begin {
                 // Recovery can replay multiple operations for the same row from one transaction
                 // (e.g. insert then delete), which share the same begin timestamp.
@@ -10178,6 +10143,13 @@ fn is_begin_visible<A: ConcurrentAllocator>(
             tx.begin_ts > rv_begin_ts
         }
         Some(TxTimestampOrID::TxID(rv_begin)) => {
+            // Our own uncommitted version: we are Active (we are executing
+            // this very read), so the Active arm below would evaluate to
+            // `rv.end().is_none()`. Answer without the map lookup — reading
+            // your own writes is the common TxID-reference case.
+            if rv_begin == tx.tx_id {
+                return rv.end().is_none();
+            }
             let visible = match txs.get(&rv_begin) {
                 Some(tb_entry) => {
                     let tb = tb_entry.value();
@@ -10263,6 +10235,13 @@ fn is_end_visible<A: ConcurrentAllocator>(
     match row_version.end() {
         Some(TxTimestampOrID::Timestamp(rv_end_ts)) => current_tx.begin_ts < rv_end_ts,
         Some(TxTimestampOrID::TxID(rv_end)) => {
+            // We deleted this version ourselves: we are Active, so the Active
+            // arm below would evaluate to false. Answer without the map
+            // lookup — seeing your own deletes is the common TxID-reference
+            // case.
+            if rv_end == current_tx.tx_id {
+                return false;
+            }
             let visible = match txs.get(&rv_end) {
                 Some(other_tx_entry) => {
                     let other_tx = other_tx_entry.value();

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3988,6 +3988,17 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// a mismatch, since a key inserted at or behind an already-positioned
     /// finger would otherwise be skipped (#7578).
     index_rows_epoch: AtomicU64,
+    /// Bumped on every write that can change which row version a transaction
+    /// sees: version inserts (tables and indexes), delete/end-marker writes,
+    /// and rollbacks (full and to-savepoint). Cursors use this to memoize the
+    /// serialized record for their current position: a snapshot of this
+    /// counter taken when the record was serialized is still current iff no
+    /// such write happened since. Only a transaction's own writes can change
+    /// its visible rows mid-transaction (snapshot isolation), and those
+    /// happen on the cursor's own thread, so `Relaxed` ordering suffices;
+    /// bumps from other threads' transactions merely cause a spurious
+    /// re-read.
+    version_mutation_epoch: AtomicU64,
     txs: SkipMap<TxID, Transaction<A>, BasicComparator, A>,
     /// Final state for removed transactions. Readers may still race with stale TxID
     /// references in row versions after a transaction is removed from `txs`.
@@ -4214,6 +4225,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             table_id_to_rootpage,
             index_rows: SkipMap::new_in(alloc.clone()),
             index_rows_epoch: AtomicU64::new(0),
+            version_mutation_epoch: AtomicU64::new(0),
             txs: SkipMap::new_in(alloc.clone()),
             finalized_tx_states: SkipMap::new_in(alloc.clone()),
             alloc,
@@ -4973,6 +4985,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         maybe_index_id: Option<MVTableId>,
     ) -> Result<()> {
         tracing::trace!("insert(tx_id={}, row.id={:?})", tx_id, row.id);
+        self.bump_version_mutation_epoch();
         let tx = self
             .txs
             .get(&tx_id)
@@ -5043,6 +5056,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         row: Row,
         maybe_index_id: Option<MVTableId>,
     ) -> Result<()> {
+        self.bump_version_mutation_epoch();
         let version_id = self.get_version_id();
         let row_version = RowVersion {
             id: version_id,
@@ -5096,6 +5110,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             tx_id,
             row.id
         );
+        self.bump_version_mutation_epoch();
         let tx = self
             .txs
             .get(&tx_id)
@@ -5229,6 +5244,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         maybe_index_id: Option<MVTableId>,
     ) -> Result<bool> {
         tracing::trace!("delete(tx_id={}, id={:?})", tx_id, id);
+        self.bump_version_mutation_epoch();
         match maybe_index_id {
             Some(index_id) => {
                 let rows = self.get_or_create_index_rows(index_id)?;
@@ -5479,7 +5495,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         table_id: MVTableId,
         mv_store_iterator: &mut Option<MvccIterator<'static, RowID, A>>,
         tx_id: TxID,
-    ) -> Option<(RowID, RowVersions<A>)> {
+    ) -> Option<(Row, RowVersions<A>)> {
         let mv_store_iterator = mv_store_iterator.as_mut().expect(
             "mv_store_iterator must be initialized when calling get_row_id_for_table_in_direction",
         );
@@ -5514,7 +5530,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         mv_store_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>, A>>,
         tx_id: TxID,
-    ) -> Option<RowID> {
+    ) -> Option<(Arc<SortableIndexKey>, RowVersions<A>)> {
         let mv_store_iterator = mv_store_iterator.as_mut().expect(
             "mv_store_iterator must be initialized when calling get_row_id_for_index_in_direction",
         );
@@ -5540,6 +5556,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         ckpt_max: u64,
         reader_mark: WalPos,
     ) -> bool {
+        self.chain_is_write_buffer_for_inner(tx, versions, ckpt_max, reader_mark, false)
+    }
+
+    fn chain_is_write_buffer_for_inner(
+        &self,
+        tx: &Transaction<A>,
+        versions: &[RowVersion],
+        ckpt_max: u64,
+        reader_mark: WalPos,
+        sole_version_known_visible: bool,
+    ) -> bool {
         if versions.is_empty() {
             return false;
         }
@@ -5550,7 +5577,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         let Some(TxTimestampOrID::Timestamp(begin_ts)) = rv.begin() else {
             return true;
         };
-        if rv.end().is_some() || !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states) {
+        if rv.end().is_some() {
+            return true;
+        }
+        // Scans already established the sole version's visibility while
+        // locating it; skip re-deriving it for every row.
+        if !sole_version_known_visible
+            && !rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states)
+        {
             return true;
         }
         // Passive may stamp materialized_at during write-out before publish.
@@ -5575,17 +5609,40 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         table_id: MVTableId,
         versions: &[RowVersion],
     ) -> bool {
+        self.btree_covers_chain_for_tx_inner(tx, table_id, versions, false)
+    }
+
+    /// `sole_version_known_visible`: the caller already proved the chain's
+    /// only version visible to `tx`; see [`Self::chain_is_write_buffer_for_inner`].
+    fn btree_covers_chain_for_tx_inner(
+        &self,
+        tx: &Transaction<A>,
+        table_id: MVTableId,
+        versions: &[RowVersion],
+        sole_version_known_visible: bool,
+    ) -> bool {
         if self.experimental_mvcc_passive_checkpoint {
             return false;
         }
         if self.checkpoint_in_progress.load(Ordering::Acquire) {
             return false;
         }
-        if !self.is_btree_readable_at(&table_id, tx.begin_ts, tx.read_mark) {
+        // Check the chain shape before the B-tree binding: both must agree for
+        // the B-tree to cover the chain, and the chain-shape check is a scan of
+        // an already-locked Vec while `is_btree_readable_at` is a skiplist
+        // lookup. Scans call this for every row, and for not-yet-materialized
+        // chains (the common case for hot data) the shape check answers alone.
+        let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
+        if self.chain_is_write_buffer_for_inner(
+            tx,
+            versions,
+            ckpt_max,
+            tx.read_mark,
+            sole_version_known_visible,
+        ) {
             return false;
         }
-        let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
-        !self.chain_is_write_buffer_for(tx, versions, ckpt_max, tx.read_mark)
+        self.is_btree_readable_at(&table_id, tx.begin_ts, tx.read_mark)
     }
 
     /// Whether an already-resolved index version chain shadows (invalidates) the
@@ -5687,42 +5744,67 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         tx: &Transaction<A>,
         row: &TableRowEntry<'_, A>,
-    ) -> Option<(RowID, RowVersions<A>)> {
+    ) -> Option<(Row, RowVersions<A>)> {
+        let versions_arc = row.value();
+        let visible_row = {
+            let versions = versions_arc.read();
+            let visible = versions
+                .iter()
+                .rev()
+                .find(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states))?;
+            let visible_row = visible.row.clone();
+            // With one version in the chain, the version just found is it, so
+            // its visibility is already proven.
+            let sole_version_known_visible = versions.len() == 1;
+            if self.btree_covers_chain_for_tx_inner(
+                tx,
+                row.key().table_id,
+                &versions,
+                sole_version_known_visible,
+            ) {
+                return None;
+            }
+            visible_row
+        };
+        Some((visible_row, versions_arc.clone()))
+    }
+
+    /// Returns the entry's canonical key (shared with the version chain's
+    /// rows) rather than a cloned `Row`: an index row's payload is its key,
+    /// so the key alone fully identifies and materializes the row.
+    fn find_last_visible_index_version(
+        &self,
+        tx: &Transaction<A>,
+        row: IndexRowEntry<'_, A>,
+    ) -> Option<(Arc<SortableIndexKey>, RowVersions<A>)> {
         let versions_arc = row.value();
         {
             let versions = versions_arc.read();
-            let has_visible = versions
+            let visible = versions
                 .iter()
                 .rev()
-                .any(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states));
-            if !has_visible {
-                return None;
-            }
-            if self.btree_covers_chain_for_tx(tx, row.key().table_id, &versions) {
+                .find(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states))?;
+            let table_id = visible.row.id.table_id;
+            // With one version in the chain, the version just found is it, so
+            // its visibility is already proven.
+            let sole_version_known_visible = versions.len() == 1;
+            if self.btree_covers_chain_for_tx_inner(
+                tx,
+                table_id,
+                &versions,
+                sole_version_known_visible,
+            ) {
                 return None;
             }
         }
         Some((row.key().clone(), versions_arc.clone()))
     }
 
-    fn find_last_visible_index_version(
+    fn find_next_visible_index_row<'a, I>(
         &self,
         tx: &Transaction<A>,
-        row: IndexRowEntry<'_, A>,
-    ) -> Option<RowID> {
-        let versions = row.value().read();
-        let visible = versions
-            .iter()
-            .rev()
-            .find(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states))?;
-        let table_id = visible.row.id.table_id;
-        if self.btree_covers_chain_for_tx(tx, table_id, &versions) {
-            return None;
-        }
-        Some(visible.row.id.clone())
-    }
-
-    fn find_next_visible_index_row<'a, I>(&self, tx: &Transaction<A>, mut rows: I) -> Option<RowID>
+        mut rows: I,
+    ) -> Option<(Arc<SortableIndexKey>, RowVersions<A>)>
     where
         I: Iterator<Item = IndexRowEntry<'a, A>>,
     {
@@ -5739,7 +5821,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         tx: &Transaction<A>,
         mut rows: I,
         table_id: MVTableId,
-    ) -> Option<(RowID, RowVersions<A>)>
+    ) -> Option<(Row, RowVersions<A>)>
     where
         I: Iterator<Item = TableRowEntry<'a, A>>,
     {
@@ -5762,7 +5844,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         direction: IterationDirection,
         tx_id: TxID,
         table_iterator: &mut Option<MvccIterator<'static, RowID, A>>,
-    ) -> Option<RowID> {
+    ) -> Option<(Row, RowVersions<A>)> {
         let table_id = start.table_id;
         let iter_box = {
             let range = if eq_only {
@@ -5807,7 +5889,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         let tx = tx.value();
 
         self.find_next_visible_table_row(tx, mv_store_iterator, table_id)
-            .map(|(row_id, _versions)| row_id)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -5820,7 +5901,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         direction: IterationDirection,
         tx_id: TxID,
         index_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>, A>>,
-    ) -> Result<Option<RowID>> {
+    ) -> Result<Option<(Arc<SortableIndexKey>, RowVersions<A>)>> {
         let index_rows = self.get_or_create_index_rows(index_id)?;
         let index_rows = index_rows.value();
         let range = if eq_only {
@@ -6483,6 +6564,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         id = "rollback_transfers_frozen_write_set"
     )]
     fn rollback_tx_inner(&self, tx_id: TxID, connection: Option<&Connection>, db: usize) {
+        self.bump_version_mutation_epoch();
         let tx_unlocked = self
             .txs
             .get(&tx_id)
@@ -6709,6 +6791,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     }
 
     fn rollback_savepoint_changes(&self, tx_id: TxID, savepoint: Savepoint<A>) {
+        self.bump_version_mutation_epoch();
         let Savepoint {
             header,
             header_dirty,
@@ -7262,6 +7345,19 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         }
         let _gate = GcGate(&self.gc_in_progress);
 
+        // GC can drop a chain's last version once the B-tree covers it, which
+        // changes where a read for that key resolves; invalidate cursors'
+        // epoch-guarded caches around the pass (entry and exit, so caches
+        // created mid-pass don't survive it either).
+        self.bump_version_mutation_epoch();
+        struct GcEpochBump<'a, Clock: LogicalClock, A: ConcurrentAllocator>(&'a MvStore<Clock, A>);
+        impl<Clock: LogicalClock, A: ConcurrentAllocator> Drop for GcEpochBump<'_, Clock, A> {
+            fn drop(&mut self) {
+                self.0.bump_version_mutation_epoch();
+            }
+        }
+        let _epoch_bump = GcEpochBump(self);
+
         let passive = self.experimental_mvcc_passive_checkpoint;
         // Passive: keep the last current SkipMap version (B-trees may still be mid-write).
         // Blocking Truncate: safe to drop it once the B-tree already has the row.
@@ -7478,6 +7574,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
         let mut referenced_tx_ids = HashSet::default();
 
+        // See `gc_incremental`: dropping versions can move a key's read to the
+        // B-tree, so cursors' epoch-guarded caches must not survive the pass.
+        self.bump_version_mutation_epoch();
+
         let dropped = self.gc_table_row_versions(
             lwm,
             ckpt_max,
@@ -7493,6 +7593,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             drop_current_if_in_btree,
             reader_mark_floor,
         );
+        self.bump_version_mutation_epoch();
         self.dec_live_version_count_approx(dropped);
         let pruned_finalized = self.prune_finalized_tx_states(&referenced_tx_ids);
 
@@ -7790,9 +7891,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     ) -> Result<RowVersions<A>, TryReserveError> {
         // Retry if GC unlinked this slot while we waited for the write lock.
         loop {
-            let row_versions = self.get_or_create_table_row_versions(id.clone())?;
+            let entry = self.get_or_create_table_row_versions(id.clone())?;
+            let row_versions = entry.value().clone();
             let mut versions = row_versions.write();
-            if !self.table_versions_still_mapped(&id, &row_versions) {
+            // GC removes a drained slot while holding its write lock, so once
+            // we hold the lock the node's removed flag is current: not removed
+            // means this arc is still the mapped chain. This replaces a second
+            // full skiplist lookup per insert.
+            if entry.is_removed() {
                 continue;
             }
             self.insert_version_raw(&mut versions, row_version)?;
@@ -7801,38 +7907,18 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         }
     }
 
-    /// True if `arc` is still the mapped value for `id`.
-    fn table_versions_still_mapped(&self, id: &RowID, arc: &RowVersions<A>) -> bool {
-        self.rows
-            .get(id)
-            .is_some_and(|entry| Arc::ptr_eq(entry.value(), arc))
-    }
-
-    /// True if `arc` is still the mapped value for `key`.
-    fn index_versions_still_mapped(
-        &self,
-        index: &IndexRowsMap<A>,
-        key: &SortableIndexKey,
-        arc: &RowVersions<A>,
-    ) -> bool {
-        index
-            .get(key)
-            .is_some_and(|entry| Arc::ptr_eq(entry.value(), arc))
-    }
-
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::TableRowsEntry)]
     fn get_or_create_table_row_versions(
         &self,
         id: RowID,
-    ) -> Result<RowVersions<A>, TryReserveError> {
+    ) -> Result<TableRowEntry<'_, A>, TryReserveError> {
         let alloc = self.alloc.clone();
-        let versions = self.rows.try_get_or_insert_with(id, move || {
+        self.rows.try_get_or_insert_with(id, move || {
             Arc::new(RwLock::new(<RowVersionChain<A> as TursoVecInExt<
                 RowVersion,
                 A,
             >>::new_in(alloc)))
-        })?;
-        Ok(versions.value().clone())
+        })
     }
 
     /// Gets an existing Arc<SortableIndexKey> from the index if the key exists,
@@ -7870,7 +7956,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             let canonical_key = entry.key().clone();
             let row_versions = entry.value().clone();
             let mut versions = row_versions.write();
-            if !self.index_versions_still_mapped(index, canonical_key.as_ref(), &row_versions) {
+            // See `insert_version`: with the write lock held, the removed flag
+            // answers "is this arc still mapped" without a second lookup.
+            if entry.is_removed() {
                 continue;
             }
             row_version.row.id.row_id = RowKey::Record(canonical_key.clone());
@@ -7883,6 +7971,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Current epoch of `index_rows` key-set mutations; see the field docs.
     pub(crate) fn index_rows_epoch(&self) -> u64 {
         self.index_rows_epoch.load(Ordering::SeqCst)
+    }
+
+    /// Current epoch of visibility-changing version mutations; see the field docs.
+    pub(crate) fn version_mutation_epoch(&self) -> u64 {
+        self.version_mutation_epoch.load(Ordering::Relaxed)
+    }
+
+    /// Record a write that can change which row version a transaction sees;
+    /// see the field docs.
+    fn bump_version_mutation_epoch(&self) {
+        self.version_mutation_epoch.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Key-set mutation of `index_rows` (insert or empty-slot remove); see field docs.
@@ -8016,6 +8115,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Clears the chain but keeps the empty SkipMap slot (write-set GC still looks it up).
     pub fn purge_row_versions_during_checkpoint(&self, rowid: RowID) {
         if let Some(entry) = self.rows.get(&rowid) {
+            self.bump_version_mutation_epoch();
             let mut versions = entry.value().write();
             self.dec_live_version_count_approx(versions.len());
             versions.clear();
@@ -8026,11 +8126,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// Passive sequence compaction: record end-stamped deletes instead of inline B-tree purge.
     pub fn seqcompact_commit_delete(&self, rowid: RowID, num_cols: usize, end_ts: u64) {
         loop {
-            let Ok(row_versions) = self.get_or_create_table_row_versions(rowid.clone()) else {
+            let Ok(entry) = self.get_or_create_table_row_versions(rowid.clone()) else {
                 return;
             };
+            let row_versions = entry.value().clone();
             let mut versions = row_versions.write();
-            if !self.table_versions_still_mapped(&rowid, &row_versions) {
+            // See `insert_version` for why the removed flag suffices here.
+            if entry.is_removed() {
                 continue;
             }
             // End-stamp the live committed version, if any — collection then
@@ -8069,7 +8171,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         table_id: MVTableId,
         table_iterator: &mut Option<MvccIterator<'static, RowID, A>>,
         tx_id: TxID,
-    ) -> Option<RowKey> {
+    ) -> Option<(Row, RowVersions<A>)> {
         let tx = self
             .txs
             .get(&tx_id)
@@ -8099,16 +8201,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 tracing::trace!("get_last_table_rowid: reached end of table");
                 return None;
             }
-            if let Some(_visible_row) = self.find_last_visible_version(tx, &entry) {
+            if let Some((visible_row, versions)) = self.find_last_visible_version(tx, &entry) {
                 tracing::trace!(
                     "get_last_table_rowid: found visible row: {:?}",
-                    _visible_row
+                    visible_row.id
+                );
+                turso_assert!(
+                    matches!(visible_row.id.row_id, RowKey::Int(_)),
+                    "Expected RowKey::Int for table rowid"
                 );
                 // There is a visible version for this rowid, so we return it
-                return Some(RowKey::Int(match &entry.key().row_id {
-                    RowKey::Int(i) => *i,
-                    _ => panic!("Expected RowKey::Int for table rowid"),
-                }));
+                return Some((visible_row, versions));
             }
         }
     }
@@ -8135,7 +8238,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         index_id: MVTableId,
         tx_id: TxID,
         index_iterator: &mut Option<MvccIterator<'static, Arc<SortableIndexKey>, A>>,
-    ) -> Result<Option<RowKey>> {
+    ) -> Result<Option<(Arc<SortableIndexKey>, RowVersions<A>)>> {
         let index = self.get_or_create_index_rows(index_id)?;
         let index = index.value();
         let iter_box = Box::new(index.iter().rev());
@@ -8148,9 +8251,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             .get(&tx_id)
             .expect("transaction should exist in txs map");
         let tx = tx.value();
-        Ok(self
-            .find_next_visible_index_row(tx, iter)
-            .map(|row| row.row_id))
+        Ok(self.find_next_visible_index_row(tx, iter))
     }
 
     pub fn get_logical_log_file(&self) -> Arc<dyn File> {
@@ -9202,9 +9303,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 materialized_at: crate::mvcc::database::WalPos::ORIGIN,
                             };
                             {
-                                let versions =
-                                    self.get_or_create_table_row_versions(rowid.clone())?;
-                                let mut versions = versions.write();
+                                let entry = self.get_or_create_table_row_versions(rowid.clone())?;
+                                let mut versions = entry.value().write();
                                 self.insert_version_raw(&mut versions, row_version)?;
                             }
                             let allocator = self.get_rowid_allocator(&rowid.table_id);
@@ -9296,9 +9396,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     btree_resident: true,
                                     materialized_at: crate::mvcc::database::WalPos::ORIGIN,
                                 };
-                                let versions =
-                                    self.get_or_create_table_row_versions(rowid.clone())?;
-                                let mut versions = versions.write();
+                                let entry = self.get_or_create_table_row_versions(rowid.clone())?;
+                                let mut versions = entry.value().write();
                                 self.insert_version_raw(&mut versions, row_version)?;
                             }
                             if rowid.table_id == SQLITE_SCHEMA_MVCC_TABLE_ID {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -20630,3 +20630,20 @@ fn truncate_checkpoint_is_busy_while_a_reader_transaction_is_open() {
     // Now that the reader is gone, Truncate can proceed.
     writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 }
+
+#[test]
+fn commit_state_machine_stays_small() {
+    use crate::alloc::DynAllocator;
+    use crate::mvcc::clock::MvccClock;
+    use crate::mvcc::database::CommitStateMachine;
+    // One CommitStateMachine is built and moved into its Box on every commit,
+    // so its size is per-commit memcpy cost. The checkpoint state machine is
+    // boxed inside the Checkpoint variant precisely to keep this small; this
+    // guards against a large variant creeping back in.
+    let size = std::mem::size_of::<CommitStateMachine<MvccClock, DynAllocator>>();
+    eprintln!("CommitStateMachine size: {size} bytes");
+    assert!(
+        size <= 512,
+        "CommitStateMachine grew to {size} bytes; commit_tx copies this struct on every commit"
+    );
+}

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -333,10 +333,11 @@ fn seqcompact_tombstone_payload_uses_store_allocator() {
     )
     .unwrap();
     let row_id = RowID::new(MVTableId::from(-2), RowKey::Int(1));
-    let versions = store
+    let entry = store
         .get_or_create_table_row_versions(row_id.clone())
         .unwrap();
-    versions.write().try_reserve(1).unwrap();
+    entry.value().write().try_reserve(1).unwrap();
+    drop(entry);
 
     alloc.fail_allocations(true);
     store.seqcompact_commit_delete(row_id, 1, 10);

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -6402,6 +6402,67 @@ fn test_sequence_watermark_reader_never_skips_committed_rows_fuzz() {
     }
 }
 
+/// What this test checks: a cursor parked on a row serves the row's NEW value
+/// after the same transaction writes to it through the store (as a trigger or
+/// another cursor would), and reports the row gone after a delete.
+/// Why this matters: the cursor caches the serialized record for its current
+/// position and reuses it while no write happened; a write must invalidate
+/// that cache, otherwise reads-after-own-writes return stale data.
+#[test]
+fn test_cursor_record_sees_same_tx_writes_through_store() {
+    let (db, tx_id, table_id, btree_root_page) = setup_lazy_db(&[1, 2, 3]);
+
+    let mut cursor = MvccLazyCursor::new(
+        db.mvcc_store.clone(),
+        &db.conn,
+        tx_id,
+        i64::from(table_id),
+        MvccCursorType::Table,
+        Box::new(BTreeCursor::new(
+            db.conn.pager.load().clone(),
+            btree_root_page,
+            1,
+        )),
+    )
+    .unwrap();
+
+    // Position on row 1 and read its record twice; repeated reads at the same
+    // position must return the same bytes.
+    assert!(matches!(cursor.next().unwrap(), IOResult::Done(())));
+    let read_payload = |cursor: &mut MvccLazyCursor<MvccClock, DynAllocator>| {
+        let IOResult::Done(record) = cursor.record().unwrap() else {
+            panic!("record IO not expected on in-memory store");
+        };
+        record.map(|r| r.get_payload().to_vec())
+    };
+    let original = read_payload(&mut cursor).expect("row 1 has a record");
+    assert_eq!(read_payload(&mut cursor).unwrap(), original);
+
+    // The same transaction updates row 1 through the store, not through this
+    // cursor (like a second cursor or a trigger would).
+    let updated_record =
+        ImmutableRecord::from_values(&[Value::Text(Text::new("updated"))], 1).unwrap();
+    let row = Row::new_table_row(
+        RowID::new(table_id, RowKey::Int(1)),
+        updated_record.as_blob(),
+        1,
+    )
+    .unwrap();
+    assert!(db.mvcc_store.update(tx_id, row).unwrap());
+
+    // The parked cursor must serve the new value, not its cached bytes.
+    let after_update = read_payload(&mut cursor).expect("row 1 still visible");
+    assert_eq!(after_update, updated_record.as_blob().to_vec());
+    assert_ne!(after_update, original);
+
+    // And after the row is deleted, the cursor must report it gone.
+    assert!(db
+        .mvcc_store
+        .delete(tx_id, RowID::new(table_id, RowKey::Int(1)))
+        .unwrap());
+    assert!(read_payload(&mut cursor).is_none());
+}
+
 /// What this test checks: Cursor traversal and seek operations honor MVCC visibility and key ordering under updates/deletes.
 /// Why this matters: Read-path correctness is critical: wrong cursor semantics directly surface as wrong query answers.
 #[test]

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1171,9 +1171,27 @@ impl BTreeCursor {
         index: &Index,
         num_columns: usize,
     ) -> Result<Self> {
+        Ok(Self::new_index_with_info(
+            pager,
+            root_page,
+            num_columns,
+            Arc::new(IndexInfo::new_from_index(index)?),
+        ))
+    }
+
+    /// Like [`Self::new_index`], but reuses an already-built `IndexInfo`
+    /// instead of deriving a fresh one from the schema. Callers that also
+    /// hand the same metadata to an MVCC cursor share one allocation this
+    /// way.
+    pub fn new_index_with_info(
+        pager: Arc<Pager>,
+        root_page: i64,
+        num_columns: usize,
+        index_info: Arc<IndexInfo>,
+    ) -> Self {
         let mut cursor = Self::new(pager, root_page, num_columns);
-        cursor.index_info = Some(Arc::new(IndexInfo::new_from_index(index)?));
-        Ok(cursor)
+        cursor.index_info = Some(index_info);
+        cursor
     }
 
     /// Resets the cached count state so the next `count()` call re-traverses the

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -152,25 +152,40 @@ impl CollationSeq {
     #[inline(always)]
     pub fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
         match *self {
-            Self::Unset | Self::Binary => Self::binary_cmp(lhs, rhs),
-            Self::NoCase => Self::nocase_cmp(lhs, rhs),
-            Self::Rtrim => Self::rtrim_cmp(lhs, rhs),
+            Self::Unset | Self::Binary => Self::binary_cmp(lhs.as_bytes(), rhs.as_bytes()),
+            Self::NoCase => Self::nocase_cmp(lhs.as_bytes(), rhs.as_bytes()),
+            Self::Rtrim => Self::rtrim_cmp(lhs.as_bytes(), rhs.as_bytes()),
             Self::Locale(id) => LocaleCollationRegistry::global().compare(id, lhs, rhs),
             // Immutable comparison paths have no connection to fetch the external
             // callback from. Runtime VDBE paths dispatch custom collations via
             // `Connection`; schema/index paths reject them before storage.
-            Self::Custom(_) => Self::binary_cmp(lhs, rhs),
+            Self::Custom(_) => Self::binary_cmp(lhs.as_bytes(), rhs.as_bytes()),
+        }
+    }
+
+    /// Compare two text values by their raw bytes, without checking that they
+    /// are valid UTF-8. Returns `None` for locale collations, which need real
+    /// strings. For every other collation this returns exactly what
+    /// [`Self::compare_strings`] would return for the same bytes: those
+    /// collations only ever look at individual bytes.
+    #[inline(always)]
+    pub fn compare_text_bytes(&self, lhs: &[u8], rhs: &[u8]) -> Option<Ordering> {
+        match *self {
+            Self::Unset | Self::Binary | Self::Custom(_) => Some(Self::binary_cmp(lhs, rhs)),
+            Self::NoCase => Some(Self::nocase_cmp(lhs, rhs)),
+            Self::Rtrim => Some(Self::rtrim_cmp(lhs, rhs)),
+            Self::Locale(_) => None,
         }
     }
 
     #[inline(always)]
-    fn binary_cmp(lhs: &str, rhs: &str) -> Ordering {
+    fn binary_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
         lhs.cmp(rhs)
     }
 
     #[inline(always)]
-    fn nocase_cmp(lhs: &str, rhs: &str) -> Ordering {
-        for (left, right) in lhs.bytes().zip(rhs.bytes()) {
+    fn nocase_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        for (left, right) in lhs.iter().zip(rhs.iter()) {
             let left = left.to_ascii_lowercase();
             let right = right.to_ascii_lowercase();
             if left != right {
@@ -184,8 +199,15 @@ impl CollationSeq {
     }
 
     #[inline(always)]
-    fn rtrim_cmp(lhs: &str, rhs: &str) -> Ordering {
-        lhs.trim_end_matches(' ').cmp(rhs.trim_end_matches(' '))
+    fn rtrim_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        fn trim_trailing_spaces(bytes: &[u8]) -> &[u8] {
+            let end = bytes
+                .iter()
+                .rposition(|&b| b != b' ')
+                .map_or(0, |pos| pos + 1);
+            &bytes[..end]
+        }
+        trim_trailing_spaces(lhs).cmp(trim_trailing_spaces(rhs))
     }
 
     pub fn hash_key(&self, text: &str) -> Vec<u8> {

--- a/core/types.rs
+++ b/core/types.rs
@@ -2507,6 +2507,242 @@ where
     Ok(std::cmp::Ordering::Equal)
 }
 
+/// A cursor over the columns of a serialized record, yielding each column's
+/// serial type and raw payload bytes without decoding values.
+struct RawColumnCursor<'a> {
+    header: &'a [u8],
+    data: &'a [u8],
+}
+
+impl<'a> RawColumnCursor<'a> {
+    #[inline(always)]
+    fn new(payload: &'a [u8]) -> Result<Self> {
+        let (header_size, header_varint_len) = read_varint(payload)?;
+        let header_size = header_size as usize;
+        if header_size > payload.len()
+            || header_varint_len > payload.len()
+            || header_varint_len > header_size
+        {
+            mark_unlikely();
+            return Err(LimboError::Corrupt(
+                "Payload too small for indicated header size".into(),
+            ));
+        }
+        Ok(Self {
+            header: &payload[header_varint_len..header_size],
+            data: &payload[header_size..],
+        })
+    }
+
+    /// Next column as (serial type, raw bytes), or `None` when the record ends.
+    #[inline(always)]
+    #[allow(clippy::type_complexity)]
+    fn next(&mut self) -> Option<Result<(u64, &'a [u8])>> {
+        if self.header.is_empty() {
+            return None;
+        }
+        let (serial_type, bytes_read) = match read_varint(self.header) {
+            Ok(v) => v,
+            Err(e) => {
+                mark_unlikely();
+                return Some(Err(e));
+            }
+        };
+        self.header = &self.header[bytes_read..];
+        let size = match get_serial_type_size(serial_type) {
+            Ok(size) => size,
+            Err(e) => {
+                mark_unlikely();
+                return Some(Err(e));
+            }
+        };
+        let Some(bytes) = self.data.get(..size) else {
+            mark_unlikely();
+            return Some(Err(LimboError::Corrupt(
+                "Data section too small for indicated serial type size".into(),
+            )));
+        };
+        self.data = &self.data[size..];
+        Some(Ok((serial_type, bytes)))
+    }
+}
+
+/// What a serialized column stores, decoded just enough to compare it.
+enum RawColumn {
+    Null,
+    Number(Numeric),
+    Text,
+    Blob,
+}
+
+#[inline(always)]
+fn classify_raw_column(serial_type: u64, bytes: &[u8]) -> Result<RawColumn> {
+    Ok(match serial_type {
+        0 => RawColumn::Null,
+        1..=6 | 8 | 9 => {
+            RawColumn::Number(Numeric::Integer(read_integer(bytes, serial_type as u8)?))
+        }
+        7 => {
+            let Some(bytes) = bytes.first_chunk::<8>() else {
+                mark_unlikely();
+                return Err(LimboError::Corrupt("Invalid 8-byte float".into()));
+            };
+            // NaN sorts as NULL, mirroring `ValueRef::from_f64`.
+            match NonNan::new(f64::from_be_bytes(*bytes)) {
+                Some(float) => RawColumn::Number(Numeric::Float(float)),
+                None => RawColumn::Null,
+            }
+        }
+        n if n >= 12 => {
+            if n.is_multiple_of(2) {
+                RawColumn::Blob
+            } else {
+                RawColumn::Text
+            }
+        }
+        _ => {
+            mark_unlikely();
+            return Err(LimboError::Corrupt(format!(
+                "Invalid serial type: {serial_type}"
+            )));
+        }
+    })
+}
+
+/// Compare one column of two serialized records the way [`cmp_in_column`]
+/// compares the decoded values, but reading the raw bytes directly. Text is
+/// compared without UTF-8 validation whenever the collation is byte-based
+/// (everything except locale collations).
+#[inline(always)]
+fn compare_raw_column(
+    l_serial_type: u64,
+    l_bytes: &[u8],
+    r_serial_type: u64,
+    r_bytes: &[u8],
+    key: &KeyInfo,
+) -> Result<Ordering> {
+    let l = classify_raw_column(l_serial_type, l_bytes)?;
+    let r = classify_raw_column(r_serial_type, r_bytes)?;
+    // Value classes sort as NULL < numeric < text < blob, like `ValueRef::cmp`.
+    let cmp = match (&l, &r) {
+        (RawColumn::Null, RawColumn::Null) => Ordering::Equal,
+        (RawColumn::Null, _) => Ordering::Less,
+        (_, RawColumn::Null) => Ordering::Greater,
+        (RawColumn::Number(a), RawColumn::Number(b)) => a.cmp(b),
+        (RawColumn::Number(_), _) => Ordering::Less,
+        (_, RawColumn::Number(_)) => Ordering::Greater,
+        (RawColumn::Text, RawColumn::Text) => {
+            match key.collation.compare_text_bytes(l_bytes, r_bytes) {
+                Some(cmp) => cmp,
+                None => {
+                    // Locale collations compare real strings; validate first.
+                    let invalid_utf8 = |_| {
+                        mark_unlikely();
+                        LimboError::Corrupt("TEXT value contains invalid UTF-8".into())
+                    };
+                    let l_text = simdutf8::basic::from_utf8(l_bytes).map_err(invalid_utf8)?;
+                    let r_text = simdutf8::basic::from_utf8(r_bytes).map_err(invalid_utf8)?;
+                    key.collation.compare_strings(l_text, r_text)
+                }
+            }
+        }
+        (RawColumn::Text, RawColumn::Blob) => Ordering::Less,
+        (RawColumn::Blob, RawColumn::Text) => Ordering::Greater,
+        (RawColumn::Blob, RawColumn::Blob) => l_bytes.cmp(r_bytes),
+    };
+    if cmp != Ordering::Equal {
+        // Mirror `cmp_with_sort`: NULLS FIRST/LAST overrides ASC/DESC when a
+        // null is involved; otherwise DESC reverses the natural order.
+        if matches!(l, RawColumn::Null) || matches!(r, RawColumn::Null) {
+            if let Some(nulls_order) = key.nulls_order {
+                return Ok(match nulls_order {
+                    turso_parser::ast::NullsOrder::First => cmp,
+                    turso_parser::ast::NullsOrder::Last => cmp.reverse(),
+                });
+            }
+        }
+        return Ok(match key.sort_order {
+            SortOrder::Asc => cmp,
+            SortOrder::Desc => cmp.reverse(),
+        });
+    }
+    Ok(Ordering::Equal)
+}
+
+/// Compare the first `num_cols` columns of two serialized records, producing
+/// the same ordering as [`compare_immutable`] over their decoded values.
+/// Reads the raw bytes directly, so text columns skip UTF-8 validation
+/// whenever the collation is byte-based (everything except locale
+/// collations). This is the hot path for index-key ordering.
+///
+/// Panics if either record has fewer than `num_cols` columns, mirroring the
+/// length assertions in [`compare_immutable`].
+pub fn compare_serialized_records(
+    l_payload: &[u8],
+    r_payload: &[u8],
+    key_info: &[KeyInfo],
+    num_cols: usize,
+) -> Result<Ordering> {
+    let mut l_cursor = RawColumnCursor::new(l_payload)?;
+    let mut r_cursor = RawColumnCursor::new(r_payload)?;
+    for key in &key_info[..num_cols] {
+        let (l_serial_type, l_bytes) = l_cursor
+            .next()
+            .expect("record has fewer columns than the index key")?;
+        let (r_serial_type, r_bytes) = r_cursor
+            .next()
+            .expect("record has fewer columns than the index key")?;
+        let cmp = compare_raw_column(l_serial_type, l_bytes, r_serial_type, r_bytes, key)?;
+        if cmp != Ordering::Equal {
+            return Ok(cmp);
+        }
+    }
+    Ok(Ordering::Equal)
+}
+
+/// Whether the first `num_cols` columns of two serialized records compare
+/// equal. Returns `Ok(false)` when either record has fewer than `num_cols`
+/// columns. Same raw-bytes fast path as [`compare_serialized_records`].
+pub fn serialized_record_prefixes_equal(
+    l_payload: &[u8],
+    r_payload: &[u8],
+    key_info: &[KeyInfo],
+    num_cols: usize,
+) -> Result<bool> {
+    let mut l_cursor = RawColumnCursor::new(l_payload)?;
+    let mut r_cursor = RawColumnCursor::new(r_payload)?;
+    for key in &key_info[..num_cols] {
+        let (Some(l), Some(r)) = (l_cursor.next(), r_cursor.next()) else {
+            return Ok(false);
+        };
+        let (l_serial_type, l_bytes) = l?;
+        let (r_serial_type, r_bytes) = r?;
+        if compare_raw_column(l_serial_type, l_bytes, r_serial_type, r_bytes, key)?
+            != Ordering::Equal
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Whether any of the first `num_cols` columns of a serialized record is
+/// NULL. A NaN float counts as NULL, mirroring `ValueRef::from_f64`. Columns
+/// past the end of the record are not counted.
+pub fn serialized_record_has_null_in_first_cols(payload: &[u8], num_cols: usize) -> Result<bool> {
+    let mut cursor = RawColumnCursor::new(payload)?;
+    for _ in 0..num_cols {
+        let Some(column) = cursor.next() else {
+            return Ok(false);
+        };
+        let (serial_type, bytes) = column?;
+        if matches!(classify_raw_column(serial_type, bytes)?, RawColumn::Null) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Treats `NULL` as equal to itself and smaller than other values.
 pub fn compare_immutable_single<V1, V2>(l: V1, r: V2, collation: CollationSeq) -> std::cmp::Ordering
 where
@@ -4849,5 +5085,209 @@ mod tests {
         for value in values {
             assert_eq!(value.try_clone().unwrap(), value);
         }
+    }
+
+    /// Every value the record serializer can produce, covering all serial
+    /// types: NULL (0), all integer widths (1-6), the 0/1 constants (8/9),
+    /// floats (7), and text/blob including empty ones.
+    fn all_serial_type_values() -> Vec<Value> {
+        vec![
+            Value::Null,
+            Value::from_i64(0),
+            Value::from_i64(1),
+            Value::from_i64(-1),
+            Value::from_i64(120),
+            Value::from_i64(-30_000),
+            Value::from_i64(5_000_000),
+            Value::from_i64(-2_000_000_000),
+            Value::from_i64(200_000_000_000),
+            Value::from_i64(i64::MAX),
+            Value::from_i64(i64::MIN),
+            Value::from_f64(0.0),
+            Value::from_f64(-0.5),
+            Value::from_f64(1.0),
+            Value::from_f64(2.5),
+            Value::from_f64(f64::INFINITY),
+            Value::from_f64(f64::NEG_INFINITY),
+            Value::build_text(""),
+            Value::build_text("a"),
+            Value::build_text("A"),
+            Value::build_text("a "),
+            Value::build_text("a  "),
+            Value::build_text("ab"),
+            Value::build_text("b"),
+            Value::build_text("B\0c"),
+            Value::build_text("b\0C"),
+            Value::build_text("grüß"),
+            Value::Blob(vec![]),
+            Value::Blob(vec![0]),
+            Value::Blob(vec![1, 2]),
+            Value::Blob(vec![1, 3]),
+            Value::Blob(b"a".to_vec()),
+        ]
+    }
+
+    fn all_key_infos() -> Vec<KeyInfo> {
+        let mut key_infos = Vec::new();
+        for sort_order in [SortOrder::Asc, SortOrder::Desc] {
+            for collation in [
+                CollationSeq::Unset,
+                CollationSeq::Binary,
+                CollationSeq::NoCase,
+                CollationSeq::Rtrim,
+            ] {
+                for nulls_order in [
+                    None,
+                    Some(turso_parser::ast::NullsOrder::First),
+                    Some(turso_parser::ast::NullsOrder::Last),
+                ] {
+                    key_infos.push(KeyInfo {
+                        sort_order,
+                        collation,
+                        nulls_order,
+                    });
+                }
+            }
+        }
+        key_infos
+    }
+
+    #[test]
+    fn serialized_record_compare_matches_decoded_compare() {
+        let values = all_serial_type_values();
+        for key in all_key_infos() {
+            let key_info = [key];
+            for l_value in &values {
+                let l_record = ImmutableRecord::from_values(&[l_value.clone()], 1).unwrap();
+                for r_value in &values {
+                    let r_record = ImmutableRecord::from_values(&[r_value.clone()], 1).unwrap();
+                    let fast = compare_serialized_records(
+                        l_record.get_payload(),
+                        r_record.get_payload(),
+                        &key_info,
+                        1,
+                    )
+                    .unwrap();
+                    let slow = compare_immutable(
+                        l_record.get_values().unwrap().iter(),
+                        r_record.get_values().unwrap().iter(),
+                        &key_info,
+                    );
+                    assert_eq!(
+                        fast, slow,
+                        "raw-bytes compare diverged from decoded compare for {l_value:?} vs {r_value:?} with {key:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn serialized_record_compare_walks_multiple_columns() {
+        let key_info = [
+            KeyInfo {
+                sort_order: SortOrder::Asc,
+                collation: CollationSeq::Binary,
+                nulls_order: None,
+            },
+            KeyInfo {
+                sort_order: SortOrder::Desc,
+                collation: CollationSeq::NoCase,
+                nulls_order: None,
+            },
+            KeyInfo {
+                sort_order: SortOrder::Asc,
+                collation: CollationSeq::Binary,
+                nulls_order: None,
+            },
+        ];
+        let rows = [
+            vec![Value::from_i64(1), Value::build_text("a"), Value::Null],
+            vec![Value::from_i64(1), Value::build_text("A"), Value::Null],
+            vec![
+                Value::from_i64(1),
+                Value::build_text("b"),
+                Value::from_i64(2),
+            ],
+            vec![
+                Value::from_i64(2),
+                Value::build_text("a"),
+                Value::Blob(vec![1]),
+            ],
+            vec![Value::Null, Value::build_text("a"), Value::from_f64(0.5)],
+        ];
+        for l_values in &rows {
+            let l_record = ImmutableRecord::from_values(l_values, l_values.len()).unwrap();
+            for r_values in &rows {
+                let r_record = ImmutableRecord::from_values(r_values, r_values.len()).unwrap();
+                let fast = compare_serialized_records(
+                    l_record.get_payload(),
+                    r_record.get_payload(),
+                    &key_info,
+                    key_info.len(),
+                )
+                .unwrap();
+                let slow = compare_immutable(
+                    l_record.get_values().unwrap().iter(),
+                    r_record.get_values().unwrap().iter(),
+                    &key_info,
+                );
+                assert_eq!(
+                    fast, slow,
+                    "raw-bytes compare diverged for {l_values:?} vs {r_values:?}"
+                );
+                let prefix_equal = serialized_record_prefixes_equal(
+                    l_record.get_payload(),
+                    r_record.get_payload(),
+                    &key_info,
+                    2,
+                )
+                .unwrap();
+                let decoded_prefix_equal = compare_immutable(
+                    l_record.get_values().unwrap()[..2].iter(),
+                    r_record.get_values().unwrap()[..2].iter(),
+                    &key_info[..2],
+                )
+                .is_eq();
+                assert_eq!(prefix_equal, decoded_prefix_equal);
+            }
+        }
+    }
+
+    #[test]
+    fn serialized_record_nan_float_sorts_as_null() {
+        // The serializer cannot produce a NaN float (`Value::from_f64` maps
+        // NaN to NULL), but a record read from disk can carry one. Patch the
+        // float payload of a serialized record to the NaN bit pattern and
+        // check both the comparator and the null scan treat it as NULL, the
+        // way decoding through `read_value_serial_type` does.
+        let float_record = ImmutableRecord::from_values(&[Value::from_f64(1.5)], 1).unwrap();
+        let payload = float_record.get_payload();
+        // One-column record: 2-byte header (size varint, serial type 7), then
+        // the 8 float bytes.
+        assert_eq!(payload.len(), 10);
+        assert_eq!(payload[1], 7);
+        let mut nan_payload = payload.to_vec();
+        nan_payload[2..].copy_from_slice(&f64::NAN.to_be_bytes());
+
+        let key_info = [KeyInfo {
+            sort_order: SortOrder::Asc,
+            collation: CollationSeq::Binary,
+            nulls_order: None,
+        }];
+        let null_record = ImmutableRecord::from_values(&[Value::Null], 1).unwrap();
+        let int_record = ImmutableRecord::from_values(&[Value::from_i64(0)], 1).unwrap();
+        assert_eq!(
+            compare_serialized_records(&nan_payload, null_record.get_payload(), &key_info, 1)
+                .unwrap(),
+            Ordering::Equal
+        );
+        assert_eq!(
+            compare_serialized_records(&nan_payload, int_record.get_payload(), &key_info, 1)
+                .unwrap(),
+            Ordering::Less
+        );
+        assert!(serialized_record_has_null_in_first_cols(&nan_payload, 1).unwrap());
+        assert!(!serialized_record_has_null_in_first_cols(int_record.get_payload(), 1).unwrap());
     }
 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -5123,12 +5123,14 @@ mod tests {
             Value::Blob(vec![0]),
             Value::Blob(vec![1, 2]),
             Value::Blob(vec![1, 3]),
-            Value::Blob(b"a".to_vec()),
+            Value::Blob(vec![b'a']),
         ]
     }
 
     fn all_key_infos() -> Vec<KeyInfo> {
-        let mut key_infos = Vec::new();
+        // The alloc `vec!` macro so the element type matches the module's
+        // allocator-aware `Vec` alias under `--cfg nightly`.
+        let mut key_infos = vec![];
         for sort_order in [SortOrder::Asc, SortOrder::Desc] {
             for collation in [
                 CollationSeq::Unset,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1303,17 +1303,17 @@ pub fn op_open_read(
                 .replace(Cursor::new_btree(cursor));
         }
         CursorType::BTreeIndex(index) => {
-            let btree_cursor = Box::new(BTreeCursor::new_index(
-                pager,
-                maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
-                index.as_ref(),
-                num_columns,
-            )?);
             let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {
                 IndexInfo::new_from_index_in(index, mv_store.allocator())?
             } else {
                 IndexInfo::new_from_index(index)?
             });
+            let btree_cursor = Box::new(BTreeCursor::new_index_with_info(
+                pager,
+                maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
+                num_columns,
+                index_info.clone(),
+            ));
             let cursor =
                 maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Index(index_info))?;
             cursors
@@ -12816,20 +12816,20 @@ pub fn op_open_write(
         };
         if let Some(index) = maybe_index {
             let num_columns = index.columns.len();
-            let btree_cursor = btree_cursor_with_yield_context(
-                Box::new(BTreeCursor::new_index(
-                    pager,
-                    maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
-                    index.as_ref(),
-                    num_columns,
-                )?),
-                &program.connection,
-            );
             let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {
                 IndexInfo::new_from_index_in(index, mv_store.allocator())?
             } else {
                 IndexInfo::new_from_index(index)?
             });
+            let btree_cursor = btree_cursor_with_yield_context(
+                Box::new(BTreeCursor::new_index_with_info(
+                    pager,
+                    maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
+                    num_columns,
+                    index_info.clone(),
+                )),
+                &program.connection,
+            );
             let cursor =
                 maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Index(index_info))?;
             cursors


### PR DESCRIPTION
## Description

Stacked on #8381: this branch starts from that PR's head, so its two commits appear here as well. The two new commits cut the remaining hot-path overhead that CodSpeed flamegraphs attributed to index-key comparison, commit-machine copying, and redundant transaction-map lookups.

**Raw-bytes index key comparison.** Every `SortableIndexKey` comparison during skiplist traversal re-parsed both records' headers, materialized `ValueRef`s, and — for text columns — validated UTF-8 with simdutf8 (on an index-seek workload the validation alone was ~14% of total time, the comparison machinery 35%). The new `compare_serialized_records` / `serialized_record_prefixes_equal` / `serialized_record_has_null_in_first_cols` walk the serialized records directly and compare column payloads in place. Text under byte-based collations (BINARY, NOCASE, RTRIM — everything except locale collations) compares raw bytes with no UTF-8 validation; the collation byte comparators are shared with `compare_strings` so the two paths cannot drift. Numerics decode through the existing `Numeric` ordering (NaN still sorts as NULL, matching `ValueRef::from_f64`). `SortableIndexKey::compare` / `matches_prefix` / `contains_null` and the cursor's eq-seek key checks all use it.

**Commit-path overhead.**
- The `Checkpoint` variant of `CommitState` inlined the whole checkpoint state machine, so every `commit_tx` built and boxed a ~4 KB `CommitStateMachine`. Boxing the variant shrinks it to 248 bytes; a test guards the size.
- `BuildLogRecord` did one rootpage skiplist lookup per logged version to canonicalize table ids; now memoized per touched table per chunk (this is most of the CREATE INDEX commit win below).

**Fewer redundant lookups.**
- A rowid handed out by the allocator is strictly greater than every rowid this transaction can see, so `insert` now skips its existence probe for auto-assigned rowids (recorded via the eq-seek memo from #8381).
- Visibility checks on a transaction's own versions (`begin`/`end` = `TxID(self)`, the common TxID reference) answer without a transactions-map lookup; delete's per-version loop no longer re-looks-up the transaction twice per version; `insert_version_raw` no longer re-resolves the new version's begin timestamp per insertion-sort step.
- `op_open_read`/`op_open_write` derived the same `IndexInfo` twice (once for the B-tree cursor, once for the MVCC cursor) — now shared; the MVCC cursor caches the truncated `IndexInfo` a prefix seek builds and the transaction's immutable `begin_ts`/WAL read mark.

## Motivation and context

CodSpeed instrumented comparison of this head against #8381's head (zero regressions across 2072 benchmarks):

| Benchmark | #8381 | this PR | Change |
|---|---|---|---|
| `begin_tx + commit_tx` | 21 µs | 15.6 µs | **+34.6%** (nightly +40%) |
| `begin_tx-read-commit_tx` | 21.8 µs | 16.9 µs | **+28.9%** |
| `begin_tx-update-commit_tx` | 22.4 µs | 17 µs | **+31.3%** |
| `mvcc_repeated_index_seek` | 12.8 ms | 9.7 ms | **+31.6%** |
| CREATE INDEX, 100k rows (6 variants) | ~1.2 s | ~0.98 s | **+20–26%** |
| `limbo_mvcc_concurrent_writes` | 62.4 ms | 60.3 ms | -3.4% (below significance bar) |

Local criterion wall-clock agrees: commit/read/update micro-benchmarks -10% to -25%, huge-multi-write guard benchmarks -6% to -13%, concurrent writes -5.8%.

## Tests

- New differential tests prove the raw-bytes comparator agrees with the decoded `compare_immutable` path across all serial types × collations × sort orders × NULLS orders, plus multi-column walks and a NaN-as-NULL case built from a patched float payload.
- A size-guard test keeps `CommitStateMachine` small.
- Full `turso_core` lib suite (2330), MVCC + hermitage (466), integration (412), SQL conformance (1560), and the collate TCL suite pass; workspace clippy clean with `--deny=warnings`.

https://claude.ai/code/session_01YatPHSb1ujg252ZMATgpn2