### PR TITLE
Introduce Affinity::None

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4874,6 +4874,7 @@ pub fn create_table(tbl_name: &str, body: &CreateTableBody, root_page: i64) -> R
                     primary_key = true;
                 }
 
+                // ok
                 let mut col = Column::new(
                     Some(name),
                     ty_str,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3507,13 +3507,13 @@ impl BTreeTable {
             if col.is_array() {
                 // Arrays are stored as record-format blobs regardless of element type.
                 col.set_ty(Type::Blob);
-                col.set_base_affinity(Affinity::Blob);
+                col.override_affinity(Affinity::Blob);
                 continue;
             }
             if let Ok(Some(resolved)) = schema.resolve_type_unchecked(&col.ty_str) {
                 let (base_ty, _) = type_from_name(&resolved.primitive);
                 col.set_ty(base_ty);
-                col.set_base_affinity(Affinity::affinity(&resolved.primitive));
+                col.override_affinity(Affinity::affinity(&resolved.primitive));
             }
         }
     }
@@ -5241,8 +5241,8 @@ const TYPE_MASK: u32 = 0b111 << TYPE_SHIFT;
 const COLL_SHIFT: u32 = TYPE_SHIFT + 3;
 const COLL_MASK: u32 = 0b1111_1111_1111 << COLL_SHIFT;
 
-// Bits 20-22: base type affinity override.
-// 0 = use ty_str-based affinity, anything else is `Affinity as u32`.
+// Bits 20-22: base type affinity. Column affinity will resolve to this
+// value only if it is > 0, else it uses ty_str.
 const BASE_AFF_SHIFT: u32 = COLL_SHIFT + 12;
 const BASE_AFF_MASK: u32 = 0b111 << BASE_AFF_SHIFT;
 
@@ -5262,12 +5262,13 @@ impl Column {
         })
     }
 
