### PR TITLE
simulator: add power loss

### DIFF
--- a/sql_generation/model/query/pragma.rs
+++ b/sql_generation/model/query/pragma.rs
@@ -6,6 +6,18 @@ use serde::{Deserialize, Serialize};
 pub enum Pragma {
     AutoVacuumMode(VacuumMode),
     ForeignKeyList(String),
+    WalCheckpoint {
+        database: Option<String>,
+        mode: CheckpointMode,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum CheckpointMode {
+    Passive,
+    Full,
+    Restart,
+    Truncate,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,6 +43,22 @@ impl Display for Pragma {
             Pragma::ForeignKeyList(table_name) => {
                 let table_name = table_name.replace('\'', "''");
                 write!(f, "PRAGMA foreign_key_list('{table_name}')")
+            }
+            Pragma::WalCheckpoint { database, mode } => {
+                write!(f, "PRAGMA ")?;
+                if let Some(database) = database {
+                    write!(f, "{database}.")?;
+                }
+                write!(
+                    f,
+                    "wal_checkpoint({})",
+                    match mode {
+                        CheckpointMode::Passive => "PASSIVE",
+                        CheckpointMode::Full => "FULL",
+                        CheckpointMode::Restart => "RESTART",
+                        CheckpointMode::Truncate => "TRUNCATE",
+                    }
+                )
             }
         }
     }

--- a/testing/simulator/generation/plan.rs
+++ b/testing/simulator/generation/plan.rs
@@ -59,15 +59,16 @@ impl InteractionPlan {
         }
 
         let num_interactions = env.opts.max_interactions as usize;
-        // If last interaction needs to check all db tables, generate the Property to do so.
-        // But only generate the interaction if we actually have any tables to check
-        // This can happen if we created a table, and then deleted the table, and there are no more tables to check
+        // After a fault or injected query, an empty expected schema still matters:
+        // it proves that the last table stayed dropped. Ordinary DML checks name
+        // one table, so those still require a non-empty schema.
         if let Some(i) = self.last_interactions()
             && i.check_tables()
-            && !env
+            && (!env
                 .connection_context(i.connection_index)
                 .tables()
                 .is_empty()
+                || !matches!(&i.interactions, InteractionsType::Query(_)))
         {
             let interactions = if let InteractionsType::Query(query) = &i.interactions {
                 assert!(query.is_dml());

--- a/testing/simulator/generation/plan.rs
+++ b/testing/simulator/generation/plan.rs
@@ -60,16 +60,16 @@ impl InteractionPlan {
         }
 
         let num_interactions = env.opts.max_interactions as usize;
-        // After a fault or injected query, an empty expected schema still matters:
-        // it proves that the last table stayed dropped. Ordinary DML checks name
-        // one table, so those still require a non-empty schema.
         if let Some(i) = self.last_interactions()
             && i.check_tables()
-            && (!env
-                .connection_context(i.connection_index)
-                .tables()
-                .is_empty()
-                || !matches!(&i.interactions, InteractionsType::Query(_)))
+            && (
+                // no need to assert expected state if there are no tables
+                // and the last interaction was a query
+                !env.connection_context(i.connection_index)
+                    .tables()
+                    .is_empty()
+                    || !matches!(&i.interactions, InteractionsType::Query(_))
+            )
         {
             let interactions = if let InteractionsType::Query(query) = &i.interactions {
                 assert!(query.is_dml());

--- a/testing/simulator/generation/plan.rs
+++ b/testing/simulator/generation/plan.rs
@@ -345,11 +345,13 @@ fn random_fault<R: rand::Rng + ?Sized>(
     env: &SimulatorEnv,
     conn_index: usize,
 ) -> Interactions {
-    let faults = if env.opts.disable_reopen_database {
-        vec![Fault::Disconnect]
-    } else {
-        vec![Fault::Disconnect, Fault::ReopenDatabase]
-    };
+    let mut faults = vec![Fault::Disconnect];
+    if !env.opts.disable_reopen_database {
+        faults.push(Fault::ReopenDatabase);
+        if env.can_simulate_power_loss() {
+            faults.push(Fault::PowerLoss);
+        }
+    }
     let fault = faults[rng.random_range(0..faults.len())];
     Interactions::new(conn_index, InteractionsType::Fault(fault))
 }

--- a/testing/simulator/generation/plan.rs
+++ b/testing/simulator/generation/plan.rs
@@ -24,6 +24,7 @@ use crate::{
         metrics::{InteractionStats, Remaining},
         property::Property,
     },
+    runner::env::SimulationType,
 };
 
 impl InteractionPlan {
@@ -204,7 +205,7 @@ impl<'a, R: rand::Rng> PlanGenerator<'a, R> {
                     };
 
                     let queries = possible_queries(conn_ctx.tables());
-                    let query_distr = QueryDistribution::new(queries, &remaining_);
+                    let query_distr = QueryDistribution::new(queries, &remaining_, false);
 
                     let query_gen = property.get_extensional_query_gen_function();
 
@@ -372,7 +373,9 @@ impl ArbitraryFrom<(&SimulatorEnv, &InteractionStats, usize)> for Interactions {
         );
 
         let queries = possible_queries(conn_ctx.tables());
-        let query_distr = QueryDistribution::new(queries, &remaining_);
+        let allow_checkpoints =
+            !env.profile.mvcc && !matches!(env.type_, SimulationType::Differential);
+        let query_distr = QueryDistribution::new(queries, &remaining_, allow_checkpoints);
 
         #[expect(clippy::type_complexity)]
         let mut choices: Vec<(u32, Box<dyn Fn(&mut R) -> Interactions>)> = vec![

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -295,7 +295,10 @@ impl Property {
     ) -> Vec<Interaction> {
         let interactions: Vec<InteractionBuilder> = match self {
             Property::AllTableHaveExpectedContent { tables } => {
-                assert_all_table_values(tables, connection_index).collect()
+                let mut interactions = vec![assert_schema_names(tables, connection_index)];
+                interactions.extend(assert_all_table_values(tables, connection_index));
+                interactions.push(assert_integrity_check(tables, connection_index));
+                interactions
             }
             Property::TableHasExpectedContent { table } => {
                 let table = table.to_string();
@@ -1596,10 +1599,99 @@ fn random_main_table_delete<R: rand::Rng + ?Sized>(rng: &mut R, table: &Table) -
     })
 }
 
+fn assert_schema_names(tables: &[String], connection_index: usize) -> InteractionBuilder {
+    let expected = tables.to_vec();
+    let dependencies = expected.clone();
+    InteractionBuilder::with_interaction(InteractionType::Assertion(Assertion::new(
+        "database schema should contain exactly the modeled tables".to_string(),
+        move |_stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
+            let actual = read_user_table_names(env, connection_index)?;
+            Ok(compare_table_names(&expected, &actual))
+        },
+        dependencies,
+    )))
+}
+
+fn compare_table_names(expected: &[String], actual: &[String]) -> Result<(), String> {
+    let mut expected = expected.to_vec();
+    let mut actual = actual.to_vec();
+    expected.sort_unstable();
+    actual.sort_unstable();
+
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(format!(
+            "expected tables {expected:?}, database has {actual:?}"
+        ))
+    }
+}
+
+fn read_user_table_names(
+    env: &mut SimulatorEnv,
+    connection_index: usize,
+) -> turso_core::Result<Vec<String>> {
+    let schemas = std::iter::once("main".to_string())
+        .chain(env.attached_dbs.iter().cloned())
+        .collect::<Vec<_>>();
+    let mut names = Vec::new();
+    for schema in schemas {
+        let query = format!(
+            "SELECT name FROM {schema}.sqlite_schema \
+             WHERE type='table' AND name NOT LIKE 'sqlite_%' \
+             AND name NOT LIKE '__turso_internal_%' ORDER BY name"
+        );
+        match &mut env.connections[connection_index] {
+            crate::runner::env::SimConnection::LimboConnection(conn) => {
+                let mut rows = conn.query(query)?.ok_or_else(|| {
+                    LimboError::InternalError(format!(
+                        "sqlite_schema returned no rows for {schema}"
+                    ))
+                })?;
+                rows.run_with_row_callback(|row| {
+                    let turso_core::Value::Text(name) = row.get_value(0) else {
+                        return Err(LimboError::InternalError(format!(
+                            "sqlite_schema returned a non-text table name for {schema}"
+                        )));
+                    };
+                    names.push(if schema == "main" {
+                        name.as_str().to_string()
+                    } else {
+                        format!("{schema}.{name}")
+                    });
+                    Ok(())
+                })?;
+            }
+            crate::runner::env::SimConnection::SQLiteConnection(conn) => {
+                let mut stmt = conn
+                    .prepare(&query)
+                    .map_err(|err| LimboError::InternalError(err.to_string()))?;
+                let rows = stmt
+                    .query_map([], |row| row.get::<_, String>(0))
+                    .map_err(|err| LimboError::InternalError(err.to_string()))?;
+                for row in rows {
+                    let name = row.map_err(|err| LimboError::InternalError(err.to_string()))?;
+                    names.push(if schema == "main" {
+                        name
+                    } else {
+                        format!("{schema}.{name}")
+                    });
+                }
+            }
+            crate::runner::env::SimConnection::Disconnected => {
+                return Err(LimboError::InternalError(
+                    "connection is disconnected during schema assertion".into(),
+                ));
+            }
+        }
+    }
+    Ok(names)
+}
+
 fn assert_integrity_check(tables: &[String], connection_index: usize) -> InteractionBuilder {
     let tables = tables.to_vec();
     InteractionBuilder::with_interaction(InteractionType::Assertion(Assertion::new(
-        "PRAGMA integrity_check should be ok after savepoint rollback".to_string(),
+        "PRAGMA integrity_check should return ok".to_string(),
         move |_stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
             let result = run_integrity_check(env, connection_index)?;
             if result == "ok" {
@@ -1616,39 +1708,67 @@ fn run_integrity_check(
     env: &mut SimulatorEnv,
     connection_index: usize,
 ) -> turso_core::Result<String> {
+    let schemas: Vec<_> = std::iter::once("main".to_string())
+        .chain(env.attached_dbs.iter().cloned())
+        .collect();
     match &mut env.connections[connection_index] {
         crate::runner::env::SimConnection::LimboConnection(conn) => {
-            let mut rows = conn.query("PRAGMA integrity_check")?.ok_or_else(|| {
-                LimboError::InternalError("integrity_check returned no rows".into())
-            })?;
-            let mut result = Vec::new();
-            rows.run_with_row_callback(|row| {
-                let value = row
-                    .get_value(0)
-                    .to_text()
-                    .ok_or_else(|| {
-                        LimboError::InternalError(
-                            "integrity_check returned a non-text value".to_string(),
-                        )
-                    })?
-                    .to_string();
-                result.push(value);
-                Ok(())
-            })?;
-            Ok(result.join("\n"))
+            let mut failures = Vec::new();
+            for schema in schemas {
+                let query = format!("PRAGMA {schema}.integrity_check");
+                let mut rows = conn.query(query)?.ok_or_else(|| {
+                    LimboError::InternalError(format!(
+                        "integrity_check returned no rows for {schema}"
+                    ))
+                })?;
+                let mut result = Vec::new();
+                rows.run_with_row_callback(|row| {
+                    let value = row
+                        .get_value(0)
+                        .to_text()
+                        .ok_or_else(|| {
+                            LimboError::InternalError(format!(
+                                "integrity_check returned a non-text value for {schema}"
+                            ))
+                        })?
+                        .to_string();
+                    result.push(value);
+                    Ok(())
+                })?;
+                let result = result.join("\n");
+                if result != "ok" {
+                    failures.push(format!("{schema}: {result}"));
+                }
+            }
+            Ok(if failures.is_empty() {
+                "ok".to_string()
+            } else {
+                failures.join("\n")
+            })
         }
         crate::runner::env::SimConnection::SQLiteConnection(conn) => {
-            let mut stmt = conn
-                .prepare("PRAGMA integrity_check")
-                .map_err(|e| LimboError::InternalError(e.to_string()))?;
-            let rows = stmt
-                .query_map([], |row| row.get::<_, String>(0))
-                .map_err(|e| LimboError::InternalError(e.to_string()))?;
-            let mut result = Vec::new();
-            for row in rows {
-                result.push(row.map_err(|e| LimboError::InternalError(e.to_string()))?);
+            let mut failures = Vec::new();
+            for schema in schemas {
+                let mut stmt = conn
+                    .prepare(&format!("PRAGMA {schema}.integrity_check"))
+                    .map_err(|e| LimboError::InternalError(e.to_string()))?;
+                let rows = stmt
+                    .query_map([], |row| row.get::<_, String>(0))
+                    .map_err(|e| LimboError::InternalError(e.to_string()))?;
+                let mut result = Vec::new();
+                for row in rows {
+                    result.push(row.map_err(|e| LimboError::InternalError(e.to_string()))?);
+                }
+                let result = result.join("\n");
+                if result != "ok" {
+                    failures.push(format!("{schema}: {result}"));
+                }
             }
-            Ok(result.join("\n"))
+            Ok(if failures.is_empty() {
+                "ok".to_string()
+            } else {
+                failures.join("\n")
+            })
         }
         crate::runner::env::SimConnection::Disconnected => Err(LimboError::InternalError(
             "connection is disconnected during integrity_check assertion".into(),
@@ -1676,7 +1796,9 @@ fn assert_all_table_values(
             Predicate::true_(),
         )));
 
-        let assertion = InteractionType::Assertion(Assertion::new(format!("table {table} should contain all of its expected values"), {
+        let assertion = InteractionType::Assertion(Assertion::new(
+            format!("table {table} should contain all of its expected values"),
+            {
                 let table = table.clone();
                 move |stack: &Vec<ResultSet>, env: &mut SimulatorEnv| {
                     let conn_ctx = env.get_conn_tables(connection_index);
@@ -1688,45 +1810,35 @@ fn assert_all_table_values(
                     let last = stack.last().unwrap();
                     match last {
                         Ok(vals) => {
-                            let expected: Vec<Vec<SimValue>> = table.rows.iter().map(|r| strip_virtual_cols(table, r)).collect();
-                            let actual: Vec<Vec<SimValue>> = vals.iter().map(|r| strip_virtual_cols(table, r)).collect();
+                            let mut expected: Vec<Vec<SimValue>> = table
+                                .rows
+                                .iter()
+                                .map(|r| strip_virtual_cols(table, r))
+                                .collect();
+                            let mut actual: Vec<Vec<SimValue>> =
+                                vals.iter().map(|r| strip_virtual_cols(table, r)).collect();
+                            expected.sort_unstable();
+                            actual.sort_unstable();
 
-                            // Check if all values in the table are present in the result set
-                            // Find a value in the table that is not in the result set
-                            let model_contains_db = expected.iter().find(|v| {
-                                !actual.contains(v)
-                            });
-                            let db_contains_model = actual.iter().find(|v| {
-                                !expected.contains(v)
-                            });
-
-                            if let Some(model_contains_db) = model_contains_db {
-                                tracing::debug!(
-                                    "table {} does not contain the expected values, the simulator model has more rows than the database: {:?}",
-                                    table.name,
-                                    print_row(model_contains_db)
-                                );
-                                print_diff(&expected, &actual, "simulator", "database");
-
-                                Ok(Err(format!("table {} does not contain the expected values, the simulator model has more rows than the database: {:?}", table.name, print_row(model_contains_db))))
-                            } else if let Some(db_contains_model) = db_contains_model {
-                                tracing::debug!(
-                                    "table {} does not contain the expected values, the database has more rows than the simulator model: {:?}",
-                                    table.name,
-                                    print_row(db_contains_model)
-                                );
-                                print_diff(&expected, &actual, "simulator", "database");
-
-                                Ok(Err(format!("table {} does not contain the expected values, the database has more rows than the simulator model: {:?}", table.name, print_row(db_contains_model))))
-                            } else {
+                            if expected == actual {
                                 Ok(Ok(()))
+                            } else {
+                                print_diff(&expected, &actual, "simulator", "database");
+                                Ok(Err(format!(
+                                    "table {} does not contain the expected values",
+                                    table.name
+                                )))
                             }
                         }
                         Err(err) => Err(LimboError::InternalError(format!("{err}"))),
                     }
                 }
-            }, vec![table.clone()]));
-        [select, assertion].into_iter().map(InteractionBuilder::with_interaction)
+            },
+            vec![table.clone()],
+        ));
+        [select, assertion]
+            .into_iter()
+            .map(InteractionBuilder::with_interaction)
     })
 }
 

--- a/testing/simulator/generation/property.rs
+++ b/testing/simulator/generation/property.rs
@@ -2227,8 +2227,9 @@ fn property_fsync_no_wait<R: rand::Rng + ?Sized>(
     rng: &mut R,
     query_distr: &QueryDistribution,
     ctx: &impl GenerationContext,
-    _mvcc: bool,
+    mvcc: bool,
 ) -> Property {
+    assert!(!mvcc, "FsyncNoWait must not be generated in MVCC mode");
     Property::FsyncNoWait {
         query: Query::arbitrary_from(rng, ctx, query_distr),
     }
@@ -2434,7 +2435,10 @@ impl PropertyDiscriminants {
                 }
             }
             PropertyDiscriminants::FsyncNoWait => {
-                if env.profile.io.enable && !env.opts.disable_fsync_no_wait {
+                if env.profile.io.enable
+                    && !env.opts.disable_fsync_no_wait
+                    && env.can_simulate_power_loss()
+                {
                     50 // Freestyle number
                 } else {
                     0

--- a/testing/simulator/generation/query.rs
+++ b/testing/simulator/generation/query.rs
@@ -16,7 +16,7 @@ use sql_generation::{
         query::{
             Create, CreateIndex, Delete, DropIndex, Insert, Select,
             alter_table::AlterTable,
-            pragma::{Pragma, VacuumMode},
+            pragma::{CheckpointMode, Pragma, VacuumMode},
             update::Update,
         },
         table::Table,
@@ -86,7 +86,28 @@ fn random_create_index<R: rand::Rng + ?Sized>(
     Query::CreateIndex(create_index)
 }
 
-fn random_pragma<R: rand::Rng + ?Sized>(rng: &mut R, conn_ctx: &impl GenerationContext) -> Query {
+fn random_pragma<R: rand::Rng + ?Sized>(
+    rng: &mut R,
+    conn_ctx: &impl GenerationContext,
+    allow_checkpoints: bool,
+) -> Query {
+    if allow_checkpoints && !conn_ctx.tables().is_empty() && rng.random_bool(0.35) {
+        let modes = [
+            CheckpointMode::Passive,
+            CheckpointMode::Full,
+            CheckpointMode::Restart,
+            CheckpointMode::Truncate,
+        ];
+        let table = conn_ctx.tables().choose(rng).unwrap();
+        let database = table
+            .name
+            .split_once('.')
+            .map(|(database, _)| database.to_string());
+        return Query::Pragma(Pragma::WalCheckpoint {
+            database,
+            mode: *modes.choose(rng).unwrap(),
+        });
+    }
     if !conn_ctx.tables().is_empty() && rng.random_bool(0.5) {
         let table = conn_ctx.tables().choose(rng).unwrap();
         return Query::Pragma(Pragma::ForeignKeyList(table.name.clone()));
@@ -203,7 +224,7 @@ impl QueryDiscriminants {
             QueryDiscriminants::CreateIndex => Some(random_create_index),
             QueryDiscriminants::AlterTable => Some(random_alter_table),
             QueryDiscriminants::DropIndex => Some(random_drop_index),
-            QueryDiscriminants::Pragma => Some(random_pragma),
+            QueryDiscriminants::Pragma => None,
             // Sequence queries are handled specially in sample() since they need sequence_names
             QueryDiscriminants::CreateSequence
             | QueryDiscriminants::DropSequence
@@ -262,10 +283,15 @@ pub(super) struct QueryDistribution {
     query_weights: Vec<u32>,
     weights: WeightedIndex<u32>,
     sequence_info: Vec<(String, i64, i64)>,
+    allow_checkpoints: bool,
 }
 
 impl QueryDistribution {
-    pub fn new(queries: &'static [QueryDiscriminants], remaining: &Remaining) -> Self {
+    pub fn new(
+        queries: &'static [QueryDiscriminants],
+        remaining: &Remaining,
+        allow_checkpoints: bool,
+    ) -> Self {
         let query_weights = queries
             .iter()
             .map(|query| query.weight(remaining))
@@ -276,6 +302,7 @@ impl QueryDistribution {
             query_weights,
             weights,
             sequence_info: remaining.sequence_info.clone(),
+            allow_checkpoints,
         }
     }
 
@@ -328,6 +355,7 @@ impl WeightedDistribution for QueryDistribution {
                 random_drop_sequence(rng, &names)
             }
             QueryDiscriminants::Setval => random_setval(rng, &self.sequence_info),
+            QueryDiscriminants::Pragma => random_pragma(rng, ctx, self.allow_checkpoints),
             _ => {
                 let query_fn = discriminant
                     .gen_function()

--- a/testing/simulator/model/interactions.rs
+++ b/testing/simulator/model/interactions.rs
@@ -309,7 +309,9 @@ impl Interactions {
             // `AllTableHaveExpectedContent` check. DISCONNECT only affects a
             // single in-memory connection and doesn't touch persistence, so
             // we don't follow it with a check.
-            InteractionsType::Fault(fault) => matches!(fault, Fault::ReopenDatabase),
+            InteractionsType::Fault(fault) => {
+                matches!(fault, Fault::ReopenDatabase | Fault::PowerLoss)
+            }
         }
     }
 
@@ -436,6 +438,7 @@ impl Assertion {
 pub enum Fault {
     Disconnect,
     ReopenDatabase,
+    PowerLoss,
 }
 
 impl Display for Fault {
@@ -443,6 +446,7 @@ impl Display for Fault {
         match self {
             Fault::Disconnect => write!(f, "DISCONNECT"),
             Fault::ReopenDatabase => write!(f, "REOPEN_DATABASE"),
+            Fault::PowerLoss => write!(f, "POWER_LOSS"),
         }
     }
 }
@@ -540,9 +544,14 @@ pub enum InteractionType {
     Assertion(Assertion),
     Fault(Fault),
     /// Will attempt to run any random query. However, when the connection tries to sync it will
-    /// close all connections and reopen the database and assert that no data was lost
+    /// simulate power loss on the memory WAL backend, then reopen and retry the query.
     FsyncQuery(Query),
     FaultyQuery(Query),
+}
+
+pub(crate) struct FsyncQueryOutcome {
+    pub(crate) result: ResultSet,
+    pub(crate) power_lost: bool,
 }
 
 // FIXME: add the connection index here later
@@ -562,8 +571,7 @@ impl Display for InteractionType {
             }
             Self::Fault(fault) => write!(f, "-- FAULT '{fault}'"),
             Self::FsyncQuery(query) => {
-                writeln!(f, "-- FSYNC QUERY")?;
-                writeln!(f, "{query};")?;
+                writeln!(f, "-- FSYNC QUERY: retry only after injected power loss")?;
                 write!(f, "{query};")
             }
             Self::FaultyQuery(query) => write!(f, "{query}; -- FAULTY QUERY"),
@@ -706,7 +714,16 @@ impl InteractionType {
                         }
                     }
                     Fault::ReopenDatabase => {
-                        reopen_database(env);
+                        reopen_database(env, false)?;
+                    }
+                    Fault::PowerLoss => {
+                        if !env.can_simulate_power_loss() {
+                            return Err(turso_core::LimboError::InvalidArgument(
+                                "POWER_LOSS requires a non-MVCC default simulation using memory I/O"
+                                    .into(),
+                            ));
+                        }
+                        reopen_database(env, true)?;
                     }
                 }
                 Ok(())
@@ -721,52 +738,67 @@ impl InteractionType {
         &self,
         conn: Arc<Connection>,
         env: &mut SimulatorEnv,
-    ) -> ResultSet {
+    ) -> FsyncQueryOutcome {
         if let Self::FsyncQuery(query) = self {
-            let query_str = query.to_string();
-            let rows = conn.query(&query_str);
-            if rows.is_err() {
-                let err = rows.err();
-                tracing::debug!(
-                    "Error running query '{}': {:?}",
-                    &query_str[0..query_str.len().min(4096)],
-                    err
-                );
-                return Err(err.unwrap());
-            }
-            let mut rows = rows.unwrap().unwrap();
-            let mut out = Vec::new();
+            assert!(
+                env.can_simulate_power_loss(),
+                "FsyncNoWait requires a non-MVCC default simulation using memory I/O"
+            );
 
-            loop {
-                match rows.step()? {
-                    StepResult::Row => {
-                        let row = rows.row().unwrap();
-                        let mut r = Vec::new();
-                        for v in row.get_values() {
-                            let v = v.into();
-                            r.push(v);
-                        }
-                        out.push(r);
-                    }
-                    StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
-                        let syncing = env.io.syncing();
-                        if syncing {
-                            reopen_database(env);
-                        } else {
-                            rows._io().step()?;
-                        }
-                    }
-                    StepResult::Done => {
-                        break;
-                    }
-                    StepResult::Busy => {
-                        return Err(turso_core::LimboError::Busy);
-                    }
-                    StepResult::Interrupt => {}
+            let mut power_lost = false;
+            let result = (|| {
+                let query_str = query.to_string();
+                let rows = conn.query(&query_str);
+                if rows.is_err() {
+                    let err = rows.err();
+                    tracing::debug!(
+                        "Error running query '{}': {:?}",
+                        &query_str[0..query_str.len().min(4096)],
+                        err
+                    );
+                    return Err(err.unwrap());
                 }
-            }
+                let mut rows = rows.unwrap().unwrap();
+                let mut out = Vec::new();
 
-            Ok(out)
+                loop {
+                    match rows.step()? {
+                        StepResult::Row => {
+                            let row = rows.row().unwrap();
+                            let mut r = Vec::new();
+                            for v in row.get_values() {
+                                let v = v.into();
+                                r.push(v);
+                            }
+                            out.push(r);
+                        }
+                        StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
+                            let syncing = env.io.syncing();
+                            if syncing {
+                                assert!(
+                                    !power_lost,
+                                    "an interrupted fsync query must stop after power loss"
+                                );
+                                reopen_database(env, true)?;
+                                power_lost = true;
+                            } else {
+                                rows._io().step()?;
+                            }
+                        }
+                        StepResult::Done => {
+                            break;
+                        }
+                        StepResult::Busy => {
+                            return Err(turso_core::LimboError::Busy);
+                        }
+                        StepResult::Interrupt => {}
+                    }
+                }
+
+                Ok(out)
+            })();
+
+            FsyncQueryOutcome { result, power_lost }
         } else {
             unreachable!("unexpected: this function should only be called on queries")
         }
@@ -884,7 +916,7 @@ impl InteractionType {
     }
 }
 
-fn reopen_database(env: &mut SimulatorEnv) {
+fn reopen_database(env: &mut SimulatorEnv, power_loss: bool) -> Result<()> {
     // 1. Close all connections without default checkpoint-on-close behavior
     // to expose bugs related to how we handle WAL
     let mvcc = env.profile.mvcc;
@@ -898,30 +930,31 @@ fn reopen_database(env: &mut SimulatorEnv) {
         }
     }
 
+    if power_loss {
+        // Reject cleanup I/O from the old database objects after the crash boundary.
+        env.io.power_loss()?;
+    }
+
     env.connections.clear();
+    env.db = None;
 
-    // Clear all open files
-    // TODO: for correct reporting of faults we should get all the recorded numbers and transfer to the new file
-    env.io.close_files();
+    if power_loss {
+        // The interrupted statement still owns its old connection while this
+        // function opens the replacement database. A real process restart has
+        // no process-wide database registry, so the simulator must discard it
+        // or the new open can return the old Database and its stale handles.
+        turso_core::clear_database_registry();
+    } else {
+        // TODO: for correct reporting of faults we should get all the recorded numbers and transfer to the new file
+        env.io.close_files();
+    }
 
-    // 2. Re-open database
+    // 2. Re-open the shared database object. Connections are recreated below
+    // through SimulatorEnv::connect so their normal cache and ATTACH setup is
+    // applied after a restart too.
     match env.type_ {
-        SimulationType::Differential => {
-            for i in 0..num_conns {
-                let conn = rusqlite::Connection::open(env.get_db_path())
-                    .expect("Failed to open SQLite connection");
-                for name in &env.attached_dbs {
-                    let aux_path = env.get_aux_db_path(name);
-                    conn.execute(&format!("ATTACH '{}' AS {name}", aux_path.display()), [])
-                        .unwrap_or_else(|e| {
-                            panic!("Failed to ATTACH {name} on SQLite reopen (conn {i}): {e}")
-                        });
-                }
-                env.connections.push(SimConnection::SQLiteConnection(conn));
-            }
-        }
+        SimulationType::Differential => {}
         SimulationType::Default | SimulationType::Doublecheck => {
-            env.db = None;
             let db = match turso_core::Database::open_file_with_flags(
                 env.io.clone(),
                 env.get_db_path().to_str().expect("path should be 'to_str'"),
@@ -952,18 +985,14 @@ fn reopen_database(env: &mut SimulatorEnv) {
                 conn.pragma_update("journal_mode", "'mvcc'")
                     .expect("enable mvcc");
             }
-
-            for i in 0..num_conns {
-                let conn = env.db.as_ref().expect("db to be Some").connect().unwrap();
-                for name in &env.attached_dbs {
-                    let aux_path = env.get_aux_db_path(name);
-                    conn.execute(format!("ATTACH '{}' AS {name}", aux_path.display()))
-                        .unwrap_or_else(|e| {
-                            panic!("Failed to ATTACH {name} on reopen (conn {i}): {e}")
-                        });
-                }
-                env.connections.push(SimConnection::LimboConnection(conn));
-            }
         }
     };
+
+    env.connections
+        .extend((0..num_conns).map(|_| SimConnection::Disconnected));
+    for connection_index in 0..num_conns {
+        env.connect(connection_index);
+    }
+
+    Ok(())
 }

--- a/testing/simulator/model/mod.rs
+++ b/testing/simulator/model/mod.rs
@@ -580,7 +580,11 @@ impl Shadow for Query {
             Query::RollbackToSavepoint(rollback_to) => rollback_to.shadow(env),
             Query::ReleaseSavepoint(release) => release.shadow(env),
             Query::Placeholder => Ok(vec![]),
-            Query::Pragma(Pragma::AutoVacuumMode(_) | Pragma::ForeignKeyList(_)) => Ok(vec![]),
+            Query::Pragma(
+                Pragma::AutoVacuumMode(_)
+                | Pragma::ForeignKeyList(_)
+                | Pragma::WalCheckpoint { .. },
+            ) => Ok(vec![]),
         }
     }
 }

--- a/testing/simulator/model/property.rs
+++ b/testing/simulator/model/property.rs
@@ -168,13 +168,13 @@ pub enum Property {
         select: Select,
         where_clause: Predicate,
     },
-    /// FsyncNoWait is a property which tests if we do not loose any data after not waiting for fsync.
+    /// FsyncNoWait tests recovery when a query is interrupted at fsync.
     ///
     /// # Interactions
-    /// - Executes the `query` without waiting for fsync
-    /// - Drop all connections and Reopen the database
-    /// - Execute the `query` again
-    /// - Query tables to assert that the values were inserted
+    /// - Execute `query` until the memory backend has a pending fsync
+    /// - Simulate power loss and reopen the database
+    /// - Retry `query`; a query that reaches no fsync is not retried
+    /// - Compare the recovered database with the shadow model
     ///
     FsyncNoWait {
         query: Query,

--- a/testing/simulator/plan_to_test.rs
+++ b/testing/simulator/plan_to_test.rs
@@ -6,13 +6,14 @@
 //! Lines ending with "-- <number>" indicate which connection should execute that statement.
 //! Lines beginning with "--" are comments and are ignored (except FAULT commands).
 
+use anyhow::{Result, bail};
 use regex::Regex;
 use std::collections::BTreeSet;
 use std::env;
 use std::fs;
 use std::path::Path;
 
-fn main() {
+fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
         eprintln!(
@@ -28,8 +29,9 @@ fn main() {
         std::process::exit(1);
     });
 
-    let test_code = generate_test(&content, sql_path);
+    let test_code = generate_test(&content, sql_path)?;
     println!("{test_code}");
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -45,7 +47,7 @@ enum PlanAction {
     Disconnect { connection: u32 },
 }
 
-fn parse_plan(content: &str) -> (Vec<PlanAction>, BTreeSet<u32>) {
+fn parse_plan(content: &str) -> Result<(Vec<PlanAction>, BTreeSet<u32>)> {
     let mut actions = Vec::new();
     let mut connections = BTreeSet::new();
 
@@ -77,11 +79,18 @@ fn parse_plan(content: &str) -> (Vec<PlanAction>, BTreeSet<u32>) {
                         connection: conn_num,
                     });
                 }
-                _ => {
-                    // Unknown fault type, skip
-                }
+                "POWER_LOSS" => bail!(
+                    "POWER_LOSS cannot be converted to a TempDatabase test; reproduce it with MemorySimIO or UnreliableIo"
+                ),
+                _ => bail!("unsupported simulator fault: {fault_type}"),
             }
             continue;
+        }
+
+        if trimmed.starts_with("-- FSYNC QUERY") {
+            bail!(
+                "FSYNC QUERY cannot be converted to a TempDatabase test; reproduce it with MemorySimIO or UnreliableIo"
+            );
         }
 
         // Skip lines that begin with "--" (pure comments)
@@ -110,7 +119,7 @@ fn parse_plan(content: &str) -> (Vec<PlanAction>, BTreeSet<u32>) {
         }
     }
 
-    (actions, connections)
+    Ok((actions, connections))
 }
 
 fn escape_sql_string(s: &str) -> String {
@@ -119,8 +128,8 @@ fn escape_sql_string(s: &str) -> String {
         .replace('\n', "\\n")
 }
 
-fn generate_test(content: &str, sql_path: &str) -> String {
-    let (actions, connections) = parse_plan(content);
+fn generate_test(content: &str, sql_path: &str) -> Result<String> {
+    let (actions, connections) = parse_plan(content)?;
 
     let path = Path::new(sql_path);
     let test_name = path
@@ -194,5 +203,5 @@ fn generate_test(content: &str, sql_path: &str) -> String {
 
     code.push_str("}\n");
 
-    code
+    Ok(code)
 }

--- a/testing/simulator/runner/cli.rs
+++ b/testing/simulator/runner/cli.rs
@@ -151,7 +151,7 @@ pub struct SimulatorCLI {
         default_value_t = false
     )]
     pub disable_savepoint_rollback: bool,
-    #[clap(long, help = "disable FsyncNoWait Property", default_value_t = true)]
+    #[clap(long, help = "disable FsyncNoWait Property", default_value_t = false)]
     pub disable_fsync_no_wait: bool,
     #[clap(long, help = "disable FaultyQuery Property")]
     pub disable_faulty_query: bool,

--- a/testing/simulator/runner/differential.rs
+++ b/testing/simulator/runner/differential.rs
@@ -72,8 +72,10 @@ pub(crate) fn execute_interactions(
     env.clear_tables();
     rusqlite_env.clear_tables();
 
+    // Generate from the comparison environment so mode-gated interactions,
+    // such as simulated power loss, cannot leak in through the Default clone.
     let mut interaction = plan
-        .next(&mut env)
+        .next(&mut rusqlite_env)
         .expect("we should always have at least 1 interaction to start");
 
     let now = std::time::Instant::now();
@@ -116,7 +118,7 @@ pub(crate) fn execute_interactions(
                 let current_property_id = interaction.id();
                 loop {
                     state.interaction_pointer += 1;
-                    let Some(new_interaction) = plan.next(&mut env) else {
+                    let Some(new_interaction) = plan.next(&mut rusqlite_env) else {
                         // No more interactions, we're done
                         return ExecutionResult::new(history, None);
                     };
@@ -128,7 +130,7 @@ pub(crate) fn execute_interactions(
             }
             ExecutionContinuation::NextInteraction => {
                 state.interaction_pointer += 1;
-                let Some(new_interaction) = plan.next(&mut env) else {
+                let Some(new_interaction) = plan.next(&mut rusqlite_env) else {
                     break;
                 };
                 interaction = new_interaction;

--- a/testing/simulator/runner/doublecheck.rs
+++ b/testing/simulator/runner/doublecheck.rs
@@ -95,8 +95,10 @@ pub(crate) fn execute_plans(
     env.clear_tables();
     doublecheck_env.clear_tables();
 
+    // Generate from the comparison environment so mode-gated interactions,
+    // such as simulated power loss, cannot leak in through the Default clone.
     let mut interaction = plan
-        .next(&mut env)
+        .next(&mut doublecheck_env)
         .expect("we should always have at least 1 interaction to start");
 
     let now = std::time::Instant::now();
@@ -142,7 +144,7 @@ pub(crate) fn execute_plans(
                 let current_property_id = interaction.id();
                 loop {
                     state.interaction_pointer += 1;
-                    let Some(new_interaction) = plan.next(&mut env) else {
+                    let Some(new_interaction) = plan.next(&mut doublecheck_env) else {
                         // No more interactions, we're done
                         return ExecutionResult::new(history, None);
                     };
@@ -154,7 +156,7 @@ pub(crate) fn execute_plans(
             }
             ExecutionContinuation::NextInteraction => {
                 state.interaction_pointer += 1;
-                let Some(new_interaction) = plan.next(&mut env) else {
+                let Some(new_interaction) = plan.next(&mut doublecheck_env) else {
                     break;
                 };
                 interaction = new_interaction;

--- a/testing/simulator/runner/doublecheck.rs
+++ b/testing/simulator/runner/doublecheck.rs
@@ -95,8 +95,7 @@ pub(crate) fn execute_plans(
     env.clear_tables();
     doublecheck_env.clear_tables();
 
-    // Generate from the comparison environment so mode-gated interactions,
-    // such as simulated power loss, cannot leak in through the Default clone.
+    // Use the doublecheck environment so we don't generate unsupported power-loss operations.
     let mut interaction = plan
         .next(&mut doublecheck_env)
         .expect("we should always have at least 1 interaction to start");

--- a/testing/simulator/runner/env.rs
+++ b/testing/simulator/runner/env.rs
@@ -1370,6 +1370,12 @@ impl SimulatorEnv {
         rng.random_range(0..self.connections.len())
     }
 
+    pub(crate) fn can_simulate_power_loss(&self) -> bool {
+        !self.profile.mvcc
+            && self.io_backend == IoBackend::Memory
+            && matches!(self.type_, SimulationType::Default)
+    }
+
     /// Rng only used for generating interactions. By having a separate Rng we can guarantee that a particular seed
     /// will always create the same interactions plan, regardless of the changes that happen in the Database code
     pub fn gen_rng(&self) -> ChaCha8Rng {

--- a/testing/simulator/runner/execution.rs
+++ b/testing/simulator/runner/execution.rs
@@ -238,48 +238,7 @@ pub fn execute_interaction_turso(
                     .execute_query(conn)
                     .inspect_err(|err| tracing::error!(?err))
             };
-
-            if let Err(err) = &results
-                && !interaction.ignore_error
-            {
-                let continuation = match err {
-                    err if is_recoverable_tx_error(err) => {
-                        if error_causes_rollback(err) && env.conn_in_transaction(connection_index) {
-                            env.rollback_conn(connection_index);
-                        }
-                        ExecutionContinuation::NextInteractionOutsideThisProperty
-                    }
-                    LimboError::Constraint(_) => {
-                        let shadow_result =
-                            interaction.shadow(&mut env.get_conn_tables_mut(connection_index));
-                        if shadow_result.is_ok() {
-                            return Err(LimboError::InternalError(format!(
-                                "Turso rejected with constraint error but shadow would accept: {err:?}"
-                            )));
-                        }
-                        ExecutionContinuation::NextInteraction
-                    }
-                    _ => return Err(err.clone()),
-                };
-                stack.push(results);
-                return Ok(continuation);
-            }
-
-            if results.is_err() {
-                stack.push(results);
-                return Ok(ExecutionContinuation::NextInteraction);
-            }
-
-            stack.push(results);
-            // TODO: skip integrity check with mvcc
-            if !env.profile.mvcc && env.rng.random_ratio(1, 10) {
-                let SimConnection::LimboConnection(conn) = &mut env.connections[connection_index]
-                else {
-                    unreachable!()
-                };
-                limbo_integrity_check(conn)?;
-            }
-            env.update_conn_last_interaction(connection_index, Some(query));
+            return finish_turso_query(env, interaction, query, results, stack);
         }
         InteractionType::FsyncQuery(query) => {
             let conn = {
@@ -289,18 +248,26 @@ pub fn execute_interaction_turso(
                 };
                 conn.clone()
             };
-            let results = interaction
-                .execute_fsync_query(conn, env)
-                .inspect_err(|err| tracing::error!(?err));
-
-            stack.push(results);
+            let outcome = interaction.execute_fsync_query(conn, env);
+            if let Err(err) = &outcome.result {
+                tracing::error!(?err);
+            }
 
             let query_interaction = InteractionBuilder::from_interaction(interaction)
                 .interaction(InteractionType::Query(query.clone()))
                 .build()
                 .unwrap();
 
-            execute_interaction(env, &query_interaction, stack)?;
+            if outcome.power_lost {
+                assert!(
+                    outcome.result.is_err(),
+                    "a query interrupted by power loss must not report success"
+                );
+                stack.push(outcome.result);
+                return execute_interaction(env, &query_interaction, stack);
+            }
+
+            return finish_turso_query(env, &query_interaction, query, outcome.result, stack);
         }
         InteractionType::Assertion(_) => {
             interaction.execute_assertion(stack, env)?;
@@ -344,6 +311,62 @@ pub fn execute_interaction_turso(
             "DB succeeded but shadow detected error: {e}"
         )));
     }
+    Ok(ExecutionContinuation::NextInteraction)
+}
+
+fn finish_turso_query(
+    env: &mut SimulatorEnv,
+    interaction: &Interaction,
+    query: &Query,
+    results: ResultSet,
+    stack: &mut Vec<ResultSet>,
+) -> Result<ExecutionContinuation> {
+    let connection_index = interaction.connection_index;
+    if let Err(err) = &results
+        && !interaction.ignore_error
+    {
+        let continuation = match err {
+            err if is_recoverable_tx_error(err) => {
+                if error_causes_rollback(err) && env.conn_in_transaction(connection_index) {
+                    env.rollback_conn(connection_index);
+                }
+                ExecutionContinuation::NextInteractionOutsideThisProperty
+            }
+            LimboError::Constraint(_) => {
+                let shadow_result =
+                    interaction.shadow(&mut env.get_conn_tables_mut(connection_index));
+                if shadow_result.is_ok() {
+                    return Err(LimboError::InternalError(format!(
+                        "Turso rejected with constraint error but shadow would accept: {err:?}"
+                    )));
+                }
+                ExecutionContinuation::NextInteraction
+            }
+            _ => return Err(err.clone()),
+        };
+        stack.push(results);
+        return Ok(continuation);
+    }
+
+    if results.is_err() {
+        stack.push(results);
+        return Ok(ExecutionContinuation::NextInteraction);
+    }
+
+    stack.push(results);
+    // TODO: skip integrity check with mvcc
+    if !env.profile.mvcc && env.rng.random_ratio(1, 10) {
+        let SimConnection::LimboConnection(conn) = &mut env.connections[connection_index] else {
+            unreachable!()
+        };
+        limbo_integrity_check(conn)?;
+    }
+    env.update_conn_last_interaction(connection_index, Some(query));
+    interaction
+        .shadow(&mut env.get_conn_tables_mut(connection_index))
+        .map_err(|err| {
+            LimboError::InternalError(format!("DB succeeded but shadow detected error: {err}"))
+        })?;
     Ok(ExecutionContinuation::NextInteraction)
 }
 

--- a/testing/simulator/runner/io.rs
+++ b/testing/simulator/runner/io.rs
@@ -105,6 +105,12 @@ impl SimIO for SimulatorIO {
         self.files.borrow_mut().clear()
     }
 
+    fn power_loss(&self) -> Result<()> {
+        Err(turso_core::LimboError::InvalidArgument(
+            "POWER_LOSS requires --io-backend memory".into(),
+        ))
+    }
+
     fn persist_files(&self) -> anyhow::Result<()> {
         // Files are persisted automatically
         Ok(())

--- a/testing/simulator/runner/memory/file.rs
+++ b/testing/simulator/runner/memory/file.rs
@@ -1,20 +1,23 @@
 use std::{
     cell::{Cell, RefCell},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use rand::{Rng as _, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use tracing::{Level, instrument};
-use turso_core::{Completion, File, Result};
+use turso_core::{Completion, CompletionError, File, LimboError, Result};
 
 use crate::runner::{
     clock::SimulatorClock,
-    memory::io::{CallbackQueue, Fd, Operation, OperationType},
+    memory::io::{CallbackQueue, FileState, Operation, OperationType},
 };
 
 /// Tracks IO calls and faults for each type of I/O operation
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 struct IOTracker {
     pread_calls: usize,
     pread_faults: usize,
@@ -45,11 +48,12 @@ impl IOTracker {
 pub struct MemorySimFile {
     // TODO: maybe have a pending queue which is fast to append
     // and then we just do a mem swap the pending with the callback to minimize lock contention on callback queue
-    pub callbacks: CallbackQueue,
-    pub fd: Arc<Fd>,
-    pub buffer: RefCell<Vec<u8>>,
+    pub(super) callbacks: CallbackQueue,
+    pub(super) state: Arc<RefCell<FileState>>,
     // TODO: add fault map later here
-    pub closed: Cell<bool>,
+    pub(super) closed: Cell<bool>,
+    generation: Arc<AtomicU64>,
+    opened_generation: u64,
     io_tracker: RefCell<IOTracker>,
     pub rng: RefCell<ChaCha8Rng>,
     pub latency_probability: u8,
@@ -61,18 +65,20 @@ unsafe impl Send for MemorySimFile {}
 unsafe impl Sync for MemorySimFile {}
 
 impl MemorySimFile {
-    pub fn new(
+    pub(super) fn new(
         callbacks: CallbackQueue,
-        fd: Fd,
         seed: u64,
         latency_probability: u8,
         clock: Arc<SimulatorClock>,
+        generation: Arc<AtomicU64>,
     ) -> Self {
+        let opened_generation = generation.load(Ordering::Acquire);
         Self {
             callbacks,
-            fd: Arc::new(fd),
-            buffer: RefCell::new(Vec::new()),
+            state: Arc::new(RefCell::new(FileState::default())),
             closed: Cell::new(false),
+            generation,
+            opened_generation,
             io_tracker: RefCell::new(IOTracker::default()),
             rng: RefCell::new(ChaCha8Rng::seed_from_u64(seed)),
             latency_probability,
@@ -83,6 +89,35 @@ impl MemorySimFile {
 
     pub fn inject_fault(&self, fault: bool) {
         self.fault.set(fault);
+    }
+
+    pub(super) fn reopen(&self) -> Self {
+        Self {
+            callbacks: self.callbacks.clone(),
+            state: self.state.clone(),
+            closed: Cell::new(false),
+            generation: self.generation.clone(),
+            opened_generation: self.generation.load(Ordering::Acquire),
+            io_tracker: RefCell::new(self.io_tracker.borrow().clone()),
+            rng: RefCell::new(self.rng.borrow().clone()),
+            latency_probability: self.latency_probability,
+            clock: self.clock.clone(),
+            fault: Cell::new(self.fault.get()),
+        }
+    }
+
+    fn ensure_open(&self) -> Result<()> {
+        if !self.is_open() {
+            return Err(LimboError::CompletionError(CompletionError::IOError(
+                std::io::ErrorKind::Other,
+                "memory simulator file is closed",
+            )));
+        }
+        Ok(())
+    }
+
+    pub(super) fn is_open(&self) -> bool {
+        !self.closed.get() && self.opened_generation == self.generation.load(Ordering::Acquire)
     }
 
     pub fn stats_table(&self) -> String {
@@ -148,39 +183,22 @@ impl MemorySimFile {
             time: self.generate_latency(),
             op,
             fault,
-            fd: self.fd.clone(),
+            file: self.state.clone(),
         });
-    }
-
-    pub fn write_buf(&self, buf: &[u8], offset: usize) -> usize {
-        let mut file_buf = self.buffer.borrow_mut();
-        let more_space = if file_buf.len() < offset {
-            (offset + buf.len()) - file_buf.len()
-        } else {
-            buf.len().saturating_sub(file_buf.len() - offset)
-        };
-        if more_space > 0 {
-            file_buf.reserve(more_space);
-            for _ in 0..more_space {
-                file_buf.push(0);
-            }
-        }
-
-        file_buf[offset..][0..buf.len()].copy_from_slice(buf);
-        buf.len()
     }
 }
 
 impl File for MemorySimFile {
     fn lock_file(&self, _exclusive: bool) -> Result<()> {
-        Ok(())
+        self.ensure_open()
     }
 
     fn unlock_file(&self) -> Result<()> {
-        Ok(())
+        self.ensure_open()
     }
 
     fn pread(&self, pos: u64, c: Completion) -> Result<Completion> {
+        self.ensure_open()?;
         self.io_tracker.borrow_mut().pread_calls += 1;
 
         let op = OperationType::Read {
@@ -197,6 +215,7 @@ impl File for MemorySimFile {
         buffer: Arc<turso_core::Buffer>,
         c: Completion,
     ) -> Result<Completion> {
+        self.ensure_open()?;
         self.io_tracker.borrow_mut().pwrite_calls += 1;
         let op = OperationType::Write {
             buffer,
@@ -213,6 +232,11 @@ impl File for MemorySimFile {
         buffers: Vec<Arc<turso_core::Buffer>>,
         c: Completion,
     ) -> Result<Completion> {
+        self.ensure_open()?;
+        if buffers.is_empty() {
+            c.complete(0);
+            return Ok(c);
+        }
         if buffers.len() == 1 {
             return self.pwrite(pos, buffers[0].clone(), c);
         }
@@ -227,21 +251,25 @@ impl File for MemorySimFile {
     }
 
     fn sync(&self, c: Completion, _sync_type: turso_core::io::FileSyncType) -> Result<Completion> {
+        self.ensure_open()?;
         self.io_tracker.borrow_mut().sync_calls += 1;
         let op = OperationType::Sync {
             completion: c.clone(),
+            snapshot: self.state.borrow_mut().sync_started(),
         };
         self.insert_op(op);
         Ok(c)
     }
 
     fn size(&self) -> Result<u64> {
+        self.ensure_open()?;
         // TODO: size operation should also be scheduled. But this requires a change in how we
         // Use this function internally in Turso
-        Ok(self.buffer.borrow().len() as u64)
+        Ok(self.state.borrow().buffer.len as u64)
     }
 
     fn truncate(&self, len: u64, c: Completion) -> Result<Completion> {
+        self.ensure_open()?;
         self.io_tracker.borrow_mut().truncate_calls += 1;
         let op = OperationType::Truncate {
             completion: c.clone(),

--- a/testing/simulator/runner/memory/io.rs
+++ b/testing/simulator/runner/memory/io.rs
@@ -1,11 +1,19 @@
 use std::cell::RefCell;
-use std::sync::Arc;
+use std::collections::BTreeSet;
+use std::io::{BufWriter, Write};
+use std::sync::{
+    Arc, Weak,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
 
 use indexmap::IndexMap;
 use parking_lot::Mutex;
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use turso_core::{Clock, Completion, IO, MonotonicInstant, OpenFlags, Result, WallClockInstant};
+use turso_core::{
+    Clock, Completion, CompletionError, IO, LimboError, MonotonicInstant, OpenFlags, Result,
+    WallClockInstant,
+};
 
 use crate::runner::SimIO;
 use crate::runner::clock::SimulatorClock;
@@ -14,8 +22,84 @@ use crate::runner::memory::file::MemorySimFile;
 /// File descriptor
 pub type Fd = String;
 
+const FILE_BLOCK_SIZE: usize = 4096;
+
+#[derive(Debug, Default)]
+pub(super) struct FileContents {
+    blocks: Vec<Arc<[u8; FILE_BLOCK_SIZE]>>,
+    pub(super) len: usize,
+}
+
 #[derive(Debug)]
-pub enum OperationType {
+pub(super) struct SyncSnapshot {
+    sequence: u64,
+    blocks: Vec<(usize, Arc<[u8; FILE_BLOCK_SIZE]>)>,
+    len: usize,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct FileState {
+    pub(super) buffer: FileContents,
+    durable: FileContents,
+    dirty_blocks: BTreeSet<usize>,
+    sync_sequence: u64,
+    durable_sequence: u64,
+}
+
+impl FileState {
+    pub(super) fn sync_started(&mut self) -> SyncSnapshot {
+        self.sync_sequence = self
+            .sync_sequence
+            .checked_add(1)
+            .expect("file sync sequence overflow");
+        SyncSnapshot {
+            sequence: self.sync_sequence,
+            // Pending or failed syncs cannot serve as the baseline for later
+            // snapshots, so keep blocks dirty until a sync succeeds.
+            blocks: self
+                .dirty_blocks
+                .iter()
+                .map(|&index| (index, self.buffer.blocks[index].clone()))
+                .collect(),
+            len: self.buffer.len,
+        }
+    }
+
+    fn sync_completed(&mut self, snapshot: SyncSnapshot) {
+        if snapshot.sequence <= self.durable_sequence {
+            return;
+        }
+        let block_count = snapshot.len.div_ceil(FILE_BLOCK_SIZE);
+        self.durable.blocks.truncate(block_count);
+        for (index, block) in snapshot.blocks {
+            if self
+                .buffer
+                .blocks
+                .get(index)
+                .is_some_and(|current| Arc::ptr_eq(current, &block))
+            {
+                self.dirty_blocks.remove(&index);
+            }
+            if index == self.durable.blocks.len() {
+                self.durable.blocks.push(block);
+            } else {
+                self.durable.blocks[index] = block;
+            }
+        }
+        assert_eq!(self.durable.blocks.len(), block_count);
+        self.durable.len = snapshot.len;
+        self.durable_sequence = snapshot.sequence;
+    }
+
+    fn power_loss(&mut self) {
+        self.buffer.blocks.clone_from(&self.durable.blocks);
+        self.buffer.len = self.durable.len;
+        self.dirty_blocks.clear();
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum OperationType {
     Read {
         completion: Completion,
         offset: usize,
@@ -32,6 +116,7 @@ pub enum OperationType {
     },
     Sync {
         completion: Completion,
+        snapshot: SyncSnapshot,
     },
     Truncate {
         completion: Completion,
@@ -40,7 +125,7 @@ pub enum OperationType {
 }
 
 impl OperationType {
-    fn get_completion(&self) -> &Completion {
+    pub(super) fn get_completion(&self) -> &Completion {
         match self {
             OperationType::Read { completion, .. }
             | OperationType::Write { completion, .. }
@@ -52,45 +137,31 @@ impl OperationType {
 }
 
 #[derive(Debug)]
-pub struct Operation {
-    pub time: Option<turso_core::WallClockInstant>,
-    pub op: OperationType,
-    pub fault: bool,
-    pub fd: Arc<Fd>,
+pub(super) struct Operation {
+    pub(super) time: Option<turso_core::WallClockInstant>,
+    pub(super) op: OperationType,
+    pub(super) fault: bool,
+    pub(super) file: Arc<RefCell<FileState>>,
 }
 
 impl Operation {
-    fn do_operation(self, files: &IndexMap<Fd, Arc<MemorySimFile>>) {
-        let fd = self.fd;
+    fn do_operation(self) {
         match self.op {
             OperationType::Read { completion, offset } => {
-                let file = files.get(fd.as_str()).unwrap();
-                let file_buf = file.buffer.borrow();
-                let buffer = completion.as_read().buf.clone();
-                let bytes_read = {
-                    let buf = buffer.as_mut_slice();
-                    if buf.is_empty() || offset >= file_buf.len() {
-                        0
-                    } else {
-                        let available = file_buf.len() - offset;
-                        let to_copy = available.min(buf.len());
-                        buf[..to_copy].copy_from_slice(&file_buf[offset..offset + to_copy]);
-                        if to_copy < buf.len() {
-                            // Keep deterministic behavior for unread tail bytes.
-                            buf[to_copy..].fill(0);
-                        }
-                        to_copy as i32
-                    }
-                };
-                completion.complete(bytes_read);
+                let buffer = &completion.as_read().buf;
+                let bytes_read = self
+                    .file
+                    .borrow()
+                    .buffer
+                    .read(offset, buffer.as_mut_slice());
+                completion.complete(bytes_read as i32);
             }
             OperationType::Write {
                 buffer,
                 completion,
                 offset,
             } => {
-                let file = files.get(fd.as_str()).unwrap();
-                let buf_size = file.write_buf(buffer.as_slice(), offset);
+                let buf_size = self.file.borrow_mut().write(offset, buffer.as_slice());
                 completion.complete(buf_size as i32);
             }
             OperationType::WriteV {
@@ -98,38 +169,40 @@ impl Operation {
                 completion,
                 offset,
             } => {
-                if buffers.is_empty() {
-                    return;
-                }
-                let file = files.get(fd.as_str()).unwrap();
+                let mut file = self.file.borrow_mut();
                 let mut pos = offset;
                 let written = buffers.into_iter().fold(0, |written, buffer| {
-                    let buf_size = file.write_buf(buffer.as_slice(), pos);
+                    let buf_size = file.write(pos, buffer.as_slice());
                     pos += buf_size;
                     written + buf_size
                 });
+                drop(file);
                 completion.complete(written as i32);
             }
-            OperationType::Sync { completion, .. } => {
-                // There is no Sync for in memory
+            OperationType::Sync {
+                completion,
+                snapshot,
+            } => {
+                self.file.borrow_mut().sync_completed(snapshot);
                 completion.complete(0);
             }
             OperationType::Truncate { completion, len } => {
-                let file = files.get(fd.as_str()).unwrap();
-                let mut file_buf = file.buffer.borrow_mut();
-                file_buf.truncate(len);
+                self.file.borrow_mut().resize(len);
                 completion.complete(0);
             }
         }
     }
 }
 
-pub type CallbackQueue = Arc<Mutex<Vec<Operation>>>;
+pub(super) type CallbackQueue = Arc<Mutex<Vec<Operation>>>;
 
 pub struct MemorySimIO {
     callbacks: CallbackQueue,
     timeouts: CallbackQueue,
     pub files: RefCell<IndexMap<Fd, Arc<MemorySimFile>>>,
+    file_states: RefCell<Vec<Weak<RefCell<FileState>>>>,
+    generation: Arc<AtomicU64>,
+    power_loss_in_progress: AtomicBool,
     pub rng: RefCell<ChaCha8Rng>,
     #[expect(dead_code)]
     pub page_size: usize,
@@ -155,6 +228,9 @@ impl MemorySimIO {
             callbacks: Arc::new(Mutex::new(Vec::new())),
             timeouts: Arc::new(Mutex::new(Vec::new())),
             files,
+            file_states: RefCell::new(Vec::new()),
+            generation: Arc::new(AtomicU64::new(0)),
+            power_loss_in_progress: AtomicBool::new(false),
             rng,
             page_size,
             seed,
@@ -165,6 +241,16 @@ impl MemorySimIO {
                 max_tick,
             )),
         }
+    }
+
+    fn ensure_io_allowed(&self) -> Result<()> {
+        if self.power_loss_in_progress.load(Ordering::Acquire) {
+            return Err(LimboError::CompletionError(CompletionError::IOError(
+                std::io::ErrorKind::Other,
+                "memory simulator I/O is unavailable during power loss",
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -205,9 +291,11 @@ impl SimIO for MemorySimIO {
 
     fn syncing(&self) -> bool {
         let callbacks = self.callbacks.try_lock().unwrap();
-        callbacks
-            .iter()
-            .any(|operation| matches!(operation.op, OperationType::Sync { .. }))
+        let timeouts = self.timeouts.try_lock().unwrap();
+        callbacks.iter().chain(timeouts.iter()).any(|operation| {
+            matches!(operation.op, OperationType::Sync { .. })
+                && !operation.op.get_completion().finished()
+        })
     }
 
     fn close_files(&self) {
@@ -216,12 +304,63 @@ impl SimIO for MemorySimIO {
         }
     }
 
+    fn power_loss(&self) -> Result<()> {
+        assert!(
+            !self.power_loss_in_progress.swap(true, Ordering::AcqRel),
+            "power loss cannot be nested"
+        );
+        self.generation
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |generation| {
+                generation.checked_add(1)
+            })
+            .expect("memory simulator crash generation overflow");
+        self.close_files();
+        let pending = {
+            let mut callbacks = self.callbacks.lock();
+            let mut timeouts = self.timeouts.lock();
+            callbacks
+                .drain(..)
+                .chain(timeouts.drain(..))
+                .collect::<Vec<_>>()
+        };
+        for operation in pending {
+            let completion = operation.op.get_completion();
+            if completion.succeeded() {
+                panic!("queued file operation completed without running its operation");
+            }
+            if !completion.finished() {
+                completion.abort();
+            } else {
+                assert!(completion.failed());
+            }
+        }
+        assert!(
+            self.callbacks.lock().is_empty() && self.timeouts.lock().is_empty(),
+            "completion callbacks must not queue new I/O during power loss"
+        );
+        self.file_states.borrow_mut().retain(|state| {
+            let Some(state) = state.upgrade() else {
+                return false;
+            };
+            state.borrow_mut().power_loss();
+            true
+        });
+        self.power_loss_in_progress.store(false, Ordering::Release);
+        Ok(())
+    }
+
     fn persist_files(&self) -> anyhow::Result<()> {
         let files = self.files.borrow();
         for (file_path, file) in files.iter() {
             if file_path.ends_with(".db") || file_path.ends_with("wal") || file_path.ends_with("lg")
             {
-                std::fs::write(file_path, &*file.buffer.borrow())?;
+                let state = file.state.borrow();
+                let mut output = BufWriter::new(std::fs::File::create(file_path)?);
+                for (index, block) in state.buffer.blocks.iter().enumerate() {
+                    let len = (state.buffer.len - index * FILE_BLOCK_SIZE).min(FILE_BLOCK_SIZE);
+                    output.write_all(&block[..len])?;
+                }
+                output.flush()?;
             }
         }
         Ok(())
@@ -245,19 +384,28 @@ impl IO for MemorySimIO {
         _flags: OpenFlags, // TODO: ignoring open flags for now as we don't test read only mode in the simulator yet
         _direct: bool,
     ) -> Result<Arc<dyn turso_core::File>> {
+        self.ensure_io_allowed()?;
         let mut files = self.files.borrow_mut();
         let fd = path.to_string();
-        let file = if let Some(file) = files.get(path) {
-            file.closed.set(false);
-            file.clone()
+        let file = if let Some(file) = files.get(path).cloned() {
+            if !file.is_open() {
+                let file = Arc::new(file.reopen());
+                files.insert(fd, file.clone());
+                file
+            } else {
+                file
+            }
         } else {
             let file = Arc::new(MemorySimFile::new(
                 self.callbacks.clone(),
-                fd.clone(),
                 self.seed,
                 self.latency_probability,
                 self.clock.clone(),
+                self.generation.clone(),
             ));
+            self.file_states
+                .borrow_mut()
+                .push(Arc::downgrade(&file.state));
             files.insert(fd, file.clone());
             file
         };
@@ -272,7 +420,6 @@ impl IO for MemorySimIO {
             callbacks.len = callbacks.len(),
             timeouts.len = timeouts.len()
         );
-        let files = self.files.borrow_mut();
         let now = self.current_time_wall_clock();
 
         callbacks.append(&mut timeouts);
@@ -280,6 +427,10 @@ impl IO for MemorySimIO {
         while let Some(callback) = callbacks.pop() {
             let completion = callback.op.get_completion();
             if completion.finished() {
+                assert!(
+                    completion.failed(),
+                    "queued file operation completed without running its operation"
+                );
                 continue;
             }
 
@@ -290,7 +441,7 @@ impl IO for MemorySimIO {
                     completion.abort();
                     continue;
                 }
-                callback.do_operation(&files);
+                callback.do_operation();
             } else {
                 timeouts.push(callback);
             }
@@ -307,11 +458,78 @@ impl IO for MemorySimIO {
     }
 
     fn remove_file(&self, path: &str) -> Result<()> {
+        self.ensure_io_allowed()?;
         self.files.borrow_mut().shift_remove(path);
         Ok(())
     }
 
     fn file_id(&self, path: &str) -> Result<turso_core::io::FileId> {
         Ok(turso_core::io::FileId::from_path_hash(path))
+    }
+}
+
+impl FileContents {
+    pub(super) fn read(&self, offset: usize, buf: &mut [u8]) -> usize {
+        let len = self.len.saturating_sub(offset).min(buf.len());
+        if len == 0 {
+            return 0;
+        }
+        let mut copied = 0;
+        while copied < len {
+            let pos = offset + copied;
+            let within_block = pos % FILE_BLOCK_SIZE;
+            let count = (FILE_BLOCK_SIZE - within_block).min(len - copied);
+            buf[copied..copied + count].copy_from_slice(
+                &self.blocks[pos / FILE_BLOCK_SIZE][within_block..within_block + count],
+            );
+            copied += count;
+        }
+        buf[len..].fill(0);
+        len
+    }
+}
+
+impl FileState {
+    pub(super) fn write(&mut self, offset: usize, buf: &[u8]) -> usize {
+        self.resize(self.buffer.len.max(offset + buf.len()));
+        let mut copied = 0;
+        while copied < buf.len() {
+            let pos = offset + copied;
+            let within_block = pos % FILE_BLOCK_SIZE;
+            let count = (FILE_BLOCK_SIZE - within_block).min(buf.len() - copied);
+            let index = pos / FILE_BLOCK_SIZE;
+            let block = &mut self.buffer.blocks[index];
+            let bytes = &buf[copied..copied + count];
+            match Arc::get_mut(block) {
+                Some(block) => block[within_block..within_block + count].copy_from_slice(bytes),
+                None if count == FILE_BLOCK_SIZE => *block = Arc::new(bytes.try_into().unwrap()),
+                None => {
+                    Arc::make_mut(block)[within_block..within_block + count].copy_from_slice(bytes)
+                }
+            }
+            self.dirty_blocks.insert(index);
+            copied += count;
+        }
+        buf.len()
+    }
+
+    pub(super) fn resize(&mut self, len: usize) {
+        let old_len = self.buffer.len;
+        let block_count = len.div_ceil(FILE_BLOCK_SIZE);
+        self.buffer
+            .blocks
+            .resize_with(block_count, || Arc::new([0; FILE_BLOCK_SIZE]));
+        if len < old_len {
+            self.dirty_blocks.retain(|&index| index < block_count);
+            if !len.is_multiple_of(FILE_BLOCK_SIZE) {
+                let last = Arc::make_mut(self.buffer.blocks.last_mut().unwrap());
+                last[len % FILE_BLOCK_SIZE..].fill(0);
+            }
+        }
+        if len != old_len {
+            self.dirty_blocks
+                .extend(len.min(old_len) / FILE_BLOCK_SIZE..block_count);
+        }
+        self.buffer.len = len;
     }
 }

--- a/testing/simulator/runner/memory/mvcc_recovery.rs
+++ b/testing/simulator/runner/memory/mvcc_recovery.rs
@@ -102,7 +102,12 @@ fn mutate_file_by_suffix(io: &MemorySimIO, suffix: &str, mutator: impl FnOnce(&m
     let file = files
         .get(&path)
         .unwrap_or_else(|| panic!("missing file for path {path}"));
-    mutator(&mut file.buffer.borrow_mut());
+    let mut state = file.state.borrow_mut();
+    let mut bytes = vec![0; state.buffer.len];
+    state.buffer.read(0, &mut bytes);
+    mutator(&mut bytes);
+    state.resize(bytes.len());
+    state.write(0, &bytes);
 }
 
 fn remove_file_by_suffix(io: &MemorySimIO, suffix: &str) -> Result<()> {

--- a/testing/simulator/runner/mod.rs
+++ b/testing/simulator/runner/mod.rs
@@ -26,5 +26,8 @@ pub trait SimIO: turso_core::IO {
 
     fn close_files(&self);
 
+    /// Discard writes not covered by a completed successful file sync.
+    fn power_loss(&self) -> turso_core::Result<()>;
+
     fn persist_files(&self) -> anyhow::Result<()>;
 }


### PR DESCRIPTION
 ## simulator: add WAL power-loss recovery testing

  Adds power-loss testing for main and attached WAL databases. The memory backend tracks durable file state using copy-on-write snapshots. A crash discards unsynced changes, aborts pending I/O, and invalidates old file handles.

  FsyncNoWait crashes before a pending fsync completes, reopens connections with their normal setup, and retries only the interrupted query.

  Recovery checks compare the exact schema and table contents against the simulator model, including duplicate counts and an empty schema after dropping the last table. Integrity checks
  cover main and attached databases.

  Also generates PASSIVE, FULL, RESTART, and TRUNCATE checkpoints alongside normal workloads.

  Power-loss injection is limited to non-MVCC default simulations using memory I/O. Checkpoints stay out of MVCC, SQLite differential runs, and queries embedded in generated properties.