### PR TITLE
fix(compound-select): bare columns keep BINARY collation against a COLLATE arm

### DIFF
--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -377,6 +377,26 @@ pub fn get_collseq_from_expr_with_symbols(
     Ok(explicit.or(column))
 }
 
+/// Collation for one arm's result column in a compound SELECT, following
+/// SQLite's multiSelectCollSeq -> sqlite3ExprCollSeq semantics (#8272): a
+/// bare column operand carries its declared collation or the default BINARY
+/// and never defers to later arms; literals, functions and other synthetic
+/// expressions have no opinion and return None so resolution falls through.
+pub fn get_compound_arm_collseq(
+    top_expr: &Expr,
+    referenced_tables: &TableReferences,
+) -> Result<Option<CollationSeq>> {
+    let (explicit, column) =
+        get_collseq_parts_from_expr_with_symbols(top_expr, referenced_tables, None)?;
+    if let Some(seq) = explicit.or(column) {
+        return Ok(Some(seq));
+    }
+    Ok(match top_expr {
+        Expr::Column { .. } | Expr::RowId { .. } => Some(CollationSeq::default()),
+        _ => None,
+    })
+}
+
 /// Return the collation context that standalone expression translation would
 /// propagate to a parent comparison when this expression is reused from cache.
 ///

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -1,7 +1,7 @@
 use crate::alloc::TursoIteratorExt;
 use crate::schema::{Index, IndexColumn, PseudoCursorType};
 use crate::sync::Arc;
