### PR TITLE
core: fix planner, lifecycle, and MVCC gaps for index-method backing storage

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1844,8 +1844,13 @@ impl Limbo {
         if let Some(mut rows) = conn.query(q_tables)? {
             rows.run_with_row_callback(|row| {
                 let name: &str = row.get::<&str>(0)?;
-                // Skip sqlite_sequence and internal types metadata table
-                if name == "sqlite_sequence" || name == turso_core::schema::TURSO_TYPES_TABLE_NAME {
+                // Skip sqlite_sequence and every internal object. Index-method
+                // backing tables (e.g. FTS's __turso_internal_fts_dir_*) are
+                // rejected on replay because their names are reserved, and the
+                // trailing CREATE INDEX ... USING ... rebuilds them anyway.
+                if name == "sqlite_sequence"
+                    || name.starts_with(turso_core::schema::TURSO_INTERNAL_PREFIX)
+                {
                     return Ok(());
                 }
                 let ddl: &str = row.get::<&str>(1)?;
@@ -1991,6 +1996,7 @@ impl Limbo {
             SELECT name, sql FROM sqlite_schema
             WHERE sql NOT NULL
               AND name NOT LIKE 'sqlite_%'
+              AND name NOT LIKE '\_\_turso\_internal\_%' ESCAPE '\'
               AND type IN ('index','trigger','view')
             ORDER BY CASE type WHEN 'view' THEN 1 WHEN 'index' THEN 2 WHEN 'trigger' THEN 3 END, rowid
         "#;

--- a/cli/mvcc_repl.rs
+++ b/cli/mvcc_repl.rs
@@ -95,7 +95,9 @@ fn open_mvcc_db(path: &str, passive_checkpoint: bool) -> anyhow::Result<Arc<Data
         path,
         None,
         OpenFlags::default(),
-        DatabaseOpts::default().with_experimental_mvcc_passive_checkpoint(passive_checkpoint),
+        DatabaseOpts::default()
+            .with_experimental_mvcc_passive_checkpoint(passive_checkpoint)
+            .with_index_method(true),
         None,
         Arc::new(SqliteDialect),
     )

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -526,6 +526,10 @@ pub struct Connection {
     /// eventual transaction outcome is delivered exactly once per attachment.
     pub(crate) index_method_tx_cursors:
         Mutex<Vec<crate::index_method::TransactionIndexMethodCursor>>,
+    /// True while `index_method_tx_cursors` may be non-empty. Lets every
+    /// commit/rollback skip the mutex and sort when no index method was ever
+    /// touched — the overwhelmingly common case.
+    pub(crate) has_index_method_tx_cursors: crate::sync::atomic::AtomicBool,
     /// Connection-level named savepoint stack used to mirror savepoint state
     /// onto temp/attached databases that start participating after SAVEPOINT.
     pub(crate) named_savepoints: RwLock<Vec<NamedSavepointFrame>>,
@@ -551,6 +555,11 @@ crate::assert::assert_send_sync!(Connection);
 impl Drop for Connection {
     fn drop(&mut self) {
         if !self.is_closed() {
+            // A handle dropped mid-transaction rolls that transaction back
+            // below, so parked index-method cursors must receive the same
+            // rollback outcome they would get from an explicit close().
+            self.index_methods_transaction_rolled_back();
+
             // Roll back any active MVCC transactions so that MvStore entries
             // don't leak and block future checkpoints.  The tx may have
             // already been committed/aborted externally (e.g. by tests that
@@ -4988,11 +4997,20 @@ impl Connection {
         self.named_savepoints.write().clear();
     }
 
+    /// Park a statement's index-method cursor on the connection until the
+    /// transaction's outcome is known. A cursor replaced by a later
+    /// statement's cursor for the same attachment is closed immediately and
+    /// receives neither `transaction_committed` nor `transaction_rolled_back`
+    /// — that replacement is the third legitimate end of a cursor's life
+    /// (see the `IndexMethodCursor` trait docs). Only the newest cursor per
+    /// attachment gets the final outcome.
     pub(crate) fn register_index_method_transaction_cursor(
         &self,
         mut entry: crate::index_method::TransactionIndexMethodCursor,
     ) {
         entry.cursor.statement_committed(&entry.context);
+        self.has_index_method_tx_cursors
+            .store(true, Ordering::Release);
         let mut entries = self.index_method_tx_cursors.lock();
         let previous = if let Some(position) = entries
             .iter()
@@ -5013,6 +5031,14 @@ impl Connection {
     fn take_index_method_transaction_cursors(
         &self,
     ) -> Vec<crate::index_method::TransactionIndexMethodCursor> {
+        // Fast path for the overwhelmingly common no-index-method case:
+        // skip the mutex and the sort below entirely.
+        if !self
+            .has_index_method_tx_cursors
+            .swap(false, Ordering::AcqRel)
+        {
+            return Vec::new();
+        }
         let mut entries = std::mem::take(&mut *self.index_method_tx_cursors.lock());
         entries.sort_by(|left, right| {
             (
@@ -5058,6 +5084,9 @@ impl Connection {
     }
 
     pub(crate) fn index_methods_savepoint_rolled_back(&self) {
+        if !self.has_index_method_tx_cursors.load(Ordering::Acquire) {
+            return;
+        }
         let mut entries = self.index_method_tx_cursors.lock();
         tracing::trace!(
             attachments = entries.len(),

--- a/core/database.rs
+++ b/core/database.rs
@@ -549,6 +549,10 @@ pub struct Database<A: alloc::ConcurrentAllocator = alloc::DynAllocator> {
     dialect: Arc<dyn Dialect>,
     pub(crate) opts: DatabaseOpts,
     pub(crate) n_connections: AtomicUsize,
+    /// Process-unique id minted at construction. Unlike the `Arc`'s heap
+    /// address, this can never repeat within a process, so detach/reattach
+    /// and close/reopen produce distinguishable values.
+    pub(crate) incarnation: u64,
 
     /// In Memory Page 1 for Empty Dbs
     init_page_1: Arc<ArcSwapOption<Page>>,
@@ -688,6 +692,18 @@ impl Database {
             opts,
             buffer_pool: BufferPool::begin_init(io, arena_size),
             n_connections: AtomicUsize::new(0),
+            incarnation: {
+                // Deliberately std, not crate::sync: this static outlives a
+                // shuttle test execution, and a shuttle-tracked atomic that
+                // survives into the next execution corrupts shuttle's vector
+                // clocks (task ids restart, the stale clock is longer than
+                // the new task table, and clock bookkeeping underflows).
+                // A plain std atomic is fine here: the counter only mints
+                // process-unique ids and needs no ordering guarantees.
+                static NEXT_DATABASE_INCARNATION: std::sync::atomic::AtomicU64 =
+                    std::sync::atomic::AtomicU64::new(1);
+                NEXT_DATABASE_INCARNATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            },
 
             init_page_1: Arc::new(ArcSwapOption::new(init_page_1)),
 
@@ -2397,6 +2413,7 @@ impl Database {
             check_constraints_pragma: AtomicBool::new(false),
             vtab_txn_states: RwLock::new(HashSet::default()),
             index_method_tx_cursors: crate::sync::Mutex::new(Vec::new()),
+            has_index_method_tx_cursors: crate::sync::atomic::AtomicBool::new(false),
             named_savepoints: RwLock::new(Vec::new()),
             schema_reparse_in_progress: AtomicBool::new(false),
             prepare_context_generation: AtomicU64::new(0),

--- a/core/index_method/fts.rs
+++ b/core/index_method/fts.rs
@@ -59,13 +59,12 @@ pub const DEFAULT_CHUNK_SIZE: usize = 512 * 1024;
 /// Higher values improve throughput but increase memory usage and latency.
 pub const BATCH_COMMIT_SIZE: usize = 1000;
 
-/// Default memory budget (64MB) for hot cache (metadata + term dictionaries).
-/// Hot files are frequently accessed and kept in an LRU cache.
-pub const DEFAULT_HOT_CACHE_BYTES: usize = 64 * 1024 * 1024;
+/// Longest accepted `fts_match` / MATCH query string, in bytes.
+const FTS_MAX_QUERY_BYTES: usize = 16 * 1024;
 
-/// Default memory budget (128MB) for chunk LRU cache.
-/// Caches segment data chunks loaded on-demand from the BTree.
-pub const DEFAULT_CHUNK_CACHE_BYTES: usize = 128 * 1024 * 1024;
+/// Deepest accepted parenthesis nesting in a query string. Guards Tantivy's
+/// recursive parser against stack overflow.
+const FTS_MAX_QUERY_NESTING: usize = 64;
 
 /// Fanout for synchronous tiered segment maintenance.
 ///
@@ -89,7 +88,14 @@ const FTS_MAX_SYNC_MERGE_BYTES: u64 = 32 * 1024 * 1024;
 const FTS_MAX_CACHED_CONNECTIONS: usize = 4;
 
 /// Aggregate resident file-cache budget across retained connection snapshots.
-const FTS_MAX_RETAINED_CACHE_BYTES: usize = DEFAULT_HOT_CACHE_BYTES + DEFAULT_CHUNK_CACHE_BYTES;
+///
+/// This bounds only what is *retained for reuse* after a statement finishes
+/// (read snapshots in `CachedFtsStates`, the shared writer). It is not a
+/// bound on live memory: a cursor always keeps its own complete file
+/// snapshot resident while it runs, however large the index is, because
+/// Tantivy reads through synchronous callbacks that cannot fall back to
+/// storage I/O.
+const FTS_MAX_RETAINED_CACHE_BYTES: usize = 192 * 1024 * 1024;
 
 #[cfg(feature = "test_helper")]
 crate::thread::thread_local! {
@@ -122,6 +128,10 @@ const FTS_CONTROL_FORMAT_VERSION: u32 = 1;
 /// first control record is staged and is never this value.
 const FTS_EMPTY_INDEX_INCARNATION: u64 = 0;
 static NEXT_FTS_INDEX_INCARNATION: AtomicU64 = AtomicU64::new(1);
+/// Distinguishes cursor instances within a process so a cursor can recognize
+/// its own claim on the per-index writer slot across re-entrant `open_write`
+/// calls.
+static NEXT_FTS_CURSOR_INSTANCE: AtomicU64 = AtomicU64::new(1);
 
 const ROWID_FIELD: &str = "rowid";
 
@@ -304,13 +314,6 @@ impl FtsControlRecord {
         };
         let mut files = HashMap::default();
         for (path, metadata) in catalog {
-            let path_text = path.to_str().ok_or_else(|| {
-                LimboError::InternalError(format!(
-                    "FTS manifest path is not valid UTF-8: {}",
-                    path.display()
-                ))
-            })?;
-            let _ = path_text;
             files.insert(
                 path.clone(),
                 FtsManifestFile {
@@ -471,110 +474,53 @@ fn fts_control_checksum(bytes: &[u8]) -> u64 {
 }
 
 /// Eviction samples per put
-const EVICTION_SAMPLES: usize = 8;
-
-/// Generic bounded LRU cache with sampling-based eviction.
-pub struct LruCache<K> {
-    capacity: usize,
-    inner: RwLock<LruCacheInner<K>>,
+/// Size-tracked map of a Tantivy directory's complete file contents.
+///
+/// Deliberately unbounded: every cataloged file must stay resident, because
+/// Tantivy reads through synchronous callbacks that cannot fall back to
+/// storage I/O. Nothing is ever evicted — the memory bound on FTS state is
+/// the retention budget in `CachedFtsStates` / `cache_writer`, which decides
+/// whether a *finished* snapshot is kept for reuse at all.
+pub struct FileCache<K> {
+    inner: RwLock<FileCacheInner<K>>,
 }
 
 #[derive(Debug)]
-struct LruCacheInner<K> {
+struct FileCacheInner<K> {
     current_size: usize,
-    clock: u64,
-    entries: HashMap<K, LruCacheEntry>,
+    entries: HashMap<K, Arc<[u8]>>,
 }
 
-#[derive(Debug)]
-struct LruCacheEntry {
-    data: Arc<[u8]>,
-    accessed: u64,
-}
-
-impl<K: std::fmt::Debug> std::fmt::Debug for LruCache<K> {
+impl<K: std::fmt::Debug> std::fmt::Debug for FileCache<K> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let inner = self.inner.read();
-        f.debug_struct("LruCache")
-            .field("capacity", &self.capacity)
+        f.debug_struct("FileCache")
             .field("current_size", &inner.current_size)
             .field("entries", &inner.entries.len())
             .finish()
     }
 }
 
-impl<K: Eq + std::hash::Hash + Clone> LruCache<K> {
-    /// Lookup entry, updating access timestamp. Returns Arc-cloned data.
+impl<K: Eq + std::hash::Hash + Clone> FileCache<K> {
+    /// Lookup entry. Returns Arc-cloned data.
     fn get<Q>(&self, key: &Q) -> Option<Arc<[u8]>>
     where
         K: std::borrow::Borrow<Q>,
         Q: Eq + std::hash::Hash + ?Sized,
     {
-        let mut inner = self.inner.write();
-        inner.clock += 1;
-        let ts = inner.clock;
-        if let Some(entry) = inner.entries.get_mut(key) {
-            entry.accessed = ts;
-            Some(Arc::clone(&entry.data))
-        } else {
-            None
-        }
+        self.inner.read().entries.get(key).map(Arc::clone)
     }
 
-    /// Insert entry, evicting stale entries if over capacity.
-    ///
-    /// Eviction uses sampling: examines K entries and evicts the one with
-    /// the oldest access timestamp. Repeat until under capacity.
+    /// Insert or replace an entry.
     fn put(&self, key: K, value: Vec<u8>) {
         let arc_value: Arc<[u8]> = Arc::from(value);
         let size = arc_value.len();
         let mut inner = self.inner.write();
-
-        // Check for existing entry - get old size if present
-        let old_size = inner.entries.get(&key).map(|e| e.data.len());
-
-        if let Some(old) = old_size {
-            // Update existing entry
-            inner.clock += 1;
-            let ts = inner.clock;
-            let entry = inner.entries.get_mut(&key).expect("entry must exist");
-            entry.data = arc_value;
-            entry.accessed = ts;
-            inner.current_size = inner.current_size - old + size;
-            return;
-        }
-
-        // Evict until under capacity
-        while inner.current_size + size > self.capacity && !inner.entries.is_empty() {
-            let victim = {
-                inner
-                    .entries
-                    .iter()
-                    .take(EVICTION_SAMPLES)
-                    .min_by_key(|(_, e)| e.accessed)
-                    .map(|(k, _)| k.clone())
-            };
-
-            match victim {
-                Some(k) => {
-                    if let Some(e) = inner.entries.remove(&k) {
-                        inner.current_size -= e.data.len();
-                    }
-                }
-                None => break,
-            }
-        }
-
-        inner.clock += 1;
-        let ts = inner.clock;
-        inner.entries.insert(
-            key,
-            LruCacheEntry {
-                data: arc_value,
-                accessed: ts,
-            },
-        );
-        inner.current_size += size;
+        let old_size = inner
+            .entries
+            .insert(key, arc_value)
+            .map_or(0, |old| old.len());
+        inner.current_size = inner.current_size - old_size + size;
     }
 
     /// Remove an entry from the cache.
@@ -584,8 +530,8 @@ impl<K: Eq + std::hash::Hash + Clone> LruCache<K> {
         Q: Eq + std::hash::Hash + ?Sized,
     {
         let mut inner = self.inner.write();
-        if let Some(e) = inner.entries.remove(key) {
-            inner.current_size -= e.data.len();
+        if let Some(data) = inner.entries.remove(key) {
+            inner.current_size -= data.len();
         }
     }
 
@@ -610,29 +556,13 @@ impl<K: Eq + std::hash::Hash + Clone> LruCache<K> {
 }
 
 /// Specialized methods for PathBuf caches (hot files).
-impl LruCache<PathBuf> {
-    fn with_preloaded_arcs(capacity: usize, files: HashMap<PathBuf, Arc<[u8]>>) -> Self {
+impl FileCache<PathBuf> {
+    fn with_preloaded_arcs(files: HashMap<PathBuf, Arc<[u8]>>) -> Self {
         let current_size: usize = files.values().map(|data| data.len()).sum();
-        let entries: HashMap<PathBuf, LruCacheEntry> = files
-            .into_iter()
-            .enumerate()
-            .map(|(i, (path, data))| {
-                (
-                    path,
-                    LruCacheEntry {
-                        data,
-                        accessed: i as u64,
-                    },
-                )
-            })
-            .collect();
-
         Self {
-            capacity,
-            inner: RwLock::new(LruCacheInner {
+            inner: RwLock::new(FileCacheInner {
                 current_size,
-                clock: entries.len() as u64,
-                entries,
+                entries: files,
             }),
         }
     }
@@ -642,7 +572,7 @@ impl LruCache<PathBuf> {
             .read()
             .entries
             .iter()
-            .map(|(path, entry)| (path.clone(), Arc::clone(&entry.data)))
+            .map(|(path, data)| (path.clone(), Arc::clone(data)))
             .collect()
     }
 }
@@ -706,11 +636,10 @@ struct HybridBTreeDirectory {
     /// File catalog: path -> metadata (always in memory, no content)
     catalog: Arc<RwLock<Catalog>>,
 
-    /// Complete file snapshot loaded before Tantivy is invoked.
-    ///
-    /// The capacity is deliberately unbounded: eviction would turn a synchronous Tantivy
-    /// callback into a storage read. Connection-level cache pruning bounds retained snapshots.
-    hot_cache: Arc<LruCache<PathBuf>>,
+    /// Complete file snapshot loaded before Tantivy is invoked. Unbounded by
+    /// design (see [`FileCache`]); the retention budget bounds what outlives
+    /// the cursor, not what it holds while running.
+    hot_cache: Arc<FileCache<PathBuf>>,
 
     /// Storage view at cursor checkout, kept separate from Tantivy's mutable
     /// in-memory view so unchanged rewrites can be elided.
@@ -751,10 +680,7 @@ impl HybridBTreeDirectory {
         let files = self.hot_cache.arc_snapshot();
         Self {
             catalog: Arc::new(RwLock::new(self.catalog.read().clone())),
-            hot_cache: Arc::new(LruCache::<PathBuf>::with_preloaded_arcs(
-                usize::MAX,
-                files.clone(),
-            )),
+            hot_cache: Arc::new(FileCache::<PathBuf>::with_preloaded_arcs(files.clone())),
             base_files: Arc::new(RwLock::new(files)),
             // Fresh pending state - not shared with cache
             pending_mutations: Arc::new(RwLock::new(PendingFileMutations::default())),
@@ -779,8 +705,7 @@ impl HybridBTreeDirectory {
             .collect::<HashMap<_, _>>();
         Self {
             catalog: Arc::new(RwLock::new(catalog)),
-            hot_cache: Arc::new(LruCache::<PathBuf>::with_preloaded_arcs(
-                usize::MAX,
+            hot_cache: Arc::new(FileCache::<PathBuf>::with_preloaded_arcs(
                 base_files.clone(),
             )),
             base_files: Arc::new(RwLock::new(base_files)),
@@ -934,18 +859,18 @@ impl Write for HybridWriter {
 
 impl Drop for HybridWriter {
     fn drop(&mut self) {
-        // Commit the write to the directory
-        let data = std::mem::take(&mut self.buffer);
-        if !data.is_empty() {
-            // Update catalog
-            let num_chunks = data.len().div_ceil(DEFAULT_CHUNK_SIZE);
-            let metadata = FileMetadata::new(&self.path, data.len(), num_chunks);
-            self.directory.update_catalog(self.path.clone(), metadata);
-
-            self.directory
-                .add_to_hot_cache(self.path.clone(), data.clone());
-
-            self.directory.queue_write(self.path.clone(), data);
+        // Only `terminate_ref` publishes: Tantivy's Directory contract says
+        // callers must not rely on Drop flushing, and ManagedDirectory's
+        // FooterProxy appends its CRC footer only in terminate. A file
+        // published from Drop would have no footer and read back as
+        // "Footer magic byte mismatch" — a recoverable serialization error
+        // turned into persisted state that reports itself as corruption.
+        if !self.buffer.is_empty() {
+            tracing::error!(
+                path = %self.path.display(),
+                bytes = self.buffer.len(),
+                "FTS writer dropped without terminate; discarding buffered file"
+            );
         }
     }
 }
@@ -1038,6 +963,13 @@ impl Directory for HybridBTreeDirectory {
         //
         // Skip delete for the meta lock file: Tantivy calls open_write on it for every
         // search query and it does not need BTree deletion.
+        //
+        // Because this never returns FileAlreadyExists, Tantivy's file-based
+        // single-writer lock is intentionally disabled for this directory:
+        // it cannot work anyway, since every cursor gets its own directory
+        // clone. Writer exclusion is enforced instead by the per-connection
+        // writer slot (`FtsWriterSlot`), the pager write lock in WAL mode,
+        // and the per-index MVCC write lease.
         if path != Path::new(TANTIVY_META_LOCK_FILE) {
             let _ = self.delete(path);
         }
@@ -1093,6 +1025,9 @@ impl Directory for HybridBTreeDirectory {
         Ok(())
     }
 
+    // No change notifications: every reader is built with
+    // `ReloadPolicy::Manual` and reloaded explicitly after commits, so a
+    // registered callback would never need to fire.
     fn watch(&self, _cb: WatchCallback) -> std::result::Result<WatchHandle, tantivy::TantivyError> {
         Ok(WatchHandle::empty())
     }
@@ -1277,9 +1212,11 @@ impl CachedFtsStates {
     fn insert(&mut self, state: CachedFtsState, byte_budget: usize) -> bool {
         self.entries
             .retain(|cached| !Weak::ptr_eq(&cached.connection, &state.connection));
-        if state.resident_cache_bytes() > byte_budget {
-            return false;
-        }
+        // Always keep the newest snapshot and evict older ones to make room.
+        // Rejecting an oversized snapshot outright would not save memory —
+        // the live cursor holds the whole snapshot anyway — it would only
+        // force the next statement to reload it all from storage, turning
+        // the budget cliff into a full cold load per statement.
         self.entries.push(state);
         self.prune();
         while self.entries.len() > 1 && self.resident_cache_bytes() > byte_budget {
@@ -1288,8 +1225,11 @@ impl CachedFtsStates {
         true
     }
 
-    fn clear(&mut self) {
-        self.entries.clear();
+    /// Evict oldest retained snapshots until at or under `byte_budget`.
+    fn evict_to_fit(&mut self, byte_budget: usize) {
+        while !self.entries.is_empty() && self.resident_cache_bytes() > byte_budget {
+            self.entries.remove(0);
+        }
     }
 }
 
@@ -1332,7 +1272,33 @@ pub struct FtsIndexAttachment {
     /// `Mutex` provides exclusive access without requiring `IndexWriter` to be
     /// `Sync`; SQLite transaction rules already serialize writers.
     cached_writer: Arc<Mutex<Option<CachedFtsWriter>>>,
+    /// The one cursor currently allowed to flush this index per connection.
+    /// See [`FtsWriterSlot`].
+    writer_slot: Arc<Mutex<Option<FtsWriterSlot>>>,
     runtime_stats: Arc<FtsRuntimeStats>,
+}
+
+/// The single cursor allowed to flush this FTS index for a given connection.
+///
+/// One statement can open two write cursors over the same index — a trigger
+/// whose body writes the FTS-indexed table it fired on. Each cursor builds its
+/// own Tantivy directory from the same starting snapshot, so letting both
+/// flush would store the union of two divergent file sets under one manifest
+/// and make the index unreadable on disk, permanently. The second writer is
+/// refused with a `Raise(Abort)` error instead, and the statement rolls back
+/// cleanly.
+///
+/// The slot is claimed on the cursor's first document mutation (a plan may
+/// open several write-mode cursors on one index but only one ever mutates it)
+/// and released once the cursor has staged its statement's writes
+/// (`prepare_statement_commit`), aborted, or closed — after that the cursor
+/// never flushes again, so a later statement's cursor may write. Writers on
+/// different connections are already serialized by the pager write lock (WAL)
+/// or the per-index MVCC write lease.
+#[derive(Debug)]
+struct FtsWriterSlot {
+    connection: Weak<Connection>,
+    cursor_instance: u64,
 }
 
 #[derive(Debug, Default)]
@@ -1563,6 +1529,7 @@ impl FtsIndexAttachment {
             ngram_window,
             cached_state: Arc::new(RwLock::new(CachedFtsStates::default())),
             cached_writer: Arc::new(Mutex::new(None)),
+            writer_slot: Arc::new(Mutex::new(None)),
             runtime_stats: Arc::new(FtsRuntimeStats::default()),
         })
     }
@@ -1593,6 +1560,17 @@ fn initialize_btree_storage_table(
     database_id: usize,
     table_name: &str,
 ) -> Result<()> {
+    // Fast path: both objects already exist (every open after the index was
+    // created). Skips preparing and running two nested DDL statements per
+    // write cursor open.
+    let index_name = format!("{table_name}_key");
+    let already_exists = conn.with_schema(database_id, |schema| {
+        schema.get_btree_table(table_name).is_some()
+            && schema.get_index(table_name, &index_name).is_some()
+    });
+    if already_exists {
+        return Ok(());
+    }
     let db_prefix = conn
         .get_database_name_by_index(database_id)
         .filter(|name| name != "main")
@@ -1860,7 +1838,14 @@ pub struct FtsCursor {
     cached_parser: Option<Arc<tantivy::query::QueryParser>>,
     shared_cache: Arc<RwLock<CachedFtsStates>>,
     shared_writer: Arc<Mutex<Option<CachedFtsWriter>>>,
-    connection: Option<Arc<Connection>>,
+    /// Shared with the attachment: the one cursor allowed to flush this index
+    /// per connection. See [`FtsWriterSlot`].
+    writer_slot: Arc<Mutex<Option<FtsWriterSlot>>>,
+    /// This cursor's identity in [`FtsWriterSlot`] claims.
+    cursor_instance_id: u64,
+    /// Weak so a cursor parked on its connection does not keep the connection
+    /// alive (see `IndexMethodContext::connection`).
+    connection: Option<Weak<Connection>>,
     database_id: Option<usize>,
     fts_dir_cursor: Option<Box<dyn CursorTrait>>,
     btree_root_page: Option<i64>,
@@ -1879,6 +1864,9 @@ pub struct FtsCursor {
     /// True while `open_write` is driving the shared open state machine.
     /// Read state is never published or reused in this mode.
     opening_for_write: bool,
+    /// True once this cursor holds the per-index writer slot (and the MVCC
+    /// write lease). See [`FtsWriterSlot`].
+    holds_writer_slot: bool,
     runtime_stats: Arc<FtsRuntimeStats>,
 }
 
@@ -1912,6 +1900,8 @@ impl FtsCursor {
             cached_parser: None,
             shared_cache: Arc::clone(&attachment.cached_state),
             shared_writer: Arc::clone(&attachment.cached_writer),
+            writer_slot: Arc::clone(&attachment.writer_slot),
+            cursor_instance_id: NEXT_FTS_CURSOR_INSTANCE.fetch_add(1, Ordering::Relaxed),
             connection: None,
             database_id: None,
             fts_dir_cursor: None,
@@ -1929,7 +1919,193 @@ impl FtsCursor {
             hit_pos: 0,
             current_pattern: FTS_PATTERN_SCORE,
             opening_for_write: false,
+            holds_writer_slot: false,
             runtime_stats: Arc::clone(&attachment.runtime_stats),
+        }
+    }
+
+    /// Claim the per-index writer slot for this cursor, or refuse if another
+    /// cursor on the same connection already holds it. Under MVCC this also
+    /// acquires the per-index write lease, so a transaction only pays for the
+    /// lease once it actually mutates the index. See [`FtsWriterSlot`].
+    fn claim_writer_slot(&mut self) -> Result<()> {
+        if self.holds_writer_slot {
+            return Ok(());
+        }
+        let conn = self
+            .connection
+            .as_ref()
+            .and_then(Weak::upgrade)
+            .ok_or_else(|| {
+                LimboError::InternalError("FTS cursor claimed writer slot before open".to_string())
+            })?;
+        {
+            let mut slot = self.writer_slot.lock();
+            if let Some(claim) = slot.as_ref() {
+                let same_live_connection = claim
+                    .connection
+                    .upgrade()
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, &conn));
+                if same_live_connection && claim.cursor_instance != self.cursor_instance_id {
+                    // Raise(Abort) so the whole statement rolls back: the
+                    // refused write may sit mid-statement (a trigger body),
+                    // and its base rows must not commit without their index
+                    // entries.
+                    return Err(LimboError::Raise(
+                        turso_parser::ast::ResolveType::Abort,
+                        "statement already has an open writer on this FTS index; \
+                         a trigger cannot write the FTS-indexed table its firing \
+                         statement is writing"
+                            .to_string(),
+                    ));
+                }
+                // A claim from another (or dead) connection: cross-connection
+                // writers are serialized by the pager write lock or the MVCC
+                // write lease, so this claim is stale. Replace it.
+            }
+            *slot = Some(FtsWriterSlot {
+                connection: Arc::downgrade(&conn),
+                cursor_instance: self.cursor_instance_id,
+            });
+        }
+        if let Err(err) = self.acquire_mvcc_write_lease() {
+            self.release_writer_slot();
+            return Err(err);
+        }
+        self.holds_writer_slot = true;
+        Ok(())
+    }
+
+    /// Under MVCC, take the per-index write lease for this cursor's
+    /// transaction. Reentrant for the owning transaction; a no-op in WAL mode.
+    fn acquire_mvcc_write_lease(&self) -> Result<()> {
+        let conn = self
+            .connection
+            .as_ref()
+            .and_then(Weak::upgrade)
+            .ok_or_else(|| LimboError::InternalError("FTS cursor has no connection".to_string()))?;
+        let database_id = self.database_id.ok_or_else(|| {
+            LimboError::InternalError("FTS database id is not initialized".to_string())
+        })?;
+        let Some(mv_store) = conn.mv_store_for_db(database_id) else {
+            return Ok(());
+        };
+        let tx_id = conn.get_mv_tx_id_for_db(database_id).ok_or_else(|| {
+            LimboError::InternalError(
+                "FTS write opened without an active MVCC transaction".to_string(),
+            )
+        })?;
+        let root_page = self.btree_root_page.ok_or_else(|| {
+            LimboError::InternalError("FTS backing root is not initialized".to_string())
+        })?;
+        let snapshot_ts = mv_store.read_snapshot_ts(tx_id);
+        // A PASSIVE checkpoint can retire this root page under a stale
+        // compiled plan; that is a stale-schema read, not corruption.
+        let index_id = if conn.experimental_mvcc_passive_checkpoint_enabled() {
+            mv_store
+                .try_get_table_id_from_root_page_at(root_page, snapshot_ts)
+                .ok_or(LimboError::SchemaUpdated)?
+        } else {
+            mv_store.get_table_id_from_root_page_at(root_page, snapshot_ts)
+        };
+        match mv_store.acquire_index_method_write_lease(tx_id, index_id) {
+            Ok(()) => {
+                self.runtime_stats
+                    .write_lease_acquisitions
+                    .fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(err @ (LimboError::WriteWriteConflict | LimboError::Busy)) => {
+                self.runtime_stats
+                    .write_lease_rejections
+                    .fetch_add(1, Ordering::Relaxed);
+                Err(err)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Body of `open_write`; split out so the wrapper can clear
+    /// `opening_for_write` on every error return.
+    fn open_write_inner(
+        &mut self,
+        context: &IndexMethodContext,
+        conn: &Arc<Connection>,
+        database_id: usize,
+    ) -> Result<IOResult<()>> {
+        if self.writer.is_some() {
+            return Ok(IOResult::Done(()));
+        }
+
+        initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
+        self.open_cursor(conn, database_id)?;
+        // The per-index write lease is taken lazily, on the first document
+        // mutation (see `claim_writer_slot`): a write cursor that never
+        // touches a document — an UPDATE matching no rows — must not lock the
+        // index for the rest of its transaction.
+        if self.restore_cached_writer(context)? {
+            return Ok(IOResult::Done(()));
+        }
+
+        // First do open_read to load existing index
+        match &self.state {
+            FtsState::Ready => {}
+            _ => {
+                let result = self.open_read(context)?;
+                if let IOResult::IO(io) = result {
+                    return Ok(IOResult::IO(io));
+                }
+            }
+        }
+        // The IndexWriter itself is built lazily on the first document
+        // mutation (`ensure_writer`), after the writer slot and MVCC lease
+        // are claimed — so a refused writer never pays for Tantivy writer
+        // construction, and a write cursor that never mutates never builds
+        // one at all.
+        Ok(IOResult::Done(()))
+    }
+
+    /// Build the Tantivy `IndexWriter` if this cursor does not have one yet.
+    /// Callers must claim the writer slot first (`claim_writer_slot`).
+    fn ensure_writer(&mut self) -> Result<()> {
+        if self.writer.is_some() {
+            return Ok(());
+        }
+        let index = self
+            .index
+            .as_ref()
+            .ok_or_else(|| LimboError::InternalError("FTS index not initialized".into()))?;
+        // One worker and one merge thread: merges are driven synchronously by
+        // commit_writer_with_maintenance, so the default four merge threads
+        // would sit idle forever, at three OS threads apiece.
+        self.runtime_stats
+            .tantivy_writer_constructions
+            .fetch_add(1, Ordering::Relaxed);
+        let writer = index
+            .writer_with_options(
+                tantivy::indexer::IndexWriterOptions::builder()
+                    .num_worker_threads(1)
+                    .num_merge_threads(1)
+                    .memory_budget_per_thread(DEFAULT_MEMORY_BUDGET_BYTES)
+                    .build(),
+            )
+            .map_err(|e| LimboError::InternalError(e.to_string()))?;
+        // Disable background merges.
+        writer.set_merge_policy(Box::new(NoMergePolicy));
+        self.writer = Some(writer);
+        Ok(())
+    }
+
+    /// Release the writer slot if this cursor holds it. Idempotent. The MVCC
+    /// write lease stays with the transaction until it commits or rolls back.
+    fn release_writer_slot(&mut self) {
+        self.holds_writer_slot = false;
+        let mut slot = self.writer_slot.lock();
+        if slot
+            .as_ref()
+            .is_some_and(|claim| claim.cursor_instance == self.cursor_instance_id)
+        {
+            *slot = None;
         }
     }
 
@@ -2009,13 +2185,13 @@ impl FtsCursor {
         context: &IndexMethodContext,
         visible_control: Option<&FtsControlRecord>,
     ) -> Option<CachedFtsCheckout> {
-        let conn = context.connection();
+        let conn = context.connection().ok()?;
         if conn.is_in_write_tx() {
             return None;
         }
         let mut cache = self.shared_cache.write();
         cache.prune();
-        let position = cache.connection_position(conn)?;
+        let position = cache.connection_position(&conn)?;
         let cached = &cache.entries[position];
         let same_snapshot = match (context.transaction_id(), cached.transaction_id) {
             (Some(current), Some(cached)) => current == cached,
@@ -2048,29 +2224,50 @@ impl FtsCursor {
     }
 
     fn has_cached_state(&self, context: &IndexMethodContext) -> bool {
-        let conn = context.connection();
-        !conn.is_in_write_tx() && self.shared_cache.read().connection_position(conn).is_some()
+        let Ok(conn) = context.connection() else {
+            return false;
+        };
+        !conn.is_in_write_tx()
+            && self
+                .shared_cache
+                .read()
+                .connection_position(&conn)
+                .is_some()
     }
 
-    fn install_cached_checkout(&mut self, checkout: CachedFtsCheckout) {
+    /// Install a cache checkout on this cursor. Returns `true` when the cursor
+    /// is ready to serve queries, `false` when the caller must keep driving the
+    /// state machine (a write cursor still has to build its own Tantivy index).
+    fn install_cached_checkout(&mut self, checkout: CachedFtsCheckout) -> bool {
         let (directory, index, reader, query_parser, control) = checkout;
+        self.hybrid_directory = Some(directory);
+        self.control = Some(control);
+        if self.opening_for_write {
+            // A writer needs an Index whose Directory owns cursor-local pending
+            // state. The cached Index shares the cache entry's directory, so
+            // installing it would send this cursor's writes into the cache
+            // entry's pending map, where the flush never finds them. Rebuild
+            // the Index over the fresh directory clone instead.
+            tracing::debug!("FTS open_write: using cached directory snapshot, rebuilding index");
+            self.state = FtsState::CreatingIndex;
+            return false;
+        }
         self.runtime_stats
             .read_cache_hits
             .fetch_add(1, Ordering::Relaxed);
         tracing::debug!("FTS open_read: using cached state (skipping catalog load)");
-        self.hybrid_directory = Some(directory);
-        self.control = Some(control);
         self.index = Some(index);
         self.searcher = Some(reader.searcher());
         self.reader = Some(reader);
         self.cached_parser = Some(query_parser);
         self.state = FtsState::Ready;
+        true
     }
 
     /// Restore a writer retained by the previous statement when its committed
     /// metadata still matches this transaction's backing B-tree view.
     fn restore_cached_writer(&mut self, context: &IndexMethodContext) -> Result<bool> {
-        let conn = context.connection();
+        let conn = context.connection()?;
         self.runtime_stats
             .writer_cache_lookups
             .fetch_add(1, Ordering::Relaxed);
@@ -2088,7 +2285,7 @@ impl FtsCursor {
         let same_connection = cached
             .connection
             .upgrade()
-            .is_some_and(|owner| Arc::ptr_eq(&owner, conn));
+            .is_some_and(|owner| Arc::ptr_eq(&owner, &conn));
         let metadata_matches = if conn.mv_store_for_db(database_id).is_some() {
             same_connection
                 && context.transaction_id().is_some()
@@ -2128,9 +2325,9 @@ impl FtsCursor {
             return Ok(false);
         }
 
-        let cached = cached_writer
-            .take()
-            .expect("validated cached writer must still be present");
+        let cached = cached_writer.take().ok_or_else(|| {
+            LimboError::InternalError("validated cached FTS writer disappeared".to_string())
+        })?;
         drop(cached_writer);
         self.runtime_stats
             .writer_cache_hits
@@ -2147,29 +2344,42 @@ impl FtsCursor {
         Ok(true)
     }
 
-    fn has_deferred_cached_writer(&self, context: &IndexMethodContext) -> bool {
-        let conn = context.connection();
+    /// Does this connection have a writer whose transaction committed but
+    /// whose view has not been re-checked against the on-disk control record
+    /// yet? Such a writer may only be reused after that check
+    /// (`take_writer_if_control_matches`).
+    fn writer_needs_control_check(&self, context: &IndexMethodContext) -> bool {
+        let Ok(conn) = context.connection() else {
+            return false;
+        };
         self.shared_writer.lock().as_ref().is_some_and(|cached| {
             cached.transaction_id.is_none()
                 && cached
                     .connection
                     .upgrade()
-                    .is_some_and(|owner| Arc::ptr_eq(&owner, conn))
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, &conn))
         })
     }
 
-    fn checkout_validated_cached_writer(
+    /// Reuse this connection's committed writer if the control record it was
+    /// built on is still the one visible on disk; otherwise leave (or drop)
+    /// it and report a miss.
+    fn take_writer_if_control_matches(
         &mut self,
         context: &IndexMethodContext,
         visible_control: &FtsControlRecord,
     ) -> bool {
-        let conn = context.connection();
+        let Ok(conn) = context.connection() else {
+            return false;
+        };
         let mut cached_writer = self.shared_writer.lock();
         let Some(cached) = cached_writer.as_ref() else {
             return false;
         };
         let owner = cached.connection.upgrade();
-        let same_connection = owner.as_ref().is_some_and(|owner| Arc::ptr_eq(owner, conn));
+        let same_connection = owner
+            .as_ref()
+            .is_some_and(|owner| Arc::ptr_eq(owner, &conn));
         let deferred = cached.transaction_id.is_none();
         let matches_control = cached.control.index_incarnation == visible_control.index_incarnation
             && cached.control.manifest_generation == visible_control.manifest_generation;
@@ -2193,9 +2403,12 @@ impl FtsCursor {
             return false;
         }
 
-        let cached = cached_writer
-            .take()
-            .expect("validated cached writer must still be present");
+        // The invariant (slot lock held from the check to the take) makes
+        // this infallible; treat a violation as a cache miss, not a crash.
+        let Some(cached) = cached_writer.take() else {
+            tracing::error!("validated cached FTS writer disappeared");
+            return false;
+        };
         drop(cached_writer);
         self.runtime_stats
             .writer_cache_hits
@@ -2211,8 +2424,12 @@ impl FtsCursor {
         true
     }
 
-    fn discard_deferred_cached_writer(&self, context: &IndexMethodContext) {
-        let conn = context.connection();
+    /// Drop this connection's committed-but-unchecked writer when the control
+    /// record it needed to validate against turns out not to exist.
+    fn drop_unchecked_writer(&self, context: &IndexMethodContext) {
+        let Ok(conn) = context.connection() else {
+            return;
+        };
         let mut cached_writer = self.shared_writer.lock();
         // A missing control record proves this connection's deferred writer is
         // stale. The slot is shared by every connection, so a live writer
@@ -2222,7 +2439,7 @@ impl FtsCursor {
                 .as_ref()
                 .is_some_and(|cached| match cached.connection.upgrade() {
                     None => true,
-                    Some(owner) => Arc::ptr_eq(&owner, conn) && cached.transaction_id.is_none(),
+                    Some(owner) => Arc::ptr_eq(&owner, &conn) && cached.transaction_id.is_none(),
                 });
         if !discard {
             return;
@@ -2240,7 +2457,9 @@ impl FtsCursor {
 
     /// Retain a fully flushed writer for the next statement on this connection.
     fn cache_writer(&mut self, context: &IndexMethodContext) {
-        let conn = context.connection();
+        let Ok(conn) = context.connection() else {
+            return;
+        };
         if self.pending_docs_count != 0 || !matches!(self.state, FtsState::Ready) {
             tracing::trace!(
                 pending_documents = self.pending_docs_count,
@@ -2260,15 +2479,22 @@ impl FtsCursor {
             .saturating_add(retained_read_bytes)
             > fts_max_retained_cache_bytes()
         {
+            // Keep the writer — it is the newest committed state, and the
+            // cursor held these bytes while it ran anyway — and make room by
+            // evicting retained read snapshots instead. Rejecting the writer
+            // would leave a stale one in the slot and force the next write
+            // statement into a full cold load.
             self.runtime_stats
                 .cache_admission_rejections
                 .fetch_add(1, Ordering::Relaxed);
+            let read_budget =
+                fts_max_retained_cache_bytes().saturating_sub(directory.hot_cache.size());
+            self.shared_cache.write().evict_to_fit(read_budget);
             tracing::debug!(
                 resident_bytes = directory.hot_cache.size(),
                 budget_bytes = fts_max_retained_cache_bytes(),
-                "FTS writer cache: snapshot exceeds retention budget"
+                "FTS writer cache: over retention budget; evicted read snapshots"
             );
-            return;
         }
         // Index creation and failed statements can close a cursor before all
         // directory mutations enter the normal document flush state machine.
@@ -2303,7 +2529,7 @@ impl FtsCursor {
         let snapshot_wal_pos = (wal_pos != (u32::MAX, u64::MAX)).then_some(wal_pos);
 
         let previous = self.shared_writer.lock().replace(CachedFtsWriter {
-            connection: Arc::downgrade(conn),
+            connection: Arc::downgrade(&conn),
             transaction_id: context.transaction_id(),
             snapshot_wal_pos,
             control,
@@ -2715,11 +2941,11 @@ impl FtsCursor {
             committed_writer = true;
 
             // The cached reader belongs to the previous index snapshot.
-            if let Some(conn) = &self.connection {
+            if let Some(conn) = self.connection.as_ref().and_then(Weak::upgrade) {
                 let mut cache = self.shared_cache.write();
-                if cache.connection_position(conn).is_some() {
+                if cache.connection_position(&conn).is_some() {
                     tracing::debug!("FTS commit_and_flush: invalidating cached read state");
-                    cache.remove_connection(conn);
+                    cache.remove_connection(&conn);
                 }
             }
         }
@@ -2812,8 +3038,18 @@ impl FtsCursor {
             // eligible level first prevents fresh tiny segments from piling up.
             .rev()
         {
-            let segment_ids = candidate
-                .0
+            // Prefer the smallest segments of the candidate: taking the first
+            // eight of Tantivy's largest-first list picks exactly the eight
+            // most likely to blow the foreground budget, which silently
+            // stalls maintenance at that level forever.
+            let mut candidate_ids = candidate.0;
+            candidate_ids.sort_by_key(|id| {
+                segment_metas
+                    .iter()
+                    .find(|meta| meta.id() == *id)
+                    .map_or(u64::MAX, |meta| u64::from(meta.max_doc()))
+            });
+            let segment_ids = candidate_ids
                 .into_iter()
                 .take(FTS_MERGE_FACTOR)
                 .collect::<Vec<_>>();
@@ -2821,10 +3057,13 @@ impl FtsCursor {
             let mut source_bytes = 0u64;
 
             for segment_id in &segment_ids {
-                let segment_meta = segment_metas
-                    .iter()
-                    .find(|meta| meta.id() == *segment_id)
-                    .expect("merge policy returned an unknown FTS segment");
+                // The merge policy is third-party code; do not trust it to
+                // return only segments it was given.
+                let Some(segment_meta) = segment_metas.iter().find(|meta| meta.id() == *segment_id)
+                else {
+                    tracing::error!("merge policy returned an unknown FTS segment; skipping merge");
+                    return None;
+                };
                 source_docs = source_docs.saturating_add(u64::from(segment_meta.max_doc()));
                 for path in segment_meta.list_files() {
                     if let Some(size) = file_size(&path) {
@@ -2921,14 +3160,26 @@ impl FtsCursor {
             .filter(|&incarnation| incarnation != FTS_EMPTY_INDEX_INCARNATION)
             .or_else(|| {
                 self.btree_root_page.map(|root_page| {
+                    // Mix in IO-provided entropy so two processes creating
+                    // the same index in different files do not mint the same
+                    // on-disk incarnation (the counter restarts at 1 in every
+                    // process). The IO trait's generator is deterministic
+                    // under the simulator.
                     let nonce = NEXT_FTS_INDEX_INCARNATION.fetch_add(1, Ordering::Relaxed);
+                    let entropy = directory.pager.io.generate_random_number() as u64;
                     // The placeholder value marks "never written": never mint it.
-                    ((root_page as u64).rotate_left(32) ^ nonce).max(1)
+                    ((root_page as u64).rotate_left(32) ^ nonce ^ entropy).max(1)
                 })
             })
             .ok_or_else(|| {
                 LimboError::InternalError("FTS backing root is not initialized".to_string())
             })?;
+        // Deriving the next generation from this cursor's copy of the control
+        // record is safe only because writers are serialized: within a
+        // connection by the per-index writer slot (one flushing cursor at a
+        // time), across connections by the pager write lock (WAL) or the
+        // per-index MVCC write lease, which also refuses any writer whose
+        // snapshot predates the last published generation.
         let control = FtsControlRecord::from_catalog(
             self.control.as_ref(),
             index_incarnation,
@@ -2942,6 +3193,7 @@ impl FtsCursor {
 
 impl Drop for FtsCursor {
     fn drop(&mut self) {
+        self.release_writer_slot();
         let is_flushing = self.state.is_flushing();
         if self.pending_docs_count != 0 || is_flushing {
             tracing::error!(
@@ -2960,23 +3212,34 @@ impl Drop for FtsCursor {
 impl IndexMethodCursor for FtsCursor {
     /// Creates the FTS index storage (internal BTree table for Tantivy files).
     fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
-        let conn = context.connection();
+        let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
-        initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
+        initialize_btree_storage_table(&conn, database_id, &self.dir_table_name)?;
         return_if_io!(self.open_write(context));
+        // The forced flush below stages the index's first control record,
+        // which requires a committed writer even for an empty table.
+        self.claim_writer_slot()?;
+        self.ensure_writer()?;
         self.commit_and_flush_inner(true)
     }
 
     /// Destroys the FTS index, dropping all storage and clearing caches.
     fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
-        let conn = context.connection();
+        let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
+        self.connection = Some(Arc::downgrade(&conn));
         tracing::debug!(
             "FTS destroy: dropping internal storage {}",
             self.dir_table_name
         );
+
+        // Serialize with live writers through the same per-index writer slot
+        // and MVCC write lease as DML, so DROP INDEX cannot tear the index
+        // down under a transaction that is mid-write.
+        self.open_cursor(&conn, database_id)?;
+        self.claim_writer_slot()?;
 
         // Drop all in-memory components first
         self.searcher = None;
@@ -2987,13 +3250,29 @@ impl IndexMethodCursor for FtsCursor {
         self.fts_dir_cursor = None;
         self.control = None;
 
-        // Invalidate cached read state.
+        // Invalidate only this connection's cached read state and writer. The
+        // drop is not committed yet, so other connections' caches must stay;
+        // if the drop commits, their next access misses on the schema change,
+        // and a recreated index carries a fresh incarnation so no stale
+        // snapshot can validate against it.
+        self.shared_cache.write().remove_connection(&conn);
         {
-            let mut cache = self.shared_cache.write();
-            cache.clear();
+            let mut cached_writer = self.shared_writer.lock();
+            let owned_or_dead =
+                cached_writer
+                    .as_ref()
+                    .is_some_and(|cached| match cached.connection.upgrade() {
+                        None => true,
+                        Some(owner) => Arc::ptr_eq(&owner, &conn),
+                    });
+            let stale = if owned_or_dead {
+                cached_writer.take()
+            } else {
+                None
+            };
+            drop(cached_writer);
+            drop(stale);
         }
-        let cached_writer = self.shared_writer.lock().take();
-        drop(cached_writer);
 
         // Drop the internal storage table and index
         // The backing_btree index will be dropped automatically when the table is dropped
@@ -3026,7 +3305,7 @@ impl IndexMethodCursor for FtsCursor {
     /// Opens the index for reading, loading the catalog and creating a searcher.
     /// Uses async state machine for non-blocking IO during catalog/file loading.
     fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
-        let conn = context.connection();
+        let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
         loop {
@@ -3037,23 +3316,30 @@ impl IndexMethodCursor for FtsCursor {
                             .read_cache_lookups
                             .fetch_add(1, Ordering::Relaxed);
                     }
-                    self.connection = Some(conn.clone());
-                    // Ensure storage table exists
-                    initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
+                    self.connection = Some(Arc::downgrade(&conn));
+                    // The backing table is created by create() / open_write();
+                    // a pure read must not run DDL, or FTS queries fail on
+                    // read-only databases. If the table is genuinely missing,
+                    // open_cursor reports it.
+                    if self.opening_for_write {
+                        initialize_btree_storage_table(&conn, database_id, &self.dir_table_name)?;
+                    }
                     // Open BTree cursor (needed for btree_root_page)
-                    self.open_cursor(conn, database_id)?;
+                    self.open_cursor(&conn, database_id)?;
 
                     // A cache entry from the exact same snapshot can be used
                     // immediately. A cache from an older snapshot is retained
                     // until the small transactional control record has been
                     // read asynchronously and its identity validated.
                     if let Some(checkout) = self.checkout_cached_state(context, None) {
-                        self.install_cached_checkout(checkout);
-                        return Ok(IOResult::Done(()));
+                        if self.install_cached_checkout(checkout) {
+                            return Ok(IOResult::Done(()));
+                        }
+                        continue;
                     }
 
                     self.state = if self.has_cached_state(context)
-                        || (self.opening_for_write && self.has_deferred_cached_writer(context))
+                        || (self.opening_for_write && self.writer_needs_control_check(context))
                     {
                         FtsState::SeekingControl
                     } else {
@@ -3084,7 +3370,7 @@ impl IndexMethodCursor for FtsCursor {
                     self.state = match seek_result {
                         SeekResult::NotFound => {
                             if self.opening_for_write {
-                                self.discard_deferred_cached_writer(context);
+                                self.drop_unchecked_writer(context);
                             }
                             FtsState::Rewinding
                         }
@@ -3107,7 +3393,7 @@ impl IndexMethodCursor for FtsCursor {
                         }
                     } else {
                         if self.opening_for_write {
-                            self.discard_deferred_cached_writer(context);
+                            self.drop_unchecked_writer(context);
                         }
                         FtsState::Rewinding
                     };
@@ -3177,7 +3463,7 @@ impl IndexMethodCursor for FtsCursor {
                     if finished {
                         if chunks.is_empty() {
                             if self.opening_for_write {
-                                self.discard_deferred_cached_writer(context);
+                                self.drop_unchecked_writer(context);
                             }
                             self.runtime_stats
                                 .manifest_validation_misses
@@ -3195,7 +3481,7 @@ impl IndexMethodCursor for FtsCursor {
                             assemble_catalog_file(Path::new(FTS_CONTROL_PATH), &control_chunks)?;
                         let control = FtsControlRecord::decode(&control_bytes)?;
                         if self.opening_for_write
-                            && self.checkout_validated_cached_writer(context, &control)
+                            && self.take_writer_if_control_matches(context, &control)
                         {
                             return Ok(IOResult::Done(()));
                         }
@@ -3204,8 +3490,10 @@ impl IndexMethodCursor for FtsCursor {
                             self.runtime_stats
                                 .manifest_validation_hits
                                 .fetch_add(1, Ordering::Relaxed);
-                            self.install_cached_checkout(checkout);
-                            return Ok(IOResult::Done(()));
+                            if self.install_cached_checkout(checkout) {
+                                return Ok(IOResult::Done(()));
+                            }
+                            continue;
                         }
                         self.runtime_stats
                             .manifest_validation_misses
@@ -3262,7 +3550,21 @@ impl IndexMethodCursor for FtsCursor {
                                 .copied()
                                 .expect("catalog builder entries have chunks");
                             let total_size: usize = chunks.values().map(|(size, _)| size).sum();
-                            let num_chunks = (max_chunk + 1) as usize;
+                            // The chunk number comes straight out of a stored
+                            // record; a corrupted value must not overflow.
+                            let num_chunks =
+                                usize::try_from(max_chunk.checked_add(1).ok_or_else(|| {
+                                    LimboError::Corrupt(format!(
+                                        "FTS chunk number out of range for {}",
+                                        path.display()
+                                    ))
+                                })?)
+                                .map_err(|_| {
+                                    LimboError::Corrupt(format!(
+                                        "FTS chunk number is negative for {}",
+                                        path.display()
+                                    ))
+                                })?;
                             let metadata = FileMetadata::new(&path, total_size, num_chunks);
                             let assembled = assemble_catalog_file(&path, &chunks)?;
                             files.insert(path.clone(), assembled);
@@ -3273,10 +3575,21 @@ impl IndexMethodCursor for FtsCursor {
                             if catalog.is_empty() {
                                 Some(FtsControlRecord::new(FTS_EMPTY_INDEX_INCARNATION))
                             } else {
-                                return Err(LimboError::Corrupt(
-                                    "FTS storage predates control-record format v1; rebuild the index"
-                                        .into(),
-                                ));
+                                // An index written by a build that predates the
+                                // control record: adopt the catalog we just
+                                // loaded as the manifest, so reads and writes
+                                // keep working. The placeholder incarnation
+                                // makes the next staged control record mint a
+                                // real one and persist the manifest durably.
+                                tracing::info!(
+                                    files = catalog.len(),
+                                    "FTS storage has no control record; adopting existing catalog"
+                                );
+                                Some(FtsControlRecord::from_catalog(
+                                    None,
+                                    FTS_EMPTY_INDEX_INCARNATION,
+                                    &catalog,
+                                )?)
                             }
                         } else {
                             let control_bytes = assemble_catalog_file(
@@ -3356,16 +3669,21 @@ impl IndexMethodCursor for FtsCursor {
                     } else {
                         catalog_builder.entry(path_buf.clone()).or_default()
                     };
+                    // Move the blob into the builder — copying it just to keep
+                    // a reference for the error message below would duplicate
+                    // the whole index once per cold load.
+                    let blob_len = blob.len();
                     if let Some((existing_size, existing_blob)) =
-                        chunks.insert(chunk_no, (blob.len(), Some(blob.clone())))
+                        chunks.insert(chunk_no, (blob_len, Some(blob)))
                     {
+                        let new_blob = chunks.get(&chunk_no).and_then(|(_, blob)| blob.as_deref());
                         return Err(LimboError::Corrupt(format!(
                             "duplicate FTS chunk {}:{} (existing_size={}, new_size={}, equal={})",
                             path_buf.display(),
                             chunk_no,
                             existing_size,
-                            blob.len(),
-                            existing_blob.as_deref() == Some(blob.as_slice())
+                            blob_len,
+                            existing_blob.as_deref() == new_blob
                         )));
                     }
 
@@ -3380,13 +3698,19 @@ impl IndexMethodCursor for FtsCursor {
                     // Create Tantivy index from directory
                     self.create_index_from_directory()?;
 
-                    // Create reader and searcher
+                    // Create reader and searcher. Reload is explicit: this
+                    // directory's `watch` cannot deliver callbacks, so the
+                    // default on-commit policy would silently never fire.
                     let index = self.index.as_ref().ok_or_else(|| {
                         LimboError::InternalError("FTS index not initialized".into())
                     })?;
                     let reader = index
-                        .reader()
-                        .map_err(|e| LimboError::InternalError(e.to_string()))?;
+                        .reader_builder()
+                        .reload_policy(tantivy::ReloadPolicy::Manual)
+                        .try_into()
+                        .map_err(|e: tantivy::TantivyError| {
+                            LimboError::InternalError(e.to_string())
+                        })?;
                     self.searcher = Some(reader.searcher());
                     self.reader = Some(reader);
 
@@ -3420,7 +3744,7 @@ impl IndexMethodCursor for FtsCursor {
                             fts_max_retained_cache_bytes().saturating_sub(writer_bytes);
                         let retained = cache.insert(
                             CachedFtsState {
-                                connection: Arc::downgrade(conn),
+                                connection: Arc::downgrade(&conn),
                                 transaction_id: context.transaction_id(),
                                 snapshot_wal_pos,
                                 control,
@@ -3461,88 +3785,29 @@ impl IndexMethodCursor for FtsCursor {
     /// Opens the index for writing, creating the IndexWriter.
     /// Calls `open_read` first if not already initialized.
     fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
-        let conn = context.connection();
+        let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
         self.opening_for_write = true;
         if self.connection.is_none() {
-            self.connection = Some(conn.clone());
+            self.connection = Some(Arc::downgrade(&conn));
         }
 
-        if self.writer.is_some() {
+        // `opening_for_write` must stay set across IO yields (the opcode
+        // re-enters), but never survive an error: a later open_read on the
+        // same cursor would then skip publishing read state forever.
+        let result = self.open_write_inner(context, &conn, database_id);
+        if !matches!(result, Ok(IOResult::IO(_))) {
             self.opening_for_write = false;
-            return Ok(IOResult::Done(()));
         }
-
-        initialize_btree_storage_table(conn, database_id, &self.dir_table_name)?;
-        self.open_cursor(conn, database_id)?;
-        if let Some(mv_store) = conn.mv_store_for_db(database_id) {
-            let tx_id = conn.get_mv_tx_id_for_db(database_id).ok_or_else(|| {
-                LimboError::InternalError(
-                    "FTS write opened without an active MVCC transaction".to_string(),
-                )
-            })?;
-            let root_page = self.btree_root_page.ok_or_else(|| {
-                LimboError::InternalError("FTS backing root is not initialized".to_string())
-            })?;
-            let snapshot_ts = mv_store.read_snapshot_ts(tx_id);
-            let index_id = mv_store.get_table_id_from_root_page_at(root_page, snapshot_ts);
-            match mv_store.acquire_index_method_write_lease(tx_id, index_id) {
-                Ok(()) => {
-                    self.runtime_stats
-                        .write_lease_acquisitions
-                        .fetch_add(1, Ordering::Relaxed);
-                }
-                Err(err @ LimboError::WriteWriteConflict) => {
-                    self.runtime_stats
-                        .write_lease_rejections
-                        .fetch_add(1, Ordering::Relaxed);
-                    return Err(err);
-                }
-                Err(err) => return Err(err),
-            }
-        }
-        if self.restore_cached_writer(context)? {
-            self.opening_for_write = false;
-            return Ok(IOResult::Done(()));
-        }
-
-        // First do open_read to load existing index
-        match &self.state {
-            FtsState::Ready => {}
-            _ => {
-                let result = self.open_read(context)?;
-                if let IOResult::IO(io) = result {
-                    return Ok(IOResult::IO(io));
-                }
-            }
-        }
-        if self.writer.is_some() {
-            self.opening_for_write = false;
-            return Ok(IOResult::Done(()));
-        }
-
-        let index = self
-            .index
-            .as_ref()
-            .ok_or_else(|| LimboError::InternalError("FTS index not initialized".into()))?;
-        // Use single-threaded mode to avoid concurrent access.
-        self.runtime_stats
-            .tantivy_writer_constructions
-            .fetch_add(1, Ordering::Relaxed);
-        let writer = index
-            .writer_with_num_threads(1, DEFAULT_MEMORY_BUDGET_BYTES)
-            .map_err(|e| LimboError::InternalError(e.to_string()))?;
-        // Disable background merges.
-        writer.set_merge_policy(Box::new(NoMergePolicy));
-        self.writer = Some(writer);
-        self.opening_for_write = false;
-        Ok(IOResult::Done(()))
+        result
     }
 
     /// Inserts a document into the FTS index.
     /// Values are text columns followed by rowid. Batches commits for efficiency.
     fn insert(&mut self, values: &[Register]) -> Result<IOResult<()>> {
+        self.claim_writer_slot()?;
+        self.ensure_writer()?;
         return_if_io!(self.flush_full_batch_before_mutation());
 
         let Some(ref mut writer) = self.writer else {
@@ -3573,6 +3838,14 @@ impl IndexMethodCursor for FtsCursor {
                     doc.add_text(*field, t.as_str());
                 }
                 Register::Value(Value::Null) => continue,
+                // Coerce every non-NULL value to text before tokenizing, the
+                // way FTS5's sqlite3_value_text() does. Skipping them would
+                // make the index silently miss rows a plain scan matches.
+                Register::Value(value) => {
+                    if let Some(text) = value.cast_text() {
+                        doc.add_text(*field, &text);
+                    }
+                }
                 _ => continue,
             }
         }
@@ -3588,6 +3861,8 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Deletes a document from the FTS index by rowid.
     fn delete(&mut self, values: &[Register]) -> Result<IOResult<()>> {
+        self.claim_writer_slot()?;
+        self.ensure_writer()?;
         return_if_io!(self.flush_full_batch_before_mutation());
 
         let Some(ref mut writer) = self.writer else {
@@ -3625,9 +3900,13 @@ impl IndexMethodCursor for FtsCursor {
             let index = self.index.as_ref().ok_or_else(|| {
                 LimboError::InternalError("FTS index not initialized - call open_read first".into())
             })?;
+            // Manual reload policy: this directory's `watch` cannot deliver
+            // callbacks, so the default on-commit policy never fires.
             let reader = index
-                .reader()
-                .map_err(|e| LimboError::InternalError(e.to_string()))?;
+                .reader_builder()
+                .reload_policy(tantivy::ReloadPolicy::Manual)
+                .try_into()
+                .map_err(|e: tantivy::TantivyError| LimboError::InternalError(e.to_string()))?;
             self.searcher = Some(reader.searcher());
             self.reader = Some(reader);
         }
@@ -3635,9 +3914,9 @@ impl IndexMethodCursor for FtsCursor {
             .searcher
             .as_ref()
             .expect("FTS searcher initialized immediately above");
-        if values.is_empty() {
+        if values.len() < 2 {
             return Err(LimboError::InternalError(
-                "FTS query_start: missing pattern id".into(),
+                "FTS query_start: expected pattern id and query string".into(),
             ));
         }
 
@@ -3663,27 +3942,39 @@ impl IndexMethodCursor for FtsCursor {
             | FTS_PATTERN_MATCH_LIMIT
             | FTS_PATTERN_COMBINED_LIMIT
             | FTS_PATTERN_COMBINED_ORDERED_LIMIT => Some(if values.len() > 2 {
-                match &values[2] {
-                    Register::Value(Value::Numeric(crate::numeric::Numeric::Integer(i))) => *i,
-                    _ => {
-                        tracing::debug!(
-                            "FTS query_start: LIMIT value is not an integer, using default 10"
-                        );
-                        10
+                // Coerce with the same rules as a plain LIMIT (MustBeInt):
+                // numeric text and integral reals become integers; anything
+                // else is a datatype mismatch, never a silent default.
+                let coerced = match &values[2] {
+                    Register::Value(Value::Numeric(crate::numeric::Numeric::Integer(i))) => {
+                        Some(*i)
                     }
-                }
+                    Register::Value(Value::Numeric(crate::numeric::Numeric::Float(f))) => {
+                        crate::util::cast_real_to_integer(f64::from(*f)).ok()
+                    }
+                    Register::Value(Value::Text(text)) => {
+                        match crate::util::checked_cast_text_to_numeric(text.as_str(), true) {
+                            Ok(Value::Numeric(crate::numeric::Numeric::Integer(i))) => Some(i),
+                            Ok(Value::Numeric(crate::numeric::Numeric::Float(f))) => {
+                                crate::util::cast_real_to_integer(f64::from(f)).ok()
+                            }
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                };
+                coerced
+                    .ok_or_else(|| LimboError::Constraint("datatype mismatch (19)".to_string()))?
             } else {
-                tracing::debug!(
-                    "FTS query_start: LIMIT pattern but no limit value provided, using default 10"
-                );
-                10
+                return Err(LimboError::InternalError(
+                    "FTS query_start: LIMIT pattern selected but no limit value captured"
+                        .to_string(),
+                ));
             }),
             _ => {
-                tracing::debug!(
-                    "FTS query_start: unknown pattern {}, using default limit 10",
-                    pattern_idx
-                );
-                Some(10)
+                return Err(LimboError::InternalError(format!(
+                    "FTS query_start: unknown pattern {pattern_idx}"
+                )));
             }
         };
 
@@ -3697,9 +3988,38 @@ impl IndexMethodCursor for FtsCursor {
         }
         let parser = self.cached_parser.as_deref().unwrap();
 
-        let query = parser
-            .parse_query(&query_str)
-            .map_err(|e| LimboError::InternalError(format!("FTS parse error: {e}")))?;
+        // Bound the query string before it reaches Tantivy's recursive
+        // parser: a few KiB of nested parentheses would otherwise burn
+        // minutes of CPU or overflow the stack (an abort no catch_unwind
+        // contains). `parse_query_lenient` uses the non-backtracking parse
+        // path, so nesting inside these bounds stays linear.
+        if query_str.len() > FTS_MAX_QUERY_BYTES {
+            return Err(LimboError::InternalError(format!(
+                "FTS query is too long ({} bytes; the limit is {FTS_MAX_QUERY_BYTES})",
+                query_str.len()
+            )));
+        }
+        let mut depth = 0usize;
+        for byte in query_str.bytes() {
+            match byte {
+                b'(' => {
+                    depth += 1;
+                    if depth > FTS_MAX_QUERY_NESTING {
+                        return Err(LimboError::InternalError(format!(
+                            "FTS query nests deeper than {FTS_MAX_QUERY_NESTING} parentheses"
+                        )));
+                    }
+                }
+                b')' => depth = depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+        let (query, parse_errors) = parser.parse_query_lenient(&query_str);
+        if let Some(error) = parse_errors.first() {
+            return Err(LimboError::InternalError(format!(
+                "FTS parse error: {error:?}"
+            )));
+        }
 
         // TopDocs keeps a heap proportional to its limit. Cap that heap at the
         // number of live documents: this preserves unlimited-query semantics,
@@ -3755,6 +4075,48 @@ impl IndexMethodCursor for FtsCursor {
             let has_result = stream.advance()?;
             self.streaming_hits = Some(stream);
             return Ok(IOResult::Done(has_result));
+        }
+
+        // A global score ordering with no effective LIMIT: TopDocs would
+        // eagerly allocate per-segment heaps sized to the whole corpus before
+        // scoring a single document. Walk the scorers and sort what actually
+        // matched instead, so memory is proportional to the matches.
+        if limit >= searcher.num_docs() as usize {
+            let weight = query
+                .weight(EnableScoring::enabled_from_searcher(searcher))
+                .map_err(|e| LimboError::InternalError(format!("FTS query weight error: {e}")))?;
+            for (segment_ord, segment_reader) in searcher.segment_readers().iter().enumerate() {
+                let mut scorer = weight
+                    .scorer(segment_reader, 1.0)
+                    .map_err(|e| LimboError::InternalError(format!("FTS scorer error: {e}")))?;
+                let rowids = segment_reader
+                    .fast_fields()
+                    .i64(ROWID_FIELD)
+                    .map_err(|e| LimboError::InternalError(format!("FTS fast field error: {e}")))?;
+                let alive = segment_reader.alive_bitset();
+                loop {
+                    let doc_id = scorer.doc();
+                    if doc_id == TERMINATED {
+                        break;
+                    }
+                    let score = scorer.score();
+                    scorer.advance();
+                    if alive.is_some_and(|alive| alive.is_deleted(doc_id)) {
+                        continue;
+                    }
+                    let rowid = rowids.first(doc_id).ok_or_else(|| {
+                        LimboError::InternalError("FTS: rowid fast field missing value".into())
+                    })?;
+                    self.current_hits.push((
+                        score,
+                        DocAddress::new(segment_ord as u32, doc_id),
+                        rowid,
+                    ));
+                }
+            }
+            self.current_hits
+                .sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+            return Ok(IOResult::Done(!self.current_hits.is_empty()));
         }
 
         let top_docs = searcher
@@ -3883,34 +4245,47 @@ impl IndexMethodCursor for FtsCursor {
         // This handles the case where commit_and_flush() returned IOResult::IO and we need
         // to continue the flush after IO completes
         if self.state.is_flushing() {
-            return self.flush_writes_internal();
-        }
-
-        if self.pending_docs_count > 0 {
+            return_if_io!(self.flush_writes_internal());
+        } else if self.pending_docs_count > 0 {
             tracing::debug!(
                 "FTS pre_commit: flushing {} pending documents",
                 self.pending_docs_count
             );
-            return self.commit_and_flush();
+            return_if_io!(self.commit_and_flush());
         }
+        // This cursor's statement-scope writes are staged; it never flushes
+        // again, so a later statement's cursor may write this index.
+        self.release_writer_slot();
         Ok(IOResult::Done(()))
     }
 
     fn abort_statement(&mut self, context: &IndexMethodContext) {
+        self.release_writer_slot();
         self.pending_docs_count = 0;
-        self.writer = None;
+        // Dropping a Tantivy writer joins its worker threads. Take the heavy
+        // pieces into locals and drop them after the shared-cache bookkeeping
+        // below, mirroring cache_writer's drop(previous) pattern, so no lock
+        // is held while the join runs.
+        let deferred_writer = self.writer.take();
+        let deferred_index = self.index.take();
+        let deferred_directory = self.hybrid_directory.take();
         self.reader = None;
         self.searcher = None;
-        self.index = None;
-        self.hybrid_directory = None;
         self.fts_dir_cursor = None;
         self.control = None;
         self.cached_parser = None;
         self.current_hits.clear();
         self.streaming_hits = None;
-        self.shared_cache
-            .write()
-            .remove_connection(context.connection());
+        // During connection teardown there is no live connection left; the
+        // shared caches are then cleaned up by `prune()` / dead-owner checks.
+        let Ok(conn) = context.connection() else {
+            self.state = FtsState::Init;
+            drop(deferred_writer);
+            drop(deferred_index);
+            drop(deferred_directory);
+            return;
+        };
+        self.shared_cache.write().remove_connection(&conn);
         // The slot is shared by every connection: a failed statement here
         // (e.g. the losing side of a lease conflict) must not evict another
         // connection's writer. Only remove what this connection's failed
@@ -3926,8 +4301,7 @@ impl IndexMethodCursor for FtsCursor {
                 None => (true, false),
                 Some(owner) => (
                     false,
-                    Arc::ptr_eq(&owner, context.connection())
-                        && cached.transaction_id == context.transaction_id(),
+                    Arc::ptr_eq(&owner, &conn) && cached.transaction_id == context.transaction_id(),
                 ),
             },
         };
@@ -3942,8 +4316,12 @@ impl IndexMethodCursor for FtsCursor {
                 .writer_cache_rollback_discards
                 .fetch_add(1, Ordering::Relaxed);
         }
-        drop(stale);
         self.state = FtsState::Init;
+        // Thread joins happen last, with no lock held.
+        drop(stale);
+        drop(deferred_writer);
+        drop(deferred_index);
+        drop(deferred_directory);
     }
 
     fn statement_committed(&mut self, context: &IndexMethodContext) {
@@ -3959,6 +4337,10 @@ impl IndexMethodCursor for FtsCursor {
             "FTS transaction outcome: committed"
         );
         self.cache_writer(context);
+        let Ok(conn) = context.connection() else {
+            self.shared_cache.write().prune();
+            return;
+        };
         if let Some(transaction_id) = context.transaction_id() {
             // The backing transaction is now committed, so its private writer
             // may be considered by a future transaction only after validating
@@ -3967,7 +4349,7 @@ impl IndexMethodCursor for FtsCursor {
                 let same_connection = cached
                     .connection
                     .upgrade()
-                    .is_some_and(|owner| Arc::ptr_eq(&owner, context.connection()));
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, &conn));
                 if same_connection && cached.transaction_id == Some(transaction_id) {
                     cached.transaction_id = None;
                     cached.snapshot_wal_pos = None;
@@ -3984,7 +4366,7 @@ impl IndexMethodCursor for FtsCursor {
             let same_connection = cached
                 .connection
                 .upgrade()
-                .is_some_and(|owner| Arc::ptr_eq(&owner, context.connection()));
+                .is_some_and(|owner| Arc::ptr_eq(&owner, &conn));
             let matches_cursor_control = self.control.as_ref().is_some_and(|control| {
                 control.index_incarnation == cached.control.index_incarnation
                     && control.manifest_generation == cached.control.manifest_generation
@@ -4002,16 +4384,30 @@ impl IndexMethodCursor for FtsCursor {
     }
 
     fn savepoint_rolled_back(&mut self, context: &IndexMethodContext) {
+        // Correct but coarse: the hook carries no savepoint identity, so we
+        // cannot tell whether the rollback actually reverted FTS chunk rows
+        // this cursor's view depends on. Discard everything; the next FTS
+        // access reloads from the (correctly reverted) backing B-tree.
+        // Finer granularity needs a savepoint-creation sequence passed into
+        // this hook and compared against the sequence at which this cursor
+        // materialized its view.
         self.abort_statement(context);
     }
 
     fn close(&mut self, context: &IndexMethodContext) {
-        if self.pending_docs_count != 0 {
+        if self.pending_docs_count != 0 || self.state.is_flushing() {
+            // close() is the explicit "discard whatever is left" hook, so it
+            // owns this decision: log it loudly, then normalize the cursor so
+            // Drop has nothing left to enforce.
             tracing::error!(
                 pending_documents = self.pending_docs_count,
-                "closing FTS cursor with unprepared writes"
+                is_flushing = self.state.is_flushing(),
+                "closing FTS cursor with unprepared writes; discarding them"
             );
         }
+        self.release_writer_slot();
+        self.pending_docs_count = 0;
+        self.state = FtsState::Init;
         self.writer = None;
         self.reader = None;
         self.searcher = None;
@@ -4030,6 +4426,14 @@ impl IndexMethodCursor for FtsCursor {
     fn optimize(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
         let database_id = context.database().id;
         self.database_id = Some(database_id);
+        // Resume a flush this opcode started before its last IO yield.
+        // Re-entry arrives with `pending_docs_count` already zeroed (the
+        // flush zeroes it before its first yield), so the state machine is
+        // the only reliable marker; skipping this would run the merge while
+        // the old flush is mid-flight and drop the merge's output.
+        if self.state.is_flushing() {
+            return_if_io!(self.flush_writes_internal());
+        }
         // First ensure any pending documents are flushed
         if self.pending_docs_count > 0 {
             tracing::info!(
@@ -4043,6 +4447,10 @@ impl IndexMethodCursor for FtsCursor {
         if self.writer.is_none() {
             return_if_io!(self.open_write(context));
         }
+        // The merge publishes new index state, so it needs the writer slot
+        // and (under MVCC) the write lease like any document mutation.
+        self.claim_writer_slot()?;
+        self.ensure_writer()?;
 
         let index = self
             .index
@@ -4095,9 +4503,9 @@ impl IndexMethodCursor for FtsCursor {
         writer
             .commit()
             .map_err(|e| LimboError::InternalError(format!("FTS optimize commit failed: {e}")))?;
-        if let Some(conn) = &self.connection {
+        if let Some(conn) = self.connection.as_ref().and_then(Weak::upgrade) {
             let mut cache = self.shared_cache.write();
-            cache.remove_connection(conn);
+            cache.remove_connection(&conn);
         }
 
         // Reload reader to see merged segments
@@ -4173,10 +4581,32 @@ impl IndexMethodCursor for FtsCursor {
         };
 
         // Cost model:
+        // - Load cost: the dominant real cost. A query materializes the whole
+        //   index in memory, linear in index bytes, regardless of how
+        //   selective it is. Size is known exactly when a snapshot or writer
+        //   is retained (which also means the load is warm); otherwise it is
+        //   approximated from the base table and charged as a cold load.
         // - Base cost: logarithmic in vocabulary size (approximated by table size)
         // - Posting traversal: stops at LIMIT for unordered streaming patterns
         // - Scoring: omitted for MATCH-only patterns
         // - Top-k materialization: required only for global score ordering
+        let retained_bytes = {
+            let read_bytes = self.shared_cache.read().resident_cache_bytes();
+            let writer_bytes = self
+                .shared_writer
+                .lock()
+                .as_ref()
+                .map_or(0, |cached| cached.directory.hot_cache.size());
+            read_bytes.max(writer_bytes)
+        };
+        const ESTIMATED_INDEX_BYTES_PER_ROW: f64 = 64.0;
+        const PAGE_BYTES: f64 = 4096.0;
+        let load_cost = if retained_bytes > 0 {
+            // A retained snapshot makes reuse likely; charge a token amount.
+            retained_bytes as f64 / PAGE_BYTES * 0.01
+        } else {
+            (context.base_table_rows * ESTIMATED_INDEX_BYTES_PER_ROW) / PAGE_BYTES
+        };
         let base_cost = context.base_table_rows.max(1.0).ln() * 10.0;
         let traversal_cost = visited_matches as f64 * 0.05;
         let scoring_cost = scored_matches as f64 * 0.05;
@@ -4187,7 +4617,11 @@ impl IndexMethodCursor for FtsCursor {
         };
 
         Some(super::IndexMethodCostEstimate {
-            estimated_cost: base_cost + traversal_cost + scoring_cost + materialization_cost,
+            estimated_cost: load_cost
+                + base_cost
+                + traversal_cost
+                + scoring_cost
+                + materialization_cost,
             estimated_rows,
         })
     }

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use rustc_hash::FxHashMap as HashMap;
 #[cfg(any(test, injected_yields))]
@@ -63,6 +63,14 @@ pub enum IndexMethodMvccSupport {
     ReadOnly,
     /// Persistent state is stored exclusively through core-provided,
     /// MVCC-aware backing storage.
+    ///
+    /// Under MVCC, at most one transaction may write a given index at a time
+    /// (a per-index write lease, taken on the first document mutation).
+    /// Contention is a retryable `Busy`; a writer whose read snapshot
+    /// predates the index's last publication gets `WriteWriteConflict` and
+    /// must restart its transaction. `BEGIN CONCURRENT` therefore does not
+    /// parallelize writes to one index of this kind — that is the write
+    /// throughput ceiling per index.
     TransactionalBackingStore,
     /// Persistent state is external and implements transaction outcome hooks.
     ExternalTransactional,
@@ -147,8 +155,13 @@ pub struct IndexMethodIdentity {
     pub method_name: String,
     pub table_name: String,
     pub index_name: String,
-    /// Runtime-stable identity for this schema incarnation. Drop/recreate and
-    /// attach/detach cannot compare equal even when names are reused.
+    /// Runtime identity derived from the database incarnation, the schema
+    /// generation, and the index's names. Attach/detach and close/reopen
+    /// cannot compare equal. Drop/recreate inside one MVCC transaction can
+    /// (MVCC DDL does not advance the schema generation); the consumers
+    /// tolerate that, because a colliding cursor is merely replaced-and-closed
+    /// and index content is validated separately by the persisted
+    /// (incarnation, generation) pair.
     pub runtime_id: u64,
     /// Schema root assigned to the logical definition. Custom index methods
     /// must keep this at zero; physical ownership belongs to backing objects.
@@ -179,7 +192,10 @@ fn index_method_runtime_id(
 /// are promoted to snapshot-aware MVCC cursors whenever MVCC is active.
 #[derive(Clone)]
 pub struct IndexMethodContext {
-    connection: Arc<Connection>,
+    /// Weak so a cursor parked on its connection (with its context) does not
+    /// make the connection reference itself — a strong edge here kept leaked
+    /// connections alive forever, holding their WAL locks.
+    connection: Weak<Connection>,
     database: IndexMethodDatabaseIdentity,
     journal_mode: JournalMode,
     transaction_mode: IndexMethodTransactionMode,
@@ -268,12 +284,12 @@ impl IndexMethodContext {
             };
 
         let source_database = connection.get_source_database(database_id);
-        let database_incarnation = Arc::as_ptr(&source_database) as usize as u64;
+        let database_incarnation = source_database.incarnation;
         let runtime_id =
             index_method_runtime_id(database_incarnation, schema_generation, definition);
 
         Ok(Self {
-            connection: Arc::clone(connection),
+            connection: Arc::downgrade(connection),
             database: IndexMethodDatabaseIdentity {
                 id: database_id,
                 name: connection
@@ -310,8 +326,13 @@ impl IndexMethodContext {
         Self::new(connection, database_id, &attachment.definition())
     }
 
-    pub fn connection(&self) -> &Arc<Connection> {
-        &self.connection
+    /// The connection this context was built for. Errors once the connection
+    /// is being torn down; outcome hooks running at that point have nothing
+    /// left to clean up and should just return.
+    pub fn connection(&self) -> Result<Arc<Connection>> {
+        self.connection.upgrade().ok_or_else(|| {
+            LimboError::InternalError("index method context outlived its connection".to_string())
+        })
     }
 
     pub fn database(&self) -> &IndexMethodDatabaseIdentity {
@@ -343,7 +364,7 @@ impl IndexMethodContext {
     }
 
     pub fn open_table_cursor(&self, table: &str) -> Result<Box<dyn CursorTrait>> {
-        open_table_cursor(&self.connection, self.database.id, table)
+        open_table_cursor(&self.connection()?, self.database.id, table)
     }
 
     pub fn open_index_cursor<I, E>(
@@ -356,7 +377,7 @@ impl IndexMethodContext {
         I: IntoIterator<Item = KeyInfo, IntoIter = E>,
         E: ExactSizeIterator<Item = KeyInfo>,
     {
-        open_index_cursor(&self.connection, self.database.id, table, index, keys)
+        open_index_cursor(&self.connection()?, self.database.id, table, index, keys)
     }
 }
 
@@ -375,9 +396,13 @@ impl crate::mvcc::yield_hooks::ProvidesYieldContext for IndexMethodContext {
         {
             selection_key = selection_key.wrapping_mul(0x100_0000_01b3) ^ u64::from(byte);
         }
+        let connection = self
+            .connection
+            .upgrade()
+            .expect("yield context requires a live connection");
         crate::mvcc::yield_hooks::YieldContext::new(
-            self.connection.yield_injector(),
-            self.connection.failure_injector(),
+            connection.yield_injector(),
+            connection.failure_injector(),
             self.yield_instance_id,
             selection_key,
         )
@@ -486,6 +511,31 @@ pub struct IndexMethodTestStats {
 }
 
 /// cursor opened for index method and capable of executing DML/DDL/DQL queries for the index method over fixed table
+///
+/// # Statement and transaction lifecycle
+///
+/// A cursor that wrote anything goes through these hooks, in this order:
+///
+/// 1. `prepare_statement_commit` — stage every pending change durably (the
+///    only fallible, I/O-capable phase), at the statement's halt.
+/// 2. `statement_committed` — the statement's savepoint was released.
+/// 3. Exactly one of three ends:
+///    * `transaction_committed` — the transaction is durable;
+///    * `transaction_rolled_back` — everything the transaction staged was
+///      undone;
+///    * replacement — a later statement in the same transaction opened a
+///      newer cursor for the same attachment, so this one is closed without
+///      either transaction outcome (the newer cursor receives it).
+/// 4. `close`.
+///
+/// A failed statement gets `abort_statement` instead of steps 1–2.
+///
+/// The empty default bodies below are correct **only for a method that keeps
+/// no transaction-private in-memory state** (everything lives in core-owned
+/// backing storage, which the engine rolls back on its own). A method that
+/// mirrors state in memory must implement every outcome hook: skipping
+/// `transaction_rolled_back` silently publishes rolled-back work, and
+/// skipping `prepare_statement_commit` silently loses writes.
 pub trait IndexMethodCursor: Send {
     /// create necessary components for index method (usually, this is a bunch of btree-s)
     fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
@@ -595,7 +645,7 @@ pub trait IndexMethodCursor: Send {
 
 pub(crate) struct TransactionIndexMethodCursor {
     pub(crate) cursor: Box<dyn IndexMethodCursor>,
-    pub(crate) context: IndexMethodContext,
+    pub(crate) context: Arc<IndexMethodContext>,
 }
 
 impl TransactionIndexMethodCursor {

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -406,7 +406,7 @@ fn key_info() -> KeyInfo {
 impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
     fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
         // we need to properly track subprograms and propagate result to the root program to make this execution async
-        let connection = context.connection();
+        let connection = context.connection()?;
         let database_id = context.database().id;
 
         let columns = &self.configuration.columns;
@@ -451,7 +451,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
     }
 
     fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
-        let connection = context.connection();
+        let connection = context.connection()?;
         let database_id = context.database().id;
         let db_prefix = connection
             .get_database_name_by_index(database_id)

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -155,9 +155,13 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> ProvidesYieldContext
     for MvccLazyCursor<Clock, A>
 {
     fn yield_context(&self) -> YieldContext {
+        let connection = self
+            .connection
+            .upgrade()
+            .expect("yield context requires a live connection");
         YieldContext::new(
-            self.connection.yield_injector(),
-            self.connection.failure_injector(),
+            connection.yield_injector(),
+            connection.failure_injector(),
             self.yield_instance_id,
             cursor_yield_key(self.tx_id, self.table_id),
         )
@@ -491,8 +495,10 @@ impl<A: ConcurrentAllocator> IndexShadowFinger<A> {
 
 pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator = TursoAllocator> {
     pub db: Arc<MvStore<Clock, A>>,
+    /// Weak so a cursor retained past its statement (an index-method cursor
+    /// parked on its connection) cannot keep the connection alive.
     #[cfg(any(test, injected_yields))]
-    connection: Arc<Connection>,
+    connection: crate::sync::Weak<Connection>,
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
     current_pos: CursorPosition<A>,
@@ -575,7 +581,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
             #[cfg(any(test, injected_yields))]
             yield_instance_id: connection.next_yield_instance_id(),
             #[cfg(any(test, injected_yields))]
-            connection: connection.clone(),
+            connection: Arc::downgrade(connection),
             tx_id,
             table_iterator: None,
             index_iterator: None,

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1816,19 +1816,25 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             // Skip indexes which are not unique or not primary key
             return Ok(());
         }
+        // A key without an appended rowid (an index method's backing B-tree)
+        // is unique over the whole key; keys with a rowid are unique over
+        // everything before it.
+        let num_indexed_cols = if record.metadata.has_rowid {
+            record.metadata.num_cols.saturating_sub(1) // exclude rowid column
+        } else {
+            record.metadata.num_cols
+        };
         // In SQLite, NULLs don't violate UNIQUE constraints - skip conflict check for keys containing NULL
-        let num_indexed_cols = record.metadata.num_cols.saturating_sub(1); // exclude rowid column
         if record.contains_null(num_indexed_cols)? {
             return Ok(());
         }
 
-        // Create a prefix key with num_cols - 1 for range lookup.
+        // Create a prefix key over the indexed columns for range lookup.
         // Due to SortableIndexKey's Ord using min(num_cols), this key compares Equal
         // to all entries with the same indexed columns (regardless of rowid).
         let prefix_key = {
             let mut index_info = record.metadata.as_ref().clone();
-            turso_assert!(index_info.has_rowid, "not supported yet without rowid");
-            index_info.num_cols -= 1;
+            index_info.num_cols = num_indexed_cols;
             SortableIndexKey {
                 key: record.key.clone(),
                 metadata: Arc::new(index_info),
@@ -3959,6 +3965,16 @@ pub(crate) struct GcDebugSnapshot {
     pub backfill_floor: WalPos,
 }
 
+/// One custom index's writer lease plus the commit timestamp of its last
+/// publication. See `MvStore::index_method_write_leases`.
+#[derive(Debug, Default)]
+struct IndexMethodWriteLease {
+    /// Transaction currently allowed to write the index, if any.
+    holder: Option<TxID>,
+    /// Commit timestamp of the last transaction that published this index.
+    last_publish_ts: Option<u64>,
+}
+
 /// A multi-version concurrency control database.
 #[derive(Debug)]
 pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator> {
@@ -4018,10 +4034,14 @@ pub struct MvStore<Clock: LogicalClock, A: ConcurrentAllocator = TursoAllocator>
     ///
     /// If there is no exclusive transaction, the field is set to `NO_EXCLUSIVE_TX`.
     exclusive_tx: AtomicU64,
-    /// Active custom-index writer leases keyed by the backing object's stable
-    /// MVCC table ID. Leases reject contention instead of waiting, so acquiring
-    /// several leases cannot deadlock.
-    index_method_write_leases: Mutex<HashMap<MVTableId, TxID>>,
+    /// Custom-index writer leases keyed by the backing object's stable MVCC
+    /// table ID. Leases reject contention instead of waiting, so acquiring
+    /// several leases cannot deadlock. Entries outlive their holder: each one
+    /// remembers when the index was last published, so a transaction whose
+    /// read snapshot predates that publication is refused — its rebuild of
+    /// the index state starts from a superseded base and committing it would
+    /// overwrite the newer publication.
+    index_method_write_leases: Mutex<HashMap<MVTableId, IndexMethodWriteLease>>,
     commit_coordinator: Arc<CommitCoordinator>,
     global_header: Arc<RwLock<Option<DatabaseHeader>>>,
     /// Held by checkpoints only during the brief in-memory publish phase; the I/O-heavy
@@ -6212,9 +6232,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
     /// Acquire a transaction-scoped custom-index writer lease.
     ///
-    /// Acquisition is reentrant for the owning transaction. Contention is an
-    /// eager write conflict so expensive index construction never starts for a
-    /// transaction that cannot publish its work.
+    /// Acquisition is reentrant for the owning transaction. Contention with a
+    /// live holder is `Busy` — the caller can retry once the holder finishes,
+    /// exactly what `busy_timeout` handles. A transaction whose read snapshot
+    /// predates the index's last publication gets `WriteWriteConflict`
+    /// instead: it would rebuild the index from a superseded base, and no
+    /// amount of retrying inside the same transaction can fix that.
     pub(crate) fn acquire_index_method_write_lease(
         &self,
         tx_id: TxID,
@@ -6224,21 +6247,44 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             return Err(LimboError::NoSuchTransactionID(tx_id.to_string()));
         }
 
+        let snapshot_ts = self.read_snapshot_ts(tx_id);
         let mut leases = self.index_method_write_leases.lock();
-        match leases.get(&index_id) {
-            Some(owner) if *owner == tx_id => Ok(()),
-            Some(_) => Err(LimboError::WriteWriteConflict),
+        let lease = leases.entry(index_id).or_default();
+        match lease.holder {
+            Some(owner) if owner == tx_id => Ok(()),
+            Some(_) => Err(LimboError::Busy),
             None => {
-                leases.insert(index_id, tx_id);
+                if lease
+                    .last_publish_ts
+                    .is_some_and(|publish_ts| publish_ts > snapshot_ts)
+                {
+                    return Err(LimboError::WriteWriteConflict);
+                }
+                lease.holder = Some(tx_id);
                 Ok(())
             }
         }
     }
 
     fn release_index_method_write_leases(&self, tx_id: TxID) {
-        self.index_method_write_leases
-            .lock()
-            .retain(|_, owner| *owner != tx_id);
+        // A committed holder published new index state: remember its commit
+        // timestamp so later writers with older snapshots are refused.
+        let committed_at =
+            self.txs
+                .get(&tx_id)
+                .and_then(|entry| match entry.value().state.load() {
+                    TransactionState::Committed(commit_ts) => Some(commit_ts),
+                    _ => None,
+                });
+        let mut leases = self.index_method_write_leases.lock();
+        for lease in leases.values_mut() {
+            if lease.holder == Some(tx_id) {
+                lease.holder = None;
+                if committed_at.is_some() {
+                    lease.last_publish_ts = committed_at;
+                }
+            }
+        }
     }
 
     #[turso_macros::allocation_site(crate::alloc::MvStoreAllocationSite::FinalizedTxStateInsert)]

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -622,6 +622,16 @@ fn translate_integrity_check_impl(
         program.preassign_label_to_next_insn(table_empty_label);
 
         for bound_index in &bound_indexes {
+            // An index method's backing B-tree stores its data in the index
+            // alone; the owning table has zero rows by construction, so the
+            // entry-count comparison below would report every healthy FTS
+            // database as corrupt. Its pages are still visited above.
+            if bound_index.index.is_backing_btree_index() {
+                program.emit_insn(Insn::Close {
+                    cursor_id: bound_index.cursor_id,
+                });
+                continue;
+            }
             if bound_index.where_expr.is_none() {
                 let actual_count_reg = program.alloc_register();
                 program.emit_insn(Insn::Count {

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -696,7 +696,7 @@ fn optimize_recursive_cte_query_with_cache(
 /// Transform MATCH expressions to fts_match() function calls.
 fn transform_match_to_fts_match(
     where_clause: &mut [WhereTerm],
-    schema: &Schema,
+    resolver: &Resolver,
     table_references: &TableReferences,
 ) -> Result<()> {
     use super::ast::{FunctionTail, LikeOperator, Name, TableInternalId};
@@ -711,7 +711,9 @@ fn transform_match_to_fts_match(
         }
     }
 
-    // Helper to check if a table has an FTS index by its internal ID
+    // Helper to check if a table has an FTS index by its internal ID.
+    // Resolve against the schema of the table's own database, so MATCH also
+    // plans against FTS indexes in ATTACHed databases.
     let table_has_fts_index = |table_id: TableInternalId| -> bool {
         table_references
             .joined_tables()
@@ -719,7 +721,10 @@ fn transform_match_to_fts_match(
             .find(|t| t.internal_id == table_id)
             .and_then(|t| {
                 if let Table::BTree(btree) = &t.table {
-                    Some(schema.has_fts_index(&btree.name))
+                    Some(
+                        resolver
+                            .with_schema(t.database_id, |schema| schema.has_fts_index(&btree.name)),
+                    )
                 } else {
                     None
                 }
@@ -975,7 +980,7 @@ fn find_select_plan_form(
     // A rewrite can move MATCH terms out of a subquery, so do this after the
     // query form has been chosen.
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
+    transform_match_to_fts_match(&mut plan.where_clause, resolver, &plan.table_references)?;
 
     // EXISTS only needs one row. Add LIMIT 1 to subqueries left after the
     // rewrite. The rewrite must see the limit written by the user, if any.
@@ -1145,7 +1150,7 @@ fn optimize_delete_plan(plan: &mut DeletePlan, resolver: &Resolver) -> Result<()
     let available_indexes =
         AvailableIndexes::for_table_references(resolver, &plan.table_references);
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &plan.table_references)?;
+    transform_match_to_fts_match(&mut plan.where_clause, resolver, &plan.table_references)?;
 
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
@@ -1194,7 +1199,7 @@ fn optimize_update_plan(
         plan.from_tables.outer_query_refs().to_vec(),
     );
     #[cfg(all(feature = "fts", not(target_family = "wasm")))]
-    transform_match_to_fts_match(&mut plan.where_clause, schema, &target_tables)?;
+    transform_match_to_fts_match(&mut plan.where_clause, resolver, &target_tables)?;
     lift_common_subexpressions_from_binary_or_terms(&mut plan.where_clause)?;
     if let ConstantConditionEliminationResult::ImpossibleCondition =
         eliminate_constant_conditions(&mut plan.where_clause)?

--- a/core/types.rs
+++ b/core/types.rs
@@ -2423,6 +2423,9 @@ impl IndexInfo {
     ) -> Result<Self, TryReserveError> {
         // A backing_btree stores the index method's complete opaque key. Unlike
         // an ordinary secondary index, it must not append the base-table rowid.
+        // MVCC's commit-time conflict validation handles these
+        // `has_rowid == false` records by treating the whole key as the
+        // uniqueness prefix (see `check_index_for_conflicts`).
         let has_rowid = index.has_rowid && !index.is_backing_btree_index();
         let key_info = index
             .columns
@@ -3374,6 +3377,11 @@ impl Cursor {
             Self::Pseudo(_) => {}
             // Permanently null; the flag is a no-op.
             Self::NullRow => {}
+            // The FTS side of an outer join: columns are decoded from the
+            // base-table cursor (which receives its own NullRow), never from
+            // the index-method cursor, so there is no column state to null
+            // out here.
+            Self::IndexMethod(_) => {}
             _ => {
                 mark_unlikely();
                 panic!("set_null_flag on unexpected cursor type");

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -758,7 +758,9 @@ pub fn op_null_row(
         turso_assert!(
             matches!(
                 cursor_type,
-                CursorType::BTreeTable(_) | CursorType::BTreeIndex(_)
+                CursorType::BTreeTable(_)
+                    | CursorType::BTreeIndex(_)
+                    | CursorType::IndexMethod(_)
             ),
             "NullRow on unopened non-btree cursor",
             { "cursor_id": cursor_id }
@@ -1192,17 +1194,19 @@ fn ensure_index_method_context(
     cursor_id: usize,
     database_id: usize,
     attachment: &dyn crate::index_method::IndexMethodAttachment,
-) -> Result<crate::index_method::IndexMethodContext> {
+) -> Result<Arc<crate::index_method::IndexMethodContext>> {
+    // Arc, not a deep clone: an opcode that yields on IO re-enters and calls
+    // this again — a cold FTS open does that hundreds of times per megabyte,
+    // and cloning the context's four heap strings each time adds up.
     if let Some(context) = state.index_method_contexts[cursor_id].as_ref() {
-        return Ok(context.clone());
+        return Ok(Arc::clone(context));
     }
-    let definition = attachment.definition();
-    let context = crate::index_method::IndexMethodContext::new(
+    let context = Arc::new(crate::index_method::IndexMethodContext::new(
         &program.connection,
         database_id,
-        &definition,
-    )?;
-    state.index_method_contexts[cursor_id] = Some(context.clone());
+        &attachment.definition(),
+    )?);
+    state.index_method_contexts[cursor_id] = Some(Arc::clone(&context));
     Ok(context)
 }
 
@@ -3430,6 +3434,7 @@ pub fn halt(
     description: &str,
     on_error: Option<ResolveType>,
 ) -> Result<InsnFunctionStepResult> {
+    state.halt_in_progress = true;
     let mv_store = program.connection.mv_store();
     let auto_commit = program.connection.auto_commit.load(Ordering::SeqCst);
     // halt() runs while the statement is still stepping, so it is always
@@ -3460,6 +3465,13 @@ pub fn halt(
     if let Some(resolve_type) = on_error {
         // RAISE(IGNORE) signals the parent to skip the current row
         if resolve_type == ResolveType::Ignore {
+            // RAISE(IGNORE) is not an error: the frame unwinds, but everything
+            // the trigger wrote before the RAISE is kept. Stage index-method
+            // writes now, exactly like the normal trigger-subprogram halt
+            // below, so the kept base rows keep their index entries too.
+            if program.is_trigger_subprogram() {
+                return_if_io!(index_method_prepare_statement_all(state));
+            }
             return Err(LimboError::RaiseIgnore);
         }
         if err_code > 0 {
@@ -3638,10 +3650,16 @@ pub fn halt(
             }
             result
         } else {
-            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
             // Another root statement may own the implicit autocommit
             // transaction. This statement can finish, but must not commit or
-            // roll back connection-level state it did not start.
+            // roll back connection-level state it did not start. Its
+            // index-method writes must still be staged before the statement
+            // savepoint is released, and its cursors handed to the connection
+            // so the sibling that eventually commits (or rolls back) the
+            // shared transaction delivers their outcome.
+            return_if_io!(index_method_prepare_statement_all(state));
+            state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
+            index_method_register_transaction_all(state, &program.connection)?;
             //
             // FIXME: when this statement is a writer in MVCC mode, deferring
             // its commit to the last sibling statement means the writer's
@@ -3796,6 +3814,12 @@ pub(crate) fn index_method_abort_statement_all(state: &mut ProgramState) {
             continue;
         };
         let Some(context) = state.index_method_contexts[cursor_id].as_ref() else {
+            // Every opcode that installs an index-method cursor builds its
+            // context first, so this cursor cannot have pending work.
+            debug_assert!(
+                false,
+                "index-method cursor {cursor_id} installed without a context"
+            );
             continue;
         };
         cursor.abort_statement(context);
@@ -3832,6 +3856,12 @@ pub(crate) fn index_method_transaction_committed_all(
             continue;
         };
         let Some(context) = state.index_method_contexts[cursor_id].as_ref() else {
+            // Every opcode that installs an index-method cursor builds its
+            // context first, so this cursor cannot have pending work.
+            debug_assert!(
+                false,
+                "index-method cursor {cursor_id} installed without a context"
+            );
             continue;
         };
         cursor.transaction_committed(context);
@@ -4928,12 +4958,13 @@ pub fn op_auto_commit(
         { "tx_op": tx_op }
     );
 
-    // For explicit COMMIT, flush pending writes before the actual commit
-    // so they are part of the same transaction. Sequence flush no longer
-    // belongs here — see the long-form comment in `op_halt` above.
-    if matches!(tx_op, TxOp::Commit) {
-        return_if_io!(index_method_prepare_statement_all(state));
-    }
+    // Index-method staging is a per-statement Halt responsibility (each
+    // statement stages its writes at its own halt and hands its cursors to
+    // the connection), so the COMMIT program has nothing to stage here. A
+    // yield point at this spot would also be unsafe: `conn.auto_commit` was
+    // already flipped above, and re-entering this opcode from the top after
+    // an IO yield would then fail `valid_transition` with a torn-down
+    // transaction.
 
     let res = match program
         .commit_txn(pager.clone(), state, mv_store.as_ref(), *rollback)
@@ -13202,23 +13233,25 @@ pub fn op_index_method_create(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
-        if program.connection.mv_store_for_db(*db).is_some() {
-            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
-        }
-        if state.cursors[*cursor_id].is_none() {
-            let cursor = module.init()?;
-            let cursor_ref = &mut state.cursors[*cursor_id];
-            *cursor_ref = Some(Cursor::IndexMethod(cursor));
-        }
-        let context =
-            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
-        let cursor = state.cursors[*cursor_id]
-            .as_mut()
-            .expect("cursor should exist");
-        let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.create(&context));
+    let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] else {
+        unreachable!("IndexMethodCreate emitted against a non-index-method cursor {cursor_id}");
+    };
+    if program.connection.mv_store_for_db(*db).is_some() {
+        crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
     }
+    // Build the context before installing the cursor: a context error must
+    // not leave a cursor in the slot with no context, a state the statement
+    // outcome helpers cannot deliver hooks to.
+    let context = ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+    if state.cursors[*cursor_id].is_none() {
+        let cursor = module.init()?;
+        state.cursors[*cursor_id] = Some(Cursor::IndexMethod(cursor));
+    }
+    let cursor = state.cursors[*cursor_id]
+        .as_mut()
+        .expect("cursor should exist")
+        .as_index_method_mut();
+    return_if_io!(cursor.create(&context));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13234,23 +13267,23 @@ pub fn op_index_method_destroy(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
-        if program.connection.mv_store_for_db(*db).is_some() {
-            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
-        }
-        if state.cursors[*cursor_id].is_none() {
-            let cursor = module.init()?;
-            let cursor_ref = &mut state.cursors[*cursor_id];
-            *cursor_ref = Some(Cursor::IndexMethod(cursor));
-        }
-        let context =
-            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
-        let cursor = state.cursors[*cursor_id]
-            .as_mut()
-            .expect("cursor should exist");
-        let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.destroy(&context));
+    let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) else {
+        unreachable!("IndexMethodDestroy emitted against a non-index-method cursor {cursor_id}");
+    };
+    if program.connection.mv_store_for_db(*db).is_some() {
+        crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
     }
+    // Context before cursor install; see op_index_method_create.
+    let context = ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+    if state.cursors[*cursor_id].is_none() {
+        let cursor = module.init()?;
+        state.cursors[*cursor_id] = Some(Cursor::IndexMethod(cursor));
+    }
+    let cursor = state.cursors[*cursor_id]
+        .as_mut()
+        .expect("cursor should exist")
+        .as_index_method_mut();
+    return_if_io!(cursor.destroy(&context));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13266,23 +13299,23 @@ pub fn op_index_method_optimize(
     if program.connection.is_readonly(*db) {
         return Err(LimboError::ReadOnly);
     }
-    if let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) {
-        if program.connection.mv_store_for_db(*db).is_some() {
-            crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
-        }
-        if state.cursors[*cursor_id].is_none() {
-            let cursor = module.init()?;
-            let cursor_ref = &mut state.cursors[*cursor_id];
-            *cursor_ref = Some(Cursor::IndexMethod(cursor));
-        }
-        let context =
-            ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
-        let cursor = state.cursors[*cursor_id]
-            .as_mut()
-            .expect("cursor should exist");
-        let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.optimize(&context));
+    let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) else {
+        unreachable!("IndexMethodOptimize emitted against a non-index-method cursor {cursor_id}");
+    };
+    if program.connection.mv_store_for_db(*db).is_some() {
+        crate::index_method::ensure_mvcc_support(&module.definition(), true)?;
     }
+    // Context before cursor install; see op_index_method_create.
+    let context = ensure_index_method_context(program, state, *cursor_id, *db, module.as_ref())?;
+    if state.cursors[*cursor_id].is_none() {
+        let cursor = module.init()?;
+        state.cursors[*cursor_id] = Some(Cursor::IndexMethod(cursor));
+    }
+    let cursor = state.cursors[*cursor_id]
+        .as_mut()
+        .expect("cursor should exist")
+        .as_index_method_mut();
+    return_if_io!(cursor.optimize(&context));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -782,13 +782,15 @@ pub struct ProgramState {
     pub(crate) cursors: Vec<Option<Cursor>>,
     /// Immutable execution/storage context captured when each index-method
     /// cursor is first opened for this statement.
-    pub(crate) index_method_contexts: Vec<Option<crate::index_method::IndexMethodContext>>,
+    pub(crate) index_method_contexts:
+        Vec<Option<std::sync::Arc<crate::index_method::IndexMethodContext>>>,
     /// Index-method cursors explicitly closed by bytecode after their
-    /// statement work was prepared. Retain them until commit/rollback decides
-    /// whether prepared in-memory state may be published.
+    /// statement work was prepared (CREATE INDEX closes its backfill cursor
+    /// this way). Retain them until commit/rollback decides whether prepared
+    /// in-memory state may be published.
     pub(crate) closed_index_method_cursors: Vec<(
         Box<dyn crate::index_method::IndexMethodCursor>,
-        crate::index_method::IndexMethodContext,
+        std::sync::Arc<crate::index_method::IndexMethodContext>,
     )>,
     /// Resumption coordinates for statement-level index-method finalization.
     pub(crate) index_method_finalize_cursor: usize,
@@ -869,6 +871,13 @@ pub struct ProgramState {
     /// Keep the error here while index-method writes from earlier rows finish
     /// through the normal resumable I/O path.
     pending_fail_prepare_error: Option<LimboError>,
+    /// True once the Halt opcode has started finishing the statement. The
+    /// statement's outcome is decided at that point, so an interrupt request
+    /// arriving during Halt's resumable work (staging index-method writes,
+    /// committing the rows FAIL keeps) must not preempt it — it would replace
+    /// the promised outcome and drop staged work. The connection-level flag
+    /// stays set and clears once no root statement is active.
+    pub(crate) halt_in_progress: bool,
     /// Pending CDC info to apply after the program completes successfully.
     /// Set by InitCdcVersion opcode, applied at Halt/Done so that if the
     /// transaction rolls back, the connection's CDC state remains unchanged.
@@ -970,6 +979,7 @@ impl ProgramState {
             explain_state: RwLock::new(ExplainState::default()),
             pending_fail_error: None,
             pending_fail_prepare_error: None,
+            halt_in_progress: false,
             pending_cdc_info: None,
             subprogram_stmt_cache: HashMap::default(),
         }
@@ -1119,6 +1129,7 @@ impl ProgramState {
         *self.explain_state.write() = ExplainState::default();
         self.pending_fail_error = None;
         self.pending_fail_prepare_error = None;
+        self.halt_in_progress = false;
         self.pending_cdc_info = None;
         self.subprogram_stmt_cache.clear();
     }
@@ -1705,6 +1716,13 @@ impl Program {
     where
         I: crate::IO + ?Sized,
     {
+        // Once Halt has started finishing the statement, its outcome is
+        // decided; an interrupt (or deadline, or progress handler) must not
+        // preempt the remaining resumable finalization work. A request that
+        // arrived before Halt began still interrupts as usual.
+        if state.halt_in_progress && !state.is_interrupted() {
+            return false;
+        }
         let connection_interrupt = self.connection.is_interrupted();
         let hit_query_deadline = state
             .query_deadline
@@ -2800,7 +2818,21 @@ impl Program {
         // nested helper statements whose drop releases nested guards. Drop
         // them before the `is_nested_stmt()` check below for the same reason.
         state.close_virtual_table_cursors();
-        if err.is_some() || state.execution_state.is_running() {
+        // RAISE(IGNORE) rolls nothing back — halt() already staged the
+        // trigger's index-method writes and the kept rows keep their index
+        // entries — so it must not discard staged index-method work here.
+        // FAIL-class errors likewise keep the changes made before the error:
+        // their index-method writes were staged by the interception in
+        // `program_step` before abort() was called (and, on the autocommit
+        // path, already committed by halt()), so discarding cursor state here
+        // would deliver a rollback outcome for work that commits below.
+        let keeps_prior_changes = match err {
+            Some(LimboError::RaiseIgnore) => true,
+            Some(LimboError::Raise(ResolveType::Fail, _)) => true,
+            Some(LimboError::Constraint(_)) => self.resolve_type == ResolveType::Fail,
+            _ => false,
+        };
+        if (err.is_some() || state.execution_state.is_running()) && !keeps_prior_changes {
             execute::index_method_abort_statement_all(state);
         }
 
@@ -2980,6 +3012,10 @@ impl Program {
                             if can_autocommit_now {
                                 // Autocommit FAIL: commit partial changes.
                                 // This matches halt()'s FAIL+autocommit path.
+                                // Index-method writes were already staged by
+                                // the FAIL interception in `program_step`
+                                // (the resumable path) before abort() ran, so
+                                // there is nothing left to stage here.
                                 let mv_store = self.connection.mv_store();
                                 if let Err(e) = execute::vtab_commit_all(&self.connection) {
                                     capture_abort_error(
@@ -2988,28 +3024,7 @@ impl Program {
                                         "vtab_commit_all failed during FAIL abort",
                                     );
                                 }
-                                match execute::index_method_prepare_statement_all(state) {
-                                    Ok(IOResult::Done(())) => {}
-                                    Ok(IOResult::IO(io)) => {
-                                        io.abort();
-                                        capture_abort_error(
-                                            &mut abort_error,
-                                            LimboError::InternalError(
-                                                "FAIL cleanup reached asynchronous index-method \
-                                                 finalization outside the resumable Halt path"
-                                                    .to_string(),
-                                            ),
-                                            "index-method finalization yielded during FAIL abort",
-                                        );
-                                    }
-                                    Err(e) => {
-                                        capture_abort_error(
-                                            &mut abort_error,
-                                            e,
-                                            "index-method finalization failed during FAIL abort",
-                                        );
-                                    }
-                                }
+                                let mut committed = false;
                                 loop {
                                     match self.commit_txn(
                                         pager.clone(),
@@ -3017,7 +3032,10 @@ impl Program {
                                         mv_store.as_ref(),
                                         false,
                                     ) {
-                                        Ok(IOResult::Done(_)) => break,
+                                        Ok(IOResult::Done(_)) => {
+                                            committed = true;
+                                            break;
+                                        }
                                         Ok(IOResult::IO(io)) => {
                                             if let Err(e) = io.wait(pager.io.as_ref()) {
                                                 capture_abort_error(
@@ -3037,6 +3055,20 @@ impl Program {
                                             break;
                                         }
                                     }
+                                }
+                                // Deliver the committed outcome exactly once.
+                                // For a plain constraint error with FAIL
+                                // resolution, halt() already committed and
+                                // delivered it before returning the error;
+                                // only the trigger RAISE(FAIL) shape reaches
+                                // the commit through this arm.
+                                let halt_already_delivered =
+                                    matches!(err, Some(LimboError::Constraint(_)));
+                                if committed && !halt_already_delivered {
+                                    execute::index_method_transaction_committed_all(
+                                        state,
+                                        &self.connection,
+                                    );
                                 }
                             }
                         }

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -1613,3 +1613,165 @@ fn test_mvcc_completed_writer_changes_lost_when_joining_writer_errors() {
         "pins the deferred-commit gap: a failing joined writer discards the completed writer's row"
     );
 }
+
+#[cfg(feature = "fts")]
+fn open_fts_mvcc_db(path: &str) -> (Arc<Database>, Arc<Connection>, Arc<Connection>) {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io,
+        path,
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    let observer = db.connect().unwrap();
+    (db, conn, observer)
+}
+
+/// A writer that finishes while a sibling statement holds the shared implicit
+/// MVCC transaction open defers its commit to the last sibling (see
+/// test_completed_writer_waits_for_sibling_mvcc_reader_to_commit). Its FTS
+/// writes must be deferred with it: once the base row commits, the document
+/// must be searchable. The deferred halt path must stage the writer's
+/// index-method work or hand its cursor to the connection — otherwise the
+/// pending documents die with the statement and the base row commits without
+/// its index entries.
+#[cfg(feature = "fts")]
+#[test]
+fn fts_writes_survive_deferred_shared_autocommit() {
+    let (_db, conn, observer) = open_fts_mvcc_db(":memory:fts-deferred-shared-autocommit");
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (10, 'existing seed')")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let mut reader = conn.prepare("SELECT id FROM docs ORDER BY id").unwrap();
+    assert_eq!(step_returning_id(&mut reader), 10);
+
+    let mut writer = conn
+        .prepare("INSERT INTO docs VALUES (1, 'deferred needle') RETURNING id")
+        .unwrap();
+    assert_eq!(step_returning_id(&mut writer), 1);
+    finish_without_rows(&mut writer);
+    drop(writer);
+
+    finish_without_rows(&mut reader);
+    drop(reader);
+
+    assert_eq!(
+        ids_from_query(&observer, "SELECT id FROM docs ORDER BY id"),
+        vec![1, 10],
+        "the last sibling statement commits the completed writer's base row"
+    );
+    assert_eq!(
+        ids_from_query(
+            &observer,
+            "SELECT id FROM docs WHERE fts_match(body, 'needle')"
+        ),
+        vec![1],
+        "the FTS document must commit together with its base row"
+    );
+}
+
+/// Dropping a connection mid-transaction is how the engine recovers when an
+/// application abandons its handle (e.g. after a panic): Connection::drop
+/// rolls the transaction back and releases its locks and leases. A
+/// transaction-owned index-method cursor registered on the connection holds a
+/// context whose Arc points back at that same connection, and the cycle must
+/// not keep the connection alive — otherwise the drop recovery never runs,
+/// the MVCC transaction stays active, and its FTS write lease blocks every
+/// other writer forever.
+#[cfg(feature = "fts")]
+#[test]
+fn dropping_connection_mid_transaction_releases_its_fts_write_lease() {
+    let (_db, conn, observer) = open_fts_mvcc_db(":memory:fts-conn-drop-mid-tx");
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'abandoned mid transaction')")
+        .unwrap();
+
+    let weak = Arc::downgrade(&conn);
+    drop(conn);
+
+    observer
+        .execute("INSERT INTO docs VALUES (2, 'after the drop')")
+        .expect("dropping the writing connection must release its FTS write lease");
+    assert!(
+        weak.upgrade().is_none(),
+        "a dropped connection must be freed; a registered index-method cursor must not keep it alive"
+    );
+}
+
+/// INSERT OR FAIL keeps the rows changed before the failing one. The
+/// constraint error is parked while the kept rows' index-method writes are
+/// staged; an interrupt request arriving in that window must not replace the
+/// statement's outcome and roll back the rows FAIL promised to keep.
+#[cfg(feature = "fts")]
+#[test]
+fn interrupt_during_fail_staging_keeps_fail_outcome() {
+    use crate::index_method::IndexMethodYieldPoint;
+
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        ":memory:fts-interrupt-during-fail",
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    conn.set_yield_injector(Some(FixedYieldInjector::new([
+        IndexMethodYieldPoint::AfterPrepareStatement.point(),
+    ])));
+    let mut insert = conn
+        .prepare("INSERT OR FAIL INTO docs VALUES (1, 'kept row'), (1, 'duplicate')")
+        .unwrap();
+    expect_injected_yield(&mut insert, "OR FAIL index-method staging");
+    conn.set_yield_injector(None);
+
+    // The statement is suspended between staging the kept row's FTS writes
+    // and surfacing the parked constraint error.
+    conn.interrupt();
+
+    let err = loop {
+        match insert.step() {
+            Err(err) => break err,
+            Ok(StepResult::IO) => io.step().unwrap(),
+            Ok(other) => panic!("OR FAIL must surface its constraint error, got {other:?}"),
+        }
+    };
+    assert!(
+        matches!(err, LimboError::Constraint(_)),
+        "expected the parked constraint error, got {err:?}"
+    );
+    drop(insert);
+
+    assert_eq!(
+        ids_from_query(&conn, "SELECT id FROM docs ORDER BY id"),
+        vec![1],
+        "OR FAIL keeps rows changed before the failure"
+    );
+    assert_eq!(
+        ids_from_query(&conn, "SELECT id FROM docs WHERE fts_match(body, 'kept')"),
+        vec![1],
+        "the kept row's FTS document must survive the interrupt request"
+    );
+}

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -404,6 +404,63 @@ fn test_attach_inherits_index_method_flag_on_reattach(_tmp_db: TempDatabase) -> 
     Ok(())
 }
 
+/// Statements on an attached database never set the connection-level write
+/// transaction state, so an attached FTS write can pick up the connection's
+/// cached read state from an earlier query instead of loading writer state.
+/// The write must still reach the backing B-tree: a document inserted after a
+/// warm read has to be findable. The writing connection has no retained FTS
+/// writer of its own (another connection did the earlier write), which is
+/// what routes its open_write through the cached read state.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test]
+fn test_attached_fts_insert_after_warm_read_is_searchable(
+    _tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let db = attach_enabled_db(DatabaseOpts::new().with_index_method(true));
+    let seeder = db.connect_limbo();
+
+    let aux_path = db.path.with_extension("attached_fts_warm_read.db");
+    seeder.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    seeder.execute("CREATE TABLE aux.docs(id INTEGER PRIMARY KEY, content TEXT)")?;
+    seeder.execute("CREATE INDEX aux.docs_fts ON docs USING fts(content)")?;
+    seeder.execute("INSERT INTO aux.docs VALUES (1, 'hello world')")?;
+
+    let conn = db.connect_limbo();
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+
+    // Warm this connection's cached FTS read state for the attached index.
+    let warm: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'hello')");
+    assert_eq!(warm, vec![(1,)]);
+
+    conn.execute("INSERT INTO aux.docs VALUES (2, 'fresh needle')")?;
+
+    let fresh: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'needle')");
+    assert_eq!(
+        fresh,
+        vec![(2,)],
+        "a document inserted after a warm FTS read must be searchable"
+    );
+    let still_there: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'hello')");
+    assert_eq!(still_there, vec![(1,)]);
+
+    // The document must also have been persisted, not merely retained in
+    // this connection's in-memory caches.
+    conn.execute("DETACH aux")?;
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+    let reopened: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'needle')");
+    assert_eq!(
+        reopened,
+        vec![(2,)],
+        "the document inserted after a warm FTS read must survive reattach"
+    );
+
+    Ok(())
+}
+
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
 #[turso_macros::test]
 fn test_attached_mvcc_fts_uses_attached_store(_tmp_db: TempDatabase) -> anyhow::Result<()> {
@@ -426,6 +483,12 @@ fn test_attached_mvcc_fts_uses_attached_store(_tmp_db: TempDatabase) -> anyhow::
     let committed: Vec<(i64,)> =
         conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'committed')");
     assert_eq!(committed, vec![(1,)]);
+    // The MATCH operator spelling must plan against the attached database's
+    // FTS index too (it used to be rejected because the planner resolved the
+    // index against the main schema only).
+    let committed_match: Vec<(i64,)> =
+        conn.exec_rows("SELECT id FROM aux.docs WHERE content MATCH 'committed'");
+    assert_eq!(committed_match, vec![(1,)]);
     let rolled_back: Vec<(i64,)> =
         conn.exec_rows("SELECT id FROM aux.docs WHERE fts_match(content, 'rolledback')");
     assert!(rolled_back.is_empty());

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -2098,6 +2098,116 @@ fn test_fts_mvcc_lifecycle(tmp_db: TempDatabase) {
     );
 }
 
+/// A connection handle dropped mid-transaction with a parked FTS cursor used
+/// to keep itself alive forever: the cursor's context held a strong
+/// `Arc<Connection>`, so the connection referenced itself, its `Drop` never
+/// ran, and its WAL write lock was never released — every later writer got
+/// Busy until the process died.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_dropped_connection_mid_transaction_releases_locks(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'hello')")
+        .unwrap();
+
+    // Drop the handle with no COMMIT / ROLLBACK / close().
+    let weak = std::sync::Arc::downgrade(&conn);
+    drop(conn);
+    assert_eq!(
+        weak.strong_count(),
+        0,
+        "dropping the handle must actually drop the connection"
+    );
+
+    // A fresh connection must be able to write; the dropped transaction's
+    // row must be gone.
+    let fresh = tmp_db.connect_limbo();
+    fresh
+        .execute("INSERT INTO docs VALUES (2, 'world')")
+        .unwrap();
+    assert!(
+        limbo_exec_rows(&fresh, "SELECT id FROM docs WHERE fts_match(body, 'hello')").is_empty()
+    );
+    assert_eq!(
+        limbo_exec_rows(&fresh, "SELECT id FROM docs WHERE fts_match(body, 'world')"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+/// One statement driving two FTS write cursors over the same index — here a
+/// trigger inserting into the table it fired on — used to let both cursors
+/// flush divergent Tantivy directories over one backing store, killing the
+/// index on disk permanently (every later read returned Corrupt). The second
+/// writer must be refused, the statement must roll back atomically, and the
+/// index must stay fully usable.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_second_write_cursor_in_one_statement_fails_cleanly(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE t(a TEXT)").unwrap();
+    conn.execute("CREATE INDEX ft ON t USING fts(a)").unwrap();
+    conn.execute(
+        "CREATE TRIGGER tr AFTER INSERT ON t WHEN NEW.a <> 'stop' BEGIN \
+         INSERT INTO t VALUES('stop'); END",
+    )
+    .unwrap();
+
+    // The trigger's INSERT opens a second write cursor on the same FTS index
+    // while the firing statement's writer is still open. It must fail...
+    assert!(conn.execute("INSERT INTO t VALUES ('go')").is_err());
+    // ...and the whole statement must roll back, keeping table and index in
+    // sync (previously the base row committed and the index died on disk).
+    assert!(limbo_exec_rows(&conn, "SELECT rowid FROM t").is_empty());
+
+    // The index must stay healthy and writable afterwards.
+    conn.execute("DROP TRIGGER tr").unwrap();
+    conn.execute("INSERT INTO t VALUES ('after')").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT a FROM t WHERE fts_match(a, 'after')"),
+        vec![vec![rusqlite::types::Value::Text("after".to_string())]]
+    );
+}
+
+/// Regression test: a write cursor that hits the shared read cache must not
+/// adopt the cached Tantivy `Index`, whose directory belongs to the cache
+/// entry — its writes would land in the cache entry's pending map and never
+/// reach the backing B-tree. On a TEMP (or ATTACHed) database the
+/// `is_in_write_tx()` guard is false, so a read followed by a write used to
+/// lose every later FTS write silently.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_temp_db_write_after_cached_read_reaches_index(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TEMP TABLE t(a TEXT)").unwrap();
+    conn.execute("CREATE INDEX temp.ft ON t USING fts(a)")
+        .unwrap();
+    // Warm the read cache for the TEMP database before any write.
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT rowid FROM t WHERE fts_match(a, 'alpha')"),
+        Vec::<Vec<rusqlite::types::Value>>::new()
+    );
+
+    conn.execute("INSERT INTO t VALUES ('alpha')").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT rowid FROM t WHERE fts_match(a, 'alpha')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+
+    conn.execute("DELETE FROM t WHERE rowid = 1").unwrap();
+    // The deleted row must not come back as a phantom from a stale index.
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT rowid FROM t WHERE fts_match(a, 'alpha')"),
+        Vec::<Vec<rusqlite::types::Value>>::new()
+    );
+}
+
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
 #[turso_macros::test(mvcc)]
 fn fts_trigger_writes_survive_repeated_subprogram_runs(tmp_db: TempDatabase) {
@@ -2127,6 +2237,77 @@ fn fts_trigger_writes_survive_repeated_subprogram_runs(tmp_db: TempDatabase) {
             vec![rusqlite::types::Value::Integer(1)],
             vec![rusqlite::types::Value::Integer(2)],
         ]
+    );
+}
+
+/// RAISE(IGNORE) is not an error: everything the trigger wrote before the
+/// RAISE is kept. The trigger's FTS writes used to be discarded while its base
+/// rows survived, leaving the table and index permanently out of sync in both
+/// directions (missing entry after an INSERT, phantom entry after a DELETE).
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_raise_ignore_keeps_trigger_writes_in_index(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("CREATE TABLE src(v INTEGER)").unwrap();
+    conn.execute(
+        "CREATE TRIGGER tr BEFORE INSERT ON src BEGIN \
+         INSERT INTO docs VALUES(NEW.v, 'ignoredrow'); \
+         SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+
+    conn.execute("INSERT INTO src VALUES (1)").unwrap();
+
+    // The trigger's row is kept, and so must its index entry be.
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs ORDER BY id"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'ignoredrow')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+}
+
+/// The DELETE direction of the RAISE(IGNORE) divergence: a row deleted by the
+/// trigger must not come back as a phantom from a stale index entry.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[turso_macros::test(mvcc)]
+fn fts_raise_ignore_keeps_trigger_deletes_in_index(tmp_db: TempDatabase) {
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'orphanword')")
+        .unwrap();
+    conn.execute("CREATE TABLE src(v INTEGER)").unwrap();
+    conn.execute(
+        "CREATE TRIGGER tr BEFORE INSERT ON src BEGIN \
+         DELETE FROM docs WHERE id = 1; \
+         SELECT RAISE(IGNORE); END",
+    )
+    .unwrap();
+
+    conn.execute("INSERT INTO src VALUES (1)").unwrap();
+
+    assert!(limbo_exec_rows(&conn, "SELECT id FROM docs").is_empty());
+    assert!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT id FROM docs WHERE fts_match(body, 'orphanword')"
+        )
+        .is_empty(),
+        "the deleted row must not survive as a phantom index entry"
     );
 }
 
@@ -2295,13 +2476,12 @@ fn test_fts_mvcc_same_index_writer_conflicts_before_tantivy_work() {
         .unwrap();
     let stats_before_conflict = fts_attachment_test_stats(&tmp_db, &first, "docs", "docs_fts");
 
+    // Contention with the live lease holder is Busy — retryable, without
+    // rolling back the loser's transaction or its unrelated work.
     let conflict = second
         .execute("INSERT INTO docs VALUES (2, 'writer two')")
         .unwrap_err();
-    assert!(matches!(
-        conflict,
-        turso_core::LimboError::WriteWriteConflict
-    ));
+    assert!(matches!(conflict, turso_core::LimboError::Busy));
     let stats_after_conflict = fts_attachment_test_stats(&tmp_db, &first, "docs", "docs_fts");
     assert_eq!(
         stats_after_conflict.tantivy_writer_constructions,
@@ -2316,6 +2496,16 @@ fn test_fts_mvcc_same_index_writer_conflicts_before_tantivy_work() {
     );
 
     first.execute("COMMIT").unwrap();
+
+    // The loser's snapshot now predates the winner's publication, so retrying
+    // inside the same transaction is a write-write conflict: committing its
+    // rebuild of the index would overwrite the winner's. The transaction is
+    // rolled back.
+    let stale = second
+        .execute("INSERT INTO docs VALUES (2, 'writer two')")
+        .unwrap_err();
+    assert!(matches!(stale, turso_core::LimboError::WriteWriteConflict));
+
     second.execute("BEGIN CONCURRENT").unwrap();
     second
         .execute("INSERT INTO docs VALUES (2, 'writer two retry')")
@@ -2339,6 +2529,65 @@ fn test_fts_mvcc_same_index_writer_conflicts_before_tantivy_work() {
             vec![rusqlite::types::Value::Integer(2)],
         ]
     );
+}
+
+/// Two overlapping BEGIN CONCURRENT writers used to both publish: the lease
+/// was freed when the first writer committed, so the second — still on its
+/// pre-commit snapshot — rewrote the Tantivy directory from a superseded base.
+/// The backing store ended up holding the union of two divergent directories,
+/// making the index unreadable and the base table unwritable, permanently.
+/// With chunk rows checkpointed into the B-tree (threshold 0), MVCC row
+/// validation cannot catch this, so the lease itself must: a writer whose
+/// snapshot predates the last publication is refused.
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn test_fts_mvcc_stale_snapshot_writer_is_refused_after_checkpoint() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let first = tmp_db.connect_limbo();
+    let second = tmp_db.connect_limbo();
+
+    first
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    first
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    first
+        .execute("CREATE INDEX ft ON t USING fts (body)")
+        .unwrap();
+
+    first.execute("BEGIN CONCURRENT").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    first.execute("INSERT INTO t VALUES (1, 'alpha')").unwrap();
+    first.execute("COMMIT").unwrap();
+
+    // `second` began before `first` published, so its rebuild of the index
+    // would start from a superseded base. It must be refused — previously it
+    // silently succeeded and corrupted the index on disk.
+    let stale = second
+        .execute("INSERT INTO t VALUES (2, 'beta')")
+        .unwrap_err();
+    assert!(matches!(stale, turso_core::LimboError::WriteWriteConflict));
+
+    // A fresh transaction sees the publication and works; the index must be
+    // readable and the base table writable.
+    second.execute("BEGIN CONCURRENT").unwrap();
+    second.execute("INSERT INTO t VALUES (2, 'beta')").unwrap();
+    second.execute("COMMIT").unwrap();
+
+    let third = tmp_db.connect_limbo();
+    assert_eq!(
+        limbo_exec_rows(&third, "SELECT id FROM t WHERE fts_match(body, 'alpha')"),
+        vec![vec![rusqlite::types::Value::Integer(1)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(&third, "SELECT id FROM t WHERE fts_match(body, 'beta')"),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+    third.execute("INSERT INTO t VALUES (3, 'gamma')").unwrap();
 }
 
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
@@ -2425,14 +2674,26 @@ fn test_fts_mvcc_opposite_index_order_rejects_without_deadlock() {
         .execute("INSERT INTO b VALUES (2, 'survives')")
         .unwrap();
 
+    // Opposite-order lease acquisition cannot deadlock: contention is an
+    // immediate Busy, and neither transaction is destroyed.
     let conflict = first
         .execute("INSERT INTO b VALUES (1, 'rolled back')")
         .unwrap_err();
-    assert!(matches!(
-        conflict,
-        turso_core::LimboError::WriteWriteConflict
-    ));
+    assert!(matches!(conflict, turso_core::LimboError::Busy));
+    let conflict = second
+        .execute("INSERT INTO a VALUES (2, 'survives')")
+        .unwrap_err();
+    assert!(matches!(conflict, turso_core::LimboError::Busy));
 
+    // Both sides back off (a write statement abandoned on Busy leaves its
+    // transaction commit-poisoned); a fresh transaction then takes the freed
+    // leases. Neither original transaction published, so nothing is stale.
+    first.execute("ROLLBACK").unwrap();
+    second.execute("ROLLBACK").unwrap();
+    second.execute("BEGIN CONCURRENT").unwrap();
+    second
+        .execute("INSERT INTO b VALUES (2, 'survives')")
+        .unwrap();
     second
         .execute("INSERT INTO a VALUES (2, 'survives')")
         .unwrap();
@@ -2488,15 +2749,18 @@ fn test_fts_mvcc_savepoint_rollback_keeps_transaction_lease() {
     first.execute("ROLLBACK TO pending_write").unwrap();
 
     second.execute("BEGIN CONCURRENT").unwrap();
+    // The savepoint rollback must not release the transaction's lease, so a
+    // concurrent writer still sees it held (Busy, retryable).
     let conflict = second
         .execute("INSERT INTO docs VALUES (2, 'blocked writer')")
         .unwrap_err();
-    assert!(matches!(
-        conflict,
-        turso_core::LimboError::WriteWriteConflict
-    ));
+    assert!(matches!(conflict, turso_core::LimboError::Busy));
 
+    // `first` never published, so a retry from a fresh transaction succeeds
+    // (the Busy write statement was abandoned, which poisons the commit of
+    // `second`'s original transaction).
     first.execute("ROLLBACK").unwrap();
+    second.execute("ROLLBACK").unwrap();
     second.execute("BEGIN CONCURRENT").unwrap();
     second
         .execute("INSERT INTO docs VALUES (2, 'successful retry')")
@@ -3800,13 +4064,13 @@ fn fts_mvcc_loser_rollback_keeps_winner_cached_writer() {
         "the winner's statement must retain its transaction-tagged writer"
     );
 
+    // Contention with a live lease holder is Busy: retryable, and it does
+    // not destroy the loser's transaction.
     let conflict = loser
         .execute("INSERT INTO docs VALUES (2, 'loser writer')")
         .unwrap_err();
-    assert!(matches!(
-        conflict,
-        turso_core::LimboError::WriteWriteConflict
-    ));
+    assert!(matches!(conflict, turso_core::LimboError::Busy));
+    loser.execute("ROLLBACK").unwrap();
 
     let after_conflict = fts_attachment_test_stats(&tmp_db, &winner, "docs", "docs_fts");
     assert_eq!(
@@ -3834,8 +4098,8 @@ fn fts_mvcc_loser_rollback_keeps_winner_cached_writer() {
     );
     winner.execute("COMMIT").unwrap();
 
-    // The conflict rolled back the loser's whole transaction; a retry from a
-    // fresh transaction succeeds.
+    // A retry from a fresh transaction, whose snapshot includes the winner's
+    // publication, succeeds.
     loser.execute("BEGIN CONCURRENT").unwrap();
     loser
         .execute("INSERT INTO docs VALUES (2, 'loser retry writer')")
@@ -4089,8 +4353,11 @@ fn fts_mvcc_reuses_snapshot_within_one_read_transaction() {
         after_second.full_snapshot_loads, after_first.full_snapshot_loads,
         "the second read in one MVCC transaction must not rescan the directory"
     );
+    // The stats probe itself opens a read cursor and scores one cache hit, so
+    // require two: the probe's and the SELECT under test's. A plain `>` would
+    // pass even with the SELECT deleted.
     assert!(
-        after_second.read_cache_hits > after_first.read_cache_hits,
+        after_second.read_cache_hits.unwrap() >= after_first.read_cache_hits.unwrap() + 2,
         "the second read must use the transaction-bound snapshot cache"
     );
 }
@@ -4227,6 +4494,14 @@ fn fts_manifest_generation_invalidates_stale_snapshot_once() {
     assert!(
         after_write.full_snapshot_loads > before_write.full_snapshot_loads,
         "the first reader of a new generation must load its directory snapshot"
+    );
+    // Pins that the SELECT — not the stats probe — performed the reload: the
+    // probe after a successful reload scores a cache hit, while a probe that
+    // had to do the reload itself would not. Without this, deleting the
+    // SELECT above still satisfies the two counter assertions.
+    assert!(
+        after_write.read_cache_hits > before_write.read_cache_hits,
+        "the stats probe after the reload must hit the refreshed cache"
     );
 
     assert_eq!(
@@ -4384,6 +4659,67 @@ fn fts_read_cache_is_connection_local_and_bounded() {
 
 /// Unordered MATCH cursors stream from Tantivy. UPDATE and DELETE must first
 /// collect their rowids so index maintenance cannot perturb the active scorer.
+/// Regression test: under MVCC, an autocommit write that runs while a sibling
+/// root statement is still open cannot commit at its own halt — it joins the
+/// shared implicit transaction. That halt exit used to release the statement
+/// savepoint without staging the FTS documents or handing the cursor to the
+/// connection, so the base row committed while its index entry was silently
+/// dropped (and the cursor's Drop tripped a debug assert).
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn fts_mvcc_deferred_autocommit_write_keeps_index_entries() {
+    let tmp_db = TempDatabase::builder()
+        .with_mvcc(true)
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("INSERT INTO docs VALUES (1, 'alpha')")
+        .unwrap();
+
+    // Statement A: step to the first row and hold it open.
+    let mut reader = conn.prepare("SELECT id FROM docs").unwrap();
+    loop {
+        match reader.step().unwrap() {
+            turso_core::StepResult::Row => break,
+            turso_core::StepResult::IO => reader.get_pager().io.step().unwrap(),
+            other => panic!("expected a row from the held-open reader, got {other:?}"),
+        }
+    }
+
+    // Statement B on the same connection: its halt defers the commit to the
+    // shared implicit transaction that statement A still holds open.
+    conn.execute("INSERT INTO docs VALUES (2, 'bravo')")
+        .unwrap();
+
+    // Finish statement A so the shared transaction commits.
+    loop {
+        match reader.step().unwrap() {
+            turso_core::StepResult::Row => {}
+            turso_core::StepResult::IO => reader.get_pager().io.step().unwrap(),
+            turso_core::StepResult::Done => break,
+            other => panic!("expected the reader to finish, got {other:?}"),
+        }
+    }
+    drop(reader);
+
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs ORDER BY id"),
+        vec![
+            vec![rusqlite::types::Value::Integer(1)],
+            vec![rusqlite::types::Value::Integer(2)],
+        ]
+    );
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'bravo')"),
+        vec![vec![rusqlite::types::Value::Integer(2)]],
+        "the deferred autocommit write must keep its FTS index entry"
+    );
+}
+
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
 #[test]
 fn fts_streaming_dml_collects_stable_rowids() {


### PR DESCRIPTION
This PR has fixes for the current MVCC design introduced in the above stacked PR

### Fixes

- **Planner: MATCH only resolved FTS indexes in the main schema.** A `MATCH` against a table in an attached database silently fell back to a full scan instead of using its FTS index. The optimizer now resolves index methods against the owning database's schema.

- **`integrity_check` reported healthy FTS databases as corrupt.** An index method's backing B-tree holds its data in the index alone, the owning table has zero rows by construction so the entry-count comparison flagged every backing tree. The backing tree's pages are still visited for structural verification; only the count comparison is skipped.

- **`.dump` replayed internal backing tables.** Backing objects use reserved names that are rejected on restore, so a dump of an FTS database could not be re-imported. The CLI now skips them the way it skips other internal objects.

- **A parked index-method cursor kept its connection alive.** Cursors parked on the connection until transaction outcome held a strong `Arc<Connection>` through `MvccLazyCursor`, so dropping the last user handle leaked the connection. The cursor now holds a `Weak` reference.

- **Dropped connection handles now roll back parked cursors.** A handle dropped mid-transaction rolls the transaction back, and parked index-method cursors now receive the same rollback outcome they would get from an explicit `close()` — previously they never learned the transaction's fate. Cursor parking also settles the outcome protocol: only the newest cursor per attachment receives the final commit/rollback callback; a cursor replaced by a later statement is closed immediately.

- **Stricter same-index MVCC writer serialization**, and retained FTS state is now finalized on the trigger and `ON CONFLICT FAIL` paths, which previously skipped statement finalization.

The lifecycle bookkeeping adds a fast path for the common case: connections that never touch an index method skip the parked-cursor mutex and sort entirely (one atomic check per commit/rollback).

A note for reviewers of the stack: the `fts.rs` portions of this diff are transitional and are superseded by the segment-registry redesign in the next PR (`stack/05`); the engine and planner fixes above are the durable content.