### PR TITLE
bindings/dotnet: expose the native sync ABI

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -11,6 +11,8 @@ on:
       - "Cargo.lock"
       - "core/**"
       - "sdk-kit/**"
+      - "sync/engine/**"
+      - "sync/sdk-kit/**"
   # Manual trigger with dry-run / publish controls
   workflow_dispatch:
     inputs:
@@ -176,24 +178,24 @@ jobs:
                 export CFLAGS="-DSIMSIMD_TARGET_SIERRA=0 -DSIMSIMD_TARGET_TURIN=0 -DSIMSIMD_TARGET_SAPPHIRE=0 -DSIMSIMD_TARGET_GENOA=0 -DSIMSIMD_TARGET_ICE=0 -DSIMSIMD_TARGET_SKYLAKE=0 -DSIMSIMD_TARGET_HASWELL=0"
                 export CFLAGS_aarch64_unknown_linux_gnu="$CFLAGS"
               fi
-              make ${{ matrix.make-target }} RUST_RELEASE_OPT="--profile release-official"
+              make ${{ matrix.make-target }} RUST_RELEASE_OPT="--profile release-official" RUST_PROFILE_DIR="release-official"
             '
 
       - name: Build rust native library (macOS)
         if: contains(matrix.target, 'apple-darwin')
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos-deployment-target }}
-        run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official'
+        run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official' RUST_PROFILE_DIR='release-official'
 
       - name: Build rust native library (iOS)
         if: contains(matrix.target, 'apple-ios')
         env:
           IPHONEOS_DEPLOYMENT_TARGET: ${{ matrix.ios-deployment-target }}
-        run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official'
+        run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official' RUST_PROFILE_DIR='release-official'
 
       - name: Build rust native library
         if: ${{ !contains(matrix.target, 'unknown-linux-gnu') && !contains(matrix.target, 'apple-darwin') && !contains(matrix.target, 'apple-ios') }}
-        run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official'
+        run: make ${{ matrix.make-target }} RUST_RELEASE_OPT='--profile release-official' RUST_PROFILE_DIR='release-official'
 
       - name: Collect Windows static native dependencies
         if: contains(matrix.target, 'pc-windows-msvc')
@@ -372,6 +374,8 @@ jobs:
             "runtimes/win-arm64/native/turso_sdk_kit.dll"
             "runtimes/linux-x64/native/libturso_sdk_kit.so"
             "runtimes/linux-arm64/native/libturso_sdk_kit.so"
+            "runtimes/osx-x64/native/libturso_sdk_kit.dylib"
+            "runtimes/osx-arm64/native/libturso_sdk_kit.dylib"
             "runtimes/android-arm64/native/libturso_sdk_kit.so"
             "runtimes/android-arm/native/libturso_sdk_kit.so"
             "runtimes/android-x64/native/libturso_sdk_kit.so"

--- a/bindings/dotnet/Makefile
+++ b/bindings/dotnet/Makefile
@@ -19,7 +19,7 @@ RUST_RELEASE_OPT ?=
 RUST_PROFILE_DIR ?= debug
 DOTNET_RELEASE_OPT ?=
 IOS_FRAMEWORK_NAME = libturso_sdk_kit
-IOS_DYLIB_FILE = libturso_sdk_kit.dylib
+IOS_DYLIB_FILE = libturso_sync_sdk_kit.dylib
 IOS_FRAMEWORK_BUILD_DIR = ./rs_compiled/ios-frameworks
 IOS_XCFRAMEWORK_DIR = ./rs_compiled/ios-universal/native/$(IOS_FRAMEWORK_NAME).xcframework
 
@@ -27,42 +27,60 @@ all:
 	echo "make [build|test|benchmark|build-production]"
 
 build-rust-windows64:
-	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target x86_64-pc-windows-msvc $(RUST_RELEASE_OPT)
+	cargo build -p turso_sync_sdk_kit --target-dir ./rs_compiled --target x86_64-pc-windows-msvc $(RUST_RELEASE_OPT)
+	powershell -NoProfile -Command "Copy-Item -Force './rs_compiled/x86_64-pc-windows-msvc/$(RUST_PROFILE_DIR)/turso_sync_sdk_kit.dll' './rs_compiled/x86_64-pc-windows-msvc/$(RUST_PROFILE_DIR)/turso_sdk_kit.dll'"
+	powershell -NoProfile -Command "Copy-Item -Force './rs_compiled/x86_64-pc-windows-msvc/$(RUST_PROFILE_DIR)/turso_sync_sdk_kit.lib' './rs_compiled/x86_64-pc-windows-msvc/$(RUST_PROFILE_DIR)/turso_sdk_kit.lib'"
 
 build-rust-windowsarm64:
-	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target aarch64-pc-windows-msvc $(RUST_RELEASE_OPT)
+	cargo build -p turso_sync_sdk_kit --target-dir ./rs_compiled --target aarch64-pc-windows-msvc $(RUST_RELEASE_OPT)
+	powershell -NoProfile -Command "Copy-Item -Force './rs_compiled/aarch64-pc-windows-msvc/$(RUST_PROFILE_DIR)/turso_sync_sdk_kit.dll' './rs_compiled/aarch64-pc-windows-msvc/$(RUST_PROFILE_DIR)/turso_sdk_kit.dll'"
+	powershell -NoProfile -Command "Copy-Item -Force './rs_compiled/aarch64-pc-windows-msvc/$(RUST_PROFILE_DIR)/turso_sync_sdk_kit.lib' './rs_compiled/aarch64-pc-windows-msvc/$(RUST_PROFILE_DIR)/turso_sdk_kit.lib'"
 
 build-rust-linux64:
-	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target x86_64-unknown-linux-gnu $(RUST_RELEASE_OPT)
+	cargo build -p turso_sync_sdk_kit --target-dir ./rs_compiled --target x86_64-unknown-linux-gnu $(RUST_RELEASE_OPT)
+	cp ./rs_compiled/x86_64-unknown-linux-gnu/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.so ./rs_compiled/x86_64-unknown-linux-gnu/$(RUST_PROFILE_DIR)/libturso_sdk_kit.so
+	cp ./rs_compiled/x86_64-unknown-linux-gnu/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.a ./rs_compiled/x86_64-unknown-linux-gnu/$(RUST_PROFILE_DIR)/libturso_sdk_kit.a
 
 build-rust-linuxarm64:
-	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target aarch64-unknown-linux-gnu $(RUST_RELEASE_OPT)
+	cargo build -p turso_sync_sdk_kit --target-dir ./rs_compiled --target aarch64-unknown-linux-gnu $(RUST_RELEASE_OPT)
+	cp ./rs_compiled/aarch64-unknown-linux-gnu/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.so ./rs_compiled/aarch64-unknown-linux-gnu/$(RUST_PROFILE_DIR)/libturso_sdk_kit.so
+	cp ./rs_compiled/aarch64-unknown-linux-gnu/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.a ./rs_compiled/aarch64-unknown-linux-gnu/$(RUST_PROFILE_DIR)/libturso_sdk_kit.a
 
 build-rust-macos64:
-	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target x86_64-apple-darwin $(RUST_RELEASE_OPT)
+	cargo build -p turso_sync_sdk_kit --target-dir ./rs_compiled --target x86_64-apple-darwin $(RUST_RELEASE_OPT)
+	cp ./rs_compiled/x86_64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.dylib ./rs_compiled/x86_64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sdk_kit.dylib
+	install_name_tool -id @rpath/libturso_sdk_kit.dylib ./rs_compiled/x86_64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sdk_kit.dylib
+	cp ./rs_compiled/x86_64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.a ./rs_compiled/x86_64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sdk_kit.a
 
 build-rust-macosarm64:
