### PR TITLE
core/translate: Fix handling of NULLs for row-value comparison against literal list

### DIFF
--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -72,21 +72,10 @@ pub(super) fn translate_in_list(
 
     if false_null_jump_targets_differ {
         check_null_reg = program.alloc_register();
-	program.emit_insn(Insn::BitAnd {
-	    lhs: lhs_reg,
-	    rhs: lhs_reg,
-	    dest: check_null_reg,
-        });
-	for i in 1..lhs_arity {
-	    program.emit_insn(Insn::BitAnd {
-		lhs: lhs_reg + i,
-		rhs: check_null_reg,
-		dest: check_null_reg,
-            });
-	}
-	program.emit_insn(Insn::IsNull {
-	    reg: check_null_reg,
-	    target_pc: condition_metadata.jump_target_when_null,
+        program.emit_insn(Insn::BitAnd {
+            lhs: lhs_reg,
+            rhs: lhs_reg,
+            dest: check_null_reg,
         });
     }
 
@@ -95,16 +84,16 @@ pub(super) fn translate_in_list(
         let rhs_reg = program.alloc_registers(lhs_arity);
         let _ = translate_expr(program, referenced_tables, expr, rhs_reg, resolver)?;
 
-        if check_null_reg != 0 && expr.can_be_null() {
-            program.emit_insn(Insn::BitAnd {
-                lhs: check_null_reg,
-                rhs: rhs_reg,
-                dest: check_null_reg,
-            });
-        }
-
         if lhs_arity == 1 {
             // Scalar comparison path
+            if check_null_reg != 0 && expr.can_be_null() {
+                program.emit_insn(Insn::BitAnd {
+                    lhs: check_null_reg,
+                    rhs: rhs_reg,
+                    dest: check_null_reg,
+                });
+            }
+
             if !last_condition || false_null_jump_targets_differ {
                 if lhs_reg != rhs_reg {
                     program.emit_insn(Insn::Eq {
@@ -139,6 +128,8 @@ pub(super) fn translate_in_list(
             if !last_condition || false_null_jump_targets_differ {
                 // If all components match, jump to label_ok; otherwise skip to next RHS item
                 let skip_label = program.allocate_label();
+
+                // Check for unequal values and skip if one is found.
                 for j in 0..lhs_arity {
                     let (aff, collation) = row_component_affinity_collation(
                         lhs,
@@ -147,25 +138,33 @@ pub(super) fn translate_in_list(
                         referenced_tables,
                         Some(resolver),
                     )?;
-                    let flags = CmpInsFlags::default().with_affinity(aff).jump_if_null();
-                    if j < lhs_arity - 1 {
-                        program.emit_insn(Insn::Ne {
-                            lhs: lhs_reg + j,
-                            rhs: rhs_reg + j,
-                            target_pc: skip_label,
-                            flags,
-                            collation,
-                        });
-                    } else {
-                        program.emit_insn(Insn::Eq {
-                            lhs: lhs_reg + j,
-                            rhs: rhs_reg + j,
-                            target_pc: label_ok,
-                            flags,
-                            collation,
-                        });
-                    }
+                    let flags = CmpInsFlags::default().with_affinity(aff);
+                    program.emit_insn(Insn::Ne {
+                        lhs: lhs_reg + j,
+                        rhs: rhs_reg + j,
+                        target_pc: skip_label,
+                        flags,
+                        collation,
+                    });
                 }
+
+                // Checking for NULL comes after confirming there are no inequalities in order to
+                // avoid prematurely resolving the result to NULL when inequalities exist.
+                // See https://sqlite.org/rowvalue.html#row_value_comparisons for details.
+                for j in 0..lhs_arity {
+                    program.emit_insn(Insn::IsNull {
+                        reg: lhs_reg + j,
+                        target_pc: condition_metadata.jump_target_when_null,
+                    });
+                    program.emit_insn(Insn::IsNull {
+                        reg: rhs_reg + j,
+                        target_pc: condition_metadata.jump_target_when_null,
+                    });
+                }
+
+                program.emit_insn(Insn::Goto {
+                    target_pc: label_ok,
+                });
                 program.preassign_label_to_next_insn(skip_label);
             } else {
                 // Last condition, simple case: jump to false if any component doesn't match

--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -159,13 +159,13 @@ pub(super) fn translate_in_list(
 
                 // Checking for null values after fully confirming there are no inequalities.
                 // The goal is to avoid prematurely resolving the result to NULL when inequalities are
-		// found when comparing row-values component-by-component. E.g. (NULL,1) IN ((2,2)) resolves
-		// to FALSE but (NULL,2) IN ((2,2)) resolves to NULL.
+                // found when comparing row-values component-by-component. E.g. (NULL,1) IN ((2,2)) resolves
+                // to FALSE but (NULL,2) IN ((2,2)) resolves to NULL.
                 let set_null_flag_label = program.allocate_label();
                 let null_target_label = if check_null_in_row_values_reg != 0 {
                     set_null_flag_label
                 } else {
-		    // skip setting the null flag when nulls are treated the same way as falses
+                    // skip setting the null flag when nulls are treated the same way as falses
                     skip_label
                 };
                 for j in 0..lhs_arity {

--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -62,13 +62,15 @@ pub(super) fn translate_in_list(
     let _ = translate_expr(program, referenced_tables, lhs, lhs_reg, resolver)?;
     let mut check_null_reg = 0;
     let label_ok = program.allocate_label();
+    let false_null_jump_targets_differ =
+        condition_metadata.jump_target_when_false != condition_metadata.jump_target_when_null;
 
     // Compute the affinity for the IN comparison based on the LHS expression
     // This follows SQLite's exprINAffinity() approach
     let affinity = in_expr_affinity(lhs, referenced_tables, Some(resolver));
     let cmp_flags = CmpInsFlags::default().with_affinity(affinity);
 
-    if condition_metadata.jump_target_when_false != condition_metadata.jump_target_when_null {
+    if false_null_jump_targets_differ {
         check_null_reg = program.alloc_register();
         program.emit_insn(Insn::BitAnd {
             lhs: lhs_reg,
@@ -92,10 +94,7 @@ pub(super) fn translate_in_list(
 
         if lhs_arity == 1 {
             // Scalar comparison path
-            if !last_condition
-                || condition_metadata.jump_target_when_false
-                    != condition_metadata.jump_target_when_null
-            {
+            if !last_condition || false_null_jump_targets_differ {
                 if lhs_reg != rhs_reg {
                     program.emit_insn(Insn::Eq {
                         lhs: lhs_reg,
@@ -126,10 +125,7 @@ pub(super) fn translate_in_list(
             }
         } else {
             // Row-valued comparison path: compare each component
-            if !last_condition
-                || condition_metadata.jump_target_when_false
-                    != condition_metadata.jump_target_when_null
-            {
+            if !last_condition || false_null_jump_targets_differ {
                 // If all components match, jump to label_ok; otherwise skip to next RHS item
                 let skip_label = program.allocate_label();
                 for j in 0..lhs_arity {
@@ -140,7 +136,7 @@ pub(super) fn translate_in_list(
                         referenced_tables,
                         Some(resolver),
                     )?;
-                    let flags = CmpInsFlags::default().with_affinity(aff);
+                    let flags = CmpInsFlags::default().with_affinity(aff).jump_if_null();
                     if j < lhs_arity - 1 {
                         program.emit_insn(Insn::Ne {
                             lhs: lhs_reg + j,

--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -72,10 +72,21 @@ pub(super) fn translate_in_list(
 
     if false_null_jump_targets_differ {
         check_null_reg = program.alloc_register();
-        program.emit_insn(Insn::BitAnd {
-            lhs: lhs_reg,
-            rhs: lhs_reg,
-            dest: check_null_reg,
+	program.emit_insn(Insn::BitAnd {
+	    lhs: lhs_reg,
+	    rhs: lhs_reg,
+	    dest: check_null_reg,
+        });
+	for i in 1..lhs_arity {
+	    program.emit_insn(Insn::BitAnd {
+		lhs: lhs_reg + i,
+		rhs: check_null_reg,
+		dest: check_null_reg,
+            });
+	}
+	program.emit_insn(Insn::IsNull {
+	    reg: check_null_reg,
+	    target_pc: condition_metadata.jump_target_when_null,
         });
     }
 

--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -61,6 +61,7 @@ pub(super) fn translate_in_list(
     let lhs_reg = program.alloc_registers(lhs_arity);
     let _ = translate_expr(program, referenced_tables, lhs, lhs_reg, resolver)?;
     let mut check_null_reg = 0;
+    let mut check_null_in_row_values_reg = 0;
     let label_ok = program.allocate_label();
     let false_null_jump_targets_differ =
         condition_metadata.jump_target_when_false != condition_metadata.jump_target_when_null;
@@ -71,12 +72,20 @@ pub(super) fn translate_in_list(
     let cmp_flags = CmpInsFlags::default().with_affinity(affinity);
 
     if false_null_jump_targets_differ {
-        check_null_reg = program.alloc_register();
-        program.emit_insn(Insn::BitAnd {
-            lhs: lhs_reg,
-            rhs: lhs_reg,
-            dest: check_null_reg,
-        });
+        if lhs_arity == 1 {
+            check_null_reg = program.alloc_register();
+            program.emit_insn(Insn::BitAnd {
+                lhs: lhs_reg,
+                rhs: lhs_reg,
+                dest: check_null_reg,
+            });
+        } else if lhs_arity > 1 {
+            check_null_in_row_values_reg = program.alloc_register();
+            program.emit_insn(Insn::Integer {
+                dest: check_null_in_row_values_reg,
+                value: 0,
+            });
+        }
     }
 
     for (i, expr) in rhs.iter().enumerate() {
@@ -148,23 +157,39 @@ pub(super) fn translate_in_list(
                     });
                 }
 
-                // Checking for NULL comes after confirming there are no inequalities in order to
-                // avoid prematurely resolving the result to NULL when inequalities exist.
-                // See https://sqlite.org/rowvalue.html#row_value_comparisons for details.
+                // Checking for null values after fully confirming there are no inequalities.
+                // The goal is to avoid prematurely resolving the result to NULL when inequalities are
+		// found when comparing row-values component-by-component. E.g. (NULL,1) IN ((2,2)) resolves
+		// to FALSE but (NULL,2) IN ((2,2)) resolves to NULL.
+                let set_null_flag_label = program.allocate_label();
+                let null_target_label = if check_null_in_row_values_reg != 0 {
+                    set_null_flag_label
+                } else {
+		    // skip setting the null flag when nulls are treated the same way as falses
+                    skip_label
+                };
                 for j in 0..lhs_arity {
                     program.emit_insn(Insn::IsNull {
                         reg: lhs_reg + j,
-                        target_pc: condition_metadata.jump_target_when_null,
+                        target_pc: null_target_label,
                     });
                     program.emit_insn(Insn::IsNull {
                         reg: rhs_reg + j,
-                        target_pc: condition_metadata.jump_target_when_null,
+                        target_pc: null_target_label,
                     });
                 }
-
                 program.emit_insn(Insn::Goto {
                     target_pc: label_ok,
                 });
+
+                if check_null_in_row_values_reg != 0 {
+                    program.preassign_label_to_next_insn(set_null_flag_label);
+                    program.emit_insn(Insn::Integer {
+                        value: 1,
+                        dest: check_null_in_row_values_reg,
+                    });
+                }
+
                 program.preassign_label_to_next_insn(skip_label);
             } else {
                 // Last condition, simple case: jump to false if any component doesn't match
@@ -193,6 +218,17 @@ pub(super) fn translate_in_list(
         program.emit_insn(Insn::IsNull {
             reg: check_null_reg,
             target_pc: condition_metadata.jump_target_when_null,
+        });
+        program.emit_insn(Insn::Goto {
+            target_pc: condition_metadata.jump_target_when_false,
+        });
+    }
+
+    if check_null_in_row_values_reg != 0 {
+        program.emit_insn(Insn::If {
+            reg: check_null_in_row_values_reg,
+            target_pc: condition_metadata.jump_target_when_null,
+            jump_if_null: false,
         });
         program.emit_insn(Insn::Goto {
             target_pc: condition_metadata.jump_target_when_false,

--- a/sqlite/conformance/sqlite-sqltests/row-value-in.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/row-value-in.sqltest
@@ -217,3 +217,17 @@ test row-value-null-against-multiple-literal-tuples-in {
 expect {
     1
 }
+
+test row-value-null-in-rhs-literal-list {
+   SELECT ((2,2) IN ((2,NULL))) IS NULL;
+}
+expect {
+    1
+}
+
+test row-value-null-in-rhs-literal-list-overeager {
+   SELECT ((1,2,3) IN ((1,NULL,9))) IS FALSE;
+}
+expect {
+    1
+}

--- a/sqlite/conformance/sqlite-sqltests/row-value-in.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/row-value-in.sqltest
@@ -182,3 +182,38 @@ test row-value-nulls-literal-list-not-in {
 }
 expect {
 }
+
+test row-value-null-in-first-position-in {
+    SELECT ((NULL,1) IN ((1,1))) IS NULL;
+}
+expect {
+    1
+}
+
+test row-value-null-in-second-position-in {
+    SELECT ((2,NULL) IN ((2,2))) IS NULL;
+}
+expect {
+    1
+}
+
+test row-value-null-in-second-position-not-in {
+    SELECT ((2,NULL) NOT IN ((2,2))) IS NULL;
+}
+expect {
+    1
+}
+
+test row-value-null-in-middle-position-in {
+    SELECT ((1,NULL,3) IN ((1,2,3))) IS NULL;
+}
+expect {
+    1
+}
+
+test row-value-null-against-multiple-literal-tuples-in {
+    SELECT ((NULL,1) IN ((9,9),(1,1))) IS NULL;
+}
+expect {
+    1
+}

--- a/sqlite/conformance/sqlite-sqltests/row-value-in.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/row-value-in.sqltest
@@ -161,3 +161,24 @@ expect {
     m5|-1
     m6|-1
 }
+
+setup row_values_with_null_schema {
+    CREATE TABLE w(a, b);
+    INSERT INTO w VALUES (NULL,1),(1,1),(2,NULL),(2,2);
+}
+
+@setup row_values_with_null_schema
+test row-value-nulls-literal-list-in {
+    SELECT a, b FROM w WHERE (a,b) IN ((1,1),(2,2)) ORDER BY 1,2;
+}
+expect {
+    1|1
+    2|2
+}
+
+@setup row_values_with_null_schema
+test row-value-nulls-literal-list-not-in {
+    SELECT a, b FROM w WHERE (a,b) NOT IN ((1,1),(2,2)) ORDER BY 1,2;
+}
+expect {
+}

--- a/sqlite/conformance/sqlite-sqltests/row-value-in.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/row-value-in.sqltest
@@ -168,7 +168,7 @@ setup row_values_with_null_schema {
 }
 
 @setup row_values_with_null_schema
-test row-value-nulls-literal-list-in {
+test row-value-filter-nulls-literal-list-in {
     SELECT a, b FROM w WHERE (a,b) IN ((1,1),(2,2)) ORDER BY 1,2;
 }
 expect {
@@ -177,56 +177,78 @@ expect {
 }
 
 @setup row_values_with_null_schema
-test row-value-nulls-literal-list-not-in {
+test row-value-filter-nulls-literal-list-not-in {
     SELECT a, b FROM w WHERE (a,b) NOT IN ((1,1),(2,2)) ORDER BY 1,2;
 }
 expect {
 }
 
-test row-value-null-in-first-position-in {
+@setup row_values_with_null_schema
+test row-value-filter-nulls-literal-list-containing-null-in {
+    SELECT a, b FROM w WHERE (a,b) IN ((2,NULL),(2,2)) ORDER BY 1,2;
+}
+expect {
+    2|2
+}
+
+test row-value-false-null-first-in {
     SELECT ((NULL,1) IN ((1,1))) IS NULL;
 }
 expect {
     1
 }
 
-test row-value-null-in-second-position-in {
+test row-value-false-null-second-in {
     SELECT ((2,NULL) IN ((2,2))) IS NULL;
 }
 expect {
     1
 }
 
-test row-value-null-in-second-position-not-in {
+test row-value-false-null-second-not-in {
     SELECT ((2,NULL) NOT IN ((2,2))) IS NULL;
 }
 expect {
     1
 }
 
-test row-value-null-in-middle-position-in {
+test row-value-false-null-three-values-in {
     SELECT ((1,NULL,3) IN ((1,2,3))) IS NULL;
 }
 expect {
     1
 }
 
-test row-value-null-against-multiple-literal-tuples-in {
-    SELECT ((NULL,1) IN ((9,9),(1,1))) IS NULL;
+test row-value-false-null-multiple-tuples-in {
+    SELECT ((NULL,1) IN ((1,1),(9,9))) IS NULL;
 }
 expect {
     1
 }
 
-test row-value-null-in-rhs-literal-list {
-   SELECT ((2,2) IN ((2,NULL))) IS NULL;
+test row-value-false-null-multiple-tuples-with-null-in {
+   SELECT ((2,2) IN ((2,NULL),(9,9))) IS NULL;
 }
 expect {
     1
 }
 
-test row-value-null-in-rhs-literal-list-overeager {
+test row-value-false-null-multiple-tuples-with-null-not-in {
+   SELECT ((2,2) NOT IN ((2,NULL),(9,9))) IS NULL;
+}
+expect {
+    1
+}
+
+test row-value-false-null-check-inequality-after-null-in {
    SELECT ((1,2,3) IN ((1,NULL,9))) IS FALSE;
+}
+expect {
+    1
+}
+
+test row-value-false-null-check-matches-after-null-in {
+   SELECT ((2,2) IN ((2,NULL),(2,2))) IS TRUE;
 }
 expect {
     1


### PR DESCRIPTION
## Description
Updates logic inside `translate_in_list` to handle different ways NULL values in either LHS or RHS expression can affect the behavior of the IN/NOT IN operators.

A new flag (`check_null_in_row_values_reg`) is introduced to keep track of whether or not a NULL is encountered while scanning the LHS and RHS values. The scan for NULL is kept as a separate loop after comparing the LHS and RHS row-value components. Once the comparison scan is finished without skipping (meaning that no comparisons resulted in FALSE), the scan for NULL values can determine if the LHS/RHS comparison resolves to NULL immediately upon encountering a NULL value in either LHS/RHS. The flag is needed in order to keep track of NULLs encountered when comparing the LHS against multiple RHS row-values, e.g. `SELECT (2,2) IN ((2,NULL),(9,9))` should resolve to `NULL` instead of `FALSE`.

Tests: Added sqltest regression tests from original issue ticket and a couple of my own that were helpful for developing this fix. These new tests were checked against SQLite 3.53.4 behavior

Fixes https://github.com/tursodatabase/turso/issues/8255

## Future work
I noticed that SQLite converts the literal list to an ephemeral index and uses its original IN operator logic but I decided to keep the changes here minimal and not stray much from the original architecture. That can be one future improvement if someone feels that's worthwhile.

Another future improvement would be to hoist the LHS NULL value check outside of the loop since that won't change when comparing against multiple RHS row-values.

## Description of AI Usage
Used OpenCode with GLM 5.2/5.3 to review code after each commit and find bugs and opportunities for improvement. AI was not used to generate code; I hand-typed every line of code myself so that I can get a better understanding of Turso's codebase.
