### PR TITLE
core/optimizer: analyze a table's OR terms once per join order search

### DIFF
--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -736,7 +736,7 @@ pub fn find_best_access_method_for_join_order(
             rhs_constraints,
             lhs_mask,
             join_order,
-            planning_context.maybe_order_target,
+            planning_context,
             where_clause,
             ready_where,
             available_indexes,
@@ -792,7 +792,7 @@ fn find_best_access_method_for_btree(
     rhs_constraints: &TableConstraints,
     lhs_mask: &TableMask,
     join_order: &[JoinOrderMember],
-    maybe_order_target: Option<&OrderTarget>,
+    planning_context: JoinPlanningContext<'_>,
     where_clause: &[WhereTerm],
     ready_where: &[(usize, usize)],
     available_indexes: &AvailableIndexes,
@@ -804,6 +804,7 @@ fn find_best_access_method_for_btree(
     base_row_count: RowCountEstimate,
     params: &CostModelParams,
 ) -> Result<Option<AccessMethod>> {
+    let maybe_order_target = planning_context.maybe_order_target;
     let rhs_table_idx = join_order.last().unwrap().original_idx;
     let best = choose_best_btree_candidate(
         rhs_table,
@@ -1026,6 +1027,8 @@ fn find_best_access_method_for_btree(
 
         if let Some(multi_idx_and_method) = consider_multi_index_intersection(
             rhs_table,
+            rhs_table_idx,
+            planning_context.and_terms_memo,
             where_clause,
             available_indexes,
             table_references,
@@ -1242,7 +1245,7 @@ pub fn try_hash_join_access_method(
     probe_table_idx: usize,
     build_constraints: &TableConstraints,
     probe_constraints: &TableConstraints,
-    where_clause: &mut [WhereTerm],
+    where_clause: &[WhereTerm],
     equal_terms: impl Iterator<Item = (usize, TableInternalId, TableInternalId)>,
     build_cardinality: f64,
     probe_cardinality: f64,

--- a/core/translate/optimizer/access_method.rs
+++ b/core/translate/optimizer/access_method.rs
@@ -1003,6 +1003,8 @@ fn find_best_access_method_for_btree(
 
         if let Some(multi_idx_method) = consider_multi_index_union(
             rhs_table,
+            rhs_table_idx,
+            planning_context.or_terms_memo,
             where_clause,
             available_indexes,
             table_references,

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -531,323 +531,423 @@ pub fn constraints_from_where_clause(
     schema: &Schema,
     params: &CostModelParams,
 ) -> Result<Vec<TableConstraints>> {
-    let mut constraints = Vec::new();
-
     // For each table, collect all the Constraints and all potential index candidates that may use them.
-    for table_reference in table_references.joined_tables() {
-        let rowid_alias_column = table_reference
-            .columns()
-            .iter()
-            .position(|c| c.is_rowid_alias());
+    table_references
+        .joined_tables()
+        .iter()
+        .map(|table_reference| {
+            constraints_for_table(
+                table_reference,
+                where_clause,
+                table_references,
+                available_indexes,
+                subqueries,
+                schema,
+                params,
+            )
+        })
+        .collect()
+}
 
-        let mut cs = TableConstraints {
-            table_id: table_reference.internal_id,
-            constraints: Vec::new(),
-            temporary_index_terms: SmallVec::new(),
-            candidates: available_indexes
-                .indexes_for_table(table_reference.internal_id)
-                .map_or(Vec::new(), |indexes| {
-                    indexes
-                        .iter()
-                        // Skip IndexMethod-based indexes (FTS, vector, etc.) - they use
-                        // pattern matching rather than btree index scans
-                        .filter(|index| index.index_method.is_none())
-                        .map(|index| ConstraintUseCandidate {
-                            index: Some(index.clone()),
-                            refs: Vec::new(),
-                        })
-                        .collect()
-                }),
-        };
-        // Add a candidate for the rowid index, which is always available when the table has a rowid alias.
-        cs.candidates.push(ConstraintUseCandidate {
-            index: None,
-            refs: Vec::new(),
-        });
+/// Collect the potentially usable [Constraint]s for a single table.
+///
+/// Callers that need only one table's constraints must use this instead of
+/// calling [constraints_from_where_clause] and dropping the other tables:
+/// building constraints for every joined table costs time proportional to the
+/// number of tables, and the join order search calls this from its innermost
+/// loop, where that factor shows up directly in planning time.
+pub fn constraints_for_table(
+    table_reference: &JoinedTable,
+    where_clause: &[WhereTerm],
+    table_references: &TableReferences,
+    available_indexes: &AvailableIndexes,
+    subqueries: &[NonFromClauseSubquery],
+    schema: &Schema,
+    params: &CostModelParams,
+) -> Result<TableConstraints> {
+    let rowid_alias_column = table_reference
+        .columns()
+        .iter()
+        .position(|c| c.is_rowid_alias());
 
-        let index_for_column = |column_pos| {
-            selectivity_index_for_column(schema, table_reference, available_indexes, column_pos)
-        };
+    let mut cs = TableConstraints {
+        table_id: table_reference.internal_id,
+        constraints: Vec::new(),
+        temporary_index_terms: SmallVec::new(),
+        candidates: available_indexes
+            .indexes_for_table(table_reference.internal_id)
+            .map_or(Vec::new(), |indexes| {
+                indexes
+                    .iter()
+                    // Skip IndexMethod-based indexes (FTS, vector, etc.) - they use
+                    // pattern matching rather than btree index scans
+                    .filter(|index| index.index_method.is_none())
+                    .map(|index| ConstraintUseCandidate {
+                        index: Some(index.clone()),
+                        refs: Vec::new(),
+                    })
+                    .collect()
+            }),
+    };
+    // Add a candidate for the rowid index, which is always available when the table has a rowid alias.
+    cs.candidates.push(ConstraintUseCandidate {
+        index: None,
+        refs: Vec::new(),
+    });
 
-        for (i, term) in where_clause.iter().enumerate() {
-            // Constraints originating from a LEFT JOIN must always be evaluated in that join's RHS table's loop,
-            // regardless of which tables the constraint references.
-            if let Some(outer_join_tbl) = term.from_outer_join {
-                if outer_join_tbl != table_reference.internal_id {
-                    continue;
-                }
+    let index_for_column = |column_pos| {
+        selectivity_index_for_column(schema, table_reference, available_indexes, column_pos)
+    };
+
+    for (i, term) in where_clause.iter().enumerate() {
+        // Constraints originating from a LEFT JOIN must always be evaluated in that join's RHS table's loop,
+        // regardless of which tables the constraint references.
+        if let Some(outer_join_tbl) = term.from_outer_join {
+            if outer_join_tbl != table_reference.internal_id {
+                continue;
             }
+        }
 
-            // Try to extract as binary expression first
-            if let Some((lhs, operator, rhs)) = as_binary_components(&term.expr)? {
-                // `x IS TRUE` checks whether x is true; it does not compare x
-                // with 1. For example, `2 IS TRUE` is true, so an index lookup
-                // for 1 would miss that row. The same rule applies to FALSE,
-                // and it holds through parentheses and COLLATE: `x IS (TRUE)`
-                // is still a truth test (see [truth_test_rhs]).
-                if matches!(operator.as_ast_operator(), Some(ast::Operator::Is))
-                    && truth_test_rhs(rhs).is_some()
-                {
-                    continue;
-                }
-                // Resolve the comparison affinity once per term per SQLite's
-                // `comparisonAffinity` (see `Constraint::comparison_affinity`)
-                // and propagate it to every constraint derived from this term.
-                let cmp_aff = operator
-                    .as_ast_operator()
-                    .filter(|op| op.is_comparison())
-                    .map(|_| comparison_affinity(lhs, rhs, Some(table_references), None));
-                // A WHERE term must not constrain the loop of a table that an
-                // outer join can null-extend, with two exceptions below.
-                // Consuming the term into the access path filters that table's
-                // rows, which changes which rows of the other side count as
-                // unmatched — and the join then emits null-extended rows the
-                // consumed term is never checked against.
-                //
-                // Exception 1: terms from that join's own ON clause define what
-                // counts as a match, so they are always fine.
-                //
-                // Exception 2: on the right side of a plain LEFT JOIN, the
-                // engine re-checks consumed terms when it emits the
-                // null-extended row, so any operator except `IS` stays usable
-                // there: such terms are never TRUE on a null-extended row, so
-                // the re-check removes the bogus rows. `IS` (e.g. `e.id IS
-                // NULL`) *is* TRUE on the null-extended row, so no re-check can
-                // repair it — it is unusable for every null-extendable table.
-                // A FULL JOIN synthesizes its extra rows by jumping past the
-                // scan with no re-check, so nothing is usable for any table a
-                // FULL JOIN can null-extend.
-                let is_op = matches!(operator.as_ast_operator(), Some(ast::Operator::Is));
-                let usable = term.from_outer_join == Some(table_reference.internal_id)
-                    || if is_op {
-                        !table_references.outer_join_may_null_extend(table_reference.internal_id)
-                    } else {
-                        !table_references.full_join_may_null_extend(table_reference.internal_id)
-                    };
-                // See [Constraint::null_matching]. The constraining value sits
-                // on the opposite side of the constrained column.
-                let null_matching = |constraining_expr: &ast::Expr| {
-                    is_op && !is_non_null_literal(constraining_expr)
+        // Try to extract as binary expression first
+        if let Some((lhs, operator, rhs)) = as_binary_components(&term.expr)? {
+            // `x IS TRUE` checks whether x is true; it does not compare x
+            // with 1. For example, `2 IS TRUE` is true, so an index lookup
+            // for 1 would miss that row. The same rule applies to FALSE,
+            // and it holds through parentheses and COLLATE: `x IS (TRUE)`
+            // is still a truth test (see [truth_test_rhs]).
+            if matches!(operator.as_ast_operator(), Some(ast::Operator::Is))
+                && truth_test_rhs(rhs).is_some()
+            {
+                continue;
+            }
+            // Resolve the comparison affinity once per term per SQLite's
+            // `comparisonAffinity` (see `Constraint::comparison_affinity`)
+            // and propagate it to every constraint derived from this term.
+            let cmp_aff = operator
+                .as_ast_operator()
+                .filter(|op| op.is_comparison())
+                .map(|_| comparison_affinity(lhs, rhs, Some(table_references), None));
+            // A WHERE term must not constrain the loop of a table that an
+            // outer join can null-extend, with two exceptions below.
+            // Consuming the term into the access path filters that table's
+            // rows, which changes which rows of the other side count as
+            // unmatched — and the join then emits null-extended rows the
+            // consumed term is never checked against.
+            //
+            // Exception 1: terms from that join's own ON clause define what
+            // counts as a match, so they are always fine.
+            //
+            // Exception 2: on the right side of a plain LEFT JOIN, the
+            // engine re-checks consumed terms when it emits the
+            // null-extended row, so any operator except `IS` stays usable
+            // there: such terms are never TRUE on a null-extended row, so
+            // the re-check removes the bogus rows. `IS` (e.g. `e.id IS
+            // NULL`) *is* TRUE on the null-extended row, so no re-check can
+            // repair it — it is unusable for every null-extendable table.
+            // A FULL JOIN synthesizes its extra rows by jumping past the
+            // scan with no re-check, so nothing is usable for any table a
+            // FULL JOIN can null-extend.
+            let is_op = matches!(operator.as_ast_operator(), Some(ast::Operator::Is));
+            let usable = term.from_outer_join == Some(table_reference.internal_id)
+                || if is_op {
+                    !table_references.outer_join_may_null_extend(table_reference.internal_id)
+                } else {
+                    !table_references.full_join_may_null_extend(table_reference.internal_id)
                 };
-                // If either the LHS or RHS of the constraint is a column from the table, add the constraint.
-                match lhs {
-                    ast::Expr::Column { table, column, .. } => {
-                        if *table == table_reference.internal_id {
-                            let table_column = &table_reference.table.columns()[*column];
-                            cs.constraints.push(Constraint {
-                                where_clause_pos: (i, BinaryExprSide::Rhs),
-                                operator,
-                                table_col_pos: Some(*column),
-                                expr: None,
-                                constraining_expr: None,
-                                lhs_mask: table_mask_from_expr(rhs, table_references, subqueries)?,
-                                selectivity: estimate_constraint_selectivity(
-                                    schema,
-                                    table_reference,
-                                    Some(table_column),
-                                    operator,
-                                    null_matching(rhs),
-                                    index_for_column(*column),
-                                    params,
-                                    false,
-                                ),
-                                usable,
-                                is_rowid: false,
-                                comparison_affinity: cmp_aff,
-                                null_matching: null_matching(rhs),
-                            });
-                        }
-                    }
-                    ast::Expr::RowId { table, .. } => {
-                        if *table == table_reference.internal_id {
-                            let (col, col_pos) = if let Some(alias) = rowid_alias_column {
-                                (Some(&table_reference.table.columns()[alias]), Some(alias))
-                            } else {
-                                (None, None)
-                            };
-                            cs.constraints.push(Constraint {
-                                where_clause_pos: (i, BinaryExprSide::Rhs),
-                                operator,
-                                table_col_pos: col_pos,
-                                expr: None,
-                                constraining_expr: None,
-                                lhs_mask: table_mask_from_expr(rhs, table_references, subqueries)?,
-                                selectivity: estimate_constraint_selectivity(
-                                    schema,
-                                    table_reference,
-                                    col,
-                                    operator,
-                                    null_matching(rhs),
-                                    None,
-                                    params,
-                                    true,
-                                ),
-                                usable,
-                                is_rowid: true,
-                                comparison_affinity: cmp_aff,
-                                null_matching: null_matching(rhs),
-                            });
-                        }
-                    }
-                    _ if expression_matches_table(
-                        lhs,
-                        table_reference,
-                        table_references,
-                        subqueries,
-                    ) =>
-                    {
-                        let selectivity = estimate_constraint_selectivity(
-                            schema,
-                            table_reference,
-                            None,
-                            operator,
-                            null_matching(rhs),
-                            None,
-                            params,
-                            false,
-                        );
-                        tracing::debug!(
-                            table = table_reference.table.get_name(),
-                            where_clause_pos = i,
-                            operator = ?operator,
-                            lhs_mask = ?table_mask_from_expr(rhs, table_references, subqueries)?,
-                            selectivity,
-                            "expr constraint (lhs matches table)"
-                        );
+            // See [Constraint::null_matching]. The constraining value sits
+            // on the opposite side of the constrained column.
+            let null_matching =
+                |constraining_expr: &ast::Expr| is_op && !is_non_null_literal(constraining_expr);
+            // If either the LHS or RHS of the constraint is a column from the table, add the constraint.
+            match lhs {
+                ast::Expr::Column { table, column, .. } => {
+                    if *table == table_reference.internal_id {
+                        let table_column = &table_reference.table.columns()[*column];
                         cs.constraints.push(Constraint {
                             where_clause_pos: (i, BinaryExprSide::Rhs),
                             operator,
-                            table_col_pos: None,
-                            expr: Some(lhs.clone()),
+                            table_col_pos: Some(*column),
+                            expr: None,
                             constraining_expr: None,
                             lhs_mask: table_mask_from_expr(rhs, table_references, subqueries)?,
-                            selectivity,
+                            selectivity: estimate_constraint_selectivity(
+                                schema,
+                                table_reference,
+                                Some(table_column),
+                                operator,
+                                null_matching(rhs),
+                                index_for_column(*column),
+                                params,
+                                false,
+                            ),
                             usable,
                             is_rowid: false,
                             comparison_affinity: cmp_aff,
                             null_matching: null_matching(rhs),
                         });
                     }
-                    _ => {}
-                };
-                match rhs {
-                    ast::Expr::Column { table, column, .. } => {
-                        if *table == table_reference.internal_id {
-                            let table_column = &table_reference.table.columns()[*column];
-                            cs.constraints.push(Constraint {
-                                where_clause_pos: (i, BinaryExprSide::Lhs),
-                                operator: opposite_cmp_op(operator),
-                                table_col_pos: Some(*column),
-                                expr: None,
-                                constraining_expr: None,
-                                lhs_mask: table_mask_from_expr(lhs, table_references, subqueries)?,
-                                selectivity: estimate_constraint_selectivity(
-                                    schema,
-                                    table_reference,
-                                    Some(table_column),
-                                    operator,
-                                    null_matching(lhs),
-                                    index_for_column(*column),
-                                    params,
-                                    false,
-                                ),
-                                usable,
-                                is_rowid: false,
-                                comparison_affinity: cmp_aff,
-                                null_matching: null_matching(lhs),
-                            });
-                        }
-                    }
-                    ast::Expr::RowId { table, .. } => {
-                        if *table == table_reference.internal_id {
-                            let (col, col_pos) = if let Some(alias) = rowid_alias_column {
-                                (Some(&table_reference.table.columns()[alias]), Some(alias))
-                            } else {
-                                (None, None)
-                            };
-                            cs.constraints.push(Constraint {
-                                where_clause_pos: (i, BinaryExprSide::Lhs),
-                                operator: opposite_cmp_op(operator),
-                                table_col_pos: col_pos,
-                                expr: None,
-                                constraining_expr: None,
-                                lhs_mask: table_mask_from_expr(lhs, table_references, subqueries)?,
-                                selectivity: estimate_constraint_selectivity(
-                                    schema,
-                                    table_reference,
-                                    col,
-                                    operator,
-                                    null_matching(lhs),
-                                    None,
-                                    params,
-                                    true,
-                                ),
-                                usable,
-                                is_rowid: true,
-                                comparison_affinity: cmp_aff,
-                                null_matching: null_matching(lhs),
-                            });
-                        }
-                    }
-                    _ if expression_matches_table(
-                        rhs,
-                        table_reference,
-                        table_references,
-                        subqueries,
-                    ) =>
-                    {
-                        let selectivity = estimate_constraint_selectivity(
-                            schema,
-                            table_reference,
-                            None,
+                }
+                ast::Expr::RowId { table, .. } => {
+                    if *table == table_reference.internal_id {
+                        let (col, col_pos) = if let Some(alias) = rowid_alias_column {
+                            (Some(&table_reference.table.columns()[alias]), Some(alias))
+                        } else {
+                            (None, None)
+                        };
+                        cs.constraints.push(Constraint {
+                            where_clause_pos: (i, BinaryExprSide::Rhs),
                             operator,
-                            null_matching(lhs),
-                            None,
-                            params,
-                            false,
-                        );
-                        tracing::debug!(
-                            table = table_reference.table.get_name(),
-                            where_clause_pos = i,
-                            operator = ?operator,
-                            lhs_mask = ?table_mask_from_expr(lhs, table_references, subqueries)?,
-                            selectivity,
-                            "expr constraint (rhs matches table)"
-                        );
+                            table_col_pos: col_pos,
+                            expr: None,
+                            constraining_expr: None,
+                            lhs_mask: table_mask_from_expr(rhs, table_references, subqueries)?,
+                            selectivity: estimate_constraint_selectivity(
+                                schema,
+                                table_reference,
+                                col,
+                                operator,
+                                null_matching(rhs),
+                                None,
+                                params,
+                                true,
+                            ),
+                            usable,
+                            is_rowid: true,
+                            comparison_affinity: cmp_aff,
+                            null_matching: null_matching(rhs),
+                        });
+                    }
+                }
+                _ if expression_matches_table(
+                    lhs,
+                    table_reference,
+                    table_references,
+                    subqueries,
+                ) =>
+                {
+                    let selectivity = estimate_constraint_selectivity(
+                        schema,
+                        table_reference,
+                        None,
+                        operator,
+                        null_matching(rhs),
+                        None,
+                        params,
+                        false,
+                    );
+                    tracing::debug!(
+                        table = table_reference.table.get_name(),
+                        where_clause_pos = i,
+                        operator = ?operator,
+                        lhs_mask = ?table_mask_from_expr(rhs, table_references, subqueries)?,
+                        selectivity,
+                        "expr constraint (lhs matches table)"
+                    );
+                    cs.constraints.push(Constraint {
+                        where_clause_pos: (i, BinaryExprSide::Rhs),
+                        operator,
+                        table_col_pos: None,
+                        expr: Some(lhs.clone()),
+                        constraining_expr: None,
+                        lhs_mask: table_mask_from_expr(rhs, table_references, subqueries)?,
+                        selectivity,
+                        usable,
+                        is_rowid: false,
+                        comparison_affinity: cmp_aff,
+                        null_matching: null_matching(rhs),
+                    });
+                }
+                _ => {}
+            };
+            match rhs {
+                ast::Expr::Column { table, column, .. } => {
+                    if *table == table_reference.internal_id {
+                        let table_column = &table_reference.table.columns()[*column];
                         cs.constraints.push(Constraint {
                             where_clause_pos: (i, BinaryExprSide::Lhs),
                             operator: opposite_cmp_op(operator),
-                            table_col_pos: None,
-                            expr: Some(rhs.clone()),
+                            table_col_pos: Some(*column),
+                            expr: None,
                             constraining_expr: None,
                             lhs_mask: table_mask_from_expr(lhs, table_references, subqueries)?,
-                            selectivity,
+                            selectivity: estimate_constraint_selectivity(
+                                schema,
+                                table_reference,
+                                Some(table_column),
+                                operator,
+                                null_matching(lhs),
+                                index_for_column(*column),
+                                params,
+                                false,
+                            ),
                             usable,
                             is_rowid: false,
                             comparison_affinity: cmp_aff,
                             null_matching: null_matching(lhs),
                         });
                     }
-                    _ => {}
-                };
-            }
-
-            // IN expressions are handled separately from binary expressions above because:
-            // - as_binary_components returns (&Expr, ConstraintOperator, &Expr) - a single RHS
-            // - InList has Vec<Expr> as RHS, SubqueryResult has a different structure entirely
-            // - They don't fit the binary expression abstraction without a more complex return type
-
-            // Handle IN list: col IN (val1, val2, ...)
-            if let ast::Expr::InList { lhs, not, rhs } = &term.expr {
-                let estimated_values = rhs.len() as f64;
-                let mut rhs_mask = TableMask::default();
-                for rhs_expr in rhs.iter() {
-                    rhs_mask.union_with(&table_mask_from_expr(
-                        rhs_expr,
-                        table_references,
-                        subqueries,
-                    )?)?;
                 }
+                ast::Expr::RowId { table, .. } => {
+                    if *table == table_reference.internal_id {
+                        let (col, col_pos) = if let Some(alias) = rowid_alias_column {
+                            (Some(&table_reference.table.columns()[alias]), Some(alias))
+                        } else {
+                            (None, None)
+                        };
+                        cs.constraints.push(Constraint {
+                            where_clause_pos: (i, BinaryExprSide::Lhs),
+                            operator: opposite_cmp_op(operator),
+                            table_col_pos: col_pos,
+                            expr: None,
+                            constraining_expr: None,
+                            lhs_mask: table_mask_from_expr(lhs, table_references, subqueries)?,
+                            selectivity: estimate_constraint_selectivity(
+                                schema,
+                                table_reference,
+                                col,
+                                operator,
+                                null_matching(lhs),
+                                None,
+                                params,
+                                true,
+                            ),
+                            usable,
+                            is_rowid: true,
+                            comparison_affinity: cmp_aff,
+                            null_matching: null_matching(lhs),
+                        });
+                    }
+                }
+                _ if expression_matches_table(
+                    rhs,
+                    table_reference,
+                    table_references,
+                    subqueries,
+                ) =>
+                {
+                    let selectivity = estimate_constraint_selectivity(
+                        schema,
+                        table_reference,
+                        None,
+                        operator,
+                        null_matching(lhs),
+                        None,
+                        params,
+                        false,
+                    );
+                    tracing::debug!(
+                        table = table_reference.table.get_name(),
+                        where_clause_pos = i,
+                        operator = ?operator,
+                        lhs_mask = ?table_mask_from_expr(lhs, table_references, subqueries)?,
+                        selectivity,
+                        "expr constraint (rhs matches table)"
+                    );
+                    cs.constraints.push(Constraint {
+                        where_clause_pos: (i, BinaryExprSide::Lhs),
+                        operator: opposite_cmp_op(operator),
+                        table_col_pos: None,
+                        expr: Some(rhs.clone()),
+                        constraining_expr: None,
+                        lhs_mask: table_mask_from_expr(lhs, table_references, subqueries)?,
+                        selectivity,
+                        usable,
+                        is_rowid: false,
+                        comparison_affinity: cmp_aff,
+                        null_matching: null_matching(lhs),
+                    });
+                }
+                _ => {}
+            };
+        }
+
+        // IN expressions are handled separately from binary expressions above because:
+        // - as_binary_components returns (&Expr, ConstraintOperator, &Expr) - a single RHS
+        // - InList has Vec<Expr> as RHS, SubqueryResult has a different structure entirely
+        // - They don't fit the binary expression abstraction without a more complex return type
+
+        // Handle IN list: col IN (val1, val2, ...)
+        if let ast::Expr::InList { lhs, not, rhs } = &term.expr {
+            let estimated_values = rhs.len() as f64;
+            let mut rhs_mask = TableMask::default();
+            for rhs_expr in rhs.iter() {
+                rhs_mask.union_with(&table_mask_from_expr(
+                    rhs_expr,
+                    table_references,
+                    subqueries,
+                )?)?;
+            }
+            let table_stats = schema
+                .analyze_stats
+                .table_stats(table_reference.table.get_name());
+            let row_count = table_stats
+                .and_then(|s| s.row_count)
+                .unwrap_or(params.rows_per_table_fallback as u64)
+                as f64;
+            let selectivity = estimate_in_selectivity(estimated_values, row_count, *not);
+            // SQLite's `comparisonAffinity` for IN-list (`x IN (lit, ...)`)
+            // is the LHS column's affinity; the RHS literals are not folded.
+            let cmp_aff = Some(get_expr_affinity(lhs, Some(table_references), None));
+
+            match lhs.as_ref() {
+                ast::Expr::Column { table, column, .. }
+                    if *table == table_reference.internal_id =>
+                {
+                    let is_rowid = rowid_alias_column == Some(*column);
+                    cs.constraints.push(Constraint {
+                        where_clause_pos: (i, BinaryExprSide::Rhs),
+                        operator: ConstraintOperator::In {
+                            not: *not,
+                            estimated_values,
+                        },
+                        table_col_pos: Some(*column),
+                        expr: None,
+                        constraining_expr: None,
+                        lhs_mask: rhs_mask,
+                        selectivity,
+                        usable: false, // IN uses a separate seek path, not the range-seek model
+                        is_rowid,
+                        comparison_affinity: cmp_aff,
+                        null_matching: false,
+                    });
+                }
+                ast::Expr::RowId { table, .. } if *table == table_reference.internal_id => {
+                    cs.constraints.push(Constraint {
+                        where_clause_pos: (i, BinaryExprSide::Rhs),
+                        operator: ConstraintOperator::In {
+                            not: *not,
+                            estimated_values,
+                        },
+                        table_col_pos: rowid_alias_column,
+                        expr: None,
+                        constraining_expr: None,
+                        lhs_mask: rhs_mask,
+                        selectivity,
+                        usable: false,
+                        is_rowid: true,
+                        comparison_affinity: cmp_aff,
+                        null_matching: false,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        // Handle IN subquery: col IN (SELECT ...)
+        if let ast::Expr::SubqueryResult {
+            subquery_id,
+            lhs: Some(lhs_expr),
+            not_in,
+            query_type: ast::SubqueryType::In { affinity_str, .. },
+        } = &term.expr
+        {
+            // Find the subquery to check if it's correlated
+            let subquery = subqueries
+                .iter()
+                .find(|s| s.internal_id == *subquery_id)
+                .expect("subquery not found");
+            // Only use as constraint if NOT correlated
+            if !subquery.correlated {
                 let table_stats = schema
                     .analyze_stats
                     .table_stats(table_reference.table.get_name());
@@ -855,12 +955,38 @@ pub fn constraints_from_where_clause(
                     .and_then(|s| s.row_count)
                     .unwrap_or(params.rows_per_table_fallback as u64)
                     as f64;
-                let selectivity = estimate_in_selectivity(estimated_values, row_count, *not);
-                // SQLite's `comparisonAffinity` for IN-list (`x IN (lit, ...)`)
-                // is the LHS column's affinity; the RHS literals are not folded.
-                let cmp_aff = Some(get_expr_affinity(lhs, Some(table_references), None));
+                // Use the inner plan's row count instead of always using 25.
+                // FIXME: The plan does not estimate distinct result values.
+                // Until it does, cap this estimate at the square root of the
+                // table row count.
+                let planned_rows = match &subquery.state {
+                    SubqueryState::Unevaluated {
+                        plan: Some(inner_plan),
+                    } => match inner_plan.as_ref() {
+                        Plan::Select(plan) => plan.estimated_output_rows,
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                let estimated_values = planned_rows
+                    .map(|rows| rows.clamp(0.0, row_count.sqrt().max(1.0)))
+                    .unwrap_or_else(|| params.in_subquery_rows.min(row_count));
+                let selectivity = estimate_in_selectivity(estimated_values, row_count, *not_in);
+                // SQLite's `comparisonAffinity` for IN-subquery combines the
+                // LHS column affinity with each result column via
+                // `sqlite3CompareAffinity` — that result is already cached on
+                // `SubqueryType::In::affinity_str`. For a single-LHS-column
+                // IN it is the first character; row-value IN has no single
+                // resolved affinity and is left as `None`.
+                let is_row_value = matches!(
+                    unwrap_parens(lhs_expr.as_ref()).ok(),
+                    Some(ast::Expr::Parenthesized(exprs)) if exprs.len() != 1
+                );
+                let cmp_aff = (!is_row_value)
+                    .then(|| affinity_str.chars().next().map(Affinity::from_char))
+                    .flatten();
 
-                match lhs.as_ref() {
+                match lhs_expr.as_ref() {
                     ast::Expr::Column { table, column, .. }
                         if *table == table_reference.internal_id =>
                     {
@@ -868,15 +994,15 @@ pub fn constraints_from_where_clause(
                         cs.constraints.push(Constraint {
                             where_clause_pos: (i, BinaryExprSide::Rhs),
                             operator: ConstraintOperator::In {
-                                not: *not,
+                                not: *not_in,
                                 estimated_values,
                             },
                             table_col_pos: Some(*column),
                             expr: None,
                             constraining_expr: None,
-                            lhs_mask: rhs_mask,
+                            lhs_mask: TableMask::default(), // non-correlated = no dependencies
                             selectivity,
-                            usable: false, // IN uses a separate seek path, not the range-seek model
+                            usable: false, // IN uses a separate seek path (consider_in_list_seek)
                             is_rowid,
                             comparison_affinity: cmp_aff,
                             null_matching: false,
@@ -886,13 +1012,13 @@ pub fn constraints_from_where_clause(
                         cs.constraints.push(Constraint {
                             where_clause_pos: (i, BinaryExprSide::Rhs),
                             operator: ConstraintOperator::In {
-                                not: *not,
+                                not: *not_in,
                                 estimated_values,
                             },
                             table_col_pos: rowid_alias_column,
                             expr: None,
                             constraining_expr: None,
-                            lhs_mask: rhs_mask,
+                            lhs_mask: TableMask::default(),
                             selectivity,
                             usable: false,
                             is_rowid: true,
@@ -903,258 +1029,158 @@ pub fn constraints_from_where_clause(
                     _ => {}
                 }
             }
-
-            // Handle IN subquery: col IN (SELECT ...)
-            if let ast::Expr::SubqueryResult {
-                subquery_id,
-                lhs: Some(lhs_expr),
-                not_in,
-                query_type: ast::SubqueryType::In { affinity_str, .. },
-            } = &term.expr
-            {
-                // Find the subquery to check if it's correlated
-                let subquery = subqueries
-                    .iter()
-                    .find(|s| s.internal_id == *subquery_id)
-                    .expect("subquery not found");
-                // Only use as constraint if NOT correlated
-                if !subquery.correlated {
-                    let table_stats = schema
-                        .analyze_stats
-                        .table_stats(table_reference.table.get_name());
-                    let row_count = table_stats
-                        .and_then(|s| s.row_count)
-                        .unwrap_or(params.rows_per_table_fallback as u64)
-                        as f64;
-                    // Use the inner plan's row count instead of always using 25.
-                    // FIXME: The plan does not estimate distinct result values.
-                    // Until it does, cap this estimate at the square root of the
-                    // table row count.
-                    let planned_rows = match &subquery.state {
-                        SubqueryState::Unevaluated {
-                            plan: Some(inner_plan),
-                        } => match inner_plan.as_ref() {
-                            Plan::Select(plan) => plan.estimated_output_rows,
-                            _ => None,
-                        },
-                        _ => None,
-                    };
-                    let estimated_values = planned_rows
-                        .map(|rows| rows.clamp(0.0, row_count.sqrt().max(1.0)))
-                        .unwrap_or_else(|| params.in_subquery_rows.min(row_count));
-                    let selectivity = estimate_in_selectivity(estimated_values, row_count, *not_in);
-                    // SQLite's `comparisonAffinity` for IN-subquery combines the
-                    // LHS column affinity with each result column via
-                    // `sqlite3CompareAffinity` — that result is already cached on
-                    // `SubqueryType::In::affinity_str`. For a single-LHS-column
-                    // IN it is the first character; row-value IN has no single
-                    // resolved affinity and is left as `None`.
-                    let is_row_value = matches!(
-                        unwrap_parens(lhs_expr.as_ref()).ok(),
-                        Some(ast::Expr::Parenthesized(exprs)) if exprs.len() != 1
-                    );
-                    let cmp_aff = (!is_row_value)
-                        .then(|| affinity_str.chars().next().map(Affinity::from_char))
-                        .flatten();
-
-                    match lhs_expr.as_ref() {
-                        ast::Expr::Column { table, column, .. }
-                            if *table == table_reference.internal_id =>
-                        {
-                            let is_rowid = rowid_alias_column == Some(*column);
-                            cs.constraints.push(Constraint {
-                                where_clause_pos: (i, BinaryExprSide::Rhs),
-                                operator: ConstraintOperator::In {
-                                    not: *not_in,
-                                    estimated_values,
-                                },
-                                table_col_pos: Some(*column),
-                                expr: None,
-                                constraining_expr: None,
-                                lhs_mask: TableMask::default(), // non-correlated = no dependencies
-                                selectivity,
-                                usable: false, // IN uses a separate seek path (consider_in_list_seek)
-                                is_rowid,
-                                comparison_affinity: cmp_aff,
-                                null_matching: false,
-                            });
-                        }
-                        ast::Expr::RowId { table, .. } if *table == table_reference.internal_id => {
-                            cs.constraints.push(Constraint {
-                                where_clause_pos: (i, BinaryExprSide::Rhs),
-                                operator: ConstraintOperator::In {
-                                    not: *not_in,
-                                    estimated_values,
-                                },
-                                table_col_pos: rowid_alias_column,
-                                expr: None,
-                                constraining_expr: None,
-                                lhs_mask: TableMask::default(),
-                                selectivity,
-                                usable: false,
-                                is_rowid: true,
-                                comparison_affinity: cmp_aff,
-                                null_matching: false,
-                            });
-                        }
-                        _ => {}
-                    }
-                }
-            }
         }
-        // sort equalities first so that index keys will be properly constructed.
-        // see e.g.: https://www.solarwinds.com/blog/the-left-prefix-index-rule
-        // A stable partition, not a comparison: comparing two equalities as
-        // "less" in both directions is not a valid ordering, and now that `IS`
-        // counts as an equality there are more pairs that would hit it.
-        cs.constraints
-            .sort_by_key(|c| !is_equality_operator(c.operator));
+    }
+    // sort equalities first so that index keys will be properly constructed.
+    // see e.g.: https://www.solarwinds.com/blog/the-left-prefix-index-rule
+    // A stable partition, not a comparison: comparing two equalities as
+    // "less" in both directions is not a valid ordering, and now that `IS`
+    // counts as an equality there are more pairs that would hit it.
+    cs.constraints
+        .sort_by_key(|c| !is_equality_operator(c.operator));
 
-        // For each constraint we found, add a reference to it for each index that may be able to use it.
-        for (i, constraint) in cs.constraints.iter_mut().enumerate() {
-            // Skip constraints that don't participate in range-seek matching (IN, collation mismatches)
-            if !constraint.usable {
+    // For each constraint we found, add a reference to it for each index that may be able to use it.
+    for (i, constraint) in cs.constraints.iter_mut().enumerate() {
+        // Skip constraints that don't participate in range-seek matching (IN, collation mismatches)
+        if !constraint.usable {
+            continue;
+        }
+
+        let constrained_column = constraint
+            .table_col_pos
+            .and_then(|pos| table_reference.table.columns().get(pos));
+        let column_collation = constrained_column.map(|c| c.collation());
+        let constraining_expr = constraint.get_constraining_expr_ref(where_clause);
+        // Index seek keys must use the same collation as the constrained column.
+        match (
+            get_collseq_from_expr(constraining_expr, table_references)?,
+            column_collation,
+        ) {
+            (Some(collation), Some(column_collation)) if collation != column_collation => {
+                constraint.usable = false;
                 continue;
             }
-
-            let constrained_column = constraint
-                .table_col_pos
-                .and_then(|pos| table_reference.table.columns().get(pos));
-            let column_collation = constrained_column.map(|c| c.collation());
-            let constraining_expr = constraint.get_constraining_expr_ref(where_clause);
-            // Index seek keys must use the same collation as the constrained column.
-            match (
-                get_collseq_from_expr(constraining_expr, table_references)?,
-                column_collation,
-            ) {
-                (Some(collation), Some(column_collation)) if collation != column_collation => {
-                    constraint.usable = false;
-                    continue;
-                }
-                _ => {}
-            }
-
-            if constraint.is_rowid
-                || rowid_alias_column.is_some_and(|p| constraint.table_col_pos == Some(p))
-            {
-                let rowid_candidate = cs
-                    .candidates
-                    .iter_mut()
-                    .find_map(|candidate| {
-                        if candidate.index.is_none() {
-                            Some(candidate)
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap();
-                rowid_candidate.refs.push(ConstraintRef {
-                    constraint_vec_pos: i,
-                    index_col_pos: 0,
-                    sort_order: SortOrder::Asc,
-                    nulls_order: ast::NullsOrder::First,
-                });
-            }
-            for index in available_indexes
-                .indexes_for_table(table_reference.internal_id)
-                .into_iter()
-                .flat_map(|indexes| indexes.iter())
-                .filter(|idx| idx.index_method.is_none())
-            {
-                if let Some(position_in_index) = match constraint.table_col_pos {
-                    Some(pos) => index.column_table_pos_to_index_pos(pos),
-                    None => constraint.expr.as_ref().and_then(|e| {
-                        let normalized =
-                            normalize_expr_for_index_matching(e, table_reference, table_references);
-                        index.expression_to_index_pos(&normalized)
-                    }),
-                } {
-                    turso_assert!(
-                        constraint.usable,
-                        "constraint collation must match table column collation"
-                    );
-                    if let Some(table_col_pos) = constraint.table_col_pos {
-                        let constrained_column = &table_reference.table.columns()[table_col_pos];
-                        let table_collation = constrained_column.collation();
-                        let index_collation = index.columns[position_in_index]
-                            .collation
-                            .unwrap_or_default();
-                        if table_collation != index_collation {
-                            continue;
-                        }
-                        // Custom type columns encode values as blobs. Blob ordering (memcmp)
-                        // doesn't necessarily match the custom type's semantic ordering, so
-                        // range constraints (>, <, >=, <=) can't use the index. Equality (=)
-                        // still works because encoded(A) == encoded(B) iff A == B.
-                        if schema
-                            .get_type_def(
-                                &constrained_column.ty_str,
-                                table_reference.table.is_strict(),
-                            )
-                            .is_some()
-                            && constraint.operator != ast::Operator::Equals.into()
-                        {
-                            continue;
-                        }
-                        let idx_col_aff = constrained_column
-                            .affinity_with_strict(table_reference.table.is_strict());
-                        if !constraint.satisfies_index_affinity(idx_col_aff) {
-                            continue;
-                        }
-                    }
-                    if let Some(index_candidate) = cs.candidates.iter_mut().find_map(|candidate| {
-                        if candidate.index.as_ref().is_some_and(|i| {
-                            Arc::ptr_eq(index, i)
-                                && (index.where_clause.is_none()
-                                    || can_use_partial_index(index, table_reference, where_clause))
-                        }) {
-                            Some(candidate)
-                        } else {
-                            None
-                        }
-                    }) {
-                        index_candidate.refs.push(ConstraintRef {
-                            constraint_vec_pos: i,
-                            index_col_pos: position_in_index,
-                            sort_order: index.columns[position_in_index].order,
-                            nulls_order: index.columns[position_in_index].effective_nulls_order(),
-                        });
-                    }
-                }
-            }
+            _ => {}
         }
 
-        for candidate in cs.candidates.iter_mut() {
-            // Sort by index_col_pos, ascending -- index columns must be consumed in contiguous order.
-            candidate.refs.sort_by_key(|cref| cref.index_col_pos);
+        if constraint.is_rowid
+            || rowid_alias_column.is_some_and(|p| constraint.table_col_pos == Some(p))
+        {
+            let rowid_candidate = cs
+                .candidates
+                .iter_mut()
+                .find_map(|candidate| {
+                    if candidate.index.is_none() {
+                        Some(candidate)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap();
+            rowid_candidate.refs.push(ConstraintRef {
+                constraint_vec_pos: i,
+                index_col_pos: 0,
+                sort_order: SortOrder::Asc,
+                nulls_order: ast::NullsOrder::First,
+            });
         }
-        cs.candidates.retain(|c| {
-            if let Some(idx) = &c.index {
-                if idx.where_clause.is_some()
-                    && c.refs.is_empty()
-                    && !can_use_partial_index(idx, table_reference, where_clause)
-                {
-                    // A partial index with no column constraints can still drive a
-                    // scan, but only if every conjunct of its WHERE clause is implied
-                    // by the query's WHERE. Otherwise it would skip rows the query
-                    // needs.
-                    return false;
-                }
-            }
-            true
-        });
-        cs.temporary_index_terms = automatic_index_terms(table_reference, &cs)
+        for index in available_indexes
+            .indexes_for_table(table_reference.internal_id)
             .into_iter()
-            .filter(|term| {
-                let constraint = &cs.constraints[term.constraint_vec_pos];
-                let where_term = &where_clause[constraint.where_clause_pos.0];
-                !expr_uses_custom_collation(&where_term.expr)
-            })
-            .collect();
-        constraints.push(cs);
+            .flat_map(|indexes| indexes.iter())
+            .filter(|idx| idx.index_method.is_none())
+        {
+            if let Some(position_in_index) = match constraint.table_col_pos {
+                Some(pos) => index.column_table_pos_to_index_pos(pos),
+                None => constraint.expr.as_ref().and_then(|e| {
+                    let normalized =
+                        normalize_expr_for_index_matching(e, table_reference, table_references);
+                    index.expression_to_index_pos(&normalized)
+                }),
+            } {
+                turso_assert!(
+                    constraint.usable,
+                    "constraint collation must match table column collation"
+                );
+                if let Some(table_col_pos) = constraint.table_col_pos {
+                    let constrained_column = &table_reference.table.columns()[table_col_pos];
+                    let table_collation = constrained_column.collation();
+                    let index_collation = index.columns[position_in_index]
+                        .collation
+                        .unwrap_or_default();
+                    if table_collation != index_collation {
+                        continue;
+                    }
+                    // Custom type columns encode values as blobs. Blob ordering (memcmp)
+                    // doesn't necessarily match the custom type's semantic ordering, so
+                    // range constraints (>, <, >=, <=) can't use the index. Equality (=)
+                    // still works because encoded(A) == encoded(B) iff A == B.
+                    if schema
+                        .get_type_def(
+                            &constrained_column.ty_str,
+                            table_reference.table.is_strict(),
+                        )
+                        .is_some()
+                        && constraint.operator != ast::Operator::Equals.into()
+                    {
+                        continue;
+                    }
+                    let idx_col_aff =
+                        constrained_column.affinity_with_strict(table_reference.table.is_strict());
+                    if !constraint.satisfies_index_affinity(idx_col_aff) {
+                        continue;
+                    }
+                }
+                if let Some(index_candidate) = cs.candidates.iter_mut().find_map(|candidate| {
+                    if candidate.index.as_ref().is_some_and(|i| {
+                        Arc::ptr_eq(index, i)
+                            && (index.where_clause.is_none()
+                                || can_use_partial_index(index, table_reference, where_clause))
+                    }) {
+                        Some(candidate)
+                    } else {
+                        None
+                    }
+                }) {
+                    index_candidate.refs.push(ConstraintRef {
+                        constraint_vec_pos: i,
+                        index_col_pos: position_in_index,
+                        sort_order: index.columns[position_in_index].order,
+                        nulls_order: index.columns[position_in_index].effective_nulls_order(),
+                    });
+                }
+            }
+        }
     }
 
-    Ok(constraints)
+    for candidate in cs.candidates.iter_mut() {
+        // Sort by index_col_pos, ascending -- index columns must be consumed in contiguous order.
+        candidate.refs.sort_by_key(|cref| cref.index_col_pos);
+    }
+    cs.candidates.retain(|c| {
+        if let Some(idx) = &c.index {
+            if idx.where_clause.is_some()
+                && c.refs.is_empty()
+                && !can_use_partial_index(idx, table_reference, where_clause)
+            {
+                // A partial index with no column constraints can still drive a
+                // scan, but only if every conjunct of its WHERE clause is implied
+                // by the query's WHERE. Otherwise it would skip rows the query
+                // needs.
+                return false;
+            }
+        }
+        true
+    });
+    cs.temporary_index_terms = automatic_index_terms(table_reference, &cs)
+        .into_iter()
+        .filter(|term| {
+            let constraint = &cs.constraints[term.constraint_vec_pos];
+            let where_term = &where_clause[constraint.where_clause_pos.0];
+            !expr_uses_custom_collation(&where_term.expr)
+        })
+        .collect();
+    Ok(cs)
 }
 
 /// A reference to a [Constraint]s in a [TableConstraints] for single column.

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -9,7 +9,7 @@ use super::{
     access_method::{add_where_cost, find_best_access_method_for_join_order, AccessMethod},
     constraints::{usable_constraints_for_lhs_mask, TableConstraints},
     cost_params::CostModelParams,
-    multi_index::MultiIndexAndTermsMemo,
+    multi_index::{MultiIndexAndTermsMemo, MultiIndexOrTermsMemo},
     order::OrderTarget,
     AvailableIndexes, IndexMethodCandidate,
 };
@@ -52,6 +52,9 @@ pub(crate) struct JoinPlanningContext<'a> {
     /// order this search tries. Only valid for the `WHERE` clause the search
     /// was started with.
     pub and_terms_memo: &'a MultiIndexAndTermsMemo,
+    /// Per-table OR-by-union prepass results, with the same validity rules as
+    /// `and_terms_memo`.
+    pub or_terms_memo: &'a MultiIndexOrTermsMemo,
 }
 
 impl<'a> JoinPlanningContext<'a> {
@@ -60,11 +63,13 @@ impl<'a> JoinPlanningContext<'a> {
     fn default_with_order_target(
         maybe_order_target: Option<&'a OrderTarget>,
         and_terms_memo: &'a MultiIndexAndTermsMemo,
+        or_terms_memo: &'a MultiIndexOrTermsMemo,
     ) -> Self {
         Self {
             maybe_order_target,
             cost_limit: None,
             and_terms_memo,
+            or_terms_memo,
         }
     }
 }
@@ -1074,10 +1079,15 @@ pub fn compute_best_join_order<'a>(
     schema: &Schema,
 ) -> Result<Option<BestJoinOrderResult>> {
     let and_terms_memo = MultiIndexAndTermsMemo::new(joined_tables.len());
+    let or_terms_memo = MultiIndexOrTermsMemo::new(joined_tables.len());
     compute_best_join_order_with_context(
         joined_tables,
         initial_input_cardinality,
-        JoinPlanningContext::default_with_order_target(maybe_order_target, &and_terms_memo),
+        JoinPlanningContext::default_with_order_target(
+            maybe_order_target,
+            &and_terms_memo,
+            &or_terms_memo,
+        ),
         constraints,
         base_table_rows,
         access_methods_arena,

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -9,6 +9,7 @@ use super::{
     access_method::{add_where_cost, find_best_access_method_for_join_order, AccessMethod},
     constraints::{usable_constraints_for_lhs_mask, TableConstraints},
     cost_params::CostModelParams,
+    multi_index::MultiIndexAndTermsMemo,
     order::OrderTarget,
     AvailableIndexes, IndexMethodCandidate,
 };
@@ -47,15 +48,23 @@ pub(crate) struct JoinPlanningContext<'a> {
     pub maybe_order_target: Option<&'a OrderTarget>,
     /// Stop growing a join plan after it costs more than another query form.
     pub cost_limit: Option<Cost>,
+    /// Per-table AND-by-intersection prepass results, shared by every join
+    /// order this search tries. Only valid for the `WHERE` clause the search
+    /// was started with.
+    pub and_terms_memo: &'a MultiIndexAndTermsMemo,
 }
 
 impl<'a> JoinPlanningContext<'a> {
     /// Convenience constructor used by the default planner entrypoints and tests.
     #[cfg_attr(not(test), allow(dead_code))]
-    fn default_with_order_target(maybe_order_target: Option<&'a OrderTarget>) -> Self {
+    fn default_with_order_target(
+        maybe_order_target: Option<&'a OrderTarget>,
+        and_terms_memo: &'a MultiIndexAndTermsMemo,
+    ) -> Self {
         Self {
             maybe_order_target,
             cost_limit: None,
+            and_terms_memo,
         }
     }
 }
@@ -322,7 +331,7 @@ fn join_lhs_and_rhs<'a>(
     access_methods_arena: &'a mut Vec<AccessMethod>,
     cost_upper_bound: Cost,
     joined_tables: &[JoinedTable],
-    where_clause: &mut [WhereTerm],
+    where_clause: &[WhereTerm],
     where_terms: &[WhereTermInfo],
     subqueries: &[NonFromClauseSubquery],
     index_method_candidates: &[IndexMethodCandidate],
@@ -1055,7 +1064,7 @@ pub fn compute_best_join_order<'a>(
     constraints: &'a [TableConstraints],
     base_table_rows: &[RowCountEstimate],
     access_methods_arena: &'a mut Vec<AccessMethod>,
-    where_clause: &mut [WhereTerm],
+    where_clause: &[WhereTerm],
     subqueries: &[NonFromClauseSubquery],
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
@@ -1064,10 +1073,11 @@ pub fn compute_best_join_order<'a>(
     table_references: &TableReferences,
     schema: &Schema,
 ) -> Result<Option<BestJoinOrderResult>> {
+    let and_terms_memo = MultiIndexAndTermsMemo::new(joined_tables.len());
     compute_best_join_order_with_context(
         joined_tables,
         initial_input_cardinality,
-        JoinPlanningContext::default_with_order_target(maybe_order_target),
+        JoinPlanningContext::default_with_order_target(maybe_order_target, &and_terms_memo),
         constraints,
         base_table_rows,
         access_methods_arena,
@@ -1093,7 +1103,7 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
     constraints: &'a [TableConstraints],
     base_table_rows: &[RowCountEstimate],
     access_methods_arena: &'a mut Vec<AccessMethod>,
-    where_clause: &mut [WhereTerm],
+    where_clause: &[WhereTerm],
     subqueries: &[NonFromClauseSubquery],
     index_method_candidates: &[IndexMethodCandidate],
     params: &CostModelParams,
@@ -1582,7 +1592,7 @@ fn compute_greedy_join_order<'a>(
     constraints: &'a [TableConstraints],
     base_table_rows: &[RowCountEstimate],
     access_methods_arena: &'a mut Vec<AccessMethod>,
-    where_clause: &mut [WhereTerm],
+    where_clause: &[WhereTerm],
     where_terms: &[WhereTermInfo],
     subqueries: &[NonFromClauseSubquery],
     index_method_candidates: &[IndexMethodCandidate],
@@ -2035,7 +2045,7 @@ fn compute_naive_left_deep_plan<'a>(
     base_table_rows: &[RowCountEstimate],
     access_methods_arena: &'a mut Vec<AccessMethod>,
     constraints: &'a [TableConstraints],
-    where_clause: &mut [WhereTerm],
+    where_clause: &[WhereTerm],
     where_terms: &[WhereTermInfo],
     subqueries: &[NonFromClauseSubquery],
     index_method_candidates: &[IndexMethodCandidate],
@@ -2266,7 +2276,7 @@ mod tests {
         )];
         let table_references = TableReferences::new(joined_tables, vec![]);
         let available_indexes = AvailableIndexes::default();
-        let mut where_clause = vec![WhereTerm::from(where_expr)];
+        let where_clause = vec![WhereTerm::from(where_expr)];
         let constraints = constraints_from_where_clause(
             &where_clause,
             &table_references,
@@ -2286,7 +2296,7 @@ mod tests {
             &constraints,
             &base_rows,
             &mut access_methods,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -2528,7 +2538,7 @@ mod tests {
     fn test_compute_best_join_order_empty() {
         let table_references = TableReferences::new(vec![], vec![]);
         let available_indexes = AvailableIndexes::default();
-        let mut where_clause = vec![];
+        let where_clause = vec![];
 
         let mut access_methods_arena = Vec::new();
         let table_constraints = constraints_from_where_clause(
@@ -2550,7 +2560,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -2571,7 +2581,7 @@ mod tests {
         let joined_tables = vec![_create_table_reference(t1, None, table_id_counter.next())];
         let table_references = TableReferences::new(joined_tables, vec![]);
         let available_indexes = AvailableIndexes::default();
-        let mut where_clause = vec![];
+        let where_clause = vec![];
 
         let mut access_methods_arena = Vec::new();
         let table_constraints = constraints_from_where_clause(
@@ -2595,7 +2605,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -2620,7 +2630,7 @@ mod tests {
         let mut table_id_counter = TableRefIdCounter::new();
         let joined_tables = vec![_create_table_reference(t1, None, table_id_counter.next())];
 
-        let mut where_clause = vec![_create_binary_expr(
+        let where_clause = vec![_create_binary_expr(
             _create_column_expr(joined_tables[0].internal_id, 0, true), // table 0, column 0 (rowid)
             ast::Operator::Equals,
             _create_numeric_literal("42"),
@@ -2650,7 +2660,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -2686,7 +2696,7 @@ mod tests {
         let mut table_id_counter = TableRefIdCounter::new();
         let joined_tables = vec![_create_table_reference(t1, None, table_id_counter.next())];
 
-        let mut where_clause = vec![_create_binary_expr(
+        let where_clause = vec![_create_binary_expr(
             _create_column_expr(joined_tables[0].internal_id, 0, false), // table 0, column 0 (id)
             ast::Operator::Equals,
             _create_numeric_literal("42"),
@@ -2733,7 +2743,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -2801,7 +2811,7 @@ mod tests {
 
         // SELECT * FROM table1 JOIN table2 WHERE table1.id = table2.id
         // expecting table2 to be chosen first due to the index on table1.id
-        let mut where_clause = vec![_create_binary_expr(
+        let where_clause = vec![_create_binary_expr(
             _create_column_expr(joined_tables[TABLE1].internal_id, 0, false), // table1.id
             ast::Operator::Equals,
             _create_column_expr(joined_tables[TABLE2].internal_id, 0, false), // table2.id
@@ -2828,7 +2838,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -2971,7 +2981,7 @@ mod tests {
         // expecting customers to be chosen first due to the index on customers.id and it having a selective filter (=42)
         // then orders to be chosen next due to the index on orders.customer_id
         // then order_items to be chosen last due to the index on order_items.order_id
-        let mut where_clause = vec![
+        let where_clause = vec![
             // orders.customer_id = customers.id
             _create_binary_expr(
                 _create_column_expr(joined_tables[TABLE_NO_ORDERS].internal_id, 1, false), // orders.customer_id
@@ -3013,7 +3023,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -3105,7 +3115,7 @@ mod tests {
             ),
         ];
 
-        let mut where_clause = vec![
+        let where_clause = vec![
             // t2.foo = 42 (equality filter, more selective)
             _create_binary_expr(
                 _create_column_expr(joined_tables[1].internal_id, 1, false), // table 1, column 1 (foo)
@@ -3142,7 +3152,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -3283,7 +3293,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -3386,7 +3396,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -3479,7 +3489,7 @@ mod tests {
         available_indexes.insert_for_table_name(&joined_tables, "t1", VecDeque::from([index]));
 
         // Create where clause that only references second column
-        let mut where_clause = vec![WhereTerm {
+        let where_clause = vec![WhereTerm {
             expr: Expr::Binary(
                 Box::new(Expr::Column {
                     database: None,
@@ -3515,7 +3525,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -3575,7 +3585,7 @@ mod tests {
         available_indexes.insert_for_table_name(&joined_tables, "t1", VecDeque::from([index]));
 
         // Create where clause that references first and third columns
-        let mut where_clause = vec![
+        let where_clause = vec![
             WhereTerm {
                 expr: Expr::Binary(
                     Box::new(Expr::Column {
@@ -3627,7 +3637,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -3688,7 +3698,7 @@ mod tests {
         available_indexes.insert_for_table_name(&joined_tables, "t1", VecDeque::from([index]));
 
         // Create where clause: c1 = 5 AND c2 > 10 AND c3 = 7
-        let mut where_clause = vec![
+        let where_clause = vec![
             WhereTerm {
                 expr: Expr::Binary(
                     Box::new(Expr::Column {
@@ -3754,7 +3764,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -4001,7 +4011,7 @@ mod tests {
         available_indexes.insert_for_table_name(&joined_tables, "t2", VecDeque::from([index_t2_a]));
 
         // WHERE t1.a = t2.a
-        let mut where_clause = vec![_create_binary_expr(
+        let where_clause = vec![_create_binary_expr(
             _create_column_expr(joined_tables[TABLE1].internal_id, 0, false), // t1.a
             ast::Operator::Equals,
             _create_column_expr(joined_tables[TABLE2].internal_id, 0, false), // t2.a
@@ -4028,7 +4038,7 @@ mod tests {
             &table_constraints,
             &base_table_rows,
             &mut access_methods_arena,
-            &mut where_clause,
+            &where_clause,
             &[],
             &[],
             &DEFAULT_PARAMS,
@@ -4103,7 +4113,7 @@ mod tests {
                 table_id_counter.next(),
             ),
         ];
-        let mut where_clause = vec![_create_binary_expr(
+        let where_clause = vec![_create_binary_expr(
             _create_column_expr(joined_tables[0].internal_id, 0, false),
             Operator::Equals,
             _create_column_expr(joined_tables[1].internal_id, 0, false),
@@ -4126,7 +4136,7 @@ mod tests {
             1,
             &constraints[0],
             &constraints[1],
-            &mut where_clause,
+            &where_clause,
             std::iter::once((
                 0,
                 table_references.joined_tables()[0].internal_id,

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -29,7 +29,9 @@ use crate::{
                 ConstraintUseCandidate, RangeConstraintRef, SeekRangeConstraint, TableConstraints,
             },
             cost::RowCountEstimate,
-            multi_index::{MultiIndexAndTermsMemo, MultiIndexBranchAccessParams},
+            multi_index::{
+                MultiIndexAndTermsMemo, MultiIndexBranchAccessParams, MultiIndexOrTermsMemo,
+            },
             order::{ColumnTarget, OrderTarget},
         },
         plan::{
@@ -2458,10 +2460,12 @@ fn find_table_access_plan(
     )?;
 
     let and_terms_memo = MultiIndexAndTermsMemo::new(table_references.joined_tables().len());
+    let or_terms_memo = MultiIndexOrTermsMemo::new(table_references.joined_tables().len());
     let planning_context = JoinPlanningContext {
         maybe_order_target: maybe_order_target.as_ref(),
         cost_limit,
         and_terms_memo: &and_terms_memo,
+        or_terms_memo: &or_terms_memo,
     };
 
     let Some(best_join_order_result) = compute_best_join_order_with_context(

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -29,7 +29,7 @@ use crate::{
                 ConstraintUseCandidate, RangeConstraintRef, SeekRangeConstraint, TableConstraints,
             },
             cost::RowCountEstimate,
-            multi_index::MultiIndexBranchAccessParams,
+            multi_index::{MultiIndexAndTermsMemo, MultiIndexBranchAccessParams},
             order::{ColumnTarget, OrderTarget},
         },
         plan::{
@@ -2457,9 +2457,11 @@ fn find_table_access_plan(
         &mut constraints_per_table,
     )?;
 
+    let and_terms_memo = MultiIndexAndTermsMemo::new(table_references.joined_tables().len());
     let planning_context = JoinPlanningContext {
         maybe_order_target: maybe_order_target.as_ref(),
         cost_limit,
+        and_terms_memo: &and_terms_memo,
     };
 
     let Some(best_join_order_result) = compute_best_join_order_with_context(

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -107,6 +107,77 @@ impl MultiIndexAndTermsMemo {
     }
 }
 
+/// One slot per joined table, filled on first use.
+///
+/// Before the planner can cost an OR-by-union path it has to know what each
+/// disjunct of an `OR` term constrains on the table being planned: build
+/// branch-local `WhereTerm`s out of the disjunct's conjuncts and run the normal
+/// constraint analysis over them. That answer depends on the table, the `WHERE`
+/// clause, the available indexes and the schema — and on nothing that changes
+/// while the join order search runs. The search asked it again for every (join
+/// order prefix, table) pair it tried, so a join-heavy query rebuilt the same
+/// answer thousands of times. Ask once per (table, term) instead.
+///
+/// The prepass also settles, once and for all, which `OR` terms are even
+/// shaped like something that could drive a union scan of the table, so the
+/// rest are never looked at again. In a join-heavy query the answer for nearly
+/// every (table, term) pair is "this term constrains nothing here": an `OR`
+/// term is about one table, and the rest of the query's tables were paying the
+/// full analysis only to find they had nothing to seek by.
+///
+/// Both halves stay as lazy as the search was: the term list is built the first
+/// time the table is planned, and a term's disjuncts are analyzed the first
+/// time the search actually reaches that term. A term the search always decides
+/// before is never analyzed at all.
+///
+/// Like [`MultiIndexAndTermsMemo`], the memo is only sound while the `WHERE`
+/// clause it was built against holds still, so it lives in the join planner's
+/// context and dies with the search that created it.
+#[derive(Debug)]
+pub(crate) struct MultiIndexOrTermsMemo {
+    per_table: Vec<OnceCell<Vec<OrTermSlot>>>,
+}
+
+impl MultiIndexOrTermsMemo {
+    /// One slot per entry of [`TableReferences::joined_tables`].
+    pub(crate) fn new(joined_table_count: usize) -> Self {
+        Self {
+            per_table: (0..joined_table_count).map(|_| OnceCell::new()).collect(),
+        }
+    }
+
+    /// The `OR` terms worth trying on the table at `table_idx`, finding them if
+    /// this is the first time they have been asked for.
+    fn get_or_find_terms(
+        &self,
+        table_idx: usize,
+        find_terms: impl FnOnce() -> Vec<OrTermSlot>,
+    ) -> &[OrTermSlot] {
+        self.per_table[table_idx].get_or_init(find_terms)
+    }
+}
+
+/// One `OR` term worth trying on one table, with room for the analysis of its
+/// disjuncts.
+#[derive(Debug)]
+struct OrTermSlot {
+    /// Where the term sits in the `WHERE` clause.
+    where_term_idx: usize,
+    /// The join whose `ON` clause the term came from, if any.
+    from_outer_join: Option<TableInternalId>,
+    /// One entry per disjunct once analyzed, or `None` once the disjuncts have
+    /// been found unusable. Empty until the search first reaches this term.
+    disjuncts: OnceCell<Option<Vec<BranchConstraints>>>,
+}
+
+/// One disjunct's conjuncts as planner terms, plus what they constrain on the
+/// table being planned.
+#[derive(Debug)]
+struct BranchConstraints {
+    terms: Vec<WhereTerm>,
+    constraints: TableConstraints,
+}
+
 /// One term that can participate in an AND-by-intersection plan.
 #[derive(Debug)]
 struct AndBranch {
@@ -994,6 +1065,114 @@ fn analyze_and_terms_for_multi_index(
     })
 }
 
+/// The `OR` terms of the `WHERE` clause that a union scan of `table_reference`
+/// could be built from, by shape alone.
+///
+/// These are the cheap checks. What each disjunct actually constrains on the
+/// table is worked out later, per term, by
+/// [`branch_constraints_for_or_term`].
+fn or_terms_worth_trying(
+    table_reference: &JoinedTable,
+    where_clause: &[WhereTerm],
+    table_references: &TableReferences,
+) -> Vec<OrTermSlot> {
+    where_clause
+        .iter()
+        .enumerate()
+        .filter(|(_, term)| {
+            !term.consumed
+                && multi_index_can_consume_term(table_reference, term, table_references)
+                && matches!(&term.expr, ast::Expr::Binary(_, ast::Operator::Or, _))
+                && flatten_or_expr(&term.expr).len() >= 2
+        })
+        .map(|(where_term_idx, term)| OrTermSlot {
+            where_term_idx,
+            from_outer_join: term.from_outer_join,
+            disjuncts: OnceCell::new(),
+        })
+        .collect()
+}
+
+/// What each disjunct of an `OR` term constrains on `table_reference`, or
+/// `None` when no join order can turn the term into a union scan of it.
+#[expect(clippy::too_many_arguments)]
+fn branch_constraints_for_or_term(
+    term_expr: &ast::Expr,
+    from_outer_join: Option<TableInternalId>,
+    table_reference: &JoinedTable,
+    table_references: &TableReferences,
+    available_indexes: &AvailableIndexes,
+    subqueries: &[NonFromClauseSubquery],
+    schema: &Schema,
+    params: &CostModelParams,
+) -> Option<Vec<BranchConstraints>> {
+    // Every disjunct has to become a branch, so one unusable disjunct rules out
+    // the whole term.
+    flatten_or_expr(term_expr)
+        .into_iter()
+        .map(|disjunct_expr| {
+            branch_constraints_for_disjunct(
+                disjunct_expr,
+                from_outer_join,
+                table_reference,
+                table_references,
+                available_indexes,
+                subqueries,
+                schema,
+                params,
+            )
+        })
+        .collect()
+}
+
+/// What one disjunct constrains on `table_reference`, or `None` when no join
+/// order can turn it into a union branch.
+#[expect(clippy::too_many_arguments)]
+fn branch_constraints_for_disjunct(
+    disjunct_expr: &ast::Expr,
+    from_outer_join: Option<TableInternalId>,
+    table_reference: &JoinedTable,
+    table_references: &TableReferences,
+    available_indexes: &AvailableIndexes,
+    subqueries: &[NonFromClauseSubquery],
+    schema: &Schema,
+    params: &CostModelParams,
+) -> Option<BranchConstraints> {
+    let Ok(disjunct_expr) = crate::translate::expr::unwrap_parens(disjunct_expr) else {
+        return None;
+    };
+    // Each disjunct is replanned with branch-local `TableConstraints`, so
+    // compound conjuncts can reuse the same compound-seek analysis as ordinary
+    // btree access.
+    let conjuncts = flatten_and_expr(disjunct_expr)
+        .into_iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    let (terms, constraints) = get_table_local_constraints_for_branch(
+        &conjuncts,
+        from_outer_join,
+        table_reference,
+        table_references,
+        available_indexes,
+        subqueries,
+        schema,
+        params,
+    )
+    .ok()?;
+
+    // A branch is a seek on this table, so a disjunct that constrains nothing
+    // on it has nothing to seek by. Both branch access paths agree on that:
+    // `choose_best_btree_candidate` can only pick constraint refs drawn from
+    // these constraints, and `choose_best_in_seek_candidate` scans them for an
+    // `IN`. A join order prefix only ever narrows which of them may be used, so
+    // no prefix can conjure a branch out of none.
+    if constraints.constraints.is_empty() {
+        return None;
+    }
+
+    Some(BranchConstraints { terms, constraints })
+}
+
 #[allow(clippy::too_many_arguments)]
 /// Analyze OR clauses for OR-by-union optimization.
 ///
@@ -1002,6 +1181,8 @@ fn analyze_and_terms_for_multi_index(
 /// non-multi-index alternative.
 pub fn consider_multi_index_union(
     rhs_table: &JoinedTable,
+    rhs_table_idx: usize,
+    or_terms_memo: &MultiIndexOrTermsMemo,
     where_clause: &[WhereTerm],
     available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
@@ -1014,67 +1195,41 @@ pub fn consider_multi_index_union(
     lhs_mask: &TableMask,
     analyze_stats: &AnalyzeStats,
 ) -> Result<Option<AccessMethod>> {
-    for (where_term_idx, term) in where_clause.iter().enumerate() {
-        if term.consumed {
-            continue;
-        }
-        if !multi_index_can_consume_term(rhs_table, term, table_references) {
-            continue;
-        }
+    let or_terms = or_terms_memo.get_or_find_terms(rhs_table_idx, || {
+        or_terms_worth_trying(rhs_table, where_clause, table_references)
+    });
+    if or_terms.is_empty() {
+        return Ok(None);
+    }
 
-        let ast::Expr::Binary(_, ast::Operator::Or, _) = &term.expr else {
+    let mut allowed_mask = lhs_mask.try_clone()?;
+    allowed_mask.set(rhs_table_idx)?;
+
+    for or_term in or_terms {
+        let Some(disjuncts) = or_term.disjuncts.get_or_init(|| {
+            branch_constraints_for_or_term(
+                &where_clause[or_term.where_term_idx].expr,
+                or_term.from_outer_join,
+                rhs_table,
+                table_references,
+                available_indexes,
+                subqueries,
+                schema,
+                params,
+            )
+        }) else {
             continue;
         };
 
-        let disjuncts = flatten_or_expr(&term.expr);
-        if disjuncts.len() < 2 {
-            continue;
-        }
-
-        let mut allowed_mask = lhs_mask.try_clone()?;
-        let Some(rhs_idx) = table_references
-            .joined_tables()
-            .iter()
-            .position(|t| t.internal_id == rhs_table.internal_id)
-        else {
-            continue;
-        };
-        allowed_mask.set(rhs_idx)?;
-
-        // Each disjunct is replanned with branch-local `TableConstraints`, so
-        // compound conjuncts can reuse the same compound-seek analysis as
-        // ordinary btree access.
         let branches = disjuncts
-            .into_iter()
-            .map(|disjunct_expr| {
-                let Ok(disjunct_expr) = crate::translate::expr::unwrap_parens(disjunct_expr) else {
-                    return Ok(None);
-                };
-                let conjuncts = flatten_and_expr(disjunct_expr)
-                    .into_iter()
-                    .cloned()
-                    .collect::<Vec<_>>();
-                let Some((synthetic_where_terms, table_constraints)) =
-                    get_table_local_constraints_for_branch(
-                        &conjuncts,
-                        term.from_outer_join,
-                        rhs_table,
-                        table_references,
-                        available_indexes,
-                        subqueries,
-                        schema,
-                        params,
-                    )
-                    .ok()
-                else {
-                    return Ok(None);
-                };
+            .iter()
+            .map(|disjunct| {
                 let Some(mut chosen) = choose_multi_index_branch_access(
                     rhs_table,
-                    &table_constraints,
-                    &synthetic_where_terms,
+                    &disjunct.constraints,
+                    &disjunct.terms,
                     lhs_mask,
-                    rhs_idx,
+                    rhs_table_idx,
                     schema,
                     available_indexes,
                     base_row_count,
@@ -1089,7 +1244,7 @@ pub fn consider_multi_index_union(
                 // before the index seek; post-filters reference the target
                 // table and are evaluated after the seek.
                 let Some(partitioned_pre_post) = partition_residual_multi_or_exprs(
-                    &synthetic_where_terms,
+                    &disjunct.terms,
                     &chosen.access,
                     chosen.index.as_deref(),
                     rhs_table,
@@ -1104,7 +1259,7 @@ pub fn consider_multi_index_union(
                     return Ok(None);
                 }
                 chosen.union_prepost_filters = Some(UnionBranchPrePostFilters {
-                    requires_table_cursor: partitioned_pre_post.post_mask.get(rhs_idx),
+                    requires_table_cursor: partitioned_pre_post.post_mask.get(rhs_table_idx),
                     pre_filter_exprs: partitioned_pre_post.pre_filter_exprs,
                     post_filter_exprs: partitioned_pre_post.post_filter_exprs,
                 });
@@ -1119,7 +1274,7 @@ pub fn consider_multi_index_union(
         if let Some(access_method) = evaluate_multi_index_branches(
             branches,
             SetOperation::Union,
-            where_term_idx,
+            or_term.where_term_idx,
             rhs_table,
             table_references,
             available_indexes,
@@ -1261,6 +1416,7 @@ mod tests {
     use super::{
         consider_multi_index_intersection, consider_multi_index_union, AnalyzeStats,
         AndClauseDecomposition, MultiIndexAndTermsMemo, MultiIndexBranchParams,
+        MultiIndexOrTermsMemo, OrTermSlot,
     };
     use crate::alloc::TursoIteratorExt;
     use crate::alloc::TursoSliceExt;
@@ -1285,7 +1441,7 @@ mod tests {
         vdbe::builder::TableRefIdCounter,
         MAIN_DB_ID,
     };
-    use std::cell::Cell;
+    use std::cell::{Cell, OnceCell};
     use std::{collections::VecDeque, sync::Arc};
     use turso_parser::ast::{self, Expr, Operator, TableInternalId};
 
@@ -1541,6 +1697,8 @@ mod tests {
 
         let access_method = consider_multi_index_union(
             &table_references.joined_tables()[ITEM],
+            ITEM,
+            &MultiIndexOrTermsMemo::new(table_references.joined_tables().len()),
             &where_clause,
             &available_indexes,
             &table_references,
@@ -1727,6 +1885,149 @@ mod tests {
     }
 
     #[test]
+    fn or_terms_memo_finds_each_table_s_terms_once() {
+        let memo = MultiIndexOrTermsMemo::new(2);
+        let searches = Cell::new(0);
+        // Both closures only capture `&searches`, so they are `Copy` and can be
+        // handed to the memo more than once.
+        let find_for_table_0 = || {
+            searches.set(searches.get() + 1);
+            vec![OrTermSlot {
+                where_term_idx: 7,
+                from_outer_join: None,
+                disjuncts: OnceCell::new(),
+            }]
+        };
+        let find_for_table_1 = || {
+            searches.set(searches.get() + 1);
+            vec![]
+        };
+
+        let term_indices =
+            |slots: &[OrTermSlot]| slots.iter().map(|s| s.where_term_idx).collect::<Vec<_>>();
+
+        assert_eq!(
+            term_indices(memo.get_or_find_terms(0, find_for_table_0)),
+            [7]
+        );
+        assert_eq!(searches.get(), 1);
+
+        // Asking about the same table again answers from the memo. This is the
+        // whole point: the join order search asks once per join order it tries.
+        assert_eq!(
+            term_indices(memo.get_or_find_terms(0, find_for_table_0)),
+            [7]
+        );
+        assert_eq!(searches.get(), 1);
+
+        // Another table is a separate question, so it gets its own search.
+        assert!(memo.get_or_find_terms(1, find_for_table_1).is_empty());
+        assert_eq!(searches.get(), 1 + 1);
+
+        // "No OR term is worth trying on this table" is an answer worth
+        // remembering too - it is the answer for most tables in a join-heavy
+        // query.
+        assert!(memo.get_or_find_terms(1, find_for_table_1).is_empty());
+        assert_eq!(searches.get(), 2);
+    }
+
+    /// An `OR` term only offers union branches to the table its disjuncts
+    /// constrain. Every other table in the query has nothing to seek by, so the
+    /// term is rejected once instead of being re-analyzed for every join order
+    /// the search tries.
+    #[test]
+    fn or_term_is_usable_only_by_the_table_its_disjuncts_constrain() {
+        let link = create_btree_table(
+            "link",
+            vec![
+                create_column_of_type("src", Type::Integer),
+                create_column_of_type("dst", Type::Integer),
+            ],
+        );
+        let item = create_btree_table(
+            "item",
+            vec![
+                create_column_of_type("id", Type::Integer),
+                create_column_of_type("kind", Type::Integer),
+            ],
+        );
+
+        let mut table_id_counter = TableRefIdCounter::new();
+        let joined_tables = vec![
+            create_table_reference(link, None, table_id_counter.next()),
+            create_table_reference(
+                item,
+                Some(JoinInfo {
+                    join_type: JoinType::Inner,
+                    using: vec![],
+                    no_reorder: false,
+                }),
+                table_id_counter.next(),
+            ),
+        ];
+
+        const LINK: usize = 0;
+        const ITEM: usize = 1;
+        let item_id = joined_tables[ITEM].internal_id;
+
+        // `item.id = 1 OR item.id = 2` - about `item`, and about nothing else.
+        let where_clause = vec![WhereTerm {
+            expr: Expr::Binary(
+                Box::new(Expr::Binary(
+                    Box::new(create_column_expr(item_id, 0, false)),
+                    Operator::Equals,
+                    Box::new(create_numeric_literal("1")),
+                )),
+                Operator::Or,
+                Box::new(Expr::Binary(
+                    Box::new(create_column_expr(item_id, 0, false)),
+                    Operator::Equals,
+                    Box::new(create_numeric_literal("2")),
+                )),
+            ),
+            from_outer_join: None,
+            consumed: false,
+        }];
+
+        let table_references = TableReferences::new(joined_tables, vec![]);
+        let available_indexes = AvailableIndexes::default();
+
+        // By shape alone the term is worth trying on either table.
+        for table_idx in [LINK, ITEM] {
+            let slots = super::or_terms_worth_trying(
+                &table_references.joined_tables()[table_idx],
+                &where_clause,
+                &table_references,
+            );
+            assert_eq!(slots.len(), 1);
+            assert_eq!(slots[0].where_term_idx, 0);
+        }
+
+        let branches = |table_idx: usize| {
+            super::branch_constraints_for_or_term(
+                &where_clause[0].expr,
+                None,
+                &table_references.joined_tables()[table_idx],
+                &table_references,
+                &available_indexes,
+                &[],
+                &empty_schema(),
+                &DEFAULT_PARAMS,
+            )
+        };
+
+        assert_eq!(
+            branches(ITEM).map(|b| b.len()),
+            Some(2),
+            "both disjuncts constrain `item`, so both become branches"
+        );
+        assert!(
+            branches(LINK).is_none(),
+            "an OR term that constrains nothing on `link` cannot drive a union scan of it"
+        );
+    }
+
+    #[test]
     fn test_multi_index_union_branch_reuses_compound_seek_analysis() {
         let link = create_btree_table(
             "link",
@@ -1869,6 +2170,8 @@ mod tests {
 
         let access_method = consider_multi_index_union(
             &table_references.joined_tables()[ITEM],
+            ITEM,
+            &MultiIndexOrTermsMemo::new(table_references.joined_tables().len()),
             &where_clause,
             &available_indexes,
             &table_references,
@@ -2004,8 +2307,12 @@ mod tests {
         let lhs_mask = [LINK].into_iter().try_collect().unwrap();
         let base_row_count = RowCountEstimate::hardcoded_fallback(&DEFAULT_PARAMS);
 
+        // Each call plans a different `WHERE` clause, so each gets its own
+        // memo: a memo only answers for the clause it was built against.
         let without_residual = consider_multi_index_union(
             &table_references.joined_tables()[ITEM],
+            ITEM,
+            &MultiIndexOrTermsMemo::new(table_references.joined_tables().len()),
             &make_join_expr(None),
             &available_indexes,
             &table_references,
@@ -2023,6 +2330,8 @@ mod tests {
 
         let with_residual = consider_multi_index_union(
             &table_references.joined_tables()[ITEM],
+            ITEM,
+            &MultiIndexOrTermsMemo::new(table_references.joined_tables().len()),
             &make_join_expr(Some("7")),
             &available_indexes,
             &table_references,

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -32,6 +32,7 @@ use crate::translate::plan::{
 use crate::translate::planner::{table_mask_from_expr, TableMask};
 use crate::Result;
 use smallvec::SmallVec;
+use std::cell::OnceCell;
 use std::sync::Arc;
 use turso_macros::turso_assert_eq;
 use turso_parser::ast::{self, TableInternalId};
@@ -65,6 +66,45 @@ pub enum MultiIndexBranchAccessParams {
 struct AndClauseDecomposition {
     term_indices: Vec<usize>,
     branches: Vec<AndBranch>,
+}
+
+/// One decomposition slot per joined table, filled on first use.
+///
+/// [`analyze_and_terms_for_multi_index`] answers a single question: which of
+/// the query's top-level `AND` terms could each drive their own index lookup on
+/// one table. That answer depends on the table, the `WHERE` clause, the
+/// available indexes and the schema — and on nothing that changes while the
+/// join order search runs. The search, however, asks it again for every (join
+/// order prefix, table) pair it tries, so a join-heavy query rebuilt the same
+/// answer thousands of times, and the wasted work grew with the number of join
+/// orders explored. Ask once per table instead.
+///
+/// The memo is only sound while the `WHERE` clause it was built against holds
+/// still, so it lives in the join planner's context and dies with the search
+/// that created it. The search borrows the clause as `&[WhereTerm]`, which is
+/// what keeps that true.
+#[derive(Debug)]
+pub(crate) struct MultiIndexAndTermsMemo {
+    per_table: Vec<OnceCell<Option<AndClauseDecomposition>>>,
+}
+
+impl MultiIndexAndTermsMemo {
+    /// One slot per entry of [`TableReferences::joined_tables`].
+    pub(crate) fn new(joined_table_count: usize) -> Self {
+        Self {
+            per_table: (0..joined_table_count).map(|_| OnceCell::new()).collect(),
+        }
+    }
+
+    /// The decomposition for the table at `table_idx`, computing it if this is
+    /// the first time it has been asked for.
+    fn get_or_analyze(
+        &self,
+        table_idx: usize,
+        analyze: impl FnOnce() -> Option<AndClauseDecomposition>,
+    ) -> Option<&AndClauseDecomposition> {
+        self.per_table[table_idx].get_or_init(analyze).as_ref()
+    }
 }
 
 /// One term that can participate in an AND-by-intersection plan.
@@ -1105,6 +1145,8 @@ pub fn consider_multi_index_union(
 #[expect(clippy::too_many_arguments)]
 pub fn consider_multi_index_intersection(
     rhs_table: &JoinedTable,
+    rhs_table_idx: usize,
+    and_terms_memo: &MultiIndexAndTermsMemo,
     where_clause: &[WhereTerm],
     available_indexes: &AvailableIndexes,
     table_references: &TableReferences,
@@ -1117,15 +1159,17 @@ pub fn consider_multi_index_intersection(
     lhs_mask: &TableMask,
     analyze_stats: &AnalyzeStats,
 ) -> Result<Option<AccessMethod>> {
-    let Some(decomposition) = analyze_and_terms_for_multi_index(
-        rhs_table,
-        where_clause,
-        available_indexes,
-        table_references,
-        subqueries,
-        schema,
-        params,
-    ) else {
+    let Some(decomposition) = and_terms_memo.get_or_analyze(rhs_table_idx, || {
+        analyze_and_terms_for_multi_index(
+            rhs_table,
+            where_clause,
+            available_indexes,
+            table_references,
+            subqueries,
+            schema,
+            params,
+        )
+    }) else {
         return Ok(None);
     };
 
@@ -1216,7 +1260,7 @@ pub fn consider_multi_index_intersection(
 mod tests {
     use super::{
         consider_multi_index_intersection, consider_multi_index_union, AnalyzeStats,
-        MultiIndexBranchParams,
+        AndClauseDecomposition, MultiIndexAndTermsMemo, MultiIndexBranchParams,
     };
     use crate::alloc::TursoIteratorExt;
     use crate::alloc::TursoSliceExt;
@@ -1241,6 +1285,7 @@ mod tests {
         vdbe::builder::TableRefIdCounter,
         MAIN_DB_ID,
     };
+    use std::cell::Cell;
     use std::{collections::VecDeque, sync::Arc};
     use turso_parser::ast::{self, Expr, Operator, TableInternalId};
 
@@ -1576,8 +1621,11 @@ mod tests {
         let table_references = TableReferences::new(joined_tables, vec![]);
         let base_row_count = RowCountEstimate::hardcoded_fallback(&DEFAULT_PARAMS);
 
+        let and_terms_memo = MultiIndexAndTermsMemo::new(table_references.joined_tables().len());
         let access_method = consider_multi_index_intersection(
             &table_references.joined_tables()[0],
+            0,
+            &and_terms_memo,
             &where_clause,
             &available_indexes,
             &table_references,
@@ -1606,6 +1654,76 @@ mod tests {
                     == Some("idx_item_a")),
             "expected one secondary-index branch"
         );
+
+        // The memo holds the decomposition, not the plan built from it: asking
+        // again with a cost ceiling the intersection cannot beat must still
+        // reject it. A memo that froze the whole answer would hand back the
+        // plan above a second time.
+        let too_expensive = consider_multi_index_intersection(
+            &table_references.joined_tables()[0],
+            0,
+            &and_terms_memo,
+            &where_clause,
+            &available_indexes,
+            &table_references,
+            &[],
+            &empty_schema(),
+            1.0,
+            base_row_count,
+            &DEFAULT_PARAMS,
+            Cost(0.0),
+            &TableMask::default(),
+            &AnalyzeStats::default(),
+        )
+        .unwrap();
+        assert!(
+            too_expensive.is_none(),
+            "a zero cost ceiling must reject the intersection plan"
+        );
+    }
+
+    #[test]
+    fn and_terms_memo_analyzes_each_table_once() {
+        let memo = MultiIndexAndTermsMemo::new(2);
+        let analyses = Cell::new(0);
+        // Both closures only capture `&analyses`, so they are `Copy` and can be
+        // handed to the memo more than once.
+        let analyze_table_0 = || {
+            analyses.set(analyses.get() + 1);
+            Some(AndClauseDecomposition {
+                term_indices: vec![7],
+                branches: vec![],
+            })
+        };
+        let analyze_table_1 = || {
+            analyses.set(analyses.get() + 1);
+            None
+        };
+
+        assert_eq!(
+            memo.get_or_analyze(0, analyze_table_0)
+                .map(|d| d.term_indices.as_slice()),
+            Some([7].as_slice())
+        );
+        assert_eq!(analyses.get(), 1);
+
+        // Asking about the same table again answers from the memo. This is the
+        // whole point: the join order search asks once per join order it tries.
+        assert_eq!(
+            memo.get_or_analyze(0, analyze_table_0)
+                .map(|d| d.term_indices.as_slice()),
+            Some([7].as_slice())
+        );
+        assert_eq!(analyses.get(), 1);
+
+        // Another table is a separate question, so it gets analyzed.
+        assert!(memo.get_or_analyze(1, analyze_table_1).is_none());
+        assert_eq!(analyses.get(), 2);
+
+        // "No intersection possible" is an answer worth remembering too - it is
+        // the answer for most tables in a join-heavy query.
+        assert!(memo.get_or_analyze(1, analyze_table_1).is_none());
+        assert_eq!(analyses.get(), 2);
     }
 
     #[test]

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -15,7 +15,7 @@ use crate::translate::optimizer::access_method::{
     BranchReadMode, ChosenInSeekCandidate,
 };
 use crate::translate::optimizer::constraints::{
-    analyze_binary_term_for_index, can_use_partial_index, constraints_from_where_clause,
+    analyze_binary_term_for_index, can_use_partial_index, constraints_for_table,
     partial_index_predicate_terms, summarize_binary_term_for_index, Constraint, RangeConstraintRef,
     TableConstraints,
 };
@@ -133,7 +133,7 @@ fn flatten_and_expr(expr: &ast::Expr) -> Vec<&ast::Expr> {
 /// Build temporary `WhereTerm`s from branch-local expressions and extract the
 /// constraints for exactly one target table.
 ///
-/// This is narrower than `constraints_from_where_clause()`:
+/// This is narrower than `constraints_for_table()`:
 /// - `exprs` are synthetic planner inputs, not the query's real top-level
 ///   `WHERE` terms.
 /// - The returned `WhereTerm`s are only suitable for branch-local planning
@@ -141,9 +141,8 @@ fn flatten_and_expr(expr: &ast::Expr) -> Vec<&ast::Expr> {
 ///   for global predicate consumption or join rewrites.
 ///
 /// FIXME: stop synthesizing `WhereTerm`s here just to reuse
-/// `constraints_from_where_clause()`. Branch-local planning should have a
-/// direct constraint-extraction path that does not fabricate top-level planner
-/// terms.
+/// `constraints_for_table()`. Branch-local planning should have a direct
+/// constraint-extraction path that does not fabricate top-level planner terms.
 #[expect(clippy::too_many_arguments)]
 fn get_table_local_constraints_for_branch(
     exprs: &[ast::Expr],
@@ -164,18 +163,15 @@ fn get_table_local_constraints_for_branch(
             consumed: false,
         })
         .collect::<Vec<_>>();
-    let table_constraints = constraints_from_where_clause(
+    let mut table_constraints = constraints_for_table(
+        table_reference,
         &synthetic_where_terms,
         table_references,
         available_indexes,
         subqueries,
         schema,
         params,
-    )?
-    .into_iter()
-    .find(|constraints| constraints.table_id == table_reference.internal_id)
-    .expect("constraints_from_where_clause must return constraints for every joined table");
-    let mut table_constraints = table_constraints;
+    )?;
     // Branch-local constraints originate from synthetic `WhereTerm`s, so copy
     // out their constraining expressions while those temporary terms still
     // exist.


### PR DESCRIPTION
# NOTICE:

> **This PR stacks on #8386 and #8387 and is opened against `main`, so it carries three
> commits.** The first two are those PRs, already under review there. **Only the third
> commit, `6b8e01e`, is new work.** Once #8386 and #8387 merge this reduces to that one
> commit on its own; happy to retarget the base at `claude/turso-perf-bottleneck-o5syoz`
> instead if that reviews more easily.

## Description

Before the planner can cost an OR-by-union access path for a table, it has to work out what
each disjunct of an `OR` term constrains on that table: build branch-local `WhereTerm`s out
of the disjunct's conjuncts and run the normal constraint analysis over them.

That answer depends on the table, the `WHERE` clause, the available indexes and the schema —
and on nothing that changes while the join order search runs. But the search asked it again
for every (join order prefix, table) pair it explored, so a join-heavy query rebuilt the same
answer thousands of times, and the waste grew with the number of join orders tried.

This PR gives the join planner a `MultiIndexOrTermsMemo` alongside #8387's AND memo: one slot
per joined table holding the `OR` terms worth trying there by shape alone, each with room for
its disjuncts' analysis, filled on first use and dropped with the search that created it.
Both halves stay as lazy as the search was, so a term the search always decides before is
never analyzed at all.

A disjunct that constrains nothing on the table is now rejected once rather than re-costed per
join order. That is sound because both branch access paths can only draw on those constraints
— `choose_best_btree_candidate` picks constraint refs out of them and
`choose_best_in_seek_candidate` scans them for an `IN` — so with none there is nothing to seek
by, and a join order prefix only ever picks a subset of them.

Like the AND memo, the memo is only sound while the `WHERE` clause it was built against holds
still. #8387 already made that a compiler-checked property by taking the clause as
`&[WhereTerm]` through the whole search, so this change inherits the guarantee rather than
restating it in a comment.

### Results

CodSpeed, this commit vs #8387's head (`c253ec3`) — **the effect of this commit alone**:
**129 improvements, 1957 unchanged, 0 regressions.**

| Benchmark | base | head | |
|---|---:|---:|---|
| `corpus_tpcds[85]` | 77.1 ms | 16.0 ms | ×4.8 |
| `corpus_tpcds[13]` | 12.0 ms | 3.0 ms | ×3.9 |
| `corpus_job[12b]` | 40.0 ms | 13.9 ms | ×2.9 |
| `corpus_job[7c]` | 43.1 ms | 15.1 ms | ×2.9 |
| `corpus_job[19a/19b]` | 188.1 / 234.9 ms | 67.1 / 84.1 ms | ×2.8 |
| `corpus_tpcds[48]` | 4.4 ms | 1.6 ms | ×2.8 |
| `corpus_job[8b]` | 12.6 ms | 5.1 ms | ×2.5 |
| `corpus_job[27a–c]` | 1.08–1.11 s | 488–503 ms | ×2.2 |
| `corpus_job[26a–c]` | 908–917 ms | 411–414 ms | ×2.2 |
| `corpus_job[24a/24b]` | ~914 ms | ~420 ms | ×2.2 |
| `corpus_job[30b]` | 824.2 ms | 373.2 ms | ×2.2 |
| `corpus_job[20a–c]` | 120–127 ms | 56–58 ms | ×2.2 |
| `corpus_job[23a/23c]` | ~440 ms | ~206 ms | ×2.1 |
| `corpus_job[21a–c]` | ~73.8 ms | 35.3 ms | ×2.1 |
| `corpus_tpch[7]` | 1.9 ms | 1.0 ms | ×1.9 |

Gains reach well past JOB — TPC-DS (85, 13, 48, 91, 61, 45) and TPC-H (7) all improve — and
the stable and nightly shards agree throughout. `corpus_job[27c]`, still the slowest benchmark
in the suite, drops from 1.11 s to 503 ms.

> **Note on the two sets of numbers.** The CodSpeed bot comment below compares against `main`,
> so it reports all three stacked commits together. The table above is the narrower comparison
> — this commit measured against #8387's head — so the two differ by baseline, not by
> disagreement.

### Validation

Since this is a planner change, the bar is that plans must not move:

- **Generated bytecode is byte-identical** before and after for all 113 JOB queries and all 99
  TPC-DS queries — 44,076 lines of `EXPLAIN` output compared between a build of this branch
  and a build of `c253ec3`
- `cargo test -p turso_core --lib` — 2328 passed, 0 failed
- `cargo fmt --check`, `cargo clippy --workspace --all-features --all-targets --deny=warnings`
  — clean
- `make -C sqlite/conformance run-rust` — 12,946 passed, 8 failed. Those 8 are **pre-existing
  and not from this change**: they are snapshot mismatches on queries with no `OR` term at all
  (TPC-H `q13-customer-distribution` and seven `hash-join-*`), they fail identically at
  `c253ec3` (same 8, same 12946/8/7 counts), and the `.snap.new` files the two builds generate
  are byte-identical. Refreshing those snapshots is out of scope here but someone should.

Two new tests: `or_terms_memo_finds_each_table_s_terms_once` pins the memo's contract
(including that a negative answer is remembered), and
`or_term_is_usable_only_by_the_table_its_disjuncts_constrain` pins that a term is rejected for
the tables its disjuncts say nothing about.

## Motivation and context

`prepare_benchmark.rs` is the most expensive target in the CodSpeed suite by a wide margin.
After #8387 the flame graph for `corpus_job[27c]` had one clear remaining peak:

```
join_lhs_and_rhs                                 95.1%
└─ find_best_access_method_for_join_order        75.6%
   ├─ (OR-by-union prepass)                      34.9%   <-- this PR
   │  ├─ get_table_local_constraints_for_branch  13.9%
   │  └─ choose_multi_index_branch_access        11.2%
   └─ choose_best_btree_candidate                13.7%
```

The telling detail is what that 34.9% was spent on. JOB 27c has exactly one `OR` term,
`cn.name LIKE '%Film%' OR cn.name LIKE '%Warner%'`, over twelve joined tables. Eleven of them
can never turn it into a union scan — an `OR` term is about one table, and the rest have
nothing to seek by — yet each was paying the full disjunct analysis to rediscover that, for
every join order the search tried.

This was follow-up 2 of the two that #8386 named, and the one #8387 deliberately left out to
keep its correctness surface small. After this change the whole prepass subtree falls below
CodSpeed's 1% reporting threshold in the `27c` flame graph, and what remains at the top is
real cost estimation (`choose_best_btree_candidate` at 30.5%, `estimate_cost_for_scan_or_seek`
at 9.6%) rather than repeated prepass work.

## Description of AI Usage

This PR was written by Claude Code, driven end to end by AI: it read the CodSpeed flame graphs
on top of #8387, identified the redundant prepass, implemented the memo, and validated it.

Worth sharing on method:

- The target was picked from CodSpeed flame graph data (`query_flamegraph` over the branch's
  own run) rather than guessed, and the "eleven of twelve tables can never use this term"
  observation is what turned a 35% attribution into a specific, actionable claim about *why*
  it was expensive.
- The new "reject a constraint-free disjunct once" shortcut was not assumed safe. It was
  checked against both branch access paths — `choose_best_btree_candidate` draws its
  constraint refs from that list and `choose_best_in_seek_candidate` iterates the same list —
  so an empty list provably yields no branch under any `lhs_mask`.
- Correctness was established by diffing generated bytecode between a build of this branch and
  a build of the base commit in a `git worktree`, over two whole query corpora. For a planner
  change this is stronger evidence than any test suite: the plans provably did not move.
- The eight conformance failures were not waved away as "probably pre-existing". They were
  attributed: the failing queries were replayed through both builds (identical bytecode), then
  the whole suite was re-run at the base commit in the worktree (identical failure set), then
  the generated snapshots were compared byte for byte.
- Performance was measured on CodSpeed itself via `workflow_dispatch` on the branch, comparing
  against the parent commit's own dispatch run so the two sides share an event type and the
  numbers isolate this commit rather than the whole stack.

The committer is responsible for reviewing this output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tfe89M8AAPtqRwEq5bKtyr