### PR TITLE
core/optimizer: allow partial-index predicates to cover scans

### DIFF
--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -165,10 +165,11 @@ pub fn translate_expr(
 
     // At the very start we try to satisfy the expression from an expression index
     let has_expression_indexes = referenced_tables.is_some_and(|tables| {
-        tables
-            .joined_tables()
-            .iter()
-            .any(|t| !t.expression_index_usages.is_empty())
+        tables.joined_tables().iter().any(|t| {
+            t.expression_index_usages
+                .iter()
+                .any(|usage| usage.expression_index)
+        })
     });
     if has_expression_indexes
         && try_emit_expression_index_value(program, referenced_tables, expr, target_register)?

--- a/core/translate/expression_index.rs
+++ b/core/translate/expression_index.rs
@@ -8,6 +8,34 @@ use crate::Result;
 use turso_parser::ast;
 use turso_parser::ast::TableInternalId;
 
+pub(crate) fn normalize_bound_expr_for_index_matching(
+    expr: &ast::Expr,
+    table_reference: &JoinedTable,
+) -> ast::Expr {
+    let mut expr = expr.clone();
+    let columns = table_reference.table.columns();
+
+    let mut normalize = |e: &mut ast::Expr| -> Result<WalkControl> {
+        match e {
+            ast::Expr::Column { column, .. } => {
+                if let Some(name) = columns.get(*column).and_then(|c| c.name.as_ref()) {
+                    *e = ast::Expr::Id(ast::Name::exact(name.clone()));
+                }
+            }
+            ast::Expr::RowId { .. } => {
+                *e = ast::Expr::Id(ast::Name::exact(ROWID_STRS[0].to_string()));
+            }
+            _ => {}
+        }
+
+        Ok(WalkControl::Continue)
+    };
+
+    let _ = walk_expr_mut(&mut expr, &mut normalize);
+
+    expr
+}
+
 /// Normalize a query expression so it can be compared with an
 /// expression stored on an index definition.
 ///
@@ -23,29 +51,13 @@ pub fn normalize_expr_for_index_matching(
     table_reference: &JoinedTable,
     table_references: &TableReferences,
 ) -> ast::Expr {
-    let mut expr = expr.clone();
     let _table_idx = table_references
         .joined_tables()
         .iter()
         .position(|t| t.internal_id == table_reference.internal_id)
         .expect("table must exist in table_references");
-    let columns = table_reference.table.columns();
-    let mut normalize = |e: &mut ast::Expr| -> Result<WalkControl> {
-        match e {
-            ast::Expr::Column { column, .. } => {
-                if let Some(name) = columns.get(*column).and_then(|c| c.name.as_ref()) {
-                    *e = ast::Expr::Id(ast::Name::exact(name.clone()));
-                }
-            }
-            ast::Expr::RowId { .. } => {
-                *e = ast::Expr::Id(ast::Name::exact(ROWID_STRS[0].to_string()));
-            }
-            _ => {}
-        }
-        Ok(WalkControl::Continue)
-    };
-    let _ = walk_expr_mut(&mut expr, &mut normalize);
-    expr
+
+    normalize_bound_expr_for_index_matching(expr, table_reference)
 }
 
 /// Determine whether an expression references columns from exactly one table

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -1458,45 +1458,67 @@ pub fn ordered_ephemeral_key_columns(constraints: &[&Constraint]) -> SmallVec<[u
     ordered
 }
 
+pub(crate) fn partial_index_predicate_conjuncts(
+    index: &Index,
+    table_reference: &JoinedTable,
+) -> Option<Vec<ast::Expr>> {
+    let index_where = index.where_clause.as_ref()?;
+
+    // Bind the index WHERE expression's column references to this query's
+    // table reference, rewrite equivalent predicate forms, and split the
+    // predicate into individual AND conjuncts.
+    let mut bound = (**index_where).clone();
+    bind_partial_index_columns(&mut bound, table_reference);
+    rewrite_between_exprs(&mut bound).ok()?;
+
+    let mut conjuncts = Vec::new();
+    break_predicate_at_and_boundaries(&bound, &mut conjuncts);
+
+    Some(conjuncts)
+}
+
 pub(super) fn partial_index_predicate_terms(
     index: &Index,
     table_reference: &JoinedTable,
     query_where_clause: &[WhereTerm],
 ) -> Option<SmallVec<[usize; 4]>> {
-    let index_where = index
+    index
         .where_clause
         .as_ref()
         .expect("partial_index_predicate_terms requires a partial index");
+
     let can_use_query_term = |term: &WhereTerm| -> bool {
         let Some(join_info) = &table_reference.join_info else {
             return true;
         };
+
         if join_info.is_full_outer() {
             return false;
         }
+
         if join_info.is_outer() {
             return term.from_outer_join == Some(table_reference.internal_id);
         }
+
         true
     };
-    // Bind the index WHERE expression's column references to this query's
-    // table reference so it can be compared symmetrically against bound query
-    // WHERE terms. Each conjunct of the index WHERE must match some query
-    // WHERE term for the partial index to be safe to use.
-    let mut bound = (**index_where).clone();
-    bind_partial_index_columns(&mut bound, table_reference);
-    rewrite_between_exprs(&mut bound).ok()?;
-    let mut index_conjuncts: Vec<ast::Expr> = Vec::new();
-    break_predicate_at_and_boundaries(&bound, &mut index_conjuncts);
+
+    let index_conjuncts = partial_index_predicate_conjuncts(index, table_reference)?;
+
+    // Each conjunct of the index WHERE must match a query WHERE term for
+    // the partial index to be safe to use.
     let mut matched_terms = SmallVec::<[usize; 4]>::new();
-    for index_conjunct in index_conjuncts.iter() {
+
+    for index_conjunct in &index_conjuncts {
         let (term_idx, _) = query_where_clause.iter().enumerate().find(|(_, term)| {
             can_use_query_term(term) && exprs_are_equivalent(index_conjunct, &term.expr)
         })?;
+
         if !matched_terms.contains(&term_idx) {
             matched_terms.push(term_idx);
         }
     }
+
     Some(matched_terms)
     // TODO: recognize implication beyond syntactic equivalence (e.g. `x = 5` implies
     // `x IS NOT NULL`, `x > 10` implies `x > 5`).

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1872,15 +1872,16 @@ fn optimize_table_access_with_custom_modules(
     Ok(false)
 }
 
-/// We do a single pass over projected, grouping, and ordering expressions to
-/// capture every expression that could be served directly from an expression index.
+/// We do a single pass over projected, grouping, ordering, and filtering
+/// expressions to capture every expression whose column reads may be covered by
+/// index metadata.
 /// Example:
 ///   CREATE INDEX idx ON t(lower(a));
 ///   SELECT lower(a) FROM t ORDER BY lower(a);
 /// Both the SELECT list and ORDER BY can be covered by idx, avoiding a
 /// table cursor entirely. Recording them upfront lets both the cost model
 /// and covering checks reuse the same facts.
-fn register_expression_index_usages_for_plan(
+fn register_index_coverage_usages_for_plan(
     table_references: &mut TableReferences,
     result_columns: &[ResultSetColumn],
     order_by: &[(
@@ -1889,8 +1890,10 @@ fn register_expression_index_usages_for_plan(
         Option<turso_parser::ast::NullsOrder>,
     )],
     group_by: Option<&GroupBy>,
+    where_clause: &[WhereTerm],
+    has_partial_index: bool,
 ) {
-    table_references.reset_expression_index_usages();
+    table_references.reset_index_coverage_usages();
     for rc in result_columns {
         table_references.register_expression_index_usage(&rc.expr);
     }
@@ -1905,6 +1908,11 @@ fn register_expression_index_usages_for_plan(
             for expr in having {
                 table_references.register_expression_index_usage(expr);
             }
+        }
+    }
+    if has_partial_index {
+        for term in where_clause {
+            table_references.register_partial_index_predicate_usage(&term.expr);
         }
     }
 }
@@ -2315,12 +2323,20 @@ fn find_table_access_plan(
             .is_some_and(|indexes| indexes.iter().any(|index| index.is_expression_index())))
     });
 
-    if has_expression_index {
-        register_expression_index_usages_for_plan(
+    let has_partial_index = table_references.joined_tables().iter().any(|t| {
+        matches!(&t.table, Table::BTree(_) if available_indexes
+        .indexes_for_table(t.internal_id)
+        .is_some_and(|indexes| indexes.iter().any(|index| index.where_clause.is_some())))
+    });
+
+    if has_expression_index || has_partial_index {
+        register_index_coverage_usages_for_plan(
             table_references,
             result_columns,
             order_by.as_slice(),
             group_by.as_ref(),
+            where_clause,
+            has_partial_index,
         );
     }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -12,8 +12,13 @@ use crate::{
             as_binary_components, expr_data_type, get_expr_affinity, get_expr_affinity_info,
             ExprAffinityInfo, StorageClassMask,
         },
-        expression_index::{normalize_expr_for_index_matching, single_table_column_usage},
-        optimizer::constraints::{BinaryExprSide, SeekRangeConstraint},
+        expression_index::{
+            normalize_bound_expr_for_index_matching, normalize_expr_for_index_matching,
+            single_table_column_usage,
+        },
+        optimizer::constraints::{
+            partial_index_predicate_conjuncts, BinaryExprSide, SeekRangeConstraint,
+        },
         planner::determine_where_to_eval_term,
     },
     types::SeekOp,
@@ -1193,20 +1198,16 @@ pub struct JoinedTable {
     /// Bitmask of columns that are referenced in the query.
     /// Used to decide whether a covering index can be used.
     pub col_used_mask: ColumnUsedMask,
-    /// Count of how many times each column is referenced.
-    ///
-    /// Expression indexes can satisfy a column requirement if the column is
-    /// only used to build the expression itself. Tracking counts lets us
-    /// subtract a column from the covering set only when every usage is
-    /// accounted for by an expression index.
+    /// Tracks how many times each column is referenced so it can be removed
+    /// from the covering set only when every usage is satisfied by the index.
     pub column_use_counts: Vec<usize>,
-    /// Expressions referencing this table that may be satisfied by an expression index.
+    /// Expressions referencing this table that may be satisfied by index metadata.
     ///
     /// Each entry stores the normalized expression text and the columns it
-    /// needs. During covering checks we ask: does an index contain this
-    /// expression? If yes, all columns that *only* feed this expression can be
-    /// removed from the required-column set.
-    pub expression_index_usages: Vec<ExpressionIndexUsage>,
+    /// needs. During covering checks we ask whether those column references
+    /// are covered by an expression-index key or by a proven partial-index
+    /// predicate.
+    pub expression_index_usages: Vec<IndexCoverageUsage>,
     /// The index of the database. "main" is always zero.
     pub database_id: usize,
     /// INDEXED BY / NOT INDEXED hint from the SQL statement.
@@ -1433,19 +1434,29 @@ impl TableReferences {
             .any(|t| t.join_info.as_ref().is_some_and(JoinInfo::is_full_outer))
     }
 
-    /// Resets the expression index usages for all joined tables.
-    pub fn reset_expression_index_usages(&mut self) {
+    /// Resets the index coverage usages for all joined tables.
+    pub fn reset_index_coverage_usages(&mut self) {
         for table in self.joined_tables.iter_mut() {
-            table.clear_expression_index_usages();
+            table.clear_index_coverage_usages();
         }
     }
 
-    /// Called before optimization so we can reuse the same registration
-    /// for result columns, ORDER BY, and GROUP BY expressions. If a
-    /// SELECT lists `LOWER(name)` and an index exists on `LOWER(name)`, we
-    /// can plan a covering scan because the expression value lives inside
-    /// the index key.
     pub fn register_expression_index_usage(&mut self, expr: &ast::Expr) {
+        self.register_index_coverage_usage(expr, true, false);
+    }
+
+    pub fn register_partial_index_predicate_usage(&mut self, expr: &ast::Expr) {
+        self.register_index_coverage_usage(expr, false, true);
+    }
+
+    /// Called before optimization so we can reuse the same registration for
+    /// result columns, ORDER BY, GROUP BY, and partial-index predicates.
+    fn register_index_coverage_usage(
+        &mut self,
+        expr: &ast::Expr,
+        expression_index: bool,
+        partial_index_predicate: bool,
+    ) {
         let Some((table_id, columns_mask)) = single_table_column_usage(expr) else {
             return;
         };
@@ -1462,7 +1473,12 @@ impl TableReferences {
             .iter_mut()
             .find(|t| t.internal_id == table_id)
         {
-            table_ref_mut.register_expression_index_usage(normalized, columns_mask);
+            table_ref_mut.register_index_coverage_usage(
+                normalized,
+                columns_mask,
+                expression_index,
+                partial_index_predicate,
+            );
         }
     }
 
@@ -2164,13 +2180,18 @@ impl<T> TryFrom<u128> for BitSet<T> {
 }
 
 #[derive(Clone, Debug)]
-pub struct ExpressionIndexUsage {
-    /// Normalized (non-bound) ast of the expression as stored on an index column.
-    /// Example: `lower(name)` for INDEX ON t(lower(name)).
+pub struct IndexCoverageUsage {
+    /// Normalized (non-bound) AST of the expression.
     pub normalized_expr: Box<ast::Expr>,
-    /// Columns required to compute the expression. Helps decide whether using
-    /// the expression value from the index fully covers those column reads.
+
+    /// Columns referenced by the expression.
     pub columns_mask: ColumnUsedMask,
+
+    /// Whether an expression-index key may satisfy this usage.
+    pub expression_index: bool,
+
+    /// Whether a proven partial-index predicate may satisfy this usage.
+    pub partial_index_predicate: bool,
 }
 
 /// Represents one key pair in a hash join equality condition.
@@ -2664,46 +2685,51 @@ impl JoinedTable {
         self.col_used_mask.set(index).expect("TODO: alloc error");
     }
 
-    /// Clear any previously registered expression index usages.
-    pub fn clear_expression_index_usages(&mut self) {
+    /// Clear any previously registered index coverage usages.
+    pub fn clear_index_coverage_usages(&mut self) {
         self.expression_index_usages.clear();
     }
 
-    /// Example: SELECT a+b FROM t WHERE a+b=5 with INDEX ON t(a+b)
-    /// We want to remember that (a+b) is available on an index key and that
-    /// columns a and b are only needed to produce that expression. Later we
-    /// can avoid opening the table cursor if all column references are
-    /// covered by expression keys.
-    pub fn register_expression_index_usage(
+    fn register_index_coverage_usage(
         &mut self,
         normalized_expr: ast::Expr,
         columns_mask: ColumnUsedMask,
+        expression_index: bool,
+        partial_index_predicate: bool,
     ) {
         if columns_mask.is_empty() {
             return;
         }
-        if self
+        if let Some(usage) = self
             .expression_index_usages
-            .iter()
-            .any(|usage| exprs_are_equivalent(&usage.normalized_expr, &normalized_expr))
+            .iter_mut()
+            .find(|usage| exprs_are_equivalent(&usage.normalized_expr, &normalized_expr))
         {
+            debug_assert_eq!(usage.columns_mask, columns_mask);
+            usage.expression_index |= expression_index;
+            usage.partial_index_predicate |= partial_index_predicate;
             return;
         }
-        self.expression_index_usages.push(ExpressionIndexUsage {
+        self.expression_index_usages.push(IndexCoverageUsage {
             normalized_expr: Box::new(normalized_expr),
             columns_mask,
+            expression_index,
+            partial_index_predicate,
         });
     }
 
-    /// Provided an index that may contain expression keys, remove any
-    /// columns from `required_columns` that are fully covered by expression index values.
-    fn apply_expression_index_coverage(
-        &self,
-        index: &Index,
-        required_columns: &mut ColumnUsedMask,
-    ) {
+    /// Provided an index, remove any columns from `required_columns` that are
+    /// fully covered by index metadata.
+    fn apply_index_coverage(&self, index: &Index, required_columns: &mut ColumnUsedMask) {
         let mut coverage_counts = vec![0usize; self.column_use_counts.len()];
         let mut any_covered = false;
+        let partial_index_predicates =
+            partial_index_predicate_conjuncts(index, self).map(|predicates| {
+                predicates
+                    .into_iter()
+                    .map(|predicate| normalize_bound_expr_for_index_matching(&predicate, self))
+                    .collect::<Vec<_>>()
+            });
         for usage in &self.expression_index_usages {
             // If the index stores the expression (e.g. idx on lower(name)), all
             // columns needed *solely* for that expression can be treated as
@@ -2712,10 +2738,19 @@ impl JoinedTable {
             //   SELECT lower(name) FROM t;
             // Column `name` is not otherwise needed, so we can rely on the
             // expression value from the index and drop the table cursor.
-            if index
-                .expression_to_index_pos(&usage.normalized_expr)
-                .is_some()
-            {
+            let covered_by_expression_index = usage.expression_index
+                && index
+                    .expression_to_index_pos(&usage.normalized_expr)
+                    .is_some();
+
+            let covered_by_partial_index = usage.partial_index_predicate
+                && partial_index_predicates.as_ref().is_some_and(|predicates| {
+                    predicates
+                        .iter()
+                        .any(|predicate| exprs_are_equivalent(predicate, &usage.normalized_expr))
+                });
+
+            if covered_by_expression_index || covered_by_partial_index {
                 any_covered = true;
                 for col_idx in usage.columns_mask.iter() {
                     if col_idx >= coverage_counts.len() {
@@ -2873,7 +2908,7 @@ impl JoinedTable {
             Self::index_covers_columns(index, btree, &self.col_used_mask)
         } else {
             let mut required_columns = self.col_used_mask.clone();
-            self.apply_expression_index_coverage(index, &mut required_columns);
+            self.apply_index_coverage(index, &mut required_columns);
             if required_columns.is_empty() {
                 return true;
             }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1138,11 +1138,11 @@ fn update_column_used_masks(
             if let Some(joined_table) =
                 table_refs.find_joined_table_by_internal_id_mut(child_outer_query_ref.internal_id)
             {
-                // Propagate column_use_counts so that expression index coverage
+                // Propagate column_use_counts so that index coverage
                 // checks see the additional references from correlated subqueries.
-                // Without this, apply_expression_index_coverage() may conclude that
-                // all uses of a column are satisfied by an expression index when in
-                // fact the correlated subquery needs the column directly.
+                // Without this, apply_index_coverage() may conclude that all uses
+                // of a column are satisfied by index metadata when in fact the
+                // correlated subquery needs the column directly.
                 for col_idx in child_outer_query_ref.col_used_mask.iter() {
                     if col_idx >= joined_table.column_use_counts.len() {
                         joined_table.column_use_counts.resize(col_idx + 1, 0);

--- a/sqlite/conformance/sqlite-sqltests/partial_idx.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/partial_idx.sqltest
@@ -1164,7 +1164,7 @@ test plan-partial-index-and-where-eq-seek {
         WHERE library_id IS NULL AND attack_score IS NOT NULL AND name = 'foo';
 }
 expect {
-    1|0|0|SEARCH samples USING INDEX samples_pidx (name=?)
+    1|0|0|SEARCH samples USING COVERING INDEX samples_pidx (name=?)
 }
 
 @skip-if sqlite "query plan explanation output is different in sqlite"
@@ -1176,7 +1176,7 @@ test plan-partial-index-and-where-reversed-order {
         WHERE attack_score IS NOT NULL AND library_id IS NULL AND name = 'foo';
 }
 expect {
-    1|0|0|SEARCH samples USING INDEX samples_pidx (name=?)
+    1|0|0|SEARCH samples USING COVERING INDEX samples_pidx (name=?)
 }
 
 # Partial index WHERE uses qualified column references; query references the same columns unqualified.
@@ -1190,7 +1190,7 @@ test plan-partial-index-qualified-where-matches {
         WHERE library_id IS NULL AND attack_score IS NOT NULL AND name = 'foo';
 }
 expect {
-    1|0|0|SEARCH samples USING INDEX samples_pidx (name=?)
+    1|0|0|SEARCH samples USING COVERING INDEX samples_pidx (name=?)
 }
 
 # Partial index drives a full scan when the query WHERE matches the index
@@ -1204,7 +1204,139 @@ test plan-partial-index-full-scan-when-where-matched {
         WHERE library_id IS NULL AND attack_score IS NOT NULL;
 }
 expect {
-    1|0|0|SCAN samples USING INDEX samples_user_processed_idx
+    1|0|0|SCAN samples USING COVERING INDEX samples_user_processed_idx
+}
+
+# A column referenced only by the predicate of a partial index does not need
+# to be read from the table, allowing the index to be covering.
+# https://github.com/tursodatabase/turso/issues/8376
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test plan-partial-index-predicate-allows-covering-scan {
+    CREATE TABLE partial_covering(a INTEGER, b INTEGER);
+    CREATE INDEX partial_covering_idx ON partial_covering(a) WHERE b < 5;
+
+    EXPLAIN QUERY PLAN
+        SELECT a FROM partial_covering WHERE b < 5;
+}
+expect {
+    1|0|0|SCAN partial_covering USING COVERING INDEX partial_covering_idx
+}
+
+# The partial-index predicate is enough to satisfy b < 5,
+# so only column a has to be read from the index.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test partial-index-predicate-can-cover {
+    CREATE TABLE partial_covering_seek(a INTEGER, b INTEGER, c INTEGER);
+    CREATE INDEX partial_covering_seek_idx ON partial_covering_seek(a) WHERE b < 5;
+
+    EXPLAIN QUERY PLAN
+        SELECT a
+        FROM partial_covering_seek
+        WHERE b < 5 AND a > 10;
+}
+expect {
+    1|0|0|SEARCH partial_covering_seek USING COVERING INDEX partial_covering_seek_idx (a>?)
+}
+
+# b is also part of the result, so its actual value still has to
+# be read from the table.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test partial-index-selected-predicate-column-is-not-covering {
+    CREATE TABLE partial_covering_selected(a INTEGER, b INTEGER, c INTEGER);
+    CREATE INDEX partial_covering_selected_idx ON partial_covering_selected(a) WHERE b < 5;
+
+    EXPLAIN QUERY PLAN
+        SELECT a, b
+        FROM partial_covering_selected
+        WHERE b < 5 AND a > 10;
+}
+expect {
+    1|0|0|SEARCH partial_covering_selected USING INDEX partial_covering_selected_idx (a>?)
+}
+
+# Only one matching WHERE term is consumed by the partial-index proof.
+# The duplicate predicate still requires evaluating b.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test partial-index-duplicate-predicate-is-not-covering {
+    CREATE TABLE partial_covering_duplicate(a INTEGER, b INTEGER, c INTEGER);
+    CREATE INDEX partial_covering_duplicate_idx ON partial_covering_duplicate(a) WHERE b < 5;
+
+    EXPLAIN QUERY PLAN
+        SELECT a
+        FROM partial_covering_duplicate
+        WHERE b < 5 AND b < 5 AND a > 10;
+}
+expect {
+    1|0|0|SEARCH partial_covering_duplicate USING INDEX partial_covering_duplicate_idx (a>?)
+}
+
+# c = 1 is not guaranteed by the partial index and c is not stored
+# in the index, so the table is still required.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test partial-index-residual-filter-is-not-covering {
+    CREATE TABLE partial_covering_residual(a INTEGER, b INTEGER, c INTEGER);
+    CREATE INDEX partial_covering_residual_idx ON partial_covering_residual(a) WHERE b < 5;
+
+    EXPLAIN QUERY PLAN
+        SELECT a
+        FROM partial_covering_residual
+        WHERE b < 5 AND c = 1 AND a > 10;
+}
+expect {
+    1|0|0|SEARCH partial_covering_residual USING INDEX partial_covering_residual_idx (a>?)
+}
+
+# A partial index and an expression index can coexist without making
+# the expression index incorrectly cover a WHERE predicate.
+@skip-if sqlite "query plan explanation output is different in sqlite"
+test partial-index-does-not-leak-coverage-to-expression-index {
+    CREATE TABLE mixed_indexes(
+        id INTEGER PRIMARY KEY,
+        b INTEGER,
+        c INTEGER
+    );
+
+    CREATE INDEX mixed_expr_idx
+        ON mixed_indexes((b < 5));
+
+    CREATE INDEX mixed_partial_idx
+        ON mixed_indexes(c)
+        WHERE c > 0;
+
+    EXPLAIN QUERY PLAN
+        SELECT id
+        FROM mixed_indexes INDEXED BY mixed_expr_idx
+        WHERE b < 5;
+}
+expect {
+    1|0|0|SCAN mixed_indexes USING INDEX mixed_expr_idx
+}
+
+# Verify that expression-index values and a partial-index predicate can
+# satisfy the query together without changing the result.
+test expression-partial-index-can-cover-both-parts {
+    CREATE TABLE mixed_partial_expr(
+        name TEXT,
+        active INTEGER
+    );
+
+    CREATE INDEX mixed_partial_expr_idx
+        ON mixed_partial_expr(lower(name))
+        WHERE active = 1;
+
+    INSERT INTO mixed_partial_expr VALUES
+        ('Alice', 1),
+        ('Bob', 1),
+        ('Carol', 0);
+
+    SELECT lower(name)
+    FROM mixed_partial_expr INDEXED BY mixed_partial_expr_idx
+    WHERE active = 1
+    ORDER BY lower(name);
+}
+expect {
+    alice
+    bob
 }
 
 # Partial index must NOT be used when the query only satisfies a subset of the
@@ -1229,7 +1361,7 @@ test plan-partial-index-equality-predicate {
         SELECT id FROM products WHERE status = 'active' AND sku = 'X';
 }
 expect {
-    1|0|0|SEARCH products USING INDEX idx_active_sku (sku=?)
+    1|0|0|SEARCH products USING COVERING INDEX idx_active_sku (sku=?)
 }
 
 # Partial index with range predicate in WHERE.
@@ -1240,7 +1372,7 @@ test plan-partial-index-range-predicate {
     EXPLAIN QUERY PLAN SELECT id FROM products WHERE price > 100 AND sku = 'X';
 }
 expect {
-    1|0|0|SEARCH products USING INDEX idx_expensive (sku=?)
+    1|0|0|SEARCH products USING COVERING INDEX idx_expensive (sku=?)
 }
 
 # Partial index whose WHERE predicate is *not* implied by the query → fallback

--- a/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-full-scan-correctness-eqp.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-full-scan-correctness-eqp.snap
@@ -10,4 +10,4 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SCAN samples USING INDEX samples_user_processed_idx
+`--SCAN samples USING COVERING INDEX samples_user_processed_idx

--- a/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-indexed-by-left-join-null-rejecting-where-can-prove-after-rewrite-eqp.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-indexed-by-left-join-null-rejecting-where-can-prove-after-rewrite-eqp.snap
@@ -17,4 +17,4 @@ info:
 ---
 QUERY PLAN
 |--SCAN left_items
-`--SEARCH right_items USING INDEX right_marker_five_idx (id=?)
+`--SEARCH right_items USING COVERING INDEX right_marker_five_idx (id=?)

--- a/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-seek-correctness-eqp.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-seek-correctness-eqp.snap
@@ -10,4 +10,4 @@ info:
   database: ':memory:'
 ---
 QUERY PLAN
-`--SEARCH samples USING INDEX samples_pidx (name=?)
+`--SEARCH samples USING COVERING INDEX samples_pidx (name=?)


### PR DESCRIPTION
## Description

Allow partial-index predicates to satisfy covering-index reads when the
predicate has already been proven by the optimizer.

Columns referenced only by a proven partial-index predicate are no longer
treated as requiring a table read. Expression-index coverage and
partial-index predicate coverage remain separate paths so one cannot
accidentally enable the other.

This also:
- reuses the existing partial-index predicate binding and matching logic;
- preserves the existing partial-index matching contract;
- updates affected EXPLAIN QUERY PLAN expectations;
- adds regression coverage to the existing `partial_idx.sqltest` suite,
  including positive, negative, duplicate-predicate, residual-filter, and
  expression-index interaction cases.

Validation:
- `cargo fmt --all --check`
- `git diff --check`
- `make -C sqlite/conformance run-one FILE=sqlite-sqltests/partial_idx.sqltest` — 115 passed

Fixes #8376

## Motivation and context

A partial index only contains rows that satisfy its predicate. Once the
optimizer has proven that the query implies that predicate, a column used
only to evaluate the predicate does not need to be read from the table.

For example:

```sql
CREATE TABLE t(a, b);
CREATE INDEX idx ON t(a) WHERE b < 5;

SELECT a FROM t WHERE b < 5;
```

The value of `b` is not needed at execution time: every row present in `idx`
already satisfies `b < 5`, and `a` is stored in the index. The scan can
therefore be covering.

Previously Turso still counted `b` as a required table column, which prevented
the partial index from being considered covering.

The implementation only removes a column requirement when all uses of that
column are satisfied by index coverage. Cases such as selecting the predicate
column directly, evaluating a residual predicate, or having a duplicate
predicate still require the table when appropriate.

## Description of AI Usage

I used ChatGPT as a pair-programming and review assistant while working on
this change.

It was used to help:
- investigate the planner and existing partial-index/expression-index code;
- reason about the covering-index invariants and possible regressions;
- identify and design positive and negative regression cases;
- review the implementation and diff for scope and maintainability.

I implemented and reviewed the code locally, ran the tests and validation
commands, and verified the resulting query plans and behavior.