### PR TITLE
github: run each nightly Nyrkiö benchmark in its own step under a memory cap

### DIFF
--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -40,11 +40,67 @@ jobs:
           cp perf/graph-queries/graph-queries.db perf/graph-queries/graph-queries-analyzed.db
           sqlite3 perf/graph-queries/graph-queries-analyzed.db "ANALYZE;"
 
-      - name: Bench
-        # `shell: bash` turns on pipefail, so a benchmark binary that crashes
-        # (e.g. gets OOM-killed) fails this step instead of being hidden by `tee`.
-        shell: bash
-        run: make bench-exclude-tpc-h  2>&1 | tee output.txt
+      # One step per bench binary, so that when a benchmark starves the runner
+      # and GitHub throws the job log away, the step timings still say which
+      # benchmark it was. scripts/nightly-bench.sh explains the rest.
+      - name: Runner facts
+        run: |
+          nproc
+          free -m
+          swapon --show
+          df -hT
+          findmnt -t tmpfs || true
+          ulimit -a
+          cat /proc/self/cgroup
+          if sudo -n true 2>/dev/null; then echo "sudo: yes"; else echo "sudo: no"; fi
+      - name: Build benchmarks
+        run: scripts/nightly-bench.sh build
+      - name: Check every benchmark has a step
+        run: scripts/nightly-bench.sh check .github/workflows/perf_nightly.yml
+      - name: Bench alloc_collections
+        run: scripts/nightly-bench.sh run alloc_collections
+      - name: Bench benchmark
+        run: scripts/nightly-bench.sh run benchmark
+      - name: Bench count_benchmark
+        run: scripts/nightly-bench.sh run count_benchmark
+      - name: Bench create_index_benchmark
+        run: scripts/nightly-bench.sh run create_index_benchmark
+      - name: Bench fts_benchmark
+        run: scripts/nightly-bench.sh run fts_benchmark
+      - name: Bench fts_comparison_benchmark
+        run: scripts/nightly-bench.sh run fts_comparison_benchmark
+      - name: Bench graph_queries_benchmark
+        run: scripts/nightly-bench.sh run graph_queries_benchmark
+      - name: Bench hash_spill_benchmark
+        run: scripts/nightly-bench.sh run hash_spill_benchmark
+      - name: Bench json_benchmark
+        run: scripts/nightly-bench.sh run json_benchmark
+      - name: Bench logical_log_serialization
+        run: scripts/nightly-bench.sh run logical_log_serialization
+      - name: Bench mvcc_benchmark
+        run: scripts/nightly-bench.sh run mvcc_benchmark
+      - name: Bench mvcc_recovery_benchmark
+        run: scripts/nightly-bench.sh run mvcc_recovery_benchmark
+      - name: Bench parser_benchmark
+        run: scripts/nightly-bench.sh run parser_benchmark
+      - name: Bench prepare_benchmark
+        run: scripts/nightly-bench.sh run prepare_benchmark
+      - name: Bench prepare_params_benchmark
+        run: scripts/nightly-bench.sh run prepare_params_benchmark
+      - name: Bench record_recycling
+        run: scripts/nightly-bench.sh run record_recycling
+      - name: Bench select_star_benchmark
+        run: scripts/nightly-bench.sh run select_star_benchmark
+      - name: Bench sql_functions
+        run: scripts/nightly-bench.sh run sql_functions
+      - name: Bench struct_union_benchmark
+        run: scripts/nightly-bench.sh run struct_union_benchmark
+      - name: Bench struct_union_profile
+        run: scripts/nightly-bench.sh run struct_union_profile
+      - name: Bench triggers
+        run: scripts/nightly-bench.sh run triggers
+      - name: Bench write_perf_benchmark
+        run: scripts/nightly-bench.sh run write_perf_benchmark
       - name: Analyze benchmark result with Nyrkiö
         uses: nyrkio/change-detection@f1e26bea1b51177e5d4fe3f83dbc807410c4bc1d
         with:

