### PR TITLE
build: stop clippy from clobbering cargo check caches, trim core check graph

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,17 @@
 [env]
 LIBSQLITE3_FLAGS = "-DSQLITE_ENABLE_MATH_FUNCTIONS" # necessary for rusqlite dependency in order to bundle SQLite with math functions included
 
+[alias]
+# Clippy and `cargo check` share the same fingerprint files, but clippy stamps
+# them with its own driver. Running one after the other therefore rebuilds every
+# workspace crate from scratch each time (turso_core alone is ~25s of that).
+# `cargo lint` runs the exact clippy invocation CI uses, but under the `clippy`
+# profile (see [profile.clippy] in Cargo.toml) so its artifacts live in
+# target/clippy/ and never invalidate the `cargo check`/`cargo build` caches.
+# Note: extra args land after the final `--`, so pass them to clippy directly
+# (with `--profile clippy`) if you need to lint a single package.
+lint = "clippy --workspace --all-features --all-targets --profile clippy -- --deny=warnings"
+
 [build]
 # turso-sync package uses tokio_unstable to seed LocalRuntime and make it deterministic
 # unfortunately, cargo commands invoked from workspace root didn't capture config.toml from dependent crate

--- a/.github/workflows/codspeed-memory.yml
+++ b/.github/workflows/codspeed-memory.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-rust-toolchain
         with:
-          toolchain: "1.88.0"
+          toolchain: "1.98.0"
 
       - name: Setup mold linker
         uses: rui314/setup-mold@v1
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-rust-toolchain
         with:
-          toolchain: "1.88.0"
+          toolchain: "1.98.0"
 
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-rust-toolchain
         with:
-          toolchain: "1.88.0"
+          toolchain: "1.98.0"
 
       - name: Resolve benchmark shards
         id: benchmarks
@@ -71,7 +71,7 @@ jobs:
       built: ${{ steps.build_status.outputs.built }}
     env:
       TOOLCHAIN_LABEL: stable
-      TOOLCHAIN_VERSION: "1.88.0"
+      TOOLCHAIN_VERSION: "1.98.0"
       TOOLCHAIN_RUSTFLAGS: ""
     steps:
       - uses: actions/checkout@v4
@@ -207,7 +207,7 @@ jobs:
     # Allow this job to fail without failing the entire CI run
     continue-on-error: true
     env:
-      TOOLCHAIN_VERSION: "1.88.0"
+      TOOLCHAIN_VERSION: "1.98.0"
       TOOLCHAIN_LABEL: stable
       TOOLCHAIN_RUSTFLAGS: ""
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -463,7 +463,7 @@ jobs:
       matrix:
         toolchain:
           - label: stable
-            version: "1.88.0"
+            version: "1.98.0"
             rustflags: ""
           - label: nightly
             version: "nightly-2025-12-17"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,14 @@ SQLite rewrite in Rust. 40+ crate workspace.
 
 ```bash
 cargo build                    # build. never build with --release
+cargo check -p turso_core      # fast type-check while iterating on core
 cargo test                     # rust unit/integration tests
 cargo fmt                      # format (required)
-cargo clippy --workspace --all-features --all-targets -- --deny=warnings  # lint
+cargo lint                     # clippy, same flags as CI (alias in .cargo/config.toml).
+                               # Runs under its own profile (artifacts in target/clippy/)
+                               # because clippy overwrites cargo check's fingerprints:
+                               # plain `cargo clippy` forces a full ~25s recheck of every
+                               # workspace crate afterwards
 cargo run -q --bin tursodb -- -q # run the interactive cli. never run with --release
 
 make test                      # TCL compat + sqlite3 + extensions + MVCC

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,31 @@ echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
 cargo bench --profile bench-profile --bench benchmark -- --profile-time=5
 ```
 
+## IDE setup and keeping `cargo check` fast
+
+RustRover's external linter and rust-analyzer's save check both run
+`cargo check --all-targets` across the workspace every time you save. With warm
+caches that costs a few seconds per save, even right after editing
+`turso_core`. If your IDE check regularly takes 25s+, the caches are being
+invalidated between runs. The usual causes, in order of likelihood:
+
+* Something runs clippy into the default target dir. Clippy overwrites plain
+  check/build fingerprints (and vice versa), so every clippy pass forces the
+  next check to rebuild every workspace crate from scratch. Always run clippy
+  through `cargo lint` (its own profile keeps the caches isolated), and in
+  RustRover keep Settings | Rust | External Linters set to **Cargo Check**, not
+  Clippy. If you want Clippy diagnostics in the IDE anyway, add
+  `--target-dir target/rustrover` to the linter's additional arguments so the
+  IDE gets its own cache universe.
+* The IDE and your terminal disagree on the environment. A `RUSTFLAGS` or
+  `RUSTC_WRAPPER` (e.g. sccache) configured in one but not the other flips the
+  shared fingerprints on every alternation, exactly like clippy does.
+
+If on-save checking still feels too slow, turn off "Run external linter to
+analyze code on the fly" in RustRover — its built-in analyzer keeps showing
+errors inline — and run `cargo check -p turso_core` yourself while iterating
+on core.
+
 ## Developing with AI coding agents
 
 You're welcome to develop Turso with AI coding agents such as Claude Code, Codex, or OpenCode. Used well, they can help you explore the codebase, draft tests, and polish your contributions. To make the most of them — and to get your PRs merged — keep the following in mind.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ Fork the repository and open a pull request to submit your work.
 
 The CI checks for formatting, Clippy warnings, and test failures so remember to run the following before submitting your pull request:
 
-* `cargo fmt` and `cargo clippy --workspace --all-features --all-targets -- --deny=warnings` to keep the code formatting in check.
+* `cargo fmt` and `cargo lint` to keep the code formatting in check. (`cargo lint` is an alias defined in `.cargo/config.toml` that runs the same clippy invocation as CI, under a dedicated build profile so it doesn't invalidate your `cargo check`/`cargo build` caches.)
 * `make test` to run the test suite.
 
 **Keep your pull requests focused and as small as possible, but not smaller.** IOW, when preparing a pull request, ensure it focuses on a single thing and that your commits align with that. For example, a good pull request might fix a specific bug or a group of related bugs. Or a good pull request might add a new feature and test for it. Conversely, a bad pull request might fix a bug, add a new feature, and refactor some code.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,14 @@ shuttle = { version = "0.8.1" }
 [profile.dev.package.similar]
 opt-level = 3
 
+# Same as dev, but under its own name so the `cargo lint` alias (see
+# .cargo/config.toml) writes to target/clippy/ instead of target/debug/.
+# Clippy overwrites plain check/build fingerprints, so running it in the
+# default profile forces a full rebuild of every workspace crate on the next
+# `cargo check`/`cargo build` and vice versa.
+[profile.clippy]
+inherits = "dev"
+
 [profile.release]
 debug = "line-tables-only"
 codegen-units = 4

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -605,12 +605,10 @@ fn parse_uri_filename(uri: &str) -> Result<(String, bool, bool), ()> {
                     "ro" | "rw" | "rwc" => {} // valid modes, no-op (Turso doesn't enforce read-only yet)
                     _ => return Err(()),      // unknown mode -> SQLITE_CANTOPEN
                 },
-                "cache" => {
-                    if value == "shared" {
-                        cache_shared = true;
-                    }
-                    // "private" is also valid but is the default behavior
+                "cache" if value == "shared" => {
+                    cache_shared = true;
                 }
+                // "private" is also valid but is the default behavior
                 _ => {}
             }
         }

