### PR TITLE
core: format multi-index UPDATE plans

### DIFF
--- a/core/translate/display.rs
+++ b/core/translate/display.rs
@@ -12,8 +12,8 @@ use turso_parser::{
 use crate::{schema::Table, translate::plan::TableReferences};
 
 use super::plan::{
-    Aggregate, DeletePlan, JoinedTable, Operation, Plan, ResultSetColumn, Scan, Search, SeekDef,
-    SelectPlan, SetOperation, UpdatePlan,
+    Aggregate, DeletePlan, JoinedTable, MultiIndexScanOp, Operation, Plan, ResultSetColumn, Scan,
+    Search, SeekDef, SelectPlan, SetOperation, UpdatePlan,
 };
 
 fn fmt_order_by_item(
@@ -220,26 +220,8 @@ impl Display for SelectPlan {
                     writeln!(f, "{indent}HASH JOIN")?;
                 }
                 Operation::MultiIndexScan(multi_idx) => {
-                    let index_names: Vec<&str> = multi_idx
-                        .branches
-                        .iter()
-                        .map(|b| {
-                            b.index
-                                .as_ref()
-                                .map(|i| i.name.as_str())
-                                .unwrap_or("PRIMARY KEY")
-                        })
-                        .collect();
-                    let op_name = match multi_idx.set_op {
-                        SetOperation::Union => "MULTI-INDEX OR",
-                        SetOperation::Intersection { .. } => "MULTI-INDEX AND",
-                    };
-                    writeln!(
-                        f,
-                        "{indent}{op_name} {} ({}) ",
-                        reference.identifier,
-                        index_names.join(", ")
-                    )?;
+                    write_multi_index_scan(f, &indent, &reference.identifier, multi_idx)?;
+                    writeln!(f, " ")?;
                 }
             }
         }
@@ -340,26 +322,8 @@ impl Display for DeletePlan {
                     unreachable!("Delete plan should not have hash joins");
                 }
                 Operation::MultiIndexScan(multi_idx) => {
-                    let index_names: Vec<&str> = multi_idx
-                        .branches
-                        .iter()
-                        .map(|b| {
-                            b.index
-                                .as_ref()
-                                .map(|i| i.name.as_str())
-                                .unwrap_or("PRIMARY KEY")
-                        })
-                        .collect();
-                    let op_name = match multi_idx.set_op {
-                        SetOperation::Union => "MULTI-INDEX OR",
-                        SetOperation::Intersection { .. } => "MULTI-INDEX AND",
-                    };
-                    writeln!(
-                        f,
-                        "{indent}{op_name} {} ({})",
-                        reference.identifier,
-                        index_names.join(", ")
-                    )?;
+                    write_multi_index_scan(f, indent, &reference.identifier, multi_idx)?;
+                    writeln!(f)?;
                 }
             }
         }
@@ -471,8 +435,9 @@ impl fmt::Display for UpdatePlan {
                 Operation::HashJoin(_) => {
                     unreachable!("Update plan should not have hash joins");
                 }
-                Operation::MultiIndexScan(_) => {
-                    unreachable!("Update plan should not have multi-index scans");
+                Operation::MultiIndexScan(multi_idx) => {
+                    write_multi_index_scan(f, &indent, &reference.identifier, multi_idx)?;
+                    writeln!(f)?;
                 }
             }
         }
@@ -485,6 +450,31 @@ impl fmt::Display for UpdatePlan {
 
         Ok(())
     }
+}
+
+fn write_multi_index_scan(
+    f: &mut Formatter<'_>,
+    indent: &str,
+    table_identifier: &str,
+    multi_idx: &MultiIndexScanOp,
+) -> fmt::Result {
+    let op_name = match multi_idx.set_op {
+        SetOperation::Union => "MULTI-INDEX OR",
+        SetOperation::Intersection { .. } => "MULTI-INDEX AND",
+    };
+    write!(f, "{indent}{op_name} {table_identifier} (")?;
+    for (branch_idx, branch) in multi_idx.branches.iter().enumerate() {
+        if branch_idx > 0 {
+            f.write_str(", ")?;
+        }
+        let index_name = branch
+            .index
+            .as_ref()
+            .map(|index| index.name.as_str())
+            .unwrap_or("PRIMARY KEY");
+        f.write_str(index_name)?;
+    }
+    f.write_str(")")
 }
 
 pub struct PlanContext<'a>(pub &'a [&'a TableReferences]);

--- a/tests/integration/query_processing/test_multi_index_scan.rs
+++ b/tests/integration/query_processing/test_multi_index_scan.rs
@@ -141,3 +141,59 @@ JOIN t4 ON t3.b = t4.b OR t3.c = t4.c";
         limbo_exec_rows(&conn, inner)
     );
 }
