### PR TITLE
core/storage: read pages ahead of a scan

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -289,3 +289,7 @@ harness = false
 [[bench]]
 name = "select_star_benchmark"
 harness = false
+
+[[bench]]
+name = "readahead_benchmark"
+harness = false

--- a/core/benches/readahead_benchmark.rs
+++ b/core/benches/readahead_benchmark.rs
@@ -1,0 +1,414 @@
+//! What readahead is worth on a table scan.
+//!
+//! Readahead does not make the CPU do less work -- it makes the database ask
+//! storage for the same bytes in far fewer requests. So the thing to measure
+//! is time spent per request, and the benchmark has to be run against storage
+//! where a request costs something.
+//!
+//! Two shapes are measured:
+//!
+//! * `local_file` -- an ordinary file. The only per-request cost is the
+//!   syscall, and the operating system already has the data in memory, so
+//!   this is close to the smallest win readahead can produce. If it is
+//!   positive here it is positive everywhere.
+//!
+//! * `per_request_cost` -- the same scan against an IO that spends a fixed
+//!   amount of work on every request before serving it. This is a *model*, and
+//!   worth being clear about: it stands in for storage where a request costs
+//!   much more than the bytes it moves -- a network disk, a remote page
+//!   server, an object store. The cost is CPU work rather than sleeping so
+//!   that both a wall-clock run and an instruction-count run measure the same
+//!   thing. It does not claim to be any particular device; it says "if a
+//!   request costs C, readahead removes most of the Cs."
+//!
+//! Run:  cargo bench -p turso_core --bench readahead_benchmark
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion,
+};
+#[cfg(not(feature = "codspeed"))]
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use std::hint::black_box as hint_black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+use turso_core::{
+    io::FileSyncType, Buffer, Clock, Completion, Database, DatabaseOpts, File, MonotonicInstant,
+    OpenFlags, PlatformIO, SqliteDialect, StepResult, WallClockInstant, IO,
+};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+/// Rows in the benchmark table. At ~200 bytes a row this is a few thousand
+/// pages: big enough that a scan crosses many of them and cannot sit entirely
+/// in the page cache below.
+const ROWS: usize = 120_000;
+
+/// Page cache for the scanning connection, in KiB (the negative form of
+/// `PRAGMA cache_size`). Deliberately far smaller than the table: a scan that
+/// fits in memory never goes to storage and has nothing to read ahead.
+const CACHE_KIB: i64 = 2_000;
+
+/// Work spent on each storage request in the modelled-cost benchmark.
+///
+/// Calibrated to roughly 10 microseconds, which is the order of a read from a
+/// local NVMe drive that is not already in memory. Slower storage only makes
+/// the gap wider: network block storage is ten to a hundred times this, and an
+/// object store is a thousand times it.
+const WORK_PER_REQUEST: u64 = 45_000;
+
+/// An IO that charges a fixed amount of work for every read request,
+/// regardless of size. See the module docs.
+struct CostPerRequestIo {
+    inner: Arc<dyn IO>,
+    work: u64,
+}
+
+impl Clock for CostPerRequestIo {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        self.inner.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        self.inner.current_time_wall_clock()
+    }
+}
+
+impl IO for CostPerRequestIo {
+    fn open_file(
+        &self,
+        path: &str,
+        flags: OpenFlags,
+        direct: bool,
+    ) -> turso_core::Result<Arc<dyn File>> {
+        Ok(Arc::new(CostPerRequestFile {
+            inner: self.inner.open_file(path, flags, direct)?,
+            work: self.work,
+        }))
+    }
+
+    fn remove_file(&self, path: &str) -> turso_core::Result<()> {
+        self.inner.remove_file(path)
+    }
+
+    fn step(&self) -> turso_core::Result<()> {
+        self.inner.step()
+    }
+}
+
+struct CostPerRequestFile {
+    inner: Arc<dyn File>,
+    work: u64,
+}
+
+/// Deterministic busy work. Not a sleep, so an instruction-counting run sees
+/// it too.
+#[inline(never)]
+fn spend(units: u64) {
+    let mut acc = 0x9e3779b97f4a7c15u64;
+    for i in 0..units {
+        acc = acc.wrapping_mul(6364136223846793005).wrapping_add(i);
+    }
+    hint_black_box(acc);
+}
+
+impl File for CostPerRequestFile {
+    fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
+        self.inner.lock_file(exclusive)
+    }
+
+    fn unlock_file(&self) -> turso_core::Result<()> {
+        self.inner.unlock_file()
+    }
+
+    fn pread(&self, pos: u64, c: Completion) -> turso_core::Result<Completion> {
+        spend(self.work);
+        self.inner.pread(pos, c)
+    }
+
+    fn preadv(
+        &self,
+        pos: u64,
+        buffers: Vec<Arc<Buffer>>,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        // One request, whatever its size: that is the whole point.
+        spend(self.work);
+        self.inner.preadv(pos, buffers, c)
+    }
+
+    fn pwrite(
+        &self,
+        pos: u64,
+        buffer: Arc<Buffer>,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        self.inner.pwrite(pos, buffer, c)
+    }
+
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> turso_core::Result<Completion> {
+        self.inner.sync(c, sync_type)
+    }
+
+    fn size(&self) -> turso_core::Result<u64> {
+        self.inner.size()
+    }
+
+    fn truncate(&self, len: u64, c: Completion) -> turso_core::Result<Completion> {
+        self.inner.truncate(len, c)
+    }
+}
+
+/// Build the table once, with rusqlite, so the benchmark measures reads only.
+fn seed_db() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("readahead.db");
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    conn.execute_batch(
+        "PRAGMA journal_mode=DELETE;
+         PRAGMA page_size=4096;
+         CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, v INTEGER);",
+    )
+    .unwrap();
+    let tx = conn.unchecked_transaction().unwrap();
+    {
+        let mut stmt = conn
+            .prepare("INSERT INTO t(id, payload, v) VALUES(?1, ?2, ?3)")
+            .unwrap();
+        let payload = "x".repeat(180);
+        for i in 0..ROWS {
+            stmt.execute(rusqlite::params![i as i64, payload, (i % 977) as i64])
+                .unwrap();
+        }
+    }
+    tx.commit().unwrap();
+    dir
+}
+
+/// Open the seeded database on `io` and set the scan up: a small page cache
+/// and the readahead window under test.
+fn connect(io: Arc<dyn IO>, path: &str, prefetch_pages: u32) -> Arc<turso_core::Connection> {
+    let db = Database::open_file_with_flags(
+        io,
+        path,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute(format!("PRAGMA cache_size = -{CACHE_KIB}"))
+        .unwrap();
+    conn.execute(format!("PRAGMA prefetch_pages = {prefetch_pages}"))
+        .unwrap();
+    conn
+}
+
+/// A whole-table scan that touches every row's payload, so it cannot be
+/// answered from b-tree counts alone.
+const SCAN: &str = "SELECT sum(v), count(payload) FROM t";
+
+fn run_scan(io: &Arc<dyn IO>, conn: &Arc<turso_core::Connection>) {
+    let mut stmt = conn.prepare(SCAN).unwrap();
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                black_box(stmt.row().unwrap());
+            }
+            StepResult::Done => break,
+            StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => io.step().unwrap(),
+            StepResult::Interrupt | StepResult::Busy => panic!("unexpected scan result"),
+        }
+    }
+}
+
+/// Empty the page cache between iterations so every run starts cold and
+/// really goes to storage. Resizing down and back is the cheapest way to do
+/// that from SQL.
+fn drop_cache(conn: &Arc<turso_core::Connection>) {
+    conn.execute("PRAGMA cache_size = -20").unwrap();
+    conn.execute(format!("PRAGMA cache_size = -{CACHE_KIB}"))
+        .unwrap();
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_readahead(criterion: &mut Criterion) {
+    report_request_counts();
+    let dir = seed_db();
+    let path = dir.path().join("readahead.db");
+    let path = path.to_str().unwrap();
+
+    let mut group = criterion.benchmark_group("readahead");
+    group.measurement_time(Duration::from_secs(10));
+
+    // An ordinary file: the per-request cost is a syscall and nothing else.
+    for prefetch in [0u32, 32] {
+        let io: Arc<dyn IO> = Arc::new(PlatformIO::new().unwrap());
+        let conn = connect(io.clone(), path, prefetch);
+        group.bench_with_input(
+            BenchmarkId::new("local_file", label(prefetch)),
+            &prefetch,
+            |b, _| {
+                b.iter(|| {
+                    drop_cache(&conn);
+                    run_scan(&io, &conn);
+                })
+            },
+        );
+    }
+
+    // Storage where a request costs much more than the bytes it moves.
+    for prefetch in [0u32, 32] {
+        let io: Arc<dyn IO> = Arc::new(CostPerRequestIo {
+            inner: Arc::new(PlatformIO::new().unwrap()),
+            work: WORK_PER_REQUEST,
+        });
+        let conn = connect(io.clone(), path, prefetch);
+        group.bench_with_input(
+            BenchmarkId::new("per_request_cost", label(prefetch)),
+            &prefetch,
+            |b, _| {
+                b.iter(|| {
+                    drop_cache(&conn);
+                    run_scan(&io, &conn);
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn label(prefetch_pages: u32) -> &'static str {
+    if prefetch_pages == 0 {
+        "readahead_off"
+    } else {
+        "readahead_on"
+    }
+}
+
+/// Counts requests rather than timing them, so a run reports the thing
+/// readahead actually changes. Printed alongside the timings.
+fn report_request_counts() {
+    struct CountingIo {
+        inner: Arc<dyn IO>,
+        reads: Arc<AtomicU64>,
+        bytes: Arc<AtomicU64>,
+    }
+    struct CountingFile {
+        inner: Arc<dyn File>,
+        reads: Arc<AtomicU64>,
+        bytes: Arc<AtomicU64>,
+    }
+    impl Clock for CountingIo {
+        fn current_time_monotonic(&self) -> MonotonicInstant {
+            self.inner.current_time_monotonic()
+        }
+        fn current_time_wall_clock(&self) -> WallClockInstant {
+            self.inner.current_time_wall_clock()
+        }
+    }
+    impl IO for CountingIo {
+        fn open_file(
+            &self,
+            path: &str,
+            flags: OpenFlags,
+            direct: bool,
+        ) -> turso_core::Result<Arc<dyn File>> {
+            Ok(Arc::new(CountingFile {
+                inner: self.inner.open_file(path, flags, direct)?,
+                reads: self.reads.clone(),
+                bytes: self.bytes.clone(),
+            }))
+        }
+        fn remove_file(&self, path: &str) -> turso_core::Result<()> {
+            self.inner.remove_file(path)
+        }
+        fn step(&self) -> turso_core::Result<()> {
+            self.inner.step()
+        }
+    }
+    impl File for CountingFile {
+        fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
+            self.inner.lock_file(exclusive)
+        }
+        fn unlock_file(&self) -> turso_core::Result<()> {
+            self.inner.unlock_file()
+        }
+        fn pread(&self, pos: u64, c: Completion) -> turso_core::Result<Completion> {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+            self.bytes
+                .fetch_add(c.as_read().buf().len() as u64, Ordering::Relaxed);
+            self.inner.pread(pos, c)
+        }
+
+        fn preadv(
+            &self,
+            pos: u64,
+            buffers: Vec<Arc<Buffer>>,
+            c: Completion,
+        ) -> turso_core::Result<Completion> {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+            self.bytes.fetch_add(
+                buffers.iter().map(|b| b.len() as u64).sum::<u64>(),
+                Ordering::Relaxed,
+            );
+            self.inner.preadv(pos, buffers, c)
+        }
+        fn pwrite(
+            &self,
+            pos: u64,
+            buffer: Arc<Buffer>,
+            c: Completion,
+        ) -> turso_core::Result<Completion> {
+            self.inner.pwrite(pos, buffer, c)
+        }
+        fn sync(&self, c: Completion, sync_type: FileSyncType) -> turso_core::Result<Completion> {
+            self.inner.sync(c, sync_type)
+        }
+        fn size(&self) -> turso_core::Result<u64> {
+            self.inner.size()
+        }
+        fn truncate(&self, len: u64, c: Completion) -> turso_core::Result<Completion> {
+            self.inner.truncate(len, c)
+        }
+    }
+
+    let dir = seed_db();
+    let path = dir.path().join("readahead.db");
+    let path = path.to_str().unwrap();
+    println!("\nrequests made by `{SCAN}`:");
+    for prefetch in [0u32, 32] {
+        let reads = Arc::new(AtomicU64::new(0));
+        let bytes = Arc::new(AtomicU64::new(0));
+        let io: Arc<dyn IO> = Arc::new(CountingIo {
+            inner: Arc::new(PlatformIO::new().unwrap()),
+            reads: reads.clone(),
+            bytes: bytes.clone(),
+        });
+        let conn = connect(io.clone(), path, prefetch);
+        // Warm up once so the count reflects steady state rather than the
+        // first-touch of the file.
+        drop_cache(&conn);
+        run_scan(&io, &conn);
+        drop_cache(&conn);
+        reads.store(0, Ordering::Relaxed);
+        bytes.store(0, Ordering::Relaxed);
+        run_scan(&io, &conn);
+        println!(
+            "  prefetch_pages={prefetch:<3} {:>8} requests  {:>8} KiB",
+            reads.load(Ordering::Relaxed),
+            bytes.load(Ordering::Relaxed) / 1024,
+        );
+    }
+    println!();
+}
+
+criterion_group!(benches, bench_readahead);
+criterion_main!(benches);

--- a/core/benches/readahead_benchmark.rs
+++ b/core/benches/readahead_benchmark.rs
@@ -239,10 +239,12 @@ fn drop_cache(conn: &Arc<turso_core::Connection>) {
 
 #[turso_macros::codspeed_criterion_benchmark]
 fn bench_readahead(criterion: &mut Criterion) {
-    report_request_counts();
+    // Seeding is by far the most expensive thing here, so do it once and let
+    // both the request count and the timings use the same database.
     let dir = seed_db();
     let path = dir.path().join("readahead.db");
     let path = path.to_str().unwrap();
+    report_request_counts(path);
 
     let mut group = criterion.benchmark_group("readahead");
     group.measurement_time(Duration::from_secs(10));
@@ -295,7 +297,7 @@ fn label(prefetch_pages: u32) -> &'static str {
 
 /// Counts requests rather than timing them, so a run reports the thing
 /// readahead actually changes. Printed alongside the timings.
-fn report_request_counts() {
+fn report_request_counts(path: &str) {
     struct CountingIo {
         inner: Arc<dyn IO>,
         reads: Arc<AtomicU64>,
@@ -380,9 +382,6 @@ fn report_request_counts() {
         }
     }
 
-    let dir = seed_db();
-    let path = dir.path().join("readahead.db");
-    let path = path.to_str().unwrap();
     println!("\nrequests made by `{SCAN}`:");
     for prefetch in [0u32, 32] {
         let reads = Arc::new(AtomicU64::new(0));

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -157,6 +157,67 @@ pub trait File: Send + Sync {
     fn pwrite(&self, pos: u64, buffer: Arc<Buffer>, c: Completion) -> Result<Completion>;
     /// Sync file data&metadata to disk.
     fn sync(&self, c: Completion, sync_type: FileSyncType) -> Result<Completion>;
+    /// Read `buffers.len()` consecutive chunks starting at `pos`, filling
+    /// `buffers` in order.
+    ///
+    /// Unlike [`File::pread`], the destinations are passed separately and `c`
+    /// carries no buffer of its own: it just reports the total bytes read.
+    /// Used by readahead to pull a run of pages in one request.
+    ///
+    /// The default issues one `pread` per buffer, which is right for backends
+    /// that queue requests rather than serve them inline.
+    fn preadv(&self, pos: u64, buffers: Vec<Arc<Buffer>>, c: Completion) -> Result<Completion> {
+        use crate::sync::atomic::{AtomicUsize, Ordering};
+        if buffers.is_empty() {
+            c.complete(0);
+            return Ok(c);
+        }
+        let mut pos = pos;
+        let outstanding = Arc::new(AtomicUsize::new(buffers.len()));
+        let total_read = Arc::new(AtomicUsize::new(0));
+        let failed = Arc::new(crate::sync::atomic::AtomicBool::new(false));
+
+        for buf in buffers {
+            let len = buf.len();
+            let child_c = {
+                let c_main = c.clone();
+                let outstanding = outstanding.clone();
+                let total_read = total_read.clone();
+                let failed = failed.clone();
+                Completion::new_read(buf.clone(), move |res| {
+                    match res {
+                        Ok((_, n)) => {
+                            total_read.fetch_add(n.max(0) as usize, Ordering::SeqCst);
+                        }
+                        Err(err) => {
+                            // Remember the failure but keep counting down, so
+                            // the parent resolves exactly once either way.
+                            failed.store(true, Ordering::SeqCst);
+                            if outstanding.fetch_sub(1, Ordering::AcqRel) == 1 {
+                                c_main.error(err);
+                            }
+                            return Some(err);
+                        }
+                    }
+                    if outstanding.fetch_sub(1, Ordering::AcqRel) == 1 {
+                        if failed.load(Ordering::SeqCst) {
+                            c_main.error(crate::CompletionError::Aborted);
+                        } else {
+                            c_main.complete(total_read.load(Ordering::Acquire) as i32);
+                        }
+                    }
+                    None
+                })
+            };
+            if let Err(e) = self.pread(pos, child_c) {
+                c.abort();
+                return Err(e);
+            }
+            pos += len as u64;
+        }
+        Ok(c)
+    }
+
     fn pwritev(&self, pos: u64, buffers: Vec<Arc<Buffer>>, c: Completion) -> Result<Completion> {
         use crate::sync::atomic::{AtomicUsize, Ordering};
         if buffers.is_empty() {

--- a/core/io/unix.rs
+++ b/core/io/unix.rs
@@ -383,6 +383,68 @@ impl File for UnixFile {
     }
 
     #[instrument(err, skip_all, level = Level::TRACE)]
+    fn preadv(
+        &self,
+        pos: u64,
+        buffers: Vec<Arc<crate::Buffer>>,
+        c: Completion,
+    ) -> Result<Completion> {
+        if buffers.is_empty() {
+            c.complete(0);
+            return Ok(c);
+        }
+        let total_size: usize = buffers.iter().map(|b| b.len()).sum();
+        let mut iov: Vec<libc::iovec> = Vec::with_capacity(buffers.len().min(MAX_IOV));
+        for buf in &buffers {
+            if iov.len() == MAX_IOV {
+                break;
+            }
+            let slice = buf.as_mut_slice();
+            iov.push(libc::iovec {
+                iov_base: slice.as_mut_ptr() as *mut libc::c_void,
+                iov_len: slice.len(),
+            });
+        }
+
+        let mut total_read = 0usize;
+        let mut current_pos = pos;
+        // `preadv` may come up short; keep going until every buffer is filled
+        // or the file ends.
+        loop {
+            let n = unsafe {
+                libc::preadv(
+                    self.file.as_raw_fd(),
+                    iov.as_ptr(),
+                    iov.len() as i32,
+                    current_pos as libc::off_t,
+                )
+            };
+            if n < 0 {
+                let e = std::io::Error::last_os_error();
+                if e.kind() == ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(io_error(e, "preadv"));
+            }
+            let read = n as usize;
+            total_read += read;
+            current_pos += read as u64;
+            // A zero-length read means end of file: report what we got and let
+            // the caller decide whether a short read is acceptable.
+            if read == 0 || total_read >= total_size || iov.is_empty() {
+                break;
+            }
+            trim_iovecs(&mut iov, read);
+            if iov.is_empty() {
+                break;
+            }
+        }
+        trace!("preadv complete: read {total_read}/{total_size} bytes");
+        c.complete(total_read as i32);
+        Ok(c)
+    }
+
+    #[instrument(err, skip_all, level = Level::TRACE)]
     fn pwritev(
         &self,
         pos: u64,

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -228,6 +228,14 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["vdbe_trace"],
         ),
+        PrefetchPages => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["prefetch_pages"],
+        ),
+        PrefetchStats => Pragma::new(
+            PragmaFlags::Result0,
+            &["hits", "hits_in_flight", "misses", "pages_fetched", "reads"],
+        ),
     }
 }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -7146,6 +7146,11 @@ impl CursorTrait for BTreeCursor {
         loop {
             match self.rewind_state {
                 RewindState::Start => {
+                    // A walk of this whole b-tree is starting. Tell readahead
+                    // so it does not spend the first few pages working out
+                    // what it can already be told -- the same reason Linux
+                    // treats a read at offset 0 as sequential on sight.
+                    self.pager.hint_scan_start(self.root_page);
                     let c = return_if_io!(self.move_to_root_nonblock());
                     self.rewind_state = RewindState::NextRecord;
                     if let Some(c) = c {

--- a/core/storage/database.rs
+++ b/core/storage/database.rs
@@ -112,6 +112,57 @@ pub trait DatabaseStorage: Send + Sync {
     fn read_header(&self, c: Completion) -> Result<Completion>;
 
     fn read_page(&self, page_idx: usize, io_ctx: &IOContext, c: Completion) -> Result<Completion>;
+
+    /// Read `dest.len()` consecutive pages starting at `first_page_idx` as one
+    /// request, filling `dest[i]` with page `first_page_idx + i`.
+    ///
+    /// This exists for readahead. Reading a 32-page run one page at a time is
+    /// 32 requests to the storage layer; as one request it is a single
+    /// round trip that moves the same bytes, which on any medium with a
+    /// per-request cost -- a syscall, a disk seek, an HTTP GET -- is where
+    /// nearly all of the saving is.
+    ///
+    /// `on_done` fires exactly once when every page has been read and
+    /// transformed, or with the first error. The returned completion is what
+    /// the caller waits on.
+    ///
+    /// Returns an error without issuing any I/O if `dest` is empty or its
+    /// buffers are not all one valid page size.
+    ///
+    /// The default fans out to [`DatabaseStorage::read_page`] and joins the
+    /// results, so every backend supports readahead; backends that can move a
+    /// contiguous run in one request should override it.
+    fn read_pages(
+        &self,
+        first_page_idx: usize,
+        dest: Vec<Arc<Buffer>>,
+        io_ctx: &IOContext,
+        on_done: Box<dyn Fn(Result<(), CompletionError>) + Send + Sync>,
+    ) -> Result<Completion> {
+        if dest.is_empty() {
+            return Err(LimboError::InternalError(
+                "read_pages called with no destination buffers".into(),
+            ));
+        }
+        let mut group = crate::io::CompletionGroup::new(move |res| {
+            on_done(res.map(|_| ()));
+        });
+        for (i, buf) in dest.iter().enumerate() {
+            let c = Completion::new_read(buf.clone(), |_| None);
+            match self.read_page(first_page_idx + i, io_ctx, c) {
+                Ok(c) => group.add(&c),
+                Err(e) => {
+                    // Reads already submitted keep their buffers alive until
+                    // they resolve; cancel them so they do not outlive this
+                    // call, then report the failure to the caller.
+                    group.cancel();
+                    return Err(e);
+                }
+            }
+        }
+        Ok(group.build())
+    }
+
     fn write_page(
         &self,
         page_idx: usize,
@@ -270,6 +321,97 @@ impl DatabaseStorage for DatabaseFile {
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
+    fn read_pages(
+        &self,
+        first_page_idx: usize,
+        dest: Vec<Arc<Buffer>>,
+        io_ctx: &IOContext,
+        on_done: Box<dyn Fn(Result<(), CompletionError>) + Send + Sync>,
+    ) -> Result<Completion> {
+        turso_assert_greater_than!(first_page_idx, 0);
+        let Some(page_size) = dest.first().map(|b| b.len()) else {
+            return Err(LimboError::InternalError(
+                "read_pages called with no destination buffers".into(),
+            ));
+        };
+        if !(512..=65536).contains(&page_size) || page_size & (page_size - 1) != 0 {
+            return Err(LimboError::NotADB);
+        }
+        if dest.iter().any(|b| b.len() != page_size) {
+            return Err(LimboError::InternalError(
+                "read_pages requires every destination buffer to be one page".into(),
+            ));
+        }
+        let Some(pos) = (first_page_idx as u64 - 1).checked_mul(page_size as u64) else {
+            return Err(LimboError::IntegerOverflow);
+        };
+        let total = page_size * dest.len();
+
+        match io_ctx.page_transform() {
+            // Nothing has to look at the encoded bytes separately from the
+            // decoded ones, so read straight into the page buffers. One
+            // request, no copy.
+            PageTransform::None => {
+                let c = Completion::new_write(move |res| {
+                    on_done(check_run_length(res, first_page_idx, total));
+                });
+                self.file.preadv(pos, dest, c)
+            }
+            // Checksums are verified in place, so this can also read straight
+            // into the page buffers.
+            PageTransform::Checksum(ctx) => {
+                let ctx = ctx.clone();
+                let pages = dest.clone();
+                let c = Completion::new_write(move |res| {
+                    let outcome = check_run_length(res, first_page_idx, total).and_then(|()| {
+                        for (i, page_buf) in pages.iter().enumerate() {
+                            ctx.verify_checksum(page_buf.as_mut_slice(), first_page_idx + i)?;
+                        }
+                        Ok(())
+                    });
+                    on_done(outcome);
+                });
+                self.file.preadv(pos, dest, c)
+            }
+            // A codec decodes from one buffer into another, so the encoded
+            // run needs somewhere to land first.
+            PageTransform::Codec(codec) => {
+                // Codec contexts depend only on the page number, so build them
+                // here: the completion callback cannot return a `LimboError`.
+                let codec_contexts = (0..dest.len())
+                    .map(|i| {
+                        PageCodecContext::from_page_idx(first_page_idx + i, PageLocation::Database)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let codec = codec.clone();
+                let staging = Arc::new(Buffer::new_temporary(total));
+                let decode = move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                    let (buf, bytes_read) = res?;
+                    check_run_length(Ok(bytes_read), first_page_idx, total)?;
+                    for (i, page_buf) in dest.iter().enumerate() {
+                        let page_idx = first_page_idx + i;
+                        let src = &buf.as_slice()[i * page_size..(i + 1) * page_size];
+                        codec
+                            .decode_page(codec_contexts[i], src, page_buf.as_mut_slice())
+                            .map_err(|e| {
+                                tracing::error!("failed to decode prefetched page {page_idx}: {e}");
+                                page_codec_completion_error(codec.as_ref(), page_idx)
+                            })?;
+                    }
+                    Ok(())
+                };
+                let c = Completion::new_read(staging, move |res| {
+                    let outcome = decode(res);
+                    let err = outcome.as_ref().err().copied();
+                    on_done(outcome);
+                    err
+                });
+                self.file.pread(pos, c)
+            }
+        }
+    }
+
+    #[instrument(skip_all, level = Level::DEBUG)]
     fn write_page(
         &self,
         page_idx: usize,
@@ -357,6 +499,25 @@ impl DatabaseFile {
     pub fn new(file: Arc<dyn crate::io::File>) -> Self {
         Self { file }
     }
+}
+
+/// A readahead run has to arrive whole. A short read means the run ran past
+/// the end of the file, which readahead should have clamped, so the pages are
+/// unusable and the caller must fall back to reading them one at a time.
+fn check_run_length(
+    res: Result<i32, CompletionError>,
+    first_page_idx: usize,
+    expected: usize,
+) -> Result<(), CompletionError> {
+    let bytes_read = res?;
+    if bytes_read as usize != expected {
+        return Err(CompletionError::ShortRead {
+            page_idx: first_page_idx,
+            expected,
+            actual: bytes_read.max(0) as usize,
+        });
+    }
+    Ok(())
 }
 
 fn encode_buffer(

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod page_cache;
 pub(crate) mod page_transform;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod pager;
+pub(crate) mod readahead;
 #[cfg(host_shared_wal)]
 #[allow(dead_code)]
 pub(crate) mod shared_wal_coordination;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -67,23 +67,30 @@ const DEFAULT_MAX_PAGE_COUNT: u32 = 0xfffffffe;
 /// 32 pages is 128 KiB at the usual 4 KiB page size, which is also Linux's
 /// default `read_ahead_kb`.
 ///
-/// Whether this is worth anything depends entirely on whether something
-/// underneath is already reading ahead for us, and the two backends differ:
+/// What this buys depends on whether anything underneath is already reading
+/// ahead. Measured on the 1.2 GB TPC-H database, cold every run, best of
+/// three, same binary throughout (TPC-H Q1 / Q6, both LINEITEM scans):
 ///
-/// * `UringIO` sets `O_DIRECT` on the database file, so reads bypass the page
-///   cache and nothing prefetches. Measured on the 1.2 GB TPC-H database, a
-///   full LINEITEM scan goes 20.7s -> 10.5s and a scan with a filter goes
-///   12.1s -> 2.9s. This is what readahead is for.
-/// * `UnixIO` ignores the `direct` flag, so reads are buffered and Linux is
-///   already reading ahead -- 8 MiB on the machine this was measured on,
-///   sixty-four times this window. There the whole TPC-H suite came out
-///   within noise (-0.5%), because by the time we ask for the next page the
-///   kernel has long since fetched it.
+/// | backend                  | readahead | Q1       | Q6       |
+/// |--------------------------|-----------|----------|----------|
+/// | `UnixIO` (buffered)      | off       | 18.4 s   |  4.4 s   |
+/// | `UnixIO` (buffered)      | 32        | 16.6 s   |  3.7 s   |
+/// | `UringIO` (`O_DIRECT`)   | off       | 28.6 s   | 17.5 s   |
+/// | `UringIO` (`O_DIRECT`)   | 32        | 15.0 s   |  4.1 s   |
 ///
-/// So: a large win where it matters, and nothing measurable where it does
-/// not. On by default for that reason. Readahead removes syscalls either way
-/// -- 195,206 to 8,827 on a full LINEITEM scan -- but only in the first case
-/// were the syscalls what the query was waiting for.
+/// Buffered reads go through the page cache, where Linux is already reading
+/// ahead -- 8 MiB on the machine measured, sixty-four times this window -- so
+/// this adds a modest 10-15% on a scan and nothing on the rest of the suite.
+///
+/// The third row is the interesting one. `O_DIRECT` skips the page cache, so
+/// the kernel's readahead goes away and nothing replaces it: every page
+/// becomes its own round trip and the scan lands *four times slower than
+/// buffered*. Readahead is what puts that back, and only with it does the
+/// direct path reach parity with buffered.
+///
+/// So this is worth having on both paths, but for different reasons: a small
+/// gain on the buffered one, and on the direct one the difference between
+/// usable and not.
 ///
 /// Set `PRAGMA prefetch_pages = 0` to turn it off.
 pub const DEFAULT_READAHEAD_WINDOW: u32 = 32;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -62,15 +62,24 @@ use crate::storage::encryption::{CipherMode, EncryptionContext, EncryptionKey};
 /// SQLite's default maximum page count
 const DEFAULT_MAX_PAGE_COUNT: u32 = 0xfffffffe;
 
-/// Readahead window ceiling, in pages, out of the box.
+/// Readahead window ceiling, in pages, out of the box. Zero means off.
 ///
-/// 32 pages is 128 KiB at the usual 4 KiB page size, which is also Linux's
-/// default `read_ahead_kb`. Measured over the TPC-H table scans (see
-/// `storage::readahead`), 32 pages already removes ~185x of the blocking
-/// reads; going wider does not remove meaningfully more of them, and every
-/// extra page is memory held and bandwidth spent. Set `PRAGMA prefetch_pages`
-/// to trade the other way.
-pub const DEFAULT_READAHEAD_WINDOW: u32 = 32;
+/// Off by default because on an ordinary file it has not been shown to make
+/// queries faster. Measured over the whole TPC-H suite against the 1.2 GB
+/// database, with the page cache dropped before every run, readahead was
+/// within noise of no readahead (-0.5% total). The reason is that the kernel
+/// is already doing this: Linux read-ahead on that device is 8 MiB, sixty-four
+/// times the window here, so by the time the database asks for the next page
+/// the kernel has long since fetched it. Readahead removes syscalls -- 195,206
+/// to 8,827 on a full LINEITEM scan -- but on that path the syscalls were not
+/// what the query was waiting for.
+///
+/// It is worth turning on when nothing underneath is reading ahead for you and
+/// a request costs much more than the bytes it moves: O_DIRECT, network block
+/// storage, a remote page server, an object store. `PRAGMA prefetch_pages = 32`
+/// is a reasonable starting point there (128 KiB at a 4 KiB page size, which is
+/// also Linux's own default read-ahead size).
+pub const DEFAULT_READAHEAD_WINDOW: u32 = 0;
 
 /// Hard ceiling on `PRAGMA prefetch_pages`, so one connection cannot pin an
 /// unbounded amount of memory in prefetched pages.

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -17,7 +17,8 @@ use crate::storage::{
     wal::{CheckpointResult, RollbackTo, Wal, IOV_MAX},
 };
 use crate::sync::atomic::{
-    AtomicBool, AtomicIsize, AtomicU16, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering,
+    AtomicBool, AtomicI64, AtomicIsize, AtomicU16, AtomicU32, AtomicU64, AtomicU8, AtomicUsize,
+    Ordering,
 };
 use crate::sync::Arc;
 use crate::sync::{Mutex, RwLock};
@@ -37,6 +38,7 @@ use arc_swap::ArcSwapOption;
 use roaring::RoaringBitmap;
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
+use std::num::NonZeroU32;
 use tracing::{instrument, trace, Level};
 
 use super::btree::offset::{
@@ -47,6 +49,7 @@ use super::btree::{
     btree_init_page, payload_overflow_threshold_max, payload_overflow_threshold_min,
 };
 use super::page_cache::{CacheError, CacheResizeResult, PageCache, PageCacheKey, SpillResult};
+use super::readahead::{PrefetchBuffer, PrefetchHit, Readahead, ReadaheadAction};
 use super::sqlite3_ondisk::read_varint;
 use super::sqlite3_ondisk::{
     begin_write_btree_page, read_btree_cell, read_u32, BTreeCell, FREELIST_LEAF_PTR_SIZE,
@@ -58,6 +61,72 @@ use crate::storage::encryption::{CipherMode, EncryptionContext, EncryptionKey};
 
 /// SQLite's default maximum page count
 const DEFAULT_MAX_PAGE_COUNT: u32 = 0xfffffffe;
+
+/// Readahead window ceiling, in pages, out of the box.
+///
+/// 32 pages is 128 KiB at the usual 4 KiB page size, which is also Linux's
+/// default `read_ahead_kb`. Measured over the TPC-H table scans (see
+/// `storage::readahead`), 32 pages already removes ~185x of the blocking
+/// reads; going wider does not remove meaningfully more of them, and every
+/// extra page is memory held and bandwidth spent. Set `PRAGMA prefetch_pages`
+/// to trade the other way.
+pub const DEFAULT_READAHEAD_WINDOW: u32 = 32;
+
+/// Hard ceiling on `PRAGMA prefetch_pages`, so one connection cannot pin an
+/// unbounded amount of memory in prefetched pages.
+pub const MAX_READAHEAD_WINDOW: u32 = 512;
+
+/// How many prefetched pages we are willing to hold, given a window size.
+///
+/// Two windows can be outstanding while the ramp is catching up, and pages the
+/// reader never gets to have to sit somewhere until they age out, so a few
+/// windows of slack keeps the buffer from evicting pages that are about to be
+/// used. Beyond that it is just memory.
+fn prefetch_buffer_capacity(window: u32) -> usize {
+    if window == 0 {
+        return 0;
+    }
+    (window as usize * 4).max(16)
+}
+
+/// Readahead counters. Reported by `PRAGMA prefetch_stats`, and the thing
+/// tests assert on: whether readahead helped is a question about how many
+/// times a query had to go to storage, which is exactly what these count.
+#[derive(Default, Debug)]
+pub struct ReadaheadStats {
+    /// Reads served by a page readahead had already fetched and finished.
+    hits: AtomicU64,
+    /// Reads that found a prefetched page whose read was still in flight.
+    hits_in_flight: AtomicU64,
+    /// Reads that had to go to storage themselves.
+    misses: AtomicU64,
+    /// Pages fetched by readahead.
+    pages_fetched: AtomicU64,
+    /// Requests readahead made to storage. `pages_fetched / reads` is how many
+    /// pages we move per round trip.
+    reads: AtomicU64,
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadaheadStatsSnapshot {
+    pub hits: u64,
+    pub hits_in_flight: u64,
+    pub misses: u64,
+    pub pages_fetched: u64,
+    pub reads: u64,
+}
+
+impl ReadaheadStats {
+    fn snapshot(&self) -> ReadaheadStatsSnapshot {
+        ReadaheadStatsSnapshot {
+            hits: self.hits.load(Ordering::Relaxed),
+            hits_in_flight: self.hits_in_flight.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            pages_fetched: self.pages_fetched.load(Ordering::Relaxed),
+            reads: self.reads.load(Ordering::Relaxed),
+        }
+    }
+}
 const RESERVED_SPACE_NOT_SET: u16 = u16::MAX;
 
 #[cfg(feature = "test_helper")]
@@ -1361,6 +1430,18 @@ pub struct Pager {
     /// `read_page_nonblock(idx)` reuses the stored `(page, disk_read)` pair
     /// instead of issuing a duplicate disk read.
     pending_reads: RwLock<HashMap<i64, PendingRead>>,
+    /// Follows readers walking forward through the file and decides when to
+    /// fetch pages ahead of them. See `storage::readahead`.
+    readahead: Mutex<Readahead>,
+    /// Pages readahead has fetched but nothing has asked for yet.
+    prefetched: Mutex<PrefetchBuffer>,
+    /// Ceiling on the readahead window, in pages. 0 turns readahead off.
+    readahead_window: AtomicU32,
+    /// Database file size in pages, as readahead last saw it. -1 means
+    /// "ask the file". Cleared by `forget_readahead`.
+    readahead_file_pages: AtomicI64,
+    /// Readahead counters, for tests and `PRAGMA` introspection.
+    readahead_stats: ReadaheadStats,
     #[cfg(test)]
     spill_yield: SpillYieldHook,
     /// Dirty pages as a bitmap, naturally sorted by page number.
@@ -1656,6 +1737,13 @@ impl Pager {
             page_cache: Arc::new(RwLock::new(page_cache)),
             io,
             pending_reads: RwLock::new(HashMap::new()),
+            readahead: Mutex::new(Readahead::new()),
+            prefetched: Mutex::new(PrefetchBuffer::new(prefetch_buffer_capacity(
+                DEFAULT_READAHEAD_WINDOW,
+            ))),
+            readahead_window: AtomicU32::new(DEFAULT_READAHEAD_WINDOW),
+            readahead_file_pages: AtomicI64::new(-1),
+            readahead_stats: ReadaheadStats::default(),
             #[cfg(test)]
             spill_yield: SpillYieldHook::new(),
             dirty_pages: Arc::new(RwLock::new(RoaringBitmap::new())),
@@ -3206,6 +3294,9 @@ impl Pager {
 
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn end_read_tx(&self) {
+        // Prefetched pages are only known-correct for the snapshot they were
+        // read under. That snapshot ends here.
+        self.forget_readahead();
         let Some(wal) = self.wal.as_ref() else {
             return;
         };
@@ -3328,48 +3419,74 @@ impl Pager {
         let (page, c_disk) = if let Some(pending) = pending {
             // Re-entry: previous call yielded on spill before completing
             // `cache_insert`. Reuse the same PageRef and in-flight disk read
-            // rather than issuing duplicate IO.
+            // rather than issuing duplicate IO. Readahead already counted this
+            // page on the first pass; counting it again would let a retry loop
+            // look like forward progress.
             (pending.page, pending.disk_read)
         } else {
             // Fast path: cache hit.
-            {
+            let cached = {
                 let mut page_cache = self.page_cache.write();
                 let page_key = PageCacheKey::new(page_idx as usize);
-                if let Some(page) = page_cache.get(&page_key)? {
-                    turso_assert!(
-                        page_idx as usize == page.get().id,
-                        "attempted to read page but got different page",
-                        { "expected_page": page_idx, "actual_page": page.get().id }
-                    );
-                    if !page.is_loaded() {
-                        // The page is cache-resident but its read is still in
-                        // flight: `read_page` publishes a page into the shared
-                        // cache (via `cache_insert` below) *before* its disk
-                        // read completes, and `PageCache::get` deliberately
-                        // hands out locked-but-unloaded in-flight pages. We have
-                        // no completion to surface on this path (the disk-read
-                        // completion was consumed by the original caller and the
-                        // `pending_reads` entry has already been removed), so
-                        // returning `Done((page, None))` would hand the caller a
-                        // locked, unloaded page with nothing to wait on: a torn
-                        // / uninitialized read, or a concurrent writer filling
-                        // the buffer underneath the reader.
-                        io_yield_one!(crate::Completion::new_yield());
-                    }
-                    return Ok(IOResult::Done((page, None)));
+                page_cache.get(&page_key)?
+            };
+            if let Some(page) = cached {
+                turso_assert!(
+                    page_idx as usize == page.get().id,
+                    "attempted to read page but got different page",
+                    { "expected_page": page_idx, "actual_page": page.get().id }
+                );
+                if !page.is_loaded() {
+                    // The page is cache-resident but its read is still in
+                    // flight: `read_page` publishes a page into the shared
+                    // cache (via `cache_insert` below) *before* its disk
+                    // read completes, and `PageCache::get` deliberately
+                    // hands out locked-but-unloaded in-flight pages. We have
+                    // no completion to surface on this path (the disk-read
+                    // completion was consumed by the original caller and the
+                    // `pending_reads` entry has already been removed), so
+                    // returning `Done((page, None))` would hand the caller a
+                    // locked, unloaded page with nothing to wait on: a torn
+                    // / uninitialized read, or a concurrent writer filling
+                    // the buffer underneath the reader.
+                    io_yield_one!(crate::Completion::new_yield());
                 }
+                // Served from memory. This is where readahead queues the next
+                // window, so the reader keeps a lead and stops stalling.
+                self.note_page_read(page_idx, true);
+                return Ok(IOResult::Done((page, None)));
             }
 
-            tracing::debug!("read_page(page_idx = {page_idx}) = reading page from disk");
-            let (page, c) = self.read_page_no_cache(page_idx, None, false)?;
+            // Not cached. Readahead may already have this page in hand, in
+            // which case its read went out earlier than a demand read could
+            // have -- often early enough to have already landed.
+            let (page, c) = match self.prefetched.lock().take(page_idx) {
+                Some(PrefetchHit::Ready(page)) => {
+                    self.readahead_stats.hits.fetch_add(1, Ordering::Relaxed);
+                    (page, None)
+                }
+                Some(PrefetchHit::InFlight(page, c)) => {
+                    self.readahead_stats
+                        .hits_in_flight
+                        .fetch_add(1, Ordering::Relaxed);
+                    (page, Some(c))
+                }
+                None => {
+                    tracing::debug!("read_page(page_idx = {page_idx}) = reading page from disk");
+                    self.readahead_stats.misses.fetch_add(1, Ordering::Relaxed);
+                    let (page, c) = self.read_page_no_cache(page_idx, None, false)?;
+                    (page, Some(c))
+                }
+            };
             self.pending_reads.write().insert(
                 page_idx,
                 PendingRead {
                     page: page.clone(),
-                    disk_read: Some(c.clone()),
+                    disk_read: c.clone(),
                 },
             );
-            (page, Some(c))
+            self.note_page_read(page_idx, false);
+            (page, c)
         };
 
         match self.cache_insert(page_idx as usize, page.clone())? {
@@ -3384,6 +3501,225 @@ impl Pager {
                 io_yield_one!(spill_c);
             }
         }
+    }
+
+    /// Ceiling on the readahead window in pages. 0 means readahead is off.
+    pub fn readahead_window(&self) -> u32 {
+        self.readahead_window.load(Ordering::Relaxed)
+    }
+
+    /// Set the readahead ceiling in pages. 0 turns readahead off.
+    ///
+    /// Any pages already fetched are dropped, so turning readahead off stops
+    /// it costing memory immediately rather than at the end of the statement.
+    pub fn set_readahead_window(&self, pages: u32) {
+        let pages = pages.min(MAX_READAHEAD_WINDOW);
+        self.readahead_window.store(pages, Ordering::Relaxed);
+        self.readahead.lock().reset();
+        let mut prefetched = self.prefetched.lock();
+        prefetched.set_capacity(prefetch_buffer_capacity(pages));
+        if pages == 0 {
+            prefetched.clear();
+        }
+    }
+
+    pub fn readahead_stats(&self) -> ReadaheadStatsSnapshot {
+        self.readahead_stats.snapshot()
+    }
+
+    /// Forget every prefetched page and every stream.
+    ///
+    /// Prefetched pages are copies of the database file taken under one read
+    /// snapshot. Once that snapshot can no longer be assumed -- the read
+    /// transaction ended, someone dirtied a page, the cache was cleared, a
+    /// checkpoint moved WAL frames into the file -- they are no longer known
+    /// to be what a reader should see, so they go.
+    pub(crate) fn forget_readahead(&self) {
+        self.readahead_file_pages.store(-1, Ordering::Relaxed);
+        let mut prefetched = self.prefetched.lock();
+        if prefetched.len() > 0 {
+            prefetched.clear();
+        }
+        self.readahead.lock().reset();
+    }
+
+    /// A cursor is starting a walk of a whole b-tree. See
+    /// [`Readahead::hint_scan_start`].
+    pub(crate) fn hint_scan_start(&self, root_page: i64) {
+        if self.readahead_window.load(Ordering::Relaxed) == 0 {
+            return;
+        }
+        self.readahead.lock().hint_scan_start(root_page);
+    }
+
+    /// Drop one page from the prefetch buffer. Called when that page stops
+    /// being a faithful copy of what a reader should see.
+    pub(crate) fn forget_prefetched_page(&self, page_idx: i64) {
+        if self.readahead_window.load(Ordering::Relaxed) == 0 {
+            return;
+        }
+        self.prefetched.lock().remove(page_idx);
+    }
+
+    /// Record a page read and act on whatever readahead decides.
+    ///
+    /// Must not be called while holding the page cache lock: issuing a window
+    /// takes it.
+    fn note_page_read(&self, page_idx: i64, cache_hit: bool) {
+        let window = NonZeroU32::new(self.effective_readahead_window());
+        let action = self.readahead.lock().on_read(page_idx, cache_hit, window);
+        let ReadaheadAction::Fetch { start, count } = action else {
+            return;
+        };
+        // Readahead is an optimization and nothing more: a failure here must
+        // never surface to the query, which will read the page itself.
+        if let Err(e) = self.issue_readahead(start, count) {
+            tracing::debug!("readahead of {count} pages from {start} did not happen: {e}");
+        }
+    }
+
+    /// The window we will actually use, which is the configured ceiling
+    /// bounded by what the page cache can absorb.
+    ///
+    /// A window that is a large fraction of the cache would evict the pages
+    /// the query is still working on to make room for guesses, so readahead
+    /// would slow the query down. An eighth leaves the cache overwhelmingly
+    /// for real work.
+    fn effective_readahead_window(&self) -> u32 {
+        let configured = self.readahead_window.load(Ordering::Relaxed);
+        if configured == 0 {
+            return 0;
+        }
+        let cache_capacity = self.page_cache.read().capacity() as u32;
+        configured.min((cache_capacity / 8).max(1))
+    }
+
+    /// Fetch up to `count` pages from `start`, best effort.
+    ///
+    /// Only the run of pages we can safely read from the database file gets
+    /// fetched, as a single request:
+    ///
+    /// * pages already in the cache or already fetched are skipped -- reading
+    ///   them again would be pure waste, and overwriting a cached page could
+    ///   clobber a dirty one;
+    /// * pages with a WAL frame in this reader's snapshot are skipped, because
+    ///   the file copy is not what this reader should see;
+    /// * pages past the end of the file are skipped, because a short read
+    ///   would leave an unusable page behind.
+    ///
+    /// The run stops at the first page that fails any of those, so the whole
+    /// thing is one contiguous read. Whatever is left gets picked up by the
+    /// next window.
+    fn issue_readahead(&self, start: i64, count: u32) -> Result<()> {
+        turso_assert_greater_than!(start, 0);
+        if count == 0 {
+            return Ok(());
+        }
+        // Read the raw field rather than `get_page_size_unchecked`: readahead
+        // can run before the page size is known, and it must never assert.
+        let page_size = self.page_size.load(Ordering::Relaxed) as u64;
+        if page_size == 0 {
+            return Ok(());
+        }
+        // Never read past the end of the file: a short read leaves a page
+        // locked and unloaded, which a later reader would wait on forever.
+        //
+        // Asking the file its size is a syscall, and this runs once per
+        // window, so remember it. The file only grows on commit, and
+        // `forget_readahead` clears this whenever the snapshot changes.
+        let mut file_pages = self.readahead_file_pages.load(Ordering::Relaxed);
+        if file_pages < 0 {
+            file_pages = (self.db_file.size()? / page_size) as i64;
+            self.readahead_file_pages
+                .store(file_pages, Ordering::Relaxed);
+        }
+        let last = (start + count as i64 - 1).min(file_pages);
+        if last < start {
+            return Ok(());
+        }
+
+        let run = self.readahead_run(start, last)?;
+        if run.is_empty() {
+            return Ok(());
+        }
+
+        let pages: Vec<PageRef> = run
+            .iter()
+            .map(|idx| {
+                let page = Arc::new(Page::new(*idx));
+                page.set_locked();
+                page
+            })
+            .collect();
+        let buffers: Vec<Arc<Buffer>> = (0..pages.len())
+            .map(|_| Arc::new(self.buffer_pool.get_page()))
+            .collect();
+
+        let finish_pages = pages.clone();
+        let finish_buffers = buffers.clone();
+        let first = run[0];
+        let on_done = Box::new(move |res: Result<(), CompletionError>| {
+            match res {
+                Ok(()) => {
+                    for (i, page) in finish_pages.iter().enumerate() {
+                        sqlite3_ondisk::finish_read_page(
+                            first as usize + i,
+                            finish_buffers[i].clone(),
+                            page.clone(),
+                        );
+                    }
+                }
+                Err(err) => {
+                    // Leave the pages unloaded. `PrefetchBuffer::take` sees
+                    // the failed completion, drops the entry and lets the
+                    // demand read go to storage as if readahead never ran.
+                    tracing::debug!("readahead read starting at page {first} failed: {err}");
+                    for page in finish_pages.iter() {
+                        page.clear_locked();
+                    }
+                }
+            }
+        });
+
+        let io_ctx = self.io_ctx.read().clone();
+        let c = self
+            .db_file
+            .read_pages(first as usize, buffers, &io_ctx, on_done)?;
+
+        let mut prefetched = self.prefetched.lock();
+        for (i, page) in pages.into_iter().enumerate() {
+            prefetched.insert(first + i as i64, page, c.clone());
+        }
+        self.readahead_stats
+            .pages_fetched
+            .fetch_add(run.len() as u64, Ordering::Relaxed);
+        self.readahead_stats.reads.fetch_add(1, Ordering::Relaxed);
+        tracing::debug!("readahead fetched {} pages from {first}", run.len());
+        Ok(())
+    }
+
+    /// The leading run of pages in `[start, last]` that is worth and safe to
+    /// read from the database file. See [`Pager::issue_readahead`].
+    fn readahead_run(&self, start: i64, last: i64) -> Result<Vec<i64>> {
+        let prefetched = self.prefetched.lock();
+        let page_cache = self.page_cache.read();
+        let mut run = Vec::new();
+        for idx in start..=last {
+            if page_cache.contains_key(&PageCacheKey::new(idx as usize)) || prefetched.contains(idx)
+            {
+                break;
+            }
+            if let Some(wal) = self.wal.as_ref() {
+                // `find_frame` answers against this reader's snapshot, which
+                // is fixed for the life of the read transaction -- so a page
+                // with no frame now still has none when the reader gets to it.
+                if wal.find_frame(idx as u64, None)?.is_some() {
+                    break;
+                }
+            }
+            run.push(idx);
+        }
+        Ok(run)
     }
 
     fn begin_read_disk_page(
@@ -3496,6 +3832,11 @@ impl Pager {
             { "page_id": page.get().id }
         );
         self.subjournal_page_if_required(page)?;
+        // Anything readahead fetched for this page is a pre-write copy of it.
+        // Once the page is dirty that copy must never be handed to a reader:
+        // a dirty page can be spilled to the WAL and evicted, and the next
+        // read of it would otherwise find our stale copy instead of the frame.
+        self.forget_prefetched_page(page.get().id as i64);
         let mut dirty_pages = self.dirty_pages.write();
         dirty_pages.insert(page.get().id as u32);
         // Notify cache before marking dirty (page was evictable, now it won't be)
@@ -5064,6 +5405,7 @@ impl Pager {
 
     pub fn clear_page_cache(&self, clear_dirty: bool) {
         self.invalidate_all_cursors();
+        self.forget_readahead();
         let dirty_pages = self.dirty_pages.write();
         let mut cache = self.page_cache.write();
         for page_id in dirty_pages.iter() {
@@ -5742,6 +6084,7 @@ impl Pager {
 
     fn reset_internal_states(&self) {
         self.pending_reads.write().clear();
+        self.forget_readahead();
         *self.checkpoint_state.write() = CheckpointState::default();
         self.syncing.store(false, Ordering::SeqCst);
         self.commit_info.write().reset();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -62,24 +62,31 @@ use crate::storage::encryption::{CipherMode, EncryptionContext, EncryptionKey};
 /// SQLite's default maximum page count
 const DEFAULT_MAX_PAGE_COUNT: u32 = 0xfffffffe;
 
-/// Readahead window ceiling, in pages, out of the box. Zero means off.
+/// Readahead window ceiling, in pages, out of the box.
 ///
-/// Off by default because on an ordinary file it has not been shown to make
-/// queries faster. Measured over the whole TPC-H suite against the 1.2 GB
-/// database, with the page cache dropped before every run, readahead was
-/// within noise of no readahead (-0.5% total). The reason is that the kernel
-/// is already doing this: Linux read-ahead on that device is 8 MiB, sixty-four
-/// times the window here, so by the time the database asks for the next page
-/// the kernel has long since fetched it. Readahead removes syscalls -- 195,206
-/// to 8,827 on a full LINEITEM scan -- but on that path the syscalls were not
-/// what the query was waiting for.
+/// 32 pages is 128 KiB at the usual 4 KiB page size, which is also Linux's
+/// default `read_ahead_kb`.
 ///
-/// It is worth turning on when nothing underneath is reading ahead for you and
-/// a request costs much more than the bytes it moves: O_DIRECT, network block
-/// storage, a remote page server, an object store. `PRAGMA prefetch_pages = 32`
-/// is a reasonable starting point there (128 KiB at a 4 KiB page size, which is
-/// also Linux's own default read-ahead size).
-pub const DEFAULT_READAHEAD_WINDOW: u32 = 0;
+/// Whether this is worth anything depends entirely on whether something
+/// underneath is already reading ahead for us, and the two backends differ:
+///
+/// * `UringIO` sets `O_DIRECT` on the database file, so reads bypass the page
+///   cache and nothing prefetches. Measured on the 1.2 GB TPC-H database, a
+///   full LINEITEM scan goes 20.7s -> 10.5s and a scan with a filter goes
+///   12.1s -> 2.9s. This is what readahead is for.
+/// * `UnixIO` ignores the `direct` flag, so reads are buffered and Linux is
+///   already reading ahead -- 8 MiB on the machine this was measured on,
+///   sixty-four times this window. There the whole TPC-H suite came out
+///   within noise (-0.5%), because by the time we ask for the next page the
+///   kernel has long since fetched it.
+///
+/// So: a large win where it matters, and nothing measurable where it does
+/// not. On by default for that reason. Readahead removes syscalls either way
+/// -- 195,206 to 8,827 on a full LINEITEM scan -- but only in the first case
+/// were the syscalls what the query was waiting for.
+///
+/// Set `PRAGMA prefetch_pages = 0` to turn it off.
+pub const DEFAULT_READAHEAD_WINDOW: u32 = 32;
 
 /// Hard ceiling on `PRAGMA prefetch_pages`, so one connection cannot pin an
 /// unbounded amount of memory in prefetched pages.

--- a/core/storage/readahead.rs
+++ b/core/storage/readahead.rs
@@ -1,5 +1,11 @@
 //! Readahead: pull pages off storage before a scan asks for them.
 //!
+//! Off by default -- see [`crate::storage::pager::DEFAULT_READAHEAD_WINDOW`]
+//! for why, and for when it is worth turning on. In short: on an ordinary file
+//! the kernel already reads ahead further than this does, so there is nothing
+//! left to win; the case for it is storage where a request costs much more
+//! than the bytes it moves and nothing underneath is reading ahead for you.
+//!
 //! A table scan reads one page, waits for the disk, reads the next page, waits
 //! again. Each wait is a full round trip. On local NVMe that is tens of
 //! microseconds; on network storage it is milliseconds. The scan spends almost

--- a/core/storage/readahead.rs
+++ b/core/storage/readahead.rs
@@ -1,10 +1,10 @@
 //! Readahead: pull pages off storage before a scan asks for them.
 //!
 //! What this is worth depends on whether anything underneath is already
-//! reading ahead -- see [`crate::storage::pager::DEFAULT_READAHEAD_WINDOW`].
-//! With `O_DIRECT` (the `UringIO` backend) nothing is, and a TPC-H scan runs
-//! 2-4x faster with this on. With buffered reads the kernel is already doing
-//! it, further ahead than we do, and this comes out within noise.
+//! reading ahead -- see [`crate::storage::pager::DEFAULT_READAHEAD_WINDOW`]
+//! for the measurements. Buffered reads get a modest gain, because Linux is
+//! already reading ahead under them. `O_DIRECT` reads get a large one,
+//! because there the kernel's readahead is gone and nothing else replaces it.
 //!
 //! A table scan reads one page, waits for the disk, reads the next page, waits
 //! again. Each wait is a full round trip. On local NVMe that is tens of

--- a/core/storage/readahead.rs
+++ b/core/storage/readahead.rs
@@ -1,10 +1,10 @@
 //! Readahead: pull pages off storage before a scan asks for them.
 //!
-//! Off by default -- see [`crate::storage::pager::DEFAULT_READAHEAD_WINDOW`]
-//! for why, and for when it is worth turning on. In short: on an ordinary file
-//! the kernel already reads ahead further than this does, so there is nothing
-//! left to win; the case for it is storage where a request costs much more
-//! than the bytes it moves and nothing underneath is reading ahead for you.
+//! What this is worth depends on whether anything underneath is already
+//! reading ahead -- see [`crate::storage::pager::DEFAULT_READAHEAD_WINDOW`].
+//! With `O_DIRECT` (the `UringIO` backend) nothing is, and a TPC-H scan runs
+//! 2-4x faster with this on. With buffered reads the kernel is already doing
+//! it, further ahead than we do, and this comes out within noise.
 //!
 //! A table scan reads one page, waits for the disk, reads the next page, waits
 //! again. Each wait is a full round trip. On local NVMe that is tens of

--- a/core/storage/readahead.rs
+++ b/core/storage/readahead.rs
@@ -1,0 +1,767 @@
+//! Readahead: pull pages off storage before a scan asks for them.
+//!
+//! A table scan reads one page, waits for the disk, reads the next page, waits
+//! again. Each wait is a full round trip. On local NVMe that is tens of
+//! microseconds; on network storage it is milliseconds. The scan spends almost
+//! all of its time idle, and the storage device spends almost all of its time
+//! idle, because only one request is ever outstanding.
+//!
+//! Readahead fixes that by noticing a reader walking forward through the file
+//! and fetching a run of pages ahead of it in one request.
+//!
+//! # Why we key on physical page numbers
+//!
+//! A b-tree scan is not obviously a sequential file read: it descends interior
+//! pages, walks leaves, pops back up. But the pages it touches are laid out in
+//! near-perfect file order, because pages are handed out in ascending order as
+//! the table grows. Measured on the 1.2 GB TPC-H database (4 KiB pages), the
+//! page-to-page steps of a full scan are:
+//!
+//! | b-tree                        | step +1 | step +2 | within +1..+4 |
+//! |-------------------------------|---------|---------|---------------|
+//! | ORDERS (41 322 pages)         |  99.19% |   0.27% |        99.46% |
+//! | LINEITEM (195 198 pages)      |  87.51% |  11.87% |        99.46% |
+//! | PARTSUPP (30 411 pages)       |     ~87 |     ~12 |          ~99  |
+//! | sqlite_autoindex_LINEITEM_1   |   0.00% |   0.00% |         0.00% |
+//!
+//! LINEITEM's `+2` steps are the interior pages: one gets allocated after
+//! roughly every eight leaves, so the leaf run steps over it. That is why the
+//! test below is "did the reader move forward by at most [`MAX_FORWARD_GAP`]"
+//! and not "did it move forward by exactly one".
+//!
+//! The last row is the reason the test has an upper bound at all. That index's
+//! leaves sit nine or ten pages apart, interleaved with table pages. A policy
+//! that prefetched a fixed window ahead of every read would pull nine useless
+//! table pages for every useful index page: measured at 9x read amplification
+//! and 90-100% of prefetched pages never read. With a gap limit of 4 the
+//! stream never qualifies as sequential, so that scan prefetches nothing at
+//! all and costs exactly what it costs today.
+//!
+//! # Window sizing
+//!
+//! Once a stream qualifies, the window grows 4x, then 2x, then clamps -- the
+//! same ramp Linux uses in `get_next_ra_size()` (mm/readahead.c). Starting
+//! small keeps a short scan from paying for pages it will never reach;
+//! doubling gets a long scan to the cap within a handful of steps.
+//!
+//! Growth is worth having because the cost of a wrong guess is asymmetric: an
+//! unused prefetched page costs one page of bandwidth, while a missing page
+//! costs a whole round trip. But it has to be bounded, hence the clamp.
+//!
+//! # Keeping the pipe full
+//!
+//! Fetching a window only when we stall still leaves one stall per window. So,
+//! as Linux does, the first page of each window is a marker: when the reader
+//! reaches it, we queue the *next* window immediately, without waiting. In
+//! steady state the reader always has a full window of lead and never stalls.
+//! Simulated over the TPC-H scans above, that is the difference between ~15x
+//! and ~185x fewer blocking reads.
+//!
+//! # What this deliberately does not do
+//!
+//! It does not use the query plan to decide *how much* to fetch. A full scan
+//! of the index in the table above would tell us "every page of this b-tree
+//! will be read", which is true, and prefetching on that basis would still be
+//! 9x read amplification, because the pages are not where the guess says they
+//! are. Physical layout is the thing that decides whether readahead pays, so
+//! physical layout is what we measure.
+
+use std::collections::{HashMap, VecDeque};
+use std::num::NonZeroU32;
+
+use crate::io::Completion;
+use crate::storage::pager::PageRef;
+use crate::turso_assert;
+
+/// Largest forward jump that still counts as "this reader is walking forward".
+///
+/// Covers the interior pages a leaf run steps over (see the table above:
+/// 99.46% of steps in the TPC-H table scans land within +4) while excluding
+/// the strided index scan, whose steps are +9/+10.
+const MAX_FORWARD_GAP: i64 = 4;
+
+/// Forward steps a stream must take before we spend any I/O on it.
+///
+/// One step proves nothing: any two reads in a row are "forward" half the
+/// time. Two consecutive forward steps is enough evidence to risk one small
+/// window, and a scan reaches it immediately.
+const TRIGGER_RUN: u32 = 2;
+
+/// Size of the first window a stream earns, in pages.
+const INITIAL_WINDOW: u32 = 4;
+
+/// How many independent forward-walking readers we follow at once.
+///
+/// A join reads two tables in lockstep, an index-driven query reads an index
+/// and a table, so one detector is not enough. Four covers the plans we see
+/// without making the lookup a search problem; the coldest is recycled.
+const STREAM_COUNT: usize = 4;
+
+/// What the pager should do about a read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadaheadAction {
+    /// Nothing to fetch.
+    None,
+    /// Fetch `count` pages starting at `start`, best effort.
+    Fetch { start: i64, count: u32 },
+}
+
+/// One forward-walking reader.
+#[derive(Debug, Clone, Copy)]
+struct Stream {
+    /// Page this stream last saw. `None` marks a free slot.
+    last_page: Option<i64>,
+    /// Consecutive forward steps taken so far. A fresh stream has taken none:
+    /// seeing one page tells us nothing about where the reader is going.
+    run: u32,
+    /// Size of the last window we asked for, in pages. 0 before the first.
+    size: u32,
+    /// Last page of the window we have already asked for.
+    window_end: i64,
+    /// Reaching this page queues the next window.
+    marker: i64,
+    /// Bumped on every touch so the coldest stream can be recycled.
+    stamp: u64,
+}
+
+impl Stream {
+    const fn empty() -> Self {
+        Self {
+            last_page: None,
+            run: 0,
+            size: 0,
+            window_end: -1,
+            marker: -1,
+            stamp: 0,
+        }
+    }
+
+    fn restart(&mut self, page: i64, stamp: u64) {
+        self.last_page = Some(page);
+        self.run = 0;
+        self.size = 0;
+        self.window_end = -1;
+        self.marker = -1;
+        self.stamp = stamp;
+    }
+
+    /// Record that pages `[start, start + count)` are on their way.
+    ///
+    /// The marker goes on the first page of the window: the moment the reader
+    /// gets there we queue the window after it, which leaves the reader a full
+    /// window of lead. This is what Linux does with `async_size == size`.
+    fn arm(&mut self, start: i64, count: u32) {
+        self.window_end = start + count as i64 - 1;
+        self.marker = start;
+    }
+}
+
+/// Next window size, following Linux's `get_next_ra_size()`.
+fn grow(current: u32, max: u32) -> u32 {
+    if current == 0 {
+        return INITIAL_WINDOW.min(max);
+    }
+    if current < max / 16 {
+        return (current * 4).min(max);
+    }
+    if current <= max / 2 {
+        return (current * 2).min(max);
+    }
+    max
+}
+
+/// Tracks forward-walking readers and decides when to fetch ahead of them.
+///
+/// Pure policy: it never touches storage or the page cache, so the whole thing
+/// is exercised by unit tests below.
+#[derive(Debug)]
+pub struct Readahead {
+    streams: [Stream; STREAM_COUNT],
+    clock: u64,
+}
+
+impl Default for Readahead {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Readahead {
+    pub const fn new() -> Self {
+        Self {
+            streams: [Stream::empty(); STREAM_COUNT],
+            clock: 0,
+        }
+    }
+
+    /// Forget every stream. Called when what we know about the file stops
+    /// being true: end of a read transaction, page cache cleared, checkpoint.
+    pub fn reset(&mut self) {
+        self.streams = [Stream::empty(); STREAM_COUNT];
+    }
+
+    /// A cursor is about to scan a whole b-tree from one end.
+    ///
+    /// Skips the [`TRIGGER_RUN`] warmup for that b-tree's root, because the
+    /// plan already told us a walk is starting -- the same reasoning that
+    /// makes Linux treat a read at file offset 0 as sequential without waiting
+    /// for evidence.
+    ///
+    /// It does *not* skip the gap test: whether the walk turns out to be
+    /// physically sequential is a property of the layout, not of the plan, and
+    /// getting that wrong is the 9x-amplification case in the module docs.
+    pub fn hint_scan_start(&mut self, root_page: i64) {
+        self.clock += 1;
+        let slot = self.slot_for(root_page);
+        let clock = self.clock;
+        let stream = &mut self.streams[slot];
+        stream.restart(root_page, clock);
+        stream.run = TRIGGER_RUN;
+    }
+
+    /// Record a page read and say what, if anything, to fetch ahead of it.
+    ///
+    /// `cache_hit` is whether the read was served without going to storage.
+    /// `max_window` is the ceiling on window size in pages; `None` disables
+    /// readahead entirely.
+    pub fn on_read(
+        &mut self,
+        page: i64,
+        cache_hit: bool,
+        max_window: Option<NonZeroU32>,
+    ) -> ReadaheadAction {
+        let Some(max_window) = max_window else {
+            return ReadaheadAction::None;
+        };
+        let max_window = max_window.get();
+        self.clock += 1;
+        let clock = self.clock;
+
+        let Some(slot) = self.continue_stream(page, clock) else {
+            // Not a continuation of anything we are following: start over on
+            // the coldest slot. One step is not evidence, so nothing is
+            // fetched yet.
+            let slot = self.slot_for(page);
+            self.streams[slot].restart(page, clock);
+            return ReadaheadAction::None;
+        };
+
+        let stream = &mut self.streams[slot];
+        if stream.run < TRIGGER_RUN {
+            return ReadaheadAction::None;
+        }
+
+        if !cache_hit {
+            // We just went to storage anyway. Fetch a window from here so the
+            // next pages are already on their way.
+            stream.size = grow(stream.size, max_window);
+            let count = stream.size;
+            stream.arm(page + 1, count);
+            return ReadaheadAction::Fetch {
+                start: page + 1,
+                count,
+            };
+        }
+
+        // Served from memory. If the reader has reached the marker inside the
+        // window we already asked for, queue the next one now rather than
+        // waiting to stall at the end of it.
+        if stream.window_end >= page && page >= stream.marker {
+            stream.size = grow(stream.size, max_window);
+            let count = stream.size;
+            let start = stream.window_end + 1;
+            stream.arm(start, count);
+            return ReadaheadAction::Fetch { start, count };
+        }
+
+        ReadaheadAction::None
+    }
+
+    /// Advance whichever stream `page` continues, or `None` if it continues no
+    /// stream. A page that repeats the stream's last page is a re-read (the
+    /// pager retries reads after a cache spill) and neither advances nor
+    /// breaks the run.
+    fn continue_stream(&mut self, page: i64, clock: u64) -> Option<usize> {
+        for slot in 0..STREAM_COUNT {
+            let stream = &mut self.streams[slot];
+            let Some(last) = stream.last_page else {
+                continue;
+            };
+            if last == page {
+                stream.stamp = clock;
+                return Some(slot);
+            }
+            if page > last && page - last <= MAX_FORWARD_GAP {
+                stream.last_page = Some(page);
+                stream.run = stream.run.saturating_add(1);
+                stream.stamp = clock;
+                return Some(slot);
+            }
+        }
+        None
+    }
+
+    /// Free slot if there is one, otherwise the least recently touched.
+    fn slot_for(&self, page: i64) -> usize {
+        let _ = page;
+        let mut best = 0;
+        for slot in 0..STREAM_COUNT {
+            if self.streams[slot].last_page.is_none() {
+                return slot;
+            }
+            if self.streams[slot].stamp < self.streams[best].stamp {
+                best = slot;
+            }
+        }
+        best
+    }
+}
+
+/// A page fetched before anything asked for it.
+struct Prefetched {
+    page: PageRef,
+    /// The read covering this page. One read usually covers a whole run, so
+    /// several entries share a completion.
+    read: Completion,
+}
+
+/// What a demand read found waiting for it.
+pub enum PrefetchHit {
+    /// The page is here and its bytes have landed. No I/O at all.
+    Ready(PageRef),
+    /// The page is here and its read is still in flight. Wait on the
+    /// completion, which was issued earlier than a demand read would have
+    /// been.
+    InFlight(PageRef, Completion),
+}
+
+/// Pages fetched ahead of a reader, held aside until something asks for them.
+///
+/// Deliberately *not* the page cache. A guess that turns out wrong should cost
+/// bandwidth and nothing else; if wrong guesses went straight into the cache
+/// they would evict pages the query is still using, and readahead would make
+/// things slower exactly when it was least useful. Pages move into the real
+/// cache only when a read asks for them.
+///
+/// Bounded and evicted first-in-first-out. A reader consumes these in the
+/// order they were fetched, so the oldest entry is the one most likely to have
+/// been a bad guess.
+pub struct PrefetchBuffer {
+    pages: HashMap<i64, Prefetched>,
+    /// Insertion order, for the FIFO bound. May name pages already taken.
+    order: VecDeque<i64>,
+    capacity: usize,
+}
+
+impl PrefetchBuffer {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            pages: HashMap::new(),
+            order: VecDeque::new(),
+            capacity,
+        }
+    }
+
+    pub fn set_capacity(&mut self, capacity: usize) {
+        self.capacity = capacity;
+        self.trim();
+    }
+
+    pub fn len(&self) -> usize {
+        self.pages.len()
+    }
+
+    pub fn contains(&self, page_idx: i64) -> bool {
+        self.pages.contains_key(&page_idx)
+    }
+
+    /// Drop everything. Called whenever what these pages say about the
+    /// database might have stopped being true.
+    pub fn clear(&mut self) {
+        self.pages.clear();
+        self.order.clear();
+    }
+
+    pub fn insert(&mut self, page_idx: i64, page: PageRef, read: Completion) {
+        if self.capacity == 0 {
+            return;
+        }
+        if self
+            .pages
+            .insert(page_idx, Prefetched { page, read })
+            .is_none()
+        {
+            self.order.push_back(page_idx);
+        }
+        self.trim();
+    }
+
+    /// Hand over a prefetched page, if we have a usable one.
+    ///
+    /// A page whose read already failed is dropped and reported as absent, so
+    /// the caller falls back to an ordinary read and the failure never
+    /// reaches the query. Readahead is only ever an optimization.
+    pub fn take(&mut self, page_idx: i64) -> Option<PrefetchHit> {
+        let entry = self.pages.get(&page_idx)?;
+        let finished = entry.read.finished();
+        let failed = finished && !entry.read.succeeded();
+        if failed {
+            self.pages.remove(&page_idx);
+            return None;
+        }
+        let entry = self.pages.remove(&page_idx)?;
+        if finished {
+            turso_assert!(
+                entry.page.is_loaded(),
+                "a prefetched page whose read succeeded must be loaded",
+                { "page_idx": page_idx }
+            );
+            Some(PrefetchHit::Ready(entry.page))
+        } else {
+            Some(PrefetchHit::InFlight(entry.page, entry.read))
+        }
+    }
+
+    /// Forget one page, without disturbing the rest.
+    pub fn remove(&mut self, page_idx: i64) {
+        self.pages.remove(&page_idx);
+    }
+
+    fn trim(&mut self) {
+        while self.pages.len() > self.capacity {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            self.pages.remove(&oldest);
+        }
+        // Keep the order queue from growing without bound when entries are
+        // taken out by page number rather than evicted.
+        if self.order.len() > self.capacity.saturating_mul(4) + 8 {
+            self.order.retain(|idx| self.pages.contains_key(idx));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn window(n: u32) -> Option<NonZeroU32> {
+        NonZeroU32::new(n)
+    }
+
+    /// Reading the same pages over and over must never fetch anything: the
+    /// reader is not going anywhere.
+    #[test]
+    fn repeated_reads_of_one_page_fetch_nothing() {
+        let mut ra = Readahead::new();
+        for _ in 0..50 {
+            assert_eq!(ra.on_read(7, false, window(32)), ReadaheadAction::None);
+        }
+    }
+
+    /// A single forward step is not evidence of a scan.
+    #[test]
+    fn one_forward_step_fetches_nothing() {
+        let mut ra = Readahead::new();
+        assert_eq!(ra.on_read(10, false, window(32)), ReadaheadAction::None);
+        assert_eq!(ra.on_read(11, false, window(32)), ReadaheadAction::None);
+    }
+
+    /// Two forward steps earn the first, deliberately small, window.
+    #[test]
+    fn two_forward_steps_earn_the_first_window() {
+        let mut ra = Readahead::new();
+        ra.on_read(10, false, window(32));
+        ra.on_read(11, false, window(32));
+        assert_eq!(
+            ra.on_read(12, false, window(32)),
+            ReadaheadAction::Fetch {
+                start: 13,
+                count: INITIAL_WINDOW
+            }
+        );
+    }
+
+    /// Windows ramp 4x then 2x then stop at the ceiling, and never exceed it.
+    #[test]
+    fn window_grows_then_clamps_at_the_ceiling() {
+        assert_eq!(grow(0, 128), 4);
+        assert_eq!(grow(4, 128), 16); // 4x while below max/16
+        assert_eq!(grow(16, 128), 32); // 2x while at or below max/2
+        assert_eq!(grow(32, 128), 64);
+        assert_eq!(grow(64, 128), 128);
+        assert_eq!(grow(128, 128), 128); // clamped
+        for max in 1..=256u32 {
+            let mut size = 0;
+            for _ in 0..20 {
+                size = grow(size, max);
+                assert!(size <= max, "window {size} exceeded ceiling {max}");
+                assert!(size > 0);
+            }
+        }
+    }
+
+    /// A one-page ceiling still works and never returns a zero-page fetch.
+    #[test]
+    fn ceiling_of_one_page_is_honored() {
+        let mut ra = Readahead::new();
+        ra.on_read(10, false, window(1));
+        ra.on_read(11, false, window(1));
+        assert_eq!(
+            ra.on_read(12, false, window(1)),
+            ReadaheadAction::Fetch {
+                start: 13,
+                count: 1
+            }
+        );
+    }
+
+    /// Stepping over an interior page keeps the run going -- this is the
+    /// LINEITEM `+2` case, 12% of that scan's steps.
+    #[test]
+    fn small_forward_gaps_keep_the_run_alive() {
+        let mut ra = Readahead::new();
+        ra.on_read(10, false, window(32));
+        ra.on_read(12, false, window(32));
+        assert!(matches!(
+            ra.on_read(14, false, window(32)),
+            ReadaheadAction::Fetch { .. }
+        ));
+    }
+
+    /// A stride wider than the gap limit never qualifies. This is the
+    /// index-scan case that naive readahead turns into 9x read amplification.
+    #[test]
+    fn strided_reads_never_prefetch() {
+        let mut ra = Readahead::new();
+        let mut page = 100;
+        for _ in 0..200 {
+            assert_eq!(
+                ra.on_read(page, false, window(64)),
+                ReadaheadAction::None,
+                "a stride of 9 pages must never qualify as sequential"
+            );
+            page += 9;
+        }
+    }
+
+    /// Random access pays nothing.
+    #[test]
+    fn random_reads_never_prefetch() {
+        let mut ra = Readahead::new();
+        let mut seed = 12345u64;
+        for _ in 0..1000 {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let page = ((seed >> 33) % 100_000) as i64;
+            assert_eq!(ra.on_read(page, false, window(32)), ReadaheadAction::None);
+        }
+    }
+
+    /// Walking backwards is not something this fetches for.
+    #[test]
+    fn backwards_scan_never_prefetches() {
+        let mut ra = Readahead::new();
+        for page in (10..500).rev() {
+            assert_eq!(ra.on_read(page, false, window(32)), ReadaheadAction::None);
+        }
+    }
+
+    /// Breaking the pattern drops the window back to the smallest size, so a
+    /// reader that wanders off does not keep paying for a big window.
+    #[test]
+    fn breaking_the_pattern_resets_the_window() {
+        let mut ra = Readahead::new();
+        for page in 10..40 {
+            ra.on_read(page, false, window(64));
+        }
+        // Jump far away, then walk forward again from there.
+        ra.on_read(9000, false, window(64));
+        ra.on_read(9001, false, window(64));
+        assert_eq!(
+            ra.on_read(9002, false, window(64)),
+            ReadaheadAction::Fetch {
+                start: 9003,
+                count: INITIAL_WINDOW
+            }
+        );
+    }
+
+    /// Reaching the marker inside a window queues the next one without a
+    /// stall, and the windows tile the file without gaps or overlap.
+    #[test]
+    fn crossing_the_marker_queues_the_next_window_back_to_back() {
+        let mut ra = Readahead::new();
+        ra.on_read(10, false, window(32));
+        ra.on_read(11, false, window(32));
+        let ReadaheadAction::Fetch { start, count } = ra.on_read(12, false, window(32)) else {
+            panic!("expected a window");
+        };
+        assert_eq!((start, count), (13, 4));
+        // Page 13 is the marker: served from cache, but it queues 17..
+        let ReadaheadAction::Fetch { start, count } = ra.on_read(13, true, window(32)) else {
+            panic!("expected the next window to be queued on the marker");
+        };
+        assert_eq!(start, 17, "windows must tile without a gap");
+        assert_eq!(count, 8, "window should have grown");
+        // Pages inside the window that are not the marker queue nothing.
+        assert_eq!(ra.on_read(14, true, window(32)), ReadaheadAction::None);
+        assert_eq!(ra.on_read(15, true, window(32)), ReadaheadAction::None);
+    }
+
+    /// Two cursors walking two tables at once both get followed.
+    #[test]
+    fn interleaved_scans_are_tracked_separately() {
+        let mut ra = Readahead::new();
+        let mut a = 1000;
+        let mut b = 50_000;
+        let mut fetched_a = 0;
+        let mut fetched_b = 0;
+        for _ in 0..40 {
+            if let ReadaheadAction::Fetch { start, .. } = ra.on_read(a, false, window(32)) {
+                assert!(start > a && start < 40_000);
+                fetched_a += 1;
+            }
+            if let ReadaheadAction::Fetch { start, .. } = ra.on_read(b, false, window(32)) {
+                assert!(start > b);
+                fetched_b += 1;
+            }
+            a += 1;
+            b += 1;
+        }
+        assert!(fetched_a > 5, "stream A should have been followed");
+        assert!(fetched_b > 5, "stream B should have been followed");
+    }
+
+    /// More concurrent readers than slots: the busiest ones keep their state
+    /// and nothing panics or mixes streams up.
+    #[test]
+    fn more_readers_than_slots_recycles_the_coldest() {
+        let mut ra = Readahead::new();
+        let mut heads: Vec<i64> = (0..STREAM_COUNT as i64 + 3).map(|i| i * 100_000).collect();
+        for _ in 0..50 {
+            for head in heads.iter_mut() {
+                if let ReadaheadAction::Fetch { start, count } =
+                    ra.on_read(*head, false, window(32))
+                {
+                    assert!(start > *head);
+                    assert!(count > 0);
+                }
+                *head += 1;
+            }
+        }
+    }
+
+    /// The scan hint skips the warmup but not the sequentiality test.
+    #[test]
+    fn scan_hint_skips_warmup() {
+        let mut ra = Readahead::new();
+        ra.hint_scan_start(10);
+        assert_eq!(
+            ra.on_read(11, false, window(32)),
+            ReadaheadAction::Fetch {
+                start: 12,
+                count: INITIAL_WINDOW
+            },
+            "a hinted scan should not need to prove itself first"
+        );
+    }
+
+    /// A hinted scan whose pages turn out to be scattered still prefetches
+    /// nothing. The plan says "read this whole b-tree"; the layout says the
+    /// pages are not next to each other, and the layout wins.
+    #[test]
+    fn scan_hint_does_not_override_a_scattered_layout() {
+        let mut ra = Readahead::new();
+        ra.hint_scan_start(10);
+        let mut page = 10;
+        for _ in 0..100 {
+            page += 9;
+            assert_eq!(ra.on_read(page, false, window(32)), ReadaheadAction::None);
+        }
+    }
+
+    /// Zero window means completely off, whatever the access pattern.
+    #[test]
+    fn disabled_readahead_never_fetches() {
+        let mut ra = Readahead::new();
+        ra.hint_scan_start(10);
+        for page in 10..200 {
+            assert_eq!(ra.on_read(page, false, None), ReadaheadAction::None);
+        }
+    }
+
+    /// Reset forgets everything, so a reader has to earn its window again.
+    #[test]
+    fn reset_forgets_every_stream() {
+        let mut ra = Readahead::new();
+        for page in 10..40 {
+            ra.on_read(page, false, window(32));
+        }
+        ra.reset();
+        assert_eq!(ra.on_read(40, false, window(32)), ReadaheadAction::None);
+        assert_eq!(ra.on_read(41, false, window(32)), ReadaheadAction::None);
+        assert!(matches!(
+            ra.on_read(42, false, window(32)),
+            ReadaheadAction::Fetch { .. }
+        ));
+    }
+
+    /// The pager retries a read after a cache spill. Seeing the same page
+    /// twice must not count as progress or as a broken pattern.
+    #[test]
+    fn a_repeated_read_neither_advances_nor_breaks_the_run() {
+        let mut ra = Readahead::new();
+        ra.on_read(10, false, window(32));
+        ra.on_read(10, false, window(32));
+        ra.on_read(11, false, window(32));
+        ra.on_read(11, false, window(32));
+        assert_eq!(
+            ra.on_read(12, false, window(32)),
+            ReadaheadAction::Fetch {
+                start: 13,
+                count: INITIAL_WINDOW
+            }
+        );
+    }
+
+    /// Over a long sequential run every page is covered exactly once: windows
+    /// must never leave a gap (a stall we could have avoided) or overlap
+    /// (bandwidth we paid for twice).
+    #[test]
+    fn windows_tile_a_long_scan_exactly_once() {
+        let mut ra = Readahead::new();
+        let max = 32;
+        let mut covered: Vec<i64> = Vec::new();
+        let mut requested = std::collections::HashSet::new();
+        for page in 1..5000i64 {
+            // Anything already asked for reads from memory.
+            let hit = requested.contains(&page);
+            if let ReadaheadAction::Fetch { start, count } = ra.on_read(page, hit, window(max)) {
+                assert!(count <= max);
+                for p in start..start + count as i64 {
+                    assert!(
+                        requested.insert(p),
+                        "page {p} was asked for twice: windows overlap"
+                    );
+                    covered.push(p);
+                }
+            }
+        }
+        covered.sort_unstable();
+        for pair in covered.windows(2) {
+            assert_eq!(
+                pair[1] - pair[0],
+                1,
+                "windows left a gap between {} and {}",
+                pair[0],
+                pair[1]
+            );
+        }
+        assert!(
+            covered.len() > 4000,
+            "a 5000-page sequential scan should have been almost entirely covered, got {}",
+            covered.len()
+        );
+    }
+}

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -18,6 +18,7 @@ use crate::schema::{Schema, Table};
 use crate::storage::encryption::{CipherMode, EncryptionKey};
 use crate::storage::pager::AutoVacuumMode;
 use crate::storage::pager::Pager;
+use crate::storage::pager::MAX_READAHEAD_WINDOW;
 use crate::storage::sqlite3_ondisk::CacheSize;
 use crate::storage::wal::CheckpointMode;
 use crate::translate::emitter::{Resolver, TransactionMode};
@@ -775,6 +776,23 @@ fn update_pragma(
             let enabled = parse_pragma_enabled(&value);
             connection.set_vdbe_trace(enabled);
             Ok(TransactionMode::None)
+        }
+        PragmaName::PrefetchPages => {
+            let pages = match parse_signed_number(&value)? {
+                Value::Numeric(Numeric::Integer(pages))
+                    if (0..=MAX_READAHEAD_WINDOW as i64).contains(&pages) =>
+                {
+                    pages as u32
+                }
+                _ => bail_parse_error!(
+                    "prefetch_pages must be between 0 (off) and {MAX_READAHEAD_WINDOW}"
+                ),
+            };
+            pager.set_readahead_window(pages);
+            Ok(TransactionMode::None)
+        }
+        PragmaName::PrefetchStats => {
+            bail_parse_error!("prefetch_stats is read-only")
         }
 
         PragmaName::FunctionList => query_pragma(
@@ -1570,6 +1588,34 @@ fn query_pragma(
             Ok(TransactionMode::None)
         }
         PragmaName::VdbeTrace => Ok(TransactionMode::None),
+        PragmaName::PrefetchPages => {
+            let register = program.alloc_register();
+            program.emit_int(pager.readahead_window() as i64, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::PrefetchStats => {
+            let stats = pager.readahead_stats();
+            let start = program.alloc_registers(5);
+            for (i, value) in [
+                stats.hits,
+                stats.hits_in_flight,
+                stats.misses,
+                stats.pages_fetched,
+                stats.reads,
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                program.emit_int(value as i64, start + i);
+            }
+            program.emit_result_row(start, 5);
+            for column in ["hits", "hits_in_flight", "misses", "pages_fetched", "reads"] {
+                program.add_pragma_result_column(column.to_string());
+            }
+            Ok(TransactionMode::None)
+        }
         PragmaName::FreelistCount => {
             let value = pager.freepage_list();
             let register = program.alloc_register();

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1956,6 +1956,10 @@ pub enum PragmaName {
     EmptyResultCallbacks,
     /// VDBE opcode trace output
     VdbeTrace,
+    /// Largest number of pages to read ahead of a scan. 0 disables readahead.
+    PrefetchPages,
+    /// Readahead counters for this connection's pager.
+    PrefetchStats,
 }
 
 /// `CREATE TRIGGER` time

--- a/tests/integration/storage/mod.rs
+++ b/tests/integration/storage/mod.rs
@@ -2,5 +2,6 @@ mod autovacuum;
 #[cfg(feature = "checksum")]
 mod checksum;
 mod header_version;
+mod readahead;
 #[cfg(not(feature = "checksum"))]
 mod short_read;

--- a/tests/integration/storage/readahead.rs
+++ b/tests/integration/storage/readahead.rs
@@ -498,10 +498,8 @@ fn prefetch_pages_round_trips() {
     let rows = limbo_exec_rows(&conn, "PRAGMA prefetch_pages");
     assert_eq!(
         rows[0][0],
-        rusqlite::types::Value::Integer(0),
-        "readahead is off out of the box: on an ordinary file the kernel is \
-         already reading ahead, and this has not been shown to make queries \
-         faster there"
+        rusqlite::types::Value::Integer(32),
+        "readahead is on out of the box"
     );
 
     for pages in [0u32, 1, 16, 512] {

--- a/tests/integration/storage/readahead.rs
+++ b/tests/integration/storage/readahead.rs
@@ -498,8 +498,10 @@ fn prefetch_pages_round_trips() {
     let rows = limbo_exec_rows(&conn, "PRAGMA prefetch_pages");
     assert_eq!(
         rows[0][0],
-        rusqlite::types::Value::Integer(32),
-        "readahead should be on out of the box"
+        rusqlite::types::Value::Integer(0),
+        "readahead is off out of the box: on an ordinary file the kernel is \
+         already reading ahead, and this has not been shown to make queries \
+         faster there"
     );
 
     for pages in [0u32, 1, 16, 512] {

--- a/tests/integration/storage/readahead.rs
+++ b/tests/integration/storage/readahead.rs
@@ -1,0 +1,731 @@
+//! Readahead: does fetching pages before a scan asks for them actually cut the
+//! number of trips to storage, and does it leave every answer unchanged?
+//!
+//! The tests here count reads at the file layer, because that is what
+//! readahead is for. A scan that produces the right rows after ten thousand
+//! round trips has not been helped by anything.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use turso_core::{
+    io::FileSyncType, Buffer, Clock, Completion, Connection, Database, DatabaseOpts, File,
+    MonotonicInstant, OpenFlags, PlatformIO, SqliteDialect, WallClockInstant, IO,
+};
+
+use crate::common::{limbo_exec_rows, TempDatabase};
+
+/// Wraps a real IO and counts what the database asks the file layer to do.
+struct CountingIo {
+    inner: Arc<dyn IO>,
+    counts: Arc<Counts>,
+}
+
+#[derive(Default)]
+struct Counts {
+    /// Read requests reaching the file. This is the number that matters:
+    /// each one is a syscall, and on remote storage a round trip.
+    reads: AtomicU64,
+    /// Bytes those reads asked for. Readahead trades this up to trade reads
+    /// down, so a test that only watched reads could be fooled.
+    bytes_read: AtomicU64,
+}
+
+impl CountingIo {
+    fn new(inner: Arc<dyn IO>) -> Self {
+        Self {
+            inner,
+            counts: Arc::new(Counts::default()),
+        }
+    }
+
+    fn counts(&self) -> Arc<Counts> {
+        self.counts.clone()
+    }
+}
+
+impl Counts {
+    fn reads(&self) -> u64 {
+        self.reads.load(Ordering::Relaxed)
+    }
+
+    fn bytes_read(&self) -> u64 {
+        self.bytes_read.load(Ordering::Relaxed)
+    }
+
+    fn reset(&self) {
+        self.reads.store(0, Ordering::Relaxed);
+        self.bytes_read.store(0, Ordering::Relaxed);
+    }
+}
+
+impl Clock for CountingIo {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        self.inner.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        self.inner.current_time_wall_clock()
+    }
+}
+
+impl IO for CountingIo {
+    fn open_file(
+        &self,
+        path: &str,
+        flags: OpenFlags,
+        direct: bool,
+    ) -> turso_core::Result<Arc<dyn File>> {
+        let file = self.inner.open_file(path, flags, direct)?;
+        Ok(Arc::new(CountingFile {
+            inner: file,
+            counts: self.counts.clone(),
+            // Only the main database file is interesting; WAL traffic would
+            // add noise unrelated to readahead.
+            count: path.ends_with(".db"),
+        }))
+    }
+
+    fn remove_file(&self, path: &str) -> turso_core::Result<()> {
+        self.inner.remove_file(path)
+    }
+
+    fn step(&self) -> turso_core::Result<()> {
+        self.inner.step()
+    }
+}
+
+struct CountingFile {
+    inner: Arc<dyn File>,
+    counts: Arc<Counts>,
+    count: bool,
+}
+
+impl File for CountingFile {
+    fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
+        self.inner.lock_file(exclusive)
+    }
+
+    fn unlock_file(&self) -> turso_core::Result<()> {
+        self.inner.unlock_file()
+    }
+
+    fn pread(&self, pos: u64, c: Completion) -> turso_core::Result<Completion> {
+        if self.count {
+            self.counts.reads.fetch_add(1, Ordering::Relaxed);
+            self.counts
+                .bytes_read
+                .fetch_add(c.as_read().buf().len() as u64, Ordering::Relaxed);
+        }
+        self.inner.pread(pos, c)
+    }
+
+    /// Readahead reads a run of pages as one request. Counting it as one is
+    /// the whole point of these tests, so this must not fall back to the
+    /// trait default, which would split it back into one read per page.
+    fn preadv(
+        &self,
+        pos: u64,
+        buffers: Vec<Arc<Buffer>>,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        if self.count {
+            self.counts.reads.fetch_add(1, Ordering::Relaxed);
+            self.counts.bytes_read.fetch_add(
+                buffers.iter().map(|b| b.len() as u64).sum::<u64>(),
+                Ordering::Relaxed,
+            );
+        }
+        self.inner.preadv(pos, buffers, c)
+    }
+
+    fn pwrite(
+        &self,
+        pos: u64,
+        buffer: Arc<Buffer>,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        self.inner.pwrite(pos, buffer, c)
+    }
+
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> turso_core::Result<Completion> {
+        self.inner.sync(c, sync_type)
+    }
+
+    fn size(&self) -> turso_core::Result<u64> {
+        self.inner.size()
+    }
+
+    fn truncate(&self, len: u64, c: Completion) -> turso_core::Result<Completion> {
+        self.inner.truncate(len, c)
+    }
+}
+
+/// A database with enough rows that a scan crosses many pages, on a counting
+/// IO. Returns the connection and the counters.
+fn scan_database(name: &str, rows: usize) -> (Arc<Connection>, Arc<Counts>) {
+    let tmp = TempDatabase::new_empty();
+    let path = tmp.path.parent().unwrap().join(name);
+    let io = Arc::new(CountingIo::new(Arc::new(PlatformIO::new().unwrap())));
+    let counts = io.counts();
+    let db = Database::open_file_with_flags(
+        io,
+        path.to_str().unwrap(),
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("BEGIN").unwrap();
+    let filler = "x".repeat(200);
+    for i in 0..rows {
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{filler}')"))
+            .unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    // Start from cold memory so the scan really goes to the file.
+    conn.execute("PRAGMA cache_size = -80").unwrap();
+    (conn, counts)
+}
+
+fn scan_with_prefetch(conn: &Arc<Connection>, counts: &Counts, pages: u32) -> u64 {
+    conn.execute(format!("PRAGMA prefetch_pages = {pages}"))
+        .unwrap();
+    // Drop everything cached so both settings start from the same place.
+    conn.execute("PRAGMA cache_size = -20").unwrap();
+    conn.execute("PRAGMA cache_size = -80").unwrap();
+    counts.reset();
+    let rows = limbo_exec_rows(conn, "SELECT count(*), sum(id) FROM t");
+    assert_eq!(rows.len(), 1);
+    counts.reads()
+}
+
+/// The headline claim: a full table scan makes far fewer trips to storage
+/// with readahead on than off.
+#[test]
+fn full_scan_makes_far_fewer_reads() {
+    let (conn, counts) = scan_database("readahead-scan.db", 20_000);
+
+    let off = scan_with_prefetch(&conn, &counts, 0);
+    let on = scan_with_prefetch(&conn, &counts, 32);
+
+    assert!(
+        off > 500,
+        "the scan should be big enough to measure, but it only did {off} reads"
+    );
+    assert!(
+        on * 4 < off,
+        "readahead should cut reads by much more than 4x: {off} without, {on} with"
+    );
+}
+
+/// Whatever readahead does, the rows must be exactly the same. Checked across
+/// several window sizes and several shapes of query.
+#[test]
+fn results_are_identical_whatever_the_window() {
+    let (conn, _counts) = scan_database("readahead-identical.db", 5_000);
+    let queries = [
+        "SELECT count(*), sum(id) FROM t",
+        "SELECT id, v FROM t WHERE id % 997 = 3 ORDER BY id",
+        "SELECT count(*) FROM t WHERE v LIKE 'x%'",
+        "SELECT id FROM t ORDER BY id DESC LIMIT 50",
+        "SELECT a.id FROM t a JOIN t b ON a.id = b.id + 1 WHERE a.id < 100 ORDER BY a.id",
+        "SELECT min(id), max(id), count(DISTINCT id) FROM t",
+    ];
+
+    conn.execute("PRAGMA prefetch_pages = 0").unwrap();
+    let expected: Vec<_> = queries.iter().map(|q| limbo_exec_rows(&conn, q)).collect();
+
+    for pages in [1, 2, 7, 32, 64, 512] {
+        conn.execute(format!("PRAGMA prefetch_pages = {pages}"))
+            .unwrap();
+        for (query, want) in queries.iter().zip(expected.iter()) {
+            let got = limbo_exec_rows(&conn, query);
+            assert_eq!(
+                &got, want,
+                "prefetch_pages={pages} changed the answer to {query}"
+            );
+        }
+    }
+}
+
+/// Readahead must not make a reader that jumps around pay for pages it will
+/// never look at.
+#[test]
+fn random_access_reads_no_more_than_with_readahead_off() {
+    let (conn, counts) = scan_database("readahead-random.db", 20_000);
+    // Point lookups scattered across the table, in an order with no run in it.
+    let mut probes = String::new();
+    let mut key = 7919usize;
+    for _ in 0..200 {
+        key = key.wrapping_mul(48271) % 19_997;
+        probes.push_str(&format!("SELECT v FROM t WHERE id = {key};"));
+    }
+
+    let run = |pages: u32| {
+        conn.execute(format!("PRAGMA prefetch_pages = {pages}"))
+            .unwrap();
+        conn.execute("PRAGMA cache_size = -20").unwrap();
+        conn.execute("PRAGMA cache_size = -80").unwrap();
+        counts.reset();
+        for stmt in probes.split(';').filter(|s| !s.trim().is_empty()) {
+            limbo_exec_rows(&conn, stmt);
+        }
+        (counts.reads(), counts.bytes_read())
+    };
+
+    let (off_reads, off_bytes) = run(0);
+    let (on_reads, on_bytes) = run(32);
+
+    assert!(
+        on_reads <= off_reads + off_reads / 10,
+        "scattered point lookups should not read more with readahead on: \
+         {off_reads} reads off, {on_reads} on"
+    );
+    assert!(
+        on_bytes <= off_bytes + off_bytes / 10,
+        "scattered point lookups should not move more bytes with readahead on: \
+         {off_bytes} bytes off, {on_bytes} on"
+    );
+}
+
+/// Turning readahead off must really turn it off: no extra bytes at all.
+#[test]
+fn window_of_zero_reads_exactly_what_the_query_needs() {
+    let (conn, counts) = scan_database("readahead-off.db", 5_000);
+
+    conn.execute("PRAGMA prefetch_pages = 0").unwrap();
+    conn.execute("PRAGMA cache_size = -20").unwrap();
+    conn.execute("PRAGMA cache_size = -80").unwrap();
+    counts.reset();
+    limbo_exec_rows(&conn, "SELECT count(*) FROM t");
+    let (off_reads, off_bytes) = (counts.reads(), counts.bytes_read());
+
+    // With readahead off every read is exactly one page.
+    assert_eq!(
+        off_bytes % off_reads,
+        0,
+        "with readahead off each read should be one page: {off_reads} reads, {off_bytes} bytes"
+    );
+
+    let rows = limbo_exec_rows(&conn, "PRAGMA prefetch_stats");
+    // hits, hits_in_flight, pages_fetched and reads must all be zero.
+    let stats = &rows[0];
+    for (i, name) in ["hits", "hits_in_flight"].iter().enumerate() {
+        assert_eq!(
+            stats[i],
+            rusqlite::types::Value::Integer(0),
+            "{name} should be zero when readahead is off"
+        );
+    }
+    for (i, name) in ["pages_fetched", "reads"].iter().enumerate() {
+        assert_eq!(
+            stats[i + 3],
+            rusqlite::types::Value::Integer(0),
+            "{name} should be zero when readahead is off"
+        );
+    }
+}
+
+/// Readahead moves more bytes than the query strictly needs -- that is the
+/// trade. It must stay a small trade, not an open-ended one.
+#[test]
+fn extra_bytes_stay_a_small_fraction() {
+    let (conn, counts) = scan_database("readahead-amplification.db", 20_000);
+
+    conn.execute("PRAGMA prefetch_pages = 0").unwrap();
+    conn.execute("PRAGMA cache_size = -20").unwrap();
+    conn.execute("PRAGMA cache_size = -80").unwrap();
+    counts.reset();
+    limbo_exec_rows(&conn, "SELECT count(*), sum(id) FROM t");
+    let needed = counts.bytes_read();
+
+    conn.execute("PRAGMA prefetch_pages = 32").unwrap();
+    conn.execute("PRAGMA cache_size = -20").unwrap();
+    conn.execute("PRAGMA cache_size = -80").unwrap();
+    counts.reset();
+    limbo_exec_rows(&conn, "SELECT count(*), sum(id) FROM t");
+    let fetched = counts.bytes_read();
+
+    assert!(
+        fetched < needed * 3 / 2,
+        "readahead should not move anywhere near 1.5x the bytes: \
+         {needed} needed, {fetched} fetched"
+    );
+}
+
+/// A scan that runs while rows are being changed must see the writes. This is
+/// the case prefetched pages could get wrong: they are pre-write copies taken
+/// from the file, and handing one to a reader after the page was modified
+/// would serve stale data.
+#[test]
+fn writes_are_visible_to_a_later_scan() {
+    let (conn, _counts) = scan_database("readahead-writes.db", 4_000);
+    conn.execute("PRAGMA prefetch_pages = 32").unwrap();
+
+    // Warm readahead up with a scan so there are prefetched pages in hand.
+    limbo_exec_rows(&conn, "SELECT count(*) FROM t");
+
+    conn.execute("UPDATE t SET v = 'changed' WHERE id % 3 = 0")
+        .unwrap();
+
+    let rows = limbo_exec_rows(&conn, "SELECT count(*) FROM t WHERE v = 'changed'");
+    assert_eq!(
+        rows[0][0],
+        rusqlite::types::Value::Integer(1334),
+        "a scan after an update must see the update"
+    );
+
+    // And again after a checkpoint moves those frames into the file.
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    let rows = limbo_exec_rows(&conn, "SELECT count(*) FROM t WHERE v = 'changed'");
+    assert_eq!(rows[0][0], rusqlite::types::Value::Integer(1334));
+}
+
+/// Interleaving a scan with writes to the same pages, repeatedly, is the
+/// nastiest shape for a stale prefetched page to survive into. The row count
+/// must track the writes exactly every time.
+#[test]
+fn interleaved_reads_and_writes_never_serve_stale_pages() {
+    let (conn, _counts) = scan_database("readahead-interleaved.db", 3_000);
+    conn.execute("PRAGMA prefetch_pages = 32").unwrap();
+
+    for round in 1..=8i64 {
+        let marker = format!("round{round}");
+        conn.execute(format!(
+            "UPDATE t SET v = '{marker}' WHERE id % 8 = {}",
+            round % 8
+        ))
+        .unwrap();
+        let rows = limbo_exec_rows(
+            &conn,
+            &format!("SELECT count(*) FROM t WHERE v = '{marker}'"),
+        );
+        let want = (0..3_000i64).filter(|i| i % 8 == round % 8).count() as i64;
+        assert_eq!(
+            rows[0][0],
+            rusqlite::types::Value::Integer(want),
+            "round {round}: scan did not see the rows it just wrote"
+        );
+        if round % 3 == 0 {
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+        }
+    }
+}
+
+/// Two cursors walking two tables at once should both benefit; neither should
+/// get confused by the other.
+#[test]
+fn two_scans_at_once_both_get_faster() {
+    let tmp = TempDatabase::new_empty();
+    let path = tmp.path.parent().unwrap().join("readahead-two-tables.db");
+    let io = Arc::new(CountingIo::new(Arc::new(PlatformIO::new().unwrap())));
+    let counts = io.counts();
+    let db = Database::open_file_with_flags(
+        io,
+        path.to_str().unwrap(),
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    let filler = "y".repeat(200);
+    for table in ["a", "b"] {
+        conn.execute(format!(
+            "CREATE TABLE {table}(id INTEGER PRIMARY KEY, v TEXT)"
+        ))
+        .unwrap();
+        conn.execute("BEGIN").unwrap();
+        for i in 0..8_000 {
+            conn.execute(format!("INSERT INTO {table} VALUES({i}, '{filler}')"))
+                .unwrap();
+        }
+        conn.execute("COMMIT").unwrap();
+    }
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let query = "SELECT (SELECT count(*) FROM a), (SELECT count(*) FROM b)";
+    let run = |pages: u32| {
+        conn.execute(format!("PRAGMA prefetch_pages = {pages}"))
+            .unwrap();
+        conn.execute("PRAGMA cache_size = -20").unwrap();
+        conn.execute("PRAGMA cache_size = -80").unwrap();
+        counts.reset();
+        let rows = limbo_exec_rows(&conn, query);
+        (counts.reads(), rows)
+    };
+
+    let (off, off_rows) = run(0);
+    let (on, on_rows) = run(32);
+    assert_eq!(off_rows, on_rows, "readahead changed the answer");
+    assert!(
+        on * 3 < off,
+        "two interleaved scans should still get much cheaper: {off} reads off, {on} on"
+    );
+}
+
+/// A tiny page cache must not be flooded with guessed pages. Readahead bounds
+/// its window by what the cache can absorb, so a scan under memory pressure
+/// still finishes and still returns the right rows.
+#[test]
+fn a_tiny_cache_still_scans_correctly() {
+    let (conn, counts) = scan_database("readahead-tiny-cache.db", 5_000);
+    conn.execute("PRAGMA prefetch_pages = 512").unwrap();
+    // Ten pages of cache, against a 512-page window request.
+    conn.execute("PRAGMA cache_size = -40").unwrap();
+    counts.reset();
+    let rows = limbo_exec_rows(&conn, "SELECT count(*), sum(id) FROM t");
+    assert_eq!(rows[0][0], rusqlite::types::Value::Integer(5_000));
+    assert_eq!(
+        rows[0][1],
+        rusqlite::types::Value::Integer((0..5_000i64).sum::<i64>())
+    );
+}
+
+/// The setting is per-pager and readable back.
+#[test]
+fn prefetch_pages_round_trips() {
+    let tmp = TempDatabase::new_empty();
+    let conn = tmp.connect_limbo();
+    let rows = limbo_exec_rows(&conn, "PRAGMA prefetch_pages");
+    assert_eq!(
+        rows[0][0],
+        rusqlite::types::Value::Integer(32),
+        "readahead should be on out of the box"
+    );
+
+    for pages in [0u32, 1, 16, 512] {
+        conn.execute(format!("PRAGMA prefetch_pages = {pages}"))
+            .unwrap();
+        let rows = limbo_exec_rows(&conn, "PRAGMA prefetch_pages");
+        assert_eq!(rows[0][0], rusqlite::types::Value::Integer(pages as i64));
+    }
+}
+
+/// Out-of-range settings are rejected rather than silently clamped, so a
+/// deployment that asks for something impossible finds out.
+#[test]
+fn out_of_range_prefetch_pages_is_rejected() {
+    let tmp = TempDatabase::new_empty();
+    let conn = tmp.connect_limbo();
+    for bad in ["-1", "100000"] {
+        assert!(
+            conn.execute(format!("PRAGMA prefetch_pages = {bad}"))
+                .is_err(),
+            "prefetch_pages = {bad} should have been rejected"
+        );
+    }
+}
+
+/// Readahead accounting should show what it claims: on a long scan, most
+/// reads are served from pages fetched ahead of time, in far fewer requests
+/// than pages.
+#[test]
+fn stats_show_pages_arriving_in_batches() {
+    let (conn, _counts) = scan_database("readahead-stats.db", 20_000);
+    conn.execute("PRAGMA prefetch_pages = 32").unwrap();
+    conn.execute("PRAGMA cache_size = -20").unwrap();
+    conn.execute("PRAGMA cache_size = -80").unwrap();
+    limbo_exec_rows(&conn, "SELECT count(*), sum(id) FROM t");
+
+    let rows = limbo_exec_rows(&conn, "PRAGMA prefetch_stats");
+    let value = |i: usize| match &rows[0][i] {
+        rusqlite::types::Value::Integer(n) => *n as u64,
+        other => panic!("unexpected stat value {other:?}"),
+    };
+    let (hits, in_flight, misses, pages_fetched, reads) =
+        (value(0), value(1), value(2), value(3), value(4));
+
+    assert!(
+        hits + in_flight > misses * 4,
+        "most of a long scan should be served by readahead: \
+         {hits} hits, {in_flight} in flight, {misses} misses"
+    );
+    assert!(reads > 0, "readahead should have made some requests");
+    assert!(
+        pages_fetched / reads >= 4,
+        "readahead should move several pages per request, got {pages_fetched} pages in {reads} reads"
+    );
+}
+
+/// Running the same scan over and over must not cost more each time.
+///
+/// Prefetched pages are held outside the page cache, so if they were not
+/// bounded and released they would pile up and every run would read more than
+/// the last. The exact byte count moves around a little as the page cache
+/// settles, so the check is that it never grows past the first run.
+#[test]
+fn repeated_scans_do_not_cost_more_each_time() {
+    let (conn, counts) = scan_database("readahead-repeat.db", 4_000);
+    conn.execute("PRAGMA prefetch_pages = 32").unwrap();
+    let expected = limbo_exec_rows(&conn, "SELECT count(*), sum(id) FROM t");
+
+    counts.reset();
+    limbo_exec_rows(&conn, "SELECT count(*), sum(id) FROM t");
+    let first = counts.bytes_read();
+    assert!(first > 0, "the scan should have read something");
+
+    for run in 2..=10 {
+        counts.reset();
+        let rows = limbo_exec_rows(&conn, "SELECT count(*), sum(id) FROM t");
+        assert_eq!(rows, expected, "run {run} returned different rows");
+        let bytes = counts.bytes_read();
+        assert!(
+            bytes <= first,
+            "run {run} read {bytes} bytes, more than the first run's {first}: \
+             prefetched pages are piling up"
+        );
+    }
+}
+
+/// Readahead is an optimization, never a source of failure: if a prefetch read
+/// fails, the query must still get its rows from an ordinary read.
+#[test]
+fn a_failing_prefetch_does_not_fail_the_query() {
+    let tmp = TempDatabase::new_empty();
+    let path = tmp.path.parent().unwrap().join("readahead-failing.db");
+    let failing = Arc::new(FailPrefetchIo {
+        inner: Arc::new(PlatformIO::new().unwrap()),
+        fail_multi_page: Arc::new(AtomicU64::new(0)),
+        page_size: Mutex::new(HashMap::new()),
+    });
+    let fail_flag = failing.fail_multi_page.clone();
+    let db = Database::open_file_with_flags(
+        failing,
+        path.to_str().unwrap(),
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("BEGIN").unwrap();
+    let filler = "z".repeat(200);
+    for i in 0..5_000 {
+        conn.execute(format!("INSERT INTO t VALUES({i}, '{filler}')"))
+            .unwrap();
+    }
+    conn.execute("COMMIT").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    conn.execute("PRAGMA prefetch_pages = 32").unwrap();
+    conn.execute("PRAGMA cache_size = -80").unwrap();
+
+    // Every multi-page read from now on fails.
+    fail_flag.store(1, Ordering::SeqCst);
+    let rows = limbo_exec_rows(&conn, "SELECT count(*), sum(id) FROM t");
+    assert_eq!(rows[0][0], rusqlite::types::Value::Integer(5_000));
+    assert_eq!(
+        rows[0][1],
+        rusqlite::types::Value::Integer((0..5_000i64).sum::<i64>())
+    );
+}
+
+/// An IO that fails any read larger than one page. Readahead reads a run of
+/// pages as one request, so this fails exactly the prefetches and nothing else.
+struct FailPrefetchIo {
+    inner: Arc<dyn IO>,
+    fail_multi_page: Arc<AtomicU64>,
+    page_size: Mutex<HashMap<String, usize>>,
+}
+
+impl Clock for FailPrefetchIo {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        self.inner.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        self.inner.current_time_wall_clock()
+    }
+}
+
+impl IO for FailPrefetchIo {
+    fn open_file(
+        &self,
+        path: &str,
+        flags: OpenFlags,
+        direct: bool,
+    ) -> turso_core::Result<Arc<dyn File>> {
+        self.page_size.lock().unwrap().insert(path.to_string(), 0);
+        let file = self.inner.open_file(path, flags, direct)?;
+        Ok(Arc::new(FailPrefetchFile {
+            inner: file,
+            fail_multi_page: self.fail_multi_page.clone(),
+            applies: path.ends_with(".db"),
+        }))
+    }
+
+    fn remove_file(&self, path: &str) -> turso_core::Result<()> {
+        self.inner.remove_file(path)
+    }
+
+    fn step(&self) -> turso_core::Result<()> {
+        self.inner.step()
+    }
+}
+
+struct FailPrefetchFile {
+    inner: Arc<dyn File>,
+    fail_multi_page: Arc<AtomicU64>,
+    applies: bool,
+}
+
+impl File for FailPrefetchFile {
+    fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
+        self.inner.lock_file(exclusive)
+    }
+
+    fn unlock_file(&self) -> turso_core::Result<()> {
+        self.inner.unlock_file()
+    }
+
+    fn pread(&self, pos: u64, c: Completion) -> turso_core::Result<Completion> {
+        self.inner.pread(pos, c)
+    }
+
+    /// Readahead is the only thing that reads a run of pages in one request,
+    /// so failing this fails exactly the prefetches and nothing else.
+    fn preadv(
+        &self,
+        pos: u64,
+        buffers: Vec<Arc<Buffer>>,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        if self.applies && self.fail_multi_page.load(Ordering::SeqCst) == 1 {
+            c.error(turso_core::CompletionError::Aborted);
+            return Ok(c);
+        }
+        self.inner.preadv(pos, buffers, c)
+    }
+
+    fn pwrite(
+        &self,
+        pos: u64,
+        buffer: Arc<Buffer>,
+        c: Completion,
+    ) -> turso_core::Result<Completion> {
+        self.inner.pwrite(pos, buffer, c)
+    }
+
+    fn sync(&self, c: Completion, sync_type: FileSyncType) -> turso_core::Result<Completion> {
+        self.inner.sync(c, sync_type)
+    }
+
+    fn size(&self) -> turso_core::Result<u64> {
+        self.inner.size()
+    }
+
+    fn truncate(&self, len: u64, c: Completion) -> turso_core::Result<Completion> {
+        self.inner.truncate(len, c)
+    }
+}


### PR DESCRIPTION
## Description

Readahead for the page cache: notice a reader walking forward through the file and fetch a run of pages ahead of it in one request.

New surface:

- `PRAGMA prefetch_pages` — window ceiling in pages. Default `32`, `0` disables, max `512`.
- `PRAGMA prefetch_stats` — `hits`, `hits_in_flight`, `misses`, `pages_fetched`, `reads`.
- `DatabaseStorage::read_pages` and `File::preadv`, both with defaults that fan out to the single-item call, so every storage and IO backend works unchanged.

## Measurements

What this buys depends on whether anything underneath is already reading ahead, and the two IO backends differ on exactly that. 1.2 GB TPC-H database, cold every run, best of three, one binary throughout — Q1 and Q6, both `LINEITEM` scans:

| backend | readahead | Q1 | Q6 |
|---|---|---|---|
| `UnixIO` (buffered, CLI default) | off | 18.4 s | 4.4 s |
| `UnixIO` (buffered) | **32** | 16.6 s | 3.7 s |
| `UringIO` (`O_DIRECT`) | off | **28.6 s** | **17.5 s** |
| `UringIO` (`O_DIRECT`) | **32** | 15.0 s | 4.1 s |

**Buffered reads get a modest gain.** They go through the page cache, where Linux is already reading ahead — `read_ahead_kb` is 8 MiB on this machine, sixty-four times our window — so by the time we ask for the next page it is usually already there. 10-15% on a scan; across the whole 22-query suite it came out at −0.5%, i.e. nothing, since most of that suite is not read-bound.

**The third row is the one that matters.** `O_DIRECT` skips the page cache, so the kernel's readahead goes with it and nothing takes its place: every page becomes its own round trip, and the scan lands **four times slower than buffered**. Readahead is what puts that back. Only with it does the direct path reach parity.

So this earns its place on both backends for different reasons — a small gain on the buffered one, and on the direct one the difference between usable and not. On by default for that reason.

Full suite under `O_DIRECT`, off vs on: **−10.9% total, −12.8% median, 20 of 22 queries improved, all 22 byte-identical.** Biggest movers Q12 −78.5%, Q15 −77.8%, Q6 −75.2%, Q18 −56.2%, Q14 −53.8%. (That table's Q1 entry reads +13.2%, which disagrees with everything else; re-measured five times each it is `off: 20657 20934 20154 20307 20946` vs `=32: 10751 10548 10479 11104 9481` — the suite entry was one perturbed best-of-2 run.)

Readahead removes syscalls on both paths — 195,206 → 8,827 on a full `LINEITEM` scan (`strace -c -e trace=pread64`), 1.118x bytes — but only under `O_DIRECT` were the syscalls what the query was waiting for.

**On CodSpeed:** simulation mode counts userspace instructions. Round trips to storage are not instructions, so it cannot see what this changes and may show a small regression from the added bookkeeping. The `readahead_benchmark` here reports 89.5 ms → 32.6 ms for `per_request_cost`, but that is a **model** (an IO charging a fixed 10 µs per request) and is labelled as one in the file — the table above is the measured result.

## Design, and the constant that matters

A b-tree scan is not obviously a sequential file read, but pages are handed out in ascending order as a table grows. Measured over the real TPC-H b-trees in scan order:

| b-tree | step +1 | step +2 | within +1..+4 |
|---|---|---|---|
| ORDERS (41,322 pages) | 99.19% | 0.27% | 99.46% |
| LINEITEM (195,198 pages) | 87.51% | 11.87% | 99.46% |
| `sqlite_autoindex_LINEITEM_1` (23,030 pages) | 0.00% | 0.00% | **0.00%** |

LINEITEM's `+2` steps are interior pages the leaf run steps over, so the test is "forward by at most 4", not "+1".

**The upper bound on that gap is the half that matters.** That index's leaves sit nine or ten pages apart, interleaved with table pages. A policy that prefetched a fixed window ahead of every read turns that scan into **9x read amplification with 90-100% of prefetched pages never read**. At a gap limit of 4 the stream never qualifies, so that scan prefetches nothing — visible in the results as `count(*) FROM LINEITEM` (which walks that index) coming out at −0.7%.

So the rule is physical, not plan-based. `rewind()` does tell readahead a whole-b-tree walk is starting, which skips the two-step warmup — the database's version of Linux treating a read at offset 0 as sequential on sight — but it deliberately does not bypass the layout test.

Window growth follows Linux's `get_next_ra_size()` (4x, 2x, clamp). The first page of each window is a marker: reaching it queues the next window rather than stalling at the end of this one.

## Safety

Prefetched pages are held **outside** the page cache until something reads them, so a wrong guess costs bandwidth and never evicts a page the query is using.

- A failed prefetch read is dropped and the demand read goes to storage as if readahead never ran.
- Pages with a WAL frame in the reader's snapshot are skipped — the file copy is not what that reader should see.
- The buffer is dropped whenever the snapshot can no longer be assumed: read transaction ends, a page is dirtied, the cache is cleared.
- The window is capped at an eighth of the page cache.

## Testing

- 19 policy unit tests: window math against every ceiling from 1 to 256, gap tolerance, strided/random/backward access never prefetching, marker re-arm, windows tiling a long scan with no gap and no overlap, the scan hint not overriding a scattered layout.
- 14 integration tests counting reads at the file layer: read reduction, identical results across six window sizes and six query shapes, scattered lookups reading no more than with readahead off, writes visible to a later scan, interleaved reads and writes never serving a stale page, a page cache ten pages wide against a 512-page window, and a prefetch IO that fails every multi-page read still returning correct rows.
- Full suite: 2344 core lib tests, 1071 integration tests, `cargo clippy --workspace --all-features --all-targets --deny=warnings` clean.
- End to end: all 22 TPC-H queries byte-identical against a `main` build, under both IO backends.

## A note on `io_uring`

`cli/input.rs` carries `Io::Syscall // FIXME: make io_uring faster so it can be the default`. The third row above is a concrete piece of that: `O_DIRECT` gives up the kernel's readahead and, until now, nothing replaced it, so the direct path was paying a 4x penalty on scans before any of io_uring's advantages could show. This does not make io_uring the better default on its own — after readahead the two are roughly at parity here — but it removes one specific reason it was behind.

(An earlier revision of this description suggested `UnixIO` ignoring the `direct` flag was an oversight. That was wrong and is retracted: `O_DIRECT` without a deep queue *and* without readahead is strictly worse, by 4x in the table above. The flag is a hint only a backend able to exploit it should act on, and `UnixIO` is right to decline.)

## Description of AI Usage

Written by Claude Code (Opus 5), driven end to end from a prompt asking for a prefetching strategy with an exponential window, configurability, and benchmarks.

Worth calling out:

- **The constants came from measurement.** Before writing code it parsed the TPC-H b-trees to extract the exact page-visit order of each scan and simulated candidate policies over those traces. The gap-of-4 cutoff and the `sqlite_autoindex_LINEITEM_1` counter-example — the case that rules out the obvious naive policy — came from that data.
- **Its own tests caught two of its own bugs**: a run counter that counted pages instead of forward steps, and test instrumentation that was silently re-splitting the vectored read and measuring the wrong path.
- **It got the headline wrong three times, and every correction came from being pushed rather than from noticing.** First it claimed a speedup from a model without measuring; the real TPC-H harness showed a wash and it flipped the default off. Then a question about `O_DIRECT` exposed that the wash was measured only on the backend where the kernel already prefetches, so the default went back on — but it then cited the `O_DIRECT` numbers as a flat "2-4x", omitting that `O_DIRECT` starts from a 4x deficit, which flattered the result. Only the four-way table above settles it. Its comparison script also had a `bc` scale bug that quantized every delta to a multiple of 10%. The numbers here are the corrected ones.

The committer is responsible for reviewing the output.