### PR TITLE
fts/testing: add FTS workload to concurrent simulator

### DIFF
--- a/core/index_method/fts/mod.rs
+++ b/core/index_method/fts/mod.rs
@@ -1944,21 +1944,44 @@ impl FtsCursor {
         result
     }
 
-    /// Mint a fresh on-disk index incarnation. Mixes in IO-provided entropy
-    /// so two processes creating the same index in different files do not
-    /// mint the same value (the counter restarts at 1 in every process);
-    /// the IO trait's generator is deterministic under the simulator.
+    /// Mint a fresh on-disk index incarnation. Drawn from the IO's random
+    /// source when the cursor is attached to a database: two processes
+    /// creating the same index in different files get different values,
+    /// and the simulator's seeded IO hands out the same value on the same
+    /// seed, so a seeded run replays byte for byte. Without an IO
+    /// (connection-less unit tests) a process-local counter keeps values
+    /// distinct.
     fn mint_index_incarnation(&self) -> u64 {
-        let nonce = NEXT_FTS_INDEX_INCARNATION.fetch_add(1, Ordering::Relaxed);
+        let root = self.btree_root_page.unwrap_or_default() as u64;
         let entropy = self
-            .connection
+            .io_random_u64()
+            .unwrap_or_else(|| NEXT_FTS_INDEX_INCARNATION.fetch_add(1, Ordering::Relaxed));
+        (root.rotate_left(32) ^ entropy).max(1)
+    }
+
+    /// One 64-bit draw from the pager's IO random source, if the cursor is
+    /// attached to a database.
+    fn io_random_u64(&self) -> Option<u64> {
+        self.connection
             .as_ref()
             .and_then(Weak::upgrade)
             .zip(self.database_id)
             .and_then(|(conn, database_id)| conn.get_pager_from_database_index(&database_id).ok())
-            .map_or(0, |pager| pager.io.generate_random_number() as u64);
-        let root = self.btree_root_page.unwrap_or_default() as u64;
-        (root.rotate_left(32) ^ nonce ^ entropy).max(1)
+            .map(|pager| pager.io.generate_random_number() as u64)
+    }
+
+    /// Mint the id of a segment this cursor is about to build. The id is
+    /// the key prefix of every backing row, so it decides B-tree layout;
+    /// drawing it from the IO random source keeps seeded simulator runs
+    /// replaying byte for byte (tantivy's own ids come from OS entropy).
+    /// Without an IO, tantivy's random id is used.
+    fn mint_segment_id(&self) -> SegmentId {
+        let (Some(hi), Some(lo)) = (self.io_random_u64(), self.io_random_u64()) else {
+            return SegmentId::generate_random();
+        };
+        let value = (u128::from(hi) << 64) | u128::from(lo);
+        SegmentId::from_uuid_string(&format!("{value:032x}"))
+            .expect("32 hex digits are a valid simple uuid")
     }
 
     /// Build one immutable segment from the buffered documents (if any) and
