### PR TITLE
sqlite/parser: report bad parameter names as unrecognized tokens

### DIFF
--- a/sqlite/parser/src/error.rs
+++ b/sqlite/parser/src/error.rs
@@ -6,7 +6,7 @@ use crate::token::TokenType;
 #[diagnostic()]
 pub enum Error {
     /// Lexer error
-    #[error("unrecognized token '{token_text}' at offset {offset}")]
+    #[error("unrecognized token: \"{token_text}\"")]
     UnrecognizedToken {
         #[label("here")]
         span: miette::SourceSpan,
@@ -32,14 +32,6 @@ pub enum Error {
     /// Missing `*/`
     #[error("non-terminated block comment '{token_text}' at offset {offset}")]
     UnterminatedBlockComment {
-        #[label("here")]
-        span: miette::SourceSpan,
-        token_text: String,
-        offset: usize,
-    },
-    /// Invalid parameter name
-    #[error("bad variable name '{token_text}' at offset {offset}")]
-    BadVariableName {
         #[label("here")]
         span: miette::SourceSpan,
         token_text: String,

--- a/sqlite/parser/src/lexer.rs
+++ b/sqlite/parser/src/lexer.rs
@@ -898,8 +898,10 @@ impl<'a> Lexer<'a> {
         }
 
         if n_id == 0 || bad_suffix {
+            // SQLite marks these TK_ILLEGAL and reports "unrecognized
+            // token", not a variable-specific error.
             let token_text = String::from_utf8_lossy(&self.input[start..self.offset]).to_string();
-            return Err(Error::BadVariableName {
+            return Err(Error::UnrecognizedToken {
                 span: (start, self.offset - start).into(),
                 token_text,
                 offset: start,
@@ -1224,8 +1226,8 @@ mod tests {
             let mut lexer = Lexer::new(input);
             let result = lexer.next().unwrap();
             assert!(
-                matches!(result, Err(Error::BadVariableName { .. })),
-                "expected BadVariableName for {:?}, got {result:?}",
+                matches!(result, Err(Error::UnrecognizedToken { .. })),
+                "expected UnrecognizedToken for {:?}, got {result:?}",
                 String::from_utf8_lossy(input)
             );
         }

--- a/sqlite/parser/src/parser.rs
+++ b/sqlite/parser/src/parser.rs
@@ -5513,7 +5513,7 @@ mod tests {
         assert!(p.next_cmd().is_err());
         let mut p = Parser::new(b"SELECT $a(b c)");
         let err = p.next_cmd().unwrap_err().to_string();
-        assert!(err.contains("bad variable name '$a(b'"), "{err}");
+        assert!(err.contains("unrecognized token: \"$a(b\""), "{err}");
     }
 
     #[test]

--- a/testing/cli_tests/extensions.py
+++ b/testing/cli_tests/extensions.py
@@ -901,7 +901,7 @@ def test_csv():
     )
     turso.run_test_fn(
         "create virtual table t1 using csv(data='1'\\'2');",
-        lambda res: "unrecognized token " in res,
+        lambda res: "unrecognized token" in res,
         "Create CSV table with malformed escape sequence",
     )
 


### PR DESCRIPTION
SQLite marks a parameter with no identifier bytes ("$", "$::") or an
unterminated "(...)" suffix ("$abc(") as TK_ILLEGAL, so its error is
unrecognized token: "$abc(". We reported a Turso-only "bad variable
name" message instead. Report these through UnrecognizedToken, drop
the now-unused BadVariableName variant, and change the UnrecognizedToken
message to SQLite's exact wording, quotes included.

Tests: main-3.2.9, main-3.2.10, main-3.2.13 and bind-11.1 in
sqlite/conformance/upstream now pass, and so does main-3.2.7 (blob
literal with an odd number of hex digits), which already used
UnrecognizedToken and only had the wrong wording.
