### PR TITLE
core/fts: make backing state transactional under MVCC

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1844,8 +1844,13 @@ impl Limbo {
         if let Some(mut rows) = conn.query(q_tables)? {
             rows.run_with_row_callback(|row| {
                 let name: &str = row.get::<&str>(0)?;
-                // Skip sqlite_sequence and internal types metadata table
-                if name == "sqlite_sequence" || name == turso_core::schema::TURSO_TYPES_TABLE_NAME {
+                // Skip sqlite_sequence and every internal object. Index-method
+                // backing tables (e.g. FTS's __turso_internal_fts_dir_*) are
+                // rejected on replay because their names are reserved, and the
+                // trailing CREATE INDEX ... USING ... rebuilds them anyway.
+                if name == "sqlite_sequence"
+                    || name.starts_with(turso_core::schema::TURSO_INTERNAL_PREFIX)
+                {
                     return Ok(());
                 }
                 let ddl: &str = row.get::<&str>(1)?;
@@ -1991,6 +1996,7 @@ impl Limbo {
             SELECT name, sql FROM sqlite_schema
             WHERE sql NOT NULL
               AND name NOT LIKE 'sqlite_%'
+              AND name NOT LIKE '\_\_turso\_internal\_%' ESCAPE '\'
               AND type IN ('index','trigger','view')
             ORDER BY CASE type WHEN 'view' THEN 1 WHEN 'index' THEN 2 WHEN 'trigger' THEN 3 END, rowid
         "#;

--- a/cli/mvcc_repl.rs
+++ b/cli/mvcc_repl.rs
@@ -95,7 +95,9 @@ fn open_mvcc_db(path: &str, passive_checkpoint: bool) -> anyhow::Result<Arc<Data
         path,
         None,
         OpenFlags::default(),
-        DatabaseOpts::default().with_experimental_mvcc_passive_checkpoint(passive_checkpoint),
+        DatabaseOpts::default()
+            .with_experimental_mvcc_passive_checkpoint(passive_checkpoint)
+            .with_index_method(true),
         None,
         Arc::new(SqliteDialect),
     )

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -526,6 +526,10 @@ pub struct Connection {
     /// eventual transaction outcome is delivered exactly once per attachment.
     pub(crate) index_method_tx_cursors:
         Mutex<Vec<crate::index_method::TransactionIndexMethodCursor>>,
+    /// True while `index_method_tx_cursors` may be non-empty. Lets every
+    /// commit/rollback skip the mutex and sort when no index method was ever
+    /// touched — the overwhelmingly common case.
+    pub(crate) has_index_method_tx_cursors: crate::sync::atomic::AtomicBool,
     /// Connection-level named savepoint stack used to mirror savepoint state
     /// onto temp/attached databases that start participating after SAVEPOINT.
     pub(crate) named_savepoints: RwLock<Vec<NamedSavepointFrame>>,
@@ -551,6 +555,11 @@ crate::assert::assert_send_sync!(Connection);
 impl Drop for Connection {
     fn drop(&mut self) {
         if !self.is_closed() {
+            // A handle dropped mid-transaction rolls that transaction back
+            // below, so parked index-method cursors must receive the same
+            // rollback outcome they would get from an explicit close().
+            self.index_methods_transaction_rolled_back();
+
             // Roll back any active MVCC transactions so that MvStore entries
             // don't leak and block future checkpoints.  The tx may have
             // already been committed/aborted externally (e.g. by tests that
@@ -4988,11 +4997,20 @@ impl Connection {
         self.named_savepoints.write().clear();
     }
 
+    /// Park a statement's index-method cursor on the connection until the
+    /// transaction's outcome is known. A cursor replaced by a later
+    /// statement's cursor for the same attachment is closed immediately and
+    /// receives neither `transaction_committed` nor `transaction_rolled_back`
+    /// — that replacement is the third legitimate end of a cursor's life
+    /// (see the `IndexMethodCursor` trait docs). Only the newest cursor per
+    /// attachment gets the final outcome.
     pub(crate) fn register_index_method_transaction_cursor(
         &self,
         mut entry: crate::index_method::TransactionIndexMethodCursor,
     ) {
         entry.cursor.statement_committed(&entry.context);
+        self.has_index_method_tx_cursors
+            .store(true, Ordering::Release);
         let mut entries = self.index_method_tx_cursors.lock();
         let previous = if let Some(position) = entries
             .iter()
@@ -5013,6 +5031,14 @@ impl Connection {
     fn take_index_method_transaction_cursors(
         &self,
     ) -> Vec<crate::index_method::TransactionIndexMethodCursor> {
+        // Fast path for the overwhelmingly common no-index-method case:
+        // skip the mutex and the sort below entirely.
+        if !self
+            .has_index_method_tx_cursors
+            .swap(false, Ordering::AcqRel)
+        {
+            return Vec::new();
+        }
         let mut entries = std::mem::take(&mut *self.index_method_tx_cursors.lock());
         entries.sort_by(|left, right| {
             (
@@ -5058,6 +5084,9 @@ impl Connection {
     }
 
     pub(crate) fn index_methods_savepoint_rolled_back(&self) {
+        if !self.has_index_method_tx_cursors.load(Ordering::Acquire) {
+            return;
+        }
         let mut entries = self.index_method_tx_cursors.lock();
         tracing::trace!(
             attachments = entries.len(),

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -521,6 +521,11 @@ pub struct Connection {
     pub(super) check_constraints_pragma: AtomicBool,
     /// Track when each virtual table instance is currently in transaction.
     pub(crate) vtab_txn_states: RwLock<HashSet<u64>>,
+    /// One prepared cursor per index-method attachment touched by the active
+    /// database transaction. Statement reset transfers cursors here so the
+    /// eventual transaction outcome is delivered exactly once per attachment.
+    pub(crate) index_method_tx_cursors:
+        Mutex<Vec<crate::index_method::TransactionIndexMethodCursor>>,
     /// Connection-level named savepoint stack used to mirror savepoint state
     /// onto temp/attached databases that start participating after SAVEPOINT.
     pub(crate) named_savepoints: RwLock<Vec<NamedSavepointFrame>>,
@@ -2410,6 +2415,7 @@ impl Connection {
                 self.set_tx_state(TransactionState::None);
             }
         }
+        self.index_methods_transaction_rolled_back();
         self.clear_mvcc_log_meta();
 
         let is_memory_db = is_memory_like(&self.db.path);
@@ -4982,6 +4988,86 @@ impl Connection {
         self.named_savepoints.write().clear();
     }
 
+    pub(crate) fn register_index_method_transaction_cursor(
+        &self,
+        mut entry: crate::index_method::TransactionIndexMethodCursor,
+    ) {
+        entry.cursor.statement_committed(&entry.context);
+        let mut entries = self.index_method_tx_cursors.lock();
+        let previous = if let Some(position) = entries
+            .iter()
+            .position(|existing| existing.same_attachment(&entry.context))
+        {
+            Some(std::mem::replace(&mut entries[position], entry))
+        } else {
+            entries.push(entry);
+            None
+        };
+        drop(entries);
+
+        if let Some(mut previous) = previous {
+            previous.cursor.close(&previous.context);
+        }
+    }
+
+    fn take_index_method_transaction_cursors(
+        &self,
+    ) -> Vec<crate::index_method::TransactionIndexMethodCursor> {
+        let mut entries = std::mem::take(&mut *self.index_method_tx_cursors.lock());
+        entries.sort_by(|left, right| {
+            (
+                left.context.database().id,
+                left.context.index().method_name.as_str(),
+                left.context.index().table_name.as_str(),
+                left.context.index().index_name.as_str(),
+                left.context.index().runtime_id,
+            )
+                .cmp(&(
+                    right.context.database().id,
+                    right.context.index().method_name.as_str(),
+                    right.context.index().table_name.as_str(),
+                    right.context.index().index_name.as_str(),
+                    right.context.index().runtime_id,
+                ))
+        });
+        entries
+    }
+
+    pub(crate) fn index_methods_transaction_committed(&self) {
+        let entries = self.take_index_method_transaction_cursors();
+        tracing::trace!(
+            attachments = entries.len(),
+            "publishing transaction-scoped index-method state"
+        );
+        for mut entry in entries {
+            entry.cursor.transaction_committed(&entry.context);
+            entry.cursor.close(&entry.context);
+        }
+    }
+
+    pub(crate) fn index_methods_transaction_rolled_back(&self) {
+        let entries = self.take_index_method_transaction_cursors();
+        tracing::trace!(
+            attachments = entries.len(),
+            "invalidating transaction-scoped index-method state"
+        );
+        for mut entry in entries {
+            entry.cursor.transaction_rolled_back(&entry.context);
+            entry.cursor.close(&entry.context);
+        }
+    }
+
+    pub(crate) fn index_methods_savepoint_rolled_back(&self) {
+        let mut entries = self.index_method_tx_cursors.lock();
+        tracing::trace!(
+            attachments = entries.len(),
+            "invalidating index-method state after savepoint rollback"
+        );
+        for entry in entries.iter_mut() {
+            entry.cursor.savepoint_rolled_back(&entry.context);
+        }
+    }
+
     /// Roll back the current main-db transaction state and any attached-db
     /// transaction state on this connection.
     pub(crate) fn rollback_current_txn_state(
@@ -5005,6 +5091,7 @@ impl Connection {
             self.auto_commit.store(true, Ordering::SeqCst);
         }
         self.rollback_attached_wal_txns();
+        self.index_methods_transaction_rolled_back();
         self.set_tx_state(TransactionState::None);
         self.clear_tx_poison();
     }
@@ -5032,6 +5119,7 @@ impl Connection {
                 self.rollback_attached_mvcc_txs(clear_attached_schemas);
             }
             self.rollback_attached_wal_txns();
+            self.index_methods_transaction_rolled_back();
             self.set_tx_state(TransactionState::None);
             self.auto_commit.store(true, Ordering::SeqCst);
         }

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -558,7 +558,7 @@ impl Drop for Connection {
             // A handle dropped mid-transaction rolls that transaction back
             // below, so parked index-method cursors must receive the same
             // rollback outcome they would get from an explicit close().
-            self.index_methods_transaction_rolled_back();
+            self.index_methods_on_transaction_rolled_back();
 
             // Roll back any active MVCC transactions so that MvStore entries
             // don't leak and block future checkpoints.  The tx may have
@@ -2424,7 +2424,7 @@ impl Connection {
                 self.set_tx_state(TransactionState::None);
             }
         }
-        self.index_methods_transaction_rolled_back();
+        self.index_methods_on_transaction_rolled_back();
         self.clear_mvcc_log_meta();
 
         let is_memory_db = is_memory_like(&self.db.path);
@@ -5000,7 +5000,7 @@ impl Connection {
     /// Park a statement's index-method cursor on the connection until the
     /// transaction's outcome is known. A cursor replaced by a later
     /// statement's cursor for the same attachment is closed immediately and
-    /// receives neither `transaction_committed` nor `transaction_rolled_back`
+    /// receives neither `on_transaction_committed` nor `on_transaction_rolled_back`
     /// — that replacement is the third legitimate end of a cursor's life
     /// (see the `IndexMethodCursor` trait docs). Only the newest cursor per
     /// attachment gets the final outcome.
@@ -5008,7 +5008,7 @@ impl Connection {
         &self,
         mut entry: crate::index_method::TransactionIndexMethodCursor,
     ) {
-        entry.cursor.statement_committed(&entry.context);
+        entry.cursor.on_statement_committed(&entry.context);
         self.has_index_method_tx_cursors
             .store(true, Ordering::Release);
         let mut entries = self.index_method_tx_cursors.lock();
@@ -5059,31 +5059,31 @@ impl Connection {
         entries
     }
 
-    pub(crate) fn index_methods_transaction_committed(&self) {
+    pub(crate) fn index_methods_on_transaction_committed(&self) {
         let entries = self.take_index_method_transaction_cursors();
         tracing::trace!(
             attachments = entries.len(),
             "publishing transaction-scoped index-method state"
         );
         for mut entry in entries {
-            entry.cursor.transaction_committed(&entry.context);
+            entry.cursor.on_transaction_committed(&entry.context);
             entry.cursor.close(&entry.context);
         }
     }
 
-    pub(crate) fn index_methods_transaction_rolled_back(&self) {
+    pub(crate) fn index_methods_on_transaction_rolled_back(&self) {
         let entries = self.take_index_method_transaction_cursors();
         tracing::trace!(
             attachments = entries.len(),
             "invalidating transaction-scoped index-method state"
         );
         for mut entry in entries {
-            entry.cursor.transaction_rolled_back(&entry.context);
+            entry.cursor.on_transaction_rolled_back(&entry.context);
             entry.cursor.close(&entry.context);
         }
     }
 
-    pub(crate) fn index_methods_savepoint_rolled_back(&self) {
+    pub(crate) fn index_methods_on_savepoint_rolled_back(&self) {
         if !self.has_index_method_tx_cursors.load(Ordering::Acquire) {
             return;
         }
@@ -5093,7 +5093,7 @@ impl Connection {
             "invalidating index-method state after savepoint rollback"
         );
         for entry in entries.iter_mut() {
-            entry.cursor.savepoint_rolled_back(&entry.context);
+            entry.cursor.on_savepoint_rolled_back(&entry.context);
         }
     }
 
@@ -5120,7 +5120,7 @@ impl Connection {
             self.auto_commit.store(true, Ordering::SeqCst);
         }
         self.rollback_attached_wal_txns();
-        self.index_methods_transaction_rolled_back();
+        self.index_methods_on_transaction_rolled_back();
         self.set_tx_state(TransactionState::None);
         self.clear_tx_poison();
     }
@@ -5148,7 +5148,7 @@ impl Connection {
                 self.rollback_attached_mvcc_txs(clear_attached_schemas);
             }
             self.rollback_attached_wal_txns();
-            self.index_methods_transaction_rolled_back();
+            self.index_methods_on_transaction_rolled_back();
             self.set_tx_state(TransactionState::None);
             self.auto_commit.store(true, Ordering::SeqCst);
         }

--- a/core/database.rs
+++ b/core/database.rs
@@ -2396,6 +2396,7 @@ impl Database {
             )),
             check_constraints_pragma: AtomicBool::new(false),
             vtab_txn_states: RwLock::new(HashSet::default()),
+            index_method_tx_cursors: crate::sync::Mutex::new(Vec::new()),
             named_savepoints: RwLock::new(Vec::new()),
             schema_reparse_in_progress: AtomicBool::new(false),
             prepare_context_generation: AtomicU64::new(0),

--- a/core/database.rs
+++ b/core/database.rs
@@ -549,6 +549,10 @@ pub struct Database<A: alloc::ConcurrentAllocator = alloc::DynAllocator> {
     dialect: Arc<dyn Dialect>,
     pub(crate) opts: DatabaseOpts,
     pub(crate) n_connections: AtomicUsize,
+    /// Process-unique id minted at construction. Unlike the `Arc`'s heap
+    /// address, this can never repeat within a process, so detach/reattach
+    /// and close/reopen produce distinguishable values.
+    pub(crate) incarnation: u64,
 
     /// In Memory Page 1 for Empty Dbs
     init_page_1: Arc<ArcSwapOption<Page>>,
@@ -688,6 +692,18 @@ impl Database {
             opts,
             buffer_pool: BufferPool::begin_init(io, arena_size),
             n_connections: AtomicUsize::new(0),
+            incarnation: {
+                // Deliberately std, not crate::sync: this static outlives a
+                // shuttle test execution, and a shuttle-tracked atomic that
+                // survives into the next execution corrupts shuttle's vector
+                // clocks (task ids restart, the stale clock is longer than
+                // the new task table, and clock bookkeeping underflows).
+                // A plain std atomic is fine here: the counter only mints
+                // process-unique ids and needs no ordering guarantees.
+                static NEXT_DATABASE_INCARNATION: std::sync::atomic::AtomicU64 =
+                    std::sync::atomic::AtomicU64::new(1);
+                NEXT_DATABASE_INCARNATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            },
 
             init_page_1: Arc::new(ArcSwapOption::new(init_page_1)),
 
@@ -2397,6 +2413,7 @@ impl Database {
             check_constraints_pragma: AtomicBool::new(false),
             vtab_txn_states: RwLock::new(HashSet::default()),
             index_method_tx_cursors: crate::sync::Mutex::new(Vec::new()),
+            has_index_method_tx_cursors: crate::sync::atomic::AtomicBool::new(false),
             named_savepoints: RwLock::new(Vec::new()),
             schema_reparse_in_progress: AtomicBool::new(false),
             prepare_context_generation: AtomicU64::new(0),

--- a/core/index_method/backing_btree.rs
+++ b/core/index_method/backing_btree.rs
@@ -16,16 +16,20 @@ use crate::{
 pub struct BackingBtreeIndexMethod;
 
 #[derive(Debug)]
-pub struct BackingBTreeIndexMethodAttachment(String);
+pub struct BackingBTreeIndexMethodAttachment {
+    table_name: String,
+    index_name: String,
+}
 
 impl IndexMethod for BackingBtreeIndexMethod {
     fn attach(
         &self,
         configuration: &IndexMethodConfiguration,
     ) -> Result<Arc<dyn IndexMethodAttachment>> {
-        Ok(Arc::new(BackingBTreeIndexMethodAttachment(
-            configuration.index_name.clone(),
-        )))
+        Ok(Arc::new(BackingBTreeIndexMethodAttachment {
+            table_name: configuration.table_name.clone(),
+            index_name: configuration.index_name.clone(),
+        }))
     }
 }
 
@@ -33,7 +37,8 @@ impl IndexMethodAttachment for BackingBTreeIndexMethodAttachment {
     fn definition<'a>(&'a self) -> IndexMethodDefinition<'a> {
         IndexMethodDefinition {
             method_name: BACKING_BTREE_INDEX_METHOD_NAME,
-            index_name: &self.0,
+            table_name: &self.table_name,
+            index_name: &self.index_name,
             patterns: &[],
             backing_btree: true,
             results_materialized: false,

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -59,13 +59,12 @@ pub const DEFAULT_CHUNK_SIZE: usize = 512 * 1024;
 /// Higher values improve throughput but increase memory usage and latency.
 pub const BATCH_COMMIT_SIZE: usize = 1000;
 
-/// Default memory budget (64MB) for hot cache (metadata + term dictionaries).
-/// Hot files are frequently accessed and kept in an LRU cache.
-pub const DEFAULT_HOT_CACHE_BYTES: usize = 64 * 1024 * 1024;
+/// Longest accepted `fts_match` / MATCH query string, in bytes.
+const FTS_MAX_QUERY_BYTES: usize = 16 * 1024;
 
-/// Default memory budget (128MB) for chunk LRU cache.
-/// Caches segment data chunks loaded on-demand from the BTree.
-pub const DEFAULT_CHUNK_CACHE_BYTES: usize = 128 * 1024 * 1024;
+/// Deepest accepted parenthesis nesting in a query string. Guards Tantivy's
+/// recursive parser against stack overflow.
+const FTS_MAX_QUERY_NESTING: usize = 64;
 
 /// Fanout for synchronous tiered segment maintenance.
 ///
@@ -89,7 +88,14 @@ const FTS_MAX_SYNC_MERGE_BYTES: u64 = 32 * 1024 * 1024;
 const FTS_MAX_CACHED_CONNECTIONS: usize = 4;
 
 /// Aggregate resident file-cache budget across retained connection snapshots.
-const FTS_MAX_RETAINED_CACHE_BYTES: usize = DEFAULT_HOT_CACHE_BYTES + DEFAULT_CHUNK_CACHE_BYTES;
+///
+/// This bounds only what is *retained for reuse* after a statement finishes
+/// (read snapshots in `CachedFtsStates`, the shared writer). It is not a
+/// bound on live memory: a cursor always keeps its own complete file
+/// snapshot resident while it runs, however large the index is, because
+/// Tantivy reads through synchronous callbacks that cannot fall back to
+/// storage I/O.
+const FTS_MAX_RETAINED_CACHE_BYTES: usize = 192 * 1024 * 1024;
 
 #[cfg(feature = "test_helper")]
 crate::thread::thread_local! {
@@ -122,6 +128,10 @@ const FTS_CONTROL_FORMAT_VERSION: u32 = 1;
 /// first control record is staged and is never this value.
 const FTS_EMPTY_INDEX_INCARNATION: u64 = 0;
 static NEXT_FTS_INDEX_INCARNATION: AtomicU64 = AtomicU64::new(1);
+/// Distinguishes cursor instances within a process so a cursor can recognize
+/// its own claim on the per-index writer slot across re-entrant `open_write`
+/// calls.
+static NEXT_FTS_CURSOR_INSTANCE: AtomicU64 = AtomicU64::new(1);
 
 const ROWID_FIELD: &str = "rowid";
 
@@ -304,13 +314,6 @@ impl FtsControlRecord {
         };
         let mut files = HashMap::default();
         for (path, metadata) in catalog {
-            let path_text = path.to_str().ok_or_else(|| {
-                LimboError::InternalError(format!(
-                    "FTS manifest path is not valid UTF-8: {}",
-                    path.display()
-                ))
-            })?;
-            let _ = path_text;
             files.insert(
                 path.clone(),
                 FtsManifestFile {
@@ -471,110 +474,53 @@ fn fts_control_checksum(bytes: &[u8]) -> u64 {
 }
 
 /// Eviction samples per put
-const EVICTION_SAMPLES: usize = 8;
-
-/// Generic bounded LRU cache with sampling-based eviction.
-pub struct LruCache<K> {
-    capacity: usize,
-    inner: RwLock<LruCacheInner<K>>,
+/// Size-tracked map of a Tantivy directory's complete file contents.
+///
+/// Deliberately unbounded: every cataloged file must stay resident, because
+/// Tantivy reads through synchronous callbacks that cannot fall back to
+/// storage I/O. Nothing is ever evicted — the memory bound on FTS state is
+/// the retention budget in `CachedFtsStates` / `cache_writer`, which decides
+/// whether a *finished* snapshot is kept for reuse at all.
+pub struct FileCache<K> {
+    inner: RwLock<FileCacheInner<K>>,
 }
 
 #[derive(Debug)]
-struct LruCacheInner<K> {
+struct FileCacheInner<K> {
     current_size: usize,
-    clock: u64,
-    entries: HashMap<K, LruCacheEntry>,
+    entries: HashMap<K, Arc<[u8]>>,
 }
 
-#[derive(Debug)]
-struct LruCacheEntry {
-    data: Arc<[u8]>,
-    accessed: u64,
-}
-
-impl<K: std::fmt::Debug> std::fmt::Debug for LruCache<K> {
+impl<K: std::fmt::Debug> std::fmt::Debug for FileCache<K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let inner = self.inner.read();
-        f.debug_struct("LruCache")
-            .field("capacity", &self.capacity)
+        f.debug_struct("FileCache")
             .field("current_size", &inner.current_size)
             .field("entries", &inner.entries.len())
             .finish()
     }
 }
 
-impl<K: Eq + std::hash::Hash + Clone> LruCache<K> {
-    /// Lookup entry, updating access timestamp. Returns Arc-cloned data.
+impl<K: Eq + std::hash::Hash + Clone> FileCache<K> {
+    /// Lookup entry. Returns Arc-cloned data.
     fn get<Q>(&self, key: &Q) -> Option<Arc<[u8]>>
     where
         K: std::borrow::Borrow<Q>,
         Q: Eq + std::hash::Hash + ?Sized,
     {
-        let mut inner = self.inner.write();
-        inner.clock += 1;
-        let ts = inner.clock;
-        if let Some(entry) = inner.entries.get_mut(key) {
-            entry.accessed = ts;
-            Some(Arc::clone(&entry.data))
-        } else {
-            None
-        }
+        self.inner.read().entries.get(key).map(Arc::clone)
     }
 
-    /// Insert entry, evicting stale entries if over capacity.
-    ///
-    /// Eviction uses sampling: examines K entries and evicts the one with
-    /// the oldest access timestamp. Repeat until under capacity.
+    /// Insert or replace an entry.
     fn put(&self, key: K, value: Vec<u8>) {
         let arc_value: Arc<[u8]> = Arc::from(value);
         let size = arc_value.len();
         let mut inner = self.inner.write();
-
-        // Check for existing entry - get old size if present
-        let old_size = inner.entries.get(&key).map(|e| e.data.len());
-
-        if let Some(old) = old_size {
-            // Update existing entry
-            inner.clock += 1;
-            let ts = inner.clock;
-            let entry = inner.entries.get_mut(&key).expect("entry must exist");
-            entry.data = arc_value;
-            entry.accessed = ts;
-            inner.current_size = inner.current_size - old + size;
-            return;
-        }
-
-        // Evict until under capacity
-        while inner.current_size + size > self.capacity && !inner.entries.is_empty() {
-            let victim = {
-                inner
-                    .entries
-                    .iter()
-                    .take(EVICTION_SAMPLES)
-                    .min_by_key(|(_, e)| e.accessed)
-                    .map(|(k, _)| k.clone())
-            };
-
-            match victim {
-                Some(k) => {
-                    if let Some(e) = inner.entries.remove(&k) {
-                        inner.current_size -= e.data.len();
-                    }
-                }
-                None => break,
-            }
-        }
-
-        inner.clock += 1;
-        let ts = inner.clock;
-        inner.entries.insert(
-            key,
-            LruCacheEntry {
-                data: arc_value,
-                accessed: ts,
-            },
-        );
-        inner.current_size += size;
+        let old_size = inner
+            .entries
+            .insert(key, arc_value)
+            .map_or(0, |old| old.len());
+        inner.current_size = inner.current_size - old_size + size;
     }
 
     /// Remove an entry from the cache.
@@ -584,8 +530,8 @@ impl<K: Eq + std::hash::Hash + Clone> LruCache<K> {
         Q: Eq + std::hash::Hash + ?Sized,
     {
         let mut inner = self.inner.write();
-        if let Some(e) = inner.entries.remove(key) {
-            inner.current_size -= e.data.len();
+        if let Some(data) = inner.entries.remove(key) {
+            inner.current_size -= data.len();
         }
     }
 
@@ -610,29 +556,13 @@ impl<K: Eq + std::hash::Hash + Clone> LruCache<K> {
 }
 
 /// Specialized methods for PathBuf caches (hot files).
-impl LruCache<PathBuf> {
-    fn with_preloaded_arcs(capacity: usize, files: HashMap<PathBuf, Arc<[u8]>>) -> Self {
+impl FileCache<PathBuf> {
+    fn with_preloaded_arcs(files: HashMap<PathBuf, Arc<[u8]>>) -> Self {
         let current_size: usize = files.values().map(|data| data.len()).sum();
-        let entries: HashMap<PathBuf, LruCacheEntry> = files
-            .into_iter()
-            .enumerate()
-            .map(|(i, (path, data))| {
-                (
-                    path,
-                    LruCacheEntry {
-                        data,
-                        accessed: i as u64,
-                    },
-                )
-            })
-            .collect();
-
         Self {
-            capacity,
-            inner: RwLock::new(LruCacheInner {
+            inner: RwLock::new(FileCacheInner {
                 current_size,
-                clock: entries.len() as u64,
-                entries,
+                entries: files,
             }),
         }
     }
@@ -642,7 +572,7 @@ impl LruCache<PathBuf> {
             .read()
             .entries
             .iter()
-            .map(|(path, entry)| (path.clone(), Arc::clone(&entry.data)))
+            .map(|(path, data)| (path.clone(), Arc::clone(data)))
             .collect()
     }
 }
@@ -706,11 +636,10 @@ struct HybridBTreeDirectory {
     /// File catalog: path -> metadata (always in memory, no content)
     catalog: Arc<RwLock<Catalog>>,
 
-    /// Complete file snapshot loaded before Tantivy is invoked.
-    ///
-    /// The capacity is deliberately unbounded: eviction would turn a synchronous Tantivy
-    /// callback into a storage read. Connection-level cache pruning bounds retained snapshots.
-    hot_cache: Arc<LruCache<PathBuf>>,
+    /// Complete file snapshot loaded before Tantivy is invoked. Unbounded by
+    /// design (see [`FileCache`]); the retention budget bounds what outlives
+    /// the cursor, not what it holds while running.
+    hot_cache: Arc<FileCache<PathBuf>>,
 
     /// Storage view at cursor checkout, kept separate from Tantivy's mutable
     /// in-memory view so unchanged rewrites can be elided.
@@ -751,10 +680,7 @@ impl HybridBTreeDirectory {
         let files = self.hot_cache.arc_snapshot();
         Self {
             catalog: Arc::new(RwLock::new(self.catalog.read().clone())),
-            hot_cache: Arc::new(LruCache::<PathBuf>::with_preloaded_arcs(
-                usize::MAX,
-                files.clone(),
-            )),
+            hot_cache: Arc::new(FileCache::<PathBuf>::with_preloaded_arcs(files.clone())),
             base_files: Arc::new(RwLock::new(files)),
             // Fresh pending state - not shared with cache
             pending_mutations: Arc::new(RwLock::new(PendingFileMutations::default())),
@@ -779,8 +705,7 @@ impl HybridBTreeDirectory {
             .collect::<HashMap<_, _>>();
         Self {
             catalog: Arc::new(RwLock::new(catalog)),
-            hot_cache: Arc::new(LruCache::<PathBuf>::with_preloaded_arcs(
-                usize::MAX,
+            hot_cache: Arc::new(FileCache::<PathBuf>::with_preloaded_arcs(
                 base_files.clone(),
             )),
             base_files: Arc::new(RwLock::new(base_files)),
@@ -934,18 +859,18 @@ impl Write for HybridWriter {
 
 impl Drop for HybridWriter {
     fn drop(&mut self) {
-        // Commit the write to the directory
-        let data = std::mem::take(&mut self.buffer);
-        if !data.is_empty() {
-            // Update catalog
-            let num_chunks = data.len().div_ceil(DEFAULT_CHUNK_SIZE);
-            let metadata = FileMetadata::new(&self.path, data.len(), num_chunks);
-            self.directory.update_catalog(self.path.clone(), metadata);
-
-            self.directory
-                .add_to_hot_cache(self.path.clone(), data.clone());
-
-            self.directory.queue_write(self.path.clone(), data);
+        // Only `terminate_ref` publishes: Tantivy's Directory contract says
+        // callers must not rely on Drop flushing, and ManagedDirectory's
+        // FooterProxy appends its CRC footer only in terminate. A file
+        // published from Drop would have no footer and read back as
+        // "Footer magic byte mismatch" — a recoverable serialization error
+        // turned into persisted state that reports itself as corruption.
+        if !self.buffer.is_empty() {
+            tracing::error!(
+                path = %self.path.display(),
+                bytes = self.buffer.len(),
+                "FTS writer dropped without terminate; discarding buffered file"
+            );
         }
     }
 }
@@ -1038,6 +963,13 @@ impl Directory for HybridBTreeDirectory {
         //
         // Skip delete for the meta lock file: Tantivy calls open_write on it for every
         // search query and it does not need BTree deletion.
+        //
+        // Because this never returns FileAlreadyExists, Tantivy's file-based
+        // single-writer lock is intentionally disabled for this directory:
+        // it cannot work anyway, since every cursor gets its own directory
+        // clone. Writer exclusion is enforced instead by the per-connection
+        // writer slot (`FtsWriterSlot`), the pager write lock in WAL mode,
+        // and the per-index MVCC write lease.
         if path != Path::new(TANTIVY_META_LOCK_FILE) {
             let _ = self.delete(path);
         }
@@ -1093,6 +1025,9 @@ impl Directory for HybridBTreeDirectory {
         Ok(())
     }
 
+    // No change notifications: every reader is built with
+    // `ReloadPolicy::Manual` and reloaded explicitly after commits, so a
+    // registered callback would never need to fire.
     fn watch(&self, _cb: WatchCallback) -> std::result::Result<WatchHandle, tantivy::TantivyError> {
         Ok(WatchHandle::empty())
     }
@@ -1277,9 +1212,11 @@ impl CachedFtsStates {
     fn insert(&mut self, state: CachedFtsState, byte_budget: usize) -> bool {
         self.entries
             .retain(|cached| !Weak::ptr_eq(&cached.connection, &state.connection));
-        if state.resident_cache_bytes() > byte_budget {
-            return false;
-        }
+        // Always keep the newest snapshot and evict older ones to make room.
+        // Rejecting an oversized snapshot outright would not save memory —
+        // the live cursor holds the whole snapshot anyway — it would only
+        // force the next statement to reload it all from storage, turning
+        // the budget cliff into a full cold load per statement.
         self.entries.push(state);
         self.prune();
         while self.entries.len() > 1 && self.resident_cache_bytes() > byte_budget {
@@ -1288,8 +1225,11 @@ impl CachedFtsStates {
         true
     }
 
-    fn clear(&mut self) {
-        self.entries.clear();
+    /// Evict oldest retained snapshots until at or under `byte_budget`.
+    fn evict_to_fit(&mut self, byte_budget: usize) {
+        while !self.entries.is_empty() && self.resident_cache_bytes() > byte_budget {
+            self.entries.remove(0);
+        }
     }
 }
 
@@ -1332,7 +1272,33 @@ pub struct FtsIndexAttachment {
     /// `Mutex` provides exclusive access without requiring `IndexWriter` to be
     /// `Sync`; SQLite transaction rules already serialize writers.
     cached_writer: Arc<Mutex<Option<CachedFtsWriter>>>,
+    /// The one cursor currently allowed to flush this index per connection.
+    /// See [`FtsWriterSlot`].
+    writer_slot: Arc<Mutex<Option<FtsWriterSlot>>>,
     runtime_stats: Arc<FtsRuntimeStats>,
+}
+
+/// The single cursor allowed to flush this FTS index for a given connection.
+///
+/// One statement can open two write cursors over the same index — a trigger
+/// whose body writes the FTS-indexed table it fired on. Each cursor builds its
+/// own Tantivy directory from the same starting snapshot, so letting both
+/// flush would store the union of two divergent file sets under one manifest
+/// and make the index unreadable on disk, permanently. The second writer is
+/// refused with a `Raise(Abort)` error instead, and the statement rolls back
+/// cleanly.
+///
+/// The slot is claimed on the cursor's first document mutation (a plan may
+/// open several write-mode cursors on one index but only one ever mutates it)
+/// and released once the cursor has staged its statement's writes
+/// (`prepare_statement_commit`), aborted, or closed — after that the cursor
+/// never flushes again, so a later statement's cursor may write. Writers on
+/// different connections are already serialized by the pager write lock (WAL)
+/// or the per-index MVCC write lease.
+#[derive(Debug)]
+struct FtsWriterSlot {
+    connection: Weak<Connection>,
+    cursor_instance: u64,
 }
 
 #[derive(Debug, Default)]
@@ -1563,6 +1529,7 @@ impl FtsIndexAttachment {
             ngram_window,
             cached_state: Arc::new(RwLock::new(CachedFtsStates::default())),
             cached_writer: Arc::new(Mutex::new(None)),
+            writer_slot: Arc::new(Mutex::new(None)),
             runtime_stats: Arc::new(FtsRuntimeStats::default()),
         })
     }
@@ -1593,6 +1560,17 @@ fn initialize_btree_storage_table(
     database_id: usize,
     table_name: &str,
 ) -> Result<()> {
+    // Fast path: both objects already exist (every open after the index was
+    // created). Skips preparing and running two nested DDL statements per
+    // write cursor open.
+    let index_name = format!("{table_name}_key");
+    let already_exists = conn.with_schema(database_id, |schema| {
+        schema.get_btree_table(table_name).is_some()
+            && schema.get_index(table_name, &index_name).is_some()
+    });
+    if already_exists {
+        return Ok(());
+    }
     let db_prefix = conn
         .get_database_name_by_index(database_id)
         .filter(|name| name != "main")
@@ -1860,7 +1838,14 @@ pub struct FtsCursor {
     cached_parser: Option<Arc<tantivy::query::QueryParser>>,
     shared_cache: Arc<RwLock<CachedFtsStates>>,
     shared_writer: Arc<Mutex<Option<CachedFtsWriter>>>,
-    connection: Option<Arc<Connection>>,
+    /// Shared with the attachment: the one cursor allowed to flush this index
+    /// per connection. See [`FtsWriterSlot`].
+    writer_slot: Arc<Mutex<Option<FtsWriterSlot>>>,
+    /// This cursor's identity in [`FtsWriterSlot`] claims.
+    cursor_instance_id: u64,
+    /// Weak so a cursor parked on its connection does not keep the connection
+    /// alive (see `IndexMethodContext::connection`).
+    connection: Option<Weak<Connection>>,
     database_id: Option<usize>,
     fts_dir_cursor: Option<Box<dyn CursorTrait>>,
     btree_root_page: Option<i64>,
@@ -1879,6 +1864,9 @@ pub struct FtsCursor {
     /// True while `open_write` is driving the shared open state machine.
     /// Read state is never published or reused in this mode.
     opening_for_write: bool,
+    /// True once this cursor holds the per-index writer slot (and the MVCC
+    /// write lease). See [`FtsWriterSlot`].
+    holds_writer_slot: bool,
     runtime_stats: Arc<FtsRuntimeStats>,
 }
 
@@ -1912,6 +1900,8 @@ impl FtsCursor {
             cached_parser: None,
             shared_cache: Arc::clone(&attachment.cached_state),
             shared_writer: Arc::clone(&attachment.cached_writer),
+            writer_slot: Arc::clone(&attachment.writer_slot),
+            cursor_instance_id: NEXT_FTS_CURSOR_INSTANCE.fetch_add(1, Ordering::Relaxed),
             connection: None,
             database_id: None,
             fts_dir_cursor: None,
@@ -1929,7 +1919,193 @@ impl FtsCursor {
             hit_pos: 0,
             current_pattern: FTS_PATTERN_SCORE,
             opening_for_write: false,
+            holds_writer_slot: false,
             runtime_stats: Arc::clone(&attachment.runtime_stats),
+        }
+    }
+
+    /// Claim the per-index writer slot for this cursor, or refuse if another
+    /// cursor on the same connection already holds it. Under MVCC this also
+    /// acquires the per-index write lease, so a transaction only pays for the
+    /// lease once it actually mutates the index. See [`FtsWriterSlot`].
+    fn claim_writer_slot(&mut self) -> Result<()> {
+        if self.holds_writer_slot {
+            return Ok(());
+        }
+        let conn = self
+            .connection
+            .as_ref()
+            .and_then(Weak::upgrade)
+            .ok_or_else(|| {
+                LimboError::InternalError("FTS cursor claimed writer slot before open".to_string())
+            })?;
+        {
+            let mut slot = self.writer_slot.lock();
+            if let Some(claim) = slot.as_ref() {
+                let same_live_connection = claim
+                    .connection
+                    .upgrade()
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, &conn));
+                if same_live_connection && claim.cursor_instance != self.cursor_instance_id {
+                    // Raise(Abort) so the whole statement rolls back: the
+                    // refused write may sit mid-statement (a trigger body),
+                    // and its base rows must not commit without their index
+                    // entries.
+                    return Err(LimboError::Raise(
+                        turso_parser::ast::ResolveType::Abort,
+                        "statement already has an open writer on this FTS index; \
+                         a trigger cannot write the FTS-indexed table its firing \
+                         statement is writing"
+                            .to_string(),
+                    ));
+                }
+                // A claim from another (or dead) connection: cross-connection
+                // writers are serialized by the pager write lock or the MVCC
+                // write lease, so this claim is stale. Replace it.
+            }
+            *slot = Some(FtsWriterSlot {
+                connection: Arc::downgrade(&conn),
+                cursor_instance: self.cursor_instance_id,
+            });
+        }
+        if let Err(err) = self.acquire_mvcc_write_lease() {
+            self.release_writer_slot();
+            return Err(err);
+        }
+        self.holds_writer_slot = true;
+        Ok(())
+    }
+
+    /// Under MVCC, take the per-index write lease for this cursor's
+    /// transaction. Reentrant for the owning transaction; a no-op in WAL mode.
+    fn acquire_mvcc_write_lease(&self) -> Result<()> {
+        let conn = self
+            .connection
+            .as_ref()
+            .and_then(Weak::upgrade)
+            .ok_or_else(|| LimboError::InternalError("FTS cursor has no connection".to_string()))?;
+        let database_id = self.database_id.ok_or_else(|| {
+            LimboError::InternalError("FTS database id is not initialized".to_string())
+        })?;
+        let Some(mv_store) = conn.mv_store_for_db(database_id) else {
+            return Ok(());
+        };
+        let tx_id = conn.get_mv_tx_id_for_db(database_id).ok_or_else(|| {
+            LimboError::InternalError(
+                "FTS write opened without an active MVCC transaction".to_string(),
+            )
+        })?;
+        let root_page = self.btree_root_page.ok_or_else(|| {
+            LimboError::InternalError("FTS backing root is not initialized".to_string())
+        })?;
+        let snapshot_ts = mv_store.read_snapshot_ts(tx_id);
+        // A PASSIVE checkpoint can retire this root page under a stale
+        // compiled plan; that is a stale-schema read, not corruption.
+        let index_id = if conn.experimental_mvcc_passive_checkpoint_enabled() {
+            mv_store
+                .try_get_table_id_from_root_page_at(root_page, snapshot_ts)
+                .ok_or(LimboError::SchemaUpdated)?
+        } else {
+            mv_store.get_table_id_from_root_page_at(root_page, snapshot_ts)
+        };
+        match mv_store.acquire_index_method_write_lease(tx_id, index_id) {
+            Ok(()) => {
+                self.runtime_stats
+                    .write_lease_acquisitions
+                    .fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(err @ (LimboError::WriteWriteConflict | LimboError::Busy)) => {
+                self.runtime_stats
+                    .write_lease_rejections
+                    .fetch_add(1, Ordering::Relaxed);
+                Err(err)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Body of `open_write`; split out so the wrapper can clear
+    /// `opening_for_write` on every error return.
+    fn open_write_inner(
+        &mut self,
+        context: &IndexMethodContext,
+        conn: &Arc<Connection>,
+        database_id: usize,
+    ) -> Result<IOResult<()>> {
+        if self.writer.is_some() {
+            return Ok(IOResult::Done(()));
+        }
+
+        initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
+        self.open_cursor(conn, database_id)?;
+        // The per-index write lease is taken lazily, on the first document
+        // mutation (see `claim_writer_slot`): a write cursor that never
+        // touches a document — an UPDATE matching no rows — must not lock the
+        // index for the rest of its transaction.
+        if self.restore_cached_writer(context)? {
+            return Ok(IOResult::Done(()));
+        }
+
+        // First do open_read to load existing index
+        match &self.state {
+            FtsState::Ready => {}
+            _ => {
+                let result = self.open_read(context)?;
+                if let IOResult::IO(io) = result {
+                    return Ok(IOResult::IO(io));
+                }
+            }
+        }
+        // The IndexWriter itself is built lazily on the first document
+        // mutation (`ensure_writer`), after the writer slot and MVCC lease
+        // are claimed — so a refused writer never pays for Tantivy writer
+        // construction, and a write cursor that never mutates never builds
+        // one at all.
+        Ok(IOResult::Done(()))
+    }
+
+    /// Build the Tantivy `IndexWriter` if this cursor does not have one yet.
+    /// Callers must claim the writer slot first (`claim_writer_slot`).
+    fn ensure_writer(&mut self) -> Result<()> {
+        if self.writer.is_some() {
+            return Ok(());
+        }
+        let index = self
+            .index
+            .as_ref()
+            .ok_or_else(|| LimboError::InternalError("FTS index not initialized".into()))?;
+        // One worker and one merge thread: merges are driven synchronously by
+        // commit_writer_with_maintenance, so the default four merge threads
+        // would sit idle forever, at three OS threads apiece.
+        self.runtime_stats
+            .tantivy_writer_constructions
+            .fetch_add(1, Ordering::Relaxed);
+        let writer = index
+            .writer_with_options(
+                tantivy::indexer::IndexWriterOptions::builder()
+                    .num_worker_threads(1)
+                    .num_merge_threads(1)
+                    .memory_budget_per_thread(DEFAULT_MEMORY_BUDGET_BYTES)
+                    .build(),
+            )
+            .map_err(|e| LimboError::InternalError(e.to_string()))?;
+        // Disable background merges.
+        writer.set_merge_policy(Box::new(NoMergePolicy));
+        self.writer = Some(writer);
+        Ok(())
+    }
+
+    /// Release the writer slot if this cursor holds it. Idempotent. The MVCC
+    /// write lease stays with the transaction until it commits or rolls back.
+    fn release_writer_slot(&mut self) {
+        self.holds_writer_slot = false;
+        let mut slot = self.writer_slot.lock();
+        if slot
+            .as_ref()
+            .is_some_and(|claim| claim.cursor_instance == self.cursor_instance_id)
+        {
+            *slot = None;
         }
     }
 
@@ -2009,13 +2185,13 @@ impl FtsCursor {
         context: &IndexMethodContext,
         visible_control: Option<&FtsControlRecord>,
     ) -> Option<CachedFtsCheckout> {
-        let conn = context.connection();
+        let conn = context.connection().ok()?;
         if conn.is_in_write_tx() {
             return None;
         }
         let mut cache = self.shared_cache.write();
         cache.prune();
-        let position = cache.connection_position(conn)?;
+        let position = cache.connection_position(&conn)?;
         let cached = &cache.entries[position];
         let same_snapshot = match (context.transaction_id(), cached.transaction_id) {
             (Some(current), Some(cached)) => current == cached,
@@ -2048,29 +2224,50 @@ impl FtsCursor {
     }
 
     fn has_cached_state(&self, context: &IndexMethodContext) -> bool {
-        let conn = context.connection();
-        !conn.is_in_write_tx() && self.shared_cache.read().connection_position(conn).is_some()
+        let Ok(conn) = context.connection() else {
+            return false;
+        };
+        !conn.is_in_write_tx()
+            && self
+                .shared_cache
+                .read()
+                .connection_position(&conn)
+                .is_some()
     }
 
-    fn install_cached_checkout(&mut self, checkout: CachedFtsCheckout) {
+    /// Install a cache checkout on this cursor. Returns `true` when the cursor
+    /// is ready to serve queries, `false` when the caller must keep driving the
+    /// state machine (a write cursor still has to build its own Tantivy index).
+    fn install_cached_checkout(&mut self, checkout: CachedFtsCheckout) -> bool {
         let (directory, index, reader, query_parser, control) = checkout;
+        self.hybrid_directory = Some(directory);
+        self.control = Some(control);
+        if self.opening_for_write {
+            // A writer needs an Index whose Directory owns cursor-local pending
+            // state. The cached Index shares the cache entry's directory, so
+            // installing it would send this cursor's writes into the cache
+            // entry's pending map, where the flush never finds them. Rebuild
+            // the Index over the fresh directory clone instead.
+            tracing::debug!("FTS open_write: using cached directory snapshot, rebuilding index");
+            self.state = FtsState::CreatingIndex;
+            return false;
+        }
         self.runtime_stats
             .read_cache_hits
             .fetch_add(1, Ordering::Relaxed);
         tracing::debug!("FTS open_read: using cached state (skipping catalog load)");
-        self.hybrid_directory = Some(directory);
-        self.control = Some(control);
         self.index = Some(index);
         self.searcher = Some(reader.searcher());
         self.reader = Some(reader);
         self.cached_parser = Some(query_parser);
         self.state = FtsState::Ready;
+        true
     }
 
     /// Restore a writer retained by the previous statement when its committed
     /// metadata still matches this transaction's backing B-tree view.
     fn restore_cached_writer(&mut self, context: &IndexMethodContext) -> Result<bool> {
-        let conn = context.connection();
+        let conn = context.connection()?;
         self.runtime_stats
             .writer_cache_lookups
             .fetch_add(1, Ordering::Relaxed);
@@ -2088,7 +2285,7 @@ impl FtsCursor {
         let same_connection = cached
             .connection
             .upgrade()
-            .is_some_and(|owner| Arc::ptr_eq(&owner, conn));
+            .is_some_and(|owner| Arc::ptr_eq(&owner, &conn));
         let metadata_matches = if conn.mv_store_for_db(database_id).is_some() {
             same_connection
                 && context.transaction_id().is_some()
@@ -2128,9 +2325,9 @@ impl FtsCursor {
             return Ok(false);
         }
 
-        let cached = cached_writer
-            .take()
-            .expect("validated cached writer must still be present");
+        let cached = cached_writer.take().ok_or_else(|| {
+            LimboError::InternalError("validated cached FTS writer disappeared".to_string())
+        })?;
         drop(cached_writer);
         self.runtime_stats
             .writer_cache_hits
@@ -2147,29 +2344,42 @@ impl FtsCursor {
         Ok(true)
     }
 
-    fn has_deferred_cached_writer(&self, context: &IndexMethodContext) -> bool {
-        let conn = context.connection();
+    /// Does this connection have a writer whose transaction committed but
+    /// whose view has not been re-checked against the on-disk control record
+    /// yet? Such a writer may only be reused after that check
+    /// (`take_writer_if_control_matches`).
+    fn writer_needs_control_check(&self, context: &IndexMethodContext) -> bool {
+        let Ok(conn) = context.connection() else {
+            return false;
+        };
         self.shared_writer.lock().as_ref().is_some_and(|cached| {
             cached.transaction_id.is_none()
                 && cached
                     .connection
                     .upgrade()
-                    .is_some_and(|owner| Arc::ptr_eq(&owner, conn))
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, &conn))
         })
     }
 
-    fn checkout_validated_cached_writer(
+    /// Reuse this connection's committed writer if the control record it was
+    /// built on is still the one visible on disk; otherwise leave (or drop)
+    /// it and report a miss.
+    fn take_writer_if_control_matches(
         &mut self,
         context: &IndexMethodContext,
         visible_control: &FtsControlRecord,
     ) -> bool {
-        let conn = context.connection();
+        let Ok(conn) = context.connection() else {
+            return false;
+        };
         let mut cached_writer = self.shared_writer.lock();
         let Some(cached) = cached_writer.as_ref() else {
             return false;
         };
         let owner = cached.connection.upgrade();
-        let same_connection = owner.as_ref().is_some_and(|owner| Arc::ptr_eq(owner, conn));
+        let same_connection = owner
+            .as_ref()
+            .is_some_and(|owner| Arc::ptr_eq(owner, &conn));
         let deferred = cached.transaction_id.is_none();
         let matches_control = cached.control.index_incarnation == visible_control.index_incarnation
             && cached.control.manifest_generation == visible_control.manifest_generation;
@@ -2193,9 +2403,12 @@ impl FtsCursor {
             return false;
         }
 
-        let cached = cached_writer
-            .take()
-            .expect("validated cached writer must still be present");
+        // The invariant (slot lock held from the check to the take) makes
+        // this infallible; treat a violation as a cache miss, not a crash.
+        let Some(cached) = cached_writer.take() else {
+            tracing::error!("validated cached FTS writer disappeared");
+            return false;
+        };
         drop(cached_writer);
         self.runtime_stats
             .writer_cache_hits
@@ -2211,8 +2424,12 @@ impl FtsCursor {
         true
     }
 
-    fn discard_deferred_cached_writer(&self, context: &IndexMethodContext) {
-        let conn = context.connection();
+    /// Drop this connection's committed-but-unchecked writer when the control
+    /// record it needed to validate against turns out not to exist.
+    fn drop_unchecked_writer(&self, context: &IndexMethodContext) {
+        let Ok(conn) = context.connection() else {
+            return;
+        };
         let mut cached_writer = self.shared_writer.lock();
         // A missing control record proves this connection's deferred writer is
         // stale. The slot is shared by every connection, so a live writer
@@ -2222,7 +2439,7 @@ impl FtsCursor {
                 .as_ref()
                 .is_some_and(|cached| match cached.connection.upgrade() {
                     None => true,
-                    Some(owner) => Arc::ptr_eq(&owner, conn) && cached.transaction_id.is_none(),
+                    Some(owner) => Arc::ptr_eq(&owner, &conn) && cached.transaction_id.is_none(),
                 });
         if !discard {
             return;
@@ -2240,7 +2457,9 @@ impl FtsCursor {
 
     /// Retain a fully flushed writer for the next statement on this connection.
     fn cache_writer(&mut self, context: &IndexMethodContext) {
-        let conn = context.connection();
+        let Ok(conn) = context.connection() else {
+            return;
+        };
         if self.pending_docs_count != 0 || !matches!(self.state, FtsState::Ready) {
             tracing::trace!(
                 pending_documents = self.pending_docs_count,
@@ -2260,15 +2479,22 @@ impl FtsCursor {
             .saturating_add(retained_read_bytes)
             > fts_max_retained_cache_bytes()
         {
+            // Keep the writer — it is the newest committed state, and the
+            // cursor held these bytes while it ran anyway — and make room by
+            // evicting retained read snapshots instead. Rejecting the writer
+            // would leave a stale one in the slot and force the next write
+            // statement into a full cold load.
             self.runtime_stats
                 .cache_admission_rejections
                 .fetch_add(1, Ordering::Relaxed);
+            let read_budget =
+                fts_max_retained_cache_bytes().saturating_sub(directory.hot_cache.size());
+            self.shared_cache.write().evict_to_fit(read_budget);
             tracing::debug!(
                 resident_bytes = directory.hot_cache.size(),
                 budget_bytes = fts_max_retained_cache_bytes(),
-                "FTS writer cache: snapshot exceeds retention budget"
+                "FTS writer cache: over retention budget; evicted read snapshots"
             );
-            return;
         }
         // Index creation and failed statements can close a cursor before all
         // directory mutations enter the normal document flush state machine.
@@ -2303,7 +2529,7 @@ impl FtsCursor {
         let snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
 
         let previous = self.shared_writer.lock().replace(CachedFtsWriter {
-            connection: Arc::downgrade(conn),
+            connection: Arc::downgrade(&conn),
             transaction_id: context.transaction_id(),
             snapshot_wal_pos,
             control,
@@ -2715,11 +2941,11 @@ impl FtsCursor {
             committed_writer = true;
 
             // The cached reader belongs to the previous index snapshot.
-            if let Some(conn) = &self.connection {
+            if let Some(conn) = self.connection.as_ref().and_then(Weak::upgrade) {
                 let mut cache = self.shared_cache.write();
-                if cache.connection_position(conn).is_some() {
+                if cache.connection_position(&conn).is_some() {
                     tracing::debug!("FTS commit_and_flush: invalidating cached read state");
-                    cache.remove_connection(conn);
+                    cache.remove_connection(&conn);
                 }
             }
         }
@@ -2812,8 +3038,18 @@ impl FtsCursor {
             // eligible level first prevents fresh tiny segments from piling up.
             .rev()
         {
-            let segment_ids = candidate
-                .0
+            // Prefer the smallest segments of the candidate: taking the first
+            // eight of Tantivy's largest-first list picks exactly the eight
+            // most likely to blow the foreground budget, which silently
+            // stalls maintenance at that level forever.
+            let mut candidate_ids = candidate.0;
+            candidate_ids.sort_by_key(|id| {
+                segment_metas
+                    .iter()
+                    .find(|meta| meta.id() == *id)
+                    .map_or(u64::MAX, |meta| u64::from(meta.max_doc()))
+            });
+            let segment_ids = candidate_ids
                 .into_iter()
                 .take(FTS_MERGE_FACTOR)
                 .collect::<Vec<_>>();
@@ -2821,10 +3057,13 @@ impl FtsCursor {
             let mut source_bytes = 0u64;
 
             for segment_id in &segment_ids {
-                let segment_meta = segment_metas
-                    .iter()
-                    .find(|meta| meta.id() == *segment_id)
-                    .expect("merge policy returned an unknown FTS segment");
+                // The merge policy is third-party code; do not trust it to
+                // return only segments it was given.
+                let Some(segment_meta) = segment_metas.iter().find(|meta| meta.id() == *segment_id)
+                else {
+                    tracing::error!("merge policy returned an unknown FTS segment; skipping merge");
+                    return None;
+                };
                 source_docs = source_docs.saturating_add(u64::from(segment_meta.max_doc()));
                 for path in segment_meta.list_files() {
                     if let Some(size) = file_size(&path) {
@@ -2921,14 +3160,26 @@ impl FtsCursor {
             .filter(|&incarnation| incarnation != FTS_EMPTY_INDEX_INCARNATION)
             .or_else(|| {
                 self.btree_root_page.map(|root_page| {
+                    // Mix in IO-provided entropy so two processes creating
+                    // the same index in different files do not mint the same
+                    // on-disk incarnation (the counter restarts at 1 in every
+                    // process). The IO trait's generator is deterministic
+                    // under the simulator.
                     let nonce = NEXT_FTS_INDEX_INCARNATION.fetch_add(1, Ordering::Relaxed);
+                    let entropy = directory.pager.io.generate_random_number() as u64;
                     // The placeholder value marks "never written": never mint it.
-                    ((root_page as u64).rotate_left(32) ^ nonce).max(1)
+                    ((root_page as u64).rotate_left(32) ^ nonce ^ entropy).max(1)
                 })
             })
             .ok_or_else(|| {
                 LimboError::InternalError("FTS backing root is not initialized".to_string())
             })?;
+        // Deriving the next generation from this cursor's copy of the control
+        // record is safe only because writers are serialized: within a
+        // connection by the per-index writer slot (one flushing cursor at a
+        // time), across connections by the pager write lock (WAL) or the
+        // per-index MVCC write lease, which also refuses any writer whose
+        // snapshot predates the last published generation.
         let control = FtsControlRecord::from_catalog(
             self.control.as_ref(),
             index_incarnation,
@@ -2942,6 +3193,7 @@ impl FtsCursor {
 
 impl Drop for FtsCursor {
     fn drop(&mut self) {
+        self.release_writer_slot();
         let is_flushing = self.state.is_flushing();
         if self.pending_docs_count != 0 || is_flushing {
             tracing::error!(
@@ -2960,23 +3212,34 @@ impl Drop for FtsCursor {
 impl IndexMethodCursor for FtsCursor {
     /// Creates the FTS index storage (internal BTree table for Tantivy files).
     fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
-        let conn = context.connection();
+        let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
-        initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
+        initialize_btree_storage_table(&conn, database_id, &self.dir_table_name)?;
         return_if_io!(self.open_write(context));
+        // The forced flush below stages the index's first control record,
+        // which requires a committed writer even for an empty table.
+        self.claim_writer_slot()?;
+        self.ensure_writer()?;
         self.commit_and_flush_inner(true)
     }
 
     /// Destroys the FTS index, dropping all storage and clearing caches.
     fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
-        let conn = context.connection();
+        let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
+        self.connection = Some(Arc::downgrade(&conn));
         tracing::debug!(
             "FTS destroy: dropping internal storage {}",
             self.dir_table_name
         );
+
+        // Serialize with live writers through the same per-index writer slot
+        // and MVCC write lease as DML, so DROP INDEX cannot tear the index
+        // down under a transaction that is mid-write.
+        self.open_cursor(&conn, database_id)?;
+        self.claim_writer_slot()?;
 
         // Drop all in-memory components first
         self.searcher = None;
@@ -2987,13 +3250,29 @@ impl IndexMethodCursor for FtsCursor {
         self.fts_dir_cursor = None;
         self.control = None;
 
-        // Invalidate cached read state.
+        // Invalidate only this connection's cached read state and writer. The
+        // drop is not committed yet, so other connections' caches must stay;
+        // if the drop commits, their next access misses on the schema change,
+        // and a recreated index carries a fresh incarnation so no stale
+        // snapshot can validate against it.
+        self.shared_cache.write().remove_connection(&conn);
         {
-            let mut cache = self.shared_cache.write();
-            cache.clear();
+            let mut cached_writer = self.shared_writer.lock();
+            let owned_or_dead =
+                cached_writer
+                    .as_ref()
+                    .is_some_and(|cached| match cached.connection.upgrade() {
+                        None => true,
+                        Some(owner) => Arc::ptr_eq(&owner, &conn),
+                    });
+            let stale = if owned_or_dead {
+                cached_writer.take()
+            } else {
+                None
+            };
+            drop(cached_writer);
+            drop(stale);
         }
-        let cached_writer = self.shared_writer.lock().take();
-        drop(cached_writer);
 
         // Drop the internal storage table and index
         // The backing_btree index will be dropped automatically when the table is dropped
@@ -3026,7 +3305,7 @@ impl IndexMethodCursor for FtsCursor {
     /// Opens the index for reading, loading the catalog and creating a searcher.
     /// Uses async state machine for non-blocking IO during catalog/file loading.
     fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
-        let conn = context.connection();
+        let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
         loop {
@@ -3037,23 +3316,30 @@ impl IndexMethodCursor for FtsCursor {
                             .read_cache_lookups
                             .fetch_add(1, Ordering::Relaxed);
                     }
-                    self.connection = Some(conn.clone());
-                    // Ensure storage table exists
-                    initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
+                    self.connection = Some(Arc::downgrade(&conn));
+                    // The backing table is created by create() / open_write();
+                    // a pure read must not run DDL, or FTS queries fail on
+                    // read-only databases. If the table is genuinely missing,
+                    // open_cursor reports it.
+                    if self.opening_for_write {
+                        initialize_btree_storage_table(&conn, database_id, &self.dir_table_name)?;
+                    }
                     // Open BTree cursor (needed for btree_root_page)
-                    self.open_cursor(conn, database_id)?;
+                    self.open_cursor(&conn, database_id)?;
 
                     // A cache entry from the exact same snapshot can be used
                     // immediately. A cache from an older snapshot is retained
                     // until the small transactional control record has been
                     // read asynchronously and its identity validated.
                     if let Some(checkout) = self.checkout_cached_state(context, None) {
-                        self.install_cached_checkout(checkout);
-                        return Ok(IOResult::Done(()));
+                        if self.install_cached_checkout(checkout) {
+                            return Ok(IOResult::Done(()));
+                        }
+                        continue;
                     }
 
                     self.state = if self.has_cached_state(context)
-                        || (self.opening_for_write && self.has_deferred_cached_writer(context))
+                        || (self.opening_for_write && self.writer_needs_control_check(context))
                     {
                         FtsState::SeekingControl
                     } else {
@@ -3084,7 +3370,7 @@ impl IndexMethodCursor for FtsCursor {
                     self.state = match seek_result {
                         SeekResult::NotFound => {
                             if self.opening_for_write {
-                                self.discard_deferred_cached_writer(context);
+                                self.drop_unchecked_writer(context);
                             }
                             FtsState::Rewinding
                         }
@@ -3107,7 +3393,7 @@ impl IndexMethodCursor for FtsCursor {
                         }
                     } else {
                         if self.opening_for_write {
-                            self.discard_deferred_cached_writer(context);
+                            self.drop_unchecked_writer(context);
                         }
                         FtsState::Rewinding
                     };
@@ -3177,7 +3463,7 @@ impl IndexMethodCursor for FtsCursor {
                     if finished {
                         if chunks.is_empty() {
                             if self.opening_for_write {
-                                self.discard_deferred_cached_writer(context);
+                                self.drop_unchecked_writer(context);
                             }
                             self.runtime_stats
                                 .manifest_validation_misses
@@ -3195,7 +3481,7 @@ impl IndexMethodCursor for FtsCursor {
                             assemble_catalog_file(Path::new(FTS_CONTROL_PATH), &control_chunks)?;
                         let control = FtsControlRecord::decode(&control_bytes)?;
                         if self.opening_for_write
-                            && self.checkout_validated_cached_writer(context, &control)
+                            && self.take_writer_if_control_matches(context, &control)
                         {
                             return Ok(IOResult::Done(()));
                         }
@@ -3204,8 +3490,10 @@ impl IndexMethodCursor for FtsCursor {
                             self.runtime_stats
                                 .manifest_validation_hits
                                 .fetch_add(1, Ordering::Relaxed);
-                            self.install_cached_checkout(checkout);
-                            return Ok(IOResult::Done(()));
+                            if self.install_cached_checkout(checkout) {
+                                return Ok(IOResult::Done(()));
+                            }
+                            continue;
                         }
                         self.runtime_stats
                             .manifest_validation_misses
@@ -3262,7 +3550,21 @@ impl IndexMethodCursor for FtsCursor {
                                 .copied()
                                 .expect("catalog builder entries have chunks");
                             let total_size: usize = chunks.values().map(|(size, _)| size).sum();
-                            let num_chunks = (max_chunk + 1) as usize;
+                            // The chunk number comes straight out of a stored
+                            // record; a corrupted value must not overflow.
+                            let num_chunks =
+                                usize::try_from(max_chunk.checked_add(1).ok_or_else(|| {
+                                    LimboError::Corrupt(format!(
+                                        "FTS chunk number out of range for {}",
+                                        path.display()
+                                    ))
+                                })?)
+                                .map_err(|_| {
+                                    LimboError::Corrupt(format!(
+                                        "FTS chunk number is negative for {}",
+                                        path.display()
+                                    ))
+                                })?;
                             let metadata = FileMetadata::new(&path, total_size, num_chunks);
                             let assembled = assemble_catalog_file(&path, &chunks)?;
                             files.insert(path.clone(), assembled);
@@ -3273,10 +3575,21 @@ impl IndexMethodCursor for FtsCursor {
                             if catalog.is_empty() {
                                 Some(FtsControlRecord::new(FTS_EMPTY_INDEX_INCARNATION))
                             } else {
-                                return Err(LimboError::Corrupt(
-                                    "FTS storage predates control-record format v1; rebuild the index"
-                                        .into(),
-                                ));
+                                // An index written by a build that predates the
+                                // control record: adopt the catalog we just
+                                // loaded as the manifest, so reads and writes
+                                // keep working. The placeholder incarnation
+                                // makes the next staged control record mint a
+                                // real one and persist the manifest durably.
+                                tracing::info!(
+                                    files = catalog.len(),
+                                    "FTS storage has no control record; adopting existing catalog"
+                                );
+                                Some(FtsControlRecord::from_catalog(
+                                    None,
+                                    FTS_EMPTY_INDEX_INCARNATION,
+                                    &catalog,
+                                )?)
                             }
                         } else {
                             let control_bytes = assemble_catalog_file(
@@ -3356,16 +3669,21 @@ impl IndexMethodCursor for FtsCursor {
                     } else {
                         catalog_builder.entry(path_buf.clone()).or_default()
                     };
+                    // Move the blob into the builder — copying it just to keep
+                    // a reference for the error message below would duplicate
+                    // the whole index once per cold load.
+                    let blob_len = blob.len();
                     if let Some((existing_size, existing_blob)) =
-                        chunks.insert(chunk_no, (blob.len(), Some(blob.clone())))
+                        chunks.insert(chunk_no, (blob_len, Some(blob)))
                     {
+                        let new_blob = chunks.get(&chunk_no).and_then(|(_, blob)| blob.as_deref());
                         return Err(LimboError::Corrupt(format!(
                             "duplicate FTS chunk {}:{} (existing_size={}, new_size={}, equal={})",
                             path_buf.display(),
                             chunk_no,
                             existing_size,
-                            blob.len(),
-                            existing_blob.as_deref() == Some(blob.as_slice())
+                            blob_len,
+                            existing_blob.as_deref() == new_blob
                         )));
                     }
 
@@ -3380,13 +3698,19 @@ impl IndexMethodCursor for FtsCursor {
                     // Create Tantivy index from directory
                     self.create_index_from_directory()?;
 
-                    // Create reader and searcher
+                    // Create reader and searcher. Reload is explicit: this
+                    // directory's `watch` cannot deliver callbacks, so the
+                    // default on-commit policy would silently never fire.
                     let index = self.index.as_ref().ok_or_else(|| {
                         LimboError::InternalError("FTS index not initialized".into())
                     })?;
                     let reader = index
-                        .reader()
-                        .map_err(|e| LimboError::InternalError(e.to_string()))?;
+                        .reader_builder()
+                        .reload_policy(tantivy::ReloadPolicy::Manual)
+                        .try_into()
+                        .map_err(|e: tantivy::TantivyError| {
+                            LimboError::InternalError(e.to_string())
+                        })?;
                     self.searcher = Some(reader.searcher());
                     self.reader = Some(reader);
 
@@ -3420,7 +3744,7 @@ impl IndexMethodCursor for FtsCursor {
                             fts_max_retained_cache_bytes().saturating_sub(writer_bytes);
                         let retained = cache.insert(
                             CachedFtsState {
-                                connection: Arc::downgrade(conn),
+                                connection: Arc::downgrade(&conn),
                                 transaction_id: context.transaction_id(),
                                 snapshot_wal_pos,
                                 control,
@@ -3461,88 +3785,29 @@ impl IndexMethodCursor for FtsCursor {
     /// Opens the index for writing, creating the IndexWriter.
     /// Calls `open_read` first if not already initialized.
     fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
-        let conn = context.connection();
+        let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
         self.opening_for_write = true;
         if self.connection.is_none() {
-            self.connection = Some(conn.clone());
+            self.connection = Some(Arc::downgrade(&conn));
         }
 
-        if self.writer.is_some() {
+        // `opening_for_write` must stay set across IO yields (the opcode
+        // re-enters), but never survive an error: a later open_read on the
+        // same cursor would then skip publishing read state forever.
+        let result = self.open_write_inner(context, &conn, database_id);
+        if !matches!(result, Ok(IOResult::IO(_))) {
             self.opening_for_write = false;
-            return Ok(IOResult::Done(()));
         }
-
-        initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
-        self.open_cursor(conn, database_id)?;
-        if let Some(mv_store) = conn.mv_store_for_db(database_id) {
-            let tx_id = conn.get_mv_tx_id_for_db(database_id).ok_or_else(|| {
-                LimboError::InternalError(
-                    "FTS write opened without an active MVCC transaction".to_string(),
-                )
-            })?;
-            let root_page = self.btree_root_page.ok_or_else(|| {
-                LimboError::InternalError("FTS backing root is not initialized".to_string())
-            })?;
-            let snapshot_ts = mv_store.read_snapshot_ts(tx_id);
-            let index_id = mv_store.get_table_id_from_root_page_at(root_page, snapshot_ts);
-            match mv_store.acquire_index_method_write_lease(tx_id, index_id) {
-                Ok(()) => {
-                    self.runtime_stats
-                        .write_lease_acquisitions
-                        .fetch_add(1, Ordering::Relaxed);
-                }
-                Err(err @ LimboError::WriteWriteConflict) => {
-                    self.runtime_stats
-                        .write_lease_rejections
-                        .fetch_add(1, Ordering::Relaxed);
-                    return Err(err);
-                }
-                Err(err) => return Err(err),
-            }
-        }
-        if self.restore_cached_writer(context)? {
-            self.opening_for_write = false;
-            return Ok(IOResult::Done(()));
-        }
-
-        // First do open_read to load existing index
-        match &self.state {
-            FtsState::Ready => {}
-            _ => {
-                let result = self.open_read(context)?;
-                if let IOResult::IO(io) = result {
-                    return Ok(IOResult::IO(io));
-                }
-            }
-        }
-        if self.writer.is_some() {
-            self.opening_for_write = false;
-            return Ok(IOResult::Done(()));
-        }
-
-        let index = self
-            .index
-            .as_ref()
-            .ok_or_else(|| LimboError::InternalError("FTS index not initialized".into()))?;
-        // Use single-threaded mode to avoid concurrent access.
-        self.runtime_stats
-            .tantivy_writer_constructions
-            .fetch_add(1, Ordering::Relaxed);
-        let writer = index
-            .writer_with_num_threads(1, DEFAULT_MEMORY_BUDGET_BYTES)
-            .map_err(|e| LimboError::InternalError(e.to_string()))?;
-        // Disable background merges.
-        writer.set_merge_policy(Box::new(NoMergePolicy));
-        self.writer = Some(writer);
-        self.opening_for_write = false;
-        Ok(IOResult::Done(()))
+        result
     }
 
     /// Inserts a document into the FTS index.
     /// Values are text columns followed by rowid. Batches commits for efficiency.
     fn insert(&mut self, values: &[Register]) -> Result<IOResult<()>> {
+        self.claim_writer_slot()?;
+        self.ensure_writer()?;
         return_if_io!(self.flush_full_batch_before_mutation());
 
         let Some(ref mut writer) = self.writer else {
@@ -3573,6 +3838,14 @@ impl IndexMethodCursor for FtsCursor {
                     doc.add_text(*field, t.as_str());
                 }
                 Register::Value(Value::Null) => continue,
+                // Coerce every non-NULL value to text before tokenizing, the
+                // way FTS5's sqlite3_value_text() does. Skipping them would
+                // make the index silently miss rows a plain scan matches.
+                Register::Value(value) => {
+                    if let Some(text) = value.cast_text() {
+                        doc.add_text(*field, &text);
+                    }
+                }
                 _ => continue,
             }
         }
@@ -3588,6 +3861,8 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Deletes a document from the FTS index by rowid.
     fn delete(&mut self, values: &[Register]) -> Result<IOResult<()>> {
+        self.claim_writer_slot()?;
+        self.ensure_writer()?;
         return_if_io!(self.flush_full_batch_before_mutation());
 
         let Some(ref mut writer) = self.writer else {
@@ -3625,9 +3900,13 @@ impl IndexMethodCursor for FtsCursor {
             let index = self.index.as_ref().ok_or_else(|| {
                 LimboError::InternalError("FTS index not initialized - call open_read first".into())
             })?;
+            // Manual reload policy: this directory's `watch` cannot deliver
+            // callbacks, so the default on-commit policy never fires.
             let reader = index
-                .reader()
-                .map_err(|e| LimboError::InternalError(e.to_string()))?;
+                .reader_builder()
+                .reload_policy(tantivy::ReloadPolicy::Manual)
+                .try_into()
+                .map_err(|e: tantivy::TantivyError| LimboError::InternalError(e.to_string()))?;
             self.searcher = Some(reader.searcher());
             self.reader = Some(reader);
         }
@@ -3635,9 +3914,9 @@ impl IndexMethodCursor for FtsCursor {
             .searcher
             .as_ref()
             .expect("FTS searcher initialized immediately above");
-        if values.is_empty() {
+        if values.len() < 2 {
             return Err(LimboError::InternalError(
-                "FTS query_start: missing pattern id".into(),
+                "FTS query_start: expected pattern id and query string".into(),
             ));
         }
 
@@ -3663,27 +3942,39 @@ impl IndexMethodCursor for FtsCursor {
             | FTS_PATTERN_MATCH_LIMIT
             | FTS_PATTERN_COMBINED_LIMIT
             | FTS_PATTERN_COMBINED_ORDERED_LIMIT => Some(if values.len() > 2 {
-                match &values[2] {
-                    Register::Value(Value::Numeric(crate::numeric::Numeric::Integer(i))) => *i,
-                    _ => {
-                        tracing::debug!(
-                            "FTS query_start: LIMIT value is not an integer, using default 10"
-                        );
-                        10
+                // Coerce with the same rules as a plain LIMIT (MustBeInt):
+                // numeric text and integral reals become integers; anything
+                // else is a datatype mismatch, never a silent default.
+                let coerced = match &values[2] {
+                    Register::Value(Value::Numeric(crate::numeric::Numeric::Integer(i))) => {
+                        Some(*i)
                     }
-                }
+                    Register::Value(Value::Numeric(crate::numeric::Numeric::Float(f))) => {
+                        crate::util::cast_real_to_integer(f64::from(*f)).ok()
+                    }
+                    Register::Value(Value::Text(text)) => {
+                        match crate::util::checked_cast_text_to_numeric(text.as_str(), true) {
+                            Ok(Value::Numeric(crate::numeric::Numeric::Integer(i))) => Some(i),
+                            Ok(Value::Numeric(crate::numeric::Numeric::Float(f))) => {
+                                crate::util::cast_real_to_integer(f64::from(f)).ok()
+                            }
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                };
+                coerced
+                    .ok_or_else(|| LimboError::Constraint("datatype mismatch (19)".to_string()))?
             } else {
-                tracing::debug!(
-                    "FTS query_start: LIMIT pattern but no limit value provided, using default 10"
-                );
-                10
+                return Err(LimboError::InternalError(
+                    "FTS query_start: LIMIT pattern selected but no limit value captured"
+                        .to_string(),
+                ));
             }),
             _ => {
-                tracing::debug!(
-                    "FTS query_start: unknown pattern {}, using default limit 10",
-                    pattern_idx
-                );
-                Some(10)
+                return Err(LimboError::InternalError(format!(
+                    "FTS query_start: unknown pattern {pattern_idx}"
+                )));
             }
         };
 
@@ -3697,9 +3988,38 @@ impl IndexMethodCursor for FtsCursor {
         }
         let parser = self.cached_parser.as_deref().unwrap();
 
-        let query = parser
-            .parse_query(&query_str)
-            .map_err(|e| LimboError::InternalError(format!("FTS parse error: {e}")))?;
+        // Bound the query string before it reaches Tantivy's recursive
+        // parser: a few KiB of nested parentheses would otherwise burn
+        // minutes of CPU or overflow the stack (an abort no catch_unwind
+        // contains). `parse_query_lenient` uses the non-backtracking parse
+        // path, so nesting inside these bounds stays linear.
+        if query_str.len() > FTS_MAX_QUERY_BYTES {
+            return Err(LimboError::InternalError(format!(
+                "FTS query is too long ({} bytes; the limit is {FTS_MAX_QUERY_BYTES})",
+                query_str.len()
+            )));
+        }
+        let mut depth = 0usize;
+        for byte in query_str.bytes() {
+            match byte {
+                b'(' => {
+                    depth += 1;
+                    if depth > FTS_MAX_QUERY_NESTING {
+                        return Err(LimboError::InternalError(format!(
+                            "FTS query nests deeper than {FTS_MAX_QUERY_NESTING} parentheses"
+                        )));
+                    }
+                }
+                b')' => depth = depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+        let (query, parse_errors) = parser.parse_query_lenient(&query_str);
+        if let Some(error) = parse_errors.first() {
+            return Err(LimboError::InternalError(format!(
+                "FTS parse error: {error:?}"
+            )));
+        }
 
         // TopDocs keeps a heap proportional to its limit. Cap that heap at the
         // number of live documents: this preserves unlimited-query semantics,
@@ -3755,6 +4075,48 @@ impl IndexMethodCursor for FtsCursor {
             let has_result = stream.advance()?;
             self.streaming_hits = Some(stream);
             return Ok(IOResult::Done(has_result));
+        }
+
+        // A global score ordering with no effective LIMIT: TopDocs would
+        // eagerly allocate per-segment heaps sized to the whole corpus before
+        // scoring a single document. Walk the scorers and sort what actually
+        // matched instead, so memory is proportional to the matches.
+        if limit >= searcher.num_docs() as usize {
+            let weight = query
+                .weight(EnableScoring::enabled_from_searcher(searcher))
+                .map_err(|e| LimboError::InternalError(format!("FTS query weight error: {e}")))?;
+            for (segment_ord, segment_reader) in searcher.segment_readers().iter().enumerate() {
+                let mut scorer = weight
+                    .scorer(segment_reader, 1.0)
+                    .map_err(|e| LimboError::InternalError(format!("FTS scorer error: {e}")))?;
+                let rowids = segment_reader
+                    .fast_fields()
+                    .i64(ROWID_FIELD)
+                    .map_err(|e| LimboError::InternalError(format!("FTS fast field error: {e}")))?;
+                let alive = segment_reader.alive_bitset();
+                loop {
+                    let doc_id = scorer.doc();
+                    if doc_id == TERMINATED {
+                        break;
+                    }
+                    let score = scorer.score();
+                    scorer.advance();
+                    if alive.is_some_and(|alive| alive.is_deleted(doc_id)) {
+                        continue;
+                    }
+                    let rowid = rowids.first(doc_id).ok_or_else(|| {
+                        LimboError::InternalError("FTS: rowid fast field missing value".into())
+                    })?;
+                    self.current_hits.push((
+                        score,
+                        DocAddress::new(segment_ord as u32, doc_id),
+                        rowid,
+                    ));
+                }
+            }
+            self.current_hits
+                .sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+            return Ok(IOResult::Done(!self.current_hits.is_empty()));
         }
 
         let top_docs = searcher
@@ -3883,34 +4245,47 @@ impl IndexMethodCursor for FtsCursor {
         // This handles the case where commit_and_flush() returned IOResult::IO and we need
         // to continue the flush after IO completes
         if self.state.is_flushing() {
-            return self.flush_writes_internal();
-        }
-
-        if self.pending_docs_count > 0 {
+            return_if_io!(self.flush_writes_internal());
+        } else if self.pending_docs_count > 0 {
             tracing::debug!(
                 "FTS pre_commit: flushing {} pending documents",
                 self.pending_docs_count
             );
-            return self.commit_and_flush();
+            return_if_io!(self.commit_and_flush());
         }
+        // This cursor's statement-scope writes are staged; it never flushes
+        // again, so a later statement's cursor may write this index.
+        self.release_writer_slot();
         Ok(IOResult::Done(()))
     }
 
     fn abort_statement(&mut self, context: &IndexMethodContext) {
+        self.release_writer_slot();
         self.pending_docs_count = 0;
-        self.writer = None;
+        // Dropping a Tantivy writer joins its worker threads. Take the heavy
+        // pieces into locals and drop them after the shared-cache bookkeeping
+        // below, mirroring cache_writer's drop(previous) pattern, so no lock
+        // is held while the join runs.
+        let deferred_writer = self.writer.take();
+        let deferred_index = self.index.take();
+        let deferred_directory = self.hybrid_directory.take();
         self.reader = None;
         self.searcher = None;
-        self.index = None;
-        self.hybrid_directory = None;
         self.fts_dir_cursor = None;
         self.control = None;
         self.cached_parser = None;
         self.current_hits.clear();
         self.streaming_hits = None;
-        self.shared_cache
-            .write()
-            .remove_connection(context.connection());
+        // During connection teardown there is no live connection left; the
+        // shared caches are then cleaned up by `prune()` / dead-owner checks.
+        let Ok(conn) = context.connection() else {
+            self.state = FtsState::Init;
+            drop(deferred_writer);
+            drop(deferred_index);
+            drop(deferred_directory);
+            return;
+        };
+        self.shared_cache.write().remove_connection(&conn);
         // The slot is shared by every connection: a failed statement here
         // (e.g. the losing side of a lease conflict) must not evict another
         // connection's writer. Only remove what this connection's failed
@@ -3926,8 +4301,7 @@ impl IndexMethodCursor for FtsCursor {
                 None => (true, false),
                 Some(owner) => (
                     false,
-                    Arc::ptr_eq(&owner, context.connection())
-                        && cached.transaction_id == context.transaction_id(),
+                    Arc::ptr_eq(&owner, &conn) && cached.transaction_id == context.transaction_id(),
                 ),
             },
         };
@@ -3942,8 +4316,12 @@ impl IndexMethodCursor for FtsCursor {
                 .writer_cache_rollback_discards
                 .fetch_add(1, Ordering::Relaxed);
         }
-        drop(stale);
         self.state = FtsState::Init;
+        // Thread joins happen last, with no lock held.
+        drop(stale);
+        drop(deferred_writer);
+        drop(deferred_index);
+        drop(deferred_directory);
     }
 
     fn statement_committed(&mut self, context: &IndexMethodContext) {
@@ -3959,6 +4337,10 @@ impl IndexMethodCursor for FtsCursor {
             "FTS transaction outcome: committed"
         );
         self.cache_writer(context);
+        let Ok(conn) = context.connection() else {
+            self.shared_cache.write().prune();
+            return;
+        };
         if let Some(transaction_id) = context.transaction_id() {
             // The backing transaction is now committed, so its private writer
             // may be considered by a future transaction only after validating
@@ -3967,7 +4349,7 @@ impl IndexMethodCursor for FtsCursor {
                 let same_connection = cached
                     .connection
                     .upgrade()
-                    .is_some_and(|owner| Arc::ptr_eq(&owner, context.connection()));
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, &conn));
                 if same_connection && cached.transaction_id == Some(transaction_id) {
                     cached.transaction_id = None;
                     cached.snapshot_wal_pos = None;
@@ -3984,7 +4366,7 @@ impl IndexMethodCursor for FtsCursor {
             let same_connection = cached
                 .connection
                 .upgrade()
-                .is_some_and(|owner| Arc::ptr_eq(&owner, context.connection()));
+                .is_some_and(|owner| Arc::ptr_eq(&owner, &conn));
             let matches_cursor_control = self.control.as_ref().is_some_and(|control| {
                 control.index_incarnation == cached.control.index_incarnation
                     && control.manifest_generation == cached.control.manifest_generation
@@ -4002,16 +4384,30 @@ impl IndexMethodCursor for FtsCursor {
     }
 
     fn savepoint_rolled_back(&mut self, context: &IndexMethodContext) {
+        // Correct but coarse: the hook carries no savepoint identity, so we
+        // cannot tell whether the rollback actually reverted FTS chunk rows
+        // this cursor's view depends on. Discard everything; the next FTS
+        // access reloads from the (correctly reverted) backing B-tree.
+        // Finer granularity needs a savepoint-creation sequence passed into
+        // this hook and compared against the sequence at which this cursor
+        // materialized its view.
         self.abort_statement(context);
     }
 
     fn close(&mut self, context: &IndexMethodContext) {
-        if self.pending_docs_count != 0 {
+        if self.pending_docs_count != 0 || self.state.is_flushing() {
+            // close() is the explicit "discard whatever is left" hook, so it
+            // owns this decision: log it loudly, then normalize the cursor so
+            // Drop has nothing left to enforce.
             tracing::error!(
                 pending_documents = self.pending_docs_count,
-                "closing FTS cursor with unprepared writes"
+                is_flushing = self.state.is_flushing(),
+                "closing FTS cursor with unprepared writes; discarding them"
             );
         }
+        self.release_writer_slot();
+        self.pending_docs_count = 0;
+        self.state = FtsState::Init;
         self.writer = None;
         self.reader = None;
         self.searcher = None;
@@ -4030,6 +4426,14 @@ impl IndexMethodCursor for FtsCursor {
     fn optimize(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
         let database_id = context.database().id;
         self.database_id = Some(database_id);
+        // Resume a flush this opcode started before its last IO yield.
+        // Re-entry arrives with `pending_docs_count` already zeroed (the
+        // flush zeroes it before its first yield), so the state machine is
+        // the only reliable marker; skipping this would run the merge while
+        // the old flush is mid-flight and drop the merge's output.
+        if self.state.is_flushing() {
+            return_if_io!(self.flush_writes_internal());
+        }
         // First ensure any pending documents are flushed
         if self.pending_docs_count > 0 {
             tracing::info!(
@@ -4043,6 +4447,10 @@ impl IndexMethodCursor for FtsCursor {
         if self.writer.is_none() {
             return_if_io!(self.open_write(context));
         }
+        // The merge publishes new index state, so it needs the writer slot
+        // and (under MVCC) the write lease like any document mutation.
+        self.claim_writer_slot()?;
+        self.ensure_writer()?;
 
         let index = self
             .index
@@ -4095,9 +4503,9 @@ impl IndexMethodCursor for FtsCursor {
         writer
             .commit()
             .map_err(|e| LimboError::InternalError(format!("FTS optimize commit failed: {e}")))?;
-        if let Some(conn) = &self.connection {
+        if let Some(conn) = self.connection.as_ref().and_then(Weak::upgrade) {
             let mut cache = self.shared_cache.write();
-            cache.remove_connection(conn);
+            cache.remove_connection(&conn);
         }
 
         // Reload reader to see merged segments
@@ -4173,10 +4581,32 @@ impl IndexMethodCursor for FtsCursor {
         };
 
         // Cost model:
+        // - Load cost: the dominant real cost. A query materializes the whole
+        //   index in memory, linear in index bytes, regardless of how
+        //   selective it is. Size is known exactly when a snapshot or writer
+        //   is retained (which also means the load is warm); otherwise it is
+        //   approximated from the base table and charged as a cold load.
         // - Base cost: logarithmic in vocabulary size (approximated by table size)
         // - Posting traversal: stops at LIMIT for unordered streaming patterns
         // - Scoring: omitted for MATCH-only patterns
         // - Top-k materialization: required only for global score ordering
+        let retained_bytes = {
+            let read_bytes = self.shared_cache.read().resident_cache_bytes();
+            let writer_bytes = self
+                .shared_writer
+                .lock()
+                .as_ref()
+                .map_or(0, |cached| cached.directory.hot_cache.size());
+            read_bytes.max(writer_bytes)
+        };
+        const ESTIMATED_INDEX_BYTES_PER_ROW: f64 = 64.0;
+        const PAGE_BYTES: f64 = 4096.0;
+        let load_cost = if retained_bytes > 0 {
+            // A retained snapshot makes reuse likely; charge a token amount.
+            retained_bytes as f64 / PAGE_BYTES * 0.01
+        } else {
+            (context.base_table_rows * ESTIMATED_INDEX_BYTES_PER_ROW) / PAGE_BYTES
+        };
         let base_cost = context.base_table_rows.max(1.0).ln() * 10.0;
         let traversal_cost = visited_matches as f64 * 0.05;
         let scoring_cost = scored_matches as f64 * 0.05;
@@ -4187,7 +4617,11 @@ impl IndexMethodCursor for FtsCursor {
         };
 
         Some(super::IndexMethodCostEstimate {
-            estimated_cost: base_cost + traversal_cost + scoring_cost + materialization_cost,
+            estimated_cost: load_cost
+                + base_cost
+                + traversal_cost
+                + scoring_cost
+                + materialization_cost,
             estimated_rows,
         })
     }

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -122,10 +122,20 @@ fn fts_max_retained_cache_bytes() -> usize {
 const FTS_CONTROL_PATH: &str = "__turso_fts_control_v1";
 const FTS_CONTROL_MAGIC: &[u8; 8] = b"TFTSCTL1";
 const FTS_CONTROL_FORMAT_VERSION: u32 = 1;
-/// Placeholder incarnation for an index with no persisted control record yet
-/// (an empty catalog). Deterministic, so every connection opening a
-/// never-written index agrees on it; the real incarnation is minted when the
-/// first control record is staged and is never this value.
+/// An "incarnation" identifies one lifetime of an index's stored content: it
+/// is minted once when the first control record is written and stays the same
+/// for every later write to that index. Dropping and recreating the index
+/// mints a new one. It is not a version counter — `manifest_generation`
+/// advances on every publish; the incarnation only changes when the stored
+/// content belongs to a different index life. Comparing it tells caches and
+/// verification that "the bytes I remembered" and "the bytes on disk" come
+/// from the same life of the index, even when names, root pages, or table ids
+/// were reused by a recreate.
+///
+/// This constant is the placeholder for an index with no persisted control
+/// record yet (an empty catalog). Deterministic, so every connection opening
+/// a never-written index agrees on it; the real incarnation is minted when
+/// the first control record is staged and is never this value.
 const FTS_EMPTY_INDEX_INCARNATION: u64 = 0;
 static NEXT_FTS_INDEX_INCARNATION: AtomicU64 = AtomicU64::new(1);
 /// Distinguishes cursor instances within a process so a cursor can recognize
@@ -261,8 +271,10 @@ pub fn fts_match(text: &str, query: &str) -> bool {
     })
 }
 
-/// Metadata about a file stored in the FTS directory.
-/// Used for merge-budget accounting.
+/// In-memory catalog entry for a file stored in the FTS directory: how big
+/// the file is and how many B-tree chunk rows hold its bytes. Used for
+/// merge-budget accounting. [`FtsManifestFile`] is this entry's persisted
+/// twin inside the control record.
 #[derive(Debug, Clone)]
 struct FileMetadata {
     /// Total file size in bytes
@@ -279,12 +291,24 @@ impl FileMetadata {
     }
 }
 
+/// The persisted form of one [`FileMetadata`] entry, as serialized inside the
+/// control record. `size` and `chunks` mean the same thing as there; both are
+/// `u64` here because the on-disk encoding is fixed-width and must not depend
+/// on the platform's `usize`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct FtsManifestFile {
     size: u64,
     chunks: u64,
 }
 
+/// The one persisted record that says what the index's storage currently
+/// contains: which life of the index the bytes belong to
+/// (`index_incarnation`), how many times the file set has been published
+/// (`manifest_generation`), and the expected size and chunk count of every
+/// file. It is written in the same transaction as the file bytes, so reading
+/// it back answers two questions at once: "is my cached state still current?"
+/// (compare incarnation + generation) and "are the stored files intact?"
+/// (compare sizes and chunk counts).
 #[derive(Debug, Clone)]
 struct FtsControlRecord {
     index_incarnation: u64,
@@ -627,7 +651,7 @@ impl PendingFileMutations {
 ///
 /// File mutations are buffered in memory and flushed to the BTree when:
 /// - A Tantivy commit occurs (via `commit_and_flush`)
-/// - The statement is finalized (via `prepare_statement_commit`)
+/// - The statement is finalized (via `stage_statement_commit`)
 ///
 /// During flush, writes are moved to `flushing_writes` so they remain readable while
 /// the async BTree write completes.
@@ -1115,6 +1139,39 @@ impl IndexMethod for FtsIndexMethod {
     }
 }
 
+/// Which snapshot a cached FTS entry belongs to, and so who may reuse it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FtsCachedSnapshot {
+    /// Private to one live MVCC transaction; only that transaction may reuse
+    /// the entry, and only until the transaction resolves.
+    Mvcc { transaction_id: u64 },
+    /// Not private to any live transaction. `pos` is the WAL position the
+    /// entry was built at; `None` means there is nothing to compare cheaply
+    /// (the pager had no WAL identity, or the entry is a writer whose MVCC
+    /// transaction committed), so reuse first requires the slower
+    /// control-record or metadata-byte comparison.
+    Wal { pos: Option<(u32, u64)> },
+}
+
+impl FtsCachedSnapshot {
+    /// The live MVCC transaction that owns the entry, if any.
+    fn transaction_id(self) -> Option<u64> {
+        match self {
+            Self::Mvcc { transaction_id } => Some(transaction_id),
+            Self::Wal { .. } => None,
+        }
+    }
+
+    /// The WAL position to validate reuse against. `None` both for entries
+    /// that need the slower comparison and for transaction-private entries.
+    fn wal_pos(self) -> Option<(u32, u64)> {
+        match self {
+            Self::Wal { pos } => pos,
+            Self::Mvcc { .. } => None,
+        }
+    }
+}
+
 /// Cached FTS read state reused by cursors on the connection that populated it.
 ///
 /// The connection owner is part of the cache identity because the directory and
@@ -1124,13 +1181,8 @@ impl IndexMethod for FtsIndexMethod {
 /// pending-write state.
 pub struct CachedFtsState {
     connection: Weak<Connection>,
-    /// MVCC transaction that owns this snapshot. `None` denotes a WAL entry.
-    transaction_id: Option<u64>,
-    /// WAL snapshot at which the cached Tantivy metadata was loaded.
-    ///
-    /// `None` means the pager has no WAL identity and requires the slower
-    /// metadata-byte comparison before reuse.
-    snapshot_wal_pos: Option<(u32, u64)>,
+    /// Snapshot at which the cached Tantivy metadata was loaded.
+    snapshot: FtsCachedSnapshot,
     control: FtsControlRecord,
     directory: HybridBTreeDirectory,
     index: Index,
@@ -1146,10 +1198,11 @@ pub struct CachedFtsState {
 /// stale Tantivy segments.
 struct CachedFtsWriter {
     connection: Weak<Connection>,
-    /// MVCC transaction that exclusively owns this writer. `None` denotes a
-    /// WAL writer whose visibility remains connection-local until commit.
-    transaction_id: Option<u64>,
-    snapshot_wal_pos: Option<(u32, u64)>,
+    /// While the owning MVCC transaction is live this is `Mvcc`, and the
+    /// writer's visibility stays private to that transaction. On commit it is
+    /// re-tagged `Wal { pos: None }` so the next reuse validates against the
+    /// on-disk control record first.
+    snapshot: FtsCachedSnapshot,
     control: FtsControlRecord,
     directory: HybridBTreeDirectory,
     index: Index,
@@ -1173,6 +1226,31 @@ struct CachedFtsStates {
 impl CachedFtsState {
     fn resident_cache_bytes(&self) -> usize {
         self.directory.hot_cache.size()
+    }
+
+    /// Is this entry positioned at the very snapshot the current operation
+    /// reads from? MVCC entries compare transaction ids; WAL entries compare
+    /// the WAL position the entry was built at against the pager's current
+    /// one.
+    fn matches_snapshot(&self, context: &IndexMethodContext) -> bool {
+        match (context.transaction_id(), self.snapshot) {
+            (Some(current), FtsCachedSnapshot::Mvcc { transaction_id }) => {
+                current == transaction_id
+            }
+            (None, FtsCachedSnapshot::Wal { pos }) => pos
+                .is_some_and(|snapshot_wal_pos| self.directory.pager.wal_pos() == snapshot_wal_pos),
+            _ => false,
+        }
+    }
+
+    /// Was this entry built from the control record that is currently visible
+    /// on disk? True only when both the index life (incarnation) and the
+    /// publish counter (manifest generation) match.
+    fn matches_manifest(&self, visible_control: Option<&FtsControlRecord>) -> bool {
+        visible_control.is_some_and(|control| {
+            control.index_incarnation == self.control.index_incarnation
+                && control.manifest_generation == self.control.manifest_generation
+        })
     }
 }
 
@@ -1291,7 +1369,7 @@ pub struct FtsIndexAttachment {
 /// The slot is claimed on the cursor's first document mutation (a plan may
 /// open several write-mode cursors on one index but only one ever mutates it)
 /// and released once the cursor has staged its statement's writes
-/// (`prepare_statement_commit`), aborted, or closed — after that the cursor
+/// (`stage_statement_commit`), aborted, or closed — after that the cursor
 /// never flushes again, so a later statement's cursor may write. Writers on
 /// different connections are already serialized by the pager write lock (WAL)
 /// or the per-index MVCC write lease.
@@ -1301,6 +1379,12 @@ struct FtsWriterSlot {
     cursor_instance: u64,
 }
 
+/// Counters for cache and writer behavior, read back by invariant tests.
+///
+/// The fields are atomics because one `FtsRuntimeStats` is shared through an
+/// `Arc` by the attachment and every cursor opened on it, across all
+/// connections and their threads, and the counters are bumped at spots where
+/// no common lock is held.
 #[derive(Debug, Default)]
 struct FtsRuntimeStats {
     tantivy_writer_constructions: AtomicUsize,
@@ -2180,6 +2264,14 @@ impl FtsCursor {
         Arc::new(parser)
     }
 
+    /// "Check out" this connection's cached read state: hand the cursor
+    /// clones of the cache entry's immutable Tantivy objects (directory
+    /// catalog, index, reader, parser) so it can serve queries without
+    /// reloading everything from the backing B-tree. The entry itself stays
+    /// in the cache for the next cursor; only its position moves to
+    /// most-recently-used. Returns `None` when there is no entry for this
+    /// connection or the entry no longer reflects what a query would see on
+    /// disk.
     fn checkout_cached_state(
         &self,
         context: &IndexMethodContext,
@@ -2193,17 +2285,8 @@ impl FtsCursor {
         cache.prune();
         let position = cache.connection_position(&conn)?;
         let cached = &cache.entries[position];
-        let same_snapshot = match (context.transaction_id(), cached.transaction_id) {
-            (Some(current), Some(cached)) => current == cached,
-            (None, None) => cached.snapshot_wal_pos.is_some_and(|snapshot_wal_pos| {
-                cached.directory.pager.wal_pos() == snapshot_wal_pos
-            }),
-            _ => false,
-        };
-        let same_manifest = visible_control.is_some_and(|control| {
-            control.index_incarnation == cached.control.index_incarnation
-                && control.manifest_generation == cached.control.manifest_generation
-        });
+        let same_snapshot = cached.matches_snapshot(context);
+        let same_manifest = cached.matches_manifest(visible_control);
         if !same_snapshot && !same_manifest {
             if visible_control.is_some() {
                 cache.entries.remove(position);
@@ -2289,12 +2372,12 @@ impl FtsCursor {
         let metadata_matches = if conn.mv_store_for_db(database_id).is_some() {
             same_connection
                 && context.transaction_id().is_some()
-                && context.transaction_id() == cached.transaction_id
+                && context.transaction_id() == cached.snapshot.transaction_id()
         } else {
             same_connection
-                && cached.transaction_id.is_none()
                 && cached
-                    .snapshot_wal_pos
+                    .snapshot
+                    .wal_pos()
                     .is_some_and(|position| cached.directory.pager.wal_pos() == position)
         };
         if !metadata_matches {
@@ -2302,7 +2385,7 @@ impl FtsCursor {
             // record can be validated asynchronously by open_read().
             if conn.mv_store_for_db(database_id).is_some()
                 && same_connection
-                && cached.transaction_id.is_none()
+                && cached.snapshot.transaction_id().is_none()
             {
                 return Ok(false);
             }
@@ -2353,7 +2436,7 @@ impl FtsCursor {
             return false;
         };
         self.shared_writer.lock().as_ref().is_some_and(|cached| {
-            cached.transaction_id.is_none()
+            cached.snapshot.transaction_id().is_none()
                 && cached
                     .connection
                     .upgrade()
@@ -2380,7 +2463,7 @@ impl FtsCursor {
         let same_connection = owner
             .as_ref()
             .is_some_and(|owner| Arc::ptr_eq(owner, &conn));
-        let deferred = cached.transaction_id.is_none();
+        let deferred = cached.snapshot.transaction_id().is_none();
         let matches_control = cached.control.index_incarnation == visible_control.index_incarnation
             && cached.control.manifest_generation == visible_control.manifest_generation;
         if !(same_connection && deferred && matches_control) {
@@ -2439,7 +2522,9 @@ impl FtsCursor {
                 .as_ref()
                 .is_some_and(|cached| match cached.connection.upgrade() {
                     None => true,
-                    Some(owner) => Arc::ptr_eq(&owner, &conn) && cached.transaction_id.is_none(),
+                    Some(owner) => {
+                        Arc::ptr_eq(&owner, &conn) && cached.snapshot.transaction_id().is_none()
+                    }
                 });
         if !discard {
             return;
@@ -2509,7 +2594,7 @@ impl FtsCursor {
             tracing::trace!("FTS writer cache: cursor has no writer");
             return;
         }
-        // Keep `self.control` set: `transaction_committed` compares it against
+        // Keep `self.control` set: `on_transaction_committed` compares it against
         // the cached writer's control record before re-stamping the WAL
         // position.
         let Some(control) = self.control.clone() else {
@@ -2526,12 +2611,16 @@ impl FtsCursor {
             .take()
             .expect("FTS writer must have an initialized directory");
         let wal_pos = directory.pager.wal_pos();
-        let snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
+        let snapshot = match context.transaction_id() {
+            Some(transaction_id) => FtsCachedSnapshot::Mvcc { transaction_id },
+            None => FtsCachedSnapshot::Wal {
+                pos: (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos),
+            },
+        };
 
         let previous = self.shared_writer.lock().replace(CachedFtsWriter {
             connection: Arc::downgrade(&conn),
-            transaction_id: context.transaction_id(),
-            snapshot_wal_pos,
+            snapshot,
             control,
             directory,
             index,
@@ -3729,7 +3818,12 @@ impl IndexMethodCursor for FtsCursor {
                         let query_parser = self.build_query_parser(index);
                         self.cached_parser = Some(Arc::clone(&query_parser));
                         let wal_pos = dir.pager.wal_pos();
-                        let snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
+                        let snapshot = match context.transaction_id() {
+                            Some(transaction_id) => FtsCachedSnapshot::Mvcc { transaction_id },
+                            None => FtsCachedSnapshot::Wal {
+                                pos: (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos),
+                            },
+                        };
 
                         let mut cache = self.shared_cache.write();
                         let control = self.control.clone().ok_or_else(|| {
@@ -3745,8 +3839,7 @@ impl IndexMethodCursor for FtsCursor {
                         let retained = cache.insert(
                             CachedFtsState {
                                 connection: Arc::downgrade(&conn),
-                                transaction_id: context.transaction_id(),
-                                snapshot_wal_pos,
+                                snapshot,
                                 control,
                                 directory: dir.clone(),
                                 index: index.clone(),
@@ -4240,7 +4333,7 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Flushes pending writes before transaction commit.
     /// This ensures FTS writes are persisted as part of the transaction.
-    fn prepare_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn stage_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         // First, check if we're in the middle of a flush operation that needs to continue
         // This handles the case where commit_and_flush() returned IOResult::IO and we need
         // to continue the flush after IO completes
@@ -4290,8 +4383,8 @@ impl IndexMethodCursor for FtsCursor {
         // (e.g. the losing side of a lease conflict) must not evict another
         // connection's writer. Only remove what this connection's failed
         // statement could have produced: its own writer tagged with this
-        // transaction (both `None` in WAL mode). An MVCC deferred writer
-        // (`transaction_id == None`) predates this transaction, so it stays
+        // transaction (both WAL in WAL mode). An MVCC deferred writer
+        // (already re-tagged `Wal`) predates this transaction, so it stays
         // valid across this rollback. Entries with a dead owner are removed
         // opportunistically.
         let mut cached_writer = self.shared_writer.lock();
@@ -4301,7 +4394,8 @@ impl IndexMethodCursor for FtsCursor {
                 None => (true, false),
                 Some(owner) => (
                     false,
-                    Arc::ptr_eq(&owner, &conn) && cached.transaction_id == context.transaction_id(),
+                    Arc::ptr_eq(&owner, &conn)
+                        && cached.snapshot.transaction_id() == context.transaction_id(),
                 ),
             },
         };
@@ -4324,11 +4418,11 @@ impl IndexMethodCursor for FtsCursor {
         drop(deferred_directory);
     }
 
-    fn statement_committed(&mut self, context: &IndexMethodContext) {
+    fn on_statement_committed(&mut self, context: &IndexMethodContext) {
         self.cache_writer(context);
     }
 
-    fn transaction_committed(&mut self, context: &IndexMethodContext) {
+    fn on_transaction_committed(&mut self, context: &IndexMethodContext) {
         tracing::trace!(
             index = context.index().index_name,
             pending_documents = self.pending_docs_count,
@@ -4350,9 +4444,12 @@ impl IndexMethodCursor for FtsCursor {
                     .connection
                     .upgrade()
                     .is_some_and(|owner| Arc::ptr_eq(&owner, &conn));
-                if same_connection && cached.transaction_id == Some(transaction_id) {
-                    cached.transaction_id = None;
-                    cached.snapshot_wal_pos = None;
+                if same_connection
+                    && cached.snapshot == (FtsCachedSnapshot::Mvcc { transaction_id })
+                {
+                    // No WAL position on purpose: the next reuse must first
+                    // validate against the on-disk control record.
+                    cached.snapshot = FtsCachedSnapshot::Wal { pos: None };
                 }
             }
         } else if let Some(cached) = self.shared_writer.lock().as_mut() {
@@ -4373,17 +4470,19 @@ impl IndexMethodCursor for FtsCursor {
             });
             if same_connection && matches_cursor_control {
                 let wal_pos = cached.directory.pager.wal_pos();
-                cached.snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
+                cached.snapshot = FtsCachedSnapshot::Wal {
+                    pos: (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos),
+                };
             }
         }
         self.shared_cache.write().prune();
     }
 
-    fn transaction_rolled_back(&mut self, context: &IndexMethodContext) {
+    fn on_transaction_rolled_back(&mut self, context: &IndexMethodContext) {
         self.abort_statement(context);
     }
 
-    fn savepoint_rolled_back(&mut self, context: &IndexMethodContext) {
+    fn on_savepoint_rolled_back(&mut self, context: &IndexMethodContext) {
         // Correct but coarse: the hook carries no savepoint identity, so we
         // cannot tell whether the rollback actually reverted FTS chunk rows
         // this cursor's view depends on. Discard everything; the next FTS

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -1,20 +1,18 @@
-use crate::alloc::ALLOC_ERR_MSG;
 use crate::sync::{Arc, Weak};
-use crate::turso_assert;
-use crate::turso_debug_assert;
 use crate::{
     index_method::{
-        parse_patterns, IndexMethod, IndexMethodAttachment, IndexMethodConfiguration,
-        IndexMethodCursor, IndexMethodDefinition,
+        open_index_cursor, parse_patterns, IndexMethod, IndexMethodAttachment,
+        IndexMethodConfiguration, IndexMethodContext, IndexMethodCursor, IndexMethodDefinition,
     },
     return_if_io,
     schema::IndexColumn,
     storage::{
-        btree::{BTreeCursor, BTreeKey, CursorTrait},
+        btree::{BTreeKey, CursorTrait},
         pager::Pager,
     },
     translate::collate::CollationSeq,
-    types::{IOResult, ImmutableRecord, IndexInfo, KeyInfo, SeekKey, SeekOp, SeekResult, Text},
+    turso_assert,
+    types::{IOResult, ImmutableRecord, KeyInfo, SeekKey, SeekOp, SeekResult, Text},
     util::quote_identifier,
     vdbe::Register,
     Connection, LimboError, Result, Value,
@@ -24,7 +22,10 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::io::{BufWriter, Write};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::{cell::RefCell, sync::atomic::Ordering};
+use std::{
+    cell::RefCell,
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+};
 use tantivy::{
     directory::{
         error::{DeleteError, OpenReadError, OpenWriteError},
@@ -50,7 +51,7 @@ pub const FTS_INDEX_METHOD_NAME: &str = "fts";
 /// Controls how much memory Tantivy uses for in-memory indexing before flushing to disk.
 pub const DEFAULT_MEMORY_BUDGET_BYTES: usize = 64 * 1024 * 1024;
 
-/// Default chunk size (152KB) for splitting large files when storing in BTree.
+/// Default chunk size (512 KiB) for splitting large files when storing in BTree.
 /// Files larger than this are split into multiple chunks for efficient storage and retrieval.
 pub const DEFAULT_CHUNK_SIZE: usize = 512 * 1024;
 
@@ -89,6 +90,38 @@ const FTS_MAX_CACHED_CONNECTIONS: usize = 4;
 
 /// Aggregate resident file-cache budget across retained connection snapshots.
 const FTS_MAX_RETAINED_CACHE_BYTES: usize = DEFAULT_HOT_CACHE_BYTES + DEFAULT_CHUNK_CACHE_BYTES;
+
+#[cfg(feature = "test_helper")]
+crate::thread::thread_local! {
+    static FTS_RETAINED_CACHE_BYTES_OVERRIDE: core::cell::Cell<Option<usize>> =
+        const { core::cell::Cell::new(None) };
+}
+
+/// Override the retained-cache budget for tests on the current thread, so
+/// budget-admission rejection is reachable without multi-hundred-MiB indexes.
+/// Pass `None` to restore the default.
+#[cfg(feature = "test_helper")]
+pub fn set_fts_retained_cache_bytes_for_test(bytes: Option<usize>) {
+    FTS_RETAINED_CACHE_BYTES_OVERRIDE.with(|cell| cell.set(bytes));
+}
+
+fn fts_max_retained_cache_bytes() -> usize {
+    #[cfg(feature = "test_helper")]
+    if let Some(bytes) = FTS_RETAINED_CACHE_BYTES_OVERRIDE.with(|cell| cell.get()) {
+        return bytes;
+    }
+    FTS_MAX_RETAINED_CACHE_BYTES
+}
+
+const FTS_CONTROL_PATH: &str = "__turso_fts_control_v1";
+const FTS_CONTROL_MAGIC: &[u8; 8] = b"TFTSCTL1";
+const FTS_CONTROL_FORMAT_VERSION: u32 = 1;
+/// Placeholder incarnation for an index with no persisted control record yet
+/// (an empty catalog). Deterministic, so every connection opening a
+/// never-written index agrees on it; the real incarnation is minted when the
+/// first control record is staged and is never this value.
+const FTS_EMPTY_INDEX_INCARNATION: u64 = 0;
+static NEXT_FTS_INDEX_INCARNATION: AtomicU64 = AtomicU64::new(1);
 
 const ROWID_FIELD: &str = "rowid";
 
@@ -218,83 +251,224 @@ pub fn fts_match(text: &str, query: &str) -> bool {
     })
 }
 
-/// File classification for hybrid caching strategy.
-/// Determines which files are kept hot in memory vs lazy-loaded on demand.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FileCategory {
-    /// Always in memory: meta.json, .managed.json, .lock (typically < 64KB)
-    Metadata,
-    /// Hot files: .term dictionaries - loaded on first access, kept in LRU
-    TermDictionary,
-    /// Fast fields and field norms - small, frequently accessed
-    FastFields,
-    /// Cold files: .idx, .pos, .store - lazy-loaded on demand
-    SegmentData,
-}
-
-impl FileCategory {
-    const METADATA_FILES: [&'static str; 3] = [TANTIVY_META_FILE, ".managed.json", ".lock"];
-    /// Classify a file based on its path/extension.
-    /// https://fulmicoton.gitbooks.io/tantivy-doc/content/index-files.html
-    fn from_path(path: &Path) -> Self {
-        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-
-        // Check for known Tantivy metadata files first
-        if Self::METADATA_FILES.contains(&name) {
-            return FileCategory::Metadata;
-        }
-
-        match ext {
-            // Term dictionary - hot for queries
-            "term" => FileCategory::TermDictionary,
-            // Fast fields and field norms - small, frequently accessed
-            "fast" | "fieldnorm" => FileCategory::FastFields,
-            // Segment data - large, lazy-loaded
-            "idx" | "pos" | "store" => FileCategory::SegmentData,
-            "lock" | "info" => FileCategory::Metadata,
-            // Default to segment data (lazy-loaded)
-            _ => FileCategory::SegmentData,
-        }
-    }
-
-    /// Returns true if files in this category should be preloaded at startup.
-    const fn should_preload(&self) -> bool {
-        matches!(self, FileCategory::Metadata)
-    }
-
-    /// Returns true if files in this category should be kept in the hot cache.
-    const fn is_hot(&self) -> bool {
-        matches!(
-            self,
-            FileCategory::Metadata | FileCategory::TermDictionary | FileCategory::FastFields
-        )
-    }
-}
-
 /// Metadata about a file stored in the FTS directory.
-/// Used for catalog-first loading where we build file metadata without loading content.
+/// Used for merge-budget accounting.
 #[derive(Debug, Clone)]
 struct FileMetadata {
     /// Total file size in bytes
     size: usize,
-    /// Number of chunks this file is split into
-    num_chunks: usize,
-    /// File category for caching decisions
-    category: FileCategory,
+    chunks: u64,
 }
 
 impl FileMetadata {
-    fn new(path: &Path, size: usize, num_chunks: usize) -> Self {
+    fn new(_path: &Path, size: usize, num_chunks: usize) -> Self {
         Self {
             size,
-            num_chunks,
-            category: FileCategory::from_path(path),
+            chunks: num_chunks as u64,
         }
     }
 }
 
-type ChunkKey = (PathBuf, i64);
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FtsManifestFile {
+    size: u64,
+    chunks: u64,
+}
+
+#[derive(Debug, Clone)]
+struct FtsControlRecord {
+    index_incarnation: u64,
+    manifest_generation: u64,
+    files: HashMap<PathBuf, FtsManifestFile>,
+}
+
+impl FtsControlRecord {
+    fn new(index_incarnation: u64) -> Self {
+        Self {
+            index_incarnation,
+            manifest_generation: 0,
+            files: HashMap::default(),
+        }
+    }
+
+    fn from_catalog(
+        previous: Option<&Self>,
+        index_incarnation: u64,
+        catalog: &Catalog,
+    ) -> Result<Self> {
+        let manifest_generation = match previous {
+            Some(control) => control.manifest_generation.checked_add(1).ok_or_else(|| {
+                LimboError::InternalError("FTS manifest generation is exhausted".to_string())
+            })?,
+            None => 1,
+        };
+        let mut files = HashMap::default();
+        for (path, metadata) in catalog {
+            let path_text = path.to_str().ok_or_else(|| {
+                LimboError::InternalError(format!(
+                    "FTS manifest path is not valid UTF-8: {}",
+                    path.display()
+                ))
+            })?;
+            let _ = path_text;
+            files.insert(
+                path.clone(),
+                FtsManifestFile {
+                    size: metadata.size as u64,
+                    chunks: metadata.chunks,
+                },
+            );
+        }
+        Ok(Self {
+            index_incarnation,
+            manifest_generation,
+            files,
+        })
+    }
+
+    fn encode(&self) -> Result<Vec<u8>> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(FTS_CONTROL_MAGIC);
+        bytes.extend_from_slice(&FTS_CONTROL_FORMAT_VERSION.to_le_bytes());
+        bytes.extend_from_slice(&self.index_incarnation.to_le_bytes());
+        bytes.extend_from_slice(&self.manifest_generation.to_le_bytes());
+        let mut files = self.files.iter().collect::<Vec<_>>();
+        files.sort_by(|(left, _), (right, _)| left.cmp(right));
+        let file_count = u32::try_from(files.len())
+            .map_err(|_| LimboError::InternalError("FTS manifest has too many files".into()))?;
+        bytes.extend_from_slice(&file_count.to_le_bytes());
+        for (path, metadata) in files {
+            let path = path.to_str().ok_or_else(|| {
+                LimboError::InternalError(format!(
+                    "FTS manifest path is not valid UTF-8: {}",
+                    path.display()
+                ))
+            })?;
+            let path_len = u32::try_from(path.len())
+                .map_err(|_| LimboError::InternalError("FTS manifest path is too long".into()))?;
+            bytes.extend_from_slice(&path_len.to_le_bytes());
+            bytes.extend_from_slice(path.as_bytes());
+            bytes.extend_from_slice(&metadata.size.to_le_bytes());
+            bytes.extend_from_slice(&metadata.chunks.to_le_bytes());
+        }
+        let checksum = fts_control_checksum(&bytes);
+        bytes.extend_from_slice(&checksum.to_le_bytes());
+        Ok(bytes)
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self> {
+        fn take<const N: usize>(bytes: &[u8], offset: &mut usize) -> Result<[u8; N]> {
+            let end = offset
+                .checked_add(N)
+                .ok_or_else(|| LimboError::Corrupt("FTS control record offset overflow".into()))?;
+            let value = bytes
+                .get(*offset..end)
+                .ok_or_else(|| LimboError::Corrupt("truncated FTS control record".into()))?;
+            *offset = end;
+            Ok(value.try_into().expect("slice length checked"))
+        }
+
+        if bytes.len() < FTS_CONTROL_MAGIC.len() + 4 + 8 + 8 + 4 + 8 {
+            return Err(LimboError::Corrupt("truncated FTS control record".into()));
+        }
+        let payload_len = bytes.len() - 8;
+        let expected_checksum = u64::from_le_bytes(
+            bytes[payload_len..]
+                .try_into()
+                .expect("checksum length checked"),
+        );
+        if fts_control_checksum(&bytes[..payload_len]) != expected_checksum {
+            return Err(LimboError::Corrupt(
+                "FTS control record checksum mismatch".into(),
+            ));
+        }
+
+        let mut offset = 0;
+        if take::<8>(bytes, &mut offset)? != *FTS_CONTROL_MAGIC {
+            return Err(LimboError::Corrupt(
+                "unrecognized FTS control record".into(),
+            ));
+        }
+        let version = u32::from_le_bytes(take(bytes, &mut offset)?);
+        if version != FTS_CONTROL_FORMAT_VERSION {
+            return Err(LimboError::Corrupt(format!(
+                "unsupported FTS control format version {version}"
+            )));
+        }
+        let index_incarnation = u64::from_le_bytes(take(bytes, &mut offset)?);
+        let manifest_generation = u64::from_le_bytes(take(bytes, &mut offset)?);
+        let file_count = u32::from_le_bytes(take(bytes, &mut offset)?) as usize;
+        let mut files = HashMap::default();
+        for _ in 0..file_count {
+            let path_len = u32::from_le_bytes(take(bytes, &mut offset)?) as usize;
+            let path_end = offset
+                .checked_add(path_len)
+                .ok_or_else(|| LimboError::Corrupt("FTS manifest path offset overflow".into()))?;
+            let path_bytes = bytes
+                .get(offset..path_end)
+                .ok_or_else(|| LimboError::Corrupt("truncated FTS manifest path".into()))?;
+            offset = path_end;
+            let path = std::str::from_utf8(path_bytes)
+                .map_err(|_| LimboError::Corrupt("FTS manifest path is not UTF-8".into()))?;
+            let size = u64::from_le_bytes(take(bytes, &mut offset)?);
+            let chunks = u64::from_le_bytes(take(bytes, &mut offset)?);
+            if chunks == 0 {
+                return Err(LimboError::Corrupt(format!(
+                    "FTS manifest file {path} has zero chunks"
+                )));
+            }
+            if files
+                .insert(PathBuf::from(path), FtsManifestFile { size, chunks })
+                .is_some()
+            {
+                return Err(LimboError::Corrupt(format!(
+                    "duplicate FTS manifest entry for {path}"
+                )));
+            }
+        }
+        if offset != payload_len {
+            return Err(LimboError::Corrupt(
+                "FTS control record has trailing payload bytes".into(),
+            ));
+        }
+        Ok(Self {
+            index_incarnation,
+            manifest_generation,
+            files,
+        })
+    }
+
+    fn validate_catalog(&self, catalog: &Catalog) -> Result<()> {
+        if self.files.len() != catalog.len() {
+            return Err(LimboError::Corrupt(format!(
+                "FTS manifest contains {} files but storage contains {}",
+                self.files.len(),
+                catalog.len()
+            )));
+        }
+        for (path, metadata) in catalog {
+            let manifest = self.files.get(path).ok_or_else(|| {
+                LimboError::Corrupt(format!(
+                    "FTS storage file {} is absent from the manifest",
+                    path.display()
+                ))
+            })?;
+            if manifest.size != metadata.size as u64 || manifest.chunks != metadata.chunks {
+                return Err(LimboError::Corrupt(format!(
+                    "FTS manifest metadata mismatch for {}",
+                    path.display()
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn fts_control_checksum(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf2_9ce4_8422_2325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100_0000_01b3)
+    })
+}
 
 /// Eviction samples per put
 const EVICTION_SAMPLES: usize = 8;
@@ -330,18 +504,6 @@ impl<K: std::fmt::Debug> std::fmt::Debug for LruCache<K> {
 }
 
 impl<K: Eq + std::hash::Hash + Clone> LruCache<K> {
-    /// Creates a new empty cache with the specified capacity in bytes.
-    fn new(capacity: usize) -> Self {
-        Self {
-            capacity,
-            inner: RwLock::new(LruCacheInner {
-                current_size: 0,
-                clock: 0,
-                entries: HashMap::default(),
-            }),
-        }
-    }
-
     /// Lookup entry, updating access timestamp. Returns Arc-cloned data.
     fn get<Q>(&self, key: &Q) -> Option<Arc<[u8]>>
     where
@@ -447,30 +609,10 @@ impl<K: Eq + std::hash::Hash + Clone> LruCache<K> {
     }
 }
 
-/// Specialized methods for ChunkKey (PathBuf, i64) caches.
-impl LruCache<ChunkKey> {
-    /// Invalidate all chunks for a file path.
-    /// Called when a file is deleted or overwritten.
-    fn invalidate(&self, path: &Path) {
-        let mut inner = self.inner.write();
-        let mut freed = 0usize;
-        inner.entries.retain(|(p, _), e| {
-            if p == path {
-                freed += e.data.len();
-                false
-            } else {
-                true
-            }
-        });
-        inner.current_size -= freed;
-    }
-}
-
 /// Specialized methods for PathBuf caches (hot files).
 impl LruCache<PathBuf> {
-    /// Create from preloaded files (used during initialization).
-    fn with_preloaded(capacity: usize, files: HashMap<PathBuf, Vec<u8>>) -> Self {
-        let current_size: usize = files.values().map(|v| v.len()).sum();
+    fn with_preloaded_arcs(capacity: usize, files: HashMap<PathBuf, Arc<[u8]>>) -> Self {
+        let current_size: usize = files.values().map(|data| data.len()).sum();
         let entries: HashMap<PathBuf, LruCacheEntry> = files
             .into_iter()
             .enumerate()
@@ -478,7 +620,7 @@ impl LruCache<PathBuf> {
                 (
                     path,
                     LruCacheEntry {
-                        data: Arc::from(data),
+                        data,
                         accessed: i as u64,
                     },
                 )
@@ -493,6 +635,15 @@ impl LruCache<PathBuf> {
                 entries,
             }),
         }
+    }
+
+    fn arc_snapshot(&self) -> HashMap<PathBuf, Arc<[u8]>> {
+        self.inner
+            .read()
+            .entries
+            .iter()
+            .map(|(path, entry)| (path.clone(), Arc::clone(&entry.data)))
+            .collect()
     }
 }
 
@@ -532,35 +683,21 @@ impl PendingFileMutations {
     }
 }
 
-/// Tantivy Directory implementation backed by Turso's BTree storage.
+/// Tantivy Directory implementation backed by a complete in-memory snapshot.
 ///
 /// Tantivy stores its index as a collection of files (segments, metadata, term dictionaries, etc.).
-/// The `Directory` trait is Tantivy's storage abstraction for reading, writing, and managing
-/// these files. Tantivy's Directory methods are synchronous, so we must do blocking IO to back
-/// these operations and cache data in memory for performance.
+/// The `Directory` trait is synchronous, while Turso storage is asynchronous. The FTS cursor
+/// therefore loads the complete directory through its resumable state machine before constructing
+/// Tantivy objects. Directory callbacks only read this snapshot or cursor-local pending writes;
+/// they must never open a B-tree cursor or drive the pager.
 ///
 /// FTS index files are stored in a BTree with the schema `(path TEXT, chunk_no INTEGER, bytes BLOB)`.
-/// Large files are split into chunks of `DEFAULT_CHUNK_SIZE` (1MB) to enable efficient
+/// Large files are split into chunks of `DEFAULT_CHUNK_SIZE` (512 KiB) to enable efficient
 /// partial reads and bounded memory usage during loading.
-///
-/// We use a two-tier caching strategy to optimize for Tantivy's access patterns:
-///
-/// 1. `hot_cache` (keyed by `PathBuf`): Caches entire files for small,
-///    frequently-accessed files that benefit from being fully resident in memory:
-///    - Metadata files (meta.json, .managed.json, .lock)
-///    - Term dictionaries (.term) - critical for query performance
-///    - Fast fields and field norms (.fast, .fieldnorm)
-///
-/// 2. `chunk_cache` (keyed by `(PathBuf, chunk_no)`): Caches individual 1MB chunks
-///    of large segment files. Large files like posting lists (.idx), positions (.pos),
-///    and document store (.store) are split into 1MB chunks when stored in the BTree.
-///    When Tantivy reads a byte range, we load only the chunks covering that range,
-///    allowing partial file access without loading entire multi-MB files into memory.
 ///
 /// File mutations are buffered in memory and flushed to the BTree when:
 /// - A Tantivy commit occurs (via `commit_and_flush`)
-/// - The cursor is dropped with pending documents
-/// - The transaction is about to commit (via `pre_commit`)
+/// - The statement is finalized (via `prepare_statement_commit`)
 ///
 /// During flush, writes are moved to `flushing_writes` so they remain readable while
 /// the async BTree write completes.
@@ -569,12 +706,15 @@ struct HybridBTreeDirectory {
     /// File catalog: path -> metadata (always in memory, no content)
     catalog: Arc<RwLock<Catalog>>,
 
-    /// Hot cache: LRU cache for frequently accessed files (metadata, term dictionaries)
-    /// Bounded to DEFAULT_HOT_CACHE_BYTES (64MB) to prevent unbounded memory growth
+    /// Complete file snapshot loaded before Tantivy is invoked.
+    ///
+    /// The capacity is deliberately unbounded: eviction would turn a synchronous Tantivy
+    /// callback into a storage read. Connection-level cache pruning bounds retained snapshots.
     hot_cache: Arc<LruCache<PathBuf>>,
 
-    /// Chunk cache: LRU cache for lazy-loaded segment chunks
-    chunk_cache: Arc<LruCache<ChunkKey>>,
+    /// Storage view at cursor checkout, kept separate from Tantivy's mutable
+    /// in-memory view so unchanged rewrites can be elided.
+    base_files: Arc<RwLock<HashMap<PathBuf, Arc<[u8]>>>>,
 
     /// Latest pending mutation for each path.
     pending_mutations: Arc<RwLock<PendingFileMutations>>,
@@ -596,7 +736,6 @@ impl std::fmt::Debug for HybridBTreeDirectory {
             .field("catalog_size", &self.catalog.read().len())
             .field("hot_cache_size", &self.hot_cache.len())
             .field("hot_cache_bytes", &self.hot_cache.size())
-            .field("chunk_cache_size", &self.chunk_cache.size())
             .field("btree_root_page", &self.btree_root_page)
             .finish()
     }
@@ -609,10 +748,14 @@ impl HybridBTreeDirectory {
     /// This prevents the bug where writes from one cursor affect the Drop behavior
     /// of another cursor.
     fn clone_with_fresh_pending(&self) -> Self {
+        let files = self.hot_cache.arc_snapshot();
         Self {
-            catalog: Arc::clone(&self.catalog),
-            hot_cache: Arc::clone(&self.hot_cache),
-            chunk_cache: Arc::clone(&self.chunk_cache),
+            catalog: Arc::new(RwLock::new(self.catalog.read().clone())),
+            hot_cache: Arc::new(LruCache::<PathBuf>::with_preloaded_arcs(
+                usize::MAX,
+                files.clone(),
+            )),
+            base_files: Arc::new(RwLock::new(files)),
             // Fresh pending state - not shared with cache
             pending_mutations: Arc::new(RwLock::new(PendingFileMutations::default())),
             flushing_writes: Arc::new(RwLock::new(HashMap::default())),
@@ -622,27 +765,25 @@ impl HybridBTreeDirectory {
     }
 }
 
-fn io_not_found<M: Into<Box<dyn std::error::Error + Send + Sync>>>(msg: M) -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::NotFound, msg)
-}
-
 impl HybridBTreeDirectory {
-    /// Create from preloaded catalog and hot cache files.
+    /// Create from a complete, asynchronously preloaded snapshot.
     fn with_preloaded(
         pager: Arc<Pager>,
         btree_root_page: i64,
         catalog: HashMap<PathBuf, FileMetadata>,
-        hot_files: HashMap<PathBuf, Vec<u8>>,
-        hot_cache_capacity: usize,
-        chunk_cache_capacity: usize,
+        files: HashMap<PathBuf, Vec<u8>>,
     ) -> Self {
+        let base_files = files
+            .into_iter()
+            .map(|(path, data)| (path, Arc::<[u8]>::from(data)))
+            .collect::<HashMap<_, _>>();
         Self {
             catalog: Arc::new(RwLock::new(catalog)),
-            hot_cache: Arc::new(LruCache::<PathBuf>::with_preloaded(
-                hot_cache_capacity,
-                hot_files,
+            hot_cache: Arc::new(LruCache::<PathBuf>::with_preloaded_arcs(
+                usize::MAX,
+                base_files.clone(),
             )),
-            chunk_cache: Arc::new(LruCache::<ChunkKey>::new(chunk_cache_capacity)),
+            base_files: Arc::new(RwLock::new(base_files)),
             pending_mutations: Arc::new(RwLock::new(PendingFileMutations::default())),
             flushing_writes: Arc::new(RwLock::new(HashMap::default())),
             pager,
@@ -664,7 +805,20 @@ impl HybridBTreeDirectory {
     /// while the resumable BTree flush is in progress. `None` is an explicit
     /// delete; `Some(Vec::new())` is an empty file.
     fn take_pending_flushes(&self) -> PendingFlushes {
-        let flushes = self.pending_mutations.write().take_flushes();
+        let base_files = self.base_files.read();
+        let flushes = self
+            .pending_mutations
+            .write()
+            .take_flushes()
+            .into_iter()
+            .filter(|(path, data)| match data {
+                Some(data) => base_files
+                    .get(path)
+                    .is_none_or(|base| base.as_ref() != data.as_slice()),
+                None => base_files.contains_key(path),
+            })
+            .collect::<Vec<_>>();
+        drop(base_files);
 
         {
             let mut flushing = self.flushing_writes.write();
@@ -688,6 +842,7 @@ impl HybridBTreeDirectory {
             flushing.len()
         );
         flushing.clear();
+        *self.base_files.write() = self.hot_cache.arc_snapshot();
     }
 
     /// Find file data in pending or flushing writes.
@@ -710,352 +865,6 @@ impl HybridBTreeDirectory {
         }
 
         None
-    }
-
-    const CHUNK_LEN: usize = 3;
-
-    /// Blocking read of a range of chunks from BTree using a single cursor.
-    /// Efficient for both single and multiple chunk reads, as it only seeks once
-    /// and advances sequentially.
-    fn get_chunks_range_blocking(
-        &self,
-        path: &Path,
-        start_chunk: usize,
-        end_chunk: usize,
-    ) -> std::io::Result<Vec<Arc<[u8]>>> {
-        if start_chunk > end_chunk {
-            return Ok(Vec::new());
-        }
-
-        let mut chunks = Vec::with_capacity(end_chunk - start_chunk + 1);
-        let path_str = path.to_string_lossy().to_string();
-
-        // Check cache for all requested chunks first
-        let mut uncached_start = None;
-        for chunk_no in start_chunk..=end_chunk {
-            let cache_key = (path.to_path_buf(), chunk_no as i64);
-            if let Some(chunk) = self.chunk_cache.get(&cache_key) {
-                chunks.push(chunk);
-            } else {
-                // Found first uncached chunk
-                uncached_start = Some(chunk_no);
-                break;
-            }
-        }
-
-        // If all chunks were cached, return them
-        if uncached_start.is_none() {
-            return Ok(chunks);
-        }
-
-        let uncached_start = uncached_start.unwrap();
-
-        // Create cursor and seek to first uncached chunk
-        let mut cursor =
-            BTreeCursor::new(self.pager.clone(), self.btree_root_page, Self::CHUNK_LEN);
-        cursor.index_info = Some(Arc::new(
-            IndexInfo::new(
-                [key_info(), key_info(), key_info()],
-                false,
-                Self::CHUNK_LEN,
-                false,
-            )
-            .expect(ALLOC_ERR_MSG),
-        ));
-
-        let seek_key = ImmutableRecord::from_values(
-            &[
-                Value::Text(Text::new(path_str.clone())),
-                Value::from_i64(uncached_start as i64),
-                Value::Blob(crate::alloc::vec![]),
-            ],
-            Self::CHUNK_LEN,
-        )
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-
-        // Blocking seek to first chunk
-        loop {
-            match cursor.seek(
-                SeekKey::IndexKey(seek_key.as_record_ref()),
-                SeekOp::GE { eq_only: false },
-            ) {
-                Ok(IOResult::Done(SeekResult::Found)) => break,
-                Ok(IOResult::Done(SeekResult::TryAdvance)) => {
-                    loop {
-                        match cursor.next() {
-                            Ok(IOResult::Done(_)) => {
-                                if !cursor.has_record() {
-                                    return Err(io_not_found(format!(
-                                        "chunk {}:{} not found",
-                                        path.display(),
-                                        uncached_start
-                                    )));
-                                }
-                                break;
-                            }
-                            Ok(IOResult::IO(_)) => {
-                                self.pager
-                                    .io
-                                    .step()
-                                    .map_err(|e| std::io::Error::other(e.to_string()))?;
-                            }
-                            Err(e) => return Err(std::io::Error::other(e.to_string())),
-                        }
-                    }
-                    break;
-                }
-                Ok(IOResult::Done(SeekResult::NotFound)) => {
-                    return Err(io_not_found(format!(
-                        "chunk {}:{} not found",
-                        path.display(),
-                        uncached_start
-                    )));
-                }
-                Ok(IOResult::IO(_)) => {
-                    self.pager
-                        .io
-                        .step()
-                        .map_err(|e| std::io::Error::other(e.to_string()))?;
-                }
-                Err(e) => return Err(std::io::Error::other(e.to_string())),
-            }
-        }
-
-        // Read remaining chunks sequentially
-        for expected_chunk_no in uncached_start..=end_chunk {
-            // Check if cursor has a record
-            if !cursor.has_record() {
-                return Err(io_not_found(format!(
-                    "chunk {}:{} not found (cursor exhausted)",
-                    path.display(),
-                    expected_chunk_no
-                )));
-            }
-
-            // Read current record
-            let record = loop {
-                match cursor.record() {
-                    Ok(IOResult::Done(r)) => break r,
-                    Ok(IOResult::IO(_)) => {
-                        self.pager
-                            .io
-                            .step()
-                            .map_err(|e| std::io::Error::other(e.to_string()))?;
-                    }
-                    Err(e) => return Err(std::io::Error::other(e.to_string())),
-                }
-            };
-
-            let record = record.ok_or_else(|| io_not_found("no record at cursor"))?;
-
-            // Extract and validate
-            let found_path = record.get_value_opt(0).and_then(|v| match v {
-                crate::types::ValueRef::Text(t) => Some(t.value.to_string()),
-                _ => None,
-            });
-            let found_chunk = record.get_value_opt(1).and_then(|v| match v {
-                crate::types::ValueRef::Numeric(crate::numeric::Numeric::Integer(i)) => Some(i),
-                _ => None,
-            });
-            let bytes = record.get_value_opt(2).and_then(|v| match v {
-                crate::types::ValueRef::Blob(b) => Some(b.to_vec()),
-                _ => None,
-            });
-
-            let (found_path_str, found_chunk_no, bytes) = match (found_path, found_chunk, bytes) {
-                (Some(p), Some(c), Some(b)) => (p, c, b),
-                _ => {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "malformed chunk record",
-                    ));
-                }
-            };
-
-            if found_path_str != path_str || found_chunk_no != expected_chunk_no as i64 {
-                return Err(io_not_found(format!(
-                    "wrong chunk: expected {path_str}:{expected_chunk_no}, got {found_path_str}:{found_chunk_no}",
-                )));
-            }
-
-            // Cache and collect the chunk
-            if can_cache_chunks(path) {
-                let cache_key = (path.to_path_buf(), expected_chunk_no as i64);
-                self.chunk_cache.put(cache_key, bytes.clone());
-            }
-            chunks.push(Arc::from(bytes));
-
-            // Advance cursor to next record (unless this is the last chunk we need)
-            if expected_chunk_no < end_chunk {
-                loop {
-                    match cursor.next() {
-                        Ok(IOResult::Done(_)) => break,
-                        Ok(IOResult::IO(_)) => {
-                            self.pager
-                                .io
-                                .step()
-                                .map_err(|e| std::io::Error::other(e.to_string()))?;
-                        }
-                        Err(e) => return Err(std::io::Error::other(e.to_string())),
-                    }
-                }
-            }
-        }
-
-        Ok(chunks)
-    }
-
-    /// Load an entire file by concatenating all its chunks (blocking).
-    /// Uses efficient bulk read with a single cursor seek.
-    fn load_file_blocking(&self, path: &Path) -> std::io::Result<Vec<u8>> {
-        let catalog = self.catalog.read();
-        let metadata = catalog
-            .get(path)
-            .ok_or_else(|| io_not_found(format!("file not in catalog: {}", path.display())))?;
-
-        if metadata.num_chunks == 0 {
-            return Ok(Vec::new());
-        }
-
-        let chunks =
-            self.get_chunks_range_blocking(path, 0, metadata.num_chunks.saturating_sub(1))?;
-
-        let mut result = Vec::with_capacity(metadata.size);
-        for chunk in chunks {
-            result.extend_from_slice(&chunk);
-        }
-
-        Ok(result)
-    }
-
-    /// Read a file's full contents straight from the BTree, bypassing the
-    /// catalog and every cache layer. Returns `None` when the BTree holds no
-    /// rows for the path. Used to validate cached read state.
-    /// against durable state at cursor checkout.
-    fn read_file_from_btree_uncached(&self, path: &Path) -> std::io::Result<Option<Vec<u8>>> {
-        let path_str = path.to_string_lossy().to_string();
-        let mut cursor =
-            BTreeCursor::new(self.pager.clone(), self.btree_root_page, Self::CHUNK_LEN);
-        cursor.index_info = Some(Arc::new(
-            IndexInfo::new(
-                [key_info(), key_info(), key_info()],
-                false,
-                Self::CHUNK_LEN,
-                false,
-            )
-            .expect(ALLOC_ERR_MSG),
-        ));
-
-        let seek_key = ImmutableRecord::from_values(
-            &[
-                Value::Text(Text::new(path_str.clone())),
-                Value::from_i64(0),
-                Value::Blob(crate::alloc::vec![]),
-            ],
-            Self::CHUNK_LEN,
-        )
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-
-        loop {
-            match cursor.seek(
-                SeekKey::IndexKey(seek_key.as_record_ref()),
-                SeekOp::GE { eq_only: false },
-            ) {
-                Ok(IOResult::Done(SeekResult::Found)) => break,
-                Ok(IOResult::Done(SeekResult::TryAdvance)) => {
-                    loop {
-                        match cursor.next() {
-                            Ok(IOResult::Done(_)) => break,
-                            Ok(IOResult::IO(_)) => {
-                                self.pager
-                                    .io
-                                    .step()
-                                    .map_err(|e| std::io::Error::other(e.to_string()))?;
-                            }
-                            Err(e) => return Err(std::io::Error::other(e.to_string())),
-                        }
-                    }
-                    break;
-                }
-                Ok(IOResult::Done(SeekResult::NotFound)) => return Ok(None),
-                Ok(IOResult::IO(_)) => {
-                    self.pager
-                        .io
-                        .step()
-                        .map_err(|e| std::io::Error::other(e.to_string()))?;
-                }
-                Err(e) => return Err(std::io::Error::other(e.to_string())),
-            }
-        }
-
-        let mut result: Option<Vec<u8>> = None;
-        loop {
-            if !cursor.has_record() {
-                return Ok(result);
-            }
-            let record = loop {
-                match cursor.record() {
-                    Ok(IOResult::Done(r)) => break r,
-                    Ok(IOResult::IO(_)) => {
-                        self.pager
-                            .io
-                            .step()
-                            .map_err(|e| std::io::Error::other(e.to_string()))?;
-                    }
-                    Err(e) => return Err(std::io::Error::other(e.to_string())),
-                }
-            };
-            let Some(record) = record else {
-                return Ok(result);
-            };
-            let matches_path = record.get_value_opt(0).is_some_and(|v| match v {
-                crate::types::ValueRef::Text(t) => t.value == path_str.as_str(),
-                _ => false,
-            });
-            if !matches_path {
-                return Ok(result);
-            }
-            let bytes = record.get_value_opt(2).and_then(|v| match v {
-                crate::types::ValueRef::Blob(b) => Some(b.to_vec()),
-                _ => None,
-            });
-            let Some(bytes) = bytes else {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "malformed chunk record",
-                ));
-            };
-            result
-                .get_or_insert_with(Vec::new)
-                .extend_from_slice(&bytes);
-            loop {
-                match cursor.next() {
-                    Ok(IOResult::Done(_)) => break,
-                    Ok(IOResult::IO(_)) => {
-                        self.pager
-                            .io
-                            .step()
-                            .map_err(|e| std::io::Error::other(e.to_string()))?;
-                    }
-                    Err(e) => return Err(std::io::Error::other(e.to_string())),
-                }
-            }
-        }
-    }
-
-    /// True when this directory's in-memory view of the Tantivy metadata file
-    /// matches what the BTree currently holds. Cached read state can
-    /// go stale without any notification — a rolled-back transaction (or
-    /// savepoint) reverts the BTree while the cache keeps the state published
-    /// mid-transaction (issue 7522) — so cursors verify before trusting it.
-    fn is_consistent_with_btree(&self) -> std::io::Result<bool> {
-        let meta_path = Path::new(TANTIVY_META_FILE);
-        let Some(cached_meta) = self.hot_cache.get(meta_path) else {
-            // No in-memory metadata to compare — cannot vouch for the cache.
-            return Ok(false);
-        };
-        let btree_meta = self.read_file_from_btree_uncached(meta_path)?;
-        Ok(btree_meta.as_deref() == Some(&cached_meta[..]))
     }
 
     /// Add a file to the hot cache.
@@ -1105,99 +914,6 @@ impl FileHandle for InMemoryFileHandle {
     }
 }
 
-/// Lazy file handle that fetches chunks on demand.
-struct LazyFileHandle {
-    path: PathBuf,
-    size: usize,
-    directory: HybridBTreeDirectory,
-}
-
-impl std::fmt::Debug for LazyFileHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LazyFileHandle")
-            .field("path", &self.path)
-            .field("size", &self.size)
-            .finish()
-    }
-}
-
-impl HasLen for LazyFileHandle {
-    fn len(&self) -> usize {
-        self.size
-    }
-}
-
-impl FileHandle for LazyFileHandle {
-    fn read_bytes(&self, range: Range<usize>) -> std::io::Result<OwnedBytes> {
-        if range.end > self.size {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                format!(
-                    "range {:?} exceeds file size {} for {}",
-                    range,
-                    self.size,
-                    self.path.display()
-                ),
-            ));
-        }
-        if range.start >= range.end {
-            return Ok(OwnedBytes::new(Vec::new()));
-        }
-
-        // Check hot cache first
-        if let Some(data) = self.directory.hot_cache.get(&self.path) {
-            return Ok(OwnedBytes::new(data).slice(range));
-        }
-
-        // Check pending/flushing writes (data not yet persisted to BTree)
-        if let Some(data) = self.directory.find_in_pending_writes(&self.path) {
-            return Ok(OwnedBytes::new(data[range].to_vec()));
-        }
-
-        // Calculate required chunks
-        let chunk_size = DEFAULT_CHUNK_SIZE;
-        let start_chunk = range.start / chunk_size;
-        let end_chunk = range.end.saturating_sub(1) / chunk_size;
-
-        // Use efficient bulk read when multiple chunks are needed
-        let chunks =
-            self.directory
-                .get_chunks_range_blocking(&self.path, start_chunk, end_chunk)?;
-
-        // Collect result from chunks
-        let mut result = Vec::with_capacity(range.len());
-        for (i, chunk) in chunks.into_iter().enumerate() {
-            let chunk_no = start_chunk + i;
-            let chunk_start = chunk_no * chunk_size;
-
-            // Calculate slice within this chunk
-            let local_start = if chunk_no == start_chunk {
-                range.start - chunk_start
-            } else {
-                0
-            };
-            let local_end = if chunk_no == end_chunk {
-                range.end - chunk_start
-            } else {
-                chunk.len()
-            };
-
-            // Defensive bounds check - should not be needed if logic is correct
-            turso_debug_assert!(
-                local_start <= chunk.len() && local_end <= chunk.len(),
-                "chunk slice out of bounds",
-                { "local_start": local_start, "local_end": local_end, "chunk_len": chunk.len() }
-            );
-            let local_end = local_end.min(chunk.len());
-            let local_start = local_start.min(local_end);
-
-            result.extend_from_slice(&chunk[local_start..local_end]);
-        }
-
-        Ok(OwnedBytes::new(result))
-    }
-}
-
 /// In-memory writer for HybridBTreeDirectory.
 struct HybridWriter {
     path: PathBuf,
@@ -1224,14 +940,10 @@ impl Drop for HybridWriter {
             // Update catalog
             let num_chunks = data.len().div_ceil(DEFAULT_CHUNK_SIZE);
             let metadata = FileMetadata::new(&self.path, data.len(), num_chunks);
-            self.directory
-                .update_catalog(self.path.clone(), metadata.clone());
+            self.directory.update_catalog(self.path.clone(), metadata);
 
-            // If it's a hot file category, add to hot cache
-            if metadata.category.is_hot() {
-                self.directory
-                    .add_to_hot_cache(self.path.clone(), data.clone());
-            }
+            self.directory
+                .add_to_hot_cache(self.path.clone(), data.clone());
 
             self.directory.queue_write(self.path.clone(), data);
         }
@@ -1246,14 +958,10 @@ impl TerminatingWrite for HybridWriter {
 
         // Update catalog - even empty files should exist in the catalog
         let metadata = FileMetadata::new(&self.path, data.len(), num_chunks);
-        self.directory
-            .update_catalog(self.path.clone(), metadata.clone());
+        self.directory.update_catalog(self.path.clone(), metadata);
 
-        // If it's a hot file category, add to hot cache (even if empty)
-        if metadata.category.is_hot() {
-            self.directory
-                .add_to_hot_cache(self.path.clone(), data.clone());
-        }
+        self.directory
+            .add_to_hot_cache(self.path.clone(), data.clone());
 
         self.directory.queue_write(self.path.clone(), data);
         Ok(())
@@ -1277,17 +985,17 @@ impl Directory for HybridBTreeDirectory {
             }));
         }
 
-        // Check catalog for file metadata
-        let catalog = self.catalog.read();
-        let metadata = catalog
-            .get(path)
-            .ok_or_else(|| OpenReadError::FileDoesNotExist(path.to_path_buf()))?;
+        if !self.catalog.read().contains_key(path) {
+            return Err(OpenReadError::FileDoesNotExist(path.to_path_buf()));
+        }
 
-        Ok(Arc::new(LazyFileHandle {
-            path: path.to_path_buf(),
-            size: metadata.size,
-            directory: self.clone(),
-        }))
+        Err(OpenReadError::IoError {
+            io_error: Arc::new(std::io::Error::other(format!(
+                "FTS snapshot invariant violated: {} is cataloged but was not preloaded",
+                path.display()
+            ))),
+            filepath: path.to_path_buf(),
+        })
     }
 
     fn exists(&self, path: &Path) -> std::result::Result<bool, OpenReadError> {
@@ -1308,10 +1016,6 @@ impl Directory for HybridBTreeDirectory {
             let mut catalog = self.catalog.write();
             catalog.remove(path);
         }
-        if can_cache_chunks(path) {
-            // Invalidate chunk cache
-            self.chunk_cache.invalidate(path);
-        }
         self.queue_delete(path.to_path_buf());
         Ok(())
     }
@@ -1329,12 +1033,11 @@ impl Directory for HybridBTreeDirectory {
         // existing file first. The error is ignored because:
         // 1. If the file doesn't exist, delete() succeeds (no-op on missing files)
         // 2. Our delete() implementation always returns Ok(()) - it only removes entries
-        //    from in-memory structures (hot_cache, catalog, chunk_cache) and queues the
+        //    from in-memory structures and queues the
         //    BTree deletion, none of which can fail.
         //
         // Skip delete for the meta lock file: Tantivy calls open_write on it for every
-        // search query, but it's never cached (can_cache_chunks returns false), never in
-        // hot_cache, and doesn't need BTree deletion, so delete() is pure overhead.
+        // search query and it does not need BTree deletion.
         if path != Path::new(TANTIVY_META_LOCK_FILE) {
             let _ = self.delete(path);
         }
@@ -1365,24 +1068,22 @@ impl Directory for HybridBTreeDirectory {
             }
         }
 
-        // Load file blocking from BTree
-        self.load_file_blocking(path)
-            .map_err(|e| OpenReadError::IoError {
-                io_error: Arc::new(e),
-                filepath: path.to_path_buf(),
-            })
+        Err(OpenReadError::IoError {
+            io_error: Arc::new(std::io::Error::other(format!(
+                "FTS snapshot invariant violated: {} is cataloged but was not preloaded",
+                path.display()
+            ))),
+            filepath: path.to_path_buf(),
+        })
     }
 
     fn atomic_write(&self, path: &Path, data: &[u8]) -> std::io::Result<()> {
         // Update catalog
         let num_chunks = data.len().div_ceil(DEFAULT_CHUNK_SIZE).max(1);
         let metadata = FileMetadata::new(path, data.len(), num_chunks);
-        self.update_catalog(path.to_path_buf(), metadata.clone());
+        self.update_catalog(path.to_path_buf(), metadata);
 
-        // If it's a hot file category, add to hot cache
-        if metadata.category.is_hot() {
-            self.add_to_hot_cache(path.to_path_buf(), data.to_vec());
-        }
+        self.add_to_hot_cache(path.to_path_buf(), data.to_vec());
 
         self.queue_write(path.to_path_buf(), data.to_vec());
         Ok(())
@@ -1488,11 +1189,14 @@ impl IndexMethod for FtsIndexMethod {
 /// pending-write state.
 pub struct CachedFtsState {
     connection: Weak<Connection>,
+    /// MVCC transaction that owns this snapshot. `None` denotes a WAL entry.
+    transaction_id: Option<u64>,
     /// WAL snapshot at which the cached Tantivy metadata was loaded.
     ///
     /// `None` means the pager has no WAL identity and requires the slower
     /// metadata-byte comparison before reuse.
     snapshot_wal_pos: Option<(u32, u64)>,
+    control: FtsControlRecord,
     directory: HybridBTreeDirectory,
     index: Index,
     reader: IndexReader,
@@ -1507,6 +1211,11 @@ pub struct CachedFtsState {
 /// stale Tantivy segments.
 struct CachedFtsWriter {
     connection: Weak<Connection>,
+    /// MVCC transaction that exclusively owns this writer. `None` denotes a
+    /// WAL writer whose visibility remains connection-local until commit.
+    transaction_id: Option<u64>,
+    snapshot_wal_pos: Option<(u32, u64)>,
+    control: FtsControlRecord,
     directory: HybridBTreeDirectory,
     index: Index,
     writer: IndexWriter,
@@ -1528,10 +1237,7 @@ struct CachedFtsStates {
 
 impl CachedFtsState {
     fn resident_cache_bytes(&self) -> usize {
-        self.directory
-            .hot_cache
-            .size()
-            .saturating_add(self.directory.chunk_cache.size())
+        self.directory.hot_cache.size()
     }
 }
 
@@ -1547,7 +1253,7 @@ impl CachedFtsStates {
             .retain(|cached| cached.connection.strong_count() > 0);
         while self.entries.len() > FTS_MAX_CACHED_CONNECTIONS
             || (self.entries.len() > 1
-                && self.resident_cache_bytes() > FTS_MAX_RETAINED_CACHE_BYTES)
+                && self.resident_cache_bytes() > fts_max_retained_cache_bytes())
         {
             self.entries.remove(0);
         }
@@ -1568,11 +1274,18 @@ impl CachedFtsStates {
         }
     }
 
-    fn insert(&mut self, state: CachedFtsState) {
+    fn insert(&mut self, state: CachedFtsState, byte_budget: usize) -> bool {
         self.entries
             .retain(|cached| !Weak::ptr_eq(&cached.connection, &state.connection));
+        if state.resident_cache_bytes() > byte_budget {
+            return false;
+        }
         self.entries.push(state);
         self.prune();
+        while self.entries.len() > 1 && self.resident_cache_bytes() > byte_budget {
+            self.entries.remove(0);
+        }
+        true
     }
 
     fn clear(&mut self) {
@@ -1619,6 +1332,26 @@ pub struct FtsIndexAttachment {
     /// `Mutex` provides exclusive access without requiring `IndexWriter` to be
     /// `Sync`; SQLite transaction rules already serialize writers.
     cached_writer: Arc<Mutex<Option<CachedFtsWriter>>>,
+    runtime_stats: Arc<FtsRuntimeStats>,
+}
+
+#[derive(Debug, Default)]
+struct FtsRuntimeStats {
+    tantivy_writer_constructions: AtomicUsize,
+    writer_cache_lookups: AtomicUsize,
+    writer_cache_hits: AtomicUsize,
+    writer_cache_validation_failures: AtomicUsize,
+    writer_cache_rollback_discards: AtomicUsize,
+    writer_cache_misses: AtomicUsize,
+    read_cache_lookups: AtomicUsize,
+    read_cache_hits: AtomicUsize,
+    read_cache_misses: AtomicUsize,
+    cache_admission_rejections: AtomicUsize,
+    full_snapshot_loads: AtomicUsize,
+    manifest_validation_hits: AtomicUsize,
+    manifest_validation_misses: AtomicUsize,
+    write_lease_acquisitions: AtomicUsize,
+    write_lease_rejections: AtomicUsize,
 }
 
 /// Supported tokenizer names for FTS indexes
@@ -1830,6 +1563,7 @@ impl FtsIndexAttachment {
             ngram_window,
             cached_state: Arc::new(RwLock::new(CachedFtsStates::default())),
             cached_writer: Arc::new(Mutex::new(None)),
+            runtime_stats: Arc::new(FtsRuntimeStats::default()),
         })
     }
 }
@@ -1838,13 +1572,14 @@ impl IndexMethodAttachment for FtsIndexAttachment {
     fn definition<'a>(&'a self) -> IndexMethodDefinition<'a> {
         IndexMethodDefinition {
             method_name: FTS_INDEX_METHOD_NAME,
+            table_name: &self.cfg.table_name,
             index_name: &self.cfg.index_name,
             patterns: &self.patterns,
             backing_btree: false,
             // Unordered match queries stream directly from Tantivy scorers.
             // UPDATE/DELETE must therefore collect stable rowids before writes.
             results_materialized: false,
-            mvcc_support: super::IndexMethodMvccSupport::Unsupported,
+            mvcc_support: super::IndexMethodMvccSupport::TransactionalBackingStore,
         }
     }
 
@@ -1925,17 +1660,41 @@ fn bounded_query_limit(limit: Option<i64>, live_docs: u64) -> usize {
     }
 }
 
-/// Check if a file's chunks should be cached.
-///
-/// The meta lock file is excluded because Tantivy calls `open_write` on it for every search query.
-/// Since `open_write` calls `delete` first, caching the lock file would trigger a full chunk cache
-/// scan on every query, causing significant overhead.
-fn can_cache_chunks(path: &Path) -> bool {
-    path.as_os_str().to_str() != Some(TANTIVY_META_LOCK_FILE)
-}
-
 /// Accumulated file metadata: path -> (chunk_no -> (blob_size, Option<blob_data>))
 type CatalogBuilder = HashMap<i64, (usize, Option<Vec<u8>>)>;
+type CachedFtsCheckout = (
+    HybridBTreeDirectory,
+    Index,
+    IndexReader,
+    Arc<tantivy::query::QueryParser>,
+    FtsControlRecord,
+);
+
+fn assemble_catalog_file(path: &Path, chunks: &CatalogBuilder) -> Result<Vec<u8>> {
+    let max_chunk =
+        chunks.keys().max().copied().ok_or_else(|| {
+            LimboError::Corrupt(format!("FTS file {} has no chunks", path.display()))
+        })?;
+    if max_chunk < 0 {
+        return Err(LimboError::Corrupt(format!(
+            "FTS file {} has a negative chunk number",
+            path.display()
+        )));
+    }
+    let total_size = chunks.values().map(|(size, _)| size).sum();
+    let mut assembled = Vec::with_capacity(total_size);
+    for chunk_no in 0..=max_chunk {
+        let Some((_, Some(data))) = chunks.get(&chunk_no) else {
+            return Err(LimboError::Corrupt(format!(
+                "FTS directory file {} is missing chunk {}",
+                path.display(),
+                chunk_no
+            )));
+        };
+        assembled.extend_from_slice(data);
+    }
+    Ok(assembled)
+}
 
 /// State machine for FTS cursor async operations
 #[derive(Debug)]
@@ -1944,23 +1703,24 @@ enum FtsState {
     Init,
     /// Rewinding cursor to start
     Rewinding,
+    /// Seeking the small control record for cross-transaction cache validation.
+    SeekingControl,
+    /// Advancing after the control-record seek returned `TryAdvance`.
+    AdvancingToControl,
+    /// Reading the control record's chunks without scanning directory files.
+    LoadingControl {
+        chunks: CatalogBuilder,
+        advance_pending: bool,
+    },
     /// Loading file catalog from BTree (metadata only, not content)
     /// This is the new catalog-first approach for HybridBTreeDirectory
     LoadingCatalog {
-        /// Hot files capture blob data during scan to avoid a second pass.
         catalog_builder: HashMap<PathBuf, CatalogBuilder>,
+        control_builder: CatalogBuilder,
         current_path: Option<PathBuf>,
-    },
-    /// Preloading essential files (meta.json and other hot files)
-    PreloadingEssentials {
-        /// Files that need to be preloaded
-        files_to_load: Vec<PathBuf>,
-        /// Files already loaded
-        loaded_files: HashMap<PathBuf, Vec<u8>>,
-        /// Current file being loaded
-        current_loading: Option<PathBuf>,
-        /// Current chunks being accumulated for the file being loaded
-        current_chunks: Vec<(i64, Vec<u8>)>,
+        /// The current record was captured and `cursor.next()` must finish
+        /// before it can be observed again.
+        advance_pending: bool,
     },
     /// Creating/opening Tantivy index
     CreatingIndex,
@@ -1986,12 +1746,6 @@ enum FtsState {
     },
     /// Performing the actual delete of a chunk
     DeletingChunk {
-        writes: PendingFlushes,
-        write_idx: usize,
-        path_str: String,
-    },
-    /// Advancing cursor after delete to check next record
-    AdvancingAfterDelete {
         writes: PendingFlushes,
         write_idx: usize,
         path_str: String,
@@ -2028,7 +1782,6 @@ impl FtsState {
                 | Self::AdvancingAfterSeek { .. }
                 | Self::CheckingChunkPath { .. }
                 | Self::DeletingChunk { .. }
-                | Self::AdvancingAfterDelete { .. }
                 | Self::SeekingWrite { .. }
                 | Self::InsertingWrite { .. }
         )
@@ -2109,8 +1862,9 @@ pub struct FtsCursor {
     shared_writer: Arc<Mutex<Option<CachedFtsWriter>>>,
     connection: Option<Arc<Connection>>,
     database_id: Option<usize>,
-    fts_dir_cursor: Option<BTreeCursor>,
+    fts_dir_cursor: Option<Box<dyn CursorTrait>>,
     btree_root_page: Option<i64>,
+    control: Option<FtsControlRecord>,
     hybrid_directory: Option<HybridBTreeDirectory>,
     index: Option<Index>,
     reader: Option<IndexReader>,
@@ -2125,10 +1879,11 @@ pub struct FtsCursor {
     /// True while `open_write` is driving the shared open state machine.
     /// Read state is never published or reused in this mode.
     opening_for_write: bool,
+    runtime_stats: Arc<FtsRuntimeStats>,
 }
 
 impl FtsCursor {
-    /// Creates a new FTS cursor from the attachment's configuration.
+    /// Creates a new FTS cursor with the given configuration.
     fn new(attachment: &FtsIndexAttachment) -> Self {
         let dir_table_name = format!(
             "{}fts_dir_{}",
@@ -2155,12 +1910,13 @@ impl FtsCursor {
             field_boosts,
             ngram_window: attachment.ngram_window,
             cached_parser: None,
-            shared_cache: attachment.cached_state.clone(),
-            shared_writer: attachment.cached_writer.clone(),
+            shared_cache: Arc::clone(&attachment.cached_state),
+            shared_writer: Arc::clone(&attachment.cached_writer),
             connection: None,
             database_id: None,
             fts_dir_cursor: None,
             btree_root_page: None,
+            control: None,
             hybrid_directory: None,
             index: None,
             reader: None,
@@ -2173,6 +1929,7 @@ impl FtsCursor {
             hit_pos: 0,
             current_pattern: FTS_PATTERN_SCORE,
             opening_for_write: false,
+            runtime_stats: Arc::clone(&attachment.runtime_stats),
         }
     }
 
@@ -2187,7 +1944,6 @@ impl FtsCursor {
         let index_name = format!("{}_key", self.dir_table_name);
 
         // Get root page for HybridBTreeDirectory
-        let pager = conn.get_pager_from_database_index(&database_id)?;
         let scratch = conn
             .with_schema(database_id, |schema| {
                 schema.get_index(&self.dir_table_name, &index_name).cloned()
@@ -2202,14 +1958,13 @@ impl FtsCursor {
 
         self.btree_root_page = Some(root_page);
 
-        let mut cursor = BTreeCursor::new(pager, root_page, 3);
-        cursor.index_info = Some(Arc::new(IndexInfo::new(
+        self.fts_dir_cursor = Some(open_index_cursor(
+            conn,
+            database_id,
+            &self.dir_table_name,
+            &index_name,
             [key_info(), key_info(), key_info()],
-            false,
-            3,
-            false,
-        )?));
-        self.fts_dir_cursor = Some(cursor);
+        )?);
         Ok(())
     }
 
@@ -2249,11 +2004,84 @@ impl FtsCursor {
         Arc::new(parser)
     }
 
+    fn checkout_cached_state(
+        &self,
+        context: &IndexMethodContext,
+        visible_control: Option<&FtsControlRecord>,
+    ) -> Option<CachedFtsCheckout> {
+        let conn = context.connection();
+        if conn.is_in_write_tx() {
+            return None;
+        }
+        let mut cache = self.shared_cache.write();
+        cache.prune();
+        let position = cache.connection_position(conn)?;
+        let cached = &cache.entries[position];
+        let same_snapshot = match (context.transaction_id(), cached.transaction_id) {
+            (Some(current), Some(cached)) => current == cached,
+            (None, None) => cached.snapshot_wal_pos.is_some_and(|snapshot_wal_pos| {
+                cached.directory.pager.wal_pos() == snapshot_wal_pos
+            }),
+            _ => false,
+        };
+        let same_manifest = visible_control.is_some_and(|control| {
+            control.index_incarnation == cached.control.index_incarnation
+                && control.manifest_generation == cached.control.manifest_generation
+        });
+        if !same_snapshot && !same_manifest {
+            if visible_control.is_some() {
+                cache.entries.remove(position);
+            }
+            return None;
+        }
+
+        let cached = cache.entries.remove(position);
+        let checkout = (
+            cached.directory.clone_with_fresh_pending(),
+            cached.index.clone(),
+            cached.reader.clone(),
+            Arc::clone(&cached.query_parser),
+            cached.control.clone(),
+        );
+        cache.entries.push(cached);
+        Some(checkout)
+    }
+
+    fn has_cached_state(&self, context: &IndexMethodContext) -> bool {
+        let conn = context.connection();
+        !conn.is_in_write_tx() && self.shared_cache.read().connection_position(conn).is_some()
+    }
+
+    fn install_cached_checkout(&mut self, checkout: CachedFtsCheckout) {
+        let (directory, index, reader, query_parser, control) = checkout;
+        self.runtime_stats
+            .read_cache_hits
+            .fetch_add(1, Ordering::Relaxed);
+        tracing::debug!("FTS open_read: using cached state (skipping catalog load)");
+        self.hybrid_directory = Some(directory);
+        self.control = Some(control);
+        self.index = Some(index);
+        self.searcher = Some(reader.searcher());
+        self.reader = Some(reader);
+        self.cached_parser = Some(query_parser);
+        self.state = FtsState::Ready;
+    }
+
     /// Restore a writer retained by the previous statement when its committed
     /// metadata still matches this transaction's backing B-tree view.
-    fn restore_cached_writer(&mut self, conn: &Arc<Connection>) -> Result<bool> {
-        let cached = self.shared_writer.lock().take();
-        let Some(cached) = cached else {
+    fn restore_cached_writer(&mut self, context: &IndexMethodContext) -> Result<bool> {
+        let conn = context.connection();
+        self.runtime_stats
+            .writer_cache_lookups
+            .fetch_add(1, Ordering::Relaxed);
+        let database_id = self.database_id.ok_or_else(|| {
+            LimboError::InternalError("FTS database id is not initialized".to_string())
+        })?;
+        let mut cached_writer = self.shared_writer.lock();
+        let Some(cached) = cached_writer.as_ref() else {
+            self.runtime_stats
+                .writer_cache_misses
+                .fetch_add(1, Ordering::Relaxed);
             return Ok(false);
         };
 
@@ -2261,15 +2089,54 @@ impl FtsCursor {
             .connection
             .upgrade()
             .is_some_and(|owner| Arc::ptr_eq(&owner, conn));
-        let metadata_matches = same_connection
-            && cached.directory.is_consistent_with_btree().map_err(|e| {
-                LimboError::InternalError(format!("FTS writer cache validation failed: {e}"))
-            })?;
+        let metadata_matches = if conn.mv_store_for_db(database_id).is_some() {
+            same_connection
+                && context.transaction_id().is_some()
+                && context.transaction_id() == cached.transaction_id
+        } else {
+            same_connection
+                && cached.transaction_id.is_none()
+                && cached
+                    .snapshot_wal_pos
+                    .is_some_and(|position| cached.directory.pager.wal_pos() == position)
+        };
         if !metadata_matches {
+            // A committed MVCC writer is retained until its small control
+            // record can be validated asynchronously by open_read().
+            if conn.mv_store_for_db(database_id).is_some()
+                && same_connection
+                && cached.transaction_id.is_none()
+            {
+                return Ok(false);
+            }
+            // The slot is shared by every connection. Only remove an entry
+            // this connection owns, or one whose owner is gone; a live writer
+            // owned by another connection stays cached for its owner.
+            let stale = if same_connection || cached.connection.strong_count() == 0 {
+                cached_writer.take()
+            } else {
+                None
+            };
+            drop(cached_writer);
+            self.runtime_stats
+                .writer_cache_validation_failures
+                .fetch_add(1, Ordering::Relaxed);
+            self.runtime_stats
+                .writer_cache_misses
+                .fetch_add(1, Ordering::Relaxed);
+            drop(stale);
             return Ok(false);
         }
 
+        let cached = cached_writer
+            .take()
+            .expect("validated cached writer must still be present");
+        drop(cached_writer);
+        self.runtime_stats
+            .writer_cache_hits
+            .fetch_add(1, Ordering::Relaxed);
         tracing::debug!("FTS open_write: reusing committed writer state");
+        self.control = Some(cached.control);
         self.hybrid_directory = Some(cached.directory);
         self.index = Some(cached.index);
         self.writer = Some(cached.writer);
@@ -2280,25 +2147,150 @@ impl FtsCursor {
         Ok(true)
     }
 
+    fn has_deferred_cached_writer(&self, context: &IndexMethodContext) -> bool {
+        let conn = context.connection();
+        self.shared_writer.lock().as_ref().is_some_and(|cached| {
+            cached.transaction_id.is_none()
+                && cached
+                    .connection
+                    .upgrade()
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, conn))
+        })
+    }
+
+    fn checkout_validated_cached_writer(
+        &mut self,
+        context: &IndexMethodContext,
+        visible_control: &FtsControlRecord,
+    ) -> bool {
+        let conn = context.connection();
+        let mut cached_writer = self.shared_writer.lock();
+        let Some(cached) = cached_writer.as_ref() else {
+            return false;
+        };
+        let owner = cached.connection.upgrade();
+        let same_connection = owner.as_ref().is_some_and(|owner| Arc::ptr_eq(owner, conn));
+        let deferred = cached.transaction_id.is_none();
+        let matches_control = cached.control.index_incarnation == visible_control.index_incarnation
+            && cached.control.manifest_generation == visible_control.manifest_generation;
+        if !(same_connection && deferred && matches_control) {
+            // A dead owner, or a committed writer the committed control record
+            // has moved past, can never be reused by anyone: remove it. A live
+            // writer owned by another connection stays cached for its owner.
+            let stale = if owner.is_none() || (deferred && !matches_control) {
+                cached_writer.take()
+            } else {
+                None
+            };
+            drop(cached_writer);
+            self.runtime_stats
+                .writer_cache_validation_failures
+                .fetch_add(1, Ordering::Relaxed);
+            self.runtime_stats
+                .writer_cache_misses
+                .fetch_add(1, Ordering::Relaxed);
+            drop(stale);
+            return false;
+        }
+
+        let cached = cached_writer
+            .take()
+            .expect("validated cached writer must still be present");
+        drop(cached_writer);
+        self.runtime_stats
+            .writer_cache_hits
+            .fetch_add(1, Ordering::Relaxed);
+        self.control = Some(cached.control);
+        self.hybrid_directory = Some(cached.directory);
+        self.index = Some(cached.index);
+        self.writer = Some(cached.writer);
+        self.reader = None;
+        self.searcher = None;
+        self.cached_parser = None;
+        self.state = FtsState::Ready;
+        true
+    }
+
+    fn discard_deferred_cached_writer(&self, context: &IndexMethodContext) {
+        let conn = context.connection();
+        let mut cached_writer = self.shared_writer.lock();
+        // A missing control record proves this connection's deferred writer is
+        // stale. The slot is shared by every connection, so a live writer
+        // owned by another connection stays cached for its owner.
+        let discard =
+            cached_writer
+                .as_ref()
+                .is_some_and(|cached| match cached.connection.upgrade() {
+                    None => true,
+                    Some(owner) => Arc::ptr_eq(&owner, conn) && cached.transaction_id.is_none(),
+                });
+        if !discard {
+            return;
+        }
+        let stale = cached_writer.take();
+        drop(cached_writer);
+        self.runtime_stats
+            .writer_cache_validation_failures
+            .fetch_add(1, Ordering::Relaxed);
+        self.runtime_stats
+            .writer_cache_misses
+            .fetch_add(1, Ordering::Relaxed);
+        drop(stale);
+    }
+
     /// Retain a fully flushed writer for the next statement on this connection.
-    fn cache_writer(&mut self, conn: &Arc<Connection>) {
+    fn cache_writer(&mut self, context: &IndexMethodContext) {
+        let conn = context.connection();
         if self.pending_docs_count != 0 || !matches!(self.state, FtsState::Ready) {
+            tracing::trace!(
+                pending_documents = self.pending_docs_count,
+                state = ?self.state,
+                "FTS writer cache: cursor is not fully prepared"
+            );
             return;
         }
         let Some(directory) = self.hybrid_directory.as_ref() else {
+            tracing::trace!("FTS writer cache: directory is not initialized");
             return;
         };
+        let retained_read_bytes = self.shared_cache.read().resident_cache_bytes();
+        if directory
+            .hot_cache
+            .size()
+            .saturating_add(retained_read_bytes)
+            > fts_max_retained_cache_bytes()
+        {
+            self.runtime_stats
+                .cache_admission_rejections
+                .fetch_add(1, Ordering::Relaxed);
+            tracing::debug!(
+                resident_bytes = directory.hot_cache.size(),
+                budget_bytes = fts_max_retained_cache_bytes(),
+                "FTS writer cache: snapshot exceeds retention budget"
+            );
+            return;
+        }
         // Index creation and failed statements can close a cursor before all
         // directory mutations enter the normal document flush state machine.
         // Such a writer is not reusable.
         if !directory.pending_mutations.read().by_path.is_empty()
             || !directory.flushing_writes.read().is_empty()
         {
+            tracing::trace!("FTS writer cache: directory still has pending mutations");
             return;
         }
-        let Some(writer) = self.writer.take() else {
+        if self.writer.is_none() {
+            tracing::trace!("FTS writer cache: cursor has no writer");
+            return;
+        }
+        // Keep `self.control` set: `transaction_committed` compares it against
+        // the cached writer's control record before re-stamping the WAL
+        // position.
+        let Some(control) = self.control.clone() else {
+            tracing::error!("FTS writer cache: control record is not initialized");
             return;
         };
+        let writer = self.writer.take().expect("writer checked above");
         let index = self
             .index
             .take()
@@ -2307,9 +2299,14 @@ impl FtsCursor {
             .hybrid_directory
             .take()
             .expect("FTS writer must have an initialized directory");
+        let wal_pos = directory.pager.wal_pos();
+        let snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
 
         let previous = self.shared_writer.lock().replace(CachedFtsWriter {
             connection: Arc::downgrade(conn),
+            transaction_id: context.transaction_id(),
+            snapshot_wal_pos,
+            control,
             directory,
             index,
             writer,
@@ -2553,41 +2550,18 @@ impl FtsCursor {
                     // Perform the delete - if IO is needed, we'll come back to this state
                     return_if_io!(cursor.delete());
 
-                    // Delete completed, advance cursor to next record before checking again
-                    self.state = FtsState::AdvancingAfterDelete {
+                    // Re-seek from the logical prefix after every delete.
+                    // B-tree deletion may retreat, preserve, or advance the
+                    // physical cursor depending on balancing; calling next()
+                    // can therefore skip a sibling value for the same
+                    // (path, chunk_no) prefix. Re-seeking is unambiguous and
+                    // enforces one logical value even though bytes remain a
+                    // physical key column.
+                    self.state = FtsState::SeekingOldChunks {
                         writes: std::mem::take(writes),
                         write_idx: *write_idx,
                         path_str: std::mem::take(path_str),
                     };
-                }
-                FtsState::AdvancingAfterDelete {
-                    writes,
-                    write_idx,
-                    path_str,
-                } => {
-                    let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
-                        LimboError::InternalError("cursor not initialized".into())
-                    })?;
-
-                    // Advance cursor to next record after delete
-                    return_if_io!(cursor.next());
-                    let has_next = cursor.has_record();
-
-                    if has_next {
-                        // Check the next record in CheckingChunkPath state
-                        self.state = FtsState::CheckingChunkPath {
-                            writes: std::mem::take(writes),
-                            write_idx: *write_idx,
-                            path_str: std::mem::take(path_str),
-                        };
-                    } else {
-                        // No more records, start writing
-                        self.state = FtsState::FlushingWrites {
-                            writes: std::mem::take(writes),
-                            write_idx: *write_idx,
-                            chunk_idx: None, // Ready to start from chunk 0
-                        };
-                    }
                 }
                 FtsState::SeekingWrite {
                     writes,
@@ -2627,18 +2601,58 @@ impl FtsCursor {
 
                     // Seek to find the correct position using GE (not eq_only)
                     // This positions the cursor at or after where the record should be inserted
-                    let _result = return_if_io!(cursor.seek(
+                    let seek_result = return_if_io!(cursor.seek(
                         SeekKey::IndexKey(record.as_record_ref()),
                         SeekOp::GE { eq_only: false },
                     ));
 
-                    // don't do insert in same state to avoid re-seeking on IO
-                    self.state = FtsState::InsertingWrite {
-                        writes: std::mem::take(writes),
-                        write_idx: *write_idx,
-                        chunk_idx: actual_chunk_idx,
-                        record,
-                    };
+                    let exact_key_exists =
+                        if matches!(seek_result, SeekResult::Found) && cursor.has_record() {
+                            return_if_io!(cursor.record()).is_some_and(|existing| {
+                                let existing_path =
+                                    existing.get_value_opt(0).and_then(|value| match value {
+                                        crate::types::ValueRef::Text(text) => Some(text.value),
+                                        _ => None,
+                                    });
+                                let existing_chunk =
+                                    existing.get_value_opt(1).and_then(|value| match value {
+                                        crate::types::ValueRef::Numeric(
+                                            crate::numeric::Numeric::Integer(value),
+                                        ) => Some(value),
+                                        _ => None,
+                                    });
+                                let existing_bytes =
+                                    existing.get_value_opt(2).and_then(|value| match value {
+                                        crate::types::ValueRef::Blob(bytes) => Some(bytes),
+                                        _ => None,
+                                    });
+                                existing_path == Some(path_str.as_str())
+                                    && existing_chunk == Some(actual_chunk_idx as i64)
+                                    && existing_bytes == Some(chunk_data)
+                            })
+                        } else {
+                            false
+                        };
+
+                    if exact_key_exists {
+                        // Resumption or a previously duplicated physical row
+                        // may leave the exact full key present. Treat the
+                        // logical write as idempotent instead of inserting a
+                        // second identical `(path, chunk_no, bytes)` key.
+                        self.state = FtsState::FlushingWrites {
+                            writes: std::mem::take(writes),
+                            write_idx: *write_idx,
+                            chunk_idx: Some(actual_chunk_idx + 1),
+                        };
+                    } else {
+                        // Don't do insert in the same state to avoid re-seeking on I/O.
+                        self.state = FtsState::InsertingWrite {
+                            writes: std::mem::take(writes),
+                            write_idx: *write_idx,
+                            chunk_idx: actual_chunk_idx,
+                            record,
+                        };
+                    }
                 }
                 FtsState::InsertingWrite {
                     writes,
@@ -2685,6 +2699,7 @@ impl FtsCursor {
         }
 
         // Commit Tantivy to make documents visible
+        let mut committed_writer = false;
         if let Some(ref mut writer) = self.writer {
             tracing::debug!(
                 "FTS commit_and_flush: committing {} documents",
@@ -2697,6 +2712,7 @@ impl FtsCursor {
                 LimboError::InternalError("FTS directory not initialized".to_string())
             })?;
             Self::commit_writer_with_maintenance(index, writer, directory)?;
+            committed_writer = true;
 
             // The cached reader belongs to the previous index snapshot.
             if let Some(conn) = &self.connection {
@@ -2706,6 +2722,9 @@ impl FtsCursor {
                     cache.remove_connection(conn);
                 }
             }
+        }
+        if committed_writer {
+            self.stage_control_record()?;
         }
         if let Some(ref reader) = self.reader {
             reader
@@ -2888,161 +2907,71 @@ impl FtsCursor {
             .map_err(|e| LimboError::InternalError(format!("FTS maintenance merge commit: {e}")))?;
         Ok(())
     }
+
+    fn stage_control_record(&mut self) -> Result<()> {
+        let directory = self.hybrid_directory.as_ref().ok_or_else(|| {
+            LimboError::InternalError("FTS directory not initialized".to_string())
+        })?;
+        let index_incarnation = self
+            .control
+            .as_ref()
+            .map(|control| control.index_incarnation)
+            // A never-written index carries the placeholder incarnation; the
+            // first staged control record mints the real one.
+            .filter(|&incarnation| incarnation != FTS_EMPTY_INDEX_INCARNATION)
+            .or_else(|| {
+                self.btree_root_page.map(|root_page| {
+                    let nonce = NEXT_FTS_INDEX_INCARNATION.fetch_add(1, Ordering::Relaxed);
+                    // The placeholder value marks "never written": never mint it.
+                    ((root_page as u64).rotate_left(32) ^ nonce).max(1)
+                })
+            })
+            .ok_or_else(|| {
+                LimboError::InternalError("FTS backing root is not initialized".to_string())
+            })?;
+        let control = FtsControlRecord::from_catalog(
+            self.control.as_ref(),
+            index_incarnation,
+            &directory.catalog.read(),
+        )?;
+        directory.queue_write(PathBuf::from(FTS_CONTROL_PATH), control.encode()?);
+        self.control = Some(control);
+        Ok(())
+    }
 }
 
 impl Drop for FtsCursor {
     fn drop(&mut self) {
-        // Skip cleanup if we're already panicking
-        if crate::thread::panicking() {
-            return;
-        }
-
-        // Get connection reference for transaction check and pager access
-        let conn = match &self.connection {
-            Some(conn) => conn.clone(),
-            None => {
-                if self.pending_docs_count > 0 {
-                    tracing::warn!(
-                        "FTS Drop: {} pending documents lost (no connection)",
-                        self.pending_docs_count
-                    );
-                }
-                return;
-            }
-        };
-
-        let pager = conn.pager.load().clone();
-
-        // Check if we're already in a flushing state (from commit_and_flush)
-        // This can happen when commit_and_flush started a flush but yielded for IO
-        // and the cursor is being dropped before the flush completed
-        if self.state.is_flushing() {
-            turso_assert!(
-                conn.is_in_write_tx(),
-                "FTS Drop: in-progress flush abandoned (transaction already committed). pre_commit should have completed the flush."
+        let is_flushing = self.state.is_flushing();
+        if self.pending_docs_count != 0 || is_flushing {
+            tracing::error!(
+                pending_documents = self.pending_docs_count,
+                is_flushing,
+                "FTS cursor dropped before explicit statement finalization"
             );
-
-            tracing::debug!("FTS Drop: completing in-progress flush");
-            loop {
-                match self.flush_writes_internal() {
-                    Ok(IOResult::Done(())) => {
-                        self.cache_writer(&conn);
-                        break;
-                    }
-                    Ok(IOResult::IO(_)) => {
-                        if let Err(e) = pager.io.step() {
-                            tracing::error!("FTS Drop: IO error during flush: {}", e);
-                            return;
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!("FTS Drop: error during flush: {}", e);
-                        return;
-                    }
-                }
-            }
-            return;
-        }
-
-        // Only flush new pending documents if we have any
-        if self.pending_docs_count == 0 {
-            self.cache_writer(&conn);
-            // Query execution may have populated file caches after checkout.
-            // Enforce the aggregate retention budget when the cursor releases
-            // its snapshot.
-            self.shared_cache.write().prune();
-            return;
-        }
-
-        // If the transaction has already committed (auto-commit), flushing to BTree
-        // would create dirty pages outside of any transaction, causing the
-        // "dirty pages must be empty for read txn" panic on the next read.
-        turso_assert!(
-            conn.is_in_write_tx(),
-            "FTS Drop: transaction already committed, cannot flush",
-            { "pending_docs_count": self.pending_docs_count }
-        );
-
-        // Commit any pending writes to Tantivy
-        if let Some(ref mut writer) = self.writer {
-            let Some(ref index) = self.index else {
-                tracing::error!("FTS Drop: index not initialized");
-                return;
-            };
-            let Some(ref directory) = self.hybrid_directory else {
-                tracing::error!("FTS Drop: directory not initialized");
-                return;
-            };
-            if let Err(e) = Self::commit_writer_with_maintenance(index, writer, directory) {
-                tracing::error!("FTS Drop: failed to commit writer: {}", e);
-                return;
-            }
-
-            // Invalidate the read state for the previous index snapshot.
-            // This MUST happen after commit but before we check for pending writes
-            // to ensure the next cursor loads fresh data from BTree
-            {
-                let mut cache = self.shared_cache.write();
-                if cache.connection_position(&conn).is_some() {
-                    tracing::debug!("FTS Drop: invalidating cached read state");
-                    cache.remove_connection(&conn);
-                }
-            }
-        }
-
-        let Some(ref dir) = self.hybrid_directory else {
-            return;
-        };
-        let writes = dir.take_pending_flushes();
-
-        if writes.is_empty() {
-            return;
-        }
-
-        tracing::debug!(
-            "FTS Drop: blocking flush of {} files to BTree",
-            writes.len()
-        );
-
-        // Set up flush state machine
-        self.state = FtsState::FlushingWrites {
-            writes,
-            write_idx: 0,
-            chunk_idx: Some(0),
-        };
-
-        // Run blocking flush
-        loop {
-            match self.flush_writes_internal() {
-                Ok(IOResult::Done(())) => {
-                    self.cache_writer(&conn);
-                    break;
-                }
-                Ok(IOResult::IO(_)) => {
-                    if let Err(e) = pager.io.step() {
-                        tracing::error!("FTS Drop: IO error during flush: {}", e);
-                        return;
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("FTS Drop: error during flush: {}", e);
-                    return;
-                }
-            }
+            debug_assert!(
+                crate::thread::panicking(),
+                "FTS cursor dropped with pending persistence work"
+            );
         }
     }
 }
 
 impl IndexMethodCursor for FtsCursor {
     /// Creates the FTS index storage (internal BTree table for Tantivy files).
-    fn create(&mut self, conn: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>> {
+    fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let conn = context.connection();
+        let database_id = context.database().id;
         self.database_id = Some(database_id);
         initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
-        Ok(IOResult::Done(()))
+        return_if_io!(self.open_write(context));
+        self.commit_and_flush_inner(true)
     }
 
     /// Destroys the FTS index, dropping all storage and clearing caches.
-    fn destroy(&mut self, conn: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>> {
+    fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let conn = context.connection();
+        let database_id = context.database().id;
         self.database_id = Some(database_id);
         tracing::debug!(
             "FTS destroy: dropping internal storage {}",
@@ -3056,6 +2985,7 @@ impl IndexMethodCursor for FtsCursor {
         self.index = None;
         self.hybrid_directory = None;
         self.fts_dir_cursor = None;
+        self.control = None;
 
         // Invalidate cached read state.
         {
@@ -3095,90 +3025,198 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Opens the index for reading, loading the catalog and creating a searcher.
     /// Uses async state machine for non-blocking IO during catalog/file loading.
-    fn open_read(&mut self, conn: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>> {
+    fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let conn = context.connection();
+        let database_id = context.database().id;
         self.database_id = Some(database_id);
         loop {
             match &mut self.state {
                 FtsState::Init => {
+                    if !self.opening_for_write {
+                        self.runtime_stats
+                            .read_cache_lookups
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
                     self.connection = Some(conn.clone());
                     // Ensure storage table exists
                     initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
                     // Open BTree cursor (needed for btree_root_page)
                     self.open_cursor(conn, database_id)?;
 
-                    // Check for cached read state. Caches are never published
-                    // or consumed during a write transaction, so rollback and
-                    // savepoint rollback cannot leave uncommitted Tantivy
-                    // state reusable. For committed snapshots, the pager's WAL
-                    // position is an O(1) cache identity. Pagers without a WAL
-                    // identity fall back to comparing meta.json bytes.
-                    let cached_hit = {
-                        let mut cache = self.shared_cache.write();
-                        cache.prune();
-                        if let Some(position) = cache.connection_position(conn) {
-                            if conn.is_in_write_tx() {
-                                tracing::debug!(
-                                    "FTS open_read: bypassing shared cache in write transaction"
-                                );
-                                None
-                            } else {
-                                let cached = &cache.entries[position];
-                                let snapshot_matches = if let Some(snapshot_wal_pos) =
-                                    cached.snapshot_wal_pos
-                                {
-                                    cached.directory.pager.wal_pos() == snapshot_wal_pos
-                                } else {
-                                    cached.directory.is_consistent_with_btree().map_err(|e| {
-                                        LimboError::InternalError(format!(
-                                            "FTS cache validation failed: {e}"
-                                        ))
-                                    })?
-                                };
-                                if snapshot_matches {
-                                    let cached = cache.entries.remove(position);
-                                    let hit = (
-                                        cached.directory.clone_with_fresh_pending(),
-                                        cached.index.clone(),
-                                        cached.reader.clone(),
-                                        Arc::clone(&cached.query_parser),
-                                    );
-                                    // Move the successful checkout to the MRU end.
-                                    cache.entries.push(cached);
-                                    Some(hit)
-                                } else {
-                                    tracing::debug!(
-                                    "FTS open_read: cached directory is stale (snapshot diverged), reloading"
-                                );
-                                    cache.entries.remove(position);
-                                    None
-                                }
-                            }
-                        } else {
-                            None
-                        }
-                    };
-                    if let Some((directory, index, reader, query_parser)) = cached_hit {
-                        tracing::debug!(
-                            "FTS open_read: using cached state (skipping catalog load)"
-                        );
-                        self.hybrid_directory = Some(directory);
-                        if self.opening_for_write {
-                            // A writer needs an Index whose Directory owns
-                            // cursor-local pending state.
-                            self.state = FtsState::CreatingIndex;
-                            continue;
-                        }
-
-                        self.index = Some(index);
-                        self.searcher = Some(reader.searcher());
-                        self.reader = Some(reader);
-                        self.cached_parser = Some(query_parser);
-                        self.state = FtsState::Ready;
+                    // A cache entry from the exact same snapshot can be used
+                    // immediately. A cache from an older snapshot is retained
+                    // until the small transactional control record has been
+                    // read asynchronously and its identity validated.
+                    if let Some(checkout) = self.checkout_cached_state(context, None) {
+                        self.install_cached_checkout(checkout);
                         return Ok(IOResult::Done(()));
                     }
 
-                    // No cache available, proceed with full catalog loading
-                    self.state = FtsState::Rewinding;
+                    self.state = if self.has_cached_state(context)
+                        || (self.opening_for_write && self.has_deferred_cached_writer(context))
+                    {
+                        FtsState::SeekingControl
+                    } else {
+                        if !self.opening_for_write {
+                            self.runtime_stats
+                                .read_cache_misses
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
+                        FtsState::Rewinding
+                    };
+                }
+                FtsState::SeekingControl => {
+                    let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
+                        LimboError::InternalError("cursor not initialized".into())
+                    })?;
+                    let seek_key = ImmutableRecord::from_values(
+                        &[
+                            Value::Text(Text::new(FTS_CONTROL_PATH.to_string())),
+                            Value::from_i64(0),
+                            Value::Blob(crate::alloc::vec![]),
+                        ],
+                        3,
+                    )?;
+                    let seek_result = return_if_io!(cursor.seek(
+                        SeekKey::IndexKey(seek_key.as_record_ref()),
+                        SeekOp::GE { eq_only: false },
+                    ));
+                    self.state = match seek_result {
+                        SeekResult::NotFound => {
+                            if self.opening_for_write {
+                                self.discard_deferred_cached_writer(context);
+                            }
+                            FtsState::Rewinding
+                        }
+                        SeekResult::TryAdvance => FtsState::AdvancingToControl,
+                        SeekResult::Found => FtsState::LoadingControl {
+                            chunks: HashMap::default(),
+                            advance_pending: false,
+                        },
+                    };
+                }
+                FtsState::AdvancingToControl => {
+                    let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
+                        LimboError::InternalError("cursor not initialized".into())
+                    })?;
+                    return_if_io!(cursor.next());
+                    self.state = if cursor.has_record() {
+                        FtsState::LoadingControl {
+                            chunks: HashMap::default(),
+                            advance_pending: false,
+                        }
+                    } else {
+                        if self.opening_for_write {
+                            self.discard_deferred_cached_writer(context);
+                        }
+                        FtsState::Rewinding
+                    };
+                }
+                FtsState::LoadingControl {
+                    chunks,
+                    advance_pending,
+                } => {
+                    let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
+                        LimboError::InternalError("cursor not initialized".into())
+                    })?;
+                    if *advance_pending {
+                        return_if_io!(cursor.next());
+                        *advance_pending = false;
+                        continue;
+                    }
+
+                    let mut finished = !cursor.has_record();
+                    if !finished {
+                        let record = return_if_io!(cursor.record()).ok_or_else(|| {
+                            LimboError::Corrupt("FTS cursor has no record payload".into())
+                        })?;
+                        let path = record
+                            .get_value_opt(0)
+                            .and_then(|value| match value {
+                                crate::types::ValueRef::Text(text) => Some(text.value),
+                                _ => None,
+                            })
+                            .ok_or_else(|| {
+                                LimboError::Corrupt("FTS chunk path is not text".into())
+                            })?;
+                        finished = path != FTS_CONTROL_PATH;
+                        if !finished {
+                            let chunk_no = record
+                                .get_value_opt(1)
+                                .and_then(|value| match value {
+                                    crate::types::ValueRef::Numeric(
+                                        crate::numeric::Numeric::Integer(value),
+                                    ) => Some(value),
+                                    _ => None,
+                                })
+                                .ok_or_else(|| {
+                                    LimboError::Corrupt(
+                                        "FTS control chunk number is not an integer".into(),
+                                    )
+                                })?;
+                            let blob = record
+                                .get_value_opt(2)
+                                .and_then(|value| match value {
+                                    crate::types::ValueRef::Blob(blob) => Some(blob.to_vec()),
+                                    _ => None,
+                                })
+                                .ok_or_else(|| {
+                                    LimboError::Corrupt(
+                                        "FTS control chunk payload is not a blob".into(),
+                                    )
+                                })?;
+                            if chunks.insert(chunk_no, (blob.len(), Some(blob))).is_some() {
+                                return Err(LimboError::Corrupt(format!(
+                                    "duplicate FTS control chunk {chunk_no}"
+                                )));
+                            }
+                            *advance_pending = true;
+                        }
+                    }
+
+                    if finished {
+                        if chunks.is_empty() {
+                            if self.opening_for_write {
+                                self.discard_deferred_cached_writer(context);
+                            }
+                            self.runtime_stats
+                                .manifest_validation_misses
+                                .fetch_add(1, Ordering::Relaxed);
+                            if !self.opening_for_write {
+                                self.runtime_stats
+                                    .read_cache_misses
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                            self.state = FtsState::Rewinding;
+                            continue;
+                        }
+                        let control_chunks = std::mem::take(chunks);
+                        let control_bytes =
+                            assemble_catalog_file(Path::new(FTS_CONTROL_PATH), &control_chunks)?;
+                        let control = FtsControlRecord::decode(&control_bytes)?;
+                        if self.opening_for_write
+                            && self.checkout_validated_cached_writer(context, &control)
+                        {
+                            return Ok(IOResult::Done(()));
+                        }
+                        if let Some(checkout) = self.checkout_cached_state(context, Some(&control))
+                        {
+                            self.runtime_stats
+                                .manifest_validation_hits
+                                .fetch_add(1, Ordering::Relaxed);
+                            self.install_cached_checkout(checkout);
+                            return Ok(IOResult::Done(()));
+                        }
+                        self.runtime_stats
+                            .manifest_validation_misses
+                            .fetch_add(1, Ordering::Relaxed);
+                        if !self.opening_for_write {
+                            self.runtime_stats
+                                .read_cache_misses
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
+                        self.state = FtsState::Rewinding;
+                    }
                 }
                 FtsState::Rewinding => {
                     let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
@@ -3188,225 +3226,150 @@ impl IndexMethodCursor for FtsCursor {
                     // Use catalog-first loading for HybridBTreeDirectory
                     self.state = FtsState::LoadingCatalog {
                         catalog_builder: HashMap::default(),
+                        control_builder: HashMap::default(),
                         current_path: None,
+                        advance_pending: false,
                     };
                 }
                 FtsState::LoadingCatalog {
                     catalog_builder,
+                    control_builder,
                     current_path,
+                    advance_pending,
                 } => {
                     let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
                         LimboError::InternalError("cursor not initialized".into())
                     })?;
 
+                    if *advance_pending {
+                        return_if_io!(cursor.next());
+                        *advance_pending = false;
+                        continue;
+                    }
+
                     if !cursor.has_record() {
-                        // Done scanning: build catalog and assemble hot files in single pass
+                        self.runtime_stats
+                            .full_snapshot_loads
+                            .fetch_add(1, Ordering::Relaxed);
+                        // Done scanning: build a complete file snapshot before Tantivy can run.
                         let mut catalog = HashMap::default();
-                        let mut hot_files: HashMap<PathBuf, Vec<u8>> = HashMap::default();
-                        let mut files_to_load = Vec::new();
+                        let mut files: HashMap<PathBuf, Vec<u8>> = HashMap::default();
 
                         for (path, chunks) in catalog_builder.drain() {
-                            let max_chunk = chunks.keys().max().copied().unwrap_or(0);
+                            let max_chunk = chunks
+                                .keys()
+                                .max()
+                                .copied()
+                                .expect("catalog builder entries have chunks");
                             let total_size: usize = chunks.values().map(|(size, _)| size).sum();
                             let num_chunks = (max_chunk + 1) as usize;
                             let metadata = FileMetadata::new(&path, total_size, num_chunks);
-
-                            if metadata.category.is_hot() {
-                                // Try to assemble from captured blob data
-                                let mut all_captured = true;
-                                let mut assembled = Vec::with_capacity(total_size);
-                                for chunk_no in 0..=(max_chunk) {
-                                    if let Some((_, Some(data))) = chunks.get(&chunk_no) {
-                                        assembled.extend_from_slice(data);
-                                    } else {
-                                        all_captured = false;
-                                        break;
-                                    }
-                                }
-                                if all_captured {
-                                    hot_files.insert(path.clone(), assembled);
-                                } else {
-                                    files_to_load.push(path.clone());
-                                }
-                            } else if metadata.category.should_preload() {
-                                files_to_load.push(path.clone());
-                            }
-
+                            let assembled = assemble_catalog_file(&path, &chunks)?;
+                            files.insert(path.clone(), assembled);
                             catalog.insert(path, metadata);
                         }
 
+                        let control = if control_builder.is_empty() {
+                            if catalog.is_empty() {
+                                Some(FtsControlRecord::new(FTS_EMPTY_INDEX_INCARNATION))
+                            } else {
+                                return Err(LimboError::Corrupt(
+                                    "FTS storage predates control-record format v1; rebuild the index"
+                                        .into(),
+                                ));
+                            }
+                        } else {
+                            let control_bytes = assemble_catalog_file(
+                                Path::new(FTS_CONTROL_PATH),
+                                control_builder,
+                            )?;
+                            let control = FtsControlRecord::decode(&control_bytes)?;
+                            control.validate_catalog(&catalog)?;
+                            Some(control)
+                        };
+                        self.control = control;
+
                         tracing::debug!(
-                            "FTS LoadingCatalog: found {} files, {} hot assembled, {} to preload",
+                            "FTS LoadingCatalog: preloaded {} files ({} bytes)",
                             catalog.len(),
-                            hot_files.len(),
-                            files_to_load.len()
+                            files.values().map(Vec::len).sum::<usize>()
                         );
 
-                        // Create HybridBTreeDirectory with catalog and pre-assembled hot files
                         let pager = conn.get_pager_from_database_index(&database_id)?;
                         let root_page = self.btree_root_page.ok_or_else(|| {
                             LimboError::InternalError("btree_root_page not set".into())
                         })?;
 
-                        let hybrid_dir = HybridBTreeDirectory::with_preloaded(
-                            pager,
-                            root_page,
-                            catalog,
-                            hot_files,
-                            DEFAULT_HOT_CACHE_BYTES,
-                            DEFAULT_CHUNK_CACHE_BYTES,
-                        );
+                        let hybrid_dir =
+                            HybridBTreeDirectory::with_preloaded(pager, root_page, catalog, files);
                         self.hybrid_directory = Some(hybrid_dir);
-
-                        if files_to_load.is_empty() {
-                            // All hot files assembled in single pass, skip PreloadingEssentials
-                            self.state = FtsState::CreatingIndex;
-                        } else {
-                            self.state = FtsState::PreloadingEssentials {
-                                files_to_load,
-                                loaded_files: HashMap::default(),
-                                current_loading: None,
-                                current_chunks: Vec::new(),
-                            };
-                        }
+                        self.state = FtsState::CreatingIndex;
                         continue;
                     }
 
-                    // Read record metadata and capture hot file blobs in single pass
+                    // Capture every blob while storage I/O is under the cursor state machine.
                     let record = return_if_io!(cursor.record());
-                    if let Some(record) = record {
-                        let path_str = record.get_value_opt(0).and_then(|v| match v {
+                    let record = record.ok_or_else(|| {
+                        LimboError::Corrupt("FTS cursor has no record payload".into())
+                    })?;
+                    let path_str = record
+                        .get_value_opt(0)
+                        .and_then(|v| match v {
                             crate::types::ValueRef::Text(t) => Some(t.value.to_string()),
                             _ => None,
-                        });
-                        let chunk_no = record.get_value_opt(1).and_then(|v| match v {
+                        })
+                        .ok_or_else(|| LimboError::Corrupt("FTS chunk path is not text".into()))?;
+                    let chunk_no = record
+                        .get_value_opt(1)
+                        .and_then(|v| match v {
                             crate::types::ValueRef::Numeric(crate::numeric::Numeric::Integer(
                                 i,
                             )) => Some(i),
                             _ => None,
-                        });
+                        })
+                        .ok_or_else(|| {
+                            LimboError::Corrupt("FTS chunk number is not an integer".into())
+                        })?;
+                    let blob = record
+                        .get_value_opt(2)
+                        .and_then(|v| match v {
+                            crate::types::ValueRef::Blob(blob) => Some(blob.to_vec()),
+                            _ => None,
+                        })
+                        .ok_or_else(|| {
+                            LimboError::Corrupt("FTS chunk payload is not a blob".into())
+                        })?;
 
-                        if let (Some(path_str), Some(chunk_no)) = (path_str, chunk_no) {
-                            // Reuse PathBuf when path hasn't changed (records are BTree-ordered)
-                            let path_buf = if current_path.as_ref().map(|p| p.as_os_str().to_str())
-                                == Some(Some(&path_str))
-                            {
-                                current_path.clone().unwrap()
-                            } else {
-                                let p = PathBuf::from(&path_str);
-                                *current_path = Some(p.clone());
-                                p
-                            };
+                    // Reuse PathBuf when path hasn't changed (records are BTree-ordered).
+                    let path_buf = if current_path.as_ref().map(|p| p.as_os_str().to_str())
+                        == Some(Some(&path_str))
+                    {
+                        current_path.clone().unwrap()
+                    } else {
+                        let path = PathBuf::from(&path_str);
+                        *current_path = Some(path.clone());
+                        path
+                    };
 
-                            // Classify file to decide whether to capture blob data
-                            let category = FileCategory::from_path(&path_buf);
-                            let (blob_size, blob_data) = record
-                                .get_value_opt(2)
-                                .map(|v| match v {
-                                    crate::types::ValueRef::Blob(b) => {
-                                        let size = b.len();
-                                        if category.is_hot() {
-                                            (size, Some(b.to_vec()))
-                                        } else {
-                                            (size, None)
-                                        }
-                                    }
-                                    _ => (0, None),
-                                })
-                                .unwrap_or((0, None));
-
-                            let chunks = catalog_builder.entry(path_buf).or_default();
-                            chunks.insert(chunk_no, (blob_size, blob_data));
-                        }
+                    let chunks = if path_buf == Path::new(FTS_CONTROL_PATH) {
+                        control_builder
+                    } else {
+                        catalog_builder.entry(path_buf.clone()).or_default()
+                    };
+                    if let Some((existing_size, existing_blob)) =
+                        chunks.insert(chunk_no, (blob.len(), Some(blob.clone())))
+                    {
+                        return Err(LimboError::Corrupt(format!(
+                            "duplicate FTS chunk {}:{} (existing_size={}, new_size={}, equal={})",
+                            path_buf.display(),
+                            chunk_no,
+                            existing_size,
+                            blob.len(),
+                            existing_blob.as_deref() == Some(blob.as_slice())
+                        )));
                     }
 
-                    return_if_io!(cursor.next());
-                }
-                FtsState::PreloadingEssentials {
-                    files_to_load,
-                    loaded_files,
-                    current_loading,
-                    current_chunks,
-                } => {
-                    // Use blocking file load from HybridBTreeDirectory
-                    let hybrid_dir = self.hybrid_directory.as_ref().ok_or_else(|| {
-                        LimboError::InternalError("hybrid_directory not initialized".into())
-                    })?;
-
-                    // If we're loading a file, continue with it
-                    if let Some(path) = current_loading.take() {
-                        // We loaded chunks, finalize the file
-                        if !current_chunks.is_empty() {
-                            current_chunks.sort_by_key(|(chunk_no, _)| *chunk_no);
-
-                            // Deduplicate
-                            let mut deduped: Vec<(i64, Vec<u8>)> = Vec::new();
-                            for (chunk_no, bytes) in current_chunks.drain(..) {
-                                if let Some(last) = deduped.last_mut() {
-                                    if last.0 == chunk_no {
-                                        *last = (chunk_no, bytes);
-                                    } else {
-                                        deduped.push((chunk_no, bytes));
-                                    }
-                                } else {
-                                    deduped.push((chunk_no, bytes));
-                                }
-                            }
-
-                            let data: Vec<u8> =
-                                deduped.iter().flat_map(|(_, b)| b.clone()).collect();
-                            loaded_files.insert(path.clone(), data.clone());
-
-                            // Add to hot cache
-                            hybrid_dir.add_to_hot_cache(path, data);
-                        }
-                    }
-
-                    // Check if we have more files to load
-                    if let Some(next_path) = files_to_load.pop() {
-                        // Load this file using blocking IO
-                        match hybrid_dir.load_file_blocking(&next_path) {
-                            Ok(data) => {
-                                loaded_files.insert(next_path.clone(), data.clone());
-                                hybrid_dir.add_to_hot_cache(next_path, data);
-                            }
-                            Err(e) => {
-                                let category = FileCategory::from_path(&next_path);
-                                // NotFound is expected for new empty indexes
-                                if e.kind() == std::io::ErrorKind::NotFound {
-                                    // Expected for new index, just log at debug level
-                                    tracing::debug!(
-                                        "FTS: preload skipped (not found): {}",
-                                        next_path.display()
-                                    );
-                                } else if category == FileCategory::Metadata {
-                                    // Metadata files are critical - propagate error
-                                    return Err(LimboError::InternalError(format!(
-                                        "FTS: failed to preload metadata file {}: {}",
-                                        next_path.display(),
-                                        e
-                                    )));
-                                } else {
-                                    // Non-critical file, warn but continue
-                                    tracing::warn!(
-                                        "FTS: could not preload {} ({:?}): {}",
-                                        next_path.display(),
-                                        category,
-                                        e
-                                    );
-                                }
-                            }
-                        }
-                        continue;
-                    }
-
-                    // All files loaded
-                    tracing::debug!(
-                        "FTS PreloadingEssentials: loaded {} files into hot cache",
-                        loaded_files.len()
-                    );
-                    self.state = FtsState::CreatingIndex;
-                    continue;
+                    *advance_pending = true;
                 }
                 FtsState::CreatingIndex => {
                     // Log loaded files for debugging
@@ -3445,15 +3408,36 @@ impl IndexMethodCursor for FtsCursor {
                         let snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
 
                         let mut cache = self.shared_cache.write();
-                        cache.insert(CachedFtsState {
-                            connection: Arc::downgrade(conn),
-                            snapshot_wal_pos,
-                            directory: dir.clone(),
-                            index: index.clone(),
-                            reader: reader.clone(),
-                            query_parser,
-                        });
+                        let control = self.control.clone().ok_or_else(|| {
+                            LimboError::InternalError("FTS control record not initialized".into())
+                        })?;
+                        let writer_bytes = self
+                            .shared_writer
+                            .lock()
+                            .as_ref()
+                            .map_or(0, |cached| cached.directory.hot_cache.size());
+                        let cache_budget =
+                            fts_max_retained_cache_bytes().saturating_sub(writer_bytes);
+                        let retained = cache.insert(
+                            CachedFtsState {
+                                connection: Arc::downgrade(conn),
+                                transaction_id: context.transaction_id(),
+                                snapshot_wal_pos,
+                                control,
+                                directory: dir.clone(),
+                                index: index.clone(),
+                                reader: reader.clone(),
+                                query_parser,
+                            },
+                            cache_budget,
+                        );
+                        if !retained {
+                            self.runtime_stats
+                                .cache_admission_rejections
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
                         tracing::debug!(
+                            retained,
                             cached_connections = cache.entries.len(),
                             "FTS CreatingIndex: cached read state for future queries"
                         );
@@ -3476,7 +3460,9 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Opens the index for writing, creating the IndexWriter.
     /// Calls `open_read` first if not already initialized.
-    fn open_write(&mut self, conn: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>> {
+    fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let conn = context.connection();
+        let database_id = context.database().id;
         self.database_id = Some(database_id);
         self.opening_for_write = true;
         if self.connection.is_none() {
@@ -3490,7 +3476,33 @@ impl IndexMethodCursor for FtsCursor {
 
         initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
         self.open_cursor(conn, database_id)?;
-        if self.restore_cached_writer(conn)? {
+        if let Some(mv_store) = conn.mv_store_for_db(database_id) {
+            let tx_id = conn.get_mv_tx_id_for_db(database_id).ok_or_else(|| {
+                LimboError::InternalError(
+                    "FTS write opened without an active MVCC transaction".to_string(),
+                )
+            })?;
+            let root_page = self.btree_root_page.ok_or_else(|| {
+                LimboError::InternalError("FTS backing root is not initialized".to_string())
+            })?;
+            let snapshot_ts = mv_store.read_snapshot_ts(tx_id);
+            let index_id = mv_store.get_table_id_from_root_page_at(root_page, snapshot_ts);
+            match mv_store.acquire_index_method_write_lease(tx_id, index_id) {
+                Ok(()) => {
+                    self.runtime_stats
+                        .write_lease_acquisitions
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                Err(err @ LimboError::WriteWriteConflict) => {
+                    self.runtime_stats
+                        .write_lease_rejections
+                        .fetch_add(1, Ordering::Relaxed);
+                    return Err(err);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        if self.restore_cached_writer(context)? {
             self.opening_for_write = false;
             return Ok(IOResult::Done(()));
         }
@@ -3499,11 +3511,15 @@ impl IndexMethodCursor for FtsCursor {
         match &self.state {
             FtsState::Ready => {}
             _ => {
-                let result = self.open_read(conn, database_id)?;
+                let result = self.open_read(context)?;
                 if let IOResult::IO(io) = result {
                     return Ok(IOResult::IO(io));
                 }
             }
+        }
+        if self.writer.is_some() {
+            self.opening_for_write = false;
+            return Ok(IOResult::Done(()));
         }
 
         let index = self
@@ -3511,6 +3527,9 @@ impl IndexMethodCursor for FtsCursor {
             .as_ref()
             .ok_or_else(|| LimboError::InternalError("FTS index not initialized".into()))?;
         // Use single-threaded mode to avoid concurrent access.
+        self.runtime_stats
+            .tantivy_writer_constructions
+            .fetch_add(1, Ordering::Relaxed);
         let writer = index
             .writer_with_num_threads(1, DEFAULT_MEMORY_BUDGET_BYTES)
             .map_err(|e| LimboError::InternalError(e.to_string()))?;
@@ -3859,7 +3878,7 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Flushes pending writes before transaction commit.
     /// This ensures FTS writes are persisted as part of the transaction.
-    fn pre_commit(&mut self) -> Result<IOResult<()>> {
+    fn prepare_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         // First, check if we're in the middle of a flush operation that needs to continue
         // This handles the case where commit_and_flush() returned IOResult::IO and we need
         // to continue the flush after IO completes
@@ -3877,13 +3896,139 @@ impl IndexMethodCursor for FtsCursor {
         Ok(IOResult::Done(()))
     }
 
+    fn abort_statement(&mut self, context: &IndexMethodContext) {
+        self.pending_docs_count = 0;
+        self.writer = None;
+        self.reader = None;
+        self.searcher = None;
+        self.index = None;
+        self.hybrid_directory = None;
+        self.fts_dir_cursor = None;
+        self.control = None;
+        self.cached_parser = None;
+        self.current_hits.clear();
+        self.streaming_hits = None;
+        self.shared_cache
+            .write()
+            .remove_connection(context.connection());
+        // The slot is shared by every connection: a failed statement here
+        // (e.g. the losing side of a lease conflict) must not evict another
+        // connection's writer. Only remove what this connection's failed
+        // statement could have produced: its own writer tagged with this
+        // transaction (both `None` in WAL mode). An MVCC deferred writer
+        // (`transaction_id == None`) predates this transaction, so it stays
+        // valid across this rollback. Entries with a dead owner are removed
+        // opportunistically.
+        let mut cached_writer = self.shared_writer.lock();
+        let (dead_owner, owned) = match cached_writer.as_ref() {
+            None => (false, false),
+            Some(cached) => match cached.connection.upgrade() {
+                None => (true, false),
+                Some(owner) => (
+                    false,
+                    Arc::ptr_eq(&owner, context.connection())
+                        && cached.transaction_id == context.transaction_id(),
+                ),
+            },
+        };
+        let stale = if dead_owner || owned {
+            cached_writer.take()
+        } else {
+            None
+        };
+        drop(cached_writer);
+        if owned {
+            self.runtime_stats
+                .writer_cache_rollback_discards
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        drop(stale);
+        self.state = FtsState::Init;
+    }
+
+    fn statement_committed(&mut self, context: &IndexMethodContext) {
+        self.cache_writer(context);
+    }
+
+    fn transaction_committed(&mut self, context: &IndexMethodContext) {
+        tracing::trace!(
+            index = context.index().index_name,
+            pending_documents = self.pending_docs_count,
+            state = ?self.state,
+            has_writer = self.writer.is_some(),
+            "FTS transaction outcome: committed"
+        );
+        self.cache_writer(context);
+        if let Some(transaction_id) = context.transaction_id() {
+            // The backing transaction is now committed, so its private writer
+            // may be considered by a future transaction only after validating
+            // the transactional control record.
+            if let Some(cached) = self.shared_writer.lock().as_mut() {
+                let same_connection = cached
+                    .connection
+                    .upgrade()
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, context.connection()));
+                if same_connection && cached.transaction_id == Some(transaction_id) {
+                    cached.transaction_id = None;
+                    cached.snapshot_wal_pos = None;
+                }
+            }
+        } else if let Some(cached) = self.shared_writer.lock().as_mut() {
+            // This hook also runs for read-only FTS cursors, and the shared
+            // slot can still hold an older writer (e.g. one a later statement
+            // failed to replace under the retention budget). Re-stamping a
+            // writer this commit did not produce or validate would make its
+            // stale segments pass WAL-position validation, losing documents
+            // committed since. Stamp only when this connection owns the writer
+            // and this cursor's control record matches it.
+            let same_connection = cached
+                .connection
+                .upgrade()
+                .is_some_and(|owner| Arc::ptr_eq(&owner, context.connection()));
+            let matches_cursor_control = self.control.as_ref().is_some_and(|control| {
+                control.index_incarnation == cached.control.index_incarnation
+                    && control.manifest_generation == cached.control.manifest_generation
+            });
+            if same_connection && matches_cursor_control {
+                let wal_pos = cached.directory.pager.wal_pos();
+                cached.snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
+            }
+        }
+        self.shared_cache.write().prune();
+    }
+
+    fn transaction_rolled_back(&mut self, context: &IndexMethodContext) {
+        self.abort_statement(context);
+    }
+
+    fn savepoint_rolled_back(&mut self, context: &IndexMethodContext) {
+        self.abort_statement(context);
+    }
+
+    fn close(&mut self, context: &IndexMethodContext) {
+        if self.pending_docs_count != 0 {
+            tracing::error!(
+                pending_documents = self.pending_docs_count,
+                "closing FTS cursor with unprepared writes"
+            );
+        }
+        self.writer = None;
+        self.reader = None;
+        self.searcher = None;
+        self.index = None;
+        self.hybrid_directory = None;
+        self.fts_dir_cursor = None;
+        self.cached_parser = None;
+        self.current_hits.clear();
+        self.streaming_hits = None;
+        let _ = context;
+        self.shared_cache.write().prune();
+    }
+
     /// Optimizes the FTS index by merging all segments into one.
     /// Call via `OPTIMIZE INDEX idx_name` SQL command.
-    fn optimize(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>> {
+    fn optimize(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let database_id = context.database().id;
         self.database_id = Some(database_id);
         // First ensure any pending documents are flushed
         if self.pending_docs_count > 0 {
@@ -3896,7 +4041,7 @@ impl IndexMethodCursor for FtsCursor {
 
         // If we're not open for writing, open it
         if self.writer.is_none() {
-            return_if_io!(self.open_write(connection, database_id));
+            return_if_io!(self.open_write(context));
         }
 
         let index = self
@@ -4062,12 +4207,91 @@ impl IndexMethodCursor for FtsCursor {
             .len();
 
         let cache = self.shared_cache.read();
+        let cached_writer_bytes = self
+            .shared_writer
+            .lock()
+            .as_ref()
+            .map_or(0, |cached| cached.directory.hot_cache.size());
+        let control = self.control.as_ref().ok_or_else(|| {
+            LimboError::InternalError("FTS control record not initialized".to_string())
+        })?;
         Ok(Some(super::IndexMethodTestStats {
+            storage_format_version: Some(FTS_CONTROL_FORMAT_VERSION),
+            index_incarnation: Some(control.index_incarnation),
+            manifest_generation: Some(control.manifest_generation),
+            manifest_file_count: Some(control.files.len()),
             storage_file_count: directory.catalog.read().len(),
             segment_count: Some(segment_count),
             cached_connection_count: Some(cache.entries.len()),
-            cached_bytes: Some(cache.resident_cache_bytes()),
+            cached_bytes: Some(
+                cache
+                    .resident_cache_bytes()
+                    .saturating_add(cached_writer_bytes),
+            ),
+            cache_admission_rejections: Some(
+                self.runtime_stats
+                    .cache_admission_rejections
+                    .load(Ordering::Relaxed),
+            ),
             cached_writer: Some(self.shared_writer.lock().is_some()),
+            tantivy_writer_constructions: Some(
+                self.runtime_stats
+                    .tantivy_writer_constructions
+                    .load(Ordering::Relaxed),
+            ),
+            writer_cache_lookups: Some(
+                self.runtime_stats
+                    .writer_cache_lookups
+                    .load(Ordering::Relaxed),
+            ),
+            writer_cache_hits: Some(self.runtime_stats.writer_cache_hits.load(Ordering::Relaxed)),
+            writer_cache_validation_failures: Some(
+                self.runtime_stats
+                    .writer_cache_validation_failures
+                    .load(Ordering::Relaxed),
+            ),
+            writer_cache_rollback_discards: Some(
+                self.runtime_stats
+                    .writer_cache_rollback_discards
+                    .load(Ordering::Relaxed),
+            ),
+            writer_cache_misses: Some(
+                self.runtime_stats
+                    .writer_cache_misses
+                    .load(Ordering::Relaxed),
+            ),
+            read_cache_lookups: Some(
+                self.runtime_stats
+                    .read_cache_lookups
+                    .load(Ordering::Relaxed),
+            ),
+            read_cache_hits: Some(self.runtime_stats.read_cache_hits.load(Ordering::Relaxed)),
+            read_cache_misses: Some(self.runtime_stats.read_cache_misses.load(Ordering::Relaxed)),
+            full_snapshot_loads: Some(
+                self.runtime_stats
+                    .full_snapshot_loads
+                    .load(Ordering::Relaxed),
+            ),
+            manifest_validation_hits: Some(
+                self.runtime_stats
+                    .manifest_validation_hits
+                    .load(Ordering::Relaxed),
+            ),
+            manifest_validation_misses: Some(
+                self.runtime_stats
+                    .manifest_validation_misses
+                    .load(Ordering::Relaxed),
+            ),
+            write_lease_acquisitions: Some(
+                self.runtime_stats
+                    .write_lease_acquisitions
+                    .load(Ordering::Relaxed),
+            ),
+            write_lease_rejections: Some(
+                self.runtime_stats
+                    .write_lease_rejections
+                    .load(Ordering::Relaxed),
+            ),
         }))
     }
 }
@@ -4075,8 +4299,8 @@ impl IndexMethodCursor for FtsCursor {
 #[cfg(test)]
 mod tests {
     use super::{
-        FtsCursor, FtsIndexAttachment, PendingFileMutations, DEFAULT_MEMORY_BUDGET_BYTES,
-        FTS_PATTERN_MATCH, FTS_PATTERN_MATCH_LIMIT, FTS_PATTERN_SCORE,
+        FtsControlRecord, FtsCursor, FtsIndexAttachment, FtsManifestFile, PendingFileMutations,
+        DEFAULT_MEMORY_BUDGET_BYTES, FTS_PATTERN_MATCH, FTS_PATTERN_MATCH_LIMIT, FTS_PATTERN_SCORE,
     };
     use crate::{
         index_method::{
@@ -4099,6 +4323,50 @@ mod tests {
         let flushes = mutations.take_flushes();
         assert_eq!(flushes.len(), 1);
         flushes.into_iter().next().unwrap()
+    }
+
+    #[test]
+    fn control_record_round_trips_and_detects_corruption() {
+        let mut files = FxHashMap::default();
+        files.insert(
+            PathBuf::from("segment.idx"),
+            FtsManifestFile {
+                size: 42,
+                chunks: 2,
+            },
+        );
+        let control = FtsControlRecord {
+            index_incarnation: 17,
+            manifest_generation: 9,
+            files,
+        };
+
+        let encoded = control.encode().unwrap();
+        let decoded = FtsControlRecord::decode(&encoded).unwrap();
+        assert_eq!(decoded.index_incarnation, 17);
+        assert_eq!(decoded.manifest_generation, 9);
+        assert_eq!(decoded.files, control.files);
+
+        let mut corrupt = encoded;
+        corrupt[8] ^= 1;
+        assert!(matches!(
+            FtsControlRecord::decode(&corrupt),
+            Err(crate::LimboError::Corrupt(message))
+                if message.contains("checksum mismatch")
+        ));
+
+        let exhausted = FtsControlRecord {
+            index_incarnation: 17,
+            manifest_generation: u64::MAX,
+            files: FxHashMap::default(),
+        };
+        let error = FtsControlRecord::from_catalog(
+            Some(&exhausted),
+            exhausted.index_incarnation,
+            &FxHashMap::default(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("generation is exhausted"));
     }
 
     #[test]

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -116,7 +116,11 @@ pub enum IndexMethodSnapshotIdentity {
         max_frame: u64,
     },
     /// MVCC readers are pinned to the transaction's begin timestamp.
-    Mvcc { begin_timestamp: u64 },
+    Mvcc {
+        /// The MVCC transaction the operation runs inside.
+        transaction_id: u64,
+        begin_timestamp: u64,
+    },
 }
 
 /// Append-only synthetic-yield markers for index-method lifecycle boundaries.
@@ -199,7 +203,6 @@ pub struct IndexMethodContext {
     database: IndexMethodDatabaseIdentity,
     journal_mode: JournalMode,
     transaction_mode: IndexMethodTransactionMode,
-    transaction_id: Option<u64>,
     snapshot: IndexMethodSnapshotIdentity,
     schema_generation: u64,
     index: IndexMethodIdentity,
@@ -214,7 +217,6 @@ impl std::fmt::Debug for IndexMethodContext {
             .field("database", &self.database)
             .field("journal_mode", &self.journal_mode)
             .field("transaction_mode", &self.transaction_mode)
-            .field("transaction_id", &self.transaction_id)
             .field("snapshot", &self.snapshot)
             .field("schema_generation", &self.schema_generation)
             .field("index", &self.index)
@@ -241,47 +243,45 @@ impl IndexMethodContext {
             )));
         }
 
-        let (journal_mode, transaction_mode, transaction_id, snapshot, schema_generation) =
-            if let Some(mv_store) = connection.mv_store_for_db(database_id) {
-                let (tx_id, mode) = connection.get_mv_tx_for_db(database_id).ok_or_else(|| {
-                    LimboError::InternalError(format!(
-                        "index method '{}' opened MVCC storage without an active transaction",
-                        definition.method_name
-                    ))
-                })?;
-                let transaction_mode = match mode {
-                    TransactionMode::None | TransactionMode::Read => {
-                        IndexMethodTransactionMode::Read
-                    }
-                    TransactionMode::Write => IndexMethodTransactionMode::Write,
-                    TransactionMode::Concurrent => IndexMethodTransactionMode::Concurrent,
-                };
-                (
-                    JournalMode::Mvcc,
-                    transaction_mode,
-                    Some(tx_id),
-                    IndexMethodSnapshotIdentity::Mvcc {
-                        begin_timestamp: mv_store.read_snapshot_ts(tx_id),
-                    },
-                    mv_store.schema_generation(),
-                )
-            } else {
-                let (checkpoint_sequence, max_frame) = pager.wal_pos();
-                (
-                    JournalMode::Wal,
-                    if connection.is_in_write_tx() {
-                        IndexMethodTransactionMode::Write
-                    } else {
-                        IndexMethodTransactionMode::Read
-                    },
-                    None,
-                    IndexMethodSnapshotIdentity::Wal {
-                        checkpoint_sequence,
-                        max_frame,
-                    },
-                    pager.get_schema_cookie_cached().unwrap_or_default() as u64,
-                )
+        let (journal_mode, transaction_mode, snapshot, schema_generation) = if let Some(mv_store) =
+            connection.mv_store_for_db(database_id)
+        {
+            let (tx_id, mode) = connection.get_mv_tx_for_db(database_id).ok_or_else(|| {
+                LimboError::InternalError(format!(
+                    "index method '{}' opened MVCC storage without an active transaction",
+                    definition.method_name
+                ))
+            })?;
+            let transaction_mode = match mode {
+                TransactionMode::None | TransactionMode::Read => IndexMethodTransactionMode::Read,
+                TransactionMode::Write => IndexMethodTransactionMode::Write,
+                TransactionMode::Concurrent => IndexMethodTransactionMode::Concurrent,
             };
+            (
+                JournalMode::Mvcc,
+                transaction_mode,
+                IndexMethodSnapshotIdentity::Mvcc {
+                    transaction_id: tx_id,
+                    begin_timestamp: mv_store.read_snapshot_ts(tx_id),
+                },
+                mv_store.schema_generation(),
+            )
+        } else {
+            let (checkpoint_sequence, max_frame) = pager.wal_pos();
+            (
+                JournalMode::Wal,
+                if connection.is_in_write_tx() {
+                    IndexMethodTransactionMode::Write
+                } else {
+                    IndexMethodTransactionMode::Read
+                },
+                IndexMethodSnapshotIdentity::Wal {
+                    checkpoint_sequence,
+                    max_frame,
+                },
+                pager.get_schema_cookie_cached().unwrap_or_default() as u64,
+            )
+        };
 
         let source_database = connection.get_source_database(database_id);
         let database_incarnation = source_database.incarnation;
@@ -299,7 +299,6 @@ impl IndexMethodContext {
             },
             journal_mode,
             transaction_mode,
-            transaction_id,
             snapshot,
             schema_generation,
             index: IndexMethodIdentity {
@@ -347,8 +346,12 @@ impl IndexMethodContext {
         self.transaction_mode
     }
 
+    /// The MVCC transaction this operation runs inside; `None` under WAL.
     pub fn transaction_id(&self) -> Option<u64> {
-        self.transaction_id
+        match self.snapshot {
+            IndexMethodSnapshotIdentity::Mvcc { transaction_id, .. } => Some(transaction_id),
+            IndexMethodSnapshotIdentity::Wal { .. } => None,
+        }
     }
 
     pub fn snapshot(&self) -> IndexMethodSnapshotIdentity {
@@ -516,12 +519,12 @@ pub struct IndexMethodTestStats {
 ///
 /// A cursor that wrote anything goes through these hooks, in this order:
 ///
-/// 1. `prepare_statement_commit` — stage every pending change durably (the
+/// 1. `stage_statement_commit` — stage every pending change durably (the
 ///    only fallible, I/O-capable phase), at the statement's halt.
-/// 2. `statement_committed` — the statement's savepoint was released.
+/// 2. `on_statement_committed` — the statement's savepoint was released.
 /// 3. Exactly one of three ends:
-///    * `transaction_committed` — the transaction is durable;
-///    * `transaction_rolled_back` — everything the transaction staged was
+///    * `on_transaction_committed` — the transaction is durable;
+///    * `on_transaction_rolled_back` — everything the transaction staged was
 ///      undone;
 ///    * replacement — a later statement in the same transaction opened a
 ///      newer cursor for the same attachment, so this one is closed without
@@ -534,8 +537,8 @@ pub struct IndexMethodTestStats {
 /// no transaction-private in-memory state** (everything lives in core-owned
 /// backing storage, which the engine rolls back on its own). A method that
 /// mirrors state in memory must implement every outcome hook: skipping
-/// `transaction_rolled_back` silently publishes rolled-back work, and
-/// skipping `prepare_statement_commit` silently loses writes.
+/// `on_transaction_rolled_back` silently publishes rolled-back work, and
+/// skipping `stage_statement_commit` silently loses writes.
 pub trait IndexMethodCursor: Send {
     /// create necessary components for index method (usually, this is a bunch of btree-s)
     fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
@@ -592,7 +595,7 @@ pub trait IndexMethodCursor: Send {
 
     /// Stage all pending index changes before the statement savepoint is
     /// released. Any fallible work or I/O belongs in this phase.
-    fn prepare_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn stage_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         Ok(IOResult::Done(()))
     }
 
@@ -602,19 +605,19 @@ pub trait IndexMethodCursor: Send {
     /// Publish transaction-private in-memory state after the statement
     /// savepoint has been released successfully. This hook is infallible and
     /// must not make uncommitted state visible to another transaction.
-    fn statement_committed(&mut self, _context: &IndexMethodContext) {}
+    fn on_statement_committed(&mut self, _context: &IndexMethodContext) {}
 
     /// Publish in-memory state after the database transaction commits.
     /// This hook is infallible and must not perform I/O.
-    fn transaction_committed(&mut self, _context: &IndexMethodContext) {}
+    fn on_transaction_committed(&mut self, _context: &IndexMethodContext) {}
 
     /// Invalidate transaction-owned in-memory state after rollback.
     /// This hook is infallible and must not perform I/O.
-    fn transaction_rolled_back(&mut self, _context: &IndexMethodContext) {}
+    fn on_transaction_rolled_back(&mut self, _context: &IndexMethodContext) {}
 
     /// Invalidate state newer than a rolled-back savepoint.
     /// This hook is infallible and must not perform I/O.
-    fn savepoint_rolled_back(&mut self, _context: &IndexMethodContext) {}
+    fn on_savepoint_rolled_back(&mut self, _context: &IndexMethodContext) {}
 
     /// Release resources without performing I/O or persistent writes.
     fn close(&mut self, _context: &IndexMethodContext) {}

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use rustc_hash::FxHashMap as HashMap;
 #[cfg(any(test, injected_yields))]
@@ -63,6 +63,14 @@ pub enum IndexMethodMvccSupport {
     ReadOnly,
     /// Persistent state is stored exclusively through core-provided,
     /// MVCC-aware backing storage.
+    ///
+    /// Under MVCC, at most one transaction may write a given index at a time
+    /// (a per-index write lease, taken on the first document mutation).
+    /// Contention is a retryable `Busy`; a writer whose read snapshot
+    /// predates the index's last publication gets `WriteWriteConflict` and
+    /// must restart its transaction. `BEGIN CONCURRENT` therefore does not
+    /// parallelize writes to one index of this kind — that is the write
+    /// throughput ceiling per index.
     TransactionalBackingStore,
     /// Persistent state is external and implements transaction outcome hooks.
     ExternalTransactional,
@@ -147,8 +155,13 @@ pub struct IndexMethodIdentity {
     pub method_name: String,
     pub table_name: String,
     pub index_name: String,
-    /// Runtime-stable identity for this schema incarnation. Drop/recreate and
-    /// attach/detach cannot compare equal even when names are reused.
+    /// Runtime identity derived from the database incarnation, the schema
+    /// generation, and the index's names. Attach/detach and close/reopen
+    /// cannot compare equal. Drop/recreate inside one MVCC transaction can
+    /// (MVCC DDL does not advance the schema generation); the consumers
+    /// tolerate that, because a colliding cursor is merely replaced-and-closed
+    /// and index content is validated separately by the persisted
+    /// (incarnation, generation) pair.
     pub runtime_id: u64,
     /// Schema root assigned to the logical definition. Custom index methods
     /// must keep this at zero; physical ownership belongs to backing objects.
@@ -179,7 +192,10 @@ fn index_method_runtime_id(
 /// are promoted to snapshot-aware MVCC cursors whenever MVCC is active.
 #[derive(Clone)]
 pub struct IndexMethodContext {
-    connection: Arc<Connection>,
+    /// Weak so a cursor parked on its connection (with its context) does not
+    /// make the connection reference itself — a strong edge here kept leaked
+    /// connections alive forever, holding their WAL locks.
+    connection: Weak<Connection>,
     database: IndexMethodDatabaseIdentity,
     journal_mode: JournalMode,
     transaction_mode: IndexMethodTransactionMode,
@@ -268,12 +284,12 @@ impl IndexMethodContext {
             };
 
         let source_database = connection.get_source_database(database_id);
-        let database_incarnation = Arc::as_ptr(&source_database) as usize as u64;
+        let database_incarnation = source_database.incarnation;
         let runtime_id =
             index_method_runtime_id(database_incarnation, schema_generation, definition);
 
         Ok(Self {
-            connection: Arc::clone(connection),
+            connection: Arc::downgrade(connection),
             database: IndexMethodDatabaseIdentity {
                 id: database_id,
                 name: connection
@@ -310,8 +326,13 @@ impl IndexMethodContext {
         Self::new(connection, database_id, &attachment.definition())
     }
 
-    pub fn connection(&self) -> &Arc<Connection> {
-        &self.connection
+    /// The connection this context was built for. Errors once the connection
+    /// is being torn down; outcome hooks running at that point have nothing
+    /// left to clean up and should just return.
+    pub fn connection(&self) -> Result<Arc<Connection>> {
+        self.connection.upgrade().ok_or_else(|| {
+            LimboError::InternalError("index method context outlived its connection".to_string())
+        })
     }
 
     pub fn database(&self) -> &IndexMethodDatabaseIdentity {
@@ -343,7 +364,7 @@ impl IndexMethodContext {
     }
 
     pub fn open_table_cursor(&self, table: &str) -> Result<Box<dyn CursorTrait>> {
-        open_table_cursor(&self.connection, self.database.id, table)
+        open_table_cursor(&self.connection()?, self.database.id, table)
     }
 
     pub fn open_index_cursor<I, E>(
@@ -356,7 +377,7 @@ impl IndexMethodContext {
         I: IntoIterator<Item = KeyInfo, IntoIter = E>,
         E: ExactSizeIterator<Item = KeyInfo>,
     {
-        open_index_cursor(&self.connection, self.database.id, table, index, keys)
+        open_index_cursor(&self.connection()?, self.database.id, table, index, keys)
     }
 }
 
@@ -375,9 +396,13 @@ impl crate::mvcc::yield_hooks::ProvidesYieldContext for IndexMethodContext {
         {
             selection_key = selection_key.wrapping_mul(0x100_0000_01b3) ^ u64::from(byte);
         }
+        let connection = self
+            .connection
+            .upgrade()
+            .expect("yield context requires a live connection");
         crate::mvcc::yield_hooks::YieldContext::new(
-            self.connection.yield_injector(),
-            self.connection.failure_injector(),
+            connection.yield_injector(),
+            connection.failure_injector(),
             self.yield_instance_id,
             selection_key,
         )
@@ -486,6 +511,31 @@ pub struct IndexMethodTestStats {
 }
 
 /// cursor opened for index method and capable of executing DML/DDL/DQL queries for the index method over fixed table
+///
+/// # Statement and transaction lifecycle
+///
+/// A cursor that wrote anything goes through these hooks, in this order:
+///
+/// 1. `prepare_statement_commit` — stage every pending change durably (the
+///    only fallible, I/O-capable phase), at the statement's halt.
+/// 2. `statement_committed` — the statement's savepoint was released.
+/// 3. Exactly one of three ends:
+///    * `transaction_committed` — the transaction is durable;
+///    * `transaction_rolled_back` — everything the transaction staged was
+///      undone;
+///    * replacement — a later statement in the same transaction opened a
+///      newer cursor for the same attachment, so this one is closed without
+///      either transaction outcome (the newer cursor receives it).
+/// 4. `close`.
+///
+/// A failed statement gets `abort_statement` instead of steps 1–2.
+///
+/// The empty default bodies below are correct **only for a method that keeps
+/// no transaction-private in-memory state** (everything lives in core-owned
+/// backing storage, which the engine rolls back on its own). A method that
+/// mirrors state in memory must implement every outcome hook: skipping
+/// `transaction_rolled_back` silently publishes rolled-back work, and
+/// skipping `prepare_statement_commit` silently loses writes.
 pub trait IndexMethodCursor: Send {
     /// create necessary components for index method (usually, this is a bunch of btree-s)
     fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
@@ -595,7 +645,7 @@ pub trait IndexMethodCursor: Send {
 
 pub(crate) struct TransactionIndexMethodCursor {
     pub(crate) cursor: Box<dyn IndexMethodCursor>,
-    pub(crate) context: IndexMethodContext,
+    pub(crate) context: Arc<IndexMethodContext>,
 }
 
 impl TransactionIndexMethodCursor {

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -1,12 +1,18 @@
 use std::sync::Arc;
 
 use rustc_hash::FxHashMap as HashMap;
+#[cfg(any(test, injected_yields))]
+use strum::EnumCount;
 use turso_parser::ast;
 
 use crate::{
     mvcc::cursor::MvccCursorType,
     schema::IndexColumn,
-    storage::btree::{BTreeCursor, CursorTrait},
+    storage::{
+        btree::{BTreeCursor, CursorTrait},
+        journal_mode::JournalMode,
+    },
+    translate::emitter::TransactionMode,
     types::{IOResult, IndexInfo, KeyInfo},
     vdbe::Register,
     Connection, LimboError, MvCursor, Result, Value,
@@ -66,6 +72,8 @@ pub enum IndexMethodMvccSupport {
 pub struct IndexMethodDefinition<'a> {
     /// index method name
     pub method_name: &'a str,
+    /// table to which the index is attached
+    pub table_name: &'a str,
     /// index name
     pub index_name: &'a str,
     /// SELECT patterns where index method can be used
@@ -81,6 +89,299 @@ pub struct IndexMethodDefinition<'a> {
     pub results_materialized: bool,
     /// Declares how this method participates in MVCC transactions.
     pub mvcc_support: IndexMethodMvccSupport,
+}
+
+/// Transaction mode exposed to index methods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexMethodTransactionMode {
+    Read,
+    Write,
+    Concurrent,
+}
+
+/// Stable coordinates for the snapshot visible to an index method operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexMethodSnapshotIdentity {
+    /// WAL readers are pinned to a checkpoint sequence and maximum frame.
+    Wal {
+        checkpoint_sequence: u32,
+        max_frame: u64,
+    },
+    /// MVCC readers are pinned to the transaction's begin timestamp.
+    Mvcc { begin_timestamp: u64 },
+}
+
+/// Append-only synthetic-yield markers for index-method lifecycle boundaries.
+///
+/// Ordinals are consumed by deterministic simulator plans; never reorder or
+/// reuse an existing value.
+#[cfg(any(test, injected_yields))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::EnumCount)]
+#[repr(u8)]
+pub(crate) enum IndexMethodYieldPoint {
+    BeforePrepareStatement = 0,
+    AfterPrepareStatement = 1,
+}
+
+#[cfg(any(test, injected_yields))]
+impl crate::mvcc::yield_hooks::YieldPointMarker for IndexMethodYieldPoint {
+    const POINT_COUNT: u8 = Self::COUNT as u8;
+
+    fn ordinal(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IndexMethodDatabaseIdentity {
+    /// Connection-local slot used to address the database.
+    pub id: usize,
+    pub name: String,
+    /// Runtime identity of the shared `Database` object. Unlike `id` and
+    /// `name`, this distinguishes detach/reattach and close/reopen lifetimes.
+    pub incarnation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IndexMethodIdentity {
+    pub method_name: String,
+    pub table_name: String,
+    pub index_name: String,
+    /// Runtime-stable identity for this schema incarnation. Drop/recreate and
+    /// attach/detach cannot compare equal even when names are reused.
+    pub runtime_id: u64,
+    /// Schema root assigned to the logical definition. Custom index methods
+    /// must keep this at zero; physical ownership belongs to backing objects.
+    pub schema_root: i64,
+}
+
+fn index_method_runtime_id(
+    database_incarnation: u64,
+    schema_generation: u64,
+    definition: &IndexMethodDefinition<'_>,
+) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64 ^ database_incarnation;
+    hash = (hash ^ schema_generation).wrapping_mul(0x100_0000_01b3);
+    for byte in definition
+        .method_name
+        .bytes()
+        .chain(definition.table_name.bytes())
+        .chain(definition.index_name.bytes())
+    {
+        hash = (hash ^ u64::from(byte)).wrapping_mul(0x100_0000_01b3);
+    }
+    hash
+}
+
+/// Read-only execution and storage context for an index method operation.
+///
+/// Persistent cursors can only be created through this context, ensuring they
+/// are promoted to snapshot-aware MVCC cursors whenever MVCC is active.
+#[derive(Clone)]
+pub struct IndexMethodContext {
+    connection: Arc<Connection>,
+    database: IndexMethodDatabaseIdentity,
+    journal_mode: JournalMode,
+    transaction_mode: IndexMethodTransactionMode,
+    transaction_id: Option<u64>,
+    snapshot: IndexMethodSnapshotIdentity,
+    schema_generation: u64,
+    index: IndexMethodIdentity,
+    #[cfg(any(test, injected_yields))]
+    yield_instance_id: u64,
+}
+
+impl std::fmt::Debug for IndexMethodContext {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("IndexMethodContext")
+            .field("database", &self.database)
+            .field("journal_mode", &self.journal_mode)
+            .field("transaction_mode", &self.transaction_mode)
+            .field("transaction_id", &self.transaction_id)
+            .field("snapshot", &self.snapshot)
+            .field("schema_generation", &self.schema_generation)
+            .field("index", &self.index)
+            .finish_non_exhaustive()
+    }
+}
+
+impl IndexMethodContext {
+    pub(crate) fn new(
+        connection: &Arc<Connection>,
+        database_id: usize,
+        definition: &IndexMethodDefinition<'_>,
+    ) -> Result<Self> {
+        let pager = connection.get_pager_from_database_index(&database_id)?;
+        let schema_root = connection.with_schema(database_id, |schema| {
+            schema
+                .get_index(definition.table_name, definition.index_name)
+                .map_or(0, |index| index.root_page)
+        });
+        if !definition.backing_btree && schema_root != 0 {
+            return Err(LimboError::Corrupt(format!(
+                "logical index-method definition '{}.{}' owns physical root {schema_root}",
+                definition.table_name, definition.index_name
+            )));
+        }
+
+        let (journal_mode, transaction_mode, transaction_id, snapshot, schema_generation) =
+            if let Some(mv_store) = connection.mv_store_for_db(database_id) {
+                let (tx_id, mode) = connection.get_mv_tx_for_db(database_id).ok_or_else(|| {
+                    LimboError::InternalError(format!(
+                        "index method '{}' opened MVCC storage without an active transaction",
+                        definition.method_name
+                    ))
+                })?;
+                let transaction_mode = match mode {
+                    TransactionMode::None | TransactionMode::Read => {
+                        IndexMethodTransactionMode::Read
+                    }
+                    TransactionMode::Write => IndexMethodTransactionMode::Write,
+                    TransactionMode::Concurrent => IndexMethodTransactionMode::Concurrent,
+                };
+                (
+                    JournalMode::Mvcc,
+                    transaction_mode,
+                    Some(tx_id),
+                    IndexMethodSnapshotIdentity::Mvcc {
+                        begin_timestamp: mv_store.read_snapshot_ts(tx_id),
+                    },
+                    mv_store.schema_generation(),
+                )
+            } else {
+                let (checkpoint_sequence, max_frame) = pager.wal_pos();
+                (
+                    JournalMode::Wal,
+                    if connection.is_in_write_tx() {
+                        IndexMethodTransactionMode::Write
+                    } else {
+                        IndexMethodTransactionMode::Read
+                    },
+                    None,
+                    IndexMethodSnapshotIdentity::Wal {
+                        checkpoint_sequence,
+                        max_frame,
+                    },
+                    pager.get_schema_cookie_cached().unwrap_or_default() as u64,
+                )
+            };
+
+        let source_database = connection.get_source_database(database_id);
+        let database_incarnation = Arc::as_ptr(&source_database) as usize as u64;
+        let runtime_id =
+            index_method_runtime_id(database_incarnation, schema_generation, definition);
+
+        Ok(Self {
+            connection: Arc::clone(connection),
+            database: IndexMethodDatabaseIdentity {
+                id: database_id,
+                name: connection
+                    .get_database_name_by_index(database_id)
+                    .unwrap_or_else(|| format!("database-{database_id}")),
+                incarnation: database_incarnation,
+            },
+            journal_mode,
+            transaction_mode,
+            transaction_id,
+            snapshot,
+            schema_generation,
+            index: IndexMethodIdentity {
+                method_name: definition.method_name.to_string(),
+                table_name: definition.table_name.to_string(),
+                index_name: definition.index_name.to_string(),
+                runtime_id,
+                schema_root,
+            },
+            #[cfg(any(test, injected_yields))]
+            yield_instance_id: connection.next_yield_instance_id(),
+        })
+    }
+
+    /// Build the same core-owned context for raw index-method integration
+    /// tests. Production callers receive contexts only from the VDBE.
+    #[cfg(any(feature = "test_helper", feature = "conn_raw_api"))]
+    #[doc(hidden)]
+    pub fn for_test(
+        connection: &Arc<Connection>,
+        database_id: usize,
+        attachment: &dyn IndexMethodAttachment,
+    ) -> Result<Self> {
+        Self::new(connection, database_id, &attachment.definition())
+    }
+
+    pub fn connection(&self) -> &Arc<Connection> {
+        &self.connection
+    }
+
+    pub fn database(&self) -> &IndexMethodDatabaseIdentity {
+        &self.database
+    }
+
+    pub fn journal_mode(&self) -> JournalMode {
+        self.journal_mode
+    }
+
+    pub fn transaction_mode(&self) -> IndexMethodTransactionMode {
+        self.transaction_mode
+    }
+
+    pub fn transaction_id(&self) -> Option<u64> {
+        self.transaction_id
+    }
+
+    pub fn snapshot(&self) -> IndexMethodSnapshotIdentity {
+        self.snapshot
+    }
+
+    pub fn schema_generation(&self) -> u64 {
+        self.schema_generation
+    }
+
+    pub fn index(&self) -> &IndexMethodIdentity {
+        &self.index
+    }
+
+    pub fn open_table_cursor(&self, table: &str) -> Result<Box<dyn CursorTrait>> {
+        open_table_cursor(&self.connection, self.database.id, table)
+    }
+
+    pub fn open_index_cursor<I, E>(
+        &self,
+        table: &str,
+        index: &str,
+        keys: I,
+    ) -> Result<Box<dyn CursorTrait>>
+    where
+        I: IntoIterator<Item = KeyInfo, IntoIter = E>,
+        E: ExactSizeIterator<Item = KeyInfo>,
+    {
+        open_index_cursor(&self.connection, self.database.id, table, index, keys)
+    }
+}
+
+#[cfg(any(test, injected_yields))]
+impl crate::mvcc::yield_hooks::ProvidesYieldContext for IndexMethodContext {
+    fn yield_context(&self) -> crate::mvcc::yield_hooks::YieldContext {
+        let mut selection_key = 0x494e_4458_4d45_5448u64;
+        selection_key ^= self.database.id as u64;
+        selection_key = selection_key.rotate_left(17) ^ self.schema_generation;
+        selection_key = selection_key.rotate_left(17) ^ self.index.schema_root as u64;
+        for byte in self
+            .index
+            .method_name
+            .bytes()
+            .chain(self.index.index_name.bytes())
+        {
+            selection_key = selection_key.wrapping_mul(0x100_0000_01b3) ^ u64::from(byte);
+        }
+        crate::mvcc::yield_hooks::YieldContext::new(
+            self.connection.yield_injector(),
+            self.connection.failure_injector(),
+            self.yield_instance_id,
+            selection_key,
+        )
+    }
 }
 
 pub(crate) fn ensure_mvcc_support(
@@ -132,6 +433,14 @@ pub struct IndexMethodCostContext<'a> {
 #[cfg(feature = "test_helper")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IndexMethodTestStats {
+    /// Persistent index-method storage format version.
+    pub storage_format_version: Option<u32>,
+    /// Persistent logical incarnation from the control record.
+    pub index_incarnation: Option<u64>,
+    /// Transactional manifest generation visible to this cursor.
+    pub manifest_generation: Option<u64>,
+    /// Files referenced by the visible manifest.
+    pub manifest_file_count: Option<usize>,
     /// Number of physical files visible in the index method's storage.
     pub storage_file_count: usize,
     /// Number of searchable engine segments, when the method is segmented.
@@ -140,30 +449,53 @@ pub struct IndexMethodTestStats {
     pub cached_connection_count: Option<usize>,
     /// Resident bytes held by retained read-snapshot file caches.
     pub cached_bytes: Option<usize>,
+    /// Complete snapshots rejected from retention because they exceed the
+    /// aggregate cache budget by themselves.
+    pub cache_admission_rejections: Option<usize>,
     /// Whether the method retained a committed writer for statement reuse.
     pub cached_writer: Option<bool>,
+    /// Number of Tantivy writers constructed by this attachment.
+    pub tantivy_writer_constructions: Option<usize>,
+    /// Retained-writer cache lookups.
+    pub writer_cache_lookups: Option<usize>,
+    /// Retained-writer cache hits.
+    pub writer_cache_hits: Option<usize>,
+    /// Retained writers rejected because their owner or snapshot diverged.
+    pub writer_cache_validation_failures: Option<usize>,
+    /// Transaction-private retained writers discarded by rollback.
+    pub writer_cache_rollback_discards: Option<usize>,
+    /// Retained-writer cache lookups with no reusable entry.
+    pub writer_cache_misses: Option<usize>,
+    /// Read-snapshot cache lookups.
+    pub read_cache_lookups: Option<usize>,
+    /// Snapshot cache checkouts that avoided a backing-directory scan.
+    pub read_cache_hits: Option<usize>,
+    /// Read-snapshot cache lookups that required a full snapshot load.
+    pub read_cache_misses: Option<usize>,
+    /// Complete backing-directory snapshots loaded by the async scan.
+    pub full_snapshot_loads: Option<usize>,
+    /// Cross-snapshot control-record validations that reused a cached manifest.
+    pub manifest_validation_hits: Option<usize>,
+    /// Cross-snapshot control-record validations that rejected a stale cache.
+    pub manifest_validation_misses: Option<usize>,
+    /// Number of successful MVCC writer-lease acquisitions, including
+    /// reentrant acquisition by the owning transaction.
+    pub write_lease_acquisitions: Option<usize>,
+    /// Number of writer-lease acquisitions rejected due to contention.
+    pub write_lease_rejections: Option<usize>,
 }
 
 /// cursor opened for index method and capable of executing DML/DDL/DQL queries for the index method over fixed table
-pub trait IndexMethodCursor {
+pub trait IndexMethodCursor: Send {
     /// create necessary components for index method (usually, this is a bunch of btree-s)
-    fn create(&mut self, connection: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>>;
+    fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
     /// destroy components created in the create(...) call for index method
-    fn destroy(&mut self, connection: &Arc<Connection>, database_id: usize)
-        -> Result<IOResult<()>>;
+    fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
 
     /// open necessary components for reading the index
-    fn open_read(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>>;
+    fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
     /// open necessary components for writing the index
-    fn open_write(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>>;
+    fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
 
     /// handle insert action
     /// "values" argument contains registers with values for index columns followed by rowid Integer register
@@ -208,18 +540,37 @@ pub trait IndexMethodCursor {
     /// returned from query_rowid(...) method
     fn query_rowid(&mut self) -> Result<IOResult<Option<i64>>>;
 
-    /// Called before transaction commit to flush any pending writes.
-    /// This ensures index method writes are persisted as part of the transaction.
-    fn pre_commit(&mut self) -> Result<IOResult<()>> {
+    /// Stage all pending index changes before the statement savepoint is
+    /// released. Any fallible work or I/O belongs in this phase.
+    fn prepare_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         Ok(IOResult::Done(()))
     }
 
+    /// Discard statement-owned in-memory work. This hook must not perform I/O.
+    fn abort_statement(&mut self, _context: &IndexMethodContext) {}
+
+    /// Publish transaction-private in-memory state after the statement
+    /// savepoint has been released successfully. This hook is infallible and
+    /// must not make uncommitted state visible to another transaction.
+    fn statement_committed(&mut self, _context: &IndexMethodContext) {}
+
+    /// Publish in-memory state after the database transaction commits.
+    /// This hook is infallible and must not perform I/O.
+    fn transaction_committed(&mut self, _context: &IndexMethodContext) {}
+
+    /// Invalidate transaction-owned in-memory state after rollback.
+    /// This hook is infallible and must not perform I/O.
+    fn transaction_rolled_back(&mut self, _context: &IndexMethodContext) {}
+
+    /// Invalidate state newer than a rolled-back savepoint.
+    /// This hook is infallible and must not perform I/O.
+    fn savepoint_rolled_back(&mut self, _context: &IndexMethodContext) {}
+
+    /// Release resources without performing I/O or persistent writes.
+    fn close(&mut self, _context: &IndexMethodContext) {}
+
     /// Optimize the index by merging segments or performing other maintenance.
-    fn optimize(
-        &mut self,
-        _connection: &Arc<Connection>,
-        _database_id: usize,
-    ) -> Result<IOResult<()>> {
+    fn optimize(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         Ok(IOResult::Done(()))
     }
 
@@ -239,6 +590,17 @@ pub trait IndexMethodCursor {
     #[cfg(feature = "test_helper")]
     fn test_stats(&self) -> Result<Option<IndexMethodTestStats>> {
         Ok(None)
+    }
+}
+
+pub(crate) struct TransactionIndexMethodCursor {
+    pub(crate) cursor: Box<dyn IndexMethodCursor>,
+    pub(crate) context: IndexMethodContext,
+}
+
+impl TransactionIndexMethodCursor {
+    pub(crate) fn same_attachment(&self, context: &IndexMethodContext) -> bool {
+        self.context.database == context.database && self.context.index == context.index
     }
 }
 
@@ -369,6 +731,7 @@ mod tests {
     fn definition(support: IndexMethodMvccSupport) -> IndexMethodDefinition<'static> {
         IndexMethodDefinition {
             method_name: "test_method",
+            table_name: "test_table",
             index_name: "test_index",
             patterns: &[],
             backing_btree: false,

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -510,17 +510,17 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         Ok(IOResult::Done(()))
     }
 
-    fn prepare_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn stage_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         Ok(IOResult::Done(()))
     }
 
     fn abort_statement(&mut self, _context: &IndexMethodContext) {}
 
-    fn transaction_committed(&mut self, _context: &IndexMethodContext) {}
+    fn on_transaction_committed(&mut self, _context: &IndexMethodContext) {}
 
-    fn transaction_rolled_back(&mut self, _context: &IndexMethodContext) {}
+    fn on_transaction_rolled_back(&mut self, _context: &IndexMethodContext) {}
 
-    fn savepoint_rolled_back(&mut self, _context: &IndexMethodContext) {}
+    fn on_savepoint_rolled_back(&mut self, _context: &IndexMethodContext) {}
 
     fn close(&mut self, _context: &IndexMethodContext) {
         self.inverted_index_cursor = None;

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -9,8 +9,8 @@ use crate::numeric::Numeric;
 use crate::util::quote_identifier;
 use crate::{
     index_method::{
-        open_index_cursor, open_table_cursor, parse_patterns, IndexMethod, IndexMethodAttachment,
-        IndexMethodConfiguration, IndexMethodCursor, IndexMethodDefinition,
+        parse_patterns, IndexMethod, IndexMethodAttachment, IndexMethodConfiguration,
+        IndexMethodContext, IndexMethodCursor, IndexMethodDefinition,
         BACKING_BTREE_INDEX_METHOD_NAME, TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME,
     },
     return_if_io,
@@ -23,7 +23,7 @@ use crate::{
         operations,
         vector_types::{Vector, VectorType},
     },
-    Connection, LimboError, Result, Value, ValueRef,
+    LimboError, Result, Value, ValueRef,
 };
 
 /// Simple inverted index for sparse vectors
@@ -341,6 +341,7 @@ impl IndexMethodAttachment for VectorSparseInvertedIndexMethodAttachment {
     fn definition<'a>(&'a self) -> IndexMethodDefinition<'a> {
         IndexMethodDefinition {
             method_name: TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME,
+            table_name: &self.configuration.table_name,
             index_name: &self.configuration.index_name,
             patterns: self.patterns.as_slice(),
             backing_btree: false,
@@ -403,8 +404,10 @@ fn key_info() -> KeyInfo {
 }
 
 impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
-    fn create(&mut self, connection: &Arc<Connection>, database_id: usize) -> Result<IOResult<()>> {
+    fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
         // we need to properly track subprograms and propagate result to the root program to make this execution async
+        let connection = context.connection();
+        let database_id = context.database().id;
 
         let columns = &self.configuration.columns;
         let columns = columns.iter().map(|x| x.name.as_str()).collect::<Vec<_>>();
@@ -447,11 +450,9 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         Ok(IOResult::Done(()))
     }
 
-    fn destroy(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>> {
+    fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        let connection = context.connection();
+        let database_id = context.database().id;
         let db_prefix = connection
             .get_database_name_by_index(database_id)
             .filter(|name| name != "main")
@@ -476,57 +477,55 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         Ok(IOResult::Done(()))
     }
 
-    fn open_read(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>> {
-        self.inverted_index_cursor = Some(open_index_cursor(
-            connection,
-            database_id,
+    fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        self.inverted_index_cursor = Some(context.open_index_cursor(
             &self.configuration.table_name,
             &self.inverted_index_btree,
             // component, length, rowid
             [key_info(), key_info(), key_info()],
         )?);
-        self.stats_cursor = Some(open_index_cursor(
-            connection,
-            database_id,
+        self.stats_cursor = Some(context.open_index_cursor(
             &self.configuration.table_name,
             &self.stats_btree,
             // component
             [key_info()],
         )?);
-        self.main_btree = Some(open_table_cursor(
-            connection,
-            database_id,
+        self.main_btree = Some(context.open_table_cursor(&self.configuration.table_name)?);
+        Ok(IOResult::Done(()))
+    }
+
+    fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+        self.inverted_index_cursor = Some(context.open_index_cursor(
             &self.configuration.table_name,
+            &self.inverted_index_btree,
+            // component, length, rowid
+            [key_info(), key_info(), key_info()],
+        )?);
+        self.stats_cursor = Some(context.open_index_cursor(
+            &self.configuration.table_name,
+            &self.stats_btree,
+            // component
+            [key_info()],
         )?);
         Ok(IOResult::Done(()))
     }
 
-    fn open_write(
-        &mut self,
-        connection: &Arc<Connection>,
-        database_id: usize,
-    ) -> Result<IOResult<()>> {
-        self.inverted_index_cursor = Some(open_index_cursor(
-            connection,
-            database_id,
-            &self.configuration.table_name,
-            &self.inverted_index_btree,
-            // component, length, rowid
-            [key_info(), key_info(), key_info()],
-        )?);
-        self.stats_cursor = Some(open_index_cursor(
-            connection,
-            database_id,
-            &self.configuration.table_name,
-            &self.stats_btree,
-            // component
-            [key_info()],
-        )?);
+    fn prepare_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
         Ok(IOResult::Done(()))
+    }
+
+    fn abort_statement(&mut self, _context: &IndexMethodContext) {}
+
+    fn transaction_committed(&mut self, _context: &IndexMethodContext) {}
+
+    fn transaction_rolled_back(&mut self, _context: &IndexMethodContext) {}
+
+    fn savepoint_rolled_back(&mut self, _context: &IndexMethodContext) {}
+
+    fn close(&mut self, _context: &IndexMethodContext) {
+        self.inverted_index_cursor = None;
+        self.stats_cursor = None;
+        self.main_btree = None;
     }
 
     fn insert(&mut self, values: &[Register]) -> Result<IOResult<()>> {

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -406,7 +406,7 @@ fn key_info() -> KeyInfo {
 impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
     fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
         // we need to properly track subprograms and propagate result to the root program to make this execution async
-        let connection = context.connection();
+        let connection = context.connection()?;
         let database_id = context.database().id;
 
         let columns = &self.configuration.columns;
@@ -451,7 +451,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
     }
 
     fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
-        let connection = context.connection();
+        let connection = context.connection()?;
         let database_id = context.database().id;
         let db_prefix = connection
             .get_database_name_by_index(database_id)

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -155,9 +155,13 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> ProvidesYieldContext
     for MvccLazyCursor<Clock, A>
 {
     fn yield_context(&self) -> YieldContext {
+        let connection = self
+            .connection
+            .upgrade()
+            .expect("yield context requires a live connection");
         YieldContext::new(
-            self.connection.yield_injector(),
-            self.connection.failure_injector(),
+            connection.yield_injector(),
+            connection.failure_injector(),
             self.yield_instance_id,
             cursor_yield_key(self.tx_id, self.table_id),
         )
@@ -491,8 +495,10 @@ impl<A: ConcurrentAllocator> IndexShadowFinger<A> {
 
 pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator = TursoAllocator> {
     pub db: Arc<MvStore<Clock, A>>,
+    /// Weak so a cursor retained past its statement (an index-method cursor
+    /// parked on its connection) cannot keep the connection alive.
     #[cfg(any(test, injected_yields))]
-    connection: Arc<Connection>,
+    connection: crate::sync::Weak<Connection>,
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
     current_pos: CursorPosition<A>,
@@ -575,7 +581,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
             #[cfg(any(test, injected_yields))]
             yield_instance_id: connection.next_yield_instance_id(),
             #[cfg(any(test, injected_yields))]
-            connection: connection.clone(),
+            connection: Arc::downgrade(connection),
             tx_id,
             table_iterator: None,
             index_iterator: None,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4018,6 +4018,10 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     ///
     /// If there is no exclusive transaction, the field is set to `NO_EXCLUSIVE_TX`.
     exclusive_tx: AtomicU64,
+    /// Active custom-index writer leases keyed by the backing object's stable
+    /// MVCC table ID. Leases reject contention instead of waiting, so acquiring
+    /// several leases cannot deadlock.
+    index_method_write_leases: Mutex<HashMap<MVTableId, TxID>>,
     commit_coordinator: Arc<CommitCoordinator>,
     global_header: Arc<RwLock<Option<DatabaseHeader>>>,
     /// Held by checkpoints only during the brief in-memory publish phase; the I/O-heavy
@@ -4225,6 +4229,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             clock,
             storage,
             exclusive_tx: AtomicU64::new(NO_EXCLUSIVE_TX),
+            index_method_write_leases: Mutex::new(HashMap::default()),
             commit_coordinator: Arc::new(CommitCoordinator::new()),
             global_header: Arc::new(RwLock::new(None)),
             backfill_floor: Arc::new(RwLock::new(WalPos::ORIGIN)),
@@ -6172,6 +6177,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     }
 
     pub fn remove_tx(&self, tx_id: TxID) -> Result<(), TryReserveError> {
+        self.release_index_method_write_leases(tx_id);
         self.remove_sequence_allocations(tx_id);
         if let Some(entry) = self.txs.get(&tx_id) {
             let tx = entry.value();
@@ -6202,6 +6208,37 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         }
         self.txs.remove(&tx_id);
         Ok(())
+    }
+
+    /// Acquire a transaction-scoped custom-index writer lease.
+    ///
+    /// Acquisition is reentrant for the owning transaction. Contention is an
+    /// eager write conflict so expensive index construction never starts for a
+    /// transaction that cannot publish its work.
+    pub(crate) fn acquire_index_method_write_lease(
+        &self,
+        tx_id: TxID,
+        index_id: MVTableId,
+    ) -> Result<()> {
+        if !self.is_tx_rollbackable(tx_id) {
+            return Err(LimboError::NoSuchTransactionID(tx_id.to_string()));
+        }
+
+        let mut leases = self.index_method_write_leases.lock();
+        match leases.get(&index_id) {
+            Some(owner) if *owner == tx_id => Ok(()),
+            Some(_) => Err(LimboError::WriteWriteConflict),
+            None => {
+                leases.insert(index_id, tx_id);
+                Ok(())
+            }
+        }
+    }
+
+    fn release_index_method_write_leases(&self, tx_id: TxID) {
+        self.index_method_write_leases
+            .lock()
+            .retain(|_, owner| *owner != tx_id);
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::FinalizedTxStateInsert)]

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -4041,6 +4041,12 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     /// read snapshot predates that publication is refused — its rebuild of
     /// the index state starts from a superseded base and committing it would
     /// overwrite the newer publication.
+    ///
+    /// One writer per index is the intended concurrency model, not a stopgap:
+    /// two transactions cannot merge the index state each rebuilt from its
+    /// own snapshot, so the later one would silently overwrite the earlier
+    /// one's work. The lease makes the second writer fail fast instead.
+    /// Writers on different indexes, and all readers, still run concurrently.
     index_method_write_leases: Mutex<HashMap<MVTableId, IndexMethodWriteLease>>,
     commit_coordinator: Arc<CommitCoordinator>,
     global_header: Arc<RwLock<Option<DatabaseHeader>>>,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1816,19 +1816,25 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             // Skip indexes which are not unique or not primary key
             return Ok(());
         }
+        // A key without an appended rowid (an index method's backing B-tree)
+        // is unique over the whole key; keys with a rowid are unique over
+        // everything before it.
+        let num_indexed_cols = if record.metadata.has_rowid {
+            record.metadata.num_cols.saturating_sub(1) // exclude rowid column
+        } else {
+            record.metadata.num_cols
+        };
         // In SQLite, NULLs don't violate UNIQUE constraints - skip conflict check for keys containing NULL
-        let num_indexed_cols = record.metadata.num_cols.saturating_sub(1); // exclude rowid column
         if record.contains_null(num_indexed_cols)? {
             return Ok(());
         }
 
-        // Create a prefix key with num_cols - 1 for range lookup.
+        // Create a prefix key over the indexed columns for range lookup.
         // Due to SortableIndexKey's Ord using min(num_cols), this key compares Equal
         // to all entries with the same indexed columns (regardless of rowid).
         let prefix_key = {
             let mut index_info = record.metadata.as_ref().clone();
-            turso_assert!(index_info.has_rowid, "not supported yet without rowid");
-            index_info.num_cols -= 1;
+            index_info.num_cols = num_indexed_cols;
             SortableIndexKey {
                 key: record.key.clone(),
                 metadata: Arc::new(index_info),
@@ -3959,6 +3965,16 @@ pub(crate) struct GcDebugSnapshot {
     pub backfill_floor: WalPos,
 }
 
+/// One custom index's writer lease plus the commit timestamp of its last
+/// publication. See `MvStore::index_method_write_leases`.
+#[derive(Debug, Default)]
+struct IndexMethodWriteLease {
+    /// Transaction currently allowed to write the index, if any.
+    holder: Option<TxID>,
+    /// Commit timestamp of the last transaction that published this index.
+    last_publish_ts: Option<u64>,
+}
+
 /// A multi-version concurrency control database.
 #[derive(Debug)]
 pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator> {
@@ -4018,10 +4034,14 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     ///
     /// If there is no exclusive transaction, the field is set to `NO_EXCLUSIVE_TX`.
     exclusive_tx: AtomicU64,
-    /// Active custom-index writer leases keyed by the backing object's stable
-    /// MVCC table ID. Leases reject contention instead of waiting, so acquiring
-    /// several leases cannot deadlock.
-    index_method_write_leases: Mutex<HashMap<MVTableId, TxID>>,
+    /// Custom-index writer leases keyed by the backing object's stable MVCC
+    /// table ID. Leases reject contention instead of waiting, so acquiring
+    /// several leases cannot deadlock. Entries outlive their holder: each one
+    /// remembers when the index was last published, so a transaction whose
+    /// read snapshot predates that publication is refused — its rebuild of
+    /// the index state starts from a superseded base and committing it would
+    /// overwrite the newer publication.
+    index_method_write_leases: Mutex<HashMap<MVTableId, IndexMethodWriteLease>>,
     commit_coordinator: Arc<CommitCoordinator>,
     global_header: Arc<RwLock<Option<DatabaseHeader>>>,
     /// Held by checkpoints only during the brief in-memory publish phase; the I/O-heavy
@@ -6212,9 +6232,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
     /// Acquire a transaction-scoped custom-index writer lease.
     ///
-    /// Acquisition is reentrant for the owning transaction. Contention is an
-    /// eager write conflict so expensive index construction never starts for a
-    /// transaction that cannot publish its work.
+    /// Acquisition is reentrant for the owning transaction. Contention with a
+    /// live holder is `Busy` — the caller can retry once the holder finishes,
+    /// exactly what `busy_timeout` handles. A transaction whose read snapshot
+    /// predates the index's last publication gets `WriteWriteConflict`
+    /// instead: it would rebuild the index from a superseded base, and no
+    /// amount of retrying inside the same transaction can fix that.
     pub(crate) fn acquire_index_method_write_lease(
         &self,
         tx_id: TxID,
@@ -6224,21 +6247,44 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             return Err(LimboError::NoSuchTransactionID(tx_id.to_string()));
         }
 
+        let snapshot_ts = self.read_snapshot_ts(tx_id);
         let mut leases = self.index_method_write_leases.lock();
-        match leases.get(&index_id) {
-            Some(owner) if *owner == tx_id => Ok(()),
-            Some(_) => Err(LimboError::WriteWriteConflict),
+        let lease = leases.entry(index_id).or_default();
+        match lease.holder {
+            Some(owner) if owner == tx_id => Ok(()),
+            Some(_) => Err(LimboError::Busy),
             None => {
-                leases.insert(index_id, tx_id);
+                if lease
+                    .last_publish_ts
+                    .is_some_and(|publish_ts| publish_ts > snapshot_ts)
+                {
+                    return Err(LimboError::WriteWriteConflict);
+                }
+                lease.holder = Some(tx_id);
                 Ok(())
             }
         }
     }
 
     fn release_index_method_write_leases(&self, tx_id: TxID) {
-        self.index_method_write_leases
-            .lock()
-            .retain(|_, owner| *owner != tx_id);
+        // A committed holder published new index state: remember its commit
+        // timestamp so later writers with older snapshots are refused.
+        let committed_at =
+            self.txs
+                .get(&tx_id)
+                .and_then(|entry| match entry.value().state.load() {
+                    TransactionState::Committed(commit_ts) => Some(commit_ts),
+                    _ => None,
+                });
+        let mut leases = self.index_method_write_leases.lock();
+        for lease in leases.values_mut() {
+            if lease.holder == Some(tx_id) {
+                lease.holder = None;
+                if committed_at.is_some() {
+                    lease.last_publish_ts = committed_at;
+                }
+            }
+        }
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::FinalizedTxStateInsert)]

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1805,11 +1805,6 @@ impl Schema {
                 unparsed_sql_from_index.root_page,
                 table.as_ref(),
             )?;
-            if mvcc_enabled {
-                if let Some(index_method) = index.index_method.as_ref() {
-                    crate::index_method::ensure_mvcc_support(&index_method.definition(), false)?;
-                }
-            }
             self.add_index(Arc::new(index))?;
         }
 

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -25,7 +25,7 @@ use crate::{
             EXPLAIN_QUERY_PLAN_JSON_COLUMNS_TYPE,
         },
     },
-    EqpFormat, LimboError, MvStore, Pager, QueryMode, Result, TransactionState, Value,
+    Connection, EqpFormat, LimboError, MvStore, Pager, QueryMode, Result, TransactionState, Value,
     EXPLAIN_COLUMNS, EXPLAIN_QUERY_PLAN_COLUMNS, EXPLAIN_QUERY_PLAN_JSON_COLUMNS,
 };
 
@@ -335,6 +335,25 @@ impl std::fmt::Debug for Statement {
 }
 
 impl Statement {
+    pub(crate) fn prepare_index_methods(&mut self) -> Result<crate::IOResult<()>> {
+        crate::vdbe::execute::index_method_prepare_statement_all(&mut self.state)
+    }
+
+    pub(crate) fn abort_index_methods(&mut self) {
+        crate::vdbe::execute::index_method_abort_statement_all(&mut self.state);
+    }
+
+    pub(crate) fn commit_index_methods(&mut self) {
+        crate::vdbe::execute::index_method_transaction_committed_all(
+            &mut self.state,
+            &self.program.connection,
+        );
+    }
+
+    pub(crate) fn register_index_methods(&mut self, connection: &Connection) -> Result<()> {
+        crate::vdbe::execute::index_method_register_transaction_all(&mut self.state, connection)
+    }
+
     pub fn new(
         program: vdbe::Program,
         pager: Arc<Pager>,

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -336,7 +336,7 @@ impl std::fmt::Debug for Statement {
 
 impl Statement {
     pub(crate) fn prepare_index_methods(&mut self) -> Result<crate::IOResult<()>> {
-        crate::vdbe::execute::index_method_prepare_statement_all(&mut self.state)
+        crate::vdbe::execute::index_method_stage_statement_all(&mut self.state)
     }
 
     pub(crate) fn abort_index_methods(&mut self) {
@@ -344,7 +344,7 @@ impl Statement {
     }
 
     pub(crate) fn commit_index_methods(&mut self) {
-        crate::vdbe::execute::index_method_transaction_committed_all(
+        crate::vdbe::execute::index_method_on_transaction_committed_all(
             &mut self.state,
             &self.program.connection,
         );

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1,7 +1,7 @@
 use crate::alloc::{TryClone, TursoIteratorExt, TursoVecExt};
 use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::Func;
-use crate::index_method::{ensure_mvcc_support, IndexMethodConfiguration};
+use crate::index_method::IndexMethodConfiguration;
 use crate::numeric::Numeric;
 use crate::schema::{Column, GeneratedType, Table, EXPR_INDEX_SENTINEL, RESERVED_TABLE_PREFIXES};
 use crate::sync::Arc;
@@ -204,16 +204,12 @@ pub fn translate_create_index(
         }
         if let Some(index_module) = index_module {
             let parameters = resolve_index_method_parameters(with_clause)?;
-            let attachment = index_module.attach(&IndexMethodConfiguration {
+            index_method = Some(index_module.attach(&IndexMethodConfiguration {
                 table_name: tbl.name.clone(),
                 index_name: idx_name.clone(),
                 columns: columns.try_clone()?,
                 parameters,
-            })?;
-            if connection.mvcc_enabled() {
-                ensure_mvcc_support(&attachment.definition(), true)?;
-            }
-            index_method = Some(attachment);
+            })?);
         }
     }
     let idx = Arc::new(Index {

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -622,6 +622,16 @@ fn translate_integrity_check_impl(
         program.preassign_label_to_next_insn(table_empty_label);
 
         for bound_index in &bound_indexes {
+            // An index method's backing B-tree stores its data in the index
+            // alone; the owning table has zero rows by construction, so the
+            // entry-count comparison below would report every healthy FTS
+            // database as corrupt. Its pages are still visited above.
+            if bound_index.index.is_backing_btree_index() {
+                program.emit_insn(Insn::Close {
+                    cursor_id: bound_index.cursor_id,
+                });
+                continue;
+            }
             if bound_index.where_expr.is_none() {
                 let actual_count_reg = program.alloc_register();
                 program.emit_insn(Insn::Count {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -696,7 +696,7 @@ fn optimize_recursive_cte_query_with_cache(
 /// Transform MATCH expressions to fts_match() function calls.
 fn transform_match_to_fts_match(
     where_clause: &mut [WhereTerm],
-    schema: &Schema,
+    resolver: &Resolver,
     table_references: &TableReferences,
 ) -> Result<()> {
     use super::ast::{FunctionTail, LikeOperator, Name, TableInternalId};
@@ -711,7 +711,9 @@ fn transform_match_to_fts_match(
         }
     }
 
-    // Helper to check if a table has an FTS index by its internal ID
+    // Helper to check if a table has an FTS index by its internal ID.
+    // Resolve against the schema of the table's own database, so MATCH also
+    // plans against FTS indexes in ATTACHed databases.
     let table_has_fts_index = |table_id: TableInternalId| -> bool {
         table_references
             .joined_tables()
@@ -719,7 +721,10 @@ fn transform_match_to_fts_match(
             .find(|t| t.internal_id == table_id)
             .and_then(|t| {
                 if let Table::BTree(btree) = &t.table {
-                    Some(schema.has_fts_index(&btree.name))
+                    Some(
+                        resolver
+                            .with_schema(t.database_id, |schema| schema.has_fts_index(&btree.name)),
+                    )
                 } else {
                     None
                 }
@@ -975,7 +980,7 @@ fn find_select_plan_form(
     // A rewrite can move MATCH terms out of a subquery, so do this after the
     // query form has been chosen.
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
+    transform_match_to_fts_match(&mut plan.where_clause, resolver, &plan.table_references)?;
 
     // EXISTS only needs one row. Add LIMIT 1 to subqueries left after the
     // rewrite. The rewrite must see the limit written by the user, if any.
@@ -1145,7 +1150,7 @@ fn optimize_delete_plan(plan: &mut DeletePlan, resolver: &Resolver) -> Result<()
     let available_indexes =
         AvailableIndexes::for_table_references(resolver, &plan.table_references);
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
+    transform_match_to_fts_match(&mut plan.where_clause, resolver, &plan.table_references)?;
 
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
@@ -1194,7 +1199,7 @@ fn optimize_update_plan(
         plan.from_tables.outer_query_refs().to_vec(),
     );
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &target_tables)?;
+    transform_match_to_fts_match(&mut plan.where_clause, resolver, &target_tables)?;
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?

--- a/core/types.rs
+++ b/core/types.rs
@@ -2423,6 +2423,9 @@ impl IndexInfo {
     ) -> Result<Self, TryReserveError> {
         // A backing_btree stores the index method's complete opaque key. Unlike
         // an ordinary secondary index, it must not append the base-table rowid.
+        // MVCC's commit-time conflict validation handles these
+        // `has_rowid == false` records by treating the whole key as the
+        // uniqueness prefix (see `check_index_for_conflicts`).
         let has_rowid = index.has_rowid && !index.is_backing_btree_index();
         let key_info = index
             .columns
@@ -3374,6 +3377,11 @@ impl Cursor {
             Self::Pseudo(_) => {}
             // Permanently null; the flag is a no-op.
             Self::NullRow => {}
+            // The FTS side of an outer join: columns are decoded from the
+            // base-table cursor (which receives its own NullRow), never from
+            // the index-method cursor, so there is no column state to null
+            // out here.
+            Self::IndexMethod(_) => {}
             _ => {
                 mark_unlikely();
                 panic!("set_null_flag on unexpected cursor type");

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1186,6 +1186,26 @@ pub fn op_if_not(
     Ok(InsnFunctionStepResult::Step)
 }
 
+fn ensure_index_method_context(
+    program: &Program,
+    state: &mut ProgramState,
+    cursor_id: usize,
+    database_id: usize,
+    attachment: &dyn crate::index_method::IndexMethodAttachment,
+) -> Result<crate::index_method::IndexMethodContext> {
+    if let Some(context) = state.index_method_contexts[cursor_id].as_ref() {
+        return Ok(context.clone());
+    }
+    let definition = attachment.definition();
+    let context = crate::index_method::IndexMethodContext::new(
+        &program.connection,
+        database_id,
+        &definition,
+    )?;
+    state.index_method_contexts[cursor_id] = Some(context.clone());
+    Ok(context)
+}
+
 pub fn op_open_read(
     program: &Program,
     state: &mut ProgramState,
@@ -1207,6 +1227,11 @@ pub fn op_open_read(
     let mv_store = program.connection.mv_store_for_db(*db);
 
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
+        if mv_store.is_some() {
+            crate::index_method::ensure_mvcc_support(&module.definition(), false)?;
+        }
+        let context =
+            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
             let cursor_ref = &mut state.cursors[*cursor_id];
@@ -1217,7 +1242,7 @@ pub fn op_open_read(
             .as_mut()
             .expect("cursor should exist after initialization");
         let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.open_read(&program.connection, *db));
+        return_if_io!(cursor.open_read(&context));
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
@@ -3416,7 +3441,10 @@ pub fn halt(
     // for FAIL mode and need to continue the commit, then return the stored error.
     if let Some(pending_error) = state.pending_fail_error.take() {
         match program.commit_txn(pager.clone(), state, mv_store.as_ref(), false)? {
-            IOResult::Done(_) => return Err(pending_error),
+            IOResult::Done(_) => {
+                index_method_transaction_committed_all(state, &program.connection);
+                return Err(pending_error);
+            }
             IOResult::IO(io) => {
                 state.pending_fail_error = Some(pending_error); // put it back and wait
                 return Ok(InsnFunctionStepResult::IO(io));
@@ -3497,14 +3525,18 @@ pub fn halt(
                 ));
             }
 
-            // Release savepoint to preserve partial changes, then commit
-            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
+            // Prepare every custom index before releasing the statement
+            // savepoint, then commit the partial FAIL changes.
             vtab_commit_all(&program.connection)?;
-            index_method_pre_commit_all(state, pager)?;
+            return_if_io!(index_method_prepare_statement_all(state));
+            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
 
             // Commit the transaction with partial changes
             match program.commit_txn(pager.clone(), state, mv_store.as_ref(), false)? {
-                IOResult::Done(_) => return Err(error),
+                IOResult::Done(_) => {
+                    index_method_transaction_committed_all(state, &program.connection);
+                    return Err(error);
+                }
                 IOResult::IO(io) => {
                     // store the error for reentrancy
                     state.pending_fail_error = Some(error);
@@ -3548,7 +3580,11 @@ pub fn halt(
     }
 
     if program.is_trigger_subprogram() {
-        index_method_pre_commit_all(state, pager)?;
+        // Trigger statements are cached and reset before the next firing.
+        // Stage their index-method writes now so reset cannot drop pending
+        // work from an earlier row in the parent statement. The parent still
+        // owns the statement savepoint and the final transaction outcome.
+        return_if_io!(index_method_prepare_statement_all(state));
         return Ok(InsnFunctionStepResult::Done);
     }
 
@@ -3576,10 +3612,10 @@ pub fn halt(
                 ));
             }
         }
-        state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
         if can_autocommit_now {
             vtab_commit_all(&program.connection)?;
-            index_method_pre_commit_all(state, pager)?;
+            return_if_io!(index_method_prepare_statement_all(state));
+            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
             // Sequence backing-table compaction and sqlite_sequence sync
             // are emitted as straight-line bytecode inside the
             // nextval / advance_past / setval translators
@@ -3594,6 +3630,7 @@ pub fn halt(
                 .map(Into::into);
             // Apply deferred CDC state and reset CDC txn ID after successful commit
             if matches!(result, Ok(InsnFunctionStepResult::Done)) {
+                index_method_transaction_committed_all(state, &program.connection);
                 if let Some(cdc_info) = state.pending_cdc_info.take() {
                     program.connection.set_capture_data_changes_info(cdc_info);
                 }
@@ -3601,6 +3638,7 @@ pub fn halt(
             }
             result
         } else {
+            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
             // Another root statement may own the implicit autocommit
             // transaction. This statement can finish, but must not commit or
             // roll back connection-level state it did not start.
@@ -3644,8 +3682,9 @@ pub fn halt(
         // Otherwise the cursor's Drop fallback performs these writes after
         // statement success, where an I/O error can no longer be returned to
         // the caller or rolled back at statement scope.
-        index_method_pre_commit_all(state, pager)?;
+        return_if_io!(index_method_prepare_statement_all(state));
         state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
+        index_method_register_transaction_all(state, &program.connection)?;
         // Apply deferred CDC state after successful statement completion
         if let Some(cdc_info) = state.pending_cdc_info.take() {
             program.connection.set_capture_data_changes_info(cdc_info);
@@ -3679,27 +3718,174 @@ pub(crate) fn vtab_commit_all(conn: &Connection) -> crate::Result<()> {
     Ok(())
 }
 
-/// Flush pending writes on all index method cursors before transaction commit.
-/// This ensures index method writes are persisted as part of the transaction.
-pub(crate) fn index_method_pre_commit_all(
+/// Stage pending writes on every index-method cursor before releasing the
+/// statement savepoint. Cursor order is bytecode cursor order, which is stable
+/// across resumptions and avoids attachment-order ambiguity.
+pub(crate) fn index_method_prepare_statement_all(
     state: &mut ProgramState,
-    pager: &Arc<Pager>,
-) -> crate::Result<()> {
-    for cursor_opt in state.cursors.iter_mut().flatten() {
-        let Cursor::IndexMethod(cursor) = cursor_opt else {
-            continue;
-        };
-        loop {
-            match cursor.pre_commit()? {
-                IOResult::Done(()) => break,
-                IOResult::IO(io) => {
-                    while !io.finished() {
-                        pager.io.step()?;
-                    }
-                }
+) -> crate::Result<IOResult<()>> {
+    if state.index_methods_finalized {
+        return Ok(IOResult::Done(()));
+    }
+
+    while state.index_method_finalize_cursor < state.cursors.len() {
+        let cursor_id = state.index_method_finalize_cursor;
+        if matches!(
+            state.cursors[cursor_id].as_ref(),
+            Some(Cursor::IndexMethod(_))
+        ) {
+            let Some(context) = state.index_method_contexts[cursor_id].clone() else {
+                return Err(LimboError::InternalError(format!(
+                    "index-method cursor {cursor_id} has no execution context"
+                )));
+            };
+            crate::mvcc::yield_points::inject_io_yield!(
+                context,
+                crate::index_method::IndexMethodYieldPoint::BeforePrepareStatement
+            );
+            let Some(Cursor::IndexMethod(cursor)) = state.cursors[cursor_id].as_mut() else {
+                unreachable!("cursor kind checked above")
+            };
+            match cursor.prepare_statement_commit(&context)? {
+                IOResult::Done(()) => {}
+                IOResult::IO(io) => return Ok(IOResult::IO(io)),
             }
+            state.index_method_finalize_cursor += 1;
+            crate::mvcc::yield_points::inject_io_yield!(
+                context,
+                crate::index_method::IndexMethodYieldPoint::AfterPrepareStatement
+            );
+            continue;
+        }
+        state.index_method_finalize_cursor += 1;
+    }
+
+    let subprogram_keys = state
+        .index_method_finalize_subprogram_keys
+        .get_or_insert_with(|| {
+            let mut keys = state
+                .subprogram_stmt_cache
+                .keys()
+                .copied()
+                .collect::<Vec<_>>();
+            keys.sort_unstable();
+            keys
+        });
+    while state.index_method_finalize_subprogram < subprogram_keys.len() {
+        let key = subprogram_keys[state.index_method_finalize_subprogram];
+        let statement = state
+            .subprogram_stmt_cache
+            .get_mut(&key)
+            .expect("finalization key must reference a cached subprogram");
+        match statement.prepare_index_methods()? {
+            IOResult::Done(()) => state.index_method_finalize_subprogram += 1,
+            IOResult::IO(io) => return Ok(IOResult::IO(io)),
         }
     }
+
+    state.index_methods_finalized = true;
+    Ok(IOResult::Done(()))
+}
+
+/// Discard statement-owned index-method work before a statement savepoint or
+/// transaction is rolled back. Hooks are deliberately infallible and may not
+/// perform I/O.
+pub(crate) fn index_method_abort_statement_all(state: &mut ProgramState) {
+    for (cursor_id, cursor_opt) in state.cursors.iter_mut().enumerate() {
+        let Some(Cursor::IndexMethod(cursor)) = cursor_opt else {
+            continue;
+        };
+        let Some(context) = state.index_method_contexts[cursor_id].as_ref() else {
+            continue;
+        };
+        cursor.abort_statement(context);
+    }
+    for (cursor, context) in &mut state.closed_index_method_cursors {
+        cursor.abort_statement(context);
+    }
+    for statement in state.subprogram_stmt_cache.values_mut() {
+        statement.abort_index_methods();
+    }
+    state.index_method_finalize_cursor = 0;
+    state.index_method_finalize_subprogram_keys = None;
+    state.index_method_finalize_subprogram = 0;
+    state.index_methods_finalized = false;
+}
+
+/// Publish safe in-memory state after a durable autocommit outcome.
+pub(crate) fn index_method_transaction_committed_all(
+    state: &mut ProgramState,
+    connection: &Connection,
+) {
+    tracing::trace!(
+        open_cursors = state
+            .cursors
+            .iter()
+            .filter(|cursor| matches!(cursor, Some(Cursor::IndexMethod(_))))
+            .count(),
+        closed_cursors = state.closed_index_method_cursors.len(),
+        subprograms = state.subprogram_stmt_cache.len(),
+        "publishing committed index-method state"
+    );
+    for (cursor_id, cursor_opt) in state.cursors.iter_mut().enumerate() {
+        let Some(Cursor::IndexMethod(cursor)) = cursor_opt else {
+            continue;
+        };
+        let Some(context) = state.index_method_contexts[cursor_id].as_ref() else {
+            continue;
+        };
+        cursor.transaction_committed(context);
+    }
+    for (cursor, context) in &mut state.closed_index_method_cursors {
+        cursor.transaction_committed(context);
+    }
+    for statement in state.subprogram_stmt_cache.values_mut() {
+        statement.commit_index_methods();
+    }
+    connection.index_methods_transaction_committed();
+}
+
+/// Transfer the final prepared cursor for every attachment touched by this
+/// statement into connection-level transaction ownership. Replacing an older
+/// cursor for the same attachment keeps outcome delivery exactly once while
+/// retaining the newest in-transaction view.
+pub(crate) fn index_method_register_transaction_all(
+    state: &mut ProgramState,
+    connection: &Connection,
+) -> crate::Result<()> {
+    let mut registered = 0usize;
+    for cursor_id in 0..state.cursors.len() {
+        if !matches!(state.cursors[cursor_id], Some(Cursor::IndexMethod(_))) {
+            continue;
+        }
+        let Some(Cursor::IndexMethod(cursor)) = state.cursors[cursor_id].take() else {
+            unreachable!("cursor kind checked above")
+        };
+        let context = state.index_method_contexts[cursor_id]
+            .take()
+            .ok_or_else(|| {
+                LimboError::InternalError(format!(
+                    "index-method cursor {cursor_id} has no execution context"
+                ))
+            })?;
+        connection.register_index_method_transaction_cursor(
+            crate::index_method::TransactionIndexMethodCursor { cursor, context },
+        );
+        registered += 1;
+    }
+    for (cursor, context) in state.closed_index_method_cursors.drain(..) {
+        connection.register_index_method_transaction_cursor(
+            crate::index_method::TransactionIndexMethodCursor { cursor, context },
+        );
+        registered += 1;
+    }
+    for statement in state.subprogram_stmt_cache.values_mut() {
+        statement.register_index_methods(connection)?;
+    }
+    tracing::trace!(
+        registered,
+        "retained statement index-method cursors for transaction outcome"
+    );
     Ok(())
 }
 
@@ -4629,6 +4815,9 @@ pub fn op_auto_commit(
             res,
             Ok(InsnFunctionStepResult::Step | InsnFunctionStepResult::Done)
         ) {
+            if !*rollback {
+                conn.index_methods_transaction_committed();
+            }
             conn.clear_tx_poison();
             conn.clear_named_savepoints();
         }
@@ -4689,6 +4878,7 @@ pub fn op_auto_commit(
                 }
                 conn.rollback_attached_wal_txns();
                 conn.rollback_temp_schema();
+                conn.index_methods_transaction_rolled_back();
                 conn.set_tx_state(TransactionState::None);
                 conn.auto_commit.store(true, Ordering::SeqCst);
                 conn.set_cdc_transaction_id(-1);
@@ -4742,7 +4932,7 @@ pub fn op_auto_commit(
     // so they are part of the same transaction. Sequence flush no longer
     // belongs here — see the long-form comment in `op_halt` above.
     if matches!(tx_op, TxOp::Commit) {
-        index_method_pre_commit_all(state, pager)?;
+        return_if_io!(index_method_prepare_statement_all(state));
     }
 
     let res = match program
@@ -4776,6 +4966,9 @@ pub fn op_auto_commit(
 
     // Reset CDC transaction ID after successful COMMIT or ROLLBACK.
     conn.set_cdc_transaction_id(-1);
+    if matches!(tx_op, TxOp::Commit) {
+        conn.index_methods_transaction_committed();
+    }
     conn.clear_tx_poison();
     conn.clear_named_savepoints();
 
@@ -5016,6 +5209,7 @@ pub fn op_savepoint(
                 }
             });
             pager.set_schema_cookie(None);
+            conn.index_methods_savepoint_rolled_back();
 
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
@@ -12762,6 +12956,11 @@ pub fn op_open_write(
     let mv_store = program.connection.mv_store_for_db(*db);
 
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
+        if mv_store.is_some() {
+            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
+        }
+        let context =
+            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
             let cursor_ref = &mut state.cursors[*cursor_id];
@@ -12772,7 +12971,7 @@ pub fn op_open_write(
             .as_mut()
             .expect("cursor should exist");
         let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.open_write(&program.connection, *db));
+        return_if_io!(cursor.open_write(&context));
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
@@ -13004,17 +13203,22 @@ pub fn op_index_method_create(
         return Err(LimboError::ReadOnly);
     }
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
+        if program.connection.mv_store_for_db(*db).is_some() {
+            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
+        }
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
             let cursor_ref = &mut state.cursors[*cursor_id];
             *cursor_ref = Some(Cursor::IndexMethod(cursor));
         }
+        let context =
+            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+        let cursor = state.cursors[*cursor_id]
+            .as_mut()
+            .expect("cursor should exist");
+        let cursor = cursor.as_index_method_mut();
+        return_if_io!(cursor.create(&context));
     }
-    let cursor = state.cursors[*cursor_id]
-        .as_mut()
-        .expect("cursor should exist");
-    let cursor = cursor.as_index_method_mut();
-    return_if_io!(cursor.create(&program.connection, *db));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13031,17 +13235,22 @@ pub fn op_index_method_destroy(
         return Err(LimboError::ReadOnly);
     }
     if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
+        if program.connection.mv_store_for_db(*db).is_some() {
+            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
+        }
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
             let cursor_ref = &mut state.cursors[*cursor_id];
             *cursor_ref = Some(Cursor::IndexMethod(cursor));
         }
+        let context =
+            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+        let cursor = state.cursors[*cursor_id]
+            .as_mut()
+            .expect("cursor should exist");
+        let cursor = cursor.as_index_method_mut();
+        return_if_io!(cursor.destroy(&context));
     }
-    let cursor = state.cursors[*cursor_id]
-        .as_mut()
-        .expect("cursor should exist");
-    let cursor = cursor.as_index_method_mut();
-    return_if_io!(cursor.destroy(&program.connection, *db));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13058,17 +13267,22 @@ pub fn op_index_method_optimize(
         return Err(LimboError::ReadOnly);
     }
     if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
+        if program.connection.mv_store_for_db(*db).is_some() {
+            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
+        }
         if state.cursors[*cursor_id].is_none() {
             let cursor = module.init()?;
             let cursor_ref = &mut state.cursors[*cursor_id];
             *cursor_ref = Some(Cursor::IndexMethod(cursor));
         }
+        let context =
+            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+        let cursor = state.cursors[*cursor_id]
+            .as_mut()
+            .expect("cursor should exist");
+        let cursor = cursor.as_index_method_mut();
+        return_if_io!(cursor.optimize(&context));
     }
-    let cursor = state.cursors[*cursor_id]
-        .as_mut()
-        .expect("cursor should exist");
-    let cursor = cursor.as_index_method_mut();
-    return_if_io!(cursor.optimize(&program.connection, *db));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -14047,6 +14261,24 @@ pub fn op_close(
     _pager: &Arc<Pager>,
 ) -> Result<InsnFunctionStepResult> {
     load_insn!(Close { cursor_id }, insn);
+    if let Some(Cursor::IndexMethod(cursor)) = state.cursors[*cursor_id].as_mut() {
+        let context = state.index_method_contexts[*cursor_id]
+            .as_ref()
+            .ok_or_else(|| {
+                LimboError::InternalError(format!(
+                    "index-method cursor {cursor_id} closed without an execution context"
+                ))
+            })?
+            .clone();
+        return_if_io!(cursor.prepare_statement_commit(&context));
+        let Some(Cursor::IndexMethod(cursor)) = state.cursors[*cursor_id].take() else {
+            unreachable!("cursor variant checked above");
+        };
+        let context = state.index_method_contexts[*cursor_id]
+            .take()
+            .expect("index-method context checked above");
+        state.closed_index_method_cursors.push((cursor, context));
+    }
     let cursors = &mut state.cursors;
     cursors
         .get_mut(*cursor_id)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3447,7 +3447,7 @@ pub fn halt(
     if let Some(pending_error) = state.pending_fail_error.take() {
         match program.commit_txn(pager.clone(), state, mv_store.as_ref(), false)? {
             IOResult::Done(_) => {
-                index_method_transaction_committed_all(state, &program.connection);
+                index_method_on_transaction_committed_all(state, &program.connection);
                 return Err(pending_error);
             }
             IOResult::IO(io) => {
@@ -3470,7 +3470,7 @@ pub fn halt(
             // writes now, exactly like the normal trigger-subprogram halt
             // below, so the kept base rows keep their index entries too.
             if program.is_trigger_subprogram() {
-                return_if_io!(index_method_prepare_statement_all(state));
+                return_if_io!(index_method_stage_statement_all(state));
             }
             return Err(LimboError::RaiseIgnore);
         }
@@ -3537,16 +3537,22 @@ pub fn halt(
                 ));
             }
 
-            // Prepare every custom index before releasing the statement
-            // savepoint, then commit the partial FAIL changes.
+            // Stage every custom index before releasing the statement
+            // savepoint, then commit the partial FAIL changes. Yielding for
+            // I/O here is safe because Halt is re-entrant: the whole opcode
+            // runs again on resume, recomputes the same outcome from the same
+            // registers, and `pending_fail_error` carries the decided error
+            // across resumes further down. `halt_in_progress` keeps
+            // interrupt, deadline, and progress-handler requests from
+            // replacing the outcome while the staged work is in flight.
             vtab_commit_all(&program.connection)?;
-            return_if_io!(index_method_prepare_statement_all(state));
+            return_if_io!(index_method_stage_statement_all(state));
             state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
 
             // Commit the transaction with partial changes
             match program.commit_txn(pager.clone(), state, mv_store.as_ref(), false)? {
                 IOResult::Done(_) => {
-                    index_method_transaction_committed_all(state, &program.connection);
+                    index_method_on_transaction_committed_all(state, &program.connection);
                     return Err(error);
                 }
                 IOResult::IO(io) => {
@@ -3596,7 +3602,7 @@ pub fn halt(
         // Stage their index-method writes now so reset cannot drop pending
         // work from an earlier row in the parent statement. The parent still
         // owns the statement savepoint and the final transaction outcome.
-        return_if_io!(index_method_prepare_statement_all(state));
+        return_if_io!(index_method_stage_statement_all(state));
         return Ok(InsnFunctionStepResult::Done);
     }
 
@@ -3626,7 +3632,7 @@ pub fn halt(
         }
         if can_autocommit_now {
             vtab_commit_all(&program.connection)?;
-            return_if_io!(index_method_prepare_statement_all(state));
+            return_if_io!(index_method_stage_statement_all(state));
             state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
             // Sequence backing-table compaction and sqlite_sequence sync
             // are emitted as straight-line bytecode inside the
@@ -3642,7 +3648,7 @@ pub fn halt(
                 .map(Into::into);
             // Apply deferred CDC state and reset CDC txn ID after successful commit
             if matches!(result, Ok(InsnFunctionStepResult::Done)) {
-                index_method_transaction_committed_all(state, &program.connection);
+                index_method_on_transaction_committed_all(state, &program.connection);
                 if let Some(cdc_info) = state.pending_cdc_info.take() {
                     program.connection.set_capture_data_changes_info(cdc_info);
                 }
@@ -3657,7 +3663,7 @@ pub fn halt(
             // savepoint is released, and its cursors handed to the connection
             // so the sibling that eventually commits (or rolls back) the
             // shared transaction delivers their outcome.
-            return_if_io!(index_method_prepare_statement_all(state));
+            return_if_io!(index_method_stage_statement_all(state));
             state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
             index_method_register_transaction_all(state, &program.connection)?;
             //
@@ -3700,7 +3706,7 @@ pub fn halt(
         // Otherwise the cursor's Drop fallback performs these writes after
         // statement success, where an I/O error can no longer be returned to
         // the caller or rolled back at statement scope.
-        return_if_io!(index_method_prepare_statement_all(state));
+        return_if_io!(index_method_stage_statement_all(state));
         state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
         index_method_register_transaction_all(state, &program.connection)?;
         // Apply deferred CDC state after successful statement completion
@@ -3739,7 +3745,7 @@ pub(crate) fn vtab_commit_all(conn: &Connection) -> crate::Result<()> {
 /// Stage pending writes on every index-method cursor before releasing the
 /// statement savepoint. Cursor order is bytecode cursor order, which is stable
 /// across resumptions and avoids attachment-order ambiguity.
-pub(crate) fn index_method_prepare_statement_all(
+pub(crate) fn index_method_stage_statement_all(
     state: &mut ProgramState,
 ) -> crate::Result<IOResult<()>> {
     if state.index_methods_finalized {
@@ -3764,7 +3770,7 @@ pub(crate) fn index_method_prepare_statement_all(
             let Some(Cursor::IndexMethod(cursor)) = state.cursors[cursor_id].as_mut() else {
                 unreachable!("cursor kind checked above")
             };
-            match cursor.prepare_statement_commit(&context)? {
+            match cursor.stage_statement_commit(&context)? {
                 IOResult::Done(()) => {}
                 IOResult::IO(io) => return Ok(IOResult::IO(io)),
             }
@@ -3837,7 +3843,7 @@ pub(crate) fn index_method_abort_statement_all(state: &mut ProgramState) {
 }
 
 /// Publish safe in-memory state after a durable autocommit outcome.
-pub(crate) fn index_method_transaction_committed_all(
+pub(crate) fn index_method_on_transaction_committed_all(
     state: &mut ProgramState,
     connection: &Connection,
 ) {
@@ -3864,15 +3870,15 @@ pub(crate) fn index_method_transaction_committed_all(
             );
             continue;
         };
-        cursor.transaction_committed(context);
+        cursor.on_transaction_committed(context);
     }
     for (cursor, context) in &mut state.closed_index_method_cursors {
-        cursor.transaction_committed(context);
+        cursor.on_transaction_committed(context);
     }
     for statement in state.subprogram_stmt_cache.values_mut() {
         statement.commit_index_methods();
     }
-    connection.index_methods_transaction_committed();
+    connection.index_methods_on_transaction_committed();
 }
 
 /// Transfer the final prepared cursor for every attachment touched by this
@@ -4846,7 +4852,7 @@ pub fn op_auto_commit(
             Ok(InsnFunctionStepResult::Step | InsnFunctionStepResult::Done)
         ) {
             if !*rollback {
-                conn.index_methods_transaction_committed();
+                conn.index_methods_on_transaction_committed();
             }
             conn.clear_tx_poison();
             conn.clear_named_savepoints();
@@ -4908,7 +4914,7 @@ pub fn op_auto_commit(
                 }
                 conn.rollback_attached_wal_txns();
                 conn.rollback_temp_schema();
-                conn.index_methods_transaction_rolled_back();
+                conn.index_methods_on_transaction_rolled_back();
                 conn.set_tx_state(TransactionState::None);
                 conn.auto_commit.store(true, Ordering::SeqCst);
                 conn.set_cdc_transaction_id(-1);
@@ -4998,7 +5004,7 @@ pub fn op_auto_commit(
     // Reset CDC transaction ID after successful COMMIT or ROLLBACK.
     conn.set_cdc_transaction_id(-1);
     if matches!(tx_op, TxOp::Commit) {
-        conn.index_methods_transaction_committed();
+        conn.index_methods_on_transaction_committed();
     }
     conn.clear_tx_poison();
     conn.clear_named_savepoints();
@@ -5240,7 +5246,7 @@ pub fn op_savepoint(
                 }
             });
             pager.set_schema_cookie(None);
-            conn.index_methods_savepoint_rolled_back();
+            conn.index_methods_on_savepoint_rolled_back();
 
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
@@ -14303,7 +14309,7 @@ pub fn op_close(
                 ))
             })?
             .clone();
-        return_if_io!(cursor.prepare_statement_commit(&context));
+        return_if_io!(cursor.stage_statement_commit(&context));
         let Some(Cursor::IndexMethod(cursor)) = state.cursors[*cursor_id].take() else {
             unreachable!("cursor variant checked above");
         };

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -758,7 +758,9 @@ pub fn op_null_row(
         turso_assert!(
             matches!(
                 cursor_type,
-                CursorType::BTreeTable(_) | CursorType::BTreeIndex(_)
+                CursorType::BTreeTable(_)
+                    | CursorType::BTreeIndex(_)
+                    | CursorType::IndexMethod(_)
             ),
             "NullRow on unopened non-btree cursor",
             { "cursor_id": cursor_id }
@@ -1192,17 +1194,19 @@ fn ensure_index_method_context(
     cursor_id: usize,
     database_id: usize,
     attachment: &dyn crate::index_method::IndexMethodAttachment,
-) -> Result<crate::index_method::IndexMethodContext> {
+) -> Result<Arc<crate::index_method::IndexMethodContext>> {
+    // Arc, not a deep clone: an opcode that yields on IO re-enters and calls
+    // this again — a cold FTS open does that hundreds of times per megabyte,
+    // and cloning the context's four heap strings each time adds up.
     if let Some(context) = state.index_method_contexts[cursor_id].as_ref() {
-        return Ok(context.clone());
+        return Ok(Arc::clone(context));
     }
-    let definition = attachment.definition();
-    let context = crate::index_method::IndexMethodContext::new(
+    let context = Arc::new(crate::index_method::IndexMethodContext::new(
         &program.connection,
         database_id,
-        &definition,
-    )?;
-    state.index_method_contexts[cursor_id] = Some(context.clone());
+        &attachment.definition(),
+    )?);
+    state.index_method_contexts[cursor_id] = Some(Arc::clone(&context));
     Ok(context)
 }
 
@@ -3430,6 +3434,7 @@ pub fn halt(
     description: &str,
     on_error: Option<ResolveType>,
 ) -> Result<InsnFunctionStepResult> {
+    state.halt_in_progress = true;
     let mv_store = program.connection.mv_store();
     let auto_commit = program.connection.auto_commit.load(Ordering::SeqCst);
     // halt() runs while the statement is still stepping, so it is always
@@ -3460,6 +3465,13 @@ pub fn halt(
     if let Some(resolve_type) = on_error {
         // RAISE(IGNORE) signals the parent to skip the current row
         if resolve_type == ResolveType::Ignore {
+            // RAISE(IGNORE) is not an error: the frame unwinds, but everything
+            // the trigger wrote before the RAISE is kept. Stage index-method
+            // writes now, exactly like the normal trigger-subprogram halt
+            // below, so the kept base rows keep their index entries too.
+            if program.is_trigger_subprogram() {
+                return_if_io!(index_method_prepare_statement_all(state));
+            }
             return Err(LimboError::RaiseIgnore);
         }
         if err_code > 0 {
@@ -3638,10 +3650,16 @@ pub fn halt(
             }
             result
         } else {
-            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
             // Another root statement may own the implicit autocommit
             // transaction. This statement can finish, but must not commit or
-            // roll back connection-level state it did not start.
+            // roll back connection-level state it did not start. Its
+            // index-method writes must still be staged before the statement
+            // savepoint is released, and its cursors handed to the connection
+            // so the sibling that eventually commits (or rolls back) the
+            // shared transaction delivers their outcome.
+            return_if_io!(index_method_prepare_statement_all(state));
+            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
+            index_method_register_transaction_all(state, &program.connection)?;
             //
             // FIXME: when this statement is a writer in MVCC mode, deferring
             // its commit to the last sibling statement means the writer's
@@ -3796,6 +3814,12 @@ pub(crate) fn index_method_abort_statement_all(state: &mut ProgramState) {
             continue;
         };
         let Some(context) = state.index_method_contexts[cursor_id].as_ref() else {
+            // Every opcode that installs an index-method cursor builds its
+            // context first, so this cursor cannot have pending work.
+            debug_assert!(
+                false,
+                "index-method cursor {cursor_id} installed without a context"
+            );
             continue;
         };
         cursor.abort_statement(context);
@@ -3832,6 +3856,12 @@ pub(crate) fn index_method_transaction_committed_all(
             continue;
         };
         let Some(context) = state.index_method_contexts[cursor_id].as_ref() else {
+            // Every opcode that installs an index-method cursor builds its
+            // context first, so this cursor cannot have pending work.
+            debug_assert!(
+                false,
+                "index-method cursor {cursor_id} installed without a context"
+            );
             continue;
         };
         cursor.transaction_committed(context);
@@ -4928,12 +4958,13 @@ pub fn op_auto_commit(
         { "tx_op": tx_op }
     );
 
-    // For explicit COMMIT, flush pending writes before the actual commit
-    // so they are part of the same transaction. Sequence flush no longer
-    // belongs here — see the long-form comment in `op_halt` above.
-    if matches!(tx_op, TxOp::Commit) {
-        return_if_io!(index_method_prepare_statement_all(state));
-    }
+    // Index-method staging is a per-statement Halt responsibility (each
+    // statement stages its writes at its own halt and hands its cursors to
+    // the connection), so the COMMIT program has nothing to stage here. A
+    // yield point at this spot would also be unsafe: `conn.auto_commit` was
+    // already flipped above, and re-entering this opcode from the top after
+    // an IO yield would then fail `valid_transition` with a torn-down
+    // transaction.
 
     let res = match program
         .commit_txn(pager.clone(), state, mv_store.as_ref(), *rollback)
@@ -13202,23 +13233,25 @@ pub fn op_index_method_create(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
-        if program.connection.mv_store_for_db(*db).is_some() {
-            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
-        }
-        if state.cursors[*cursor_id].is_none() {
-            let cursor = module.init()?;
-            let cursor_ref = &mut state.cursors[*cursor_id];
-            *cursor_ref = Some(Cursor::IndexMethod(cursor));
-        }
-        let context =
-            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
-        let cursor = state.cursors[*cursor_id]
-            .as_mut()
-            .expect("cursor should exist");
-        let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.create(&context));
+    let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] else {
+        unreachable!("IndexMethodCreate emitted against a non-index-method cursor {cursor_id}");
+    };
+    if program.connection.mv_store_for_db(*db).is_some() {
+        crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
     }
+    // Build the context before installing the cursor: a context error must
+    // not leave a cursor in the slot with no context, a state the statement
+    // outcome helpers cannot deliver hooks to.
+    let context = ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+    if state.cursors[*cursor_id].is_none() {
+        let cursor = module.init()?;
+        state.cursors[*cursor_id] = Some(Cursor::IndexMethod(cursor));
+    }
+    let cursor = state.cursors[*cursor_id]
+        .as_mut()
+        .expect("cursor should exist")
+        .as_index_method_mut();
+    return_if_io!(cursor.create(&context));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13234,23 +13267,23 @@ pub fn op_index_method_destroy(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
-        if program.connection.mv_store_for_db(*db).is_some() {
-            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
-        }
-        if state.cursors[*cursor_id].is_none() {
-            let cursor = module.init()?;
-            let cursor_ref = &mut state.cursors[*cursor_id];
-            *cursor_ref = Some(Cursor::IndexMethod(cursor));
-        }
-        let context =
-            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
-        let cursor = state.cursors[*cursor_id]
-            .as_mut()
-            .expect("cursor should exist");
-        let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.destroy(&context));
+    let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) else {
+        unreachable!("IndexMethodDestroy emitted against a non-index-method cursor {cursor_id}");
+    };
+    if program.connection.mv_store_for_db(*db).is_some() {
+        crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
     }
+    // Context before cursor install; see op_index_method_create.
+    let context = ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+    if state.cursors[*cursor_id].is_none() {
+        let cursor = module.init()?;
+        state.cursors[*cursor_id] = Some(Cursor::IndexMethod(cursor));
+    }
+    let cursor = state.cursors[*cursor_id]
+        .as_mut()
+        .expect("cursor should exist")
+        .as_index_method_mut();
+    return_if_io!(cursor.destroy(&context));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13266,23 +13299,23 @@ pub fn op_index_method_optimize(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
-        if program.connection.mv_store_for_db(*db).is_some() {
-            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
-        }
-        if state.cursors[*cursor_id].is_none() {
-            let cursor = module.init()?;
-            let cursor_ref = &mut state.cursors[*cursor_id];
-            *cursor_ref = Some(Cursor::IndexMethod(cursor));
-        }
-        let context =
-            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
-        let cursor = state.cursors[*cursor_id]
-            .as_mut()
-            .expect("cursor should exist");
-        let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.optimize(&context));
+    let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) else {
+        unreachable!("IndexMethodOptimize emitted against a non-index-method cursor {cursor_id}");
+    };
+    if program.connection.mv_store_for_db(*db).is_some() {
+        crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
     }
+    // Context before cursor install; see op_index_method_create.
+    let context = ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+    if state.cursors[*cursor_id].is_none() {
+        let cursor = module.init()?;
+        state.cursors[*cursor_id] = Some(Cursor::IndexMethod(cursor));
+    }
+    let cursor = state.cursors[*cursor_id]
+        .as_mut()
+        .expect("cursor should exist")
+        .as_index_method_mut();
+    return_if_io!(cursor.optimize(&context));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -261,6 +261,7 @@ impl CommitState {
         connection.rollback_attached_mvcc_txs(true);
         connection.rollback_attached_wal_txns();
         connection.rollback_temp_schema();
+        connection.index_methods_transaction_rolled_back();
     }
 }
 
@@ -779,6 +780,21 @@ pub struct ProgramState {
     pub io_completions: Option<IOCompletions>,
     pub pc: InsnReference,
     pub(crate) cursors: Vec<Option<Cursor>>,
+    /// Immutable execution/storage context captured when each index-method
+    /// cursor is first opened for this statement.
+    pub(crate) index_method_contexts: Vec<Option<crate::index_method::IndexMethodContext>>,
+    /// Index-method cursors explicitly closed by bytecode after their
+    /// statement work was prepared. Retain them until commit/rollback decides
+    /// whether prepared in-memory state may be published.
+    pub(crate) closed_index_method_cursors: Vec<(
+        Box<dyn crate::index_method::IndexMethodCursor>,
+        crate::index_method::IndexMethodContext,
+    )>,
+    /// Resumption coordinates for statement-level index-method finalization.
+    pub(crate) index_method_finalize_cursor: usize,
+    pub(crate) index_method_finalize_subprogram_keys: Option<Vec<usize>>,
+    pub(crate) index_method_finalize_subprogram: usize,
+    pub(crate) index_methods_finalized: bool,
     cursor_seqs: Vec<i64>,
     registers: Box<[Register]>,
     /// Trace state: register snapshot for diffing.
@@ -849,6 +865,10 @@ pub struct ProgramState {
     /// When a constraint error occurs with FAIL resolve type in autocommit mode,
     /// we need to commit partial changes before returning the error.
     pub(crate) pending_fail_error: Option<LimboError>,
+    /// FAIL can escape a trigger before the parent reaches its Halt opcode.
+    /// Keep the error here while index-method writes from earlier rows finish
+    /// through the normal resumable I/O path.
+    pending_fail_prepare_error: Option<LimboError>,
     /// Pending CDC info to apply after the program completes successfully.
     /// Set by InitCdcVersion opcode, applied at Halt/Done so that if the
     /// transaction rolls back, the connection's CDC state remains unchanged.
@@ -904,6 +924,12 @@ impl ProgramState {
             io_completions: None,
             pc: 0,
             cursors,
+            index_method_contexts: vec![None; max_cursors],
+            closed_index_method_cursors: Vec::new(),
+            index_method_finalize_cursor: 0,
+            index_method_finalize_subprogram_keys: None,
+            index_method_finalize_subprogram: 0,
+            index_methods_finalized: false,
             cursor_seqs,
             registers,
             pre_op_registers: None,
@@ -943,6 +969,7 @@ impl ProgramState {
             n_total_change: AtomicI64::new(0),
             explain_state: RwLock::new(ExplainState::default()),
             pending_fail_error: None,
+            pending_fail_prepare_error: None,
             pending_cdc_info: None,
             subprogram_stmt_cache: HashMap::default(),
         }
@@ -1008,6 +1035,7 @@ impl ProgramState {
 
         if let Some(max_cursors) = max_cursors {
             self.cursors.resize_with(max_cursors, || None);
+            self.index_method_contexts.resize_with(max_cursors, || None);
             self.cursor_seqs.resize(max_cursors, 0);
             self.deferred_seeks.resize(max_cursors, None);
         }
@@ -1020,9 +1048,26 @@ impl ProgramState {
             self.registers = registers.into_boxed_slice();
         }
         // reset cursors as they can have cached information which will be no longer relevant on next program execution
-        self.cursors.iter_mut().for_each(|c| {
-            let _ = c.take();
-        });
+        for (cursor, context) in self
+            .cursors
+            .iter_mut()
+            .zip(self.index_method_contexts.iter_mut())
+        {
+            if let (Some(Cursor::IndexMethod(cursor)), Some(context)) =
+                (cursor.as_mut(), context.as_ref())
+            {
+                cursor.close(context);
+            }
+            let _ = cursor.take();
+            *context = None;
+        }
+        for (mut cursor, context) in self.closed_index_method_cursors.drain(..) {
+            cursor.close(&context);
+        }
+        self.index_method_finalize_cursor = 0;
+        self.index_method_finalize_subprogram_keys = None;
+        self.index_method_finalize_subprogram = 0;
+        self.index_methods_finalized = false;
         for r in self.registers.iter_mut() {
             match r {
                 Register::Value(v) => *v = Value::Null,
@@ -1073,6 +1118,7 @@ impl ProgramState {
         self.n_total_change.store(0, Ordering::SeqCst);
         *self.explain_state.write() = ExplainState::default();
         self.pending_fail_error = None;
+        self.pending_fail_prepare_error = None;
         self.pending_cdc_info = None;
         self.subprogram_stmt_cache.clear();
     }
@@ -1936,6 +1982,54 @@ impl Program {
                     self.abort(pager, None, state, true)?;
                     return Ok(StepResult::Interrupt);
                 }
+
+                // A trigger can return FAIL before the parent program reaches
+                // Halt. FAIL keeps changes made by earlier rows, so their
+                // index-method writes must finish before abort() releases the
+                // statement savepoint and commits those partial changes.
+                if let Some(fail_error) = state.pending_fail_prepare_error.take() {
+                    match execute::index_method_prepare_statement_all(state) {
+                        Ok(IOResult::Done(())) => {
+                            if let Err(abort_err) = self.abort(pager, Some(&fail_error), state) {
+                                tracing::error!(
+                                    "Abort failed after preparing FAIL index methods: {abort_err}"
+                                );
+                            }
+                            return Err(fail_error);
+                        }
+                        Ok(IOResult::IO(io)) => {
+                            state.pending_fail_prepare_error = Some(fail_error);
+                            io.set_waker(waker);
+                            if io.is_explicit_yield() {
+                                return Ok(StepResult::Yield);
+                            }
+                            let finished = io.finished();
+                            state.io_completions = Some(io);
+                            if !finished {
+                                return Ok(StepResult::IO);
+                            }
+                            continue 'io_check;
+                        }
+                        Err(prepare_error) => {
+                            // FAIL may keep earlier base-table rows only when every
+                            // matching index-method write was staged successfully.
+                            // Once preparation fails, committing those rows would
+                            // leave the table and index out of sync, so roll back the
+                            // whole transaction while returning the real preparation
+                            // error to the caller.
+                            let rollback_error =
+                                LimboError::Raise(ResolveType::Rollback, prepare_error.to_string());
+                            if let Err(abort_err) = self.abort(pager, Some(&rollback_error), state)
+                            {
+                                tracing::error!(
+                                    "Abort also failed after FAIL index-method preparation: \
+                                     {abort_err}"
+                                );
+                            }
+                            return Err(prepare_error);
+                        }
+                    }
+                }
                 let (insn, _) = &self.insns[state.pc as usize];
                 let insn_function = insn.to_function();
                 if enable_tracing {
@@ -2030,6 +2124,13 @@ impl Program {
                         // However, for auto-commits or BEGIN IMMEDIATE, failing to promote to write transaction means it was rolled
                         // back, so auto-retrying can be useful.
                         return Ok(StepResult::Busy);
+                    }
+                    Err(err)
+                        if (matches!(err, LimboError::Constraint(_))
+                            && self.resolve_type == ResolveType::Fail)
+                            || matches!(err, LimboError::Raise(ResolveType::Fail, _)) =>
+                    {
+                        state.pending_fail_prepare_error = Some(err);
                     }
                     Err(err) => {
                         if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
@@ -2699,6 +2800,9 @@ impl Program {
         // nested helper statements whose drop releases nested guards. Drop
         // them before the `is_nested_stmt()` check below for the same reason.
         state.close_virtual_table_cursors();
+        if err.is_some() || state.execution_state.is_running() {
+            execute::index_method_abort_statement_all(state);
+        }
 
         // Only end trigger execution if the subprogram was actually running.
         // Cached (pooled) statements may be dropped after their trigger execution
@@ -2884,12 +2988,27 @@ impl Program {
                                         "vtab_commit_all failed during FAIL abort",
                                     );
                                 }
-                                if let Err(e) = execute::index_method_pre_commit_all(state, pager) {
-                                    capture_abort_error(
-                                        &mut abort_error,
-                                        e,
-                                        "index_method_pre_commit_all failed during FAIL abort",
-                                    );
+                                match execute::index_method_prepare_statement_all(state) {
+                                    Ok(IOResult::Done(())) => {}
+                                    Ok(IOResult::IO(io)) => {
+                                        io.abort();
+                                        capture_abort_error(
+                                            &mut abort_error,
+                                            LimboError::InternalError(
+                                                "FAIL cleanup reached asynchronous index-method \
+                                                 finalization outside the resumable Halt path"
+                                                    .to_string(),
+                                            ),
+                                            "index-method finalization yielded during FAIL abort",
+                                        );
+                                    }
+                                    Err(e) => {
+                                        capture_abort_error(
+                                            &mut abort_error,
+                                            e,
+                                            "index-method finalization failed during FAIL abort",
+                                        );
+                                    }
                                 }
                                 loop {
                                     match self.commit_txn(

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -782,13 +782,15 @@ pub struct ProgramState {
     pub(crate) cursors: Vec<Option<Cursor>>,
     /// Immutable execution/storage context captured when each index-method
     /// cursor is first opened for this statement.
-    pub(crate) index_method_contexts: Vec<Option<crate::index_method::IndexMethodContext>>,
+    pub(crate) index_method_contexts:
+        Vec<Option<std::sync::Arc<crate::index_method::IndexMethodContext>>>,
     /// Index-method cursors explicitly closed by bytecode after their
-    /// statement work was prepared. Retain them until commit/rollback decides
-    /// whether prepared in-memory state may be published.
+    /// statement work was prepared (CREATE INDEX closes its backfill cursor
+    /// this way). Retain them until commit/rollback decides whether prepared
+    /// in-memory state may be published.
     pub(crate) closed_index_method_cursors: Vec<(
         Box<dyn crate::index_method::IndexMethodCursor>,
-        crate::index_method::IndexMethodContext,
+        std::sync::Arc<crate::index_method::IndexMethodContext>,
     )>,
     /// Resumption coordinates for statement-level index-method finalization.
     pub(crate) index_method_finalize_cursor: usize,
@@ -869,6 +871,13 @@ pub struct ProgramState {
     /// Keep the error here while index-method writes from earlier rows finish
     /// through the normal resumable I/O path.
     pending_fail_prepare_error: Option<LimboError>,
+    /// True once the Halt opcode has started finishing the statement. The
+    /// statement's outcome is decided at that point, so an interrupt request
+    /// arriving during Halt's resumable work (staging index-method writes,
+    /// committing the rows FAIL keeps) must not preempt it — it would replace
+    /// the promised outcome and drop staged work. The connection-level flag
+    /// stays set and clears once no root statement is active.
+    pub(crate) halt_in_progress: bool,
     /// Pending CDC info to apply after the program completes successfully.
     /// Set by InitCdcVersion opcode, applied at Halt/Done so that if the
     /// transaction rolls back, the connection's CDC state remains unchanged.
@@ -970,6 +979,7 @@ impl ProgramState {
             explain_state: RwLock::new(ExplainState::default()),
             pending_fail_error: None,
             pending_fail_prepare_error: None,
+            halt_in_progress: false,
             pending_cdc_info: None,
             subprogram_stmt_cache: HashMap::default(),
         }
@@ -1119,6 +1129,7 @@ impl ProgramState {
         *self.explain_state.write() = ExplainState::default();
         self.pending_fail_error = None;
         self.pending_fail_prepare_error = None;
+        self.halt_in_progress = false;
         self.pending_cdc_info = None;
         self.subprogram_stmt_cache.clear();
     }
@@ -1705,6 +1716,13 @@ impl Program {
     where
         I: crate::IO + ?Sized,
     {
+        // Once Halt has started finishing the statement, its outcome is
+        // decided; an interrupt (or deadline, or progress handler) must not
+        // preempt the remaining resumable finalization work. A request that
+        // arrived before Halt began still interrupts as usual.
+        if state.halt_in_progress && !state.is_interrupted() {
+            return false;
+        }
         let connection_interrupt = self.connection.is_interrupted();
         let hit_query_deadline = state
             .query_deadline
@@ -2800,7 +2818,21 @@ impl Program {
         // nested helper statements whose drop releases nested guards. Drop
         // them before the `is_nested_stmt()` check below for the same reason.
         state.close_virtual_table_cursors();
-        if err.is_some() || state.execution_state.is_running() {
+        // RAISE(IGNORE) rolls nothing back — halt() already staged the
+        // trigger's index-method writes and the kept rows keep their index
+        // entries — so it must not discard staged index-method work here.
+        // FAIL-class errors likewise keep the changes made before the error:
+        // their index-method writes were staged by the interception in
+        // `program_step` before abort() was called (and, on the autocommit
+        // path, already committed by halt()), so discarding cursor state here
+        // would deliver a rollback outcome for work that commits below.
+        let keeps_prior_changes = match err {
+            Some(LimboError::RaiseIgnore) => true,
+            Some(LimboError::Raise(ResolveType::Fail, _)) => true,
+            Some(LimboError::Constraint(_)) => self.resolve_type == ResolveType::Fail,
+            _ => false,
+        };
+        if (err.is_some() || state.execution_state.is_running()) && !keeps_prior_changes {
             execute::index_method_abort_statement_all(state);
         }
 
@@ -2980,6 +3012,10 @@ impl Program {
                             if can_autocommit_now {
                                 // Autocommit FAIL: commit partial changes.
                                 // This matches halt()'s FAIL+autocommit path.
+                                // Index-method writes were already staged by
+                                // the FAIL interception in `program_step`
+                                // (the resumable path) before abort() ran, so
+                                // there is nothing left to stage here.
                                 let mv_store = self.connection.mv_store();
                                 if let Err(e) = execute::vtab_commit_all(&self.connection) {
                                     capture_abort_error(
@@ -2988,28 +3024,7 @@ impl Program {
                                         "vtab_commit_all failed during FAIL abort",
                                     );
                                 }
-                                match execute::index_method_prepare_statement_all(state) {
-                                    Ok(IOResult::Done(())) => {}
-                                    Ok(IOResult::IO(io)) => {
-                                        io.abort();
-                                        capture_abort_error(
-                                            &mut abort_error,
-                                            LimboError::InternalError(
-                                                "FAIL cleanup reached asynchronous index-method \
-                                                 finalization outside the resumable Halt path"
-                                                    .to_string(),
-                                            ),
-                                            "index-method finalization yielded during FAIL abort",
-                                        );
-                                    }
-                                    Err(e) => {
-                                        capture_abort_error(
-                                            &mut abort_error,
-                                            e,
-                                            "index-method finalization failed during FAIL abort",
-                                        );
-                                    }
-                                }
+                                let mut committed = false;
                                 loop {
                                     match self.commit_txn(
                                         pager.clone(),
@@ -3017,7 +3032,10 @@ impl Program {
                                         mv_store.as_ref(),
                                         false,
                                     ) {
-                                        Ok(IOResult::Done(_)) => break,
+                                        Ok(IOResult::Done(_)) => {
+                                            committed = true;
+                                            break;
+                                        }
                                         Ok(IOResult::IO(io)) => {
                                             if let Err(e) = io.wait(pager.io.as_ref()) {
                                                 capture_abort_error(
@@ -3037,6 +3055,20 @@ impl Program {
                                             break;
                                         }
                                     }
+                                }
+                                // Deliver the committed outcome exactly once.
+                                // For a plain constraint error with FAIL
+                                // resolution, halt() already committed and
+                                // delivered it before returning the error;
+                                // only the trigger RAISE(FAIL) shape reaches
+                                // the commit through this arm.
+                                let halt_already_delivered =
+                                    matches!(err, Some(LimboError::Constraint(_)));
+                                if committed && !halt_already_delivered {
+                                    execute::index_method_transaction_committed_all(
+                                        state,
+                                        &self.connection,
+                                    );
                                 }
                             }
                         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -261,7 +261,7 @@ impl CommitState {
         connection.rollback_attached_mvcc_txs(true);
         connection.rollback_attached_wal_txns();
         connection.rollback_temp_schema();
-        connection.index_methods_transaction_rolled_back();
+        connection.index_methods_on_transaction_rolled_back();
     }
 }
 
@@ -2006,9 +2006,11 @@ impl Program {
                 // index-method writes must finish before abort() releases the
                 // statement savepoint and commits those partial changes.
                 if let Some(fail_error) = state.pending_fail_prepare_error.take() {
-                    match execute::index_method_prepare_statement_all(state) {
+                    match execute::index_method_stage_statement_all(state) {
                         Ok(IOResult::Done(())) => {
-                            if let Err(abort_err) = self.abort(pager, Some(&fail_error), state) {
+                            if let Err(abort_err) =
+                                self.abort(pager, Some(&fail_error), state, true)
+                            {
                                 tracing::error!(
                                     "Abort failed after preparing FAIL index methods: {abort_err}"
                                 );
@@ -2037,7 +2039,8 @@ impl Program {
                             // error to the caller.
                             let rollback_error =
                                 LimboError::Raise(ResolveType::Rollback, prepare_error.to_string());
-                            if let Err(abort_err) = self.abort(pager, Some(&rollback_error), state)
+                            if let Err(abort_err) =
+                                self.abort(pager, Some(&rollback_error), state, true)
                             {
                                 tracing::error!(
                                     "Abort also failed after FAIL index-method preparation: \
@@ -3065,7 +3068,7 @@ impl Program {
                                 let halt_already_delivered =
                                     matches!(err, Some(LimboError::Constraint(_)));
                                 if committed && !halt_already_delivered {
-                                    execute::index_method_transaction_committed_all(
+                                    execute::index_method_on_transaction_committed_all(
                                         state,
                                         &self.connection,
                                     );

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -111,7 +111,7 @@ impl crate::index_method::IndexMethodCursor for FailingPrepareCursor {
         Ok(crate::IOResult::Done(None))
     }
 
-    fn prepare_statement_commit(
+    fn stage_statement_commit(
         &mut self,
         _context: &crate::index_method::IndexMethodContext,
     ) -> Result<crate::IOResult<()>> {

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -6,7 +6,123 @@ use crate::mvcc::cursor::CursorYieldPoint;
 use crate::mvcc::yield_hooks::YieldPointMarker;
 use crate::mvcc::yield_points::{YieldInjector, YieldPoint};
 use crate::sync::{Arc, Mutex};
+#[cfg(feature = "fts")]
+use crate::StepResult;
 use crate::{Connection, Database, DatabaseOpts, LimboError, OpenFlags, Result, Value};
+
+#[derive(Debug)]
+struct FailingPrepareIndexMethod;
+
+#[derive(Debug)]
+struct FailingPrepareAttachment {
+    table_name: String,
+    index_name: String,
+}
+
+#[derive(Debug, Default)]
+struct FailingPrepareCursor {
+    dirty: bool,
+}
+
+impl crate::index_method::IndexMethod for FailingPrepareIndexMethod {
+    fn attach(
+        &self,
+        configuration: &crate::index_method::IndexMethodConfiguration,
+    ) -> Result<Arc<dyn crate::index_method::IndexMethodAttachment>> {
+        Ok(Arc::new(FailingPrepareAttachment {
+            table_name: configuration.table_name.clone(),
+            index_name: configuration.index_name.clone(),
+        }))
+    }
+}
+
+impl crate::index_method::IndexMethodAttachment for FailingPrepareAttachment {
+    fn definition<'a>(&'a self) -> crate::index_method::IndexMethodDefinition<'a> {
+        crate::index_method::IndexMethodDefinition {
+            method_name: "failing_prepare",
+            table_name: &self.table_name,
+            index_name: &self.index_name,
+            patterns: &[],
+            backing_btree: false,
+            results_materialized: true,
+            mvcc_support: crate::index_method::IndexMethodMvccSupport::ExternalTransactional,
+        }
+    }
+
+    fn init(&self) -> Result<Box<dyn crate::index_method::IndexMethodCursor>> {
+        Ok(Box::new(FailingPrepareCursor::default()))
+    }
+}
+
+impl crate::index_method::IndexMethodCursor for FailingPrepareCursor {
+    fn create(
+        &mut self,
+        _context: &crate::index_method::IndexMethodContext,
+    ) -> Result<crate::IOResult<()>> {
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn destroy(
+        &mut self,
+        _context: &crate::index_method::IndexMethodContext,
+    ) -> Result<crate::IOResult<()>> {
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn open_read(
+        &mut self,
+        _context: &crate::index_method::IndexMethodContext,
+    ) -> Result<crate::IOResult<()>> {
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn open_write(
+        &mut self,
+        _context: &crate::index_method::IndexMethodContext,
+    ) -> Result<crate::IOResult<()>> {
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn insert(&mut self, _values: &[crate::vdbe::Register]) -> Result<crate::IOResult<()>> {
+        self.dirty = true;
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn delete(&mut self, _values: &[crate::vdbe::Register]) -> Result<crate::IOResult<()>> {
+        self.dirty = true;
+        Ok(crate::IOResult::Done(()))
+    }
+
+    fn query_start(&mut self, _values: &[crate::vdbe::Register]) -> Result<crate::IOResult<bool>> {
+        Ok(crate::IOResult::Done(false))
+    }
+
+    fn query_next(&mut self) -> Result<crate::IOResult<bool>> {
+        Ok(crate::IOResult::Done(false))
+    }
+
+    fn query_column(&mut self, _idx: usize) -> Result<crate::IOResult<Value>> {
+        Err(LimboError::InternalError(
+            "failing_prepare has no query rows".to_string(),
+        ))
+    }
+
+    fn query_rowid(&mut self) -> Result<crate::IOResult<Option<i64>>> {
+        Ok(crate::IOResult::Done(None))
+    }
+
+    fn prepare_statement_commit(
+        &mut self,
+        _context: &crate::index_method::IndexMethodContext,
+    ) -> Result<crate::IOResult<()>> {
+        if self.dirty {
+            return Err(LimboError::InternalError(
+                "forced index-method preparation failure".to_string(),
+            ));
+        }
+        Ok(crate::IOResult::Done(()))
+    }
+}
 
 #[derive(Debug)]
 struct FixedYieldInjector {
@@ -47,6 +163,103 @@ fn get_rows(conn: &Arc<Connection>, query: &str) -> Vec<Vec<Value>> {
     })
     .unwrap();
     rows
+}
+
+#[test]
+fn fail_rolls_back_base_rows_when_index_method_preparation_fails() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io,
+        ":memory:index-method-failing-prepare",
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    db.builtin_syms.write().index_methods.insert(
+        "failing_prepare".to_string(),
+        Arc::new(FailingPrepareIndexMethod),
+    );
+    let conn = db.connect().unwrap();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fail ON docs USING failing_prepare(body)")
+        .unwrap();
+    conn.execute(
+        "CREATE TRIGGER fail_second BEFORE INSERT ON docs WHEN NEW.id = 2 BEGIN \
+         SELECT RAISE(FAIL, 'stop'); END",
+    )
+    .unwrap();
+
+    let error = conn
+        .execute("INSERT INTO docs VALUES (1, 'first'), (2, 'second')")
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("forced index-method preparation failure"),
+        "unexpected error: {error}"
+    );
+    assert!(get_rows(&conn, "SELECT id FROM docs").is_empty());
+}
+
+#[cfg(feature = "fts")]
+#[test]
+fn abandoning_after_index_method_prepare_rolls_back_without_drop_io() {
+    use crate::index_method::IndexMethodYieldPoint;
+
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        ":memory:index-method-finalize-abandon",
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.set_yield_injector(Some(FixedYieldInjector::new([
+        IndexMethodYieldPoint::AfterPrepareStatement.point(),
+    ])));
+    let mut insert = conn
+        .prepare("INSERT INTO docs VALUES (1, 'abandoned after prepare')")
+        .unwrap();
+    loop {
+        match insert.step().unwrap() {
+            StepResult::IO => io.step().unwrap(),
+            StepResult::Yield => break,
+            StepResult::Done => panic!("INSERT completed before the injected finalization yield"),
+            other => panic!("unexpected INSERT result: {other:?}"),
+        }
+    }
+    drop(insert);
+    conn.set_yield_injector(None);
+
+    assert!(get_rows(&conn, "SELECT id FROM docs").is_empty());
+    assert!(get_rows(
+        &conn,
+        "SELECT id FROM docs WHERE fts_match(body, 'abandoned')"
+    )
+    .is_empty());
+
+    conn.execute("INSERT INTO docs VALUES (2, 'surviving retry')")
+        .unwrap();
+    assert_eq!(
+        get_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'surviving')"
+        ),
+        vec![vec![Value::from_i64(2)]]
+    );
 }
 
 fn open_mvcc_database_with_opts(path: &str, opts: DatabaseOpts) -> Arc<Database> {

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -1613,3 +1613,165 @@ fn test_mvcc_completed_writer_changes_lost_when_joining_writer_errors() {
         "pins the deferred-commit gap: a failing joined writer discards the completed writer's row"
     );
 }
+
+#[cfg(feature = "fts")]
+fn open_fts_mvcc_db(path: &str) -> (Arc<Database>, Arc<Connection>, Arc<Connection>) {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io,
+        path,
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    let observer = db.connect().unwrap();
+    (db, conn, observer)
+}
+
+/// A writer that finishes while a sibling statement holds the shared implicit
+/// MVCC transaction open defers its commit to the last sibling (see
+/// test_completed_writer_waits_for_sibling_mvcc_reader_to_commit). Its FTS
+/// writes must be deferred with it: once the base row commits, the document
+/// must be searchable. The deferred halt path must stage the writer's
+/// index-method work or hand its cursor to the connection — otherwise the
+/// pending documents die with the statement and the base row commits without
+/// its index entries.
+#[cfg(feature = "fts")]
+#[test]
+fn fts_writes_survive_deferred_shared_autocommit() {
+    let (_db, conn, observer) = open_fts_mvcc_db(":memory:fts-deferred-shared-autocommit");
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (10, 'existing seed')")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut reader = conn.prepare("SELECT id FROM docs ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut reader), 10);
+
+    let mut writer = conn
+        .prepare("INSERT INTO docs VALUES (1, 'deferred needle') RETURNING id")
+        .unwrap();
+    assert_eq!(step_returning_id(&mut writer), 1);
+    finish_without_rows(&mut writer);
+    drop(writer);
+
+    finish_without_rows(&mut reader);
+    drop(reader);
+
+    assert_eq!(
+        ids_from_query(&observer, "SELECT id FROM docs ORDER BY id"),
+        vec![1, 10],
+        "the last sibling statement commits the completed writer's base row"
+    );
+    assert_eq!(
+        ids_from_query(
+            &observer,
+            "SELECT id FROM docs WHERE fts_match(body, 'needle')"
+        ),
+        vec![1],
+        "the FTS document must commit together with its base row"
+    );
+}
+
+/// Dropping a connection mid-transaction is how the engine recovers when an
+/// application abandons its handle (e.g. after a panic): Connection::drop
+/// rolls the transaction back and releases its locks and leases. A
+/// transaction-owned index-method cursor registered on the connection holds a
+/// context whose Arc points back at that same connection, and the cycle must
+/// not keep the connection alive — otherwise the drop recovery never runs,
+/// the MVCC transaction stays active, and its FTS write lease blocks every
+/// other writer forever.
+#[cfg(feature = "fts")]
+#[test]
+fn dropping_connection_mid_transaction_releases_its_fts_write_lease() {
+    let (_db, conn, observer) = open_fts_mvcc_db(":memory:fts-conn-drop-mid-tx");
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'abandoned mid transaction')")
+        .unwrap();
+
+    let weak = Arc::downgrade(&conn);
+    drop(conn);
+
+    observer
+        .execute("INSERT INTO docs VALUES (2, 'after the drop')")
+        .expect("dropping the writing connection must release its FTS write lease");
+    assert!(
+        weak.upgrade().is_none(),
+        "a dropped connection must be freed; a registered index-method cursor must not keep it alive"
+    );
+}
+
+/// INSERT OR FAIL keeps the rows changed before the failing one. The
+/// constraint error is parked while the kept rows' index-method writes are
+/// staged; an interrupt request arriving in that window must not replace the
+/// statement's outcome and roll back the rows FAIL promised to keep.
+#[cfg(feature = "fts")]
+#[test]
+fn interrupt_during_fail_staging_keeps_fail_outcome() {
+    use crate::index_method::IndexMethodYieldPoint;
+
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        ":memory:fts-interrupt-during-fail",
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.set_yield_injector(Some(FixedYieldInjector::new([
+        IndexMethodYieldPoint::AfterPrepareStatement.point(),
+    ])));
+    let mut insert = conn
+        .prepare("INSERT OR FAIL INTO docs VALUES (1, 'kept row'), (1, 'duplicate')")
+        .unwrap();
+    expect_injected_yield(&mut insert, "OR FAIL index-method staging");
+    conn.set_yield_injector(None);
+
+    // The statement is suspended between staging the kept row's FTS writes
+    // and surfacing the parked constraint error.
+    conn.interrupt();
+
+    let err = loop {
+        match insert.step() {
+            Err(err) => break err,
+            Ok(StepResult::IO) => io.step().unwrap(),
+            Ok(other) => panic!("OR FAIL must surface its constraint error, got {other:?}"),
+        }
+    };
+    assert!(
+        matches!(err, LimboError::Constraint(_)),
+        "expected the parked constraint error, got {err:?}"
+    );
+    drop(insert);
+
+    assert_eq!(
+        ids_from_query(&conn, "SELECT id FROM docs ORDER BY id"),
+        vec![1],
+        "OR FAIL keeps rows changed before the failure"
+    );
+    assert_eq!(
+        ids_from_query(&conn, "SELECT id FROM docs WHERE fts_match(body, 'kept')"),
+        vec![1],
+        "the kept row's FTS document must survive the interrupt request"
+    );
+}

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -404,6 +404,40 @@ fn test_attach_inherits_index_method_flag_on_reattach(_tmp_db: TempDatabase) -> 
     Ok(())
 }
 
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test]
+fn test_attached_mvcc_fts_uses_attached_store(_tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let db = attach_enabled_db(DatabaseOpts::new().with_index_method(true));
+    let conn = db.connect_limbo();
+    let aux_path = db.path.with_extension("attached_mvcc_fts.db");
+
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    conn.execute("PRAGMA aux.journal_mode = 'experimental_mvcc'")?;
+    conn.execute("CREATE TABLE aux.docs(id INTEGER PRIMARY KEY, content TEXT)")?;
+    conn.execute("CREATE INDEX aux.docs_fts ON docs USING fts(content)")?;
+
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO aux.docs VALUES (1, 'attached committed')")?;
+    conn.execute("COMMIT")?;
+    conn.execute("BEGIN")?;
+    conn.execute("INSERT INTO aux.docs VALUES (2, 'attached rolledback')")?;
+    conn.execute("ROLLBACK")?;
+
+    let committed: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'committed')");
+    assert_eq!(committed, vec![(1,)]);
+    let rolled_back: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'rolledback')");
+    assert!(rolled_back.is_empty());
+
+    conn.execute("DETACH aux")?;
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    let recovered: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'attached')");
+    assert_eq!(recovered, vec![(1,)]);
+    Ok(())
+}
+
 #[test]
 fn test_attach_create_stores_canonical_schema_sql() -> anyhow::Result<()> {
     let aux_db = TempDatabase::builder().build();

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -404,6 +404,63 @@ fn test_attach_inherits_index_method_flag_on_reattach(_tmp_db: TempDatabase) -> 
     Ok(())
 }
 
+/// Statements on an attached database never set the connection-level write
+/// transaction state, so an attached FTS write can pick up the connection's
+/// cached read state from an earlier query instead of loading writer state.
+/// The write must still reach the backing B-tree: a document inserted after a
+/// warm read has to be findable. The writing connection has no retained FTS
+/// writer of its own (another connection did the earlier write), which is
+/// what routes its open_write through the cached read state.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test]
+fn test_attached_fts_insert_after_warm_read_is_searchable(
+    _tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let db = attach_enabled_db(DatabaseOpts::new().with_index_method(true));
+    let seeder = db.connect_limbo();
+
+    let aux_path = db.path.with_extension("attached_fts_warm_read.db");
+    seeder.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    seeder.execute("CREATE TABLE aux.docs(id INTEGER PRIMARY KEY, content TEXT)")?;
+    seeder.execute("CREATE INDEX aux.docs_fts ON docs USING fts(content)")?;
+    seeder.execute("INSERT INTO aux.docs VALUES (1, 'hello world')")?;
+
+    let conn = db.connect_limbo();
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+
+    // Warm this connection's cached FTS read state for the attached index.
+    let warm: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'hello')");
+    assert_eq!(warm, vec![(1,)]);
+
+    conn.execute("INSERT INTO aux.docs VALUES (2, 'fresh needle')")?;
+
+    let fresh: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'needle')");
+    assert_eq!(
+        fresh,
+        vec![(2,)],
+        "a document inserted after a warm FTS read must be searchable"
+    );
+    let still_there: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'hello')");
+    assert_eq!(still_there, vec![(1,)]);
+
+    // The document must also have been persisted, not merely retained in
+    // this connection's in-memory caches.
+    conn.execute("DETACH aux")?;
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    let reopened: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'needle')");
+    assert_eq!(
+        reopened,
+        vec![(2,)],
+        "the document inserted after a warm FTS read must survive reattach"
+    );
+
+    Ok(())
+}
+
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
 #[turso_macros::test]
 fn test_attached_mvcc_fts_uses_attached_store(_tmp_db: TempDatabase) -> anyhow::Result<()> {
@@ -426,6 +483,12 @@ fn test_attached_mvcc_fts_uses_attached_store(_tmp_db: TempDatabase) -> anyhow::
     let committed: Vec<(i64,)> =
         conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'committed')");
     assert_eq!(committed, vec![(1,)]);
+    // The MATCH operator spelling must plan against the attached database's
+    // FTS index too (it used to be rejected because the planner resolved the
+    // index against the main schema only).
+    let committed_match: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE content MATCH 'committed'");
+    assert_eq!(committed_match, vec![(1,)]);
     let rolled_back: Vec<(i64,)> =
         conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'rolledback')");
     assert!(rolled_back.is_empty());

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -2098,6 +2098,116 @@ fn test_fts_mvcc_lifecycle(tmp_db: TempDatabase) {
     );
 }
 
+/// A connection handle dropped mid-transaction with a parked FTS cursor used
+/// to keep itself alive forever: the cursor's context held a strong
+/// `Arc<Connection>`, so the connection referenced itself, its `Drop` never
+/// ran, and its WAL write lock was never released — every later writer got
+/// Busy until the process died.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_dropped_connection_mid_transaction_releases_locks(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'hello')")
+        .unwrap();
+
+    // Drop the handle with no COMMIT / ROLLBACK / close().
+    let weak = std::sync::Arc::downgrade(&conn);
+    drop(conn);
+    assert_eq!(
+        weak.strong_count(),
+        0,
+        "dropping the handle must actually drop the connection"
+    );
+
+    // A fresh connection must be able to write; the dropped transaction's
+    // row must be gone.
+    let fresh = tmp_db.connect_limbo();
+    fresh
+        .execute("INSERT INTO docs VALUES (2, 'world')")
+        .unwrap();
+    assert!(
+        limbo_exec_rows(&fresh, "SELECT id FROM docs WHERE fts_match(body, 'hello')").is_empty()
+    );
+    assert_eq!(
+        limbo_exec_rows(&fresh, "SELECT id FROM docs WHERE fts_match(body, 'world')"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+/// One statement driving two FTS write cursors over the same index — here a
+/// trigger inserting into the table it fired on — used to let both cursors
+/// flush divergent Tantivy directories over one backing store, killing the
+/// index on disk permanently (every later read returned Corrupt). The second
+/// writer must be refused, the statement must roll back atomically, and the
+/// index must stay fully usable.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_second_write_cursor_in_one_statement_fails_cleanly(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t(a TEXT)").unwrap();
+    conn.execute("CREATE INDEX ft ON t USING fts(a)").unwrap();
+    conn.execute(
+        "CREATE TRIGGER tr AFTER INSERT ON t WHEN NEW.a <> 'stop' BEGIN \
+         INSERT INTO t VALUES('stop'); END",
+    )
+    .unwrap();
+
+    // The trigger's INSERT opens a second write cursor on the same FTS index
+    // while the firing statement's writer is still open. It must fail...
+    assert!(conn.execute("INSERT INTO t VALUES ('go')").is_err());
+    // ...and the whole statement must roll back, keeping table and index in
+    // sync (previously the base row committed and the index died on disk).
+    assert!(limbo_exec_rows(&conn, "SELECT rowid FROM t").is_empty());
+
+    // The index must stay healthy and writable afterwards.
+    conn.execute("DROP TRIGGER tr").unwrap();
+    conn.execute("INSERT INTO t VALUES ('after')").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT a FROM t WHERE fts_match(a, 'after')"),
+        vec![vec![rusqlite::types::Value::Text("after".to_string())]]
+    );
+}
+
+/// Regression test: a write cursor that hits the shared read cache must not
+/// adopt the cached Tantivy `Index`, whose directory belongs to the cache
+/// entry — its writes would land in the cache entry's pending map and never
+/// reach the backing B-tree. On a TEMP (or ATTACHed) database the
+/// `is_in_write_tx()` guard is false, so a read followed by a write used to
+/// lose every later FTS write silently.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_temp_db_write_after_cached_read_reaches_index(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TEMP TABLE t(a TEXT)").unwrap();
+    conn.execute("CREATE INDEX temp.ft ON t USING fts(a)")
+        .unwrap();
+    // Warm the read cache for the TEMP database before any write.
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT rowid FROM t WHERE fts_match(a, 'alpha')"),
+        Vec::<Vec<rusqlite::types::Value>>::new()
+    );
+
+    conn.execute("INSERT INTO t VALUES ('alpha')").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT rowid FROM t WHERE fts_match(a, 'alpha')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    conn.execute("DELETE FROM t WHERE rowid = 1").unwrap();
+    // The deleted row must not come back as a phantom from a stale index.
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT rowid FROM t WHERE fts_match(a, 'alpha')"),
+        Vec::<Vec<rusqlite::types::Value>>::new()
+    );
+}
+
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
 #[turso_macros::test(mvcc)]
 fn fts_trigger_writes_survive_repeated_subprogram_runs(tmp_db: TempDatabase) {
@@ -2127,6 +2237,77 @@ fn fts_trigger_writes_survive_repeated_subprogram_runs(tmp_db: TempDatabase) {
             vec![rusqlite::types::Value::Integer(1)],
             vec![rusqlite::types::Value::Integer(2)],
         ]
+    );
+}
+
+/// RAISE(IGNORE) is not an error: everything the trigger wrote before the
+/// RAISE is kept. The trigger's FTS writes used to be discarded while its base
+/// rows survived, leaving the table and index permanently out of sync in both
+/// directions (missing entry after an INSERT, phantom entry after a DELETE).
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_raise_ignore_keeps_trigger_writes_in_index(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("CREATE TABLE src(v INTEGER)").unwrap();
+    conn.execute(
+        "CREATE TRIGGER tr BEFORE INSERT ON src BEGIN \
+         INSERT INTO docs VALUES(NEW.v, 'ignoredrow'); \
+         SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+
+    conn.execute("INSERT INTO src VALUES (1)").unwrap();
+
+    // The trigger's row is kept, and so must its index entry be.
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs ORDER BY id"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'ignoredrow')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+}
+
+/// The DELETE direction of the RAISE(IGNORE) divergence: a row deleted by the
+/// trigger must not come back as a phantom from a stale index entry.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_raise_ignore_keeps_trigger_deletes_in_index(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'orphanword')")
+        .unwrap();
+    conn.execute("CREATE TABLE src(v INTEGER)").unwrap();
+    conn.execute(
+        "CREATE TRIGGER tr BEFORE INSERT ON src BEGIN \
+         DELETE FROM docs WHERE id = 1; \
+         SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+
+    conn.execute("INSERT INTO src VALUES (1)").unwrap();
+
+    assert!(limbo_exec_rows(&conn, "SELECT id FROM docs").is_empty());
+    assert!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'orphanword')"
+        )
+        .is_empty(),
+        "the deleted row must not survive as a phantom index entry"
     );
 }
 
@@ -2295,13 +2476,12 @@ fn test_fts_mvcc_same_index_writer_conflicts_before_tantivy_work() {
         .unwrap();
     let stats_before_conflict = fts_attachment_test_stats(&tmp_db, &first, "docs", "docs_fts");
 
+    // Contention with the live lease holder is Busy — retryable, without
+    // rolling back the loser's transaction or its unrelated work.
     let conflict = second
         .execute("INSERT INTO docs VALUES (2, 'writer two')")
         .unwrap_err();
-    assert!(matches!(
-        conflict,
-        turso_core::LimboError::WriteWriteConflict
-    ));
+    assert!(matches!(conflict, turso_core::LimboError::Busy));
     let stats_after_conflict = fts_attachment_test_stats(&tmp_db, &first, "docs", "docs_fts");
     assert_eq!(
         stats_after_conflict.tantivy_writer_constructions,
@@ -2316,6 +2496,16 @@ fn test_fts_mvcc_same_index_writer_conflicts_before_tantivy_work() {
     );
 
     first.execute("COMMIT").unwrap();
+
+    // The loser's snapshot now predates the winner's publication, so retrying
+    // inside the same transaction is a write-write conflict: committing its
+    // rebuild of the index would overwrite the winner's. The transaction is
+    // rolled back.
+    let stale = second
+        .execute("INSERT INTO docs VALUES (2, 'writer two')")
+        .unwrap_err();
+    assert!(matches!(stale, turso_core::LimboError::WriteWriteConflict));
+
     second.execute("BEGIN CONCURRENT").unwrap();
     second
         .execute("INSERT INTO docs VALUES (2, 'writer two retry')")
@@ -2339,6 +2529,65 @@ fn test_fts_mvcc_same_index_writer_conflicts_before_tantivy_work() {
             vec![rusqlite::types::Value::Integer(2)],
         ]
     );
+}
+
+/// Two overlapping BEGIN CONCURRENT writers used to both publish: the lease
+/// was freed when the first writer committed, so the second — still on its
+/// pre-commit snapshot — rewrote the Tantivy directory from a superseded base.
+/// The backing store ended up holding the union of two divergent directories,
+/// making the index unreadable and the base table unwritable, permanently.
+/// With chunk rows checkpointed into the B-tree (threshold 0), MVCC row
+/// validation cannot catch this, so the lease itself must: a writer whose
+/// snapshot predates the last publication is refused.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_stale_snapshot_writer_is_refused_after_checkpoint() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    first
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX ft ON t USING fts (body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    first.execute("INSERT INTO t VALUES (1, 'alpha')").unwrap();
+    first.execute("COMMIT").unwrap();
+
+    // `second` began before `first` published, so its rebuild of the index
+    // would start from a superseded base. It must be refused — previously it
+    // silently succeeded and corrupted the index on disk.
+    let stale = second
+        .execute("INSERT INTO t VALUES (2, 'beta')")
+        .unwrap_err();
+    assert!(matches!(stale, turso_core::LimboError::WriteWriteConflict));
+
+    // A fresh transaction sees the publication and works; the index must be
+    // readable and the base table writable.
+    second.execute("BEGIN CONCURRENT").unwrap();
+    second.execute("INSERT INTO t VALUES (2, 'beta')").unwrap();
+    second.execute("COMMIT").unwrap();
+
+    let third = tmp_db.connect_limbo();
+    assert_eq!(
+        limbo_exec_rows(&third, "SELECT id FROM t WHERE fts_match(body, 'alpha')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(&third, "SELECT id FROM t WHERE fts_match(body, 'beta')"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    third.execute("INSERT INTO t VALUES (3, 'gamma')").unwrap();
 }
 
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
@@ -2425,14 +2674,26 @@ fn test_fts_mvcc_opposite_index_order_rejects_without_deadlock() {
         .execute("INSERT INTO b VALUES (2, 'survives')")
         .unwrap();
 
+    // Opposite-order lease acquisition cannot deadlock: contention is an
+    // immediate Busy, and neither transaction is destroyed.
     let conflict = first
         .execute("INSERT INTO b VALUES (1, 'rolled back')")
         .unwrap_err();
-    assert!(matches!(
-        conflict,
-        turso_core::LimboError::WriteWriteConflict
-    ));
+    assert!(matches!(conflict, turso_core::LimboError::Busy));
+    let conflict = second
+        .execute("INSERT INTO a VALUES (2, 'survives')")
+        .unwrap_err();
+    assert!(matches!(conflict, turso_core::LimboError::Busy));
 
+    // Both sides back off (a write statement abandoned on Busy leaves its
+    // transaction commit-poisoned); a fresh transaction then takes the freed
+    // leases. Neither original transaction published, so nothing is stale.
+    first.execute("ROLLBACK").unwrap();
+    second.execute("ROLLBACK").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    second
+        .execute("INSERT INTO b VALUES (2, 'survives')")
+        .unwrap();
     second
         .execute("INSERT INTO a VALUES (2, 'survives')")
         .unwrap();
@@ -2488,15 +2749,18 @@ fn test_fts_mvcc_savepoint_rollback_keeps_transaction_lease() {
     first.execute("ROLLBACK TO pending_write").unwrap();
 
     second.execute("BEGIN CONCURRENT").unwrap();
+    // The savepoint rollback must not release the transaction's lease, so a
+    // concurrent writer still sees it held (Busy, retryable).
     let conflict = second
         .execute("INSERT INTO docs VALUES (2, 'blocked writer')")
         .unwrap_err();
-    assert!(matches!(
-        conflict,
-        turso_core::LimboError::WriteWriteConflict
-    ));
+    assert!(matches!(conflict, turso_core::LimboError::Busy));
 
+    // `first` never published, so a retry from a fresh transaction succeeds
+    // (the Busy write statement was abandoned, which poisons the commit of
+    // `second`'s original transaction).
     first.execute("ROLLBACK").unwrap();
+    second.execute("ROLLBACK").unwrap();
     second.execute("BEGIN CONCURRENT").unwrap();
     second
         .execute("INSERT INTO docs VALUES (2, 'successful retry')")
@@ -3800,13 +4064,13 @@ fn fts_mvcc_loser_rollback_keeps_winner_cached_writer() {
         "the winner's statement must retain its transaction-tagged writer"
     );
 
+    // Contention with a live lease holder is Busy: retryable, and it does
+    // not destroy the loser's transaction.
     let conflict = loser
         .execute("INSERT INTO docs VALUES (2, 'loser writer')")
         .unwrap_err();
-    assert!(matches!(
-        conflict,
-        turso_core::LimboError::WriteWriteConflict
-    ));
+    assert!(matches!(conflict, turso_core::LimboError::Busy));
+    loser.execute("ROLLBACK").unwrap();
 
     let after_conflict = fts_attachment_test_stats(&tmp_db, &winner, "docs", "docs_fts");
     assert_eq!(
@@ -3834,8 +4098,8 @@ fn fts_mvcc_loser_rollback_keeps_winner_cached_writer() {
     );
     winner.execute("COMMIT").unwrap();
 
-    // The conflict rolled back the loser's whole transaction; a retry from a
-    // fresh transaction succeeds.
+    // A retry from a fresh transaction, whose snapshot includes the winner's
+    // publication, succeeds.
     loser.execute("BEGIN CONCURRENT").unwrap();
     loser
         .execute("INSERT INTO docs VALUES (2, 'loser retry writer')")
@@ -4089,8 +4353,11 @@ fn fts_mvcc_reuses_snapshot_within_one_read_transaction() {
         after_second.full_snapshot_loads, after_first.full_snapshot_loads,
         "the second read in one MVCC transaction must not rescan the directory"
     );
+    // The stats probe itself opens a read cursor and scores one cache hit, so
+    // require two: the probe's and the SELECT under test's. A plain `>` would
+    // pass even with the SELECT deleted.
     assert!(
-        after_second.read_cache_hits > after_first.read_cache_hits,
+        after_second.read_cache_hits.unwrap() >= after_first.read_cache_hits.unwrap() + 2,
         "the second read must use the transaction-bound snapshot cache"
     );
 }
@@ -4227,6 +4494,14 @@ fn fts_manifest_generation_invalidates_stale_snapshot_once() {
     assert!(
         after_write.full_snapshot_loads > before_write.full_snapshot_loads,
         "the first reader of a new generation must load its directory snapshot"
+    );
+    // Pins that the SELECT — not the stats probe — performed the reload: the
+    // probe after a successful reload scores a cache hit, while a probe that
+    // had to do the reload itself would not. Without this, deleting the
+    // SELECT above still satisfies the two counter assertions.
+    assert!(
+        after_write.read_cache_hits > before_write.read_cache_hits,
+        "the stats probe after the reload must hit the refreshed cache"
     );
 
     assert_eq!(
@@ -4384,6 +4659,67 @@ fn fts_read_cache_is_connection_local_and_bounded() {
 
 /// Unordered MATCH cursors stream from Tantivy. UPDATE and DELETE must first
 /// collect their rowids so index maintenance cannot perturb the active scorer.
+/// Regression test: under MVCC, an autocommit write that runs while a sibling
+/// root statement is still open cannot commit at its own halt — it joins the
+/// shared implicit transaction. That halt exit used to release the statement
+/// savepoint without staging the FTS documents or handing the cursor to the
+/// connection, so the base row committed while its index entry was silently
+/// dropped (and the cursor's Drop tripped a debug assert).
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_deferred_autocommit_write_keeps_index_entries() {
+    let tmp_db = TempDatabase::builder()
+        .with_mvcc(true)
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'alpha')")
+        .unwrap();
+
+    // Statement A: step to the first row and hold it open.
+    let mut reader = conn.prepare("SELECT id FROM docs").unwrap();
+    loop {
+        match reader.step().unwrap() {
+            turso_core::StepResult::Row => break,
+            turso_core::StepResult::IO => reader.get_pager().io.step().unwrap(),
+            other => panic!("expected a row from the held-open reader, got {other:?}"),
+        }
+    }
+
+    // Statement B on the same connection: its halt defers the commit to the
+    // shared implicit transaction that statement A still holds open.
+    conn.execute("INSERT INTO docs VALUES (2, 'bravo')")
+        .unwrap();
+
+    // Finish statement A so the shared transaction commits.
+    loop {
+        match reader.step().unwrap() {
+            turso_core::StepResult::Row => {}
+            turso_core::StepResult::IO => reader.get_pager().io.step().unwrap(),
+            turso_core::StepResult::Done => break,
+            other => panic!("expected the reader to finish, got {other:?}"),
+        }
+    }
+    drop(reader);
+
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs ORDER BY id"),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'bravo')"),
+        vec![vec![rusqlite::types::Value::Integer(2)]],
+        "the deferred autocommit write must keep its FTS index entry"
+    );
+}
+
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
 #[test]
 fn fts_streaming_dml_collects_stable_rowids() {

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -624,7 +624,7 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
         // Flush FTS data before executing SQL (which auto-commits the transaction)
         // This mimics the VDBE's explicit statement-finalization phase.
         run(&tmp_db, || {
-            cursor.prepare_statement_commit(&index_method_context(&conn, attached.as_ref()))
+            cursor.stage_statement_commit(&index_method_context(&conn, attached.as_ref()))
         })
         .unwrap();
         conn.execute(format!(

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
 use std::sync::Arc;
 
 use core_tester::common::rng_from_time_or_env;
@@ -9,8 +8,8 @@ use rand_chacha::ChaCha8Rng;
 use turso_core::index_method::fts::FtsIndexMethod;
 use turso_core::{
     index_method::{
-        toy_vector_sparse_ivf::VectorSparseInvertedIndexMethod, IndexMethod,
-        IndexMethodConfiguration,
+        toy_vector_sparse_ivf::VectorSparseInvertedIndexMethod, IndexMethod, IndexMethodAttachment,
+        IndexMethodConfiguration, IndexMethodContext,
     },
     schema::IndexColumn,
     types::IOResult,
@@ -33,6 +32,13 @@ fn run<T>(db: &TempDatabase, mut f: impl FnMut() -> Result<IOResult<T>>) -> Resu
     }
 }
 
+fn index_method_context(
+    connection: &Arc<turso_core::Connection>,
+    attachment: &dyn IndexMethodAttachment,
+) -> IndexMethodContext {
+    IndexMethodContext::for_test(connection, MAIN_DB_ID, attachment).unwrap()
+}
+
 #[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
 fn fts_test_stats(
     db: &TempDatabase,
@@ -53,7 +59,10 @@ fn fts_test_stats(
         })
         .unwrap();
     let mut cursor = attachment.init().unwrap();
-    run(db, || cursor.open_read(conn, MAIN_DB_ID)).unwrap();
+    run(db, || {
+        cursor.open_read(&index_method_context(conn, attachment.as_ref()))
+    })
+    .unwrap();
     cursor.test_stats().unwrap().unwrap()
 }
 
@@ -73,7 +82,10 @@ fn fts_attachment_test_stats(
         .unwrap()
         .expect("FTS attachment must exist in the connection schema");
     let mut cursor = attachment.init().unwrap();
-    run(db, || cursor.open_read(conn, MAIN_DB_ID)).unwrap();
+    run(db, || {
+        cursor.open_read(&index_method_context(conn, attachment.as_ref()))
+    })
+    .unwrap();
     cursor.test_stats().unwrap().unwrap()
 }
 
@@ -82,26 +94,7 @@ fn sparse_vector(v: &str) -> Value {
     vector::operations::serialize::vector_serialize(vector).expect(turso_core::alloc::ALLOC_ERR_MSG)
 }
 
-#[cfg(all(feature = "fts", not(target_family = "wasm")))]
-#[turso_macros::test]
-fn fts_mvcc_capability_is_checked_before_create(tmp_db: TempDatabase) {
-    let conn = tmp_db.connect_limbo();
-    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
-    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
-        .unwrap();
-
-    let error = conn
-        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
-        .unwrap_err();
-    assert!(
-        error
-            .to_string()
-            .contains("index method 'fts' does not support MVCC"),
-        "unexpected error: {error}"
-    );
-}
-
-// TODO: cannot use MVCC as we use indexes here
+// This raw-cursor test manually opens pager write transactions.
 #[turso_macros::test(init_sql = "CREATE TABLE t(name, embedding)")]
 fn test_vector_sparse_ivf_create_destroy(tmp_db: TempDatabase) {
     let _ = env_logger::try_init();
@@ -132,7 +125,10 @@ fn test_vector_sparse_ivf_create_destroy(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.create(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.create(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
     assert_eq!(
@@ -143,13 +139,16 @@ fn test_vector_sparse_ivf_create_destroy(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.destroy(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.destroy(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
     assert_eq!(schema_rows(), vec!["t"]);
 }
 
-// TODO: cannot use MVCC as we use indexes here
+// This raw-cursor test manually opens pager write transactions.
 #[turso_macros::test(init_sql = "CREATE TABLE t(name, embedding)")]
 fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
     let _ = env_logger::try_init();
@@ -168,7 +167,10 @@ fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.create(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.create(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
 
@@ -182,7 +184,10 @@ fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
     .enumerate()
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.open_write(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.open_write(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
 
         let values = [
             Register::Value(sparse_vector(vector_str)),
@@ -206,7 +211,10 @@ fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
         ),
     ] {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.open_read(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.open_read(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
 
         let values = [
             Register::Value(Value::from_i64(0)),
@@ -232,7 +240,7 @@ fn test_vector_sparse_ivf_insert_query(tmp_db: TempDatabase) {
     }
 }
 
-// TODO: cannot use MVCC as we use indexes here
+// This raw-cursor test manually opens pager write transactions.
 #[turso_macros::test(init_sql = "CREATE TABLE t(name, embedding)")]
 fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
     let _ = env_logger::try_init();
@@ -251,12 +259,18 @@ fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.create(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.create(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
 
     let mut writer = attached.init().unwrap();
-    run(&tmp_db, || writer.open_write(&conn, MAIN_DB_ID)).unwrap();
+    run(&tmp_db, || {
+        writer.open_write(&index_method_context(&conn, attached.as_ref()))
+    })
+    .unwrap();
 
     let v0_str = "[0, 1, 0, 0]";
     let v1_str = "[1, 0, 0, 1]";
@@ -283,7 +297,10 @@ fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
     .unwrap();
 
     let mut reader = attached.init().unwrap();
-    run(&tmp_db, || reader.open_read(&conn, MAIN_DB_ID)).unwrap();
+    run(&tmp_db, || {
+        reader.open_read(&index_method_context(&conn, attached.as_ref()))
+    })
+    .unwrap();
     assert!(!run(&tmp_db, || reader.query_start(&query_values)).unwrap());
 
     conn.execute(format!(
@@ -294,7 +311,10 @@ fn test_vector_sparse_ivf_update(tmp_db: TempDatabase) {
     run(&tmp_db, || writer.insert(&insert1_values)).unwrap();
 
     let mut reader = attached.init().unwrap();
-    run(&tmp_db, || reader.open_read(&conn, MAIN_DB_ID)).unwrap();
+    run(&tmp_db, || {
+        reader.open_read(&index_method_context(&conn, attached.as_ref()))
+    })
+    .unwrap();
     assert!(run(&tmp_db, || reader.query_start(&query_values)).unwrap());
     assert_eq!(1, run(&tmp_db, || reader.query_rowid()).unwrap().unwrap());
     assert_eq!(
@@ -353,7 +373,7 @@ fn test_vector_sparse_ivf_mvcc_sql(tmp_db: TempDatabase) {
     );
 }
 
-// TODO: cannot use MVCC as we use indexes here
+// This differential harness disables automatic WAL actions on both databases.
 #[turso_macros::test]
 fn test_vector_sparse_ivf_fuzz(tmp_db: TempDatabase) {
     let _ = env_logger::try_init();
@@ -513,7 +533,10 @@ fn test_fts_create_destroy(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.create(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.create(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
 
@@ -526,7 +549,10 @@ fn test_fts_create_destroy(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.destroy(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.destroy(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
 
@@ -555,7 +581,10 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
     conn.wal_insert_begin().unwrap();
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.create(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.create(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
     }
     conn.wal_insert_end(true).unwrap();
 
@@ -581,7 +610,10 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
 
     for (id, title, body) in docs {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.open_write(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.open_write(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
 
         let values = [
             Register::Value(Value::Text(turso_core::types::Text::from(title))),
@@ -590,8 +622,11 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
         ];
         run(&tmp_db, || cursor.insert(&values)).unwrap();
         // Flush FTS data before executing SQL (which auto-commits the transaction)
-        // This mimics what VDBE does via index_method_pre_commit_all()
-        run(&tmp_db, || cursor.pre_commit()).unwrap();
+        // This mimics the VDBE's explicit statement-finalization phase.
+        run(&tmp_db, || {
+            cursor.prepare_statement_commit(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
         conn.execute(format!(
             "INSERT INTO docs VALUES ({id}, '{title}', '{body}')"
         ))
@@ -601,7 +636,10 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
     // Query for "Rust" - should match docs 1 and 3
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.open_read(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.open_read(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
 
         // Pattern 0 = fts_score pattern with ORDER BY DESC LIMIT
         let values = [
@@ -635,7 +673,10 @@ fn test_fts_insert_query(tmp_db: TempDatabase) {
     // Query for "Python" - should match doc 2
     {
         let mut cursor = attached.init().unwrap();
-        run(&tmp_db, || cursor.open_read(&conn, MAIN_DB_ID)).unwrap();
+        run(&tmp_db, || {
+            cursor.open_read(&index_method_context(&conn, attached.as_ref()))
+        })
+        .unwrap();
 
         let values = [
             Register::Value(Value::from_i64(0)),
@@ -1955,6 +1996,803 @@ fn test_fts_with_explicit_transactions(tmp_db: TempDatabase) {
 }
 
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn test_fts_mvcc_lifecycle(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'committed alpha'), (2, 'committed beta')")
+        .unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'committed') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("UPDATE docs SET body = 'ephemeral update' WHERE id = 1")
+        .unwrap();
+    conn.execute("DELETE FROM docs WHERE id = 2").unwrap();
+    conn.execute("INSERT INTO docs VALUES (3, 'ephemeral insert')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'ephemeral') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+    conn.execute("ROLLBACK").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'committed') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+    assert!(limbo_exec_rows(
+        &conn,
+        "SELECT id FROM docs WHERE fts_match(body, 'ephemeral')"
+    )
+    .is_empty());
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("UPDATE docs SET body = 'durable update' WHERE id = 1")
+        .unwrap();
+    conn.execute("DELETE FROM docs WHERE id = 2").unwrap();
+    conn.execute("INSERT INTO docs VALUES (3, 'durable insert')")
+        .unwrap();
+    conn.execute("COMMIT").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'durable') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+
+    conn.execute("OPTIMIZE INDEX docs_fts").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'durable') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+
+    conn.execute("DROP INDEX docs_fts").unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'durable') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_trigger_writes_survive_repeated_subprogram_runs(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("CREATE TABLE source(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute(
+        "CREATE TRIGGER copy_docs AFTER INSERT ON source BEGIN \
+         INSERT INTO docs VALUES(NEW.id, NEW.body); END",
+    )
+    .unwrap();
+
+    conn.execute("INSERT INTO source VALUES (1, 'first trigger'), (2, 'second trigger')")
+        .unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'trigger') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_raise_fail_keeps_base_rows_and_index_in_sync(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute(
+        "CREATE TRIGGER fail_second BEFORE INSERT ON docs WHEN NEW.id = 2 BEGIN \
+         SELECT RAISE(FAIL, 'stop'); END",
+    )
+    .unwrap();
+
+    assert!(conn
+        .execute("INSERT INTO docs VALUES (1, 'first kept row'), (2, 'second rejected row')")
+        .is_err());
+
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs ORDER BY id"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'kept') ORDER BY id"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    conn.execute("BEGIN").unwrap();
+    assert!(conn
+        .execute("INSERT INTO docs VALUES (3, 'transaction kept row'), (2, 'still rejected')")
+        .is_err());
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'kept') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+    conn.execute("COMMIT").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'kept') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+
+    conn.execute("CREATE TABLE source(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute(
+        "CREATE TRIGGER copy_then_fail AFTER INSERT ON source BEGIN \
+         INSERT INTO docs VALUES(NEW.id, NEW.body); \
+         SELECT RAISE(FAIL, 'after copy'); END",
+    )
+    .unwrap();
+    assert!(conn
+        .execute("INSERT INTO source VALUES (4, 'trigger kept row')")
+        .is_err());
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'kept') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+            vec![rusqlite::types::Value::Integer(4)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn test_fts_mvcc_connection_isolation(tmp_db: TempDatabase) {
+    let writer = tmp_db.connect_limbo();
+    let observer = tmp_db.connect_limbo();
+
+    writer
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    writer
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    writer
+        .execute("INSERT INTO docs VALUES (1, 'committed token')")
+        .unwrap();
+
+    writer.execute("BEGIN").unwrap();
+    writer
+        .execute("UPDATE docs SET body = 'uncommitted token' WHERE id = 1")
+        .unwrap();
+    writer
+        .execute("INSERT INTO docs VALUES (2, 'uncommitted token')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &writer,
+            "SELECT id FROM docs WHERE fts_match(body, 'uncommitted') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+    assert!(limbo_exec_rows(
+        &observer,
+        "SELECT id FROM docs WHERE fts_match(body, 'uncommitted')"
+    )
+    .is_empty());
+    assert_eq!(
+        limbo_exec_rows(
+            &observer,
+            "SELECT id FROM docs WHERE fts_match(body, 'committed')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    writer.execute("COMMIT").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &observer,
+            "SELECT id FROM docs WHERE fts_match(body, 'uncommitted') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_same_index_writer_conflicts_before_tantivy_work() {
+    let tmp_db = TempDatabase::builder()
+        .with_db_name("fts-same-index-writer-conflict.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    first
+        .execute("INSERT INTO docs VALUES (1, 'writer one')")
+        .unwrap();
+    let stats_before_conflict = fts_attachment_test_stats(&tmp_db, &first, "docs", "docs_fts");
+
+    let conflict = second
+        .execute("INSERT INTO docs VALUES (2, 'writer two')")
+        .unwrap_err();
+    assert!(matches!(
+        conflict,
+        turso_core::LimboError::WriteWriteConflict
+    ));
+    let stats_after_conflict = fts_attachment_test_stats(&tmp_db, &first, "docs", "docs_fts");
+    assert_eq!(
+        stats_after_conflict.tantivy_writer_constructions,
+        stats_before_conflict.tantivy_writer_constructions,
+        "the losing transaction must not construct a Tantivy writer"
+    );
+    assert_eq!(
+        stats_after_conflict.write_lease_rejections,
+        stats_before_conflict
+            .write_lease_rejections
+            .map(|count| count + 1)
+    );
+
+    first.execute("COMMIT").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    second
+        .execute("INSERT INTO docs VALUES (2, 'writer two retry')")
+        .unwrap();
+    second.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(&first, "SELECT id FROM docs ORDER BY id"),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &first,
+            "SELECT id FROM docs WHERE fts_match(body, 'writer') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_different_index_writers_do_not_conflict() {
+    let tmp_db = TempDatabase::builder()
+        .with_db_name("fts-different-index-writers.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("CREATE TABLE first_docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX first_fts ON first_docs USING fts(body)")
+        .unwrap();
+    first
+        .execute("CREATE TABLE second_docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX second_fts ON second_docs USING fts(body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    first
+        .execute("INSERT INTO first_docs VALUES (1, 'first writer')")
+        .unwrap();
+    second
+        .execute("INSERT INTO second_docs VALUES (2, 'second writer')")
+        .unwrap();
+    first.execute("COMMIT").unwrap();
+    second.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &first,
+            "SELECT id FROM first_docs WHERE fts_match(body, 'writer')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &first,
+            "SELECT id FROM second_docs WHERE fts_match(body, 'writer')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_opposite_index_order_rejects_without_deadlock() {
+    let tmp_db = TempDatabase::builder()
+        .with_db_name("fts-opposite-index-order.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("CREATE TABLE a(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX a_fts ON a USING fts(body)")
+        .unwrap();
+    first
+        .execute("CREATE TABLE b(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX b_fts ON b USING fts(body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    first
+        .execute("INSERT INTO a VALUES (1, 'rolled back')")
+        .unwrap();
+    second
+        .execute("INSERT INTO b VALUES (2, 'survives')")
+        .unwrap();
+
+    let conflict = first
+        .execute("INSERT INTO b VALUES (1, 'rolled back')")
+        .unwrap_err();
+    assert!(matches!(
+        conflict,
+        turso_core::LimboError::WriteWriteConflict
+    ));
+
+    second
+        .execute("INSERT INTO a VALUES (2, 'survives')")
+        .unwrap();
+    second.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(&second, "SELECT id FROM a"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(&second, "SELECT id FROM b"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &second,
+            "SELECT id FROM a WHERE fts_match(body, 'survives')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &second,
+            "SELECT id FROM b WHERE fts_match(body, 'survives')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_savepoint_rollback_keeps_transaction_lease() {
+    let tmp_db = TempDatabase::builder()
+        .with_db_name("fts-savepoint-writer-lease.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    first.execute("SAVEPOINT pending_write").unwrap();
+    first
+        .execute("INSERT INTO docs VALUES (1, 'rolled back savepoint')")
+        .unwrap();
+    first.execute("ROLLBACK TO pending_write").unwrap();
+
+    second.execute("BEGIN CONCURRENT").unwrap();
+    let conflict = second
+        .execute("INSERT INTO docs VALUES (2, 'blocked writer')")
+        .unwrap_err();
+    assert!(matches!(
+        conflict,
+        turso_core::LimboError::WriteWriteConflict
+    ));
+
+    first.execute("ROLLBACK").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    second
+        .execute("INSERT INTO docs VALUES (2, 'successful retry')")
+        .unwrap();
+    second.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(&second, "SELECT id FROM docs"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &second,
+            "SELECT id FROM docs WHERE fts_match(body, 'retry')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_connection_close_releases_writer_lease() {
+    let tmp_db = TempDatabase::builder()
+        .with_db_name("fts-close-writer-lease.db")
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    first
+        .execute("INSERT INTO docs VALUES (1, 'abandoned writer')")
+        .unwrap();
+    first.close().unwrap();
+
+    second.execute("BEGIN CONCURRENT").unwrap();
+    second
+        .execute("INSERT INTO docs VALUES (2, 'replacement writer')")
+        .unwrap();
+    second.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(&second, "SELECT id FROM docs"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &second,
+            "SELECT id FROM docs WHERE fts_match(body, 'replacement')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn test_fts_mvcc_recovery(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'logical recovery'), (2, 'logical recovery')")
+        .unwrap();
+
+    let path = tmp_db.path.clone();
+    let io = tmp_db.io.clone();
+    let opts = tmp_db.db_opts;
+    let flags = tmp_db.db_flags;
+    conn.close().unwrap();
+    drop(conn);
+    drop(tmp_db);
+
+    let db = turso_core::Database::open_file_with_flags(
+        io.clone(),
+        path.to_str().unwrap(),
+        flags,
+        opts,
+        None,
+        std::sync::Arc::new(turso_core::SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'recovery') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    conn.close().unwrap();
+    drop(conn);
+    drop(db);
+
+    let db = turso_core::Database::open_file_with_flags(
+        io,
+        path.to_str().unwrap(),
+        flags,
+        opts,
+        None,
+        std::sync::Arc::new(turso_core::SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'recovery') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_checkpoint_modes_preserve_manifest() {
+    for mvcc in [false, true] {
+        let opts = turso_core::DatabaseOpts::new()
+            .with_index_method(true)
+            .with_experimental_mvcc_passive_checkpoint(true);
+        let mut builder = TempDatabase::builder().with_opts(opts);
+        if mvcc {
+            builder = builder.with_mvcc(true);
+        }
+        let tmp_db = builder.build();
+        let conn = tmp_db.connect_limbo();
+        conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+            .unwrap();
+        conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+            .unwrap();
+
+        let cases = [
+            ("PASSIVE", "checkpointalpha"),
+            ("FULL", "checkpointbravo"),
+            ("RESTART", "checkpointcharlie"),
+            ("TRUNCATE", "checkpointdelta"),
+        ];
+        for (id, (mode, token)) in cases.into_iter().enumerate() {
+            let id = id as i64 + 1;
+            conn.execute(format!("INSERT INTO docs VALUES ({id}, '{token}')"))
+                .unwrap();
+            conn.execute(format!("PRAGMA wal_checkpoint({mode})"))
+                .unwrap();
+
+            for (visible_id, (_, visible_token)) in cases.iter().take(id as usize).enumerate() {
+                let visible_id = visible_id as i64 + 1;
+                assert_eq!(
+                    limbo_exec_rows(
+                        &conn,
+                        &format!("SELECT id FROM docs WHERE fts_match(body, '{visible_token}')")
+                    ),
+                    vec![vec![rusqlite::types::Value::Integer(visible_id)]],
+                    "{mode} checkpoint lost FTS generation {visible_id}"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_passive_checkpoint_preserves_pinned_reader() {
+    for mvcc in [false, true] {
+        let opts = turso_core::DatabaseOpts::new()
+            .with_index_method(true)
+            .with_experimental_mvcc_passive_checkpoint(true);
+        let mut builder = TempDatabase::builder().with_opts(opts);
+        if mvcc {
+            builder = builder.with_mvcc(true);
+        }
+        let tmp_db = builder.build();
+        let writer = tmp_db.connect_limbo();
+        let reader = tmp_db.connect_limbo();
+        writer
+            .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+            .unwrap();
+        writer
+            .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+            .unwrap();
+        writer
+            .execute("INSERT INTO docs VALUES (1, 'pinned generation')")
+            .unwrap();
+
+        reader.execute("BEGIN").unwrap();
+        assert_eq!(
+            limbo_exec_rows(
+                &reader,
+                "SELECT id FROM docs WHERE fts_match(body, 'pinned')"
+            ),
+            vec![vec![rusqlite::types::Value::Integer(1)]]
+        );
+
+        writer
+            .execute("INSERT INTO docs VALUES (2, 'new generation')")
+            .unwrap();
+        if let Err(error) = writer.execute("PRAGMA wal_checkpoint(PASSIVE)") {
+            assert!(
+                matches!(error, turso_core::LimboError::Busy),
+                "passive checkpoint returned unexpected error in {} mode: {error}",
+                if mvcc { "MVCC" } else { "WAL" }
+            );
+        }
+        assert!(
+            limbo_exec_rows(&reader, "SELECT id FROM docs WHERE fts_match(body, 'new')").is_empty(),
+            "a checkpoint must not move a pinned reader to the new FTS manifest"
+        );
+        reader.execute("COMMIT").unwrap();
+
+        assert_eq!(
+            limbo_exec_rows(&reader, "SELECT id FROM docs WHERE fts_match(body, 'new')"),
+            vec![vec![rusqlite::types::Value::Integer(2)]],
+            "the next transaction must observe the post-checkpoint manifest"
+        );
+    }
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test]
+fn test_fts_switch_to_mvcc(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'before switch')")
+        .unwrap();
+
+    conn.pragma_update("journal_mode", "'mvcc'").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'switch')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    conn.execute("UPDATE docs SET body = 'updated after transition' WHERE id = 1")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (2, 'inserted after transition')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'transition') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+    assert!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'switch')").is_empty()
+    );
+
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'transition') ORDER BY id"
+        )
+        .len(),
+        2
+    );
+
+    conn.pragma_update("journal_mode", "'wal'").unwrap();
+    conn.execute("UPDATE docs SET body = 'returned to wal' WHERE id = 1")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (3, 'created in wal')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'wal') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ],
+        "FTS state must survive the MVCC-to-WAL transition"
+    );
+}
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
 #[turso_macros::test(init_sql = "CREATE TABLE docs(id INTEGER PRIMARY KEY, title TEXT, body TEXT)")]
 fn test_fts_optimize_index(tmp_db: TempDatabase) {
     let _ = env_logger::try_init();
@@ -2711,6 +3549,7 @@ fn fts_reuses_committed_writer_across_insert_statements() {
         .len(),
         2
     );
+    let before_drop = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
 
     // Destroying an index must release the retained Tantivy writer and its
     // directory lock so an index with the same name can be created immediately.
@@ -2724,6 +3563,683 @@ fn fts_reuses_committed_writer_across_insert_statements() {
         )
         .len(),
         2
+    );
+    let after_recreate = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_ne!(
+        after_recreate.index_incarnation, before_drop.index_incarnation,
+        "drop/recreate must allocate a distinct persistent index incarnation"
+    );
+}
+
+/// A cursor prepared by a statement inside BEGIN must survive statement reset
+/// until the later COMMIT delivers the transaction outcome. The committed
+/// writer should then be reusable by the next transaction.
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_explicit_commit_publishes_transaction_scoped_writer() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'explicit transaction writer')")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (2, 'newest transaction cursor')")
+        .unwrap();
+    assert_eq!(
+        fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts").cached_writer,
+        Some(true),
+        "statement success must retain transaction-private writer state"
+    );
+    conn.execute("COMMIT").unwrap();
+
+    let committed = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(committed.cached_writer, Some(true));
+    let constructions = committed.tantivy_writer_constructions;
+
+    conn.execute("INSERT INTO docs VALUES (3, 'reused explicit writer')")
+        .unwrap();
+    assert_eq!(
+        fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts").tantivy_writer_constructions,
+        constructions,
+        "the post-COMMIT statement should restore the transaction-published writer"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'transaction') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)]
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_reuses_writer_within_explicit_transaction() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    let before = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("INSERT INTO docs VALUES (1, 'first retained writer')")
+        .unwrap();
+    let after_first = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(after_first.cached_writer, Some(true));
+    assert!(
+        after_first.tantivy_writer_constructions > before.tantivy_writer_constructions,
+        "the first write must construct one Tantivy writer"
+    );
+
+    conn.execute("INSERT INTO docs VALUES (2, 'second retained writer')")
+        .unwrap();
+    let after_second = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(
+        after_second.tantivy_writer_constructions, after_first.tantivy_writer_constructions,
+        "the next statement in the same MVCC transaction must reuse the lease-owned writer"
+    );
+    assert!(
+        after_second.writer_cache_hits > after_first.writer_cache_hits,
+        "writer-cache telemetry must record the transaction-private reuse"
+    );
+    conn.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'retained') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)]
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_reuses_validated_writer_across_transactions() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'first transaction')")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'first')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let after_first = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("COMMIT").unwrap();
+
+    conn.execute("INSERT INTO docs VALUES (2, 'second transaction')")
+        .unwrap();
+    conn.execute("BEGIN").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'second')"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    let after_second = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        after_second.tantivy_writer_constructions, after_first.tantivy_writer_constructions,
+        "an unchanged committed manifest must reuse the asynchronously validated MVCC writer"
+    );
+    assert!(
+        after_second.writer_cache_hits > after_first.writer_cache_hits,
+        "writer-cache telemetry must record cross-transaction validation reuse"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'transaction') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)]
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_savepoint_rollback_invalidates_transaction_scoped_writer() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("SAVEPOINT before_fts").unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'rolled back writer state')")
+        .unwrap();
+    conn.execute("ROLLBACK TO before_fts").unwrap();
+    conn.execute("COMMIT").unwrap();
+
+    let after_rollback = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(
+        after_rollback.cached_writer,
+        Some(false),
+        "ROLLBACK TO must invalidate the retained transaction cursor before COMMIT"
+    );
+    assert!(
+        after_rollback.writer_cache_rollback_discards > Some(0),
+        "rollback telemetry must record the discarded transaction-private writer"
+    );
+    assert!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'rolled')").is_empty()
+    );
+
+    conn.execute("INSERT INTO docs VALUES (2, 'surviving writer state')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'surviving')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_loser_rollback_keeps_winner_cached_writer() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let winner = tmp_db.connect_limbo();
+    let loser = tmp_db.connect_limbo();
+
+    winner
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    winner
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    winner.execute("BEGIN CONCURRENT").unwrap();
+    loser.execute("BEGIN CONCURRENT").unwrap();
+    winner
+        .execute("INSERT INTO docs VALUES (1, 'winner writer')")
+        .unwrap();
+    let before_conflict = fts_attachment_test_stats(&tmp_db, &winner, "docs", "docs_fts");
+    assert_eq!(
+        before_conflict.cached_writer,
+        Some(true),
+        "the winner's statement must retain its transaction-tagged writer"
+    );
+
+    let conflict = loser
+        .execute("INSERT INTO docs VALUES (2, 'loser writer')")
+        .unwrap_err();
+    assert!(matches!(
+        conflict,
+        turso_core::LimboError::WriteWriteConflict
+    ));
+
+    let after_conflict = fts_attachment_test_stats(&tmp_db, &winner, "docs", "docs_fts");
+    assert_eq!(
+        after_conflict.cached_writer,
+        Some(true),
+        "the loser's rollback must not evict the winner's cached writer"
+    );
+    assert_eq!(
+        after_conflict.writer_cache_rollback_discards,
+        before_conflict.writer_cache_rollback_discards,
+        "the loser's rollback must not count a discard of a writer it does not own"
+    );
+
+    winner
+        .execute("INSERT INTO docs VALUES (3, 'winner reuses writer')")
+        .unwrap();
+    let after_reuse = fts_attachment_test_stats(&tmp_db, &winner, "docs", "docs_fts");
+    assert_eq!(
+        after_reuse.tantivy_writer_constructions, after_conflict.tantivy_writer_constructions,
+        "the winner's next statement must reuse its writer instead of rebuilding it"
+    );
+    assert!(
+        after_reuse.writer_cache_hits > after_conflict.writer_cache_hits,
+        "writer-cache telemetry must record the winner's reuse after the conflict"
+    );
+    winner.execute("COMMIT").unwrap();
+
+    // The conflict rolled back the loser's whole transaction; a retry from a
+    // fresh transaction succeeds.
+    loser.execute("BEGIN CONCURRENT").unwrap();
+    loser
+        .execute("INSERT INTO docs VALUES (2, 'loser retry writer')")
+        .unwrap();
+    loser.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        limbo_exec_rows(
+            &winner,
+            "SELECT id FROM docs WHERE fts_match(body, 'writer') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_wal_other_connection_commit_does_not_revalidate_writer() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let writer_conn = tmp_db.connect_limbo();
+    let other = tmp_db.connect_limbo();
+
+    writer_conn
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    writer_conn
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    writer_conn
+        .execute("CREATE TABLE plain(x INTEGER)")
+        .unwrap();
+    writer_conn
+        .execute("INSERT INTO docs VALUES (1, 'alpha document')")
+        .unwrap();
+
+    let before = fts_attachment_test_stats(&tmp_db, &writer_conn, "docs", "docs_fts");
+    assert_eq!(before.cached_writer, Some(true));
+
+    // Another connection's transaction reads the FTS index and commits an
+    // unrelated write. Its commit hook must not re-stamp the first
+    // connection's cached writer to the post-commit WAL position: that would
+    // revalidate a writer whose WAL snapshot has moved.
+    other.execute("BEGIN").unwrap();
+    other.execute("INSERT INTO plain VALUES (1)").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&other, "SELECT id FROM docs WHERE fts_match(body, 'alpha')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    other.execute("COMMIT").unwrap();
+
+    writer_conn
+        .execute("INSERT INTO docs VALUES (2, 'beta document')")
+        .unwrap();
+    let after = fts_attachment_test_stats(&tmp_db, &writer_conn, "docs", "docs_fts");
+    assert!(
+        after.tantivy_writer_constructions > before.tantivy_writer_constructions,
+        "a WAL-position change committed by another connection must invalidate the \
+         cached writer, not revalidate it"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &writer_conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'document') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_wal_commit_must_not_revalidate_stale_budget_rejected_writer() {
+    use turso_core::index_method::fts::set_fts_retained_cache_bytes_for_test;
+
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn_a = tmp_db.connect_limbo();
+    let conn_b = tmp_db.connect_limbo();
+
+    conn_a
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn_a
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn_a
+        .execute("INSERT INTO docs VALUES (1, 'alpha stays visible')")
+        .unwrap();
+    // Connection A's committed writer sits in the shared slot, stamped at A's
+    // post-commit WAL position.
+    assert_eq!(
+        fts_attachment_test_stats(&tmp_db, &conn_a, "docs", "docs_fts").cached_writer,
+        Some(true)
+    );
+
+    // Shrink the retention budget: B's newer writer now fails cache admission,
+    // so A's stale writer stays in the slot while the index moves past it.
+    set_fts_retained_cache_bytes_for_test(Some(1));
+    conn_b
+        .execute("INSERT INTO docs VALUES (2, 'bravo must survive')")
+        .unwrap();
+
+    // A read-only FTS statement on connection A commits with A's WAL mark
+    // advanced past B's commit. Its commit hook must not re-stamp the stale
+    // writer to that mark: the writer's segments predate B's document, and
+    // reusing it would drop the document from the index.
+    assert_eq!(
+        limbo_exec_rows(
+            &conn_a,
+            "SELECT id FROM docs WHERE fts_match(body, 'bravo')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+
+    let before = fts_attachment_test_stats(&tmp_db, &conn_a, "docs", "docs_fts");
+    conn_a
+        .execute("INSERT INTO docs VALUES (3, 'charlie added later')")
+        .unwrap();
+    let after = fts_attachment_test_stats(&tmp_db, &conn_a, "docs", "docs_fts");
+    set_fts_retained_cache_bytes_for_test(None);
+
+    assert!(
+        after.tantivy_writer_constructions > before.tantivy_writer_constructions,
+        "connection A must rebuild its writer: the cached one predates B's committed document"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn_a,
+            "SELECT id FROM docs WHERE fts_match(body, 'bravo') OR fts_match(body, 'charlie') ORDER BY id"
+        ),
+        vec![
+            vec![rusqlite::types::Value::Integer(2)],
+            vec![rusqlite::types::Value::Integer(3)],
+        ],
+        "every committed document must stay searchable after the writer churn"
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_create_persists_real_index_incarnation() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    // A never-written index uses the deterministic placeholder incarnation 0;
+    // staging the first control record (which CREATE INDEX does) must mint a
+    // real incarnation so cache validation can distinguish incarnations.
+    let stats = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_ne!(
+        stats.index_incarnation,
+        Some(0),
+        "the persisted control record must never carry the empty-index placeholder incarnation"
+    );
+    assert_eq!(stats.manifest_generation, Some(1));
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_manifest_generation_is_transactional() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    let created = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(created.storage_format_version, Some(1));
+    assert_eq!(created.manifest_generation, Some(1));
+    assert_eq!(
+        created.storage_file_count,
+        created.manifest_file_count.unwrap()
+    );
+
+    conn.execute("INSERT INTO docs VALUES (1, 'committed generation')")
+        .unwrap();
+    let committed = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert!(
+        committed.manifest_generation > created.manifest_generation,
+        "committed write must advance the manifest"
+    );
+    assert_eq!(committed.index_incarnation, created.index_incarnation);
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO docs VALUES (2, 'rolled back generation')")
+        .unwrap();
+    conn.execute("ROLLBACK").unwrap();
+    let rolled_back = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(
+        rolled_back.manifest_generation, committed.manifest_generation,
+        "rollback must restore the prior control record"
+    );
+    assert_eq!(rolled_back.index_incarnation, created.index_incarnation);
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_reuses_snapshot_within_one_read_transaction() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'same snapshot cache')")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'snapshot')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let after_first = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'snapshot')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let after_second = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        after_second.full_snapshot_loads, after_first.full_snapshot_loads,
+        "the second read in one MVCC transaction must not rescan the directory"
+    );
+    assert!(
+        after_second.read_cache_hits > after_first.read_cache_hits,
+        "the second read must use the transaction-bound snapshot cache"
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_wal_reuses_manifest_after_unrelated_commit() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE TABLE unrelated(value TEXT)").unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'stable manifest')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'stable')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let before = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+
+    conn.execute("INSERT INTO unrelated VALUES ('changes the WAL position')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'stable')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let after = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+
+    assert_eq!(
+        after.full_snapshot_loads, before.full_snapshot_loads,
+        "an unrelated commit must validate the FTS manifest without reloading its files"
+    );
+    assert!(
+        after.manifest_validation_hits > before.manifest_validation_hits,
+        "the changed WAL snapshot must be accepted through control-record validation"
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_reuses_manifest_across_read_transactions() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'autocommit manifest')")
+        .unwrap();
+    conn.execute("BEGIN").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'autocommit')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let before = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("COMMIT").unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'autocommit')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let after = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
+    conn.execute("COMMIT").unwrap();
+
+    assert_eq!(
+        after.full_snapshot_loads, before.full_snapshot_loads,
+        "a new MVCC read transaction must not reload an unchanged FTS manifest"
+    );
+    assert!(
+        after.manifest_validation_hits > before.manifest_validation_hits,
+        "the new MVCC snapshot must validate the cached manifest by its control record"
+    );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_manifest_generation_invalidates_stale_snapshot_once() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let writer = tmp_db.connect_limbo();
+    let reader = tmp_db.connect_limbo();
+
+    writer
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    writer
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    writer
+        .execute("INSERT INTO docs VALUES (1, 'first generation')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &reader,
+            "SELECT id FROM docs WHERE fts_match(body, 'first')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    let before_write = fts_attachment_test_stats(&tmp_db, &reader, "docs", "docs_fts");
+
+    writer
+        .execute("INSERT INTO docs VALUES (2, 'second generation')")
+        .unwrap();
+    assert_eq!(
+        limbo_exec_rows(
+            &reader,
+            "SELECT id FROM docs WHERE fts_match(body, 'second')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]],
+        "the observer must reject its stale snapshot after the writer commits"
+    );
+    let after_write = fts_attachment_test_stats(&tmp_db, &reader, "docs", "docs_fts");
+    assert!(
+        after_write.manifest_validation_misses > before_write.manifest_validation_misses,
+        "an advanced manifest generation must reject the stale read snapshot"
+    );
+    assert!(
+        after_write.full_snapshot_loads > before_write.full_snapshot_loads,
+        "the first reader of a new generation must load its directory snapshot"
+    );
+
+    assert_eq!(
+        limbo_exec_rows(
+            &reader,
+            "SELECT id FROM docs WHERE fts_match(body, 'second')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    let after_reuse = fts_attachment_test_stats(&tmp_db, &reader, "docs", "docs_fts");
+    assert_eq!(
+        after_reuse.full_snapshot_loads, after_write.full_snapshot_loads,
+        "the newly loaded generation must be reusable without another full scan"
     );
 }
 
@@ -2847,7 +4363,10 @@ fn fts_read_cache_is_connection_local_and_bounded() {
     {
         let mut cursor = attachment.init().unwrap();
         run(&tmp_db, || {
-            cursor.open_read(&readers[reader_index], MAIN_DB_ID)
+            cursor.open_read(&index_method_context(
+                &readers[reader_index],
+                attachment.as_ref(),
+            ))
         })
         .unwrap();
         let stats = cursor.test_stats().unwrap().unwrap();


### PR DESCRIPTION
Move FTS persistence out of Tantivy callbacks and Drop into explicit resumable statement finalization. Carry snapshot and index identity through IndexMethod operations, retain transaction-owned cursors until the final outcome, and store a checked control manifest with the backing chunks.

Serialize same-index MVCC writers with transaction-scoped leases, validate read and writer caches against their snapshot and manifest, and invalidate retained state on every rollback and savepoint outcome.

The trigger and FAIL paths finalize kept FTS changes before cached subprogram reset or statement-savepoint release. A preparation failure forces full rollback rather than committing base rows without matching index entries.
