### PR TITLE
translate: validate trigger targets and improve INSTEAD OF error handling

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -153,7 +153,7 @@ change when they are converted to text.
 | WINDOW functions             | 🚧 Partial | Aggregate functions, `row_number`, `rank`, `dense_rank`, `first_value`, `last_value`, and `nth_value` work with the default frame. Missing: `percent_rank`, `cume_dist`, `ntile`, `lag`, and `lead`. Custom frame specs (`ROWS`/`RANGE`/`GROUPS BETWEEN`, `EXCLUDE`) are not yet supported. |
 | GENERATED                 | 🚧 Partial      | virtual columns only (no ALTER, partial affinity support). Requires `--experimental-generated-columns`. |
 | WITHOUT ROWID             | 🚧 Partial | Requires `--experimental-without-rowid`. Effectively **insert-only**: CREATE / INSERT / SELECT work (incl. composite PK), but UPDATE, DELETE, UPSERT, `INSERT OR REPLACE`, secondary UNIQUE constraints, secondary `CREATE INDEX`, `FOREIGN KEY`, CDC, and materialized views are all rejected. AUTOINCREMENT and missing PK rejection are parity with SQLite. |
-| CREATE TRIGGER ... INSTEAD OF | ❌ No  | Triggers on views are not supported. Currently errors with misleading "no such table" message. |
+| CREATE TRIGGER ... INSTEAD OF | ❌ No  | Triggers on views are not supported yet. Errors with: `INSTEAD OF triggers on views are not supported yet`. |
 | CREATE VIEW IF NOT EXISTS | 🚧 Partial | Not idempotent — second create on an existing view errors instead of no-op. |
 
 #### Same-connection write statements

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -157,35 +157,53 @@ pub fn translate_create_trigger(
         );
     }
 
-    // Verify the table exists (use the table's database, not the trigger's).
+    // Verify the table or view exists (use the target object's database, not the trigger's).
     let table = resolver.with_schema(target_table_database_id, |s| {
         s.get_table(&normalized_table_name)
     });
-    let Some(table) = table else {
-        // SQLite qualifies a non-temp trigger's missing target table with its
-        // database ("no such table: main.t1"); temp triggers report the name
-        // as the user wrote it.
-        if temporary {
-            bail_parse_error!(
-                "no such table: {}",
-                crate::util::table_name_for_error(&tbl_name)
-            );
-        }
-        let db_name = resolver
-            .get_database_name_by_index(target_table_database_id)
-            .unwrap_or_else(|| "main".to_string());
-        bail_parse_error!("no such table: {}.{}", db_name, tbl_name.name.as_str());
-    };
-    if table.virtual_table().is_some() {
-        bail_parse_error!("cannot create triggers on virtual tables");
-    }
+    let view = resolver.with_schema(target_table_database_id, |s| {
+        s.get_view(&normalized_table_name)
+    });
 
-    if time
-        .as_ref()
-        .is_some_and(|t| *t == ast::TriggerTime::InsteadOf)
-    {
-        bail_parse_error!("INSTEAD OF triggers are not supported yet");
-    }
+    let target_name = crate::util::table_name_for_error(&tbl_name);
+    let _table = match (table, view) {
+        (None, None) => {
+            // SQLite qualifies a non-temp trigger's missing target table with its
+            // database ("no such table: main.t1"); temp triggers report the name
+            // as the user wrote it.
+            if temporary {
+                bail_parse_error!("no such table: {target_name}");
+            }
+            let db_name = resolver
+                .get_database_name_by_index(target_table_database_id)
+                .unwrap_or_else(|| "main".to_string());
+            bail_parse_error!("no such table: {db_name}.{}", tbl_name.name.as_str());
+        }
+        (Some(_), _)
+            if time
+                .as_ref()
+                .is_some_and(|t| *t == ast::TriggerTime::InsteadOf) =>
+        {
+            bail_parse_error!("cannot create INSTEAD OF trigger on table: {target_name}");
+        }
+        (Some(table), _) => {
+            if table.virtual_table().is_some() {
+                bail_parse_error!("cannot create triggers on virtual tables");
+            }
+            table
+        }
+        (None, Some(_)) => match time {
+            Some(ast::TriggerTime::Before) | None => {
+                bail_parse_error!("cannot create BEFORE trigger on view: {target_name}");
+            }
+            Some(ast::TriggerTime::After) => {
+                bail_parse_error!("cannot create AFTER trigger on view: {target_name}");
+            }
+            Some(ast::TriggerTime::InsteadOf) => {
+                bail_parse_error!("INSTEAD OF triggers on views are not supported yet");
+            }
+        },
+    };
 
     let opts = ProgramBuilderOpts::new(1, 30, 1);
     program.extend(&opts);

--- a/docs/sql-reference/statements/create-trigger.mdx
+++ b/docs/sql-reference/statements/create-trigger.mdx
@@ -62,7 +62,10 @@ An `AFTER` trigger fires after the triggering statement has modified the row. Us
 ### INSTEAD OF Triggers
 
 <Warning>
