### PR TITLE
bindings/dotnet: add advanced sync database options

### DIFF
--- a/bindings/dotnet/Readme.md
+++ b/bindings/dotnet/Readme.md
@@ -123,7 +123,7 @@ batch.BatchCommands.Add(select);
 await using var reader = await batch.ExecuteReaderAsync();
 ```
 
-Use `TursoSyncDatabase` when an application needs an embedded replica with explicit sync control:
+Use `TursoSyncDatabase` when an application needs an embedded replica with explicit sync control and advanced sync configuration:
 
 ```C#
 var options = new TursoSyncDatabaseOptions(
@@ -131,6 +131,16 @@ var options = new TursoSyncDatabaseOptions(
     new Uri("turso://example-org.turso.io"))
 {
     AuthToken = authToken,
+    PartialSync = new TursoPartialSyncOptions
+    {
+        PrefixLength = 4 * 1024 * 1024,
+        SegmentSize = 256 * 1024,
+        Prefetch = true,
+    },
+    PushOperationsThreshold = 1000,
+    PullBytesThreshold = 1024 * 1024,
+    ForceLogicalMvccPull = true,
+    ExperimentalFeatures = "views",
 };
 
 await using var database = await TursoSyncDatabase.CreateAsync(options);
@@ -145,7 +155,7 @@ await database.CheckpointAsync();
 
 `PullAsync` never pushes local writes. `PushAsync` currently follows the sync engine's last-write-wins conflict behavior, so use it only when that policy is acceptable. `CheckpointAsync` runs the sync engine's local checkpoint operation, while `GetStatsAsync` reports WAL sizes, CDC operations, transfer totals, revision, and the most recent pull and push times. Sync failures are `TursoSyncException` values carrying the operation, native status, sanitized endpoint, HTTP method/status, and original exception.
 
-Partial sync, remote encryption, connection-string replica integration, pooling, and automatic synchronization are not enabled yet. Use the explicit `TursoSyncDatabase` API for managed replicas.
+Remote encryption is configured with `RemoteEncryption = new TursoRemoteEncryptionOptions { Key = key, Cipher = TursoRemoteEncryptionCipher.Aes256Gcm }`. It cannot be combined with partial sync. Query-based partial sync cannot set `PullBytesThreshold`, all partial-sync strategies require `BootstrapIfEmpty`, and partial sync is unavailable on Windows until native sparse-file hole detection is implemented. Connection-string replica integration, pooling, and automatic synchronization are not enabled yet; use the explicit `TursoSyncDatabaseOptions` API for these advanced settings.
 
 Provider factories are available through `TursoFactory.Instance`:
 

--- a/bindings/dotnet/src/Turso.Data/TursoSyncDatabase.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoSyncDatabase.cs
@@ -791,10 +791,12 @@ public sealed class TursoSyncDatabase : IDisposable, IAsyncDisposable
         return new Uri(baseText + "/" + path.TrimStart('/'), UriKind.Absolute);
     }
 
