### PR TITLE
core: apply probe-side filters to hash join null-extended rows

### DIFF
--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -1,3 +1,4 @@
+use crate::translate::plan::Operation::HashJoin;
 use crate::translate::plan::SimpleAggregate;
 use crate::translate::{
     aggregation::agg_arg_collation,
@@ -527,13 +528,8 @@ pub(super) fn emit_unmatched_row_conditions_and_loop<'a>(
                 .expect("probe table must be in join order");
             for join in &plan.join_order[..probe_pos] {
                 m.set(join.original_idx)?;
-                // An earlier hash join's probe loop is still open here, so its
-                // build table's columns are readable too: every referenced
-                // build column travels in payload registers that the probe
-                // refills for each row.
-                if let crate::translate::plan::Operation::HashJoin(hj) =
-                    &plan.table_references.joined_tables()[join.original_idx].op
-                {
+                // An earlier hash join's build table is also accessible.
+                if let HashJoin(hj) = &plan.table_references.joined_tables()[join.original_idx].op {
                     m.set(hj.build_table_idx)?;
                 }
             }

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -527,6 +527,15 @@ pub(super) fn emit_unmatched_row_conditions_and_loop<'a>(
                 .expect("probe table must be in join order");
             for join in &plan.join_order[..probe_pos] {
                 m.set(join.original_idx)?;
+                // An earlier hash join's probe loop is still open here, so its
+                // build table's columns are readable too: every referenced
+                // build column travels in payload registers that the probe
+                // refills for each row.
+                if let crate::translate::plan::Operation::HashJoin(hj) =
+                    &plan.table_references.joined_tables()[join.original_idx].op
+                {
+                    m.set(hj.build_table_idx)?;
+                }
             }
         }
         m

--- a/sqlite/conformance/sqlite-sqltests/hash-join-unmatched-row-filters.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/hash-join-unmatched-row-filters.sqltest
@@ -1,0 +1,87 @@
+@database :memory:
+
+# When a LEFT JOIN runs as a hash join, the unmatched build rows (the ones
+# that get NULLs for the probe table) are emitted by a separate scan after the
+# probe loop. That scan must still apply WHERE filters that reference the
+# probe table, including filters that came from a later join's ON clause and
+# became plain WHERE terms when that join was rewritten to an inner join.
+# The bug: the unmatched scan skipped a filter that also referenced the build
+# table of an earlier hash join, because that table's values live in payload
+# registers rather than a positioned cursor. The null-extended rows then
+# bypassed the filter entirely.
+#
+# All queries here need: no indexes (so the planner picks hash joins), a LEFT
+# JOIN whose ON clause uses IS (so it cannot itself be rewritten to inner),
+# and a WHERE term that lets the next LEFT JOIN be rewritten to inner.
+
+test hash-join-null-extended-row-must-not-skip-is-filter {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, a INT, c INT);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, a INT, c INT);
+    CREATE TABLE t3(id INTEGER PRIMARY KEY, c INT, d INT);
+    CREATE TABLE t4(id INTEGER PRIMARY KEY, c INT, d INT);
+    INSERT INTO t1 VALUES (1, 1, 1);
+    INSERT INTO t3 VALUES (1, 5, 5);
+    INSERT INTO t4 VALUES (1, 5, 5);
+    -- t1's row has no t2 match, so t2 is null-extended and `t2.c IS t3.c`
+    -- becomes `NULL IS 5`, which is false: no row may come out.
+    SELECT count(*) FROM t1
+    LEFT JOIN t2 ON t1.a = t2.a
+    LEFT JOIN t3 ON t2.c IS t3.c
+    JOIN t4 ON t3.c = t4.c AND t3.d = t4.d
+    WHERE t3.d IS NOT NULL;
+}
+expect {
+    0
+}
+
+test hash-join-filters-null-extended-rows-but-keeps-matched-rows {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, a INT, c INT);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, a INT, c INT);
+    CREATE TABLE t3(id INTEGER PRIMARY KEY, c INT, d INT);
+    CREATE TABLE t4(id INTEGER PRIMARY KEY, c INT, d INT);
+    INSERT INTO t1 VALUES (1, 1, 1);
+    INSERT INTO t1 VALUES (2, 2, 2);
+    INSERT INTO t2 VALUES (10, 2, 7);
+    INSERT INTO t3 VALUES (1, 5, 5);
+    INSERT INTO t3 VALUES (2, NULL, 6);
+    INSERT INTO t3 VALUES (3, 7, 8);
+    INSERT INTO t4 VALUES (1, 5, 5);
+    INSERT INTO t4 VALUES (2, 7, 8);
+    -- t1.id=2 matches t2.id=10 and its t2.c=7 pairs with t3.id=3/t4.id=2.
+    -- t1.id=1 has no t2 match and must be filtered out by `t2.c IS t3.c`.
+    SELECT t1.id, t2.id, t3.id, t4.id FROM t1
+    LEFT JOIN t2 ON t1.a = t2.a
+    LEFT JOIN t3 ON t2.c IS t3.c
+    JOIN t4 ON t3.c = t4.c AND t3.d = t4.d
+    WHERE t3.d IS NOT NULL ORDER BY 1, 2, 3, 4;
+}
+expect {
+    2|10|3|2
+}
+
+test hash-join-null-extended-row-still-matches-is-null-partner {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, a INT, c INT);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, a INT, c INT);
+    CREATE TABLE t3(id INTEGER PRIMARY KEY, c INT, d INT);
+    CREATE TABLE t4(id INTEGER PRIMARY KEY, c INT, d INT);
+    INSERT INTO t1 VALUES (1, 1, 1);
+    INSERT INTO t1 VALUES (2, 2, 2);
+    INSERT INTO t2 VALUES (10, 2, 7);
+    INSERT INTO t3 VALUES (1, 5, 5);
+    INSERT INTO t3 VALUES (2, NULL, 6);
+    INSERT INTO t3 VALUES (3, 7, 8);
+    INSERT INTO t4 VALUES (1, 5, 5);
+    INSERT INTO t4 VALUES (2, 7, 8);
+    INSERT INTO t4 VALUES (3, 9, 6);
+    -- The other polarity: the null-extended t2 row must still pair with the
+    -- t3.c IS NULL row, because `NULL IS NULL` is true.
+    SELECT t1.id, t2.id, t3.id, t4.id FROM t1
+    LEFT JOIN t2 ON t1.a = t2.a
+    LEFT JOIN t3 ON t2.c IS t3.c
+    JOIN t4 ON t3.d = t4.d
+    WHERE t3.d IS NOT NULL ORDER BY 1, 2, 3, 4;
+}
+expect {
+    1||2|3
+    2|10|3|2
+}