--- a/scripts/nightly-bench.sh
+++ b/scripts/nightly-bench.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# nightly-bench.sh - run the nightly Criterion suite one benchmark binary per
+# workflow step, so that a benchmark that takes the runner down can be named.
+#
+# Usage:
+#   scripts/nightly-bench.sh build             # compile every bench binary
+#   scripts/nightly-bench.sh check <workflow>  # every built bench has a step
+#   scripts/nightly-bench.sh run <bench>       # run one bench, append output.txt
+#
+# The nightly runner has 4 CPUs and 8 GiB of RAM and no swap. A benchmark that
+# grows past that starts thrashing, and the GitHub runner agent stops answering
+# the server before the kernel gets around to killing the benchmark. GitHub
+# then reports "the self-hosted runner lost communication with the server" and
+# throws the whole job log away, so nothing says which benchmark it was.
+#
+# Two things here make that failure honest instead of silent:
+#   - `run` puts an address-space limit on the benchmark, so a benchmark that
+#     outgrows the machine dies with an allocation failure while the runner is
+#     still healthy enough to upload the log.
+#   - Each benchmark is its own workflow step. GitHub records when every step
+#     started and finished even when it loses the log, so the step that never
+#     finished is the culprit.
+#
+# `check` keeps the step list in the workflow file in sync with the bench
+# targets cargo actually builds: a new bench with no step fails the job.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+target_dir=${CARGO_TARGET_DIR:-target}
+
+# Same target list as `make bench-exclude-tpc-h`.
+bench_targets() {
+    make -s codspeed-benchmarks-exclude-tpc-h
+}
+
+# Bench binaries cargo built. Feature unification across the workspace can
+# turn on features like `fts`, so this is the real list, not Cargo.toml's.
+built_benches() {
+    jq -r 'select(.reason == "compiler-artifact" and .executable != null
+                  and (.target.kind | index("bench")))
+           | .target.name' "$target_dir/nightly-bench-build.json" | sort -u
+}
+
+case "${1:-}" in
+build)
+    args=()
+    while read -r name; do
+        args+=(--bench "$name")
+    done < <(bench_targets)
+    cargo bench --no-run --features bench "${args[@]}" \
+        --message-format=json-render-diagnostics > "$target_dir/nightly-bench-build.json"
+    echo "Built bench binaries:"
+    built_benches | sed 's/^/  /'
+    ;;
+check)
+    workflow=$2
+    grep -oE 'nightly-bench\.sh run [A-Za-z0-9_]+' "$workflow" | awk '{print $3}' | sort -u > "$target_dir/nightly-bench-steps.txt"
+    built_benches | grep -vx tpc_h_benchmark > "$target_dir/nightly-bench-built.txt"
+    if ! diff -u "$target_dir/nightly-bench-steps.txt" "$target_dir/nightly-bench-built.txt"; then
+        echo "error: the bench steps in $workflow do not match the bench binaries cargo built (see diff above)." >&2
+        echo "Add a 'scripts/nightly-bench.sh run <name>' step for every '+' line and drop the steps for every '-' line." >&2
+        exit 1
+    fi
+    ;;
+run)
+    name=$2
+    # Address-space cap in KiB. Well under the 8 GiB runner, well above the
+    # ~2.5 GiB the biggest benchmark reaches.
+    cap_kb=${NIGHTLY_BENCH_MEMORY_CAP_KB:-6291456}
+    echo "free -m before $name:"
+    free -m
+    ulimit -v "$cap_kb"
+    cargo bench --bench "$name" --features bench 2>&1 | tee -a output.txt
+    echo "free -m after $name:"
+    free -m
+    ;;
+*)
+    echo "usage: $0 build | check <workflow-file> | run <bench-name>" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
The nightly bench job on the 8 GiB Nyrkiö runner died again on 2026-08-26 (run 32930874982), ~77 minutes into the benchmarks, with "the self-hosted runner lost communication with the server". When that happens GitHub throws the whole job log away, so the run says nothing about which benchmark starved the machine. The previous fix (0dd5f5f0f, "core/bench: stop create_index_benchmark from eating all memory") moved the death from minute 42 to minute 101, so a second benchmark does not fit either.

Split the single Bench step into one step per bench binary, driven by scripts/nightly-bench.sh:

- GitHub keeps every step's start and end time even when it loses the log, so the step that never finished names the benchmark.
- Each benchmark runs under `ulimit -v` (6 GiB by default), so a benchmark that outgrows the runner dies with an allocation failure while the runner is still healthy enough to upload the log, instead of thrashing the machine until the agent stops answering.
- A `check` step fails the job when a bench binary cargo built has no step, so new benchmarks cannot silently fall out of the nightly. This is computed from cargo's own build output, because workspace feature unification pulls the `fts` benches into the run even though the job never asks for that feature.
- A "Runner facts" step records memory, swap, disk, tmpfs mounts, ulimits, cgroup and sudo availability for the next investigation.

Tests: `scripts/nightly-bench.sh build`, `check` and `run` locally; every bench binary in the suite runs to completion under the 6 GiB cap on a 24-core box (mvcc_benchmark, the largest, peaks at 3.7 GiB of address space for 2.1 GiB resident).