### PR TITLE
github: publish dotnet packages with nuget trusted publishing

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -629,6 +629,9 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      # Required so nuget.org's trusted publishing policy can validate this
+      # workflow's OIDC token and mint a short-lived API key.
+      id-token: write
 
     steps:
       - name: Install dotnet SDK
@@ -642,9 +645,21 @@ jobs:
           name: nuget-packages
           path: nuget-packages
 
+      # Trusted publishing: swap the GitHub OIDC token for a NuGet API key that
+      # is only valid for an hour, so this must stay directly before the push.
+      # https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          # The individual nuget.org account the policy is registered under, not
+          # the package owner. Packages land under whichever owner the policy's
+          # "Package owner" field names (Turso), not under this account.
+          user: pjenberg
+
       # https://learn.microsoft.com/en-us/nuget/nuget-org/publish-a-package
       - name: Publish to nuget
         run: |
           for package in nuget-packages/*.nupkg; do
-            dotnet nuget push "$package" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+            dotnet nuget push "$package" --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
           done


### PR DESCRIPTION
The `publish-to-nuget` job pushed with a long-lived `secrets.NUGET_API_KEY`, but nuget.org grants this repo access through a **trusted publishing** policy instead. There is no static key behind such a policy, so every push was rejected before the scope check ever ran:

```
Pushing Turso.Data.Common.0.8.0-pre.5.nupkg to 'https://www.nuget.org/api/v2/package'...
  Forbidden https://www.nuget.org/api/v2/package/ 135ms
error: 403 (The specified API key is invalid, has expired, or does not
       have permission to access the specified package.)
```

This requests a short-lived key over OIDC instead:

- `id-token: write` on the job, without which GitHub never issues an OIDC token.
- A `NuGet/login@v1` step that trades that token for a key nuget.org mints against the policy.

The minted key is valid for one hour, so the login step stays directly before the push rather than moving earlier in the job.

`user: pjenberg` is the individual account the policy is registered under, not the package owner — packages land under whichever owner the policy's **Package owner** field names.

### Follow-up

Once a publish succeeds, the `NUGET_API_KEY` repository secret is unused and should be deleted.

### Testing

Publishing only runs on `workflow_dispatch` with `dry-run` off, so this is verified by the next release dispatch.