### PR TITLE
serverless/rust: add Builder::with_auth_token_fn for rotating tokens

### DIFF
--- a/serverless/rust/README.md
+++ b/serverless/rust/README.md
@@ -38,6 +38,21 @@ async fn main() -> turso_serverless::Result<()> {
 For a database encrypted with a customer-managed key, pass the
 base64-encoded key with `Builder::with_remote_encryption_key`.
 
+For short-lived tokens, `Builder::with_auth_token_fn` takes an async
+callback invoked before every HTTP request, so the token can be rotated
+(e.g. refreshed from a secrets manager) without rebuilding the database
+handle:
+
+```rust
+# async fn run() -> turso_serverless::Result<()> {
+let db = turso_serverless::Builder::new_remote("libsql://my-db.turso.io")
+    .with_auth_token_fn(|| async { fetch_fresh_token().await })
+    .build()
+    .await?;
+# Ok(())
+# }
+```
+
 Interactive transactions span multiple HTTP requests; the server keeps the
 connection state alive between them:
 

--- a/serverless/rust/connection.rs
+++ b/serverless/rust/connection.rs
@@ -15,7 +15,7 @@ use crate::{
     session::{Session, SharedState},
     statement::Statement,
     transaction::{DropBehavior, Transaction, TransactionBehavior},
-    Column, Error, Result,
+    AuthTokenFn, Column, Error, Result,
 };
 
 /// A connection to a remote database.
@@ -50,7 +50,7 @@ impl std::fmt::Debug for Connection {
 impl Connection {
     pub fn new(
         url: &str,
-        auth_token: Option<String>,
+        auth_token: Option<AuthTokenFn>,
         remote_encryption_key: Option<String>,
     ) -> Self {
         let (session, shared) = Session::new(url, auth_token, remote_encryption_key);

--- a/serverless/rust/lib.rs
+++ b/serverless/rust/lib.rs
@@ -24,6 +24,8 @@
 //! # }
 //! ```
 
+use std::{future::Future, pin::Pin, sync::Arc};
+
 mod column;
 pub mod connection;
 mod error;
@@ -45,10 +47,20 @@ pub use statement::Statement;
 pub use transaction::{Transaction, TransactionBehavior};
 pub use value::{FromValue, Value};
 
+/// Future returned by an auth token provider. Resolves to a bearer token
+/// string (without the `Bearer ` prefix — that prefix is added when building
+/// the header).
+pub type AuthTokenFut = Pin<Box<dyn Future<Output = Result<String>> + Send + 'static>>;
+
+/// Async callback that produces an auth token on demand. Invoked before every
+/// HTTP request, so it can return a freshly-rotated token (e.g. fetched from
+/// a secrets manager or refreshed via OAuth).
+pub type AuthTokenFn = Arc<dyn Fn() -> AuthTokenFut + Send + Sync + 'static>;
+
 /// A builder for [`Database`].
 pub struct Builder {
     url: String,
-    auth_token: Option<String>,
+    auth_token: Option<AuthTokenFn>,
     remote_encryption_key: Option<String>,
 }
 
@@ -66,8 +78,31 @@ impl Builder {
 
     /// Set the authentication token, sent as a bearer token with every
     /// request.
+    ///
+    /// Calling this overrides any previously configured token callback.
     pub fn with_auth_token(mut self, token: impl Into<String>) -> Self {
-        self.auth_token = Some(token.into());
+        let token = token.into();
+        self.auth_token = Some(Arc::new(move || {
+            let token = token.clone();
+            Box::pin(async move { Ok(token) })
+        }));
+        self
+    }
+
+    /// Set an async callback that produces an auth token on demand.
+    ///
+    /// The callback is invoked before every HTTP request, so it can return a
+    /// freshly rotated token (e.g. fetched from a secrets manager or
+    /// refreshed via OAuth). If the callback returns an error, the in-flight
+    /// operation fails with that error.
+    ///
+    /// Calling this overrides any previously configured static token.
+    pub fn with_auth_token_fn<F, Fut>(mut self, f: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<String>> + Send + 'static,
+    {
+        self.auth_token = Some(Arc::new(move || Box::pin(f())));
         self
     }
 
@@ -95,7 +130,7 @@ impl Builder {
 #[derive(Clone)]
 pub struct Database {
     url: String,
-    auth_token: Option<String>,
+    auth_token: Option<AuthTokenFn>,
     remote_encryption_key: Option<String>,
 }
 

--- a/serverless/rust/session.rs
+++ b/serverless/rust/session.rs
@@ -18,7 +18,7 @@ use crate::{
         ENCRYPTION_KEY_HEADER,
     },
     rows::Row,
-    Column, Error, Result,
+    AuthTokenFn, Column, Error, Result,
 };
 
 /// Rewrite `libsql://` and `turso://` URLs to `https://` and strip any
@@ -56,7 +56,7 @@ pub struct StmtOutput {
 
 pub struct Session {
     client: reqwest::Client,
-    auth_token: Option<String>,
+    auth_token: Option<AuthTokenFn>,
     remote_encryption_key: Option<String>,
     base_url: String,
     baton: Option<String>,
@@ -127,7 +127,7 @@ impl LineReader {
 impl Session {
     pub fn new(
         url: &str,
-        auth_token: Option<String>,
+        auth_token: Option<AuthTokenFn>,
         remote_encryption_key: Option<String>,
     ) -> (Self, Arc<SharedState>) {
         let shared = Arc::new(SharedState {
@@ -158,7 +158,10 @@ impl Session {
             .client
             .post(&url)
             .header("Content-Type", "application/json");
-        if let Some(token) = &self.auth_token {
+        // Resolved here rather than once at construction so dynamic providers
+        // can rotate the token between requests.
+        if let Some(provider) = &self.auth_token {
+            let token = provider().await?;
             request = request.header("Authorization", format!("Bearer {token}"));
         }
         if let Some(key) = &self.remote_encryption_key {


### PR DESCRIPTION
Closes #8489.

Adds `Builder::with_auth_token_fn` to `turso_serverless`, mirroring `turso::sync::Builder::with_auth_token_fn` in signature and semantics: an async callback invoked before every HTTP request, so long-running processes can rotate short-lived tokens (JWT refresh, secrets manager) without rebuilding the `Database`.

- `with_auth_token` now wraps its static token in a callback, exactly as the sync builder does, so the two methods override each other with last-call-wins semantics.
- `Session::send` resolves the token before each request. A callback error fails the in-flight operation through the existing error path (fatal for the stream, per PROTOCOL.md section 9.3, like any other request failure).
- One deliberate deviation from the sync builder: the callback resolves to `turso_serverless::Result<String>` rather than the sync crate's `Result` — the natural per-crate error type, same shape otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
