### PR TITLE
sqlite/conformance: cover GROUP BY over a recursive CTE and drop a stale skip

### DIFF
--- a/sqlite/conformance/sqlite-sqltests/cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/cte.sqltest
@@ -1045,14 +1045,6 @@ expect error {
     duplicate WITH table name
 }
 
-# @skip-if sqlite "sqlite supports recursive CTEs"
-# test cte-recursive-unsupported {
-#     WITH RECURSIVE cnt(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM cnt WHERE x<5) SELECT * FROM cnt;
-# }
-# expect error {
-#     Recursive CTEs are not yet supported
-# }
-#
 # @skip-if sqlite "sqlite supports materialized CTEs"
 # test cte-materialized-unsupported {
 #     WITH t AS MATERIALIZED (SELECT 1) SELECT * FROM t;

--- a/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/recursive-cte.sqltest
@@ -439,6 +439,36 @@ expect {
     1|15
 }
 
+# GROUP BY is rejected in the recursive term; in the query consuming the CTE it is ordinary.
+test recursive-cte-outer-group-by {
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 5
+    )
+    SELECT x % 2 AS parity, count(*) FROM c GROUP BY parity ORDER BY parity;
+}
+expect {
+    0|2
+    1|3
+}
+
+test recursive-cte-outer-group-by-having {
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 5
+    )
+    SELECT x % 2 AS parity, count(*) AS n
+    FROM c
+    GROUP BY parity
+    HAVING n > 2
+    ORDER BY parity;
+}
+expect {
+    1|3
+}
+
 test recursive-cte-outer-distinct-collapses-union-all {
     WITH RECURSIVE c(x, depth) AS (
         VALUES(1, 0)


### PR DESCRIPTION
`recursive-cte.sqltest` exercises `GROUP BY` only *inside* the recursive term, and
never `HAVING` at all, so nothing pinned the behaviour of the query that **consumes**
a recursive CTE grouping its rows. That is the interesting case: the whole result has
to be materialized before a group can close, rather than the queue emitting rows one
at a time.

This adds the two missing cases:

- `recursive-cte-outer-group-by` — outer `GROUP BY` over the CTE's rows
- `recursive-cte-outer-group-by-having` — the same plus `HAVING`

Both expectations were taken from `sqlite3` 3.54.0 rather than from Turso's output.

Separately, `cte.sqltest` still carried a commented-out `cte-recursive-unsupported`
test asserting *"Recursive CTEs are not yet supported"*. That stopped being true when
recursive CTE support landed, and the test was commented out rather than replaced.
Removed. The neighbouring `cte-materialized-unsupported` block is deliberately left
alone — that one is still accurate.

### Tests

`sqlite/conformance/sqlite-sqltests/{recursive-cte,cte}.sqltest` — **260 passed, 0 failed**

```
[PASS] recursive-cte-outer-group-by             (82.39ms)
[PASS] recursive-cte-outer-group-by-having      (2.95ms)
```
