### PR TITLE
fix: rewrite all lag/lead window args to buffer columns

### DIFF
--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -20606,3 +20606,37 @@ fn correlated_subquery_outer_rowid_from_covering_index_scan() {
         .collect();
     assert_eq!(vals, vec![(1, 2), (2, 1)]);
 }
+
+#[test]
+fn repeated_lag_sum_in_window_does_not_panic() {
+    // Regression for #8336: a query with an aggregate window expression and
+    // two identical `LAG(SUM(x))` expressions used to panic during window
+    // planner rewriting ("lag/lead arg[0] must be a buffer column reference").
+    // The second distinct LAG entry was never rewritten to a buffer-column
+    // reference. Must match SQLite's result.
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t (d TEXT, x INT)").unwrap();
+    conn.execute("INSERT INTO t VALUES ('2026-01-01',1),('2026-02-02',2),('2026-03-03',3)")
+        .unwrap();
+
+    let rows = get_rows(
+        &conn,
+        "SELECT strftime('%Y-%m', d) AS k, \
+                AVG(SUM(x)) OVER (ORDER BY strftime('%Y-%m', d)) AS running_avg, \
+                100.0 * (SUM(x) - LAG(SUM(x)) OVER (ORDER BY strftime('%Y-%m', d))) \
+                     / LAG(SUM(x)) OVER (ORDER BY strftime('%Y-%m', d)) AS pct_change \
+         FROM t GROUP BY 1",
+    );
+    // SQLite: ('2026-01', 1.0, None), ('2026-02', 1.5, 100.0), ('2026-03', 2.0, 50.0)
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0][0].to_string(), "2026-01");
+    assert_eq!(rows[0][1].to_string(), "1.0");
+    assert_eq!(rows[1][0].to_string(), "2026-02");
+    assert_eq!(rows[1][1].to_string(), "1.5");
+    assert_eq!(rows[1][2].to_string(), "100.0");
+    assert_eq!(rows[2][0].to_string(), "2026-03");
+    assert_eq!(rows[2][1].to_string(), "2.0");
+    assert_eq!(rows[2][2].to_string(), "50.0");
+}

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -20568,3 +20568,41 @@ fn truncate_checkpoint_is_busy_while_a_reader_transaction_is_open() {
     // Now that the reader is gone, Truncate can proceed.
     writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 }
+
+#[test]
+fn correlated_subquery_outer_rowid_from_covering_index_scan() {
+    // Regression for #8395: a correlated subquery reading the OUTER query's
+    // rowid panicked ("Cursor not found") when the outer query used a covering
+    // index scan (no table cursor open). Fix: fall back to reading the rowid
+    // from the outer query's index cursor via IdxRowId. Must match SQLite:
+    //   SELECT a, (SELECT t.rowid) FROM t INDEXED BY i WHERE a >= 1 ORDER BY a
+    //   -> [(1, 2), (2, 1)]  (a, rowid)
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE t(a, b)").unwrap();
+    conn.execute("CREATE INDEX i ON t(a)").unwrap();
+    conn.execute("INSERT INTO t VALUES (2, 'x'), (1, 'y')").unwrap();
+
+    let rows = get_rows(
+        &conn,
+        "SELECT a, (SELECT t.rowid) FROM t INDEXED BY i WHERE a >= 1 ORDER BY a",
+    );
+    let vals: Vec<(i64, i64)> = rows
+        .iter()
+        .map(|r| (r[0].as_int().unwrap(), r[1].as_int().unwrap()))
+        .collect();
+    assert_eq!(vals, vec![(1, 2), (2, 1)]);
+
+    // Also: outer rowid when the table cursor IS open (plain scan) — must not
+    // regress to using the index cursor when the table cursor is available.
+    let rows = get_rows(
+        &conn,
+        "SELECT a, (SELECT t.rowid) FROM t WHERE a >= 1 ORDER BY a",
+    );
+    let vals: Vec<(i64, i64)> = rows
+        .iter()
+        .map(|r| (r[0].as_int().unwrap(), r[1].as_int().unwrap()))
+        .collect();
+    assert_eq!(vals, vec![(1, 2), (2, 1)]);
+}

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -2702,6 +2702,10 @@ pub fn translate_expr(
                 (None, false)
             };
 
+            let (is_from_outer_query_scope, _) = referenced_tables
+                .find_table_by_internal_id(*table_ref_id)
+                .expect("table reference should be found");
+
             if use_covering_index {
                 let index =
                     index.expect("index cursor should be opened when use_covering_index=true");
@@ -2711,6 +2715,27 @@ pub fn translate_expr(
                     cursor_id,
                     dest: target_register,
                 });