-	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target aarch64-apple-darwin $(RUST_RELEASE_OPT)
+	cargo build -p turso_sync_sdk_kit --target-dir ./rs_compiled --target aarch64-apple-darwin $(RUST_RELEASE_OPT)
+	cp ./rs_compiled/aarch64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.dylib ./rs_compiled/aarch64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sdk_kit.dylib
+	install_name_tool -id @rpath/libturso_sdk_kit.dylib ./rs_compiled/aarch64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sdk_kit.dylib
+	cp ./rs_compiled/aarch64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.a ./rs_compiled/aarch64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sdk_kit.a
 
 build-rust-androidarm64:
-	cargo ndk --target aarch64-linux-android --platform 31 build -p turso_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+	cargo ndk --target aarch64-linux-android --platform 31 build -p turso_sync_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+	cp ./rs_compiled/aarch64-linux-android/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.so ./rs_compiled/aarch64-linux-android/$(RUST_PROFILE_DIR)/libturso_sdk_kit.so
 
 build-rust-androidarm:
-	cargo ndk --target armv7-linux-androideabi --platform 31 build -p turso_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+	cargo ndk --target armv7-linux-androideabi --platform 31 build -p turso_sync_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+	cp ./rs_compiled/armv7-linux-androideabi/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.so ./rs_compiled/armv7-linux-androideabi/$(RUST_PROFILE_DIR)/libturso_sdk_kit.so
 
 build-rust-androidx64:
-	cargo ndk --target x86_64-linux-android --platform 31 build -p turso_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+	cargo ndk --target x86_64-linux-android --platform 31 build -p turso_sync_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+	cp ./rs_compiled/x86_64-linux-android/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.so ./rs_compiled/x86_64-linux-android/$(RUST_PROFILE_DIR)/libturso_sdk_kit.so
 
 build-rust-androidx86:
-	cargo ndk --target i686-linux-android --platform 31 build -p turso_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+	cargo ndk --target i686-linux-android --platform 31 build -p turso_sync_sdk_kit --target-dir ./rs_compiled $(RUST_RELEASE_OPT)
+	cp ./rs_compiled/i686-linux-android/$(RUST_PROFILE_DIR)/libturso_sync_sdk_kit.so ./rs_compiled/i686-linux-android/$(RUST_PROFILE_DIR)/libturso_sdk_kit.so
 
 build-rust-android: build-rust-androidarm64 build-rust-androidarm build-rust-androidx64 build-rust-androidx86
 
 build-rust-iosarm64:
-	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target aarch64-apple-ios $(RUST_RELEASE_OPT)
+	cargo build -p turso_sync_sdk_kit --target-dir ./rs_compiled --target aarch64-apple-ios $(RUST_RELEASE_OPT)
 
 build-rust-iossimulatorarm64:
-	cargo build -p turso_sdk_kit --target-dir ./rs_compiled --target aarch64-apple-ios-sim $(RUST_RELEASE_OPT)
+	cargo build -p turso_sync_sdk_kit --target-dir ./rs_compiled --target aarch64-apple-ios-sim $(RUST_RELEASE_OPT)
 
 build-rust-ios: build-rust-iosarm64 build-rust-iossimulatorarm64
 
@@ -119,7 +137,7 @@ generate-platform-client:
 build: build-rust build-dotnet
 
 build-production:
-	$(MAKE) build RUST_RELEASE_OPT='--release' DOTNET_RELEASE_OPT='-c Release'
+	$(MAKE) build RUST_RELEASE_OPT='--release' RUST_PROFILE_DIR='release' DOTNET_RELEASE_OPT='-c Release'
 
 test: build
 	dotnet test ./src/Turso.Tests/Turso.Tests.csproj

--- a/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoDatabaseHandle.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoDatabaseHandle.cs
@@ -5,6 +5,8 @@ namespace Turso.Raw.Public.Handles;
 public class TursoDatabaseHandle() : SafeHandle(IntPtr.Zero, true)
 {
     private IntPtr _database;
+    private SafeHandle? _owner;
+    private bool _ownerReferenceAdded;
 
     protected override bool ReleaseHandle()
     {
@@ -20,8 +22,15 @@ public class TursoDatabaseHandle() : SafeHandle(IntPtr.Zero, true)
         if (_database != IntPtr.Zero)
             TursoInterop.DatabaseDeinit(_database);
 
+        if (_ownerReferenceAdded)
+        {
+            _owner!.DangerousRelease();
+            _ownerReferenceAdded = false;
+        }
+
         handle = IntPtr.Zero;
         _database = IntPtr.Zero;
+        _owner = null;
         return true;
     }
 
@@ -39,5 +48,33 @@ public class TursoDatabaseHandle() : SafeHandle(IntPtr.Zero, true)
         return handle;
     }
 
-    public override bool IsInvalid => handle == IntPtr.Zero || _database == IntPtr.Zero;
+    public static TursoDatabaseHandle FromConnectionPtr(IntPtr connection, SafeHandle owner)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        if (connection == IntPtr.Zero)
+            throw new ArgumentException("Connection pointer must not be null.", nameof(connection));
+        if (owner.IsInvalid || owner.IsClosed)
+            throw new ObjectDisposedException(nameof(owner));
+
+        var ownerReferenceAdded = false;
+        owner.DangerousAddRef(ref ownerReferenceAdded);
+        try
+        {
+            var result = new TursoDatabaseHandle
+            {
+                _owner = owner,
+                _ownerReferenceAdded = ownerReferenceAdded,
+            };
+            result.SetHandle(connection);
+            return result;
+        }
+        catch
+        {
+            if (ownerReferenceAdded)
+                owner.DangerousRelease();
+            throw;
+        }
+    }
+
+    public override bool IsInvalid => handle == IntPtr.Zero || _database == IntPtr.Zero && _owner is null;
 }

--- a/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoSyncChangesHandle.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoSyncChangesHandle.cs
@@ -1,0 +1,32 @@
+using System.Runtime.InteropServices;
+
+namespace Turso.Raw.Public.Handles;
+
+public sealed class TursoSyncChangesHandle() : SafeHandle(IntPtr.Zero, ownsHandle: true)
+{
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle()
+    {
+        TursoSyncInterop.ChangesDeinit(handle);
+        handle = IntPtr.Zero;
+        return true;
+    }
+
+    internal IntPtr Consume()
+    {
+        if (IsInvalid || IsClosed)
+            throw new ObjectDisposedException(nameof(TursoSyncChangesHandle));
+
+        var pointer = handle;
+        SetHandleAsInvalid();
+        return pointer;
+    }
+
+    internal static TursoSyncChangesHandle FromPtr(IntPtr pointer)
+    {
+        var result = new TursoSyncChangesHandle();
+        result.SetHandle(pointer);
+        return result;
+    }
+}

--- a/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoSyncDatabaseHandle.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoSyncDatabaseHandle.cs
@@ -1,0 +1,22 @@
+using System.Runtime.InteropServices;
+
+namespace Turso.Raw.Public.Handles;
+
+public sealed class TursoSyncDatabaseHandle() : SafeHandle(IntPtr.Zero, ownsHandle: true)
+{
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle()
+    {
+        TursoSyncInterop.DatabaseDeinit(handle);
+        handle = IntPtr.Zero;
+        return true;
+    }
+
+    internal static TursoSyncDatabaseHandle FromPtr(IntPtr pointer)
+    {
+        var result = new TursoSyncDatabaseHandle();
+        result.SetHandle(pointer);
+        return result;
+    }
+}

