### PR TITLE
sync-wasm: fix OPFS connection failures for MVCC replicas

### DIFF
--- a/bindings/javascript/sync/packages/wasm/promise-bundle.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-bundle.ts
@@ -49,20 +49,6 @@ function resolveUrl(url: string | (() => string | null)): string {
     return url;
 }
 
-function syncDatabaseFiles(path: string): string[] {
-    const lastSlash = path.lastIndexOf('/');
-    const lastDot = path.lastIndexOf('.');
-    const stem = lastDot > lastSlash + 1 ? path.slice(0, lastDot) : path;
-    return [
-        path,
-        `${path}-wal`,
-        `${stem}.db-log`,
-        `${path}-wal-revert`,
-        `${path}-info`,
-        `${path}-changes`,
-    ];
-}
-
 class Database extends DatabasePromise {
     #runner: Runner;
     #engine: any;
@@ -187,7 +173,7 @@ class Database extends DatabasePromise {
             if (!this.memory) {
                 const worker = await init();
                 this.#worker = worker;
-                await Promise.all(syncDatabaseFiles(this.name).map(path => registerFileAtWorker(worker, path)));
+                await Promise.all(this.#engine.filePaths().map((path: string) => registerFileAtWorker(worker, path)));
             }
             await run(this.#runner, this.#engine.connect(), this.execLock);
         }
@@ -356,7 +342,7 @@ class Database extends DatabasePromise {
         if (this.#engine != null) {
             if (this.name != null && this.#worker != null) {
                 const worker = this.#worker;
-                await Promise.all(syncDatabaseFiles(this.name).map(path => unregisterFileAtWorker(worker, path)));
+                await Promise.all(this.#engine.filePaths().map((path: string) => unregisterFileAtWorker(worker, path)));
             }
             this.#engine.close();
         }

--- a/bindings/javascript/sync/packages/wasm/promise-bundle.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-bundle.ts
@@ -49,6 +49,20 @@ function resolveUrl(url: string | (() => string | null)): string {
     return url;
 }
 
+function syncDatabaseFiles(path: string): string[] {
+    const lastSlash = path.lastIndexOf('/');
+    const lastDot = path.lastIndexOf('.');
+    const stem = lastDot > lastSlash + 1 ? path.slice(0, lastDot) : path;
+    return [
+        path,
+        `${path}-wal`,
+        `${stem}.db-log`,
+        `${path}-wal-revert`,
+        `${path}-info`,
+        `${path}-changes`,
+    ];
+}
+
 class Database extends DatabasePromise {
     #runner: Runner;
     #engine: any;
@@ -171,14 +185,9 @@ class Database extends DatabasePromise {
             await super.connect();
         } else {
             if (!this.memory) {
-                this.#worker = await init();
-                await Promise.all([
-                    registerFileAtWorker(this.#worker, this.name),
-                    registerFileAtWorker(this.#worker, `${this.name}-wal`),
-                    registerFileAtWorker(this.#worker, `${this.name}-wal-revert`),
-                    registerFileAtWorker(this.#worker, `${this.name}-info`),
-                    registerFileAtWorker(this.#worker, `${this.name}-changes`),
-                ]);
+                const worker = await init();
+                this.#worker = worker;
+                await Promise.all(syncDatabaseFiles(this.name).map(path => registerFileAtWorker(worker, path)));
             }
             await run(this.#runner, this.#engine.connect(), this.execLock);
         }
@@ -346,13 +355,8 @@ class Database extends DatabasePromise {
         }
         if (this.#engine != null) {
             if (this.name != null && this.#worker != null) {
-                await Promise.all([
-                    unregisterFileAtWorker(this.#worker, this.name),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-wal`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-wal-revert`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-info`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-changes`),
-                ]);
+                const worker = this.#worker;
+                await Promise.all(syncDatabaseFiles(this.name).map(path => unregisterFileAtWorker(worker, path)));
             }
             this.#engine.close();
         }

--- a/bindings/javascript/sync/packages/wasm/promise-default.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-default.ts
@@ -49,20 +49,6 @@ function resolveUrl(url: string | (() => string | null)): string {
     return url;
 }
 
-function syncDatabaseFiles(path: string): string[] {
-    const lastSlash = path.lastIndexOf('/');
-    const lastDot = path.lastIndexOf('.');
-    const stem = lastDot > lastSlash + 1 ? path.slice(0, lastDot) : path;
-    return [
-        path,
-        `${path}-wal`,
-        `${stem}.db-log`,
-        `${path}-wal-revert`,
-        `${path}-info`,
-        `${path}-changes`,
-    ];
-}
-
 class Database extends DatabasePromise {
     #runner: Runner;
     #engine: any;
@@ -187,7 +173,7 @@ class Database extends DatabasePromise {
             if (!this.memory) {
                 const worker = await init();
                 this.#worker = worker;
-                await Promise.all(syncDatabaseFiles(this.name).map(path => registerFileAtWorker(worker, path)));
+                await Promise.all(this.#engine.filePaths().map((path: string) => registerFileAtWorker(worker, path)));
             }
             await run(this.#runner, this.#engine.connect(), this.execLock);
         }
@@ -356,7 +342,7 @@ class Database extends DatabasePromise {
         if (this.#engine != null) {
             if (this.name != null && this.#worker != null) {
                 const worker = this.#worker;
-                await Promise.all(syncDatabaseFiles(this.name).map(path => unregisterFileAtWorker(worker, path)));
+                await Promise.all(this.#engine.filePaths().map((path: string) => unregisterFileAtWorker(worker, path)));
             }
             this.#engine.close();
         }

--- a/bindings/javascript/sync/packages/wasm/promise-default.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-default.ts
@@ -49,6 +49,20 @@ function resolveUrl(url: string | (() => string | null)): string {
     return url;
 }
 
+function syncDatabaseFiles(path: string): string[] {
+    const lastSlash = path.lastIndexOf('/');
+    const lastDot = path.lastIndexOf('.');
+    const stem = lastDot > lastSlash + 1 ? path.slice(0, lastDot) : path;
+    return [
+        path,
+        `${path}-wal`,
+        `${stem}.db-log`,
+        `${path}-wal-revert`,
+        `${path}-info`,
+        `${path}-changes`,
+    ];
+}
+
 class Database extends DatabasePromise {
     #runner: Runner;
     #engine: any;
@@ -171,14 +185,9 @@ class Database extends DatabasePromise {
             await super.connect();
         } else {
             if (!this.memory) {
-                this.#worker = await init();
-                await Promise.all([
-                    registerFileAtWorker(this.#worker, this.name),
-                    registerFileAtWorker(this.#worker, `${this.name}-wal`),
-                    registerFileAtWorker(this.#worker, `${this.name}-wal-revert`),
-                    registerFileAtWorker(this.#worker, `${this.name}-info`),
-                    registerFileAtWorker(this.#worker, `${this.name}-changes`),
-                ]);
+                const worker = await init();
+                this.#worker = worker;
+                await Promise.all(syncDatabaseFiles(this.name).map(path => registerFileAtWorker(worker, path)));
             }
             await run(this.#runner, this.#engine.connect(), this.execLock);
         }
@@ -346,13 +355,8 @@ class Database extends DatabasePromise {
         }
         if (this.#engine != null) {
             if (this.name != null && this.#worker != null) {
-                await Promise.all([
-                    unregisterFileAtWorker(this.#worker, this.name),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-wal`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-wal-revert`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-info`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-changes`),
-                ]);
+                const worker = this.#worker;
+                await Promise.all(syncDatabaseFiles(this.name).map(path => unregisterFileAtWorker(worker, path)));
             }
             this.#engine.close();
         }

--- a/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
@@ -49,20 +49,6 @@ function resolveUrl(url: string | (() => string | null)): string {
     return url;
 }
 
-function syncDatabaseFiles(path: string): string[] {
-    const lastSlash = path.lastIndexOf('/');
-    const lastDot = path.lastIndexOf('.');
-    const stem = lastDot > lastSlash + 1 ? path.slice(0, lastDot) : path;
-    return [
-        path,
-        `${path}-wal`,
-        `${stem}.db-log`,
-        `${path}-wal-revert`,
-        `${path}-info`,
-        `${path}-changes`,
-    ];
-}
-
 class Database extends DatabasePromise {
     #runner: Runner;
     #engine: any;
@@ -187,7 +173,7 @@ class Database extends DatabasePromise {
             if (!this.memory) {
                 const worker = await init();
                 this.#worker = worker;
-                await Promise.all(syncDatabaseFiles(this.name).map(path => registerFileAtWorker(worker, path)));
+                await Promise.all(this.#engine.filePaths().map((path: string) => registerFileAtWorker(worker, path)));
             }
             await run(this.#runner, this.#engine.connect(), this.execLock);
         }
@@ -356,7 +342,7 @@ class Database extends DatabasePromise {
         if (this.#engine != null) {
             if (this.name != null && this.#worker != null) {
                 const worker = this.#worker;
-                await Promise.all(syncDatabaseFiles(this.name).map(path => unregisterFileAtWorker(worker, path)));
+                await Promise.all(this.#engine.filePaths().map((path: string) => unregisterFileAtWorker(worker, path)));
             }
             this.#engine.close();
         }

--- a/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-turbopack-hack.ts
@@ -49,6 +49,20 @@ function resolveUrl(url: string | (() => string | null)): string {
     return url;
 }
 
+function syncDatabaseFiles(path: string): string[] {
+    const lastSlash = path.lastIndexOf('/');
+    const lastDot = path.lastIndexOf('.');
+    const stem = lastDot > lastSlash + 1 ? path.slice(0, lastDot) : path;
+    return [
+        path,
+        `${path}-wal`,
+        `${stem}.db-log`,
+        `${path}-wal-revert`,
+        `${path}-info`,
+        `${path}-changes`,
+    ];
+}
+
 class Database extends DatabasePromise {
     #runner: Runner;
     #engine: any;
@@ -171,14 +185,9 @@ class Database extends DatabasePromise {
             await super.connect();
         } else {
             if (!this.memory) {
-                this.#worker = await init();
-                await Promise.all([
-                    registerFileAtWorker(this.#worker, this.name),
-                    registerFileAtWorker(this.#worker, `${this.name}-wal`),
-                    registerFileAtWorker(this.#worker, `${this.name}-wal-revert`),
-                    registerFileAtWorker(this.#worker, `${this.name}-info`),
-                    registerFileAtWorker(this.#worker, `${this.name}-changes`),
-                ]);
+                const worker = await init();
+                this.#worker = worker;
+                await Promise.all(syncDatabaseFiles(this.name).map(path => registerFileAtWorker(worker, path)));
             }
             await run(this.#runner, this.#engine.connect(), this.execLock);
         }
@@ -346,13 +355,8 @@ class Database extends DatabasePromise {
         }
         if (this.#engine != null) {
             if (this.name != null && this.#worker != null) {
-                await Promise.all([
-                    unregisterFileAtWorker(this.#worker, this.name),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-wal`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-wal-revert`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-info`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-changes`),
-                ]);
+                const worker = this.#worker;
+                await Promise.all(syncDatabaseFiles(this.name).map(path => unregisterFileAtWorker(worker, path)));
             }
             this.#engine.close();
         }

--- a/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
@@ -49,20 +49,6 @@ function resolveUrl(url: string | (() => string | null)): string {
     return url;
 }
 
-function syncDatabaseFiles(path: string): string[] {
-    const lastSlash = path.lastIndexOf('/');
-    const lastDot = path.lastIndexOf('.');
-    const stem = lastDot > lastSlash + 1 ? path.slice(0, lastDot) : path;
-    return [
-        path,
-        `${path}-wal`,
-        `${stem}.db-log`,
-        `${path}-wal-revert`,
-        `${path}-info`,
-        `${path}-changes`,
-    ];
-}
-
 class Database extends DatabasePromise {
     #runner: Runner;
     #engine: any;
@@ -187,7 +173,7 @@ class Database extends DatabasePromise {
             if (!this.memory) {
                 const worker = await init();
                 this.#worker = worker;
-                await Promise.all(syncDatabaseFiles(this.name).map(path => registerFileAtWorker(worker, path)));
+                await Promise.all(this.#engine.filePaths().map((path: string) => registerFileAtWorker(worker, path)));
             }
             await run(this.#runner, this.#engine.connect(), this.execLock);
         }
@@ -356,7 +342,7 @@ class Database extends DatabasePromise {
         if (this.#engine != null) {
             if (this.name != null && this.#worker != null) {
                 const worker = this.#worker;
-                await Promise.all(syncDatabaseFiles(this.name).map(path => unregisterFileAtWorker(worker, path)));
+                await Promise.all(this.#engine.filePaths().map((path: string) => unregisterFileAtWorker(worker, path)));
             }
             this.#engine.close();
         }

--- a/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
+++ b/bindings/javascript/sync/packages/wasm/promise-vite-dev-hack.ts
@@ -49,6 +49,20 @@ function resolveUrl(url: string | (() => string | null)): string {
     return url;
 }
 
+function syncDatabaseFiles(path: string): string[] {
+    const lastSlash = path.lastIndexOf('/');
+    const lastDot = path.lastIndexOf('.');
+    const stem = lastDot > lastSlash + 1 ? path.slice(0, lastDot) : path;
+    return [
+        path,
+        `${path}-wal`,
+        `${stem}.db-log`,
+        `${path}-wal-revert`,
+        `${path}-info`,
+        `${path}-changes`,
+    ];
+}
+
 class Database extends DatabasePromise {
     #runner: Runner;
     #engine: any;
@@ -171,14 +185,9 @@ class Database extends DatabasePromise {
             await super.connect();
         } else {
             if (!this.memory) {
-                this.#worker = await init();
-                await Promise.all([
-                    registerFileAtWorker(this.#worker, this.name),
-                    registerFileAtWorker(this.#worker, `${this.name}-wal`),
-                    registerFileAtWorker(this.#worker, `${this.name}-wal-revert`),
-                    registerFileAtWorker(this.#worker, `${this.name}-info`),
-                    registerFileAtWorker(this.#worker, `${this.name}-changes`),
-                ]);
+                const worker = await init();
+                this.#worker = worker;
+                await Promise.all(syncDatabaseFiles(this.name).map(path => registerFileAtWorker(worker, path)));
             }
             await run(this.#runner, this.#engine.connect(), this.execLock);
         }
@@ -346,13 +355,8 @@ class Database extends DatabasePromise {
         }
         if (this.#engine != null) {
             if (this.name != null && this.#worker != null) {
-                await Promise.all([
-                    unregisterFileAtWorker(this.#worker, this.name),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-wal`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-wal-revert`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-info`),
-                    unregisterFileAtWorker(this.#worker, `${this.name}-changes`),
-                ]);
+                const worker = this.#worker;
+                await Promise.all(syncDatabaseFiles(this.name).map(path => unregisterFileAtWorker(worker, path)));
             }
             this.#engine.close();
         }

--- a/bindings/javascript/sync/packages/wasm/promise.test.ts
+++ b/bindings/javascript/sync/packages/wasm/promise.test.ts
@@ -178,6 +178,27 @@ test('reconnect-db', async () => {
     }
 })
 
+test('reopen file-backed replica after switching to MVCC sync', async () => {
+    const path = `mvcc-${crypto.randomUUID()}.sqlite`;
+    const url = process.env.VITE_TURSO_MVCC_DB_URL;
+    {
+        let remoteUrl: string | null = null;
+        const db = await connect({ path, url: () => remoteUrl, logicalMvccPull: true });
+        remoteUrl = url ?? null;
+        await db.pull();
+        await db.exec("CREATE TABLE IF NOT EXISTS mvcc_opfs_reopen(value TEXT)");
+        await db.exec("DELETE FROM mvcc_opfs_reopen");
+        await db.exec("INSERT INTO mvcc_opfs_reopen VALUES ('still here')");
+        await db.push();
+        await db.close();
+    }
+    {
+        const db = await connect({ path, url, logicalMvccPull: true });
+        expect(await (await db.prepare("SELECT value FROM mvcc_opfs_reopen")).all()).toEqual([{ value: 'still here' }]);
+        await db.close();
+    }
+})
+
 test('implicit connect', async () => {
     const db = new Database({ path: ':memory:', url: process.env.VITE_TURSO_DB_URL });
     const defer = await db.prepare("SELECT * FROM not_found");

--- a/bindings/javascript/sync/packages/wasm/turso-server-setup.ts
+++ b/bindings/javascript/sync/packages/wasm/turso-server-setup.ts
@@ -1,5 +1,8 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { request } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 function probe(url: URL): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -18,22 +21,31 @@ function probe(url: URL): Promise<void> {
     });
 }
 
-let child: ChildProcess | null = null;
+const children: ChildProcess[] = [];
 
-export default async function setup() {
-    const localSyncServer = process.env.LOCAL_SYNC_SERVER;
-    if (!localSyncServer) {
-        if (!process.env.VITE_TURSO_DB_URL) {
-            throw new Error('either LOCAL_SYNC_SERVER or VITE_TURSO_DB_URL env var must be set');
-        }
-        return;
-    }
+function run(localSyncServer: string, args: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const proc = spawn(localSyncServer, args, { stdio: 'ignore' });
+        proc.on('error', reject);
+        proc.on('exit', code => {
+            if (code === 0) {
+                resolve();
+            } else {
+                reject(new Error(`tursodb exited with code ${code}`));
+            }
+        });
+    });
+}
 
-    const target = process.env.VITE_TURSO_DB_URL || 'http://localhost:10001';
+async function startServer(localSyncServer: string, target: string, database?: string) {
     const url = new URL(target);
     const port = url.port || (url.protocol === 'https:' ? '443' : '80');
+    const args = ['--sync-server', `0.0.0.0:${port}`];
+    if (database != null) {
+        args.push(database);
+    }
 
-    const proc = spawn(localSyncServer, ['--sync-server', `0.0.0.0:${port}`], {
+    const proc = spawn(localSyncServer, args, {
         stdio: 'ignore',
     });
     const deadline = Date.now() + 30000;
@@ -52,11 +64,34 @@ export default async function setup() {
         proc.kill();
         throw new Error(`local sync server did not become available within 30s on port ${port}`);
     }
-    child = proc;
-    return () => {
-        if (child) {
-            child.kill();
-            child = null;
+    children.push(proc);
+}
+
+export default async function setup() {
+    const localSyncServer = process.env.LOCAL_SYNC_SERVER;
+    if (!localSyncServer) {
+        if (!process.env.VITE_TURSO_DB_URL || !process.env.VITE_TURSO_MVCC_DB_URL) {
+            throw new Error('LOCAL_SYNC_SERVER or both remote server URLs must be set');
         }
+        return;
+    }
+
+    const tempDir = await mkdtemp(join(tmpdir(), 'turso-sync-wasm-'));
+    const mvccDatabase = join(tempDir, 'remote.db');
+    await run(localSyncServer, [mvccDatabase, "PRAGMA journal_mode = 'mvcc'; CREATE TABLE mvcc_server_ready(x);"]);
+    await Promise.all([
+        startServer(localSyncServer, process.env.VITE_TURSO_DB_URL || 'http://localhost:10001'),
+        startServer(localSyncServer, process.env.VITE_TURSO_MVCC_DB_URL || 'http://localhost:10002', mvccDatabase),
+    ]);
+    // Keep the server's open MVCC connection, but force its first logical pull
+    // through the same page-base fallback used by a fresh hosted replica.
+    await rm(join(tempDir, 'remote.db-log'));
+
+    return async () => {
+        for (const child of children) {
+            child.kill();
+        }
+        children.length = 0;
+        await rm(tempDir, { recursive: true, force: true });
     };
 }

--- a/bindings/javascript/sync/packages/wasm/vitest.config.ts
+++ b/bindings/javascript/sync/packages/wasm/vitest.config.ts
@@ -1,12 +1,15 @@
 import { defineConfig } from 'vitest/config'
 
 const DEFAULT_LOCAL_SYNC_SERVER_URL = 'http://localhost:10001';
+const DEFAULT_LOCAL_MVCC_SYNC_SERVER_URL = 'http://localhost:10002';
 const tursoDbUrl = process.env.VITE_TURSO_DB_URL || DEFAULT_LOCAL_SYNC_SERVER_URL;
+const tursoMvccDbUrl = process.env.VITE_TURSO_MVCC_DB_URL || DEFAULT_LOCAL_MVCC_SYNC_SERVER_URL;
 
 export default defineConfig({
   define: {
     'process.env.NODE_DEBUG_NATIVE': 'false',
     'process.env.VITE_TURSO_DB_URL': JSON.stringify(tursoDbUrl),
+    'process.env.VITE_TURSO_MVCC_DB_URL': JSON.stringify(tursoMvccDbUrl),
   },
   server: {
     headers: {

--- a/bindings/javascript/sync/src/lib.rs
+++ b/bindings/javascript/sync/src/lib.rs
@@ -13,7 +13,7 @@ use napi::bindgen_prelude::{AsyncTask, Either5, Null};
 use napi_derive::napi;
 use turso_node::{DatabaseOpts, IoLoopTask};
 use turso_sync_engine::{
-    database_sync_engine::{DatabaseSyncEngine, DatabaseSyncEngineOpts},
+    database_sync_engine::{sync_database_file_paths, DatabaseSyncEngine, DatabaseSyncEngineOpts},
     database_sync_engine_io::SyncEngineIo,
     database_sync_operations::SyncEngineIoStats,
     types::{
@@ -349,6 +349,11 @@ impl SyncEngine {
             #[allow(clippy::arc_with_non_send_sync)]
             db,
         })
+    }
+
+    #[napi]
+    pub fn file_paths(&self) -> Vec<String> {
+        sync_database_file_paths(&self.opts.path)
     }
 
     #[napi]

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -137,6 +137,19 @@ fn db_size_from_page(page: &[u8]) -> u32 {
 fn is_memory(main_db_path: &str) -> bool {
     main_db_path == ":memory:"
 }
+pub fn sync_database_file_paths(main_db_path: &str) -> Vec<String> {
+    vec![
+        // Core opens the database and its WAL.
+        main_db_path.to_string(),
+        create_main_db_wal_path(main_db_path),
+        // Sync keeps rollback data, metadata, and downloaded changes separately.
+        create_revert_db_wal_path(main_db_path),
+        create_meta_path(main_db_path),
+        create_changes_path(main_db_path),
+        // MVCC may be selected only after the remote protocol is known.
+        create_main_db_log_path(main_db_path),
+    ]
+}
 fn create_main_db_wal_path(main_db_path: &str) -> String {
     format!("{main_db_path}-wal")
 }
@@ -3234,9 +3247,10 @@ mod tests {
         replace_base_backup_path, resolve_local_replay_floor_change_id,
         resolve_remote_pull_protocol, should_replay_raw_pages_on_sql_conn,
         should_request_logical_pull, stream_kind_applies_remote_pages,
-        stream_kind_for_pull_updates_v1_result, synced_change_id_after_remote_apply,
-        use_pushed_change_hint_for_local_replay, DatabaseSyncEngine, DatabaseSyncEngineOpts,
-        ReplaceBaseApplyGuard, REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
+        stream_kind_for_pull_updates_v1_result, sync_database_file_paths,
+        synced_change_id_after_remote_apply, use_pushed_change_hint_for_local_replay,
+        DatabaseSyncEngine, DatabaseSyncEngineOpts, ReplaceBaseApplyGuard,
+        REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
     };
     use crate::{
         client_proto::{
@@ -3269,6 +3283,21 @@ mod tests {
     };
     use tempfile::NamedTempFile;
     use turso_core::SqliteDialect;
+
+    #[test]
+    fn sync_database_paths_include_core_sync_and_mvcc_files() {
+        assert_eq!(
+            sync_database_file_paths("replica.sqlite"),
+            vec![
+                "replica.sqlite",
+                "replica.sqlite-wal",
+                "replica.sqlite-wal-revert",
+                "replica.sqlite-info",
+                "replica.sqlite-changes",
+                "replica.db-log",
+            ]
+        );
+    }
 
     #[test]
     fn explicit_override_wins_over_persisted_protocol() {


### PR DESCRIPTION
# NOTICE:
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

Fix `@tursodatabase/sync-wasm` file-backed replicas failing when connecting to an MVCC database through OPFS.

The sync engine can open an MVCC logical-log file whose name is derived by replacing the database filename extension with `.db-log`. The browser wrapper did not register that path with the OPFS worker, causing operations to fail with:

```
unexpected path <replica>.db-log: files must be created in advance for OPFS IO
```

This change:

- Makes the Rust sync engine the source of truth for all local files a synced database may open.
- Exposes that list to the JavaScript binding before the sync connection starts.
- Uses the same list when registering and unregistering OPFS files.
- Keeps the existing generated WASM entrypoints consistent without duplicating filename rules.
- Adds browser coverage for switching a file-backed replica to MVCC sync, writing data, closing it, and reopening it.


## Motivation and context

A fresh file-backed sync-wasm replica could not connect to a remote MVCC database because OPFS requires every file to be registered before Rust opens it.

Keeping the file list in Rust prevents the browser wrapper from drifting from the sync engine when sidecars or filename rules change. It also preserves the existing extension-replacement behavior for filenames that do not end in .db.

Fixes #8516 


## Description of AI Usage

Codex helped investigate the issue, trace the relevant Rust and JavaScript paths, write the implementation and regression tests, and run validation.

The proposed design was reviewed iteratively, especially where the file list should live and how to avoid duplicating it in the sync-wasm wrappers. That review led to keeping the list beside the Rust filename rules and exposing it to the browser binding. The final changes and test results were reviewed before submission.
