### PR TITLE
core: resolve matview table identity to one spelling

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2325,7 +2325,7 @@ fn emit_update_insns<'a>(
                 } else {
                     InsertFlags::new().skip_last_rowid()
                 },
-                table_name: target_table.identifier.clone(),
+                table_name: table_name.to_string(),
             });
 
             // MVCC AUTOINCREMENT: an UPDATE that moves the rowid forward

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -953,7 +953,7 @@ pub fn translate_insert(
         key_reg: insertion.key_register(),
         record_reg: insertion.record_register(),
         flag: insert_flags,
-        table_name: table_name.to_string(),
+        table_name: normalize_ident(table_name.as_str()),
     });
 
     // Fire AFTER INSERT triggers

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -13,6 +13,7 @@ use crate::schema::{Schema, Type};
 use crate::sync::Arc;
 use crate::turso_assert_ne;
 use crate::types::Value;
+use crate::util::normalize_ident;
 use crate::{LimboError, Result};
 use rustc_hash::FxHashMap as HashMap;
 use std::fmt::{self, Display, Formatter};
@@ -436,6 +437,14 @@ impl<'a> LogicalPlanBuilder<'a> {
         name.as_str().to_string()
     }
 
+    /// Spelling used for anything that names a table: table names, table
+    /// aliases, CTE names and the qualifier of a qualified column. SQL compares
+    /// these case-insensitively, and the IVM circuit keys its input deltas on
+    /// them, so every producer and consumer must agree on one spelling.
+    fn table_ident(name: &ast::Name) -> String {
+        normalize_ident(name.as_str())
+    }
+
     // Build a SELECT statement
     // Build a logical plan from a SELECT statement
     fn build_select(&mut self, select: &ast::Select) -> Result<LogicalPlan> {
@@ -457,7 +466,7 @@ impl<'a> LogicalPlanBuilder<'a> {
         // Build each CTE
         for cte in &with.ctes {
             let cte_plan = self.build_select(&cte.select)?;
-            let cte_name = Self::name_to_string(&cte.tbl_name);
+            let cte_name = Self::table_ident(&cte.tbl_name);
             cte_plans.insert(cte_name.clone(), Arc::new(cte_plan));
             self.ctes
                 .insert(cte_name.clone(), cte_plans[&cte_name].clone());
@@ -470,7 +479,7 @@ impl<'a> LogicalPlanBuilder<'a> {
 
         // Clear CTEs from builder context
         for cte in &with.ctes {
-            self.ctes.remove(&Self::name_to_string(&cte.tbl_name));
+            self.ctes.remove(&Self::table_ident(&cte.tbl_name));
         }
 
         Ok(LogicalPlan::WithCTE(WithCTE {
@@ -594,18 +603,22 @@ impl<'a> LogicalPlanBuilder<'a> {
     fn build_select_table(&mut self, table: &ast::SelectTable) -> Result<LogicalPlan> {
         match table {
             ast::SelectTable::Table(name, alias, _indexed) => {
-                let table_name = Self::name_to_string(&name.name);
-                // Check if it's a CTE reference
-                if let Some(cte_plan) = self.ctes.get(&table_name) {
+                let written_name = Self::table_ident(&name.name);
+                // A CTE shadows a real table of the same name
+                if let Some(cte_plan) = self.ctes.get(&written_name) {
                     return Ok(LogicalPlan::CTERef(CTERef {
-                        name: table_name.clone(),
+                        name: written_name.clone(),
                         schema: cte_plan.schema().clone(),
                     }));
                 }
 
-                // Regular table scan
-                let table_alias = alias.as_ref().map(|a| Self::name_to_string(a.name()));
-                let table_schema = self.get_table_schema(&table_name, table_alias.as_deref())?;
+                let table = self.schema.get_table(&written_name).ok_or_else(|| {
+                    LimboError::ParseError(format!("Table '{written_name}' not found"))
+                })?;
+                let table_name = table.get_name().to_string();
+                let table_alias = alias.as_ref().map(|a| Self::table_ident(a.name()));
+                let table_schema =
+                    Self::build_table_schema(&table, &table_name, table_alias.as_deref());
                 Ok(LogicalPlan::TableScan(TableScan {
                     table_name,
                     alias: table_alias,
@@ -961,7 +974,7 @@ impl<'a> LogicalPlanBuilder<'a> {
                 }
                 ast::ResultColumn::TableStar(table) => {
                     // Expand table.* to all columns from that table
-                    let table_name = Self::name_to_string(table);
+                    let table_name = Self::table_ident(table);
                     for col in &input_schema.columns {
                         // Simple check - would need proper table tracking in real implementation
                         proj_exprs.push(LogicalExpr::Column(Column::with_table(
@@ -1621,17 +1634,13 @@ impl<'a> LogicalPlanBuilder<'a> {
             ast::Expr::DoublyQualified(db, table, col) => {
                 Ok(LogicalExpr::Column(Column::with_table(
                     Self::name_to_string(col),
-                    format!(
-                        "{}.{}",
-                        Self::name_to_string(db),
-                        Self::name_to_string(table)
-                    ),
+                    format!("{}.{}", Self::table_ident(db), Self::table_ident(table)),
                 )))
             }
 
             ast::Expr::Qualified(table, col) => Ok(LogicalExpr::Column(Column::with_table(
                 Self::name_to_string(col),
-                Self::name_to_string(table),
+                Self::table_ident(table),
             ))),
 
             ast::Expr::Literal(lit) => Ok(LogicalExpr::Literal(Self::build_literal(lit)?)),
@@ -2274,13 +2283,11 @@ impl<'a> LogicalPlanBuilder<'a> {
     }
 
     // Get table schema
-    fn get_table_schema(&self, table_name: &str, alias: Option<&str>) -> Result<SchemaRef> {
-        // Look up table in schema
-        let table = self
-            .schema
-            .get_table(table_name)
-            .ok_or_else(|| LimboError::ParseError(format!("Table '{table_name}' not found")))?;
-
+    fn build_table_schema(
+        table: &crate::schema::Table,
+        table_name: &str,
+        alias: Option<&str>,
+    ) -> SchemaRef {
         // Parse table_name which might be "db.table" for attached databases
         let (database, actual_table) = if table_name.contains('.') {
             let parts: Vec<&str> = table_name.splitn(2, '.').collect();
@@ -2302,7 +2309,7 @@ impl<'a> LogicalPlanBuilder<'a> {
             }
         }
 
-        Ok(Arc::new(LogicalSchema::new(columns)))
+        Arc::new(LogicalSchema::new(columns))
     }
 
     // Infer expression type

--- a/sqlite/conformance/turso-sqltests/matview_quoted_identifier_writes.sqltest
+++ b/sqlite/conformance/turso-sqltests/matview_quoted_identifier_writes.sqltest
@@ -1,0 +1,204 @@
+@database :memory:
+@requires-file materialized_views ""
+@skip-file-if mvcc "materialized_views not supported with mvcc"
+
+# A write that spells the table name with quotes must maintain the
+# materialized view exactly like the unquoted spelling does.
+test matview-maintained-for-double-quoted-insert {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    INSERT INTO person VALUES (1, 'red');
+    INSERT INTO "person" VALUES (2, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|2
+}
+
+test matview-maintained-for-bracket-and-backtick-insert {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    INSERT INTO [person] VALUES (1, 'red');
+    INSERT INTO `person` VALUES (2, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|2
+}
+
+# Quoting does not make an identifier case-sensitive in SQLite, so a quoted
+# spelling in a different case still resolves to the same table.
+test matview-maintained-for-quoted-uppercase-insert {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    INSERT INTO "PERSON" VALUES (1, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|1
+}
+
+test matview-maintained-for-quoted-update {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO person VALUES (1, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    UPDATE "person" SET team = 'blue' WHERE id = 1;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+}
+
+test matview-maintained-for-quoted-delete {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO person VALUES (1, 'red'), (2, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    DELETE FROM "person" WHERE id = 1;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|1
+}
+
+# Quoted writes batched inside an explicit transaction must land in the view
+# when the transaction commits.
+test matview-maintained-for-quoted-writes-in-transaction {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    BEGIN;
+    INSERT INTO "person" VALUES (1, 'red');
+    INSERT INTO "person" VALUES (2, 'blue');
+    UPDATE "person" SET team = 'red' WHERE id = 2;
+    COMMIT;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|2
+}
+
+# INSERT ... SELECT and upsert reach the row-writing path differently from a
+# plain VALUES insert, so they get their own quoted-spelling coverage.
+test matview-maintained-for-quoted-insert-select-and-upsert {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE TABLE src(id INTEGER, team TEXT);
+    INSERT INTO src VALUES (1, 'red'), (2, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    INSERT INTO "person" SELECT id, team FROM src;
+    INSERT INTO "person" VALUES (1, 'blue') ON CONFLICT(id) DO UPDATE SET team = 'blue';
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+    red|1
+}
+
+# A table declared with mixed case is the same table however it is later
+# spelled, so view maintenance must key on one case-folded name everywhere.
+test matview-maintained-for-mixed-case-table-insert {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM Person GROUP BY team;
+    INSERT INTO Person VALUES (1, 'red');
+    INSERT INTO PERSON VALUES (2, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|2
+}
+
+test matview-populated-from-existing-rows-of-mixed-case-table {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO Person VALUES (1, 'red'), (2, 'blue');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM Person GROUP BY team;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+    red|1
+}
+
+test matview-maintained-for-mixed-case-table-delete {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO Person VALUES (1, 'red'), (2, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM Person GROUP BY team;
+    DELETE FROM Person WHERE id = 1;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|1
+}
+
+test matview-maintained-for-quoted-lowercase-insert-into-mixed-case-table {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM Person GROUP BY team;
+    INSERT INTO "person" VALUES (1, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|1
+}
+
+test matview-maintained-for-mixed-case-table-update {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO Person VALUES (1, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM Person GROUP BY team;
+    UPDATE Person SET team = 'blue' WHERE id = 1;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+}
+
+# A qualified column reference in the view body names the table too, so it has
+# to resolve under any spelling.
+test matview-maintained-for-mixed-case-qualified-column-and-alias {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT P.team, COUNT(*) AS cnt FROM person AS P GROUP BY P.team;
+    INSERT INTO Person VALUES (1, 'red');
+    INSERT INTO "PERSON" VALUES (2, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|2
+}
+
+# Lowercase control: if this one goes red the change broke matviews outright
+# rather than only the case-folding.
+test matview-maintained-for-all-lowercase-table {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    INSERT INTO person VALUES (1, 'red');
+    DELETE FROM person WHERE id = 1;
+    INSERT INTO person VALUES (2, 'blue');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+}
+
+# An aliased UPDATE names its target through the alias, but the row write has
+# to reach view maintenance under the table's own name.
+test matview-maintained-for-aliased-update {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO person VALUES (1, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    UPDATE person AS p SET team = 'blue' WHERE p.id = 1;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+}


### PR DESCRIPTION
A write whose table name is spelled differently from the materialized view's own `SELECT` silently skipped view maintenance. The view stopped tracking its table and nothing was reported to the caller, so it stayed stale indefinitely.

```sql
CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
CREATE MATERIALIZED VIEW team_size AS SELECT team, COUNT(*) FROM person GROUP BY team;
INSERT INTO person VALUES (1, 'red');     -- maintained
INSERT INTO "person" VALUES (2, 'red');   -- silently NOT maintained
```

Quoting was how this was found in the field, but it is not really about quoting: letter case reaches it too, since `INSERT INTO PERSON` misses in the same way.

### Cause

Maintenance resolved the written table against two seams that were keyed differently:

| seam | keyed on |
|---|---|
| schema dependency map | the normalized name |
| DBSP circuit input / `DeltaSet::get` | the table as the view's `SELECT` spelled it |

`op_insert` fed both from one string taken from the AST through `Name`'s `Display`, which reproduces the identifier exactly as written, quotes and case included. Any spelling difference between the write and the view definition missed one seam, and the dropped delta produced an empty result rather than an error.

Normalizing the publisher alone is not enough — it just moves the mismatch. Measured at the seam, keying the publisher on the folded name breaks a table declared `Person`:

```
before:  DeltaSet::get requested="Person"  available=["Person"]   match
folded:  DeltaSet::get requested="Person"  available=["person"]   MISS
```

### Fix

Resolve the table through the schema when building the logical plan and key the circuit input on the **resolved** name, so both seams agree by construction rather than by the two spellings happening to coincide. The publisher passes the same normalized name.

Table aliases keep the user's spelling, because an alias names nothing in the schema, and a CTE still shadows a real table of the same name because that check precedes resolution. `Display` keeps preserving quotes, which SQL round-tripping and the `%T`-style identifier error messages rely on.

### Tests

`sqlite/conformance/turso-sqltests/matview_quoted_identifier_writes.sqltest` — 15 cases covering quoted, bracketed, backticked, mixed-case and case-differing spellings across `INSERT`, `UPDATE`, `DELETE`, `INSERT ... SELECT`, upsert and explicit transactions, plus a lowercase control. The test commit is red on its own and green with the fix; the wider matview corpus stays green (134 passed).
