### PR TITLE
sqlite/parser: accept namespace-qualified and array-element parameter names

### DIFF
--- a/core/statement.rs
+++ b/core/statement.rs
@@ -1707,6 +1707,39 @@ mod tests {
     }
 
     #[test]
+    fn test_tcl_style_parameter_names_bind_and_expand() {
+        // The TCL binding passes namespace-qualified variables ($::x,
+        // $ns::y) and array elements ($arr(k)) as parameter names. Each
+        // spelling is one parameter, found by its full text, and expanded
+        // SQL — which re-lexes the statement text — sees the same markers
+        // the parse did, so the bound values land in the right places.
+        let conn = open_test_connection().unwrap();
+        let mut stmt = conn
+            .prepare("SELECT $::x, $ns::y, $arr(k), $::x, '$::x'")
+            .unwrap();
+        let x = stmt.parameter_index("$::x").unwrap();
+        let y = stmt.parameter_index("$ns::y").unwrap();
+        let k = stmt.parameter_index("$arr(k)").unwrap();
+        assert_eq!(stmt.parameters_count(), 3);
+        stmt.bind_at(x, Value::from_i64(1)).unwrap();
+        stmt.bind_at(y, Value::build_text("two")).unwrap();
+        stmt.bind_at(k, Value::from_i64(3)).unwrap();
+
+        assert_eq!(stmt.expanded_sql(), "SELECT 1, 'two', 3, 1, '$::x'");
+        let rows = stmt.run_collect_rows().unwrap();
+        assert_eq!(
+            rows,
+            vec![vec![
+                Value::from_i64(1),
+                Value::build_text("two"),
+                Value::from_i64(3),
+                Value::from_i64(1),
+                Value::build_text("$::x"),
+            ]]
+        );
+    }
+
+    #[test]
     fn test_metrics_persist_across_reset() {
         let conn = open_test_connection().unwrap();
         conn.execute("CREATE TABLE t(x)").unwrap();

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -176,7 +176,7 @@ set test_files {
   date2                fail
   date3                pass
   date4                fail
-  date5                fail
+  date5                pass
   dbfuzz001            fail
   dbpage               fail
   dbstatus             fail
@@ -338,7 +338,7 @@ set test_files {
   jrnlmode2            fail
   jrnlmode3            fail
   json101              fail
-  json102              fail
+  json102              pass
   json103              fail
   json104              pass
   json105              pass
@@ -574,7 +574,7 @@ set test_files {
   tkt-31338dca7e       pass
   tkt-313723c356       fail
   tkt-385a5b56b9       fail
-  tkt-38cb5df375       fail
+  tkt-38cb5df375       pass
   tkt-3998683a16       pass
   tkt-3a77c9714e       pass
   tkt-3fe897352e       fail

--- a/sqlite/parser/src/lexer.rs
+++ b/sqlite/parser/src/lexer.rs
@@ -865,9 +865,13 @@ impl<'a> Lexer<'a> {
         // the name is identifier bytes, and a "::" pair anywhere in it —
         // leading, middle or trailing — is part of the name. That is what
         // lets the TCL binding pass namespace-qualified variables ($::var,
-        // $ns::var) as one parameter. At least one identifier byte is
-        // required, so a bare `$` or `$::` is still an error.
+        // $ns::var) as one parameter. After at least one identifier byte,
+        // one "(...)" suffix ends the name, for TCL array elements like
+        // $arr(elem); it must be closed and may not contain whitespace.
+        // At least one identifier byte is required, so a bare `$` or `$::`
+        // is still an error.
         let mut n_id = 0usize;
+        let mut bad_suffix = false;
         loop {
             match self.peek() {
                 Some(b) if is_identifier_continue(b) => {
@@ -878,11 +882,22 @@ impl<'a> Lexer<'a> {
                     self.eat();
                     self.eat();
                 }
+                Some(b'(') if n_id > 0 => {
+                    self.eat();
+                    self.eat_while(|b| b != b')' && !b.is_ascii_whitespace());
+                    if self.peek() == Some(b')') {
+                        self.eat();
+                    } else {
+                        // Unclosed, or whitespace inside the suffix.
+                        bad_suffix = true;
+                    }
+                    break;
+                }
                 _ => break,
             }
         }
 
-        if n_id == 0 {
+        if n_id == 0 || bad_suffix {
             let token_text = String::from_utf8_lossy(&self.input[start..self.offset]).to_string();
             return Err(Error::BadVariableName {
                 span: (start, self.offset - start).into(),
@@ -1127,6 +1142,27 @@ mod tests {
                 b"$1::2".as_slice(),
                 Token::new(b"$1::2", TokenType::TK_VARIABLE),
             ),
+            // TCL array elements: one "(...)" suffix, no whitespace inside.
+            (
+                b"$arr(elem)".as_slice(),
+                Token::new(b"$arr(elem)", TokenType::TK_VARIABLE),
+            ),
+            (
+                b"$arr(12x)".as_slice(),
+                Token::new(b"$arr(12x)", TokenType::TK_VARIABLE),
+            ),
+            (
+                b"$a([b])".as_slice(),
+                Token::new(b"$a([b])", TokenType::TK_VARIABLE),
+            ),
+            (
+                b"$a('b')".as_slice(),
+                Token::new(b"$a('b')", TokenType::TK_VARIABLE),
+            ),
+            (
+                b"$ns::arr(k)".as_slice(),
+                Token::new(b"$ns::arr(k)", TokenType::TK_VARIABLE),
+            ),
             (
                 b"x'1234567890abcdef'".as_slice(),
                 Token::new(b"x'1234567890abcdef'", TokenType::TK_BLOB),
@@ -1170,9 +1206,20 @@ mod tests {
     #[test]
     fn test_lexer_bad_variable_names() {
         // A named parameter needs at least one identifier byte; "::" pairs
-        // alone do not make a name. Same as SQLite, which reports these as
+        // alone do not make a name, and a "(...)" suffix must be closed with
+        // no whitespace inside. Same as SQLite, which reports these as
         // unrecognized tokens.
-        let bad_inputs: Vec<&[u8]> = vec![b"$", b"$::", b"@", b"::::a"];
+        let bad_inputs: Vec<&[u8]> = vec![
+            b"$",
+            b"$::",
+            b"@",
+            b"::::a",
+            b"$(",
+            b"$(elem)",
+            b"$a(unclosed",
+            b"$a(x y)",
+            b"$a(b;",
+        ];
         for input in bad_inputs {
             let mut lexer = Lexer::new(input);
             let result = lexer.next().unwrap();
@@ -1494,6 +1541,31 @@ mod tests {
                     Token::new(b"$x::", TokenType::TK_VARIABLE),
                     Token::new(b" ", TokenType::TK_NONE),
                     Token::new(b"y", TokenType::TK_ID),
+                ],
+            ),
+            // The "(...)" suffix ends the name: what follows is a new token.
+            (
+                b"$a(b)c".as_slice(),
+                vec![
+                    Token::new(b"$a(b)", TokenType::TK_VARIABLE),
+                    Token::new(b"c", TokenType::TK_ID),
+                ],
+            ),
+            (
+                b"$a(b)+$c(d)".as_slice(),
+                vec![
+                    Token::new(b"$a(b)", TokenType::TK_VARIABLE),
+                    Token::new(b"+", TokenType::TK_PLUS),
+                    Token::new(b"$c(d)", TokenType::TK_VARIABLE),
+                ],
+            ),
+            (
+                b"$a(b)(c)".as_slice(),
+                vec![
+                    Token::new(b"$a(b)", TokenType::TK_VARIABLE),
+                    Token::new(b"(", TokenType::TK_LP),
+                    Token::new(b"c", TokenType::TK_ID),
+                    Token::new(b")", TokenType::TK_RP),
                 ],
             ),
         ];

--- a/sqlite/parser/src/lexer.rs
+++ b/sqlite/parser/src/lexer.rs
@@ -264,10 +264,18 @@ impl<'a> Iterator for Lexer<'a> {
                     )))
                 }
                 b':' => {
-                    // `:name` is a named parameter, but `:` followed by a digit
-                    // or non-identifier char is a standalone colon (used in slice syntax).
-                    match self.input.get(self.offset + 1) {
-                        Some(&b) if is_identifier_start(b) => Some(self.mark(|l| l.eat_var())),
+                    // `:name` is a named parameter, and so is `:::name` (the
+                    // name may start with a "::" pair, as in SQLite). Any other
+                    // `:` — before a digit, a space, `]`, a lone `:` — is a
+                    // standalone colon, which the slice syntax `a[1:2]` needs.
+                    // SQLite has no slices and reads `:2` as a parameter; that
+                    // is the one place we deviate from its tokenizer.
+                    match (
+                        self.input.get(self.offset + 1),
+                        self.input.get(self.offset + 2),
+                    ) {
+                        (Some(&b), _) if is_identifier_start(b) => Some(self.mark(|l| l.eat_var())),
+                        (Some(&b':'), Some(&b':')) => Some(self.mark(|l| l.eat_var())),
                         _ => Some(Ok(self.eat_one_token(TokenType::TK_COLON))),
                     }
                 }
@@ -853,11 +861,28 @@ impl<'a> Lexer<'a> {
     /// Lex the name of a named parameter. `start` is the offset of the
     /// prefix byte (`$`, `@` or `:`), which the caller has already eaten.
     fn eat_named_var(&mut self, start: usize) -> Result<Token<'a>> {
-        let start_id = self.offset;
-        self.eat_while(is_identifier_continue);
+        // Same rule as SQLite's tokenizer (sqlite3GetToken, CC_VARALPHA):
+        // the name is identifier bytes, and a "::" pair anywhere in it —
+        // leading, middle or trailing — is part of the name. That is what
+        // lets the TCL binding pass namespace-qualified variables ($::var,
+        // $ns::var) as one parameter. At least one identifier byte is
+        // required, so a bare `$` or `$::` is still an error.
+        let mut n_id = 0usize;
+        loop {
+            match self.peek() {
+                Some(b) if is_identifier_continue(b) => {
+                    n_id += 1;
+                    self.eat();
+                }
+                Some(b':') if self.input.get(self.offset + 1) == Some(&b':') => {
+                    self.eat();
+                    self.eat();
+                }
+                _ => break,
+            }
+        }
 
-        // empty variable name
-        if start_id == self.offset {
+        if n_id == 0 {
             let token_text = String::from_utf8_lossy(&self.input[start..self.offset]).to_string();
             return Err(Error::BadVariableName {
                 span: (start, self.offset - start).into(),
@@ -1068,6 +1093,40 @@ mod tests {
                 b":named_param".as_slice(),
                 Token::new(b":named_param", TokenType::TK_VARIABLE),
             ),
+            // TCL-style names, lexed as SQLite does: "::" pairs belong to
+            // the name wherever they sit.
+            (
+                b"$::global_var".as_slice(),
+                Token::new(b"$::global_var", TokenType::TK_VARIABLE),
+            ),
+            (
+                b"$ns::var".as_slice(),
+                Token::new(b"$ns::var", TokenType::TK_VARIABLE),
+            ),
+            (
+                b"@a::b::c".as_slice(),
+                Token::new(b"@a::b::c", TokenType::TK_VARIABLE),
+            ),
+            (
+                b":a::b::c".as_slice(),
+                Token::new(b":a::b::c", TokenType::TK_VARIABLE),
+            ),
+            (
+                b":::global_var".as_slice(),
+                Token::new(b":::global_var", TokenType::TK_VARIABLE),
+            ),
+            (
+                b"$a::".as_slice(),
+                Token::new(b"$a::", TokenType::TK_VARIABLE),
+            ),
+            (
+                b"$a::::b".as_slice(),
+                Token::new(b"$a::::b", TokenType::TK_VARIABLE),
+            ),
+            (
+                b"$1::2".as_slice(),
+                Token::new(b"$1::2", TokenType::TK_VARIABLE),
+            ),
             (
                 b"x'1234567890abcdef'".as_slice(),
                 Token::new(b"x'1234567890abcdef'", TokenType::TK_BLOB),
@@ -1105,6 +1164,23 @@ mod tests {
             println!("Input: {input:?}, Expected: {expect_value:?}, Got: {got_value:?}");
             assert_eq!(got_value, expect_value);
             assert_eq!(token.token_type, expected.token_type);
+        }
+    }
+
+    #[test]
+    fn test_lexer_bad_variable_names() {
+        // A named parameter needs at least one identifier byte; "::" pairs
+        // alone do not make a name. Same as SQLite, which reports these as
+        // unrecognized tokens.
+        let bad_inputs: Vec<&[u8]> = vec![b"$", b"$::", b"@", b"::::a"];
+        for input in bad_inputs {
+            let mut lexer = Lexer::new(input);
+            let result = lexer.next().unwrap();
+            assert!(
+                matches!(result, Err(Error::BadVariableName { .. })),
+                "expected BadVariableName for {:?}, got {result:?}",
+                String::from_utf8_lossy(input)
+            );
         }
     }
 
@@ -1322,6 +1398,102 @@ mod tests {
                     Token::new(b"u", TokenType::TK_ID),
                     Token::new(b".", TokenType::TK_DOT),
                     Token::new(b"email", TokenType::TK_ID),
+                ],
+            ),
+            // Slices keep their standalone colons: a `:` is only a
+            // parameter when an identifier byte or a "::" pair follows it.
+            (
+                b"a[1:2]".as_slice(),
+                vec![
+                    Token::new(b"a", TokenType::TK_ID),
+                    Token::new(b"[", TokenType::TK_LBRACKET),
+                    Token::new(b"1", TokenType::TK_INTEGER),
+                    Token::new(b":", TokenType::TK_COLON),
+                    Token::new(b"2", TokenType::TK_INTEGER),
+                    Token::new(b"]", TokenType::TK_RBRACKET),
+                ],
+            ),
+            (
+                b"a[:2]".as_slice(),
+                vec![
+                    Token::new(b"a", TokenType::TK_ID),
+                    Token::new(b"[", TokenType::TK_LBRACKET),
+                    Token::new(b":", TokenType::TK_COLON),
+                    Token::new(b"2", TokenType::TK_INTEGER),
+                    Token::new(b"]", TokenType::TK_RBRACKET),
+                ],
+            ),
+            (
+                b"a[1:]".as_slice(),
+                vec![
+                    Token::new(b"a", TokenType::TK_ID),
+                    Token::new(b"[", TokenType::TK_LBRACKET),
+                    Token::new(b"1", TokenType::TK_INTEGER),
+                    Token::new(b":", TokenType::TK_COLON),
+                    Token::new(b"]", TokenType::TK_RBRACKET),
+                ],
+            ),
+            (
+                b"a[:]".as_slice(),
+                vec![
+                    Token::new(b"a", TokenType::TK_ID),
+                    Token::new(b"[", TokenType::TK_LBRACKET),
+                    Token::new(b":", TokenType::TK_COLON),
+                    Token::new(b"]", TokenType::TK_RBRACKET),
+                ],
+            ),
+            // `1::hi` is the slice colon followed by the parameter `:hi`:
+            // the first colon has no identifier byte or "::" pair after it.
+            (
+                b"a[1::hi]".as_slice(),
+                vec![
+                    Token::new(b"a", TokenType::TK_ID),
+                    Token::new(b"[", TokenType::TK_LBRACKET),
+                    Token::new(b"1", TokenType::TK_INTEGER),
+                    Token::new(b":", TokenType::TK_COLON),
+                    Token::new(b":hi", TokenType::TK_VARIABLE),
+                    Token::new(b"]", TokenType::TK_RBRACKET),
+                ],
+            ),
+            // A bare "::" between identifiers is two colons; only ":::name"
+            // is a parameter.
+            (
+                b"a::b".as_slice(),
+                vec![
+                    Token::new(b"a", TokenType::TK_ID),
+                    Token::new(b":", TokenType::TK_COLON),
+                    Token::new(b":b", TokenType::TK_VARIABLE),
+                ],
+            ),
+            // Like SQLite, the name is greedy: an unspaced slice whose lower
+            // bound is a parameter is one name. Write `a[$lo : :hi]` or
+            // `a[$lo:$hi]` for a slice.
+            (
+                b"a[$lo::hi]".as_slice(),
+                vec![
+                    Token::new(b"a", TokenType::TK_ID),
+                    Token::new(b"[", TokenType::TK_LBRACKET),
+                    Token::new(b"$lo::hi", TokenType::TK_VARIABLE),
+                    Token::new(b"]", TokenType::TK_RBRACKET),
+                ],
+            ),
+            (
+                b"a[$lo:$hi]".as_slice(),
+                vec![
+                    Token::new(b"a", TokenType::TK_ID),
+                    Token::new(b"[", TokenType::TK_LBRACKET),
+                    Token::new(b"$lo", TokenType::TK_VARIABLE),
+                    Token::new(b":", TokenType::TK_COLON),
+                    Token::new(b"$hi", TokenType::TK_VARIABLE),
+                    Token::new(b"]", TokenType::TK_RBRACKET),
+                ],
+            ),
+            (
+                b"$x:: y".as_slice(),
+                vec![
+                    Token::new(b"$x::", TokenType::TK_VARIABLE),
+                    Token::new(b" ", TokenType::TK_NONE),
+                    Token::new(b"y", TokenType::TK_ID),
                 ],
             ),
         ];

--- a/sqlite/parser/src/lexer.rs
+++ b/sqlite/parser/src/lexer.rs
@@ -830,6 +830,8 @@ impl<'a> Lexer<'a> {
         }
     }
 
+    /// Lex a parameter marker: `?` or `?NNN`, or a named parameter that
+    /// starts with `$`, `@` or `:`.
     fn eat_var(&mut self) -> Result<Token<'a>> {
         let start = self.offset;
         let tok = self.eat().unwrap();
@@ -844,27 +846,30 @@ impl<'a> Lexer<'a> {
                     TokenType::TK_VARIABLE,
                 ))
             }
-            _ => {
-                let start_id = self.offset;
-                self.eat_while(is_identifier_continue);
-
-                // empty variable name
-                if start_id == self.offset {
-                    let token_text =
-                        String::from_utf8_lossy(&self.input[start..self.offset]).to_string();
-                    return Err(Error::BadVariableName {
-                        span: (start, self.offset - start).into(),
-                        token_text,
-                        offset: start,
-                    });
-                }
-
-                Ok(Token::new(
-                    &self.input[start..self.offset],
-                    TokenType::TK_VARIABLE,
-                ))
-            }
+            _ => self.eat_named_var(start),
         }
+    }
+
+    /// Lex the name of a named parameter. `start` is the offset of the
+    /// prefix byte (`$`, `@` or `:`), which the caller has already eaten.
+    fn eat_named_var(&mut self, start: usize) -> Result<Token<'a>> {
+        let start_id = self.offset;
+        self.eat_while(is_identifier_continue);
+
+        // empty variable name
+        if start_id == self.offset {
+            let token_text = String::from_utf8_lossy(&self.input[start..self.offset]).to_string();
+            return Err(Error::BadVariableName {
+                span: (start, self.offset - start).into(),
+                token_text,
+                offset: start,
+            });
+        }
+
+        Ok(Token::new(
+            &self.input[start..self.offset],
+            TokenType::TK_VARIABLE,
+        ))
     }
 
     #[inline]

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -5481,6 +5481,22 @@ mod tests {
     }
 
     #[test]
+    fn test_namespace_qualified_parameter_names() {
+        // TCL passes `$::g` and `$ns::var` into SQL; each spelling is one
+        // parameter, keyed on its full text, and a repeat reuses its index.
+        let sql = "SELECT $ns::var, $::g, $ns::var, :::g, @a::b::";
+        let mut p = Parser::new(sql.as_bytes());
+        let cmd = p.next_cmd().unwrap().unwrap();
+        assert_eq!(cmd.to_string(), format!("{sql};"));
+        let index = |name: &str| p.named_variables[name.as_bytes()].get();
+        assert_eq!(index("$ns::var"), 1);
+        assert_eq!(index("$::g"), 2);
+        assert_eq!(index(":::g"), 3);
+        assert_eq!(index("@a::b::"), 4);
+        assert_eq!(p.named_variables.len(), 4);
+    }
+
+    #[test]
     fn test_expect_fail() {
         let testcases = vec![
             "ALTER TABLE my_table ADD COLUMN my_column PRIMARY KEY",

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -5497,6 +5497,26 @@ mod tests {
     }
 
     #[test]
+    fn test_array_element_parameter_names() {
+        // TCL array elements, `$arr(elem)`, are one parameter including the
+        // suffix; only one suffix is allowed, so `$a(b)(c)` is a call-like
+        // syntax error, as in SQLite.
+        let sql = "SELECT $arr(elem), $ns::arr(k), $arr(elem)";
+        let mut p = Parser::new(sql.as_bytes());
+        let cmd = p.next_cmd().unwrap().unwrap();
+        assert_eq!(cmd.to_string(), format!("{sql};"));
+        assert_eq!(p.named_variables[b"$arr(elem)".as_slice()].get(), 1);
+        assert_eq!(p.named_variables[b"$ns::arr(k)".as_slice()].get(), 2);
+        assert_eq!(p.named_variables.len(), 2);
+
+        let mut p = Parser::new(b"SELECT $a(b)(c)");
+        assert!(p.next_cmd().is_err());
+        let mut p = Parser::new(b"SELECT $a(b c)");
+        let err = p.next_cmd().unwrap_err().to_string();
+        assert!(err.contains("bad variable name '$a(b'"), "{err}");
+    }
+
+    #[test]
     fn test_expect_fail() {
         let testcases = vec![
             "ALTER TABLE my_table ADD COLUMN my_column PRIMARY KEY",


### PR DESCRIPTION
Chasing the upstream TCL suite's failure rate, one error dominates
everything: `bad variable name`, 3,289 times — nearly all of `in2.test`
(1,998) and `date5.test` (874), plus `tkt-38cb5df375.test` (292) and
`json102.test` (100). The TCL binding passes TCL variables into SQL as
`$`-parameters, and TCL's interesting variable names are
namespace-qualified (`$::ii`, `$ns::var`) or array elements
(`$arr(elem)`). SQLite's tokenizer (`sqlite3GetToken`, `CC_VARALPHA`)
accepts `::` pairs anywhere in a parameter name and one trailing `(...)`
suffix precisely for this. Ours stopped at the first non-identifier byte.

This copies SQLite's rule into the lexer, and nothing else: the name is
identifier bytes plus `::` pairs (leading, middle or trailing), then at
most one `(...)` suffix that must be closed and contain no whitespace,
and needs at least one identifier byte. The rule is context-free, so
`sqlite3_expanded_sql`, which re-lexes the statement text exactly as
SQLite's `sqlite3VdbeExpandSql` does, keeps seeing the same markers the
parse did; a core test pins that down. The accept/reject behaviour was
checked against `sqlite3 3.51` on 29 spellings (`$a::`, `$a::::b`,
`$a(b)c`, `$a(b)(c)`, `$a(b c)`, `$(b)`, `$a:b`, `?1::a`, ...) and
matches on every one.

One place we deliberately keep deviating from SQLite: a `:` that is not
followed by an identifier byte or a `::` pair stays a standalone colon,
because `a[1:2]`, `a[:2]`, `a[1:]` are slices for us and SQLite has no
slice syntax (it reads `:2` as a parameter). The consequence, which is
exactly how SQLite would lex the bytes, is that an unspaced slice with a
parameter lower bound, `a[$lo::hi]`, is now the single name `$lo::hi`;
write `a[$lo : :hi]` or `a[$lo:$hi]`. Nothing in the repo uses the
unspaced spelling. I went back and forth on a context-sensitive lexer
that would preserve it (bracket frames, paren/CASE depth, lookahead,
parser hints) and rejected it: ~700 lines and a measurable lexer/parser
slowdown to rescue a spelling nobody writes, and it forced expanded SQL
onto parse-time marker positions. The parser benchmark on this branch
is within noise of main.

Commits, in order:

1. `sqlite/parser: split eat_var into numbered and named parameter scans`
   — pure refactor so the next diff is one self-contained loop.
2. `sqlite/parser: accept "::" in parameter names like SQLite`
3. `sqlite/parser: accept a "(...)" suffix in parameter names like SQLite`
4. `core: cover binding and expansion of TCL-style parameter names`
   — test-only; binding by full name and `expanded_sql` work unchanged.
5. `sqlite/conformance: bless date5, json102 and tkt-38cb5df375`

The payoff, full `all.test` run against the 2026-08-20 `main` baseline:

| | main | this branch |
|---|---|---|
| `bad variable name '$'` failures | 3,289 | 0 (one hit left, `main-3.2.13`, compares only the error wording against SQLite's `unrecognized token`) |
| `date5.test` | 0/874 | 874/874, blessed |
| `json102.test` | 209/309 | 309/309, blessed |
| `tkt-38cb5df375.test` | 1/293 | 293/293, blessed |
| total | 162,026 / 172,008 (94.2%) | 163,327 / 170,009 (96.1%), run exits `OK` |

`in2.test` finally gets to do the job it was written for in 2007: hunting
a b-tree balancing bug triggered by 3-byte cells in the ephemeral b-trees
that evaluate `IN (...)`. Now that its statements execute instead of
dying at parse, it finds one — `balance_non_root` panics with "cells were
not balanced properly" at `in2-311`. The panic crosses `sqlite3_step`'s
`extern "C"` boundary, so it is non-unwinding and aborts the child
tclsh; `all.test` contains it as `XCRASH` and the file's 1,999 tests
drop out of the total (hence 170,009). It reproduces with literal-only
SQL, so it is pre-existing and independent of this PR; `in2` stays
known-bad rather than skipped so the crash remains visible until it is
fixed separately.

Tests: `cargo test -p turso_parser`, `cargo test -p turso_core --lib`,
`cargo clippy --workspace --all-features --all-targets -D warnings`,
`make -C sqlite/conformance run-rust`, and the TCL runs above.

https://claude.ai/code/session_01TBgxUy6Wfi9u4AHn7rXr5i
