### PR TITLE
Unify SQLite tracking version to 3.50.4

### DIFF
--- a/.github/shared/install_sqlite/action.yml
+++ b/.github/shared/install_sqlite/action.yml
@@ -5,11 +5,10 @@ runs:
   using: "composite"
   steps:
     - name: Install SQLite
-      env:
-        SQLITE_VERSION: "3510100"
-        YEAR: 2025
+      # The version is pinned in scripts/install-sqlite3.sh; keep that in
+      # sync with SQLITE_VERSION in core/dialect/sqlite.rs.
       run: |
-        curl -o /tmp/sqlite.zip https://sqlite.org/$YEAR/sqlite-tools-linux-x64-$SQLITE_VERSION.zip > /dev/null
-        echo "y" | unzip -j /tmp/sqlite.zip sqlite3 -d /usr/local/bin/
-        sqlite3 --version
+        "$GITHUB_WORKSPACE/scripts/install-sqlite3.sh"
+        echo "$GITHUB_WORKSPACE/.sqlite3" >> "$GITHUB_PATH"
+        "$GITHUB_WORKSPACE/.sqlite3/sqlite3" --version
       shell: bash

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -1,9 +1,11 @@
 # Turso SQLite Compatibility
 
 Turso is a re-implementation of SQLite in Rust. This document describes the
-current state of compatibility between the two. Any deviation from SQLite
-behavior that is not explicitly documented as an opt-in extension is
-considered a bug.
+current state of compatibility between the two. Turso tracks **SQLite version
+3.50.4**: that is the version reported by `sqlite_version()` and
+`sqlite3_libversion()`, and the version used for differential testing. Any
+deviation from SQLite behavior that is not explicitly documented as an opt-in
+extension is considered a bug.
 
 Compatibility is validated through differential testing against SQLite and
 ongoing work to pass the full SQLite TCL test suite.
@@ -785,8 +787,8 @@ Modifiers:
 
 | Interface              | Status  | Comment |
 |------------------------|---------|---------|
-| sqlite3_libversion     | ✅ Yes     | Returns "3.42.0" |
-| sqlite3_libversion_number | ✅ Yes  | Returns 3042000 |
+| sqlite3_libversion     | ✅ Yes     | Returns "3.50.4" |
+| sqlite3_libversion_number | ✅ Yes  | Returns 3050004 |
 | sqlite3_sourceid       | ❌ No      |         |
 | sqlite3_threadsafe     | ✅ Yes     | Returns 1 |
 | sqlite3_complete       | ❌ No      | Stub    |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See the [FAQ](#faq) for where the project stands on its way to 1.0.
 
 ## Features and Roadmap
 
-* **SQLite compatibility** for SQL dialect, file formats, and the C API [see [document](COMPAT.md) for details]
+* **SQLite compatibility** for SQL dialect, file formats, and the C API, tracking SQLite version 3.50.4 [see [document](COMPAT.md) for details]
 * **`BEGIN CONCURRENT`** for improved write throughput using multi-version concurrency control (MVCC).
 * **Change data capture (CDC)** for real-time tracking of database changes.
 * **Multi-language support** for

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -9,7 +9,7 @@ This implementation provides SQLite3 API compatibility for Turso, allowing exist
 1. Implements the SQLite3 C API functions in Rust
 2. Translates between C and Rust data structures
 3. Maps SQLite operations to equivalent Turso operations
-4. Maintains API compatibility with SQLite version 3.42.0
+4. Maintains API compatibility with SQLite
 
 ## Testing Strategy
 

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.cs
@@ -79,7 +79,8 @@ public partial class SqliteConnection : DbConnection
         set => _readUncommitted = value;
     }
 
-    public override string ServerVersion => "3.0.0";
+    // The SQLite version Turso tracks (SQLITE_VERSION in core/dialect/sqlite.rs).
+    public override string ServerVersion => "3.50.4";
 
     public override ConnectionState State => _database is null ? ConnectionState.Closed : ConnectionState.Open;
 

--- a/bindings/python/turso/lib.py
+++ b/bindings/python/turso/lib.py
@@ -54,8 +54,9 @@ def _get_sqlite_version() -> tuple[str, tuple[int, int, int]]:
             parts = (*parts, 0)
         return version_str, parts[:3]
     except Exception:
-        # Fallback to a known compatible version
-        return "3.45.0", (3, 45, 0)
+        # Fallback to the SQLite version Turso tracks
+        # (SQLITE_VERSION in core/dialect/sqlite.rs)
+        return "3.50.4", (3, 50, 4)
 
 
 sqlite_version, sqlite_version_info = _get_sqlite_version()

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -14,6 +14,10 @@ use crate::vtab::{VirtualTable, VirtualTableType};
 use turso_ext::VTabKind;
 
 /// SQLite version reported by compatibility APIs.
+///
+/// This is the source of truth for the SQLite version Turso tracks. Keep
+/// [`SQLITE_VERSION_NUMBER`], `scripts/install-sqlite3.sh`, README.md, and
+/// COMPAT.md in sync when bumping it.
 pub const SQLITE_VERSION: &str = "3.50.4";
 
 /// Integer form of [`SQLITE_VERSION`] used by `sqlite3_libversion_number()`.

--- a/scripts/install-sqlite3.sh
+++ b/scripts/install-sqlite3.sh
@@ -5,7 +5,8 @@
 
 set -e
 
-SQLITE_VERSION="${SQLITE_VERSION:-3490100}"
+# Keep in sync with SQLITE_VERSION in core/dialect/sqlite.rs (3.50.4).
+SQLITE_VERSION="${SQLITE_VERSION:-3500400}"
 SQLITE_YEAR="${SQLITE_YEAR:-2025}"
 
 # Get the directory where this script is located


### PR DESCRIPTION
SQLite has lots of variation in behavior across versions. Turso core already was tracking 3.50.4, but as it turns out, CI and some of the bindings had different ideas. Fix that to track 3.50.4 consistenty across the project, and make the version number explicit in README.md and COMPAT.md