### PR DESCRIPTION
When a LEFT JOIN runs as a hash join, unmatched build rows are emitted
by a separate scan after the probe loop, which re-applies WHERE filters
so the null-extended rows don't slip past them. That scan silently
dropped any filter referencing a table outside its allowed-tables mask,
and the mask was built from the join order, which only lists probe
tables. A filter referencing the build table of an enclosing hash join
was dropped even though that table's columns are readable: its probe
loop is still open, and every referenced build column travels in
payload registers that the probe refills for each row.

Found by the join fuzzer (seed 1787036706640): in

  SELECT ... FROM t1
  LEFT JOIN t2 ON t1.a = t2.a
  LEFT JOIN t3 ON t2.c IS t3.c
  JOIN t4 ON t3.c = t4.c AND t3.d = t4.d
  WHERE t3.d IS NOT NULL

the t3 join is rewritten to inner, turning `t2.c IS t3.c` into a plain
WHERE filter. The null-extended t2 rows skipped it, so unmatched t1
rows cross-joined against every (t3, t4) pair instead of being
filtered out.

Fix: include the build table of every earlier hash join in the
allowed-tables mask, so such filters are emitted on the unmatched-row
path exactly as the match path already compiles them.

Tests: new hash-join-unmatched-row-filters.sqltest (fails without the
fix); join fuzz tests pass with the failing seed and a fresh seed;
full sqltest conformance corpus passes.
