### PR TITLE
Keep IN constraints when building vtab constraints

### DIFF
--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -807,3 +807,72 @@ impl InPlaceJsonPath {
         &self.last_element
     }
 }
+
+#[cfg(test)]
+mod in_constraint_tests {
+    use crate::{Database, DatabaseOpts, MemoryIO, OpenFlags, SqliteDialect, Value};
+    use std::sync::Arc;
+
+    fn count(sql: &str) -> i64 {
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            crate::util::MEMORY_PATH,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        let mut stmt = conn.prepare(sql).unwrap();
+        let rows = stmt.run_collect_rows().unwrap();
+        match rows.as_slice() {
+            [cols] => match cols.as_slice() {
+                [Value::Numeric(crate::Numeric::Integer(n))] => *n,
+                other => panic!("expected integer count from `{sql}`, got {other:?}"),
+            },
+            other => panic!("expected one row from `{sql}`, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_each_in_list_is_not_dropped() {
+        assert_eq!(
+            count("SELECT count(*) FROM json_each WHERE json = '[1,2,3]'"),
+            3
+        );
+        assert_eq!(
+            count("SELECT count(*) FROM json_each WHERE json IN ('[1,2,3]')"),
+            3
+        );
+        assert_eq!(
+            count("SELECT count(*) FROM json_each WHERE json IN ('[1,2,3]', '[4,5]')"),
+            5
+        );
+        assert_eq!(
+            count("SELECT count(*) FROM json_each WHERE json IN (SELECT '[1,2,3]')"),
+            3
+        );
+        assert_eq!(
+            count("SELECT count(*) FROM json_each WHERE json IN ('[]', '[1,2,3]')"),
+            3
+        );
+        assert_eq!(
+            count("SELECT count(*) FROM json_tree WHERE json IN ('[1,2,3]')"),
+            4
+        );
+    }
+
+    #[test]
+    fn generate_series_in_stop_is_bounded() {
+        assert_eq!(
+            count("SELECT count(*) FROM generate_series WHERE start = 1 AND stop = 5"),
+            5
+        );
+        assert_eq!(
+            count("SELECT count(*) FROM generate_series WHERE start = 1 AND stop IN (5)"),
+            5
+        );
+    }
+}

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1045,6 +1045,8 @@ pub struct TranslateCtx<'a> {
     pub meta_window: Option<WindowMetadata<'a>>,
     /// Metadata stored during `open_loop` for `Search::InSeek`, consumed by `close_loop`.
     pub meta_in_seeks: Vec<Option<InSeekMetadata>>,
+    /// Nested IN-value loops around a virtual table xFilter, one entry per IN argv.
+    pub meta_vtab_in: Vec<Vec<InSeekMetadata>>,
     pub unsafe_testing: bool,
 }
 
@@ -1084,6 +1086,7 @@ impl<'a> TranslateCtx<'a> {
             cdc_cursor_id: None,
             meta_window: None,
             meta_in_seeks: (0..table_count).map(|_| None).collect(),
+            meta_vtab_in: (0..table_count).map(|_| Vec::new()).collect(),
             unsafe_testing,
         }
     }

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -14,9 +14,9 @@ use crate::{
         main_loop::{init_distinct, CloseLoop, InitLoop, LoopBodyEmitter, OpenLoop},
         order_by::EmitOrderBy,
         plan::{
-            BitSet, Distinctness, EphemeralRowidMode, EvalAt, IndexMethodQuery, JoinOrderMember,
-            Operation, QueryDestination, Scan, Search, SeekKeyComponent, SelectPlan,
-            SimpleAggregate,
+            BitSet, Distinctness, EphemeralRowidMode, EvalAt, InSeekSource, IndexMethodQuery,
+            JoinOrderMember, Operation, QueryDestination, Scan, Search, SeekKeyComponent,
+            SelectPlan, SimpleAggregate,
         },
         planner::table_mask_from_expr,
         select::emit_simple_count,
@@ -875,7 +875,11 @@ fn build_materialized_build_input_plan(
                     }
                 }
             }
