### PR TITLE
Fix WAL frame-1 checksum after savepoint rollback and cache spill

### DIFF
--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4525,9 +4525,12 @@ impl Wal for WalFile {
         let page_transform = self.io_ctx.read().page_transform().clone();
 
         // Rolling checksum input to each frame build
-        let mut rolling_checksum: (u32, u32) = *self.last_checksum.read();
-
         let mut next_frame_id = self.max_frame.load(Ordering::Acquire) + 1;
+        let mut rolling_checksum = if next_frame_id == 1 {
+            (header.checksum_1, header.checksum_2)
+        } else {
+            *self.last_checksum.read()
+        };
         // Build every frame in order, updating the rolling checksum
         for page in pages.iter() {
             tracing::debug!("append_frames_vectored: page_id={}", page.get().id);

--- a/tests/integration/checkpoint_crash_atomicity.rs
+++ b/tests/integration/checkpoint_crash_atomicity.rs
@@ -227,6 +227,99 @@ fn full_commit_right_after_truncate_checkpoint_survives_power_loss() -> anyhow::
     Ok(())
 }
 
+#[test]
+fn savepoint_spill_crash_image_matches_sqlite_recovery() -> anyhow::Result<()> {
+    let db_path_sim = "savepoint-spill-sqlite-recovery.db";
+    const N_ROWS: usize = 82;
+    let old = "o".repeat(4096);
+    let new = "n".repeat(4096);
+    let io = Arc::new(UnreliableIo::new());
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        db_path_sim,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )?;
+    let conn = db.connect()?;
+    conn.execute("PRAGMA synchronous=FULL")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v BLOB)")?;
+    conn.execute("CREATE INDEX t_anchor_idx ON t(id, v)")?;
+    conn.execute("BEGIN IMMEDIATE")?;
+    for id in 1..=N_ROWS {
+        conn.execute(format!(
+            "INSERT INTO t VALUES ({id}, CAST('{old}' AS BLOB))"
+        ))?;
+    }
+    conn.execute("COMMIT")?;
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+    io.mark_all_durable();
+
+    conn.execute("PRAGMA cache_size=200")?;
+    conn.execute("BEGIN IMMEDIATE")?;
+    conn.execute("SAVEPOINT rollback_spill")?;
+    conn.execute("UPDATE t SET v = v || zeroblob(1024)")?;
+    conn.execute("ROLLBACK TO rollback_spill")?;
+    conn.execute("RELEASE rollback_spill")?;
+    conn.execute(format!("UPDATE t SET v = CAST('{new}' AS BLOB)"))?;
+    conn.execute("COMMIT")?;
+
+    let durable = io.durable_files();
+    let durable_db = durable
+        .get(db_path_sim)
+        .expect("the checkpointed main database must be durable");
+    let wal_path_sim = format!("{db_path_sim}-wal");
+    let durable_wal = durable
+        .get(&wal_path_sim)
+        .expect("the acknowledged FULL commit must leave a durable WAL");
+    assert!(
+        !durable_wal.is_empty(),
+        "the acknowledged FULL commit must leave durable WAL frames"
+    );
+
+    let sqlite_dir = tempfile::TempDir::new()?;
+    let sqlite_db_path = sqlite_dir.path().join("recovered.db");
+    std::fs::write(&sqlite_db_path, durable_db)?;
+    std::fs::write(sqlite_dir.path().join("recovered.db-wal"), durable_wal)?;
+
+    let (_turso_dir, turso_recovered) = crash_now_and_recover(&io, db_path_sim)?;
+    let table_sql = format!("SELECT COUNT(*) FROM t NOT INDEXED WHERE v = CAST('{new}' AS BLOB)");
+    let index_sql =
+        format!("SELECT COUNT(*) FROM t INDEXED BY t_anchor_idx WHERE v = CAST('{new}' AS BLOB)");
+    let turso_result = (
+        query_rows(&turso_recovered, "PRAGMA integrity_check")?,
+        query_rows(&turso_recovered, &table_sql)?,
+        query_rows(&turso_recovered, &index_sql)?,
+    );
+
+    let sqlite = rusqlite::Connection::open(sqlite_db_path)?;
+    let sqlite_result = (
+        vec![sqlite.query_row("PRAGMA integrity_check", [], |row| row.get::<_, String>(0))?],
+        vec![sqlite
+            .query_row(&table_sql, [], |row| row.get::<_, i64>(0))?
+            .to_string()],
+        vec![sqlite
+            .query_row(&index_sql, [], |row| row.get::<_, i64>(0))?
+            .to_string()],
+    );
+    let expected = (
+        vec!["ok".to_string()],
+        vec![N_ROWS.to_string()],
+        vec![N_ROWS.to_string()],
+    );
+
+    assert_eq!(
+        turso_result, sqlite_result,
+        "Turso and SQLite recovered different states from identical durable files"
+    );
+    assert_eq!(
+        sqlite_result, expected,
+        "SQLite rejected Turso's acknowledged commit from the durable WAL"
+    );
+    Ok(())
+}
+
 /// The same gate for the very first commit of a brand-new database: nothing
 /// has raised the WAL dirty flag yet, so before the fix the commit returned
 /// with all of its frames still unsynced.


### PR DESCRIPTION
WAL checksums form a chain: frame 1 chains from the header, frame `n` from frame `n-1`. Recovery walks the chain from the header and stops at the first mismatch.

for example lets take this

```sql
PRAGMA wal_checkpoint(TRUNCATE);
PRAGMA cache_size=200;         -- small enough to force spills
BEGIN IMMEDIATE;
SAVEPOINT sp;                  -- saves (frame 0, old checksum let's say X)
UPDATE t SET v = v || ...;     -- spill writes header H, frames seeded from H
ROLLBACK TO sp;                -- restores frame 0 and checksum X
RELEASE sp;
UPDATE t SET v = ...;          -- spills again, seeds from last_checksum = X, not H 
COMMIT;                        -- everything looks fine here so we return ok
```

The second spill seeds its checksum from `last_checksum`, which is now `X`. So frame 1 chains from `X` instead of `H`:
Live reads don't check checksums, so after a power cut, recovery sees frame 1 doesn't chain from `H` and keeps zero frames. The commit is gone, if we supply this wal to sqlite sqlite also does the same since wal is bad.


## **Fix:** 
in `append_frames_vectored`, if the next frame id is 1, seed from the header checksum instead of `last_checksum`.  
remaining all other frames use just normal `last_checksum` path


## note:
this was found while adding durability testing to simulator - will most likely have a pr on this friday.
## AI discolsure:
used claude for review and tests