### PR TITLE
postgres: fix current date and time expressions being treated as columns

### DIFF
--- a/postgres/conformance/pg-sqltests/select.sqltest
+++ b/postgres/conformance/pg-sqltests/select.sqltest
@@ -139,3 +139,13 @@ expect {
     1
     5
 }
+
+test select-current-data-and-time {
+    SELECT 'ok'
+    WHERE CURRENT_DATE IS NOT NULL
+    AND CURRENT_TIME IS NOT NULL
+    AND CURRENT_TIMESTAMP IS NOT NULL;
+}
+expect {
+    ok
+}

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -2309,20 +2309,20 @@ impl PostgreSQLTranslator {
                 use pg_query::protobuf::SqlValueFunctionOp;
                 match SqlValueFunctionOp::try_from(svf.op) {
                     Ok(SqlValueFunctionOp::SvfopCurrentDate) => {
-                        Ok(ast::Expr::Id(ast::Name::from_string("CURRENT_DATE")))
+                        Ok(ast::Expr::Literal(ast::Literal::CurrentDate))
                     }
                     Ok(
                         SqlValueFunctionOp::SvfopCurrentTime
                         | SqlValueFunctionOp::SvfopCurrentTimeN
                         | SqlValueFunctionOp::SvfopLocaltime
                         | SqlValueFunctionOp::SvfopLocaltimeN,
-                    ) => Ok(ast::Expr::Id(ast::Name::from_string("CURRENT_TIME"))),
+                    ) => Ok(ast::Expr::Literal(ast::Literal::CurrentTime)),
                     Ok(
                         SqlValueFunctionOp::SvfopCurrentTimestamp
                         | SqlValueFunctionOp::SvfopCurrentTimestampN
                         | SqlValueFunctionOp::SvfopLocaltimestamp
                         | SqlValueFunctionOp::SvfopLocaltimestampN,
-                    ) => Ok(ast::Expr::Id(ast::Name::from_string("CURRENT_TIMESTAMP"))),
+                    ) => Ok(ast::Expr::Literal(ast::Literal::CurrentTimestamp)),
                     Ok(
                         SqlValueFunctionOp::SvfopCurrentUser
                         | SqlValueFunctionOp::SvfopSessionUser
@@ -6450,8 +6450,29 @@ mod tests {
         let sql = "SELECT CURRENT_TIMESTAMP, CURRENT_DATE, CURRENT_TIME FROM t";
         let parsed = crate::parse(sql).unwrap();
         let translated = translator.translate(&parsed).unwrap();
-        // Should translate without error
-        assert!(matches!(translated, ast::Stmt::Select(_)));
+
+        let ast::Stmt::Select(selected) = translated else {
+            panic!("Expected SELECT statement");
+        };
+
+        let ast::OneSelect::Select { columns, .. } = &selected.body.select else {
+            panic!("Expected SELECT body");
+        };
+
+        let expected = [
+            ast::Expr::Literal(ast::Literal::CurrentTimestamp),
+            ast::Expr::Literal(ast::Literal::CurrentDate),
+            ast::Expr::Literal(ast::Literal::CurrentTime),
+        ];
+
+        assert_eq!(columns.len(), expected.len());
+
+        for (col, expected_expr) in columns.iter().zip(&expected) {
+            let ast::ResultColumn::Expr(expr, _) = col else {
+                panic!("Expected column expression");
+            };
+            assert_eq!(expr.as_ref(), expected_expr);
+        }
     }
 
     #[test]


### PR DESCRIPTION

<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->
Fixes an issue where `CURRENT_TIMESTAMP`, `CURRENT_DATE`, and `CURRENT_TIME` are being treated as column names rather than expression literals in TursoPG. 

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Solves this issue: https://github.com/tursodatabase/turso/issues/8331

Fixed the unit tests and added a conformance test to make sure all three of these expressions return correctly.


Also one note, there are still differences between the timestamps that Tursopg and Postgres return:
<img width="1923" height="317" alt="image" src="https://github.com/user-attachments/assets/16ae3687-8624-4070-9675-d3453d83fe21" />


## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

Used GPT 5.6 sol to understand `translator.rs` better. The AI guided my implementation but I wrote it the code
