### PR TITLE
core/vdbe: roll back a dangling write transaction after a failed commit

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3120,8 +3120,20 @@ impl Program {
                         }
                     }
                     TxnCleanup::None => {
+                        // A COMMIT that fails mid-flight (e.g. a WAL I/O error)
+                        // has already flipped `auto_commit` back to true in
+                        // op_auto_commit while the write transaction is still
+                        // open, so `!auto_commit` is not a reliable "in a
+                        // transaction" signal here: also key the rollback off
+                        // the transaction state, or a later statement silently
+                        // commits the leaked dirty pages. (Deeper fix: stop
+                        // using the autocommit flag as the commit machinery's
+                        // finalize signal and flip it only after the commit
+                        // succeeds.)
                         if can_autocommit_now
-                            || (!self.connection.get_auto_commit() && err.is_some())
+                            || (err.is_some()
+                                && (!self.connection.get_auto_commit()
+                                    || self.connection.is_in_write_tx()))
                         {
                             self.rollback_current_txn(pager);
                         }

--- a/tests/integration/unreliable_io.rs
+++ b/tests/integration/unreliable_io.rs
@@ -26,16 +26,35 @@
 //! To reopen a database on a materialized post-crash image, write each
 //! file's bytes to disk and open with the regular platform IO.
 //!
-//! Other kinds of storage misbehavior tests need — injected write or fsync
-//! errors, reordered writeback — belong in this module too.
+//! Storage misbehavior is also injected here: [`UnreliableIo::arm_io_error`]
+//! makes a file's writes or fsyncs fail at *submit* time — the `File` method
+//! itself returns `Err`, the way `UnixIO` surfaces a failed `pwrite`/`fsync`
+//! syscall (ENOSPC, EIO, ...). Other kinds — reordered writeback — belong in
+//! this module too.
 
 use std::collections::HashMap;
+use std::io::ErrorKind;
 use std::sync::{Arc, Mutex};
 
 use turso_core::{
-    io::FileSyncType, Buffer, Clock, Completion, File, MonotonicInstant, OpenFlags,
-    WallClockInstant, IO,
+    io::FileSyncType, Buffer, Clock, Completion, CompletionError, File, MonotonicInstant,
+    OpenFlags, WallClockInstant, IO,
 };
+
+/// The file operation an armed [`UnreliableIo::arm_io_error`] fault targets.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnreliableOp {
+    Pwrite,
+    Sync,
+}
+
+/// An armed submit-time I/O error: while armed, every matching operation on
+/// the target file fails.
+struct IoErrorFault {
+    path: String,
+    op: UnreliableOp,
+    fired: bool,
+}
 
 /// A single not-yet-durable file mutation.
 enum UnsyncedOp {
@@ -92,6 +111,8 @@ struct UnreliableIoState {
     /// simulated power-loss point.
     armed_path: Mutex<Option<String>>,
     snapshot: Mutex<Option<CrashSnapshot>>,
+    /// When set, matching operations on the target file fail at submit time.
+    io_error: Mutex<Option<IoErrorFault>>,
 }
 
 impl UnreliableIoState {
@@ -149,6 +170,7 @@ impl UnreliableIo {
                 files: Mutex::new(HashMap::new()),
                 armed_path: Mutex::new(None),
                 snapshot: Mutex::new(None),
+                io_error: Mutex::new(None),
             }),
         }
     }
@@ -181,6 +203,35 @@ impl UnreliableIo {
             .iter()
             .map(|(path, shadow)| (path.clone(), shadow.lock().unwrap().durable.clone()))
             .collect()
+    }
+
+    /// Arm a submit-time I/O error: while armed, every `op` on `path` fails
+    /// with an I/O error returned from the `File` method itself, the way
+    /// `UnixIO` surfaces a failed syscall. Disarm with
+    /// [`Self::clear_io_error`]; check [`Self::io_error_fired`] to assert the
+    /// fault was actually reached.
+    pub fn arm_io_error(&self, path: &str, op: UnreliableOp) {
+        *self.state.io_error.lock().unwrap() = Some(IoErrorFault {
+            path: path.to_string(),
+            op,
+            fired: false,
+        });
+    }
+
+    /// Disarm the submit-time I/O error so later operations succeed again.
+    pub fn clear_io_error(&self) {
+        *self.state.io_error.lock().unwrap() = None;
+    }
+
+    /// True if the armed submit-time I/O error has failed at least one
+    /// operation.
+    pub fn io_error_fired(&self) -> bool {
+        self.state
+            .io_error
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|fault| fault.fired)
     }
 
     /// True when `path` has writes not yet covered by a successful fsync.
