### PR TITLE
core/mvcc: tolerate evicted transactions in conflict validation

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -6231,6 +6231,21 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 dep_set.is_empty(),
                 "remove_tx({tx_id}): commit_dep_set is not empty"
             );
+            // Invariant: a committed writer must be findable in
+            // `finalized_tx_states` before it leaves `txs`. Other transactions'
+            // commit validation (`check_version_conflicts`) and visibility
+            // checks (`is_end_visible`) look a tombstone's TxID marker up in
+            // `txs` first and `finalized_tx_states` second; a writer absent
+            // from both is treated as "no conflict" / "visible", so reordering
+            // the insert above after this remove would let a conflicting
+            // commit through instead of returning WriteWriteConflict.
+            turso_assert!(
+                !matches!(tx.state.load(), TransactionState::Committed(_))
+                    || tx.write_set.lock().is_empty()
+                    || lookup_finalized_tx_state(&self.finalized_tx_states, tx_id).is_some(),
+                "committed writer must be visible in finalized_tx_states before leaving txs",
+                { "tx_id": tx_id }
+            );
             self.txs.remove(&tx_id);
             if held_checkpoint_read {
                 self.blocking_checkpoint_lock.unlock();

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1904,21 +1904,26 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 // in-flight tombstones (end: TxID) from other transactions.
                 if let Some(TxTimestampOrID::TxID(other_tx_id)) = version.end() {
                     if other_tx_id != self.tx_id {
-                        let other_tx = mvcc_store.txs.get(&other_tx_id).expect(
-                            "check_version_conflicts: tombstone end TxID not found in txn map",
+                        // The other transaction may already have moved from
+                        // `txs` to `finalized_tx_states`; consult both
+                        // instead of panicking on the race.
+                        let other_state = lookup_tx_state(
+                            &mvcc_store.txs,
+                            &mvcc_store.finalized_tx_states,
+                            other_tx_id,
                         );
-                        let other_tx = other_tx.value();
-                        match other_tx.state.load() {
-                            TransactionState::Committed(_) => {
+                        match other_state {
+                            Some(TransactionState::Committed(_)) => {
                                 return Err(LimboError::WriteWriteConflict);
                             }
-                            TransactionState::Preparing(other_end_ts) => {
+                            Some(TransactionState::Preparing(other_end_ts)) => {
                                 if other_end_ts < end_ts {
                                     return Err(LimboError::WriteWriteConflict);
                                 }
                             }
-                            TransactionState::Active => {}
-                            TransactionState::Aborted | TransactionState::Terminated => {}
+                            Some(TransactionState::Active) => {}
+                            Some(TransactionState::Aborted | TransactionState::Terminated)
+                            | None => {}
                         }
                     }
                 }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -20568,3 +20568,67 @@ fn truncate_checkpoint_is_busy_while_a_reader_transaction_is_open() {
     // Now that the reader is gone, Truncate can proceed.
     writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
 }
+
+/// What this test checks: commit-time conflict validation reports a
+/// write-write conflict, instead of panicking, when it meets an in-flight
+/// B-tree tombstone whose writer has already been evicted from the live
+/// transaction map into `finalized_tx_states`.
+/// Why this matters: eviction (`remove_tx`) runs concurrently with other
+/// transactions' commit validation. Validation reads the tombstone's TxID
+/// marker first and looks the writer up second, so the writer can move maps
+/// in between; this used to panic with "tombstone end TxID not found in txn
+/// map" and take the process down. Found by the FTS concurrent-writers fuzz
+/// soak.
+#[test]
+fn commit_validation_reports_conflict_for_evicted_tombstone_writer() {
+    let db = MvccTestDb::new();
+
+    // T1 creates the row so a version chain exists.
+    let tx1 = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+    db.mvcc_store
+        .insert(tx1, generate_simple_string_row((-2).into(), 1, "original"))
+        .unwrap();
+    commit_tx(db.mvcc_store.clone(), &db.conn, tx1).unwrap();
+
+    // T2 updates the row, putting it into T2's write set so T2's commit
+    // walks this version chain.
+    let conn2 = db.db.connect().unwrap();
+    let tx2 = db.mvcc_store.begin_tx(conn2.pager.load().clone()).unwrap();
+    assert!(db
+        .mvcc_store
+        .update(tx2, generate_simple_string_row((-2).into(), 1, "updated"))
+        .unwrap());
+
+    // Recreate the state T2's validation observes mid-race: another
+    // transaction deleted the B-tree-resident row, its tombstone still
+    // carries the in-flight TxID marker, and the writer itself has already
+    // committed and been evicted from `txs` into `finalized_tx_states`.
+    let evicted_writer: TxID = 9999;
+    db.mvcc_store
+        .insert_finalized_tx_state(evicted_writer, 1000)
+        .unwrap();
+    let row_id = RowID {
+        table_id: (-2).into(),
+        row_id: RowKey::Int(1),
+    };
+    let entry = db.mvcc_store.rows.get(&row_id).unwrap();
+    entry.value().write().push(RowVersion {
+        id: 0,
+        begin: PackedTs::pack(None),
+        end: PackedTs::pack(Some(TxTimestampOrID::TxID(evicted_writer))),
+        row: generate_simple_string_row((-2).into(), 1, "original"),
+        btree_resident: true,
+        materialized_at: WalPos::ORIGIN,
+    });
+    drop(entry);
+
+    // The evicted writer committed, so T2 must lose with a write-write
+    // conflict — not a panic.
+    assert!(matches!(
+        commit_tx(db.mvcc_store.clone(), &conn2, tx2),
+        Err(LimboError::WriteWriteConflict)
+    ));
+}


### PR DESCRIPTION
`check_version_conflicts` expected the writing transaction behind an in-flight tombstone to still be resident in the transaction map and panicked when it had already moved to `finalized_tx_states`; look the state up through `lookup_tx_state` and treat eviction like the finalized outcome it represents. Found by the FTS concurrent-writers fuzz (which lands later in this stack).

The regression test rebuilds the mid-race state directly, a B-tree tombstone still carrying its writer's TxID marker while that committed writer only exists in `finalized_tx_states` and pins the outcome: the competing commit gets WriteWriteConflict instead of a panic.