--- a/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoSyncIoItemHandle.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoSyncIoItemHandle.cs
@@ -1,0 +1,22 @@
+using System.Runtime.InteropServices;
+
+namespace Turso.Raw.Public.Handles;
+
+public sealed class TursoSyncIoItemHandle() : SafeHandle(IntPtr.Zero, ownsHandle: true)
+{
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle()
+    {
+        TursoSyncInterop.IoItemDeinit(handle);
+        handle = IntPtr.Zero;
+        return true;
+    }
+
+    internal static TursoSyncIoItemHandle FromPtr(IntPtr pointer)
+    {
+        var result = new TursoSyncIoItemHandle();
+        result.SetHandle(pointer);
+        return result;
+    }
+}

--- a/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoSyncOperationHandle.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/Handles/TursoSyncOperationHandle.cs
@@ -1,0 +1,22 @@
+using System.Runtime.InteropServices;
+
+namespace Turso.Raw.Public.Handles;
+
+public sealed class TursoSyncOperationHandle() : SafeHandle(IntPtr.Zero, ownsHandle: true)
+{
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle()
+    {
+        TursoSyncInterop.OperationDeinit(handle);
+        handle = IntPtr.Zero;
+        return true;
+    }
+
+    internal static TursoSyncOperationHandle FromPtr(IntPtr pointer)
+    {
+        var result = new TursoSyncOperationHandle();
+        result.SetHandle(pointer);
+        return result;
+    }
+}

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoException.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoException.cs
@@ -1,3 +1,8 @@
 namespace Turso.Raw.Public;
 
 public class TursoException(string message) : Exception(message);
