### PR TITLE
fix: bind db.table.column references to the qualified database in correlated subqueries

### DIFF
--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -528,7 +528,10 @@ pub fn bind_and_rewrite_expr<'a>(
                                 let is_rowid_alias = col.is_rowid_alias();
                                 let normalized_tbl_name = normalize_ident(&tbl_name_str);
                                 let matching_tbl = referenced_tables
-                                    .find_table_and_internal_id_by_identifier(&normalized_tbl_name);
+                                    .find_table_and_internal_id_by_database_and_identifier(
+                                        database_id,
+                                        &normalized_tbl_name,
+                                    );
 
                                 if let Some((tbl_id, _)) = matching_tbl {
                                     *expr = Expr::Column {

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1588,6 +1588,27 @@ impl TableReferences {
             })
     }
 
+    /// Like [`Self::find_table_and_internal_id_by_identifier`], but prefers a table
+    /// whose database matches `database_id`. Used for explicitly database-qualified
+    /// column references (`db.table.column`) so that a same-named table in another
+    /// database does not shadow the referenced one.
+    pub fn find_table_and_internal_id_by_database_and_identifier(
+        &self,
+        database_id: usize,
+        identifier: &str,
+    ) -> Option<(TableInternalId, &Table)> {
+        self.joined_tables
+            .iter()
+            .find(|t| t.identifier == identifier && t.database_id == database_id)
+            .map(|t| (t.internal_id, &t.table))
+            .or_else(|| {
+                self.outer_query_refs
+                    .iter()
+                    .find(|t| t.identifier == identifier && !t.cte_definition_only)
+                    .map(|t| (t.internal_id, &t.table))
+            })
+    }
+
     /// Returns an immutable reference to the [JoinedTable] with the given internal ID.
     pub fn find_joined_table_by_internal_id(
         &self,

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -796,3 +796,65 @@ fn test_attached_write_txn_rolled_back_after_io_error() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[turso_macros::test]
+fn test_correlated_subquery_with_same_named_table_across_databases(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let aux_path = tmp_db
+        .path
+        .parent()
+        .unwrap()
+        .join("correlated_same_name_aux.db")
+        .to_string_lossy()
+        .to_string();
+
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE t1 (id INTEGER PRIMARY KEY, val TEXT)")?;
+    conn.execute("INSERT INTO t1 VALUES (2, 'x')")?;
+    conn.execute(format!("ATTACH '{aux_path}' AS aux"))?;
+    conn.execute("CREATE TABLE aux.t1 (id INTEGER PRIMARY KEY, val TEXT)")?;
+    conn.execute("INSERT INTO aux.t1 VALUES (1, 'a'), (2, 'b'), (3, 'c')")?;
+
+    // Regression test for #6279: a database-qualified column reference
+    // (`aux.t1.id`) inside a correlated subquery must bind to the outer
+    // `aux.t1`, not be shadowed by the same-named inner `main.t1`.
+    let rows = limbo_exec_rows(
+        &conn,
+        "SELECT id, val FROM aux.t1 WHERE EXISTS (SELECT 1 FROM t1 WHERE t1.id = aux.t1.id)",
+    );
+    assert_eq!(
+        rows,
+        vec![
+            vec![
+                rusqlite::types::Value::Integer(2),
+                rusqlite::types::Value::Text("b".into())
+            ],
+        ],
+        "EXISTS must correlate against outer aux.t1, not the same-named main.t1"
+    );
+
+    let rows = limbo_exec_rows(
+        &conn,
+        "SELECT id, val FROM aux.t1 WHERE NOT EXISTS (SELECT 1 FROM t1 WHERE t1.id = aux.t1.id)",
+    );
+    assert_eq!(
+        rows.len(),
+        2,
+        "NOT EXISTS must return the non-matching aux rows"
+    );
+
+    let rows = limbo_exec_rows(
+        &conn,
+        "SELECT id, (SELECT val FROM t1 WHERE t1.id = aux.t1.id) AS mv FROM aux.t1",
+    );
+    assert_eq!(
+        rows[0],
+        vec![
+            rusqlite::types::Value::Integer(1),
+            rusqlite::types::Value::Null
+        ],
+        "scalar subquery must evaluate per-row, not once"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Correlated subqueries silently returned wrong results when a table with the same name existed in both an attached database and the subquery's own FROM clause (#6279).

```sql
ATTACH '' AS aux;
CREATE TABLE aux.t1 (id INTEGER PRIMARY KEY, val TEXT);
INSERT INTO aux.t1 VALUES (1,'a'),(2,'b'),(3,'c');
CREATE TABLE main.t1 (id INTEGER PRIMARY KEY, val TEXT);
INSERT INTO main.t1 VALUES (2,'x');

SELECT * FROM aux.t1 WHERE EXISTS (SELECT 1 FROM t1 WHERE t1.id = aux.t1.id);
-- before: all 3 rows (EXISTS always true)
-- after:  only (2,'b')   [matches SQLite]
```

Scalar subqueries had the same failure mode (`aux.t1.id` correlation ignored,
returning a constant instead of per-row values).

## Root cause

`find_table_and_internal_id_by_identifier` matched table references by identifier
only. For `db.table.column` bindings, `DoublyQualified` binding resolved the
database correctly but then looked up the table by bare name, so a same-named
inner-table shadowed the explicitly qualified outer reference, and the outer-scope
correlation fallback was never reached.

## Fix

- plan.rs: add `find_table_and_internal_id_by_database_and_identifier`, which
  prefers joined tables whose `database_id` matches the qualifier's resolved
  database and still falls back to `outer_query_refs` for correlation.
- expr/binding.rs: DoublyQualified binding uses the database-aware lookup.

## Testing

- New integration test `attach::test_correlated_subquery_with_same_named_table_across_databases`
  covers EXISTS / NOT EXISTS / scalar-subquery cases plus the regression scenario.
- Behavioral checks: EXISTS now returns only matching rows; NOT EXISTS the
  complement; scalar subquery returns per-row values (NULL for non-matches) —
  identical to SQLite.
- Full attach suite passes (23/23). Controls confirmed unaffected: different
  table names across databases, same-name with aliased inner table, plain queries.

Fixes #6279