-    /// Set the base type affinity override for a custom type column.
-    /// This ensures affinity rules use the custom type's BASE type
-    /// rather than applying SQLite name-based rules to the type name.
-    pub fn set_base_affinity(&mut self, affinity: Affinity) {
+    pub fn override_affinity(&mut self, affinity: Affinity) {
+        Self::set_raw_affinity(&mut self.raw, affinity);
+    }
+
+    fn set_raw_affinity(raw: &mut u32, affinity: Affinity) {
         let v: u32 = affinity as u32;
-        self.raw = (self.raw & !BASE_AFF_MASK) | ((v << BASE_AFF_SHIFT) & BASE_AFF_MASK);
+        *raw = (*raw & !BASE_AFF_MASK) | ((v << BASE_AFF_SHIFT) & BASE_AFF_MASK);
     }
 
     pub fn affinity_with_strict(&self, is_strict: bool) -> Affinity {
@@ -5344,6 +5345,8 @@ impl Column {
         if coldef.hidden {
             raw |= F_HIDDEN
         }
+        Self::set_raw_affinity(&mut raw, Affinity::affinity(&ty_str));
+
         Self {
             name,
             ty_str,
@@ -7408,7 +7411,7 @@ mod tests {
                 None,
                 ColDef::default(),
             );
-            col.set_base_affinity(affinity);
+            col.override_affinity(affinity);
             assert_eq!(
                 col.affinity(),
                 affinity,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -5241,12 +5241,9 @@ const COLL_SHIFT: u32 = TYPE_SHIFT + 3;
 const COLL_MASK: u32 = 0b1111_1111_1111 << COLL_SHIFT;
 
 // Bits 20-22: base type affinity override.
-// 0 = not set (use ty_str-based affinity), 1-5 = Affinity value + 1,
-// 6 = no declared affinity at all (e.g. a FROM-subquery/CTE/view column
-// backed by a literal or computed expression, not a real declared type)
+// 0 = use ty_str-based affinity, anything else is `Affinity as u32`.
 const BASE_AFF_SHIFT: u32 = COLL_SHIFT + 12;
 const BASE_AFF_MASK: u32 = 0b111 << BASE_AFF_SHIFT;
-const BASE_AFF_NO_DECLARED: u32 = 6;
 
 // Bits 23-25: array dimensions (0 = scalar, 1-7 = number of [] dimensions)
 const ARRAY_DIM_SHIFT: u32 = BASE_AFF_SHIFT + 3;
@@ -5254,46 +5251,24 @@ const ARRAY_DIM_MASK: u32 = 0b111 << ARRAY_DIM_SHIFT;
 
 impl Column {
     pub fn affinity(&self) -> Affinity {
-        let v = ((self.raw & BASE_AFF_MASK) >> BASE_AFF_SHIFT) as u8;
-        if v > 0 {
-            match v {
-                1 => Affinity::Integer,
-                2 => Affinity::Text,
-                3 => Affinity::Blob,
-                4 => Affinity::Real,
-                5 => Affinity::Numeric,
-                _ => Affinity::Blob,
-            }
-        } else {
-            Affinity::affinity(&self.ty_str)
+        let v = (self.raw & BASE_AFF_MASK) >> BASE_AFF_SHIFT;
+        if v == 0 {
+            return Affinity::affinity(&self.ty_str);
         }
+        Affinity::from_repr(v).unwrap_or_else(|| {
+            tracing::error!("column had invalid raw affinity {v}");
+            Affinity::None
+        })
     }
 
     /// Set the base type affinity override for a custom type column.
     /// This ensures affinity rules use the custom type's BASE type
     /// rather than applying SQLite name-based rules to the type name.
     pub fn set_base_affinity(&mut self, affinity: Affinity) {
-        let v: u32 = match affinity {
-            Affinity::Integer => 1,
-            Affinity::Text => 2,
-            Affinity::Blob => 3,
-            Affinity::Real => 4,
-            Affinity::Numeric => 5,
-        };
+        let v: u32 = affinity as u32;
         self.raw = (self.raw & !BASE_AFF_MASK) | ((v << BASE_AFF_SHIFT) & BASE_AFF_MASK);
     }
 
-    /// Mark this column as backed by an expression with no real declared type
-    /// (e.g. a literal column in a FROM-subquery, CTE, or view).
-    pub fn set_no_declared_affinity(&mut self) {
-        self.raw = (self.raw & !BASE_AFF_MASK)
-            | ((BASE_AFF_NO_DECLARED << BASE_AFF_SHIFT) & BASE_AFF_MASK);
-    }
-
-    /// Whether this column has a real declared type. Always `true` for table columns.
-    pub fn has_declared_affinity(&self) -> bool {
-        ((self.raw & BASE_AFF_MASK) >> BASE_AFF_SHIFT) != BASE_AFF_NO_DECLARED
-    }
     pub fn affinity_with_strict(&self, is_strict: bool) -> Affinity {
         if is_strict && self.ty_str.eq_ignore_ascii_case("ANY") {
             Affinity::Blob
@@ -7413,48 +7388,32 @@ mod tests {
         );
     }
 
-    fn new_blob_column() -> Column {
-        Column::new(
-            Some("x".to_string()),
-            "BLOB".to_string(),
-            None,
-            None,
-            Type::Blob,
-            None,
-            ColDef::default(),
-        )
-    }
-
     #[test]
-    fn column_has_declared_affinity_by_default() {
-        let col = new_blob_column();
-        assert!(col.has_declared_affinity());
-        assert_eq!(col.affinity(), Affinity::Blob);
-    }
-
-    #[test]
-    fn column_set_no_declared_affinity_reports_no_affinity() {
-        let mut col = new_blob_column();
-        col.set_no_declared_affinity();
-        assert!(!col.has_declared_affinity());
-        // Still resolves to BLOB at the runtime-conversion level.
-        assert_eq!(col.affinity(), Affinity::Blob);
-    }
-
-    #[test]
-    fn column_set_base_affinity_still_has_declared_affinity() {
-        let mut col = new_blob_column();
-        col.set_base_affinity(Affinity::Real);
-        assert!(col.has_declared_affinity());
-        assert_eq!(col.affinity(), Affinity::Real);
-    }
-
-    #[test]
-    fn column_no_declared_affinity_can_be_overwritten_by_base_affinity() {
-        let mut col = new_blob_column();
-        col.set_no_declared_affinity();
-        col.set_base_affinity(Affinity::Integer);
-        assert!(col.has_declared_affinity());
-        assert_eq!(col.affinity(), Affinity::Integer);
+    fn set_base_affinity_is_consistent_with_accessor() {
+        for affinity in [
+            Affinity::Blob,
+            Affinity::Text,
+            Affinity::Numeric,
+            Affinity::Integer,
+            Affinity::Real,
+            Affinity::None,
+        ] {
+            let mut col = Column::new(
+                Some("x".to_string()),
+                "BLOB".to_string(),
+                None,
+                None,
+                Type::Blob,
+                None,
+                ColDef::default(),
+            );
+            col.set_base_affinity(affinity);
+            assert_eq!(
+                col.affinity(),
+                affinity,
+                "stored {affinity:?} but read back {:?}",
+                col.affinity(),
+            );
+        }
     }
 }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3428,8 +3428,10 @@ impl BTreeTable {
             if col.is_array() {
                 // Arrays are stored as record-format blobs.
                 col.ty_str = "BLOB".to_string();
+                col.override_affinity(Affinity::Blob);
             } else if let Ok(Some(resolved)) = schema.resolve_type(&col.ty_str, table.is_strict) {
                 col.ty_str = resolved.primitive.to_uppercase();
+                col.override_affinity(Affinity::None);
             }
         }
         Arc::new(modified)
@@ -3481,6 +3483,7 @@ impl BTreeTable {
             if let Some(only) = effective_only {
                 if !only.get(i) {
                     col.ty_str = "ANY".to_string();
+                    col.override_affinity(Affinity::Blob);
                     continue;
                 }
             }
@@ -3488,6 +3491,7 @@ impl BTreeTable {
                 // Pre-encode: user input can be text ('[1,2]') or blob (ARRAY[]),
                 // so accept ANY here; the encoder handles conversion.
                 col.ty_str = "ANY".to_string();
+                col.override_affinity(Affinity::Blob);
             } else if let Some(type_def) = schema.get_type_def(&col.ty_str, table.is_strict) {
                 col.ty_str = type_def.value_input_type().to_uppercase();
             }
@@ -5345,7 +5349,7 @@ impl Column {
         if coldef.hidden {
             raw |= F_HIDDEN
         }
-        Self::set_raw_affinity(&mut raw, Affinity::affinity(&ty_str));
+        Self::set_raw_affinity(&mut raw, Affinity::affinity(&ty_str)); //FIXME this isn't compatible with custom types. But how do I know that the type is custom?
 
         Self {
             name,

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -268,7 +268,7 @@ fn affinity_to_primitive(affinity: crate::vdbe::affinity::Affinity) -> Option<&'
         crate::vdbe::affinity::Affinity::Real => Some("REAL"),
         crate::vdbe::affinity::Affinity::Text => Some("TEXT"),
         crate::vdbe::affinity::Affinity::Numeric => Some("NUMERIC"),
-        crate::vdbe::affinity::Affinity::Blob => None,
+        crate::vdbe::affinity::Affinity::Blob | crate::vdbe::affinity::Affinity::None => None,
     }
 }
 
@@ -1310,13 +1310,7 @@ impl Statement {
             Some(&self.program.table_references),
             None,
         );
-        match affinity {
-            crate::vdbe::affinity::Affinity::Integer => Some("INTEGER".to_string()),
-            crate::vdbe::affinity::Affinity::Real => Some("REAL".to_string()),
-            crate::vdbe::affinity::Affinity::Text => Some("TEXT".to_string()),
-            crate::vdbe::affinity::Affinity::Numeric => Some("NUMERIC".to_string()),
-            crate::vdbe::affinity::Affinity::Blob => None, // Blob means "no affinity"
-        }
+        affinity_to_primitive(affinity).map(str::to_string)
     }
 
     pub fn parameters(&self) -> &parameters::Parameters {

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -9,7 +9,7 @@ use super::{
     },
     expr::{
         bind_and_rewrite_expr, emit_table_column, translate_expr, translate_expr_no_constant_opt,
-        walk_expr, BindingBehavior, ExprAffinityInfo, NoConstantOptReason, WalkControl,
+        walk_expr, BindingBehavior, NoConstantOptReason, WalkControl,
     },
     group_by::GroupByMetadata,
     main_loop::{LeftJoinMetadata, LoopLabels, SemiAntiJoinMetadata},
@@ -160,7 +160,7 @@ pub struct Resolver<'a> {
     /// Affinity metadata for planned scalar subqueries keyed by their internal ID.
     /// This lets comparison affinity follow SQLite rules for expressions like
     /// `(SELECT text_col FROM ...) > some_numeric_expr`.
-    pub(crate) subquery_affinities: RefCell<HashMap<TableInternalId, ExprAffinityInfo>>,
+    pub(crate) subquery_affinities: RefCell<HashMap<TableInternalId, Affinity>>,
     /// Context and metadata for resolving Expr::Column values that use
     /// [TableInternalId::SELF_TABLE] as a placeholder.
     self_table_scope: RefCell<Option<SelfTableScope>>,

--- a/core/translate/expr/affinity.rs
+++ b/core/translate/expr/affinity.rs
@@ -44,91 +44,59 @@ impl StorageClassMask {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct ExprAffinityInfo {
-    affinity: Affinity,
-    has_affinity: bool,
-}
-
-impl ExprAffinityInfo {
-    pub(crate) const fn with_affinity(affinity: Affinity) -> Self {
-        Self {
-            affinity,
-            has_affinity: true,
-        }
-    }
-
-    pub(crate) const fn no_affinity() -> Self {
-        Self {
-            affinity: Affinity::Blob,
-            has_affinity: false,
-        }
-    }
-
-    pub(crate) const fn affinity(&self) -> Affinity {
-        self.affinity
-    }
-
-    pub(crate) const fn has_affinity(&self) -> bool {
-        self.has_affinity
-    }
-}
-
-pub(crate) fn get_expr_affinity_info(
+pub(crate) fn get_expr_affinity(
     expr: &ast::Expr,
     referenced_tables: Option<&TableReferences>,
     resolver: Option<&Resolver>,
-) -> ExprAffinityInfo {
+) -> Affinity {
     match expr {
         ast::Expr::Column { table, column, .. } => {
             if table.is_self_table() {
                 if let Some(resolver) = resolver {
                     if let Some(aff) = resolver.self_table_affinity(*column) {
-                        return ExprAffinityInfo::with_affinity(aff);
+                        return aff;
                     }
                 }
             }
             if let Some(tables) = referenced_tables {
                 if let Some((_, table_ref)) = tables.find_table_by_internal_id(*table) {
                     if let Some(col) = table_ref.get_column_at(*column) {
-                        if !col.has_declared_affinity() {
-                            return ExprAffinityInfo::no_affinity();
+                        if col.affinity() == Affinity::None {
+                            return Affinity::None;
                         }
                         if let Some(btree) = table_ref.btree() {
-                            return ExprAffinityInfo::with_affinity(
-                                col.affinity_with_strict(btree.is_strict),
-                            );
+                            return col.affinity_with_strict(btree.is_strict);
                         }
-                        return ExprAffinityInfo::with_affinity(col.affinity());
+                        return col.affinity();
                     }
                 }
             }
-            ExprAffinityInfo::no_affinity()
+            Affinity::None
         }
-        ast::Expr::RowId { .. } => ExprAffinityInfo::with_affinity(Affinity::Integer),
+        ast::Expr::RowId { .. } => Affinity::Integer,
         ast::Expr::Cast { type_name, .. } => {
             if let Some(type_name) = type_name {
-                ExprAffinityInfo::with_affinity(Affinity::affinity(&type_name.name))
+                Affinity::affinity(&type_name.name)
             } else {
-                ExprAffinityInfo::no_affinity()
+                Affinity::None
             }
         }
         ast::Expr::Parenthesized(exprs) if exprs.len() == 1 => {
-            get_expr_affinity_info(exprs.first().unwrap(), referenced_tables, resolver)
+            get_expr_affinity(exprs.first().unwrap(), referenced_tables, resolver)
         }
-        ast::Expr::Collate(expr, _) => get_expr_affinity_info(expr, referenced_tables, resolver),
+        ast::Expr::Collate(expr, _) => get_expr_affinity(expr, referenced_tables, resolver),
         // Literals have NO affinity in SQLite.
-        ast::Expr::Literal(_) => ExprAffinityInfo::no_affinity(),
+        ast::Expr::Literal(_) => Affinity::None,
         ast::Expr::Register(reg) => {
             // During UPDATE expression index evaluation, column references are
             // rewritten to Expr::Register. Look up the original column affinity
             // from the resolver's register_affinities map.
             if let Some(resolver) = resolver {
                 if let Some(aff) = resolver.register_affinities.get(reg) {
-                    return ExprAffinityInfo::with_affinity(*aff);
+                    return *aff;
                 }
             }
-            ExprAffinityInfo::no_affinity()
+            Affinity::None
         }
         ast::Expr::SubqueryResult {
             subquery_id,
@@ -140,18 +108,10 @@ pub(crate) fn get_expr_affinity_info(
                     return *aff;
                 }
             }
-            ExprAffinityInfo::no_affinity()
+            Affinity::None
         }
-        _ => ExprAffinityInfo::no_affinity(),
+        _ => Affinity::None,
     }
-}
-
-pub fn get_expr_affinity(
-    expr: &ast::Expr,
-    referenced_tables: Option<&TableReferences>,
-    resolver: Option<&Resolver>,
-) -> Affinity {
-    get_expr_affinity_info(expr, referenced_tables, resolver).affinity
 }
 
 /// Mirrors SQLite's `sqlite3ExprDataType()` (expr.c): a bitmask of the storage
@@ -214,59 +174,56 @@ pub(crate) fn expr_data_type(
     }
 }
 
-pub fn comparison_affinity(
+/// Returns the [Affinity] to be used to compare two [Expr] between themselves.
+pub fn comparison_affinity_exprs(
     lhs_expr: &ast::Expr,
     rhs_expr: &ast::Expr,
     referenced_tables: Option<&TableReferences>,
     resolver: Option<&Resolver>,
 ) -> Affinity {
-    compare_affinity(
+    comparison_affinity_expr(
         rhs_expr,
-        get_expr_affinity_info(lhs_expr, referenced_tables, resolver),
+        get_expr_affinity(lhs_expr, referenced_tables, resolver),
         referenced_tables,
         resolver,
     )
 }
 
-pub(super) fn comparison_affinity_from_info(
-    lhs: ExprAffinityInfo,
-    rhs: ExprAffinityInfo,
-) -> Affinity {
-    if lhs.has_affinity && rhs.has_affinity {
+/// Returns the [Affinity] to be used to compare two affinities.
+pub(super) fn comparison_affinity(lhs: Affinity, rhs: Affinity) -> Affinity {
+    if lhs != Affinity::None && rhs != Affinity::None {
         // Both sides have affinity - use numeric if either is numeric
-        if lhs.affinity.is_numeric() || rhs.affinity.is_numeric() {
+        if lhs.is_numeric() || rhs.is_numeric() {
             Affinity::Numeric
         } else {
             Affinity::Blob
         }
-    } else if lhs.has_affinity {
+    } else if lhs != Affinity::None {
         // A lone numeric affinity still collapses to NUMERIC.
-        if lhs.affinity.is_numeric() {
+        if lhs.is_numeric() {
             Affinity::Numeric
         } else {
-            lhs.affinity
+            lhs
         }
-    } else if rhs.has_affinity {
-        if rhs.affinity.is_numeric() {
+    } else if rhs != Affinity::None {
+        if rhs.is_numeric() {
             Affinity::Numeric
         } else {
-            rhs.affinity
+            rhs
         }
     } else {
         Affinity::Blob
     }
 }
 
-pub(crate) fn compare_affinity(
+/// Returns the [Affinity] to be used to compare an [Expr] with something else.
+pub(crate) fn comparison_affinity_expr(
     expr: &ast::Expr,
-    other: ExprAffinityInfo,
+    other: Affinity,
     referenced_tables: Option<&TableReferences>,
     resolver: Option<&Resolver>,
 ) -> Affinity {
-    comparison_affinity_from_info(
-        other,
-        get_expr_affinity_info(expr, referenced_tables, resolver),
-    )
+    comparison_affinity(other, get_expr_affinity(expr, referenced_tables, resolver))
 }
 
 #[cfg(test)]
@@ -276,10 +233,7 @@ mod tests {
     #[test]
     fn both_sides_have_affinity_numeric_wins() {
         assert_eq!(
-            comparison_affinity_from_info(
-                ExprAffinityInfo::with_affinity(Affinity::Real),
-                ExprAffinityInfo::with_affinity(Affinity::Text),
-            ),
+            comparison_affinity(Affinity::Real, Affinity::Text,),
             Affinity::Numeric
         );
     }
@@ -287,10 +241,7 @@ mod tests {
     #[test]
     fn both_sides_have_affinity_neither_numeric_is_blob() {
         assert_eq!(
-            comparison_affinity_from_info(
-                ExprAffinityInfo::with_affinity(Affinity::Text),
-                ExprAffinityInfo::with_affinity(Affinity::Blob),
-            ),
+            comparison_affinity(Affinity::Text, Affinity::Blob,),
             Affinity::Blob
         );
     }
@@ -298,10 +249,7 @@ mod tests {
     #[test]
     fn only_lhs_has_real_affinity_collapses_to_numeric() {
         assert_eq!(
-            comparison_affinity_from_info(
-                ExprAffinityInfo::with_affinity(Affinity::Real),
-                ExprAffinityInfo::no_affinity(),
-            ),
+            comparison_affinity(Affinity::Real, Affinity::None,),
             Affinity::Numeric
         );
     }
@@ -309,10 +257,7 @@ mod tests {
     #[test]
     fn only_lhs_has_integer_affinity_collapses_to_numeric() {
         assert_eq!(
-            comparison_affinity_from_info(
-                ExprAffinityInfo::with_affinity(Affinity::Integer),
-                ExprAffinityInfo::no_affinity(),
-            ),
+            comparison_affinity(Affinity::Integer, Affinity::None,),
             Affinity::Numeric
         );
     }
@@ -320,10 +265,7 @@ mod tests {
     #[test]
     fn only_rhs_has_real_affinity_collapses_to_numeric() {
         assert_eq!(
-            comparison_affinity_from_info(
-                ExprAffinityInfo::no_affinity(),
-                ExprAffinityInfo::with_affinity(Affinity::Real),
-            ),
+            comparison_affinity(Affinity::None, Affinity::Real,),
             Affinity::Numeric
         );
     }
@@ -331,10 +273,7 @@ mod tests {
     #[test]
     fn only_lhs_has_text_affinity_is_preserved() {
         assert_eq!(
-            comparison_affinity_from_info(
-                ExprAffinityInfo::with_affinity(Affinity::Text),
-                ExprAffinityInfo::no_affinity(),
-            ),
+            comparison_affinity(Affinity::Text, Affinity::None,),
             Affinity::Text
         );
     }
@@ -342,10 +281,7 @@ mod tests {
     #[test]
     fn only_rhs_has_text_affinity_is_preserved() {
         assert_eq!(
-            comparison_affinity_from_info(
-                ExprAffinityInfo::no_affinity(),
-                ExprAffinityInfo::with_affinity(Affinity::Text),
-            ),
+            comparison_affinity(Affinity::None, Affinity::Text,),
             Affinity::Text
         );
     }
@@ -353,10 +289,7 @@ mod tests {
     #[test]
     fn neither_side_has_affinity_is_blob() {
         assert_eq!(
-            comparison_affinity_from_info(
-                ExprAffinityInfo::no_affinity(),
-                ExprAffinityInfo::no_affinity(),
-            ),
+            comparison_affinity(Affinity::None, Affinity::None,),
             Affinity::Blob
         );
     }

--- a/core/translate/expr/affinity.rs
+++ b/core/translate/expr/affinity.rs
@@ -174,23 +174,7 @@ pub(crate) fn expr_data_type(
     }
 }
 
-/// Returns the [Affinity] to be used to compare two [Expr] between themselves.
-pub fn comparison_affinity_exprs(
-    lhs_expr: &ast::Expr,
-    rhs_expr: &ast::Expr,
-    referenced_tables: Option<&TableReferences>,
-    resolver: Option<&Resolver>,
-) -> Affinity {
-    comparison_affinity_expr(
-        rhs_expr,
-        get_expr_affinity(lhs_expr, referenced_tables, resolver),
-        referenced_tables,
-        resolver,
-    )
-}
-
-/// Returns the [Affinity] to be used to compare two affinities.
-pub(super) fn comparison_affinity(lhs: Affinity, rhs: Affinity) -> Affinity {
+fn do_comparison_affinity(lhs: Affinity, rhs: Affinity) -> Affinity {
     if lhs != Affinity::None && rhs != Affinity::None {
         // Both sides have affinity - use numeric if either is numeric
         if lhs.is_numeric() || rhs.is_numeric() {
@@ -216,14 +200,44 @@ pub(super) fn comparison_affinity(lhs: Affinity, rhs: Affinity) -> Affinity {
     }
 }
 
-/// Returns the [Affinity] to be used to compare an [Expr] with something else.
-pub(crate) fn comparison_affinity_expr(
-    expr: &ast::Expr,
-    other: Affinity,
+/// Returns the [Affinity] to be used to compare two terms.
+pub fn comparison_affinity(
+    lhs: impl HasComparableAffinity,
+    rhs: impl HasComparableAffinity,
     referenced_tables: Option<&TableReferences>,
     resolver: Option<&Resolver>,
 ) -> Affinity {
-    comparison_affinity(other, get_expr_affinity(expr, referenced_tables, resolver))
+    let lhs = lhs.comparison_affinity(referenced_tables, resolver);
+    let rhs = rhs.comparison_affinity(referenced_tables, resolver);
+    do_comparison_affinity(lhs, rhs)
+}
+
+pub(crate) trait HasComparableAffinity {
+    fn comparison_affinity(
+        &self,
+        referenced_tables: Option<&TableReferences>,
+        resolver: Option<&Resolver>,
+    ) -> Affinity;
+}
+
+impl HasComparableAffinity for &ast::Expr {
+    fn comparison_affinity(
+        &self,
+        referenced_tables: Option<&TableReferences>,
+        resolver: Option<&Resolver>,
+    ) -> Affinity {
+        get_expr_affinity(self, referenced_tables, resolver)
+    }
+}
+
+impl HasComparableAffinity for Affinity {
+    fn comparison_affinity(
+        &self,
+        _referenced_tables: Option<&TableReferences>,
+        _resolver: Option<&Resolver>,
+    ) -> Affinity {
+        *self
+    }
 }
 
 #[cfg(test)]
@@ -233,7 +247,7 @@ mod tests {
     #[test]
     fn both_sides_have_affinity_numeric_wins() {
         assert_eq!(
-            comparison_affinity(Affinity::Real, Affinity::Text,),
+            do_comparison_affinity(Affinity::Real, Affinity::Text,),
             Affinity::Numeric
         );
     }
@@ -241,7 +255,7 @@ mod tests {
     #[test]
     fn both_sides_have_affinity_neither_numeric_is_blob() {
         assert_eq!(
-            comparison_affinity(Affinity::Text, Affinity::Blob,),
+            do_comparison_affinity(Affinity::Text, Affinity::Blob,),
             Affinity::Blob
         );
     }
@@ -249,7 +263,7 @@ mod tests {
     #[test]
     fn only_lhs_has_real_affinity_collapses_to_numeric() {
         assert_eq!(
-            comparison_affinity(Affinity::Real, Affinity::None,),
+            do_comparison_affinity(Affinity::Real, Affinity::None,),
             Affinity::Numeric
         );
     }
@@ -257,7 +271,7 @@ mod tests {
     #[test]
     fn only_lhs_has_integer_affinity_collapses_to_numeric() {
         assert_eq!(
-            comparison_affinity(Affinity::Integer, Affinity::None,),
+            do_comparison_affinity(Affinity::Integer, Affinity::None,),
             Affinity::Numeric
         );
     }
@@ -265,7 +279,7 @@ mod tests {
     #[test]
     fn only_rhs_has_real_affinity_collapses_to_numeric() {
         assert_eq!(
-            comparison_affinity(Affinity::None, Affinity::Real,),
+            do_comparison_affinity(Affinity::None, Affinity::Real,),
             Affinity::Numeric
         );
     }
@@ -273,7 +287,7 @@ mod tests {
     #[test]
     fn only_lhs_has_text_affinity_is_preserved() {
         assert_eq!(
-            comparison_affinity(Affinity::Text, Affinity::None,),
+            do_comparison_affinity(Affinity::Text, Affinity::None,),
             Affinity::Text
         );
     }
@@ -281,7 +295,7 @@ mod tests {
     #[test]
     fn only_rhs_has_text_affinity_is_preserved() {
         assert_eq!(
-            comparison_affinity(Affinity::None, Affinity::Text,),
+            do_comparison_affinity(Affinity::None, Affinity::Text,),
             Affinity::Text
         );
     }
@@ -289,7 +303,7 @@ mod tests {
     #[test]
     fn neither_side_has_affinity_is_blob() {
         assert_eq!(
-            comparison_affinity(Affinity::None, Affinity::None,),
+            do_comparison_affinity(Affinity::None, Affinity::None,),
             Affinity::Blob
         );
     }

--- a/core/translate/expr/binary.rs
+++ b/core/translate/expr/binary.rs
@@ -419,7 +419,7 @@ pub(super) fn row_component_affinity_collation(
     let lhs_for_cmp = row_value_component_expr(lhs_expr, idx)?.unwrap_or(lhs_expr);
     let rhs_for_cmp = row_value_component_expr(rhs_expr, idx)?.unwrap_or(rhs_expr);
     Ok((
-        comparison_affinity_exprs(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver),
+        comparison_affinity(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver),
         comparison_collation(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver)?,
     ))
 }
@@ -482,7 +482,7 @@ pub(super) fn emit_binary_insn(
 ) -> Result<()> {
     let mut affinity = Affinity::Blob;
     if op.is_comparison() {
-        affinity = comparison_affinity_exprs(lhs_expr, rhs_expr, referenced_tables, resolver);
+        affinity = comparison_affinity(lhs_expr, rhs_expr, referenced_tables, resolver);
     }
     let is_array_cmp =
         expr_is_array(lhs_expr, referenced_tables) && expr_is_array(rhs_expr, referenced_tables);
@@ -897,7 +897,7 @@ pub(super) fn emit_binary_condition_insn(
 ) -> Result<()> {
     let mut affinity = Affinity::Blob;
     if op.is_comparison() {
-        affinity = comparison_affinity_exprs(lhs_expr, rhs_expr, referenced_tables, resolver);
+        affinity = comparison_affinity(lhs_expr, rhs_expr, referenced_tables, resolver);
     }
 
     let opposite_op = match op {

--- a/core/translate/expr/binary.rs
+++ b/core/translate/expr/binary.rs
@@ -419,7 +419,7 @@ pub(super) fn row_component_affinity_collation(
     let lhs_for_cmp = row_value_component_expr(lhs_expr, idx)?.unwrap_or(lhs_expr);
     let rhs_for_cmp = row_value_component_expr(rhs_expr, idx)?.unwrap_or(rhs_expr);
     Ok((
-        comparison_affinity(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver),
+        comparison_affinity_exprs(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver),
         comparison_collation(lhs_for_cmp, rhs_for_cmp, referenced_tables, resolver)?,
     ))
 }
@@ -482,7 +482,7 @@ pub(super) fn emit_binary_insn(
 ) -> Result<()> {
     let mut affinity = Affinity::Blob;
     if op.is_comparison() {
-        affinity = comparison_affinity(lhs_expr, rhs_expr, referenced_tables, resolver);
+        affinity = comparison_affinity_exprs(lhs_expr, rhs_expr, referenced_tables, resolver);
     }
     let is_array_cmp =
         expr_is_array(lhs_expr, referenced_tables) && expr_is_array(rhs_expr, referenced_tables);
@@ -897,7 +897,7 @@ pub(super) fn emit_binary_condition_insn(
 ) -> Result<()> {
     let mut affinity = Affinity::Blob;
     if op.is_comparison() {
-        affinity = comparison_affinity(lhs_expr, rhs_expr, referenced_tables, resolver);
+        affinity = comparison_affinity_exprs(lhs_expr, rhs_expr, referenced_tables, resolver);
     }
 
     let opposite_op = match op {

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -79,9 +79,8 @@ use vectors::*;
 #[allow(unused_imports)]
 use walk::*;
 
-pub use affinity::comparison_affinity_exprs;
 pub(crate) use affinity::{
-    comparison_affinity_expr, expr_data_type, get_expr_affinity, StorageClassMask,
+    comparison_affinity, expr_data_type, get_expr_affinity, StorageClassMask,
 };
 pub(crate) use arrays::{
     emit_array_decode, emit_custom_type_decode_columns, emit_custom_type_encode_columns,

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -79,10 +79,10 @@ use vectors::*;
 #[allow(unused_imports)]
 use walk::*;
 
+pub use affinity::comparison_affinity_exprs;
 pub(crate) use affinity::{
-    compare_affinity, expr_data_type, get_expr_affinity_info, ExprAffinityInfo, StorageClassMask,
+    comparison_affinity_expr, expr_data_type, get_expr_affinity, StorageClassMask,
 };
-pub use affinity::{comparison_affinity, get_expr_affinity};
 pub(crate) use arrays::{
     emit_array_decode, emit_custom_type_decode_columns, emit_custom_type_encode_columns,
 };

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -116,8 +116,12 @@ impl<'a, 'plan> HashBuildPlanner<'a, 'plan> {
         for join_key in &self.hash_join_op.join_keys {
             let build_expr = join_key.get_build_expr(self.predicates);
             let probe_expr = join_key.get_probe_expr(self.predicates);
-            let affinity =
-                comparison_affinity(build_expr, probe_expr, Some(self.table_references), None);
+            let affinity = comparison_affinity_exprs(
+                build_expr,
+                probe_expr,
+                Some(self.table_references),
+                None,
+            );
             key_affinities.push(affinity.aff_mask());
         }
 

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::alloc::{TryClone, TursoIteratorExt};
 use crate::schema::GeneratedType;
 use crate::translate::emitter::HashLabels;
+use crate::translate::expr::comparison_affinity;
 use crate::translate::plan::ColumnUsedMask;
 use crate::vdbe::builder::SelfTableContext;
 
@@ -116,12 +117,8 @@ impl<'a, 'plan> HashBuildPlanner<'a, 'plan> {
         for join_key in &self.hash_join_op.join_keys {
             let build_expr = join_key.get_build_expr(self.predicates);
             let probe_expr = join_key.get_probe_expr(self.predicates);
-            let affinity = comparison_affinity_exprs(
-                build_expr,
-                probe_expr,
-                Some(self.table_references),
-                None,
-            );
+            let affinity =
+                comparison_affinity(build_expr, probe_expr, Some(self.table_references), None);
             key_affinities.push(affinity.aff_mask());
         }
 

--- a/core/translate/main_loop/mod.rs
+++ b/core/translate/main_loop/mod.rs
@@ -30,7 +30,7 @@ use crate::{
             CollationSeq,
         },
         emitter::{prepare_cdc_if_necessary, HashCtx},
-        expr::comparison_affinity,
+        expr::comparison_affinity_exprs,
         planner::{table_mask_from_expr, TableMask},
         result_row::emit_select_result,
     },

--- a/core/translate/main_loop/mod.rs
+++ b/core/translate/main_loop/mod.rs
@@ -30,7 +30,6 @@ use crate::{
             CollationSeq,
         },
         emitter::{prepare_cdc_if_necessary, HashCtx},
-        expr::comparison_affinity_exprs,
         planner::{table_mask_from_expr, TableMask},
         result_row::emit_select_result,
     },

--- a/core/translate/main_loop/seek.rs
+++ b/core/translate/main_loop/seek.rs
@@ -11,7 +11,7 @@ fn index_seek_affinities(seek_def: &SeekDef, seek_key: &SeekKey) -> String {
         .zip(seek_def.iter_affinity(seek_key))
         .map(|(key_component, aff)| match key_component {
             SeekKeyComponent::Expr(expr) if aff.expr_needs_no_affinity_change(expr) => {
-                affinity::SQLITE_AFF_NONE
+                affinity::SQLITE_AFF_BLOB
             }
             _ => aff.aff_mask(),
         })
@@ -220,7 +220,7 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
                 &self.t_ctx.resolver,
             )?;
             let affinities = index_seek_affinities(self.seek_def, &self.seek_def.start);
-            if affinities.chars().any(|c| c != affinity::SQLITE_AFF_NONE) {
+            if affinities.chars().any(|c| c != affinity::SQLITE_AFF_BLOB) {
                 self.program.emit_insn(Insn::Affinity {
                     start_reg: self.start_reg,
                     count: std::num::NonZeroUsize::new(num_regs).unwrap(),
@@ -347,7 +347,7 @@ impl<'a, 'plan> SeekEmitter<'a, 'plan> {
                         &self.t_ctx.resolver,
                     )?;
                     let affinities = index_seek_affinities(self.seek_def, &self.seek_def.end);
-                    if affinities.chars().any(|c| c != affinity::SQLITE_AFF_NONE) {
+                    if affinities.chars().any(|c| c != affinity::SQLITE_AFF_BLOB) {
                         self.program.emit_insn(Insn::Affinity {
                             start_reg: self.start_reg,
                             count: std::num::NonZeroUsize::new(num_regs).unwrap(),

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -1,11 +1,13 @@
+use super::{cost_params::CostModelParams, AvailableIndexes};
 use crate::alloc::TursoIteratorExt;
+use crate::translate::expr::comparison_affinity;
 use crate::{
     schema::{Column, Index, Schema},
     translate::{
         collate::{get_collseq_from_expr, CollationSeq},
         expr::{
-            as_binary_components, comparison_affinity_exprs, get_expr_affinity, truth_test_rhs,
-            unwrap_parens, walk_expr, walk_expr_mut, WalkControl,
+            as_binary_components, get_expr_affinity, truth_test_rhs, unwrap_parens, walk_expr,
+            walk_expr_mut, WalkControl,
         },
         expression_index::normalize_expr_for_index_matching,
         plan::{
@@ -27,8 +29,6 @@ use smallvec::SmallVec;
 use std::{collections::VecDeque, sync::Arc};
 use turso_ext::{ConstraintInfo, ConstraintOp};
 use turso_parser::ast::{self, SortOrder, TableInternalId};
-
-use super::{cost_params::CostModelParams, AvailableIndexes};
 
 /// Represents a single condition derived from a `WHERE` clause term
 /// that constrains a specific column of a table.
@@ -155,7 +155,7 @@ impl Constraint {
             // known through it. Without it, `text_col < (SELECT int_col ...)`
             // would take the TEXT side's affinity and the seek would compare
             // the integer as text.
-            affinity = comparison_affinity_exprs(lhs, rhs, referenced_tables, resolver);
+            affinity = comparison_affinity(lhs, rhs, referenced_tables, resolver);
         }
 
         if side == BinaryExprSide::Lhs {
@@ -596,7 +596,7 @@ pub fn constraints_from_where_clause(
                 let cmp_aff = operator
                     .as_ast_operator()
                     .filter(|op| op.is_comparison())
-                    .map(|_| comparison_affinity_exprs(lhs, rhs, Some(table_references), None));
+                    .map(|_| comparison_affinity(lhs, rhs, Some(table_references), None));
                 // A WHERE term must not constrain the loop of a table that an
                 // outer join can null-extend, with two exceptions below.
                 // Consuming the term into the access path filters that table's
@@ -2067,7 +2067,7 @@ pub(crate) fn analyze_binary_term_for_index(
     // Compute the affinity for the constraining expression
     let affinity = if let Some(ast_op) = operator.as_ast_operator() {
         if ast_op.is_comparison() && table_col_pos.is_some() {
-            comparison_affinity_exprs(lhs, rhs, Some(table_references), None)
+            comparison_affinity(lhs, rhs, Some(table_references), None)
         } else {
             Affinity::Blob
         }

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -4,7 +4,7 @@ use crate::{
     translate::{
         collate::{get_collseq_from_expr, CollationSeq},
         expr::{
-            as_binary_components, comparison_affinity, get_expr_affinity, truth_test_rhs,
+            as_binary_components, comparison_affinity_exprs, get_expr_affinity, truth_test_rhs,
             unwrap_parens, walk_expr, walk_expr_mut, WalkControl,
         },
         expression_index::normalize_expr_for_index_matching,
@@ -155,7 +155,7 @@ impl Constraint {
             // known through it. Without it, `text_col < (SELECT int_col ...)`
             // would take the TEXT side's affinity and the seek would compare
             // the integer as text.
-            affinity = comparison_affinity(lhs, rhs, referenced_tables, resolver);
+            affinity = comparison_affinity_exprs(lhs, rhs, referenced_tables, resolver);
         }
 
         if side == BinaryExprSide::Lhs {
@@ -596,7 +596,7 @@ pub fn constraints_from_where_clause(
                 let cmp_aff = operator
                     .as_ast_operator()
                     .filter(|op| op.is_comparison())
-                    .map(|_| comparison_affinity(lhs, rhs, Some(table_references), None));
+                    .map(|_| comparison_affinity_exprs(lhs, rhs, Some(table_references), None));
                 // A WHERE term must not constrain the loop of a table that an
                 // outer join can null-extend, with two exceptions below.
                 // Consuming the term into the access path filters that table's
@@ -2067,7 +2067,7 @@ pub(crate) fn analyze_binary_term_for_index(
     // Compute the affinity for the constraining expression
     let affinity = if let Some(ast_op) = operator.as_ast_operator() {
         if ast_op.is_comparison() && table_col_pos.is_some() {
-            comparison_affinity(lhs, rhs, Some(table_references), None)
+            comparison_affinity_exprs(lhs, rhs, Some(table_references), None)
         } else {
             Affinity::Blob
         }

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2463,7 +2463,7 @@ fn query_output_columns(
                 None,
                 ColDef::default(),
             );
-            column.set_base_affinity(affinity);
+            column.override_affinity(affinity);
             column
         })
         .try_collect::<alloc::Vec<_>>()?;
@@ -2521,7 +2521,7 @@ impl JoinedTable {
                     None,
                     ColDef::default(),
                 );
-                column.set_base_affinity(affinity);
+                column.override_affinity(affinity);
                 column
             })
             .try_collect::<alloc::Vec<_>>()?;
@@ -2619,7 +2619,7 @@ impl JoinedTable {
         // see the stored value without the anchor query's affinity. Only the
         // outer read of the CTE keeps the derived affinity.
         for column in columns.iter_mut() {
-            column.set_base_affinity(Affinity::Blob);
+            column.override_affinity(Affinity::Blob);
         }
         let table = Table::RecursiveCteInput(Arc::new(RecursiveCteInput {
             name: identifier.clone(),

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -8,10 +8,7 @@ use crate::{
     translate::{
         collate::{get_collseq_from_expr, CollationSeq},
         emitter::UpdateRowSource,
-        expr::{
-            as_binary_components, expr_data_type, get_expr_affinity, get_expr_affinity_info,
-            ExprAffinityInfo, StorageClassMask,
-        },
+        expr::{as_binary_components, expr_data_type, get_expr_affinity, StorageClassMask},
         expression_index::{normalize_expr_for_index_matching, single_table_column_usage},
         optimizer::constraints::{BinaryExprSide, SeekRangeConstraint},
         planner::determine_where_to_eval_term,
@@ -47,8 +44,8 @@ use super::emitter::OperationMode;
 ///
 /// The affinity (and whether it's a real declared one) determines comparison
 /// behavior in IN expressions, etc.
-fn infer_type_from_expr(expr: &ast::Expr, tables: Option<&TableReferences>) -> ExprAffinityInfo {
-    get_expr_affinity_info(expr, tables, None)
+fn infer_type_from_expr(expr: &ast::Expr, tables: Option<&TableReferences>) -> Affinity {
+    get_expr_affinity(expr, tables, None)
 }
 
 /// Computes the affinity of column `i` of a compound (UNION/INTERSECT/EXCEPT)
@@ -61,15 +58,15 @@ fn infer_type_from_expr(expr: &ast::Expr, tables: Option<&TableReferences>) -> E
 /// (TEXT affinity + a numeric arm, or numeric affinity + a text arm), in which
 /// case it is downgraded to BLOB (none) so the column is compared by storage
 /// class.
-fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> ExprAffinityInfo {
+fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> Affinity {
     if arms.is_empty() {
-        return ExprAffinityInfo::no_affinity();
+        return Affinity::None;
     }
-    let col_info = |arm: &SelectPlan| {
+    let col_affinities = |arm: &SelectPlan| {
         arm.result_columns
             .get(i)
-            .map(|rc| get_expr_affinity_info(&rc.expr, Some(&arm.table_references), None))
-            .unwrap_or_else(ExprAffinityInfo::no_affinity)
+            .map(|rc| get_expr_affinity(&rc.expr, Some(&arm.table_references), None))
+            .unwrap_or(Affinity::None)
     };
     let col_data_type = |arm: &SelectPlan| {
         arm.result_columns
@@ -78,30 +75,26 @@ fn compound_column_affinity(arms: &[&SelectPlan], i: usize) -> ExprAffinityInfo 
             .unwrap_or(StorageClassMask::from_null())
     };
 
-    let mut info = col_info(arms[0]);
+    let mut affinity = col_affinities(arms[0]);
     let mut data_types = StorageClassMask::from_null();
     let mut idx = 0;
     // Skip leading arms with no affinity, adopting the next arm's affinity.
-    while !info.has_affinity() && idx + 1 < arms.len() {
+    while affinity == Affinity::None && idx + 1 < arms.len() {
         data_types |= col_data_type(arms[idx]);
         idx += 1;
-        info = col_info(arms[idx]);
+        affinity = col_affinities(arms[idx]);
     }
-    if !info.has_affinity() {
-        return ExprAffinityInfo::no_affinity();
+    if affinity == Affinity::None {
+        return Affinity::None;
     }
-    // `info` has TEXT or numeric affinity here; accumulate the remaining arms' classes.
+    // This arm has a real affinity; accumulate the remaining arms' classes.
     for &arm in &arms[idx + 1..] {
         data_types |= col_data_type(arm);
     }
-    match info.affinity() {
-        Affinity::Text if data_types.has_numeric() => {
-            ExprAffinityInfo::with_affinity(Affinity::Blob)
-        }
-        a if a.is_numeric() && data_types.has_text() => {
-            ExprAffinityInfo::with_affinity(Affinity::Blob)
-        }
-        _ => info,
+    match affinity {
+        Affinity::Text if data_types.has_numeric() => Affinity::Blob,
+        a if a.is_numeric() && data_types.has_text() => Affinity::Blob,
+        _ => affinity,
     }
 }
 
@@ -2454,13 +2447,13 @@ fn query_output_columns(
             let name = explicit_columns
                 .and_then(|names| names.get(column_index).cloned())
                 .or_else(|| result_column.name(table_references).map(String::from));
-            let affinity_info = compound_arms
+            let affinity = compound_arms
                 .as_ref()
                 .map(|arms| compound_column_affinity(arms, column_index))
                 .unwrap_or_else(|| {
                     infer_type_from_expr(&result_column.expr, Some(table_references))
                 });
-            let column_type = affinity_info.affinity().to_type();
+            let column_type = affinity.to_type();
             let mut column = Column::new(
                 name,
                 column_type.to_string(),
@@ -2470,9 +2463,7 @@ fn query_output_columns(
                 None,
                 ColDef::default(),
             );
-            if !affinity_info.has_affinity() {
-                column.set_no_declared_affinity();
-            }
+            column.set_base_affinity(affinity);
             column
         })
         .try_collect::<alloc::Vec<_>>()?;
@@ -2519,8 +2510,8 @@ impl JoinedTable {
             .result_columns
             .iter()
             .map(|rc| {
-                let affinity_info = infer_type_from_expr(&rc.expr, Some(&plan.table_references));
-                let col_type = affinity_info.affinity().to_type();
+                let affinity = infer_type_from_expr(&rc.expr, Some(&plan.table_references));
+                let col_type = affinity.to_type();
                 let mut column = Column::new(
                     rc.name(&plan.table_references).map(String::from),
                     col_type.to_string(),
@@ -2530,9 +2521,7 @@ impl JoinedTable {
                     None,
                     ColDef::default(),
                 );
-                if !affinity_info.has_affinity() {
-                    column.set_no_declared_affinity();
-                }
+                column.set_base_affinity(affinity);
                 column
             })
             .try_collect::<alloc::Vec<_>>()?;
@@ -3106,10 +3095,10 @@ pub fn synthesized_seek_affinity_str(index: &Index, seek_def: &SeekDef) -> Optio
         .map(|a| a.aff_mask())
         .collect();
     for _ in num_key_cols..total_cols {
-        aff.push(affinity::SQLITE_AFF_NONE);
+        aff.push(affinity::SQLITE_AFF_BLOB);
     }
     aff.chars()
-        .any(|c| c != affinity::SQLITE_AFF_NONE)
+        .any(|c| c != affinity::SQLITE_AFF_BLOB)
         .then(|| Arc::new(aff))
 }
 

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -5,6 +5,13 @@ use crate::alloc::{TryClone, TursoSliceExt};
 use rustc_hash::FxHashMap as HashMap;
 use turso_parser::ast::{self, SortOrder, SubqueryType, TableInternalId};
 
+use super::{
+    emitter::{Resolver, TranslateCtx},
+    main_loop::LoopLabels,
+    plan::{Aggregate, Operation, QueryDestination, Search, SelectPlan},
+    planner::{resolve_window_and_aggregate_functions, TableMask},
+};
+use crate::translate::expr::comparison_affinity;
 use crate::{
     alloc::TursoIteratorExt,
     emit_explain,
@@ -17,10 +24,7 @@ use crate::{
             emit_program_for_select_with_resolver, emit_query,
         },
         eqp::{eqp_detail_for_table_op, EqpDetail, EqpJoin, EqpSubquery, EqpSubqueryExec},
-        expr::{
-            comparison_affinity_expr, get_expr_affinity, unwrap_parens, walk_expr, walk_expr_mut,
-            WalkControl,
-        },
+        expr::{get_expr_affinity, unwrap_parens, walk_expr, walk_expr_mut, WalkControl},
         optimizer::optimize_select_plan,
         plan::{
             plan_has_outer_scope_dependency, plan_is_correlated,
@@ -38,13 +42,6 @@ use crate::{
         CursorID,
     },
     Connection, Numeric, Result,
-};
-
-use super::{
-    emitter::{Resolver, TranslateCtx},
-    main_loop::LoopLabels,
-    plan::{Aggregate, Operation, QueryDestination, Search, SelectPlan},
-    planner::{resolve_window_and_aggregate_functions, TableMask},
 };
 
 struct DirectMaterializedSubquery {
@@ -980,7 +977,7 @@ fn get_subquery_parser<'a>(
                 for (i, lhs_expr) in lhs_columns.enumerate() {
                     let lhs_affinity = get_expr_affinity(lhs_expr, Some(referenced_tables), None);
                     affinity_chars.push(
-                        comparison_affinity_expr(
+                        comparison_affinity(
                             &result_columns[i].expr,
                             lhs_affinity,
                             Some(table_references),

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -18,7 +18,7 @@ use crate::{
         },
         eqp::{eqp_detail_for_table_op, EqpDetail, EqpJoin, EqpSubquery, EqpSubqueryExec},
         expr::{
-            compare_affinity, get_expr_affinity_info, unwrap_parens, walk_expr, walk_expr_mut,
+            comparison_affinity_expr, get_expr_affinity, unwrap_parens, walk_expr, walk_expr_mut,
             WalkControl,
         },
         optimizer::optimize_select_plan,
@@ -843,11 +843,8 @@ fn get_subquery_parser<'a>(
 
                 if reg_count == 1 {
                     if let Some(result_col) = plan.result_columns.first() {
-                        let affinity = get_expr_affinity_info(
-                            &result_col.expr,
-                            Some(&plan.table_references),
-                            None,
-                        );
+                        let affinity =
+                            get_expr_affinity(&result_col.expr, Some(&plan.table_references), None);
                         resolver
                             .subquery_affinities
                             .borrow_mut()
@@ -981,10 +978,9 @@ fn get_subquery_parser<'a>(
                 let mut affinity_chars = String::with_capacity(lhs_column_count);
                 let mut lhs_collations = Vec::with_capacity(lhs_column_count);
                 for (i, lhs_expr) in lhs_columns.enumerate() {
-                    let lhs_affinity =
-                        get_expr_affinity_info(lhs_expr, Some(referenced_tables), None);
+                    let lhs_affinity = get_expr_affinity(lhs_expr, Some(referenced_tables), None);
                     affinity_chars.push(
-                        compare_affinity(
+                        comparison_affinity_expr(
                             &result_columns[i].expr,
                             lhs_affinity,
                             Some(table_references),

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -75,20 +75,35 @@ use crate::{
 ///   ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Affinity {
-    Blob = 0,
-    Text = 1,
-    Numeric = 2,
-    Integer = 3,
-    Real = 4,
+    // Affinity = 0 is kept as a special value for custom types
+    Blob = 1,
+    Text = 2,
+    Numeric = 3,
+    Integer = 4,
+    Real = 5,
+    None = 6,
 }
 
-pub const SQLITE_AFF_NONE: char = 'A'; // Historically called NONE, but it's the same as BLOB
+pub const SQLITE_AFF_NONE: char = '@';
+pub const SQLITE_AFF_BLOB: char = 'A';
 pub const SQLITE_AFF_TEXT: char = 'B';
 pub const SQLITE_AFF_NUMERIC: char = 'C';
 pub const SQLITE_AFF_INTEGER: char = 'D';
 pub const SQLITE_AFF_REAL: char = 'E';
 
 impl Affinity {
+    pub fn from_repr(repr: u32) -> Option<Self> {
+        match repr {
+            1 => Some(Affinity::Blob),
+            2 => Some(Affinity::Text),
+            3 => Some(Affinity::Numeric),
+            4 => Some(Affinity::Integer),
+            5 => Some(Affinity::Real),
+            6 => Some(Affinity::None),
+            _ => None,
+        }
+    }
+
     /// This is meant to be used in opcodes like Eq, which state:
     ///
     /// "The SQLITE_AFF_MASK portion of P5 must be an affinity character - SQLITE_AFF_TEXT, SQLITE_AFF_INTEGER, and so forth.
@@ -100,9 +115,10 @@ impl Affinity {
         match self {
             Affinity::Integer => SQLITE_AFF_INTEGER,
             Affinity::Text => SQLITE_AFF_TEXT,
-            Affinity::Blob => SQLITE_AFF_NONE,
+            Affinity::Blob => SQLITE_AFF_BLOB,
             Affinity::Real => SQLITE_AFF_REAL,
             Affinity::Numeric => SQLITE_AFF_NUMERIC,
+            Affinity::None => SQLITE_AFF_NONE,
         }
     }
 
@@ -110,7 +126,7 @@ impl Affinity {
         match char {
             SQLITE_AFF_INTEGER => Affinity::Integer,
             SQLITE_AFF_TEXT => Affinity::Text,
-            SQLITE_AFF_NONE => Affinity::Blob,
+            SQLITE_AFF_BLOB => Affinity::Blob,
             SQLITE_AFF_REAL => Affinity::Real,
             SQLITE_AFF_NUMERIC => Affinity::Numeric,
             _ => Affinity::Blob,
@@ -129,7 +145,7 @@ impl Affinity {
     pub fn to_type(self) -> crate::schema::Type {
         use crate::schema::Type;
         match self {
-            Affinity::Blob => Type::Blob,
+            Affinity::Blob | Affinity::None => Type::Blob,
             Affinity::Text => Type::Text,
             Affinity::Numeric => Type::Numeric,
             Affinity::Integer => Type::Integer,
@@ -141,18 +157,11 @@ impl Affinity {
         matches!(self, Affinity::Integer | Affinity::Real | Affinity::Numeric)
     }
 
-    pub fn has_affinity(&self) -> bool {
-        !matches!(self, Affinity::Blob)
-    }
-
-    /// Returns the canonical short type name for this affinity, matching
-    /// SQLite's `azType[]` in `createTableStmt()` (`build.c`).
-    ///
-    /// Used when generating schema SQL (e.g. for `sqlite_schema.sql`).
-    /// Returns an empty string for BLOB affinity (no declared type).
+    /// Loosely matches SQLite's `azType[]` in `createTableStmt()` (`build.c`).
+    /// Returns an empty string for BLOB and NONE affinity (no declared type).
     pub fn short_type_name(&self) -> &'static str {
         match self {
-            Affinity::Blob => "",
+            Affinity::Blob | Affinity::None => "",
             Affinity::Text => "TEXT",
             Affinity::Numeric => "NUM",
             Affinity::Integer => "INT",
@@ -245,7 +254,7 @@ impl Affinity {
                 left.map(Either::Left)
             }
 
-            Affinity::Blob => None, // Do nothing for blob affinity.
+            Affinity::Blob | Affinity::None => None, // Do nothing for blob affinity.
         }
     }
 
@@ -276,7 +285,7 @@ impl Affinity {
                 .flatten()
                 .map(Either::Left),
             Affinity::Text => self.convert(val),
-            Affinity::Blob => None,
+            Affinity::Blob | Affinity::None => None,
         }
     }
 
@@ -299,7 +308,7 @@ impl Affinity {
     ///   answer from the scan. Only a numeric-affinity index is safe.
     pub fn index_affinity_ok(self, comparison_aff: Affinity) -> bool {
         match comparison_aff {
-            Affinity::Blob => true,
+            Affinity::Blob | Affinity::None => true,
             Affinity::Text => matches!(self, Affinity::Text),
             Affinity::Numeric | Affinity::Integer | Affinity::Real => self.is_numeric(),
         }
@@ -316,7 +325,7 @@ impl Affinity {
     ///
     /// reference https://github.com/sqlite/sqlite/blob/master/src/expr.c#L3000
     pub fn expr_needs_no_affinity_change(&self, expr: &Expr) -> bool {
-        if !self.has_affinity() {
+        if matches!(self, Affinity::Blob | Affinity::None) {
             return true;
         }
         // TODO: check for unary minus in the expr, as it may be an additional optimization.
@@ -793,5 +802,25 @@ mod tests {
         assert_eq!(parsed.as_integer(), None);
         let (_, parsed) = try_for_float(b"-9.223372036854775808e18");
         assert_eq!(parsed.as_integer(), None);
+    }
+
+    #[test]
+    fn affinity_repr_round_trips() {
+        for affinity in [
+            Affinity::Blob,
+            Affinity::Text,
+            Affinity::Numeric,
+            Affinity::Integer,
+            Affinity::Real,
+            Affinity::None,
+        ] {
+            assert_eq!(
+                Affinity::from_repr(affinity as u32),
+                Some(affinity),
+                "{affinity:?} did not round trip",
+            );
+        }
+
+        assert_eq!(Affinity::from_repr(0), None);
     }
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -15741,7 +15741,7 @@ pub fn op_cast(
 
     let value = state.registers[*reg].get_value().clone();
     let result = match affinity {
-        Affinity::Blob => value.exec_cast("BLOB"),
+        Affinity::Blob | Affinity::None => value.exec_cast("BLOB"),
         Affinity::Text => value.exec_cast("TEXT"),
         Affinity::Numeric => value.exec_cast("NUMERIC"),
         Affinity::Integer => value.exec_cast("INTEGER"),
@@ -17484,7 +17484,7 @@ fn apply_affinity_char(target: &mut Register, affinity: Affinity) -> bool {
         }
 
         match affinity {
-            Affinity::Blob => return true,
+            Affinity::Blob | Affinity::None => return true,
 
             Affinity::Text => {
                 if matches!(value, Value::Text(_) | Value::Null) {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -39,7 +39,7 @@ pub mod sorter;
 mod statement_lifecycle_tests;
 pub mod vacuum;
 pub mod value;
-// for benchmarks
+#[allow(unused_imports)] // for benchmarks
 pub use crate::translate::collate::CollationSeq;
 use crate::{
     alloc::{DynAllocator, TryClone},

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -949,8 +949,7 @@ impl Value {
         }
         Ok(match Affinity::affinity(datatype) {
             // NONE	Casting a value to a type-name with no affinity causes the value to be converted into a BLOB. Casting to a BLOB consists of first casting the value to TEXT in the encoding of the database connection, then interpreting the resulting byte sequence as a BLOB instead of as TEXT.
-            // Historically called NONE, but it's the same as BLOB
-            Affinity::Blob => {
+            Affinity::Blob | Affinity::None => {
                 if let Value::Blob(blob) = self {
                     return Value::from_slice(blob);
                 }


### PR DESCRIPTION
## Description

This PR extends `Affinity` with `Affinity::None`. This mimics SQLite's `SQLITE_AFF_NONE`.

It also made `ExprAffinityInfo` redundant, so I removed it, and I used the opportunity to collapse some functions that shared similar logic by using a trait with `impl` parameters.