### PR TITLE
Fix b-tree corruption with cells below minimum size

### DIFF
--- a/bindings/tcl/Makefile
+++ b/bindings/tcl/Makefile
@@ -19,7 +19,7 @@
 #   make clean
 
 ROOT_DIR  := $(shell cd ../.. && pwd)
-TURSO_LIB := $(shell $(ROOT_DIR)/scripts/cargo-target-dir)/debug
+TURSO_LIB := $(shell $(ROOT_DIR)/scripts/cargo-target-dir)/release
 SRC       := $(ROOT_DIR)/bindings/tcl/turso_tcl.c
 INCLUDE   := $(ROOT_DIR)/bindings/c/include
 
@@ -40,14 +40,14 @@ docker-build:
 	  bash -c '\
 	    apt-get update -qq && \
 	    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tcl-dev && \
-	    cargo build -p turso_sqlite3 2>&1 && \
+	    cargo build --release -p turso_sqlite3 2>&1 && \
 	    gcc -shared -fPIC -o bindings/tcl/libturso_tcl.so \
 	        bindings/tcl/turso_tcl.c \
 	        -I bindings/c/include \
 	        -I /usr/include/tcl8.6 \
-	        -L target/debug \
+	        -L target/release \
 	        -lturso_sqlite3 \
-	        -Wl,-rpath,'"'"'$$ORIGIN/../../target/debug'"'"' \
+	        -Wl,-rpath,'"'"'$$ORIGIN/../../target/release'"'"' \
 	        2>&1 && \
 	    echo "Build OK: bindings/tcl/libturso_tcl.so" \
 	  '
@@ -63,17 +63,17 @@ docker-test:
 	  bash -c '\
 	    apt-get update -qq && \
 	    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq tcl-dev && \
-	    cargo build -p turso_sqlite3 2>&1 && \
+	    cargo build --release -p turso_sqlite3 2>&1 && \
 	    gcc -shared -fPIC -o bindings/tcl/libturso_tcl.so \
 	        bindings/tcl/turso_tcl.c \
 	        -I bindings/c/include \
 	        -I /usr/include/tcl8.6 \
-	        -L target/debug \
+	        -L target/release \
 	        -lturso_sqlite3 \
-	        -Wl,-rpath,'"'"'$$ORIGIN/../../target/debug'"'"' \
+	        -Wl,-rpath,'"'"'$$ORIGIN/../../target/release'"'"' \
 	        2>&1 && \
 	    echo "Build OK: bindings/tcl/libturso_tcl.so" && \
-	    LD_LIBRARY_PATH=target/debug tclsh bindings/tcl/test_probes.tcl \
+	    LD_LIBRARY_PATH=target/release tclsh bindings/tcl/test_probes.tcl \
 	  '
 
 # ---- Local build (macOS / Linux with TCL dev headers) -----------------------
@@ -97,7 +97,7 @@ endif
 
 .PHONY: build
 build:
