### PR TITLE
serverless/compat: add reconnect support

### DIFF
--- a/serverless/javascript/integration-tests/compat.test.mjs
+++ b/serverless/javascript/integration-tests/compat.test.mjs
@@ -84,3 +84,68 @@ test.serial('compat execute preserves lastInsertRowid of 0', async t => {
 
   client.close();
 });
+
+test.serial('reconnect restores usability after close', async t => {
+  const client = createClient({
+    url: 'http://localhost:0',
+  });
+
+  client.close();
+  t.true(client.closed);
+
+  const error = await t.throwsAsync(async () => {
+    await client.execute('SELECT 1');
+  }, { instanceOf: LibsqlError });
+  t.is(error.code, 'CLIENT_CLOSED');
+
+  client.reconnect();
+  t.false(client.closed);
+
+  client.session.execute = async () => ({
+    columns: ['1'],
+    columnTypes: ['INTEGER'],
+    rows: [[1]],
+    rowsAffected: 0,
+    lastInsertRowid: undefined,
+  });
+
+  const result = await client.execute('SELECT 1');
+  t.is(result.rows[0][0], 1);
+
+  client.close();
+});
+
+test.serial('reconnect works while client is active', async t => {
+  const client = createClient({
+    url: 'http://localhost:0',
+  });
+
+  client.session.execute = async () => ({
+    columns: ['1'],
+    columnTypes: ['INTEGER'],
+    rows: [[1]],
+    rowsAffected: 0,
+    lastInsertRowid: undefined,
+  });
+
+  const result1 = await client.execute('SELECT 1');
+  t.is(result1.rows[0][0], 1);
+
+  const oldSession = client.session;
+  client.reconnect();
+  t.false(client.closed);
+  t.not(client.session, oldSession);
+
+  client.session.execute = async () => ({
+    columns: ['2'],
+    columnTypes: ['INTEGER'],
+    rows: [[2]],
+    rowsAffected: 0,
+    lastInsertRowid: undefined,
+  });
+
+  const result2 = await client.execute('SELECT 2');
+  t.is(result2.rows[0][0], 2);
+
+  client.close();
+});

--- a/serverless/javascript/src/compat.ts
+++ b/serverless/javascript/src/compat.ts
@@ -157,6 +157,7 @@ export interface Client {
   close(): void;
   closed: boolean;
   protocol: string;
+  reconnect(): void;
 }
 
 class LibSQLClient implements Client {
@@ -513,6 +514,14 @@ class LibSQLClient implements Client {
     this.session.close().catch(error => {
       console.error('Error closing session:', error);
     });
+  }
+
+  reconnect(): void {
+    this._closed = false;
+    this.session.close().catch(error => {
+      console.error('Error closing session during reconnect:', error);
+    });
+    this.session = new Session(this.sessionConfig);
   }
 }
 

--- a/serverless/javascript/src/compat.ts
+++ b/serverless/javascript/src/compat.ts
@@ -517,10 +517,15 @@ class LibSQLClient implements Client {
   }
 
   reconnect(): void {
+    const wasOpen = !this._closed;
     this._closed = false;
-    this.session.close().catch(error => {
-      console.error('Error closing session during reconnect:', error);
-    });
+
+    if (wasOpen) {
+      this.session.close().catch(error => {
+        console.error('Error closing session during reconnect:', error);
+      });
+    }
+
     this.session = new Session(this.sessionConfig);
   }
 }


### PR DESCRIPTION
## Description

Adds the missing `reconnect(): void` method to the `@tursodatabase/serverless/compat` client.
The method resets the closed state, closes the previous session asynchronously, and replaces it with a fresh lazy Session.
Also adds regression coverage for reconnecting after `close()` and reconnecting an already active client.
<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

`@tursodatabase/serverless/compat` is intended to provide compatibility with the `@libsql/client` Client interface, but it was missing `reconnect()`.

This prevented the compat client from being a complete drop-in replacement and meant a closed client could not be restored for further use.

Fixes #8451
<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->


## Description of AI Usage

AI was used as an assistant during repository exploration, implementation planning, and test development. The implementation and resulting diff were reviewed and validated manually.
<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