+
+#[test]
+fn debug_tracing_does_not_crash_multi_index_update() {
+    let log = tempfile::NamedTempFile::new().expect("create temporary debug log");
+    let log_file = log.reopen().expect("reopen temporary debug log");
+    let subscriber = tracing_subscriber::fmt()
+        .without_time()
+        .with_ansi(false)
+        .with_max_level(tracing::Level::DEBUG)
+        .with_writer(move || {
+            log_file
+                .try_clone()
+                .expect("clone temporary debug log handle")
+        })
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, || {
+        let tmp_db = TempDatabase::new_empty();
+        let conn = tmp_db.connect_limbo();
+
+        for statement in [
+            "CREATE TABLE t(a INTEGER, b INTEGER, c INTEGER)",
+            "CREATE INDEX ia ON t(a)",
+            "CREATE INDEX ib ON t(b)",
+        ] {
+            limbo_exec_rows(&conn, statement);
+        }
+
+        let plan = limbo_exec_rows(
+            &conn,
+            "EXPLAIN QUERY PLAN UPDATE t SET c = 8 WHERE a = 1 OR b = 2",
+        );
+        assert!(
+            plan.iter().any(|row| {
+                matches!(
+                    row.get(3),
+                    Some(Value::Text(detail)) if detail == "MULTI-INDEX OR t (ia, ib)"
+                )
+            }),
+            "expected a multi-index UPDATE plan, got: {plan:?}"
+        );
+
+        limbo_exec_rows(&conn, "INSERT INTO t VALUES (1, 2, 0)");
+        limbo_exec_rows(&conn, "UPDATE t SET c = 8 WHERE a = 1 OR b = 2");
+        assert_eq!(
+            limbo_exec_rows(&conn, "SELECT c FROM t"),
+            vec![vec![Value::Integer(8)]]
+        );
+    });
+
+    let log = std::fs::read_to_string(log.path()).expect("read temporary debug log");
+    assert!(
+        log.contains("MULTI-INDEX OR t (ia, ib)"),
+        "expected the debug log to contain the multi-index UPDATE plan, got: {log}"
+    );
+}


### PR DESCRIPTION
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->
this makes it so that we format multi-index `UPDATE` plans in debug mode instead of treating them as unreachable. the implementation shares the plan across `SELECT`, `DELETE`, and `UPDATE` and writes index names directly without building an intermediary list.

i also added a regression test to prevent this from happening again (though debatable whether it's needed for this specific pr)

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->
Fixes #8510 

from my understanding, Turso first collects a stable set of matching rowids before modifying the table for UPDATE but the debug tracing formats the plan with `plan.to_string()` and `UpdatePlan` still assumed that the multi-index plans were impossible resulting in a valid update panicking only when debug tracing is enabled.

my first approach to this issue was to simply copy over the formatting block of delete into update but that had several issues on its own mainly the fact that its creating a third copy and would retain the root cause of this. then i thought of just using `tracing::enabled!` because it already does the check before constructing the values but like thats redundant and could potentially alter it so upon further investigation, i made a shared helper which made the most sense (because we would have 3 copies) which boils down to the ff:
- selects multi-index or / and
- preserve the branch order
- prints indexes then primary key for rowid branches
- borrows every index name and propagates errors with ?

ntm doing it this way, compared to the old implementation we used 2 fewer (re)allocation calls, which should give us roughly 37/18/12% performance improvement for 2/4/8 branches

i did consider using `write_str` for already borrowed stuff but like that yeah it was like 1% faster 

edit: forced push to sign commit

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

AI was used to help me understand Turso code, implementation + debugging hence verification was done on my end