### PR TITLE
core: read generated columns from source cursor when building automatic indexes

### DIFF
--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -519,16 +519,18 @@ pub(super) fn emit_autoindex(
         if let Some(columns) = table_columns {
             if let Some(column_def) = columns.get(col.pos_in_table) {
                 if column_def.is_virtual_generated() {
-                    crate::translate::expr::emit_table_column(
-                        program,
-                        table_cursor_id,
-                        table_ref_id,
-                        table_references,
-                        column_def,
-                        col.pos_in_table,
-                        reg,
-                        resolver,
-                    )?;
+                    program.with_cursor_override(table_ref_id, table_cursor_id, |program| {
+                        crate::translate::expr::emit_table_column(
+                            program,
+                            table_cursor_id,
+                            table_ref_id,
+                            table_references,
+                            column_def,
+                            col.pos_in_table,
+                            reg,
+                            resolver,
+                        )
+                    })?;
                     continue;
                 }
             }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1795,6 +1795,25 @@ impl ProgramBuilder {
         self.cursor_overrides.insert(table_ref_id.into(), cursor_id);
     }
 
+    /// The bytecode emitted by `emit` must run while `cursor_id` is open and
+    /// positioned on a row of `table_ref_id`.
+    pub fn with_cursor_override<T>(
+        &mut self,
+        table_ref_id: TableInternalId,
+        cursor_id: CursorID,
+        emit: impl FnOnce(&mut Self) -> Result<T>,
+    ) -> Result<T> {
+        let table_id = table_ref_id.into();
+        let previous = self.cursor_overrides.insert(table_id, cursor_id);
+        let result = emit(self);
+        if let Some(previous) = previous {
+            self.cursor_overrides.insert(table_id, previous);
+        } else {
+            self.cursor_overrides.remove(&table_id);
+        }
+        result
+    }
+
     /// Clear the cursor override for a table.
     pub fn clear_cursor_override(&mut self, table_ref_id: TableInternalId) {
         self.cursor_overrides.remove(&table_ref_id.into());

--- a/sqlite/conformance/sqlite-sqltests/gencol.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/gencol.sqltest
@@ -5064,3 +5064,44 @@ test update-or-virtual-deferred-seek-no-panic-explicit-index {
 expect error {
     UNIQUE constraint failed
 }
+
+setup gencol_autoindex_source_row {
+    CREATE TABLE autoindex_gencol(
+        base TEXT,
+        direct TEXT AS (base),
+        chained TEXT AS (direct || '')
+    );
+    INSERT INTO autoindex_gencol(base) VALUES ('hit');
+}
+
+@setup gencol_autoindex_source_row
+test gencol-autoindex-virtual-column-uses-source-row {
+    SELECT base
+    FROM (SELECT 1) CROSS JOIN autoindex_gencol
+    WHERE direct = 'hit';
+}
+expect {
+    hit
+}
+
+@setup gencol_autoindex_source_row
+test gencol-autoindex-chained-virtual-column-uses-source-row {
+    SELECT base
+    FROM (SELECT 1) CROSS JOIN autoindex_gencol
+    WHERE chained = 'hit';
+}
+expect {
+    hit
+}
+
+@setup gencol_autoindex_source_row
+@skip-if sqlite "Turso names automatic indexes differently"
+test gencol-autoindex-virtual-column-plan {
+    EXPLAIN QUERY PLAN
+    SELECT base
+    FROM (SELECT 1) CROSS JOIN autoindex_gencol
+    WHERE direct = 'hit';
+}
+expect pattern {
+    SEARCH autoindex_gencol USING INDEX ephemeral_.* \(direct=\?\)
+}


### PR DESCRIPTION
found here https://github.com/tursodatabase/turso/actions/runs/32268670457/job/96119423822

When Turso builds an automatic index for a virtual generated column, it can read the column’s inputs from the index being built instead of the source table. This creates the wrong key and can possibly cause existing rows to be missed.
## Fix
Read virtual generated columns from the source-table cursor while building automatic indexes.


## AI disclosure
claude wrote the fix, i simplified a bit and verified against sqlite.