-    private static TursoSyncDatabaseConfiguration CreateNativeConfiguration(
+    internal static TursoSyncDatabaseConfiguration CreateNativeConfiguration(
         TursoSyncDatabaseOptions options,
         Uri remoteUri)
     {
+        var partial = options.PartialSync;
+        var encryption = options.RemoteEncryption;
         return new TursoSyncDatabaseConfiguration
         {
             Path = options.Path,
@@ -804,6 +806,21 @@ public sealed class TursoSyncDatabase : IDisposable, IAsyncDisposable
                 ? 0
                 : checked((int)options.LongPollTimeout.Value.TotalMilliseconds),
             BootstrapIfEmpty = options.BootstrapIfEmpty,
+            ReservedBytes = encryption?.ReservedBytes ?? 0,
+            PartialBootstrapStrategyPrefix = partial?.PrefixLength ?? 0,
+            PartialBootstrapStrategyQuery = partial?.Query,
+            PartialBootstrapSegmentSize = partial?.SegmentSize is null ? 0 : (nuint)partial.SegmentSize.Value,
+            PartialBootstrapPrefetch = partial?.Prefetch ?? false,
+            RemoteEncryptionKey = encryption?.Key,
+            RemoteEncryptionCipher = encryption?.NativeName,
+            PushOperationsThreshold = options.PushOperationsThreshold is null
+                ? 0
+                : (nuint)options.PushOperationsThreshold.Value,
+            PullBytesThreshold = options.PullBytesThreshold is null
+                ? 0
+                : (nuint)options.PullBytesThreshold.Value,
+            LogicalMvccPull = options.ForceLogicalMvccPull,
+            ExperimentalFeatures = options.ExperimentalFeatures,
         };
     }
 

--- a/bindings/dotnet/src/Turso.Data/TursoSyncDatabaseOptions.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoSyncDatabaseOptions.cs
@@ -1,5 +1,83 @@
 namespace Turso;
 
+public enum TursoRemoteEncryptionCipher
+{
+    Aes256Gcm,
+    Aes128Gcm,
+    ChaCha20Poly1305,
+    Aegis128L,
+    Aegis128X2,
+    Aegis128X4,
+    Aegis256,
+    Aegis256X2,
+    Aegis256X4,
+}
+
+public sealed class TursoRemoteEncryptionOptions
+{
+    public required string Key { get; init; }
+    public required TursoRemoteEncryptionCipher Cipher { get; init; }
+
+    internal int ReservedBytes => Cipher switch
+    {
+        TursoRemoteEncryptionCipher.Aes256Gcm
+            or TursoRemoteEncryptionCipher.Aes128Gcm
+            or TursoRemoteEncryptionCipher.ChaCha20Poly1305 => 28,
+        TursoRemoteEncryptionCipher.Aegis128L
+            or TursoRemoteEncryptionCipher.Aegis128X2
+            or TursoRemoteEncryptionCipher.Aegis128X4 => 32,
+        TursoRemoteEncryptionCipher.Aegis256
+            or TursoRemoteEncryptionCipher.Aegis256X2
+            or TursoRemoteEncryptionCipher.Aegis256X4 => 48,
+        _ => throw new ArgumentOutOfRangeException(nameof(Cipher), Cipher, null),
+    };
+
+    internal string NativeName => Cipher switch
+    {
+        TursoRemoteEncryptionCipher.Aes256Gcm => "aes256gcm",
+        TursoRemoteEncryptionCipher.Aes128Gcm => "aes128gcm",
+        TursoRemoteEncryptionCipher.ChaCha20Poly1305 => "chacha20poly1305",
+        TursoRemoteEncryptionCipher.Aegis128L => "aegis128l",
+        TursoRemoteEncryptionCipher.Aegis128X2 => "aegis128x2",
+        TursoRemoteEncryptionCipher.Aegis128X4 => "aegis128x4",
+        TursoRemoteEncryptionCipher.Aegis256 => "aegis256",
+        TursoRemoteEncryptionCipher.Aegis256X2 => "aegis256x2",
+        TursoRemoteEncryptionCipher.Aegis256X4 => "aegis256x4",
+        _ => throw new ArgumentOutOfRangeException(nameof(Cipher), Cipher, null),
+    };
+
+    internal void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Key);
+        _ = ReservedBytes;
+    }
+}
+
+public sealed class TursoPartialSyncOptions
+{
+    public int? PrefixLength { get; init; }
+    public string? Query { get; init; }
+    public long? SegmentSize { get; init; }
+    public bool Prefetch { get; init; }
+
+    internal void Validate()
+    {
+        if (Query is not null)
+            ArgumentException.ThrowIfNullOrWhiteSpace(Query);
+
+        var hasPrefix = PrefixLength.HasValue;
+        var hasQuery = Query is not null;
+        if (hasPrefix == hasQuery)
+            throw new InvalidOperationException("Partial sync requires exactly one prefix or query bootstrap strategy.");
+        if (PrefixLength is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(PrefixLength), PrefixLength, "Prefix length must be positive.");
+        if (SegmentSize is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(SegmentSize), SegmentSize, "Segment size must be positive.");
+        if (SegmentSize is { } segmentSize && (ulong)segmentSize > nuint.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(SegmentSize), SegmentSize, "Segment size exceeds the native platform size.");
+    }
+}
+
 public sealed class TursoSyncDatabaseOptions
 {
     public TursoSyncDatabaseOptions(string path, Uri remoteUri)
@@ -16,7 +94,13 @@ public sealed class TursoSyncDatabaseOptions
     public string ClientName { get; init; } = "turso-sync-dotnet";
     public TimeSpan? LongPollTimeout { get; init; }
     public bool BootstrapIfEmpty { get; init; } = true;
+    public TursoPartialSyncOptions? PartialSync { get; init; }
+    public TursoRemoteEncryptionOptions? RemoteEncryption { get; init; }
+    public long? PushOperationsThreshold { get; init; }
+    public long? PullBytesThreshold { get; init; }
+    public bool ForceLogicalMvccPull { get; init; }
     public HttpClient? HttpClient { get; init; }
+    public string? ExperimentalFeatures { get; init; }
 
     internal Uri GetNormalizedRemoteUri()
     {
@@ -71,6 +155,36 @@ public sealed class TursoSyncDatabaseOptions
                 $"Long-poll timeout must be between 1 and {int.MaxValue} milliseconds.");
         }
 
