### PR TITLE
fix: read outer query rowid from index cursor in covering index scans

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -20568,3 +20568,41 @@ fn truncate_checkpoint_is_busy_while_a_reader_transaction_is_open() {
     // Now that the reader is gone, Truncate can proceed.
     writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 }
+
+#[test]
+fn correlated_subquery_outer_rowid_from_covering_index_scan() {
+    // Regression for #8395: a correlated subquery reading the OUTER query's
+    // rowid panicked ("Cursor not found") when the outer query used a covering
+    // index scan (no table cursor open). Fix: fall back to reading the rowid
+    // from the outer query's index cursor via IdxRowId. Must match SQLite:
+    //   SELECT a, (SELECT t.rowid) FROM t INDEXED BY i WHERE a >= 1 ORDER BY a
+    //   -> [(1, 2), (2, 1)]  (a, rowid)
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t(a, b)").unwrap();
+    conn.execute("CREATE INDEX i ON t(a)").unwrap();
+    conn.execute("INSERT INTO t VALUES (2, 'x'), (1, 'y')").unwrap();
+
+    let rows = get_rows(
+        &conn,
+        "SELECT a, (SELECT t.rowid) FROM t INDEXED BY i WHERE a >= 1 ORDER BY a",
+    );
+    let vals: Vec<(i64, i64)> = rows
+        .iter()
+        .map(|r| (r[0].as_int().unwrap(), r[1].as_int().unwrap()))
+        .collect();
+    assert_eq!(vals, vec![(1, 2), (2, 1)]);
+
+    // Also: outer rowid when the table cursor IS open (plain scan) — must not
+    // regress to using the index cursor when the table cursor is available.
+    let rows = get_rows(
+        &conn,
+        "SELECT a, (SELECT t.rowid) FROM t WHERE a >= 1 ORDER BY a",
+    );
+    let vals: Vec<(i64, i64)> = rows
+        .iter()
+        .map(|r| (r[0].as_int().unwrap(), r[1].as_int().unwrap()))
+        .collect();
+    assert_eq!(vals, vec![(1, 2), (2, 1)]);
+}

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -2702,6 +2702,10 @@ pub fn translate_expr(
                 (None, false)
             };
 
+            let (is_from_outer_query_scope, _) = referenced_tables
+                .find_table_by_internal_id(*table_ref_id)
+                .expect("table reference should be found");
+
             if use_covering_index {
                 let index =
                     index.expect("index cursor should be opened when use_covering_index=true");
@@ -2711,6 +2715,27 @@ pub fn translate_expr(
                     cursor_id,
                     dest: target_register,
                 });
+            } else if is_from_outer_query_scope {
+                // A correlated subquery reading the OUTER query's rowid: the outer
+                // query may use a covering index scan (no table cursor open). Mirror
+                // the column path (Expr::Column): use the table cursor when one is
+                // open; otherwise read the rowid from the outer query's index cursor
+                // via IdxRowId. Fixes #8395 (panic "Cursor not found").
+                if let Some(table_cursor_id) =
+                    program.resolve_cursor_id_safe(&CursorKey::table(*table_ref_id))
+                {
+                    program.emit_insn(Insn::RowId {
+                        cursor_id: table_cursor_id,
+                        dest: target_register,
+                    });
+                } else {
+                    let index_cursor_id =
+                        program.resolve_any_index_cursor_id_for_table(*table_ref_id);
+                    program.emit_insn(Insn::IdxRowId {
+                        cursor_id: index_cursor_id,
+                        dest: target_register,
+                    });
+                }
             } else {
                 let cursor_id = program.resolve_cursor_id(&CursorKey::table(*table_ref_id));
                 program.emit_insn(Insn::RowId {


### PR DESCRIPTION
Fixes #8395

## Problem

A correlated subquery reading the **outer** query's `rowid` panicked when the outer query used a **covering index scan** (no table cursor open):

```sql
CREATE TABLE t(a, b);
CREATE INDEX i ON t(a);
INSERT INTO t VALUES(2, 'x'), (1, 'y');

SELECT a, (SELECT t.rowid) FROM t INDEXED BY i WHERE a >= 1 ORDER BY a;
```

```
thread 'main' panicked at core/vdbe/builder.rs:1753:32:
Cursor not found: CursorKey { table_reference_id: TableInternalId(1), index: None, is_build: false }
```

## Root cause

`Expr::RowId` in `core/translate/expr/translator.rs` always resolved a **table** cursor. For an outer-query table in a covering-index scan, no table cursor is opened — the rowid lives in the index cursor.

The `Expr::Column` path already handled this: for outer-query scope it tries the table cursor first, then falls back to the index cursor (`resolve_any_index_cursor_id_for_table` + `IdxRowId`). `Expr::RowId` lacked that fallback.

## Fix

Mirror the `Expr::Column` path in `Expr::RowId`:

- If the rowid belongs to an **outer query scope**, use the table cursor when one is open, otherwise read the rowid from the outer query's index cursor via `IdxRowId`.
- Non-outer (normal) case unchanged.

## Verification

- Repro now returns the correct result, matching SQLite 3.51.1: `(1, 2), (2, 1)` (a, rowid).
- Regression test added: `correlated_subquery_outer_rowid_from_covering_index_scan`.
- Existing `rowid`, `covering`, and `correlated` test sets pass (32 tests, 0 failures).
