### PR TITLE
bindings/rust: fix Windows panic when sync sends a request body over 4 GiB

### DIFF
--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use http_body_util::{BodyExt, Full};
+use http_body_util::BodyExt;
 use hyper::{header::AUTHORIZATION, Request};
 use hyper_rustls::HttpsConnector;
 use hyper_util::{
@@ -620,6 +620,51 @@ fn normalize_base_url(input: &str) -> std::result::Result<String, String> {
     Ok(base)
 }
 
+// Largest body frame we hand to hyper in one piece. Hyper turns each frame
+// into a single IoSlice for vectored socket writes, and on Windows
+// IoSlice::new panics for buffers larger than u32::MAX because WSABUF stores
+// the length as a 32-bit integer. Keep frames far below that limit.
+const MAX_BODY_FRAME_SIZE: usize = 4 * 1024 * 1024;
+
+// Request body that yields its payload in frames of at most
+// MAX_BODY_FRAME_SIZE bytes. Frames are zero-copy slices of the original
+// buffer, so this adds no extra memory over sending the body whole.
+struct ChunkedBody {
+    rest: Bytes,
+}
+
+impl ChunkedBody {
+    fn new(data: Bytes) -> Self {
+        Self { rest: data }
+    }
+}
+
+impl hyper::body::Body for ChunkedBody {
+    type Data = Bytes;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<std::result::Result<hyper::body::Frame<Bytes>, Self::Error>>> {
+        let this = self.get_mut();
+        if this.rest.is_empty() {
+            return Poll::Ready(None);
+        }
+        let len = this.rest.len().min(MAX_BODY_FRAME_SIZE);
+        let chunk = this.rest.split_to(len);
+        Poll::Ready(Some(Ok(hyper::body::Frame::data(chunk))))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.rest.is_empty()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        hyper::body::SizeHint::with_exact(self.rest.len() as u64)
+    }
+}
+
 // The IO worker owns a dedicated Tokio runtime on a separate thread, and processes
 // the SyncEngine IO queue (HTTP and atomic file operations).
 struct IoWorker {
@@ -701,8 +746,8 @@ impl IoWorker {
             .https_or_http()
             .enable_http1()
             .build();
-        let client: Client<HttpsConnector<HttpConnector>, Full<Bytes>> =
-            Client::builder(TokioExecutor::new()).build::<_, Full<Bytes>>(https);
+        let client: Client<HttpsConnector<HttpConnector>, ChunkedBody> =
+            Client::builder(TokioExecutor::new()).build::<_, ChunkedBody>(https);
 
         while rx.recv().await.is_some() {
             let Some(sync) = sync.upgrade() else {
@@ -720,7 +765,10 @@ impl IoWorker {
 
                 made_progress = true;
 
-                match item.get_request() {
+                // Take the request by value so large HTTP bodies move into
+                // the outgoing request instead of being copied.
+                let (request, completion) = item.into_parts();
+                match request {
                     turso_sync_sdk_kit::sync_engine_io::SyncEngineIoRequest::Http {
                         url,
                         method,
@@ -735,29 +783,22 @@ impl IoWorker {
                             &wakers,
                             &client,
                             url.as_deref(),
-                            method,
-                            path,
-                            body.as_ref().map(|v| Bytes::from(v.clone())),
-                            headers,
-                            item.get_completion().clone(),
+                            &method,
+                            &path,
+                            body.map(Bytes::from),
+                            &headers,
+                            completion,
                         )
                         .await;
                     }
                     turso_sync_sdk_kit::sync_engine_io::SyncEngineIoRequest::FullRead { path } => {
-                        IoWorker::process_full_read(path, item.get_completion().clone(), &sync)
-                            .await;
+                        IoWorker::process_full_read(&path, completion, &sync).await;
                     }
                     turso_sync_sdk_kit::sync_engine_io::SyncEngineIoRequest::FullWrite {
                         path,
                         content,
                     } => {
-                        IoWorker::process_full_write(
-                            path,
-                            content,
-                            item.get_completion().clone(),
-                            &sync,
-                        )
-                        .await;
+                        IoWorker::process_full_write(&path, &content, completion, &sync).await;
                     }
                 }
             }
@@ -779,7 +820,7 @@ impl IoWorker {
         base_url: Option<&str>,
         auth_token: Option<&AuthTokenFn>,
         wakers: &Mutex<Vec<Waker>>,
-        client: &Client<HttpsConnector<HttpConnector>, Full<Bytes>>,
+        client: &Client<HttpsConnector<HttpConnector>, ChunkedBody>,
         url: Option<&str>,
         method: &str,
         path: &str,
@@ -841,8 +882,7 @@ impl IoWorker {
             }
         }
 
-        // Body must be Full<Bytes> to match the client type.
-        let req_body = Full::new(body.unwrap_or_default());
+        let req_body = ChunkedBody::new(body.unwrap_or_default());
 
         let request = match builder.body(req_body) {
             Ok(r) => r,
@@ -960,6 +1000,38 @@ mod tests {
             .take(8)
             .map(char::from)
             .collect()
+    }
+
+    // Regression test for a Windows panic: hyper turns each body frame into
+    // one IoSlice, and IoSlice::new panics on Windows for buffers larger than
+    // u32::MAX. The request body must therefore never yield a frame that big.
+    #[test]
+    fn http_body_never_yields_a_frame_larger_than_the_frame_limit() {
+        use std::pin::Pin;
+        use std::task::{Context, Poll, Waker};
+
+        use hyper::body::Body;
+
+        use crate::sync::{ChunkedBody, MAX_BODY_FRAME_SIZE};
+
+        let payload = bytes::Bytes::from(vec![7u8; MAX_BODY_FRAME_SIZE * 2 + 123]);
+        let mut body = ChunkedBody::new(payload.clone());
+        let mut cx = Context::from_waker(Waker::noop());
+        let mut collected = Vec::with_capacity(payload.len());
+        loop {
+            match Pin::new(&mut body).poll_frame(&mut cx) {
+                Poll::Ready(Some(Ok(frame))) => {
+                    let data = frame.into_data().expect("body yields only data frames");
+                    assert!(data.len() <= MAX_BODY_FRAME_SIZE);
+                    collected.extend_from_slice(&data);
+                }
+                Poll::Ready(None) => break,
+                Poll::Ready(Some(Err(err))) => match err {},
+                Poll::Pending => panic!("in-memory body must never be pending"),
+            }
+        }
+        assert_eq!(collected, payload);
+        assert!(body.is_end_stream());
     }
 
     #[test]

--- a/sync/sdk-kit/src/sync_engine_io.rs
+++ b/sync/sdk-kit/src/sync_engine_io.rs
@@ -232,6 +232,11 @@ impl<TBytes: AsRef<[u8]>> SyncEngineIoQueueItem<TBytes> {
     pub fn get_completion(&self) -> &SyncEngineIoCompletion<TBytes> {
         &self.completion
     }
+    /// Split the item into its request and completion. Taking the request by
+    /// value lets IO workers send large request bodies without copying them.
+    pub fn into_parts(self) -> (SyncEngineIoRequest, SyncEngineIoCompletion<TBytes>) {
+        (self.request, self.completion)
+    }
     pub fn to_capi(self: Box<Self>) -> *mut c::turso_sync_io_item_t {
         Box::into_raw(self) as *mut c::turso_sync_io_item_t
     }


### PR DESCRIPTION
## Problem

A user with a large database reported that sync constantly panics on Windows
and never completes:

```
thread 'turso-sync-io' panicked at library/std/src/sys/io/io_slice/windows.rs:15:9:
assertion failed: buf.len() <= u32::MAX as usize
```

The sync IO worker builds its hyper client as `Client<..., Full<Bytes>>`, so
every request body is sent as one contiguous `Bytes`. Hyper turns each body
frame into a single `IoSlice` for vectored socket writes, and on Windows
`IoSlice::new` asserts `len <= u32::MAX` because `WSABUF` stores the buffer
length as a 32-bit integer.

The sync engine really does produce bodies that big for large databases:

- `wal_push` concatenates the entire frame range into one `Vec<u8>`
  (`sync/engine/src/database_sync_operations.rs`)
- the Hrana replay path (`sql_execute_http`) serializes all pending local
  changes into a single JSON pipeline body

Once either body crosses 4 GiB, every sync attempt panics on the
`turso-sync-io` thread.

## Fix

Replace `Full<Bytes>` with a small `ChunkedBody` type implementing
`hyper::body::Body` that yields the payload in frames of at most 4 MiB.
Frames are `Bytes::split_to` slices — zero-copy, refcounted views of the
original buffer — so no single `IoSlice` can ever approach the `WSABUF`
limit, and no extra memory is used. `size_hint` stays exact, so hyper still
sends `Content-Length` instead of chunked transfer encoding; nothing changes
on the wire except the write granularity.

## Also: remove a full-body copy

The worker used to do `Bytes::from(v.clone())`, copying the entire request
body before sending it — an 8 GiB peak for a 4 GiB push. Since
`take_io_item` returns an owned `Box`, this PR adds
`SyncEngineIoQueueItem::into_parts()` to `sync/sdk-kit` so the worker moves
the `Vec<u8>` straight into `Bytes` with zero copies. The C API path used by
the other bindings is untouched.

## Not addressed here

Two remaining scaling limits from the same report are memory issues, not
panics, and need engine-level changes: `copy_sync_engine_file` still buffers
whole files through `full_read`/`full_write`, and `wal_push` /
`sql_execute_http` still materialize the entire body in memory before
handing it to IO. Streaming those through the `SyncEngineIo` trait ripples
into the C API and all bindings, so it is left for a follow-up.