-	cargo build -p turso_sqlite3
+	cargo build --release -p turso_sqlite3
 	gcc $(SHARED_FLAG) -o $(TARGET) \
 	    $(SRC) \
 	    $(TCL_INCLUDE) \

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -3731,6 +3731,14 @@ impl BTreeCursor {
                         if !is_last_sibling && !is_table_leaf {
                             // If we are a index page or a interior table page we need to take the divider cell too.
                             // But we don't need the last divider as it will remain the same.
+                            if is_leaf {
+                                // The divider holds the leaf cell's real size after its child pointer;
+                                // back on a leaf the cell takes the minimum size again.
+                                ensure_min_cell_size(
+                                    &mut reusable_divider_buffers[i],
+                                    LEFT_CHILD_PTR_SIZE_BYTES,
+                                );
+                            }
                             let mut divider_cell = reusable_divider_buffers[i].as_mut_slice();
                             // TODO(pere): in case of old pages are leaf pages, so index leaf page, we need to strip page pointers
                             // from divider cells in index interior pages (parent) because those should not be included.
@@ -4275,6 +4283,21 @@ impl BTreeCursor {
                             write_varint_to_vec(rowid, &mut balance_info.reusable_divider_cell)?;
                         } else {
                             // Leaf index
+                            // A leaf cell is read as at least MINIMUM_CELL_SIZE bytes, so a 2-byte
+                            // record carries one byte of padding here. The parent stores the cell's
+                            // real size after the child pointer, so drop the padding when promoting.
+                            let (payload_len, n_payload) = read_varint(divider_cell)?;
+                            let real_len = n_payload + payload_len as usize;
+                            let divider_cell = if real_len < divider_cell.len() {
+                                turso_assert!(
+                                    real_len < MINIMUM_CELL_SIZE,
+                                    "only cells below the minimum cell size carry padding",
+                                    { "real_len": real_len, "cell_len": divider_cell.len() }
+                                );
+                                &divider_cell[..real_len]
+                            } else {
+                                &divider_cell[..]
+                            };
                             balance_info
                                 .reusable_divider_cell
                                 .extend_from_slice(&(page.get().id as u32).to_be_bytes());
@@ -4993,7 +5016,15 @@ impl BTreeCursor {
                         PageType::IndexLeaf => {
                             let parent_cell_buf =
                                 &parent_buf[parent_cell_start..parent_cell_start + parent_cell_len];
-                            if parent_cell_buf[4..] != cell_buf_in_array[..] {
+                            // The parent stores the cell's real size; the cell array pads leaf
+                            // cells up to MINIMUM_CELL_SIZE.
+                            let parent_payload = &parent_cell_buf[4..];
+                            let padded = parent_payload.len() < MINIMUM_CELL_SIZE
+                                && cell_buf_in_array.len() == MINIMUM_CELL_SIZE;
+                            let matches = cell_buf_in_array.len() >= parent_payload.len()
+                                && cell_buf_in_array[..parent_payload.len()] == *parent_payload
+                                && (cell_buf_in_array.len() == parent_payload.len() || padded);
+                            if !matches {
                                 tracing::error!("balance_non_root(cell_divider_cell_index_leaf, page_id={}, cell_divider_idx={})",
                                     page.get().id,
                                     cell_divider_idx,
@@ -8099,6 +8130,21 @@ impl PartialOrd for IntegrityCheckCellRange {
     }
 }
 
+/// Pads the cell that starts at `cell_start` in `buf` with zero bytes until it takes
+/// MINIMUM_CELL_SIZE bytes, the least space any cell takes on a page (a freed cell must be
+/// able to hold a 4-byte freeblock header).
+///
+/// Only index cells can be smaller: a one-column record of 0, 1, '' or X'' is 2 bytes, so
+/// its cell is 3. A leaf page stores such a cell padded and cell_get_raw_region reports the
+/// padded size, while a divider in the parent stores the cell's real size after its child
+/// pointer. Padding the cell whenever it is headed for a leaf keeps balancing working with
+/// one size; the record's own length prefix keeps readers from ever looking at the padding.
+fn ensure_min_cell_size(buf: &mut crate::alloc::Vec<u8>, cell_start: usize) {
+    const ZEROS: [u8; MINIMUM_CELL_SIZE] = [0; MINIMUM_CELL_SIZE];
+    let padding = (cell_start + MINIMUM_CELL_SIZE).saturating_sub(buf.len());
+    buf.extend_from_slice(&ZEROS[..padding]);
+}
+
 #[cfg(debug_assertions)]
 fn validate_cells_after_insertion(cell_array: &CellArray, leaf_data: bool) {
     for cell in &cell_array.cell_payloads {
@@ -9468,7 +9514,12 @@ fn _insert_into_cell(
                 turso_assert!(overflow_cell.index + 1 == cell_idx, "multiple overflow cells can only occur when a parent overflows during balancing as divider cells are inserted into it. those cells should always be in-order and sequential", { "page_id": page.id, "last_overflow_index": overflow_cell.index, "cell_idx": cell_idx, "cell_count": page.cell_count(), "overflow_count": page.overflow_cells.len() });
             }
         }
-        let payload = crate::with_btree_allocation_site!(OverflowCell, payload.try_to_vec())?;
+        let mut payload = crate::with_btree_allocation_site!(OverflowCell, payload.try_to_vec())?;
+        if page.page_type()? == PageType::IndexLeaf {
+            // Balancing must see one size for every leaf cell, whether it sits on the page
+            // (where cell_get_raw_region reports at least the minimum size) or overflowed.
+            ensure_min_cell_size(&mut payload, 0);
+        }
         let overflow_cell = OverflowCell {
             index: cell_idx,
             payload: Pin::new(payload),

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -9460,8 +9460,20 @@ fn defragment_page(page: &PageContent, usable_space: usize, max_frag_bytes: isiz
 #[cfg(debug_assertions)]
 /// Only enabled in debug mode, where we ensure that all cells are valid.
 fn debug_validate_cells_core(page: &PageContent, usable_space: usize) {
+    let pointer_array_end = page.offset() + page.header_size() + 2 * page.cell_count();
+    turso_assert_greater_than_or_equal!(
+        page.cell_content_area() as usize,
+        pointer_array_end,
+        "cell content area overlaps cell pointer array"
+    );
     for i in 0..page.cell_count() {
         let (offset, size) = page.cell_get_raw_region(i, usable_space).unwrap();
+        turso_assert_greater_than_or_equal!(
+            offset,
+            pointer_array_end,
+            "cell overlaps cell pointer array",
+            { "idx": i }
+        );
         let _buf = &page.as_ptr()[offset..offset + size];
         // E.g. the following table btree cell may just have two bytes:
         // Payload size 0 (stored as SerialTypeKind::ConstInt0)
@@ -9504,8 +9516,11 @@ fn _insert_into_cell(
     let enough_space = if already_has_overflow && !allow_regular_insert_despite_overflow {
         false
     } else {
-        // otherwise, we need to check if we have enough space
-        payload.len() + CELL_PTR_SIZE_BYTES <= free
+        // otherwise, we need to check if we have enough space.
+        // allocate_cell_space() never allocates less than MINIMUM_CELL_SIZE
+        // bytes, so a smaller payload must reserve that much or the cell
+        // content area slides into the cell pointer array.
+        payload.len().max(MINIMUM_CELL_SIZE) + CELL_PTR_SIZE_BYTES <= free
     };
     if !enough_space {
         #[cfg(debug_assertions)]
@@ -12828,6 +12843,48 @@ mod tests {
         let payload = add_record(0, 0, page.clone(), record, &conn);
         let free = compute_free_space(page_contents, usable_space).unwrap();
         assert_eq!(free, 4096 - payload.len() - 2 - header_size);
+    }
+
+    /// A cell smaller than MINIMUM_CELL_SIZE still takes MINIMUM_CELL_SIZE
+    /// bytes on the page. If the free-space check in insert_into_cell()
+    /// forgets that, a 3-byte cell inserted into a page with exactly 5 free
+    /// bytes passes the check (3 + 2 == 5) but the allocation takes 6, and
+    /// the cell content area slides one byte into the cell pointer array.
+    /// The cell must go to the overflow path instead.
+    #[test]
+    pub fn test_tiny_cell_insert_must_not_overlap_cell_pointer_array() {
+        let page = get_page(2);
+        btree_init_page(&page, PageType::IndexLeaf, 0, 4096);
+        let contents = page.get_contents();
+        let usable_space = 4096;
+
+        // Fill the page so exactly 5 free bytes remain: the empty index leaf
+        // has 4096 - 8 = 4088 free bytes, and 679 four-byte cells plus one
+        // seven-byte cell consume 679 * (4 + 2) + (7 + 2) = 4083 of them.
+        let four_byte_cell = [0x03, b'a', b'b', b'c'];
+        for i in 0..679 {
+            insert_into_cell(contents, &four_byte_cell, i, usable_space).unwrap();
+        }
+        let seven_byte_cell = [0x06, b'a', b'b', b'c', b'd', b'e', b'f'];
+        insert_into_cell(contents, &seven_byte_cell, 679, usable_space).unwrap();
+        assert_eq!(compute_free_space(contents, usable_space).unwrap(), 5);
+
+        let three_byte_cell = [0x02, b'x', b'y'];
+        insert_into_cell(contents, &three_byte_cell, 680, usable_space).unwrap();
+
+        assert_eq!(
+            contents.overflow_cells.len(),
+            1,
+            "a 3-byte cell needs MINIMUM_CELL_SIZE + 2 = 6 bytes, so it must overflow when only 5 are free"
+        );
+        let pointer_array_end =
+            contents.offset() + contents.header_size() + 2 * contents.cell_count();
+        assert!(
+            contents.cell_content_area() as usize >= pointer_array_end,
+            "cell content area ({}) overlaps the cell pointer array (ends at {})",
+            contents.cell_content_area(),
+            pointer_array_end
+        );
     }
 
     #[test]

--- a/sqlite/conformance/sqlite-sqltests/btree-tiny-cell-divider.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/btree-tiny-cell-divider.sqltest
@@ -1,0 +1,58 @@
+@database :memory:
+
+# A zero-length string is a 2-byte record, so its index cell is 3 bytes: one
+# byte below the 4-byte minimum cell size. When balancing promotes that cell
+# from a leaf to a divider cell in the parent, balance_non_root aborts with
+# "corrupted database, cells were not balanced properly". This is the bug
+# class upstream in2.test (2007) was written for.
+#
+# The sorted b-tree contents are N integers, one empty string, then 2000
+# short strings. N = 311 is the first count that puts the empty string on a
+# split boundary; N = 310 is a control that does not.
+
+setup tiny-cell-table {
+    CREATE TABLE a(i INTEGER PRIMARY KEY, a);
+    WITH RECURSIVE n(v) AS (SELECT 0 UNION ALL SELECT v + 1 FROM n WHERE v < 1999)
+        INSERT INTO a SELECT v, v FROM n;
+    INSERT INTO a VALUES(4000, '');
+    WITH RECURSIVE n(v) AS (SELECT 0 UNION ALL SELECT v + 1 FROM n WHERE v < 1999)
+        INSERT INTO a SELECT NULL, printf('x%04d', v) FROM n;
+}
+
+# The IN (...) subquery builds an ephemeral index b-tree from the selected
+# values, so the empty string is a 3-byte cell in it.
+
+@setup tiny-cell-table
+test in-ephemeral-btree-empty-string-off-split-boundary {
+    SELECT 1 IN (SELECT a FROM a WHERE (i < 310) OR (i >= 2000));
+}
+expect {
+    1
+}
+
+@setup tiny-cell-table
+test in-ephemeral-btree-empty-string-on-split-boundary {
+    SELECT 1 IN (SELECT a FROM a WHERE (i < 311) OR (i >= 2000));
+}
+expect {
+    1
+}
+
+# A WITHOUT ROWID table with a single-column key is a persistent index b-tree,
+# so an empty-string key is a 3-byte cell on disk and hits the same path on
+# INSERT.
+
+@skip-if mvcc "WITHOUT ROWID tables are not supported in MVCC mode"
+@cross-check-integrity
+test without-rowid-empty-string-key-on-split-boundary {
+    CREATE TABLE t(a PRIMARY KEY) WITHOUT ROWID;
+    WITH RECURSIVE n(v) AS (SELECT 0 UNION ALL SELECT v + 1 FROM n WHERE v < 310)
+        INSERT INTO t SELECT v FROM n;
+    INSERT INTO t VALUES('');
+    WITH RECURSIVE n(v) AS (SELECT 0 UNION ALL SELECT v + 1 FROM n WHERE v < 1999)
+        INSERT INTO t SELECT printf('x%04d', v) FROM n;
+    SELECT count(*), min(a), max(a) FROM t;
+}
+expect {
+    2312|0|x1999
+}

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -277,7 +277,7 @@ set test_files {
   ieee754              fail
   imposter1            fail
   in                   fail
-  in2                  fail
+  in2                  pass
   in3                  fail
   in4                  fail
   in5                  fail


### PR DESCRIPTION
SQLite's in2 TCL test crashed at in2-311. Its single-character index keys produce 3-byte index cells, one byte below SQLite's 4-byte minimum cell size, and those tiny cells broke the b-tree code in two places:

- `balance_non_root` panicked when it promoted a 3-byte leaf cell to a divider.
- `insert_into_cell` checked free space against the raw payload size, but the allocator always takes at least 4 bytes. A 3-byte cell inserted into a page with exactly 5 free bytes passed the check, and the cell content area slid one byte into the cell pointer array. The overlapped byte was later parsed as a payload-size varint, which produced a phantom overflow page pointer and read failures like "short read on page 52264576".

Fix both: store every cell with at least the minimum size during balancing, and make the free-space check reserve the same minimum the allocator uses. New coverage: a sqltest for the divider promotion, a unit test for the free-space check, and a debug assert that any cell overlapping the pointer array now trips immediately.

The TCL extension now links against a release build so the upstream suite finishes in reasonable time (in2.test: 9.4s instead of ~33 minutes), and in2 is marked passing in all.test: 1,999 tests green.