+
+public sealed class TursoSyncNativeException(uint statusCode, string message) : TursoException(message)
+{
+    public uint StatusCode { get; } = statusCode;
+}

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoSyncBindings.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoSyncBindings.cs
@@ -1,0 +1,495 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using Turso.Raw.Public.Handles;
+
+namespace Turso.Raw.Public;
+
+public enum TursoSyncOperationState
+{
+    Continue,
+    Io,
+    Done,
+}
+
+public enum TursoSyncOperationResultKind
+{
+    None,
+    Connection,
+    Changes,
+    Stats,
+}
+
+public enum TursoSyncIoKind
+{
+    None,
+    Http,
+    FullRead,
+    FullWrite,
+}
+
+public sealed class TursoSyncDatabaseConfiguration
+{
+    public required string Path { get; init; }
+    public string? RemoteUrl { get; init; }
+    public string ClientName { get; init; } = "turso-sync-dotnet";
+    public int LongPollTimeoutMilliseconds { get; init; }
+    public bool BootstrapIfEmpty { get; init; } = true;
+    public int ReservedBytes { get; init; }
+    public int PartialBootstrapStrategyPrefix { get; init; }
+    public string? PartialBootstrapStrategyQuery { get; init; }
+    public nuint PartialBootstrapSegmentSize { get; init; }
+    public bool PartialBootstrapPrefetch { get; init; }
+    public string? RemoteEncryptionKey { get; init; }
+    public string? RemoteEncryptionCipher { get; init; }
+    public nuint PushOperationsThreshold { get; init; }
+    public nuint PullBytesThreshold { get; init; }
+    public bool LogicalMvccPull { get; init; }
+    public string? ExperimentalFeatures { get; init; }
+}
+
+public sealed record TursoSyncHttpHeader(string Name, string Value);
+
+public sealed record TursoSyncHttpRequest(
+    string? Url,
+    string Method,
+    string Path,
+    byte[] Body,
+    IReadOnlyList<TursoSyncHttpHeader> Headers);
+
+public sealed record TursoSyncFullWriteRequest(string Path, byte[] Content);
+
+public sealed record TursoSyncStatistics(
+    long CdcOperations,
+    long MainWalSize,
+    long RevertWalSize,
+    long LastPullUnixTime,
+    long LastPushUnixTime,
+    long NetworkSentBytes,
+    long NetworkReceivedBytes,
+    string Revision);
+
+public static class TursoSyncBindings
+{
+    public static TursoSyncDatabaseHandle NewDatabase(TursoSyncDatabaseConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuration.Path);
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuration.ClientName);
+        ArgumentOutOfRangeException.ThrowIfNegative(configuration.LongPollTimeoutMilliseconds);
+        ArgumentOutOfRangeException.ThrowIfNegative(configuration.ReservedBytes);
+        ArgumentOutOfRangeException.ThrowIfNegative(configuration.PartialBootstrapStrategyPrefix);
+
+        using var path = NativeUtf8String.From(configuration.Path);
+        using var remoteUrl = NativeUtf8String.From(configuration.RemoteUrl);
+        using var clientName = NativeUtf8String.From(configuration.ClientName);
+        using var query = NativeUtf8String.From(configuration.PartialBootstrapStrategyQuery);
+        using var remoteEncryptionKey = NativeUtf8String.From(configuration.RemoteEncryptionKey);
+        using var remoteEncryptionCipher = NativeUtf8String.From(configuration.RemoteEncryptionCipher);
+        using var experimentalFeatures = NativeUtf8String.From(configuration.ExperimentalFeatures);
+
+        var databaseConfig = new TursoDatabaseConfig
+        {
+            AsyncIo = 1,
+            Path = path.Pointer,
+            ExperimentalFeatures = experimentalFeatures.Pointer,
+            Vfs = IntPtr.Zero,
+            EncryptionCipher = IntPtr.Zero,
+            EncryptionHexKey = IntPtr.Zero,
+            PageCodec = IntPtr.Zero,
+            OpenFlags = 0,
+        };
+        var syncConfig = new TursoSyncDatabaseConfigNative
+        {
+            Path = path.Pointer,
+            RemoteUrl = remoteUrl.Pointer,
+            ClientName = clientName.Pointer,
+            LongPollTimeoutMs = configuration.LongPollTimeoutMilliseconds,
+            BootstrapIfEmpty = configuration.BootstrapIfEmpty,
+            ReservedBytes = configuration.ReservedBytes,
+            PartialBootstrapStrategyPrefix = configuration.PartialBootstrapStrategyPrefix,
+            PartialBootstrapStrategyQuery = query.Pointer,
+            PartialBootstrapSegmentSize = configuration.PartialBootstrapSegmentSize,
+            PartialBootstrapPrefetch = configuration.PartialBootstrapPrefetch,
+            RemoteEncryptionKey = remoteEncryptionKey.Pointer,
+            RemoteEncryptionCipher = remoteEncryptionCipher.Pointer,
+            PushOperationsThreshold = configuration.PushOperationsThreshold,
+            PullBytesThreshold = configuration.PullBytesThreshold,
+            LogicalMvccPull = configuration.LogicalMvccPull,
+        };
+
+        var status = TursoSyncInterop.DatabaseNew(ref databaseConfig, ref syncConfig, out var database, out var errorPtr);
+        ThrowIfError(status, errorPtr);
+        return TursoSyncDatabaseHandle.FromPtr(database);
+    }
+
+    public static TursoSyncOperationHandle StartOpen(TursoSyncDatabaseHandle database)
+        => StartOperation(database, TursoSyncInterop.DatabaseOpen);
+
+    public static TursoSyncOperationHandle StartCreate(TursoSyncDatabaseHandle database)
+        => StartOperation(database, TursoSyncInterop.DatabaseCreate);
+
+    public static TursoSyncOperationHandle StartConnect(TursoSyncDatabaseHandle database)
+        => StartOperation(database, TursoSyncInterop.DatabaseConnect);
+
+    public static TursoSyncOperationHandle StartStats(TursoSyncDatabaseHandle database)
+        => StartOperation(database, TursoSyncInterop.DatabaseStats);
+
+    public static TursoSyncOperationHandle StartCheckpoint(TursoSyncDatabaseHandle database)
+        => StartOperation(database, TursoSyncInterop.DatabaseCheckpoint);
+
+    public static TursoSyncOperationHandle StartPush(TursoSyncDatabaseHandle database)
+        => StartOperation(database, TursoSyncInterop.DatabasePushChanges);
+
+    public static TursoSyncOperationHandle StartWaitChanges(TursoSyncDatabaseHandle database)
+        => StartOperation(database, TursoSyncInterop.DatabaseWaitChanges);
+
+    public static TursoSyncOperationHandle StartApplyChanges(
+        TursoSyncDatabaseHandle database,
+        TursoSyncChangesHandle changes)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        ArgumentNullException.ThrowIfNull(changes);
+
+        var databaseReferenceAdded = false;
+        database.DangerousAddRef(ref databaseReferenceAdded);
+        try
+        {
+            var changesPointer = changes.Consume();
+            var status = TursoSyncInterop.DatabaseApplyChanges(
+                database.DangerousGetHandle(),
+                changesPointer,
+                out var operation,
+                out var errorPtr);
+            ThrowIfError(status, errorPtr);
+            return TursoSyncOperationHandle.FromPtr(operation);
+        }
+        finally
+        {
+            if (databaseReferenceAdded)
+                database.DangerousRelease();
+        }
+    }
+
+    public static TursoSyncOperationState Resume(TursoSyncOperationHandle operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        var status = TursoSyncInterop.OperationResume(operation, out var errorPtr);
+        if (errorPtr != IntPtr.Zero)
+            ThrowException(status, errorPtr);
+
+        return status switch
+        {
+            TursoStatusCode.Ok => TursoSyncOperationState.Continue,
+            TursoStatusCode.Io => TursoSyncOperationState.Io,
+            TursoStatusCode.Done => TursoSyncOperationState.Done,
+            _ => throw new TursoSyncNativeException(
+                (uint)status,
+                $"Turso sync operation failed with status {status}."),
+        };
+    }
+
+    public static TursoSyncOperationResultKind GetResultKind(TursoSyncOperationHandle operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        return TursoSyncInterop.OperationResultKind(operation) switch
+        {
+            TursoSyncOperationResultType.None => TursoSyncOperationResultKind.None,
+            TursoSyncOperationResultType.Connection => TursoSyncOperationResultKind.Connection,
+            TursoSyncOperationResultType.Changes => TursoSyncOperationResultKind.Changes,
+            TursoSyncOperationResultType.Stats => TursoSyncOperationResultKind.Stats,
+            var value => throw new TursoException($"Unknown Turso sync result kind {value}."),
+        };
+    }
+
+    public static TursoDatabaseHandle ExtractConnection(
+        TursoSyncDatabaseHandle database,
+        TursoSyncOperationHandle operation)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var databaseReferenceAdded = false;
+        var connection = IntPtr.Zero;
+        database.DangerousAddRef(ref databaseReferenceAdded);
+        try
+        {
+            var status = TursoSyncInterop.OperationExtractConnection(operation, out connection);
+            ThrowIfError(status, IntPtr.Zero);
+            return TursoDatabaseHandle.FromConnectionPtr(connection, database);
+        }
+        catch
+        {
+            if (connection != IntPtr.Zero)
+                ReleaseConnection(connection);
+            throw;
+        }
+        finally
+        {
+            if (databaseReferenceAdded)
+                database.DangerousRelease();
+        }
+    }
+
+    public static TursoSyncChangesHandle? ExtractChanges(TursoSyncOperationHandle operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        var status = TursoSyncInterop.OperationExtractChanges(operation, out var changes);
+        ThrowIfError(status, IntPtr.Zero);
+        return changes == IntPtr.Zero ? null : TursoSyncChangesHandle.FromPtr(changes);
+    }
+
+    public static TursoSyncStatistics ExtractStats(TursoSyncOperationHandle operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var operationReferenceAdded = false;
+        operation.DangerousAddRef(ref operationReferenceAdded);
+        try
+        {
+            var status = TursoSyncInterop.OperationExtractStats(operation, out var stats);
+            ThrowIfError(status, IntPtr.Zero);
+            return new TursoSyncStatistics(
+                stats.CdcOperations,
+                stats.MainWalSize,
+                stats.RevertWalSize,
+                stats.LastPullUnixTime,
+                stats.LastPushUnixTime,
+                stats.NetworkSentBytes,
+                stats.NetworkReceivedBytes,
+                CopyUtf8(stats.Revision));
+        }
+        finally
+        {
+            if (operationReferenceAdded)
+                operation.DangerousRelease();
+        }
+    }
+
+    public static TursoSyncIoItemHandle? TakeIoItem(TursoSyncDatabaseHandle database)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        var status = TursoSyncInterop.DatabaseTakeIoItem(database, out var item, out var errorPtr);
+        ThrowIfError(status, errorPtr);
+        return item == IntPtr.Zero ? null : TursoSyncIoItemHandle.FromPtr(item);
+    }
+
+    public static void StepIoCallbacks(TursoSyncDatabaseHandle database)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        var status = TursoSyncInterop.DatabaseStepIoCallbacks(database, out var errorPtr);
+        ThrowIfError(status, errorPtr);
+    }
+
+    public static TursoSyncIoKind GetIoKind(TursoSyncIoItemHandle item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        return TursoSyncInterop.IoRequestKind(item) switch
+        {
+            TursoSyncIoRequestType.None => TursoSyncIoKind.None,
+            TursoSyncIoRequestType.Http => TursoSyncIoKind.Http,
+            TursoSyncIoRequestType.FullRead => TursoSyncIoKind.FullRead,
+            TursoSyncIoRequestType.FullWrite => TursoSyncIoKind.FullWrite,
+            var value => throw new TursoException($"Unknown Turso sync I/O kind {value}."),
+        };
+    }
+
+    public static TursoSyncHttpRequest GetHttpRequest(TursoSyncIoItemHandle item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        var itemReferenceAdded = false;
+        item.DangerousAddRef(ref itemReferenceAdded);
+        try
+        {
+            var status = TursoSyncInterop.IoRequestHttp(item, out var request);
+            ThrowIfError(status, IntPtr.Zero);
+            if (request.HeaderCount < 0)
+                throw new TursoException("Turso sync returned a negative HTTP header count.");
+
+            var headers = new List<TursoSyncHttpHeader>(request.HeaderCount);
+            for (var index = 0; index < request.HeaderCount; index++)
+            {
+                status = TursoSyncInterop.IoRequestHttpHeader(item, (nuint)index, out var header);
+                ThrowIfError(status, IntPtr.Zero);
+                headers.Add(new TursoSyncHttpHeader(CopyUtf8(header.Key), CopyUtf8(header.Value)));
+            }
+
+            var url = CopyUtf8(request.Url);
+            return new TursoSyncHttpRequest(
+                string.IsNullOrEmpty(url) ? null : url,
+                CopyUtf8(request.Method),
+                CopyUtf8(request.Path),
+                CopyBytes(request.Body),
+                headers);
+        }
+        finally
+        {
+            if (itemReferenceAdded)
+                item.DangerousRelease();
+        }
+    }
+
+    public static string GetFullReadPath(TursoSyncIoItemHandle item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        var itemReferenceAdded = false;
+        item.DangerousAddRef(ref itemReferenceAdded);
+        try
+        {
+            var status = TursoSyncInterop.IoRequestFullRead(item, out var request);
+            ThrowIfError(status, IntPtr.Zero);
+            return CopyUtf8(request.Path);
+        }
+        finally
+        {
+            if (itemReferenceAdded)
+                item.DangerousRelease();
+        }
+    }
+
+    public static TursoSyncFullWriteRequest GetFullWriteRequest(TursoSyncIoItemHandle item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        var itemReferenceAdded = false;
+        item.DangerousAddRef(ref itemReferenceAdded);
+        try
+        {
+            var status = TursoSyncInterop.IoRequestFullWrite(item, out var request);
+            ThrowIfError(status, IntPtr.Zero);
+            return new TursoSyncFullWriteRequest(CopyUtf8(request.Path), CopyBytes(request.Content));
+        }
+        finally
+        {
+            if (itemReferenceAdded)
+                item.DangerousRelease();
+        }
+    }
+
+    public static void SetIoStatus(TursoSyncIoItemHandle item, int statusCode)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ThrowIfError(TursoSyncInterop.IoStatus(item, statusCode), IntPtr.Zero);
+    }
+
+    public static void PushIoBuffer(TursoSyncIoItemHandle item, ReadOnlySpan<byte> buffer)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        unsafe
+        {
+            fixed (byte* pointer = buffer)
+            {
+                var slice = new TursoSliceRef
+                {
+                    Pointer = (IntPtr)pointer,
+                    Length = (nuint)buffer.Length,
+                };
+                ThrowIfError(TursoSyncInterop.IoPushBuffer(item, ref slice), IntPtr.Zero);
+            }
+        }
+    }
+
+    public static void PoisonIo(TursoSyncIoItemHandle item, string error)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(error);
+        var bytes = Encoding.UTF8.GetBytes(error);
+        unsafe
+        {
+            fixed (byte* pointer = bytes)
+            {
+                var slice = new TursoSliceRef
+                {
+                    Pointer = (IntPtr)pointer,
+                    Length = (nuint)bytes.Length,
+                };
+                ThrowIfError(TursoSyncInterop.IoPoison(item, ref slice), IntPtr.Zero);
+            }
+        }
+    }
+
+    public static void CompleteIo(TursoSyncIoItemHandle item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ThrowIfError(TursoSyncInterop.IoDone(item), IntPtr.Zero);
+    }
+
+    private delegate TursoStatusCode StartOperationDelegate(
+        TursoSyncDatabaseHandle database,
+        out IntPtr operation,
+        out IntPtr errorPtr);
+
+    private static TursoSyncOperationHandle StartOperation(
+        TursoSyncDatabaseHandle database,
+        StartOperationDelegate start)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        var status = start(database, out var operation, out var errorPtr);
+        ThrowIfError(status, errorPtr);
+        return TursoSyncOperationHandle.FromPtr(operation);
+    }
+
+    private static byte[] CopyBytes(TursoSliceRef slice)
+    {
+        if (slice.Length == 0)
+            return [];
+        if (slice.Pointer == IntPtr.Zero)
+            throw new TursoException("Turso sync returned a null pointer for a non-empty slice.");
+        if (slice.Length > int.MaxValue)
+            throw new TursoException("Turso sync returned a slice that is too large for a managed buffer.");
+
+        var result = new byte[(int)slice.Length];
+        Marshal.Copy(slice.Pointer, result, 0, result.Length);
+        return result;
+    }
+
+    private static string CopyUtf8(TursoSliceRef slice)
+        => slice.Length == 0 ? string.Empty : Encoding.UTF8.GetString(CopyBytes(slice));
+
+    private static void ThrowIfError(TursoStatusCode status, IntPtr errorPtr)
+    {
+        if (errorPtr != IntPtr.Zero)
+            ThrowException(status, errorPtr);
+        if (status == TursoStatusCode.Ok)
+            return;
+
+        throw new TursoSyncNativeException(
+            (uint)status,
+            $"Turso sync native call failed with status {status}.");
+    }
+
+    private static void ThrowException(TursoStatusCode status, IntPtr errorPtr)
+    {
+        var message = Marshal.PtrToStringUTF8(errorPtr) ?? "Internal error";
+        TursoSyncInterop.FreeString(errorPtr);
+        throw new TursoSyncNativeException((uint)status, message);
+    }
+
+    private static void ReleaseConnection(IntPtr connection)
+    {
+        _ = TursoInterop.ConnectionClose(connection, out var errorPtr);
+        if (errorPtr != IntPtr.Zero)
+            TursoInterop.FreeString(errorPtr);
+        TursoInterop.ConnectionDeinit(connection);
+    }
+
+    private sealed class NativeUtf8String : IDisposable
+    {
+        private NativeUtf8String(IntPtr pointer) => Pointer = pointer;
+
+        public IntPtr Pointer { get; private set; }
+
+        public static NativeUtf8String From(string? value)
+            => new(value is null ? IntPtr.Zero : Marshal.StringToCoTaskMemUTF8(value));
+
+        public void Dispose()
+        {
+            if (Pointer == IntPtr.Zero)
+                return;
+
+            Marshal.FreeCoTaskMem(Pointer);
+            Pointer = IntPtr.Zero;
+        }
+    }
+}

