### PR TITLE
core: pg_compat feature, single-column alias dialect capability, COUNT result type

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -51,6 +51,9 @@ codspeed = ["bench"]
 optimizer_params = ["serde", "dep:serde_json"]
 stacker = ["dep:stacker"]
 percentile = []
+# PostgreSQL frontend support: fields and hooks the pg wire frontend needs on
+# core types. Off by default; the postgres/frontend crate enables it.
+pg_compat = []
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -415,6 +415,11 @@ pub struct Connection {
     /// CDC v2: transaction ID for grouping CDC records by transaction.
     /// -1 means unset (will be assigned on first CDC write in the transaction).
     pub(crate) cdc_transaction_id: AtomicI64,
+    /// PostgreSQL frontend: `txid_current()` minting. Strictly increasing,
+    /// non-zero, per connection; not transaction-scoped and not globally
+    /// ordered across connections.
+    #[cfg(feature = "pg_compat")]
+    pub(crate) pg_txid_counter: AtomicI64,
     pub(super) closed: AtomicBool,
     /// Per-connection state for the `TEMP` schema (pager, last-committed
     /// snapshot, dirty-schema flag). See `TempDbContext`.
@@ -2700,6 +2705,11 @@ impl Connection {
     }
     pub fn set_cdc_transaction_id(&self, id: i64) {
         self.cdc_transaction_id.store(id, Ordering::SeqCst);
+    }
+    /// Mint the next `txid_current()` value for this connection.
+    #[cfg(feature = "pg_compat")]
+    pub fn next_pg_txid(&self) -> i64 {
+        self.pg_txid_counter.fetch_add(1, Ordering::SeqCst)
     }
     pub fn get_page_size(&self) -> PageSize {
         let value = self.page_size.load(Ordering::SeqCst);

--- a/core/database.rs
+++ b/core/database.rs
@@ -2367,6 +2367,8 @@ impl Database {
             mvcc_log_metadata: RwLock::new(HashMap::default()),
             capture_data_changes: RwLock::new(None),
             cdc_transaction_id: AtomicI64::new(-1),
+            #[cfg(feature = "pg_compat")]
+            pg_txid_counter: AtomicI64::new(1),
             closed: AtomicBool::new(false),
             temp: crate::connection::TempDbContext::new(),
             attached_databases: RwLock::new(DatabaseCatalog::new()),

--- a/core/dialect/mod.rs
+++ b/core/dialect/mod.rs
@@ -29,6 +29,13 @@ pub trait Dialect: Send + Sync + 'static {
     /// reject an open whose dialect differs from the already-open instance.
     fn name(&self) -> &'static str;
 
+    /// Whether a single-column relation referenced by its own alias also
+    /// resolves to that column (PostgreSQL's `unnest(...) x -> x` rule).
+    /// SQLite has no such rule, so the default is false.
+    fn exposes_single_column_alias(&self) -> bool {
+        false
+    }
+
     /// Parse the first statement in `sql` into the engine AST.
     ///
     /// Returns the parsed command, if any, and the number of input bytes

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -168,7 +168,8 @@ pub enum ColumnTypeKind {
 
 /// Recursively infer the result primitive of a non-table-column expression
 /// and return its uppercase name (`"INTEGER"`, `"REAL"`, `"TEXT"`,
-/// `"NUMERIC"`, `"BLOB"`) or `None` when no determination can be made.
+/// `"NUMERIC"`, `"BLOB"`, or `"INT8"` — the structurally-fixed result of
+/// `COUNT`) or `None` when no determination can be made.
 ///
 /// Used by [`Statement::get_column_type_info`] to give wire-protocol layers
 /// a usable type for `SELECT 1+1`-style result columns. Goes beyond SQLite's
@@ -249,6 +250,24 @@ fn infer_expression_primitive(
             ),
         },
         Expr::RowId { .. } => Some("INTEGER"),
+        // Aggregate/scalar functions whose result type is fixed by the standard:
+        // `COUNT` always returns a non-null 64-bit integer (PostgreSQL's
+        // count is bigint/INT8, and the wire layer maps "INT8" accordingly).
+        // Everything else depends on its argument(s), so defer to the
+        // argument's affinity rather than guessing (e.g. `MAX(text)` stays
+        // text, `ABS(1.5)` stays REAL, `SUM(int)` stays INTEGER, `SUM(real)`
+        // becomes REAL).
+        Expr::FunctionCall { name, .. } | Expr::FunctionCallStar { name, .. } => {
+            if name.as_str().eq_ignore_ascii_case("COUNT") {
+                Some("INT8")
+            } else {
+                affinity_to_primitive(translate::expr::get_expr_affinity(
+                    expr,
+                    referenced_tables,
+                    None,
+                ))
+            }
+        }
         // CAST, column references, and anything else: defer to the affinity
         // machinery, which handles these shapes correctly.
         _ => affinity_to_primitive(translate::expr::get_expr_affinity(

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -71,6 +71,15 @@ pub(super) fn resolve_qualified_on_ref(
     Ok(None)
 }
 
+/// Whether `table`, referenced under `identifier`, exposes its single visible
+/// column under the alias name too (e.g. `unnest(...) x` → `x`). This is a
+/// PostgreSQL-specific resolution rule and must only be applied when compiling
+/// under a dialect whose `exposes_single_column_alias()` is true.
+fn single_visible_column_matches(table: &Table, identifier: &str, id: &str) -> bool {
+    table.columns().iter().filter(|c| !c.hidden()).count() == 1
+        && identifier.eq_ignore_ascii_case(&normalize_ident(id))
+}
+
 /// Rewrite ast::Expr in place, binding Column references/rewriting Expr::Id -> Expr::Column
 /// using the provided TableReferences, and replacing anonymous parameters with internal named
 /// ones
@@ -145,6 +154,18 @@ pub fn bind_and_rewrite_expr<'a>(
                                     col.is_rowid_alias(),
                                 ));
                             }
+                        // PostgreSQL: a single-column relation aliased as `t` exposes that
+                        // column under the alias name too (e.g. `unnest(...) x` → `x`).
+                        } else if resolver.dialect.exposes_single_column_alias()
+                            && single_visible_column_matches(
+                                &joined_table.table,
+                                &joined_table.identifier,
+                                id.as_str(),
+                            )
+                        {
+                            if match_result.is_none() {
+                                match_result = Some((joined_table.internal_id, 0, false));
+                            }
                         // only if we haven't found a match, check for explicit rowid reference
                         } else if let Table::BTree(btree) = &joined_table.table {
                             if let Some(row_id_expr) =
@@ -209,6 +230,16 @@ pub fn bind_and_rewrite_expr<'a>(
                                 let col = outer_ref.table.columns().get(col_idx).unwrap();
                                 match_result =
                                     Some((outer_ref.internal_id, col_idx, col.is_rowid_alias()));
+                                matched_scope_depth = Some(outer_ref.scope_depth);
+                            } else if resolver.dialect.exposes_single_column_alias()
+                                && match_result.is_none()
+                                && single_visible_column_matches(
+                                    &outer_ref.table,
+                                    &outer_ref.identifier,
+                                    id.as_str(),
+                                )
+                            {
+                                match_result = Some((outer_ref.internal_id, 0, false));
                                 matched_scope_depth = Some(outer_ref.scope_depth);
                             }
                         }