+        ValidateNativeSize(PushOperationsThreshold, nameof(PushOperationsThreshold));
+        ValidateNativeSize(PullBytesThreshold, nameof(PullBytesThreshold));
+        PartialSync?.Validate();
+
+        if (PartialSync is not null && !BootstrapIfEmpty)
+            throw new InvalidOperationException("Partial sync requires BootstrapIfEmpty=True.");
+        if (PartialSync is not null && RemoteEncryption is not null)
+            throw new InvalidOperationException("Partial sync cannot be combined with remote encryption.");
+        if (PartialSync?.Query is not null && PullBytesThreshold.HasValue)
+        {
+            throw new InvalidOperationException(
+                "PullBytesThreshold cannot be combined with query partial bootstrap.");
+        }
+        if (PartialSync is not null && OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException(
+                "Partial sync on Windows requires native sparse-file hole detection that is not yet implemented.");
+        }
+
+        RemoteEncryption?.Validate();
+    }
+
+    private static void ValidateNativeSize(long? value, string parameterName)
+    {
+        if (value is null)
+            return;
+        if (value <= 0)
+            throw new ArgumentOutOfRangeException(parameterName, value, "The value must be positive.");
+        if ((ulong)value > nuint.MaxValue)
+            throw new ArgumentOutOfRangeException(parameterName, value, "The value exceeds the native platform size.");
     }
 }
 