--- a/bindings/dotnet/src/Turso.Raw/README.md
+++ b/bindings/dotnet/src/Turso.Raw/README.md
@@ -4,5 +4,5 @@ This is an implementation package used by Turso .NET providers. Application
 projects should reference a provider package such as
 `Turso.Data.Sqlite.Provider` instead of referencing this package directly.
 
-The package contains the precompiled Turso native runtime and the transitive
+The package contains the combined `turso_sdk_kit` native runtime and the transitive
 build support needed to load it on supported platforms.

--- a/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Runtime.InteropServices;
 using Turso.Raw.Public;
 using Turso.Raw.Public.Handles;
@@ -53,20 +52,7 @@ internal static class TursoInterop
 
     static TursoInterop()
     {
-        if (OperatingSystem.IsIOS())
-        {
-            NativeLibrary.SetDllImportResolver(typeof(TursoInterop).Assembly, ResolveDllImport);
-        }
-    }
-
-    private static IntPtr ResolveDllImport(
-        string libraryName,
-        Assembly assembly,
-        DllImportSearchPath? searchPath)
-    {
-        return libraryName == DllName
-            ? NativeLibrary.Load($"Frameworks/lib{libraryName}.framework/lib{libraryName}", assembly, searchPath)
-            : IntPtr.Zero;
+        TursoNativeLibraryResolver.EnsureInitialized();
     }
 
     [DllImport(DllName, EntryPoint = "turso_database_new", CallingConvention = CallingConvention.Cdecl)]