@@ -2022,8 +2045,8 @@ impl FtsCursor {
         // The segment writer pulls tokenizers off `segment.index()`, so the
         // build index needs the same registrations as the read side.
         self.register_tokenizers(&index);
-        let segment = index.new_segment();
-        let segment_id = segment.id();
+        let segment_id = self.mint_segment_id();
+        let segment = index.segment(index.new_segment_meta(segment_id, 0));
         let mut writer = SegmentWriter::for_segment(DEFAULT_MEMORY_BUDGET_BYTES, segment)
             .map_err(|e| LimboError::InternalError(format!("FTS segment writer: {e}")))?;
         for buffered in self.doc_buffer.drain(..) {
@@ -2135,9 +2158,14 @@ impl FtsCursor {
             let merged_meta = merged_metas
                 .first()
                 .ok_or_else(|| LimboError::InternalError("FTS merge produced no segment".into()))?;
-            let captured = build_dir.captured_files();
+            // `merge_filtered_segments` names its output after an OS-random
+            // id; re-key the files to a minted one (see `mint_segment_id`).
+            // Segment file bytes never embed the id, only the names do.
+            let segment_id = self.mint_segment_id();
+            let captured =
+                rename_segment_files(build_dir.captured_files(), &merged_meta.id(), &segment_id)?;
             let (segment, rows) =
-                segment_rows_from_files(merged_meta.id(), merged_meta.max_doc(), captured)?;
+                segment_rows_from_files(segment_id, merged_meta.max_doc(), captured)?;
             self.shared
                 .stats
                 .segment_builds
@@ -2416,6 +2444,33 @@ fn assemble_chunks(path: &std::path::Path, mut chunks: HashMap<i64, Vec<u8>>) ->
 
 /// Turn a built segment's captured files into a `LoadedSegment` plus its
 /// descriptor and chunk rows.
+/// Re-key captured segment files from segment id `from` to `to`. Tantivy
+/// names every component `<segment uuid>.<ext>`; the bytes never carry the
+/// id, so a rename is all a merged segment needs to take a minted id.
+fn rename_segment_files(
+    files: HashMap<PathBuf, Arc<[u8]>>,
+    from: &SegmentId,
+    to: &SegmentId,
+) -> Result<HashMap<PathBuf, Arc<[u8]>>> {
+    let from = from.uuid_string();
+    let to = to.uuid_string();
+    files
+        .into_iter()
+        .map(|(path, bytes)| {
+            let rest = path
+                .to_str()
+                .and_then(|name| name.strip_prefix(from.as_str()))
+                .ok_or_else(|| {
+                    LimboError::InternalError(format!(
+                        "FTS merge wrote a file that is not named after its segment: {}",
+                        path.display()
+                    ))
+                })?;
+            Ok((PathBuf::from(format!("{to}{rest}")), bytes))
+        })
+        .collect()
+}
+
 fn segment_rows_from_files(
     segment_id: SegmentId,
     max_doc: u32,

--- a/core/index_method/fts/mod.rs
+++ b/core/index_method/fts/mod.rs
@@ -1649,8 +1649,15 @@ impl FtsCursor {
                     {
                         self.scan_descriptors.push(descriptor);
                     } else {
+                        let existing = self
+                            .scan_descriptors
+                            .iter()
+                            .find(|existing| existing.segment_id == segment_id);
                         tracing::error!(
                             segment = %segment_id.uuid_string(),
+                            identical = existing == Some(&descriptor),
+                            existing = ?existing,
+                            duplicate = ?descriptor,
                             "duplicate FTS registry row; keeping the first"
                         );
                     }
@@ -2554,6 +2561,68 @@ impl FtsBackingRowWiper {
 
     pub fn step(&mut self) -> Result<IOResult<()>> {
         self.deleter.step(self.cursor.as_mut())
+    }
+}
+
+/// Test helper: enumerate every raw row of an FTS index's backing store as
+/// `(path, chunk_no, byte_len, fnv64-of-bytes)`. Drive `step` to completion
+/// inside a read transaction; rows land in `rows` in key order, including
+/// physical duplicates the reader normally dedupes.
+#[cfg(feature = "test_helper")]
+pub struct FtsBackingRowDumper {
+    cursor: Box<dyn CursorTrait>,
+    started: bool,
+    advance_pending: bool,
+    pub rows: Vec<(String, i64, usize, u64)>,
+}
+
+#[cfg(feature = "test_helper")]
+impl FtsBackingRowDumper {
+    pub fn new(conn: &Arc<Connection>, database_id: usize, index_name: &str) -> Result<Self> {
+        let dir_table_name = format!(
+            "{}fts_dir_{}",
+            crate::schema::TURSO_INTERNAL_PREFIX,
+            index_name
+        );
+        let key_index_name = format!("{dir_table_name}_key");
+        let cursor = open_index_cursor(
+            conn,
+            database_id,
+            &dir_table_name,
+            &key_index_name,
+            [key_info(), key_info(), key_info()],
+        )?;
+        Ok(Self {
+            cursor,
+            started: false,
+            advance_pending: false,
+            rows: Vec::new(),
+        })
+    }
+
+    pub fn step(&mut self) -> Result<IOResult<()>> {
+        loop {
+            if !self.started {
+                return_if_io!(self.cursor.rewind());
+                self.started = true;
+            }
+            if self.advance_pending {
+                return_if_io!(self.cursor.next());
+                self.advance_pending = false;
+            }
+            if !self.cursor.has_record() {
+                return Ok(IOResult::Done(()));
+            }
+            let record = return_if_io!(self.cursor.record()).ok_or_else(|| {
+                LimboError::Corrupt("FTS dump cursor has no record payload".into())
+            })?;
+            let (path, chunk_no, bytes) = row_fields(record)?;
+            let hash = bytes.iter().fold(0xcbf2_9ce4_8422_2325u64, |hash, byte| {
+                (hash ^ u64::from(*byte)).wrapping_mul(0x100_0000_01b3)
+            });
+            self.rows.push((path, chunk_no, bytes.len(), hash));
+            self.advance_pending = true;
+        }
     }
 }
 

--- a/core/index_method/fts/rows.rs
+++ b/core/index_method/fts/rows.rs
@@ -118,15 +118,30 @@ pub(super) fn seek_key_for_path(path: &str) -> Result<ImmutableRecord> {
 /// not be rebuilt on every re-entry.
 #[derive(Debug)]
 enum InsertPhase {
-    Seeking { record: ImmutableRecord },
-    Inserting { record: ImmutableRecord },
+    Seeking {
+        record: ImmutableRecord,
+    },
+    /// The seek stopped one leaf early (`SeekResult::TryAdvance`): a stale
+    /// interior divider can navigate the cursor to a leaf that no longer
+    /// holds the seek boundary. `insert` only checks the cursor's current
+    /// cell for an exact-key overwrite, so inserting from this position
+    /// would add a second physical copy of a key that already exists at the
+    /// start of the next leaf. Advance once before inserting, exactly like
+    /// the VDBE's `seek_internal` does.
+    Advancing {
+        record: ImmutableRecord,
+    },
+    Inserting {
+        record: ImmutableRecord,
+    },
 }
 
 /// Insert-only flush: every row is written once with a fresh key, so the
-/// machine is pure seek-then-insert. A row whose exact key is already
-/// present (a resumed insert) needs no probe here: the B-tree overwrites
-/// on an exact index-key match and the MVCC cursor updates the existing
-/// version, so re-inserting identical bytes is idempotent by construction.
+/// machine is seek-then-insert. A row whose exact key is already present
+/// (a resumed insert) is overwritten in place — but only if the cursor is
+/// actually positioned on the equal cell when `insert` runs. A seek that
+/// stops one leaf early (`TryAdvance`) must advance first, or the insert
+/// adds a second physical copy of the key (see [`InsertPhase::Advancing`]).
 #[derive(Debug)]
 pub(super) struct RowInserter {
     rows: Vec<PendingRow>,
@@ -156,16 +171,31 @@ impl RowInserter {
                     });
                 }
                 Some(InsertPhase::Seeking { record }) => {
-                    // Positioning only: `insert` writes at the cursor's
-                    // current position (see the struct docs for why no
-                    // existence probe is needed).
-                    return_if_io!(cursor.seek(
+                    // `eq_only: true`: `NotFound` positions the cursor at
+                    // the exact slot where the key belongs (the fresh-key
+                    // case), `Found` lands on the equal cell (the resumed
+                    // re-insert case, overwritten in place). `TryAdvance`
+                    // means the equal key may sit at the start of the next
+                    // leaf behind a stale interior divider: advancing before
+                    // the insert reaches it, so the overwrite happens
+                    // instead of a second physical copy of the key.
+                    let seek_result = return_if_io!(cursor.seek(
                         SeekKey::IndexKey(record.as_record_ref()),
-                        SeekOp::GE { eq_only: false },
+                        SeekOp::GE { eq_only: true },
                     ));
                     // Insert in a separate phase so an I/O yield does not
                     // repeat the seek.
                     let Some(InsertPhase::Seeking { record }) = self.phase.take() else {
+                        unreachable!("phase matched above");
+                    };
+                    self.phase = Some(match seek_result {
+                        SeekResult::TryAdvance => InsertPhase::Advancing { record },
+                        _ => InsertPhase::Inserting { record },
+                    });
+                }
+                Some(InsertPhase::Advancing { .. }) => {
+                    return_if_io!(cursor.next());
+                    let Some(InsertPhase::Advancing { record }) = self.phase.take() else {
                         unreachable!("phase matched above");
                     };
                     self.phase = Some(InsertPhase::Inserting { record });

--- a/core/index_method/fts/tests.rs
+++ b/core/index_method/fts/tests.rs
@@ -188,6 +188,59 @@ fn segment_build_round_trips_through_synthesized_snapshot() {
 }
 
 #[test]
+fn merged_segment_files_can_be_rekeyed_to_a_minted_id() {
+    let attachment = test_attachment();
+    let (segment, _) = build_and_load_segment(
+        &attachment,
+        &[(1, "hello turso"), (2, "hello world"), (3, "goodbye")],
+    );
+    let minted = SegmentId::from_uuid_string("0123456789abcdef0123456789abcdef").unwrap();
+    assert_ne!(segment.id(), minted);
+
+    let files: HashMap<PathBuf, Arc<[u8]>> = segment
+        .data
+        .files
+        .iter()
+        .map(|(name, bytes)| (PathBuf::from(name), Arc::clone(bytes)))
+        .collect();
+    let renamed = rename_segment_files(files.clone(), &segment.id(), &minted).unwrap();
+    assert_eq!(renamed.len(), files.len());
+    assert!(renamed
+        .keys()
+        .all(|path| path.to_str().unwrap().starts_with(&minted.uuid_string())));
+
+    // The renamed files open and answer queries under the new id: the
+    // bytes never embed the segment id.
+    let (rekeyed, _) =
+        segment_rows_from_files(minted, segment.descriptor.max_doc, renamed).unwrap();
+    let rekeyed = rekeyed.expect("non-empty segment");
+    assert_eq!(rekeyed.id(), minted);
+    let mut cursor = FtsCursor::new(&attachment);
+    cursor.segments = vec![rekeyed];
+    cursor.snapshot_loaded = true;
+    cursor.ensure_searcher().unwrap();
+    let searcher = cursor.searcher.as_ref().unwrap();
+    let (query, _) = cursor
+        .cached_parser
+        .as_ref()
+        .unwrap()
+        .parse_query_lenient("hello");
+    assert_eq!(
+        searcher.search(&query, &tantivy::collector::Count).unwrap(),
+        2
+    );
+
+    // A file that is not named after the source segment is a bug, not
+    // something to rename silently.
+    let mut stray = files;
+    stray.insert(PathBuf::from("meta.json"), Arc::from(Vec::new()));
+    assert!(matches!(
+        rename_segment_files(stray, &segment.id(), &minted),
+        Err(LimboError::InternalError(_))
+    ));
+}
+
+#[test]
 fn tombstoned_docs_are_invisible_at_the_reader_level() {
     let attachment = test_attachment();
     let (mut segment, _) = build_and_load_segment(

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -11768,6 +11768,172 @@ mod tests {
         btree_index_insert_fuzz_run(2, 10_000);
     }
 
+    /// Re-insert an already-present index key the way FTS's RowInserter
+    /// does — seek `GE { eq_only: true }`, advance once on `TryAdvance`,
+    /// insert at the cursor — after delete churn that leaves stale interior
+    /// dividers. `insert` only checks the cursor's current cell for an
+    /// exact-key overwrite, so a caller that skips the advance lands one
+    /// leaf early and writes a second physical copy of the key (the whopper
+    /// duplicate-registry-row corruption). The full scan must see every key
+    /// exactly once.
+    #[test]
+    pub fn btree_index_reinsert_after_tryadvance_never_duplicates() {
+        use crate::storage::pager::CreateBTreeFlags;
+        let (mut rng, seed) = rng_from_time_or_env();
+        tracing::info!("seed: {seed}");
+        for attempt in 0..8 {
+            let (pager, _, _db, conn) = empty_btree();
+            let index_root_page = pager
+                .io
+                .block(|| pager.btree_create(&CreateBTreeFlags::new_index()))
+                .unwrap() as i64;
+            let index_def = Index {
+                name: "testindex".to_string(),
+                where_clause: None,
+                columns: IndexColumn::new_many(vec!["testcol"]),
+                table_name: "test".to_string(),
+                root_page: index_root_page,
+                unique: false,
+                ephemeral: false,
+                has_rowid: false,
+                index_method: None,
+                on_conflict: None,
+            };
+            let mut cursor =
+                BTreeCursor::new_index(pager.clone(), index_root_page, &index_def, 1).unwrap();
+
+            let key_bytes = |i: u64| -> Vec<u8> {
+                let mut k = vec![0u8; 128];
+                k[..8].copy_from_slice(&i.to_be_bytes());
+                k
+            };
+            let record_for = |k: &[u8]| {
+                let regs = vec![Register::Value(Value::from_slice(k).unwrap())];
+                ImmutableRecord::from_registers(&regs, regs.len()).unwrap()
+            };
+
+            let mut live: Vec<u64> = Vec::new();
+            pager.begin_read_tx().unwrap();
+            pager
+                .io
+                .block(|| pager.begin_write_tx(WalAutoActions::all_enabled()))
+                .unwrap();
+            for i in 0..600u64 {
+                let record = record_for(&key_bytes(i));
+                run_until_done(
+                    || {
+                        cursor.seek(
+                            SeekKey::IndexKey(record.as_record_ref()),
+                            SeekOp::GE { eq_only: false },
+                        )
+                    },
+                    pager.deref(),
+                )
+                .unwrap();
+                run_until_done(
+                    || cursor.insert(&BTreeKey::new_index_key(record.as_record_ref())),
+                    pager.deref(),
+                )
+                .unwrap();
+                live.push(i);
+            }
+            // Delete a random half to churn interior dividers.
+            for _ in 0..300 {
+                let idx = rng.next_u64() as usize % live.len();
+                let victim = live.swap_remove(idx);
+                let record = record_for(&key_bytes(victim));
+                let seek_result = run_until_done(
+                    || {
+                        cursor.seek(
+                            SeekKey::IndexKey(record.as_record_ref()),
+                            SeekOp::GE { eq_only: true },
+                        )
+                    },
+                    pager.deref(),
+                )
+                .unwrap();
+                if matches!(seek_result, SeekResult::TryAdvance) {
+                    run_until_done(|| cursor.next(), pager.deref()).unwrap();
+                }
+                run_until_done(|| cursor.delete(), pager.deref()).unwrap();
+            }
+            // Re-insert EVERY surviving key with RowInserter's protocol:
+            // seek GE eq_only, advance once on TryAdvance, insert.
+            let mut tryadvance_reinserts = 0usize;
+            for &survivor in &live {
+                let record = record_for(&key_bytes(survivor));
+                let seek_result = run_until_done(
+                    || {
+                        cursor.seek(
+                            SeekKey::IndexKey(record.as_record_ref()),
+                            SeekOp::GE { eq_only: true },
+                        )
+                    },
+                    pager.deref(),
+                )
+                .unwrap();
+                if matches!(seek_result, SeekResult::TryAdvance) {
+                    tryadvance_reinserts += 1;
+                    run_until_done(|| cursor.next(), pager.deref()).unwrap();
+                }
+                run_until_done(
+                    || cursor.insert(&BTreeKey::new_index_key(record.as_record_ref())),
+                    pager.deref(),
+                )
+                .unwrap();
+            }
+            let c = cursor.move_to_root().unwrap();
+            if let Some(c) = c {
+                pager.io.wait_for_completion(c).unwrap();
+            }
+            pager.io.block(|| pager.commit_tx(&conn, true)).unwrap();
+
+            // Full scan: every key must appear exactly once.
+            pager.begin_read_tx().unwrap();
+            let _c = cursor.move_to_root().unwrap();
+            run_until_done(|| cursor.rewind(), pager.deref()).unwrap();
+            let mut seen: Vec<Vec<u8>> = Vec::new();
+            while cursor.has_record() {
+                let bytes = loop {
+                    match cursor.record().unwrap() {
+                        IOResult::Done(record) => {
+                            let record = record.unwrap();
+                            break record
+                                .get_value_opt(0)
+                                .and_then(|v| match v {
+                                    crate::types::ValueRef::Blob(b) => Some(b.to_vec()),
+                                    _ => None,
+                                })
+                                .unwrap();
+                        }
+                        IOResult::IO(io) => {
+                            while !io.finished() {
+                                pager.io.step().unwrap();
+                            }
+                        }
+                    }
+                };
+                seen.push(bytes);
+                run_until_done(|| cursor.next(), pager.deref()).unwrap();
+            }
+            pager.end_read_tx();
+            let total = seen.len();
+            seen.dedup();
+            assert_eq!(
+                total,
+                seen.len(),
+                "attempt {attempt}: duplicate index keys after RowInserter-style \
+                 re-inserts (seed {seed}, {tryadvance_reinserts} TryAdvance re-inserts)"
+            );
+            assert_eq!(total, live.len(), "attempt {attempt}: scan count mismatch");
+            tracing::info!(
+                "attempt {attempt}: {} keys, {} TryAdvance re-inserts, no duplicates",
+                total,
+                tryadvance_reinserts
+            );
+        }
+    }
+
     #[test]
     #[ignore]
     pub fn fuzz_long_btree_index_insert_delete_fuzz_run() {

--- a/testing/concurrent-simulator/Cargo.toml
+++ b/testing/concurrent-simulator/Cargo.toml
@@ -38,7 +38,7 @@ rand_chacha = { workspace = true }
 sql_generation = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-turso_core = { workspace = true, features = ["simulator", "fs", "experimental_win_iocp"]}
+turso_core = { workspace = true, features = ["simulator", "fs", "experimental_win_iocp", "fts"]}
 turso_parser = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/testing/concurrent-simulator/io.rs
+++ b/testing/concurrent-simulator/io.rs
@@ -59,6 +59,26 @@ impl SimulatorIO {
         self.file_sizes.clone()
     }
 
+    /// Contents of every database file (`.db`, `-wal`, `-log`), keyed by
+    /// that suffix and sorted by it.
+    pub fn db_file_bytes(&self) -> Vec<(String, Vec<u8>)> {
+        let files = self.files.lock().unwrap();
+        let sizes = self.file_sizes.lock().unwrap();
+        let mut out: Vec<(String, Vec<u8>)> = files
+            .iter()
+            .filter_map(|(path, file)| {
+                let suffix = [".db", "-wal", "-log"]
+                    .into_iter()
+                    .find(|suffix| path.ends_with(suffix))?;
+                let actual_size = sizes.get(path).copied().unwrap_or(0) as usize;
+                let mmap = file.mmap.lock().unwrap();
+                Some((suffix.to_string(), mmap[..actual_size].to_vec()))
+            })
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
     /// Dump all database files to the specified output directory.
     /// Only copies the actual file content, not the full mmap size.
     pub fn dump_files(&self, out_dir: &std::path::Path) -> anyhow::Result<()> {

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -556,6 +556,8 @@ pub struct Stats {
     pub corruption_events: usize,
     /// Sequence nextval calls
     pub sequence_nextvals: usize,
+    /// FTS self-differential checks that ran to completion
+    pub fts_checks: usize,
     /// Same-connection checkpoint probes fired against suspended statements
     pub checkpoint_probes: usize,
 }
@@ -733,7 +735,8 @@ impl Whopper {
             let db_opts = DatabaseOpts::new()
                 .with_encryption(encryption_opts.is_some())
                 // Index methods power the FTS workloads; the flag only
-                // gates `CREATE INDEX ... USING`, so it is safe globally.
+                // gates `CREATE INDEX ... USING` and `OPTIMIZE INDEX`, so
+                // it is safe globally.
                 .with_index_method(true)
                 .with_experimental_mvcc_passive_checkpoint(
                     opts.experimental_mvcc_passive_checkpoint,
@@ -1327,6 +1330,13 @@ impl Whopper {
     }
 
     /// Dump database files to simulator-output directory.
+    /// The database files the simulated IO holds, keyed by suffix (`.db`,
+    /// `-wal`, `-log`) so two runs can be compared without their unique
+    /// path prefix.
+    pub fn db_file_bytes(&self) -> Vec<(String, Vec<u8>)> {
+        self.io.db_file_bytes()
+    }
+
     pub fn dump_db_files(&self) -> anyhow::Result<()> {
         let out_dir = std::path::PathBuf::from("simulator-output");
         if !out_dir.exists() {

--- a/testing/concurrent-simulator/lib.rs
+++ b/testing/concurrent-simulator/lib.rs
@@ -732,6 +732,9 @@ impl Whopper {
         let db = {
             let db_opts = DatabaseOpts::new()
                 .with_encryption(encryption_opts.is_some())
+                // Index methods power the FTS workloads; the flag only
+                // gates `CREATE INDEX ... USING`, so it is safe globally.
+                .with_index_method(true)
                 .with_experimental_mvcc_passive_checkpoint(
                     opts.experimental_mvcc_passive_checkpoint,
                 );
@@ -1649,6 +1652,7 @@ impl Whopper {
     fn open_connections(&mut self) -> anyhow::Result<()> {
         let db_opts = DatabaseOpts::new()
             .with_encryption(self.encryption_opts.is_some())
+            .with_index_method(true)
             .with_experimental_mvcc_passive_checkpoint(self.experimental_mvcc_passive_checkpoint);
         let db = Database::open_file_with_flags(
             self.io.clone(),

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -563,12 +563,13 @@ fn format_stats(stats: &turso_whopper::Stats, elle_mode: bool) -> String {
         format!("{}/{}", stats.elle_writes, stats.elle_reads)
     } else {
         format!(
-            "{}/{}/{}/{}/{}",
+            "{}/{}/{}/{}/{}/{}",
             stats.inserts,
             stats.updates,
             stats.deletes,
             stats.integrity_checks,
-            stats.sequence_nextvals
+            stats.sequence_nextvals,
+            stats.fts_checks
         )
     }
 }
@@ -578,7 +579,7 @@ fn progress_art(elle_mode: bool) -> [&'static str; 11] {
         if elle_mode {
             "       .             W/R"
         } else {
-            "       .             I/U/D/C/S"
+            "       .             I/U/D/C/S/F"
         },
         "       .             ",
         "       .             ",

--- a/testing/concurrent-simulator/main.rs
+++ b/testing/concurrent-simulator/main.rs
@@ -479,6 +479,11 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
             (10, Box::new(AutoincInsertWorkload)),
             (5, Box::new(AutoincUpdateRowidWorkload)),
             (3, Box::new(AutoincDeleteWorkload)),
+            (12, Box::new(FtsInsertWorkload)),
+            (8, Box::new(FtsUpdateWorkload)),
+            (6, Box::new(FtsDeleteWorkload)),
+            (10, Box::new(FtsMatchWorkload)),
+            (2, Box::new(FtsOptimizeWorkload)),
             (30, Box::new(BeginWorkload)),
             (10, Box::new(CommitWorkload)),
             (10, Box::new(RollbackWorkload)),
@@ -490,9 +495,10 @@ fn build_workloads_and_properties(args: &Args) -> BuildArtifacts {
             Box::new(SimpleKeysDoNotDisappear::new()),
             Box::new(SequenceCorrectnessProperty::new()),
             Box::new(AutoincWatermarkMonotonicity::new()),
+            Box::new(FtsSelfDifferentialProperty),
         ];
 
-        (w, p, vec![], vec![])
+        (w, p, fts_sim_schema(), vec![])
     }
 }
 
@@ -596,6 +602,11 @@ fn init_logger() {
                 .without_time()
                 .with_thread_ids(false),
         )
-        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        // Tantivy chatters at INFO on every FTS segment build/merge; keep
+        // the progress display readable by default.
+        .with(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("info,tantivy=warn")),
+        )
         .try_init();
 }

--- a/testing/concurrent-simulator/multiprocess.rs
+++ b/testing/concurrent-simulator/multiprocess.rs
@@ -271,7 +271,9 @@ impl MultiprocessWhopper {
                 io,
                 db_path.to_str().unwrap(),
                 OpenFlags::default(),
-                DatabaseOpts::new().with_multiprocess_wal(true),
+                DatabaseOpts::new()
+                    .with_multiprocess_wal(true)
+                    .with_index_method(true),
                 None,
                 Arc::new(SqliteDialect),
             )?;

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -154,6 +154,11 @@ pub enum Operation {
     /// the table some non-trivial churn so the watermark/btree interplay
     /// has fewer trivially-flat scenarios.
     AutoincDelete { id: i64 },
+    /// Self-differential FTS check: within one statement (one snapshot),
+    /// compare the ids `fts_match` returns against a base-table token scan.
+    /// The result must be 0 (empty symmetric difference); the
+    /// `FtsSelfDifferentialProperty` asserts it.
+    FtsMatchDifferential { token: String },
 }
 pub type OpResult = Result<Vec<Vec<Value>>, LimboError>;
 /// Context passed to Operation::start_op and Operation::finish_op.
@@ -297,6 +302,23 @@ impl Operation {
                 format!(
                     "DELETE FROM {table} WHERE id = {id} RETURNING id",
                     table = crate::AUTOINC_TABLE_NAME
+                )
+            }
+            Operation::FtsMatchDifferential { token } => {
+                // Bodies are space-joined single tokens, so the padded LIKE
+                // is an exact token match — an FTS-free oracle in the same
+                // snapshot as the fts_match probe.
+                let table = crate::workloads::FTS_SIM_TABLE;
+                format!(
+                    "SELECT \
+                       (SELECT count(*) FROM (\
+                          SELECT id FROM {table} WHERE fts_match(body, '{token}') \
+                          EXCEPT \
+                          SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %')) \
+                     + (SELECT count(*) FROM (\
+                          SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %' \
+                          EXCEPT \
+                          SELECT id FROM {table} WHERE fts_match(body, '{token}')))"
                 )
             }
         }

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -323,7 +323,15 @@ impl Operation {
                           EXCEPT \
                           SELECT id FROM {table} WHERE fts_match(body, '{token}'))), \
                        (SELECT count(*) FROM sqlite_schema \
-                          WHERE type = 'index' AND name = '{index}')"
+                          WHERE type = 'index' AND name = '{index}'), \
+                       (SELECT group_concat(id) FROM (\
+                          SELECT id FROM {table} WHERE fts_match(body, '{token}') \
+                          EXCEPT \
+                          SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %')), \
+                       (SELECT group_concat(id) FROM (\
+                          SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %' \
+                          EXCEPT \
+                          SELECT id FROM {table} WHERE fts_match(body, '{token}')))"
                 )
             }
         }

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -156,8 +156,10 @@ pub enum Operation {
     AutoincDelete { id: i64 },
     /// Self-differential FTS check: within one statement (one snapshot),
     /// compare the ids `fts_match` returns against a base-table token scan.
-    /// The result must be 0 (empty symmetric difference); the
-    /// `FtsSelfDifferentialProperty` asserts it.
+    /// Returns one row `(symmetric difference size, index present)`; the
+    /// `FtsSelfDifferentialProperty` requires `(0, 1)`. The second column
+    /// matters because `fts_match` has a scalar fallback: without the index
+    /// both sides are table scans and the difference is trivially 0.
     FtsMatchDifferential { token: String },
 }
 pub type OpResult = Result<Vec<Vec<Value>>, LimboError>;
@@ -309,6 +311,7 @@ impl Operation {
                 // is an exact token match — an FTS-free oracle in the same
                 // snapshot as the fts_match probe.
                 let table = crate::workloads::FTS_SIM_TABLE;
+                let index = crate::workloads::FTS_SIM_INDEX;
                 format!(
                     "SELECT \
                        (SELECT count(*) FROM (\
@@ -318,7 +321,9 @@ impl Operation {
                      + (SELECT count(*) FROM (\
                           SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %' \
                           EXCEPT \
-                          SELECT id FROM {table} WHERE fts_match(body, '{token}')))"
+                          SELECT id FROM {table} WHERE fts_match(body, '{token}'))), \
+                       (SELECT count(*) FROM sqlite_schema \
+                          WHERE type = 'index' AND name = '{index}')"
                 )
             }
         }
@@ -452,6 +457,9 @@ impl Operation {
             }
             Operation::AutoincDelete { .. } => {
                 stats.deletes += 1;
+            }
+            Operation::FtsMatchDifferential { .. } => {
+                stats.fts_checks += 1;
             }
             _ => {}
         }

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -307,7 +307,9 @@ impl Property for IntegrityCheckProperty {
 
 /// The FTS self-differential: `fts_match` and a base-table token scan run
 /// inside one statement (one snapshot), so their id sets must be equal —
-/// the operation's SQL reports the size of the symmetric difference.
+/// the operation's SQL reports the size of the symmetric difference, plus
+/// whether the FTS index still exists (without it `fts_match` silently
+/// falls back to a scalar scan and the comparison proves nothing).
 pub struct FtsSelfDifferentialProperty;
 
 impl Property for FtsSelfDifferentialProperty {
@@ -324,17 +326,37 @@ impl Property for FtsSelfDifferentialProperty {
         let Operation::FtsMatchDifferential { token } = op else {
             return Ok(());
         };
-        let Ok(rows) = result else {
-            // Contention errors are the driver's business; nothing to check.
-            return Ok(());
-        };
-        match rows.first().and_then(|row| row.first()) {
-            Some(value) if value.as_int() == Some(0) => Ok(()),
-            other => bail!(
-                "step {step} fiber {fiber_id}: fts_match and the base-table \
-                 scan disagree for token {token:?}: symmetric difference {other:?}"
+        let rows = match result {
+            Ok(rows) => rows,
+            // The statement is fixed and valid, so a parse or argument
+            // rejection means the table, the index, or `fts_match` itself
+            // regressed; the driver would otherwise retry it forever.
+            Err(err @ (LimboError::ParseError(_) | LimboError::InvalidArgument(_))) => bail!(
+                "step {step} fiber {fiber_id}: the FTS differential statement was rejected: {err}"
             ),
+            // Contention errors are the driver's business; nothing to check.
+            Err(_) => return Ok(()),
+        };
+        let Some(row) = rows.first() else {
+            bail!("step {step} fiber {fiber_id}: the FTS differential returned no row");
+        };
+        let symmetric_difference = row.first().and_then(Value::as_int);
+        let index_present = row.get(1).and_then(Value::as_int);
+        if index_present != Some(1) {
+            bail!(
+                "step {step} fiber {fiber_id}: FTS index {} is missing from sqlite_schema \
+                 (count {index_present:?}); fts_match would fall back to a scalar scan and \
+                 the differential would prove nothing",
+                crate::workloads::FTS_SIM_INDEX
+            );
         }
+        if symmetric_difference != Some(0) {
+            bail!(
+                "step {step} fiber {fiber_id}: fts_match and the base-table scan disagree \
+                 for token {token:?}: symmetric difference {symmetric_difference:?}"
+            );
+        }
+        Ok(())
     }
 }
 

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -353,7 +353,10 @@ impl Property for FtsSelfDifferentialProperty {
         if symmetric_difference != Some(0) {
             bail!(
                 "step {step} fiber {fiber_id}: fts_match and the base-table scan disagree \
-                 for token {token:?}: symmetric difference {symmetric_difference:?}"
+                 for token {token:?}: symmetric difference {symmetric_difference:?} \
+                 (fts-only ids: {:?}, scan-only ids: {:?})",
+                row.get(2),
+                row.get(3)
             );
         }
         Ok(())

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -305,6 +305,39 @@ impl Property for IntegrityCheckProperty {
     }
 }
 
+/// The FTS self-differential: `fts_match` and a base-table token scan run
+/// inside one statement (one snapshot), so their id sets must be equal —
+/// the operation's SQL reports the size of the symmetric difference.
+pub struct FtsSelfDifferentialProperty;
+
+impl Property for FtsSelfDifferentialProperty {
+    fn finish_op(
+        &mut self,
+        step: usize,
+        fiber_id: usize,
+        _txn_id: Option<u64>,
+        _start_exec_id: u64,
+        _end_exec_id: u64,
+        op: &Operation,
+        result: &OpResult,
+    ) -> anyhow::Result<()> {
+        let Operation::FtsMatchDifferential { token } = op else {
+            return Ok(());
+        };
+        let Ok(rows) = result else {
+            // Contention errors are the driver's business; nothing to check.
+            return Ok(());
+        };
+        match rows.first().and_then(|row| row.first()) {
+            Some(value) if value.as_int() == Some(0) => Ok(()),
+            other => bail!(
+                "step {step} fiber {fiber_id}: fts_match and the base-table \
+                 scan disagree for token {token:?}: symmetric difference {other:?}"
+            ),
+        }
+    }
+}
+
 /// Check if an integrity_check result is informational (not actual corruption).
 /// In MVCC mode, "Page N: never used" is expected for allocated but unused pages.
 fn is_integrity_check_informational(text: &str) -> bool {

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -239,3 +239,119 @@ fn test_dropped_failed_statement_keeps_suspended_sibling_commit_intact() {
         }
     }
 }
+
+/// The FTS workloads must exercise the index, not `fts_match`'s scalar
+/// fallback, and a seeded run must replay: segment ids and index
+/// incarnations are drawn from the seeded IO, so two runs of one seed end
+/// with byte-identical database files. Before the fix the MVCC log of two
+/// same-seed runs differed in every `fts2/chunk/<uuid>` path.
+#[test]
+fn test_fts_workloads_use_the_index_and_replay_with_the_seed() {
+    use turso_whopper::operations::Operation;
+    use turso_whopper::properties::{
+        FtsSelfDifferentialProperty, IntegrityCheckProperty, Property,
+    };
+    use turso_whopper::workloads::{
+        BeginWorkload, CommitWorkload, FtsDeleteWorkload, FtsInsertWorkload, FtsMatchWorkload,
+        FtsOptimizeWorkload, FtsUpdateWorkload, RollbackWorkload, Workload, fts_sim_schema,
+    };
+    use turso_whopper::{Stats, Whopper, WhopperOpts};
+
+    fn run(seed: u64) -> (Stats, Vec<(String, Vec<u8>)>) {
+        let workloads: Vec<(u32, Box<dyn Workload>)> = vec![
+            (20, Box::new(FtsInsertWorkload)),
+            (8, Box::new(FtsUpdateWorkload)),
+            (6, Box::new(FtsDeleteWorkload)),
+            (12, Box::new(FtsMatchWorkload)),
+            (2, Box::new(FtsOptimizeWorkload)),
+            (10, Box::new(BeginWorkload)),
+            (8, Box::new(CommitWorkload)),
+            (3, Box::new(RollbackWorkload)),
+        ];
+        let properties: Vec<Box<dyn Property>> = vec![
+            Box::new(IntegrityCheckProperty),
+            Box::new(FtsSelfDifferentialProperty),
+        ];
+        let opts = WhopperOpts {
+            seed: Some(seed),
+            max_connections: 3,
+            max_steps: 4_000,
+            enable_mvcc: true,
+            elle_tables: fts_sim_schema(),
+            workloads,
+            properties,
+            ..WhopperOpts::default()
+        };
+        let mut whopper = Whopper::new(opts).expect("create whopper");
+        whopper
+            .run()
+            .expect("FTS workloads must not violate a property");
+        (whopper.stats.clone(), whopper.db_file_bytes())
+    }
+
+    let (first_stats, first_files) = run(0xF75);
+    assert!(
+        first_stats.fts_checks > 0,
+        "no FTS differential completed, so the workloads tested nothing"
+    );
+
+    let (second_stats, second_files) = run(0xF75);
+    assert_eq!(first_stats.fts_checks, second_stats.fts_checks);
+    assert!(!first_files.is_empty());
+    assert_eq!(first_files.len(), second_files.len());
+    for ((name, first), (other_name, second)) in first_files.iter().zip(&second_files) {
+        assert_eq!(name, other_name);
+        assert!(
+            first == second,
+            "{name} differs between two runs of one seed: something (FTS segment ids, index \
+             incarnations) is not drawn from the seeded IO, so seeds do not replay"
+        );
+    }
+
+    // The differential's `fts_match` side must be planned through the
+    // index method; the scalar fallback would make the comparison vacuous.
+    let io = Arc::new(SimulatorIO::new(
+        false,
+        ChaCha8Rng::seed_from_u64(7),
+        IOFaultConfig {
+            cosmic_ray_probability: 0.0,
+        },
+    ));
+    let db_path = format!("test-fts-plan-{}.db", std::process::id());
+    let db = Database::open_file_with_flags(
+        io.clone(),
+        &db_path,
+        OpenFlags::default(),
+        DatabaseOpts::new().with_index_method(true),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .expect("open db");
+    let conn = db.connect().expect("connect");
+    for (_, sql) in fts_sim_schema() {
+        conn.execute(&sql).expect("bootstrap FTS schema");
+    }
+    let differential = Operation::FtsMatchDifferential {
+        token: "alpha".to_string(),
+    }
+    .sql();
+    let mut stmt = conn
+        .prepare(format!("EXPLAIN {differential}"))
+        .expect("prepare explain");
+    let mut opcodes = Vec::new();
+    loop {
+        match stmt.step().expect("step explain") {
+            turso_core::StepResult::Row => {
+                let row = stmt.row().expect("explain row");
+                opcodes.push(row.get::<&str>(1).expect("opcode column").to_string());
+            }
+            turso_core::StepResult::IO => io.step().expect("io step"),
+            turso_core::StepResult::Done => break,
+            other => panic!("unexpected step result {other:?}"),
+        }
+    }
+    assert!(
+        opcodes.iter().any(|opcode| opcode == "IndexMethodQuery"),
+        "the FTS differential is not planned through the index method: {opcodes:?}"
+    );
+}

--- a/testing/concurrent-simulator/worker.rs
+++ b/testing/concurrent-simulator/worker.rs
@@ -53,7 +53,9 @@ pub fn run_worker(
         .try_init();
 
     let io = multiprocess_platform_io()?;
-    let db_opts = DatabaseOpts::new().with_multiprocess_wal(true);
+    let db_opts = DatabaseOpts::new()
+        .with_multiprocess_wal(true)
+        .with_index_method(true);
     let db = Database::open_file_with_flags(
         io,
         db_path,

--- a/testing/concurrent-simulator/workloads.rs
+++ b/testing/concurrent-simulator/workloads.rs
@@ -835,6 +835,118 @@ impl Workload for AutoincDeleteWorkload {
     }
 }
 
+// ============================================================================
+// FTS Workloads
+// ============================================================================
+
+/// The dedicated FTS table churned by the FTS workloads. Kept outside the
+/// generated schema so generic workloads never touch it.
+pub const FTS_SIM_TABLE: &str = "fts_docs";
+pub const FTS_SIM_INDEX: &str = "fts_docs_fts";
+
+/// Bootstrap statements for the FTS table and its index.
+pub fn fts_sim_schema() -> Vec<(String, String)> {
+    vec![
+        (
+            FTS_SIM_TABLE.to_string(),
+            format!(
+                "CREATE TABLE IF NOT EXISTS {FTS_SIM_TABLE} (id INTEGER PRIMARY KEY, body TEXT)"
+            ),
+        ),
+        (
+            FTS_SIM_INDEX.to_string(),
+            format!(
+                "CREATE INDEX IF NOT EXISTS {FTS_SIM_INDEX} ON {FTS_SIM_TABLE} USING fts(body)"
+            ),
+        ),
+    ]
+}
+
+/// Small fixed vocabulary so the self-differential's padded-LIKE oracle is
+/// exact token matching, and so matches stay non-trivial.
+const FTS_SIM_TOKENS: &[&str] = &[
+    "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+];
+
+/// Bounded id space so inserts, updates, and deletes collide across fibers.
+const FTS_SIM_MAX_ID: i64 = 400;
+
+fn fts_sim_body(rng: &mut ChaCha8Rng) -> String {
+    let count = rng.random_range(1..=4);
+    FTS_SIM_TOKENS
+        .choose_multiple(rng, count)
+        .copied()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn fts_sim_id(rng: &mut ChaCha8Rng) -> i64 {
+    rng.random_range(0..FTS_SIM_MAX_ID)
+}
+
+/// Insert (or replace) one FTS-indexed document.
+pub struct FtsInsertWorkload;
+
+impl Workload for FtsInsertWorkload {
+    fn generate(&self, _ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        let id = fts_sim_id(rng);
+        let body = fts_sim_body(rng);
+        Some(Operation::Execute {
+            sql: format!(
+                "INSERT OR REPLACE INTO {FTS_SIM_TABLE}(id, body) VALUES ({id}, '{body}')"
+            ),
+        })
+    }
+}
+
+/// Rewrite one FTS-indexed document (tombstones + re-insert through FTS).
+pub struct FtsUpdateWorkload;
+
+impl Workload for FtsUpdateWorkload {
+    fn generate(&self, _ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        let id = fts_sim_id(rng);
+        let body = fts_sim_body(rng);
+        Some(Operation::Execute {
+            sql: format!("UPDATE {FTS_SIM_TABLE} SET body = '{body}' WHERE id = {id}"),
+        })
+    }
+}
+
+/// Delete one FTS-indexed document.
+pub struct FtsDeleteWorkload;
+
+impl Workload for FtsDeleteWorkload {
+    fn generate(&self, _ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        let id = fts_sim_id(rng);
+        Some(Operation::Execute {
+            sql: format!("DELETE FROM {FTS_SIM_TABLE} WHERE id = {id}"),
+        })
+    }
+}
+
+/// Merge every visible FTS segment (contends on the per-index merge lease).
+pub struct FtsOptimizeWorkload;
+
+impl Workload for FtsOptimizeWorkload {
+    fn generate(&self, _ctx: &WorkloadContext, _rng: &mut ChaCha8Rng) -> Option<Operation> {
+        Some(Operation::Execute {
+            sql: format!("OPTIMIZE INDEX {FTS_SIM_INDEX}"),
+        })
+    }
+}
+
+/// Run the FTS self-differential (see [`Operation::FtsMatchDifferential`]).
+pub struct FtsMatchWorkload;
+
+impl Workload for FtsMatchWorkload {
+    fn generate(&self, _ctx: &WorkloadContext, rng: &mut ChaCha8Rng) -> Option<Operation> {
+        let token = FTS_SIM_TOKENS.choose(rng).expect("vocabulary is not empty");
+        Some(Operation::FtsMatchDifferential {
+            token: token.to_string(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -6112,6 +6112,16 @@ fn fts_dump_backing_rows_tool() {
 #[test]
 fn multiprocess_shared_cache_serves_snapshot_consistent_pages() {
     use turso_core::{Database, DatabaseOpts, OpenFlags, SqliteDialect};
+    // Multiprocess WAL needs an IO backend with shared-memory coordination.
+    // The default platform IO has it on unix but not on Windows (only the
+    // IOCP backend does there), and the open below refuses without it.
+    {
+        let probe: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        if !probe.supports_shared_wal_coordination() {
+            println!("skipping: platform IO does not support multiprocess WAL");
+            return;
+        }
+    }
     let tmp_dir = tempfile::TempDir::new().unwrap();
     let path = tmp_dir.path().join("torn.db");
     let path = path.to_str().unwrap();

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -6010,3 +6010,220 @@ fn fts_store_without_control_row_refuses_writes_and_reads_empty() {
         );
     }
 }
+
+/// Worktree-local debug tool: dump the raw FTS backing rows of the whopper
+/// database named by FTS_DUMP_DB, list physical duplicate keys, and re-run
+/// the fts_match/base-scan differential per token on a fresh (disk-truth)
+/// open. Does nothing without the env var.
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_dump_backing_rows_tool() {
+    let Some(path) = std::env::var_os("FTS_DUMP_DB") else {
+        return;
+    };
+    let tmp_db = TempDatabase::builder()
+        .with_db_path(std::path::Path::new(&path))
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+
+    conn.execute("BEGIN").unwrap();
+    let _ = limbo_exec_rows(&conn, "SELECT count(*) FROM fts_docs");
+    let mut dumper =
+        turso_core::index_method::fts::FtsBackingRowDumper::new(&conn, MAIN_DB_ID, "fts_docs_fts")
+            .unwrap();
+    run(&tmp_db, || dumper.step()).unwrap();
+    let rows = std::mem::take(&mut dumper.rows);
+    drop(dumper);
+    conn.execute("ROLLBACK").unwrap();
+
+    println!("total backing rows: {}", rows.len());
+    let mut counts: std::collections::BTreeMap<&str, usize> = Default::default();
+    for (path, _, _, _) in &rows {
+        let kind = if path.starts_with("fts2/seg/") {
+            "seg"
+        } else if path.starts_with("fts2/chunk/") {
+            "chunk"
+        } else if path.starts_with("fts2/tomb/") {
+            "tomb"
+        } else {
+            "other"
+        };
+        *counts.entry(kind).or_default() += 1;
+    }
+    println!("row kinds: {counts:?}");
+    for window in rows.windows(2) {
+        let (ap, ac, al, ah) = &window[0];
+        let (bp, bc, bl, bh) = &window[1];
+        if ap == bp && ac == bc {
+            println!(
+                "DUPLICATE KEY: path={ap} chunk_no={ac} len_a={al} hash_a={ah:016x} \
+                 len_b={bl} hash_b={bh:016x} identical={}",
+                al == bl && ah == bh
+            );
+        }
+    }
+    for (path, chunk_no, len, _) in &rows {
+        if path.starts_with("fts2/seg/") || path.starts_with("fts2/control") {
+            println!("row: {path} chunk_no={chunk_no} len={len}");
+        }
+    }
+    let tomb_counts: std::collections::BTreeMap<String, usize> = rows
+        .iter()
+        .filter(|(p, _, _, _)| p.starts_with("fts2/tomb/"))
+        .fold(Default::default(), |mut m, (p, _, _, _)| {
+            *m.entry(p.clone()).or_default() += 1;
+            m
+        });
+    println!("tombstone rows per segment: {tomb_counts:?}");
+
+    for token in [
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+    ] {
+        let sql = format!(
+            "SELECT \
+               (SELECT group_concat(id) FROM (\
+                  SELECT id FROM fts_docs WHERE fts_match(body, '{token}') \
+                  EXCEPT \
+                  SELECT id FROM fts_docs WHERE (' '||body||' ') LIKE '% {token} %')), \
+               (SELECT group_concat(id) FROM (\
+                  SELECT id FROM fts_docs WHERE (' '||body||' ') LIKE '% {token} %' \
+                  EXCEPT \
+                  SELECT id FROM fts_docs WHERE fts_match(body, '{token}')))"
+        );
+        let rows = limbo_exec_rows(&conn, &sql);
+        println!("differential {token}: {rows:?}");
+    }
+}
+
+/// Deterministic reproduction of the multiprocess torn-read anomaly the
+/// whopper FTS differential caught (worktree-local; asserts CONSISTENCY, so
+/// it is RED while the bug exists).
+///
+/// Mechanism under test: `Pager::read_page`'s cache-hit fast path returns
+/// shared-cache pages with no per-snapshot validation. The cache is shared
+/// by every connection of one Database (one "process"), while commits from
+/// another Database over the same file (another "process") do not write
+/// through it. A connection holding an old read snapshot legally re-loads
+/// old-version pages into the shared cache after a sibling's
+/// changed-detection cleared it; a fresh-snapshot sibling then cache-hits a
+/// MIXTURE of old and new pages inside one statement.
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn multiprocess_shared_cache_serves_snapshot_consistent_pages() {
+    use turso_core::{Database, DatabaseOpts, OpenFlags, SqliteDialect};
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let path = tmp_dir.path().join("torn.db");
+    let path = path.to_str().unwrap();
+    let open = || {
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        Database::open_file_with_flags(
+            io,
+            path,
+            OpenFlags::default(),
+            DatabaseOpts::new()
+                .with_multiprocess_wal(true)
+                .with_index_method(true),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap()
+    };
+    let db1 = open();
+    let db2 = open();
+
+    let setup = db1.connect().unwrap();
+    setup
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    setup
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    for id in 0..200 {
+        setup
+            .execute(format!(
+                "INSERT INTO docs VALUES ({id}, 'alpha filler{id}')"
+            ))
+            .unwrap();
+    }
+
+    let run_rows = |conn: &Arc<turso_core::Connection>, sql: &str| -> Vec<Vec<turso_core::Value>> {
+        let mut stmt = conn.prepare(sql).unwrap();
+        let mut rows = Vec::new();
+        loop {
+            match stmt.step().unwrap() {
+                turso_core::StepResult::Row => {
+                    rows.push(stmt.row().unwrap().get_values().cloned().collect());
+                }
+                turso_core::StepResult::IO => {
+                    stmt._io().step().unwrap();
+                }
+                turso_core::StepResult::Done => break,
+                r => panic!("unexpected step result {r:?}"),
+            }
+        }
+        rows
+    };
+
+    // Step 1: "process" 1, connection X pins an old snapshot and warms the
+    // shared cache with FTS backing pages at that snapshot.
+    let conn_x = db1.connect().unwrap();
+    conn_x.execute("BEGIN").unwrap();
+    let _ = run_rows(
+        &conn_x,
+        "SELECT count(*) FROM docs WHERE fts_match(body, 'alpha')",
+    );
+
+    // Step 2: "process" 2 commits FTS churn — deletes make old postings
+    // dead (tombstones) and add new ones. Process 1's cache sees none of it.
+    let writer = db2.connect().unwrap();
+    for id in 0..50 {
+        writer
+            .execute(format!(
+                "UPDATE docs SET body = 'bravo fresh{id}' WHERE id = {id}"
+            ))
+            .unwrap();
+    }
+
+    // Step 3: process 1, connection Z begins a fresh snapshot: its
+    // changed-detection clears the shared cache and loads some NEW pages.
+    let conn_z = db1.connect().unwrap();
+    let _ = run_rows(&conn_z, "SELECT count(*) FROM docs WHERE id < 10");
+
+    // Step 4: connection X (still pinned at the OLD snapshot) runs another
+    // FTS statement: its loads are bounded by its own snapshot and re-fill
+    // the shared cache with OLD-version FTS pages.
+    let _ = run_rows(
+        &conn_x,
+        "SELECT count(*) FROM docs WHERE fts_match(body, 'alpha')",
+    );
+    conn_x.execute("COMMIT").unwrap();
+
+    // Step 5: a fresh-snapshot statement on process 1 must see a
+    // self-consistent view: fts_match and the padded-LIKE base scan agree.
+    // `conn_z`'s last-seen snapshot is already current, so its begin skips
+    // the cache clear — it reads whatever mixture the shared cache holds.
+    let conn_y = conn_z;
+    for token in ["alpha", "bravo"] {
+        let rows = run_rows(
+            &conn_y,
+            &format!(
+                "SELECT \
+                   (SELECT count(*) FROM (\
+                      SELECT id FROM docs WHERE fts_match(body, '{token}') \
+                      EXCEPT \
+                      SELECT id FROM docs WHERE (' '||body||' ') LIKE '% {token} %')) \
+                 + (SELECT count(*) FROM (\
+                      SELECT id FROM docs WHERE (' '||body||' ') LIKE '% {token} %' \
+                      EXCEPT \
+                      SELECT id FROM docs WHERE fts_match(body, '{token}')))"
+            ),
+        );
+        assert_eq!(
+            rows,
+            vec![vec![turso_core::Value::from_i64(0)]],
+            "token {token}: fts_match and the base scan disagree — torn snapshot \
+             served from the shared page cache"
+        );
+    }
+}


### PR DESCRIPTION
Adds FTS to the whopper's default mode and makes seeded runs replay.

- **Workloads:** `FtsInsert` (`INSERT OR REPLACE`), `FtsUpdate`, `FtsDelete`,
  `FtsMatch`, `FtsOptimize` churn one `fts_docs(id, body)` table with a
  bounded id space (400 ids, 8-word vocabulary) so fibers collide on rows,
  tombstones, and the per-index merge lease. Runs under WAL, MVCC,
  fault injection, reopen, and multiprocess for free.
- **Self-differential:** `FtsMatch` runs `fts_match` and a padded-`LIKE`
  token scan as `EXCEPT` subqueries of one statement (one snapshot) and
  returns `(symmetric difference, index present)`. `FtsSelfDifferentialProperty`
  requires `(0, 1)`; the second column matters because `fts_match` has a
  scalar fallback, so a missing index would make both sides table scans
  and the comparison vacuous. A `ParseError`/`InvalidArgument` on the fixed
  statement fails the run instead of being retried as contention.
  Completed checks show as the new `F` column of the progress line.
- **Determinism (core):** segment ids were tantivy's OS-random uuids. They
  are the key prefix of every backing row, so they decide page layout and
  I/O order: two runs of one seed produced identical op streams and `.db`
  but MVCC logs differing in every `fts2/chunk/<uuid>` path. `mint_segment_id`
  now draws from `pager.io.generate_random_number()` (seeded under the
  simulator, OS entropy in production; tantivy's id only when no IO is
  attached). `build_segment` uses `Index::new_segment_meta`; the merge path
  re-keys `merge_filtered_segments`' output files to the minted id (segment
  bytes never embed the id). `mint_index_incarnation` drops its
  process-global counter when IO entropy is available.
- `with_index_method(true)` on the in-process, multiprocess, and worker
  opens; `tantivy=warn` in the default log filter.

