### PR TITLE
core/translate: Fix correlated rowid reads from covering index scans

### DIFF
--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -2677,7 +2677,7 @@ pub fn translate_expr(
         } => {
             let referenced_tables =
                 referenced_tables.expect("table_references needed translating Expr::RowId");
-            let (_, table) = referenced_tables
+            let (is_from_outer_query_scope, table) = referenced_tables
                 .find_table_by_internal_id(*table_ref_id)
                 .expect("table reference should be found");
             let Table::BTree(btree) = table else {
@@ -2685,6 +2685,26 @@ pub fn translate_expr(
             };
             if !btree.has_rowid {
                 crate::bail_parse_error!("no such column: rowid");
+            }
+
+            if is_from_outer_query_scope {
+                // A correlated subquery does not know whether the outer scan opened the
+                // table cursor or only a covering-index cursor.
+                if let Some(cursor_id) =
+                    program.resolve_cursor_id_safe(&CursorKey::table(*table_ref_id))
+                {
+                    program.emit_insn(Insn::RowId {
+                        cursor_id,
+                        dest: target_register,
+                    });
+                } else {
+                    let cursor_id = program.resolve_any_index_cursor_id_for_table(*table_ref_id);
+                    program.emit_insn(Insn::IdxRowId {
+                        cursor_id,
+                        dest: target_register,
+                    });
+                }
+                return Ok(target_register);
             }
 
             // When a cursor override is active, always read rowid from the override cursor.

--- a/sqlite/conformance/sqlite-sqltests/indexed_by.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/indexed_by.sqltest
@@ -189,3 +189,17 @@ test indexed-by-attached-update-delete {
 expect {
     1|updated
 }
+
+test indexed-by-correlated-rowid-from-covering-index {
+    CREATE TABLE t18(a, b);
+    CREATE INDEX i18 ON t18(a);
+    INSERT INTO t18 VALUES(2, 'x'), (1, 'y');
+    SELECT a, (SELECT t18.rowid)
+      FROM t18 INDEXED BY i18
+     WHERE a >= 1
+     ORDER BY a;
+}
+expect {
+    1|2
+    2|1
+}


### PR DESCRIPTION

A correlated subquery reading the outer query's rowid panics when the outer scan uses a covering index:

```sql
CREATE TABLE t(a, b);
CREATE INDEX i ON t(a);
INSERT INTO t VALUES(2, 'x'), (1, 'y');

SELECT a, (SELECT t.rowid)
FROM t INDEXED BY i
WHERE a >= 1
ORDER BY a;
```

Secondary indexes store the table rowid alongside their indexed columns. Since `i` contains both `a` and the rowid, the outer query is a covering index scan: the planner opens the index cursor without opening the table cursor.

Inside a correlated subquery, the expression translator finds t in the outer scope but previously discarded that fact. It then tried to resolve the omitted table cursor and panicked:

```text
Cursor not found: CursorKey { table_reference_id: TableInternalId(1), index: None, is_build: false }
```

## **Fix:**
 keep track of whether the rowid belongs to an outer query. Use its table cursor when one is open; otherwise read the rowid from its existing index cursor with `IdxRowId`.

