### PR TITLE
core/pragma: apply auto_vacuum on a fresh database

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,16 @@ name = "turso_core"
 path = "lib.rs"
 
 [features]
-default = ["fs", "uuid", "time", "json", "series", "encryption", "percentile"]
+default = [
+    "fs",
+    "uuid",
+    "time",
+    "json",
+    "series",
+    "encryption",
+    "percentile",
+    "autovacuum",
+]
 tracing_release = ["tracing/release_max_level_info"]
 conn_raw_api = []
 # Harness-side observability: turns on aristo's instrument surface so the
@@ -32,7 +41,7 @@ io_uring = ["dep:io-uring", "rustix/io_uring"]
 experimental_win_iocp = []
 time = []
 fuzz = []
-omit_autovacuum = []
+autovacuum = []
 simulator = ["fuzz", "serde", "io_memory_yield", "allocation_metric"]
 allocation_metric = []
 # Test only: exposed to testing/stress and the simulator, never to regular library users.

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -68,7 +68,7 @@ static PENDING_BYTE: AtomicU32 = AtomicU32::new(0x40000000);
 /// Byte offset that signifies the start of the ignored page - 1 GB mark
 const PENDING_BYTE: u32 = 0x40000000;
 
-#[cfg(not(feature = "omit_autovacuum"))]
+#[cfg(feature = "autovacuum")]
 use ptrmap::*;
 
 #[derive(Debug, Clone)]
@@ -1182,7 +1182,7 @@ const fn auto_vacuum_header_fields(mode: AutoVacuumMode) -> (u32, u32) {
 }
 
 #[derive(Debug, Clone)]
