### PR TITLE
core: protect internal tables regardless of identifier case

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -650,8 +650,8 @@ pub fn allow_user_dml(table_name: &str) -> bool {
     const NAMES: [&str; 2] = [SCHEMA_TABLE_NAME, SCHEMA_TABLE_NAME_ALT];
     !(NAMES.iter().any(|n| n.eq_ignore_ascii_case(table_name))
         || table_name
-            .to_ascii_lowercase()
-            .starts_with(TURSO_INTERNAL_PREFIX))
+            .get(..TURSO_INTERNAL_PREFIX.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(TURSO_INTERNAL_PREFIX)))
 }
 
 // Sequence persistence design

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -649,7 +649,9 @@ pub fn is_system_table(table_name: &str) -> bool {
 pub fn allow_user_dml(table_name: &str) -> bool {
     const NAMES: [&str; 2] = [SCHEMA_TABLE_NAME, SCHEMA_TABLE_NAME_ALT];
     !(NAMES.iter().any(|n| n.eq_ignore_ascii_case(table_name))
-        || table_name.starts_with(TURSO_INTERNAL_PREFIX)) // internal name wouldn't be uppercase
+        || table_name
+            .to_ascii_lowercase()
+            .starts_with(TURSO_INTERNAL_PREFIX))
 }
 
 // Sequence persistence design

--- a/sqlite/conformance/turso-sqltests/sequence.sqltest
+++ b/sqlite/conformance/turso-sqltests/sequence.sqltest
@@ -272,6 +272,38 @@ expect {
 
 # --- Reserved namespace ---
 
+test sequence-backing-table-rejects-uppercase-insert {
+    CREATE SEQUENCE s1;
+    INSERT INTO __TURSO_INTERNAL_SEQ_S1 DEFAULT VALUES;
+}
+expect error {
+    table __TURSO_INTERNAL_SEQ_S1 may not be modified
+}
+
+test sequence-backing-table-rejects-mixed-case-insert {
+    CREATE SEQUENCE s2;
+    INSERT INTO __TuRsO_iNtErNaL_sEq_S2 DEFAULT VALUES;
+}
+expect error {
+    table __TuRsO_iNtErNaL_sEq_S2 may not be modified
+}
+
+test sequence-backing-table-rejects-uppercase-update {
+    CREATE SEQUENCE s3;
+    UPDATE __TURSO_INTERNAL_SEQ_S3 SET value = 2;
+}
+expect error {
+    table __TURSO_INTERNAL_SEQ_S3 may not be modified
+}
+
+test sequence-backing-table-rejects-mixed-case-update {
+    CREATE SEQUENCE s4;
+    UPDATE __TuRsO_iNtErNaL_sEq_S4 SET value = 2;
+}
+expect error {
+    table __TuRsO_iNtErNaL_sEq_S4 may not be modified
+}
+
 # `__turso_internal_autoincrement_<table>` is the implicit sequence
 # name CREATE TABLE … AUTOINCREMENT installs internally. The nextval/
 # advance_past/setval translators detect this prefix to mirror the


### PR DESCRIPTION

<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

Essentially, make ` __turso_internal_` check in `allow_user_dml` ascii case-insensitive and add a few tests to prevent regressions

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->
Looking for a good first issue to contribute to, and found https://github.com/tursodatabase/turso/issues/8426 which suggested a sane approach as a fix, though I did consider 2 alternative approaches (normalizing INSERT & UPDATE at callsite and reusing `is_system_table()` which both was worse in my opinion)

From my understanding, the schema lookup already treats the identifiers as ascii case-insensitive but the guard in the dml used a case-sensitive check which means that mixed-names/uppercase names could resolve into an internal table and bypassing write protection so my fix is to change `allow_user_dml`  to use the same case-insensitive approach which allows us to enforce all dml callers to use the same rule, it is also the minimal fix we can use to isolate the change to address this issue without affecting other `sqlite_` tables.

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
Used aretta-ci guidance to arrive at the suggested fix see: https://github.com/tursodatabase/turso/issues/8426
