### PR TITLE
core/incremental: refuse matviews over tables that cannot be maintained

### DIFF
--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -280,6 +280,11 @@ impl DeltaSet {
         self.deltas
     }
 
+    /// Names the deltas are keyed on
+    pub fn table_names(&self) -> impl Iterator<Item = &str> {
+        self.deltas.keys().map(|k| k.as_str())
+    }
+
     /// Check if all deltas in the set are empty
     pub fn is_empty(&self) -> bool {
         self.deltas.values().all(|d| d.is_empty())
@@ -493,6 +498,32 @@ impl DbspCircuit {
         }
     }
 
+    /// Every delta handed to the circuit must name one of its Input nodes.
+    /// A key that matches nothing would silently feed an empty delta and leave
+    /// the view stale, so a mismatch is a bug in whoever produced the key.
+    fn assert_inputs_known(&self, deltas: &DeltaSet) {
+        for requested in deltas.table_names() {
+            let known = self.nodes.values().any(|node| {
+                matches!(&node.operator, DbspOperator::Input { name, .. } if name == requested)
+            });
+            assert!(
+                known,
+                "delta for table {requested:?} does not match any circuit input; known inputs: {:?}",
+                self.input_table_names()
+            );
+        }
+    }
+
+    fn input_table_names(&self) -> Vec<&str> {
+        self.nodes
+            .values()
+            .filter_map(|node| match &node.operator {
+                DbspOperator::Input { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
     /// Execute the circuit with incremental input data (deltas).
     ///
     /// # Arguments
@@ -505,6 +536,9 @@ impl DbspCircuit {
         execute_state: &mut ExecuteState,
     ) -> Result<IOResult<Delta>> {
         if let Some(root_id) = self.root {
+            if let ExecuteState::Init { input_data } = &*execute_state {
+                self.assert_inputs_known(input_data);
+            }
             // Create temporary cursors for execute (non-commit) operations
             let table_cursor =
                 BTreeCursor::new_table(pager.clone(), self.internal_state_root, OPERATOR_COLUMNS);
@@ -548,6 +582,7 @@ impl DbspCircuit {
 
         // Convert input_data to DeltaSet once, outside the loop
         let input_delta_set = DeltaSet::from_map(input_data);
+        self.assert_inputs_known(&input_delta_set);
 
         loop {
             // Take ownership of the state for processing, to avoid borrow checker issues (we have

--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -2,7 +2,7 @@ use super::compiler::{DbspCircuit, DbspCompiler, DeltaSet};
 use super::dbsp::Delta;
 use super::operator::ComputationTracker;
 use crate::numeric::Numeric;
-use crate::schema::{BTreeTable, Schema};
+use crate::schema::{BTreeTable, Schema, SCHEMA_TABLE_NAME, SQLITE_SEQUENCE_TABLE_NAME};
 use crate::storage::btree::CursorTrait;
 use crate::sync::Arc;
 use crate::sync::Mutex;
@@ -293,8 +293,39 @@ impl IncrementalView {
         schema: &Schema,
     ) -> Result<ViewColumnSchema> {
         crate::util::validate_select_for_unsupported_features(select)?;
+        Self::reject_unmaintainable_source(select, schema)?;
         // Use the shared function to extract columns with full table context
         extract_view_columns(select, schema)
+    }
+
+    /// Rows reach these tables through DDL and the AUTOINCREMENT machinery
+    /// rather than through row maintenance, so a view over one would populate
+    /// once and then stay stale. Checking the resolved name covers the
+    /// `sqlite_master` and temp spellings too. Existing views are still loaded,
+    /// only new ones refused.
+    fn reject_unmaintainable_source(select: &ast::Select, schema: &Schema) -> Result<()> {
+        let mut referenced_tables = Vec::new();
+        let mut aliases = HashMap::default();
+        let mut qualified_names = HashMap::default();
+        let mut table_conditions = HashMap::default();
+        Self::extract_all_tables(
+            select,
+            schema,
+            &mut referenced_tables,
+            &mut aliases,
+            &mut qualified_names,
+            &mut table_conditions,
+        )?;
+        let unmaintainable = referenced_tables.iter().find(|table| {
+            table.name == SCHEMA_TABLE_NAME || table.name == SQLITE_SEQUENCE_TABLE_NAME
+        });
+        if let Some(table) = unmaintainable {
+            return Err(LimboError::ParseError(format!(
+                "view cannot reference the internal table: {}",
+                table.name
+            )));
+        }
+        Ok(())
     }
 
     pub fn from_sql(

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2325,7 +2325,7 @@ fn emit_update_insns<'a>(
                 } else {
                     InsertFlags::new().skip_last_rowid()
                 },
-                table_name: target_table.identifier.clone(),
+                table_name: table_name.to_string(),
             });
 
             // MVCC AUTOINCREMENT: an UPDATE that moves the rowid forward

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -953,7 +953,7 @@ pub fn translate_insert(
         key_reg: insertion.key_register(),
         record_reg: insertion.record_register(),
         flag: insert_flags,
-        table_name: table_name.to_string(),
+        table_name: normalize_ident(table_name.as_str()),
     });
 
     // Fire AFTER INSERT triggers

--- a/core/translate/logical.rs
+++ b/core/translate/logical.rs
@@ -13,6 +13,7 @@ use crate::schema::{Schema, Type};
 use crate::sync::Arc;
 use crate::turso_assert_ne;
 use crate::types::Value;
+use crate::util::normalize_ident;
 use crate::{LimboError, Result};
 use rustc_hash::FxHashMap as HashMap;
 use std::fmt::{self, Display, Formatter};
@@ -436,6 +437,14 @@ impl<'a> LogicalPlanBuilder<'a> {
         name.as_str().to_string()
     }
 
+    /// Spelling used for anything that names a table: table names, table
+    /// aliases, CTE names and the qualifier of a qualified column. SQL compares
+    /// these case-insensitively, and the IVM circuit keys its input deltas on
+    /// them, so every producer and consumer must agree on one spelling.
+    fn table_ident(name: &ast::Name) -> String {
+        normalize_ident(name.as_str())
+    }
+
     // Build a SELECT statement
     // Build a logical plan from a SELECT statement
     fn build_select(&mut self, select: &ast::Select) -> Result<LogicalPlan> {
@@ -457,7 +466,7 @@ impl<'a> LogicalPlanBuilder<'a> {
         // Build each CTE
         for cte in &with.ctes {
             let cte_plan = self.build_select(&cte.select)?;
-            let cte_name = Self::name_to_string(&cte.tbl_name);
+            let cte_name = Self::table_ident(&cte.tbl_name);
             cte_plans.insert(cte_name.clone(), Arc::new(cte_plan));
             self.ctes
                 .insert(cte_name.clone(), cte_plans[&cte_name].clone());
@@ -470,7 +479,7 @@ impl<'a> LogicalPlanBuilder<'a> {
 
         // Clear CTEs from builder context
         for cte in &with.ctes {
-            self.ctes.remove(&Self::name_to_string(&cte.tbl_name));
+            self.ctes.remove(&Self::table_ident(&cte.tbl_name));
         }
 
         Ok(LogicalPlan::WithCTE(WithCTE {
@@ -594,18 +603,22 @@ impl<'a> LogicalPlanBuilder<'a> {
     fn build_select_table(&mut self, table: &ast::SelectTable) -> Result<LogicalPlan> {
         match table {
             ast::SelectTable::Table(name, alias, _indexed) => {
-                let table_name = Self::name_to_string(&name.name);
-                // Check if it's a CTE reference
-                if let Some(cte_plan) = self.ctes.get(&table_name) {
+                let written_name = Self::table_ident(&name.name);
+                // A CTE shadows a real table of the same name
+                if let Some(cte_plan) = self.ctes.get(&written_name) {
                     return Ok(LogicalPlan::CTERef(CTERef {
-                        name: table_name.clone(),
+                        name: written_name.clone(),
                         schema: cte_plan.schema().clone(),
                     }));
                 }
 
-                // Regular table scan
-                let table_alias = alias.as_ref().map(|a| Self::name_to_string(a.name()));
-                let table_schema = self.get_table_schema(&table_name, table_alias.as_deref())?;
+                let table = self.schema.get_table(&written_name).ok_or_else(|| {
+                    LimboError::ParseError(format!("Table '{written_name}' not found"))
+                })?;
+                let table_name = table.get_name().to_string();
+                let table_alias = alias.as_ref().map(|a| Self::table_ident(a.name()));
+                let table_schema =
+                    Self::build_table_schema(&table, &table_name, table_alias.as_deref());
                 Ok(LogicalPlan::TableScan(TableScan {
                     table_name,
                     alias: table_alias,
@@ -961,7 +974,7 @@ impl<'a> LogicalPlanBuilder<'a> {
                 }
                 ast::ResultColumn::TableStar(table) => {
                     // Expand table.* to all columns from that table
-                    let table_name = Self::name_to_string(table);
+                    let table_name = Self::table_ident(table);
                     for col in &input_schema.columns {
                         // Simple check - would need proper table tracking in real implementation
                         proj_exprs.push(LogicalExpr::Column(Column::with_table(
@@ -1621,17 +1634,13 @@ impl<'a> LogicalPlanBuilder<'a> {
             ast::Expr::DoublyQualified(db, table, col) => {
                 Ok(LogicalExpr::Column(Column::with_table(
                     Self::name_to_string(col),
-                    format!(
-                        "{}.{}",
-                        Self::name_to_string(db),
-                        Self::name_to_string(table)
-                    ),
+                    format!("{}.{}", Self::table_ident(db), Self::table_ident(table)),
                 )))
             }
 
             ast::Expr::Qualified(table, col) => Ok(LogicalExpr::Column(Column::with_table(
                 Self::name_to_string(col),
-                Self::name_to_string(table),
+                Self::table_ident(table),
             ))),
 
             ast::Expr::Literal(lit) => Ok(LogicalExpr::Literal(Self::build_literal(lit)?)),
@@ -2274,13 +2283,11 @@ impl<'a> LogicalPlanBuilder<'a> {
     }
 
     // Get table schema
-    fn get_table_schema(&self, table_name: &str, alias: Option<&str>) -> Result<SchemaRef> {
-        // Look up table in schema
-        let table = self
-            .schema
-            .get_table(table_name)
-            .ok_or_else(|| LimboError::ParseError(format!("Table '{table_name}' not found")))?;
-
+    fn build_table_schema(
+        table: &crate::schema::Table,
+        table_name: &str,
+        alias: Option<&str>,
+    ) -> SchemaRef {
         // Parse table_name which might be "db.table" for attached databases
         let (database, actual_table) = if table_name.contains('.') {
             let parts: Vec<&str> = table_name.splitn(2, '.').collect();
@@ -2302,7 +2309,7 @@ impl<'a> LogicalPlanBuilder<'a> {
             }
         }
 
-        Ok(Arc::new(LogicalSchema::new(columns)))
+        Arc::new(LogicalSchema::new(columns))
     }
 
     // Infer expression type

--- a/sqlite/conformance/turso-sqltests/matview_quoted_identifier_writes.sqltest
+++ b/sqlite/conformance/turso-sqltests/matview_quoted_identifier_writes.sqltest
@@ -1,0 +1,204 @@
+@database :memory:
+@requires-file materialized_views ""
+@skip-file-if mvcc "materialized_views not supported with mvcc"
+
+# A write that spells the table name with quotes must maintain the
+# materialized view exactly like the unquoted spelling does.
+test matview-maintained-for-double-quoted-insert {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    INSERT INTO person VALUES (1, 'red');
+    INSERT INTO "person" VALUES (2, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|2
+}
+
+test matview-maintained-for-bracket-and-backtick-insert {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    INSERT INTO [person] VALUES (1, 'red');
+    INSERT INTO `person` VALUES (2, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|2
+}
+
+# Quoting does not make an identifier case-sensitive in SQLite, so a quoted
+# spelling in a different case still resolves to the same table.
+test matview-maintained-for-quoted-uppercase-insert {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    INSERT INTO "PERSON" VALUES (1, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|1
+}
+
+test matview-maintained-for-quoted-update {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO person VALUES (1, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    UPDATE "person" SET team = 'blue' WHERE id = 1;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+}
+
+test matview-maintained-for-quoted-delete {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO person VALUES (1, 'red'), (2, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    DELETE FROM "person" WHERE id = 1;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|1
+}
+
+# Quoted writes batched inside an explicit transaction must land in the view
+# when the transaction commits.
+test matview-maintained-for-quoted-writes-in-transaction {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    BEGIN;
+    INSERT INTO "person" VALUES (1, 'red');
+    INSERT INTO "person" VALUES (2, 'blue');
+    UPDATE "person" SET team = 'red' WHERE id = 2;
+    COMMIT;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|2
+}
+
+# INSERT ... SELECT and upsert reach the row-writing path differently from a
+# plain VALUES insert, so they get their own quoted-spelling coverage.
+test matview-maintained-for-quoted-insert-select-and-upsert {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE TABLE src(id INTEGER, team TEXT);
+    INSERT INTO src VALUES (1, 'red'), (2, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    INSERT INTO "person" SELECT id, team FROM src;
+    INSERT INTO "person" VALUES (1, 'blue') ON CONFLICT(id) DO UPDATE SET team = 'blue';
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+    red|1
+}
+
+# A table declared with mixed case is the same table however it is later
+# spelled, so view maintenance must key on one case-folded name everywhere.
+test matview-maintained-for-mixed-case-table-insert {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM Person GROUP BY team;
+    INSERT INTO Person VALUES (1, 'red');
+    INSERT INTO PERSON VALUES (2, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|2
+}
+
+test matview-populated-from-existing-rows-of-mixed-case-table {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO Person VALUES (1, 'red'), (2, 'blue');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM Person GROUP BY team;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+    red|1
+}
+
+test matview-maintained-for-mixed-case-table-delete {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO Person VALUES (1, 'red'), (2, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM Person GROUP BY team;
+    DELETE FROM Person WHERE id = 1;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|1
+}
+
+test matview-maintained-for-quoted-lowercase-insert-into-mixed-case-table {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM Person GROUP BY team;
+    INSERT INTO "person" VALUES (1, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|1
+}
+
+test matview-maintained-for-mixed-case-table-update {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO Person VALUES (1, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM Person GROUP BY team;
+    UPDATE Person SET team = 'blue' WHERE id = 1;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+}
+
+# A qualified column reference in the view body names the table too, so it has
+# to resolve under any spelling.
+test matview-maintained-for-mixed-case-qualified-column-and-alias {
+    CREATE TABLE Person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT P.team, COUNT(*) AS cnt FROM person AS P GROUP BY P.team;
+    INSERT INTO Person VALUES (1, 'red');
+    INSERT INTO "PERSON" VALUES (2, 'red');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    red|2
+}
+
+# Lowercase control: if this one goes red the change broke matviews outright
+# rather than only the case-folding.
+test matview-maintained-for-all-lowercase-table {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    INSERT INTO person VALUES (1, 'red');
+    DELETE FROM person WHERE id = 1;
+    INSERT INTO person VALUES (2, 'blue');
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+}
+
+# An aliased UPDATE names its target through the alias, but the row write has
+# to reach view maintenance under the table's own name.
+test matview-maintained-for-aliased-update {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, team TEXT);
+    INSERT INTO person VALUES (1, 'red');
+    CREATE MATERIALIZED VIEW team_size AS
+    SELECT team, COUNT(*) AS cnt FROM person GROUP BY team;
+    UPDATE person AS p SET team = 'blue' WHERE p.id = 1;
+    SELECT team, cnt FROM team_size ORDER BY team;
+}
+expect {
+    blue|1
+}

--- a/sqlite/conformance/turso-sqltests/matview_unmaintainable_view_sources.sqltest
+++ b/sqlite/conformance/turso-sqltests/matview_unmaintainable_view_sources.sqltest
@@ -1,0 +1,127 @@
+@database :memory:
+@requires-file materialized_views ""
+@skip-file-if mvcc "materialized_views not supported with mvcc"
+
+# `sqlite_master` is another spelling of `sqlite_schema`, so it has to reach the
+# same table. Case folding alone does not get there: the name has to be resolved
+# through the schema, the way writes to the schema table already are. Once it
+# does resolve, the view is refused, because rows reach the schema table through
+# the DDL path and no row maintenance would ever update the view.
+test matview-over-sqlite-master-refused {
+    CREATE TABLE person(id INTEGER PRIMARY KEY);
+    CREATE MATERIALIZED VIEW person_schema AS
+    SELECT name FROM sqlite_master WHERE tbl_name = 'person';
+}
+expect error {
+    view cannot reference the internal table: sqlite_schema
+}
+
+test matview-over-mixed-case-sqlite-master-refused {
+    CREATE TABLE person(id INTEGER PRIMARY KEY);
+    CREATE MATERIALIZED VIEW person_schema AS
+    SELECT name FROM SQLite_Master WHERE tbl_name = 'person';
+}
+expect error {
+    view cannot reference the internal table: sqlite_schema
+}
+
+test matview-over-sqlite-schema-refused {
+    CREATE TABLE person(id INTEGER PRIMARY KEY);
+    CREATE MATERIALIZED VIEW person_schema AS
+    SELECT name FROM sqlite_schema WHERE tbl_name = 'person';
+}
+expect error {
+    view cannot reference the internal table: sqlite_schema
+}
+
+test matview-over-quoted-sqlite-master-refused {
+    CREATE TABLE person(id INTEGER PRIMARY KEY);
+    CREATE MATERIALIZED VIEW person_schema AS
+    SELECT name FROM "sqlite_master";
+}
+expect error {
+    view cannot reference the internal table: sqlite_schema
+}
+
+# The temp spellings resolve to the same table, so one condition catches them.
+test matview-over-sqlite-temp-master-refused {
+    CREATE TABLE person(id INTEGER PRIMARY KEY);
+    CREATE MATERIALIZED VIEW person_schema AS SELECT name FROM sqlite_temp_master;
+}
+expect error {
+    view cannot reference the internal table: sqlite_schema
+}
+
+test matview-over-sqlite-temp-schema-refused {
+    CREATE TABLE person(id INTEGER PRIMARY KEY);
+    CREATE MATERIALIZED VIEW person_schema AS SELECT name FROM sqlite_temp_schema;
+}
+expect error {
+    view cannot reference the internal table: sqlite_schema
+}
+
+# The schema table is refused wherever it appears, not only as the first table.
+test matview-joining-sqlite-master-refused {
+    CREATE TABLE person(id INTEGER PRIMARY KEY, name TEXT);
+    CREATE MATERIALIZED VIEW person_schema AS
+    SELECT person.id FROM person JOIN sqlite_master ON person.name = sqlite_master.name;
+}
+expect error {
+    view cannot reference the internal table: sqlite_schema
+}
+
+# A plain view is not incrementally maintained, so it is unaffected.
+test plain-view-over-sqlite-master-allowed {
+    CREATE TABLE person(id INTEGER PRIMARY KEY);
+    CREATE VIEW person_schema AS SELECT name FROM sqlite_master WHERE tbl_name = 'person';
+    SELECT name FROM person_schema ORDER BY name;
+}
+expect {
+    person
+}
+
+# sqlite_sequence is written by the AUTOINCREMENT machinery rather than by row
+# maintenance, so a view over it goes stale the same way and is refused too.
+test matview-over-sqlite-sequence-refused {
+    CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+    CREATE MATERIALIZED VIEW seqm AS SELECT name, seq FROM sqlite_sequence;
+}
+expect error {
+    view cannot reference the internal table: sqlite_sequence
+}
+
+test matview-over-mixed-case-sqlite-sequence-refused {
+    CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+    CREATE MATERIALIZED VIEW seqm AS SELECT name, seq FROM SQLite_Sequence;
+}
+expect error {
+    view cannot reference the internal table: sqlite_sequence
+}
+
+test matview-over-quoted-sqlite-sequence-refused {
+    CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+    CREATE MATERIALIZED VIEW seqm AS SELECT name, seq FROM "sqlite_sequence";
+}
+expect error {
+    view cannot reference the internal table: sqlite_sequence
+}
+
+test matview-joining-sqlite-sequence-refused {
+    CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+    CREATE MATERIALIZED VIEW seqm AS
+    SELECT t.v FROM t JOIN sqlite_sequence ON sqlite_sequence.name = 't';
+}
+expect error {
+    view cannot reference the internal table: sqlite_sequence
+}
+
+# A plain view is not incrementally maintained, so it is unaffected.
+test plain-view-over-sqlite-sequence-allowed {
+    CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+    INSERT INTO t(v) VALUES ('a'), ('b');
+    CREATE VIEW seqm AS SELECT name, seq FROM sqlite_sequence;
+    SELECT name, seq FROM seqm;
+}
+expect {
+    t|2
+}


### PR DESCRIPTION
> **Stacked on #8461 — review and merge that first.**
>
> GitHub cannot base a cross-fork PR on a branch in the fork, so this PR targets `main` and
> therefore *contains* #8461's two commits as well as its own. Its own change is the last two
> commits only: `testing: pin that matviews over the schema and sequence tables are refused`
> and `core/incremental: refuse matviews over tables that cannot be maintained`.
> Once #8461 merges, this diff shrinks to just those.
>
> The two are separated deliberately: #8461 alone is safe to merge on its own (it adds no
> assertion, so it introduces no new failure mode), while the assertion added here is only
> sound together with the refusals in the same commit.

### The silent failure mode

A delta whose table matched no circuit input produced an **empty** delta. A view that had stopped tracking its table was therefore indistinguishable from one with no changes, which is why the mis-keying fixed in #8461 could sit unnoticed. This asserts instead that every delta names a circuit input, so a mismatch says which key was requested and which inputs exist:

```
delta for table "sqlite_schema" does not match any circuit input; known inputs: ["sqlite_master"]
```

### What the assert immediately found

Two sources that no amount of key agreement can fix. Writes reach `sqlite_schema` through the DDL path and `sqlite_sequence` through `AUTOINCREMENT` — neither goes through row maintenance — so a materialized view over either populates once and then reports stale contents forever. Both are broken on `main` today, silently:

```sql
CREATE TABLE seed(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
INSERT INTO seed(v) VALUES ('a');
CREATE MATERIALIZED VIEW seqm AS SELECT name, seq FROM sqlite_sequence;
INSERT INTO seed(v) VALUES ('b');
INSERT INTO seed(v) VALUES ('c');
SELECT seq FROM seqm;   -- reports 1, truth is 3
```

So refuse both at `CREATE`, matching how attached-database tables and CTEs are already refused. A clear error when the view is created beats one that lies for the rest of its life.

The check runs on the **resolved** name, so `sqlite_master`, the temp variants, and quoted, bracketed, backticked, mixed-case and `main.`-qualified spellings are all covered by one condition. It runs on the CREATE path only, so databases that already contain such a view still open, and plain (non-materialized) views over those tables are unaffected.

### Verification

Checked that the refusal cannot be evaded (every spelling above refused) and produces no false positives — a column named `sqlite_schema` and a table alias named `sqlite_sequence` are both still accepted. With both sources refused, the assert is no longer reachable from valid SQL: writes to unrelated tables, fan-out to several views, triggers, `ALTER TABLE RENAME`, `DROP`+recreate and matview-over-matview were all exercised without firing it, and CTEs, derived tables, `IN`-subqueries, correlated `EXISTS` and scalar subqueries are refused by the DBSP compiler before they can reach it.

### Tests

`sqlite/conformance/turso-sqltests/matview_unmaintainable_view_sources.sqltest` — 13 cases. Red without this commit (2 passed, 11 failed), green with it. Full matview corpus 147 passed.
