### PR TITLE
core: read pages ahead of sequential btree scans (PRAGMA prefetch_pages)

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -289,3 +289,7 @@ harness = false
 [[bench]]
 name = "select_star_benchmark"
 harness = false
+
+[[bench]]
+name = "prefetch_benchmark"
+harness = false

--- a/core/benches/prefetch_benchmark.rs
+++ b/core/benches/prefetch_benchmark.rs
@@ -1,0 +1,300 @@
+//! Benchmark for scan readahead (`PRAGMA prefetch_pages`).
+//!
+//! Readahead wins by overlapping storage latency, so this benchmark models a
+//! storage device with a fixed per-read latency: every read completes only
+//! after the IO layer has been stepped a fixed number of times. Without
+//! readahead a scan pays the full latency for every leaf page in sequence;
+//! with readahead the waits overlap. The model is deterministic, so the
+//! effect shows up both in wall-clock time and in instruction-count based
+//! runners.
+//!
+//! Run:  cargo bench -p turso_core --bench prefetch_benchmark
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion,
+};
+#[cfg(not(feature = "codspeed"))]
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use turso_core::{
+    io::{FileId, FileSyncType},
+    Buffer, Clock, Completion, Connection, Database, DatabaseOpts, File, MonotonicInstant,
+    OpenFlags, SqliteDialect, StepResult, WallClockInstant, IO,
+};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+/// How many IO steps a read takes to complete: the "device latency".
+const READ_DELAY_TICKS: u64 = 16;
+
+/// Busy-work per IO step so a step costs time (roughly a microsecond) the
+/// way waiting on a real device would. Without this the whole latency model
+/// is free and the benchmark only measures row-processing CPU, hiding
+/// exactly the stalls readahead removes. A spin, unlike a sleep, is also
+/// visible to instruction-count based runners.
+const SPIN_PER_TICK: u64 = 2000;
+
+/// Rows in the scanned table; roughly 600 leaf pages at 48-byte payloads.
+const ROWS: usize = 20_000;
+
+const DB_PATH: &str = "prefetch_bench.db";
+
+struct DelayedOp {
+    due_tick: u64,
+    submit: Box<dyn FnOnce() -> turso_core::Result<()> + Send>,
+}
+
+struct LatencyIoState {
+    tick: u64,
+    pending: VecDeque<DelayedOp>,
+}
+
+/// In-memory IO where every read completes `read_delay_ticks` IO steps after
+/// it was submitted. Writes complete immediately so building the fixture
+/// stays cheap.
+struct LatencyIo {
+    inner: Arc<dyn IO>,
+    state: Arc<Mutex<LatencyIoState>>,
+    read_delay_ticks: u64,
+}
+
+impl LatencyIo {
+    fn new(read_delay_ticks: u64) -> Self {
+        Self {
+            inner: Arc::new(turso_core::MemoryIO::new()),
+            state: Arc::new(Mutex::new(LatencyIoState {
+                tick: 0,
+                pending: VecDeque::new(),
+            })),
+            read_delay_ticks,
+        }
+    }
+
+    fn step_once(&self) -> turso_core::Result<()> {
+        for _ in 0..SPIN_PER_TICK {
+            std::hint::spin_loop();
+        }
+        let mut due = Vec::new();
+        {
+            let mut state = self.state.lock().unwrap();
+            state.tick += 1;
+            let tick = state.tick;
+            while state.pending.front().is_some_and(|op| op.due_tick <= tick) {
+                due.push(state.pending.pop_front().unwrap());
+            }
+        }
+        for op in due {
+            (op.submit)()?;
+        }
+        Ok(())
+    }
+}
+
+impl Clock for LatencyIo {
+    fn current_time_monotonic(&self) -> MonotonicInstant {
+        self.inner.current_time_monotonic()
+    }
+
+    fn current_time_wall_clock(&self) -> WallClockInstant {
+        self.inner.current_time_wall_clock()
+    }
+}
+
+impl IO for LatencyIo {
+    fn open_file(
+        &self,
+        path: &str,
+        flags: OpenFlags,
+        direct: bool,
+    ) -> turso_core::Result<Arc<dyn File>> {
+        let inner = self.inner.open_file(path, flags, direct)?;
+        Ok(Arc::new(LatencyFile {
+            inner,
+            state: self.state.clone(),
+            read_delay_ticks: self.read_delay_ticks,
+        }))
+    }
+
+    fn remove_file(&self, path: &str) -> turso_core::Result<()> {
+        self.inner.remove_file(path)
+    }
+
+    fn step(&self) -> turso_core::Result<()> {
+        self.step_once()
+    }
+
+    fn drain_completions(&self, completions: &[Completion]) -> turso_core::Result<()> {
+        while completions.iter().any(|c| !c.finished()) {
+            self.step_once()?;
+        }
+        Ok(())
+    }
+
+    fn cancel(&self, completions: &[Completion]) -> turso_core::Result<()> {
+        for completion in completions {
+            completion.abort();
+        }
+        Ok(())
+    }
+
+    fn file_id(&self, path: &str) -> turso_core::Result<FileId> {
+        self.inner.file_id(path)
+    }
+
+    fn fill_bytes(&self, dest: &mut [u8]) {
+        self.inner.fill_bytes(dest);
+    }
+
+    fn generate_random_number(&self) -> i64 {
+        self.inner.generate_random_number()
+    }
+}
+
+struct LatencyFile {
+    inner: Arc<dyn File>,
+    state: Arc<Mutex<LatencyIoState>>,
+    read_delay_ticks: u64,
+}
+
+impl File for LatencyFile {
+    fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
+        self.inner.lock_file(exclusive)
+    }
+
+    fn unlock_file(&self) -> turso_core::Result<()> {
+        self.inner.unlock_file()
+    }
+
+    fn pread(&self, pos: u64, completion: Completion) -> turso_core::Result<Completion> {
+        let inner = self.inner.clone();
+        let c = completion.clone();
+        let mut state = self.state.lock().unwrap();
+        let due_tick = state.tick + self.read_delay_ticks;
+        state.pending.push_back(DelayedOp {
+            due_tick,
+            submit: Box::new(move || {
+                drop(inner.pread(pos, c)?);
+                Ok(())
+            }),
+        });
+        Ok(completion)
+    }
+
+    fn pwrite(
+        &self,
+        pos: u64,
+        buffer: Arc<Buffer>,
+        completion: Completion,
+    ) -> turso_core::Result<Completion> {
+        self.inner.pwrite(pos, buffer, completion)
+    }
+
+    fn sync(
+        &self,
+        completion: Completion,
+        sync_type: FileSyncType,
+    ) -> turso_core::Result<Completion> {
+        self.inner.sync(completion, sync_type)
+    }
+
+    fn truncate(&self, len: u64, completion: Completion) -> turso_core::Result<Completion> {
+        self.inner.truncate(len, completion)
+    }
+
+    fn size(&self) -> turso_core::Result<u64> {
+        self.inner.size()
+    }
+}
+
+fn open_db(io: Arc<LatencyIo>) -> Arc<Database> {
+    Database::open_file_with_flags(
+        io,
+        DB_PATH,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap()
+}
+
+fn execute(conn: &Arc<Connection>, io: &Arc<LatencyIo>, sql: &str) {
+    let mut stmt = conn.prepare(sql).unwrap();
+    run_to_completion(&mut stmt, io);
+}
+
+fn run_to_completion(stmt: &mut turso_core::Statement, io: &Arc<LatencyIo>) {
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                black_box(stmt.row());
+            }
+            StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
+                io.step().unwrap();
+            }
+            StepResult::Done => break,
+            StepResult::Interrupt | StepResult::Busy => unreachable!(),
+        }
+    }
+}
+
+fn build_fixture(io: &Arc<LatencyIo>) {
+    let db = open_db(io.clone());
+    let conn = db.connect().unwrap();
+    execute(&conn, io, "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT)");
+    execute(
+        &conn,
+        io,
+        &format!("INSERT INTO t SELECT value, hex(zeroblob(48)) FROM generate_series(1, {ROWS})"),
+    );
+    execute(&conn, io, "PRAGMA wal_checkpoint(TRUNCATE)");
+}
+
+/// Opens a fresh database instance (cold page cache) and scans the table.
+fn scan_cold(io: &Arc<LatencyIo>, prefetch_pages: usize) {
+    let db = open_db(io.clone());
+    let conn = db.connect().unwrap();
+    execute(
+        &conn,
+        io,
+        &format!("PRAGMA prefetch_pages = {prefetch_pages}"),
+    );
+    let mut stmt = conn.prepare("SELECT count(*), sum(a) FROM t").unwrap();
+    run_to_completion(&mut stmt, io);
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_scan_readahead(criterion: &mut Criterion) {
+    let io = Arc::new(LatencyIo::new(READ_DELAY_TICKS));
+    build_fixture(&io);
+
+    if std::env::var("PREFETCH_BENCH_DEBUG").is_ok() {
+        for pages in [0usize, 8, 32, 128] {
+            let t0 = io.state.lock().unwrap().tick;
+            scan_cold(&io, pages);
+            let t1 = io.state.lock().unwrap().tick;
+            eprintln!("prefetch_pages={pages}: ticks={}", t1 - t0);
+        }
+    }
+
+    let mut group = criterion.benchmark_group("scan_readahead_latency_device");
+    group.sample_size(10);
+    for prefetch_pages in [0usize, 8, 32, 128] {
+        group.bench_with_input(
+            BenchmarkId::new("prefetch_pages", prefetch_pages),
+            &prefetch_pages,
+            |b, &prefetch_pages| {
+                b.iter(|| scan_cold(&io, prefetch_pages));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_scan_readahead);
+criterion_main!(benches);

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -211,6 +211,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["cache_spill"],
         ),
+        PragmaName::PrefetchPages => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["prefetch_pages"],
+        ),
         #[cfg(target_vendor = "apple")]
         PragmaName::Fullfsync => Pragma::new(
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -19,6 +19,7 @@ use crate::{
     schema::{BTreeTable, Index},
     storage::{
         pager::{BtreePageAllocMode, Pager},
+        readahead::{PrefetchPlan, ScanReadahead},
         sqlite3_ondisk::{
             payload_overflows, read_u32, read_varint, write_varint, BTreeCell, DatabaseHeader,
             PageContent, PageSize, PageType, TableInteriorCell, CELL_PTR_SIZE_BYTES,
@@ -840,6 +841,9 @@ pub struct BTreeCursor {
     /// Reusable buffer for cell payloads during insert/update operations.
     /// This avoids allocating a new Vec for each write operation.
     reusable_cell_payload: crate::alloc::Vec<u8>,
+    /// Decides when a forward scan should read upcoming leaf pages before
+    /// the cursor gets to them. See `PRAGMA prefetch_pages`.
+    readahead: ScanReadahead,
     /// Per-cell access cache for incremental blob I/O. Caches the leaf cell's payload
     /// layout, the overflow-page-number array (Turso's runtime reconstruction of
     /// SQLite's `aOverflow`), and the byte range of the most recently accessed column,
@@ -1118,6 +1122,7 @@ impl BTreeCursor {
             skip_advance: false,
             reusable_cell_payload: crate::alloc::vec![],
             blob_cache: BlobCellCache::default(),
+            readahead: ScanReadahead::new(),
             blob_pinned_rowid: None,
             blob_expired: false,
             iteration_pending_descent: None,
@@ -1544,6 +1549,7 @@ impl BTreeCursor {
                 let cell_count = contents.cell_count();
                 let is_leaf = contents.is_leaf();
                 if cell_idx != -1 && is_leaf && cell_idx as usize + 1 < cell_count {
+                    self.readahead.note_leaf_level(self.stack.current());
                     self.stack.advance();
                     return Ok(IOResult::Done(true));
                 }
@@ -1585,6 +1591,7 @@ impl BTreeCursor {
                         (Some(right_most_pointer), false) => {
                             // do rightmost
                             self.stack.advance();
+                            self.maybe_readahead(&mem_page, cell_count);
                             // Spill yield from here would re-enter the loop
                             // top with cell_idx already advanced twice; we
                             // record the descent target in
@@ -1627,6 +1634,7 @@ impl BTreeCursor {
                 );
 
                 if is_leaf {
+                    self.readahead.note_leaf_level(self.stack.current());
                     return Ok(IOResult::Done(true));
                 }
                 if is_index && self.going_upwards {
@@ -1637,6 +1645,7 @@ impl BTreeCursor {
                 }
 
                 let left_child_page = contents.cell_interior_read_left_child_page(cell_idx)?;
+                self.maybe_readahead(&mem_page, cell_idx);
                 // Same re-entry handling as the rightmost branch above —
                 // the loop-top `stack.advance()` has already fired for this
                 // step, so we route a spill yield through
@@ -1708,6 +1717,110 @@ impl BTreeCursor {
         self.stack.push_backwards(page);
     }
 
+    /// Ask the readahead policy whether the scan should read pages ahead of
+    /// the cursor, and submit those reads. Called right before descending
+    /// from the interior page on top of the stack into its child at
+    /// `child_idx` (`cell_count` means the rightmost pointer). Never yields.
+    #[aristo::intent(
+        "A readahead failure turns readahead off for the rest of the scan \
+         instead of failing the statement. Prefetch targets include pages an \
+         early-stopping scan never visits, so propagating a speculative \
+         error would fail queries whose own read set is perfectly healthy; \
+         the foreground read surfaces real corruption on the pages the query \
+         actually touches.",
+        verify = "neural",
+        id = "readahead_failure_never_fails_the_scan"
+    )]
+    fn maybe_readahead(&mut self, interior: &PageRef, child_idx: usize) {
+        let level = self.stack.current();
+        let contents = interior.get_contents();
+        let cell_count = contents.cell_count();
+        let Some(plan) = self
+            .readahead
+            .on_descend(level, interior.get().id, child_idx, cell_count)
+        else {
+            return;
+        };
+        if let Err(e) = self.submit_readahead(plan, interior, level, cell_count) {
+            tracing::debug!("readahead disabled for the rest of this scan: {e}");
+            self.readahead.disable_for_scan();
+        }
+    }
+
+    /// Submit the reads for one readahead plan: upcoming children of the
+    /// current interior page, and optionally the interior page that follows
+    /// it, so the scan does not stall when it switches parents.
+    fn submit_readahead(
+        &self,
+        plan: PrefetchPlan,
+        interior: &PageRef,
+        interior_level: usize,
+        cell_count: usize,
+    ) -> Result<()> {
+        let interior_contents = interior.get_contents();
+        for idx in plan.start_child_idx..plan.start_child_idx + plan.count {
+            let page_no = if idx < cell_count {
+                interior_contents.cell_interior_read_left_child_page(idx)?
+            } else {
+                match interior_contents.rightmost_pointer()? {
+                    Some(rightmost) => rightmost,
+                    None => break,
+                }
+            };
+            // A corrupt child pointer must be reported by the foreground
+            // read that actually visits it, not by a speculative one.
+            if page_no < 1 {
+                return_corrupt!(
+                    "readahead found invalid child pointer {page_no} on page {}",
+                    interior.get().id
+                );
+            }
+            self.pager.prefetch_page(page_no as i64)?;
+        }
+        if plan.prefetch_next_interior {
+            self.prefetch_next_interior_sibling(interior_level)?;
+        }
+        Ok(())
+    }
+
+    /// Prefetch the interior page that follows the one at `level`, found
+    /// through the grandparent's next child pointer. Does nothing when the
+    /// interior page is the root or the grandparent is exhausted too.
+    fn prefetch_next_interior_sibling(&self, level: usize) -> Result<()> {
+        if level == 0 {
+            return Ok(());
+        }
+        let parent_level = level - 1;
+        let Some(parent) = self.stack.get_page_at_level(parent_level) else {
+            return Ok(());
+        };
+        let parent_contents = parent.get_contents();
+        let parent_cell_count = parent_contents.cell_count();
+        let parent_idx = self.stack.node_states[parent_level].cell_idx;
+        if parent_idx < 0 {
+            return Ok(());
+        }
+        let next_idx = parent_idx as usize + 1;
+        let page_no = if next_idx < parent_cell_count {
+            parent_contents.cell_interior_read_left_child_page(next_idx)?
+        } else if next_idx == parent_cell_count {
+            match parent_contents.rightmost_pointer()? {
+                Some(rightmost) => rightmost,
+                None => return Ok(()),
+            }
+        } else {
+            return Ok(());
+        };
+        if page_no < 1 {
+            return_corrupt!(
+                "readahead found invalid child pointer {page_no} on page {}",
+                parent.get().id
+            );
+        }
+        self.pager.prefetch_page(page_no as i64)?;
+        Ok(())
+    }
+
     /// Move the cursor to the root page of the btree.
     ///
     /// Blocking shim retained for tests and any caller that doesn't have an
@@ -1736,6 +1849,9 @@ impl BTreeCursor {
         let (mem_page, c) = return_if_io!(self.read_page(self.root_page));
         self.stack.clear();
         self.stack.push(mem_page);
+        // Every repositioning starts here, so this is where readahead
+        // forgets the old access pattern and re-reads the pragma.
+        self.readahead.on_jump(self.pager.get_prefetch_pages());
         Ok(IOResult::Done(c))
     }
 
@@ -6992,6 +7108,10 @@ impl CursorTrait for BTreeCursor {
                     self.clear_saved_seek();
                     let c = return_if_io!(self.move_to_root_nonblock());
                     self.count_state = CountState::Loop;
+                    // A count is a declared full sweep of the btree; like a
+                    // rewind, readahead may start at the first leaf. This
+                    // state transition runs exactly once per count.
+                    self.readahead.on_scan_start();
                     if let Some(c) = c {
                         io_yield_one!(c);
                     }
@@ -7007,6 +7127,9 @@ impl CursorTrait for BTreeCursor {
                      */
                     if !matches!(contents.page_type()?, PageType::TableInterior) {
                         self.count += contents.cell_count();
+                    }
+                    if contents.is_leaf() {
+                        self.readahead.note_leaf_level(self.stack.current());
                     }
 
                     let cell_idx = self.stack.current_cell_index() as usize;
@@ -7070,7 +7193,7 @@ impl CursorTrait for BTreeCursor {
                         // Move to child left page
                         let cell = contents.cell_get(cell_idx, self.usable_space())?;
 
-                        match cell {
+                        let left_child_page = match cell {
                             BTreeCell::TableInteriorCell(TableInteriorCell {
                                 left_child_page,
                                 ..
@@ -7078,26 +7201,29 @@ impl CursorTrait for BTreeCursor {
                             | BTreeCell::IndexInteriorCell(IndexInteriorCell {
                                 left_child_page,
                                 ..
-                            }) => {
-                                // Same re-entry handling as the rightmost
-                                // branch above.
-                                match self.pager.read_page(left_child_page as i64)? {
-                                    IOResult::Done((child, c)) => {
-                                        self.stack.advance();
-                                        self.stack.push(child);
-                                        if let Some(c) = c {
-                                            io_yield_one!(c);
-                                        }
-                                    }
-                                    IOResult::IO(IOCompletions(spill_c)) => {
-                                        self.count_state = CountState::Descend {
-                                            target: left_child_page as i64,
-                                        };
-                                        io_yield_one!(spill_c);
-                                    }
+                            }) => left_child_page,
+                            _ => unreachable!(),
+                        };
+                        // A count visits every leaf in order, so it benefits
+                        // from the same readahead as a next()-driven scan.
+                        let interior = mem_page.clone();
+                        self.maybe_readahead(&interior, cell_idx);
+                        // Same re-entry handling as the rightmost branch
+                        // above.
+                        match self.pager.read_page(left_child_page as i64)? {
+                            IOResult::Done((child, c)) => {
+                                self.stack.advance();
+                                self.stack.push(child);
+                                if let Some(c) = c {
+                                    io_yield_one!(c);
                                 }
                             }
-                            _ => unreachable!(),
+                            IOResult::IO(IOCompletions(spill_c)) => {
+                                self.count_state = CountState::Descend {
+                                    target: left_child_page as i64,
+                                };
+                                io_yield_one!(spill_c);
+                            }
                         }
                     }
                 }
@@ -7148,6 +7274,12 @@ impl CursorTrait for BTreeCursor {
                 RewindState::Start => {
                     let c = return_if_io!(self.move_to_root_nonblock());
                     self.rewind_state = RewindState::NextRecord;
+                    // A rewind declares a sequential scan, so readahead may
+                    // start at the first leaf instead of waiting for a
+                    // sequential streak. This state transition runs exactly
+                    // once per logical rewind, unlike the surrounding code
+                    // which re-runs when IO makes the caller re-enter.
+                    self.readahead.on_scan_start();
                     if let Some(c) = c {
                         io_yield_one!(c);
                     }

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod page_cache;
 pub(crate) mod page_transform;
 #[allow(clippy::arc_with_non_send_sync)]
 pub(crate) mod pager;
+pub(crate) mod readahead;
 #[cfg(host_shared_wal)]
 #[allow(dead_code)]
 pub(crate) mod shared_wal_coordination;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1410,6 +1410,42 @@ pub struct Pager {
     /// Counterpart of SQLite's BtShared.pCursor list; bucketing per root
     /// supplies the BTCF_Multiple fast path (btree.c:9348).
     pub(crate) cursor_registry: Mutex<rustc_hash::FxHashMap<i64, Vec<RegisteredCursor>>>,
+    /// Max pages a scan may read ahead of the cursor. 0 disables readahead.
+    /// Set with `PRAGMA prefetch_pages`.
+    prefetch_pages: AtomicUsize,
+    /// Counters for scan readahead. See [Pager::prefetch_page].
+    readahead_stats: ReadaheadStats,
+}
+
+/// Counters for scan readahead, exposed for tests and diagnostics.
+#[derive(Default)]
+pub struct ReadaheadStats {
+    /// Page reads submitted ahead of the scan.
+    pub pages_submitted: AtomicU64,
+    /// Prefetch targets skipped because the page was already cached or its
+    /// read was already in flight.
+    pub pages_already_cached: AtomicU64,
+    /// Prefetches dropped because the page cache had no room for them.
+    pub dropped_cache_full: AtomicU64,
+}
+
+/// Point-in-time copy of [ReadaheadStats].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadaheadSnapshot {
+    pub pages_submitted: u64,
+    pub pages_already_cached: u64,
+    pub dropped_cache_full: u64,
+}
+
+/// What [Pager::prefetch_page] did for one page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrefetchOutcome {
+    /// A read was submitted; the page will appear in the cache when it lands.
+    Submitted,
+    /// The page is already cached or already being read; nothing to do.
+    AlreadyCached,
+    /// The page cache has no room for a speculative page; nothing was read.
+    CacheFull,
 }
 
 /// Raw fat pointer to a registered cursor.
@@ -1697,6 +1733,8 @@ impl Pager {
             #[cfg(target_vendor = "apple")]
             sync_type: AtomicFileSyncType::new(FileSyncType::Fsync),
             cursor_registry: Mutex::new(rustc_hash::FxHashMap::default()),
+            prefetch_pages: AtomicUsize::new(0),
+            readahead_stats: ReadaheadStats::default(),
         })
     }
 
@@ -3271,6 +3309,19 @@ impl Pager {
         turso_assert_greater_than_or_equal!(page_idx, 0);
         tracing::debug!("read_page_no_cache(page_idx = {})", page_idx);
         let page = Arc::new(Page::new(page_idx));
+        let c = self.begin_read_page_into(page.clone(), frame_watermark, allow_empty_read)?;
+        Ok((page, c))
+    }
+
+    /// Start a read of `page` from either the WAL or the DB file. The page is
+    /// marked locked; the returned completion unlocks it and marks it loaded.
+    fn begin_read_page_into(
+        &self,
+        page: PageRef,
+        frame_watermark: Option<u64>,
+        allow_empty_read: bool,
+    ) -> Result<Completion> {
+        let page_idx = page.get().id;
         let io_ctx = self.io_ctx.read();
         let Some(wal) = self.wal.as_ref() else {
             turso_assert!(
@@ -3279,26 +3330,104 @@ impl Pager {
             );
 
             page.set_locked();
-            let c = self.begin_read_disk_page(
-                page_idx as usize,
-                page.clone(),
-                allow_empty_read,
-                &io_ctx,
-            )?;
-            return Ok((page, c));
+            return self.begin_read_disk_page(page_idx, page, allow_empty_read, &io_ctx);
         };
 
         if let Some(frame_id) = wal.find_frame(page_idx as u64, frame_watermark)? {
-            let c = wal.read_frame(frame_id, page.clone(), self.buffer_pool.clone())?;
             // TODO(pere) should probably first insert to page cache, and if successful,
             // read frame or page
-            return Ok((page, c));
+            return wal.read_frame(frame_id, page, self.buffer_pool.clone());
         }
 
         page.set_locked();
-        let c =
-            self.begin_read_disk_page(page_idx as usize, page.clone(), allow_empty_read, &io_ctx)?;
-        Ok((page, c))
+        self.begin_read_disk_page(page_idx, page, allow_empty_read, &io_ctx)
+    }
+
+    /// Max pages a scan may read ahead of the cursor. 0 disables readahead.
+    pub fn set_prefetch_pages(&self, pages: usize) {
+        self.prefetch_pages.store(pages, Ordering::Relaxed);
+    }
+
+    pub fn get_prefetch_pages(&self) -> usize {
+        self.prefetch_pages.load(Ordering::Relaxed)
+    }
+
+    pub fn readahead_stats(&self) -> ReadaheadSnapshot {
+        ReadaheadSnapshot {
+            pages_submitted: self.readahead_stats.pages_submitted.load(Ordering::Relaxed),
+            pages_already_cached: self
+                .readahead_stats
+                .pages_already_cached
+                .load(Ordering::Relaxed),
+            dropped_cache_full: self
+                .readahead_stats
+                .dropped_cache_full
+                .load(Ordering::Relaxed),
+        }
+    }
+
+    /// Start reading a page the caller expects to need soon, without waiting
+    /// for it. The read goes through the same WAL-aware path as
+    /// [Pager::read_page], so a later `read_page` for the same page is a cache
+    /// hit (or waits on the in-flight read via the locked page in the cache).
+    #[aristo::intent(
+        "A speculative read stays invisible to queries: it never spills dirty \
+         pages, never yields, and a failed submission leaves the page \
+         unloaded and unlocked so the next cache lookup deletes it and the \
+         real read re-issues the IO. Routing prefetch through the spilling \
+         insert path would silently convert speculation into foreground \
+         write pressure and cache-full stalls.",
+        verify = "neural",
+        id = "prefetch_is_invisible_to_queries"
+    )]
+    pub fn prefetch_page(&self, page_idx: i64) -> Result<PrefetchOutcome> {
+        turso_assert_greater_than_or_equal!(page_idx, 1, "cannot prefetch invalid page number");
+        if self.pending_reads.read().contains_key(&page_idx) {
+            self.readahead_stats
+                .pages_already_cached
+                .fetch_add(1, Ordering::Relaxed);
+            return Ok(PrefetchOutcome::AlreadyCached);
+        }
+        let page = Arc::new(Page::new(page_idx));
+        // Publish the page as locked before submitting the read: a concurrent
+        // reader that finds it in the cache treats it exactly like any other
+        // in-flight read (yields until loaded). Insert before submitting so
+        // that a full cache costs us nothing (no wasted IO).
+        page.set_locked();
+        {
+            let mut page_cache = self.page_cache.write();
+            let page_key = PageCacheKey::new(page_idx as usize);
+            if page_cache.get(&page_key)?.is_some() {
+                self.readahead_stats
+                    .pages_already_cached
+                    .fetch_add(1, Ordering::Relaxed);
+                return Ok(PrefetchOutcome::AlreadyCached);
+            }
+            match page_cache.insert(page_key, page.clone()) {
+                Ok(_) => {}
+                Err(CacheError::Full) => {
+                    self.readahead_stats
+                        .dropped_cache_full
+                        .fetch_add(1, Ordering::Relaxed);
+                    return Ok(PrefetchOutcome::CacheFull);
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+        match self.begin_read_page_into(page.clone(), None, false) {
+            Ok(_) => {
+                self.readahead_stats
+                    .pages_submitted
+                    .fetch_add(1, Ordering::Relaxed);
+                Ok(PrefetchOutcome::Submitted)
+            }
+            Err(e) => {
+                // Leave the entry unloaded+unlocked; the next cache get
+                // deletes it and the real read retries from scratch.
+                page.clear_locked();
+                Err(e)
+            }
+        }
     }
 
     /// Issue a non-blocking page read, inserting into the page cache, may spill to disk.
@@ -6716,6 +6845,135 @@ mod ptrmap_tests {
             }
             IOResult::IO(_) => panic!("loaded cache hit must not yield"),
         }
+    }
+
+    /// Writes raw bytes for `page_idx` directly into the MemoryIO-backed DB
+    /// file so a later read of that page succeeds.
+    fn write_raw_page(pager: &Pager, page_idx: usize, fill: u8) {
+        let page_size = 4096usize;
+        let io = pager.io.clone();
+        let file = io
+            .open_file("test.db", crate::io::OpenFlags::None, true)
+            .unwrap();
+        let buf = Arc::new(crate::Buffer::new_temporary(page_size));
+        buf.as_mut_slice().fill(fill);
+        let c = Completion::new_write(|_| {});
+        let c = file
+            .pwrite((page_idx as u64 - 1) * page_size as u64, buf, c)
+            .unwrap();
+        io.wait_for_completion(c).unwrap();
+    }
+
+    /// A prefetched page lands in the cache through the normal read path, a
+    /// later `read_page` is a pure cache hit, and a repeated prefetch is a
+    /// no-op.
+    #[test]
+    fn prefetch_page_lands_in_cache_and_read_page_dedups() {
+        let pager = test_pager_setup(4096, 10);
+        write_raw_page(&pager, 50, 0xAB);
+
+        assert_eq!(pager.prefetch_page(50).unwrap(), PrefetchOutcome::Submitted);
+        pager.io.step().unwrap();
+
+        let stats = pager.readahead_stats();
+        assert_eq!(stats.pages_submitted, 1);
+
+        let cached = pager.cache_get(50).unwrap().expect("page must be cached");
+        assert!(cached.is_loaded(), "prefetched page should be loaded");
+        assert_eq!(cached.get_contents().as_ptr()[0], 0xAB);
+
+        match pager.read_page(50).unwrap() {
+            IOResult::Done((page, c)) => {
+                assert!(Arc::ptr_eq(&page, &cached));
+                assert!(c.is_none(), "prefetched page must be a pure cache hit");
+            }
+            IOResult::IO(_) => panic!("prefetched page must not require IO"),
+        }
+        assert!(pager.pending_reads.read().is_empty());
+
+        assert_eq!(
+            pager.prefetch_page(50).unwrap(),
+            PrefetchOutcome::AlreadyCached
+        );
+        assert_eq!(pager.readahead_stats().pages_already_cached, 1);
+    }
+
+    /// The invariant behind `prefetch_is_invisible_to_queries`: when a
+    /// speculative read fails (here: short read past the end of the file),
+    /// the page must vanish from the cache on the next lookup and a real
+    /// read must succeed once the data exists.
+    #[test]
+    fn failed_prefetch_self_heals_and_later_reads_succeed() {
+        let pager = test_pager_setup(4096, 10);
+        write_raw_page(&pager, 50, 0xAB);
+
+        // Page 60 does not exist yet: the prefetch read comes back short.
+        assert_eq!(pager.prefetch_page(60).unwrap(), PrefetchOutcome::Submitted);
+        pager.io.step().unwrap();
+
+        // The failed page must not be served from cache.
+        assert!(
+            pager.cache_get(60).unwrap().is_none(),
+            "a page whose speculative read failed must not stay in the cache"
+        );
+
+        // Once the page exists, a normal read succeeds from scratch.
+        write_raw_page(&pager, 60, 0xCD);
+        let (page, c) = match pager.read_page(60).unwrap() {
+            IOResult::Done(v) => v,
+            IOResult::IO(_) => panic!("read after failed prefetch should proceed"),
+        };
+        if let Some(c) = c {
+            pager.io.wait_for_completion(c).unwrap();
+        }
+        assert!(page.is_loaded());
+        assert_eq!(page.get_contents().as_ptr()[0], 0xCD);
+    }
+
+    /// A full, unevictable cache drops the prefetch instead of spilling,
+    /// erroring, or blocking the foreground read that follows.
+    #[test]
+    fn prefetch_is_dropped_when_the_cache_has_no_room() {
+        let pager = test_pager_setup(4096, 10);
+        write_raw_page(&pager, 50, 0xAB);
+
+        // Fill the cache with pinned pages so nothing is evictable. The vec
+        // only keeps the PageRefs alive (an outstanding ref also blocks
+        // eviction).
+        #[allow(clippy::collection_is_never_read)]
+        let mut pinned = Vec::new();
+        for id in 1000i64.. {
+            let page: PageRef = Arc::new(Page::new(id));
+            page.set_loaded();
+            page.pin();
+            let insert = pager
+                .page_cache
+                .write()
+                .insert(PageCacheKey::new(id as usize), page.clone());
+            match insert {
+                Ok(_) => pinned.push(page),
+                Err(CacheError::Full) => break,
+                Err(e) => panic!("unexpected cache error: {e:?}"),
+            }
+        }
+
+        assert_eq!(pager.prefetch_page(50).unwrap(), PrefetchOutcome::CacheFull);
+        assert_eq!(pager.readahead_stats().dropped_cache_full, 1);
+        assert_eq!(pager.readahead_stats().pages_submitted, 0);
+        assert!(
+            pager.cache_get(50).unwrap().is_none(),
+            "a dropped prefetch must leave no cache entry behind"
+        );
+
+        // The foreground read still succeeds (over-capacity force insert).
+        let (page, c) = match pager.read_page(50).unwrap() {
+            IOResult::Done(v) => v,
+            IOResult::IO(_) => panic!("foreground read should proceed with a full cache"),
+        };
+        if let Some(c) = c {
+            pager.io.wait_for_completion(c).unwrap();
+        }
+        assert!(page.is_loaded());
     }
 }
 

--- a/core/storage/readahead.rs
+++ b/core/storage/readahead.rs
@@ -1,0 +1,371 @@
+//! Scan readahead policy: decide when a B-tree scan should read pages
+//! before the cursor gets to them, and how many.
+//!
+//! The shape is borrowed from Linux file readahead:
+//!
+//! * Random access never prefetches. Readahead starts only when access is
+//!   known to be sequential: either the scan was started with a rewind
+//!   (a declared full scan, the analog of Linux starting readahead for a
+//!   read at file offset 0), or the cursor has moved across enough
+//!   consecutive leaf pages.
+//! * The distance we stay ahead of the cursor starts small and doubles
+//!   each time the scan consumes a full window, so short scans waste at
+//!   most a few pages while long scans ramp up to the cap.
+//! * The cap comes from `PRAGMA prefetch_pages`; 0 (the default) turns
+//!   readahead off entirely.
+//!
+//! Unlike a filesystem we never guess future offsets: the cursor's parent
+//! interior page lists exactly which leaf pages the scan visits next, so a
+//! prefetched page is wrong only if the scan stops early. This module is
+//! pure policy; the B-tree cursor resolves child indexes to page numbers
+//! and the pager submits the reads.
+
+/// Upper bound for `PRAGMA prefetch_pages`. Bounds how much IO a scan can
+/// have in flight; 4096 pages is 16 MiB at the default page size.
+pub(crate) const MAX_PREFETCH_PAGES: usize = 4096;
+
+/// Window size for the first batch of a newly activated scan.
+const INITIAL_WINDOW: usize = 4;
+
+/// Number of consecutive forward leaf transitions after which access
+/// counts as sequential. A rewind pre-satisfies this.
+const ACTIVATION_STREAK: usize = 2;
+
+/// Per-cursor readahead state.
+pub(crate) struct ScanReadahead {
+    /// Max pages this scan may keep ahead of the cursor. 0 = off.
+    budget: usize,
+    /// Stack level where this btree's leaf pages live, once we've seen one.
+    leaf_level: Option<usize>,
+    /// Consecutive forward leaf transitions since the last jump.
+    streak: usize,
+    /// How many pages ahead we currently try to stay.
+    window: usize,
+    /// Leaf transitions consumed since the window last grew.
+    consumed_since_growth: usize,
+    /// How far we have prefetched into the current parent interior page.
+    frontier: Option<Frontier>,
+}
+
+struct Frontier {
+    /// Page id of the interior page the prefetched children belong to.
+    interior_page_id: usize,
+    /// First child index not prefetched yet. Child index `cell_count`
+    /// means the interior page's rightmost pointer.
+    next_child_idx: usize,
+    /// Whether the interior page that follows the current one was already
+    /// prefetched, so switching parents does not stall the scan.
+    next_interior_prefetched: bool,
+}
+
+/// One batch of prefetches for the cursor to submit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PrefetchPlan {
+    /// First child index of the current interior page to prefetch.
+    /// Index `cell_count` means the rightmost pointer.
+    pub start_child_idx: usize,
+    /// How many children to prefetch, starting at `start_child_idx`.
+    pub count: usize,
+    /// Also prefetch the next interior page at this level (found through
+    /// the grandparent): this plan reaches the end of the current parent.
+    pub prefetch_next_interior: bool,
+}
+
+impl ScanReadahead {
+    pub fn new() -> Self {
+        Self {
+            budget: 0,
+            leaf_level: None,
+            streak: 0,
+            window: INITIAL_WINDOW,
+            consumed_since_growth: 0,
+            frontier: None,
+        }
+    }
+
+    /// The cursor repositioned (seek, rewind, move to root): forget the
+    /// access pattern. `budget` is the current `PRAGMA prefetch_pages`
+    /// value; it is re-read here so the pragma takes effect on the next
+    /// scan without touching in-flight state.
+    pub fn on_jump(&mut self, budget: usize) {
+        self.budget = budget;
+        self.streak = 0;
+        self.window = INITIAL_WINDOW.min(budget.max(1));
+        self.consumed_since_growth = 0;
+        self.frontier = None;
+    }
+
+    /// A full scan was requested (cursor rewind). Sequential access is
+    /// certain, so readahead starts at the first leaf instead of waiting
+    /// for a streak.
+    pub fn on_scan_start(&mut self) {
+        self.streak = ACTIVATION_STREAK;
+    }
+
+    /// Remember at which stack level the leaves of this btree live.
+    pub fn note_leaf_level(&mut self, level: usize) {
+        self.leaf_level = Some(level);
+    }
+
+    /// Turn readahead off until the next jump. Used when a speculative
+    /// read fails; the real read will surface any real problem.
+    pub fn disable_for_scan(&mut self) {
+        self.budget = 0;
+    }
+
+    /// The cursor is about to descend from the interior page at stack
+    /// level `level` (page id `interior_page_id`, `cell_count` cells) into
+    /// its child at `child_idx` (`cell_count` = the rightmost pointer).
+    /// Returns the batch to prefetch, if any.
+    pub fn on_descend(
+        &mut self,
+        level: usize,
+        interior_page_id: usize,
+        child_idx: usize,
+        cell_count: usize,
+    ) -> Option<PrefetchPlan> {
+        if self.budget == 0 {
+            return None;
+        }
+        // Only descents into leaves count: higher-level descents happen
+        // once per hundreds of leaves and would pollute the streak/window
+        // accounting without measurably helping.
+        let leaf_level = self.leaf_level?;
+        if level + 1 != leaf_level {
+            return None;
+        }
+
+        self.streak += 1;
+        if self.streak < ACTIVATION_STREAK {
+            return None;
+        }
+
+        // The window doubles each time the scan consumes a full window of
+        // leaves, up to the budget.
+        self.consumed_since_growth += 1;
+        if self.consumed_since_growth >= self.window {
+            self.window = (self.window * 2).min(self.budget);
+            self.consumed_since_growth = 0;
+        }
+
+        // Child indexes run 0..=cell_count; index cell_count is the
+        // rightmost pointer.
+        let last_child_idx = cell_count;
+        let mut frontier = match self.frontier.take() {
+            Some(f) if f.interior_page_id == interior_page_id => f,
+            _ => Frontier {
+                interior_page_id,
+                next_child_idx: child_idx + 1,
+                next_interior_prefetched: false,
+            },
+        };
+        // Never lag behind the cursor (e.g. after it skipped over cells).
+        frontier.next_child_idx = frontier.next_child_idx.max(child_idx + 1);
+
+        let ahead = frontier.next_child_idx - (child_idx + 1);
+        let want = self.window.saturating_sub(ahead);
+        let available = (last_child_idx + 1).saturating_sub(frontier.next_child_idx);
+        let count = want.min(available);
+
+        let mut plan = None;
+        if count > 0 {
+            plan = Some(PrefetchPlan {
+                start_child_idx: frontier.next_child_idx,
+                count,
+                prefetch_next_interior: false,
+            });
+            frontier.next_child_idx += count;
+        }
+        // The window extends past this parent: also get the next interior
+        // page moving so the scan does not stall when switching parents.
+        if want > available && !frontier.next_interior_prefetched {
+            frontier.next_interior_prefetched = true;
+            match plan.as_mut() {
+                Some(p) => p.prefetch_next_interior = true,
+                None => {
+                    plan = Some(PrefetchPlan {
+                        start_child_idx: frontier.next_child_idx,
+                        count: 0,
+                        prefetch_next_interior: true,
+                    })
+                }
+            }
+        }
+        self.frontier = Some(frontier);
+        plan
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn active_readahead(budget: usize) -> ScanReadahead {
+        let mut ra = ScanReadahead::new();
+        ra.on_jump(budget);
+        ra.on_scan_start();
+        ra.note_leaf_level(2);
+        ra
+    }
+
+    #[test]
+    fn budget_zero_never_prefetches() {
+        let mut ra = ScanReadahead::new();
+        ra.on_jump(0);
+        ra.on_scan_start();
+        ra.note_leaf_level(1);
+        for child in 0..100 {
+            assert_eq!(ra.on_descend(0, 7, child, 200), None);
+        }
+    }
+
+    #[test]
+    fn no_prefetch_before_leaf_level_is_known() {
+        let mut ra = ScanReadahead::new();
+        ra.on_jump(64);
+        ra.on_scan_start();
+        assert_eq!(ra.on_descend(0, 7, 0, 200), None);
+    }
+
+    #[test]
+    fn descents_above_the_leaf_parent_level_are_ignored() {
+        let mut ra = active_readahead(64);
+        // leaf_level is 2, so only level-1 interiors trigger prefetch.
+        assert_eq!(ra.on_descend(0, 7, 0, 200), None);
+        assert!(ra.on_descend(1, 8, 0, 200).is_some());
+    }
+
+    #[test]
+    fn rewind_prefetches_on_the_first_leaf_descend() {
+        let mut ra = active_readahead(64);
+        let plan = ra.on_descend(1, 7, 0, 200).unwrap();
+        assert_eq!(plan.start_child_idx, 1);
+        assert_eq!(plan.count, INITIAL_WINDOW);
+        assert!(!plan.prefetch_next_interior);
+    }
+
+    #[test]
+    fn random_access_needs_a_streak_before_prefetching() {
+        let mut ra = ScanReadahead::new();
+        ra.on_jump(64);
+        ra.note_leaf_level(2);
+        // First leaf transition after a seek: still counts as random.
+        assert_eq!(ra.on_descend(1, 7, 3, 200), None);
+        // Second consecutive transition: sequential, start prefetching.
+        assert!(ra.on_descend(1, 7, 4, 200).is_some());
+    }
+
+    #[test]
+    fn a_jump_resets_the_streak() {
+        let mut ra = ScanReadahead::new();
+        ra.on_jump(64);
+        ra.note_leaf_level(2);
+        assert_eq!(ra.on_descend(1, 7, 3, 200), None);
+        ra.on_jump(64);
+        ra.note_leaf_level(2);
+        assert_eq!(ra.on_descend(1, 7, 9, 200), None);
+    }
+
+    #[test]
+    fn window_doubles_as_the_scan_consumes_it_and_respects_the_budget() {
+        let budget = 32;
+        let mut ra = active_readahead(budget);
+        let mut max_ahead = 0usize;
+        let mut issued = 0usize;
+        for child in 0..200usize {
+            if let Some(plan) = ra.on_descend(1, 7, child, 400) {
+                issued += plan.count;
+                let ahead = plan.start_child_idx + plan.count - (child + 1);
+                max_ahead = max_ahead.max(ahead);
+                assert!(
+                    ahead <= budget,
+                    "scan got {ahead} pages ahead with budget {budget}"
+                );
+            }
+        }
+        // The scan must actually ramp up to the full budget.
+        assert_eq!(max_ahead, budget);
+        // Everything issued is consumed by a 200-leaf scan except the final
+        // in-flight window.
+        assert!(issued <= 200 + budget);
+    }
+
+    #[test]
+    fn total_prefetch_never_exceeds_consumption_plus_one_window() {
+        // A scan aborted after N leaves must not have prefetched more than
+        // N + budget pages: this is the "do not fetch too much" bound.
+        let budget = 16;
+        for scan_len in [1usize, 2, 3, 5, 10, 50] {
+            let mut ra = active_readahead(budget);
+            let mut issued = 0usize;
+            for child in 0..scan_len {
+                if let Some(plan) = ra.on_descend(1, 7, child, 400) {
+                    issued += plan.count;
+                }
+            }
+            assert!(
+                issued <= scan_len + budget,
+                "scan of {scan_len} leaves prefetched {issued} pages"
+            );
+        }
+    }
+
+    #[test]
+    fn prefetch_covers_every_upcoming_child_exactly_once() {
+        let cell_count = 50;
+        let mut ra = active_readahead(8);
+        let mut seen = vec![0usize; cell_count + 1];
+        for child in 0..cell_count {
+            if let Some(plan) = ra.on_descend(1, 7, child, cell_count) {
+                for idx in plan.start_child_idx..plan.start_child_idx + plan.count {
+                    seen[idx] += 1;
+                }
+            }
+        }
+        // Children 0 (never upcoming) is skipped, everything else fetched
+        // exactly once: no duplicate and no missed IO.
+        for (idx, count) in seen.iter().enumerate().skip(1) {
+            assert_eq!(*count, 1, "child {idx} prefetched {count} times");
+        }
+    }
+
+    #[test]
+    fn reaching_the_end_of_a_parent_prefetches_the_next_interior_once() {
+        let cell_count = 5;
+        let mut ra = active_readahead(64);
+        let mut next_interior_plans = 0;
+        for child in 0..=cell_count {
+            if let Some(plan) = ra.on_descend(1, 7, child, cell_count) {
+                if plan.prefetch_next_interior {
+                    next_interior_plans += 1;
+                }
+            }
+        }
+        assert_eq!(next_interior_plans, 1);
+    }
+
+    #[test]
+    fn moving_to_a_new_parent_restarts_the_frontier() {
+        let mut ra = active_readahead(8);
+        // Consume parent 7 fully.
+        for child in 0..=5 {
+            ra.on_descend(1, 7, child, 5);
+        }
+        // First descend in parent 9 prefetches its upcoming children.
+        let plan = ra.on_descend(1, 9, 0, 5).unwrap();
+        assert_eq!(plan.start_child_idx, 1);
+        assert!(plan.count > 0);
+    }
+
+    #[test]
+    fn disable_for_scan_stops_prefetching_until_the_next_jump() {
+        let mut ra = active_readahead(64);
+        assert!(ra.on_descend(1, 7, 0, 200).is_some());
+        ra.disable_for_scan();
+        assert_eq!(ra.on_descend(1, 7, 1, 200), None);
+        ra.on_jump(64);
+        ra.on_scan_start();
+        ra.note_leaf_level(2);
+        assert!(ra.on_descend(1, 7, 5, 200).is_some());
+    }
+}

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -18,6 +18,7 @@ use crate::schema::{Schema, Table};
 use crate::storage::encryption::{CipherMode, EncryptionKey};
 use crate::storage::pager::AutoVacuumMode;
 use crate::storage::pager::Pager;
+use crate::storage::readahead::MAX_PREFETCH_PAGES;
 use crate::storage::sqlite3_ondisk::CacheSize;
 use crate::storage::wal::CheckpointMode;
 use crate::translate::emitter::{Resolver, TransactionMode};
@@ -362,6 +363,17 @@ fn update_pragma(
         PragmaName::CacheSpill => {
             let enabled = parse_pragma_enabled(&value);
             connection.get_pager().set_spill_enabled(enabled);
+            connection.bump_prepare_context_generation();
+            Ok(TransactionMode::None)
+        }
+        PragmaName::PrefetchPages => {
+            let pages = match parse_signed_number(&value)? {
+                Value::Numeric(Numeric::Integer(pages)) => pages,
+                Value::Numeric(Numeric::Float(pages)) => f64::from(pages) as i64,
+                _ => bail_parse_error!("Invalid value for prefetch_pages pragma"),
+            };
+            let pages = pages.clamp(0, MAX_PREFETCH_PAGES as i64) as usize;
+            connection.get_pager().set_prefetch_pages(pages);
             connection.bump_prepare_context_generation();
             Ok(TransactionMode::None)
         }
@@ -829,6 +841,13 @@ fn query_pragma(
         PragmaName::CacheSpill => {
             let spill_enabled = connection.get_pager().get_spill_enabled();
             program.emit_int(spill_enabled as i64, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::PrefetchPages => {
+            let prefetch_pages = connection.get_pager().get_prefetch_pages();
+            program.emit_int(prefetch_pages as i64, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
             Ok(TransactionMode::None)

--- a/docs/sql-reference/pragmas.mdx
+++ b/docs/sql-reference/pragmas.mdx
@@ -248,6 +248,21 @@ PRAGMA cache_spill = 0;    -- disable
 PRAGMA cache_spill = 1;    -- enable
 ```
 
+### prefetch_pages
+
+Sets how many pages a scan may read ahead of the cursor. When enabled, forward
+scans that look sequential fetch upcoming B-tree pages before they are needed,
+so the waits for storage overlap instead of happening one page at a time. The
+readahead distance starts small and doubles while the scan keeps going, up to
+this limit. `0` (the default) disables readahead. Values are clamped to at
+most `4096` pages.
+
+```sql
+PRAGMA prefetch_pages;          -- query the current limit
+PRAGMA prefetch_pages = 64;     -- scans may stay up to 64 pages ahead
+PRAGMA prefetch_pages = 0;      -- disable readahead
+```
+
 ### synchronous
 
 Controls the fsync behavior for durability guarantees.

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1905,6 +1905,8 @@ pub enum PragmaName {
     PageCount,
     /// Return the page size of the database in bytes.
     PageSize,
+    /// Max pages a scan may read ahead of the cursor. 0 disables readahead.
+    PrefetchPages,
     /// make connection query only
     QueryOnly,
     /// Returns schema version of the database file.

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -18,6 +18,7 @@ mod pragma;
 mod query_processing;
 mod query_timeout;
 mod queued_io;
+mod readahead;
 mod reindex;
 mod statement_metadata;
 mod statement_reset;

--- a/tests/integration/queued_io.rs
+++ b/tests/integration/queued_io.rs
@@ -100,6 +100,12 @@ impl QueuedIo {
     pub(crate) fn clear_fault(&self) {
         *self.state.fault.lock().unwrap() = None;
     }
+
+    /// Snapshot of every executed operation, for tests that assert on IO
+    /// behavior (op counts, ordering).
+    pub(crate) fn history(&self) -> Vec<QueuedIoEvent> {
+        self.state.history.lock().unwrap().clone()
+    }
 }
 
 impl Clock for QueuedIo {

--- a/tests/integration/readahead.rs
+++ b/tests/integration/readahead.rs
@@ -1,0 +1,352 @@
+//! End-to-end coverage for scan readahead (`PRAGMA prefetch_pages`).
+//!
+//! The tests run on `QueuedIo`, which defers every IO operation into a queue
+//! the harness drains step by step. That gives two things a plain file DB
+//! cannot: an exact history of submitted operations, and reads that stay in
+//! flight until the engine actually waits for them — which is precisely the
+//! window readahead is supposed to exploit.
+
+use crate::queued_io::{QueuedIo, QueuedIoOpKind};
+use std::sync::Arc;
+use turso_core::{Connection, Database, DatabaseOpts, OpenFlags, SqliteDialect};
+
+fn open_db(io: Arc<QueuedIo>, path: &str) -> Arc<Database> {
+    Database::open_file_with_flags(
+        io,
+        path,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap()
+}
+
+/// Executes a query and renders rows as pipe-separated values.
+fn query_rows(conn: &Arc<Connection>, sql: &str) -> Vec<String> {
+    let mut stmt = conn.prepare(sql).unwrap();
+    let mut rows = Vec::new();
+    stmt.run_with_row_callback(|row| {
+        let values: Vec<String> = row.get_values().map(|value| format!("{value}")).collect();
+        rows.push(values.join("|"));
+        Ok(())
+    })
+    .unwrap();
+    rows
+}
+
+fn count_preads(io: &QueuedIo, path_suffix: &str) -> usize {
+    io.history()
+        .iter()
+        .filter(|e| e.kind == QueuedIoOpKind::Pread && e.path.ends_with(path_suffix))
+        .count()
+}
+
+/// Creates a table whose btree spans several hundred leaf pages, then
+/// checkpoints so the pages live in the main DB file.
+fn build_scan_fixture(io: &Arc<QueuedIo>, path: &str, rows: usize) {
+    let db = open_db(io.clone(), path);
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT)")
+        .unwrap();
+    conn.execute(format!(
+        "INSERT INTO t SELECT value, hex(zeroblob(48)) FROM generate_series(1, {rows})"
+    ))
+    .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+}
+
+const SCAN_FIXTURE_ROWS: usize = 20000;
+const SCAN_QUERY: &str = "SELECT count(*), sum(a), max(b) FROM t";
+
+#[test]
+fn full_scan_with_readahead_returns_identical_rows_and_submits_reads() {
+    let io = Arc::new(QueuedIo::new());
+    build_scan_fixture(&io, "readahead-scan.db", SCAN_FIXTURE_ROWS);
+
+    // Baseline: fresh database instance (cold page cache), readahead off.
+    // The pragma runs in both variants so the schema loads before the pread
+    // counting window starts.
+    let db = open_db(io.clone(), "readahead-scan.db");
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA prefetch_pages = 0").unwrap();
+    let preads_before = count_preads(&io, "readahead-scan.db");
+    let baseline = query_rows(&conn, SCAN_QUERY);
+    let baseline_preads = count_preads(&io, "readahead-scan.db") - preads_before;
+    let stats = conn.get_pager().readahead_stats();
+    assert_eq!(
+        stats.pages_submitted, 0,
+        "readahead is off by default and must not submit reads"
+    );
+
+    // Same scan on another cold instance with readahead on.
+    let db = open_db(io.clone(), "readahead-scan.db");
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA prefetch_pages = 64").unwrap();
+    let preads_before = count_preads(&io, "readahead-scan.db");
+    let with_readahead = query_rows(&conn, SCAN_QUERY);
+    let scan_preads = count_preads(&io, "readahead-scan.db") - preads_before;
+
+    assert_eq!(baseline, with_readahead);
+    let stats = conn.get_pager().readahead_stats();
+    assert!(
+        stats.pages_submitted > 100,
+        "a scan over hundreds of leaves should submit hundreds of reads early, got {stats:?}"
+    );
+    // Readahead must not read anything a plain scan would not read: the
+    // fixture pages are visited exactly once either way.
+    assert_eq!(
+        baseline_preads, scan_preads,
+        "readahead changed the total number of DB file reads"
+    );
+}
+
+#[test]
+fn point_queries_never_prefetch() {
+    let io = Arc::new(QueuedIo::new());
+    build_scan_fixture(&io, "readahead-point.db", SCAN_FIXTURE_ROWS);
+
+    let db = open_db(io.clone(), "readahead-point.db");
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA prefetch_pages = 64").unwrap();
+    for a in [1, 5000, 9999, 12345, 19999] {
+        let rows = query_rows(&conn, &format!("SELECT a FROM t WHERE a = {a}"));
+        assert_eq!(rows, vec![a.to_string()]);
+    }
+    let stats = conn.get_pager().readahead_stats();
+    assert_eq!(
+        stats.pages_submitted, 0,
+        "point lookups are random access and must not trigger readahead: {stats:?}"
+    );
+}
+
+#[test]
+fn short_limit_scan_wastes_at_most_the_initial_window() {
+    let io = Arc::new(QueuedIo::new());
+    build_scan_fixture(&io, "readahead-limit.db", SCAN_FIXTURE_ROWS);
+
+    let db = open_db(io.clone(), "readahead-limit.db");
+    let conn = db.connect().unwrap();
+    let budget = 64;
+    conn.execute(format!("PRAGMA prefetch_pages = {budget}"))
+        .unwrap();
+    let rows = query_rows(&conn, "SELECT a FROM t LIMIT 5");
+    assert_eq!(rows.len(), 5);
+    let stats = conn.get_pager().readahead_stats();
+    assert!(
+        stats.pages_submitted <= budget as u64,
+        "a LIMIT 5 scan must not fetch more than one window ahead: {stats:?}"
+    );
+}
+
+#[test]
+fn scan_reading_from_the_wal_prefetches_frames() {
+    let io = Arc::new(QueuedIo::new());
+    // No checkpoint: all table data stays in the WAL.
+    let db = open_db(io.clone(), "readahead-wal.db");
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT)")
+        .unwrap();
+    conn.execute(format!(
+        "INSERT INTO t SELECT value, hex(zeroblob(48)) FROM generate_series(1, {SCAN_FIXTURE_ROWS})"
+    ))
+    .unwrap();
+    drop(conn);
+
+    let db = open_db(io.clone(), "readahead-wal.db");
+    let conn = db.connect().unwrap();
+    let baseline = query_rows(&conn, SCAN_QUERY);
+
+    let db = open_db(io.clone(), "readahead-wal.db");
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA prefetch_pages = 64").unwrap();
+    let with_readahead = query_rows(&conn, SCAN_QUERY);
+
+    assert_eq!(baseline, with_readahead);
+    let stats = conn.get_pager().readahead_stats();
+    assert!(
+        stats.pages_submitted > 100,
+        "WAL-resident pages must be prefetched through the WAL: {stats:?}"
+    );
+    assert!(
+        count_preads(&io, "readahead-wal.db-wal") > 0,
+        "expected WAL reads in the IO history"
+    );
+}
+
+#[test]
+fn fragmented_table_scans_match_without_readahead() {
+    let io = Arc::new(QueuedIo::new());
+    let db = open_db(io.clone(), "readahead-frag.db");
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT)")
+        .unwrap();
+    conn.execute(format!(
+        "INSERT INTO t SELECT value, hex(zeroblob(48)) FROM generate_series(1, {SCAN_FIXTURE_ROWS})"
+    ))
+    .unwrap();
+    // Punch holes everywhere, then add fresh rows so free pages get reused
+    // and the leaf order no longer matches the physical page order.
+    conn.execute("DELETE FROM t WHERE a % 3 = 0").unwrap();
+    conn.execute(format!(
+        "INSERT INTO t SELECT value + {SCAN_FIXTURE_ROWS}, hex(zeroblob(48)) FROM generate_series(1, 5000)"
+    ))
+    .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    drop(conn);
+
+    let db = open_db(io.clone(), "readahead-frag.db");
+    let conn = db.connect().unwrap();
+    let baseline = query_rows(&conn, SCAN_QUERY);
+
+    let db = open_db(io.clone(), "readahead-frag.db");
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA prefetch_pages = 64").unwrap();
+    let with_readahead = query_rows(&conn, SCAN_QUERY);
+
+    assert_eq!(baseline, with_readahead);
+    let stats = conn.get_pager().readahead_stats();
+    assert!(
+        stats.pages_submitted > 100,
+        "readahead follows btree pointers, so fragmentation must not stop it: {stats:?}"
+    );
+}
+
+#[test]
+fn index_range_scans_prefetch_index_leaves() {
+    let io = Arc::new(QueuedIo::new());
+    let db = open_db(io.clone(), "readahead-index.db");
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t(a INTEGER PRIMARY KEY, b INTEGER, c TEXT)")
+        .unwrap();
+    conn.execute(format!(
+        "INSERT INTO t SELECT value, value * 7, hex(zeroblob(48)) FROM generate_series(1, {SCAN_FIXTURE_ROWS})"
+    ))
+    .unwrap();
+    conn.execute("CREATE INDEX idx_b ON t(b)").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    drop(conn);
+
+    const RANGE_QUERY: &str = "SELECT count(*), sum(b) FROM t WHERE b > 0";
+
+    let db = open_db(io.clone(), "readahead-index.db");
+    let conn = db.connect().unwrap();
+    let baseline = query_rows(&conn, RANGE_QUERY);
+
+    let db = open_db(io.clone(), "readahead-index.db");
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA prefetch_pages = 64").unwrap();
+    let with_readahead = query_rows(&conn, RANGE_QUERY);
+
+    assert_eq!(baseline, with_readahead);
+    let stats = conn.get_pager().readahead_stats();
+    assert!(
+        stats.pages_submitted > 20,
+        "a covering index range scan should prefetch index leaves: {stats:?}"
+    );
+}
+
+#[test]
+fn backward_scans_do_not_prefetch() {
+    let io = Arc::new(QueuedIo::new());
+    build_scan_fixture(&io, "readahead-desc.db", SCAN_FIXTURE_ROWS);
+
+    let db = open_db(io.clone(), "readahead-desc.db");
+    let conn = db.connect().unwrap();
+    let baseline = query_rows(&conn, "SELECT a FROM t ORDER BY a DESC LIMIT 100");
+
+    let db = open_db(io.clone(), "readahead-desc.db");
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA prefetch_pages = 64").unwrap();
+    let with_readahead = query_rows(&conn, "SELECT a FROM t ORDER BY a DESC LIMIT 100");
+
+    assert_eq!(baseline, with_readahead);
+    let stats = conn.get_pager().readahead_stats();
+    assert_eq!(
+        stats.pages_submitted, 0,
+        "backward iteration is out of scope and must not prefetch: {stats:?}"
+    );
+}
+
+#[test]
+fn joined_scans_over_two_tables_stay_correct() {
+    let io = Arc::new(QueuedIo::new());
+    let db = open_db(io.clone(), "readahead-join.db");
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT)")
+        .unwrap();
+    conn.execute("CREATE TABLE t2(a INTEGER PRIMARY KEY, b TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO t1 SELECT value, hex(zeroblob(48)) FROM generate_series(1, 5000)")
+        .unwrap();
+    conn.execute("INSERT INTO t2 SELECT value, hex(zeroblob(48)) FROM generate_series(1, 5000)")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    drop(conn);
+
+    const JOIN_QUERY: &str = "SELECT count(*), sum(t1.a + t2.a) FROM t1 JOIN t2 ON t1.a = t2.a";
+
+    let db = open_db(io.clone(), "readahead-join.db");
+    let conn = db.connect().unwrap();
+    let baseline = query_rows(&conn, JOIN_QUERY);
+
+    let db = open_db(io.clone(), "readahead-join.db");
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA prefetch_pages = 64").unwrap();
+    let with_readahead = query_rows(&conn, JOIN_QUERY);
+
+    assert_eq!(baseline, with_readahead);
+}
+
+#[test]
+fn scans_under_a_tiny_page_cache_degrade_gracefully() {
+    let io = Arc::new(QueuedIo::new());
+    build_scan_fixture(&io, "readahead-tiny-cache.db", SCAN_FIXTURE_ROWS);
+
+    let db = open_db(io.clone(), "readahead-tiny-cache.db");
+    let conn = db.connect().unwrap();
+    // Minimum cache, maximum prefetch budget: prefetches must be dropped,
+    // not spilled or errored, and the scan must stay correct.
+    conn.execute("PRAGMA cache_size = 200").unwrap();
+    conn.execute("PRAGMA prefetch_pages = 4096").unwrap();
+    let rows = query_rows(&conn, SCAN_QUERY);
+
+    let db = open_db(io.clone(), "readahead-tiny-cache.db");
+    let conn = db.connect().unwrap();
+    let baseline = query_rows(&conn, SCAN_QUERY);
+
+    assert_eq!(baseline, rows);
+}
+
+#[test]
+fn pragma_round_trips_and_clamps() {
+    let io = Arc::new(QueuedIo::new());
+    let db = open_db(io.clone(), "readahead-pragma.db");
+    let conn = db.connect().unwrap();
+    assert_eq!(query_rows(&conn, "PRAGMA prefetch_pages"), vec!["0"]);
+    conn.execute("PRAGMA prefetch_pages = 64").unwrap();
+    assert_eq!(query_rows(&conn, "PRAGMA prefetch_pages"), vec!["64"]);
+    conn.execute("PRAGMA prefetch_pages = -3").unwrap();
+    assert_eq!(query_rows(&conn, "PRAGMA prefetch_pages"), vec!["0"]);
+    conn.execute("PRAGMA prefetch_pages = 1000000").unwrap();
+    assert_eq!(query_rows(&conn, "PRAGMA prefetch_pages"), vec!["4096"]);
+}
+
+#[test]
+fn bare_count_star_prefetches_like_a_scan() {
+    let io = Arc::new(QueuedIo::new());
+    build_scan_fixture(&io, "readahead-count.db", SCAN_FIXTURE_ROWS);
+
+    let db = open_db(io.clone(), "readahead-count.db");
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA prefetch_pages = 64").unwrap();
+    // A bare COUNT(*) uses the btree count fast path, not next(); it sweeps
+    // every leaf and must prefetch the same way.
+    let rows = query_rows(&conn, "SELECT count(*) FROM t");
+    assert_eq!(rows, vec![SCAN_FIXTURE_ROWS.to_string()]);
+    let stats = conn.get_pager().readahead_stats();
+    assert!(
+        stats.pages_submitted > 100,
+        "count(*) sweeps every leaf and should prefetch: {stats:?}"
+    );
+}


### PR DESCRIPTION
## Description

Adds readahead for forward B-tree scans, controlled by a new `PRAGMA prefetch_pages` (default `0` = off, clamped to at most 4096).

- **Policy** (`core/storage/readahead.rs`, per-cursor): shaped like OS file readahead. Random access never prefetches. A scan declared by a cursor rewind or a bare `COUNT(*)` sweep — the analog of Linux starting readahead for a read at file offset 0 — activates immediately; otherwise two consecutive leaf transitions do. The readahead distance starts at 4 pages and doubles each time the scan consumes a window, capped by the pragma. Any reposition (seek) resets the pattern, so point queries never pay anything.
- **Target selection**: unlike a filesystem we never guess future offsets. The parent interior page pinned on the cursor stack lists exactly which leaf pages the scan visits next, so prefetch follows child pointers (plus the next interior sibling so parent switches don't stall). A full scan reads **zero** extra pages (asserted in tests); an early-stopping scan wastes at most one window.
- **Execution** (`Pager::prefetch_page`): reads go through the same WAL-aware path as foreground reads and publish into the page cache as in-flight pages, so a later `read_page` either hits the cache or waits on the in-flight read — no duplicate IO. A speculative read never spills, never yields, and never fails a query: a full cache drops the prefetch, and a failed read leaves an unloaded page that the next cache lookup deletes, so the real read retries from scratch.

Default off because the win depends on the IO backend (io_uring benefits; the sync `syscall` backend cannot overlap reads) and speculation is a cost knob the embedder should own. Backward scans and MVCC-specific paths are intentionally out of scope for this first cut.

### Benchmarks

`core/benches/prefetch_benchmark.rs` (new, CodSpeed-compatible) scans a 20k-row table over an IO model where every read completes after a fixed number of IO steps, with each step costing a deterministic spin — i.e. a device with latency:

| `prefetch_pages` | scan time | IO stall ticks |
|---|---|---|
| 0 | 204.6 ms | 8560 |
| 8 | 28.6 ms | 1072 |
| 32 | 13.6 ms | 432 |
| 128 | 9.8 ms | 272 |

TPC-H (bundled 1.2 GB dataset, release build, io_uring VFS, OS page cache dropped via `posix_fadvise(DONTNEED)` before every run, `PRAGMA prefetch_pages = 256`, two reps each):

| query | prefetch off | prefetch on |
|---|---|---|
| q6 (IO-bound scan) | 12.0 s / 14.5 s | **3.6 s / 2.7 s** |
| q1 (compute-heavy scan) | 24.4 s / 29.8 s | **17.9 s / 18.6 s** |

### Tests

- `core/storage/readahead.rs`: window policy unit tests — exponential growth to the cap, waste bound (`issued <= consumed + budget` for every scan length), exactly-once coverage of upcoming children, activation/reset rules.
- `core/storage/pager.rs`: prefetch primitive unit tests — cache publish + `read_page` dedup, failure self-heal (failed speculative read vanishes from cache; later real read succeeds), full-cache drop with the foreground read still proceeding.
- `tests/integration/readahead.rs` (on `QueuedIo`, which defers ops so reads genuinely stay in flight): identical scan results with readahead on/off; **identical total DB-file read counts** on full scans; WAL-resident data prefetches through the WAL; `LIMIT` waste bound; point queries and backward scans submit nothing; tiny-cache degradation; pragma round-trip/clamping; bare `COUNT(*)`.
- `cargo test` (workspace), the sqlite conformance runner (1560 passed), `cargo clippy`, and `cargo fmt --check` pass.

## Motivation and context

Cold scans pay full storage latency for every leaf page because the cursor only asks for a page at the moment it steps onto it: a scan over N leaves serializes N round trips. Filesystem readahead solves the same problem below the database, but it cannot see through fragmentation or a WAL, and databases increasingly run on storage where the OS cannot help. Readahead driven by the B-tree itself fetches exactly the right pages and overlaps their latency.

## Description of AI Usage

This PR was implemented by Claude Code working autonomously from a prompt asking for filesystem-style prefetching for table scans (exponential window, configurable, tested exhaustively, demonstrated with benchmarks). The design (B-tree-pointer-driven target selection instead of page-number guessing, cache-publish execution reusing the WAL-aware read path, Linux-readahead-shaped policy), implementation, tests, and benchmark runs were AI-generated; the committer is responsible for reviewing the output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Du5NWKhbWuwa3aetg8yvMu)_