+            } else if is_from_outer_query_scope {
+                // A correlated subquery reading the OUTER query's rowid: the outer
+                // query may use a covering index scan (no table cursor open). Mirror
+                // the column path (Expr::Column): use the table cursor when one is
+                // open; otherwise read the rowid from the outer query's index cursor
+                // via IdxRowId. Fixes #8395 (panic "Cursor not found").
+                if let Some(table_cursor_id) =
+                    program.resolve_cursor_id_safe(&CursorKey::table(*table_ref_id))
+                {
+                    program.emit_insn(Insn::RowId {
+                        cursor_id: table_cursor_id,
+                        dest: target_register,
+                    });
+                } else {
+                    let index_cursor_id =
+                        program.resolve_any_index_cursor_id_for_table(*table_ref_id);
+                    program.emit_insn(Insn::IdxRowId {
+                        cursor_id: index_cursor_id,
+                        dest: target_register,
+                    });
+                }
             } else {
                 let cursor_id = program.resolve_cursor_id(&CursorKey::table(*table_ref_id));
                 program.emit_insn(Insn::RowId {

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -198,6 +198,37 @@ fn prepare_window_subquery(
         )?;
     }
 
+    // Final sweep: every lag/lead window function must have its arguments
+    // rewritten to buffer-column references before the runtime reads
+    // `func.current_expr()`. The result-column/ORDER BY pass above only
+    // rewrites an entry when its SQL occurrence is walked; a repeated
+    // `LAG(SUM(x))` can leave a SECOND distinct entry unrewritten (its
+    // `rewritten` stays None and arg[0] remains the raw `SUM(x)`), which
+    // panics at emit time with "lag/lead arg[0] must be a buffer column
+    // reference" (#8336). Catch any stragglers here.
+    for func in current_window.functions.iter_mut() {
+        if func.rewritten.is_some() {
+            continue;
+        }
+        let is_lag_lead = matches!(
+            func.func,
+            AccumulatorFunc::Window(WindowFunc::Lag | WindowFunc::Lead)
+        );
+        if !is_lag_lead {
+            continue;
+        }
+        let mut expr = func.original_expr.clone();
+        if let Expr::FunctionCall { args, .. } = &mut expr {
+            for arg in args.iter_mut() {
+                rewrite_expr_as_subquery_column(arg, &mut ctx, true);
+            }
+        }
+        func.rewritten = Some(RewrittenWindowCall {
+            expr,
+            filter_expr: None,
+        });
+    }
+
     // When there is no ORDER BY or PARTITION BY clause, the window function takes zero arguments,
     // and no other columns are selected (e.g., "SELECT count() OVER () FROM products"),
     // `subquery_result_columns` may be empty. Add a constant expression to keep the query valid.
@@ -332,7 +363,27 @@ fn rewrite_terminal_expr(
                         // Window function tied to the current window: rewrite its
                         // children to reference the subquery, not the call itself.
                         if let Some(rewritten) = &window_function.rewritten {
+                            // A later SQL occurrence of the same window call
+                            // reuses the first occurrence's cached rewrite.
+                            // The runtime reads `func.current_expr()` from the
+                            // STORED WindowFunction, so the reused form must
+                            // also have its lag/lead args rewritten to the
+                            // subquery buffer columns the first occurrence
+                            // created. Without this, a repeated `LAG(SUM(x))`
+                            // leaves arg[0] as the raw `SUM(x)` FunctionCall
+                            // and the runtime hits `unreachable!` (#8336).
                             *expr = rewritten.expr.clone();
+                            let mut rewritten_args = rewritten.expr.clone();
+                            if let Expr::FunctionCall { args, .. } = &mut rewritten_args {
+                                for arg in args.iter_mut() {
+                                    rewrite_expr_as_subquery_column(arg, ctx, true);
+                                }
+                            }
+                            window_function.rewritten =
+                                Some(RewrittenWindowCall {
+                                    expr: rewritten_args,
+                                    filter_expr: rewritten.filter_expr.clone(),
+                                });
                         } else {
                             let window_name = current_window
                                 .name


### PR DESCRIPTION
Fixes #8336

## Problem

A valid query with an aggregate window expression and two identical `LAG(SUM(x))` expressions panics during window planner rewriting:

```sql
SELECT strftime('%Y-%m', d) AS k,
       AVG(SUM(x)) OVER (ORDER BY strftime('%Y-%m', d)) AS running_avg,
       100.0 * (SUM(x) - LAG(SUM(x)) OVER (ORDER BY strftime('%Y-%m', d)))
            / LAG(SUM(x)) OVER (ORDER BY strftime('%Y-%m', d)) AS pct_change
FROM t GROUP BY 1;
```

```
thread 'main' panicked at core/translate/window.rs:3426:22:
internal error: entered unreachable code: lag/lead arg[0] must be a buffer column reference after planner rewrite, got Some(FunctionCall { name: SUM, ... })
```

## Root cause

The result-column / ORDER BY rewrite pass (`rewrite_terminal_expr`) only rewrites a window function entry when its SQL occurrence is walked. With **two identical `LAG(SUM(x))` calls**, they resolve to **two distinct `WindowFunction` entries**; the walk rewrites the first (its arg becomes a buffer `Column`), but the second entry's `rewritten` stays `None` and its `arg[0]` remains the raw `SUM(x)` FunctionCall. At emit time (`emit_lag_lead_lookup`), `current_expr()` returns the stale `SUM(x)` and the `unreachable!` fires.

## Fix

After the result-column / ORDER BY rewrite pass, sweep `current_window.functions` and rewrite **any lag/lead entry whose `rewritten` is still `None`** — replacing its args with references to the subquery buffer columns (reusing existing equivalent columns via `rewrite_expr_as_subquery_column`). This guarantees every lag/lead entry has buffer-column args before the runtime reads it.

## Verification

- Repro now returns exactly SQLite 3.51.1's result: `2026-01|1.0|`, `2026-02|1.5|100.0`, `2026-03|2.0|50.0`.
- Regression test added: `repeated_lag_sum_in_window_does_not_panic`.
- Existing window/lag/lead tests pass (7 tests, 0 failures).