@@ -264,6 +315,23 @@ struct UnreliableFile {
     state: Arc<UnreliableIoState>,
 }
 
+impl UnreliableFile {
+    /// Returns the armed submit-time error for `op` on this file, if any.
+    /// The failed operation never reaches the shadow: nothing entered the
+    /// page cache.
+    fn injected_error(&self, op: UnreliableOp) -> turso_core::Result<()> {
+        let mut guard = self.state.io_error.lock().unwrap();
+        let Some(fault) = guard
+            .as_mut()
+            .filter(|fault| fault.path == self.path && fault.op == op)
+        else {
+            return Ok(());
+        };
+        fault.fired = true;
+        Err(CompletionError::IOError(ErrorKind::Other, "unreliable_io injected error").into())
+    }
+}
+
 impl File for UnreliableFile {
     fn lock_file(&self, exclusive: bool) -> turso_core::Result<()> {
         self.inner.lock_file(exclusive)
@@ -283,6 +351,7 @@ impl File for UnreliableFile {
         buffer: Arc<Buffer>,
         c: Completion,
     ) -> turso_core::Result<Completion> {
+        self.injected_error(UnreliableOp::Pwrite)?;
         self.shadow
             .lock()
             .unwrap()
@@ -315,6 +384,7 @@ impl File for UnreliableFile {
     }
 
     fn sync(&self, c: Completion, sync_type: FileSyncType) -> turso_core::Result<Completion> {
+        self.injected_error(UnreliableOp::Sync)?;
         // Simulated power loss: crash while the armed file's fsync is in
         // flight, i.e. after its writes were submitted but before any of them
         // were made durable.

--- a/tests/integration/wal/commit_wal_io_error_rollback.rs
+++ b/tests/integration/wal/commit_wal_io_error_rollback.rs
@@ -1,0 +1,117 @@
+//! A COMMIT that fails because of a WAL I/O error must leave the transaction
+//! fully rolled back — not half-applied and silently committed by a later
+//! statement.
+//!
+//! Regression test. Inside an explicit `BEGIN … COMMIT`, if the WAL header
+//! write or its fsync failed at submit time (how `UnixIO` surfaces a failed
+//! `pwrite`/`fsync` syscall — ENOSPC, EIO, …), `COMMIT` returned an I/O error,
+//! yet the transaction's rows stayed visible on the same connection and the
+//! next statement silently committed them.
+//!
+//! Root cause: `op_auto_commit` flips the connection back to autocommit
+//! *before* the commit succeeds, so when the commit errored, `abort()` keyed
+//! its rollback decision off the autocommit flag, treated the still-open write
+//! transaction as "not in a transaction", and skipped the rollback — leaving
+//! dirty pages in the cache for the next statement to flush. The fix keys the
+//! rollback off the open write transaction as well.
+//!
+//! The submit-time shape matters: an error surfaced on a *completed* async op
+//! takes a different path (`commit_state` is already `Committing` after the
+//! yield, which triggers the rollback via `can_autocommit_now`). Only a
+//! synchronously-failing submit reproduces the bug, hence
+//! [`UnreliableIo::arm_io_error`] rather than the queued-completion fault of
+//! `queued_io`.
+
+use std::sync::Arc;
+
+use rusqlite::types::Value;
+use turso_core::{Database, SqliteDialect};
+
+use crate::common::limbo_exec_rows;
+use crate::unreliable_io::{UnreliableIo, UnreliableOp};
+
+/// `commit_target` is the WAL operation whose submit-time failure aborts the
+/// commit: the header write, or the header fsync. The fault targets operations
+/// on the `-wal` file, which hit the header only because the scenario
+/// truncates the WAL first — a fresh WAL generation starts by rewriting and
+/// re-syncing the WAL header (via `pwrite`; frames go through `pwritev`).
+fn assert_failed_commit_rolls_back(commit_target: UnreliableOp) {
+    let io = Arc::new(UnreliableIo::new());
+    // Distinct path per test: databases are process-globally registered by
+    // file identity, so same-named files must not coexist across tests.
+    let db_path = format!("commit-wal-io-error-{commit_target:?}.db");
+    let wal_path = format!("{db_path}-wal");
+    let db = Database::open_file(io.clone(), &db_path, Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA synchronous=FULL").unwrap();
+    conn.execute("PRAGMA data_sync_retry=ON").unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES(1, 'committed')")
+        .unwrap();
+    // Reset the WAL so the next commit rewrites and re-syncs the WAL header.
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT count(*) FROM t"),
+        [[Value::Integer(1)]],
+        "baseline before the failing commit"
+    );
+
+    conn.execute("BEGIN").unwrap();
+    conn.execute("INSERT INTO t VALUES(2, 'must-not-persist')")
+        .unwrap();
+
+    io.arm_io_error(&wal_path, commit_target);
+    let commit_result = conn.execute("COMMIT");
+    assert!(
+        io.io_error_fired(),
+        "the injected WAL {commit_target:?} fault must actually be reached"
+    );
+    io.clear_io_error();
+
+    assert!(
+        commit_result.is_err(),
+        "COMMIT must report the WAL {commit_target:?} I/O error"
+    );
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT count(*) FROM t"),
+        [[Value::Integer(1)]],
+        "a COMMIT that failed on a WAL {commit_target:?} error must roll back, \
+         not leave the row committed"
+    );
+
+    // The torn state used to surface here: an unrelated later statement flushed
+    // the leaked dirty page, committing the "failed" transaction after the fact.
+    conn.execute("INSERT INTO t VALUES(3, 'next')").unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT count(*) FROM t"),
+        [[Value::Integer(2)]],
+        "a later statement must not carry the rolled-back transaction's row"
+    );
+    assert_eq!(
+        limbo_exec_rows(&conn, "PRAGMA integrity_check"),
+        [[Value::Text("ok".into())]],
+        "database stays consistent"
+    );
+
+    // The rolled-back row must never appear, even after reopening.
+    drop(conn);
+    drop(db);
+    let db = Database::open_file(io.clone(), &db_path, Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id FROM t ORDER BY id"),
+        [[Value::Integer(1)], [Value::Integer(3)]],
+        "reopened database matches the committed rows"
+    );
+}
+
+#[test]
+fn failed_commit_on_wal_header_write_error_rolls_back() {
+    assert_failed_commit_rolls_back(UnreliableOp::Pwrite);
+}
+
+#[test]
+fn failed_commit_on_wal_header_sync_error_rolls_back() {
+    assert_failed_commit_rolls_back(UnreliableOp::Sync);
+}

--- a/tests/integration/wal/mod.rs
+++ b/tests/integration/wal/mod.rs
@@ -1,3 +1,4 @@
+mod commit_wal_io_error_rollback;
 mod test_power_loss_before_first_checkpoint;
 mod test_wal;
 mod test_wal_publish_backfill_race;


### PR DESCRIPTION
## Description

A `COMMIT` that fails with an I/O error is not rolled back. `op_auto_commit` flips the connection back to autocommit before `commit_txn` succeeds, so when the commit errors mid-flight (a WAL write or fsync failing with ENOSPC/EIO at submit time), `abort()` sees `auto_commit=true`, decides the connection is not in a transaction, and skips the rollback.

The write transaction is left dangling, which breaks the connection in both directions: its own reads keep seeing the rolled-back rows, later statements report success but run inside the dangling transaction and are never published to other connections, and an explicit `COMMIT` fails with "no transaction is active" so there is no way to flush it. What a reopen shows depends on where the error landed: if the WAL already held the transaction's frames, replay resurrects the failed `COMMIT`'s changes; either way, every later write the connection reported as committed is lost. Repro output for both shapes is in https://github.com/tursodatabase/turso/issues/8477.

This changes the rollback decision to key off the actual transaction state: roll back whenever an error leaves an open transaction, explicit or a still-open write transaction, regardless of the autocommit flag.

The regression test extends `UnreliableIo` with the submit-time error injection its module doc already calls for (real pwrite/fsync failures surface at submit, not completion) and asserts a failed `COMMIT` rolls back and never persists. It fails without the fix.

## Motivation and context

Found with [patina](https://github.com/JacobHayes/patina), a deterministic-simulation fault-injection harness, run against `turso_core` (the harness lives on my [patina-dst](https://github.com/JacobHayes/turso/tree/patina-dst) branch, stacked on this one). Injecting a WAL I/O error at commit produced a database where the "failed" transaction's writes appeared anyway. A commit that reports failure must leave no trace.

Fixes https://github.com/tursodatabase/turso/issues/8477

## Description of AI Usage

The bug was found and this fix and its regression test were written by Claude Code (deterministic-simulation harness, minimization, and patch), directed and reviewed by me; the commit message and this description were hand-edited. The fix was additionally reviewed with Codex.