--- a/bindings/dotnet/src/Turso.Tests/TursoAdvancedSyncOptionsTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/TursoAdvancedSyncOptionsTests.cs
@@ -1,0 +1,268 @@
+using AwesomeAssertions;
+
+namespace Turso.Tests;
+
+public sealed class TursoAdvancedSyncOptionsTests
+{
+    [Test]
+    public void ExplicitOptionsMapPartialSyncAndThresholds()
+    {
+        var options = new TursoSyncDatabaseOptions(
+            "replica.db",
+            new Uri("turso://example.test"))
+        {
+            AuthToken = "secret",
+            ClientName = "consumer",
+            LongPollTimeout = TimeSpan.FromMilliseconds(2500),
+            PartialSync = new TursoPartialSyncOptions
+            {
+                PrefixLength = 8192,
+                SegmentSize = 4096,
+                Prefetch = true,
+            },
+            PushOperationsThreshold = 100,
+            PullBytesThreshold = 65536,
+            ForceLogicalMvccPull = true,
+            ExperimentalFeatures = "views",
+        };
+
+        var configuration = TursoSyncDatabase.CreateNativeConfiguration(
+            options,
+            options.GetNormalizedRemoteUri());
+
+        configuration.Path.Should().Be("replica.db");
+        configuration.RemoteUrl.Should().Be("https://example.test/");
+        configuration.ClientName.Should().Be("consumer");
+        configuration.LongPollTimeoutMilliseconds.Should().Be(2500);
+        configuration.BootstrapIfEmpty.Should().BeTrue();
+        configuration.ReservedBytes.Should().Be(0);
+        configuration.PartialBootstrapStrategyPrefix.Should().Be(8192);
+        configuration.PartialBootstrapStrategyQuery.Should().BeNull();
+        configuration.PartialBootstrapSegmentSize.Should().Be((nuint)4096);
+        configuration.PartialBootstrapPrefetch.Should().BeTrue();
+        configuration.RemoteEncryptionKey.Should().BeNull();
+        configuration.RemoteEncryptionCipher.Should().BeNull();
+        configuration.PushOperationsThreshold.Should().Be((nuint)100);
+        configuration.PullBytesThreshold.Should().Be((nuint)65536);
+        configuration.LogicalMvccPull.Should().BeTrue();
+        configuration.ExperimentalFeatures.Should().Be("views");
+    }
+
+    [Test]
+    public void QueryPartialSyncMapsNativeStrategy()
+    {
+        var options = new TursoSyncDatabaseOptions(
+            "replica.db",
+            new Uri("https://example.test"))
+        {
+            PartialSync = new TursoPartialSyncOptions
+            {
+                Query = "SELECT * FROM users",
+                SegmentSize = 4096,
+                Prefetch = true,
+            },
+        };
+
+        var configuration = TursoSyncDatabase.CreateNativeConfiguration(
+            options,
+            options.GetNormalizedRemoteUri());
+
+        configuration.PartialBootstrapStrategyPrefix.Should().Be(0);
+        configuration.PartialBootstrapStrategyQuery.Should().Be("SELECT * FROM users");
+        configuration.PartialBootstrapSegmentSize.Should().Be((nuint)4096);
+        configuration.PartialBootstrapPrefetch.Should().BeTrue();
+    }
+
+    [TestCase(TursoRemoteEncryptionCipher.Aes256Gcm, "aes256gcm", 28)]
+    [TestCase(TursoRemoteEncryptionCipher.Aes128Gcm, "aes128gcm", 28)]
+    [TestCase(TursoRemoteEncryptionCipher.ChaCha20Poly1305, "chacha20poly1305", 28)]
+    [TestCase(TursoRemoteEncryptionCipher.Aegis128L, "aegis128l", 32)]
+    [TestCase(TursoRemoteEncryptionCipher.Aegis128X2, "aegis128x2", 32)]
+    [TestCase(TursoRemoteEncryptionCipher.Aegis128X4, "aegis128x4", 32)]
+    [TestCase(TursoRemoteEncryptionCipher.Aegis256, "aegis256", 48)]
+    [TestCase(TursoRemoteEncryptionCipher.Aegis256X2, "aegis256x2", 48)]
+    [TestCase(TursoRemoteEncryptionCipher.Aegis256X4, "aegis256x4", 48)]
+    public void RemoteEncryptionMapsCipherAndReservedBytes(
+        TursoRemoteEncryptionCipher cipher,
+        string nativeName,
+        int reservedBytes)
+    {
+        var options = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            RemoteEncryption = new TursoRemoteEncryptionOptions
+            {
+                Key = "base64-key",
+                Cipher = cipher,
+            },
+        };
+
+        options.Validate();
+        var configuration = TursoSyncDatabase.CreateNativeConfiguration(
+            options,
+            options.GetNormalizedRemoteUri());
+
+        configuration.RemoteEncryptionKey.Should().Be("base64-key");
+        configuration.RemoteEncryptionCipher.Should().Be(nativeName);
+        configuration.ReservedBytes.Should().Be(reservedBytes);
+    }
+
+    [Test]
+    public void PartialSyncRequiresExactlyOneBootstrapStrategy()
+    {
+        var missing = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            PartialSync = new TursoPartialSyncOptions(),
+        };
+        var contradictory = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            PartialSync = new TursoPartialSyncOptions
+            {
+                PrefixLength = 4096,
+                Query = "SELECT * FROM users",
+            },
+        };
+
+        missing.Invoking(options => options.Validate())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*exactly one*");
+        contradictory.Invoking(options => options.Validate())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*exactly one*");
+    }
+
+    [TestCase(0L)]
+    [TestCase(-1L)]
+    public void SyncThresholdsMustBePositive(long value)
+    {
+        var push = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            PushOperationsThreshold = value,
+        };
+        var pull = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            PullBytesThreshold = value,
+        };
+
+        push.Invoking(options => options.Validate())
+            .Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName(nameof(TursoSyncDatabaseOptions.PushOperationsThreshold));
+        pull.Invoking(options => options.Validate())
+            .Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName(nameof(TursoSyncDatabaseOptions.PullBytesThreshold));
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void PartialSyncSizesMustBePositive(int value)
+    {
+        var prefix = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            PartialSync = new TursoPartialSyncOptions { PrefixLength = value },
+        };
+        var segment = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            PartialSync = new TursoPartialSyncOptions
+            {
+                PrefixLength = 4096,
+                SegmentSize = value,
+            },
+        };
+
+        prefix.Invoking(options => options.Validate())
+            .Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName(nameof(TursoPartialSyncOptions.PrefixLength));
+        segment.Invoking(options => options.Validate())
+            .Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName(nameof(TursoPartialSyncOptions.SegmentSize));
+    }
+
+    [Test]
+    public void PartialSyncRequiresBootstrapIfEmpty()
+    {
+        var options = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            BootstrapIfEmpty = false,
+            PartialSync = new TursoPartialSyncOptions { PrefixLength = 4096 },
+        };
+
+        options.Invoking(value => value.Validate())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*BootstrapIfEmpty=True*");
+    }
+
+    [Test]
+    public void PartialSyncCannotUseRemoteEncryption()
+    {
+        var options = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            PartialSync = new TursoPartialSyncOptions { PrefixLength = 4096 },
+            RemoteEncryption = new TursoRemoteEncryptionOptions
+            {
+                Key = "base64-key",
+                Cipher = TursoRemoteEncryptionCipher.Aes256Gcm,
+            },
+        };
+
+        options.Invoking(value => value.Validate())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*cannot be combined*");
+    }
+
+    [Test]
+    public void QueryPartialSyncCannotUsePullByteThreshold()
+    {
+        var options = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            PartialSync = new TursoPartialSyncOptions { Query = "SELECT * FROM users" },
+            PullBytesThreshold = 65536,
+        };
+
+        options.Invoking(value => value.Validate())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*PullBytesThreshold*");
+    }
+
+    [Test]
+    public void RemoteEncryptionRequiresAKeyAndKnownCipher()
+    {
+        var missingKey = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            RemoteEncryption = new TursoRemoteEncryptionOptions
+            {
+                Key = " ",
+                Cipher = TursoRemoteEncryptionCipher.Aes256Gcm,
+            },
+        };
+        var unknownCipher = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            RemoteEncryption = new TursoRemoteEncryptionOptions
+            {
+                Key = "base64-key",
+                Cipher = (TursoRemoteEncryptionCipher)int.MaxValue,
+            },
+        };
+
+        missingKey.Invoking(options => options.Validate())
+            .Should().Throw<ArgumentException>()
+            .WithParameterName(nameof(TursoRemoteEncryptionOptions.Key));
+        unknownCipher.Invoking(options => options.Validate())
+            .Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName(nameof(TursoRemoteEncryptionOptions.Cipher));
+    }
+
+    [Test]
+    public void PartialSyncOnWindowsFailsBeforeNativeExecution()
+    {
+        if (!OperatingSystem.IsWindows())
+            Assert.Ignore("Windows-specific partial sync guard.");
+
+        var options = new TursoSyncDatabaseOptions("replica.db", new Uri("https://example.test"))
+        {
+            PartialSync = new TursoPartialSyncOptions { PrefixLength = 4096 },
+        };
+
+        options.Invoking(value => value.Validate())
+            .Should().Throw<PlatformNotSupportedException>()
+            .WithMessage("*sparse-file hole detection*");
+    }
+}


