### PR TITLE
consider partial index predicates for covering index access

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1872,15 +1872,15 @@ fn optimize_table_access_with_custom_modules(
     Ok(false)
 }
 
-/// We do a single pass over projected, grouping, and ordering expressions to
+/// We do a single pass over projected, grouping, filtering, and ordering expressions to
 /// capture every expression that could be served directly from an expression index.
 /// Example:
 ///   CREATE INDEX idx ON t(lower(a));
-///   SELECT lower(a) FROM t ORDER BY lower(a);
-/// Both the SELECT list and ORDER BY can be covered by idx, avoiding a
+///   SELECT lower(a) FROM t WHERE lower(a) ORDER BY lower(a);
+/// Both the SELECT list, WHERE, and ORDER BY can be covered by idx, avoiding a
 /// table cursor entirely. Recording them upfront lets both the cost model
 /// and covering checks reuse the same facts.
-fn register_expression_index_usages_for_plan(
+fn register_index_expression_usages_for_plan(
     table_references: &mut TableReferences,
     result_columns: &[ResultSetColumn],
     order_by: &[(
@@ -1889,14 +1889,20 @@ fn register_expression_index_usages_for_plan(
         Option<turso_parser::ast::NullsOrder>,
     )],
     group_by: Option<&GroupBy>,
+    where_clause: &mut [WhereTerm],
 ) {
     table_references.reset_expression_index_usages();
+
     for rc in result_columns {
         table_references.register_expression_index_usage(&rc.expr);
     }
     for (expr, _, _) in order_by {
         table_references.register_expression_index_usage(expr);
     }
+    for where_term in where_clause {
+        table_references.register_expression_index_usage(&where_term.expr);
+    }
+
     if let Some(group_by) = group_by {
         for expr in &group_by.exprs {
             table_references.register_expression_index_usage(expr);
@@ -2309,18 +2315,19 @@ fn find_table_access_plan(
         );
     }
 
-    let has_expression_index = table_references.joined_tables().iter().any(|t| {
+    let has_expression_idx_or_partial_idx = table_references.joined_tables().iter().any(|t| {
         matches!(&t.table, Table::BTree(_) if available_indexes
             .indexes_for_table(t.internal_id)
-            .is_some_and(|indexes| indexes.iter().any(|index| index.is_expression_index())))
+            .is_some_and(|indexes| indexes.iter().any(|index| index.is_expression_index() || index.where_clause.is_some())))
     });
 
-    if has_expression_index {
-        register_expression_index_usages_for_plan(
+    if has_expression_idx_or_partial_idx {
+        register_index_expression_usages_for_plan(
             table_references,
             result_columns,
             order_by.as_slice(),
             group_by.as_ref(),
+            where_clause,
         );
     }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2712,9 +2712,16 @@ impl JoinedTable {
             //   SELECT lower(name) FROM t;
             // Column `name` is not otherwise needed, so we can rely on the
             // expression value from the index and drop the table cursor.
+            let matches_where_clause = if let Some(idx_where_clause) = &index.where_clause {
+                exprs_are_equivalent(idx_where_clause, &usage.normalized_expr)
+            } else {
+                false
+            };
+
             if index
                 .expression_to_index_pos(&usage.normalized_expr)
                 .is_some()
+                || matches_where_clause
             {
                 any_covered = true;
                 for col_idx in usage.columns_mask.iter() {

--- a/sqlite/conformance/sqlite-sqltests/create_index.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/create_index.sqltest
@@ -302,4 +302,3 @@ test create-index-sqlite-source-id {
 }
 expect error {
 }
-

--- a/sqlite/conformance/sqlite-sqltests/partial_idx.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/partial_idx.sqltest
@@ -1229,7 +1229,7 @@ test plan-partial-index-equality-predicate {
         SELECT id FROM products WHERE status = 'active' AND sku = 'X';
 }
 expect {
-    1|0|0|SEARCH products USING INDEX idx_active_sku (sku=?)
+    1|0|0|SEARCH products USING COVERING INDEX idx_active_sku (sku=?)
 }
 
 # Partial index with range predicate in WHERE.
@@ -1240,7 +1240,7 @@ test plan-partial-index-range-predicate {
     EXPLAIN QUERY PLAN SELECT id FROM products WHERE price > 100 AND sku = 'X';
 }
 expect {
-    1|0|0|SEARCH products USING INDEX idx_expensive (sku=?)
+    1|0|0|SEARCH products USING COVERING INDEX idx_expensive (sku=?)
 }
 
 # Partial index whose WHERE predicate is *not* implied by the query → fallback
@@ -1549,4 +1549,51 @@ test partial-index-qualified-where-update-with-cte-named-like-target {
 }
 expect {
     5|1
+}
+
+test use-partial-idx-predicate-for-covering-index-scan {
+    create table t(a, b);
+    create index idx on t(a) where b < 5;
+    insert into t values (-1, 1), (-3, 3), (-5, 5), (-8, 8);
+
+    select a from t where b < 5 order by a;
+}
+expect {
+    -3
+    -1
+}
+
+@skip-if sqlite "sqlite does a covering scan here, but only accidentally (it still opens both cursors, it just doesn't read from the base table cursor)"
+test eqp-use-partial-idx-predicate-for-covering-index-scan {
+    create table t(a, b);
+    create index idx on t(a) where b < 5;
+    insert into t values (-1, 1), (-3, 3), (-5, 5), (-8, 8);
+
+    explain query plan select a from t where b < 5 order by a;
+}
+expect {
+    1|0|0|SCAN t USING COVERING INDEX idx
+}
+
+test use-partial-idx-predicate-with-residual-for-covering-index-scan {
+    create table t(a, b);
+    create index idx on t(a) where b < 5;
+    insert into t values (-1, 1), (-3, 3), (-5, 5), (-8, 8);
+
+    select a from t where b < 5 and a = -3 order by a;
+}
+expect {
+    -3
+}
+
+@skip-if sqlite "sqlite does a covering scan here, but only accidentally (it still opens both cursors, it just doesn't read from the base table cursor)"
+test eqp-use-partial-idx-predicate-with-residual-predicate-for-covering-index-scan {
+    create table t(a, b);
+    create index idx on t(a) where b < 5;
+    insert into t values (-1, 1), (-3, 3), (-5, 5), (-8, 8);
+
+    explain query plan select a from t where b < 5 and a = -3 order by a;
+}
+expect {
+    1|0|0|SEARCH t USING COVERING INDEX idx (a=?)
 }

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__partial-index-count-star.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__partial-index-count-star.snap
@@ -10,22 +10,20 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SCAN t2 USING INDEX t2_partial_aux_idx
+`--SCAN t2 USING COVERING INDEX t2_partial_aux_idx
 
 BYTECODE
-addr  opcode          p1  p2  p3  p4            p5  comment
-   0  Init             0  12   0                 0  Start at 12
-   1  Null             0   2   0                 0  r[2]=NULL
-   2  OpenRead         0   2   0  k(4,B,B,B,B)   0  table=t2, root=2, iDb=0
-   3  OpenRead         1   4   0  k(2,B)         0  index=t2_partial_aux_idx, root=4, iDb=0
-   4  Rewind           1   8   0                 0  Rewind index t2_partial_aux_idx
-   5    DeferredSeek   1   0   0                 0
-   6    AggStep        0   3   2  count          0  accum=r[2] step(r[3])
-   7  Next             1   5   0                 1
-   8  AggFinal         0   2   0  count          0  accum=r[2]
-   9  Copy             2   1   0                 0  r[1]=r[2]
-  10  ResultRow        1   1   0                 0  output=r[1]
-  11  Halt             0   0   0                 0
-  12  Transaction      0   1   3                 0  iDb=0 tx_mode=Read
-  13  Integer          1   3   0                 0  r[3]=1
-  14  Goto             0   1   0                 0
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0  10   0           0  Start at 10
+   1  Null          0   2   0           0  r[2]=NULL
+   2  OpenRead      0   4   0  k(2,B)   0  index=t2_partial_aux_idx, root=4, iDb=0
+   3  Rewind        0   6   0           0  Rewind index t2_partial_aux_idx
+   4    AggStep     0   3   2  count    0  accum=r[2] step(r[3])
+   5  Next          0   4   0           1
+   6  AggFinal      0   2   0  count    0  accum=r[2]
+   7  Copy          2   1   0           0  r[1]=r[2]
+   8  ResultRow     1   1   0           0  output=r[1]
+   9  Halt          0   0   0           0
+  10  Transaction   0   1   3           0  iDb=0 tx_mode=Read
+  11  Integer       1   3   0           0  r[3]=1
+  12  Goto          0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/indexes.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/indexes.sqltest
@@ -836,3 +836,25 @@ snapshot-eqp same-name-temp-and-main-index-lookup {
     JOIN main.same_name AS m ON m.a = t.a
     WHERE t.a = 1 AND m.a = 2;
 }
+
+setup partial-idx-predicate {
+    create table t(a, b);
+    create index idx on t(a) where b < 5;
+    insert into t values (-1, 1), (-3, 3), (-5, 5), (-8, 8);
+}
+
+@setup partial-idx-predicate
+snapshot-eqp use-partial-idx-predicate-for-covering-index-scan {
+    select a from t where b < 5;
+}
+
+setup partial-idx-predicate-disjunction {
+   create table t(a, b);
+   create index idx on t(a) where b < 5 or a > 5;
+   insert into t values (-1, 1), (-3, 3), (-5, 5), (-8, 8);
+}
+
+@setup partial-idx-predicate-disjunction
+snapshot-eqp use-partial-idx-predicate-where-predicate-is-disjunction-term-from-index-where-clause-for-covering-index-scan {
+   select a from t where b < 5;
+}

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__use-partial-idx-predicate-for-covering-index-scan.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__use-partial-idx-predicate-for-covering-index-scan.snap
@@ -1,0 +1,13 @@
+---
+source: indexes.sqltest
+expression: select a from t where b < 5;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - partial-idx-predicate
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t USING COVERING INDEX idx

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__use-partial-idx-predicate-where-predicate-is-disjunction-term-from-index-where-clause-for-covering-index-scan.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/indexes/snapshots/indexes__use-partial-idx-predicate-where-predicate-is-disjunction-term-from-index-where-clause-for-covering-index-scan.snap
@@ -1,0 +1,13 @@
+---
+source: indexes.sqltest
+expression: select a from t where b < 5;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - partial-idx-predicate-disjunction
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t

--- a/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-indexed-by-left-join-null-rejecting-where-can-prove-after-rewrite-eqp.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-indexed-by-left-join-null-rejecting-where-can-prove-after-rewrite-eqp.snap
@@ -17,4 +17,4 @@ info:
 ---
 QUERY PLAN
 |--SCAN left_items
-`--SEARCH right_items USING INDEX right_marker_five_idx (id=?)
+`--SEARCH right_items USING COVERING INDEX right_marker_five_idx (id=?)


### PR DESCRIPTION
## Description

The linked issue (https://github.com/tursodatabase/turso/issues/8376) was already kind of half-fixed on main, but I can't pinpoint where it got fixed.

I say it was half-fixed, because the DB was doing a covering index scan by accident. It still opened both the table and the index cursor, and called `Next` on the index cursor, but the base table only had a `DeferredSeek` and the `Column` read from the index. So the table never got seeked. This also showed in `EXPLAIN QUERY PLAN`, where those queries that were accidental covering index scans didn't say "covering". Incidentally, SQLite has this same quirk with accidental covering indexes.

The fix is to register the partial index's `WHERE` clause conjunct terms as "expression index usages" if they're used by the query. What then happens is that when the DB says "is this index covering?", it first removes the columns that are implicitly satisfied from the list of "required columns".

In other words, we're reusing the same machinery that already enabled things like this:

```sql
create table t(a, b);
create index idx on t(a * 5);
explain query plan select a * 5 from t;
QUERY PLAN
`--SCAN t USING COVERING INDEX idx
```

This is no-AI Wednesday, so I used no AI whatsoever for this PR.

Closes https://github.com/tursodatabase/turso/issues/8376