### PR TITLE
core/storage: look for ASCII before validating a short TEXT payload

### DIFF
--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -975,6 +975,66 @@ pub fn validate_serial_type(value: u64) -> Result<()> {
     Ok(())
 }
 
+/// Payload length from which `simdutf8` runs its SIMD kernel. Anything
+/// shorter it hands to the standard library, which walks the bytes one at a
+/// time.
+const SIMD_UTF8_MIN_LEN: usize = 64;
+
+/// Number of bytes read per step by [`is_all_ascii`].
+const ASCII_STEP: usize = 8;
+
+/// True when every byte is ASCII, meaning `0x00..=0x7F`.
+///
+/// Reads eight bytes at a time and ORs them together, so it costs one load
+/// and one OR per eight bytes and never branches on a byte's value. The final
+/// eight bytes are read overlapping the step before them, which re-reads a
+/// few bytes instead of looping over the leftovers one at a time.
+#[inline(always)]
+fn is_all_ascii(bytes: &[u8]) -> bool {
+    const HIGH_BITS: u64 = 0x8080_8080_8080_8080;
+
+    let len = bytes.len();
+    if len < ASCII_STEP {
+        let mut folded = 0u8;
+        for &byte in bytes {
+            folded |= byte;
+        }
+        return folded & 0x80 == 0;
+    }
+    let mut folded = 0u64;
+    let mut at = 0;
+    while at + ASCII_STEP <= len {
+        folded |= u64::from_ne_bytes(bytes[at..at + ASCII_STEP].try_into().unwrap());
+        at += ASCII_STEP;
+    }
+    folded |= u64::from_ne_bytes(bytes[len - ASCII_STEP..].try_into().unwrap());
+    folded & HIGH_BITS == 0
+}
+
+/// Reads a record's TEXT payload as a `&str`, rejecting bytes that are not
+/// UTF-8.
+///
+/// Stored text is usually short and usually ASCII, and short is exactly where
+/// `simdutf8` gives up and scans byte by byte. So for a short payload, look
+/// for a non-ASCII byte first: that test settles the common case on its own,
+/// because every ASCII byte is a complete one-byte UTF-8 sequence. Only a
+/// payload that really does hold non-ASCII bytes pays for the second pass,
+/// and it is under 64 bytes long.
+#[inline(always)]
+pub fn read_text(payload: &[u8]) -> Result<&str> {
+    if payload.len() < SIMD_UTF8_MIN_LEN && is_all_ascii(payload) {
+        // SAFETY: `is_all_ascii` just read every byte of this slice and found
+        // them all at or below 0x7F. Those bytes are the one-byte UTF-8
+        // sequences, so the payload is valid UTF-8. The proof is here, over
+        // these bytes, and does not lean on a validation pass run elsewhere.
+        return Ok(unsafe { std::str::from_utf8_unchecked(payload) });
+    }
+    simdutf8::basic::from_utf8(payload).map_err(|_| {
+        mark_unlikely();
+        LimboError::Corrupt("TEXT value contains invalid UTF-8".into())
+    })
+}
+
 /// Reads a value that might reference the buffer it is reading from. Be sure to store RefValue with the buffer
 /// always.
 #[inline(always)]
@@ -1096,10 +1156,7 @@ pub fn read_value<'a>(buf: &'a [u8], serial_type: SerialType) -> Result<(ValueRe
                     content_size
                 ))
             })?;
-            let val = simdutf8::basic::from_utf8(data).map_err(|_| {
-                mark_unlikely();
-                LimboError::Corrupt("TEXT value contains invalid UTF-8".into())
-            })?;
+            let val = read_text(data)?;
             Ok((
                 ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
                 content_size,
@@ -1226,10 +1283,7 @@ pub fn read_value_serial_type<'a>(
                         content_size
                     ))
                 })?;
