### PR TITLE
bindings/c: toward the unmodified PHP SQLite driver (92% conformance)

### DIFF
--- a/bindings/c/include/sqlite3.h
+++ b/bindings/c/include/sqlite3.h
@@ -3,25 +3,43 @@
 
 #include <stdint.h>
 
-#define SQLITE_OK 0
+#define SQLITE_VERSION        "3.42.0"
+#define SQLITE_VERSION_NUMBER 3042000
 
-#define SQLITE_ERROR 1
+/* SQLite C extension loading is not supported: Turso extensions are a
+** different mechanism. Consumers (e.g. PHP's ext/sqlite3) compile their
+** loadExtension paths out cleanly under this define. */
+#define SQLITE_OMIT_LOAD_EXTENSION 1
 
-#define SQLITE_ABORT 4
-
-#define SQLITE_BUSY 5
-
-#define SQLITE_NOMEM 7
-
-#define SQLITE_INTERRUPT 9
-
-#define SQLITE_NOTFOUND 12
-
-#define SQLITE_CANTOPEN 14
-
+#define SQLITE_OK          0
+#define SQLITE_ERROR       1
+#define SQLITE_INTERNAL    2
+#define SQLITE_PERM        3
+#define SQLITE_ABORT       4
+#define SQLITE_BUSY        5
+#define SQLITE_LOCKED      6
+#define SQLITE_NOMEM       7
+#define SQLITE_READONLY    8
+#define SQLITE_INTERRUPT   9
+#define SQLITE_IOERR      10
+#define SQLITE_CORRUPT    11
+#define SQLITE_NOTFOUND   12
+#define SQLITE_FULL       13
+#define SQLITE_CANTOPEN   14
+#define SQLITE_PROTOCOL   15
+#define SQLITE_EMPTY      16
+#define SQLITE_SCHEMA     17
+#define SQLITE_TOOBIG     18
 #define SQLITE_CONSTRAINT 19
-
-#define SQLITE_MISUSE 21
+#define SQLITE_MISMATCH   20
+#define SQLITE_MISUSE     21
+#define SQLITE_NOLFS      22
+#define SQLITE_AUTH       23
+#define SQLITE_FORMAT     24
+#define SQLITE_RANGE      25
+#define SQLITE_NOTADB     26
+#define SQLITE_NOTICE     27
+#define SQLITE_WARNING    28
 
 #define SQLITE_ROW 100
 
@@ -34,6 +52,19 @@
 #define SQLITE_STATE_SICK 186
 
 #define SQLITE_STATE_BUSY 109
+
+/* Flags for sqlite3_open_v2 */
+#define SQLITE_OPEN_READONLY      0x00000001
+#define SQLITE_OPEN_READWRITE     0x00000002
+#define SQLITE_OPEN_CREATE        0x00000004
+#define SQLITE_OPEN_URI           0x00000040
+#define SQLITE_OPEN_MEMORY        0x00000080
+#define SQLITE_OPEN_NOMUTEX       0x00008000
+#define SQLITE_OPEN_FULLMUTEX     0x00010000
+#define SQLITE_OPEN_SHAREDCACHE   0x00020000
+#define SQLITE_OPEN_PRIVATECACHE  0x00040000
+#define SQLITE_OPEN_NOFOLLOW      0x01000000
+#define SQLITE_OPEN_EXRESCODE     0x02000000
 
 #define SQLITE_CHECKPOINT_PASSIVE 0
 
@@ -57,6 +88,22 @@ typedef void (*sqlite3_destructor_type)(void*);
 typedef struct sqlite3 sqlite3;
 
 typedef struct sqlite3_stmt sqlite3_stmt;
+typedef struct sqlite3_context sqlite3_context;
+typedef struct sqlite3_value sqlite3_value;
+typedef struct sqlite3_blob sqlite3_blob;
+typedef struct sqlite3_backup sqlite3_backup;
+
+/* Text encodings and function flags for sqlite3_create_function */
+#define SQLITE_UTF8           1
+#define SQLITE_UTF16LE        2
+#define SQLITE_UTF16BE        3
+#define SQLITE_UTF16          4
+#define SQLITE_ANY            5
+#define SQLITE_UTF16_ALIGNED  8
+#define SQLITE_DETERMINISTIC  0x000000800
+#define SQLITE_DIRECTONLY     0x000080000
+#define SQLITE_SUBTYPE        0x000100000
+#define SQLITE_INNOCUOUS      0x000200000
 typedef int64_t sqlite3_int64;
 typedef sqlite3_int64 sqlite_int64;
 