-#[cfg(not(feature = "omit_autovacuum"))]
+#[cfg(feature = "autovacuum")]
 enum PtrMapGetState {
     Start,
     Deserialize {
@@ -1192,7 +1192,7 @@ enum PtrMapGetState {
 }
 
 #[derive(Debug, Clone)]
-#[cfg(not(feature = "omit_autovacuum"))]
+#[cfg(feature = "autovacuum")]
 enum PtrMapPutState {
     Start,
     Deserialize {
@@ -1210,7 +1210,7 @@ enum HeaderRefState {
     },
 }
 
-#[cfg(not(feature = "omit_autovacuum"))]
+#[cfg(feature = "autovacuum")]
 #[derive(Debug, Clone, Copy)]
 enum BtreeCreateVacuumFullState {
     Start,
@@ -1395,7 +1395,7 @@ pub struct Pager {
     /// Maximum number of pages allowed in the database. Default is 1073741823 (SQLite default).
     max_page_count: AtomicU32,
     header_ref_state: RwLock<HeaderRefState>,
-    #[cfg(not(feature = "omit_autovacuum"))]
+    #[cfg(feature = "autovacuum")]
     vacuum_state: RwLock<VacuumState>,
     pub(crate) io_ctx: RwLock<IOContext>,
     /// encryption is an opt-in feature. we will enable it only if the flag is passed
@@ -1509,7 +1509,7 @@ impl SpillYieldHook {
     }
 }
 
-#[cfg(not(feature = "omit_autovacuum"))]
+#[cfg(feature = "autovacuum")]
 pub struct VacuumState {
     /// State machine for [Pager::ptrmap_get]
     ptrmap_get_state: PtrMapGetState,
@@ -1685,7 +1685,7 @@ impl Pager {
             allocate_page_state: RwLock::new(AllocatePageState::Start),
             max_page_count: AtomicU32::new(DEFAULT_MAX_PAGE_COUNT),
             header_ref_state: RwLock::new(HeaderRefState::Start),
-            #[cfg(not(feature = "omit_autovacuum"))]
+            #[cfg(feature = "autovacuum")]
             vacuum_state: RwLock::new(VacuumState {
                 ptrmap_get_state: PtrMapGetState::Start,
                 ptrmap_put_state: PtrMapPutState::Start,
@@ -2406,7 +2406,7 @@ impl Pager {
     /// Retrieves the pointer map entry for a given database page.
     /// `target_page_num` (1-indexed) is the page whose entry is sought.
     /// Returns `Ok(None)` if the page is not supposed to have a ptrmap entry (e.g. header, or a ptrmap page itself).
-    #[cfg(not(feature = "omit_autovacuum"))]
+    #[cfg(feature = "autovacuum")]
     pub fn ptrmap_get(&self, target_page_num: u32) -> Result<IOResult<Option<PtrmapEntry>>> {
         loop {
             let ptrmap_get_state = {
@@ -2495,7 +2495,7 @@ impl Pager {
     /// Writes or updates the pointer map entry for a given database page.
     /// `db_page_no_to_update` (1-indexed) is the page whose entry is to be set.
     /// `entry_type` and `parent_page_no` define the new entry.
-    #[cfg(not(feature = "omit_autovacuum"))]
+    #[cfg(feature = "autovacuum")]
     pub fn ptrmap_put(
         &self,
         db_page_no_to_update: u32,
@@ -2601,14 +2601,14 @@ impl Pager {
             _ if flags.is_index() => PageType::IndexLeaf,
             _ => unreachable!("Invalid flags state"),
         };
-        #[cfg(feature = "omit_autovacuum")]
+        #[cfg(not(feature = "autovacuum"))]
         {
             let page = return_if_io!(self.do_allocate_page(page_type, 0, BtreePageAllocMode::Any));
             Ok(IOResult::Done(page.get().id as u32))
         }
 
         //  If autovacuum is enabled, we need to allocate a new page number that is greater than the largest root page number
-        #[cfg(not(feature = "omit_autovacuum"))]
+        #[cfg(feature = "autovacuum")]
         {
             let auto_vacuum_mode =
                 AutoVacuumMode::from(self.auto_vacuum_mode.load(Ordering::SeqCst));
@@ -5428,13 +5428,13 @@ impl Pager {
             match &mut *state {
                 AllocatePageState::Start => {
                     let old_db_size = header.database_size.get();
-                    #[cfg(not(feature = "omit_autovacuum"))]
+                    #[cfg(feature = "autovacuum")]
                     let mut new_db_size = old_db_size;
-                    #[cfg(feature = "omit_autovacuum")]
+                    #[cfg(not(feature = "autovacuum"))]
                     let new_db_size = old_db_size;
 
                     tracing::debug!("allocate_page(database_size={})", new_db_size);
-                    #[cfg(not(feature = "omit_autovacuum"))]
+                    #[cfg(feature = "autovacuum")]
                     {
                         //  If the following conditions are met, allocate a pointer map page, add to cache and increment the database size
                         //  - autovacuum is enabled
@@ -5748,7 +5748,7 @@ impl Pager {
         *self.allocate_page_state.write() = AllocatePageState::Start;
         *self.free_page_state.write() = FreePageState::Start;
         *self.spill_state.write() = SpillState::Idle;
-        #[cfg(not(feature = "omit_autovacuum"))]
+        #[cfg(feature = "autovacuum")]
         {
             let mut vacuum_state = self.vacuum_state.write();
             vacuum_state.ptrmap_get_state = PtrMapGetState::Start;
@@ -5994,7 +5994,7 @@ impl CreateBTreeFlags {
 ** PTRMAP_BTREE: The database page is a non-root btree page. The page number
 **               identifies the parent page in the btree.
 */
-#[cfg(not(feature = "omit_autovacuum"))]
+#[cfg(feature = "autovacuum")]
 pub(crate) mod ptrmap {
     #[allow(unused_imports)]
     use crate::{storage::sqlite3_ondisk::PageSize, LimboError, Result};
@@ -6319,7 +6319,7 @@ mod tests {
 }
 
 #[cfg(test)]
-#[cfg(not(feature = "omit_autovacuum"))]
+#[cfg(feature = "autovacuum")]
 mod ptrmap_tests {
     use crate::sync::Arc;
 

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -541,17 +541,9 @@ fn update_pragma(
                 ));
             }
 
-            let is_empty = is_database_empty(resolver.schema(), &pager)?;
-            tracing::debug!(
-                "Checking if database is empty for auto_vacuum pragma: {}",
-                is_empty
-            );
-
-            if !is_empty {
-                // SQLite's behavior is to silently ignore this pragma if the database is not empty.
-                tracing::debug!(
-                    "Attempted to set auto_vacuum, database is not empty so we are ignoring pragma."
-                );
+            // Like SQLite, the auto-vacuum mode is fixed once page 1 exists,
+            // so the pragma is silently ignored after that.
+            if pager.db_initialized() {
                 return Ok(TransactionMode::None);
             }
 
@@ -1919,34 +1911,4 @@ fn update_cache_size(
 fn update_page_size(connection: Arc<crate::Connection>, page_size: u32) -> crate::Result<()> {
     connection.reset_page_size(page_size)?;
     Ok(())
-}
-
-fn is_database_empty(schema: &Schema, pager: &Arc<Pager>) -> crate::Result<bool> {
-    if schema.tables.len() > 1 {
-        return Ok(false);
-    }
-    if let Some(table_arc) = schema.tables.values().next() {
-        let table_name = match table_arc.as_ref() {
-            Table::BTree(tbl) => &tbl.name,
-            Table::Virtual(tbl) => &tbl.name,
-            Table::FromClauseSubquery(tbl) => &tbl.name,
-            Table::RecursiveCteInput(_) => {
-                unreachable!("recursive CTE inputs are not stored in the schema")
-            }
-        };
-
-        if table_name != "sqlite_schema" {
-            return Ok(false);
-        }
-    }
-
-    let db_size_result = pager
-        .io
-        .block(|| pager.with_header(|header| header.database_size.get()));
-
-    match db_size_result {
-        Err(_) => Ok(true),
-        Ok(0 | 1) => Ok(true),
-        Ok(_) => Ok(false),
-    }
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -15956,12 +15956,12 @@ pub fn op_integrity_check(
                 )?;
             }
 
-            #[cfg(not(feature = "omit_autovacuum"))]
+            #[cfg(feature = "autovacuum")]
             let skip_page_never_used = !matches!(
                 target_pager.get_auto_vacuum_mode(),
                 crate::storage::pager::AutoVacuumMode::None
             );
-            #[cfg(feature = "omit_autovacuum")]
+            #[cfg(not(feature = "autovacuum"))]
             let skip_page_never_used = false;
 
             if !skip_page_never_used {

--- a/tests/integration/query_processing/test_vacuum.rs
+++ b/tests/integration/query_processing/test_vacuum.rs
@@ -362,6 +362,72 @@ fn assert_plain_vacuum_preserves_content_hash(
     Ok(())
 }
 
+/// `PRAGMA auto_vacuum=1` on a brand-new database must turn autovacuum on.
+/// The emptiness check used to count the built-in virtual tables
+/// (pragma_*, json_each, ...) as user tables, so it thought every fresh
+/// database was non-empty and silently ignored the pragma.
+#[test]
+fn test_auto_vacuum_pragma_applies_to_fresh_database() -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new().with_autovacuum(true);
+    let tmp_db = TempDatabase::builder().with_opts(opts).build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA auto_vacuum = 1")?;
+    conn.execute("CREATE TABLE t(x)")?;
+    conn.execute("INSERT INTO t VALUES (1), (2), (3)")?;
+
+    assert_eq!(scalar_i64(&conn, "PRAGMA auto_vacuum"), 1);
+    // Page 2 is the first pointer-map page, so the table root lands on page 3.
+    assert_eq!(
+        scalar_i64(&conn, "SELECT rootpage FROM sqlite_schema WHERE name = 't'"),
+        3
+    );
+    assert_eq!(run_integrity_check(&conn), "ok");
+
+    let reopened = TempDatabase::new_with_existent_with_opts(&tmp_db.path, opts);
+    let reopened_conn = reopened.connect_limbo();
+    assert_eq!(scalar_i64(&reopened_conn, "PRAGMA auto_vacuum"), 1);
+    Ok(())
+}
+
+/// SQLite fixes the auto-vacuum mode as soon as page 1 exists, even when the
+/// database has no tables yet. `PRAGMA user_version` writes page 1, so a
+/// later `PRAGMA auto_vacuum=1` must be silently ignored, just like it is
+/// once a table exists. The emptiness check used to look at the schema and
+/// the page count instead, and treated a one-page database as still empty.
+#[test]
+fn test_auto_vacuum_pragma_ignored_once_page_one_exists() -> anyhow::Result<()> {
+    let opts = DatabaseOpts::new().with_autovacuum(true);
+    let tmp_db = TempDatabase::builder().with_opts(opts).build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("PRAGMA user_version = 5")?;
+    conn.execute("PRAGMA auto_vacuum = 1")?;
+    conn.execute("CREATE TABLE t(x)")?;
+
+    assert_eq!(scalar_i64(&conn, "PRAGMA auto_vacuum"), 0);
+    // No pointer-map page was reserved, so the table root is page 2.
+    assert_eq!(
+        scalar_i64(&conn, "SELECT rootpage FROM sqlite_schema WHERE name = 't'"),
+        2
+    );
+    assert_eq!(run_integrity_check(&conn), "ok");
+
+    // SQLite agrees: the same statements leave auto-vacuum off.
+    let sqlite_conn = SqliteConnection::open_in_memory()?;
+    sqlite_conn
+        .execute_batch("PRAGMA user_version = 5; PRAGMA auto_vacuum = 1; CREATE TABLE t(x);")?;
+    assert_eq!(sqlite_scalar_i64(&sqlite_conn, "PRAGMA auto_vacuum"), 0);
+    assert_eq!(
+        sqlite_scalar_i64(
+            &sqlite_conn,
+            "SELECT rootpage FROM sqlite_schema WHERE name = 't'"
+        ),
+        2
+    );
+    Ok(())
+}
+
 fn assert_plain_vacuum_preserves_autovacuum_mode(
     pragma_value: &str,
     expected_mode: i64,


### PR DESCRIPTION
PRAGMA auto_vacuum was silently ignored on every new database because the
emptiness check counted the built-in virtual tables (pragma_*, json_each,
generate_series, ...) as user tables and concluded the database was not
empty. Only a B-tree table other than sqlite_schema means the user has
created something.

Note that I added a Rust integration test because a SQLTest would have
required exposing autovacuum in bindings/rust, which is something we
don't want to do yet because of stability concerns.