-                let val = simdutf8::basic::from_utf8(data).map_err(|_| {
-                    mark_unlikely();
-                    LimboError::Corrupt("TEXT value contains invalid UTF-8".into())
-                })?;
+                let val = read_text(data)?;
                 Ok((
                     ValueRef::Text(TextRef::new(val, TextSubtype::Text)),
                     content_size,
@@ -2303,6 +2357,59 @@ mod tests {
             result.0.to_owned().expect(crate::alloc::ALLOC_ERR_MSG),
             expected
         );
+    }
+
+    /// `read_text` must answer exactly what the standard library answers, on
+    /// both sides of the length where it stops looking for ASCII first, and
+    /// for every way a payload can stop being ASCII or stop being UTF-8.
+    #[test]
+    fn read_text_agrees_with_the_standard_library() {
+        let mut payloads: Vec<Vec<u8>> = Vec::new();
+        // Plain ASCII of every length across the 64-byte switchover.
+        for len in 0..=128usize {
+            payloads.push(vec![b'a'; len]);
+        }
+        // The same, with one byte that is not ASCII, moved through every
+        // position: valid two-byte UTF-8, then a byte that cannot start a
+        // sequence, then a continuation byte with nothing to continue.
+        for len in 1..=80usize {
+            for at in 0..len {
+                for tail in [&[0xC3u8, 0xA9][..], &[0xFF][..], &[0x80][..]] {
+                    let mut payload = vec![b'a'; len];
+                    payload.splice(at..at + 1, tail.iter().copied());
+                    payloads.push(payload);
+                }
+            }
+        }
+        // Sequences that are not UTF-8 for reasons a per-byte ASCII test
+        // cannot see: a truncated sequence, an overlong encoding, and a
+        // surrogate half.
+        for broken in [
+            &[0xE2u8, 0x82][..],
+            &[0xC0, 0xAF][..],
+            &[0xED, 0xA0, 0x80][..],
+        ] {
+            for pad in [0usize, 60, 70] {
+                let mut payload = vec![b'a'; pad];
+                payload.extend_from_slice(broken);
+                payloads.push(payload);
+            }
+        }
+
+        for payload in payloads {
+            assert_eq!(
+                is_all_ascii(&payload),
+                payload.iter().all(u8::is_ascii),
+                "payload {payload:?}"
+            );
+
+            let expected = std::str::from_utf8(&payload);
+            match (read_text(&payload), expected) {
+                (Ok(got), Ok(want)) => assert_eq!(got, want, "payload {payload:?}"),
+                (Err(LimboError::Corrupt(_)), Err(_)) => {}
+                (got, want) => panic!("payload {payload:?}: got {got:?}, std says {want:?}"),
+            }
+        }
     }
 
     #[test]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3321,11 +3321,9 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                 }
                 self.set_data_section(&data[content_size..]);
                 let text_data = &data[..content_size];
-                let Ok(text_str) = simdutf8::basic::from_utf8(text_data) else {
-                    mark_unlikely();
-                    return Some(Err(LimboError::Corrupt(
-                        "TEXT value contains invalid UTF-8".into(),
-                    )));
+                let text_str = match crate::storage::sqlite3_ondisk::read_text(text_data) {
+                    Ok(text_str) => text_str,
+                    Err(err) => return Some(Err(err)),
                 };
                 match dest {
                     Register::Value(Value::Text(existing_text)) => {


### PR DESCRIPTION
## Description

Every TEXT value read out of a record is checked for valid UTF-8 before it becomes a `&str`.
That check is `simdutf8::basic::from_utf8`, whose SIMD kernel only runs from 64 bytes up;
anything shorter it hands straight to the standard library, which walks the bytes one at a
time. Stored text is mostly short, so in practice the fast validator almost never ran and the
scalar one carried the load.

This PR adds `read_text`, one place that turns a TEXT payload into a `&str`, and gives it an
ASCII test first for payloads under 64 bytes. The test reads eight bytes at a time and ORs
them together, so it costs one load and one OR per eight bytes with no per-byte branch, and it
answers the common case outright: every ASCII byte is a complete one-byte UTF-8 sequence, so an
all-ASCII payload is valid UTF-8 with nothing left to check.

A short payload that really does hold non-ASCII bytes falls through to `simdutf8` as before,
having paid for one extra pass over at most 63 bytes. At 64 bytes and up nothing changes at
all, since that is where `simdutf8` starts earning its keep.

Three inline validation sites now call `read_text`: `read_value`, `read_value_serial_type`, and
the record-into-registers decode in the VDBE.

The `from_utf8_unchecked` on the fast path is guarded by a check of those exact bytes,
immediately above it. It does not lean on a validation pass having run somewhere else, which is
what made the old jsonb defect undefined behaviour rather than a clean error.

## Motivation and context

This is the largest single cost in query execution on the CodSpeed suite that is not cost
estimation or B-tree work. In the flame graphs on `main`, `core::str::from_utf8`:

- is the **top self-time function** in `graph_queries[a_cooccurrence]`, at 5.8%
- is **27.6%** of `select_star_106_wal`
- shows up under three separate callers — decoding a record into registers,
  `read_value`/`read_value_serial_type` for index keys and the sorter, and record comparison
  during index seeks

### Results

CodSpeed against this branch's parent commit (`bad083f`): **0 regressions**, and every
execution benchmark that reads text improves. Stable shard, which ran on a matching runner:

| Benchmark | base | head | |
|---|---:|---:|---|
| `select_star_106_wal[20000]` | 112.8 ms | 90.4 ms | −19.9% |
| `select_star_106_mvcc[20000]` | 130.1 ms | 107.1 ms | −17.7% |
| `select_star_21_wal[50000]` | 77.2 ms | 66.9 ms | −13.3% |
| `limbo_execute_select_rows[100]` | 183.4 µs | 160.8 µs | −12.3% |
| `limbo[d_inlist_union]` | 1.9 ms | 1.7 ms | −10.5% |
| `limbo_execute_select_rows[50]` | 111.9 µs | 100.4 µs | −10.3% |
| `select_star_10_wal[100000]` | 104.2 ms | 94.0 ms | −9.8% |
| `select_star_21_mvcc[50000]` | 121.1 ms | 109.6 ms | −9.5% |
| `mvcc-recovery/small-frames[1000000]` | 3.40 s | 3.10 s | −8.8% |
| `limbo[a_cooccurrence]` | 229.8 ms | 213.1 ms | −7.3% |
| `select_star_10_mvcc[100000]` | 188.7 ms | 176.1 ms | −6.7% |
| `count_text_col[1000000]` | 609.9 ms | 573.0 ms | −6.1% |
| `count_filtered[1000000]` | 308.8 ms | 292.0 ms | −5.4% |
| `count_groupby[1000000]` | 910.3 ms | 863.1 ms | −5.2% |
| `limbo[b_or_join]` | 6.1 ms | 5.8 ms | −4.9% |
| `limbo_analyzed[c_edge_counts]` | 315.4 ms | 301.1 ms | −4.5% |

The nightly shard agrees on every one of them.

Two notes on reading these numbers:

- CodSpeed flagged a libc build-id difference between the two runs, but **only on nightly
  shards**. Every stable number above was compared on matching runners.
- The **SQLite comparison benchmarks in those same files are the control, and they did not
  move**: `sqlite[a_cooccurrence]` +0.03%, `sqlite_analyzed[a_cooccurrence]` and both
  `sqlite[c_edge_counts]` at 0.00%, `sqlite_execute_select_rows` within 0.6%. So the machine did
  not shift under us; the Turso side moved and the SQLite side did not.

The only upward moves over 5% are the FTS `cold_query` and `insert_query` benchmarks, where the
stable and nightly shards of the same source move in **opposite directions**
(`cold_query[5000_rows]` +5.0% stable, −8.1% nightly; `cold_query[10000_rows]` +14.4% stable,
+0.9% nightly). That is shard noise, consistent with those benchmarks spending ~74% of their
time in tantivy harness and system time rather than in engine code. CodSpeed itself reported 0
regressions.

Measured on the validation alone, 512 payloads per iteration:

| payload | before | after | |
|---|---:|---:|---|
| 4 bytes | 3.89 µs | 0.88 µs | ×4.4 |
| 7 bytes | 4.30 µs | 1.17 µs | ×3.7 |
| 12 bytes | 5.23 µs | 0.69 µs | ×7.6 |
| 24 bytes | 4.64 µs | 1.07 µs | ×4.3 |
| 63 bytes | 8.00 µs | 1.80 µs | ×4.4 |
| 100 bytes | 6.38 µs | 6.25 µs | unchanged |
| 400 bytes | 6.77 µs | 6.59 µs | unchanged |

The 100- and 400-byte rows are unchanged by design: above 64 bytes the fast path is skipped.

## Testing

`read_text_agrees_with_the_standard_library` runs every payload through both `read_text` and
`std::str::from_utf8` and requires the same answer, and separately checks `is_all_ascii`
against `bytes.iter().all(u8::is_ascii)`. The corpus covers:

- ASCII of every length from 0 to 128 bytes, crossing the 64-byte switchover
- one non-ASCII byte walked through every position of every length up to 80, in three flavours:
  valid two-byte UTF-8, a byte that cannot start a sequence, and a stray continuation byte
- sequences that only a real UTF-8 check can reject — truncated, overlong, and a surrogate half
  — at padding lengths on both sides of the switchover

The test earns its keep: deleting the overlapping tail read from the ASCII scan makes it fail.
That is the one bug that matters here, because it would let a non-ASCII byte in the last
partial word slip through to `from_utf8_unchecked`.

Also run, all clean:

- `cargo test -p turso_core --lib` — 2326 passed
- `cargo test -p core_tester --test integration_tests` — 1057 passed
- `make -C sqlite/conformance run-rust` — 1560 passed, 0 failed
- `cargo fmt` and `cargo clippy --workspace --all-features --all-targets --deny=warnings`

## Description of AI Usage

**This PR was written end to end by Claude Code.** (The auto-generated description this PR was
opened with said otherwise; that was wrong and this section replaces it.)

Worth sharing on method:

- The target was picked from CodSpeed data, not guessed. I aggregated all 2,092 benchmarks by
  file to separate execution time from prepare time, then pulled flame graphs for the largest
  execution benchmarks. UTF-8 validation was not an obvious suspect from reading the code — it
  only stood out because `core::str::from_utf8` kept appearing at the top of unrelated
  profiles, which is what pointed at the shared cause underneath.
- The reason the cost existed at all came from reading `simdutf8`'s own source rather than
  assuming: its x86 entry point returns `validate_utf8_basic_fallback(input)` for anything under
  `SIMD_CHUNK_SIZE = 64`, and that fallback is `core::str::from_utf8`. That is what set the
  64-byte threshold in this patch.
- The implementation was chosen by measurement, not intuition. A first version used the standard
  library's `[u8]::is_ascii()`, which falls back to a byte loop under 8 bytes — right where these
  payloads live. A throwaway criterion bench compared three strategies across seven payload
  lengths, the word-wise fold won by roughly 2× over `is_ascii()` and 3.3–7.6× over the status
  quo, and the bench was deleted before committing.
- The `unsafe` was treated as the risky part of the change and tested accordingly. The new test
  was mutation-checked — the overlapping tail read was deleted to confirm the test actually
  fails — so the coverage is demonstrated rather than asserted.
- Performance was measured on CodSpeed itself via `workflow_dispatch` on the branch, and the
  results were read with the SQLite-side benchmarks as a control and the stable/nightly shards
  as a cross-check, so environment drift could be separated from the change.

The committer is responsible for reviewing this output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRha4rSNeJyttWVgDjEYvU