### PR TITLE
core/vdbe: record the row replaced by an upsert once, not twice

### DIFF
--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -944,9 +944,10 @@ pub fn translate_insert(
 
     // For REPLACE (statement-level or constraint-level), we need to force a seek on the
     // insert, as we may have already deleted the conflicting row and the cursor is not
-    // guaranteed to be positioned.
+    // guaranteed to be positioned. That delete already recorded the old row for
+    // materialized view maintenance, so this insert must not record it a second time.
     if matches!(ctx.on_conflict, ResolveType::Replace) || has_ddl_replace {
-        insert_flags = insert_flags.require_seek();
+        insert_flags = insert_flags.require_seek().old_row_already_deleted();
     }
     program.emit_insn(Insn::Insert {
         cursor: ctx.cursor_id,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11754,11 +11754,12 @@ pub fn op_insert(
                         .is_empty()
                 };
                 // If there are no dependent views, we don't need to capture the old record.
-                // We also don't need to do it if the rowid of the UPDATEd row was changed, because
-                // op_delete already captured the deletion for IVM, and this insert only needs to
-                // record the new row (which ApplyViewChange handles without old_record).
-                let needs_capture =
-                    has_dependent_views && !flag.has(InsertFlags::UPDATE_ROWID_CHANGE);
+                // We also don't need to do it when a preceding op_delete already captured the
+                // old row for IVM (UPDATE that moves a rowid, REPLACE that overwrites one);
+                // this insert only needs to record the new row.
+                let needs_capture = has_dependent_views
+                    && !flag.has(InsertFlags::UPDATE_ROWID_CHANGE)
+                    && !flag.has(InsertFlags::OLD_ROW_ALREADY_DELETED);
 
                 if flag.has(InsertFlags::REQUIRE_SEEK) {
                     state.active_op_state.insert().sub_state = OpInsertSubState::Seek;
@@ -11800,8 +11801,9 @@ pub fn op_insert(
                         .get_dependent_materialized_views(table_name)
                         .is_empty()
                 };
-                let needs_capture =
-                    has_dependent_views && !flag.has(InsertFlags::UPDATE_ROWID_CHANGE);
+                let needs_capture = has_dependent_views
+                    && !flag.has(InsertFlags::UPDATE_ROWID_CHANGE)
+                    && !flag.has(InsertFlags::OLD_ROW_ALREADY_DELETED);
                 if needs_capture {
                     state.active_op_state.insert().sub_state = OpInsertSubState::CaptureRecord;
                 } else {

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -184,6 +184,7 @@ impl InsertFlags {
     pub const SKIP_LAST_ROWID: u8 = 0x08; // Flag indicating that last_insert_rowid() must not be updated
     pub const SKIP_STATEMENT_CHANGE_COUNT: u8 = 0x10; // Flag indicating that changes() must not count this insert
     pub const SKIP_ALL_CHANGE_COUNTS: u8 = 0x20; // Flag indicating that neither changes() nor total_changes() must count this insert
+    pub const OLD_ROW_ALREADY_DELETED: u8 = 0x40; // Flag indicating that a preceding Insn::Delete removed the row at this rowid and already recorded it for materialized view maintenance
 
     pub fn new() -> Self {
         InsertFlags(0)
@@ -220,6 +221,11 @@ impl InsertFlags {
 
     pub fn skip_all_change_counts(mut self) -> Self {
         self.0 |= InsertFlags::SKIP_ALL_CHANGE_COUNTS;
+        self
+    }
+
+    pub fn old_row_already_deleted(mut self) -> Self {
+        self.0 |= InsertFlags::OLD_ROW_ALREADY_DELETED;
         self
     }
 }

--- a/sqlite/conformance/turso-sqltests/matview_insert_or_replace.sqltest
+++ b/sqlite/conformance/turso-sqltests/matview_insert_or_replace.sqltest
@@ -21,3 +21,260 @@ expect {
     b|1
     c|1
 }
+
+# INSERT OR REPLACE emits its own retraction for the row it overwrites
+# (Insn::Delete), so the following Insn::Insert must not record a second one.
+# Two retractions against one insertion drove the group's COUNT below zero.
+test matview-replace-same-value-single-row {
+    CREATE TABLE t2(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v2 AS SELECT val, COUNT(*) as cnt FROM t2 GROUP BY val;
+    INSERT INTO t2 VALUES (1, 'a');
+    INSERT OR REPLACE INTO t2 VALUES (1, 'a');
+    SELECT * FROM v2 ORDER BY val;
+}
+expect {
+    a|1
+}
+
+test matview-replace-same-value-repeated {
+    CREATE TABLE t3(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v3 AS SELECT val, COUNT(*) as cnt FROM t3 GROUP BY val;
+    INSERT INTO t3 VALUES (1, 'a');
+    INSERT OR REPLACE INTO t3 VALUES (1, 'a');
+    INSERT OR REPLACE INTO t3 VALUES (1, 'a');
+    INSERT OR REPLACE INTO t3 VALUES (1, 'a');
+    SELECT * FROM v3 ORDER BY val;
+}
+expect {
+    a|1
+}
+
+test matview-replace-bare-same-value-single-row {
+    CREATE TABLE t4(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v4 AS SELECT val, COUNT(*) as cnt FROM t4 GROUP BY val;
+    INSERT INTO t4 VALUES (1, 'a');
+    REPLACE INTO t4 VALUES (1, 'a');
+    SELECT * FROM v4 ORDER BY val;
+}
+expect {
+    a|1
+}
+
+test matview-replace-different-value-single-row {
+    CREATE TABLE t5(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v5 AS SELECT val, COUNT(*) as cnt FROM t5 GROUP BY val;
+    INSERT INTO t5 VALUES (1, 'a');
+    INSERT OR REPLACE INTO t5 VALUES (1, 'b');
+    SELECT * FROM v5 ORDER BY val;
+}
+expect {
+    b|1
+}
+
+test matview-replace-same-value-in-explicit-txn {
+    CREATE TABLE t6(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v6 AS SELECT val, COUNT(*) as cnt FROM t6 GROUP BY val;
+    BEGIN;
+    INSERT INTO t6 VALUES (1, 'a');
+    INSERT OR REPLACE INTO t6 VALUES (1, 'a');
+    SELECT * FROM v6 ORDER BY val;
+    COMMIT;
+    SELECT * FROM v6 ORDER BY val;
+}
+expect {
+    a|1
+    a|1
+}
+
+test matview-replace-same-value-no-aggregate {
+    CREATE TABLE t7(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v7 AS SELECT id, val FROM t7 WHERE val = 'a';
+    INSERT INTO t7 VALUES (1, 'a');
+    INSERT OR REPLACE INTO t7 VALUES (1, 'a');
+    SELECT * FROM v7 ORDER BY id;
+}
+expect {
+    1|a
+}
+
+test matview-replace-same-value-multi-row-group {
+    CREATE TABLE t8(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v8 AS SELECT val, COUNT(*) as cnt FROM t8 GROUP BY val;
+    INSERT INTO t8 VALUES (1, 'a');
+    INSERT INTO t8 VALUES (2, 'a');
+    INSERT OR REPLACE INTO t8 VALUES (1, 'a');
+    INSERT OR REPLACE INTO t8 VALUES (2, 'a');
+    SELECT * FROM v8 ORDER BY val;
+}
+expect {
+    a|2
+}
+
+# REPLACE that resolves a UNIQUE-index conflict deletes a row at a different
+# rowid than the one being inserted.
+test matview-replace-unique-index-conflict {
+    CREATE TABLE t9(id INTEGER PRIMARY KEY, val TEXT UNIQUE);
+    CREATE MATERIALIZED VIEW v9 AS SELECT val, COUNT(*) as cnt FROM t9 GROUP BY val;
+    INSERT INTO t9 VALUES (1, 'a');
+    INSERT OR REPLACE INTO t9 VALUES (2, 'a');
+    SELECT * FROM v9 ORDER BY val;
+    SELECT * FROM t9 ORDER BY id;
+}
+expect {
+    a|1
+    2|a
+}
+
+# A join view keeps its own match bookkeeping, so a replace on either side has
+# to be covered separately from the single-table cases above.
+test matview-replace-same-value-join-left-side {
+    CREATE TABLE ja(id INTEGER PRIMARY KEY, k TEXT);
+    CREATE TABLE jb(id INTEGER PRIMARY KEY, k TEXT, v TEXT);
+    INSERT INTO ja VALUES (1,'k1');
+    INSERT INTO jb VALUES (1,'k1','x');
+    CREATE MATERIALIZED VIEW jv AS SELECT ja.id AS aid, jb.v FROM ja JOIN jb ON ja.k = jb.k;
+    INSERT OR REPLACE INTO ja VALUES (1,'k1');
+    SELECT aid, v FROM jv ORDER BY aid;
+}
+expect {
+    1|x
+}
+
+test matview-replace-same-value-join-right-side {
+    CREATE TABLE ja(id INTEGER PRIMARY KEY, k TEXT);
+    CREATE TABLE jb(id INTEGER PRIMARY KEY, k TEXT, v TEXT);
+    INSERT INTO ja VALUES (1,'k1');
+    INSERT INTO jb VALUES (1,'k1','x');
+    CREATE MATERIALIZED VIEW jv AS SELECT ja.id AS aid, jb.v FROM ja JOIN jb ON ja.k = jb.k;
+    INSERT OR REPLACE INTO jb VALUES (1,'k1','x');
+    SELECT aid, v FROM jv ORDER BY aid;
+}
+expect {
+    1|x
+}
+
+# One replaced row matching several rows on the other side multiplies whatever
+# the bookkeeping gets wrong, so it fails even where a single match would not.
+test matview-replace-same-value-join-fanout {
+    CREATE TABLE ja(id INTEGER PRIMARY KEY, k TEXT);
+    CREATE TABLE jb(id INTEGER PRIMARY KEY, k TEXT, v TEXT);
+    INSERT INTO ja VALUES (1,'k1');
+    INSERT INTO jb VALUES (1,'k1','x'),(2,'k1','y');
+    CREATE MATERIALIZED VIEW jv AS SELECT ja.id AS aid, jb.v FROM ja JOIN jb ON ja.k = jb.k;
+    INSERT OR REPLACE INTO ja VALUES (1,'k1');
+    SELECT aid, v FROM jv ORDER BY v;
+}
+expect {
+    1|x
+    1|y
+}
+
+# Control: replacing a row that does not exist deletes nothing, so the view must
+# simply gain the row.
+test matview-replace-nonexistent-row-in-join {
+    CREATE TABLE ja(id INTEGER PRIMARY KEY, k TEXT);
+    CREATE TABLE jb(id INTEGER PRIMARY KEY, k TEXT, v TEXT);
+    INSERT INTO jb VALUES (1,'k1','x');
+    CREATE MATERIALIZED VIEW jv AS SELECT ja.id AS aid, jb.v FROM ja JOIN jb ON ja.k = jb.k;
+    INSERT OR REPLACE INTO ja VALUES (1,'k1');
+    SELECT aid, v FROM jv ORDER BY aid;
+}
+expect {
+    1|x
+}
+
+# Replacing a row that does not exist must not suppress a retraction that was
+# never recorded, on the single-table path either.
+test matview-replace-nonexistent-row-single-table {
+    CREATE TABLE t9(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v9 AS SELECT val, COUNT(*) AS cnt FROM t9 GROUP BY val;
+    INSERT OR REPLACE INTO t9 VALUES (1,'a');
+    INSERT OR REPLACE INTO t9 VALUES (2,'a');
+    SELECT val, cnt FROM v9 ORDER BY val;
+}
+expect {
+    a|2
+}
+
+# A conflict resolved through a unique index deletes a row with a DIFFERENT
+# rowid from the one being inserted.
+test matview-replace-unique-index-different-rowid {
+    CREATE TABLE t10(id INTEGER PRIMARY KEY, k TEXT UNIQUE, val TEXT);
+    CREATE MATERIALIZED VIEW v10 AS SELECT val, COUNT(*) AS cnt FROM t10 GROUP BY val;
+    INSERT INTO t10 VALUES (1,'k1','a');
+    INSERT OR REPLACE INTO t10 VALUES (2,'k1','a');
+    SELECT val, cnt FROM v10 ORDER BY val;
+}
+expect {
+    a|1
+}
+
+# Boundary: a replace only double-records when it overwrites a row at the same
+# rowid. A table whose primary key is not the rowid resolves the conflict
+# through an index, deleting a row that lives at a different rowid, so the
+# insert finds nothing to record and was never affected.
+test matview-replace-unchanged-value-non-rowid-key {
+    CREATE TABLE t11(region TEXT PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v11 AS SELECT val, COUNT(*) AS cnt FROM t11 GROUP BY val;
+    INSERT INTO t11 VALUES ('r1','a');
+    INSERT OR REPLACE INTO t11 VALUES ('r1','a');
+    SELECT val, cnt FROM v11 ORDER BY val;
+}
+expect {
+    a|1
+}
+
+test matview-replace-unchanged-value-composite-key {
+    CREATE TABLE t12(a TEXT, b TEXT, val TEXT, PRIMARY KEY (a,b));
+    CREATE MATERIALIZED VIEW v12 AS SELECT val, COUNT(*) AS cnt FROM t12 GROUP BY val;
+    INSERT INTO t12 VALUES ('x','y','a');
+    INSERT OR REPLACE INTO t12 VALUES ('x','y','a');
+    SELECT val, cnt FROM v12 ORDER BY val;
+}
+expect {
+    a|1
+}
+
+# An aggregate view keeps per-group state, so a replace whose value CHANGES
+# still lands on a group the view has seen before once the value returns to an
+# earlier one. That reaches the same double-recording as an unchanged value,
+# which the single-statement cases above do not cover.
+test matview-replace-changed-value-revisiting-a-group {
+    CREATE TABLE t13(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v13 AS SELECT val, COUNT(*) AS cnt FROM t13 GROUP BY val;
+    INSERT INTO t13 VALUES (1,'a');
+    INSERT OR REPLACE INTO t13 VALUES (1,'b');
+    INSERT OR REPLACE INTO t13 VALUES (1,'a');
+    SELECT val, cnt FROM v13 ORDER BY val;
+}
+expect {
+    a|1
+}
+
+test matview-replace-changed-value-revisiting-repeatedly {
+    CREATE TABLE t14(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v14 AS SELECT val, COUNT(*) AS cnt FROM t14 GROUP BY val;
+    INSERT INTO t14 VALUES (1,'a');
+    INSERT OR REPLACE INTO t14 VALUES (1,'b');
+    INSERT OR REPLACE INTO t14 VALUES (1,'a');
+    INSERT OR REPLACE INTO t14 VALUES (1,'b');
+    INSERT OR REPLACE INTO t14 VALUES (1,'a');
+    SELECT val, cnt FROM v14 ORDER BY val;
+}
+expect {
+    a|1
+}
+
+# Boundary: replacing through values that are never repeated stays correct, so
+# it is revisiting a group that matters, not the number of replaces.
+test matview-replace-changed-value-never-revisiting {
+    CREATE TABLE t15(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE MATERIALIZED VIEW v15 AS SELECT val, COUNT(*) AS cnt FROM t15 GROUP BY val;
+    INSERT INTO t15 VALUES (1,'a');
+    INSERT OR REPLACE INTO t15 VALUES (1,'b');
+    INSERT OR REPLACE INTO t15 VALUES (1,'c');
+    SELECT val, cnt FROM v15 ORDER BY val;
+}
+expect {
+    c|1
+}


### PR DESCRIPTION
Replacing a row at the same rowid with an unchanged value **silently drops that row from a materialized view**. The row is simply gone, and the read succeeds:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
CREATE MATERIALIZED VIEW m AS SELECT id, v FROM t WHERE v = 'a';
INSERT INTO t VALUES (1,'a');
INSERT OR REPLACE INTO t VALUES (1,'a');

SELECT * FROM m;                      -- returns nothing;   truth is 1|a
SELECT COUNT(*) FROM m;               -- returns 0;         truth is 1
SELECT EXISTS(SELECT 1 FROM m);       -- returns 0;         truth is 1
```

No error is raised on any of those. An aggregate view over the same table is the only shape that reports anything, and only because its read rejects the stored weight:

```sql
CREATE MATERIALIZED VIEW m AS SELECT v, COUNT(*) AS c FROM t GROUP BY v;
-- Internal error: Invalid data in materialized view: expected a positive weight, found -1
```

So the loud error is the lucky case. The general symptom is missing rows, which only an oracle comparing the view against a recomputation of its own `SELECT` will catch.

### When it happens

Both conditions are needed:

1. the replaced row is at the **same rowid** — i.e. the table's primary key is the rowid (`INTEGER PRIMARY KEY`), so the conflict is resolved by overwriting in place; and
2. the replaced value is **unchanged**.

A table keyed on something other than the rowid resolves the conflict through an index and deletes a row at a *different* rowid, which was never affected. One replace is enough, and bare `REPLACE INTO` behaves identically.

A *changed* value is safe only for a single statement. An aggregate view keeps per-group state, so a sequence of replaces that returns to a value seen earlier lands on a group the view already holds, and reaches the same double-recording:

```sql
CREATE MATERIALIZED VIEW v AS SELECT val, COUNT(*) AS cnt FROM t GROUP BY val;
INSERT INTO t VALUES (1,'a');
INSERT OR REPLACE INTO t VALUES (1,'b');
INSERT OR REPLACE INTO t VALUES (1,'a');   -- revisits group 'a'
SELECT val, cnt FROM v;                     -- empty; truth is a|1
```

Replacing through values that are never repeated stays correct, so what matters is revisiting a group, not the number of replaces.

### Cause

`INSERT OR REPLACE` emits a delete followed by an insert. The delete already records the row it removed for view maintenance. The insert then takes the `REQUIRE_SEEK` branch — it seeks because the cursor is not positioned after the delete — and that branch captured the same row a **second** time. Two retractions landed against one insertion, so the row's weight went to -1 and it dropped out of the view.

An insert following an UPDATE that moves a rowid already avoided exactly this, via `InsertFlags::UPDATE_ROWID_CHANGE`, and the comment at that site spells out the same reasoning. The replace case was never covered by it.

### Fix

Carry the same signal for replace, and skip the capture when a preceding delete has already taken it.

A replace that conflicts with nothing deletes nothing and still records its insertion, because the capture being skipped is one no delete ever made. That is covered by tests rather than left to argument: the flag is decided when the statement is compiled, while whether a row is actually deleted is only known at run time.

### Tests

`sqlite/conformance/turso-sqltests/matview_insert_or_replace.sqltest`. Assertions compare view contents against the truth, since a weight check would not see the projection case at all.

Covered: both spellings of the statement; aggregate, projection, filter and join views, including a join where one replaced row matches several rows on the other side, which multiplies the error; a conflict resolved through a unique index, deleting a row at a different rowid; a replace of a row that does not exist yet; non-rowid and composite primary keys; and a changed-value sequence that revisits a group on an aggregate view, with a never-revisiting sequence as its boundary. Replacing with a changed value and a plain insert are kept as controls.

Red before the fix and green after. The wider matview corpus is 138 passed, the whole sqltest corpus 1583 passed / 341 skipped, core 1105 passed, integration 45 passed, CDC 44 passed.

Separately verified that the skipped capture cannot go missing when it was needed: replace on a rowid that does not exist, a unique-index conflict deleting a different rowid, a two-constraint conflict deleting two rows, a multi-row replace mixing existing and new rows, a replace rolled back in a transaction, and a replace followed by a delete of the same row all report correct contents.
