### PR TITLE
sqlite/conformance: normalize expected results in do_execsql_test

### DIFF
--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -340,7 +340,7 @@ set test_files {
   json101              fail
   json102              fail
   json103              fail
-  json104              fail
+  json104              pass
   json105              fail
   json106              fail
   json107              fail

--- a/sqlite/conformance/upstream/tester.tcl
+++ b/sqlite/conformance/upstream/tester.tcl
@@ -244,9 +244,9 @@ proc do_test {name cmd expected} {
   }
 }
 
-# Execute SQL test with expected results
+# Execute SQL test with expected results.
 proc do_execsql_test {name sql {expected {}}} {
-  do_test $name [list execsql $sql] $expected
+  do_test $name [list execsql $sql] [list {*}$expected]
 }
 
 # Execute SQL test expecting an error


### PR DESCRIPTION
Upstream tester.tcl passes the expected result of do_execsql_test
through [list {*}$result], re-canonicalizing it as a TCL list so a
braced single element like {4} compares equal to the plain result 4.
Our simplified tester.tcl compared the raw string, so every test whose
expected value is written with an extra brace layer failed with noise
like "Expected: {4} Got: 4" even though the engine result was correct.

Match upstream by canonicalizing the expected value the same way.