--- a/postgres/tests/integration/postgres/dialect.rs
+++ b/postgres/tests/integration/postgres/dialect.rs
@@ -3516,3 +3516,41 @@ fn test_postgres_catalog_conkey_any_matches_no_rows(db: TempDatabase) {
     let rows = stmt.run_collect_rows().unwrap();
     assert_eq!(rows, vec![vec![Value::from_i64(0)]]);
 }
+
+/// The single-column alias resolution rule (a single-column relation exposes
+/// that column under its own name, used by the PostgreSQL
+/// `unnest(...) x → x` shape) must NOT apply under the SQLite dialect. A plain
+/// SQLite query where a table name collides with a column name of another
+/// joined table must resolve as SQLite does (the column from the matching
+/// table), not error as "ambiguous column name".
+#[turso_macros::test]
+fn test_postgres_sqlite_dialect_table_name_column_collision_not_ambiguous(db: TempDatabase) {
+    // Open a database with the *SQLite* dialect (the regression only manifests
+    // when the binder sees the SQLite dialect; `connect_limbo` inherits the
+    // TempDatabase's PostgreSQL dialect, so we open a fresh SQLite instance).
+    use turso_core::{Database, OpenOptions, SqliteDialect};
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = tmp.path().join("sqlite-regression.db");
+    let sqlite_db = Database::open(
+        db.io.clone(),
+        path.to_str().unwrap(),
+        OpenOptions::new(std::sync::Arc::new(SqliteDialect)),
+    )
+    .unwrap();
+    let conn = sqlite_db.connect().unwrap();
+
+    conn.execute("CREATE TABLE a(x)").unwrap();
+    conn.execute("CREATE TABLE b(a)").unwrap();
+    conn.execute("INSERT INTO a VALUES (111)").unwrap();
+    conn.execute("INSERT INTO b VALUES (222)").unwrap();
+
+    let mut rows = conn.query("SELECT a FROM a JOIN b ON 1").unwrap().unwrap();
+    let StepResult::Row = rows.step().unwrap() else {
+        panic!("expected a row");
+    };
+    let Value::Numeric(Numeric::Integer(value)) = rows.row().unwrap().get_value(0) else {
+        panic!("expected integer value");
+    };
+    // SQLite resolves `a` to b.a here (the only real column named `a`), → 222.
+    assert_eq!(*value, 222);
+}


### PR DESCRIPTION
core: pg_compat feature, single-column alias dialect capability, COUNT result type

Add a core pg_compat feature flag (off by default) carrying the pieces the
PostgreSQL wire frontend needs from the engine: a per-connection txid counter
(pg_txid_counter / Connection::next_pg_txid) mirroring cdc_transaction_id.

Add Dialect::exposes_single_column_alias (default false): whether a
single-column relation referenced by its own alias also resolves to that
column. The binder consults it, so PostgreSQL's unnest(...) x -> x rule can
apply without touching SQLite column resolution; a regression test pins that
SELECT a FROM a JOIN b ON 1 still resolves to b.a under the SQLite dialect.

Pin COUNT's inferred result to INT8 in infer_expression_primitive:
PostgreSQL's count is bigint, and the wire layer maps "INT8" accordingly.
This is the commit's only unconditional core behavior change and is locked by
a frontend test landing with the wire layer.

Tests: cargo test -p turso_pg_tests; cargo fmt --check;
       cargo clippy -p turso_core --all-features --all-targets -- --deny=warnings

Part 1/4 of the PostgreSQL wire-compat layer stack. Purely additive and flag-gated; SQLite behavior provably unchanged (regression test included).