--- a/bindings/dotnet/src/Turso.Raw/TursoNativeLibraryResolver.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoNativeLibraryResolver.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Turso.Raw;
+
+internal static class TursoNativeLibraryResolver
+{
+    private static readonly object s_lock = new();
+    private static bool s_initialized;
+
+    internal static void EnsureInitialized()
+    {
+        if (!OperatingSystem.IsIOS())
+            return;
+
+        lock (s_lock)
+        {
+            if (s_initialized)
+                return;
+
+            NativeLibrary.SetDllImportResolver(typeof(TursoNativeLibraryResolver).Assembly, Resolve);
+            s_initialized = true;
+        }
+    }
+
+    private static IntPtr Resolve(
+        string libraryName,
+        Assembly assembly,
+        DllImportSearchPath? searchPath)
+    {
+        return libraryName == TursoSyncInterop.DllName
+            ? NativeLibrary.Load(
+                $"Frameworks/lib{libraryName}.framework/lib{libraryName}",
+                assembly,
+                searchPath)
+            : IntPtr.Zero;
+    }
+}

--- a/bindings/dotnet/src/Turso.Raw/TursoSyncInterop.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoSyncInterop.cs
@@ -1,0 +1,249 @@
+using System.Runtime.InteropServices;
+using Turso.Raw.Public.Handles;
+
+namespace Turso.Raw;
+
+internal enum TursoSyncIoRequestType
+{
+    None = 0,
+    Http = 1,
+    FullRead = 2,
+    FullWrite = 3,
+}
+
+internal enum TursoSyncOperationResultType
+{
+    None = 0,
+    Connection = 1,
+    Changes = 2,
+    Stats = 3,
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TursoSliceRef
+{
+    public IntPtr Pointer;
+    public nuint Length;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TursoSyncDatabaseConfigNative
+{
+    public IntPtr Path;
+    public IntPtr RemoteUrl;
+    public IntPtr ClientName;
+    public int LongPollTimeoutMs;
+    [MarshalAs(UnmanagedType.I1)]
+    public bool BootstrapIfEmpty;
+    public int ReservedBytes;
+    public int PartialBootstrapStrategyPrefix;
+    public IntPtr PartialBootstrapStrategyQuery;
+    public nuint PartialBootstrapSegmentSize;
+    [MarshalAs(UnmanagedType.I1)]
+    public bool PartialBootstrapPrefetch;
+    public IntPtr RemoteEncryptionKey;
+    public IntPtr RemoteEncryptionCipher;
+    public nuint PushOperationsThreshold;
+    public nuint PullBytesThreshold;
+    [MarshalAs(UnmanagedType.I1)]
+    public bool LogicalMvccPull;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TursoSyncHttpRequestNative
+{
+    public TursoSliceRef Url;
+    public TursoSliceRef Method;
+    public TursoSliceRef Path;
+    public TursoSliceRef Body;
+    public int HeaderCount;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TursoSyncHttpHeaderNative
+{
+    public TursoSliceRef Key;
+    public TursoSliceRef Value;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TursoSyncFullReadRequestNative
+{
+    public TursoSliceRef Path;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TursoSyncFullWriteRequestNative
+{
+    public TursoSliceRef Path;
+    public TursoSliceRef Content;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct TursoSyncStatsNative
+{
+    public long CdcOperations;
+    public long MainWalSize;
+    public long RevertWalSize;
+    public long LastPullUnixTime;
+    public long LastPushUnixTime;
+    public long NetworkSentBytes;
+    public long NetworkReceivedBytes;
+    public TursoSliceRef Revision;
+}
+
+internal static class TursoSyncInterop
+{
+    internal const string DllName = "turso_sdk_kit";
+
+    static TursoSyncInterop()
+    {
+        TursoNativeLibraryResolver.EnsureInitialized();
+    }
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_new", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabaseNew(
+        ref TursoDatabaseConfig databaseConfig,
+        ref TursoSyncDatabaseConfigNative syncConfig,
+        out IntPtr database,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_open", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabaseOpen(
+        TursoSyncDatabaseHandle database,
+        out IntPtr operation,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_create", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabaseCreate(
+        TursoSyncDatabaseHandle database,
+        out IntPtr operation,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_connect", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabaseConnect(
+        TursoSyncDatabaseHandle database,
+        out IntPtr operation,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_stats", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabaseStats(
+        TursoSyncDatabaseHandle database,
+        out IntPtr operation,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_checkpoint", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabaseCheckpoint(
+        TursoSyncDatabaseHandle database,
+        out IntPtr operation,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_push_changes", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabasePushChanges(
+        TursoSyncDatabaseHandle database,
+        out IntPtr operation,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_wait_changes", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabaseWaitChanges(
+        TursoSyncDatabaseHandle database,
+        out IntPtr operation,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_apply_changes", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabaseApplyChanges(
+        IntPtr database,
+        IntPtr changes,
+        out IntPtr operation,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_operation_resume", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode OperationResume(
+        TursoSyncOperationHandle operation,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_operation_result_kind", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoSyncOperationResultType OperationResultKind(
+        TursoSyncOperationHandle operation);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_operation_result_extract_connection", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode OperationExtractConnection(
+        TursoSyncOperationHandle operation,
+        out IntPtr connection);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_operation_result_extract_changes", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode OperationExtractChanges(
+        TursoSyncOperationHandle operation,
+        out IntPtr changes);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_operation_result_extract_stats", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode OperationExtractStats(
+        TursoSyncOperationHandle operation,
+        out TursoSyncStatsNative stats);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_take_item", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabaseTakeIoItem(
+        TursoSyncDatabaseHandle database,
+        out IntPtr item,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_step_callbacks", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode DatabaseStepIoCallbacks(
+        TursoSyncDatabaseHandle database,
+        out IntPtr errorPtr);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_request_kind", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoSyncIoRequestType IoRequestKind(TursoSyncIoItemHandle item);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_request_http", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode IoRequestHttp(
+        TursoSyncIoItemHandle item,
+        out TursoSyncHttpRequestNative request);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_request_http_header", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode IoRequestHttpHeader(
+        TursoSyncIoItemHandle item,
+        nuint index,
+        out TursoSyncHttpHeaderNative header);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_request_full_read", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode IoRequestFullRead(
+        TursoSyncIoItemHandle item,
+        out TursoSyncFullReadRequestNative request);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_request_full_write", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode IoRequestFullWrite(
+        TursoSyncIoItemHandle item,
+        out TursoSyncFullWriteRequestNative request);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_poison", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode IoPoison(
+        TursoSyncIoItemHandle item,
+        ref TursoSliceRef error);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_status", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode IoStatus(TursoSyncIoItemHandle item, int status);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_push_buffer", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode IoPushBuffer(
+        TursoSyncIoItemHandle item,
+        ref TursoSliceRef buffer);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_done", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern TursoStatusCode IoDone(TursoSyncIoItemHandle item);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_deinit", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void DatabaseDeinit(IntPtr database);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_operation_deinit", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void OperationDeinit(IntPtr operation);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_database_io_item_deinit", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void IoItemDeinit(IntPtr item);
+
+    [DllImport(DllName, EntryPoint = "turso_sync_changes_deinit", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void ChangesDeinit(IntPtr changes);
+
+    [DllImport(DllName, EntryPoint = "turso_str_deinit", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void FreeString(IntPtr stringPtr);
+}

--- a/bindings/dotnet/src/Turso.Tests/TursoSyncInteropTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/TursoSyncInteropTests.cs
@@ -1,0 +1,321 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using AwesomeAssertions;
+using Turso.Raw.Public;
+using Turso.Raw.Public.Handles;
+
+namespace Turso.Tests;
+
+public sealed class TursoSyncInteropTests
+{
+    [Test]
+    public void NativeLayoutsMatchTheSyncHeader()
+    {
+        var assembly = typeof(TursoSyncBindings).Assembly;
+
+        AssertLayout(
+            GetNativeType(assembly, "TursoSliceRef"),
+            [
+                ("Pointer", Pointer()),
+                ("Length", Pointer()),
+            ]);
+        AssertLayout(
+            GetNativeType(assembly, "TursoSyncDatabaseConfigNative"),
+            [
+                ("Path", Pointer()),
+                ("RemoteUrl", Pointer()),
+                ("ClientName", Pointer()),
+                ("LongPollTimeoutMs", Int32()),
+                ("BootstrapIfEmpty", Bool()),
+                ("ReservedBytes", Int32()),
+                ("PartialBootstrapStrategyPrefix", Int32()),
+                ("PartialBootstrapStrategyQuery", Pointer()),
+                ("PartialBootstrapSegmentSize", Pointer()),
+                ("PartialBootstrapPrefetch", Bool()),
+                ("RemoteEncryptionKey", Pointer()),
+                ("RemoteEncryptionCipher", Pointer()),
+                ("PushOperationsThreshold", Pointer()),
+                ("PullBytesThreshold", Pointer()),
+                ("LogicalMvccPull", Bool()),
+            ]);
+        AssertLayout(
+            GetNativeType(assembly, "TursoSyncHttpRequestNative"),
+            [
+                ("Url", Slice()),
+                ("Method", Slice()),
+                ("Path", Slice()),
+                ("Body", Slice()),
+                ("HeaderCount", Int32()),
+            ]);
+        AssertLayout(
+            GetNativeType(assembly, "TursoSyncHttpHeaderNative"),
+            [
+                ("Key", Slice()),
+                ("Value", Slice()),
+            ]);
+        AssertLayout(
+            GetNativeType(assembly, "TursoSyncFullReadRequestNative"),
+            [("Path", Slice())]);
+        AssertLayout(
+            GetNativeType(assembly, "TursoSyncFullWriteRequestNative"),
+            [
+                ("Path", Slice()),
+                ("Content", Slice()),
+            ]);
+        AssertLayout(
+            GetNativeType(assembly, "TursoSyncStatsNative"),
+            [
+                ("CdcOperations", Int64()),
+                ("MainWalSize", Int64()),
+                ("RevertWalSize", Int64()),
+                ("LastPullUnixTime", Int64()),
+                ("LastPushUnixTime", Int64()),
+                ("NetworkSentBytes", Int64()),
+                ("NetworkReceivedBytes", Int64()),
+                ("Revision", Slice()),
+            ]);
+
+        foreach (var fieldName in new[]
+                 {
+                     "BootstrapIfEmpty",
+                     "PartialBootstrapPrefetch",
+                     "LogicalMvccPull",
+                 })
+        {
+            var field = GetNativeType(assembly, "TursoSyncDatabaseConfigNative").GetField(fieldName)!;
+            field.GetCustomAttribute<MarshalAsAttribute>()!.Value.Should().Be(UnmanagedType.I1);
+        }
+
+        Enum.GetUnderlyingType(GetNativeType(assembly, "TursoSyncIoRequestType")).Should().Be(typeof(int));
+        Enum.GetUnderlyingType(GetNativeType(assembly, "TursoSyncOperationResultType")).Should().Be(typeof(int));
+    }
+
+    [Test]
+    public void NewDatabaseAcceptsAnOmittedRemoteUrl()
+    {
+        using var database = TursoSyncBindings.NewDatabase(
+            new TursoSyncDatabaseConfiguration
+            {
+                Path = ":memory:",
+            });
+
+        database.IsInvalid.Should().BeFalse();
+    }
+
+    [Test]
+    public void SyncCreateProducesAReadableHttpIoRequest()
+    {
+        using var database = TursoSyncBindings.NewDatabase(
+            new TursoSyncDatabaseConfiguration
+            {
+                Path = ":memory:",
+                RemoteUrl = "https://example.test",
+                ClientName = "turso-dotnet-interop-test",
+            });
+        using var operation = TursoSyncBindings.StartCreate(database);
+        using var item = TakeNextIoItem(database, operation);
+
+        TursoSyncBindings.GetIoKind(item).Should().Be(TursoSyncIoKind.Http);
+        var request = TursoSyncBindings.GetHttpRequest(item);
+        request.Method.Should().Be("POST");
+        request.Path.Should().Be("/pull-updates");
+        request.Headers.Should().Contain(x => x.Name == "content-type" && x.Value == "application/protobuf");
+
+        TursoSyncBindings.PoisonIo(item, "test stopped before network I/O");
+        TursoSyncBindings.CompleteIo(item);
+        TursoSyncBindings.StepIoCallbacks(database);
+    }
+
+    [Test]
+    public void HttpIoAcceptsStatusAndResponseBytes()
+    {
+        using var database = TursoSyncBindings.NewDatabase(
+            new TursoSyncDatabaseConfiguration
+            {
+                Path = ":memory:",
+                RemoteUrl = "https://example.test",
+                ClientName = "turso-dotnet-interop-test",
+            });
+        using var operation = TursoSyncBindings.StartCreate(database);
+        using var item = TakeNextIoItem(database, operation);
+        var body = Encoding.UTF8.GetBytes("not a sync response");
+
+        TursoSyncBindings.SetIoStatus(item, 500);
+        TursoSyncBindings.PushIoBuffer(item, body);
+        TursoSyncBindings.CompleteIo(item);
+        TursoSyncBindings.StepIoCallbacks(database);
+    }
+
+    [Test]
+    public void ExtractedConnectionKeepsItsSyncDatabaseAlive()
+    {
+        var database = TursoSyncBindings.NewDatabase(
+            new TursoSyncDatabaseConfiguration
+            {
+                Path = ":memory:",
+                RemoteUrl = "https://example.test",
+                ClientName = "turso-dotnet-ownership-test",
+                BootstrapIfEmpty = false,
+            });
+        using var create = TursoSyncBindings.StartCreate(database);
+        DriveLocalOperation(database, create);
+
+        using var connect = TursoSyncBindings.StartConnect(database);
+        DriveLocalOperation(database, connect);
+        TursoSyncBindings.GetResultKind(connect).Should().Be(TursoSyncOperationResultKind.Connection);
+        var connection = TursoSyncBindings.ExtractConnection(database, connect);
+
+        database.Dispose();
+        database.IsClosed.Should().BeFalse();
+
+        using (connection)
+        {
+            using var statement = TursoBindings.PrepareStatement(connection, "SELECT 1");
+            TursoBindings.Read(statement).Should().BeTrue();
+            TursoBindings.GetValue(statement, 0).IntValue.Should().Be(1L);
+            TursoBindings.Read(statement).Should().BeFalse();
+        }
+
+        database.IsClosed.Should().BeTrue();
+    }
+
+    [Test]
+    public void NativePackageKeepsLegacyRidFilenames()
+    {
+        var makefile = File.ReadAllText(FindRepositoryFile("bindings", "dotnet", "Makefile"));
+        makefile.Should().Contain("cargo build -p turso_sync_sdk_kit");
+        makefile.Should().Contain("turso_sync_sdk_kit.dll' './rs_compiled/x86_64-pc-windows-msvc/$(RUST_PROFILE_DIR)/turso_sdk_kit.dll");
+        makefile.Should().Contain("libturso_sync_sdk_kit.so ./rs_compiled/x86_64-unknown-linux-gnu/$(RUST_PROFILE_DIR)/libturso_sdk_kit.so");
+        makefile.Should().Contain("libturso_sync_sdk_kit.dylib ./rs_compiled/x86_64-apple-darwin/$(RUST_PROFILE_DIR)/libturso_sdk_kit.dylib");
+
+        var project = File.ReadAllText(
+            FindRepositoryFile("bindings", "dotnet", "src", "Turso.Raw", "Turso.Raw.csproj"))
+            .Replace('\\', '/');
+        project.Should().NotContain("turso_sync_sdk_kit");
+
+        foreach (var packagePath in new[]
+                 {
+                     "runtimes/win-x64/native/turso_sdk_kit.dll",
+                     "runtimes/win-arm64/native/turso_sdk_kit.dll",
+                     "runtimes/linux-x64/native/libturso_sdk_kit.so",
+                     "runtimes/linux-arm64/native/libturso_sdk_kit.so",
+                     "runtimes/osx-x64/native/libturso_sdk_kit.dylib",
+                     "runtimes/osx-arm64/native/libturso_sdk_kit.dylib",
+                     "runtimes/android-arm64/native/libturso_sdk_kit.so",
+                     "runtimes/android-arm/native/libturso_sdk_kit.so",
+                     "runtimes/android-x64/native/libturso_sdk_kit.so",
+                     "runtimes/android-x86/native/libturso_sdk_kit.so",
+                     "runtimes/ios-universal/native/libturso_sdk_kit.xcframework",
+                 })
+        {
+            project.Should().Contain(packagePath);
+        }
+    }
+
+    private static Type GetNativeType(Assembly assembly, string name)
+        => assembly.GetType($"Turso.Raw.{name}", throwOnError: true)!;
+
+    private static NativeField Pointer() => new(IntPtr.Size, IntPtr.Size);
+
+    private static NativeField Int32() => new(sizeof(int), sizeof(int));
+
+    private static NativeField Int64() => new(sizeof(long), Math.Min(sizeof(long), IntPtr.Size));
+
+    private static NativeField Bool() => new(sizeof(byte), sizeof(byte));
+
+    private static NativeField Slice() => new(IntPtr.Size * 2, IntPtr.Size);
+
+    private static void AssertLayout(Type type, IReadOnlyList<(string Name, NativeField Field)> fields)
+    {
+        var offset = 0;
+        var structAlignment = 1;
+        foreach (var (name, field) in fields)
+        {
+            offset = Align(offset, field.Alignment);
+            Marshal.OffsetOf(type, name).ToInt32().Should().Be(offset, $"{type.Name}.{name} must match the C header");
+            offset += field.Size;
+            structAlignment = Math.Max(structAlignment, field.Alignment);
+        }
+
+        Marshal.SizeOf(type).Should().Be(Align(offset, structAlignment), $"{type.Name} must match the C header");
+    }
+
+    private static int Align(int value, int alignment)
+        => checked((value + alignment - 1) / alignment * alignment);
+
+    private static TursoSyncIoItemHandle TakeNextIoItem(
+        TursoSyncDatabaseHandle database,
+        TursoSyncOperationHandle operation)
+    {
+        for (var attempt = 0; attempt < 100; attempt++)
+        {
+            var state = TursoSyncBindings.Resume(operation);
+            state.Should().NotBe(TursoSyncOperationState.Done);
+            if (state != TursoSyncOperationState.Io)
+                continue;
+
+            var item = TursoSyncBindings.TakeIoItem(database);
+            if (item is not null)
+                return item;
+        }
+
+        throw new AssertionException("The sync operation did not produce an I/O item.");
+    }
+
+    private static void DriveLocalOperation(
+        TursoSyncDatabaseHandle database,
+        TursoSyncOperationHandle operation)
+    {
+        for (var attempt = 0; attempt < 1_000; attempt++)
+        {
+            switch (TursoSyncBindings.Resume(operation))
+            {
+                case TursoSyncOperationState.Continue:
+                    continue;
+                case TursoSyncOperationState.Done:
+                    return;
+                case TursoSyncOperationState.Io:
+                    using (var item = TursoSyncBindings.TakeIoItem(database))
+                    {
+                        item.Should().NotBeNull();
+                        switch (TursoSyncBindings.GetIoKind(item!))
+                        {
+                            case TursoSyncIoKind.FullRead:
+                                TursoSyncBindings.PushIoBuffer(item!, []);
+                                break;
+                            case TursoSyncIoKind.FullWrite:
+                                _ = TursoSyncBindings.GetFullWriteRequest(item!);
+                                break;
+                            default:
+                                throw new AssertionException("A deferred local create must not require HTTP I/O.");
+                        }
+
+                        TursoSyncBindings.CompleteIo(item!);
+                    }
+                    TursoSyncBindings.StepIoCallbacks(database);
+                    break;
+                default:
+                    throw new AssertionException("Unknown sync operation state.");
+            }
+        }
+
+        throw new AssertionException("The sync operation did not complete.");
+    }
+
+    private static string FindRepositoryFile(params string[] path)
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            var candidate = Path.Combine([directory.FullName, .. path]);
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        throw new FileNotFoundException($"Could not find repository file {Path.Combine(path)}.");
+    }
+
+    private readonly record struct NativeField(int Size, int Alignment);
+}


### PR DESCRIPTION
# NOTICE:

Maintainer edits are enabled for this pull request.

## Description

- expose the existing Rust sync SDK C ABI through `Turso.Raw`, including exact native layouts, SafeHandle ownership, and low-level operation, result, and I/O wrappers
- retain the sync database and I/O owner while extracted native connections or borrowed native slices still depend on them
- build the combined `turso_sync_sdk_kit` payload while preserving the public `turso_sdk_kit` native filenames and existing NuGet RID layout
- add focused coverage for ABI layout, nullable persisted remote URLs, SafeHandle lifetime, operation/I/O behavior, combined exports, and package layout

This is the first focused extraction from draft #8504: https://github.com/tursodatabase/turso/pull/8504.

Later pull requests will separately extract the managed replica API, SQLite facade and broader ADO.NET work, EF Core integration, and package-consumer/mobile validation. This PR intentionally excludes those layers.

## Motivation and context

The .NET binding currently packages `turso_sdk_kit`, which exposes the local database ABI but not the sync ABI. The existing `turso_sync_sdk_kit` crate links the core SDK kit and adds the sync exports, so this change builds that combined payload for .NET.

Cargo names the internal artifact after the sync crate. Packaging aliases it back to the established public names—`turso_sdk_kit.dll`, `libturso_sdk_kit.so`, `libturso_sdk_kit.dylib`, `turso_sdk_kit.lib`, and `libturso_sdk_kit.a`—under the same NuGet RID paths. Existing native package consumers therefore do not need to change their loader names or asset paths.

Validation performed:

- `cargo test -p turso_sync_sdk_kit --lib`
- built the combined Windows x64 payload and verified both existing database and new sync exports through the legacy DLL filename
- built `Turso.Raw` for `net8.0`, `net9.0`, and `net10.0` with zero warnings
- ran focused sync interop and existing raw database tests: 28 passed, 1 pre-existing skipped
- ran `dotnet format` with `--verify-no-changes`
- packed `Turso.Data.Native` and verified `runtimes/win-x64/native/turso_sdk_kit.dll` exists with no internal `turso_sync_sdk_kit` filename leakage

## Description of AI Usage

GitHub Copilot was used to compare the large draft implementation against `main`, carve out only the native ABI/package layer, review P/Invoke layouts and ownership, write focused tests, and run the validation above. The resulting scope and code were reviewed iteratively, including a separate correctness review of native lifetime handling.