@@ -133,7 +180,7 @@ int sqlite3_set_authorizer(sqlite3 *db,
 #define SQLITE_COPY                  0
 #define SQLITE_RECURSIVE            33
 
-void *sqlite3_context_db_handle(void *_context);
+sqlite3 *sqlite3_context_db_handle(sqlite3_context *context);
 
 int sqlite3_prepare_v2(sqlite3 *db, const char *sql, int _len, sqlite3_stmt **out_stmt, const char **_tail);
 
@@ -232,17 +279,17 @@ int sqlite3_errcode(sqlite3 *_db);
 
 const char *sqlite3_errstr(int _err);
 
-void *sqlite3_user_data(void *_context);
+void *sqlite3_user_data(sqlite3_context *context);
 
-void *sqlite3_backup_init(sqlite3 *_dest_db, const char *_dest_name, sqlite3 *_source_db, const char *_source_name);
+sqlite3_backup *sqlite3_backup_init(sqlite3 *dest_db, const char *dest_name, sqlite3 *source_db, const char *source_name);
 
-int sqlite3_backup_step(void *_backup, int _n_pages);
+int sqlite3_backup_step(sqlite3_backup *backup, int n_pages);
 
-int sqlite3_backup_remaining(void *_backup);
+int sqlite3_backup_remaining(sqlite3_backup *backup);
 
-int sqlite3_backup_pagecount(void *_backup);
+int sqlite3_backup_pagecount(sqlite3_backup *backup);
 
-int sqlite3_backup_finish(void *_backup);
+int sqlite3_backup_finish(sqlite3_backup *backup);
 
 const char *sqlite3_sql(sqlite3_stmt *stmt);
 
@@ -262,9 +309,9 @@ int sqlite3_bind_int64(sqlite3_stmt *_stmt, int _idx, int64_t _val);
 
 int sqlite3_bind_double(sqlite3_stmt *_stmt, int _idx, double _val);
 
-int sqlite3_bind_text(sqlite3_stmt *_stmt, int _idx, const char *_text, int _len, void *_destroy);
+int sqlite3_bind_text(sqlite3_stmt *stmt, int idx, const char *text, int len, sqlite3_destructor_type destroy);
 
-int sqlite3_bind_blob(sqlite3_stmt *_stmt, int _idx, const void *_blob, int _len, void *_destroy);
+int sqlite3_bind_blob(sqlite3_stmt *stmt, int idx, const void *blob, int len, sqlite3_destructor_type destroy);
 
 int sqlite3_column_type(sqlite3_stmt *_stmt, int _idx);
 
@@ -284,25 +331,25 @@ const void *sqlite3_column_blob(sqlite3_stmt *_stmt, int _idx);
 
 int sqlite3_column_bytes(sqlite3_stmt *_stmt, int _idx);
 
-void *sqlite3_column_value(sqlite3_stmt *_stmt, int _idx);
+sqlite3_value *sqlite3_column_value(sqlite3_stmt *stmt, int idx);
 
-int sqlite3_value_type(void *value);
+int sqlite3_value_type(sqlite3_value *value);
 
-int64_t sqlite3_value_int64(void *value);
+int64_t sqlite3_value_int64(sqlite3_value *value);
 
-int sqlite3_value_int(void *value);
+int sqlite3_value_int(sqlite3_value *value);
 
-double sqlite3_value_double(void *value);
+double sqlite3_value_double(sqlite3_value *value);
 
-const unsigned char *sqlite3_value_text(void *value);
+const unsigned char *sqlite3_value_text(sqlite3_value *value);
 
-const void *sqlite3_value_blob(void *value);
+const void *sqlite3_value_blob(sqlite3_value *value);
 
-int sqlite3_value_bytes(void *value);
+int sqlite3_value_bytes(sqlite3_value *value);
 
-void *sqlite3_value_dup(void *value);
+sqlite3_value *sqlite3_value_dup(sqlite3_value *value);
 
-void sqlite3_value_free(void *value);
+void sqlite3_value_free(sqlite3_value *value);
 
 const unsigned char *sqlite3_column_text(sqlite3_stmt *stmt, int idx);
 
@@ -312,25 +359,25 @@ int sqlite3_get_table(sqlite3 *db, const char *sql, char ***paz_result, int *pn_
 
 void sqlite3_free_table(char **az_result);
 
-void sqlite3_result_null(void *_context);
+void sqlite3_result_null(sqlite3_context *context);
 
-void sqlite3_result_int64(void *_context, int64_t _val);
+void sqlite3_result_int64(sqlite3_context *context, int64_t val);
 
-void sqlite3_result_int(void *_context, int _val);
+void sqlite3_result_int(sqlite3_context *context, int val);
 
-void sqlite3_result_double(void *_context, double _val);
+void sqlite3_result_double(sqlite3_context *context, double val);
 
-void sqlite3_result_text(void *_context, const char *_text, int _len, void *_destroy);
+void sqlite3_result_text(sqlite3_context *context, const char *text, int len, sqlite3_destructor_type destroy);
 
-void sqlite3_result_blob(void *_context, const void *_blob, int _len, void *_destroy);
+void sqlite3_result_blob(sqlite3_context *context, const void *blob, int len, sqlite3_destructor_type destroy);
 
-void sqlite3_result_error_nomem(void *_context);
+void sqlite3_result_error_nomem(sqlite3_context *context);
 
-void sqlite3_result_error_toobig(void *_context);
+void sqlite3_result_error_toobig(sqlite3_context *context);
 
-void sqlite3_result_error(void *_context, const char *_err, int _len);
+void sqlite3_result_error(sqlite3_context *context, const char *err, int len);
 
-void *sqlite3_aggregate_context(void *_context, int _n);
+void *sqlite3_aggregate_context(sqlite3_context *context, int n);
 
 int sqlite3_blob_open(sqlite3 *_db,
                       const char *_db_name,
@@ -338,34 +385,49 @@ int sqlite3_blob_open(sqlite3 *_db,
                       const char *_column_name,
                       int64_t _rowid,
                       int _flags,
-                      void **_blob_out);
+                      sqlite3_blob **blob_out);
 
-int sqlite3_blob_read(void *_blob, void *_data, int _n, int _offset);
+int sqlite3_blob_read(sqlite3_blob *blob, void *data, int n, int offset);
 
-int sqlite3_blob_write(void *_blob, const void *_data, int _n, int _offset);
+int sqlite3_blob_write(sqlite3_blob *blob, const void *data, int n, int offset);
 
-int sqlite3_blob_bytes(void *_blob);
+int sqlite3_blob_bytes(sqlite3_blob *blob);
 
-int sqlite3_blob_close(void *_blob);
+int sqlite3_blob_close(sqlite3_blob *blob);
 
 int sqlite3_stricmp(const char *_a, const char *_b);
 
-int sqlite3_create_collation_v2(sqlite3 *_db,
-                                const char *_name,
-                                int _enc,
-                                void *_context,
-                                int (*_cmp)(void),
-                                void (*_destroy)(void));
+int sqlite3_create_collation(sqlite3 *db,
+                             const char *name,
+                             int enc,
+                             void *context,
+                             int (*xCompare)(void*, int, const void*, int, const void*));
 
-int sqlite3_create_function_v2(sqlite3 *_db,
-                               const char *_name,
-                               int _n_args,
-                               int _enc,
-                               void *_context,
-                               void (*_func)(void),
-                               void (*_step)(void),
-                               void (*_final_)(void),
-                               void (*_destroy)(void));
+int sqlite3_create_collation_v2(sqlite3 *db,
+                                const char *name,
+                                int enc,
+                                void *context,
+                                int (*xCompare)(void*, int, const void*, int, const void*),
+                                void (*xDestroy)(void*));
+
+int sqlite3_create_function(sqlite3 *db,
+                            const char *name,
+                            int n_args,
+                            int enc,
+                            void *context,
+                            void (*xFunc)(sqlite3_context*, int, sqlite3_value**),
+                            void (*xStep)(sqlite3_context*, int, sqlite3_value**),
+                            void (*xFinal)(sqlite3_context*));
+
+int sqlite3_create_function_v2(sqlite3 *db,
+                               const char *name,
+                               int n_args,
+                               int enc,
+                               void *context,
+                               void (*xFunc)(sqlite3_context*, int, sqlite3_value**),
+                               void (*xStep)(sqlite3_context*, int, sqlite3_value**),
+                               void (*xFinal)(sqlite3_context*),
+                               void (*xDestroy)(void*));
 
 int sqlite3_create_window_function(sqlite3 *_db,
                                    const char *_name,

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -1170,8 +1170,7 @@ pub unsafe extern "C" fn sqlite3_exec(
             );
             if rc != SQLITE_OK {
                 if !err.is_null() {
-                    let err_msg = format!("Prepare failed: {rc}");
-                    *err = CString::new(err_msg).unwrap().into_raw();
+                    *err = dup_db_errmsg(db);
                 }
                 return rc;
             }
@@ -1183,8 +1182,7 @@ pub unsafe extern "C" fn sqlite3_exec(
                     _ => {
                         sqlite3_finalize(stmt_ptr);
                         if !err.is_null() {
-                            let err_msg = format!("Step failed: {step_rc}");
-                            *err = CString::new(err_msg).unwrap().into_raw();
+                            *err = dup_db_errmsg(db);
                         }
                         return step_rc;
                     }
@@ -1275,8 +1273,7 @@ unsafe fn execute_query_with_callback(
 
     if rc != SQLITE_OK {
         if !err.is_null() {
-            let err_msg = format!("Prepare failed: {rc}");
-            *err = CString::new(err_msg).unwrap().into_raw();
+            *err = dup_db_errmsg(db);
         }
         return rc;
     }
@@ -1342,8 +1339,7 @@ unsafe fn execute_query_with_callback(
             _ => {
                 sqlite3_finalize(stmt_ptr);
                 if !err.is_null() {
-                    let err_msg = format!("Step failed: {step_rc}");
-                    *err = CString::new(err_msg).unwrap().into_raw();
+                    *err = dup_db_errmsg(db);
                 }
                 return step_rc;
             }
@@ -3676,19 +3672,57 @@ fn limbo_err_code(err: &LimboError) -> i32 {
 fn handle_limbo_err(err: LimboError, container: *mut *mut ffi::c_char) -> i32 {
     let code = limbo_err_code(&err);
     if !container.is_null() {
-        let err_msg = format!("{err}");
+        let err_msg = sqlite_bare_message(&err);
         unsafe { *container = CString::new(err_msg).unwrap().into_raw() };
     }
     code
 }
 
 /// Store a LimboError on the database handle, returning the SQLite error code.
+/// SQLite's sqlite3_errmsg returns a bare message ("no such table: t"),
+/// while turso_core's Display decorates errors with a category prefix
+/// ("Parse error: ...") that the CLI relies on. Strip a leading
+/// "<Category> error: " so the C API matches SQLite; other consumers keep
+/// the decorated form.
+fn sqlite_bare_message(err: &LimboError) -> String {
+    const PREFIXES: [&str; 8] = [
+        "Parse error: ",
+        "Transaction error: ",
+        "Runtime error: ",
+        "Planning error: ",
+        "Locking error: ",
+        "Conversion error: ",
+        "Extension error: ",
+        "Internal error: ",
+    ];
+    let msg = err.to_string();
+    for p in PREFIXES {
+        if let Some(rest) = msg.strip_prefix(p) {
+            return rest.to_string();
+        }
+    }
+    msg
+}
+
+/// Duplicates the connection's current error text into a fresh
+/// sqlite3_malloc-style CString for sqlite3_exec's errmsg out-parameter,
+/// or an empty string if none is set.
+unsafe fn dup_db_errmsg(db: *mut sqlite3) -> *mut ffi::c_char {
+    let msg = sqlite3_errmsg(db);
+    let bytes = if msg.is_null() {
+        &b""[..]
+    } else {
+        CStr::from_ptr(msg).to_bytes()
+    };
+    CString::new(bytes).unwrap_or_default().into_raw()
+}
+
 unsafe fn set_db_err(db: &mut sqlite3Inner, err: LimboError) -> i32 {
     if !db.p_err.is_null() {
         let _ = CString::from_raw(db.p_err as *mut ffi::c_char);
     }
     let code = limbo_err_code(&err);
-    let err_msg = format!("{err}");
+    let err_msg = sqlite_bare_message(&err);
     db.p_err = CString::new(err_msg).unwrap().into_raw() as *mut ffi::c_void;
     db.err_code = code;
     code

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -67,12 +67,6 @@ fn default_db_opts() -> DatabaseOpts {
     opts
 }
 
-macro_rules! stub {
-    () => {
-        todo!("{} is not implemented", stringify!($fn));
-    };
-}
-
 /* generic error-codes */
 pub const SQLITE_OK: ffi::c_int = 0; /* Successful result */
 pub const SQLITE_ERROR: ffi::c_int = 1; /* Generic error */
@@ -753,6 +747,10 @@ pub unsafe extern "C" fn sqlite3_db_filename(
     inner.filename.as_ptr()
 }
 
+// Unimplemented entry points return their contract's failure value (or a
+// harmless no-op where the contract has no failure signal) instead of
+// panicking: a panic across the extern "C" boundary aborts the host
+// process.
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_trace_v2(
     _db: *mut sqlite3,
@@ -762,7 +760,7 @@ pub unsafe extern "C" fn sqlite3_trace_v2(
     >,
     _context: *mut ffi::c_void,
 ) -> ffi::c_int {
-    stub!();
+    SQLITE_ERROR
 }
 
 #[no_mangle]
@@ -1515,7 +1513,7 @@ pub unsafe extern "C" fn sqlite3_serialize(
     _out_bytes: *mut ffi::c_int,
     _flags: ffi::c_uint,
 ) -> ffi::c_int {
-    stub!();
+    SQLITE_ERROR
 }
 
 #[no_mangle]
@@ -1526,7 +1524,7 @@ pub unsafe extern "C" fn sqlite3_deserialize(
     _in_bytes: ffi::c_int,
     _flags: ffi::c_uint,
 ) -> ffi::c_int {
-    stub!();
+    SQLITE_ERROR
 }
 
 #[no_mangle]
@@ -1762,7 +1760,7 @@ pub unsafe extern "C" fn sqlite3_db_handle(stmt: *mut sqlite3_stmt) -> *mut sqli
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_sleep(_ms: ffi::c_int) {
-    stub!();
+    std::thread::sleep(std::time::Duration::from_millis(_ms.max(0) as u64));
 }
 
 #[no_mangle]
@@ -1771,7 +1769,7 @@ pub unsafe extern "C" fn sqlite3_limit(
     _id: ffi::c_int,
     _new_value: ffi::c_int,
 ) -> ffi::c_int {
-    stub!();
+    -1
 }
 
 #[no_mangle]
@@ -1857,7 +1855,7 @@ pub unsafe extern "C" fn sqlite3_backup_init(
     _source_db: *mut sqlite3,
     _source_name: *const ffi::c_char,
 ) -> *mut ffi::c_void {
-    stub!();
+    std::ptr::null_mut()
 }
 
 #[no_mangle]
@@ -1865,22 +1863,22 @@ pub unsafe extern "C" fn sqlite3_backup_step(
     _backup: *mut ffi::c_void,
     _n_pages: ffi::c_int,
 ) -> ffi::c_int {
-    stub!();
+    SQLITE_ERROR
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_backup_remaining(_backup: *mut ffi::c_void) -> ffi::c_int {
-    stub!();
+    0
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_backup_pagecount(_backup: *mut ffi::c_void) -> ffi::c_int {
-    stub!();
+    0
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_backup_finish(_backup: *mut ffi::c_void) -> ffi::c_int {
-    stub!();
+    SQLITE_OK
 }
 
 /// Returns the statement's original SQL text. The pointer is owned by the
@@ -2823,7 +2821,7 @@ pub unsafe extern "C" fn sqlite3_aggregate_context(
     _context: *mut ffi::c_void,
     _n: ffi::c_int,
 ) -> *mut ffi::c_void {
-    stub!();
+    std::ptr::null_mut()
 }
 
 // `unsafe_op_in_unsafe_fn`: opt this FFI entry point out of the legacy rule that an
@@ -3022,6 +3020,19 @@ pub unsafe extern "C" fn sqlite3_stricmp(
     a.len() as ffi::c_int - b.len() as ffi::c_int
 }
 
+/// The pre-v2 registration entry point: identical to
+/// sqlite3_create_collation_v2 without a destructor.
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_create_collation(
+    db: *mut sqlite3,
+    name: *const ffi::c_char,
+    enc: ffi::c_int,
+    context: *mut ffi::c_void,
+    cmp: Option<unsafe extern "C" fn() -> ffi::c_int>,
+) -> ffi::c_int {
+    sqlite3_create_collation_v2(db, name, enc, context, cmp, None)
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_create_collation_v2(
     _db: *mut sqlite3,
@@ -3031,7 +3042,23 @@ pub unsafe extern "C" fn sqlite3_create_collation_v2(
     _cmp: Option<unsafe extern "C" fn() -> ffi::c_int>,
     _destroy: Option<unsafe extern "C" fn()>,
 ) -> ffi::c_int {
-    stub!();
+    SQLITE_ERROR
+}
+
+/// The pre-v2 registration entry point: identical to
+/// sqlite3_create_function_v2 without a destructor.
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_create_function(
+    db: *mut sqlite3,
+    name: *const ffi::c_char,
+    n_args: ffi::c_int,
+    enc: ffi::c_int,
+    context: *mut ffi::c_void,
+    func: Option<unsafe extern "C" fn()>,
+    step: Option<unsafe extern "C" fn()>,
+    final_: Option<unsafe extern "C" fn()>,
+) -> ffi::c_int {
+    sqlite3_create_function_v2(db, name, n_args, enc, context, func, step, final_, None)
 }
 
 #[no_mangle]
@@ -3144,7 +3171,7 @@ pub unsafe extern "C" fn sqlite3_create_window_function(
     _x_inverse: Option<unsafe extern "C" fn()>,
     _destroy: Option<unsafe extern "C" fn()>,
 ) -> ffi::c_int {
-    stub!();
+    SQLITE_ERROR
 }
 
 /// Returns the error message for the most recent failed API call to connection.

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -295,6 +295,9 @@ pub struct SqliteContext {
     pub(crate) result: ExtValue,
     pub(crate) p_app: *mut ffi::c_void,
     pub(crate) db: *mut sqlite3,
+    /// Per-group accumulator for an aggregate step/final call, null for a
+    /// scalar context. Backs sqlite3_aggregate_context.
+    pub(crate) agg: *mut turso_ext::AggCtx,
 }
 
 // SAFETY: SqliteContext is only used single-threaded within a function call.
@@ -338,6 +341,7 @@ unsafe fn dispatch_func_bridge(slot_id: usize, argc: i32, argv: *const ExtValue)
         result: ExtValue::null(),
         p_app: p_app as *mut ffi::c_void,
         db: db as *mut sqlite3,
+        agg: std::ptr::null_mut(),
     };
 
     x_func(
@@ -2832,10 +2836,23 @@ pub unsafe extern "C" fn sqlite3_result_error(
 
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_aggregate_context(
-    _context: *mut ffi::c_void,
-    _n: ffi::c_int,
+    context: *mut ffi::c_void,
+    n: ffi::c_int,
 ) -> *mut ffi::c_void {
-    std::ptr::null_mut()
+    if context.is_null() {
+        return std::ptr::null_mut();
+    }
+    let ctx = &mut *(context as *mut SqliteContext);
+    if ctx.agg.is_null() {
+        return std::ptr::null_mut();
+    }
+    let agg = &mut *ctx.agg;
+    // First request with n > 0 zero-allocates the per-group buffer; later
+    // requests return the same pointer, as SQLite does.
+    if agg.state.is_null() && n > 0 {
+        agg.state = libc::calloc(1, n as usize);
+    }
+    agg.state
 }
 
 // `unsafe_op_in_unsafe_fn`: opt this FFI entry point out of the legacy rule that an
@@ -3160,6 +3177,134 @@ pub unsafe extern "C" fn sqlite3_create_function(
     sqlite3_create_function_v2(db, name, n_args, enc, context, func, step, final_, None)
 }
 
+/// Bridges one registered aggregate to turso_core's init/step/finalize ABI.
+/// Boxed and passed as the registration `context`, shared read-only across
+/// groups; the per-group accumulator lives in the AggCtx that init allocates
+/// and finalize frees, reachable from xStep/xFinal via
+/// sqlite3_aggregate_context.
+struct AggBridge {
+    step: unsafe extern "C" fn(*mut ffi::c_void, ffi::c_int, *mut *mut ffi::c_void),
+    final_: unsafe extern "C" fn(*mut ffi::c_void),
+    p_app: *mut ffi::c_void,
+    db: *mut sqlite3,
+    destroy: Option<unsafe extern "C" fn(*mut ffi::c_void)>,
+}
+
+unsafe extern "C" fn agg_init(_context: usize) -> *mut turso_ext::AggCtx {
+    Box::into_raw(Box::new(turso_ext::AggCtx {
+        state: std::ptr::null_mut(),
+    }))
+}
+
+unsafe extern "C" fn agg_step(
+    context: usize,
+    ctx: *mut turso_ext::AggCtx,
+    argc: i32,
+    argv: *const ExtValue,
+) -> ExtValue {
+    let bridge = &*(context as *const AggBridge);
+    let mut arg_ptrs: Vec<*mut ffi::c_void> = (0..argc as usize)
+        .map(|i| argv.add(i) as *mut ffi::c_void)
+        .collect();
+    let mut sctx = SqliteContext {
+        result: ExtValue::null(),
+        p_app: bridge.p_app,
+        db: bridge.db,
+        agg: ctx,
+    };
+    (bridge.step)(
+        &mut sctx as *mut SqliteContext as *mut ffi::c_void,
+        argc,
+        arg_ptrs.as_mut_ptr(),
+    );
+    // Aggregate step produces no value; state lives in the AggCtx.
+    ExtValue::null()
+}
+
+unsafe extern "C" fn agg_finalize(context: usize, ctx: *mut turso_ext::AggCtx) -> ExtValue {
+    let bridge = &*(context as *const AggBridge);
+    let mut sctx = SqliteContext {
+        result: ExtValue::null(),
+        p_app: bridge.p_app,
+        db: bridge.db,
+        agg: ctx,
+    };
+    (bridge.final_)(&mut sctx as *mut SqliteContext as *mut ffi::c_void);
+    // xFinal is called once per init; free the per-group buffer and AggCtx.
+    if !ctx.is_null() {
+        let agg = Box::from_raw(ctx);
+        if !agg.state.is_null() {
+            libc::free(agg.state);
+        }
+    }
+    sctx.result
+}
+
+/// Called by core when the aggregate is removed: free the shared bridge and
+/// run the caller's xDestroy on its application data.
+unsafe extern "C" fn agg_ctx_destructor(context: usize) {
+    let bridge = Box::from_raw(context as *mut AggBridge);
+    if let Some(destroy) = bridge.destroy {
+        destroy(bridge.p_app);
+    }
+}
+
+/// Registers an aggregate (xStep + xFinal) via turso_core's aggregate ABI.
+unsafe fn register_aggregate(
+    db: *mut sqlite3,
+    name: *const ffi::c_char,
+    n_args: ffi::c_int,
+    context: *mut ffi::c_void,
+    step_raw: unsafe extern "C" fn(),
+    final_raw: unsafe extern "C" fn(),
+    destroy_raw: Option<unsafe extern "C" fn()>,
+) -> ffi::c_int {
+    let step: unsafe extern "C" fn(*mut ffi::c_void, ffi::c_int, *mut *mut ffi::c_void) =
+        std::mem::transmute(step_raw);
+    let final_: unsafe extern "C" fn(*mut ffi::c_void) = std::mem::transmute(final_raw);
+    let destroy: Option<unsafe extern "C" fn(*mut ffi::c_void)> =
+        destroy_raw.map(|f| std::mem::transmute(f));
+
+    let name_c = match CStr::from_ptr(name).to_str() {
+        Ok(s) => match CString::new(s) {
+            Ok(c) => c,
+            Err(_) => return SQLITE_MISUSE,
+        },
+        Err(_) => return SQLITE_MISUSE,
+    };
+
+    let bridge = Box::into_raw(Box::new(AggBridge {
+        step,
+        final_,
+        p_app: context,
+        db,
+        destroy,
+    }));
+
+    let db_ref = &*db;
+    let inner = db_ref.inner.lock().unwrap();
+    let api = inner.conn._build_turso_ext();
+    let rc = (api.register_aggregate_function)(
+        api.ctx,
+        name_c.as_ptr(),
+        n_args,
+        bridge as usize,
+        agg_init,
+        agg_step,
+        agg_finalize,
+        Some(agg_ctx_destructor),
+        None,
+        None,
+    );
+    inner.conn._free_extension_ctx(api);
+
+    if rc != turso_ext::ResultCode::OK {
+        drop(Box::from_raw(bridge));
+        return SQLITE_ERROR;
+    }
+    SQLITE_OK
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_create_function_v2(
     db: *mut sqlite3,
@@ -3175,10 +3320,15 @@ pub unsafe extern "C" fn sqlite3_create_function_v2(
     if db.is_null() || name.is_null() {
         return SQLITE_MISUSE;
     }
-    // Only scalar functions (xFunc) are supported for now; skip aggregate registration.
+    // An aggregate provides xStep + xFinal and no xFunc.
     let x_func_raw = match func {
         Some(f) => f,
-        None => return SQLITE_OK,
+        None => match (_step, _final_) {
+            (Some(step), Some(final_)) => {
+                return register_aggregate(db, name, _n_args, context, step, final_, _destroy);
+            }
+            _ => return SQLITE_OK,
+        },
     };
     // Cast the opaque fn() pointer to the real scalar callback signature.
     let x_func: unsafe extern "C" fn(*mut ffi::c_void, ffi::c_int, *mut *mut ffi::c_void) =

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -476,16 +476,20 @@ pub unsafe extern "C" fn sqlite3_open(
         Ok(s) => s,
         Err(_) => return SQLITE_MISUSE,
     };
-    let io: Arc<dyn turso_core::IO> = match filename_str {
-        ":memory:" => Arc::new(turso_core::MemoryIO::new()),
-        _ => match turso_core::PlatformIO::new() {
+    // An empty filename requests a private temporary database, backed here
+    // by a private in-memory database (see sqlite3_open_v2).
+    let is_memory = filename_str == ":memory:" || filename_str.is_empty();
+    let io: Arc<dyn turso_core::IO> = if is_memory {
+        Arc::new(turso_core::MemoryIO::new())
+    } else {
+        match turso_core::PlatformIO::new() {
             Ok(io) => Arc::new(io),
             Err(_) => return SQLITE_CANTOPEN,
-        },
+        }
     };
     match turso_core::Database::open_file_with_flags(
         io.clone(),
-        filename_str,
+        if is_memory { ":memory:" } else { filename_str },
         turso_core::OpenFlags::default(),
         default_db_opts(),
         None,
@@ -493,9 +497,10 @@ pub unsafe extern "C" fn sqlite3_open(
     ) {
         Ok(db) => {
             let conn = db.connect().unwrap();
-            let filename = match filename_str {
-                ":memory:" => CString::new("".to_string()).unwrap(),
-                _ => CString::from(filename_cstr),
+            let filename = if is_memory {
+                CString::new("".to_string()).unwrap()
+            } else {
+                CString::from(filename_cstr)
             };
             *db_out = Box::leak(Box::new(sqlite3::new(io, db, conn, filename)));
             SQLITE_OK
@@ -641,7 +646,14 @@ pub unsafe extern "C" fn sqlite3_open_v2(
                 Ok(result) => result,
                 Err(()) => return SQLITE_CANTOPEN,
             }
-        } else if (flags & SQLITE_OPEN_MEMORY) != 0 || filename_str == ":memory:" {
+        } else if (flags & SQLITE_OPEN_MEMORY) != 0
+            || filename_str == ":memory:"
+            || filename_str.is_empty()
+        {
+            // An empty filename requests a private temporary database. SQLite
+            // backs it with a temp file; a private in-memory database is the
+            // same "private and discarded on close" contract, differing only
+            // in storage medium.
             (":memory:".to_string(), true, false)
         } else {
             (filename_str.to_string(), false, false)

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -3042,21 +3042,106 @@ pub unsafe extern "C" fn sqlite3_create_collation(
     name: *const ffi::c_char,
     enc: ffi::c_int,
     context: *mut ffi::c_void,
-    cmp: Option<unsafe extern "C" fn() -> ffi::c_int>,
+    cmp: Option<sqlite3_collation_compare>,
 ) -> ffi::c_int {
     sqlite3_create_collation_v2(db, name, enc, context, cmp, None)
 }
 
+/// SQLite's collation comparator: (pArg, nLeft, pLeft, nRight, pRight) -> int.
+pub type sqlite3_collation_compare = unsafe extern "C" fn(
+    *mut ffi::c_void,
+    ffi::c_int,
+    *const ffi::c_void,
+    ffi::c_int,
+    *const ffi::c_void,
+) -> ffi::c_int;
+
+/// Bridges one registered collation from turso_core's comparator ABI to the
+/// SQLite one. Boxed and handed to core as the opaque context; the trampoline
+/// and destructor below reconstitute it.
+struct CollationBridge {
+    cmp: sqlite3_collation_compare,
+    p_app: *mut ffi::c_void,
+    destroy: Option<unsafe extern "C" fn(*mut ffi::c_void)>,
+}
+
+/// turso_core's comparator passes (context, lptr, llen, rptr, rlen); SQLite's
+/// comparator wants (pArg, llen, lptr, rlen, rptr), so the arguments are
+/// reordered here.
+unsafe extern "C" fn collation_trampoline(
+    context: usize,
+    left_ptr: *const u8,
+    left_len: usize,
+    right_ptr: *const u8,
+    right_len: usize,
+) -> i32 {
+    let bridge = &*(context as *const CollationBridge);
+    (bridge.cmp)(
+        bridge.p_app,
+        left_len as ffi::c_int,
+        left_ptr as *const ffi::c_void,
+        right_len as ffi::c_int,
+        right_ptr as *const ffi::c_void,
+    )
+}
+
+/// Frees the boxed CollationBridge, first running the caller's xDestroy on
+/// its application data.
+unsafe extern "C" fn collation_ctx_destructor(context: usize) {
+    let bridge = Box::from_raw(context as *mut CollationBridge);
+    if let Some(destroy) = bridge.destroy {
+        destroy(bridge.p_app);
+    }
+}
+
+/// Registers a user collation. A NULL comparator unregisters the name, as in
+/// SQLite. `enc` is accepted and ignored: turso_core is UTF-8 only.
 #[no_mangle]
 pub unsafe extern "C" fn sqlite3_create_collation_v2(
-    _db: *mut sqlite3,
-    _name: *const ffi::c_char,
+    db: *mut sqlite3,
+    name: *const ffi::c_char,
     _enc: ffi::c_int,
-    _context: *mut ffi::c_void,
-    _cmp: Option<unsafe extern "C" fn() -> ffi::c_int>,
-    _destroy: Option<unsafe extern "C" fn()>,
+    context: *mut ffi::c_void,
+    cmp: Option<sqlite3_collation_compare>,
+    destroy: Option<unsafe extern "C" fn(*mut ffi::c_void)>,
 ) -> ffi::c_int {
-    SQLITE_ERROR
+    if db.is_null() || name.is_null() {
+        return SQLITE_MISUSE;
+    }
+    let db: &sqlite3 = &*db;
+    let inner = match db.inner.lock() {
+        Ok(guard) => guard,
+        Err(_) => return SQLITE_MISUSE,
+    };
+    let name = match CStr::from_ptr(name).to_str() {
+        Ok(s) => s.to_string(),
+        Err(_) => return SQLITE_MISUSE,
+    };
+
+    match cmp {
+        None => {
+            inner.conn.unregister_external_collation(&name);
+            // A destructor supplied with a NULL comparator still owns the
+            // application data.
+            if let Some(destroy) = destroy {
+                destroy(context);
+            }
+        }
+        Some(cmp) => {
+            let bridge = Box::into_raw(Box::new(CollationBridge {
+                cmp,
+                p_app: context,
+                destroy,
+            }));
+            inner.conn.register_external_collation(
+                name,
+                bridge as usize,
+                collation_trampoline,
+                Some(collation_ctx_destructor),
+            );
+        }
+    }
+    SQLITE_OK
 }
 
 /// The pre-v2 registration entry point: identical to

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -594,6 +594,13 @@ fn parse_uri_filename(uri: &str) -> Result<(String, bool, bool), ()> {
         percent_decode(raw_path).ok_or(())?
     };
 
+    // An empty URI path (e.g. "file:?cache=shared") requests a private
+    // temporary database, backed by an in-memory one as elsewhere.
+    let path = if path.is_empty() {
+        ":memory:".to_string()
+    } else {
+        path
+    };
     let mut is_memory = path == ":memory:";
     let mut cache_shared = false;
     if let Some(query) = query {

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -2243,10 +2243,16 @@ pub unsafe extern "C" fn sqlite3_column_name(
     stmt: *mut sqlite3_stmt,
     idx: ffi::c_int,
 ) -> *const ffi::c_char {
-    let idx = idx.try_into().unwrap();
+    if stmt.is_null() || idx < 0 {
+        return std::ptr::null();
+    }
     let stmt = &mut *stmt;
+    // Out-of-range column: SQLite returns NULL rather than erroring.
+    if idx as usize >= stmt.stmt.num_columns() {
+        return std::ptr::null();
+    }
 
-    let binding = stmt.stmt.get_column_name(idx).into_owned();
+    let binding = stmt.stmt.get_column_name(idx as usize).into_owned();
     let val = binding.as_str();
 
     if val.is_empty() {

--- a/bindings/tcl/turso_tcl.c
+++ b/bindings/tcl/turso_tcl.c
@@ -867,9 +867,9 @@ static int TursoDbCmd(ClientData cd, Tcl_Interp *interp,
             sql_n_args,
             0, /* SQLITE_UTF8 */
             (void *)func_data,
-            (void (*)(void))tcl_scalar_bridge,
+            (void (*)(sqlite3_context *, int, sqlite3_value **))tcl_scalar_bridge,
             NULL, NULL,
-            (void (*)(void))tcl_func_destroy
+            (void (*)(void *))tcl_func_destroy
         );
 
         if (rc != SQLITE_OK) {


### PR DESCRIPTION
## Goal

Support the **unmodified** PHP SQLite driver on Turso. PHP's `ext/sqlite3` and `pdo_sqlite` are thin C wrappers over libsqlite3, so the path to a first-class PHP driver is to make `libturso_sqlite3` (our `bindings/c` crate) a faithful drop-in — then php-src's own extension code, and its own test suite, come along unchanged.

We validate exactly that way: we build php-src 8.5.2's **unmodified** `ext/sqlite3` + `pdo_sqlite` against this header and library, and run PHP's own `.phpt` conformance suites against the result. (The build/run harness lives on a separate branch and is not part of this PR — it's a local yardstick until the suites are green.)

## Where we are

**264 / 287 (92%) of PHP's `ext/sqlite3` + `pdo_sqlite` conformance tests pass**, up from a starting point where opening a connection aborted the process (php-src calls `sqlite3_set_authorizer` unconditionally at open, and that was a panicking stub).

This PR is the set of `bindings/c` changes that got us there, one issue per commit:

- **Complete the `sqlite3.h` ABI surface, stop stubs panicking.** Opaque `sqlite3_context`/`value`/`blob`/`backup` types, exact callback signatures, full result-code and `SQLITE_OPEN_*` constant sets, non-v2 `create_function`/`create_collation` wrappers, version macros, `SQLITE_OMIT_LOAD_EXTENSION`. Every remaining unimplemented entry point returns its contract's failure value instead of panicking (a panic across `extern "C"` aborts the host).
- **SQLite-bare error messages.** `sqlite3_errmsg`/`sqlite3_exec` return the bare message ("no such table: t"), stripping turso_core's "<Category> error: " Display prefix; `sqlite3_exec` surfaces the real error text instead of a fabricated one.
- **`sqlite3_column_name`** returns NULL for an out-of-range index instead of panicking.
- **Empty filename / empty URI path** open a private temporary database, as SQLite does.
- **`sqlite3_create_collation(_v2)`** — bridged to core's `register_external_collation`.
- **Aggregate UDFs + `sqlite3_aggregate_context`** — bridged to core's init/step/finalize ABI, with per-group state.

All changes are `bindings/c`-only; collations and aggregates use registration hooks that already exist in `turso_core`. Verified against the existing C differential suite (linked against both libsqlite3 and libturso_sqlite3) and the Rust compat tests — no regressions.

## Remaining (not in this PR)

- **Intentional divergence, documented allowlist:** authorizer, backup (both currently return errors — deliberately unsupported unless demand appears), transaction-locking error semantics (Turso keeps its own concurrency model), and two collation tests that assert SQLite's internal comparison *count* (our sort results are identical).
- **Needs follow-up work:** extended constraint result codes (needs core to distinguish PRIMARYKEY/UNIQUE/NOTNULL), the error-carrying handle SQLite returns on a failed open, and a couple of PDO `getColumnMeta` metadata details.

Opening as a **draft** for review of the direction and the per-commit shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