-use crate::translate::collate::get_collseq_from_expr;
+use crate::translate::collate::get_compound_arm_collseq;
 use crate::translate::emitter::{
     select::{emit_materialized_build_inputs, emit_query},
     LimitCtx, Resolver, TranslateCtx,
@@ -573,20 +573,18 @@ fn create_dedupe_index(
         })
         .try_collect::<crate::alloc::Vec<_>>()?;
     for (i, column) in dedupe_columns.iter_mut().enumerate() {
-        let left_collation = get_collseq_from_expr(
+        let left_collation = get_compound_arm_collseq(
             &left_select.result_columns[i].expr,
             &left_select.table_references,
         )?;
-        let right_collation = get_collseq_from_expr(
+        let right_collation = get_compound_arm_collseq(
             &right_select.result_columns[i].expr,
             &right_select.table_references,
         )?;
-        // Left precedence
-        let collation = match (left_collation, right_collation) {
-            (None, None) => None,
-            (Some(coll), None) | (None, Some(coll)) => Some(coll),
-            (Some(coll), Some(_)) => Some(coll),
-        };
+        // Left precedence per multiSelectCollSeq: a bare column names its own
+        // (possibly default BINARY) collation and only a no-opinion arm --
+        // literal, function, ... -- defers to the other side (#8272).
+        let collation = left_collation.or(right_collation);
         column.collation = collation;
     }
 
@@ -799,19 +797,16 @@ fn create_collection_index(
         })
         .try_collect::<crate::alloc::Vec<_>>()?;
     for (i, column) in columns.iter_mut().enumerate() {
-        let left_collation = get_collseq_from_expr(
+        let left_collation = get_compound_arm_collseq(
             &left_select.result_columns[i].expr,
             &left_select.table_references,
         )?;
-        let right_collation = get_collseq_from_expr(
+        let right_collation = get_compound_arm_collseq(
             &right_select.result_columns[i].expr,
             &right_select.table_references,
         )?;
-        let collation = match (left_collation, right_collation) {
-            (None, None) => None,
-            (Some(coll), None) | (None, Some(coll)) => Some(coll),
-            (Some(coll), Some(_)) => Some(coll),
-        };
+        // Same left-precedence rule as the dedupe index (#8272).
+        let collation = left_collation.or(right_collation);
         column.collation = collation;
     }
 

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -13,6 +13,7 @@ mod test_vacuum;
 mod test_write_path;
 
 mod encryption;
+mod test_compound_select_collation;
 mod test_expr_index;
 mod test_multi_thread;
 mod test_non_utf8_text;

--- a/tests/integration/query_processing/test_compound_select_collation.rs
+++ b/tests/integration/query_processing/test_compound_select_collation.rs
@@ -1,0 +1,63 @@
+//! Regression test for issue #8272: UNION/INTERSECT/EXCEPT dedupe and
+//! collection indexes must resolve each arm's collation like SQLite's
+//! multiSelectCollSeq — a bare column carries its declared collation or the
+//! default BINARY and only a no-opinion arm (literal, function, ...) defers
+//! rightward. Before the fix the left arm's plain column silently adopted
+//! the right arm's NOCASE, returning wrong rows.
+
+use crate::common::{try_limbo_exec_rows, TempDatabase};
+
+const SEED_Q: &str = "INSERT INTO q VALUES(1,'a'),(2,'B'),(NULL,'c'),('3','z')";
+const SEED_P: &str = "INSERT INTO p VALUES(1,'A'),(2,'b'),(NULL,'C'),(3,NULL),(2,'B'),(1.0,'a')";
+
+const QUERIES: &[&str] = &[
+    "SELECT y FROM q INTERSECT SELECT y FROM p",
+    "SELECT y FROM q EXCEPT SELECT y FROM p",
+    "SELECT y FROM q UNION SELECT y FROM p ORDER BY 1",
+    // literal left arm: both engines defer to the right arm's NOCASE
+    "SELECT 'a' FROM q INTERSECT SELECT y FROM p",
+];
+
+#[turso_macros::test]
+fn compound_select_collation_matches_sqlite(
+    tmp_db: crate::common::TempDatabase,
+) -> anyhow::Result<()> {
+    let limbo_conn = tmp_db.connect_limbo();
+    limbo_conn.execute("CREATE TABLE q(x, y TEXT)")?;
+    limbo_conn.execute("CREATE TABLE p(x, y TEXT COLLATE NOCASE)")?;
+    limbo_conn.execute(SEED_Q)?;
+    limbo_conn.execute(SEED_P)?;
+    let sqlite_conn = rusqlite::Connection::open(&tmp_db.path)?;
+    // The limbo connection above created the schema; seed the same file.
+    sqlite_conn.execute_batch(
+        "INSERT INTO q VALUES(1,'a'),(2,'B'),(NULL,'c'),('3','z');
+         INSERT INTO p VALUES(1,'A'),(2,'b'),(NULL,'C'),(3,NULL),(2,'B'),(1.0,'a');",
+    )?;
+
+    for query in QUERIES {
+        let mut limbo_rows = try_limbo_exec_rows(&tmp_db, &limbo_conn, query)?;
+        limbo_rows.sort_by_key(|r| format!("{r:?}"));
+        let mut sqlite_rows: Vec<Vec<rusqlite::types::Value>> = Vec::new();
+        let mut stmt = sqlite_conn.prepare(query)?;
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            sqlite_rows.push(vec![row.get(0)?]);
+        }
+        sqlite_rows.sort_by_key(|r| format!("{r:?}"));
+        assert_eq!(limbo_rows, sqlite_rows, "wrong rows for {query}");
+    }
+
+    // Pin the oracle explicitly so a regression cannot hide behind an
+    // equally-wrong pair of engines.
+    let intersect = try_limbo_exec_rows(&tmp_db, &limbo_conn, QUERIES[0])?;
+    assert_eq!(
+        intersect,
+        vec![
+            vec![rusqlite::types::Value::Text("B".into())],
+            vec![rusqlite::types::Value::Text("a".into())],
+        ],
+        "'c' has no BINARY match in p and must not survive INTERSECT"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #8272

## Summary

Compound SELECT (`UNION`/`INTERSECT`/`EXCEPT`) dedupe and collection indexes now resolve each arm's result-column collation the way SQLite's `multiSelectCollSeq` does: a bare column operand carries its declared collation or default BINARY and never defers rightward; only expressions with no opinion (literals, functions, aggregates) fall through to the next arm.

## Root cause

Both `create_dedupe_index` and `create_collection_index` resolved arms with `get_collseq_from_expr`, which reports `None` for a plain column because `column.collation_opt()` only surfaces an explicit column-level `COLLATE`. The `(None, Some(coll)) => Some(coll)` match arm then adopted the RIGHT arm's collation despite the "left precedence" comment. For

```sql
SELECT y FROM q INTERSECT SELECT y FROM p   -- q.y BINARY, p.y NOCASE
```

the dedupe index ran under NOCASE: INTERSECT emitted `'c'` though `p` holds no exact `'c'`; EXCEPT dropped a surviving `'c'`; UNION lost rows — wrong rows, not ordering (#8272's table).

## What changed

- New `get_compound_arm_collseq` in `core/translate/collate.rs`: explicit `COLLATE` > declared column collation > `BINARY` for a bare column/rowid operand > `None`.
- Both resolution blocks use it per arm and reduce to plain left-over-right precedence.

## Verification

- New differential regression test `query_processing::test_compound_select_collation` runs all four query shapes from the issue through both limbo and rusqlite on one database and asserts identical row sets, plus pins the oracle explicitly (`INTERSECT == B,a`). Fails on unfixed sources, passes with this change.
- Full `integration_tests` suite: 1107 passed, 0 failed. `query_processing` subset: 422 passed.
- Manual CLI check against the issue's tables matches the sqlite3 column for INTERSECT (`B,a`), EXCEPT (`c,z`) and UNION (full set).
- fmt clean; clippy clean on touched crates (two pre-existing warnings elsewhere untouched).

This change was prepared with AI assistance under human direction and review.
