### PR TITLE
core/schema: add collation property in to_sql output for btree table

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3681,7 +3681,8 @@ impl BTreeTable {
                         sql.push_str(&quote_ident(&collation.name()));
                     }
                     CollationSeq::Unset | CollationSeq::Custom(_) => {
-                        unreachable!("stored column with non-renderable collation found")
+                        // Unset should not be reachable -- ignore it
+                        // Custom collation is not allowed in schema definitions
                     }
                 };
             }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -3649,6 +3649,7 @@ impl BTreeTable {
                     sql.push_str("[]");
                 }
             }
+
             if column.notnull()
                 && (column.explicit_notnull() || !self.is_without_rowid_inline_pk(column))
             {
@@ -3668,6 +3669,21 @@ impl BTreeTable {
             if let Some(default) = &column.default {
                 sql.push_str(" DEFAULT ");
                 sql.push_str(&default.to_string());
+            }
+
+            if let Some(collation) = column.collation_opt() {
+                match collation {
+                    CollationSeq::Binary => sql.push_str(" COLLATE BINARY"),
+                    CollationSeq::NoCase => sql.push_str(" COLLATE NOCASE"),
+                    CollationSeq::Rtrim => sql.push_str(" COLLATE RTRIM"),
+                    CollationSeq::Locale(_) => {
+                        sql.push_str(" COLLATE ");
+                        sql.push_str(&quote_ident(&collation.name()));
+                    }
+                    CollationSeq::Unset | CollationSeq::Custom(_) => {
+                        unreachable!("stored column with non-renderable collation found")
+                    }
+                };
             }
 
             if let GeneratedType::Virtual { original_sql, .. } = &column.generated_type() {

--- a/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
@@ -3016,3 +3016,47 @@ test alter-table-add-column-nonconstant-default-nonempty-table-errors {
 expect error {
     Cannot add a column with non-constant default
 }
+
+# The following preserve-schema-collate tests ensure that alter table
+# preserve the original collation defined on table creation.
+# https://github.com/tursodatabase/turso/issues/8254
+@cross-check-integrity
+test alter-table-add-column-preserve-schema-collate-nocase {
+    CREATE TABLE tbl (c TEXT COLLATE NOCASE);
+    ALTER TABLE tbl ADD COLUMN d;
+    SELECT sql FROM sqlite_schema WHERE name = 'tbl';
+}
+expect {
+    CREATE TABLE tbl (c TEXT COLLATE NOCASE, d)
+}
+
+@cross-check-integrity
+test alter-table-add-column-preserve-schema-collate-rtrim {
+    CREATE TABLE tbl (c TEXT COLLATE RTRIM);
+    ALTER TABLE tbl ADD COLUMN d;
+    SELECT sql FROM sqlite_schema WHERE name = 'tbl';
+}
+expect {
+    CREATE TABLE tbl (c TEXT COLLATE RTRIM, d)
+}
+
+@cross-check-integrity
+test alter-table-add-column-preserve-schema-collate-binary {
+    CREATE TABLE tbl (c TEXT COLLATE BINARY);
+    ALTER TABLE tbl ADD COLUMN d;
+    SELECT sql FROM sqlite_schema WHERE name = 'tbl';
+}
+expect {
+    CREATE TABLE tbl (c TEXT COLLATE BINARY, d)
+}
+
+@cross-check-integrity
+@skip-if sqlite "SQLite does not support locale-based collation"
+test alter-table-add-column-preserve-schema-collate-locale {
+    CREATE TABLE tbl (c TEXT COLLATE 'fr-FR');
+    ALTER TABLE tbl ADD COLUMN d;
+    SELECT sql FROM sqlite_schema WHERE name = 'tbl';
+}
+expect {
+    CREATE TABLE tbl (c TEXT COLLATE "fr-FR", d)
+}

--- a/tests/integration/query_processing/test_alter_table_reopen.rs
+++ b/tests/integration/query_processing/test_alter_table_reopen.rs
@@ -225,3 +225,41 @@ fn test_alter_add_generated_column_succeeds_with_flag() {
         conn.close().unwrap();
     }
 }
+
+#[test]
+fn test_alter_table_add_column_preserves_collation_on_reopen() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir
+        .path()
+        .join("alter_table_add_col_collate_reopen.db");
+
+    // Session 1: create table with collate nocase column, insert value, then add another column
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+        conn.execute("CREATE TABLE tbl (col1 TEXT COLLATE NOCASE)")
+            .unwrap();
+        conn.execute("INSERT INTO tbl VALUES ('ABC')").unwrap();
+        conn.execute("ALTER TABLE tbl ADD COLUMN extra TEXT")
+            .unwrap();
+        conn.close().unwrap();
+    }
+
+    // Session 2: reopen connection and check if collation property still holds
+    {
+        let db = TempDatabase::new_with_existent(&path);
+        let conn = db.connect_limbo();
+
+        let col_schema: Vec<(String,)> =
+            conn.exec_rows("SELECT sql FROM sqlite_schema WHERE name = 'tbl'");
+        assert_eq!(
+            col_schema,
+            vec![("CREATE TABLE tbl (col1 TEXT COLLATE NOCASE, extra TEXT)".to_string(),)]
+        );
+
+        let check_collate_res: Vec<(i64,)> =
+            conn.exec_rows("SELECT count(*) FROM tbl WHERE col1 = 'abc'");
+        assert_eq!(check_collate_res, vec![(1,)]);
+        conn.close().unwrap();
+    }
+}


### PR DESCRIPTION
## Description

Collation info for a column ends up getting dropped from `sqlite_schema` whenever the table containing that column gets altered. Turns out collation was never checked or added to the `to_sql` output (which the ALTER TABLE path uses for schema info) for `BTreeTable`, this PR fixes that. Without this change, the actual collation property (the logic that actually implements the collation behavior for the column) will get dropped from the column when the DB connection closes and reopens, making subsequent queries upon reopen against that column potentially incorrect.

Tests: Added an integration test that models the tests that were described in the issue. Also adds sqltests to check that the correct schema is preserved in `sqlite_schema` table.

Fixes: https://github.com/tursodatabase/turso/issues/8254

## Description of AI Usage
OpenCode with GLM 5.2 for reviewing code and quickly finding relevant parts of the codebase for the change. All code was handwritten by me.