### PR TITLE
core: link hash join plan nodes to their build input

### DIFF
--- a/core/translate/eqp.rs
+++ b/core/translate/eqp.rs
@@ -252,6 +252,7 @@ pub enum EqpDetail {
         table: EqpTable,
         join: Option<EqpJoin>,
         subquery: Option<EqpSubquery>,
+        build_node: Option<usize>,
     },
     /// Materialize the build side of a hash join into an in-memory table.
     HashBuild {
@@ -539,6 +540,7 @@ pub(crate) fn eqp_detail_for_table_op(
             table: eqp_table,
             join,
             subquery,
+            build_node: None,
         },
     }
 }
@@ -641,6 +643,39 @@ impl<'a> JsonBuilder<'a> {
 }
 
 impl EqpDetail {
+    pub(crate) fn set_hash_join_build_node(&mut self, node: usize) {
+        let Self::HashJoin { build_node, .. } = self else {
+            unreachable!("only a hash join step has a build input");
+        };
+        *build_node = Some(node);
+    }
+
+    pub(crate) fn remap_node_ids(&mut self, old_to_new: &[usize]) {
+        match self {
+            Self::HashJoin {
+                build_node: Some(node),
+                ..
+            } => *node = old_to_new[*node],
+            Self::HashJoin { .. }
+            | Self::ConstantRow
+            | Self::Scan { .. }
+            | Self::Search { .. }
+            | Self::MultiIndex { .. }
+            | Self::IndexMethod { .. }
+            | Self::HashBuild { .. }
+            | Self::Distinct
+            | Self::DistinctAggregate { .. }
+            | Self::OrderBy { .. }
+            | Self::GroupBy { .. }
+            | Self::Compound
+            | Self::CompoundArm { .. }
+            | Self::ListSubquery { .. }
+            | Self::ScalarSubquery { .. }
+            | Self::RecursiveSetup
+            | Self::RecursiveStep => {}
+        }
+    }
+
     fn write_table_fields(
         obj: &mut JsonBuilder,
         table: &EqpTable,
@@ -733,9 +768,13 @@ impl EqpDetail {
                 table,
                 join,
                 subquery,
+                build_node,
             } => {
                 obj.str("type", "hash_join");
                 Self::write_table_fields(&mut obj, table, *join, subquery.as_ref());
+                if let Some(build_node) = build_node {
+                    obj.num("build_node", *build_node);
+                }
             }
             Self::HashBuild { table } => {
                 obj.str("type", "hash_build");

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1451,7 +1451,9 @@ pub fn emit_from_clause_subqueries(
         .map(|m| m.original_idx)
         .try_collect()?;
 
-    for table_index in visit_order {
+    let mut nodes_by_table: HashMap<usize, usize> = HashMap::default();
+
+    for &table_index in &visit_order {
         let table_reference = &mut tables.joined_tables_mut()[table_index];
         let execution_mode = match &table_reference.table {
             Table::FromClauseSubquery(from_clause_subquery) => {
@@ -1463,7 +1465,7 @@ pub fn emit_from_clause_subqueries(
             _ => None,
         };
         let eqp_subquery = eqp_subquery_info(program, table_reference, execution_mode.as_ref());
-        emit_explain!(
+        let node = emit_explain!(
             program,
             true,
             eqp_detail_for_table_op(
@@ -1475,6 +1477,9 @@ pub fn emit_from_clause_subqueries(
                 eqp_subquery,
             )
         );
+        if let Some(node) = node {
+            nodes_by_table.entry(table_index).or_insert(node);
+        }
 
         if let Table::FromClauseSubquery(from_clause_subquery) = &mut table_reference.table {
             let execution_mode =
@@ -1579,6 +1584,18 @@ pub fn emit_from_clause_subqueries(
         }
 
         program.pop_current_parent_explain();
+    }
+
+    for table_index in visit_order {
+        let Some(&probe_node) = nodes_by_table.get(&table_index) else {
+            continue;
+        };
+        let Operation::HashJoin(hash_join_op) = &tables.joined_tables()[table_index].op else {
+            continue;
+        };
+        if let Some(&build_node) = nodes_by_table.get(&hash_join_op.build_table_idx) {
+            program.link_hash_join_build_node(probe_node, build_node);
+        }
     }
     Ok(())
 }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -620,7 +620,9 @@ impl ProgramBuilderOpts {
 macro_rules! emit_explain {
     ($builder:expr, $push:expr, $detail:expr) => {
         if let $crate::QueryMode::ExplainQueryPlan { .. } = $builder.get_query_mode() {
-            $builder.emit_explain_should_not_be_called_directly($push, $detail);
+            $builder.emit_explain_should_not_be_called_directly($push, $detail)
+        } else {
+            None
         }
     };
 }
@@ -1351,22 +1353,34 @@ impl ProgramBuilder {
     }
 
     /// Prefer calling the emit_explain! macro instead.
-    pub fn emit_explain_should_not_be_called_directly(&mut self, push: bool, detail: EqpDetail) {
+    pub fn emit_explain_should_not_be_called_directly(
+        &mut self,
+        push: bool,
+        detail: EqpDetail,
+    ) -> Option<usize> {
         let BuilderQueryMode::ExplainQueryPlan {
             current_parent_idx, ..
         } = self.mode
         else {
-            return;
+            return None;
         };
         self.emit_insn(Insn::Explain {
             p1: self.insns.len(),
             p2: current_parent_idx,
             detail: Box::new(detail),
         });
+        let emitted = self.insns.len() - 1;
         if push {
-            let emitted = self.insns.len() - 1;
             *self.current_parent_idx_mut() = Some(emitted);
         }
+        Some(emitted)
+    }
+
+    pub fn link_hash_join_build_node(&mut self, probe_node: usize, build_node: usize) {
+        let (Insn::Explain { detail, .. }, _) = &mut self.insns[probe_node] else {
+            unreachable!("plan node id must point to an Explain insn");
+        };
+        detail.set_hash_join_build_node(build_node);
     }
 
     pub fn with_cte_materialization_eqp<T>(
@@ -1487,12 +1501,13 @@ impl ProgramBuilder {
 
                 let new_p2 = p2.map(|old| old_to_new[old]);
 
-                let (Insn::Explain { p1, p2, .. }, _) = &mut self.insns[i] else {
+                let (Insn::Explain { p1, p2, detail }, _) = &mut self.insns[i] else {
                     unreachable!();
                 };
 
                 *p1 = i;
                 *p2 = new_p2;
+                detail.remap_node_ids(&old_to_new);
             }
 
             let current_parent_idx = self.current_parent_idx_mut();

--- a/docs/eqp-json.md
+++ b/docs/eqp-json.md
@@ -72,7 +72,7 @@ the exact display string. `op` adds the structured fields, discriminated by
 | `search`                             | seek by key                             | `table`, `alias?`, `search_kind` (`rowid_eq`/`seek`/`in_seek`), `index?` or `integer_primary_key`, `constraints`, `backwards?`, `join?`, `subquery?` |
 | `multi_index`                        | combine rowid sets from several indexes | `set_op` (`or`/`and`), `indexes`                                                                                                                     |
 | `index_method`                       | pluggable index method access           | `method`                                                                                                                                             |
-| `hash_join`                          | hash side of a hash join                | `table`, `alias?`, `join?`, `subquery?`                                                                                                              |
+| `hash_join`                          | probe a hash table built from another node's rows | `table`, `alias?`, `join?`, `subquery?`, `build_node?`                                                                                     |
 | `hash_build`                         | materialize a hash join's build input   | `table`, `alias?`                                                                                                                                    |
 | `distinct` / `distinct_aggregate`    | hash-table de-duplication               | `function` (aggregate only)                                                                                                                          |
 | `order_by` / `group_by`              | sorting stage                           | `method` (`sorter`/`temp_btree`)                                                                                                                     |
@@ -83,3 +83,8 @@ the exact display string. `op` adds the structured fields, discriminated by
 
 Fields that are absent are simply omitted (e.g. `join` on the first table,
 `index` on a rowid search).
+
+A `hash_join` node names the table it probes, not the one the hash table was
+built from. Its `build_node` is the `id` of the node that reads the build input,
+so `{"type":"hash_join","table":"t4","build_node":4}` means "read t4 and probe a
+hash table built from whatever node 4 produces".

--- a/sqlite/conformance/turso-sqltests/explain-query-plan-json.sqltest
+++ b/sqlite/conformance/turso-sqltests/explain-query-plan-json.sqltest
@@ -197,3 +197,35 @@ expect {
     {"version":1,"sql":"EXPLAIN QUERY PLAN FORMAT=JSON\n    INSERT INTO users(name) VALUES ('x');","result_columns":[],"nodes":[]}
     0
 }
+
+setup hash_join_schema {
+    CREATE TABLE t1(id INTEGER PRIMARY KEY, a INT, c INT);
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, a INT, c INT);
+    CREATE TABLE t3(id INTEGER PRIMARY KEY, c INT, d INT);
+    CREATE TABLE t4(id INTEGER PRIMARY KEY, c INT, d INT);
+}
+
+@setup hash_join_schema
+test a-hash-join-names-the-node-that-reads-its-build-input {
+    EXPLAIN QUERY PLAN FORMAT=JSON
+    SELECT * FROM t1
+    LEFT JOIN t2 ON t1.a = t2.a
+    LEFT JOIN t3 ON t2.c IS t3.c
+    JOIN t4 ON t3.c = t4.c AND t3.d = t4.d
+    WHERE t3.d IS NOT NULL;
+}
+expect {
+    {"version":1,"sql":"EXPLAIN QUERY PLAN FORMAT=JSON\n    SELECT * FROM t1\n    LEFT JOIN t2 ON t1.a = t2.a\n    LEFT JOIN t3 ON t2.c IS t3.c\n    JOIN t4 ON t3.c = t4.c AND t3.d = t4.d\n    WHERE t3.d IS NOT NULL;","result_columns":["id","a","c","id","a","c","id","c","d","id","c","d"],"nodes":[{"id":1,"parent":null,"detail":"HASH JOIN t4","op":{"type":"hash_join","table":"t4","join":"inner","build_node":4}},{"id":2,"parent":null,"detail":"HASH JOIN t2","op":{"type":"hash_join","table":"t2","join":"left","build_node":3}},{"id":3,"parent":null,"detail":"SCAN t1","op":{"type":"scan","table":"t1","source":"table"}},{"id":4,"parent":null,"detail":"SCAN t3","op":{"type":"scan","table":"t3","join":"inner","source":"table"}}]}
+}
+
+@setup hash_join_schema
+test a-hash-join-points-at-a-build-input-inside-its-own-subtree {
+    EXPLAIN QUERY PLAN FORMAT=JSON
+    SELECT t1.id, t3.d, t4.d
+    FROM t1
+    JOIN t3 ON t1.c = t3.c
+    JOIN t4 ON t1.c = t4.c;
+}
+expect {
+    {"version":1,"sql":"EXPLAIN QUERY PLAN FORMAT=JSON\n    SELECT t1.id, t3.d, t4.d\n    FROM t1\n    JOIN t3 ON t1.c = t3.c\n    JOIN t4 ON t1.c = t4.c;","result_columns":["id","d","d"],"nodes":[{"id":1,"parent":null,"detail":"MATERIALIZE hash build input for t1","op":{"type":"hash_build","table":"t1"}},{"id":3,"parent":1,"detail":"HASH JOIN t1","op":{"type":"hash_join","table":"t1","build_node":4}},{"id":4,"parent":1,"detail":"SCAN t3","op":{"type":"scan","table":"t3","join":"inner","source":"table"}},{"id":51,"parent":null,"detail":"HASH JOIN t4","op":{"type":"hash_join","table":"t4","join":"inner","build_node":53}},{"id":52,"parent":null,"detail":"SCAN t3","op":{"type":"scan","table":"t3","join":"inner","source":"table"}},{"id":53,"parent":null,"detail":"HASH JOIN t1","op":{"type":"hash_join","table":"t1","build_node":52}}]}
+}


### PR DESCRIPTION
## Description

`EXPLAIN QUERY PLAN FORMAT=JSON` now gives every `hash_join` op a `build_node` field: the `id` of the plan node that reads the rows the hash table was built from.

### Before

```
tursodb> EXPLAIN QUERY PLAN FORMAT=JSON SELECT * FROM t1
LEFT JOIN t2 ON t1.a = t2.a
LEFT JOIN t3 ON t2.c IS t3.c
JOIN t4 ON t3.c = t4.c AND t3.d = t4.d
WHERE t3.d IS NOT NULL;

[
  {"id": 1, "parent": null, "detail": "HASH JOIN t4", "op": {"type": "hash_join", "table": "t4", "join": "inner"}},
  {"id": 2, "parent": null, "detail": "HASH JOIN t2", "op": {"type": "hash_join", "table": "t2", "join": "left"}},
  {"id": 3, "parent": null, "detail": "SCAN t1", "op": {"type": "scan", "table": "t1", "source": "table"}},
  {"id": 4, "parent": null, "detail": "SCAN t3", "op": {"type": "scan", "table": "t3", "join": "inner", "source": "table"}}
]
```

Each hash join names only the table it probes. Nothing says which node built the hash table it probes into.

### After

```
tursodb> EXPLAIN QUERY PLAN FORMAT=JSON SELECT * FROM t1
LEFT JOIN t2 ON t1.a = t2.a
LEFT JOIN t3 ON t2.c IS t3.c
JOIN t4 ON t3.c = t4.c AND t3.d = t4.d
WHERE t3.d IS NOT NULL;

[
  {"id": 1, "parent": null, "detail": "HASH JOIN t4", "op": {"type": "hash_join", "table": "t4", "join": "inner", "build_node": 4}},
  {"id": 2, "parent": null, "detail": "HASH JOIN t2", "op": {"type": "hash_join", "table": "t2", "join": "left", "build_node": 3}},
  {"id": 3, "parent": null, "detail": "SCAN t1", "op": {"type": "scan", "table": "t1", "source": "table"}},
  {"id": 4, "parent": null, "detail": "SCAN t3", "op": {"type": "scan", "table": "t3", "join": "inner", "source": "table"}}
]
```

`HASH JOIN t4` (node 1) probes a hash built by node 4 = `SCAN t3`. `HASH JOIN t2` (node 2) probes a hash built by node 3 = `SCAN t1`. That matches what the bytecode does: t3 builds a hash keyed `(c, d)` and t4 drives the loop probing it; inside that loop t1 builds a hash keyed `(a)` and t2 probes it.

Notes on how it works:

- Linking happens after every FROM-clause node has been emitted, because the build node is usually emitted *after* the hash join node (build tables are appended once the join order is laid out).
- It is scoped to a single emission pass, so a materialized build subplan links to the nodes inside its own subtree rather than to same-named nodes in the outer plan. There is a test for this.
- Plan node ids are instruction offsets, so `build_node` is remapped alongside `p1`/`p2` when constant instructions are hoisted to the end of the program.
- The text format is unchanged. The other option in the issue — setting `parent` so the build scan hangs off its hash join — would silently drop rows: the shell's tree renderer skips a row whose parent it has not seen yet, and a build node can be emitted before its hash join node (the three-table hash join case in `joins__hash-join-three-table.snap` does exactly that).

`docs/eqp-json.md` is updated, including the description of `hash_join`, which called it "hash side of a hash join" when it is really the probe side — part of what made the output easy to read backwards.

## Motivation and context

Fixes #8408.

A `hash_join` node names only the table it probes, and the build table's node is appended after the join order, so adjacency in the node list carries no meaning. There was no way to reconstruct which scan feeds which hash join, and the [plan visualizer](https://tursodatabase.github.io/turso-explain/) guessed the two sides backwards.

Note that turso-explain will need a matching change to consume `build_node`; this PR only supplies the data it was missing.

## Testing

Two new cases in `sqlite/conformance/turso-sqltests/explain-query-plan-json.sqltest`:

- `a-hash-join-names-the-node-that-reads-its-build-input` — the exact query from the issue.
- `a-hash-join-points-at-a-build-input-inside-its-own-subtree` — a plan where the build input is materialized, so the same table appears both inside the materialization subtree and in the main plan; the hash join inside the subtree must point at its own subtree's node.

Both fail before the change (no `build_node` is emitted at all) and pass after. The before/after output above was captured from two real builds, at `HEAD~1` and at this branch's head.

Also run clean: full `.sqltest` conformance suite with snapshots (12969 + 1577 passed), `cargo test -p turso_core` (2329 + 53 passed), and `cargo test -p core_tester --test integration_tests` (1060 passed).

## Description of AI Usage

Written by Claude Code from the issue text, driven interactively. Claude reproduced the bug, read the EQP emission path, chose `build_node` over `parent` after checking that the shell's tree renderer drops out-of-order children, wrote the implementation and the two tests, and ran the test suites above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QW2bjK9uGQVtgwR8MCa3yi
