### PR TITLE
bindings/rust: expose read-only database opens

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -140,6 +140,7 @@ pub type EncryptionOpts = turso_sdk_kit::rsapi::EncryptionOpts;
 /// A builder for `Database`.
 pub struct Builder {
     path: String,
+    read_only: bool,
     enable_encryption: bool,
     enable_attach: bool,
     enable_custom_types: bool,
@@ -160,6 +161,7 @@ impl Builder {
     pub fn new_local(path: &str) -> Self {
         Self {
             path: path.to_string(),
+            read_only: false,
             enable_encryption: false,
             enable_attach: false,
             enable_custom_types: false,
@@ -252,6 +254,12 @@ impl Builder {
         self
     }
 
+    /// Open the database without write access.
+    pub fn read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+
     fn build_features_string(&self) -> Option<String> {
         let mut features = Vec::new();
         if self.enable_encryption {
@@ -304,7 +312,11 @@ impl Builder {
                 io: self.io,
                 db_file: None,
                 page_codec: None,
-                open_flags: Default::default(),
+                open_flags: if self.read_only {
+                    turso_core::OpenFlags::ReadOnly
+                } else {
+                    turso_core::OpenFlags::default()
+                },
             });
         while let Some(io_c) = db.open()?.io() {
             // At this point IO must already be created

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -1,6 +1,230 @@
 use tokio::fs;
 use turso::{Builder, EncryptionOpts, Error, Value};
 
+#[derive(Debug, PartialEq, Eq)]
+struct DirectorySnapshot {
+    modified: std::time::SystemTime,
+    files: Vec<FileSnapshot>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct FileSnapshot {
+    name: std::ffi::OsString,
+    contents: Vec<u8>,
+    modified: std::time::SystemTime,
+    read_only: bool,
+}
+
+fn snapshot_directory(path: &std::path::Path) -> DirectorySnapshot {
+    let mut files = std::fs::read_dir(path)
+        .expect("database directory must be readable")
+        .map(|entry| {
+            let entry = entry.expect("database directory entry must be readable");
+            let metadata = entry
+                .metadata()
+                .expect("database directory entry metadata must be readable");
+            assert!(
+                metadata.is_file(),
+                "database directory must contain only files: {:?}",
+                entry.path()
+            );
+            FileSnapshot {
+                name: entry.file_name(),
+                contents: std::fs::read(entry.path())
+                    .expect("database directory entry must be readable"),
+                modified: metadata
+                    .modified()
+                    .expect("database file modification time must be available"),
+                read_only: metadata.permissions().readonly(),
+            }
+        })
+        .collect::<Vec<_>>();
+    files.sort_by(|left, right| left.name.cmp(&right.name));
+
+    DirectorySnapshot {
+        modified: std::fs::metadata(path)
+            .expect("database directory metadata must be readable")
+            .modified()
+            .expect("database directory modification time must be available"),
+        files,
+    }
+}
+
+#[tokio::test]
+async fn test_builder_read_only_rejects_writes_without_modifying_files() {
+    let dir = tempfile::tempdir().expect("temporary directory must be created");
+    let db_path = dir.path().join("read-only.db");
+    let db_path = db_path.to_str().expect("database path must be valid UTF-8");
+
+    {
+        let db = Builder::new_local(db_path)
+            .build()
+            .await
+            .expect("writable database must open");
+        let conn = db.connect().expect("writable connection must open");
+        conn.execute("CREATE TABLE test (value INTEGER)", ())
+            .await
+            .expect("table must be created");
+        conn.execute("INSERT INTO test VALUES (1)", ())
+            .await
+            .expect("writable control insert must succeed");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(db_path, std::fs::Permissions::from_mode(0o600))
+            .expect("database must be owner-readable and owner-writable");
+    }
+    let before = snapshot_directory(dir.path());
+
+    let db = Builder::new_local(db_path)
+        .read_only(true)
+        .build()
+        .await
+        .expect("read-only database must open");
+    let conn = db.connect().expect("read-only connection must open");
+    let mut rows = conn
+        .query("SELECT value FROM test", ())
+        .await
+        .expect("read-only query must succeed");
+    let row = rows
+        .next()
+        .await
+        .expect("read-only query must execute")
+        .expect("seed row must exist");
+    assert_eq!(
+        row.get_value(0).expect("seed value must be readable"),
+        1.into()
+    );
+    assert!(
+        rows.next()
+            .await
+            .expect("read-only query must finish")
+            .is_none(),
+        "only the seed row must exist"
+    );
+    drop(rows);
+
+    let error = conn
+        .execute("INSERT INTO test VALUES (2)", ())
+        .await
+        .expect_err("write through a read-only database must fail");
+    assert!(matches!(error, Error::Readonly(_)), "{error}");
+
+    drop(conn);
+    drop(db);
+    assert_eq!(
+        snapshot_directory(dir.path()),
+        before,
+        "read-only use must not change the database, sidecars, or directory entries"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_builder_read_only_opens_os_read_only_database() {
+    use std::os::unix::fs::PermissionsExt;
+
+    struct RestorePermissions {
+        directory: std::path::PathBuf,
+        database: std::path::PathBuf,
+    }
+
+    impl Drop for RestorePermissions {
+        fn drop(&mut self) {
+            let _ =
+                std::fs::set_permissions(&self.directory, std::fs::Permissions::from_mode(0o700));
+            let _ =
+                std::fs::set_permissions(&self.database, std::fs::Permissions::from_mode(0o600));
+        }
+    }
+
+    let dir = tempfile::tempdir().expect("temporary directory must be created");
+    let db_path = dir.path().join("permissions.db");
+    let db_path_str = db_path.to_str().expect("database path must be valid UTF-8");
+
+    {
+        let db = Builder::new_local(db_path_str)
+            .build()
+            .await
+            .expect("writable database must open");
+        let conn = db.connect().expect("writable connection must open");
+        conn.execute("CREATE TABLE test (value TEXT)", ())
+            .await
+            .expect("table must be created");
+        conn.execute("INSERT INTO test VALUES ('readable')", ())
+            .await
+            .expect("seed row must be inserted");
+    }
+
+    std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o400))
+        .expect("database must be made read-only");
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o500))
+        .expect("database directory must be made read-only");
+    let _restore_permissions = RestorePermissions {
+        directory: dir.path().to_path_buf(),
+        database: db_path.clone(),
+    };
+
+    if std::fs::OpenOptions::new()
+        .write(true)
+        .open(&db_path)
+        .is_ok()
+    {
+        // Privileged users can bypass Unix mode bits, so this fixture cannot
+        // prove which access mode the database requested in that environment.
+        return;
+    }
+
+    let before = snapshot_directory(dir.path());
+    let read_write_result = Builder::new_local(db_path_str).build().await;
+    let Err(error) = read_write_result else {
+        panic!("read-write open of a mode-0400 database must fail");
+    };
+    assert!(
+        matches!(
+            error,
+            Error::IoError(std::io::ErrorKind::PermissionDenied, "open")
+        ),
+        "unexpected read-write open error: {error:?}"
+    );
+    assert_eq!(
+        snapshot_directory(dir.path()),
+        before,
+        "failed read-write open must not change database files"
+    );
+
+    let db = Builder::new_local(db_path_str)
+        .read_only(true)
+        .build()
+        .await
+        .expect("read-only open of a mode-0400 database must succeed");
+    let conn = db.connect().expect("read-only connection must open");
+    let mut rows = conn
+        .query("SELECT value FROM test", ())
+        .await
+        .expect("read-only query must succeed");
+    let row = rows
+        .next()
+        .await
+        .expect("read-only query must execute")
+        .expect("seed row must exist");
+    assert_eq!(
+        row.get_value(0).expect("seed value must be readable"),
+        Value::Text("readable".to_string())
+    );
+    drop(rows);
+    drop(conn);
+    drop(db);
+
+    assert_eq!(
+        snapshot_directory(dir.path()),
+        before,
+        "read-only open must not change the mode-0400 database or create sidecars"
+    );
+}
+
 #[tokio::test]
 async fn test_rows_next() {
     let builder = Builder::new_local(":memory:");


### PR DESCRIPTION
Allow Rust SDK callers to request OpenFlags::ReadOnly through Builder. This lets databases on read-only filesystems open without asking the OS for write access and prevents writes even when files are writable.

Cover mode-0600 and mode-0400 databases, including file and sidecar snapshots so read-only use cannot silently change storage.

Tests: cargo test -p turso --test integration_tests test_builder_read_only

# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


  ## Description

  Expose `Builder::read_only(bool)` for local databases in the Rust SDK.

  When enabled, the builder passes `OpenFlags::ReadOnly` through the existing
  `TursoDatabaseConfig.open_flags` path.

  The tests verify that:

  - a mode-0600 database opens normally in read-only mode but rejects writes with
    `Error::Readonly`
  - read-only use does not modify the database, sidecars, permissions, modification
    times, or directory entries
  - on Unix, a read-write open of a mode-0400 database fails while a read-only open
    succeeds and can query existing data

  ## Motivation and context

  This continues the work from #6248. That PR was incomplete at the time because
  the SDK-kit open path still used `OpenFlags::default()` instead of the configured
  flags.

  Since then, #8183 added end-to-end `open_flags` plumbing through SDK-kit, the
  filesystem open, and core database options. This PR therefore only needs to
  expose that existing capability through the public Rust `Builder`.

  This allows applications to query databases stored on read-only filesystems
  without requesting write access from the operating system.

  ## Testing

  ```text
  cargo test -p turso --test integration_tests test_builder_read_only
```
  Both focused tests pass. I also verified that both tests fail with the previous
  hard-coded default flags:

  - the write against the mode-0600 database succeeds unexpectedly
  - the read-only open of the mode-0400 database fails with PermissionDenied

  ## Description of AI Usage

  I used OpenAI Codex (GPT-5) to help recover and rebase the earlier implementation,
  trace the newer SDK-kit open-flags plumbing, implement the Rust builder wiring,
  and develop the filesystem regression tests.