--- a/bindings/javascript/src/browser.rs
+++ b/bindings/javascript/src/browser.rs
@@ -188,7 +188,7 @@ impl File for OpfsFile {
         let buffer = buffer.as_mut_slice();
         if web_worker {
             let result = unsafe { read(handle, buffer.as_mut_ptr(), buffer.len(), pos as i32) };
-            c.complete(result as i32);
+            c.complete(result);
         } else {
             let completion_no = self.opfs.register_completion(c.clone());
             unsafe {
@@ -224,7 +224,7 @@ impl File for OpfsFile {
         let buffer = buffer.as_slice();
         if web_worker {
             let result = unsafe { write(handle, buffer.as_ptr(), buffer.len(), pos as i32) };
-            c.complete(result as i32);
+            c.complete(result);
         } else {
             let completion_no = self.opfs.register_completion(c.clone());
             unsafe {
@@ -250,7 +250,7 @@ impl File for OpfsFile {
         let handle = self.handle;
         if web_worker {
             let result = unsafe { sync(handle) };
-            c.complete(result as i32);
+            c.complete(result);
         } else {
             let completion_no = self.opfs.register_completion(c.clone());
             unsafe { sync_async(handle, completion_no) };
@@ -273,7 +273,7 @@ impl File for OpfsFile {
         let handle = self.handle;
         if web_worker {
             let result = unsafe { truncate(handle, len as usize) };
-            c.complete(result as i32);
+            c.complete(result);
         } else {
             let completion_no = self.opfs.register_completion(c.clone());
             unsafe { truncate_async(handle, len as usize, completion_no) };

--- a/bindings/javascript/sync/src/js_protocol_io.rs
+++ b/bindings/javascript/sync/src/js_protocol_io.rs
@@ -66,7 +66,7 @@ struct JsDataCompletionInner {
 }
 
 impl JsDataCompletion {
-    fn inner(&self) -> turso_sync_engine::Result<MutexGuard<JsDataCompletionInner>> {
+    fn inner(&self) -> turso_sync_engine::Result<MutexGuard<'_, JsDataCompletionInner>> {
         let inner = self.0.lock().unwrap();
         if let Some(err) = &inner.err {
             return Err(turso_sync_engine::errors::Error::DatabaseSyncEngineError(

--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -368,7 +368,7 @@ impl PyTursoStatement {
                     .to_string(),
             );
         }
-        Ok(PyTuple::new(py, columns.into_iter())?.unbind())
+        Ok(PyTuple::new(py, columns)?.unbind())
     }
     /// Get tuple with current row values
     /// This method is only valid to call after [Self::step] returned [PyTursoStatusCode::Row] status code

--- a/bindings/python/src/turso_sync.rs
+++ b/bindings/python/src/turso_sync.rs
@@ -503,7 +503,7 @@ impl PyTursoSyncIoItem {
                                 tuples
                                     .push(PyTuple::new(py, [key.clone(), value.clone()])?.unbind());
                             }
-                            PyList::new(py, tuples.into_iter())?.unbind()
+                            PyList::new(py, tuples)?.unbind()
                         },
                     },
                 )?),

--- a/cli/app.rs
+++ b/cli/app.rs
@@ -1162,7 +1162,7 @@ impl Limbo {
                     let _ = self.writeln(format!(
                         "{:<4}  {:<17}  {:<4}  {:<4}  {:<4}  {:<13}  {:<2}  {}",
                         row.get_value(0).to_string(),
-                        &(indent.repeat(indent_count) + &insn),
+                        (indent.repeat(indent_count) + &insn),
                         p1,
                         row.get_value(3).to_string(),
                         row.get_value(4).to_string(),
@@ -2163,7 +2163,7 @@ impl Limbo {
             // ASCII
             for &byte in chunk {
                 let ch = match byte {
-                    b' '..=b'~' if ![b'{', b'}', b'"', b'\\'].contains(&byte) => byte as char,
+                    b' '..=b'~' if !b"{}\"\\".contains(&byte) => byte as char,
                     _ => '.',
                 };
                 write!(self, "{ch}")?;
@@ -2198,7 +2198,7 @@ impl Limbo {
             "| size {} pagesize {} filename {}",
             metadata.page_count * metadata.page_size,
             metadata.page_size,
-            &metadata.filename
+            metadata.filename
         )?;
 
         let dump_sql = if let Some(pgno) = page_no {
@@ -2226,7 +2226,7 @@ impl Limbo {
             self.write_page_hexdump(&page, metadata.page_size)?;
         }
 
-        writeln!(self, "| end {}", &metadata.filename)?;
+        writeln!(self, "| end {}", metadata.filename)?;
 
         Ok(())
     }

--- a/cli/config/mod.rs
+++ b/cli/config/mod.rs
@@ -24,11 +24,10 @@ where
     let v: toml::Value = Deserialize::deserialize(deserializer)?;
     let x = T::deserialize(v)
         .map(|v| {
-            let validate = v.validate();
-            if validate.is_err() {
+            if let Err(err) = v.validate() {
                 tracing::error!(
                     "Invalid value for {}.\n Original config value: {:?}",
-                    validate.unwrap_err(),
+                    err,
                     v
                 );
                 T::default()

--- a/cli/manual.rs
+++ b/cli/manual.rs
@@ -143,7 +143,7 @@ pub fn display_manual(page: Option<&str>, writer: &mut dyn Write) -> anyhow::Res
         Ok(())
     } else if page.is_none() {
         // If no page specified, list available pages
-        return list_available_manuals(writer);
+        list_available_manuals(writer)
     } else {
         let available_pages = MANUAL_DIR
             .files()

--- a/cli/mcp_server.rs
+++ b/cli/mcp_server.rs
@@ -40,6 +40,9 @@ struct JsonRpcError {
     data: Option<Value>,
 }
 
+// Documents the initialize payload shape; handle_initialize does not parse it
+// today. rustc 1.98 stopped counting derives as uses, hence the allow.
+#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize)]
 struct InitializeRequest {
     #[serde(rename = "protocolVersion")]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -125,7 +125,6 @@ roaring = "0.11.2"
 arc-swap = "1.7"
 rustc-hash = "2.0"
 either = { workspace = true }
-tracing-subscriber.workspace = true
 rapidhash = "4.1.1"
 simdutf8 = "0.1.5"
 branches = { version = "0.4.3", default-features = false }
@@ -175,6 +174,8 @@ pprof = { version = "0.14.0", features = ["criterion", "flamegraph"] }
 [dev-dependencies]
 memory-stats = "1.2.0"
 serde_json = { workspace = true }
+# Only tests set up a subscriber; the library itself just emits `tracing` events.
+tracing-subscriber = { workspace = true }
 criterion = { workspace = true, features = [
     "html_reports",
     "async",

--- a/core/alloc/collections/iterator.rs
+++ b/core/alloc/collections/iterator.rs
@@ -1,11 +1,11 @@
 use super::{TursoFromIterator, TursoIteratorExt};
 use crate::alloc::TryReserveError;
+
 #[cfg(nightly)]
-use {
-    super::{trusted_len, TursoTryWithCapacityExt},
-    crate::alloc::Vec,
-    std::iter::TrustedLen,
-};
+#[path = "iterator_spec.rs"]
+mod spec;
+#[cfg(nightly)]
+use spec::TrySpecFromResultIter;
 
 fn try_from_result_iter<T, E, F, C, I>(iter: I) -> Result<Result<C, F>, TryReserveError>
 where
@@ -24,47 +24,6 @@ where
     if let Some(error) = error {
         Ok(Err(error))
     } else {
-        Ok(Ok(values))
-    }
-}
-
-#[cfg(nightly)]
-trait TrySpecFromResultIter<T, E, I>: Sized {
-    fn try_from_result_iter(iter: I) -> Result<Self, TryReserveError>;
-}
-
-#[cfg(nightly)]
-impl<T, E, F, C, I> TrySpecFromResultIter<T, E, I> for Result<C, F>
-where
-    C: TursoFromIterator<T>,
-    F: From<E>,
-    I: Iterator<Item = Result<T, E>>,
-{
-    default fn try_from_result_iter(iter: I) -> Result<Self, TryReserveError> {
-        try_from_result_iter(iter)
-    }
-}
-
-#[cfg(nightly)]
-impl<T, E, F, I> TrySpecFromResultIter<T, E, I> for Result<Vec<T>, F>
-where
-    F: From<E>,
-    I: TrustedLen<Item = Result<T, E>>,
-{
-    fn try_from_result_iter(iter: I) -> Result<Self, TryReserveError> {
-        // Specialize before the fallback's `map_while`, which cannot retain
-        // `TrustedLen` because an error may stop collection early.
-        let additional = trusted_len(iter.size_hint())?;
-        let mut values = <Vec<T> as TursoTryWithCapacityExt>::try_with_capacity_ext(additional)?;
-
-        for item in iter {
-            match item {
-                Ok(value) => {
-                    let _ = values.push_within_capacity(value);
-                }
-                Err(error) => return Ok(Err(F::from(error))),
-            }
-        }
         Ok(Ok(values))
     }
 }

--- a/core/alloc/collections/iterator_spec.rs
+++ b/core/alloc/collections/iterator_spec.rs
@@ -1,0 +1,49 @@
+//! Specialized `TursoFromIterator` collection for `Result` items.
+//!
+//! Lives in its own file because `default fn` is gated syntax: stable rustc
+//! (>= 1.98) warns about it before cfg stripping, so it must not appear in any
+//! file a stable build parses. The `#[cfg(nightly)]` on the `mod` declaration
+//! keeps this file out of stable builds entirely.
+
+use super::super::{trusted_len, TursoFromIterator, TursoTryWithCapacityExt};
+use super::try_from_result_iter;
+use crate::alloc::{TryReserveError, Vec};
+use std::iter::TrustedLen;
+
+pub(super) trait TrySpecFromResultIter<T, E, I>: Sized {
+    fn try_from_result_iter(iter: I) -> Result<Self, TryReserveError>;
+}
+
+impl<T, E, F, C, I> TrySpecFromResultIter<T, E, I> for Result<C, F>
+where
+    C: TursoFromIterator<T>,
+    F: From<E>,
+    I: Iterator<Item = Result<T, E>>,
+{
+    default fn try_from_result_iter(iter: I) -> Result<Self, TryReserveError> {
+        try_from_result_iter(iter)
+    }
+}
+
+impl<T, E, F, I> TrySpecFromResultIter<T, E, I> for Result<Vec<T>, F>
+where
+    F: From<E>,
+    I: TrustedLen<Item = Result<T, E>>,
+{
+    fn try_from_result_iter(iter: I) -> Result<Self, TryReserveError> {
+        // Specialize before the fallback's `map_while`, which cannot retain
+        // `TrustedLen` because an error may stop collection early.
+        let additional = trusted_len(iter.size_hint())?;
+        let mut values = <Vec<T> as TursoTryWithCapacityExt>::try_with_capacity_ext(additional)?;
+
+        for item in iter {
+            match item {
+                Ok(value) => {
+                    let _ = values.push_within_capacity(value);
+                }
+                Err(error) => return Ok(Err(F::from(error))),
+            }
+        }
+        Ok(Ok(values))
+    }
+}

--- a/core/database.rs
+++ b/core/database.rs
@@ -2422,7 +2422,7 @@ impl Database {
             match st {
                 DbHeaderReadState::Start => {
                     turso_assert!(
-                        PageSize::MIN % 512 == 0,
+                        PageSize::MIN.is_multiple_of(512),
                         "header read must be a multiple of 512 for O_DIRECT"
                     );
                     let buf = Arc::new(Buffer::new_temporary(PageSize::MIN as usize));

--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -396,12 +396,11 @@ fn parse_timezone(mut z: &str, p: &mut DateTime) -> bool {
     }
 
     let c = z.as_bytes()[0] as char;
-    let sgn: i32;
 
-    if c == '-' {
-        sgn = -1;
+    let sgn: i32 = if c == '-' {
+        -1
     } else if c == '+' {
-        sgn = 1;
+        1
     } else if c == 'Z' || c == 'z' {
         z = &z[1..];
         p.is_local = false;
@@ -409,7 +408,7 @@ fn parse_timezone(mut z: &str, p: &mut DateTime) -> bool {
         return check_trailing_garbage(z);
     } else {
         return true;
-    }
+    };
 
     z = &z[1..];
 
@@ -1120,8 +1119,8 @@ where
     let sign: char;
     let mut y: i32;
     let mut m: i32;
-    let diff_ms: i64;
-    if d1.i_jd >= d2.i_jd {
+
+    let diff_ms: i64 = if d1.i_jd >= d2.i_jd {
         sign = '+';
         y = d1.y - d2.y;
         if y != 0 {
@@ -1155,7 +1154,7 @@ where
             d2.valid_jd = false;
             d2.compute_jd();
         }
-        diff_ms = d1.i_jd - d2.i_jd;
+        d1.i_jd - d2.i_jd
     } else {
         sign = '-';
         y = d2.y - d1.y;
@@ -1190,8 +1189,8 @@ where
             d2.valid_jd = false;
             d2.compute_jd();
         }
-        diff_ms = d2.i_jd - d1.i_jd;
-    }
+        d2.i_jd - d1.i_jd
+    };
     let days = diff_ms / 86400000;
     let rem_ms = diff_ms % 86400000;
     let hours = rem_ms / 3600000;
@@ -1535,7 +1534,7 @@ mod tests {
         ];
 
         for (input, expected) in test_cases {
-            let result = exec_date(&[input.clone()]);
+            let result = exec_date(std::slice::from_ref(&input));
             assert_eq!(
                 result,
                 Value::build_text(expected.to_string()),
@@ -1709,7 +1708,7 @@ mod tests {
         ];
 
         for case in invalid_cases {
-            let result = exec_time(&[case.clone()]);
+            let result = exec_time(std::slice::from_ref(&case));
             assert_eq!(result, Value::Null);
         }
     }

--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -2825,7 +2825,7 @@ impl FetchDistinctState {
                 FetchDistinctState::Done => {
                     // For plain DISTINCT, construct AggregateState from the weights we fetched
                     if is_plain_distinct {
-                        for (_group_key_str, state) in existing_groups.iter_mut() {
+                        for state in existing_groups.values_mut() {
                             // For plain DISTINCT, sum all the weights to get total count
                             // Each weight represents how many times the distinct value appears
                             let total_weight: i64 = state.distinct_value_weights.values().sum();

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -622,11 +622,8 @@ impl DbspCircuit {
                         // If we're starting a new row (GetRecord state), we need a fresh cursor
                         // due to btree cursor state machine limitations
                         if matches!(write_row_state, WriteRowView::GetRecord) {
-                            *view_cursor = Box::new(BTreeCursor::new_table(
-                                pager.clone(),
-                                main_data_root,
-                                num_columns,
-                            ));
+                            **view_cursor =
+                                BTreeCursor::new_table(pager.clone(), main_data_root, num_columns);
                         }
 
                         // Build the view row format: row values + weight

--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -548,7 +548,7 @@ impl IO for UringIO {
 
     fn register_fixed_buffer(&self, ptr: std::ptr::NonNull<u8>, len: usize) -> Result<u32> {
         turso_assert!(
-            len % 512 == 0,
+            len.is_multiple_of(512),
             "fixed buffer length must be logical block aligned"
         );
         let mut state = self.state.lock();

--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -253,7 +253,7 @@ impl MemStore {
 
     pub(super) fn punch_hole(&self, pos: usize, len: usize) {
         turso_assert!(
-            pos % PAGE_SIZE == 0 && len % PAGE_SIZE == 0,
+            pos.is_multiple_of(PAGE_SIZE) && len.is_multiple_of(PAGE_SIZE),
             "hole must be page aligned"
         );
         let mut inner = self.inner.write();

--- a/core/json/jsonb.rs
+++ b/core/json/jsonb.rs
@@ -827,33 +827,27 @@ impl JsonbHeader {
                         None => bail_parse_error!("Failed to read 1-byte size"),
                     },
 
-                    13 => match Self::get_size_bytes(slice, cursor + 1, 2) {
-                        Ok(bytes) => {
-                            offset = 3;
-                            u16::from_be_bytes([bytes[0], bytes[1]]) as usize
-                        }
-                        Err(e) => return Err(e),
-                    },
+                    13 => {
+                        let bytes = Self::get_size_bytes(slice, cursor + 1, 2)?;
+                        offset = 3;
+                        u16::from_be_bytes([bytes[0], bytes[1]]) as usize
+                    }
 
-                    14 => match Self::get_size_bytes(slice, cursor + 1, 4) {
-                        Ok(bytes) => {
-                            offset = 5;
-                            u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize
-                        }
-                        Err(e) => return Err(e),
-                    },
+                    14 => {
+                        let bytes = Self::get_size_bytes(slice, cursor + 1, 4)?;
+                        offset = 5;
+                        u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize
+                    }
 
                     // 15 = 8-byte payload size (for future expansion per SQLite spec)
-                    15 => match Self::get_size_bytes(slice, cursor + 1, 8) {
-                        Ok(bytes) => {
-                            offset = 9;
-                            u64::from_be_bytes([
-                                bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5],
-                                bytes[6], bytes[7],
-                            ]) as usize
-                        }
-                        Err(e) => return Err(e),
-                    },
+                    15 => {
+                        let bytes = Self::get_size_bytes(slice, cursor + 1, 8)?;
+                        offset = 9;
+                        u64::from_be_bytes([
+                            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6],
+                            bytes[7],
+                        ]) as usize
+                    }
 
                     _ => unreachable!(),
                 };

--- a/core/json/mod.rs
+++ b/core/json/mod.rs
@@ -878,7 +878,7 @@ where
     I: IntoIterator<IntoIter = E, Item = V>,
 {
     let mut values = values.into_iter();
-    if values.len() % 2 != 0 {
+    if !values.len().is_multiple_of(2) {
         bail_constraint_error!("json_object() requires an even number of arguments")
     }
     let mut json = Jsonb::make_empty_obj(values.len() * 50)?;
@@ -919,7 +919,7 @@ where
     I: IntoIterator<IntoIter = E, Item = V>,
 {
     let mut values = values.into_iter();
-    if values.len() % 2 != 0 {
+    if !values.len().is_multiple_of(2) {
         bail_constraint_error!("json_object() requires an even number of arguments")
     }
     let mut json = Jsonb::make_empty_obj(values.len() * 50)?;

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -292,8 +292,9 @@ impl<A: ConcurrentAllocator> DualCursorPeek<A> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 enum CursorPeek<A: ConcurrentAllocator = TursoAllocator> {
+    #[default]
     Uninitialized,
     Row {
         key: RowKey,
@@ -302,12 +303,6 @@ enum CursorPeek<A: ConcurrentAllocator = TursoAllocator> {
         versions: Option<RowVersions<A>>,
     },
     Exhausted,
-}
-
-impl<A: ConcurrentAllocator> Default for CursorPeek<A> {
-    fn default() -> Self {
-        Self::Uninitialized
-    }
 }
 
 impl<A: ConcurrentAllocator> CursorPeek<A> {
@@ -1463,11 +1458,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
             return Ok(IOResult::Done(None));
         }
         let rowid = match self.get_current_pos() {
-            CursorPosition::Loaded {
-                row_id,
-                in_btree: _,
-                ..
-            } => match &row_id.row_id {
+            CursorPosition::Loaded { row_id, .. } => match &row_id.row_id {
                 RowKey::Int(id) => Some(*id),
                 RowKey::Record(sortable_key) => {
                     // For index cursors, the rowid is stored in the last column of the index record
@@ -2069,12 +2060,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                     inject_io_yield!(self, CursorYieldPoint::CountProgress);
                 }
                 Some(CountState::CheckBtreeKey { count }) => {
-                    if let CursorPosition::Loaded {
-                        row_id: _,
-                        in_btree: _,
-                        ..
-                    } = self.get_current_pos()
-                    {
+                    if let CursorPosition::Loaded { .. } = self.get_current_pos() {
                         self.count_state
                             .replace(CountState::NextBtree { count: count + 1 });
                         inject_io_yield!(self, CursorYieldPoint::CountProgress);

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -9421,12 +9421,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 }
             }
 
-            if schema_rows_after.is_some() {
+            if let Some(schema_rows_after) = schema_rows_after {
                 // Now that all table and index ops from this transaction have
                 // been replayed, publish the frame's final schema. No later index
                 // op from this frame can observe a half-applied sqlite_schema.
-                let schema_rows_after =
-                    schema_rows_after.expect("schema_rows_after must exist when schema changed");
                 let schema_after = schema_after
                     .expect("schema_after must exist when frame_changes_schema is true");
                 schema_rows = schema_rows_after;

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -8867,11 +8867,13 @@ fn test_cursor_with_btree_and_mvcc_fuzz() {
 }
 
 pub fn rng_from_time_or_env() -> (ChaCha8Rng, u64) {
-    let seed = std::env::var("SEED").map_or(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_millis(),
+    let seed = std::env::var("SEED").map_or_else(
+        |_| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+        },
         |v| {
             v.parse()
                 .expect("Failed to parse SEED environment variable as u64")

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -258,9 +258,11 @@ use serializer::EncryptedPayload;
 use serializer::{
     extension_record_len, ExtensionRecord, PortableChangePayload, PortableEndOffsetCtx,
 };
+pub(crate) use serializer::{LogBufferWrite, LogChunkStream, LogSerializer};
+// Only the conn_raw_api portable-changes encoder consumes the raw proto pieces.
+#[cfg(feature = "conn_raw_api")]
 pub(crate) use serializer::{
-    log_write, LogBufferWrite, LogChunkStream, LogSerializer, ProtoKey, ProtoSint64, ProtoVarint,
-    PROTO_WIRE_LENGTH_DELIMITED, PROTO_WIRE_VARINT,
+    log_write, ProtoKey, ProtoSint64, ProtoVarint, PROTO_WIRE_LENGTH_DELIMITED, PROTO_WIRE_VARINT,
 };
 
 /// Logical log size in bytes at which a committing transaction will trigger a checkpoint.

--- a/core/mvcc/persistent_storage/logical_log/serializer.rs
+++ b/core/mvcc/persistent_storage/logical_log/serializer.rs
@@ -203,6 +203,9 @@ macro_rules! log_write {
         )
     }};
 }
+// In-file callers reach the macro textually; the path export is only needed
+// by the conn_raw_api portable-changes encoder.
+#[cfg(feature = "conn_raw_api")]
 pub(crate) use log_write;
 
 pub(crate) struct LogSerializer<'a, B: ?Sized = Vec<u8>> {

--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -675,7 +675,7 @@ pub fn str_to_f64(input: impl AsRef<str>) -> Option<StrToF64> {
         exponent -= 1;
     }
 
-    while exponent.is_negative() && significant % 10 == 0 {
+    while exponent.is_negative() && significant.is_multiple_of(10) {
         significant /= 10;
         exponent += 1;
     }

--- a/core/progress.rs
+++ b/core/progress.rs
@@ -59,7 +59,7 @@ impl ProgressHandler {
     /// configured multiple of `ops`.
     pub(crate) fn should_interrupt(&self, vm_steps: u64) -> bool {
         let ops = self.ops();
-        if ops == 0 || vm_steps % ops != 0 {
+        if ops == 0 || !vm_steps.is_multiple_of(ops) {
             return false;
         }
         let callback = self.callback.read();

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3899,12 +3899,7 @@ impl BTreeTable {
             };
 
             walk_expr_mut(expr, &mut |e| match e {
-                Expr::Column {
-                    table,
-                    column,
-                    is_rowid_alias: _,
-                    ..
-                } if table.is_self_table() => {
+                Expr::Column { table, column, .. } if table.is_self_table() => {
                     if *column == dropped_index {
                         return Err(LimboError::InternalError(
                             "dropped column remained referenced by generated column".to_string(),

--- a/core/skiplist/set_tests.rs
+++ b/core/skiplist/set_tests.rs
@@ -785,8 +785,10 @@ fn comparator() {
 
     fn decode(slice: &[u8]) -> impl Iterator<Item = OrderedF32> + '_ {
         slice
-            .chunks_exact(4)
-            .map(|b| OrderedF32(f32::from_le_bytes(b.try_into().unwrap())))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|b| OrderedF32(f32::from_le_bytes(*b)))
     }
 
     fn compare(lhs: &[u8], rhs: &[u8]) -> Ordering {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -9325,7 +9325,7 @@ fn defragment_page(page: &PageContent, usable_space: usize, max_frag_bytes: isiz
         if !is_physically_sorted {
             // Sort cells by old physical offset in descending order.
             // Using unstable sort is fine as the original order doesn't matter.
-            cells.sort_unstable_by(|a, b| b.old_offset.cmp(&a.old_offset));
+            cells.sort_unstable_by_key(|c| std::cmp::Reverse(c.old_offset));
         }
 
         // Get direct mutable access to the page buffer.
@@ -11039,11 +11039,13 @@ mod tests {
     }
 
     fn rng_from_time_or_env() -> (ChaCha8Rng, u64) {
-        let seed = std::env::var("SEED").map_or(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
+        let seed = std::env::var("SEED").map_or_else(
+            |_| {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis()
+            },
             |v| {
                 v.parse()
                     .expect("Failed to parse SEED environment variable as u64")
@@ -13301,8 +13303,9 @@ mod tests {
             #[cfg(debug_assertions)]
             debug_validate_cells_core(contents, pager.usable_space());
             // check cells are correct
-            let mut cell_idx_cloned = if prefix { size } else { 0 };
-            for cell_idx in 0..contents.cell_count() {
+            for (cell_idx_cloned, cell_idx) in
+                (if prefix { size } else { 0 }..).zip(0..contents.cell_count())
+            {
                 let buf = contents.as_ptr();
                 let (start, len) = contents
                     .cell_get_raw_region(cell_idx, pager.usable_space())
@@ -13310,7 +13313,6 @@ mod tests {
                 let cell_in_page = &buf[start..start + len];
                 let cell_in_array = &cells_cloned[cell_idx_cloned];
                 assert_eq!(cell_in_page, cell_in_array);
-                cell_idx_cloned += 1;
             }
         }
     }

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -572,7 +572,7 @@ impl PageCache {
         const EST_SPILL: usize = 128;
         let mut spillable: Vec<PinGuard> = Vec::with_capacity(EST_SPILL);
 
-        for (_, &entry_ptr) in self.map.iter() {
+        for &entry_ptr in self.map.values() {
             let entry = unsafe { &*entry_ptr };
             let page = &entry.page;
             if Self::spillable(page) {

--- a/core/storage/shared_wal_coordination.rs
+++ b/core/storage/shared_wal_coordination.rs
@@ -909,7 +909,7 @@ impl MappedSharedWalCoordination {
         ownership_mode: SharedWalOwnershipMode,
     ) -> Result<Self> {
         turso_assert!(
-            reader_slot_count >= 64 && reader_slot_count % 64 == 0,
+            reader_slot_count >= 64 && reader_slot_count.is_multiple_of(64),
             "reader_slot_count must be a non-zero multiple of 64"
         );
 
@@ -982,7 +982,7 @@ impl MappedSharedWalCoordination {
         ownership_mode: SharedWalOwnershipMode,
     ) -> Result<Option<Self>> {
         turso_assert!(
-            reader_slot_count >= 64 && reader_slot_count % 64 == 0,
+            reader_slot_count >= 64 && reader_slot_count.is_multiple_of(64),
             "reader_slot_count must be a non-zero multiple of 64"
         );
 

--- a/core/storage/slot_bitmap.rs
+++ b/core/storage/slot_bitmap.rs
@@ -52,7 +52,7 @@ impl AtomicSlotBitmap {
     pub fn new(n_slots: u32) -> Self {
         turso_assert!(n_slots > 0, "number of slots must be non-zero");
         turso_assert!(
-            n_slots % WORD_BITS == 0,
+            n_slots.is_multiple_of(WORD_BITS),
             "number of slots in map must be a multiple of 64"
         );
         let n_words = (n_slots / WORD_BITS) as usize;

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4525,14 +4525,14 @@ impl Wal for WalFile {
         let page_transform = self.io_ctx.read().page_transform().clone();
 
         // Rolling checksum input to each frame build
-        let mut next_frame_id = self.max_frame.load(Ordering::Acquire) + 1;
-        let mut rolling_checksum = if next_frame_id == 1 {
+        let first_frame_id = self.max_frame.load(Ordering::Acquire) + 1;
+        let mut rolling_checksum = if first_frame_id == 1 {
             (header.checksum_1, header.checksum_2)
         } else {
             *self.last_checksum.read()
         };
         // Build every frame in order, updating the rolling checksum
-        for page in pages.iter() {
+        for (next_frame_id, page) in (first_frame_id..).zip(pages.iter()) {
             tracing::debug!("append_frames_vectored: page_id={}", page.get().id);
             let page_id = page.get().id;
             let plain = page.get_contents().as_ptr();
@@ -4555,10 +4555,8 @@ impl Wal for WalFile {
 
             // Advance for the next frame
             rolling_checksum = new_checksum;
-            next_frame_id += 1;
         }
 
-        let first_frame_id = self.max_frame.load(Ordering::Acquire) + 1;
         let start_off = self.frame_offset(first_frame_id);
 
         // single completion for the whole batch
@@ -4859,7 +4857,7 @@ impl WalFile {
                         .coordination
                         .iter_latest_frames(oc_min_frame, oc_max_frame);
                     // sort by frame_id for read locality
-                    to_checkpoint.sort_unstable_by(|a, b| (a.1, a.0).cmp(&(b.1, b.0)));
+                    to_checkpoint.sort_unstable_by_key(|a| (a.1, a.0));
                     // Every frame we are about to backfill must be durable in
                     // the WAL before it may be copied into the database file:
                     // commits under synchronous=NORMAL do not fsync the WAL,
@@ -6701,7 +6699,7 @@ pub mod test {
 
         let target_page = Arc::new(crate::Page::new(32));
         let completion = wal
-            .read_frames_batch(1, &[target_page.clone()], buffer_pool, None)
+            .read_frames_batch(1, std::slice::from_ref(&target_page), buffer_pool, None)
             .unwrap();
         io.wait_for_completion(completion).unwrap();
         assert_eq!(target_page.get_contents().as_ptr(), expected.as_slice());

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -417,7 +417,9 @@ pub(crate) fn literal_default_value(literal: &ast::Literal) -> Result<Value> {
         ast::Literal::Blob(s) => Ok(Value::Blob(
             ast::blob_literal_hex(s)
                 .as_bytes()
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|pair| {
                     let hex_byte = std::str::from_utf8(pair).expect("parser validated hex string");
                     u8::from_str_radix(hex_byte, 16).expect("parser validated hex digit")

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -22,9 +22,10 @@ use crate::{
 /// **Pre defined collation sequences**\
 /// Collating functions only matter when comparing string values.
 /// Numeric values are always compared numerically, and BLOBs are always compared byte-by-byte using memcmp().
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, PartialOrd, Ord, Default)]
 pub enum CollationSeq {
     Unset,
+    #[default]
     Binary,
     NoCase,
     Rtrim,
@@ -209,12 +210,6 @@ fn resolve_collation_name(
         return Ok(collation);
     }
     CollationSeq::new(collation)
-}
-
-impl Default for CollationSeq {
-    fn default() -> Self {
-        Self::Binary
-    }
 }
 
 impl std::fmt::Display for CollationSeq {
@@ -403,10 +398,10 @@ pub fn get_expr_collation_ctx_with_symbols(
                 }
                 return Ok(WalkControl::SkipChildren);
             }
-            Expr::Column { table, column, .. } => {
+            Expr::Column { table, column, .. }
                 // generated columns (the SELF_TABLE placeholder) don't inherit an implicit
                 // collation from their expression, so we skip them
-                if !table.is_self_table() {
+                if !table.is_self_table() => {
                     let (_, table_ref) = referenced_tables
                         .find_table_by_internal_id(*table)
                         .ok_or_else(|| {
@@ -419,7 +414,6 @@ pub fn get_expr_collation_ctx_with_symbols(
                         maybe_column_collseq = Some(column.collation());
                     }
                 }
-            }
             _ => {}
         }
         Ok(WalkControl::Continue)

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1502,7 +1502,6 @@ fn emit_cdc_insns_v1(
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 fn emit_cdc_insns_v2(
     program: &mut ProgramBuilder,
     resolver: &Resolver,

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -886,15 +886,14 @@ fn build_materialized_build_input_plan(
                     }
                 }
             }
-            Operation::HashJoin(hash_join_op) => {
+            Operation::HashJoin(hash_join_op)
                 // Hash joins are driven by the probe table's loop. That probe table
                 // must be in the prefix; otherwise the hash join cannot be evaluated
                 // inside this subplan. The build table may live outside the prefix
                 // because the hash build phase scans it independently.
-                if !join_prefix_mask.get(hash_join_op.probe_table_idx) {
+                if !join_prefix_mask.get(hash_join_op.probe_table_idx) => {
                     reset_op = true;
                 }
-            }
             _ => {}
         }
 

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -118,7 +118,7 @@ pub fn bind_and_rewrite_expr<'a>(
                                 .as_ref()
                                 .is_some_and(|name| name.eq_ignore_ascii_case(&normalized_id))
                         });
-                        if col_idx.is_some() {
+                        if let Some(col_idx) = col_idx {
                             if match_result.is_some() {
                                 let mut ok = false;
                                 // Column name ambiguity is ok if it is in the USING clause because then it is deduplicated
@@ -137,13 +137,9 @@ pub fn bind_and_rewrite_expr<'a>(
                                     );
                                 }
                             } else {
-                                let col =
-                                    joined_table.table.columns().get(col_idx.unwrap()).unwrap();
-                                match_result = Some((
-                                    joined_table.internal_id,
-                                    col_idx.unwrap(),
-                                    col.is_rowid_alias(),
-                                ));
+                                let col = joined_table.table.columns().get(col_idx).unwrap();
+                                match_result =
+                                    Some((joined_table.internal_id, col_idx, col.is_rowid_alias()));
                             }
                         // only if we haven't found a match, check for explicit rowid reference
                         } else if let Table::BTree(btree) = &joined_table.table {
@@ -195,8 +191,7 @@ pub fn bind_and_rewrite_expr<'a>(
                                     .as_ref()
                                     .is_some_and(|name| name.eq_ignore_ascii_case(&normalized_id))
                             });
-                            if col_idx.is_some() {
-                                let col_idx = col_idx.unwrap();
+                            if let Some(col_idx) = col_idx {
                                 if outer_ref.using_dedup_hidden_cols.get(col_idx) {
                                     continue;
                                 }

--- a/core/translate/expr/emission.rs
+++ b/core/translate/expr/emission.rs
@@ -36,7 +36,9 @@ pub fn emit_literal(
         ast::Literal::Blob(s) => {
             let bytes = ast::blob_literal_hex(s)
                 .as_bytes()
-                .chunks_exact(2)
+                .as_chunks::<2>()
+                .0
+                .iter()
                 .map(|pair| {
                     // We assume that sqlite3-parser has already validated that
                     // the input is valid hex string, thus unwrap is safe.

--- a/core/translate/expr/functions.rs
+++ b/core/translate/expr/functions.rs
@@ -129,11 +129,9 @@ pub(super) fn translate_function(
     func_ctx: FuncCtx,
 ) -> Result<usize> {
     let start_reg = program.alloc_registers(args.len());
-    let mut current_reg = start_reg;
 
-    for arg in args.iter() {
+    for (current_reg, arg) in (start_reg..).zip(args.iter()) {
         translate_expr(program, referenced_tables, arg, current_reg, resolver)?;
-        current_reg += 1;
     }
 
     program.emit_insn(Insn::Function {

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -1135,7 +1135,7 @@ pub fn translate_expr(
                             let iif_end_label = program.allocate_label();
                             let condition_reg = program.alloc_register();
 
-                            for pair in args.chunks_exact(2) {
+                            for pair in args.as_chunks::<2>().0 {
                                 let condition_expr = &pair[0];
                                 let value_expr = &pair[1];
                                 let next_check_label = program.allocate_label();

--- a/core/translate/expr/walk.rs
+++ b/core/translate/expr/walk.rs
@@ -117,7 +117,7 @@ where
                         }
                         stack.push(WalkItem::Expr(lhs));
                     }
-                    ast::Expr::InSelect { lhs, rhs: _, .. } => {
+                    ast::Expr::InSelect { lhs, .. } => {
                         stack.push(WalkItem::Expr(lhs));
                         // TODO: Walk through select statements if needed
                     }
@@ -393,7 +393,7 @@ where
                         }
                         stack.push(WalkItem::Expr(lhs));
                     }
-                    ast::Expr::InSelect { lhs, rhs: _, .. } => {
+                    ast::Expr::InSelect { lhs, .. } => {
                         stack.push(WalkItem::Expr(lhs));
                         // TODO: Walk through select statements if needed
                     }

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -1183,7 +1183,9 @@ pub fn resolve_index_method_parameters(
                 ast::Literal::Blob(b) => crate::Value::Blob(
                     ast::blob_literal_hex(&b)
                         .as_bytes()
-                        .chunks_exact(2)
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
                         .map(|pair| {
                             // We assume that sqlite3-parser has already validated that
                             // the input is valid hex string, thus unwrap is safe.
@@ -1237,7 +1239,7 @@ pub fn translate_drop_index(
         } else {
             return Err(crate::error::LimboError::InvalidArgument(format!(
                 "No such index: {}",
-                &idx_name
+                idx_name
             )));
         }
     }

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -19,13 +19,12 @@ fn expr_references_outer_query(expr: &Expr, table_references: &TableReferences) 
     let mut has_outer_ref = false;
     let _ = walk_expr(expr, &mut |e: &Expr| -> Result<WalkControl> {
         match e {
-            Expr::Column { table, .. } | Expr::RowId { table, .. } => {
+            Expr::Column { table, .. } | Expr::RowId { table, .. }
                 if table_references
                     .find_outer_query_ref_by_internal_id(*table)
-                    .is_some()
-                {
-                    has_outer_ref = true;
-                }
+                    .is_some() =>
+            {
+                has_outer_ref = true;
             }
             _ => {}
         }

--- a/core/translate/main_loop/multi_index.rs
+++ b/core/translate/main_loop/multi_index.rs
@@ -460,7 +460,7 @@ pub(super) fn emit_multi_index_scan_loop(
 
     let final_rowset = if is_intersection && multi_idx_op.branches.len() > 1 {
         let num_swaps = multi_idx_op.branches.len().saturating_sub(2);
-        if num_swaps % 2 == 0 {
+        if num_swaps.is_multiple_of(2) {
             rowset2_reg
         } else {
             rowset1_reg

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -73,7 +73,6 @@ use update::translate_update;
 #[instrument(skip_all, level = Level::DEBUG)]
 #[allow(clippy::too_many_arguments)]
 #[turso_macros::trace_stack]
-#[allow(clippy::too_many_arguments)]
 pub fn translate(
     schema: &Schema,
     stmt: ast::Stmt,

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -1579,13 +1579,13 @@ fn bind_partial_index_columns(expr: &mut ast::Expr, table_reference: &JoinedTabl
                     *e = make_rowid();
                 }
             }
-            ast::Expr::Qualified(ns, col) | ast::Expr::DoublyQualified(_, ns, col) => {
-                if qualifier_matches(ns.as_str()) {
-                    if let Some(idx) = column_pos(col.as_str()) {
-                        *e = make_column(idx);
-                    } else if is_rowid_keyword(col.as_str()) {
-                        *e = make_rowid();
-                    }
+            ast::Expr::Qualified(ns, col) | ast::Expr::DoublyQualified(_, ns, col)
+                if qualifier_matches(ns.as_str()) =>
+            {
+                if let Some(idx) = column_pos(col.as_str()) {
+                    *e = make_column(idx);
+                } else if is_rowid_keyword(col.as_str()) {
+                    *e = make_rowid();
                 }
             }
             _ => {}

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -1630,7 +1630,7 @@ fn optimize_subqueries(
         if let Table::FromClauseSubquery(from_clause_subquery) = &mut table.table {
             let from_clause_subquery = Arc::make_mut(from_clause_subquery);
             if let Some(cached) = cache.from_clause.remove(&table.internal_id) {
-                from_clause_subquery.plan = Box::new(cached);
+                *from_clause_subquery.plan = cached;
                 continue;
             }
             // Use match to handle both SelectPlan and CompoundSelect variants
@@ -1951,8 +1951,8 @@ fn base_row_estimate(
                 // We fold left-to-right: seed with A, then apply op_i with plan_{i+1}.
                 let fallback = *RowCountEstimate::hardcoded_fallback(params);
                 let est = |p: &SelectPlan| p.estimated_output_rows.unwrap_or(fallback);
-                let mut combined = left.first().map_or(
-                    right_most.estimated_output_rows.unwrap_or(fallback),
+                let mut combined = left.first().map_or_else(
+                    || right_most.estimated_output_rows.unwrap_or(fallback),
                     |(p, _)| est(p),
                 );
                 // The estimates to the right of each operator: left[1..].est, then right_most.est

--- a/core/translate/optimizer/multi_index.rs
+++ b/core/translate/optimizer/multi_index.rs
@@ -591,7 +591,7 @@ fn estimate_residual_expr_selectivity(
         }
         _ => {
             let Ok((_, table_constraints)) = get_table_local_constraints_for_branch(
-                &[expr.clone()],
+                std::slice::from_ref(expr),
                 None,
                 rhs_table,
                 table_references,

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -199,7 +199,7 @@ pub fn compute_order_target(
                 order_by
                     .iter()
                     .position(|(order_by_expr, _, _)| exprs_are_equivalent(expr, order_by_expr))
-                    .map_or(usize::MAX, |i| i)
+                    .unwrap_or(usize::MAX)
             });
 
             // Now, regardless of whether we can eventually eliminate the sorting entirely in the optimizer,

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -2908,7 +2908,7 @@ pub fn translate_drop_type(
     }
 
     // Check if any table uses this type
-    for (_, table) in resolver.schema().tables.iter() {
+    for table in resolver.schema().tables.values() {
         for col in table.columns() {
             if normalize_ident(&col.ty_str) == normalized_name {
                 bail_parse_error!(

--- a/core/translate/update.rs
+++ b/core/translate/update.rs
@@ -467,7 +467,7 @@ fn collect_update_set_clauses(
         let expr = std::mem::replace(&mut set.expr, Box::new(Expr::Literal(ast::Literal::Null)));
         let values = split_update_set_values(*expr, set.col_names.len())?;
 
-        for (col_name, expr) in set.col_names.iter().zip(values.into_iter()) {
+        for (col_name, expr) in set.col_names.iter().zip(values) {
             let expr = Box::new(expr);
             let ident = normalize_ident(col_name.as_str());
 
@@ -508,7 +508,7 @@ fn compose_update_set_clause(existing: &mut UpdateSetClause, expr: Box<Expr>) {
         if name.as_str().eq_ignore_ascii_case("array_set_element") && new_args.len() == 3 {
             let mut composed_args = new_args.clone();
             composed_args[0].clone_from(&existing.expr);
-            existing.expr = Box::new(Expr::FunctionCall {
+            *existing.expr = Expr::FunctionCall {
                 name: name.clone(),
                 distinctness: None,
                 args: composed_args,
@@ -518,7 +518,7 @@ fn compose_update_set_clause(existing: &mut UpdateSetClause, expr: Box<Expr>) {
                     filter_clause: None,
                     over_clause: None,
                 },
-            });
+            };
             return;
         }
     }

--- a/core/translate/upsert.rs
+++ b/core/translate/upsert.rs
@@ -450,7 +450,6 @@ pub fn resolve_upsert_target(
     );
 }
 
-#[allow(clippy::too_many_arguments)]
 /// Emit the bytecode to implement the `DO UPDATE` arm of an UPSERT.
 ///
 /// This routine is entered after the caller has determined that an INSERT
@@ -1553,7 +1552,7 @@ pub fn collect_set_clauses_for_upsert(
                 values.len()
             );
         }
-        for (cn, e) in set.col_names.iter().zip(values.into_iter()) {
+        for (cn, e) in set.col_names.iter().zip(values) {
             let Some(idx) = lookup.get(&normalize_ident(cn.as_str())) else {
                 bail_parse_error!("no such column: {}", cn);
             };

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -233,7 +233,7 @@ pub fn translate_create_materialized_view(
     let dbsp_index_name = format!(
         "{}{}_1",
         PRIMARY_KEY_AUTOMATIC_INDEX_NAME_PREFIX,
-        &dbsp_table_name.as_str()
+        dbsp_table_name.as_str()
     );
     emit_schema_entry(
         program,

--- a/core/types.rs
+++ b/core/types.rs
@@ -659,6 +659,9 @@ impl Value {
     }
 }
 
+// Equality deliberately compares the registered callbacks by address: two
+// states are the same aggregate only if they use the same functions.
+#[allow(unpredictable_function_pointer_comparisons)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExternalAggState {
     pub context: usize,

--- a/core/types.rs
+++ b/core/types.rs
@@ -2912,11 +2912,10 @@ where
         }
     }
 
-    let mut field_idx = skip;
     let field_limit = unpacked.len().min(index_info.key_info.len());
 
     // assumes that that the `unpacked' iterator was not skipped outside this function call`
-    for rhs_value in unpacked.skip(skip) {
+    for (field_idx, rhs_value) in (skip..).zip(unpacked.skip(skip)) {
         let rhs_value = &rhs_value.as_value_ref();
         if field_idx >= field_limit || header_pos >= header_end {
             break;
@@ -2950,8 +2949,6 @@ where
         if final_comparison != std::cmp::Ordering::Equal {
             return Ok(final_comparison);
         }
-
-        field_idx += 1;
     }
 
     Ok(tie_breaker)

--- a/core/util.rs
+++ b/core/util.rs
@@ -430,14 +430,10 @@ pub fn module_args_from_sql(sql: &str) -> Result<Vec<turso_ext::Value>> {
                     in_quotes = true;
                 }
             }
-            ',' => {
-                if !in_quotes {
-                    if !current_arg.trim().is_empty() {
-                        args.push(turso_ext::Value::from_text(current_arg.trim().to_string()));
-                        current_arg.clear();
-                    }
-                } else {
-                    current_arg.push(c);
+            ',' if !in_quotes => {
+                if !current_arg.trim().is_empty() {
+                    args.push(turso_ext::Value::from_text(current_arg.trim().to_string()));
+                    current_arg.clear();
                 }
             }
             _ => {
@@ -2306,11 +2302,11 @@ pub fn check_expr_references_column(expr: &ast::Expr, col_name_normalized: &str)
                     return Ok(WalkControl::SkipChildren);
                 }
             }
-            ast::Expr::Qualified(_, col) | ast::Expr::DoublyQualified(_, _, col) => {
-                if col.as_str().eq_ignore_ascii_case(col_name_normalized) {
-                    found = true;
-                    return Ok(WalkControl::SkipChildren);
-                }
+            ast::Expr::Qualified(_, col) | ast::Expr::DoublyQualified(_, _, col)
+                if col.as_str().eq_ignore_ascii_case(col_name_normalized) =>
+            {
+                found = true;
+                return Ok(WalkControl::SkipChildren);
             }
             _ => {}
         }
@@ -3511,10 +3507,8 @@ pub fn rewrite_check_expr_table_refs(expr: &mut ast::Expr, from: &str, to: &str)
                 ast::Expr::InSelect { rhs, .. } => {
                     rewrite_select_table_refs(rhs, from, to);
                 }
-                ast::Expr::InTable { rhs, .. } => {
-                    if rhs.name.as_str().eq_ignore_ascii_case(from) {
-                        rhs.name = ast::Name::exact(to.to_owned());
-                    }
+                ast::Expr::InTable { rhs, .. } if rhs.name.as_str().eq_ignore_ascii_case(from) => {
+                    rhs.name = ast::Name::exact(to.to_owned());
                 }
                 _ => {}
             }
@@ -4227,10 +4221,10 @@ fn expr_still_references_renamed_column(
                     }
                 }
             }
-            ast::Expr::Id(name) | ast::Expr::Name(name) => {
-                if rename_unqualified && name.as_str().eq_ignore_ascii_case(old_col) {
-                    found = true;
-                }
+            ast::Expr::Id(name) | ast::Expr::Name(name)
+                if rename_unqualified && name.as_str().eq_ignore_ascii_case(old_col) =>
+            {
+                found = true;
             }
             _ => {}
         }

--- a/core/vdbe/blob_io_tests.rs
+++ b/core/vdbe/blob_io_tests.rs
@@ -827,7 +827,7 @@ fn blob_boundary_read_write_sweep() {
     // back through SQL substr (independent of the blob write path).
     let mut blob = conn.blob_open("t", "data", 1, true).unwrap();
     for &(off, len) in &[(4090usize, 6usize), (4092, 8184), (0, 4093), (19990, 10)] {
-        let repl: Vec<u8> = (0..len).map(|i| (255 - (i as u8))).collect();
+        let repl: Vec<u8> = (0..len).map(|i| 255 - (i as u8)).collect();
         blob.write(off, &repl).unwrap();
         let mut sq = conn
             .query(format!(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4147,7 +4147,31 @@ pub fn op_transaction_inner(
                         pager.mvcc_refresh_if_db_changed();
 
                         let current_mv_tx = conn.get_mv_tx_for_db(*db);
-                        if current_mv_tx.is_none() {
+                        if let Some((tx_id, current_mode)) = current_mv_tx {
+                            if write {
+                                // Upgrade: attached DB has a Read/Concurrent tx but the
+                                // statement needs write access. Mirror the main DB's
+                                // upgrade logic so that exclusive locks are acquired.
+                                if matches!(
+                                    current_mode,
+                                    TransactionMode::None | TransactionMode::Read
+                                ) && matches!(tx_mode, TransactionMode::Write)
+                                {
+                                    if let Err(err) = begin_mvcc_tx(
+                                        mv_store,
+                                        &pager,
+                                        tx_mode,
+                                        Some(tx_id),
+                                        &conn,
+                                        None,
+                                    ) {
+                                        pager.end_read_tx();
+                                        return Err(err);
+                                    }
+                                    conn.set_mv_tx_for_db(*db, Some((tx_id, *tx_mode)));
+                                }
+                            }
+                        } else {
                             // Reject CONCURRENT on an attached DB if the main
                             // DB already started with BEGIN DEFERRED.
                             let conn_has_executed_begin_deferred =
@@ -4183,27 +4207,6 @@ pub fn op_transaction_inner(
                                     pager.end_read_tx();
                                     return Err(err);
                                 }
-                            }
-                        } else if write {
-                            // Upgrade: attached DB has a Read/Concurrent tx but the
-                            // statement needs write access. Mirror the main DB's
-                            // upgrade logic so that exclusive locks are acquired.
-                            let (tx_id, current_mode) = current_mv_tx.unwrap();
-                            if matches!(current_mode, TransactionMode::None | TransactionMode::Read)
-                                && matches!(tx_mode, TransactionMode::Write)
-                            {
-                                if let Err(err) = begin_mvcc_tx(
-                                    mv_store,
-                                    &pager,
-                                    tx_mode,
-                                    Some(tx_id),
-                                    &conn,
-                                    None,
-                                ) {
-                                    pager.end_read_tx();
-                                    return Err(err);
-                                }
-                                conn.set_mv_tx_for_db(*db, Some((tx_id, *tx_mode)));
                             }
                         }
                     } else {
@@ -5111,7 +5114,9 @@ pub fn op_integer(
     Ok(InsnFunctionStepResult::Step)
 }
 
+#[derive(Default)]
 pub enum OpProgramState {
+    #[default]
     Start,
     /// Step state tracks whether we're executing a trigger subprogram (vs FK action subprogram)
     Step {
@@ -5125,12 +5130,6 @@ pub enum OpProgramState {
         /// value becomes visible again once the trigger returns.
         saved_changes_value: Option<i64>,
     },
-}
-
-impl Default for OpProgramState {
-    fn default() -> Self {
-        Self::Start
-    }
 }
 
 fn finish_subprogram(
@@ -8864,18 +8863,18 @@ pub fn op_function(
             JsonFunc::Json => {
                 let json_value = &state.registers[*start_reg];
                 let json_str = get_json(json_value.get_value(), None);
-                match json_str {
-                    Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                {
+                    let json = json_str?;
+                    state.registers[*dest].set_value(json)
                 }
             }
 
             JsonFunc::Jsonb => {
                 let json_value = &state.registers[*start_reg];
                 let json_blob = jsonb(json_value.get_value(), &state.json_cache);
-                match json_blob {
-                    Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                {
+                    let json = json_blob?;
+                    state.registers[*dest].set_value(json)
                 }
             }
 
@@ -8895,9 +8894,9 @@ pub fn op_function(
                 };
                 let json_result = json_func(reg_values);
 
-                match json_result {
-                    Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                {
+                    let json = json_result?;
+                    state.registers[*dest].set_value(json)
                 }
             }
             JsonFunc::JsonExtract => {
@@ -8913,9 +8912,9 @@ pub fn op_function(
                     }
                 };
 
-                match result {
-                    Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                {
+                    let json = result?;
+                    state.registers[*dest].set_value(json)
                 }
             }
             JsonFunc::JsonbExtract => {
@@ -8931,9 +8930,9 @@ pub fn op_function(
                     }
                 };
 
-                match result {
-                    Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                {
+                    let json = result?;
+                    state.registers[*dest].set_value(json)
                 }
             }
 
@@ -8947,9 +8946,9 @@ pub fn op_function(
                     _ => unreachable!(),
                 };
                 let json_str = json_func(json.get_value(), path.get_value(), &state.json_cache);
-                match json_str {
-                    Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                {
+                    let json = json_str?;
+                    state.registers[*dest].set_value(json)
                 }
             }
             JsonFunc::JsonArrayLength | JsonFunc::JsonType => {
@@ -8971,16 +8970,16 @@ pub fn op_function(
                     _ => unreachable!(),
                 };
 
-                match func_result {
-                    Ok(result) => state.registers[*dest].set_value(result),
-                    Err(e) => return Err(e),
+                {
+                    let result = func_result?;
+                    state.registers[*dest].set_value(result)
                 }
             }
             JsonFunc::JsonErrorPosition => {
                 let json_value = &state.registers[*start_reg];
-                match json_error_position(json_value.get_value()) {
-                    Ok(pos) => state.registers[*dest].set_value(pos),
-                    Err(e) => return Err(e),
+                {
+                    let pos = json_error_position(json_value.get_value())?;
+                    state.registers[*dest].set_value(pos)
                 }
             }
             JsonFunc::JsonValid => {
@@ -9125,9 +9124,9 @@ pub fn op_function(
 
                 let json_result = json_set(reg_values, &state.json_cache);
 
-                match json_result {
-                    Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                {
+                    let json = json_result?;
+                    state.registers[*dest].set_value(json)
                 }
             }
             JsonFunc::JsonbSet => {
@@ -9139,17 +9138,17 @@ pub fn op_function(
 
                 let json_result = jsonb_set(reg_values, &state.json_cache);
 
-                match json_result {
-                    Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                {
+                    let json = json_result?;
+                    state.registers[*dest].set_value(json)
                 }
             }
             JsonFunc::JsonQuote => {
                 let json_value = &state.registers[*start_reg];
 
-                match json_quote(json_value.get_value()) {
-                    Ok(result) => state.registers[*dest].set_value(result),
-                    Err(e) => return Err(e),
+                {
+                    let result = json_quote(json_value.get_value())?;
+                    state.registers[*dest].set_value(result)
                 }
             }
         },
@@ -10020,13 +10019,7 @@ pub fn op_function(
                             ScalarFunc::TestUintAdd => a.checked_add(b),
                             ScalarFunc::TestUintSub => a.checked_sub(b),
                             ScalarFunc::TestUintMul => a.checked_mul(b),
-                            ScalarFunc::TestUintDiv => {
-                                if b == 0 {
-                                    None
-                                } else {
-                                    Some(a / b)
-                                }
-                            }
+                            ScalarFunc::TestUintDiv => a.checked_div(b),
                             _ => unreachable!(),
                         };
                         match r {
@@ -15995,7 +15988,7 @@ pub fn op_rename_table(
 
         // Also update triggers on OTHER tables that reference the renamed table
         // in their body commands (e.g., INSERT INTO old_name in a trigger on another table)
-        for (_, triggers) in schema.triggers.iter_mut() {
+        for triggers in schema.triggers.values_mut() {
             for trigger_arc in triggers.iter_mut() {
                 if !sql_might_reference_identifier(&trigger_arc.sql, &normalized_from) {
                     continue;

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -647,7 +647,7 @@ pub fn insn_to_row(
                         "r[{}]={}.{}",
                         dest,
                         get_table_or_index_name(*cursor_id),
-                        &column_name.map_or_else(|| format!("column {}", *column), |name| name.to_string())
+                        column_name.map_or_else(|| format!("column {}", *column), |name| name.to_string())
                     ),
                 )
             }
@@ -1201,7 +1201,7 @@ pub fn insn_to_row(
                 format!(
                     "if (r[{}]!={}.rowid) goto {}",
                     src_reg,
-                    &program.cursor_ref[*cursor_id]
+                    program.cursor_ref[*cursor_id]
                         .0
                         .as_ref()
                         .map(|k| format!(
@@ -2752,7 +2752,7 @@ pub fn insn_to_row_with_comment(
         p3,
         p4,
         p5,
-        manual_comment.map_or(comment.to_string(), |mc| format!("{comment}; {mc}")),
+        manual_comment.map_or_else(|| comment.to_string(), |mc| format!("{comment}; {mc}")),
     )
 }
 
@@ -2767,12 +2767,12 @@ pub fn insn_to_str(
     format!(
         "{:<4}  {:<17}  {:<4}  {:<4}  {:<4}  {:<13}  {:<2}  {}",
         addr,
-        &(indent + opcode),
+        (indent + opcode),
         p1,
         p2,
         p3,
         p4.to_string(),
         p5,
-        manual_comment.map_or(comment.to_string(), |mc| format!("{comment}; {mc}"))
+        manual_comment.map_or_else(|| comment.to_string(), |mc| format!("{comment}; {mc}"))
     )
 }

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -1111,11 +1111,10 @@ impl HashTable {
             return count;
         }
 
-        let avg_entry_size = if self.num_entries > 0 {
-            (self.mem_used / self.num_entries).max(entry_size)
-        } else {
-            entry_size.max(1)
-        };
+        let avg_entry_size = self
+            .mem_used
+            .checked_div(self.num_entries)
+            .map_or_else(|| entry_size.max(1), |avg| avg.max(entry_size));
         let target_partition_bytes = (self.mem_budget / 2).max(avg_entry_size);
         let target_entries_per_partition = (target_partition_bytes / avg_entry_size).max(1);
         let estimated_total_entries = self.num_entries.saturating_add(1);
@@ -1229,12 +1228,8 @@ impl HashTable {
             HashEntry::new_with_payload(hash, key_values, rowid, payload_values)
         };
 
-        if self.spill_state.is_some() {
-            let partition_idx = {
-                let spill_state = self.spill_state.as_ref().expect("spill state must exist");
-                spill_state.partitioning.index(hash)
-            };
-            let spill_state = self.spill_state.as_mut().expect("spill state must exist");
+        if let Some(spill_state) = self.spill_state.as_mut() {
+            let partition_idx = spill_state.partitioning.index(hash);
             // In spilled mode, insert into partition buffer
             spill_state.partition_buffers[partition_idx].insert(entry)?;
         } else {
@@ -1743,7 +1738,7 @@ impl HashTable {
             .filter(|(_, p)| !p.is_empty())
             .map(|(idx, p)| (idx, p.mem_used))
             .try_collect()?;
-        candidates.sort_by(|a, b| b.1.cmp(&a.1)); // Sort descending by mem_used
+        candidates.sort_by_key(|c| std::cmp::Reverse(c.1)); // Sort descending by mem_used
 
         for (partition_idx, mem_used) in candidates {
             if projected_mem_used + entry_size <= self.mem_budget {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -40,6 +40,8 @@ mod statement_lifecycle_tests;
 pub mod vacuum;
 pub mod value;
 // for benchmarks
+// Re-exported for the benches, which reach vdbe only when it is public.
+#[cfg(any(feature = "fuzz", feature = "bench"))]
 pub use crate::translate::collate::CollationSeq;
 use crate::{
     alloc::{DynAllocator, TryClone},

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -527,7 +527,9 @@ pub struct OpHashProbeState {
     pub probe_buffered: bool,
 }
 
+#[derive(Default)]
 enum ActiveOpState {
+    #[default]
     None,
     ClearBtree(OpClearBtreeState),
     Delete(OpDeleteState),
@@ -601,12 +603,6 @@ macro_rules! active_state_accessor {
             }
         }
     };
-}
-
-impl Default for ActiveOpState {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 impl ActiveOpStateSlot {
@@ -749,16 +745,12 @@ pub(crate) struct DeferredSeekState {
     pub table_cursor_id: CursorID,
 }
 
+#[derive(Default)]
 pub(crate) enum VacuumOpState {
+    #[default]
     None,
     IntoFile(Box<VacuumIntoOpContext>),
     InPlace(Box<VacuumInPlaceOpContext>),
-}
-
-impl Default for VacuumOpState {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 /// The program state describes the environment in which the program executes.
@@ -1316,7 +1308,7 @@ impl ProgramState {
         self.has_stmt_transaction = false;
 
         // Drain attached pagers upfront so we can clean them up regardless of path.
-        let attached_pagers: Vec<Arc<Pager>> = self.attached_savepoint_pagers.drain(..).collect();
+        let attached_pagers: Vec<Arc<Pager>> = std::mem::take(&mut self.attached_savepoint_pagers);
         let result = match end_statement {
             EndStatement::ReleaseSavepoint => {
                 if let Some(mv_store) = connection.mv_store().as_ref() {
@@ -2403,10 +2395,7 @@ impl Program {
         }
 
         // Start/continue committing remaining attached MVCC transactions
-        loop {
-            let Some((db_id, tx_id, _mode)) = conn.next_attached_mv_tx() else {
-                break;
-            };
+        while let Some((db_id, tx_id, _mode)) = conn.next_attached_mv_tx() {
             let Some(attached_mv_store) = conn.mv_store_for_db(db_id) else {
                 conn.set_mv_tx_for_db(db_id, None);
                 continue;

--- a/core/vdbe/rowset.rs
+++ b/core/vdbe/rowset.rs
@@ -180,11 +180,13 @@ mod tests {
     };
 
     fn get_seed() -> u64 {
-        std::env::var("SEED").map_or(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
+        std::env::var("SEED").map_or_else(
+            |_| {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis()
+            },
             |v| {
                 v.parse()
                     .expect("Failed to parse SEED environment variable as u64")

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1139,11 +1139,13 @@ mod tests {
     };
 
     fn get_seed() -> u64 {
-        std::env::var("SEED").map_or(
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis(),
+        std::env::var("SEED").map_or_else(
+            |_| {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis()
+            },
             |v| {
                 v.parse()
                     .expect("Failed to parse SEED environment variable as u64")
@@ -1175,9 +1177,13 @@ mod tests {
                     let denominator = (rng.next_u64() as f64).abs().max(1.0);
                     Value::from_f64(numerator / denominator)
                 }
-                5 => Value::from_f64(if rng.next_u64() % 2 == 0 { 0.0 } else { -0.0 }),
+                5 => Value::from_f64(if rng.next_u64().is_multiple_of(2) {
+                    0.0
+                } else {
+                    -0.0
+                }),
                 6..=8 => {
-                    let alphabet = [b'a', b'b', b'\0'];
+                    let alphabet = *b"ab\0";
                     let len = (rng.next_u64() % 10) as usize;
                     let s: String = (0..len)
                         .map(|_| alphabet[(rng.next_u64() % 3) as usize] as char)
@@ -1194,7 +1200,7 @@ mod tests {
         };
 
         let gen_key = |rng: &mut ChaCha8Rng| KeyInfo {
-            sort_order: if rng.next_u64() % 2 == 0 {
+            sort_order: if rng.next_u64().is_multiple_of(2) {
                 SortOrder::Asc
             } else {
                 SortOrder::Desc

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1258,9 +1258,11 @@ struct VacuumInPlaceCleanupState {
 }
 
 /// Phases for the in-place VACUUM state machine.
+#[derive(Default)]
 enum VacuumInPlacePhase {
     /// Validate preconditions (auto_commit, active statements, readonly, memory,
     /// MVCC, WAL-backed pager). Then acquire check_point lock
+    #[default]
     Preflight,
     /// Acquire exclusive source access on the source WAL via
     /// `begin_vacuum_blocking_tx`: checkpoint_lock is already held from Preflight;
@@ -1333,12 +1335,6 @@ enum VacuumInPlacePhase {
     InstallCommittedImage,
     /// Clean up after successful commit.
     Done,
-}
-
-impl Default for VacuumInPlacePhase {
-    fn default() -> Self {
-        Self::Preflight
-    }
 }
 
 /// Holds the context for the in-place VACUUM operation across async yields.

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -105,7 +105,7 @@ mod cmath {
     }
 
     // SQLite's M_PI constant (same value as SQLite's func.c)
-    #[allow(clippy::excessive_precision)]
+    #[allow(clippy::excessive_precision, clippy::approx_constant)]
     const M_PI: f64 = 3.141592653589793238462643383279502884;
 
     pub fn degrees(x: f64) -> f64 {
@@ -263,10 +263,12 @@ impl Value {
             }
 
             let code = get_code(b);
-            if code.is_some() && code != prev_code {
-                result.push(code.unwrap());
-                prev_code = code;
-            } else if code.is_none() {
+            if let Some(c) = code {
+                if code != prev_code {
+                    result.push(c);
+                    prev_code = code;
+                }
+            } else {
                 // Reset previous code for vowels/separators (a,e,i,o,u,y)
                 prev_code = None;
             }
@@ -2130,7 +2132,7 @@ mod tests {
 
     #[test]
     fn test_exec_and() {
-        let inputs = vec![
+        let inputs = [
             (Value::from_i64(0), Value::Null),
             (Value::Null, Value::from_i64(1)),
             (Value::Null, Value::Null),

--- a/core/vector/operations/serialize.rs
+++ b/core/vector/operations/serialize.rs
@@ -26,7 +26,7 @@ pub fn vector_serialize(x: Vector) -> Result<Value, TryReserveError> {
             // Format: [data bytes][optional padding][trailing_bits][0x03]
             let dims = x.dims;
             let data_size = dims.div_ceil(8);
-            let needs_padding = data_size % 2 == 0;
+            let needs_padding = data_size.is_multiple_of(2);
             let mut blob = x.bin_eject()?;
             blob.truncate(data_size);
             blob.try_reserve(usize::from(needs_padding) + 2)?;

--- a/core/vector/operations/slice.rs
+++ b/core/vector/operations/slice.rs
@@ -70,7 +70,7 @@ mod tests {
         vector_types::{Vector, VectorType},
     };
 
-    fn float32_vec_from(slice: &[f32]) -> Vector {
+    fn float32_vec_from(slice: &[f32]) -> Vector<'_> {
         let mut data = crate::alloc::vec![];
         for &v in slice {
             data.extend_from_slice(&v.to_le_bytes());

--- a/core/vector/operations/text.rs
+++ b/core/vector/operations/text.rs
@@ -66,7 +66,7 @@ fn format_text<T: std::string::ToString>(values: impl Iterator<Item = T>) -> Str
 /// [1.0, 2.0, 3.0]
 /// ```
 #[turso_macros::allocation_site(crate::alloc::VectorAllocationSite::Parse)]
-pub fn vector_from_text(vector_type: VectorType, text: &str) -> Result<Vector> {
+pub fn vector_from_text(vector_type: VectorType, text: &str) -> Result<Vector<'_>> {
     let text = text.trim();
     let mut chars = text.chars();
     if chars.next() != Some('[') || chars.last() != Some(']') {

--- a/core/vector/vector_types.rs
+++ b/core/vector/vector_types.rs
@@ -36,7 +36,7 @@ impl<'a> Vector<'a> {
     /// computed later in from_data).
     pub fn vector_type(blob: &[u8]) -> Result<(VectorType, usize, usize)> {
         // Even-sized blobs are always float32.
-        if blob.len() % 2 == 0 {
+        if blob.len().is_multiple_of(2) {
             return Ok((VectorType::Float32Dense, blob.len(), 0));
         }
         // Odd-sized blobs have type byte at the end
@@ -57,7 +57,7 @@ impl<'a> Vector<'a> {
             3 => {
                 // Float1Bit: [data bytes][optional padding][trailing_bits][0x03]
                 let n_blob_size = blob.len() - 1; // without type byte
-                if n_blob_size == 0 || n_blob_size % 2 != 0 {
+                if n_blob_size == 0 || !n_blob_size.is_multiple_of(2) {
                     return Err(LimboError::ConversionError(
                         "float1bit vector blob length must be even and non-empty".to_string(),
                     ));
@@ -86,7 +86,7 @@ impl<'a> Vector<'a> {
             4 => {
                 // Float8: [quantized bytes][alignment padding][alpha f32][shift f32][padding 0x00][trailing_bytes][0x04]
                 let n_blob_size = blob.len() - 1; // without type byte
-                if n_blob_size < 2 || n_blob_size % 2 != 0 {
+                if n_blob_size < 2 || !n_blob_size.is_multiple_of(2) {
                     return Err(LimboError::ConversionError(
                         "float8 vector blob must have even length >= 2 (excluding type byte)"
                             .to_string(),
@@ -341,7 +341,7 @@ impl<'a> Vector<'a> {
                 // `idx` entry comes from the blob and is used to index a dense
                 // `dims` buffer, so check it here rather than in each consumer.
                 let entries = (original_len - 4) / 8;
-                for entry in data[entries * 4..entries * 8].chunks_exact(4) {
+                for entry in data[entries * 4..entries * 8].as_chunks::<4>().0 {
                     let index =
                         u32::from_le_bytes([entry[0], entry[1], entry[2], entry[3]]) as usize;
                     if index >= dims {
@@ -641,7 +641,7 @@ pub(crate) mod tests {
                         *b = u8::arbitrary(g);
                     }
                     // Mask off unused bits in the last byte
-                    if DIMS % 8 != 0 {
+                    if !DIMS.is_multiple_of(8) {
                         let mask = (1u8 << (DIMS % 8)) - 1;
                         if let Some(last) = bits.last_mut() {
                             *last &= mask;

--- a/extensions/fuzzy/src/phonetic.rs
+++ b/extensions/fuzzy/src/phonetic.rs
@@ -25,10 +25,8 @@ pub fn phonetic_hash(z_in: &[u8]) -> Option<Vec<u8>> {
     let mut input = z_in;
     if z_in.len() > 2 {
         match z_in[0] {
-            b'g' | b'k' => {
-                if z_in[1] == b'n' {
-                    input = &z_in[1..];
-                }
+            b'g' | b'k' if z_in[1] == b'n' => {
+                input = &z_in[1..];
             }
             _ => {}
         }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -225,10 +225,8 @@ fn process_payload(payload_group: Group) -> String {
                 }
                 is_variable_name = false;
             }
-            TokenTree::Punct(punct) => {
-                if punct.to_string() == "," {
-                    is_variable_name = true;
-                }
+            TokenTree::Punct(punct) if punct.to_string() == "," => {
+                is_variable_name = true;
             }
             _ => {}
         }

--- a/postgres/cli/main.rs
+++ b/postgres/cli/main.rs
@@ -995,10 +995,10 @@ fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
     let _guard = init_tracing(&opts)?;
 
-    let db_file = opts
-        .database
-        .as_ref()
-        .map_or(":memory:".to_string(), |p| p.to_string_lossy().to_string());
+    let db_file = opts.database.as_ref().map_or_else(
+        || ":memory:".to_string(),
+        |p| p.to_string_lossy().to_string(),
+    );
 
     let (io, conn) = open_database(&db_file, opts.vfs.as_ref(), opts.readonly)?;
 

--- a/postgres/frontend/catalog.rs
+++ b/postgres/frontend/catalog.rs
@@ -621,15 +621,13 @@ impl PgNamespaceCursor {
 
         // Add attached schemas (CREATE SCHEMA creates attached databases)
         let schema_names = self.conn.attached_database_names();
-        let mut oid = 16384i64;
-        for name in schema_names {
+        for (oid, name) in (16384i64..).zip(schema_names) {
             self.rows.push(vec![
                 Value::from_i64(oid),
                 Value::build_text(name),
                 Value::from_i64(10), // nspowner (bootstrap superuser)
                 Value::Null,         // nspacl
             ]);
-            oid += 1;
         }
         Ok(())
     }
@@ -763,12 +761,7 @@ impl PgAttributeCursor {
         let schema = self.conn.current_schema();
         self.rows.clear();
 
-        let mut oid_counter = USER_TABLE_OID_START;
-
-        for (_, table) in user_tables_sorted(&schema) {
-            let table_oid = oid_counter;
-            oid_counter += 1;
-
+        for (table_oid, (_, table)) in (USER_TABLE_OID_START..).zip(user_tables_sorted(&schema)) {
             let columns = table.columns();
             for (i, col) in columns.iter().enumerate() {
                 let col_name = col.name.clone().unwrap_or_default();

--- a/postgres/frontend/functions.rs
+++ b/postgres/frontend/functions.rs
@@ -768,10 +768,8 @@ fn validate_json_braces(s: &str) -> bool {
         match ch {
             '{' => stack.push('}'),
             '[' => stack.push(']'),
-            '}' | ']' => {
-                if stack.pop() != Some(ch) {
-                    return false;
-                }
+            '}' | ']' if stack.pop() != Some(ch) => {
+                return false;
             }
             _ => {}
         }

--- a/postgres/server/lib.rs
+++ b/postgres/server/lib.rs
@@ -523,7 +523,7 @@ fn pg_bytes_to_value(bytes: &[u8], pg_type: &Type) -> PgWireResult<Value> {
 
 /// Decode a hex string into bytes.
 fn decode_hex(hex: &str) -> Result<Vec<u8>, String> {
-    if hex.len() % 2 != 0 {
+    if !hex.len().is_multiple_of(2) {
         return Err("odd-length hex string".to_owned());
     }
     (0..hex.len())

--- a/postgres/tests/integration/postgres/functions.rs
+++ b/postgres/tests/integration/postgres/functions.rs
@@ -73,16 +73,16 @@ fn test_pg_current_database_matches_pg_database(db: TempDatabase) {
     let expected = db.path.file_stem().unwrap().to_str().unwrap().to_string();
     assert_eq!(
         query_text(&conn, "SELECT current_database()"),
-        [expected.clone()]
+        std::slice::from_ref(&expected)
     );
     assert_eq!(
         query_text(&conn, "SELECT * FROM current_database()"),
-        [expected.clone()]
+        std::slice::from_ref(&expected)
     );
     // The bare current_catalog keyword is the same function per PG docs.
     assert_eq!(
         query_text(&conn, "SELECT current_catalog"),
-        [expected.clone()]
+        std::slice::from_ref(&expected)
     );
     // Must agree with what the pg_database catalog reports as datname.
     assert_eq!(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.98"
 components = ["clippy", "rustfmt", "rust-analyzer"]

--- a/serverless/rust/differential/lib.rs
+++ b/serverless/rust/differential/lib.rs
@@ -247,7 +247,7 @@ pub fn gen_value(tc: &TestCase) -> Val {
         "empty_blob" => Val::Blob(vec![]),
         "large_or_unicode" => {
             let pick: u8 = tc.draw(gs::integers::<u8>());
-            if pick % 2 == 0 {
+            if pick.is_multiple_of(2) {
                 Val::Blob(vec![0xAB; 256])
             } else {
                 let options = spec_unicode_options();
@@ -545,7 +545,7 @@ fn gen_transaction_workflow(
     let commit_byte: u8 = tc.draw(gs::integers::<u8>());
     Op::TransactionWorkflow {
         inner_ops,
-        commit: commit_byte % 2 == 0,
+        commit: commit_byte.is_multiple_of(2),
     }
 }
 

--- a/sql_generation/model/query/select.rs
+++ b/sql_generation/model/query/select.rs
@@ -122,8 +122,7 @@ impl Select {
                     .from
                     .as_ref()
                     .map(|f| f.dependencies())
-                    .unwrap_or(vec![])
-                    .into_iter(),
+                    .unwrap_or(vec![]),
             );
         }
 

--- a/sql_generation/model/table.rs
+++ b/sql_generation/model/table.rs
@@ -457,7 +457,9 @@ impl From<&ast::Literal> for SimValue {
             ast::Literal::Blob(blob) => types::Value::Blob(
                 ast::blob_literal_hex(blob)
                     .as_bytes()
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|pair| {
                         // We assume that sqlite3-parser has already validated that
                         // the input is valid hex string, thus unwrap is safe.

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -5511,7 +5511,6 @@ mod tests {
         }
     }
 
-    #[expect(clippy::large_stack_frames)]
     #[test]
     fn test_parser() {
         let test_cases = vec![

--- a/sync/engine/src/database_replay_generator.rs
+++ b/sync/engine/src/database_replay_generator.rs
@@ -139,7 +139,7 @@ impl DatabaseReplayGenerator {
         updates: &[turso_core::Value],
     ) -> HashMap<String, turso_core::Value> {
         let mut row = HashMap::with_capacity(info.column_names.len());
-        assert!(updates.len() % 2 == 0);
+        assert!(updates.len().is_multiple_of(2));
         let columns_cnt = updates.len() / 2;
         for (i, value) in updates.iter().take(columns_cnt).enumerate() {
             let updated = match value {
@@ -194,7 +194,7 @@ impl DatabaseReplayGenerator {
             }
             DatabaseChangeType::Update => {
                 let mut updates = updates.unwrap();
-                assert!(updates.len() % 2 == 0);
+                assert!(updates.len().is_multiple_of(2));
                 let columns_cnt = updates.len() / 2;
                 let mut values =
                     <crate::alloc::Vec<turso_core::Value> as TursoVecExt<_>>::with_capacity(

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -3799,7 +3799,12 @@ mod tests {
             coro.yield_(SyncEngineIoResult::IO).await?;
         }
 
-        for (page_idx, page) in pages.chunks_exact(super::PAGE_SIZE).enumerate() {
+        for (page_idx, page) in pages
+            .as_chunks::<{ super::PAGE_SIZE }>()
+            .0
+            .iter()
+            .enumerate()
+        {
             let mut frame = vec![0; super::WAL_FRAME_SIZE];
             frame[super::WAL_FRAME_HEADER..].copy_from_slice(page);
             let frame_info = turso_core::types::WalFrameInfo {
@@ -4663,7 +4668,12 @@ mod tests {
             protocol: protocol as i32,
         };
         let mut bytes = header.encode_length_delimited_to_vec();
-        for (page_idx, page) in db_bytes.chunks_exact(super::PAGE_SIZE).enumerate() {
+        for (page_idx, page) in db_bytes
+            .as_chunks::<{ super::PAGE_SIZE }>()
+            .0
+            .iter()
+            .enumerate()
+        {
             let page_data = PageData {
                 page_id: page_idx as u64,
                 encoded_page: Bytes::copy_from_slice(page),

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -3016,12 +3016,14 @@ async fn send_push_batch<IO: SyncEngineIo, Ctx>(
         );
         rows_changed += 1;
         // we give user full control over CDC table - so let's not emit assert here for now
-        if last_change_id.is_some() && last_change_id.unwrap() + 1 != change_id {
-            tracing::debug!(
-                "out of order change sequence: {} -> {}",
-                last_change_id.unwrap(),
-                change_id
-            );
+        if let Some(last_change_id) = last_change_id {
+            if last_change_id + 1 != change_id {
+                tracing::debug!(
+                    "out of order change sequence: {} -> {}",
+                    last_change_id,
+                    change_id
+                );
+            }
         }
         last_change_id = Some(change_id);
         match transform_result {

--- a/sync/sdk-kit/src/sync_engine_io.rs
+++ b/sync/sdk-kit/src/sync_engine_io.rs
@@ -208,7 +208,9 @@ impl<TBytes: AsRef<[u8]>> SyncEngineIoCompletion<TBytes> {
         completion.finished = true;
     }
 
-    fn inner(&self) -> turso_sync_engine::Result<MutexGuard<SyncEngineIoCompletionInner<TBytes>>> {
+    fn inner(
+        &self,
+    ) -> turso_sync_engine::Result<MutexGuard<'_, SyncEngineIoCompletionInner<TBytes>>> {
         let inner = self.inner.lock().unwrap();
         if let Some(err) = &inner.err {
             return Err(turso_sync_engine::errors::Error::DatabaseSyncEngineError(

--- a/testing/concurrent-simulator/allocation_fault.rs
+++ b/testing/concurrent-simulator/allocation_fault.rs
@@ -80,16 +80,16 @@ pub(crate) fn install_global_allocation_fault_backend(
     }
 
     ALLOCATION_FAULT_INJECTOR.configure(config, seed);
-    if !ALLOCATION_FAULT_BACKEND_INSTALLED.swap(true, Ordering::AcqRel) {
-        if let Err(err) = unsafe { turso_core::alloc::set_allocator(&ALLOCATION_FAULT_INJECTOR) } {
-            ALLOCATION_FAULT_BACKEND_INSTALLED.store(false, Ordering::Release);
-            return Err(match err {
-                SetAllocatorError::AlreadyInitialized => anyhow::anyhow!(
-                    "allocation fault injection requires installing Whopper's allocator before \
+    if !ALLOCATION_FAULT_BACKEND_INSTALLED.swap(true, Ordering::AcqRel)
+        && let Err(err) = unsafe { turso_core::alloc::set_allocator(&ALLOCATION_FAULT_INJECTOR) }
+    {
+        ALLOCATION_FAULT_BACKEND_INSTALLED.store(false, Ordering::Release);
+        return Err(match err {
+            SetAllocatorError::AlreadyInitialized => anyhow::anyhow!(
+                "allocation fault injection requires installing Whopper's allocator before \
                      another Turso allocator backend is installed"
-                ),
-            });
-        }
+            ),
+        });
     }
 
     Ok(Some(&ALLOCATION_FAULT_INJECTOR))

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -1071,14 +1071,14 @@ impl Whopper {
             let _enter = span.enter();
             debug!("result={step_result:?}, rows.len()={}", rows.len());
 
-            if let Operation::Begin { mode } = completed_op {
-                if step_result.is_ok() {
-                    ctx.fiber.state = if mode == TxMode::Concurrent {
-                        FiberState::InConcurrentTx
-                    } else {
-                        FiberState::InTx
-                    };
-                }
+            if let Operation::Begin { mode } = completed_op
+                && step_result.is_ok()
+            {
+                ctx.fiber.state = if mode == TxMode::Concurrent {
+                    FiberState::InConcurrentTx
+                } else {
+                    FiberState::InTx
+                };
             }
 
             let txn_id = ctx.fiber.txn_id;
@@ -1164,7 +1164,7 @@ impl Whopper {
                         continue;
                     }
                     let fiber = &self.context.fibers[fiber_idx];
-                    let state_str = format!("{:?}", &fiber.state);
+                    let state_str = format!("{:?}", fiber.state);
                     let span =
                         tracing::debug_span!("generate", fiber = fiber_idx, state = state_str);
                     let _enter = span.enter();
@@ -1195,7 +1195,7 @@ impl Whopper {
             let exec_id = self.context.state.gen_execution_id();
 
             let fiber = &mut self.context.fibers[fiber_idx];
-            let state_str = format!("{:?}", &fiber.state);
+            let state_str = format!("{:?}", fiber.state);
             let span = tracing::debug_span!(
                 "init",
                 step = self.current_step,
@@ -1269,10 +1269,9 @@ impl Whopper {
         // workloads start with BEGIN and can't nest inside an existing transaction)
         if self.context.fibers[fiber_idx].chaotic_workload.is_none()
             && self.context.fibers[fiber_idx].state == FiberState::Idle
+            && let Some(op) = self.pick_chaotic_workload(fiber_idx)
         {
-            if let Some(op) = self.pick_chaotic_workload(fiber_idx) {
-                self.context.fibers[fiber_idx].current_op = Some(op);
-            }
+            self.context.fibers[fiber_idx].current_op = Some(op);
         }
     }
 
@@ -1487,13 +1486,13 @@ impl Whopper {
         self.drain_active_statements("reopen")?;
         // Close and drop all fiber connections to release database Arc references
         {
-            let fibers = self.context.fibers.drain(..).collect::<Vec<_>>();
+            let fibers = std::mem::take(&mut self.context.fibers);
             for fiber in fibers {
                 drop(fiber.statement.into_inner());
-                if self.close_connections_gracefully {
-                    if let Err(e) = fiber.connection.close() {
-                        debug!("Error closing connection during restart: {}", e);
-                    }
+                if self.close_connections_gracefully
+                    && let Err(e) = fiber.connection.close()
+                {
+                    debug!("Error closing connection during restart: {}", e);
                 }
                 drop(fiber.connection);
             }
@@ -1664,10 +1663,10 @@ impl Whopper {
             if let Some(mv_store) = db.get_mv_store().as_ref() {
                 mv_store.set_checkpoint_threshold(-1);
             }
-        } else if let Some(threshold) = self.mvcc_checkpoint_threshold {
-            if let Some(mv_store) = db.get_mv_store().as_ref() {
-                mv_store.set_checkpoint_threshold(threshold);
-            }
+        } else if let Some(threshold) = self.mvcc_checkpoint_threshold
+            && let Some(mv_store) = db.get_mv_store().as_ref()
+        {
+            mv_store.set_checkpoint_threshold(threshold);
         }
 
         for i in 0..self.max_connections {

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -307,11 +307,11 @@ fn run_inprocess(args: &Args, seed: u64) -> anyhow::Result<()> {
 
     let mut loop_err: Option<anyhow::Error> = None;
     while !whopper.is_done() {
-        if whopper.rng.random_bool(reopen_probability) {
-            if let Err(e) = whopper.reopen() {
-                loop_err = Some(e);
-                break;
-            }
+        if whopper.rng.random_bool(reopen_probability)
+            && let Err(e) = whopper.reopen()
+        {
+            loop_err = Some(e);
+            break;
         }
         match whopper.step() {
             Ok(StepResult::Ok) => {}

--- a/testing/concurrent-simulator/multiprocess.rs
+++ b/testing/concurrent-simulator/multiprocess.rs
@@ -60,10 +60,10 @@ struct OperationHistoryWriter {
 impl OperationHistoryWriter {
     fn new(output_path: Option<&Path>) -> anyhow::Result<Self> {
         let output = if let Some(path) = output_path {
-            if let Some(parent) = path.parent() {
-                if !parent.as_os_str().is_empty() {
-                    create_dir_all(parent)?;
-                }
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                create_dir_all(parent)?;
             }
             Some(BufWriter::new(File::create(path)?))
         } else {
@@ -917,15 +917,14 @@ impl MultiprocessWhopper {
         }
 
         // Update fiber state for BEGIN
-        if let Operation::Begin { mode } = &op {
-            if op_result.is_ok() {
-                self.connection_states[connection_idx].fiber_state = if *mode == TxMode::Concurrent
-                {
-                    FiberState::InConcurrentTx
-                } else {
-                    FiberState::InTx
-                };
-            }
+        if let Operation::Begin { mode } = &op
+            && op_result.is_ok()
+        {
+            self.connection_states[connection_idx].fiber_state = if *mode == TxMode::Concurrent {
+                FiberState::InConcurrentTx
+            } else {
+                FiberState::InTx
+            };
         }
 
         // Apply state changes (sim_state + stats)
@@ -1043,10 +1042,9 @@ impl MultiprocessWhopper {
             .chaotic_workload
             .is_none()
             && self.connection_states[connection_idx].fiber_state == FiberState::Idle
+            && let Some(op) = self.pick_chaotic_workload(connection_idx)
         {
-            if let Some(op) = self.pick_chaotic_workload(connection_idx) {
-                self.connection_states[connection_idx].current_op = Some(op);
-            }
+            self.connection_states[connection_idx].current_op = Some(op);
         }
     }
 

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -121,12 +121,12 @@ impl Property for SimpleKeysDoNotDisappear {
 
         // on successful COMMIT we move information about current transaction keys to the "commited" state (None key in the map)
         // note, that we use end_exec_id of current COMMIT operation as AdditionMoment of moved keys
-        if let Operation::Commit = &op {
-            if let Some(keys) = self.simple_keys_added_at.remove(&txn_id) {
-                let global = self.simple_keys_added_at.get_mut(&None).unwrap();
-                for (key, _) in keys {
-                    global.insert(key, end_exec_id);
-                }
+        if let Operation::Commit = &op
+            && let Some(keys) = self.simple_keys_added_at.remove(&txn_id)
+        {
+            let global = self.simple_keys_added_at.get_mut(&None).unwrap();
+            for (key, _) in keys {
+                global.insert(key, end_exec_id);
             }
         }
 
@@ -177,10 +177,9 @@ impl Property for SimpleKeysDoNotDisappear {
         // We still catch the canonical INSERT-then-SELECT pattern on
         // seeds without intervening arbitrary mutators.
         if let Operation::Delete { .. } | Operation::Update { .. } | Operation::Insert { .. } = &op
+            && let Some(global) = self.simple_keys_added_at.get_mut(&None)
         {
-            if let Some(global) = self.simple_keys_added_at.get_mut(&None) {
-                global.clear();
-            }
+            global.clear();
         }
 
         // on successful SELECT get information about the key AdditionMoment from the "commited" state: key_exec_id
@@ -420,14 +419,14 @@ impl ElleHistoryRecorder {
         } else {
             None
         };
-        if let Some(pending) = self.pending_txns.get_mut(&fiber_id) {
-            if result.is_ok() {
-                if let Some(idx) = new_index {
-                    pending.invoke_index = Some(idx);
-                    pending.invoke_time = Some(start_exec_id);
-                }
-                pending.ops.push(op);
+        if let Some(pending) = self.pending_txns.get_mut(&fiber_id)
+            && result.is_ok()
+        {
+            if let Some(idx) = new_index {
+                pending.invoke_index = Some(idx);
+                pending.invoke_time = Some(start_exec_id);
             }
+            pending.ops.push(op);
         }
     }
 
@@ -721,30 +720,29 @@ impl Property for ElleHistoryRecorder {
     }
 
     fn abort_fiber(&mut self, fiber_id: usize, _txn_id: Option<u64>) -> anyhow::Result<()> {
-        if let Some(pending) = self.pending_txns.remove(&fiber_id) {
-            if let Some(invoke_index) = pending.invoke_index {
-                if !pending.ops.is_empty() {
-                    let invoke_time = pending
-                        .invoke_time
-                        .expect("invoke_time must be set when invoke_index is set");
-                    let invoke_ops = nil_reads(&pending.ops);
-                    self.add_event(
-                        invoke_index,
-                        ElleEventType::Invoke,
-                        fiber_id,
-                        invoke_ops,
-                        invoke_time,
-                    );
-                    let info_index = self.next_index();
-                    self.add_event(
-                        info_index,
-                        ElleEventType::Info,
-                        fiber_id,
-                        pending.ops,
-                        invoke_time,
-                    );
-                }
-            }
+        if let Some(pending) = self.pending_txns.remove(&fiber_id)
+            && let Some(invoke_index) = pending.invoke_index
+            && !pending.ops.is_empty()
+        {
+            let invoke_time = pending
+                .invoke_time
+                .expect("invoke_time must be set when invoke_index is set");
+            let invoke_ops = nil_reads(&pending.ops);
+            self.add_event(
+                invoke_index,
+                ElleEventType::Invoke,
+                fiber_id,
+                invoke_ops,
+                invoke_time,
+            );
+            let info_index = self.next_index();
+            self.add_event(
+                info_index,
+                ElleEventType::Info,
+                fiber_id,
+                pending.ops,
+                invoke_time,
+            );
         }
 
         if let Some(pending) = self.pending_auto_commits.remove(&fiber_id) {
@@ -1144,71 +1142,71 @@ impl Property for SequenceCorrectnessProperty {
         result: &OpResult,
     ) -> anyhow::Result<()> {
         // Handle NextVal/SetVal errors
-        if let Operation::NextVal { seq_name } | Operation::SetVal { seq_name, .. } = op {
-            if let Err(e) = result {
-                // Drop the in-flight baseline so a future NextVal on the
-                // same (fiber, seq) doesn't reuse a stale snapshot.
-                self.in_flight_nextval_baselines
-                    .remove(&(fiber_id, seq_name.clone()));
-                let err_msg = e.to_string();
-                // Sequence may have been dropped concurrently
-                if err_msg.contains("does not exist") {
-                    self.params.remove(seq_name);
-                    self.all_values.remove(seq_name);
-                    self.watermark.remove(seq_name);
-                    self.committed_watermark.remove(seq_name);
-                    self.last_setval_exec_id.remove(seq_name);
-                    self.fiber_last_nextval
-                        .retain(|(_fid, name), _| name != seq_name);
-                    return Ok(());
-                }
-                // nextval/setval are write transactions (backing table write),
-                // so concurrency errors are expected. Clear fiber_last_nextval
-                // because the Function instruction may have already set the
-                // connection's currval before the backing table write failed.
-                //
-                // The "setval requires an exclusive transaction" error is
-                // also accepted: SetValWorkload should not generate setval
-                // inside BEGIN CONCURRENT, but if a future scheduling change
-                // ever lets the fiber state drift between generate and
-                // execute we want a clean ignore rather than a spurious
-                // failure.
-                if matches!(e, LimboError::OutOfMemory)
-                    || err_msg.contains("Database is busy")
-                    || err_msg.contains("Database schema changed")
-                    || err_msg.contains("Database snapshot is stale")
-                    || err_msg.contains("Write-write conflict")
-                    || err_msg.contains("Commit dependency aborted")
-                    || err_msg.contains("Database schema conflict")
-                    || err_msg.contains("setval requires an exclusive transaction")
-                {
-                    self.fiber_last_nextval
-                        .remove(&(fiber_id, seq_name.clone()));
-                    return Ok(());
-                }
-                // Overflow is expected for bounded non-cycling sequences.
-                // If the sequence is no longer tracked, accept it too:
-                // the simulator can pick NextVal on a sequence that another
-                // fiber concurrently drops (generate-vs-execute race). The
-                // engine may still expose the dropped sequence as exhausted
-                // (e.g. when a defaulting table keeps it materialized), so
-                // "reached maximum/minimum" is a valid engine response and
-                // not a property violation.
-                let overflow_msg = err_msg.contains("reached maximum value")
-                    || err_msg.contains("reached minimum value");
-                if overflow_msg {
-                    match self.params.get(seq_name) {
-                        Some(params) if !params.cycle => return Ok(()),
-                        None => return Ok(()),
-                        _ => {}
-                    }
-                }
-                bail!(
-                    "unexpected nextval/setval error for seq={}: {}",
-                    seq_name,
-                    err_msg
-                );
+        if let Operation::NextVal { seq_name } | Operation::SetVal { seq_name, .. } = op
+            && let Err(e) = result
+        {
+            // Drop the in-flight baseline so a future NextVal on the
+            // same (fiber, seq) doesn't reuse a stale snapshot.
+            self.in_flight_nextval_baselines
+                .remove(&(fiber_id, seq_name.clone()));
+            let err_msg = e.to_string();
+            // Sequence may have been dropped concurrently
+            if err_msg.contains("does not exist") {
+                self.params.remove(seq_name);
+                self.all_values.remove(seq_name);
+                self.watermark.remove(seq_name);
+                self.committed_watermark.remove(seq_name);
+                self.last_setval_exec_id.remove(seq_name);
+                self.fiber_last_nextval
+                    .retain(|(_fid, name), _| name != seq_name);
+                return Ok(());
             }
+            // nextval/setval are write transactions (backing table write),
+            // so concurrency errors are expected. Clear fiber_last_nextval
+            // because the Function instruction may have already set the
+            // connection's currval before the backing table write failed.
+            //
+            // The "setval requires an exclusive transaction" error is
+            // also accepted: SetValWorkload should not generate setval
+            // inside BEGIN CONCURRENT, but if a future scheduling change
+            // ever lets the fiber state drift between generate and
+            // execute we want a clean ignore rather than a spurious
+            // failure.
+            if matches!(e, LimboError::OutOfMemory)
+                || err_msg.contains("Database is busy")
+                || err_msg.contains("Database schema changed")
+                || err_msg.contains("Database snapshot is stale")
+                || err_msg.contains("Write-write conflict")
+                || err_msg.contains("Commit dependency aborted")
+                || err_msg.contains("Database schema conflict")
+                || err_msg.contains("setval requires an exclusive transaction")
+            {
+                self.fiber_last_nextval
+                    .remove(&(fiber_id, seq_name.clone()));
+                return Ok(());
+            }
+            // Overflow is expected for bounded non-cycling sequences.
+            // If the sequence is no longer tracked, accept it too:
+            // the simulator can pick NextVal on a sequence that another
+            // fiber concurrently drops (generate-vs-execute race). The
+            // engine may still expose the dropped sequence as exhausted
+            // (e.g. when a defaulting table keeps it materialized), so
+            // "reached maximum/minimum" is a valid engine response and
+            // not a property violation.
+            let overflow_msg = err_msg.contains("reached maximum value")
+                || err_msg.contains("reached minimum value");
+            if overflow_msg {
+                match self.params.get(seq_name) {
+                    Some(params) if !params.cycle => return Ok(()),
+                    None => return Ok(()),
+                    _ => {}
+                }
+            }
+            bail!(
+                "unexpected nextval/setval error for seq={}: {}",
+                seq_name,
+                err_msg
+            );
         }
 
         // Handle CurrVal: validate against tracked per-fiber state
@@ -1505,12 +1503,11 @@ impl Property for SequenceCorrectnessProperty {
                     // wrapping) still fires.
                     if params.cycle {
                         let prev_wm = self.watermark.get(seq_name).map(|&(wm, _)| wm);
-                        if let Some(prev) = prev_wm {
-                            if is_cycle_wrap(params, value, prev) {
-                                if let Some(values) = self.all_values.get_mut(seq_name) {
-                                    values.clear();
-                                }
-                            }
+                        if let Some(prev) = prev_wm
+                            && is_cycle_wrap(params, value, prev)
+                            && let Some(values) = self.all_values.get_mut(seq_name)
+                        {
+                            values.clear();
                         }
                     }
                     // Skip the duplicate check for seqs that have ever been
@@ -1570,15 +1567,15 @@ impl Property for SequenceCorrectnessProperty {
                     // target whose target+inc was the actual match). A
                     // second emission of the same value WOULD trip the
                     // duplicate check on the next observation.
-                    if is_allowed_re_emission {
-                        if let Some(allowed) = self.pending_setval_re_emission.get_mut(seq_name) {
-                            if !allowed.remove(&value) {
-                                let derived = value.saturating_sub(params.increment);
-                                allowed.remove(&derived);
-                            }
-                            if allowed.is_empty() {
-                                self.pending_setval_re_emission.remove(seq_name);
-                            }
+                    if is_allowed_re_emission
+                        && let Some(allowed) = self.pending_setval_re_emission.get_mut(seq_name)
+                    {
+                        if !allowed.remove(&value) {
+                            let derived = value.saturating_sub(params.increment);
+                            allowed.remove(&derived);
+                        }
+                        if allowed.is_empty() {
+                            self.pending_setval_re_emission.remove(seq_name);
                         }
                     }
                 }
@@ -1629,28 +1626,30 @@ impl Property for SequenceCorrectnessProperty {
                 // so post-setval duplicates still fire there.
                 let skip_monotonicity = self.seqs_with_setval_ever.contains(seq_name)
                     || self.seqs_with_seq_default_ever.contains(seq_name);
-                if txn_id.is_none() && !setval_could_have_raced && !skip_monotonicity {
-                    if let Some(&(wm, wm_eid)) = self.watermark.get(seq_name) {
-                        if wm_eid < start_exec_id && !is_cycle_wrap(params, value, wm) {
-                            if params.increment > 0 && value <= wm {
-                                bail!(
-                                    "sequence went in wrong direction: seq={}, value={}, watermark={}, increment={}",
-                                    seq_name,
-                                    value,
-                                    wm,
-                                    params.increment
-                                );
-                            }
-                            if params.increment < 0 && value >= wm {
-                                bail!(
-                                    "sequence went in wrong direction: seq={}, value={}, watermark={}, increment={}",
-                                    seq_name,
-                                    value,
-                                    wm,
-                                    params.increment
-                                );
-                            }
-                        }
+                if txn_id.is_none()
+                    && !setval_could_have_raced
+                    && !skip_monotonicity
+                    && let Some(&(wm, wm_eid)) = self.watermark.get(seq_name)
+                    && wm_eid < start_exec_id
+                    && !is_cycle_wrap(params, value, wm)
+                {
+                    if params.increment > 0 && value <= wm {
+                        bail!(
+                            "sequence went in wrong direction: seq={}, value={}, watermark={}, increment={}",
+                            seq_name,
+                            value,
+                            wm,
+                            params.increment
+                        );
+                    }
+                    if params.increment < 0 && value >= wm {
+                        bail!(
+                            "sequence went in wrong direction: seq={}, value={}, watermark={}, increment={}",
+                            seq_name,
+                            value,
+                            wm,
+                            params.increment
+                        );
                     }
                 }
                 // Only autocommit emissions update the cross-fiber
@@ -1783,28 +1782,28 @@ impl Property for SequenceCorrectnessProperty {
                             // emit X+k*inc for varying k.
                             let skip_monotonicity = self.seqs_with_setval_ever.contains(&seq_name)
                                 || self.seqs_with_seq_default_ever.contains(&seq_name);
-                            if let Some(params) = params.as_ref() {
-                                if !params.cycle && !skip_monotonicity {
-                                    if let Some(prev) = baseline {
-                                        if params.increment > 0 && value <= prev {
-                                            bail!(
-                                                "sequence went in wrong direction: seq={}, value={}, watermark={}, increment={}",
-                                                seq_name,
-                                                value,
-                                                prev,
-                                                params.increment
-                                            );
-                                        }
-                                        if params.increment < 0 && value >= prev {
-                                            bail!(
-                                                "sequence went in wrong direction: seq={}, value={}, watermark={}, increment={}",
-                                                seq_name,
-                                                value,
-                                                prev,
-                                                params.increment
-                                            );
-                                        }
-                                    }
+                            if let Some(params) = params.as_ref()
+                                && !params.cycle
+                                && !skip_monotonicity
+                                && let Some(prev) = baseline
+                            {
+                                if params.increment > 0 && value <= prev {
+                                    bail!(
+                                        "sequence went in wrong direction: seq={}, value={}, watermark={}, increment={}",
+                                        seq_name,
+                                        value,
+                                        prev,
+                                        params.increment
+                                    );
+                                }
+                                if params.increment < 0 && value >= prev {
+                                    bail!(
+                                        "sequence went in wrong direction: seq={}, value={}, watermark={}, increment={}",
+                                        seq_name,
+                                        value,
+                                        prev,
+                                        params.increment
+                                    );
                                 }
                             }
                             // Duplicate check: tightened post-setval. The
@@ -1853,19 +1852,18 @@ impl Property for SequenceCorrectnessProperty {
                             } else {
                                 entry.insert(value);
                             }
-                            if is_allowed_re_emission {
-                                if let Some(allowed) =
+                            if is_allowed_re_emission
+                                && let Some(allowed) =
                                     self.pending_setval_re_emission.get_mut(&seq_name)
+                            {
+                                if !allowed.remove(&value)
+                                    && let Some(p) = params.as_ref()
                                 {
-                                    if !allowed.remove(&value) {
-                                        if let Some(p) = params.as_ref() {
-                                            let derived = value.saturating_sub(p.increment);
-                                            allowed.remove(&derived);
-                                        }
-                                    }
-                                    if allowed.is_empty() {
-                                        self.pending_setval_re_emission.remove(&seq_name);
-                                    }
+                                    let derived = value.saturating_sub(p.increment);
+                                    allowed.remove(&derived);
+                                }
+                                if allowed.is_empty() {
+                                    self.pending_setval_re_emission.remove(&seq_name);
                                 }
                             }
                             self.promote_committed(&seq_name, value);
@@ -2429,12 +2427,11 @@ impl Property for AutoincWatermarkMonotonicity {
                 self.snapshot_at_init.remove(&start_exec_id);
             }
             Operation::Commit => {
-                if let Some(t) = txn_id {
-                    if let Some(pending) = self.pending_per_tx.remove(&t) {
-                        if pending > self.committed_max {
-                            self.committed_max = pending;
-                        }
-                    }
+                if let Some(t) = txn_id
+                    && let Some(pending) = self.pending_per_tx.remove(&t)
+                    && pending > self.committed_max
+                {
+                    self.committed_max = pending;
                 }
             }
             Operation::Rollback => {

--- a/testing/concurrent-simulator/worker.rs
+++ b/testing/concurrent-simulator/worker.rs
@@ -109,10 +109,9 @@ pub fn run_worker(
                     ref error_kind,
                     ref message,
                 } = response
+                    && (error_kind == "Panic" || error_kind == "Internal")
                 {
-                    if error_kind == "Panic" || error_kind == "Internal" {
-                        eprintln!("WORKER SQL ERROR [{error_kind}]: {message} (sql: {sql})");
-                    }
+                    eprintln!("WORKER SQL ERROR [{error_kind}]: {message} (sql: {sql})");
                 }
                 send_response(&response)?;
             }
@@ -430,7 +429,7 @@ fn execute_sql_inner(conn: &Arc<Connection>, sql: &str) -> WorkerResponse {
                 "WORKER TRACE pid={} finish sql={:?} result={:?} steps={} ios={} elapsed_ms={} auto_commit={}",
                 std::process::id(),
                 sql,
-                &result,
+                result,
                 step_count,
                 io_count,
                 started_at.elapsed().as_millis(),

--- a/testing/differential-oracle/fuzzer/custom_types_fuzzer.rs
+++ b/testing/differential-oracle/fuzzer/custom_types_fuzzer.rs
@@ -3466,7 +3466,7 @@ fn gen_triggers(
             // Build sink table columns: id, tag, then one column per struct field
             let mut sink_cols = vec!["id INTEGER PRIMARY KEY".to_string(), "tag TEXT".to_string()];
             let mut sink_col_names = vec!["id".to_string(), "tag".to_string()];
-            let mut insert_exprs = vec![format!("NEW.id"), format!("union_tag(NEW.{col_name})")];
+            let mut insert_exprs = vec!["NEW.id".to_string(), format!("union_tag(NEW.{col_name})")];
 
             for (fi, (fname, ftype)) in sdef.fields.iter().enumerate() {
                 let sink_col = format!("f{fi}");
@@ -3555,17 +3555,17 @@ fn run_consistency_checks(
             }
         };
 
-        if let Ok(idx_rows) = execute_turso_rows(conn, &idx_sql) {
-            if scan_rows != idx_rows {
-                stats.consistency_failures += 1;
-                tracing::error!(
-                    "CONSISTENCY: scan vs index mismatch for {}\n  scan: {:?}\n  idx:  {:?}",
-                    eidx.expr_sql,
-                    scan_rows,
-                    idx_rows,
-                );
-                executed_sql.push(format!("-- CONSISTENCY FAIL: {}", eidx.expr_sql));
-            }
+        if let Ok(idx_rows) = execute_turso_rows(conn, &idx_sql)
+            && scan_rows != idx_rows
+        {
+            stats.consistency_failures += 1;
+            tracing::error!(
+                "CONSISTENCY: scan vs index mismatch for {}\n  scan: {:?}\n  idx:  {:?}",
+                eidx.expr_sql,
+                scan_rows,
+                idx_rows,
+            );
+            executed_sql.push(format!("-- CONSISTENCY FAIL: {}", eidx.expr_sql));
         }
     }
 
@@ -3579,19 +3579,21 @@ fn run_consistency_checks(
                     "SELECT COUNT(*) FROM {} WHERE {col_name} IS NOT NULL AND union_tag({col_name}) IS NULL",
                     table.name
                 );
-                if let Ok(rows) = execute_turso_rows(conn, &check_sql) {
-                    if rows.len() == 1 && rows[0].len() == 1 && rows[0][0] != "0" {
-                        stats.consistency_failures += 1;
-                        tracing::error!(
-                            "CONSISTENCY: union_tag returned NULL for non-NULL union values in {}.{col_name} ({} rows)",
-                            table.name,
-                            rows[0][0]
-                        );
-                        executed_sql.push(format!(
-                            "-- CONSISTENCY FAIL: NULL union_tag in {}.{col_name}",
-                            table.name
-                        ));
-                    }
+                if let Ok(rows) = execute_turso_rows(conn, &check_sql)
+                    && rows.len() == 1
+                    && rows[0].len() == 1
+                    && rows[0][0] != "0"
+                {
+                    stats.consistency_failures += 1;
+                    tracing::error!(
+                        "CONSISTENCY: union_tag returned NULL for non-NULL union values in {}.{col_name} ({} rows)",
+                        table.name,
+                        rows[0][0]
+                    );
+                    executed_sql.push(format!(
+                        "-- CONSISTENCY FAIL: NULL union_tag in {}.{col_name}",
+                        table.name
+                    ));
                 }
             }
         }
@@ -3611,16 +3613,15 @@ fn run_consistency_checks(
         if let (Ok(scan_rows), Ok(idx_rows)) = (
             execute_turso_rows(conn, &scan_count),
             execute_turso_rows(conn, &idx_count),
-        ) {
-            if scan_rows != idx_rows {
-                stats.consistency_failures += 1;
-                tracing::error!(
-                    "CONSISTENCY: COUNT mismatch for {} IS NOT NULL\n  scan: {:?}\n  idx:  {:?}",
-                    eidx.expr_sql,
-                    scan_rows,
-                    idx_rows,
-                );
-            }
+        ) && scan_rows != idx_rows
+        {
+            stats.consistency_failures += 1;
+            tracing::error!(
+                "CONSISTENCY: COUNT mismatch for {} IS NOT NULL\n  scan: {:?}\n  idx:  {:?}",
+                eidx.expr_sql,
+                scan_rows,
+                idx_rows,
+            );
         }
     }
 
@@ -3659,21 +3660,20 @@ fn run_consistency_checks(
             if let (Ok(scan_rows), Ok(idx_rows)) = (
                 execute_turso_rows(conn, &scan_sql),
                 execute_turso_rows(conn, &idx_sql),
-            ) {
-                if scan_rows != idx_rows {
-                    stats.consistency_failures += 1;
-                    tracing::error!(
-                        "CONSISTENCY: value lookup mismatch for {} = {}\n  scan: {:?}\n  idx:  {:?}",
-                        eidx.expr_sql,
-                        where_val,
-                        scan_rows,
-                        idx_rows,
-                    );
-                    executed_sql.push(format!(
-                        "-- CONSISTENCY FAIL: {} = {} lookup mismatch",
-                        eidx.expr_sql, where_val
-                    ));
-                }
+            ) && scan_rows != idx_rows
+            {
+                stats.consistency_failures += 1;
+                tracing::error!(
+                    "CONSISTENCY: value lookup mismatch for {} = {}\n  scan: {:?}\n  idx:  {:?}",
+                    eidx.expr_sql,
+                    where_val,
+                    scan_rows,
+                    idx_rows,
+                );
+                executed_sql.push(format!(
+                    "-- CONSISTENCY FAIL: {} = {} lookup mismatch",
+                    eidx.expr_sql, where_val
+                ));
             }
         }
     }
@@ -3699,20 +3699,19 @@ fn run_consistency_checks(
         if let (Ok(scan_rows), Ok(idx_rows)) = (
             execute_turso_rows(conn, &scan_sum),
             execute_turso_rows(conn, &idx_sum),
-        ) {
-            if scan_rows != idx_rows {
-                stats.consistency_failures += 1;
-                tracing::error!(
-                    "CONSISTENCY: SUM mismatch for {}\n  scan: {:?}\n  idx:  {:?}",
-                    eidx.expr_sql,
-                    scan_rows,
-                    idx_rows,
-                );
-                executed_sql.push(format!(
-                    "-- CONSISTENCY FAIL: SUM({}) mismatch",
-                    eidx.expr_sql
-                ));
-            }
+        ) && scan_rows != idx_rows
+        {
+            stats.consistency_failures += 1;
+            tracing::error!(
+                "CONSISTENCY: SUM mismatch for {}\n  scan: {:?}\n  idx:  {:?}",
+                eidx.expr_sql,
+                scan_rows,
+                idx_rows,
+            );
+            executed_sql.push(format!(
+                "-- CONSISTENCY FAIL: SUM({}) mismatch",
+                eidx.expr_sql
+            ));
         }
     }
 
@@ -3726,19 +3725,21 @@ fn run_consistency_checks(
                      array_length(array_append({col_name}, 99)) != array_length({col_name}) + 1",
                     table.name
                 );
-                if let Ok(rows) = execute_turso_rows(conn, &check_sql) {
-                    if rows.len() == 1 && rows[0].len() == 1 && rows[0][0] != "0" {
-                        stats.consistency_failures += 1;
-                        tracing::error!(
-                            "CONSISTENCY: array append identity violated for {}.{col_name}: {} rows",
-                            table.name,
-                            rows[0][0]
-                        );
-                        executed_sql.push(format!(
-                            "-- CONSISTENCY FAIL: array append identity {}.{col_name}",
-                            table.name
-                        ));
-                    }
+                if let Ok(rows) = execute_turso_rows(conn, &check_sql)
+                    && rows.len() == 1
+                    && rows[0].len() == 1
+                    && rows[0][0] != "0"
+                {
+                    stats.consistency_failures += 1;
+                    tracing::error!(
+                        "CONSISTENCY: array append identity violated for {}.{col_name}: {} rows",
+                        table.name,
+                        rows[0][0]
+                    );
+                    executed_sql.push(format!(
+                        "-- CONSISTENCY FAIL: array append identity {}.{col_name}",
+                        table.name
+                    ));
                 }
             }
         }
@@ -3753,15 +3754,17 @@ fn run_consistency_checks(
                     "SELECT COUNT(*) FROM {} WHERE {col_name} IS NOT NULL AND array_length({col_name}) < 0",
                     table.name
                 );
-                if let Ok(rows) = execute_turso_rows(conn, &check_sql) {
-                    if rows.len() == 1 && rows[0].len() == 1 && rows[0][0] != "0" {
-                        stats.consistency_failures += 1;
-                        tracing::error!(
-                            "CONSISTENCY: negative array_length for {}.{col_name}: {} rows",
-                            table.name,
-                            rows[0][0]
-                        );
-                    }
+                if let Ok(rows) = execute_turso_rows(conn, &check_sql)
+                    && rows.len() == 1
+                    && rows[0].len() == 1
+                    && rows[0][0] != "0"
+                {
+                    stats.consistency_failures += 1;
+                    tracing::error!(
+                        "CONSISTENCY: negative array_length for {}.{col_name}: {} rows",
+                        table.name,
+                        rows[0][0]
+                    );
                 }
             }
         }
@@ -3772,32 +3775,33 @@ fn run_consistency_checks(
     // from before the ALTER TABLE ADD COLUMN.
     for table in tables {
         for (col_idx, kind) in &table.custom_type_columns {
-            if let CustomColKind::Domain(dname) = kind {
-                if let Some(d) = types.domains.iter().find(|d| &d.name == dname) {
-                    if d.not_null {
-                        let col_name = &table.columns[*col_idx].0;
-                        if col_name.starts_with("alt") {
-                            continue;
-                        }
-                        let check_sql = format!(
-                            "SELECT COUNT(*) FROM {} WHERE {col_name} IS NULL",
-                            table.name
-                        );
-                        if let Ok(rows) = execute_turso_rows(conn, &check_sql) {
-                            if rows.len() == 1 && rows[0].len() == 1 && rows[0][0] != "0" {
-                                stats.consistency_failures += 1;
-                                tracing::error!(
-                                    "CONSISTENCY: NOT NULL domain {dname} has NULL values in {}.{col_name}: {} rows",
-                                    table.name,
-                                    rows[0][0]
-                                );
-                                executed_sql.push(format!(
-                                    "-- CONSISTENCY FAIL: NOT NULL domain {dname} has NULLs in {}.{col_name}",
-                                    table.name
-                                ));
-                            }
-                        }
-                    }
+            if let CustomColKind::Domain(dname) = kind
+                && let Some(d) = types.domains.iter().find(|d| &d.name == dname)
+                && d.not_null
+            {
+                let col_name = &table.columns[*col_idx].0;
+                if col_name.starts_with("alt") {
+                    continue;
+                }
+                let check_sql = format!(
+                    "SELECT COUNT(*) FROM {} WHERE {col_name} IS NULL",
+                    table.name
+                );
+                if let Ok(rows) = execute_turso_rows(conn, &check_sql)
+                    && rows.len() == 1
+                    && rows[0].len() == 1
+                    && rows[0][0] != "0"
+                {
+                    stats.consistency_failures += 1;
+                    tracing::error!(
+                        "CONSISTENCY: NOT NULL domain {dname} has NULL values in {}.{col_name}: {} rows",
+                        table.name,
+                        rows[0][0]
+                    );
+                    executed_sql.push(format!(
+                        "-- CONSISTENCY FAIL: NOT NULL domain {dname} has NULLs in {}.{col_name}",
+                        table.name
+                    ));
                 }
             }
         }
@@ -3806,29 +3810,31 @@ fn run_consistency_checks(
     // Check 9: domain CHECK constraints hold for all rows
     for table in tables {
         for (col_idx, kind) in &table.custom_type_columns {
-            if let CustomColKind::Domain(dname) = kind {
-                if let Some(d) = types.domains.iter().find(|d| &d.name == dname) {
-                    let col_name = &table.columns[*col_idx].0;
-                    for check_expr in &d.checks {
-                        let where_expr = check_expr.replace("value", col_name);
-                        let check_sql = format!(
-                            "SELECT COUNT(*) FROM {} WHERE {col_name} IS NOT NULL AND NOT ({where_expr})",
-                            table.name
+            if let CustomColKind::Domain(dname) = kind
+                && let Some(d) = types.domains.iter().find(|d| &d.name == dname)
+            {
+                let col_name = &table.columns[*col_idx].0;
+                for check_expr in &d.checks {
+                    let where_expr = check_expr.replace("value", col_name);
+                    let check_sql = format!(
+                        "SELECT COUNT(*) FROM {} WHERE {col_name} IS NOT NULL AND NOT ({where_expr})",
+                        table.name
+                    );
+                    if let Ok(rows) = execute_turso_rows(conn, &check_sql)
+                        && rows.len() == 1
+                        && rows[0].len() == 1
+                        && rows[0][0] != "0"
+                    {
+                        stats.consistency_failures += 1;
+                        tracing::error!(
+                            "CONSISTENCY: domain CHECK({check_expr}) violated in {}.{col_name}: {} rows",
+                            table.name,
+                            rows[0][0]
                         );
-                        if let Ok(rows) = execute_turso_rows(conn, &check_sql) {
-                            if rows.len() == 1 && rows[0].len() == 1 && rows[0][0] != "0" {
-                                stats.consistency_failures += 1;
-                                tracing::error!(
-                                    "CONSISTENCY: domain CHECK({check_expr}) violated in {}.{col_name}: {} rows",
-                                    table.name,
-                                    rows[0][0]
-                                );
-                                executed_sql.push(format!(
-                                    "-- CONSISTENCY FAIL: domain CHECK violated in {}.{col_name}",
-                                    table.name
-                                ));
-                            }
-                        }
+                        executed_sql.push(format!(
+                            "-- CONSISTENCY FAIL: domain CHECK violated in {}.{col_name}",
+                            table.name
+                        ));
                     }
                 }
             }
@@ -4640,7 +4646,7 @@ fn main() -> Result<()> {
         i += 1;
 
         // Periodic consistency checks (only outside transactions)
-        if i % 50 == 0 && !in_transaction {
+        if i.is_multiple_of(50) && !in_transaction {
             run_consistency_checks(
                 &conn,
                 &tables,

--- a/testing/differential-oracle/fuzzer/generate.rs
+++ b/testing/differential-oracle/fuzzer/generate.rs
@@ -305,11 +305,11 @@ impl SqlGenerator for PropTestBackend {
         // too - so that this oracle bug cannot change the compared row set.
         // Recursive LIMIT/OFFSET and priority ordering remain fully generated
         // inside the CTE.
-        if let sql_gen_prop::SqlStatement::Select(select) = &mut stmt {
-            if select.has_recursive_cte() {
-                select.limit = None;
-                select.offset = None;
-            }
+        if let sql_gen_prop::SqlStatement::Select(select) = &mut stmt
+            && select.has_recursive_cte()
+        {
+            select.limit = None;
+            select.offset = None;
         }
         let sql = stmt.to_string();
         let stmt_kind = sql_gen_prop::StatementKind::from(&stmt);

--- a/testing/differential-oracle/fuzzer/printf_fuzzer.rs
+++ b/testing/differential-oracle/fuzzer/printf_fuzzer.rs
@@ -113,13 +113,13 @@ fn fuzzy_text_eq(a: &str, b: &str) -> bool {
         if a_num_end > a_num_start && b_num_end > b_num_start {
             let a_str: String = a[a_num_start..a_num_end].iter().collect();
             let b_str: String = b[b_num_start..b_num_end].iter().collect();
-            if let (Ok(af), Ok(bf)) = (a_str.parse::<f64>(), b_str.parse::<f64>()) {
-                if floats_close(af, bf) {
-                    // Advance past the number, guaranteeing at least 1 step of progress
-                    ai = a_num_end.max(ai + 1);
-                    bi = b_num_end.max(bi + 1);
-                    continue;
-                }
+            if let (Ok(af), Ok(bf)) = (a_str.parse::<f64>(), b_str.parse::<f64>())
+                && floats_close(af, bf)
+            {
+                // Advance past the number, guaranteeing at least 1 step of progress
+                ai = a_num_end.max(ai + 1);
+                bi = b_num_end.max(bi + 1);
+                continue;
             }
         }
 
@@ -244,10 +244,10 @@ fn fmt_result_diff(turso: &QueryResult, sqlite: &QueryResult) -> String {
         (QueryResult::Rows(t_rows), QueryResult::Rows(s_rows)) => {
             for (tr, sr) in t_rows.iter().zip(s_rows.iter()) {
                 for (tv, sv) in tr.0.iter().zip(sr.0.iter()) {
-                    if let (SqlValue::Text(ta), SqlValue::Text(tb)) = (tv, sv) {
-                        if ta != tb {
-                            return fmt_text_diff(ta, tb);
-                        }
+                    if let (SqlValue::Text(ta), SqlValue::Text(tb)) = (tv, sv)
+                        && ta != tb
+                    {
+                        return fmt_text_diff(ta, tb);
                     }
                 }
             }

--- a/testing/differential-oracle/fuzzer/runner.rs
+++ b/testing/differential-oracle/fuzzer/runner.rs
@@ -441,12 +441,11 @@ impl Fuzzer {
         if let Err(e) = self.write_sql_file(&executed_sql) {
             tracing::warn!("Failed to write test.sql: {e}");
         }
-        if self.config.coverage {
-            if let Some(cov) = coverage {
-                if let Err(e) = self.write_coverage_report(&cov) {
-                    tracing::warn!("Failed to write coverage report: {e}");
-                }
-            }
+        if self.config.coverage
+            && let Some(cov) = coverage
+            && let Err(e) = self.write_coverage_report(&cov)
+        {
+            tracing::warn!("Failed to write coverage report: {e}");
         }
         stats.print_table(&self.config);
 
@@ -713,10 +712,10 @@ impl Fuzzer {
         let check_ok = |result: &QueryResult, db_name: &str| -> Result<()> {
             match result {
                 QueryResult::Rows(rows) if rows.len() == 1 && rows[0].0.len() == 1 => {
-                    if let SqlValue::Text(ref text) = rows[0].0[0] {
-                        if text == "ok" {
-                            return Ok(());
-                        }
+                    if let SqlValue::Text(ref text) = rows[0].0[0]
+                        && text == "ok"
+                    {
+                        return Ok(());
                     }
                     bail!("{db_name} integrity check failed: {:?}", rows);
                 }

--- a/testing/differential-oracle/fuzzer/shrink.rs
+++ b/testing/differential-oracle/fuzzer/shrink.rs
@@ -481,12 +481,12 @@ fn apply_clause_action(site: &mut Site<'_>, action: ClauseDrop) {
             }
         }
         (Site::Outer(select), ClauseDrop::Cte(i)) => {
-            if let Some(with) = &mut select.with {
-                if i < with.ctes.len() {
-                    with.ctes.remove(i);
-                    if with.ctes.is_empty() {
-                        select.with = None;
-                    }
+            if let Some(with) = &mut select.with
+                && i < with.ctes.len()
+            {
+                with.ctes.remove(i);
+                if with.ctes.is_empty() {
+                    select.with = None;
                 }
             }
         }
@@ -494,10 +494,9 @@ fn apply_clause_action(site: &mut Site<'_>, action: ClauseDrop) {
             if let OneSelect::Select {
                 from: Some(from), ..
             } = &mut select.body.select
+                && i < from.joins.len()
             {
-                if i < from.joins.len() {
-                    from.joins.remove(i);
-                }
+                from.joins.remove(i);
             }
         }
         (Site::Update(update), ClauseDrop::Where) => update.where_clause = None,
@@ -513,10 +512,10 @@ fn apply_clause_action(site: &mut Site<'_>, action: ClauseDrop) {
         }
         (Site::Delete { where_clause, .. }, ClauseDrop::Where) => **where_clause = None,
         (Site::Delete { returning, .. }, ClauseDrop::ReturningItem(i))
-        | (Site::InsertReturning(returning), ClauseDrop::ReturningItem(i)) => {
-            if i < returning.len() {
-                returning.remove(i);
-            }
+        | (Site::InsertReturning(returning), ClauseDrop::ReturningItem(i))
+            if i < returning.len() =>
+        {
+            returning.remove(i);
         }
         _ => {}
     }
@@ -531,10 +530,10 @@ fn walk_exprs(stmt: &mut Stmt, f: &mut dyn FnMut(&mut Expr) -> bool) -> bool {
         Stmt::Insert {
             body, returning, ..
         } => {
-            if let InsertBody::Select(select, _) = body {
-                if walk_select(select, f) {
-                    return true;
-                }
+            if let InsertBody::Select(select, _) = body
+                && walk_select(select, f)
+            {
+                return true;
             }
             walk_result_columns(returning, f)
         }
@@ -551,15 +550,15 @@ fn walk_exprs(stmt: &mut Stmt, f: &mut dyn FnMut(&mut Expr) -> bool) -> bool {
                     return true;
                 }
             }
-            if let Some(from) = &mut update.from {
-                if walk_from(from, f) {
-                    return true;
-                }
+            if let Some(from) = &mut update.from
+                && walk_from(from, f)
+            {
+                return true;
             }
-            if let Some(w) = &mut update.where_clause {
-                if walk_expr(w, f) {
-                    return true;
-                }
+            if let Some(w) = &mut update.where_clause
+                && walk_expr(w, f)
+            {
+                return true;
             }
             walk_result_columns(&mut update.returning, f)
         }
@@ -576,10 +575,10 @@ fn walk_exprs(stmt: &mut Stmt, f: &mut dyn FnMut(&mut Expr) -> bool) -> bool {
                     }
                 }
             }
-            if let Some(w) = where_clause {
-                if walk_expr(w, f) {
-                    return true;
-                }
+            if let Some(w) = where_clause
+                && walk_expr(w, f)
+            {
+                return true;
             }
             walk_result_columns(returning, f)
         }
@@ -595,10 +594,10 @@ fn walk_limit(
         if walk_expr(&mut limit.expr, f) {
             return true;
         }
-        if let Some(offset) = &mut limit.offset {
-            if walk_expr(offset, f) {
-                return true;
-            }
+        if let Some(offset) = &mut limit.offset
+            && walk_expr(offset, f)
+        {
+            return true;
         }
     }
     false
@@ -606,10 +605,10 @@ fn walk_limit(
 
 fn walk_result_columns(columns: &mut [ResultColumn], f: &mut dyn FnMut(&mut Expr) -> bool) -> bool {
     for rc in columns {
-        if let ResultColumn::Expr(expr, _) = rc {
-            if walk_expr(expr, f) {
-                return true;
-            }
+        if let ResultColumn::Expr(expr, _) = rc
+            && walk_expr(expr, f)
+        {
+            return true;
         }
     }
     false
@@ -651,15 +650,15 @@ fn walk_one_select(one: &mut OneSelect, f: &mut dyn FnMut(&mut Expr) -> bool) ->
             if walk_result_columns(columns, f) {
                 return true;
             }
-            if let Some(from) = from {
-                if walk_from(from, f) {
-                    return true;
-                }
+            if let Some(from) = from
+                && walk_from(from, f)
+            {
+                return true;
             }
-            if let Some(w) = where_clause {
-                if walk_expr(w, f) {
-                    return true;
-                }
+            if let Some(w) = where_clause
+                && walk_expr(w, f)
+            {
+                return true;
             }
             if let Some(gb) = group_by {
                 for e in &mut gb.exprs {
@@ -667,10 +666,10 @@ fn walk_one_select(one: &mut OneSelect, f: &mut dyn FnMut(&mut Expr) -> bool) ->
                         return true;
                     }
                 }
-                if let Some(h) = &mut gb.having {
-                    if walk_expr(h, f) {
-                        return true;
-                    }
+                if let Some(h) = &mut gb.having
+                    && walk_expr(h, f)
+                {
+                    return true;
                 }
             }
             false
@@ -699,10 +698,10 @@ fn walk_from(
         if walk_select_table(&mut join.table, f) {
             return true;
         }
-        if let Some(turso_parser::ast::JoinConstraint::On(e)) = &mut join.constraint {
-            if walk_expr(e, f) {
-                return true;
-            }
+        if let Some(turso_parser::ast::JoinConstraint::On(e)) = &mut join.constraint
+            && walk_expr(e, f)
+        {
+            return true;
         }
     }
     false
@@ -755,10 +754,10 @@ fn walk_sites(stmt: &mut Stmt, f: &mut dyn FnMut(&mut Site<'_>) -> bool) -> bool
         Stmt::Insert {
             body, returning, ..
         } => {
-            if let InsertBody::Select(select, _) = body {
-                if walk_select_sites(select, f) {
-                    return true;
-                }
+            if let InsertBody::Select(select, _) = body
+                && walk_select_sites(select, f)
+            {
+                return true;
             }
             f(&mut Site::InsertReturning(returning))
         }
@@ -770,10 +769,10 @@ fn walk_sites(stmt: &mut Stmt, f: &mut dyn FnMut(&mut Site<'_>) -> bool) -> bool
                     }
                 }
             }
-            if let Some(from) = &mut update.from {
-                if walk_from_sites(from, f) {
-                    return true;
-                }
+            if let Some(from) = &mut update.from
+                && walk_from_sites(from, f)
+            {
+                return true;
             }
             f(&mut Site::Update(update))
         }
@@ -822,10 +821,9 @@ fn walk_select_sites(select: &mut Select, f: &mut dyn FnMut(&mut Site<'_>) -> bo
     if let OneSelect::Select {
         from: Some(from), ..
     } = &mut select.body.select
+        && walk_from_sites(from, f)
     {
-        if walk_from_sites(from, f) {
-            return true;
-        }
+        return true;
     }
     false
 }
@@ -834,16 +832,16 @@ fn walk_from_sites(
     from: &mut turso_parser::ast::FromClause,
     f: &mut dyn FnMut(&mut Site<'_>) -> bool,
 ) -> bool {
-    if let SelectTable::Select(select, _) = &mut *from.select {
-        if walk_select_sites(select, f) {
-            return true;
-        }
+    if let SelectTable::Select(select, _) = &mut *from.select
+        && walk_select_sites(select, f)
+    {
+        return true;
     }
     for join in &mut from.joins {
-        if let SelectTable::Select(select, _) = &mut *join.table {
-            if walk_select_sites(select, f) {
-                return true;
-            }
+        if let SelectTable::Select(select, _) = &mut *join.table
+            && walk_select_sites(select, f)
+        {
+            return true;
         }
     }
     false

--- a/testing/differential-oracle/sql_gen/src/ast.rs
+++ b/testing/differential-oracle/sql_gen/src/ast.rs
@@ -170,17 +170,17 @@ impl SelectStmt {
         }
         // Check JOIN ON conditions
         for join in &self.joins {
-            if let Some(JoinConstraint::On(expr)) = &join.constraint {
-                if let Some(reason) = expr.unordered_limit_reason() {
-                    return Some(reason);
-                }
+            if let Some(JoinConstraint::On(expr)) = &join.constraint
+                && let Some(reason) = expr.unordered_limit_reason()
+            {
+                return Some(reason);
             }
         }
         // Check WHERE clause
-        if let Some(w) = &self.where_clause {
-            if let Some(reason) = w.unordered_limit_reason() {
-                return Some(reason);
-            }
+        if let Some(w) = &self.where_clause
+            && let Some(reason) = w.unordered_limit_reason()
+        {
+            return Some(reason);
         }
         // Check GROUP BY / HAVING
         if let Some(gb) = &self.group_by {
@@ -189,10 +189,10 @@ impl SelectStmt {
                     return Some(reason);
                 }
             }
-            if let Some(h) = &gb.having {
-                if let Some(reason) = h.unordered_limit_reason() {
-                    return Some(reason);
-                }
+            if let Some(h) = &gb.having
+                && let Some(reason) = h.unordered_limit_reason()
+            {
+                return Some(reason);
             }
         }
         // Check compound arms' subquery expressions
@@ -202,10 +202,10 @@ impl SelectStmt {
                     return Some(reason);
                 }
             }
-            if let Some(w) = &arm.where_clause {
-                if let Some(reason) = w.unordered_limit_reason() {
-                    return Some(reason);
-                }
+            if let Some(w) = &arm.where_clause
+                && let Some(reason) = w.unordered_limit_reason()
+            {
+                return Some(reason);
             }
         }
         // Check ORDER BY expressions
@@ -249,16 +249,16 @@ impl SelectStmt {
             }
         }
         for join in &self.joins {
-            if let Some(JoinConstraint::On(expr)) = &join.constraint {
-                if let Some(r) = expr.non_unique_order_by_reason(schema) {
-                    return Some(r);
-                }
-            }
-        }
-        if let Some(w) = &self.where_clause {
-            if let Some(r) = w.non_unique_order_by_reason(schema) {
+            if let Some(JoinConstraint::On(expr)) = &join.constraint
+                && let Some(r) = expr.non_unique_order_by_reason(schema)
+            {
                 return Some(r);
             }
+        }
+        if let Some(w) = &self.where_clause
+            && let Some(r) = w.non_unique_order_by_reason(schema)
+        {
+            return Some(r);
         }
         if let Some(gb) = &self.group_by {
             for expr in &gb.exprs {
@@ -266,10 +266,10 @@ impl SelectStmt {
                     return Some(r);
                 }
             }
-            if let Some(h) = &gb.having {
-                if let Some(r) = h.non_unique_order_by_reason(schema) {
-                    return Some(r);
-                }
+            if let Some(h) = &gb.having
+                && let Some(r) = h.non_unique_order_by_reason(schema)
+            {
+                return Some(r);
             }
         }
         for item in &self.order_by {
@@ -297,10 +297,11 @@ impl SelectStmt {
         self.order_by.iter().any(|item| {
             if let Expr::ColumnRef(col_ref) = &item.expr {
                 // If table-qualified, verify it matches the FROM table
-                if let Some(ref tbl) = col_ref.table {
-                    if *tbl != from.table && from.alias.as_deref() != Some(tbl) {
-                        return false;
-                    }
+                if let Some(ref tbl) = col_ref.table
+                    && *tbl != from.table
+                    && from.alias.as_deref() != Some(tbl)
+                {
+                    return false;
                 }
                 table.columns.iter().any(|c| {
                     c.name == col_ref.column && (c.primary_key || (c.unique && !c.nullable))

--- a/testing/differential-oracle/sql_gen/src/generate/expr.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/expr.rs
@@ -461,12 +461,12 @@ fn generate_function_arg<C: Capabilities>(
 ) -> Result<Expr, GenError> {
     // Check if this function has integer argument constraints (e.g., zeroblob)
     if let Some(max_val) = func.int_arg_max {
-        if let Some(expected_type) = func.arg_type_at(arg_index) {
-            if expected_type == DataType::Integer {
-                // Generate a constrained integer literal
-                let val = ctx.gen_range_inclusive(0, max_val as usize) as i64;
-                return Ok(Expr::literal(ctx, Literal::Integer(val)));
-            }
+        if let Some(expected_type) = func.arg_type_at(arg_index)
+            && expected_type == DataType::Integer
+        {
+            // Generate a constrained integer literal
+            let val = ctx.gen_range_inclusive(0, max_val as usize) as i64;
+            return Ok(Expr::literal(ctx, Literal::Integer(val)));
         }
         // If no specific type, still apply the constraint for safety
         if func.arg_types.is_empty() {

--- a/testing/differential-oracle/sql_gen/src/generate/select.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/select.rs
@@ -2527,19 +2527,18 @@ mod tests {
         let mut found_qualified = false;
         for seed in 0..100 {
             let mut ctx = Context::new_with_seed(seed);
-            if let Ok(select) = generate_select_impl(&generator, &mut ctx, SelectMode::Full) {
-                if !select.joins.is_empty() {
-                    let sql = select.to_string();
-                    // With multiple tables, column refs should be qualified (contain a dot)
-                    // Check that the SELECT columns part contains qualified references
-                    if let Some(select_part) = sql.strip_prefix("SELECT ") {
-                        if let Some(cols_part) = select_part.split(" FROM ").next() {
-                            if cols_part.contains('.') {
-                                found_qualified = true;
-                                break;
-                            }
-                        }
-                    }
+            if let Ok(select) = generate_select_impl(&generator, &mut ctx, SelectMode::Full)
+                && !select.joins.is_empty()
+            {
+                let sql = select.to_string();
+                // With multiple tables, column refs should be qualified (contain a dot)
+                // Check that the SELECT columns part contains qualified references
+                if let Some(select_part) = sql.strip_prefix("SELECT ")
+                    && let Some(cols_part) = select_part.split(" FROM ").next()
+                    && cols_part.contains('.')
+                {
+                    found_qualified = true;
+                    break;
                 }
             }
         }
@@ -2577,19 +2576,19 @@ mod tests {
         let mut found_self_join = false;
         for seed in 0..50 {
             let mut ctx = Context::new_with_seed(seed);
-            if let Ok(select) = generate_select_impl(&generator, &mut ctx, SelectMode::Full) {
-                if !select.joins.is_empty() {
-                    let sql = select.to_string();
-                    // Self-join should have aliases (AS tN)
-                    if sql.contains("JOIN users AS ") {
-                        found_self_join = true;
-                        // The joined table must have an alias
-                        assert!(
-                            select.joins[0].alias.is_some(),
-                            "Self-join must have alias: {sql}"
-                        );
-                        break;
-                    }
+            if let Ok(select) = generate_select_impl(&generator, &mut ctx, SelectMode::Full)
+                && !select.joins.is_empty()
+            {
+                let sql = select.to_string();
+                // Self-join should have aliases (AS tN)
+                if sql.contains("JOIN users AS ") {
+                    found_self_join = true;
+                    // The joined table must have an alias
+                    assert!(
+                        select.joins[0].alias.is_some(),
+                        "Self-join must have alias: {sql}"
+                    );
+                    break;
                 }
             }
         }
@@ -2720,15 +2719,15 @@ mod tests {
 
         for seed in 0..50 {
             let mut ctx = Context::new_with_seed(seed);
-            if let Ok(select) = generate_select_impl(&generator, &mut ctx, SelectMode::Full) {
-                if let Some(with) = &select.with_clause {
-                    for cte in &with.ctes {
-                        // Inner CTE query should NOT have its own WITH clause
-                        assert!(
-                            cte.query.with_clause.is_none(),
-                            "CTE inner query should not have a WITH clause (no recursion)"
-                        );
-                    }
+            if let Ok(select) = generate_select_impl(&generator, &mut ctx, SelectMode::Full)
+                && let Some(with) = &select.with_clause
+            {
+                for cte in &with.ctes {
+                    // Inner CTE query should NOT have its own WITH clause
+                    assert!(
+                        cte.query.with_clause.is_none(),
+                        "CTE inner query should not have a WITH clause (no recursion)"
+                    );
                 }
             }
         }
@@ -2784,15 +2783,13 @@ mod tests {
         let mut found_cte_from = false;
         for seed in 0..200 {
             let mut ctx = Context::new_with_seed(seed);
-            if let Ok(select) = generate_select_impl(&generator, &mut ctx, SelectMode::Full) {
-                if select.with_clause.is_some() {
-                    if let Some(from) = &select.from {
-                        if from.table.starts_with("cte_") {
-                            found_cte_from = true;
-                            break;
-                        }
-                    }
-                }
+            if let Ok(select) = generate_select_impl(&generator, &mut ctx, SelectMode::Full)
+                && select.with_clause.is_some()
+                && let Some(from) = &select.from
+                && from.table.starts_with("cte_")
+            {
+                found_cte_from = true;
+                break;
             }
         }
         assert!(found_cte_from, "CTE table should be usable as FROM source");
@@ -2826,13 +2823,13 @@ mod tests {
         let mut found_cte_join = false;
         for seed in 0..200 {
             let mut ctx = Context::new_with_seed(seed);
-            if let Ok(select) = generate_select_impl(&generator, &mut ctx, SelectMode::Full) {
-                if select.with_clause.is_some() {
-                    let sql = select.to_string();
-                    if sql.contains("JOIN cte_") {
-                        found_cte_join = true;
-                        break;
-                    }
+            if let Ok(select) = generate_select_impl(&generator, &mut ctx, SelectMode::Full)
+                && select.with_clause.is_some()
+            {
+                let sql = select.to_string();
+                if sql.contains("JOIN cte_") {
+                    found_cte_join = true;
+                    break;
                 }
             }
         }

--- a/testing/differential-oracle/sql_gen/src/generate/stmt.rs
+++ b/testing/differential-oracle/sql_gen/src/generate/stmt.rs
@@ -347,13 +347,12 @@ fn generate_insert_values<C: Capabilities>(
         let mut row = Vec::with_capacity(columns.len());
         for col_name in columns {
             let col = table_columns.iter().find(|c| &c.name == col_name).unwrap();
-            if let Some(ref expr_gen) = insert_expr_gen {
-                if ctx.gen_bool_with_prob(expr_prob) {
-                    if let Ok(expr) = generate_expr(expr_gen, ctx, 0) {
-                        row.push(expr);
-                        continue;
-                    }
-                }
+            if let Some(ref expr_gen) = insert_expr_gen
+                && ctx.gen_bool_with_prob(expr_prob)
+                && let Ok(expr) = generate_expr(expr_gen, ctx, 0)
+            {
+                row.push(expr);
+                continue;
             }
             let lit = generate_literal(ctx, col.data_type, generator.policy());
             row.push(Expr::literal(ctx, lit));
@@ -586,21 +585,20 @@ fn generate_update_sets<C: Capabilities>(
         }
 
         // When FROM is active, try referencing a FROM-side column
-        if !from_tables.is_empty() && ctx.gen_bool_with_prob(from_ref_prob) {
-            if let Some(expr) = generate_from_column_ref(ctx, col, &from_tables, generator.policy())
-            {
-                sets.push((col.name.clone(), expr));
-                continue;
-            }
+        if !from_tables.is_empty()
+            && ctx.gen_bool_with_prob(from_ref_prob)
+            && let Some(expr) = generate_from_column_ref(ctx, col, &from_tables, generator.policy())
+        {
+            sets.push((col.name.clone(), expr));
+            continue;
         }
 
-        if let Some(ref expr_gen) = update_expr_gen {
-            if ctx.gen_bool_with_prob(expr_prob) {
-                if let Ok(expr) = generate_expr(expr_gen, ctx, 0) {
-                    sets.push((col.name.clone(), expr));
-                    continue;
-                }
-            }
+        if let Some(ref expr_gen) = update_expr_gen
+            && ctx.gen_bool_with_prob(expr_prob)
+            && let Ok(expr) = generate_expr(expr_gen, ctx, 0)
+        {
+            sets.push((col.name.clone(), expr));
+            continue;
         }
         let lit = generate_literal(ctx, col.data_type, generator.policy());
         sets.push((col.name.clone(), Expr::literal(ctx, lit)));
@@ -2039,15 +2037,15 @@ mod tests {
             let mut ctx = Context::new_with_seed(seed);
             let stmt = generate_update(&generator, &mut ctx)
                 .expect("single-table schemas should still generate UPDATE");
-            if let Stmt::Update(update) = stmt {
-                if update.from.is_some() {
-                    // Self-join: FROM same table with alias
-                    assert!(
-                        update.from.as_ref().unwrap().alias.is_some(),
-                        "Self-join FROM must have an alias"
-                    );
-                    found_self_join = true;
-                }
+            if let Stmt::Update(update) = stmt
+                && update.from.is_some()
+            {
+                // Self-join: FROM same table with alias
+                assert!(
+                    update.from.as_ref().unwrap().alias.is_some(),
+                    "Self-join FROM must have an alias"
+                );
+                found_self_join = true;
             }
         }
         assert!(
@@ -2130,16 +2128,15 @@ mod tests {
         let mut found_correlated_where = false;
         for seed in 0..50 {
             let mut ctx = Context::new_with_seed(seed);
-            if let Ok(Stmt::Update(update)) = generate_update(&generator, &mut ctx) {
-                if update.from.is_some()
-                    && update.where_clause.as_ref().is_some_and(|expr| {
-                        let rendered = expr.to_string();
-                        rendered.contains("users.") && rendered.contains("posts.")
-                    })
-                {
-                    found_correlated_where = true;
-                    break;
-                }
+            if let Ok(Stmt::Update(update)) = generate_update(&generator, &mut ctx)
+                && update.from.is_some()
+                && update.where_clause.as_ref().is_some_and(|expr| {
+                    let rendered = expr.to_string();
+                    rendered.contains("users.") && rendered.contains("posts.")
+                })
+            {
+                found_correlated_where = true;
+                break;
             }
         }
         assert!(

--- a/testing/differential-oracle/sql_gen/src/trace.rs
+++ b/testing/differential-oracle/sql_gen/src/trace.rs
@@ -274,7 +274,7 @@ impl CoverageTreeNode {
             .filter(|(_, c)| **c > 0)
             .map(|(k, c)| (*k, *c))
             .collect();
-        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.sort_by_key(|e| std::cmp::Reverse(e.1));
         sorted
             .iter()
             .map(|(k, c)| format!("{k}: {c}"))
@@ -482,7 +482,7 @@ impl fmt::Display for CoverageReport<'_> {
         let mut stmt_distribution: Vec<_> = StmtKind::iter()
             .map(|k| (k, *self.coverage.stmt_counts.get(&k).unwrap_or(&0)))
             .collect();
-        stmt_distribution.sort_by(|a, b| b.1.cmp(&a.1));
+        stmt_distribution.sort_by_key(|e| std::cmp::Reverse(e.1));
 
         writeln!(f, "\n--- Statement Distribution ---")?;
         for (kind, count) in &stmt_distribution {
@@ -503,7 +503,7 @@ impl fmt::Display for CoverageReport<'_> {
         let mut expr_distribution: Vec<_> = ExprKind::iter()
             .map(|k| (k, *expr_counts.get(&k).unwrap_or(&0)))
             .collect();
-        expr_distribution.sort_by(|a, b| b.1.cmp(&a.1));
+        expr_distribution.sort_by_key(|e| std::cmp::Reverse(e.1));
 
         writeln!(f, "\n--- Expression Distribution ---")?;
         for (kind, count) in &expr_distribution {
@@ -574,7 +574,7 @@ impl fmt::Display for CoverageReport<'_> {
                             .filter(|(_, c)| **c > 0)
                             .map(|(k, c)| (*k, *c))
                             .collect();
-                        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+                        sorted.sort_by_key(|e| std::cmp::Reverse(e.1));
                         let line: Vec<String> =
                             sorted.iter().map(|(k, c)| format!("{k}: {c}")).collect();
                         writeln!(f, "    {}", line.join(", "))?;

--- a/testing/differential-oracle/sql_gen_macros/src/lib.rs
+++ b/testing/differential-oracle/sql_gen_macros/src/lib.rs
@@ -65,7 +65,7 @@ fn transform_function(origin: Path, mut func: ItemFn) -> syn::Result<TokenStream
         }
     };
 
-    func.block = Box::new(new_body);
+    *func.block = new_body;
 
     Ok(func.to_token_stream())
 }
@@ -90,14 +90,13 @@ fn find_context_param(func: &ItemFn) -> syn::Result<syn::Ident> {
 }
 
 fn is_mut_context_type(ty: &Type) -> bool {
-    if let Type::Reference(type_ref) = ty {
-        if type_ref.mutability.is_some() {
-            if let Type::Path(type_path) = type_ref.elem.as_ref() {
-                // Check if the last segment is "Context"
-                if let Some(segment) = type_path.path.segments.last() {
-                    return segment.ident == "Context";
-                }
-            }
+    if let Type::Reference(type_ref) = ty
+        && type_ref.mutability.is_some()
+        && let Type::Path(type_path) = type_ref.elem.as_ref()
+    {
+        // Check if the last segment is "Context"
+        if let Some(segment) = type_path.path.segments.last() {
+            return segment.ident == "Context";
         }
     }
     false

--- a/testing/differential-oracle/sql_gen_prop/select.rs
+++ b/testing/differential-oracle/sql_gen_prop/select.rs
@@ -286,10 +286,10 @@ impl SelectStatement {
             }
         }
         // Check WHERE clause
-        if let Some(w) = &self.where_clause {
-            if w.has_unordered_limit() {
-                return true;
-            }
+        if let Some(w) = &self.where_clause
+            && w.has_unordered_limit()
+        {
+            return true;
         }
         // Check ORDER BY expressions
         for item in &self.order_by {

--- a/testing/simulator/generation/plan.rs
+++ b/testing/simulator/generation/plan.rs
@@ -116,11 +116,11 @@ impl InteractionPlan {
                 // With 30% probability, redirect CREATE TABLE to an attached database
                 if let InteractionsType::Query(Query::Create(ref mut create)) =
                     interactions.interactions
+                    && !env.attached_dbs.is_empty()
+                    && rng.random_bool(0.3)
                 {
-                    if !env.attached_dbs.is_empty() && rng.random_bool(0.3) {
-                        let db = &env.attached_dbs[rng.random_range(0..env.attached_dbs.len())];
-                        create.table.name = format!("{}.{}", db, create.table.name);
-                    }
+                    let db = &env.attached_dbs[rng.random_range(0..env.attached_dbs.len())];
+                    create.table.name = format!("{}.{}", db, create.table.name);
                 }
 
                 interactions

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -45,7 +45,7 @@ type PropertyQueryGenFunc<'a, R, G> =
     fn(&mut R, &G, &QueryDistribution, &Property) -> Option<Query>;
 
 impl Property {
-    pub(super) fn get_extensional_query_gen_function<R, G>(&self) -> PropertyQueryGenFunc<R, G>
+    pub(super) fn get_extensional_query_gen_function<R, G>(&self) -> PropertyQueryGenFunc<'_, R, G>
     where
         R: rand::Rng + ?Sized,
         G: GenerationContext,

--- a/testing/simulator/model/metrics.rs
+++ b/testing/simulator/model/metrics.rs
@@ -55,49 +55,26 @@ impl Remaining {
         let total_setval = (max_interactions * opts.setval_weight) / total_weight;
         let total_drop_sequence = (max_interactions * opts.drop_sequence_weight) / total_weight;
 
-        let remaining_select = total_select
-            .checked_sub(stats.select_count)
-            .unwrap_or_default();
-        let remaining_insert = total_insert
-            .checked_sub(stats.insert_count)
-            .unwrap_or_default();
-        let remaining_create = total_create
-            .checked_sub(stats.create_count)
-            .unwrap_or_default();
-        let mut remaining_create_index = total_create_index
-            .checked_sub(stats.create_index_count)
-            .unwrap_or_default();
-        let remaining_delete = total_delete
-            .checked_sub(stats.delete_count)
-            .unwrap_or_default();
-        let remaining_update = total_update
-            .checked_sub(stats.update_count)
-            .unwrap_or_default();
-        let remaining_drop = total_drop.checked_sub(stats.drop_count).unwrap_or_default();
-        let remaining_pragma = total_pragma
-            .checked_sub(stats.pragma_count)
-            .unwrap_or_default();
+        let remaining_select = total_select.saturating_sub(stats.select_count);
+        let remaining_insert = total_insert.saturating_sub(stats.insert_count);
+        let remaining_create = total_create.saturating_sub(stats.create_count);
+        let mut remaining_create_index =
+            total_create_index.saturating_sub(stats.create_index_count);
+        let remaining_delete = total_delete.saturating_sub(stats.delete_count);
+        let remaining_update = total_update.saturating_sub(stats.update_count);
+        let remaining_drop = total_drop.saturating_sub(stats.drop_count);
+        let remaining_pragma = total_pragma.saturating_sub(stats.pragma_count);
 
-        let remaining_alter_table = total_alter_table
-            .checked_sub(stats.alter_table_count)
-            .unwrap_or_default();
+        let remaining_alter_table = total_alter_table.saturating_sub(stats.alter_table_count);
 
-        let mut remaining_drop_index = total_drop_index
-            .checked_sub(stats.drop_index_count)
-            .unwrap_or_default();
+        let mut remaining_drop_index = total_drop_index.saturating_sub(stats.drop_index_count);
 
-        let remaining_create_sequence = total_create_sequence
-            .checked_sub(stats.create_sequence_count)
-            .unwrap_or_default();
-        let mut remaining_nextval = total_nextval
-            .checked_sub(stats.nextval_count)
-            .unwrap_or_default();
-        let mut remaining_setval = total_setval
-            .checked_sub(stats.setval_count)
-            .unwrap_or_default();
-        let mut remaining_drop_sequence = total_drop_sequence
-            .checked_sub(stats.drop_sequence_count)
-            .unwrap_or_default();
+        let remaining_create_sequence =
+            total_create_sequence.saturating_sub(stats.create_sequence_count);
+        let mut remaining_nextval = total_nextval.saturating_sub(stats.nextval_count);
+        let mut remaining_setval = total_setval.saturating_sub(stats.setval_count);
+        let mut remaining_drop_sequence =
+            total_drop_sequence.saturating_sub(stats.drop_sequence_count);
 
         if mvcc {
             // TODO: index not supported yet for mvcc

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -790,10 +790,10 @@ pub(crate) fn expand_with_generated_columns(
 
     // Evaluate virtual generated column expressions
     for (col_idx, col) in table.columns.iter().enumerate() {
-        if let Some(expr) = col.generated_expr() {
-            if let Some(value) = expr_to_value(expr, &full_row, table) {
-                full_row[col_idx] = value.apply_affinity(col.column_type);
-            }
+        if let Some(expr) = col.generated_expr()
+            && let Some(value) = expr_to_value(expr, &full_row, table)
+        {
+            full_row[col_idx] = value.apply_affinity(col.column_type);
         }
     }
 
@@ -1208,7 +1208,7 @@ impl Shadow for Select {
                 }
                 CompoundOperator::UnionAll => {
                     // Union all means we just concatenate the results
-                    rows.extend(compound_results.rows.into_iter());
+                    rows.extend(compound_results.rows);
                 }
             }
         }
@@ -1326,10 +1326,10 @@ impl Shadow for Update {
                     }
                     // Recompute virtual generated columns after SET assignments
                     for (col_idx, col) in columns.iter().enumerate() {
-                        if let Some(expr) = col.generated_expr() {
-                            if let Some(value) = expr_to_value(expr, &new_row, &t2) {
-                                new_row[col_idx] = value.apply_affinity(col.column_type);
-                            }
+                        if let Some(expr) = col.generated_expr()
+                            && let Some(value) = expr_to_value(expr, &new_row, &t2)
+                        {
+                            new_row[col_idx] = value.apply_affinity(col.column_type);
                         }
                     }
                     (row_idx, old_row.clone(), new_row)

--- a/testing/simulator/profiles/query.rs
+++ b/testing/simulator/profiles/query.rs
@@ -84,6 +84,9 @@ impl QueryProfile {
     }
 }
 
+// Not consumed yet; rustc 1.98 stopped counting derives as uses, hence the
+// allow.
+#[allow(dead_code)]
 #[derive(Debug, Clone, strum::VariantArray)]
 pub enum QueryTypes {
     CreateTable,

--- a/testing/simulator/runner/bugbase.rs
+++ b/testing/simulator/runner/bugbase.rs
@@ -342,10 +342,10 @@ fn find_git_dir(start_path: impl AsRef<Path>) -> Option<PathBuf> {
             return Some(git_path);
         } else if git_path.is_file() {
             // Handle git worktrees - .git is a file containing "gitdir: <path>"
-            if let Ok(contents) = read_to_string(&git_path) {
-                if let Some(gitdir) = contents.strip_prefix("gitdir: ") {
-                    return Some(PathBuf::from(gitdir));
-                }
+            if let Ok(contents) = read_to_string(&git_path)
+                && let Some(gitdir) = contents.strip_prefix("gitdir: ")
+            {
+                return Some(PathBuf::from(gitdir));
             }
         }
         if !current.pop() {

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -1,7 +1,6 @@
 use clap::{
     Arg, Command, Error, Parser, ValueEnum,
     builder::{PossibleValue, TypedValueParser, ValueParserFactory},
-    command,
     error::{ContextKind, ContextValue, ErrorKind},
 };
 use serde::{Deserialize, Serialize};

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -651,16 +651,16 @@ where
                         (TransactionMode::Read, TransactionMode::Write) => {
                             snapshot.set_transaction_mode(transaction_mode)
                         }
-                        (TransactionMode::Concurrent, TransactionMode::Write) => {
-                            if query.requires_exclusive_tx() {
-                                // MVCC requires an exclusive write tx for DDL
-                                // (see Query::requires_exclusive_tx). The plan
-                                // generator forces a commit before these
-                                // statements, so this upgrade rarely fires —
-                                // kept for defensive correctness if a snapshot
-                                // is built directly.
-                                snapshot.set_transaction_mode(transaction_mode)
-                            }
+                        (TransactionMode::Concurrent, TransactionMode::Write)
+                            if query.requires_exclusive_tx() =>
+                        {
+                            // MVCC requires an exclusive write tx for DDL
+                            // (see Query::requires_exclusive_tx). The plan
+                            // generator forces a commit before these
+                            // statements, so this upgrade rarely fires —
+                            // kept for defensive correctness if a snapshot
+                            // is built directly.
+                            snapshot.set_transaction_mode(transaction_mode)
                         }
                         _ => {}
                     };
@@ -1832,11 +1832,10 @@ impl Paths {
     }
 
     pub fn delete_all_files(&self) {
-        if self.base.exists() {
-            let res = std::fs::remove_dir_all(&self.base);
-            if res.is_err() {
-                tracing::error!(error = %res.unwrap_err(),"failed to remove directory");
-            }
+        if self.base.exists()
+            && let Err(err) = std::fs::remove_dir_all(&self.base)
+        {
+            tracing::error!(error = %err, "failed to remove directory");
         }
     }
 }

--- a/testing/simulator/shrink/plan.rs
+++ b/testing/simulator/shrink/plan.rs
@@ -66,13 +66,11 @@ impl InteractionPlan {
                         table_name,
                         alter_table_type: AlterTableType::RenameTo { new_name },
                     }) = query
+                        && (depending_tables.contains(new_name)
+                            || depending_tables.contains(table_name))
                     {
-                        if depending_tables.contains(new_name)
-                            || depending_tables.contains(table_name)
-                        {
-                            depending_tables.insert(new_name.clone());
-                            depending_tables.insert(table_name.clone());
-                        }
+                        depending_tables.insert(new_name.clone());
+                        depending_tables.insert(table_name.clone());
                     }
                 }
                 _ => {}
@@ -322,14 +320,14 @@ impl InteractionPlan {
 
             let iter = range_transactions.get_mut(&interactions.connection_index);
 
-            if let Some(iter) = iter {
-                if let Some(txn_interaction_idx) = iter.peek().copied() {
-                    if txn_interaction_idx == idx {
-                        iter.next();
-                    }
-                    if txn_interaction_idx == idx || txn_interaction_idx.saturating_sub(1) == idx {
-                        retain = false;
-                    }
+            if let Some(iter) = iter
+                && let Some(txn_interaction_idx) = iter.peek().copied()
+            {
+                if txn_interaction_idx == idx {
+                    iter.next();
+                }
+                if txn_interaction_idx == idx || txn_interaction_idx.saturating_sub(1) == idx {
+                    retain = false;
                 }
             }
 

--- a/testing/sqltest/src/backends/cli.rs
+++ b/testing/sqltest/src/backends/cli.rs
@@ -211,12 +211,12 @@ impl CliDatabaseInstance {
         const PREFIXES: &[&str] = &["CREATE TABLE ", "CREATE TABLE IF NOT EXISTS "];
 
         for prefix in PREFIXES {
-            if let Some(rest) = line.strip_prefix(prefix) {
-                if let Some(paren_idx) = rest.find('(') {
-                    let name_part = &rest[..paren_idx];
-                    if !name_part.ends_with(' ') {
-                        return format!("{prefix}{name_part} {}", &rest[paren_idx..]);
-                    }
+            if let Some(rest) = line.strip_prefix(prefix)
+                && let Some(paren_idx) = rest.find('(')
+            {
+                let name_part = &rest[..paren_idx];
+                if !name_part.ends_with(' ') {
+                    return format!("{prefix}{name_part} {}", &rest[paren_idx..]);
                 }
             }
         }
@@ -356,12 +356,13 @@ impl CliDatabaseInstance {
             let mut rows = parse_list_output(&stdout);
 
             // Filter out MVCC pragma output if present
-            if self.mvcc && !rows.is_empty() {
-                if let Some(first_row) = rows.first() {
-                    if first_row.len() == 1 && first_row[0] == "mvcc" {
-                        rows.remove(0);
-                    }
-                }
+            if self.mvcc
+                && !rows.is_empty()
+                && let Some(first_row) = rows.first()
+                && first_row.len() == 1
+                && first_row[0] == "mvcc"
+            {
+                rows.remove(0);
             }
 
             Ok(QueryResult::success(rows))
@@ -468,12 +469,12 @@ fn strip_shell_error_prefix<'a>(line: &'a str, kind: &str) -> Option<&'a str> {
 /// Strip a trailing ` (<code>)` result code the sqlite3 and tursodb shells
 /// append after runtime error messages.
 fn strip_result_code(message: &str) -> &str {
-    if let Some(open) = message.rfind(" (") {
-        if let Some(code) = message[open + 2..].strip_suffix(')') {
-            if !code.is_empty() && code.bytes().all(|b| b.is_ascii_digit()) {
-                return &message[..open];
-            }
-        }
+    if let Some(open) = message.rfind(" (")
+        && let Some(code) = message[open + 2..].strip_suffix(')')
+        && !code.is_empty()
+        && code.bytes().all(|b| b.is_ascii_digit())
+    {
+        return &message[..open];
     }
     message
 }

--- a/testing/sqltest/src/backends/js.rs
+++ b/testing/sqltest/src/backends/js.rs
@@ -208,12 +208,13 @@ impl JsDatabaseInstance {
         let mut rows = parse_list_output(&stdout);
 
         // Filter out MVCC pragma output if present
-        if self.mvcc && !rows.is_empty() {
-            if let Some(first_row) = rows.first() {
-                if first_row.len() == 1 && first_row[0] == "mvcc" {
-                    rows.remove(0);
-                }
-            }
+        if self.mvcc
+            && !rows.is_empty()
+            && let Some(first_row) = rows.first()
+            && first_row.len() == 1
+            && first_row[0] == "mvcc"
+        {
+            rows.remove(0);
         }
 
         Ok(QueryResult::success(rows))

--- a/testing/sqltest/src/main.rs
+++ b/testing/sqltest/src/main.rs
@@ -426,7 +426,7 @@ async fn run_tests(
         "pg" => {
             // --binary defaults to tursodb for the cli backend; for pg the
             // server binary is tursopg, so rewrite an untouched default.
-            let binary = if binary == PathBuf::from("tursodb") {
+            let binary = if binary == *"tursodb" {
                 PathBuf::from("tursopg")
             } else {
                 binary
@@ -746,30 +746,30 @@ fn convert_single_file(
         // If multiple files, create a subdirectory
         let (output_base, use_subdir) = if num_files > 1 {
             let subdir = base_dir.join(file_stem.as_ref());
-            if !subdir.exists() {
-                if let Err(e) = std::fs::create_dir_all(&subdir) {
-                    eprintln!(
-                        "  {} Failed to create directory {}: {}",
-                        "ERROR".red().bold(),
-                        subdir.display(),
-                        e
-                    );
-                    return (0, warning_count);
-                }
+            if !subdir.exists()
+                && let Err(e) = std::fs::create_dir_all(&subdir)
+            {
+                eprintln!(
+                    "  {} Failed to create directory {}: {}",
+                    "ERROR".red().bold(),
+                    subdir.display(),
+                    e
+                );
+                return (0, warning_count);
             }
             (subdir, true)
         } else {
             // Ensure base dir exists
-            if !base_dir.exists() {
-                if let Err(e) = std::fs::create_dir_all(&base_dir) {
-                    eprintln!(
-                        "  {} Failed to create directory {}: {}",
-                        "ERROR".red().bold(),
-                        base_dir.display(),
-                        e
-                    );
-                    return (0, warning_count);
-                }
+            if !base_dir.exists()
+                && let Err(e) = std::fs::create_dir_all(&base_dir)
+            {
+                eprintln!(
+                    "  {} Failed to create directory {}: {}",
+                    "ERROR".red().bold(),
+                    base_dir.display(),
+                    e
+                );
+                return (0, warning_count);
             }
             (base_dir, false)
         };
@@ -830,16 +830,16 @@ async fn generate_debug_databases(
     eprintln!();
 
     // Create output directory if it doesn't exist
-    if !output_dir.exists() {
-        if let Err(e) = std::fs::create_dir_all(&output_dir) {
-            eprintln!(
-                "{}: Failed to create output directory {}: {}",
-                "Error".red().bold(),
-                output_dir.display(),
-                e
-            );
-            return ExitCode::from(1);
-        }
+    if !output_dir.exists()
+        && let Err(e) = std::fs::create_dir_all(&output_dir)
+    {
+        eprintln!(
+            "{}: Failed to create output directory {}: {}",
+            "Error".red().bold(),
+            output_dir.display(),
+            e
+        );
+        return ExitCode::from(1);
     }
 
     // Generate default database (INTEGER PRIMARY KEY - has rowid alias)

--- a/testing/sqltest/src/parser/lexer.rs
+++ b/testing/sqltest/src/parser/lexer.rs
@@ -24,13 +24,13 @@ fn extract_block_content(lexer: &mut Lexer<'_, Token>) -> Option<String> {
         match ch {
             '\\' => {
                 // Escape sequence: check next character
-                if let Some(&(_, next_ch)) = chars.peek() {
-                    if next_ch == '}' || next_ch == '{' || next_ch == '\\' {
-                        // Consume the escaped character and add it literally
-                        chars.next();
-                        content.push(next_ch);
-                        continue;
-                    }
+                if let Some(&(_, next_ch)) = chars.peek()
+                    && (next_ch == '}' || next_ch == '{' || next_ch == '\\')
+                {
+                    // Consume the escaped character and add it literally
+                    chars.next();
+                    content.push(next_ch);
+                    continue;
                 }
                 // Not a recognized escape sequence, keep the backslash
                 content.push(ch);

--- a/testing/sqltest/src/runner/mod.rs
+++ b/testing/sqltest/src/runner/mod.rs
@@ -528,17 +528,15 @@ async fn run_single<B: SqlBackend, R: Runnable>(
             && !options.db_config.readonly
             && !test.expects_error()
             && !options.mvcc
+            && let Some(ref binary) = options.cross_check_binary
+            && let Some(ref db_path) = file_handle.path
         {
-            if let Some(ref binary) = options.cross_check_binary {
-                if let Some(ref db_path) = file_handle.path {
-                    match run_cross_check_integrity(binary, db_path).await {
-                        Ok(()) => {} // integrity check passed
-                        Err(msg) => {
-                            outcome = TestOutcome::Failed {
-                                reason: format!("cross-check integrity_check failed: {msg}"),
-                            };
-                        }
-                    }
+            match run_cross_check_integrity(binary, db_path).await {
+                Ok(()) => {} // integrity check passed
+                Err(msg) => {
+                    outcome = TestOutcome::Failed {
+                        reason: format!("cross-check integrity_check failed: {msg}"),
+                    };
                 }
             }
         }
@@ -914,17 +912,17 @@ impl<B: SqlBackend + 'static> TestRunner<B> {
             // For each test
             for test in &test_file.tests {
                 // Apply filter if present
-                if let Some(ref filter) = self.config.filter {
-                    if !matches_filter(&test.name, filter) {
-                        continue;
-                    }
+                if let Some(ref filter) = self.config.filter
+                    && !matches_filter(&test.name, filter)
+                {
+                    continue;
                 }
 
                 // Skip tests that don't match the current backend
-                if let Some(required_backend) = test.modifiers.backend {
-                    if required_backend != backend_type {
-                        continue;
-                    }
+                if let Some(required_backend) = test.modifiers.backend
+                    && required_backend != backend_type
+                {
+                    continue;
                 }
 
                 let backend = Arc::clone(&self.backend);
@@ -985,24 +983,24 @@ impl<B: SqlBackend + 'static> TestRunner<B> {
             // For each snapshot
             for snapshot in &test_file.snapshots {
                 // Apply snapshot filter if present
-                if let Some(ref filter) = self.config.snapshot_filter {
-                    if !matches_filter(&snapshot.name, filter) {
-                        continue;
-                    }
+                if let Some(ref filter) = self.config.snapshot_filter
+                    && !matches_filter(&snapshot.name, filter)
+                {
+                    continue;
                 }
 
                 // Also check the regular filter (it applies to both tests and snapshots)
-                if let Some(ref filter) = self.config.filter {
-                    if !matches_filter(&snapshot.name, filter) {
-                        continue;
-                    }
+                if let Some(ref filter) = self.config.filter
+                    && !matches_filter(&snapshot.name, filter)
+                {
+                    continue;
                 }
 
                 // Skip snapshots that don't match the current backend
-                if let Some(required_backend) = snapshot.modifiers.backend {
-                    if required_backend != backend_type {
-                        continue;
-                    }
+                if let Some(required_backend) = snapshot.modifiers.backend
+                    && required_backend != backend_type
+                {
+                    continue;
                 }
 
                 let backend = Arc::clone(&self.backend);
@@ -1052,10 +1050,10 @@ impl<B: SqlBackend + 'static> TestRunner<B> {
         if let Some(db_config) = test_file.databases.first() {
             for matrix in &test_file.matrices {
                 for expansion in matrix.expand() {
-                    if let Some(ref filter) = self.config.filter {
-                        if !matches_filter(&expansion.name, filter) {
-                            continue;
-                        }
+                    if let Some(ref filter) = self.config.filter
+                        && !matches_filter(&expansion.name, filter)
+                    {
+                        continue;
                     }
 
                     let backend = Arc::clone(&self.backend);

--- a/testing/sqltest/src/snapshot/mod.rs
+++ b/testing/sqltest/src/snapshot/mod.rs
@@ -508,10 +508,10 @@ pub async fn find_pending_snapshots(dir: &Path) -> Vec<PathBuf> {
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "new") {
                 // Check if it's a .snap.new file
-                if let Some(stem) = path.file_stem() {
-                    if stem.to_string_lossy().ends_with(".snap") {
-                        pending.push(path);
-                    }
+                if let Some(stem) = path.file_stem()
+                    && stem.to_string_lossy().ends_with(".snap")
+                {
+                    pending.push(path);
                 }
             }
         }
@@ -528,17 +528,16 @@ pub async fn find_all_pending_snapshots(base_dir: &Path) -> Vec<PathBuf> {
     async fn scan_dir(dir: &Path, pending: &mut Vec<PathBuf>) {
         // Check for snapshots directory
         let snapshots_dir = dir.join("snapshots");
-        if snapshots_dir.exists() {
-            if let Ok(mut entries) = fs::read_dir(&snapshots_dir).await {
-                while let Ok(Some(entry)) = entries.next_entry().await {
-                    let path = entry.path();
-                    if path.extension().is_some_and(|ext| ext == "new") {
-                        if let Some(stem) = path.file_stem() {
-                            if stem.to_string_lossy().ends_with(".snap") {
-                                pending.push(path);
-                            }
-                        }
-                    }
+        if snapshots_dir.exists()
+            && let Ok(mut entries) = fs::read_dir(&snapshots_dir).await
+        {
+            while let Ok(Some(entry)) = entries.next_entry().await {
+                let path = entry.path();
+                if path.extension().is_some_and(|ext| ext == "new")
+                    && let Some(stem) = path.file_stem()
+                    && stem.to_string_lossy().ends_with(".snap")
+                {
+                    pending.push(path);
                 }
             }
         }

--- a/testing/stress/opts.rs
+++ b/testing/stress/opts.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
-use clap::{command, Parser};
+use clap::Parser;
 
 /// Transaction mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]

--- a/tests/fuzz/helpers.rs
+++ b/tests/fuzz/helpers.rs
@@ -129,7 +129,7 @@ pub fn execute_on_both(
 /// Print progress at evenly spaced intervals through a loop.
 pub fn log_progress(name: &str, iter: usize, total: usize, num_prints: usize) {
     let interval = (total / num_prints).max(1);
-    if iter % interval == 0 {
+    if iter.is_multiple_of(interval) {
         println!("{name} iteration {}/{}", iter + 1, total);
     }
 }

--- a/tests/fuzz/mod.rs
+++ b/tests/fuzz/mod.rs
@@ -5567,7 +5567,7 @@ mod fuzz_tests {
 
                         let alter_sql = format!(
                             "ALTER TABLE {} ADD COLUMN {} {}",
-                            table_to_alter, &new_col_name, col_type
+                            table_to_alter, new_col_name, col_type
                         );
 
                         stmts.push(alter_sql.clone());

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -375,7 +375,7 @@ pub fn compare_string(a: impl AsRef<str>, b: impl AsRef<str>) {
     for i in 0..len {
         if a[i] != b[i] {
             println!(
-                "Bytes differ \n\t at index: dec -> {} hex -> {:#02x} \n\t values dec -> {}!={} hex -> {:#02x}!={:#02x}",
+                "Bytes differ \n\t at index: dec -> {} hex -> {:#x} \n\t values dec -> {}!={} hex -> {:#x}!={:#x}",
                 i, i, a[i], b[i], a[i], b[i]
             );
             break;

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -393,7 +393,7 @@ fn test_vector_sparse_ivf_fuzz(tmp_db: TempDatabase) {
         let vector = |rng: &mut ChaCha8Rng| {
             let mut values = Vec::with_capacity(DIMS);
             for _ in 0..DIMS {
-                if rng.next_u32() % MOD == 0 {
+                if rng.next_u32().is_multiple_of(MOD) {
                     values.push((rng.next_u32() as f32 / (u32::MAX as f32)).to_string());
                 } else {
                     values.push("0".to_string())

--- a/tests/integration/query_processing/test_hash_join_materialization.rs
+++ b/tests/integration/query_processing/test_hash_join_materialization.rs
@@ -178,14 +178,12 @@ fn hash_join_materialization_does_not_read_unrewound_probe_cursor() {
                     positioned = true;
                 }
             }
-            "Column" | "RowId" => {
-                if p1 == Some(test_table3_cursor_id) {
-                    assert!(
-                        positioned,
-                        "test_table3 cursor read before being positioned; EXPLAIN row: {row:?}"
-                    );
-                    break;
-                }
+            "Column" | "RowId" if p1 == Some(test_table3_cursor_id) => {
+                assert!(
+                    positioned,
+                    "test_table3 cursor read before being positioned; EXPLAIN row: {row:?}"
+                );
+                break;
             }
             _ => {}
         }

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -568,7 +568,7 @@ fn test_mvcc_checkpoint_works() {
     // because MVCC bootstrap may already have persisted its internal metadata table.
     let db_file_size = std::fs::metadata(&tmp_db.path).unwrap().len();
     assert!(
-        db_file_size >= 4096 && db_file_size % 4096 == 0,
+        db_file_size >= 4096 && db_file_size.is_multiple_of(4096),
         "db file size should be a positive multiple of 4096 bytes, but is {db_file_size}",
     );
     let wal_file_size = std::fs::metadata(tmp_db.path.with_extension("db-wal"))
@@ -612,7 +612,7 @@ fn test_mvcc_checkpoint_works() {
     // Assert that the db file size is larger than 4096, .db-wal is empty, and .db-log is truncated to 0.
     let db_file_size = std::fs::metadata(&tmp_db.path).unwrap().len();
     assert!(db_file_size > 4096);
-    assert!(db_file_size % 4096 == 0);
+    assert!(db_file_size.is_multiple_of(4096));
     let wal_size = std::fs::metadata(tmp_db.path.with_extension("db-wal"))
         .unwrap()
         .len();

--- a/tests/integration/unreliable_io.rs
+++ b/tests/integration/unreliable_io.rs
@@ -110,7 +110,7 @@ impl UnreliableIoState {
                 let mut write_idx = 0usize;
                 for op in &shadow.unsynced {
                     if matches!(op, UnsyncedOp::Write { .. }) {
-                        if write_idx % 2 == 0 {
+                        if write_idx.is_multiple_of(2) {
                             op.apply(&mut image);
                             persisted += 1;
                         } else {


### PR DESCRIPTION
# NOTICE:

## Description

Everything measured-and-shipped here serves one goal: `cargo check` staying fast while working in `turso_core`.

1. **A `clippy` profile + `cargo lint` alias.** Clippy and `cargo check` write the same fingerprint files but stamp them with different drivers, so alternating the two rebuilds every workspace crate from scratch in both directions. `cargo lint` runs the exact clippy invocation CI uses, but under `[profile.clippy]` (artifacts in `target/clippy/`), so lint runs never invalidate the `cargo check`/`cargo build` caches. Host units (proc macros, build scripts) verified to land in the profile dir too.
2. **`tracing-subscriber` moved to `[dev-dependencies]` in `turso_core`.** Only `#[cfg(test)]` code installs a subscriber. Drops 8 crates from the `turso_core` check graph (188 → 180). `Cargo.lock` unchanged.
3. **Toolchain bump 1.88 → 1.98** (`rust-toolchain.toml` + the six workflow pins). Interleaved A/B on identical trees measured the newer front-end 10–17% faster on the warm check loop (1.88 median 7.3–7.6s vs 6.1–6.7s on 1.94/1.98 on the measurement box). The bump carries three commits of fallout cleanup:
   * `core: fix warnings surfaced by rustc 1.98` — fn-pointer `PartialEq` derive allowed with intent comment, an elided `Vector<'_>` lifetime spelled out, the `min_specialization` impls moved to an out-of-line `cfg(nightly)` module (`default fn` is gated syntax that stable now warns about even in cfg'd-out code), and the two long-standing unused-import warnings fixed properly (they were missing `conn_raw_api`/`bench` cfg gates on re-exports) — `cargo check -p turso_core` is now **zero-warning**.
   * `core, macros` + `workspace` clippy 1.98 fallout — ~180 findings total, the large majority `cargo clippy --fix` mechanical rewrites (collapsible ifs, `map_or_else`, `is_multiple_of`, `checked_div`, zip-instead-of-counter, `sort_by_key`, `slice::from_ref`, `as_chunks`), plus a handful of manual `if let` rewrites of unwrap-after-check patterns. Two types that rustc 1.98 newly reports as never constructed (derives no longer count as uses) keep their definitions under a commented `allow(dead_code)` rather than being deleted in a toolchain change.
4. **Docs.** AGENTS.md/CLAUDE.md and CONTRIBUTING.md lead with `cargo check -p turso_core` for core iteration, route lint runs through `cargo lint`, and CONTRIBUTING.md gains an "IDE setup" section (RustRover/rust-analyzer fire `cargo check --all-targets` per save; what keeps that fast vs. what silently turns it into full rebuilds).

Validation on this branch: `cargo clippy --workspace --all-features --all-targets` **clean under 1.98** (the exact CI invocation); `cargo fmt --check` clean; `cargo check -p turso_core` zero warnings on both 1.88 and 1.98 across default/`conn_raw_api`/`bench` feature sets; the `nightly-cfg` workflow's exact command (`--cfg nightly --all-targets` on `nightly-2025-12-17`) passes; `cargo test -p turso_core --lib` run for the behavior-adjacent rewrites.

## Motivation and context

`cargo check` while working in `turso_core` was reported at 25s+ on a MacBook Pro M4 (terminal and RustRover's on-save check alike). That matches a *non-incremental* rebuild — warm incremental checks are only a few seconds. Measurements from a 4-core Linux container (roughly 2× slower than an M4; ratios hold):

**Warm-cache cost of one core edit (`touch core/vdbe/execute.rs`), by invocation, on 1.88:**

| Invocation | Warm time |
|---|---|
| `cargo check -p turso_core` | 5.9s |
| `cargo check -p turso_core --all-targets` | 7.9s |
| root `cargo check` (default members, 21 crates re-check) | 10.0s |
| `cargo check --workspace --all-targets [--message-format=json]` (what IDEs run) | 8.8–11.0s |
| no-op re-run of the IDE invocation | 1.6–2.6s |

So with warm caches every scenario lands in the ~3–5s range on an M4 (the reporter confirmed 8–9s for the IDE loop before the toolchain bump). Seeing 25s+ *repeatedly* means the caches die between runs, and the reproducible cause is the clippy↔check fingerprint clobbering:

| Scenario | Before | After |
|---|---|---|
| `cargo check -p turso_core` right after any same-feature clippy run | **23.3s** | **0.2s** (lint via `cargo lint`) |
| cold `cargo check -p turso_core` incl. dependencies | 49.2s wall / 76.2s user | 41.5s wall / 71.5s user (measured pre-bump) |
| warm touch-and-check floor | 7.3–7.6s (1.88) | 6.1–6.7s (1.98) |

Where the cold ~23s of `turso_core` self-time goes (rustc self-profile): typeck 6.3s, MIR borrowck 5.3s, MIR building 1.4s, expansion 1.8s, resolve ~1s, trait solving ~1s, incremental bookkeeping ~1s — spread evenly across ~17k function bodies, no hotspot; the warm floor is the front-end re-running over 357k LOC on every check. Ideas measured and rejected:

* Converting the 729 `turso_assert!`-family proc-macro call sites to `macro_rules!`: all assert macros together cost ~0.1s of expansion. Not worth the churn.
* Gating all 22 core bench targets behind `required-features = ["bench"]` so `--all-targets` skips them: **zero** warm-loop difference (warm incremental bench re-checks are nearly free) — reverted rather than shipped.
* The build script's git-HEAD tracking: one near-floor rebuild (~7.5s) per commit, not a recurring tax.

Pre-existing and unchanged: `cargo check --workspace --all-targets` fails on `memory-benchmark` (`#[global_allocator]` conflict with `turso`'s default-on mimalloc under workspace feature unification; CI already excludes it), and cargo retries the failed units on every subsequent run.

Remaining follow-up (needs design buy-in): **splitting `turso_core` is the only structural fix for the warm floor.** The intra-crate graph supports a layered split — `translate` 97k LOC, `vdbe` 50k, `mvcc` 48k, `storage` 46k over a ~35k foundation, with thin cycles (`vdbe → translate` is ~15 type/helper imports; `storage → mvcc` only the yield-hook traits). With `translate` high in the stack, an edit there would re-front-end roughly a third of today's volume: ~2–3s terminal / ~4–5s IDE per save on an M4.

## Description of AI Usage

This PR was produced by Claude Code working autonomously from the prompt "reduce as much as possible the time that `cargo check` takes when working in `turso_core`", with follow-ups that the pain shows up through RustRover's `cargo check` and a request to try the toolchain bump. The workflow: measure cold/warm/incremental check times across terminal and IDE-style invocations, profile rustc with `-Ztime-passes` and `-Zself-profile` to attribute the cost, form and falsify hypotheses (proc-macro overhead, build-script reruns, dependency bloat, bench-target gating, clippy fingerprint clobbering), A/B the toolchains, then implement and re-measure only what survived measurement. The clippy 1.98 fallout was cleaned with `cargo clippy --fix` plus manual rewrites, each reviewed. All numbers were measured in the session; the human contribution was task framing, steering, and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Frre42fyyx2iT4s42Gwgo8