### PR TITLE
bindings/js: report StepResult::Yield as STEP_SLEEP instead of STEP_IO

### DIFF
--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -26,8 +26,9 @@ function createErrorByName(name, message) {
   return new ErrorConstructor(message);
 }
 
-// The engine returned STEP_SLEEP: its busy handler wants the statement retried
-// after a backoff delay. Park the step loop on a timer promise — unlike STEP_IO
+// The engine returned STEP_SLEEP: it wants the statement stepped again after a
+// delay (busy-handler backoff, or a yield with no pending I/O). Park the step
+// loop on a timer promise — unlike STEP_IO
 // there is no I/O completion coming to wake us up, so waiting on the IO
 // notifier would hang (WASM) or spin (native).
 function sleepBeforeRetry(ms: number): Promise<void> {

--- a/bindings/javascript/src/lib.rs
+++ b/bindings/javascript/src/lib.rs
@@ -208,7 +208,8 @@ fn step_sync(stmt: &StatementHandle) -> napi::Result<(u32, u32)> {
         .ok_or_else(|| create_generic_error("statement has been finalized"))?;
     match core_stmt.step() {
         Ok(turso_core::StepResult::Row) => Ok((STEP_ROW, 0)),
-        Ok(turso_core::StepResult::IO | turso_core::StepResult::Yield) => Ok((STEP_IO, 0)),
+        Ok(turso_core::StepResult::IO) => Ok((STEP_IO, 0)),
+        Ok(turso_core::StepResult::Yield) => Ok((STEP_SLEEP, 1)),
         Ok(turso_core::StepResult::Sleep { duration }) => {
             // Round sub-millisecond delays up to 1ms: a 0ms setTimeout would
             // make the JS step loop spin without letting the backoff expire.


### PR DESCRIPTION
A yield carries no pending I/O completion by design: core deliberately
does not store yields in io_completions, so no completion callback will
ever fire for one. The JS binding folded Yield into STEP_IO, and the
wasm driver handles STEP_IO by awaiting an I/O notification from the
OPFS worker. When a statement yielded while no I/O was in flight,
nothing ever notified the waiter, so the statement (and everything
queued behind the connection's exec lock) hung forever in the browser.
Node was unaffected only because its ioStep is a no-op.

Map Yield to STEP_SLEEP with a 1ms delay so the step loops re-step on a
timer instead of waiting for a notification that was never scheduled.
This mirrors the STEP_SLEEP approach from #8325 for busy_timeout and
needs no driver changes: both the native and wasm step loops already
handle STEP_SLEEP by sleeping and stepping again, which matches core's
contract that a yielded instruction simply re-executes on the next
step.

No regression test: per review, an injection-based test was rejected
and the bug cannot be reproduced from pure JavaScript. Every natural
yield source in core (btree cursor-restore TryAdvance, materialized
view populate, pager init lock, in-flight page reads, MVCC allocator
contention) needs async I/O in flight or cross-connection thread
contention, neither of which single-threaded JS can trigger through
the native binding, whose PlatformIO completes I/O synchronously.

Tests: cd bindings/javascript && yarn install && yarn workspace @tursodatabase/database-common build && yarn workspace @tursodatabase/database exec napi build --platform --esm --manifest-path ../../Cargo.toml --output-dir . && yarn workspace @tursodatabase/database run test && git checkout -- packages/native/index.js packages/native/index.d.ts

Fixes #8341