-`INSTEAD OF` triggers are not yet supported in Turso. `CREATE TRIGGER ... INSTEAD OF ...` returns an error.
+`INSTEAD OF` triggers are not yet supported in Turso. 
+- Attempting to create an `INSTEAD OF` trigger on a view returns the error: `INSTEAD OF triggers on views are not supported yet`.
+- Attempting to create an `INSTEAD OF` trigger on a table returns the SQLite-compatible error: `cannot create INSTEAD OF trigger on table: <table_name>`.
+- Attempting to create a `BEFORE` or `AFTER` trigger on a view returns: `cannot create BEFORE trigger on view: <view_name>` or `cannot create AFTER trigger on view: <view_name>`.
 </Warning>
 
 In SQLite, an `INSTEAD OF` trigger can only be created on a view and fires in place of the triggering INSERT, UPDATE, or DELETE, allowing you to make views writable. Turso parses this syntax but does not yet execute it.

--- a/tests/integration/trigger.rs
+++ b/tests/integration/trigger.rs
@@ -2097,6 +2097,64 @@ fn test_changes_after_trigger_ignore_preserves_outer_and_trigger_counts(db: Temp
 }
 
 #[turso_macros::test()]
+fn test_trigger_view_and_instead_of_validation(db: TempDatabase) {
+    let conn = db.connect_limbo();
+
+    conn.execute("CREATE TABLE t1 (a, b)").unwrap();
+    conn.execute("CREATE VIEW v1 AS SELECT * FROM t1").unwrap();
+
+    // 1. INSTEAD OF on a physical table is illegal in SQLite
+    let err = conn
+        .execute("CREATE TRIGGER tr_table_instead INSTEAD OF INSERT ON t1 BEGIN SELECT 1; END")
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("cannot create INSTEAD OF trigger on table: t1"),
+        "Unexpected error: {err}"
+    );
+
+    // 2. BEFORE trigger on a view is illegal in SQLite
+    let err = conn
+        .execute("CREATE TRIGGER tr_view_before BEFORE INSERT ON v1 BEGIN SELECT 1; END")
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("cannot create BEFORE trigger on view: v1"),
+        "Unexpected error: {err}"
+    );
+
+    // 3. AFTER trigger on a view is illegal in SQLite
+    let err = conn
+        .execute("CREATE TRIGGER tr_view_after AFTER INSERT ON v1 BEGIN SELECT 1; END")
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("cannot create AFTER trigger on view: v1"),
+        "Unexpected error: {err}"
+    );
+
+    // 4. Default timing (no BEFORE/AFTER specified) on a view defaults to BEFORE in SQLite
+    let err = conn
+        .execute("CREATE TRIGGER tr_view_default INSERT ON v1 BEGIN SELECT 1; END")
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("cannot create BEFORE trigger on view: v1"),
+        "Unexpected error: {err}"
+    );
+
+    // 5. INSTEAD OF on a view gives a clear message
+    let err = conn
+        .execute("CREATE TRIGGER tr_view_instead INSTEAD OF INSERT ON v1 BEGIN SELECT 1; END")
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("INSTEAD OF triggers on views are not supported yet"),
+        "Unexpected error: {err}"
+    );
+}
+
+#[turso_macros::test()]
 fn test_changes_after_foreign_key_failure_reset_to_zero(db: TempDatabase) {
     let conn = db.connect_limbo();
 


### PR DESCRIPTION
## Description

When creating a trigger via `CREATE TRIGGER`, target validation in `core/translate/trigger.rs` previously only queried `s.get_table(&normalized_table_name)`. Because views are stored in `s.get_view(...)`, attempting to define any trigger on an existing view resulted in a misleading `"no such table: <name>"` error instead of identifying that the object is a view.

This PR updates trigger target validation to check both tables and views and enforces SQLite-compatible error handling:
- **`INSTEAD OF` on a physical table**: Returns `cannot create INSTEAD OF trigger on table: <table_name>` (SQLite conformance parity).
- **`BEFORE` / `AFTER` on a view**: Returns `cannot create BEFORE trigger on view: <view_name>` or `cannot create AFTER trigger on view: <view_name>`.
- **Default timing on a view**: Defaults to `BEFORE` and returns `cannot create BEFORE trigger on view: <view_name>`.
- **`INSTEAD OF` on a view**: Replaces the misleading "no such table" error with a clear message: `INSTEAD OF triggers on views are not supported yet`.
- Updated `COMPAT.md` and `docs/sql-reference/statements/create-trigger.mdx` with the documented error behavior.

---

## Validation & Testing

- Added integration test `test_trigger_view_and_instead_of_validation` in `tests/integration/trigger.rs` covering all combinations (table + INSTEAD OF, view + BEFORE/AFTER/default/INSTEAD OF).
- Ran all 99 trigger integration tests:
  ```bash
  cargo test -p core_tester --test integration_tests trigger::
  ```
  Result: `99 passed; 0 failed`
- Ran code hygiene checks:
  ```bash
  cargo fmt --check
  cargo clippy --workspace --all-targets -- --deny=warnings
  ```

---

## Attribution
*This PR was authored and prepared in collaboration with an AI coding assistant (Antigravity).*