-            Operation::Scan(Scan::VirtualTable { constraints, .. }) => {
+            Operation::Scan(Scan::VirtualTable {
+                constraints,
+                in_args,
+                ..
+            }) => {
                 // Virtual table constraints are evaluated against expressions.
                 // If any constraint depends on non-prefix tables, drop the scan
                 // specialization and fall back to a full scan.
@@ -883,6 +887,18 @@ fn build_materialized_build_input_plan(
                     if expr_depends_outside_prefix(expr)? {
                         reset_op = true;
                         break;
+                    }
+                }
+                if !reset_op {
+                    'in_args: for (_, source) in in_args {
+                        if let InSeekSource::LiteralList { values, .. } = source {
+                            for expr in values {
+                                if expr_depends_outside_prefix(expr)? {
+                                    reset_op = true;
+                                    break 'in_args;
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -110,6 +110,14 @@ impl CloseLoop {
                                     .expect("Virtual tables do not support covering indexes"),
                                 pc_if_next: loop_labels.loop_start,
                             });
+                            for meta in t_ctx.meta_vtab_in[table_index].iter().rev() {
+                                program.preassign_label_to_next_insn(meta.next_val_label);
+                                program.emit_insn(Insn::Next {
+                                    cursor_id: meta.ephemeral_cursor_id,
+                                    pc_if_next: meta.outer_loop_start,
+                                    fullscan: false,
+                                });
+                            }
                         }
                         Scan::Subquery { iter_dir } => {
                             // Check if this is a materialized CTE (EphemeralTable) or coroutine

--- a/core/translate/main_loop/open.rs
+++ b/core/translate/main_loop/open.rs
@@ -133,49 +133,92 @@ impl OpenLoop {
                                 idx_num,
                                 idx_str,
                                 constraints,
+                                in_args,
                             },
                             Table::Virtual(_),
                         ) => {
-                            let (start_reg, count, maybe_idx_str, maybe_idx_int) = {
-                                let args_needed = constraints.len();
-                                let start_reg = program.alloc_registers(args_needed);
+                            let args_needed = constraints.len();
+                            let start_reg = program.alloc_registers(args_needed);
 
-                                for (argv_index, expr) in constraints.iter().enumerate() {
-                                    let target_reg = start_reg + argv_index;
-                                    translate_expr(
-                                        program,
-                                        Some(table_references),
-                                        expr,
-                                        target_reg,
-                                        &t_ctx.resolver,
-                                    )?;
-                                }
+                            let mut vtab_in_loops = Vec::new();
+                            for (argv_idx, source) in in_args {
+                                let ephemeral_cursor_id = open_in_seek_source_cursor(
+                                    program,
+                                    table_references,
+                                    &t_ctx.resolver,
+                                    None,
+                                    source,
+                                )?;
+                                vtab_in_loops.push((
+                                    *argv_idx,
+                                    InSeekMetadata {
+                                        ephemeral_cursor_id,
+                                        outer_loop_start: program.allocate_label(),
+                                        next_val_label: program.allocate_label(),
+                                    },
+                                ));
+                            }
 
-                                // If best_index provided an idx_str, translate it.
-                                let maybe_idx_str = if let Some(idx_str) = idx_str {
-                                    let reg = program.alloc_register();
-                                    program.emit_insn(Insn::String8 {
-                                        dest: reg,
-                                        value: idx_str.to_owned(),
-                                    });
-                                    Some(reg)
+                            for i in 0..vtab_in_loops.len() {
+                                let pc_if_empty = if i == 0 {
+                                    loop_end
                                 } else {
-                                    None
+                                    vtab_in_loops[i - 1].1.next_val_label
                                 };
-                                (start_reg, args_needed, maybe_idx_str, Some(*idx_num))
+                                let (argv_idx, meta) = &vtab_in_loops[i];
+                                program.emit_insn(Insn::Rewind {
+                                    cursor_id: meta.ephemeral_cursor_id,
+                                    pc_if_empty,
+                                });
+                                program.preassign_label_to_next_insn(meta.outer_loop_start);
+                                program.emit_insn(Insn::Column {
+                                    cursor_id: meta.ephemeral_cursor_id,
+                                    column: 0,
+                                    dest: start_reg + *argv_idx,
+                                    default: None,
+                                });
+                            }
+
+                            for (argv_index, expr) in constraints.iter().enumerate() {
+                                if vtab_in_loops.iter().any(|(i, _)| *i == argv_index) {
+                                    continue;
+                                }
+                                translate_expr(
+                                    program,
+                                    Some(table_references),
+                                    expr,
+                                    start_reg + argv_index,
+                                    &t_ctx.resolver,
+                                )?;
+                            }
+
+                            let maybe_idx_str = if let Some(idx_str) = idx_str {
+                                let reg = program.alloc_register();
+                                program.emit_insn(Insn::String8 {
+                                    dest: reg,
+                                    value: idx_str.to_owned(),
+                                });
+                                Some(reg)
+                            } else {
+                                None
                             };
 
-                            // Emit VFilter with the computed arguments.
+                            let pc_if_empty = vtab_in_loops
+                                .last()
+                                .map(|(_, meta)| meta.next_val_label)
+                                .unwrap_or(loop_end);
                             program.emit_insn(Insn::VFilter {
                                 cursor_id: table_cursor_id
                                     .expect("Virtual tables do not support covering indexes"),
-                                arg_count: count,
+                                arg_count: args_needed,
                                 args_reg: start_reg,
                                 idx_str: maybe_idx_str,
-                                idx_num: maybe_idx_int.unwrap_or(0) as usize,
-                                pc_if_empty: loop_end,
+                                idx_num: *idx_num as usize,
+                                pc_if_empty,
                             });
                             program.preassign_label_to_next_insn(loop_start);
+                            t_ctx.meta_vtab_in[joined_table_index] =
+                                vtab_in_loops.into_iter().map(|(_, meta)| meta).collect();
                         }
                         (
                             Scan::Subquery { iter_dir },

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -1828,17 +1828,20 @@ pub fn is_equality_operator(op: ConstraintOperator) -> bool {
 }
 
 fn to_ext_constraint_op(op: &ConstraintOperator) -> Option<ConstraintOp> {
-    let ConstraintOperator::AstNativeOperator(op) = op else {
-        return None;
-    };
     match op {
-        ast::Operator::Equals => Some(ConstraintOp::Eq),
-        ast::Operator::Less => Some(ConstraintOp::Lt),
-        ast::Operator::LessEquals => Some(ConstraintOp::Le),
-        ast::Operator::Greater => Some(ConstraintOp::Gt),
-        ast::Operator::GreaterEquals => Some(ConstraintOp::Ge),
-        ast::Operator::NotEquals => Some(ConstraintOp::Ne),
-        _ => None,
+        ConstraintOperator::AstNativeOperator(op) => match op {
+            ast::Operator::Equals => Some(ConstraintOp::Eq),
+            ast::Operator::Less => Some(ConstraintOp::Lt),
+            ast::Operator::LessEquals => Some(ConstraintOp::Le),
+            ast::Operator::Greater => Some(ConstraintOp::Gt),
+            ast::Operator::GreaterEquals => Some(ConstraintOp::Ge),
+            ast::Operator::NotEquals => Some(ConstraintOp::Ne),
+            _ => None,
+        },
+        // SQLite presents IN to xBestIndex as EQ, then re-invokes xFilter per value.
+        ConstraintOperator::In { not: false, .. } => Some(ConstraintOp::Eq),
+        ConstraintOperator::Like { not: false } => Some(ConstraintOp::Like),
+        ConstraintOperator::In { not: true, .. } | ConstraintOperator::Like { not: true } => None,
     }
 }
 

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -21,6 +21,7 @@ use crate::{
         BTreeCharacteristics, BTreeTable, ColDef, Column, Index, IndexColumn, Schema, Table, Type,
         ROWID_SENTINEL,
     },
+    translate::expr::as_binary_components,
     translate::{
         insert::ROWID_COLUMN,
         optimizer::{
@@ -53,7 +54,7 @@ use crate::{
 use crate::{turso_assert, turso_assert_eq, turso_debug_assert, turso_soft_unreachable};
 use constraints::{
     can_use_partial_index, constraints_from_where_clause, partial_index,
-    partial_index_predicate_terms, Constraint,
+    partial_index_predicate_terms, Constraint, ConstraintOperator,
 };
 use cost::Cost;
 use join::{
@@ -3109,6 +3110,7 @@ fn build_vtab_scan_op(
     }
 
     let mut constraints = vec![None; constraint_usages.len()];
+    let mut in_args: Vec<(usize, InSeekSource)> = Vec::new();
     let mut arg_count = 0;
 
     for (i, vtab_constraint) in vtab_constraints.iter().enumerate() {
@@ -3136,8 +3138,11 @@ fn build_vtab_scan_op(
         if usage.omit {
             where_clause[constraint.where_clause_pos.0].consumed = true;
         }
-        let (_, expr, _) = constraint.get_constraining_expr(where_clause, referenced_tables, None);
-        constraints[zero_based_argv_index] = Some(expr);
+        constraints[zero_based_argv_index] =
+            Some(vtab_argv_expr(constraint, where_clause, referenced_tables));
+        if let Some(source) = vtab_in_loop_source(constraint, where_clause) {
+            in_args.push((zero_based_argv_index, source));
+        }
         arg_count += 1;
     }
 
@@ -3160,7 +3165,56 @@ fn build_vtab_scan_op(
         idx_num: *idx_num,
         idx_str: idx_str.clone(),
         constraints,
+        in_args,
     }))
+}
+
+/// IN lists with more than one value, and IN subqueries, need a per-value xFilter loop.
+fn vtab_in_loop_source(
+    constraint: &Constraint,
+    where_clause: &[WhereTerm],
+) -> Option<InSeekSource> {
+    let ConstraintOperator::In { not: false, .. } = constraint.operator else {
+        return None;
+    };
+    match &where_clause[constraint.where_clause_pos.0].expr {
+        Expr::InList { rhs, .. } if rhs.len() != 1 => Some(InSeekSource::LiteralList {
+            values: rhs.iter().map(|e| *e.clone()).collect(),
+            affinity: constraint.comparison_affinity.unwrap_or(Affinity::Blob),
+        }),
+        Expr::SubqueryResult {
+            query_type: SubqueryType::In { cursor_id, .. },
+            ..
+        } => Some(InSeekSource::Subquery {
+            cursor_id: *cursor_id,
+        }),
+        _ => None,
+    }
+}
+
+fn vtab_argv_expr(
+    constraint: &Constraint,
+    where_clause: &[WhereTerm],
+    referenced_tables: Option<&TableReferences>,
+) -> Expr {
+    match &constraint.operator {
+        ConstraintOperator::In { .. } => match &where_clause[constraint.where_clause_pos.0].expr {
+            Expr::InList { rhs, .. } if rhs.len() == 1 => *rhs[0].clone(),
+            _ => Expr::Literal(ast::Literal::Null),
+        },
+        ConstraintOperator::Like { .. } => {
+            let term = &where_clause[constraint.where_clause_pos.0].expr;
+            let Ok(Some((_, _, rhs))) = as_binary_components(term) else {
+                panic!("LIKE constraint where term is not a LIKE expression");
+            };
+            rhs.clone()
+        }
+        _ => {
+            constraint
+                .get_constraining_expr(where_clause, referenced_tables, None)
+                .1
+        }
+    }
 }
 
 /// Mark WHERE clause terms as consumed when they are covered by a seek

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2343,6 +2343,7 @@ impl Operation {
                 idx_num: -1,
                 idx_str: None,
                 constraints: Vec::new(),
+                in_args: Vec::new(),
             }),
             Table::FromClauseSubquery(_) => Operation::Scan(Scan::Subquery {
                 iter_dir: IterationDirection::Forwards,
@@ -3146,6 +3147,9 @@ pub enum Scan {
         /// Constraining expressions to be passed to the table’s `filter` method.
         /// The order of expressions matches the argument order expected by the virtual table.
         constraints: Vec<Expr>,
+        /// IN-driven argv slots. SQLite presents IN as EQ to xBestIndex, then
+        /// re-invokes xFilter once per RHS value.
+        in_args: Vec<(usize, InSeekSource)>,
     },
     /// A scan of a subquery in the `FROM` clause.
     Subquery {

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1656,6 +1656,9 @@ pub fn emit_from_clause_subquery(
                     meta_in_seeks: (0..select_plan.joined_tables().len())
                         .map(|_| None)
                         .collect(),
+                    meta_vtab_in: (0..select_plan.joined_tables().len())
+                        .map(|_| Vec::new())
+                        .collect(),
                     materialized_build_inputs: HashMap::default(),
                     hash_table_contexts: HashMap::default(),
                     unsafe_testing: t_ctx.unsafe_testing,
@@ -1752,6 +1755,9 @@ fn emit_indexed_materialized_subquery(
                 meta_window: None,
                 meta_in_seeks: (0..select_plan.joined_tables().len())
                     .map(|_| None)
+                    .collect(),
+                meta_vtab_in: (0..select_plan.joined_tables().len())
+                    .map(|_| Vec::new())
                     .collect(),
                 materialized_build_inputs: HashMap::default(),
                 hash_table_contexts: HashMap::default(),
@@ -1853,6 +1859,9 @@ fn emit_materialized_subquery_table(
                 meta_window: None,
                 meta_in_seeks: (0..select_plan.joined_tables().len())
                     .map(|_| None)
+                    .collect(),
+                meta_vtab_in: (0..select_plan.joined_tables().len())
+                    .map(|_| Vec::new())
                     .collect(),
                 materialized_build_inputs: HashMap::default(),
                 hash_table_contexts: HashMap::default(),

--- a/sqlite/conformance/turso-sqltests/vtab-in-constraints.sqltest
+++ b/sqlite/conformance/turso-sqltests/vtab-in-constraints.sqltest
@@ -1,0 +1,54 @@
+@database :memory:
+
+# IN on a TVF hidden argument was dropped before xBestIndex, so json_each
+# returned 0 rows and generate_series scanned to u32::MAX. SQLite presents
+# IN as EQ and re-invokes xFilter once per value.
+
+test json-each-eq-control {
+    SELECT count(*) FROM json_each WHERE json = '[1,2,3]';
+}
+expect {
+    3
+}
+
+test json-each-in-list {
+    SELECT count(*) FROM json_each WHERE json IN ('[1,2,3]');
+}
+expect {
+    3
+}
+
+test json-each-in-two-documents {
+    SELECT count(*) FROM json_each WHERE json IN ('[1,2,3]', '[4,5]');
+}
+expect {
+    5
+}
+
+test json-each-in-subquery {
+    SELECT count(*) FROM json_each WHERE json IN (SELECT '[1,2,3]');
+}
+expect {
+    3
+}
+
+test json-tree-in-list {
+    SELECT count(*) FROM json_tree WHERE json IN ('[1,2,3]');
+}
+expect {
+    4
+}
+
+test generate-series-eq-control {
+    SELECT count(*) FROM generate_series WHERE start = 1 AND stop = 5;
+}
+expect {
+    5
+}
+
+test generate-series-in-stop {
+    SELECT count(*) FROM generate_series WHERE start = 1 AND stop IN (5);
+}
+expect {
+    5
+}

--- a/testing/system/vtab.test
+++ b/testing/system/vtab.test
@@ -430,6 +430,14 @@ do_execsql_test tvf-args-from-another-tvf {
 2|2
 3|2}
 
+do_execsql_test tvf-in-constraint-json-each {
+    SELECT count(*) FROM json_each WHERE json IN ('[1,2,3]');
+} {3}
+
+do_execsql_test tvf-in-constraint-generate-series {
+    SELECT count(*) FROM generate_series WHERE start = 1 AND stop IN (5);
+} {5}
+
 do_execsql_test_error tvf-circular-column-references {
     SELECT * FROM generate_series(a.start, a.stop) b, generate_series(b.start, b.stop) a;
 } {No valid query plan found|no query solution}

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -21,3 +21,4 @@ mod test_schema_updated;
 mod test_subquery_unnesting;
 mod test_transactions;
 mod test_type_affinity;
+mod test_vtab_in;

--- a/tests/integration/query_processing/test_vtab_in.rs
+++ b/tests/integration/query_processing/test_vtab_in.rs
@@ -1,0 +1,75 @@
+use crate::common::{limbo_exec_rows, TempDatabase};
+use rusqlite::types::Value;
+
+fn count(conn: &std::sync::Arc<turso_core::Connection>, sql: &str) -> i64 {
+    match limbo_exec_rows(conn, sql).as_slice() {
+        [row] => match row.as_slice() {
+            [Value::Integer(n)] => *n,
+            other => panic!("expected integer count from `{sql}`, got {other:?}"),
+        },
+        other => panic!("expected one row from `{sql}`, got {other:?}"),
+    }
+}
+
+#[test]
+fn json_each_in_list_is_not_dropped() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT count(*) FROM json_each WHERE json = '[1,2,3]'"
+        ),
+        3
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT count(*) FROM json_each WHERE json IN ('[1,2,3]')"
+        ),
+        3
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT count(*) FROM json_each WHERE json IN ('[1,2,3]', '[4,5]')"
+        ),
+        5
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT count(*) FROM json_each WHERE json IN (SELECT '[1,2,3]')"
+        ),
+        3
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT count(*) FROM json_tree WHERE json IN ('[1,2,3]')"
+        ),
+        4
+    );
+}
+
+#[test]
+fn generate_series_in_stop_is_bounded() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT count(*) FROM generate_series WHERE start = 1 AND stop = 5"
+        ),
+        5
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT count(*) FROM generate_series WHERE start = 1 AND stop IN (5)"
+        ),
+        5
+    );
+}


### PR DESCRIPTION
`SELECT count(*) FROM json_each WHERE json IN ('[1,2,3]')` currently returns 0 with no error. The `=` form of the same query returns 3. `generate_series` with `stop IN (5)` never comes back: the dropped bound falls through to `u32::MAX`.

SQLite presents `IN` to `xBestIndex` as `SQLITE_INDEX_CONSTRAINT_EQ` and re-invokes `xFilter` once per RHS value. Turso's `to_ext_constraint_op` returned `None` for `ConstraintOperator::In` / `Like`, and `convert_to_vtab_constraint` filtered those entries out, so `best_index` never saw the hidden argument.

This maps `IN` to `ConstraintOp::Eq` (and `LIKE` to `ConstraintOp::Like`), extracts the argv the way a comparison already does for a one-value list, and reuses the existing IN-list ephemeral cursor to drive `VFilter` per value for multi-value lists and IN subqueries.

Fixes #8273