### PR DESCRIPTION
## Summary
- add public partial-sync and remote-encryption configuration for the explicit `TursoSyncDatabase` API, including native cipher names and reserved-byte calculation
- expose push-operation and pull-byte thresholds, logical MVCC pull, and experimental features, and map every setting into the existing native sync configuration
- reject invalid or contradictory combinations before native execution, preserve the Windows partial-sync guard, and document the explicit options and limitations

## Extraction context
This is the next regular PR extracted from the closed source draft #8504. It is based on `main` after #8514 (native sync ABI), #8519 (managed pull replica API), and #8523 (managed sync controls), and adds only advanced configuration for the already-merged explicit `TursoSyncDatabase` surface.

## Deferred work
Connection-string replica integration and advanced connection-string keys remain deferred, along with replica pooling/registry, automatic sync coordination/status/events and interval sync, replica `DbBatch`, Hrana stream recovery and broader ADO.NET compatibility, the managed `Turso.Data.Sqlite` remote/replica backend, EF Core integration, and NativeAOT/mobile/package-consumer samples or CI. This PR contains no Rust changes.

## Validation
- `dotnet format` for the changed projects/files and `--verify-no-changes`
- `dotnet build bindings\dotnet\src\Turso.Data\Turso.Data.csproj --no-restore`
- `dotnet test bindings\dotnet\src\Turso.Tests\Turso.Tests.csproj --filter "FullyQualifiedName~TursoAdvancedSyncOptionsTests|FullyQualifiedName~TursoManagedSyncTests" --no-restore` (36 passed)