### PR TITLE
core/translate: fix autoindex construction to read virtual generated-column dependencies from the source table instead of the index being built

### DIFF
--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -519,12 +519,9 @@ pub(super) fn emit_autoindex(
         if let Some(columns) = table_columns {
             if let Some(column_def) = columns.get(col.pos_in_table) {
                 if column_def.is_virtual_generated() {
-                    // Generated-column dependencies must come from the source row while the
-                    // automatic index is still being populated. Without this override, expression
-                    // translation sees the new index in the table's plan and reads dependencies
-                    // from the empty index cursor instead.
-                    let previous_cursor_id =
-                        program.set_cursor_override(table_ref_id, table_cursor_id);
+                    // Override the table cursor to the base table, because generated
+                    // columns may need to read from it to compute their expression.
+                    program.set_cursor_override(table_ref_id, table_cursor_id);
                     let result = crate::translate::expr::emit_table_column(
                         program,
                         table_cursor_id,
@@ -535,12 +532,7 @@ pub(super) fn emit_autoindex(
                         reg,
                         resolver,
                     );
-                    match previous_cursor_id {
-                        Some(cursor_id) => {
-                            program.set_cursor_override(table_ref_id, cursor_id);
-                        }
-                        None => program.clear_cursor_override(table_ref_id),
-                    }
+                    program.clear_cursor_override(table_ref_id);
                     result?;
                     continue;
                 }

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -519,7 +519,13 @@ pub(super) fn emit_autoindex(
         if let Some(columns) = table_columns {
             if let Some(column_def) = columns.get(col.pos_in_table) {
                 if column_def.is_virtual_generated() {
-                    crate::translate::expr::emit_table_column(
+                    // Generated-column dependencies must come from the source row while the
+                    // automatic index is still being populated. Without this override, expression
+                    // translation sees the new index in the table's plan and reads dependencies
+                    // from the empty index cursor instead.
+                    let previous_cursor_id =
+                        program.set_cursor_override(table_ref_id, table_cursor_id);
+                    let result = crate::translate::expr::emit_table_column(
                         program,
                         table_cursor_id,
                         table_ref_id,
@@ -528,7 +534,14 @@ pub(super) fn emit_autoindex(
                         col.pos_in_table,
                         reg,
                         resolver,
-                    )?;
+                    );
+                    match previous_cursor_id {
+                        Some(cursor_id) => {
+                            program.set_cursor_override(table_ref_id, cursor_id);
+                        }
+                        None => program.clear_cursor_override(table_ref_id),
+                    }
+                    result?;
                     continue;
                 }
             }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1791,8 +1791,13 @@ impl ProgramBuilder {
 
     /// Set a cursor override for a table. When resolving a table cursor for this table,
     /// the override cursor will be used instead of the normal resolution.
-    pub fn set_cursor_override(&mut self, table_ref_id: TableInternalId, cursor_id: CursorID) {
-        self.cursor_overrides.insert(table_ref_id.into(), cursor_id);
+    /// Returns the previous override, if any.
+    pub fn set_cursor_override(
+        &mut self,
+        table_ref_id: TableInternalId,
+        cursor_id: CursorID,
+    ) -> Option<CursorID> {
+        self.cursor_overrides.insert(table_ref_id.into(), cursor_id)
     }
 
     /// Clear the cursor override for a table.

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1791,13 +1791,8 @@ impl ProgramBuilder {
 
     /// Set a cursor override for a table. When resolving a table cursor for this table,
     /// the override cursor will be used instead of the normal resolution.
-    /// Returns the previous override, if any.
-    pub fn set_cursor_override(
-        &mut self,
-        table_ref_id: TableInternalId,
-        cursor_id: CursorID,
-    ) -> Option<CursorID> {
-        self.cursor_overrides.insert(table_ref_id.into(), cursor_id)
+    pub fn set_cursor_override(&mut self, table_ref_id: TableInternalId, cursor_id: CursorID) {
+        self.cursor_overrides.insert(table_ref_id.into(), cursor_id);
     }
 
     /// Clear the cursor override for a table.

--- a/sqlite/conformance/sqlite-sqltests/gencol.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/gencol.sqltest
@@ -4261,6 +4261,21 @@ expect {
     3|30|3|30
 }
 
+# Regression test for https://github.com/tursodatabase/turso/issues/8472
+test gencol_autoindex_dependency {
+    CREATE TABLE measurements (
+        computed_value AS (base_value),
+        base_value
+    );
+    INSERT INTO measurements (base_value) VALUES (1);
+    SELECT measurements.base_value
+      FROM measurements, (SELECT 1) AS one_row
+     WHERE measurements.computed_value > 0;
+}
+expect {
+    1
+}
+
 # =============================================================================
 # Three-table INNER JOIN with virtual generated columns (#6151)
 # =============================================================================


### PR DESCRIPTION
Fixes #8472

## Initial investigation as described here https://github.com/tursodatabase/turso/issues/8472#issuecomment-5412094948

> This might be the minimal repro where failure still occurs and there is a difference in behavior between turso and sqlite, turso returns `0 rows` vs sqlite returns `1 row` in this minimal repo. Attaching a screenshot which shows turso vs sqlite both along with their vdbe outputs. Seems like the wrong cursor is being used. I am debugging it further but this is what i have figured out so far.

> Minimal repro sql
> ```
> CREATE TABLE measurements (
>     computed_value AS (base_value),
>     base_value
> );
> 
> INSERT INTO measurements (base_value)
> VALUES (1);
> 
> SELECT measurements.base_value
> FROM measurements,
>      (SELECT 1) AS one_row
> WHERE measurements.computed_value > 0;
> ```

> turso 0 rows vs sqlite 1 row execution screenshot:
> <img width="2810" height="2002" alt="image" src="https://github.com/user-attachments/assets/24aaaa3f-85f1-4fc1-bee6-199741a09979" />


## The problem and its fix

During automatic index construction, the virtual generated column branch of emit_autoindex read the generated expression’s dependency from the still empty index cursor which is incorrect. Temporarily mapping table_ref_id to the source table cursor while emitting the expression fixes this, and restoring the previous mapping leaves later index reads unchanged.

## Evidence of sim seed 11305753108394820671 passing for the fix vs main branch

<img width="1044" height="982" alt="Screenshot 2026-08-25 at 9 42 41 PM" src="https://github.com/user-attachments/assets/1bcb5282-4ffe-4447-ab7f-ff286ba043a9" />

## Failing `no output` discrepancy from before is fixed, now matches sqlite behavior (which means minimal repro is also correct, and the same thing is added as a test also)

<img width="819" height="407" alt="Screenshot 2026-08-25 at 9 47 35 PM" src="https://github.com/user-attachments/assets/6ef75a14-e9b3-4085-93b4-1e2b2a04c3f7" />



## Description of AI Usage

Codex for in the process of coming up with a minimal repro, debugging to the problematic codepath, and locally reviewing my change with it. I own the manual verification and correctness.