### PR TITLE
core: skip vertical tab (0x0B) as whitespace in numeric affinity/cast

### DIFF
--- a/core/util.rs
+++ b/core/util.rs
@@ -1260,14 +1260,18 @@ pub fn decode_percent(uri: &str) -> String {
 }
 
 pub fn trim_ascii_whitespace(s: &str) -> &str {
+    // SQLite's ctype table treats 0x0B (vertical tab) as whitespace, unlike
+    // Rust's is_ascii_whitespace() which follows the WHATWG definition and
+    // excludes it. Match SQLite here.
+    let is_space = |b: u8| b.is_ascii_whitespace() || b == b'\x0b';
     let bytes = s.as_bytes();
     let start = bytes
         .iter()
-        .position(|&b| !b.is_ascii_whitespace())
+        .position(|&b| !is_space(b))
         .unwrap_or(bytes.len());
     let end = bytes
         .iter()
-        .rposition(|&b| !b.is_ascii_whitespace())
+        .rposition(|&b| !is_space(b))
         .map(|i| i + 1)
         .unwrap_or(0);
     if start <= end {
@@ -6230,6 +6234,16 @@ pub mod tests {
             checked_cast_text_to_numeric("123xxx", false).unwrap(),
             Value::from_i64(123)
         );
+        // vertical tab (0x0B) is whitespace to SQLite, unlike Rust's
+        // is_ascii_whitespace(). https://github.com/tursodatabase/turso/issues/8454
+        assert_eq!(
+            checked_cast_text_to_numeric("\x0b12", false).unwrap(),
+            Value::from_i64(12)
+        );
+        assert_eq!(
+            checked_cast_text_to_numeric("12\x0b", false).unwrap(),
+            Value::from_i64(12)
+        );
         assert_eq!(
             checked_cast_text_to_numeric("9223372036854775807", false).unwrap(),
             Value::from_i64(i64::MAX)
@@ -6768,6 +6782,10 @@ pub mod tests {
         assert_eq!(trim_ascii_whitespace("hello"), "hello");
         assert_eq!(trim_ascii_whitespace("   "), "");
         assert_eq!(trim_ascii_whitespace(""), "");
+
+        // vertical tab (0x0B) is whitespace to SQLite's ctype table, unlike
+        // Rust's is_ascii_whitespace(). https://github.com/tursodatabase/turso/issues/8454
+        assert_eq!(trim_ascii_whitespace("\x0bhello\x0b"), "hello");
 
         // non-breaking space should NOT be trimmed
         assert_eq!(

--- a/core/vdbe/affinity.rs
+++ b/core/vdbe/affinity.rs
@@ -610,7 +610,9 @@ fn create_result_from_significand(
 }
 
 pub fn is_space(byte: u8) -> bool {
-    matches!(byte, b' ' | b'\t' | b'\n' | b'\r' | b'\x0c')
+    // Matches SQLite's ctype table (0x09-0x0D, 0x20), which includes 0x0B
+    // (vertical tab) unlike Rust's is_ascii_whitespace().
+    matches!(byte, b' ' | b'\t' | b'\n' | b'\x0b' | b'\x0c' | b'\r')
 }
 
 pub(crate) fn real_to_i64(r: f64) -> i64 {
@@ -741,6 +743,19 @@ mod tests {
         let val = Value::Text("0".into());
         let res = apply_numeric_affinity(val.as_value_ref(), false);
         assert_eq!(res, Some(ValueRef::Numeric(Numeric::Integer(0))));
+    }
+
+    #[test]
+    fn test_apply_numeric_affinity_vertical_tab() {
+        // vertical tab (0x0B) is whitespace to SQLite, unlike Rust's
+        // is_ascii_whitespace(). https://github.com/tursodatabase/turso/issues/8454
+        let val = Value::Text("\x0b12".into());
+        let res = apply_numeric_affinity(val.as_value_ref(), false);
+        assert_eq!(res, Some(ValueRef::Numeric(Numeric::Integer(12))));
+
+        let val = Value::Text("12\x0b".into());
+        let res = apply_numeric_affinity(val.as_value_ref(), false);
+        assert_eq!(res, Some(ValueRef::Numeric(Numeric::Integer(12))));
     }
 
     #[test]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -19418,6 +19418,8 @@ mod tests {
             ("\t42\t", 42i64),         // tab
             ("\n99\n", 99i64),         // newline
             (" \t\n123\r\n ", 123i64), // mixed ASCII whitespace
+            ("\x0b12", 12i64),         // leading vertical tab (0x0B)
+            ("12\x0b", 12i64),         // trailing vertical tab (0x0B)
         ];
 
         for (input, expected_int) in ascii_whitespace_cases {

--- a/sqlite/conformance/sqlite-sqltests/affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/affinity.sqltest
@@ -467,6 +467,41 @@ expect {
     text|3
 }
 
+# ============================================
+# Vertical tab (0x0B) is whitespace to SQLite's ctype table (0x09-0x0D)
+# even though it is not "ASCII whitespace" per Rust's is_ascii_whitespace().
+# https://github.com/tursodatabase/turso/issues/8454
+# ============================================
+@cross-check-integrity
+test affinity-vertical-tab-leading {
+    CREATE TABLE t1(i INTEGER);
+    INSERT INTO t1 VALUES (CHAR(11) || '12');
+    SELECT TYPEOF(i), i = 12 FROM t1;
+}
+expect {
+    integer|1
+}
+
+@cross-check-integrity
+test affinity-vertical-tab-trailing {
+    CREATE TABLE t1(i INTEGER);
+    INSERT INTO t1 VALUES ('12' || CHAR(11));
+    SELECT TYPEOF(i), i = 12 FROM t1;
+}
+expect {
+    integer|1
+}
+
+@cross-check-integrity
+test affinity-vertical-tab-integer-primary-key {
+    CREATE TABLE t1(i INTEGER PRIMARY KEY);
+    INSERT INTO t1 VALUES (CHAR(11) || '12');
+    SELECT COUNT(*), TYPEOF(i), i FROM t1;
+}
+expect {
+    1|integer|12
+}
+
 
 # ============================================
 # REAL affinity with leading + sign
@@ -560,6 +595,18 @@ expect {
     1.0e+100|real
     2251799813685247|integer
     2.25179981368525e+15|real
+}
+
+@cross-check-integrity
+test cast-text-to-numeric-vertical-tab {
+    SELECT CAST(CHAR(11) || '12' AS NUMERIC);
+    SELECT CAST('12' || CHAR(11) AS NUMERIC);
+    SELECT CAST(CHAR(9) || '12' AS NUMERIC);
+}
+expect {
+    12
+    12
+    12
 }
 expect @js {
     3|integer

--- a/sqlite/conformance/sqlite-sqltests/affinity.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/affinity.sqltest
@@ -596,6 +596,16 @@ expect {
     2251799813685247|integer
     2.25179981368525e+15|real
 }
+expect @js {
+    3|integer
+    3.5|real
+    10000000000|integer
+    1e-10|real
+    0|integer
+    1e+100|real
+    2251799813685247|integer
+    2251799813685248|real
+}
 
 @cross-check-integrity
 test cast-text-to-numeric-vertical-tab {
@@ -607,16 +617,6 @@ expect {
     12
     12
     12
-}
-expect @js {
-    3|integer
-    3.5|real
-    10000000000|integer
-    1e-10|real
-    0|integer
-    1e+100|real
-    2251799813685247|integer
-    2251799813685248|real
 }
 
 # Regression tests for https://github.com/tursodatabase/turso/issues/4927


### PR DESCRIPTION
SQLite's ctype table treats `0x09`–`0x0D` (tab, LF, VT, FF, CR) plus space as whitespace, while Rust's `is_ascii_whitespace()` follows the WHATWG "ASCII whitespace" definition and excludes `0x0B` (vertical tab).

As a result, `CAST(text AS NUMERIC)` and INTEGER/NUMERIC/REAL column affinity failed to skip a leading or trailing vertical tab. The value could remain TEXT, or `CAST AS NUMERIC` could fall back to `0`, instead of parsing the numeric value as SQLite does.

The `INTEGER PRIMARY KEY` case exposed this most clearly: because the value remained TEXT, it could not be used as the rowid and the insert failed with `datatype mismatch`.

`core/numeric/mod.rs::str_to_i64` and `str_to_f64`, used by `CAST AS INTEGER` and `CAST AS REAL`, already handle this correctly by explicitly treating vertical tab as whitespace:

    const VERTICAL_TAB: char = '\u{b}';

The same handling was missing from two other independent whitespace predicates:

- `core/util.rs::trim_ascii_whitespace`
  - backs `CAST AS NUMERIC` through `checked_cast_text_to_numeric`
  - is also used during column-affinity coercion

- `core/vdbe/affinity.rs::is_space`
  - backs `try_for_float`
  - is used by `apply_numeric_affinity`
  - is also used by the `OP_Affinity` path exercised by INSERT/UPDATE

This change adds the same `0x0B` handling to both predicates, matching the existing behavior in `numeric/mod.rs`.

It also adds regression coverage, cross-checked against SQLite, for:

- leading and trailing vertical tabs in INTEGER-affinity inserts
- the `INTEGER PRIMARY KEY` / rowid case
- `CAST AS NUMERIC`
- the existing whitespace unit-test coverage in `util.rs`, `affinity.rs`, and `execute.rs`

## Motivation and context

Fixes #8454.

All repro cases from the issue now match SQLite:

    CAST(char(11)||'12' AS NUMERIC)      -> 12
                                             was: 0

    INTEGER-affinity column insert       -> integer, x = 12
                                             was: text

    INTEGER PRIMARY KEY insert           -> 1 row
                                             was: datatype mismatch (19)

    CAST(char(11)||'12' AS INTEGER)      -> 12
                                             unaffected, already correct

    CAST(char(9)||'12' AS NUMERIC)       -> 12
                                             unaffected, already correct

## Testing

Verified with:

    cargo fmt --check

    cargo clippy -p turso_core --all-features --all-targets -- --deny=warnings

    cargo test -p turso_core --lib
    2346 passed

    make -C sqlite/conformance run-rust ARGS='--filter affinity'

The conformance tests were cross-checked against `sqlite3`. All checks pass.

## Description of AI Usage

Used Claude Code to research the issue, trace the root cause across the three independent whitespace-parsing implementations under `core/`, implement the fix, and add regression tests.

I reviewed the root-cause analysis and the resulting diff before pushing.