### PR TITLE
batch API: full per-statement results in every driver, fixing a complaint we've carried since libSQL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ complete example.
 4. **Assert invariants.** Don't silently fail. Don't hedge with if-statements
 5. **Own your regressions.** If tests fail after your change, they are your regressions. Debug them directly. Never stash/revert to "check if they fail on main" — that wastes time and is categorically banned.
 6. **Validate your hypotheses.**: If you suspect a given cause for a bug, validate it and provide incontrovertible evidence. NEVER make unearned assumptions.
+7. **Driver API parity.** Embedded (`bindings/rust`) and serverless (`serverless/rust`) drivers expose the same public API; add features to both in the same change. Spec: `serverless/conformance/differential/README.md`.
 
 ## Always use plain language instead of complex jargon
 

--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -87,6 +87,20 @@ export interface ResultSet {
   rows: Array<BatchRow>;
   /** Number of rows changed by the statement (0 for SELECT). */
   rowsAffected: number;
+  /** Rowid inserted by the statement, when the statement inserted one. */
+  lastInsertRowid?: number;
+  /** Rows read while executing the statement. The embedded engine does
+   * not report this per statement; the serverless driver reports the
+   * server's value. */
+  rowsRead?: number;
+  /** Rows written while executing the statement. The embedded engine
+   * does not report this per statement; the serverless driver reports
+   * the server's value. */
+  rowsWritten?: number;
+  /** Server-side execution time in milliseconds. The embedded engine
+   * does not report this per statement; the serverless driver reports
+   * the server's value. */
+  queryDurationMs?: number;
 }
 
 function normalizeBatchMode(mode: BatchMode): string {
@@ -128,13 +142,20 @@ function makeResultSet(
   columnTypes: string[],
   rows: any[],
   rowsAffected: number,
+  lastInsertRowid?: number,
 ): ResultSet {
-  return {
+  const resultSet: ResultSet = {
     columns,
     columnTypes,
     rows,
     rowsAffected,
   };
+  // Only statements that inserted carry the key, so callers can use
+  // `"lastInsertRowid" in resultSet` to detect an insert.
+  if (lastInsertRowid !== undefined) {
+    resultSet.lastInsertRowid = lastInsertRowid;
+  }
+  return resultSet;
 }
 
 /**
@@ -431,7 +452,12 @@ class Database {
    *   transaction.
    * @returns An array of `ResultSet`s — one per input statement, in order —
    *   matching the libsql-js batch contract. Each `ResultSet` carries that
-   *   statement's `columns`, `columnTypes`, `rows`, and `rowsAffected`.
+   *   statement's `columns`, `columnTypes`, `rows`, `rowsAffected`, and
+   *   `lastInsertRowid`. Execution stops at the first statement that
+   *   fails: the thrown error carries `batchIndex` (the zero-based index
+   *   of the failing statement) and `batchResults` (one entry per
+   *   statement — the completed statement's `ResultSet`, or `null` for
+   *   the failing statement and the statements that did not run).
    *
    * @example
    * // Plain SQL strings (non-atomic).
@@ -704,57 +730,82 @@ async function executeBatch(
   }
 
   const results: ResultSet[] = [];
-  try {
-    for (const statement of statements) {
-      const sql = typeof statement === "string" ? statement : statement.sql;
-      const args = typeof statement === "string" ? undefined : statement.args;
+  const executeStatement = async (
+    statement: string | { sql: string; args?: any[] | Record<string, any> },
+  ): Promise<ResultSet> => {
+    const sql = typeof statement === "string" ? statement : statement.sql;
+    const args = typeof statement === "string" ? undefined : statement.args;
 
-      let nativeStmt: NativeStatement;
-      try {
-        nativeStmt = native.prepare(sql);
-      } catch (err) {
-        throw convertError(err);
+    let nativeStmt: NativeStatement;
+    try {
+      nativeStmt = native.prepare(sql);
+    } catch (err) {
+      throw convertError(err);
+    }
+    try {
+      if (args !== undefined) {
+        bindParams(nativeStmt, [args]);
       }
-      try {
-        if (args !== undefined) {
-          bindParams(nativeStmt, [args]);
-        }
-        const cols = nativeStmt.columns();
-        const columnNames = cols.map((c) => c.name);
-        const columnTypes = cols.map((c) => c.type ?? "");
-        if (columnNames.length > 0) {
-          nativeStmt.raw(raw);
-        }
+      const cols = nativeStmt.columns();
+      const columnNames = cols.map((c) => c.name);
+      const columnTypes = cols.map((c) => c.type ?? "");
+      if (columnNames.length > 0) {
+        nativeStmt.raw(raw);
+      }
 
-        const totalChangesBefore = native.totalChanges();
-        const rows: any[] = [];
-        try {
-          while (true) {
-            const [stepResult, sleepMs] = await nativeStmt.stepSync();
-            if (stepResult === STEP_IO) {
-              await io();
-              continue;
-            }
-            if (stepResult === STEP_SLEEP) {
-              await sleepBeforeRetry(sleepMs);
-              continue;
-            }
-            if (stepResult === STEP_DONE) {
-              break;
-            }
-            rows.push(nativeStmt.row());
+      const totalChangesBefore = native.totalChanges();
+      const rowidBefore = native.lastInsertRowid();
+      const rows: any[] = [];
+      try {
+        while (true) {
+          const [stepResult, sleepMs] = await nativeStmt.stepSync();
+          if (stepResult === STEP_IO) {
+            await io();
+            continue;
           }
-          const rowsAffected = columnNames.length > 0
-            ? 0
-            : native.totalChanges() !== totalChangesBefore ? native.changes() : 0;
-          results.push(
-            makeResultSet(columnNames, columnTypes, rows, rowsAffected),
-          );
-        } finally {
-          nativeStmt.reset();
+          if (stepResult === STEP_SLEEP) {
+            await sleepBeforeRetry(sleepMs);
+            continue;
+          }
+          if (stepResult === STEP_DONE) {
+            break;
+          }
+          rows.push(nativeStmt.row());
         }
+        const rowsAffected = columnNames.length > 0
+          ? 0
+          : native.totalChanges() !== totalChangesBefore ? native.changes() : 0;
+        // The engine tracks the inserted rowid per connection, not per
+        // statement; a change across this statement means it inserted.
+        const rowidAfter = native.lastInsertRowid();
+        const lastInsertRowid = rowidAfter !== rowidBefore ? rowidAfter : undefined;
+        return makeResultSet(columnNames, columnTypes, rows, rowsAffected, lastInsertRowid);
       } finally {
-        nativeStmt.finalize();
+        nativeStmt.reset();
+      }
+    } finally {
+      nativeStmt.finalize();
+    }
+  };
+
+  try {
+    for (let index = 0; index < statements.length; index++) {
+      try {
+        results.push(await executeStatement(statements[index]));
+      } catch (err: any) {
+        // Identify the failing statement and carry the results of the
+        // statements that completed, matching the serverless driver:
+        // one entry per statement, null for the failing statement and
+        // the ones that never ran.
+        if (err instanceof Error) {
+          const batchErr = err as Error & { batchIndex?: number; batchResults?: Array<ResultSet | null> };
+          batchErr.batchIndex = index;
+          batchErr.batchResults = [
+            ...results.map((result) => result as ResultSet | null),
+            ...Array(statements.length - results.length).fill(null),
+          ];
+        }
+        throw err;
       }
     }
 

--- a/bindings/javascript/packages/common/promise.ts
+++ b/bindings/javascript/packages/common/promise.ts
@@ -72,6 +72,20 @@ export interface BatchOptions {
   raw?: boolean;
 }
 
+type BatchStatement = string | {
+  sql: string;
+  args?: any[] | Record<string, any>;
+};
+
+const TRANSACTION_CONTROL_KEYWORDS = new Set([
+  "BEGIN",
+  "COMMIT",
+  "END",
+  "ROLLBACK",
+  "SAVEPOINT",
+  "RELEASE",
+]);
+
 export type BatchRow = Record<string, any> | any[];
 
 /**
@@ -132,6 +146,53 @@ function normalizeBatchOptions(options?: BatchMode | BatchOptions): { mode?: Bat
     mode: options as BatchMode | undefined,
     raw: false,
   };
+}
+
+function firstSqlKeyword(sql: string): string | undefined {
+  let offset = 0;
+  while (offset < sql.length) {
+    if (/\s/.test(sql[offset]) || sql[offset] === ";") {
+      offset++;
+      continue;
+    }
+    if (sql.startsWith("--", offset)) {
+      const newline = sql.indexOf("\n", offset + 2);
+      if (newline < 0) return undefined;
+      offset = newline + 1;
+      continue;
+    }
+    if (sql.startsWith("/*", offset)) {
+      const end = sql.indexOf("*/", offset + 2);
+      if (end < 0) return undefined;
+      offset = end + 2;
+      continue;
+    }
+    break;
+  }
+  return /^[A-Za-z]+/.exec(sql.slice(offset))?.[0].toUpperCase();
+}
+
+function batchInputError(index: number, cause: unknown): Error {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  const error = new TypeError(`batch statement ${index} failed: ${message}`) as TypeError & {
+    batchIndex?: number;
+    batchResults?: Array<ResultSet | null>;
+  };
+  error.batchIndex = index;
+  error.batchResults = [];
+  return error;
+}
+
+function attachRollbackError(primary: unknown, rollback: unknown): Error {
+  const rollbackError = rollback instanceof Error ? rollback : new Error(String(rollback));
+  if (primary instanceof Error) {
+    (primary as Error & { rollbackError?: Error }).rollbackError = rollbackError;
+    return primary;
+  }
+  const error = new Error(String(primary)) as Error & { cause?: unknown; rollbackError?: Error };
+  error.cause = primary;
+  error.rollbackError = rollbackError;
+  return error;
 }
 
 /**
@@ -441,10 +502,8 @@ class Database {
    * When `mode` is set, `batch()` owns the surrounding
    * `BEGIN`/`COMMIT`/`ROLLBACK`, so the `statements` array must not
    * contain its own transaction-control SQL (`BEGIN`, `COMMIT`,
-   * `ROLLBACK`, `SAVEPOINT`, `RELEASE`). The input is not validated
-   * for that — a user-supplied `COMMIT` will close the wrapper
-   * transaction mid-batch and leave earlier statements committed,
-   * defeating the all-or-nothing contract.
+   * `END`, `ROLLBACK`, `SAVEPOINT`, `RELEASE`). Such input is rejected
+   * before the batch starts.
    *
    * @param statements - An array of SQL strings or `{ sql, args }` objects.
    * @param mode - When set, wraps the batch in `BEGIN <mode>` / `COMMIT`
@@ -489,7 +548,7 @@ class Database {
    * await txn.immediate();
    */
   async batch(
-    statements: Array<string | { sql: string; args?: any[] | Record<string, any> }>,
+    statements: BatchStatement[],
     options?: BatchMode | BatchOptions,
   ): Promise<ResultSet[]> {
     if (!Array.isArray(statements)) {
@@ -698,7 +757,7 @@ class Database {
 async function executeBatch(
   native: NativeDatabase,
   io: () => Promise<void>,
-  statements: Array<string | { sql: string; args?: any[] | Record<string, any> }>,
+  statements: BatchStatement[],
   options?: BatchMode | BatchOptions,
 ): Promise<ResultSet[]> {
   const runRawSql = async (sql: string) => {
@@ -725,13 +784,38 @@ async function executeBatch(
 
   const { mode, raw } = normalizeBatchOptions(options);
   const wrap = mode != null && !native.inTransaction();
+  const normalizedStatements = statements.map((statement, index): BatchStatement => {
+    if (typeof statement === "string" || statement.args === undefined) {
+      return statement;
+    }
+    try {
+      const args = Array.isArray(statement.args)
+        ? statement.args.map(normalizeBatchBindValue)
+        : Object.fromEntries(
+          Object.entries(statement.args).map(([name, value]) => [name, normalizeBatchBindValue(value)]),
+        );
+      return { sql: statement.sql, args };
+    } catch (error) {
+      throw batchInputError(index, error);
+    }
+  });
+  if (wrap) {
+    for (let index = 0; index < normalizedStatements.length; index++) {
+      const statement = normalizedStatements[index];
+      const sql = typeof statement === "string" ? statement : statement.sql;
+      const keyword = firstSqlKeyword(sql);
+      if (keyword !== undefined && TRANSACTION_CONTROL_KEYWORDS.has(keyword)) {
+        throw batchInputError(index, new Error(`${keyword} is not allowed in an atomic batch`));
+      }
+    }
+  }
   if (wrap) {
     await runRawSql(`BEGIN ${normalizeBatchMode(mode!)}`);
   }
 
   const results: ResultSet[] = [];
   const executeStatement = async (
-    statement: string | { sql: string; args?: any[] | Record<string, any> },
+    statement: BatchStatement,
   ): Promise<ResultSet> => {
     const sql = typeof statement === "string" ? statement : statement.sql;
     const args = typeof statement === "string" ? undefined : statement.args;
@@ -789,9 +873,9 @@ async function executeBatch(
   };
 
   try {
-    for (let index = 0; index < statements.length; index++) {
+    for (let index = 0; index < normalizedStatements.length; index++) {
       try {
-        results.push(await executeStatement(statements[index]));
+        results.push(await executeStatement(normalizedStatements[index]));
       } catch (err: any) {
         // Identify the failing statement and carry the results of the
         // statements that completed, matching the serverless driver:
@@ -802,7 +886,7 @@ async function executeBatch(
           batchErr.batchIndex = index;
           batchErr.batchResults = [
             ...results.map((result) => result as ResultSet | null),
-            ...Array(statements.length - results.length).fill(null),
+            ...Array(normalizedStatements.length - results.length).fill(null),
           ];
         }
         throw err;
@@ -814,11 +898,40 @@ async function executeBatch(
     }
   } catch (err) {
     if (wrap) {
-      try { await runRawSql("ROLLBACK"); } catch { /* ignore */ }
+      try {
+        await runRawSql("ROLLBACK");
+      } catch (rollbackError) {
+        throw attachRollbackError(err, rollbackError);
+      }
     }
     throw err;
   }
   return results;
+}
+
+function normalizeBatchBindValue(value: any): any {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError("Only finite numbers (not Infinity or NaN) can be passed as arguments");
+    }
+    return value;
+  }
+  if (typeof value === "bigint") {
+    if (value < -(1n << 63n) || value > (1n << 63n) - 1n) {
+      throw new TypeError("BigInt value is outside SQLite's signed 64-bit integer range");
+    }
+    return value;
+  }
+  if (
+    typeof value === "boolean" ||
+    typeof value === "string" ||
+    (ArrayBuffer.isView(value) && !(value instanceof DataView))
+  ) {
+    return value;
+  }
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  return String(value);
 }
 
 /**
@@ -993,7 +1106,7 @@ class Transaction {
    * @param statements - An array of SQL strings or `{ sql, args }` objects.
    */
   async batch(
-    statements: Array<string | { sql: string; args?: any[] | Record<string, any> }>,
+    statements: BatchStatement[],
     options?: BatchMode | BatchOptions,
   ): Promise<ResultSet[]> {
     this.assertActive();

--- a/bindings/javascript/packages/common/sqlite-error.ts
+++ b/bindings/javascript/packages/common/sqlite-error.ts
@@ -2,6 +2,16 @@ export class SqliteError extends Error {
   name: string;
   code: string;
   rawCode: string;
+  /** For errors raised by `batch()`: the zero-based index of the failing
+   * statement. */
+  batchIndex?: number;
+  /** For errors raised by `batch()`: one entry per input statement, in
+   * order — the completed statement's `ResultSet`, or `null` for the
+   * failing statement and the statements that did not run. In a
+   * non-atomic batch the completed statements' effects are committed; in
+   * an atomic batch they were rolled back. Empty when the batch failed
+   * client-side before anything was sent. */
+  batchResults?: Array<any | null>;
   constructor(message, code, rawCode) {
     super(message);
     this.name = 'SqliteError';

--- a/bindings/javascript/packages/common/sqlite-error.ts
+++ b/bindings/javascript/packages/common/sqlite-error.ts
@@ -9,9 +9,11 @@ export class SqliteError extends Error {
    * order — the completed statement's `ResultSet`, or `null` for the
    * failing statement and the statements that did not run. In a
    * non-atomic batch the completed statements' effects are committed; in
-   * an atomic batch they were rolled back. Empty when the batch failed
-   * client-side before anything was sent. */
+   * an atomic batch they were rolled back unless `rollbackError` is set.
+   * Empty when the batch failed client-side before anything was sent. */
   batchResults?: Array<any | null>;
+  /** A rollback error that occurred while handling this error. */
+  rollbackError?: Error;
   constructor(message, code, rawCode) {
     super(message);
     this.name = 'SqliteError';

--- a/bindings/javascript/packages/native/promise.test.ts
+++ b/bindings/javascript/packages/native/promise.test.ts
@@ -525,3 +525,65 @@ test('transactionAsync() rejects callbacks that do not declare the handle', asyn
     expect(() => db.transactionAsync(async () => { })).toThrow(/Transaction handle/);
     expect(() => db.transactionAsync((async (...args: any[]) => { }) as any)).toThrow(/Transaction handle/);
 })
+
+test('batch returns per-statement details and stops at the first failure', async () => {
+    const db = await connect(":memory:");
+    const results = await db.batch([
+        "CREATE TABLE t_batch (id INTEGER PRIMARY KEY, name TEXT)",
+        { sql: "INSERT INTO t_batch (name) VALUES (?)", args: ["Alice"] },
+        { sql: "INSERT INTO t_batch (name) VALUES (?)", args: ["Bob"] },
+        "SELECT name FROM t_batch ORDER BY id",
+    ]);
+    expect(results.length).toBe(4);
+    expect(results[1].rowsAffected).toBe(1);
+    expect(results[1].lastInsertRowid).toBe(1);
+    expect(results[2].lastInsertRowid).toBe(2);
+    expect(results[3].rows).toEqual([{ name: "Alice" }, { name: "Bob" }]);
+    // The embedded engine does not report per-statement execution
+    // statistics; the serverless driver fills these from the server.
+    expect(results[1].rowsRead).toBeUndefined();
+    expect(results[1].rowsWritten).toBeUndefined();
+    expect(results[1].queryDurationMs).toBeUndefined();
+
+    let error: any = null;
+    try {
+        await db.batch([
+            { sql: "INSERT INTO t_batch (name) VALUES (?)", args: ["Carol"] },
+            "INSERT INTO no_such_table VALUES (1)",
+            { sql: "INSERT INTO t_batch (name) VALUES (?)", args: ["Dave"] },
+        ]);
+    } catch (e) {
+        error = e;
+    }
+    expect(error).not.toBeNull();
+    // The error identifies the failing statement and carries one entry
+    // per statement: the completed first statement's ResultSet, null for
+    // the failing statement and the skipped one after it.
+    expect(error.batchIndex).toBe(1);
+    expect(error.batchResults.length).toBe(3);
+    expect(error.batchResults[0].rowsAffected).toBe(1);
+    expect(error.batchResults[1]).toBeNull();
+    expect(error.batchResults[2]).toBeNull();
+    // Execution stopped at the failure: Carol committed, Dave never ran.
+    const stmt = await db.prepare("SELECT COUNT(*) AS n FROM t_batch");
+    expect(await stmt.all([])).toEqual([{ n: 3 }]);
+})
+
+test('atomic batch failure rolls back and reports the failing statement', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t_atomic (x)");
+    let error: any = null;
+    try {
+        await db.batch([
+            { sql: "INSERT INTO t_atomic VALUES (?)", args: [1] },
+            "INSERT INTO no_such_table VALUES (1)",
+        ], "immediate");
+    } catch (e) {
+        error = e;
+    }
+    expect(error).not.toBeNull();
+    expect(error.batchIndex).toBe(1);
+    expect(error.batchResults.length).toBe(2);
+    const stmt = await db.prepare("SELECT COUNT(*) AS n FROM t_atomic");
+    expect(await stmt.all([])).toEqual([{ n: 0 }]);
+})

--- a/bindings/javascript/packages/native/promise.test.ts
+++ b/bindings/javascript/packages/native/promise.test.ts
@@ -587,3 +587,119 @@ test('atomic batch failure rolls back and reports the failing statement', async 
     const stmt = await db.prepare("SELECT COUNT(*) AS n FROM t_atomic");
     expect(await stmt.all([])).toEqual([{ n: 0 }]);
 })
+
+test('batch validates every bind value before executing the first statement', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t_batch_bind_validation (x)");
+
+    let error: any;
+    try {
+        await db.batch([
+            { sql: "INSERT INTO t_batch_bind_validation VALUES (?)", args: [1] },
+            { sql: "INSERT INTO t_batch_bind_validation VALUES (?)", args: [Number.POSITIVE_INFINITY] },
+        ]);
+    } catch (caught) {
+        error = caught;
+    }
+
+    expect(error.batchIndex).toBe(1);
+    expect(error.batchResults).toEqual([]);
+    const stmt = await db.prepare("SELECT COUNT(*) AS n FROM t_batch_bind_validation");
+    expect(await stmt.all([])).toEqual([{ n: 0 }]);
+})
+
+test('batch validates every bigint before executing the first statement', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t_batch_bigint_validation (x)");
+
+    let error: any;
+    try {
+        await db.batch([
+            { sql: "INSERT INTO t_batch_bigint_validation VALUES (?)", args: [1] },
+            { sql: "INSERT INTO t_batch_bigint_validation VALUES (?)", args: [1n << 63n] },
+        ]);
+    } catch (caught) {
+        error = caught;
+    }
+
+    expect(error.batchIndex).toBe(1);
+    expect(error.batchResults).toEqual([]);
+    const stmt = await db.prepare("SELECT COUNT(*) AS n FROM t_batch_bigint_validation");
+    expect(await stmt.all([])).toEqual([{ n: 0 }]);
+})
+
+test('batch coerces bind values once during validation', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t_batch_coercion (x TEXT)");
+    let coercions = 0;
+    const value = {
+        toString() {
+            coercions++;
+            if (coercions > 1) throw new Error("value was coerced twice");
+            return "coerced";
+        },
+    };
+
+    await db.batch([
+        { sql: "INSERT INTO t_batch_coercion VALUES (?)", args: [value] },
+    ]);
+
+    expect(coercions).toBe(1);
+    const stmt = await db.prepare("SELECT x FROM t_batch_coercion");
+    expect(await stmt.all([])).toEqual([{ x: "coerced" }]);
+})
+
+test('atomic batch rejects transaction control before BEGIN', async () => {
+    const db = await connect(":memory:");
+    await db.exec("CREATE TABLE t_batch_control (x)");
+    const controls = [
+        "BEGIN",
+        "COMMIT",
+        "END",
+        "ROLLBACK",
+        "SAVEPOINT nested",
+        "RELEASE nested",
+        "\ufeffCOMMIT",
+    ];
+
+    for (const control of controls) {
+        let error: any;
+        try {
+            await db.batch([
+                "INSERT INTO t_batch_control VALUES (1)",
+                ` ; \n-- leading line comment\n; /* leading block comment */ ${control}`,
+            ], "immediate");
+        } catch (caught) {
+            error = caught;
+        }
+        expect(error.batchIndex).toBe(1);
+        expect(error.batchResults).toEqual([]);
+    }
+
+    const stmt = await db.prepare("SELECT COUNT(*) AS n FROM t_batch_control");
+    expect(await stmt.all([])).toEqual([{ n: 0 }]);
+})
+
+test('atomic batch attaches a rollback failure to the primary error', async () => {
+    const db = await connect(":memory:");
+    const native = (db as any).db;
+    const originalExecutor = native.executor.bind(native);
+    native.executor = (sql: string, ...args: any[]) => {
+        if (sql === "ROLLBACK") throw new Error("rollback failed");
+        return originalExecutor(sql, ...args);
+    };
+
+    let error: any;
+    try {
+        await db.batch(["INSERT INTO no_such_batch_table VALUES (1)"], "immediate");
+    } catch (caught) {
+        error = caught;
+    } finally {
+        native.executor = originalExecutor;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toMatch(/no_such_batch_table/);
+    expect(error.rollbackError).toBeInstanceOf(Error);
+    expect(error.rollbackError.message).toBe("rollback failed");
+})

--- a/bindings/python/src/turso.rs
+++ b/bindings/python/src/turso.rs
@@ -262,6 +262,10 @@ impl PyTursoConnection {
     pub fn get_auto_commit(&self) -> PyResult<bool> {
         Ok(self.connection.get_auto_commit())
     }
+    /// Rowid of the most recent successful INSERT on this connection.
+    pub fn last_insert_rowid(&self) -> i64 {
+        self.connection.last_insert_rowid()
+    }
     /// Request interruption of the statement currently executing on this connection.
     pub fn interrupt(&self) {
         self.connection.interrupt();

--- a/bindings/python/tests/test_database.py
+++ b/bindings/python/tests/test_database.py
@@ -1870,6 +1870,42 @@ def test_batch_error_identifies_the_failing_statement():
     conn.close()
 
 
+@pytest.mark.parametrize("mode", [None, "immediate"])
+def test_batch_validates_every_parameter_before_execution(mode):
+    conn = _batch_connection()
+    with pytest.raises(turso.DatabaseError, match="batch statement 1 failed") as excinfo:
+        conn.batch(
+            [
+                ("INSERT INTO t_batch (name) VALUES (?)", ("Alice",)),
+                ("INSERT INTO t_batch (name) VALUES (?)", (object(),)),
+            ],
+            mode=mode,
+        )
+    assert excinfo.value.batch_index == 1
+    assert excinfo.value.batch_results == []
+    assert conn.execute("SELECT COUNT(*) FROM t_batch").fetchone() == (0,)
+    assert not conn.in_transaction
+    conn.close()
+
+
+@pytest.mark.parametrize("mode", [None, "immediate"])
+def test_batch_rejects_infinity_before_execution(mode):
+    conn = _batch_connection()
+    with pytest.raises(ValueError, match="infinite float") as excinfo:
+        conn.batch(
+            [
+                ("INSERT INTO t_batch (name) VALUES (?)", ("Alice",)),
+                ("INSERT INTO t_batch (name) VALUES (?)", (float("inf"),)),
+            ],
+            mode=mode,
+        )
+    assert excinfo.value.batch_index == 1
+    assert excinfo.value.batch_results == []
+    assert conn.execute("SELECT COUNT(*) FROM t_batch").fetchone() == (0,)
+    assert not conn.in_transaction
+    conn.close()
+
+
 def test_batch_joins_an_open_transaction():
     conn = _batch_connection()
     conn.execute("BEGIN")
@@ -1914,6 +1950,59 @@ def test_batch_mode_rolls_back_on_failure():
     assert not conn.in_transaction
     # The rollback undid the first insert.
     assert conn.execute("SELECT COUNT(*) FROM t_batch").fetchone() == (0,)
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "BEGIN",
+        "COMMIT",
+        "END",
+        "ROLLBACK",
+        "SAVEPOINT batch_savepoint",
+        "RELEASE batch_savepoint",
+        "; /* empty statement */ COMMIT",
+        "\ufeffCOMMIT",
+    ],
+)
+def test_batch_mode_rejects_transaction_control_before_begin(sql):
+    conn = _batch_connection()
+    with pytest.raises(
+        turso.ProgrammingError, match="transaction-control SQL is not allowed"
+    ) as excinfo:
+        conn.batch([sql], mode="immediate")
+    assert excinfo.value.batch_index == 0
+    assert excinfo.value.batch_results == []
+    assert not conn.in_transaction
+    conn.close()
+
+
+def test_batch_preserves_rollback_failure_on_primary_error():
+    conn = _batch_connection()
+    execute_transaction_sql = conn._exec_ddl_only
+
+    def fail_rollback(sql):
+        if sql == "ROLLBACK":
+            raise turso.OperationalError("rollback failed")
+        execute_transaction_sql(sql)
+
+    conn._exec_ddl_only = fail_rollback
+    with pytest.raises(turso.DatabaseError) as excinfo:
+        conn.batch(
+            [
+                ("INSERT INTO t_batch (name) VALUES (?)", ("Alice",)),
+                ("INSERT INTO no_such_table VALUES (?)", (2,)),
+            ],
+            mode="immediate",
+        )
+    assert excinfo.value.batch_index == 1
+    assert len(excinfo.value.batch_results) == 2
+    assert isinstance(excinfo.value.rollback_error, turso.OperationalError)
+    assert str(excinfo.value.rollback_error) == "rollback failed"
+
+    conn._exec_ddl_only = execute_transaction_sql
+    conn.rollback()
     conn.close()
 
 

--- a/bindings/python/tests/test_database.py
+++ b/bindings/python/tests/test_database.py
@@ -1800,3 +1800,151 @@ def test_fts_highlight_wraps_matched_terms():
     cur.execute("SELECT fts_highlight(body, '<b>', '</b>', 'rust') FROM articles WHERE fts_match(title, body, 'rust')")
     assert cur.fetchall() == [("Turso is a SQLite rewrite in <b>Rust</b>",)]
     conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Parameterized batches (turso extension; no sqlite3 equivalent)
+# ---------------------------------------------------------------------------
+
+
+def _batch_connection():
+    conn = turso.connect("tests/database.db")
+    conn.execute("CREATE TABLE t_batch (id INTEGER PRIMARY KEY, name TEXT)")
+    conn.commit()
+    return conn
+
+
+def test_batch_executes_parameterized_statements_in_order():
+    conn = _batch_connection()
+    results = conn.batch(
+        [
+            ("INSERT INTO t_batch (name) VALUES (?)", ("Alice",)),
+            ("INSERT INTO t_batch (name) VALUES (?)", ("Bob",)),
+            "SELECT name FROM t_batch ORDER BY id",
+        ]
+    )
+    assert len(results) == 3
+    assert results[0].rowcount == 1
+    assert results[0].lastrowid == 1
+    # The embedded engine does not report per-statement execution
+    # statistics; the serverless driver fills these from the server.
+    assert results[0].rows_read is None
+    assert results[0].rows_written is None
+    assert results[0].query_duration_ms is None
+    assert results[1].lastrowid == 2
+    select = results[2]
+    assert select.description is not None
+    assert select.description[0][0] == "name"
+    assert select.rows == [("Alice",), ("Bob",)]
+    assert select.rowcount == -1
+    # The batch is not transactional: the inserts are already committed.
+    assert not conn.in_transaction
+    conn.close()
+
+    conn = turso.connect("tests/database.db")
+    assert conn.execute("SELECT COUNT(*) FROM t_batch").fetchone() == (2,)
+    conn.close()
+
+
+def test_batch_error_identifies_the_failing_statement():
+    conn = _batch_connection()
+    with pytest.raises(turso.DatabaseError, match="batch statement 1 failed") as excinfo:
+        conn.batch(
+            [
+                ("INSERT INTO t_batch (name) VALUES (?)", ("Alice",)),
+                ("INSERT INTO no_such_table VALUES (?)", (2,)),
+                ("INSERT INTO t_batch (name) VALUES (?)", ("Carol",)),
+            ]
+        )
+    assert excinfo.value.batch_index == 1
+    # One entry per statement: the completed first statement's result,
+    # None for the failing and skipped ones.
+    partial = excinfo.value.batch_results
+    assert len(partial) == 3
+    assert partial[0].rowcount == 1
+    assert partial[1] is None
+    assert partial[2] is None
+    # The statement before the failing one keeps its effect, and the one
+    # after it never ran.
+    assert conn.execute("SELECT COUNT(*) FROM t_batch").fetchone() == (1,)
+    conn.close()
+
+
+def test_batch_joins_an_open_transaction():
+    conn = _batch_connection()
+    conn.execute("BEGIN")
+    conn.batch(
+        [
+            ("INSERT INTO t_batch (name) VALUES (?)", ("Alice",)),
+            ("INSERT INTO t_batch (name) VALUES (?)", ("Bob",)),
+        ]
+    )
+    assert conn.in_transaction
+    conn.rollback()
+    assert conn.execute("SELECT COUNT(*) FROM t_batch").fetchone() == (0,)
+    conn.close()
+
+
+def test_batch_mode_commits_atomically():
+    conn = _batch_connection()
+    results = conn.batch(
+        [
+            ("INSERT INTO t_batch (name) VALUES (?)", ("Alice",)),
+            ("INSERT INTO t_batch (name) VALUES (?)", ("Bob",)),
+        ],
+        mode="immediate",
+    )
+    assert len(results) == 2
+    assert not conn.in_transaction
+    assert conn.execute("SELECT COUNT(*) FROM t_batch").fetchone() == (2,)
+    conn.close()
+
+
+def test_batch_mode_rolls_back_on_failure():
+    conn = _batch_connection()
+    with pytest.raises(turso.DatabaseError) as excinfo:
+        conn.batch(
+            [
+                ("INSERT INTO t_batch (name) VALUES (?)", ("Alice",)),
+                ("INSERT INTO no_such_table VALUES (?)", (2,)),
+            ],
+            mode="immediate",
+        )
+    assert excinfo.value.batch_index == 1
+    assert not conn.in_transaction
+    # The rollback undid the first insert.
+    assert conn.execute("SELECT COUNT(*) FROM t_batch").fetchone() == (0,)
+    conn.close()
+
+
+def test_batch_constraint_error_preserves_exception_class():
+    conn = _batch_connection()
+    conn.execute("CREATE TABLE t_batch_uniq (x UNIQUE)")
+    conn.commit()
+    with pytest.raises(turso.IntegrityError) as excinfo:
+        conn.batch(
+            [
+                ("INSERT INTO t_batch_uniq VALUES (?)", (1,)),
+                ("INSERT INTO t_batch_uniq VALUES (?)", (1,)),
+            ]
+        )
+    assert excinfo.value.batch_index == 1
+    conn.close()
+
+
+def test_empty_batch_returns_no_results():
+    conn = _batch_connection()
+    assert conn.batch([]) == []
+    assert conn.batch([], mode="immediate") == []
+    conn.close()
+
+
+def test_batch_rejects_invalid_mode_and_statements():
+    conn = _batch_connection()
+    with pytest.raises(turso.ProgrammingError, match="batch mode"):
+        conn.batch(["SELECT 1"], mode="bogus")
+    with pytest.raises(turso.ProgrammingError, match="batch statement 1"):
+        conn.batch(["SELECT 1", 42])
+    with pytest.raises(turso.ProgrammingError, match="one statement at a time"):
+        conn.batch(["SELECT 1; SELECT 2"])
+    conn.close()

--- a/bindings/python/tests/test_database_aio.py
+++ b/bindings/python/tests/test_database_aio.py
@@ -234,3 +234,33 @@ async def test_cursor_async_context_manager_closes_cursor():
             await cur.fetchone()
     finally:
         await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_batch_executes_parameterized_statements():
+    async with turso.aio.connect(":memory:") as conn:
+        results = await conn.batch(
+            [
+                "CREATE TABLE t_batch (id INTEGER PRIMARY KEY, name TEXT)",
+                ("INSERT INTO t_batch (name) VALUES (?)", ("Alice",)),
+                "SELECT name FROM t_batch",
+            ]
+        )
+        assert len(results) == 3
+        assert results[1].rowcount == 1
+        assert results[1].lastrowid == 1
+        assert results[2].rows == [("Alice",)]
+
+
+@pytest.mark.asyncio
+async def test_batch_error_identifies_the_failing_statement():
+    async with turso.aio.connect(":memory:") as conn:
+        await conn.execute("CREATE TABLE t_batch (x)")
+        with pytest.raises(turso.DatabaseError, match="batch statement 1 failed") as excinfo:
+            await conn.batch(
+                [
+                    ("INSERT INTO t_batch VALUES (?)", (1,)),
+                    ("INSERT INTO no_such_table VALUES (?)", (2,)),
+                ]
+            )
+        assert excinfo.value.batch_index == 1

--- a/bindings/python/turso/__init__.py
+++ b/bindings/python/turso/__init__.py
@@ -3,6 +3,7 @@ import logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 from .lib import (  # noqa: E402
+    BatchResult,
     Connection,
     Cursor,
     DatabaseError,
@@ -27,6 +28,7 @@ from .lib import (  # noqa: E402
 )
 
 __all__ = [
+    "BatchResult",
     "Connection",
     "Cursor",
     "Row",

--- a/bindings/python/turso/lib.py
+++ b/bindings/python/turso/lib.py
@@ -498,6 +498,14 @@ class Connection:
         cur.executescript(sql_script)
         return cur
 
+    def _last_insert_rowid(self) -> Optional[int]:
+        """The rowid of the most recent successful INSERT on this
+        connection, read from the engine without executing a statement."""
+        try:
+            return self._conn.last_insert_rowid()
+        except Exception:
+            return None
+
     def __call__(self, sql: str) -> PyTursoStatement:
         # Shortcut to prepare a single statement
         try:
@@ -727,31 +735,9 @@ class Cursor:
     def _fetch_last_insert_rowid_if_needed(self, sql: str, rows_changed: int) -> Optional[int]:
         if rows_changed <= 0 or not _is_insert_or_replace(sql):
             return self._lastrowid
-        # Query last_insert_rowid(); this is connection-scoped and cheap
-        try:
-            q = self._connection._conn.prepare_single("SELECT last_insert_rowid()")
-            # No parameters; this produces a single-row single-column result
-            # Use stepping to fetch the row
-            status = _step_once_with_io(q, self._connection.extra_io)
-            if status == Status.Row:
-                py_row = q.row()
-                # row() returns a Python tuple with one element
-                # We avoid complex conversions: take first item
-                value = tuple(py_row)[0]  # type: ignore[call-arg]
-                # Finalize to complete
-                q.finalize()
-                if isinstance(value, int):
-                    return value
-                try:
-                    return int(value)
-                except Exception:
-                    return self._lastrowid
-            # Finalize anyway
-            q.finalize()
-        except Exception:
-            # Ignore errors; lastrowid remains unchanged on failure
-            pass
-        return self._lastrowid
+        rowid = self._connection._last_insert_rowid()
+        # lastrowid remains unchanged when it cannot be determined.
+        return rowid if rowid is not None else self._lastrowid
 
     def executemany(self, sql: str, seq_of_parameters: Iterable[Sequence[Any] | Mapping[str, Any]]) -> "Cursor":
         self._ensure_open()

--- a/bindings/python/turso/lib.py
+++ b/bindings/python/turso/lib.py
@@ -179,6 +179,86 @@ def _is_insert_or_replace(sql: str) -> bool:
     return kw in ("INSERT", "REPLACE")
 
 
+@dataclass
+class BatchResult:
+    """The result of one statement of a [`Connection.batch`] call, in
+    DB-API vocabulary: `description` and `rows` for statements that return
+    rows, `rowcount` for DML (−1 when the statement returned rows), and
+    `lastrowid` for INSERT/REPLACE. `rows_read`, `rows_written`, and
+    `query_duration_ms` are server-side execution statistics reported by
+    the serverless driver; the embedded engine does not report them per
+    statement, so they are None here."""
+
+    rows: list[tuple]
+    description: Optional[tuple[tuple[str, None, None, None, None, None, None], ...]]
+    rowcount: int
+    lastrowid: Optional[int]
+    rows_read: Optional[int] = None
+    rows_written: Optional[int] = None
+    query_duration_ms: Optional[float] = None
+
+
+# Accepted values for the `mode` argument of Connection.batch and the
+# BEGIN statement each maps to.
+_BATCH_MODES = {
+    "deferred": "BEGIN DEFERRED",
+    "immediate": "BEGIN IMMEDIATE",
+    "exclusive": "BEGIN EXCLUSIVE",
+    "concurrent": "BEGIN CONCURRENT",
+}
+
+
+def _batch_begin_sql(mode: Optional[str]) -> Optional[str]:
+    if mode is None:
+        return None
+    begin_sql = _BATCH_MODES.get(str(mode).lower())
+    if begin_sql is None:
+        raise ProgrammingError(
+            f"batch mode must be one of {sorted(_BATCH_MODES)} or None, got {mode!r}"
+        )
+    return begin_sql
+
+
+def _normalize_batch_statements(
+    statements: Iterable[Any],
+) -> list[tuple[str, Sequence[Any] | Mapping[str, Any]]]:
+    """Normalize batch input to (sql, parameters) pairs. Accepts SQL
+    strings and (sql, parameters) pairs."""
+    normalized = []
+    for index, statement in enumerate(statements):
+        if isinstance(statement, str):
+            normalized.append((statement, ()))
+            continue
+        if (
+            isinstance(statement, (tuple, list))
+            and len(statement) == 2
+            and isinstance(statement[0], str)
+        ):
+            normalized.append((statement[0], statement[1]))
+            continue
+        raise ProgrammingError(
+            f"batch statement {index} must be a SQL string or a (sql, parameters) pair"
+        )
+    return normalized
+
+
+def _batch_statement_error(
+    index: int,
+    error: Exception,
+    results: Optional[list] = None,
+) -> Exception:
+    """Wrap a statement failure so the raised exception identifies which
+    statement failed, preserving the DB-API exception class. The zero-based
+    index is available as the `batch_index` attribute, and `batch_results`
+    carries one entry per statement: the completed statement's
+    `BatchResult`, or None for the failing statement and the statements
+    that did not run."""
+    wrapped = type(error)(f"batch statement {index} failed: {error}")
+    wrapped.batch_index = index
+    wrapped.batch_results = results if results is not None else []
+    return wrapped
+
+
 def _run_execute_with_io(stmt: PyTursoStatement, extra_io: Optional[Callable[[], None]]) -> PyTursoExecutionResult:
     """
     Run PyTursoStatement.execute() handling potential async IO loops.
@@ -497,6 +577,113 @@ class Connection:
         cur = self.cursor()
         cur.executescript(sql_script)
         return cur
+
+    def batch(
+        self,
+        statements: Iterable[str | tuple[str, Sequence[Any] | Mapping[str, Any]]],
+        mode: Optional[str] = None,
+    ) -> list[BatchResult]:
+        """Execute multiple parameterized statements as a batch.
+
+        The statements — SQL strings or (sql, parameters) pairs, with the
+        same parameter forms as `execute()` — execute in order. Execution
+        stops at the first statement that fails: the remaining statements
+        are skipped and the raised exception identifies the failing
+        statement by its zero-based index (the `batch_index` attribute)
+        and carries the per-statement results (the `batch_results`
+        attribute: one entry per statement — the completed statement's
+        `BatchResult`, or None for the failing statement and the
+        statements that did not run).
+
+        With `mode` set to "deferred", "immediate", "exclusive", or
+        "concurrent", the statements are wrapped in `BEGIN <mode>` /
+        `COMMIT`, with a `ROLLBACK` on failure: either every statement
+        commits or none does. The statements must not contain their own
+        transaction-control SQL in that case. With `mode` unset the batch
+        is not transactional: each statement commits as it executes.
+
+        Unlike `execute()`, `batch()` never opens a legacy implicit
+        transaction. If a transaction is already open on this connection,
+        the statements join it (and `mode` is ignored).
+
+        Returns one `BatchResult` per statement, in order.
+        """
+        begin_sql = _batch_begin_sql(mode)
+        stmts = _normalize_batch_statements(statements)
+        if not stmts:
+            return []
+        if self.in_transaction:
+            begin_sql = None
+        if begin_sql is None:
+            return self._run_batch_statements(stmts)
+        self._exec_ddl_only(begin_sql)
+        try:
+            results = self._run_batch_statements(stmts)
+            self._exec_ddl_only("COMMIT")
+        except Exception:
+            # ROLLBACK errors are ignored: the failure being re-raised is
+            # the error being reported, and surfacing a rollback error
+            # would mask it.
+            try:
+                self._exec_ddl_only("ROLLBACK")
+            except Exception:
+                pass
+            raise
+        return results
+
+    def _run_batch_statements(
+        self, stmts: list[tuple[str, Sequence[Any] | Mapping[str, Any]]]
+    ) -> list[BatchResult]:
+        """Execute the statements of a batch in order, stopping at the
+        first failure and reporting its index along with the results of
+        the statements that completed."""
+        results = []
+        for index, (sql, parameters) in enumerate(stmts):
+            try:
+                results.append(self._execute_batch_statement(sql, parameters))
+            except Exception as exc:  # noqa: BLE001
+                # One entry per statement: the completed statements'
+                # results, None for the failing and skipped ones.
+                partial = list(results) + [None] * (len(stmts) - len(results))
+                raise _batch_statement_error(index, exc, partial) from exc
+        return results
+
+    def _execute_batch_statement(
+        self, sql: str, parameters: Sequence[Any] | Mapping[str, Any]
+    ) -> BatchResult:
+        """Execute one statement of a batch, buffering its rows."""
+        prepared = self._prepare_first(sql)
+        self._raise_if_multiple_statements(sql, prepared.tail_index)
+        stmt = prepared.stmt
+        try:
+            Cursor._bind_params(stmt, parameters)
+            if prepared.has_columns:
+                rows = []
+                while _step_once_with_io(stmt, self.extra_io) == Status.Row:
+                    rows.append(tuple(stmt.row()))  # type: ignore[call-arg]
+                description = tuple(
+                    (name, None, None, None, None, None, None) for name in prepared.column_names
+                )
+                result = BatchResult(rows=rows, description=description, rowcount=-1, lastrowid=None)
+            else:
+                execution = _run_execute_with_io(stmt, self.extra_io)
+                lastrowid = None
+                if execution.rows_changed > 0 and _is_insert_or_replace(sql):
+                    lastrowid = self._last_insert_rowid()
+                result = BatchResult(
+                    rows=[],
+                    description=None,
+                    rowcount=int(execution.rows_changed),
+                    lastrowid=lastrowid,
+                )
+            stmt.finalize()
+            return result
+        except Exception as exc:  # noqa: BLE001
+            try:
+                stmt.finalize()
+            except Exception:
+                pass
+            raise _map_turso_exception(exc)
 
     def _last_insert_rowid(self) -> Optional[int]:
         """The rowid of the most recent successful INSERT on this

--- a/bindings/python/turso/lib.py
+++ b/bindings/python/turso/lib.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import sys
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
@@ -132,8 +133,8 @@ _DBCursorT = TypeVar("_DBCursorT", bound="Cursor")
 
 def _first_keyword(sql: str) -> str:
     """
-    Return the first SQL keyword (uppercased) ignoring leading whitespace
-    and single-line and multi-line comments.
+    Return the first SQL keyword (uppercased) ignoring leading whitespace,
+    empty statements, and single-line and multi-line comments.
 
     This is intentionally minimal and only used to detect DML for implicit
     transaction handling. It may not handle all edge cases (e.g. complex WITH).
@@ -142,7 +143,7 @@ def _first_keyword(sql: str) -> str:
     n = len(sql)
     while i < n:
         c = sql[i]
-        if c.isspace():
+        if c.isspace() or c in (";", "\ufeff"):
             i += 1
             continue
         if c == "-" and i + 1 < n and sql[i + 1] == "-":
@@ -207,6 +208,15 @@ _BATCH_MODES = {
     "concurrent": "BEGIN CONCURRENT",
 }
 
+_TRANSACTION_CONTROL_KEYWORDS = {
+    "BEGIN",
+    "COMMIT",
+    "END",
+    "ROLLBACK",
+    "SAVEPOINT",
+    "RELEASE",
+}
+
 
 def _batch_begin_sql(mode: Optional[str]) -> Optional[str]:
     if mode is None:
@@ -242,6 +252,17 @@ def _normalize_batch_statements(
     return normalized
 
 
+def _reject_transaction_control_statements(
+    statements: list[tuple[str, Sequence[Any] | Mapping[str, Any]]],
+) -> None:
+    for index, (sql, _parameters) in enumerate(statements):
+        if _first_keyword(sql) in _TRANSACTION_CONTROL_KEYWORDS:
+            error = ProgrammingError(
+                "transaction-control SQL is not allowed in a batch with a transaction mode"
+            )
+            raise _batch_statement_error(index, error) from error
+
+
 def _batch_statement_error(
     index: int,
     error: Exception,
@@ -250,9 +271,9 @@ def _batch_statement_error(
     """Wrap a statement failure so the raised exception identifies which
     statement failed, preserving the DB-API exception class. The zero-based
     index is available as the `batch_index` attribute, and `batch_results`
-    carries one entry per statement: the completed statement's
-    `BatchResult`, or None for the failing statement and the statements
-    that did not run."""
+    is empty when validation fails before execution. Otherwise it carries
+    one entry per statement: the completed statement's `BatchResult`, or
+    None for the failing statement and the statements that did not run."""
     wrapped = type(error)(f"batch statement {index} failed: {error}")
     wrapped.batch_index = index
     wrapped.batch_results = results if results is not None else []
@@ -590,17 +611,20 @@ class Connection:
         stops at the first statement that fails: the remaining statements
         are skipped and the raised exception identifies the failing
         statement by its zero-based index (the `batch_index` attribute)
-        and carries the per-statement results (the `batch_results`
-        attribute: one entry per statement — the completed statement's
-        `BatchResult`, or None for the failing statement and the
-        statements that did not run).
+        and carries the per-statement results in the `batch_results`
+        attribute. It is empty when parameter validation fails before
+        execution; otherwise it has one entry per statement — the completed
+        statement's `BatchResult`, or None for the failing statement and
+        the statements that did not run.
 
         With `mode` set to "deferred", "immediate", "exclusive", or
         "concurrent", the statements are wrapped in `BEGIN <mode>` /
         `COMMIT`, with a `ROLLBACK` on failure: either every statement
         commits or none does. The statements must not contain their own
-        transaction-control SQL in that case. With `mode` unset the batch
-        is not transactional: each statement commits as it executes.
+        transaction-control SQL in that case. If `ROLLBACK` itself fails,
+        the primary exception has a `rollback_error` attribute and the
+        connection's transaction state is unknown. With `mode` unset the
+        batch is not transactional: each statement commits as it executes.
 
         Unlike `execute()`, `batch()` never opens a legacy implicit
         transaction. If a transaction is already open on this connection,
@@ -612,24 +636,50 @@ class Connection:
         stmts = _normalize_batch_statements(statements)
         if not stmts:
             return []
+        stmts = self._prevalidate_batch_parameters(stmts)
         if self.in_transaction:
             begin_sql = None
         if begin_sql is None:
             return self._run_batch_statements(stmts)
+        _reject_transaction_control_statements(stmts)
         self._exec_ddl_only(begin_sql)
         try:
             results = self._run_batch_statements(stmts)
             self._exec_ddl_only("COMMIT")
-        except Exception:
-            # ROLLBACK errors are ignored: the failure being re-raised is
-            # the error being reported, and surfacing a rollback error
-            # would mask it.
+        except Exception as primary_error:
             try:
                 self._exec_ddl_only("ROLLBACK")
-            except Exception:
-                pass
+            except Exception as rollback_error:
+                primary_error.rollback_error = rollback_error
             raise
         return results
+
+    def _prevalidate_batch_parameters(
+        self, stmts: list[tuple[str, Sequence[Any] | Mapping[str, Any]]]
+    ) -> list[tuple[str, Sequence[Any] | Mapping[str, Any]]]:
+        validator = self._conn.prepare_single("SELECT ?")
+        validated = []
+        try:
+            for index, (sql, parameters) in enumerate(stmts):
+                try:
+                    if isinstance(parameters, Mapping):
+                        copied_parameters: Sequence[Any] | Mapping[str, Any] = dict(parameters)
+                        values = copied_parameters.values()
+                    else:
+                        copied_parameters = Cursor._to_positional_params(parameters)
+                        values = copied_parameters
+                    for value in values:
+                        if isinstance(value, float) and math.isinf(value):
+                            raise ValueError(
+                                "infinite float values cannot be sent over the protocol"
+                            )
+                        validator.bind_positional(1, value)
+                except Exception as exc:  # noqa: BLE001
+                    raise _batch_statement_error(index, _map_turso_exception(exc)) from exc
+                validated.append((sql, copied_parameters))
+        finally:
+            validator.finalize()
+        return validated
 
     def _run_batch_statements(
         self, stmts: list[tuple[str, Sequence[Any] | Mapping[str, Any]]]

--- a/bindings/python/turso/lib_aio.py
+++ b/bindings/python/turso/lib_aio.py
@@ -5,13 +5,14 @@ from queue import SimpleQueue
 from typing import Any, Callable, Iterable, Mapping, Optional, Sequence
 
 from .lib import (
+    BatchResult,
+    ProgrammingError,
+)
+from .lib import (
     Connection as BlockingConnection,
 )
 from .lib import (
     Cursor as BlockingCursor,
-)
-from .lib import (
-    ProgrammingError,
 )
 from .lib import (
     connect as blocking_connect,
@@ -121,6 +122,17 @@ class Connection:
         cur = self.cursor()
         await cur.executescript(sql_script)
         return cur
+
+    async def batch(
+        self,
+        statements: Iterable[str | tuple[str, Sequence[Any] | Mapping[str, Any]]],
+        mode: Optional[str] = None,
+    ) -> list[BatchResult]:
+        """Execute multiple parameterized statements as a batch. See
+        `turso.Connection.batch` for the accepted statement forms, the
+        `mode` argument, and the error and transaction semantics."""
+        statements = list(statements)
+        return await self._run(lambda: self._conn.batch(statements, mode))  # type: ignore[union-attr]
 
     async def commit(self) -> None:
         await self._run(lambda: self._conn.commit())  # type: ignore[union-attr]

--- a/bindings/rust/src/batch.rs
+++ b/bindings/rust/src/batch.rs
@@ -8,7 +8,7 @@
 use crate::{
     params::{IntoParams, Params},
     rows::Row,
-    Column, Result,
+    Column, Error, Result, Value,
 };
 
 mod sealed {
@@ -48,6 +48,76 @@ impl BatchStatement {
             params: params.into_params()?,
         })
     }
+
+    pub(crate) fn validate_params(&self) -> Result<()> {
+        let has_infinity = match &self.params {
+            Params::None => false,
+            Params::Positional(values) => values.iter().any(is_infinite),
+            Params::Named(values) => values.iter().any(|(_, value)| is_infinite(value)),
+        };
+        if has_infinity {
+            return Err(Error::ToSqlConversionFailure(Box::new(
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "only finite floating-point values can be bound",
+                ),
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn controls_transaction(&self) -> bool {
+        matches!(
+            first_sql_keyword(&self.sql).as_deref(),
+            Some("BEGIN" | "COMMIT" | "END" | "ROLLBACK" | "SAVEPOINT" | "RELEASE")
+        )
+    }
+}
+
+fn is_infinite(value: &Value) -> bool {
+    matches!(value, Value::Real(number) if number.is_infinite())
+}
+
+fn first_sql_keyword(sql: &str) -> Option<String> {
+    let bytes = sql.as_bytes();
+    let mut offset = 0;
+    loop {
+        if bytes.get(offset..offset + 3) == Some(&[0xef, 0xbb, 0xbf]) {
+            offset += 3;
+            continue;
+        }
+        while bytes
+            .get(offset)
+            .is_some_and(|byte| byte.is_ascii_whitespace() || *byte == b';')
+        {
+            offset += 1;
+        }
+        if bytes.get(offset..offset + 2) == Some(b"--") {
+            offset += 2;
+            while bytes.get(offset).is_some_and(|byte| *byte != b'\n') {
+                offset += 1;
+            }
+            continue;
+        }
+        if bytes.get(offset..offset + 2) == Some(b"/*") {
+            offset += 2;
+            while bytes.get(offset..offset + 2) != Some(b"*/") {
+                bytes.get(offset)?;
+                offset += 1;
+            }
+            offset += 2;
+            continue;
+        }
+        break;
+    }
+    let start = offset;
+    while bytes
+        .get(offset)
+        .is_some_and(|byte| byte.is_ascii_alphabetic())
+    {
+        offset += 1;
+    }
+    (offset > start).then(|| sql[start..offset].to_ascii_uppercase())
 }
 
 /// Converts some type into one statement of a batch.

--- a/bindings/rust/src/batch.rs
+++ b/bindings/rust/src/batch.rs
@@ -1,0 +1,168 @@
+//! Parameterized statement batches.
+//!
+//! A batch executes multiple statements — each with its own bind
+//! parameters — in order, stopping at the first failure. See
+//! [`Connection::batch`](crate::Connection::batch) and
+//! [`Connection::transactional_batch`](crate::Connection::transactional_batch).
+
+use crate::{
+    params::{IntoParams, Params},
+    rows::Row,
+    Column, Result,
+};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+use sealed::Sealed;
+
+/// One statement of a batch, with its bind parameters.
+///
+/// Usually built implicitly from a SQL string or a `(sql, params)` pair
+/// (see [`IntoBatchStatement`]). Build `BatchStatement`s explicitly to mix
+/// parameter shapes in one batch, since the elements of a single array or
+/// `Vec` must share one type:
+///
+/// ```rust
+/// # fn build() -> turso::Result<Vec<turso::BatchStatement>> {
+/// use turso::BatchStatement;
+/// Ok(vec![
+///     BatchStatement::new("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())?,
+///     BatchStatement::new("INSERT INTO t (v) VALUES (?1)", ("x",))?,
+/// ])
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct BatchStatement {
+    pub(crate) sql: String,
+    pub(crate) params: Params,
+}
+
+impl BatchStatement {
+    /// Create a batch statement from SQL text and parameters, accepting the
+    /// same parameter forms as [`Connection::execute`](crate::Connection::execute).
+    pub fn new(sql: impl Into<String>, params: impl IntoParams) -> Result<Self> {
+        Ok(Self {
+            sql: sql.into(),
+            params: params.into_params()?,
+        })
+    }
+}
+
+/// Converts some type into one statement of a batch.
+///
+/// Implemented for:
+///
+/// - SQL strings without parameters: `"DELETE FROM t"`.
+/// - `(sql, params)` pairs, with the same parameter forms as
+///   [`Connection::execute`](crate::Connection::execute):
+///   `("INSERT INTO t (v) VALUES (?1)", ("x",))`.
+/// - [`BatchStatement`], for batches that mix parameter shapes.
+pub trait IntoBatchStatement: Sealed {
+    #[doc(hidden)]
+    fn into_batch_statement(self) -> Result<BatchStatement>;
+}
+
+impl Sealed for BatchStatement {}
+impl IntoBatchStatement for BatchStatement {
+    fn into_batch_statement(self) -> Result<BatchStatement> {
+        Ok(self)
+    }
+}
+
+impl Sealed for &str {}
+impl IntoBatchStatement for &str {
+    fn into_batch_statement(self) -> Result<BatchStatement> {
+        BatchStatement::new(self, ())
+    }
+}
+
+impl Sealed for String {}
+impl IntoBatchStatement for String {
+    fn into_batch_statement(self) -> Result<BatchStatement> {
+        BatchStatement::new(self, ())
+    }
+}
+
+impl<S: Into<String>, P: IntoParams> Sealed for (S, P) {}
+impl<S: Into<String>, P: IntoParams> IntoBatchStatement for (S, P) {
+    fn into_batch_statement(self) -> Result<BatchStatement> {
+        BatchStatement::new(self.0, self.1)
+    }
+}
+
+/// The result of one statement of a batch.
+#[derive(Debug)]
+pub struct BatchResult {
+    columns: Vec<Column>,
+    rows: Vec<Row>,
+    rows_affected: u64,
+    last_insert_rowid: Option<i64>,
+    rows_read: Option<u64>,
+    rows_written: Option<u64>,
+    query_duration_ms: Option<f64>,
+}
+
+impl BatchResult {
+    pub(crate) fn new(
+        columns: Vec<Column>,
+        rows: Vec<Row>,
+        rows_affected: u64,
+        last_insert_rowid: Option<i64>,
+    ) -> Self {
+        Self {
+            columns,
+            rows,
+            rows_affected,
+            last_insert_rowid,
+            rows_read: None,
+            rows_written: None,
+            query_duration_ms: None,
+        }
+    }
+
+    /// Returns the columns of the statement's result set.
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    /// Returns the rows returned by the statement.
+    pub fn rows(&self) -> &[Row] {
+        &self.rows
+    }
+
+    /// Returns the number of rows changed by the statement.
+    pub fn rows_affected(&self) -> u64 {
+        self.rows_affected
+    }
+
+    /// Returns the rowid inserted by the statement, when the statement was
+    /// an INSERT into a table with a rowid.
+    pub fn last_insert_rowid(&self) -> Option<i64> {
+        self.last_insert_rowid
+    }
+
+    /// Returns the number of rows read while executing the statement.
+    /// The embedded engine does not report this counter per statement,
+    /// so this is `None`; the serverless driver reports the server's
+    /// value.
+    pub fn rows_read(&self) -> Option<u64> {
+        self.rows_read
+    }
+
+    /// Returns the number of rows written while executing the statement.
+    /// The embedded engine does not report this counter per statement,
+    /// so this is `None`; the serverless driver reports the server's
+    /// value.
+    pub fn rows_written(&self) -> Option<u64> {
+        self.rows_written
+    }
+
+    /// Returns the execution time of the statement in milliseconds. The
+    /// embedded engine does not report this per statement, so this is
+    /// `None`; the serverless driver reports the server's value.
+    pub fn query_duration_ms(&self) -> Option<f64> {
+        self.query_duration_ms
+    }
+}

--- a/bindings/rust/src/connection.rs
+++ b/bindings/rust/src/connection.rs
@@ -9,11 +9,23 @@ use crate::Rows;
 use crate::Statement;
 use std::fmt::Debug;
 use std::sync::atomic::AtomicU8;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::task::Waker;
 pub type Result<T> = std::result::Result<T, Error>;
+
+const EXCLUSIVE_OPERATION: usize = usize::MAX;
+
+pub(crate) struct ConnectionOperationGate {
+    state: AtomicUsize,
+}
+
+pub(crate) struct ConnectionOperationGuard {
+    gate: Arc<ConnectionOperationGate>,
+    exclusive: bool,
+}
 
 /// Atomic wrapper for [DropBehavior]
 pub(crate) struct AtomicDropBehavior {
@@ -53,6 +65,7 @@ pub struct Connection {
     /// By default, the value is [DropBehavior::Ignore] which effectively does nothing.
     pub(crate) dangling_tx: AtomicDropBehavior,
     pub(crate) extra_io: Option<Arc<dyn Fn(Waker) -> Result<()> + Send + Sync>>,
+    pub(crate) operation_gate: Arc<ConnectionOperationGate>,
 }
 
 assert_send_sync!(Connection);
@@ -64,6 +77,7 @@ impl Clone for Connection {
             transaction_behavior: self.transaction_behavior,
             dangling_tx: AtomicDropBehavior::new(self.dangling_tx.load(Ordering::SeqCst)),
             extra_io: self.extra_io.clone(),
+            operation_gate: self.operation_gate.clone(),
         }
     }
 }
@@ -79,6 +93,7 @@ impl Connection {
             transaction_behavior: TransactionBehavior::Deferred,
             dangling_tx: AtomicDropBehavior::new(DropBehavior::Ignore),
             extra_io,
+            operation_gate: Arc::new(ConnectionOperationGate::new()),
         };
         connection
     }
@@ -129,7 +144,9 @@ impl Connection {
 
     /// Execute a batch of SQL statements on the database.
     pub async fn execute_batch(&self, sql: impl AsRef<str>) -> Result<()> {
-        self.maybe_handle_dangling_tx().await?;
+        let _operation = self.acquire_exclusive_operation()?;
+        self.maybe_handle_dangling_tx_without_operation_guard()
+            .await?;
         self.prepare_execute_batch(sql).await?;
         Ok(())
     }
@@ -196,7 +213,7 @@ impl Connection {
     ///
     /// This method owns the surrounding transaction, so the statements must
     /// not contain their own transaction-control SQL (`BEGIN`, `COMMIT`,
-    /// `ROLLBACK`, `SAVEPOINT`, `RELEASE`); a user-supplied `COMMIT` would
+    /// `END`, `ROLLBACK`, `SAVEPOINT`, `RELEASE`); a user-supplied `COMMIT` would
     /// close the wrapper transaction mid-batch and leave earlier statements
     /// committed, defeating the all-or-nothing contract. If a transaction
     /// is already open on this connection, the wrapping is skipped and the
@@ -237,13 +254,39 @@ impl Connection {
         if stmts.is_empty() {
             return Ok(Vec::new());
         }
-        self.maybe_handle_dangling_tx().await?;
+        for (index, stmt) in stmts.iter().enumerate() {
+            stmt.validate_params()
+                .map_err(|error| Error::BatchStatementFailed {
+                    index,
+                    error: Box::new(error),
+                    results: Vec::new(),
+                })?;
+        }
+        let _operation = self.acquire_exclusive_operation()?;
+        self.maybe_handle_dangling_tx_without_operation_guard()
+            .await?;
         // With a transaction already open on the connection, another BEGIN
         // would fail; the statements join the open transaction instead
         // (matching the serverless driver).
         let wrap = if self.is_autocommit()? { wrap } else { None };
+        if wrap.is_some() {
+            if let Some((index, _)) = stmts
+                .iter()
+                .enumerate()
+                .find(|(_, stmt)| stmt.controls_transaction())
+            {
+                return Err(Error::BatchStatementFailed {
+                    index,
+                    error: Box::new(Error::Misuse(
+                        "transactional batch statements must not control transactions".to_string(),
+                    )),
+                    results: Vec::new(),
+                });
+            }
+        }
         if let Some(behavior) = wrap {
-            self.execute(behavior.begin_sql(), ()).await?;
+            self.execute_without_operation_guard(behavior.begin_sql(), ())
+                .await?;
         }
         let statement_count = stmts.len();
         let mut results = Vec::with_capacity(statement_count);
@@ -251,29 +294,27 @@ impl Connection {
             match self.execute_batch_statement(stmt).await {
                 Ok(result) => results.push(result),
                 Err(error) => {
-                    // ROLLBACK errors are ignored: the statement failure is
-                    // the error being reported, and surfacing a rollback
-                    // error would mask it.
-                    if wrap.is_some() {
-                        let _ = self.execute("ROLLBACK", ()).await;
-                    }
                     // One entry per statement: the completed statements'
                     // results, None for the failing and skipped ones.
                     let mut partial: Vec<Option<BatchResult>> =
                         results.into_iter().map(Some).collect();
                     partial.resize_with(statement_count, || None);
-                    return Err(Error::BatchStatementFailed {
+                    let error = Error::BatchStatementFailed {
                         index,
                         error: Box::new(error),
                         results: partial,
-                    });
+                    };
+                    return if wrap.is_some() {
+                        self.rollback_batch(error).await
+                    } else {
+                        Err(error)
+                    };
                 }
             }
         }
         if wrap.is_some() {
-            if let Err(error) = self.execute("COMMIT", ()).await {
-                let _ = self.execute("ROLLBACK", ()).await;
-                return Err(error);
+            if let Err(error) = self.execute_without_operation_guard("COMMIT", ()).await {
+                return self.rollback_batch(error).await;
             }
         }
         Ok(results)
@@ -283,7 +324,7 @@ impl Connection {
     async fn execute_batch_statement(&self, stmt: BatchStatement) -> Result<BatchResult> {
         let rowid_before = self.last_insert_rowid();
         let mut prepared = self.prepare(&stmt.sql).await?;
-        let mut rows = prepared.query(stmt.params).await?;
+        let mut rows = prepared.query_without_operation_guard(stmt.params).await?;
         let columns = rows.columns();
         let mut buffered = Vec::new();
         while let Some(row) = rows.next().await? {
@@ -336,7 +377,6 @@ impl Connection {
     }
 
     async fn prepare_execute_batch(&self, sql: impl AsRef<str>) -> Result<()> {
-        self.maybe_handle_dangling_tx().await?;
         let conn = self.get_inner_connection()?;
         let mut sql = sql.as_ref();
         while let Some((stmt, offset)) = conn.prepare_first(sql)? {
@@ -344,10 +384,55 @@ impl Connection {
                 conn: self.clone(),
                 inner: Arc::new(Mutex::new(stmt)),
             };
-            let _ = stmt.execute(()).await?;
+            let _ = stmt.execute_without_operation_guard(()).await?;
             sql = &sql[offset..];
         }
         Ok(())
+    }
+
+    async fn rollback_batch<T>(&self, error: Error) -> Result<T> {
+        match self.execute_without_operation_guard("ROLLBACK", ()).await {
+            Ok(_) => Err(error),
+            Err(rollback_error) => Err(Error::BatchRollbackFailed {
+                error: Box::new(error),
+                rollback_error: Box::new(rollback_error),
+            }),
+        }
+    }
+
+    pub(crate) fn acquire_shared_operation(&self) -> Result<ConnectionOperationGuard> {
+        self.operation_gate.acquire_shared()
+    }
+
+    fn acquire_exclusive_operation(&self) -> Result<ConnectionOperationGuard> {
+        self.operation_gate.acquire_exclusive()
+    }
+
+    async fn maybe_handle_dangling_tx_without_operation_guard(&self) -> Result<()> {
+        match self.dangling_tx.load(Ordering::SeqCst) {
+            DropBehavior::Rollback => {
+                self.execute_without_operation_guard("ROLLBACK", ()).await?;
+                self.dangling_tx
+                    .store(DropBehavior::Ignore, Ordering::SeqCst);
+            }
+            DropBehavior::Commit => {
+                self.execute_without_operation_guard("COMMIT", ()).await?;
+                self.dangling_tx
+                    .store(DropBehavior::Ignore, Ordering::SeqCst);
+            }
+            DropBehavior::Ignore => {}
+            DropBehavior::Panic => panic!("Transaction dropped unexpectedly."),
+        }
+        Ok(())
+    }
+
+    async fn execute_without_operation_guard(
+        &self,
+        sql: impl AsRef<str>,
+        params: impl IntoParams,
+    ) -> Result<u64> {
+        let mut stmt = self.prepare(sql).await?;
+        stmt.execute_without_operation_guard(params).await
     }
 
     /// Query a pragma.
@@ -423,5 +508,89 @@ impl Connection {
 impl Debug for Connection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Connection").finish()
+    }
+}
+
+impl ConnectionOperationGate {
+    fn new() -> Self {
+        Self {
+            state: AtomicUsize::new(0),
+        }
+    }
+
+    fn acquire_shared(self: &Arc<Self>) -> Result<ConnectionOperationGuard> {
+        let mut state = self.state.load(Ordering::Acquire);
+        loop {
+            if state == EXCLUSIVE_OPERATION {
+                return Err(Error::Misuse(
+                    "connection is busy executing a batch".to_string(),
+                ));
+            }
+            match self.state.compare_exchange_weak(
+                state,
+                state + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Ok(ConnectionOperationGuard {
+                        gate: self.clone(),
+                        exclusive: false,
+                    });
+                }
+                Err(current) => state = current,
+            }
+        }
+    }
+
+    fn acquire_exclusive(self: &Arc<Self>) -> Result<ConnectionOperationGuard> {
+        self.state
+            .compare_exchange(0, EXCLUSIVE_OPERATION, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| Error::Misuse("connection is busy with another operation".to_string()))?;
+        Ok(ConnectionOperationGuard {
+            gate: self.clone(),
+            exclusive: true,
+        })
+    }
+}
+
+impl Drop for ConnectionOperationGuard {
+    fn drop(&mut self) {
+        if self.exclusive {
+            let previous = self.gate.state.swap(0, Ordering::Release);
+            debug_assert_eq!(previous, EXCLUSIVE_OPERATION);
+        } else {
+            let previous = self.gate.state.fetch_sub(1, Ordering::Release);
+            debug_assert!(previous > 0 && previous != EXCLUSIVE_OPERATION);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Builder;
+
+    #[tokio::test]
+    async fn rollback_batch_preserves_both_errors() {
+        let db = Builder::new_local(":memory:").build().await.unwrap();
+        let conn = db.connect().unwrap();
+
+        let error = conn
+            .rollback_batch::<()>(Error::Error("statement failed".to_string()))
+            .await
+            .unwrap_err();
+        match error {
+            Error::BatchRollbackFailed {
+                error,
+                rollback_error,
+            } => {
+                assert!(
+                    matches!(*error, Error::Error(ref message) if message == "statement failed")
+                );
+                assert!(rollback_error.to_string().contains("transaction"));
+            }
+            other => panic!("expected BatchRollbackFailed, got {other:?}"),
+        }
     }
 }

--- a/bindings/rust/src/connection.rs
+++ b/bindings/rust/src/connection.rs
@@ -1,4 +1,5 @@
 use crate::assert_send_sync;
+use crate::batch::{BatchResult, BatchStatement, IntoBatchStatement};
 use crate::transaction::DropBehavior;
 use crate::transaction::TransactionBehavior;
 use crate::Error;
@@ -131,6 +132,181 @@ impl Connection {
         self.maybe_handle_dangling_tx().await?;
         self.prepare_execute_batch(sql).await?;
         Ok(())
+    }
+
+    /// Execute multiple parameterized statements as a batch.
+    ///
+    /// The statements execute in order. Execution stops at the first
+    /// statement that fails: the remaining statements are skipped and the
+    /// returned [`Error::BatchStatementFailed`](crate::Error::BatchStatementFailed)
+    /// carries the zero-based index of the failing statement together with
+    /// the underlying error.
+    ///
+    /// The batch is not transactional: each statement commits as it
+    /// executes, so statements that ran before a failure stay committed.
+    /// For all-or-nothing execution use
+    /// [`transactional_batch`](Connection::transactional_batch). If a
+    /// transaction is open on this connection — including when calling
+    /// through a [`Transaction`](crate::transaction::Transaction) — the
+    /// statements join it instead of committing individually.
+    ///
+    /// Accepts plain SQL strings, `(sql, params)` pairs, and
+    /// [`crate::BatchStatement`]s (see [`IntoBatchStatement`]). Returns one
+    /// [`BatchResult`] per statement, in order.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # async fn run(conn: turso::Connection) -> turso::Result<()> {
+    /// // Statements whose parameters have the same type can be passed
+    /// // as (sql, params) pairs.
+    /// conn.batch([
+    ///     ("INSERT INTO users (name) VALUES (?1)", ("Alice",)),
+    ///     ("INSERT INTO users (name) VALUES (?1)", ("Bob",)),
+    /// ])
+    /// .await?;
+    ///
+    /// // Batches mixing parameter shapes use `BatchStatement`.
+    /// use turso::BatchStatement;
+    /// let results = conn
+    ///     .batch(vec![
+    ///         BatchStatement::new("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())?,
+    ///         BatchStatement::new("INSERT INTO t (v) VALUES (?1)", ("x",))?,
+    ///     ])
+    ///     .await?;
+    /// assert_eq!(results[1].rows_affected(), 1);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn batch<I>(&self, stmts: I) -> Result<Vec<BatchResult>>
+    where
+        I: IntoIterator,
+        I::Item: IntoBatchStatement,
+    {
+        self.run_batch(stmts, None).await
+    }
+
+    /// Execute multiple parameterized statements atomically.
+    ///
+    /// Like [`batch`](Connection::batch), but the statements are wrapped in
+    /// `BEGIN <behavior>` / `COMMIT`, with a `ROLLBACK` on failure: either
+    /// every statement commits or none does. On failure the returned
+    /// [`Error::BatchStatementFailed`](crate::Error::BatchStatementFailed)
+    /// carries the zero-based index of the failing statement.
+    ///
+    /// This method owns the surrounding transaction, so the statements must
+    /// not contain their own transaction-control SQL (`BEGIN`, `COMMIT`,
+    /// `ROLLBACK`, `SAVEPOINT`, `RELEASE`); a user-supplied `COMMIT` would
+    /// close the wrapper transaction mid-batch and leave earlier statements
+    /// committed, defeating the all-or-nothing contract. If a transaction
+    /// is already open on this connection, the wrapping is skipped and the
+    /// statements join it, exactly as with [`batch`](Connection::batch).
+    pub async fn transactional_batch<I>(
+        &self,
+        stmts: I,
+        behavior: TransactionBehavior,
+    ) -> Result<Vec<BatchResult>>
+    where
+        I: IntoIterator,
+        I::Item: IntoBatchStatement,
+    {
+        self.run_batch(stmts, Some(behavior)).await
+    }
+
+    async fn run_batch<I>(
+        &self,
+        stmts: I,
+        wrap: Option<TransactionBehavior>,
+    ) -> Result<Vec<BatchResult>>
+    where
+        I: IntoIterator,
+        I::Item: IntoBatchStatement,
+    {
+        let stmts = stmts
+            .into_iter()
+            .enumerate()
+            .map(|(index, stmt)| {
+                stmt.into_batch_statement()
+                    .map_err(|error| Error::BatchStatementFailed {
+                        index,
+                        error: Box::new(error),
+                        results: Vec::new(),
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        if stmts.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.maybe_handle_dangling_tx().await?;
+        // With a transaction already open on the connection, another BEGIN
+        // would fail; the statements join the open transaction instead
+        // (matching the serverless driver).
+        let wrap = if self.is_autocommit()? { wrap } else { None };
+        if let Some(behavior) = wrap {
+            self.execute(behavior.begin_sql(), ()).await?;
+        }
+        let statement_count = stmts.len();
+        let mut results = Vec::with_capacity(statement_count);
+        for (index, stmt) in stmts.into_iter().enumerate() {
+            match self.execute_batch_statement(stmt).await {
+                Ok(result) => results.push(result),
+                Err(error) => {
+                    // ROLLBACK errors are ignored: the statement failure is
+                    // the error being reported, and surfacing a rollback
+                    // error would mask it.
+                    if wrap.is_some() {
+                        let _ = self.execute("ROLLBACK", ()).await;
+                    }
+                    // One entry per statement: the completed statements'
+                    // results, None for the failing and skipped ones.
+                    let mut partial: Vec<Option<BatchResult>> =
+                        results.into_iter().map(Some).collect();
+                    partial.resize_with(statement_count, || None);
+                    return Err(Error::BatchStatementFailed {
+                        index,
+                        error: Box::new(error),
+                        results: partial,
+                    });
+                }
+            }
+        }
+        if wrap.is_some() {
+            if let Err(error) = self.execute("COMMIT", ()).await {
+                let _ = self.execute("ROLLBACK", ()).await;
+                return Err(error);
+            }
+        }
+        Ok(results)
+    }
+
+    /// Execute one statement of a batch, buffering its rows.
+    async fn execute_batch_statement(&self, stmt: BatchStatement) -> Result<BatchResult> {
+        let rowid_before = self.last_insert_rowid();
+        let mut prepared = self.prepare(&stmt.sql).await?;
+        let mut rows = prepared.query(stmt.params).await?;
+        let columns = rows.columns();
+        let mut buffered = Vec::new();
+        while let Some(row) = rows.next().await? {
+            buffered.push(row);
+        }
+        let rowid_after = self.last_insert_rowid();
+        // The engine tracks the inserted rowid per connection, not per
+        // statement; a change across this statement means it inserted.
+        let last_insert_rowid = (rowid_after != rowid_before).then_some(rowid_after);
+        // n_change reports the connection's last change count, which a
+        // row-returning statement does not update; report 0 for those
+        // rather than the previous statement's count, matching the server.
+        let rows_affected = if columns.is_empty() {
+            prepared.n_change()
+        } else {
+            0
+        };
+        Ok(BatchResult::new(
+            columns,
+            buffered,
+            rows_affected,
+            last_insert_rowid,
+        ))
     }
 
     /// Prepare a SQL statement for later execution.

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -36,6 +36,7 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+pub mod batch;
 pub mod connection;
 pub mod params;
 mod rows;
@@ -45,6 +46,7 @@ pub mod value;
 #[cfg(feature = "sync")]
 pub mod sync;
 
+pub use batch::{BatchResult, BatchStatement, IntoBatchStatement};
 pub use connection::Connection;
 use turso_sdk_kit::rsapi::TursoError;
 pub use turso_sdk_kit::IoBackend;
@@ -112,6 +114,21 @@ pub enum Error {
     Corrupt(String),
     #[error("I/O error ({1}): {0}")]
     IoError(std::io::ErrorKind, &'static str),
+    /// A statement of a [`batch`](crate::Connection::batch) failed.
+    /// Carries the zero-based index of the failing statement within the
+    /// batch, the underlying error, and the per-statement results.
+    #[error("batch statement {index} failed: {error}")]
+    BatchStatementFailed {
+        index: usize,
+        error: Box<Error>,
+        /// One entry per statement of the batch, in order: the result of
+        /// each statement that completed, or `None` for the failing
+        /// statement and the statements that did not run. In a
+        /// non-transactional batch the completed statements' effects are
+        /// committed; in a transactional batch they were rolled back.
+        /// Empty when the batch failed before reaching the database.
+        results: Vec<Option<BatchResult>>,
+    },
 }
 
 impl From<turso_sdk_kit::rsapi::TursoError> for Error {
@@ -563,6 +580,7 @@ impl Statement {
 }
 
 /// Column information.
+#[derive(Debug, Clone)]
 pub struct Column {
     name: String,
     decl_type: Option<String>,

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -125,9 +125,18 @@ pub enum Error {
         /// each statement that completed, or `None` for the failing
         /// statement and the statements that did not run. In a
         /// non-transactional batch the completed statements' effects are
-        /// committed; in a transactional batch they were rolled back.
+        /// committed; in a transactional batch they were rolled back unless
+        /// this error is wrapped in [`Error::BatchRollbackFailed`].
         /// Empty when the batch failed before reaching the database.
         results: Vec<Option<BatchResult>>,
+    },
+    /// The batch failed and the attempt to roll back its transaction also
+    /// failed. Both errors are preserved because the connection's transaction
+    /// state is unknown.
+    #[error("{error}; rollback also failed: {rollback_error}")]
+    BatchRollbackFailed {
+        error: Box<Error>,
+        rollback_error: Box<Error>,
     },
 }
 
@@ -379,6 +388,7 @@ pub struct Statement {
 
 struct Execute {
     stmt: Statement,
+    _operation_guard: Option<connection::ConnectionOperationGuard>,
 }
 
 assert_send_sync!(Execute);
@@ -434,6 +444,23 @@ impl Statement {
     }
     /// Query the database with this prepared statement.
     pub async fn query(&mut self, params: impl IntoParams) -> Result<Rows> {
+        let operation_guard = self.conn.acquire_shared_operation()?;
+        self.query_with_operation_guard(params, Some(operation_guard))
+            .await
+    }
+
+    pub(crate) async fn query_without_operation_guard(
+        &mut self,
+        params: impl IntoParams,
+    ) -> Result<Rows> {
+        self.query_with_operation_guard(params, None).await
+    }
+
+    async fn query_with_operation_guard(
+        &mut self,
+        params: impl IntoParams,
+        operation_guard: Option<connection::ConnectionOperationGuard>,
+    ) -> Result<Rows> {
         self.reset()?;
 
         let mut stmt = self.inner.lock().unwrap();
@@ -452,12 +479,29 @@ impl Statement {
                 }
             }
         }
-        let rows = Rows::new(self.clone());
+        let rows = Rows::new(self.clone(), operation_guard);
         Ok(rows)
     }
 
     /// Execute this prepared statement.
     pub async fn execute(&mut self, params: impl IntoParams) -> Result<u64> {
+        let operation_guard = self.conn.acquire_shared_operation()?;
+        self.execute_with_operation_guard(params, Some(operation_guard))
+            .await
+    }
+
+    pub(crate) async fn execute_without_operation_guard(
+        &mut self,
+        params: impl IntoParams,
+    ) -> Result<u64> {
+        self.execute_with_operation_guard(params, None).await
+    }
+
+    async fn execute_with_operation_guard(
+        &mut self,
+        params: impl IntoParams,
+        operation_guard: Option<connection::ConnectionOperationGuard>,
+    ) -> Result<u64> {
         {
             // Reset the statement before executing
             self.inner.lock().unwrap().reset()?;
@@ -480,7 +524,10 @@ impl Statement {
             }
         }
 
-        let execute = Execute { stmt: self.clone() };
+        let execute = Execute {
+            stmt: self.clone(),
+            _operation_guard: operation_guard,
+        };
         execute.await
     }
 
@@ -732,7 +779,9 @@ mod tests {
             .await;
 
         match query_result_after_wal_delete {
-            Ok(_) => panic!("Query succeeded after WAL deletion and DB reopen, but was expected to fail because the table definition should have been in the WAL."),
+            Ok(_) => panic!(
+                "Query succeeded after WAL deletion and DB reopen, but was expected to fail because the table definition should have been in the WAL."
+            ),
             Err(Error::Error(msg)) => {
                 assert!(
                     msg.contains("no such table: test_large_persistence"),

--- a/bindings/rust/src/rows.rs
+++ b/bindings/rust/src/rows.rs
@@ -1,15 +1,21 @@
-use crate::{assert_send_sync, Column, Error, Result, Statement, Value};
+use crate::{
+    assert_send_sync, connection::ConnectionOperationGuard, Column, Error, Result, Statement, Value,
+};
 use std::fmt::Debug;
 use std::future::Future;
 
 /// Results of a prepared statement query.
 pub struct Rows {
     inner: Statement,
+    _operation_guard: Option<ConnectionOperationGuard>,
 }
 
 impl Rows {
-    pub(crate) fn new(inner: Statement) -> Self {
-        Self { inner }
+    pub(crate) fn new(inner: Statement, operation_guard: Option<ConnectionOperationGuard>) -> Self {
+        Self {
+            inner,
+            _operation_guard: operation_guard,
+        }
     }
 
     /// Returns the number of columns in the result set.
@@ -62,7 +68,11 @@ impl Rows {
             stmt: self.inner.clone(),
         };
 
-        next.await
+        let result = next.await;
+        if !matches!(result, Ok(Some(_))) {
+            self._operation_guard.take();
+        }
+        result
     }
 }
 

--- a/bindings/rust/src/sync.rs
+++ b/bindings/rust/src/sync.rs
@@ -1090,7 +1090,9 @@ mod tests {
                 .experimental_without_rowid(true)
                 .experimental_features_string()
                 .as_deref(),
-            Some("attach,custom_types,index_method,views,vacuum,generated_columns,multiprocess_wal,without_rowid")
+            Some(
+                "attach,custom_types,index_method,views,vacuum,generated_columns,multiprocess_wal,without_rowid"
+            )
         );
     }
 

--- a/bindings/rust/src/transaction.rs
+++ b/bindings/rust/src/transaction.rs
@@ -22,6 +22,17 @@ pub enum TransactionBehavior {
     Concurrent,
 }
 
+impl TransactionBehavior {
+    pub(crate) fn begin_sql(self) -> &'static str {
+        match self {
+            TransactionBehavior::Deferred => "BEGIN DEFERRED",
+            TransactionBehavior::Immediate => "BEGIN IMMEDIATE",
+            TransactionBehavior::Exclusive => "BEGIN EXCLUSIVE",
+            TransactionBehavior::Concurrent => "BEGIN CONCURRENT",
+        }
+    }
+}
+
 /// Options for how a Transaction should behave when it is dropped.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
@@ -117,18 +128,13 @@ impl Transaction<'_> {
         conn: &Connection,
         behavior: TransactionBehavior,
     ) -> Result<Transaction<'_>> {
-        let query = match behavior {
-            TransactionBehavior::Deferred => "BEGIN DEFERRED",
-            TransactionBehavior::Immediate => "BEGIN IMMEDIATE",
-            TransactionBehavior::Exclusive => "BEGIN EXCLUSIVE",
-            TransactionBehavior::Concurrent => "BEGIN CONCURRENT",
-        };
-        // TODO: Use execute_batch instead
-        conn.execute(query, ()).await.map(move |_| Transaction {
-            conn,
-            drop_behavior: DropBehavior::Rollback,
-            in_progress: true,
-        })
+        conn.execute(behavior.begin_sql(), ())
+            .await
+            .map(move |_| Transaction {
+                conn,
+                drop_behavior: DropBehavior::Rollback,
+                in_progress: true,
+            })
     }
 
     // Use the Connection to Prepare a statement.

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -2193,3 +2193,238 @@ async fn test_typed_numeric_row_conversions() {
     assert_eq!(row.get::<f64>(4).unwrap(), -1.0);
     assert_eq!(row.get::<f64>(9).unwrap(), 9_007_199_254_740_993_i64 as f64);
 }
+
+async fn memory_connection() -> turso::Connection {
+    Builder::new_local(":memory:")
+        .build()
+        .await
+        .expect("in-memory database must open")
+        .connect()
+        .expect("connection must open")
+}
+
+#[tokio::test]
+async fn test_batch_executes_parameterized_statements_in_order() {
+    use turso::{named_params, BatchStatement};
+
+    let conn = memory_connection().await;
+    let results = conn
+        .batch(vec![
+            BatchStatement::new("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)", ()).unwrap(),
+            BatchStatement::new("INSERT INTO t (name) VALUES (?1)", ("Alice",)).unwrap(),
+            BatchStatement::new(
+                "INSERT INTO t (name) VALUES (:name)",
+                named_params![":name": "Bob"],
+            )
+            .unwrap(),
+            BatchStatement::new("SELECT name FROM t ORDER BY id", ()).unwrap(),
+        ])
+        .await
+        .unwrap();
+
+    // One result per statement, in order.
+    assert_eq!(results.len(), 4);
+    assert_eq!(results[1].rows_affected(), 1);
+    assert_eq!(results[1].last_insert_rowid(), Some(1));
+    assert_eq!(results[2].last_insert_rowid(), Some(2));
+    let select = &results[3];
+    assert_eq!(select.columns()[0].name(), "name");
+    assert_eq!(select.rows().len(), 2);
+    assert_eq!(
+        select.rows()[0].get_value(0).unwrap(),
+        Value::Text("Alice".to_string())
+    );
+    assert_eq!(
+        select.rows()[1].get_value(0).unwrap(),
+        Value::Text("Bob".to_string())
+    );
+    assert_eq!(conn.last_insert_rowid(), 2);
+}
+
+#[tokio::test]
+async fn test_batch_accepts_strings_and_pairs() {
+    let conn = memory_connection().await;
+    conn.execute("CREATE TABLE t (x INTEGER)", ())
+        .await
+        .unwrap();
+
+    conn.batch(["INSERT INTO t VALUES (1)", "INSERT INTO t VALUES (2)"])
+        .await
+        .unwrap();
+    conn.batch([
+        ("INSERT INTO t VALUES (?1)", (3,)),
+        ("INSERT INTO t VALUES (?1)", (4,)),
+    ])
+    .await
+    .unwrap();
+
+    let mut rows = conn
+        .query("SELECT count(*), sum(x) FROM t", ())
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 4);
+    assert_eq!(row.get::<i64>(1).unwrap(), 10);
+}
+
+#[tokio::test]
+async fn test_batch_error_identifies_the_failing_statement() {
+    let conn = memory_connection().await;
+    conn.execute("CREATE TABLE t (x INTEGER)", ())
+        .await
+        .unwrap();
+
+    let error = conn
+        .batch([
+            ("INSERT INTO t VALUES (?1)", (1,)),
+            ("INSERT INTO no_such_table VALUES (?1)", (2,)),
+            ("INSERT INTO t VALUES (?1)", (3,)),
+        ])
+        .await
+        .unwrap_err();
+    match error {
+        Error::BatchStatementFailed {
+            index,
+            error,
+            results,
+        } => {
+            assert_eq!(index, 1);
+            assert!(error.to_string().contains("no_such_table"), "{error}");
+            // One entry per statement: the completed first statement's
+            // result, None for the failing and skipped ones.
+            assert_eq!(results.len(), 3);
+            assert_eq!(results[0].as_ref().unwrap().rows_affected(), 1);
+            assert!(results[1].is_none());
+            assert!(results[2].is_none());
+        }
+        other => panic!("expected BatchStatementFailed, got {other:?}"),
+    }
+
+    // The batch is not transactional: the statement before the failing one
+    // keeps its effect, and the one after it never ran.
+    let mut rows = conn.query("SELECT count(*) FROM t", ()).await.unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 1);
+}
+
+#[tokio::test]
+async fn test_batch_joins_an_open_transaction() {
+    let mut conn = memory_connection().await;
+    conn.execute("CREATE TABLE t (x INTEGER)", ())
+        .await
+        .unwrap();
+
+    let tx = conn.transaction().await.unwrap();
+    tx.batch([
+        ("INSERT INTO t VALUES (?1)", (1,)),
+        ("INSERT INTO t VALUES (?1)", (2,)),
+    ])
+    .await
+    .unwrap();
+    // The batch ran inside the transaction rather than committing on its
+    // own.
+    assert!(!tx.is_autocommit().unwrap());
+    tx.rollback().await.unwrap();
+
+    let mut rows = conn.query("SELECT count(*) FROM t", ()).await.unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 0);
+}
+
+#[tokio::test]
+async fn test_empty_batch_returns_no_results() {
+    use turso::{transaction::TransactionBehavior, BatchStatement};
+
+    let conn = memory_connection().await;
+    let results = conn.batch(Vec::<BatchStatement>::new()).await.unwrap();
+    assert!(results.is_empty());
+    let results = conn
+        .transactional_batch(Vec::<BatchStatement>::new(), TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn test_transactional_batch_commits_atomically() {
+    use turso::transaction::TransactionBehavior;
+
+    let conn = memory_connection().await;
+    conn.execute("CREATE TABLE t (x INTEGER)", ())
+        .await
+        .unwrap();
+
+    let results = conn
+        .transactional_batch(
+            [
+                ("INSERT INTO t VALUES (?1)", (1,)),
+                ("INSERT INTO t VALUES (?1)", (2,)),
+            ],
+            TransactionBehavior::Immediate,
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(conn.is_autocommit().unwrap());
+
+    let mut rows = conn.query("SELECT count(*) FROM t", ()).await.unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 2);
+}
+
+#[tokio::test]
+async fn test_transactional_batch_rolls_back_on_failure() {
+    use turso::transaction::TransactionBehavior;
+
+    let conn = memory_connection().await;
+    conn.execute("CREATE TABLE t (x INTEGER)", ())
+        .await
+        .unwrap();
+
+    let error = conn
+        .transactional_batch(
+            [
+                ("INSERT INTO t VALUES (?1)", (1,)),
+                ("INSERT INTO no_such_table VALUES (?1)", (2,)),
+            ],
+            TransactionBehavior::Immediate,
+        )
+        .await
+        .unwrap_err();
+    match error {
+        Error::BatchStatementFailed { index, .. } => assert_eq!(index, 1),
+        other => panic!("expected BatchStatementFailed, got {other:?}"),
+    }
+    assert!(conn.is_autocommit().unwrap());
+
+    // The rollback undid the first insert.
+    let mut rows = conn.query("SELECT count(*) FROM t", ()).await.unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 0);
+}
+
+#[tokio::test]
+async fn test_transactional_batch_joins_an_open_transaction() {
+    use turso::transaction::TransactionBehavior;
+
+    let mut conn = memory_connection().await;
+    conn.execute("CREATE TABLE t (x INTEGER)", ())
+        .await
+        .unwrap();
+
+    // With a transaction already open the wrapping is skipped and the
+    // statements join it, so the outer rollback undoes them.
+    let tx = conn.transaction().await.unwrap();
+    tx.transactional_batch(
+        [("INSERT INTO t VALUES (?1)", (1,))],
+        TransactionBehavior::Immediate,
+    )
+    .await
+    .unwrap();
+    assert!(!tx.is_autocommit().unwrap());
+    tx.rollback().await.unwrap();
+
+    let mut rows = conn.query("SELECT count(*) FROM t", ()).await.unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 0);
+}

--- a/bindings/rust/tests/integration_tests.rs
+++ b/bindings/rust/tests/integration_tests.rs
@@ -2007,7 +2007,9 @@ async fn test_ghost_commits() {
         let conn = db.connect().unwrap();
         let actual_rows = query_i64(&conn, "SELECT COUNT(*) FROM t").await;
         if iteration % 100 == 0 {
-            eprintln!("test_ghost_commits: Iteration {iteration}, actual_rows={actual_rows}, total_successes={total_successes}, total_errors={total_errors}");
+            eprintln!(
+                "test_ghost_commits: Iteration {iteration}, actual_rows={actual_rows}, total_successes={total_successes}, total_errors={total_errors}"
+            );
         }
         assert_eq!(
             actual_rows,
@@ -2401,6 +2403,88 @@ async fn test_transactional_batch_rolls_back_on_failure() {
     let mut rows = conn.query("SELECT count(*) FROM t", ()).await.unwrap();
     let row = rows.next().await.unwrap().unwrap();
     assert_eq!(row.get::<i64>(0).unwrap(), 0);
+}
+
+#[tokio::test]
+async fn test_batch_validates_every_parameter_before_execution() {
+    use turso::BatchStatement;
+
+    let conn = memory_connection().await;
+    conn.execute("CREATE TABLE t (x REAL)", ()).await.unwrap();
+
+    let error = conn
+        .batch(vec![
+            BatchStatement::new("INSERT INTO t VALUES (?1)", (1.0,)).unwrap(),
+            BatchStatement::new("INSERT INTO t VALUES (?1)", (f64::INFINITY,)).unwrap(),
+        ])
+        .await
+        .unwrap_err();
+    match error {
+        Error::BatchStatementFailed { index, results, .. } => {
+            assert_eq!(index, 1);
+            assert!(results.is_empty());
+        }
+        other => panic!("expected BatchStatementFailed, got {other:?}"),
+    }
+
+    let mut rows = conn.query("SELECT count(*) FROM t", ()).await.unwrap();
+    assert_eq!(
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn test_transactional_batch_rejects_transaction_control_before_execution() {
+    use turso::{transaction::TransactionBehavior, BatchStatement};
+
+    let conn = memory_connection().await;
+    conn.execute("CREATE TABLE t (x INTEGER)", ())
+        .await
+        .unwrap();
+
+    let error = conn
+        .transactional_batch(
+            vec![
+                BatchStatement::new("INSERT INTO t VALUES (1)", ()).unwrap(),
+                BatchStatement::new("/* leave the wrapper */ COMMIT", ()).unwrap(),
+            ],
+            TransactionBehavior::Immediate,
+        )
+        .await
+        .unwrap_err();
+    match error {
+        Error::BatchStatementFailed { index, results, .. } => {
+            assert_eq!(index, 1);
+            assert!(results.is_empty());
+        }
+        other => panic!("expected BatchStatementFailed, got {other:?}"),
+    }
+
+    let mut rows = conn.query("SELECT count(*) FROM t", ()).await.unwrap();
+    assert_eq!(
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn test_batch_does_not_start_while_another_operation_is_active() {
+    let conn = memory_connection().await;
+    conn.execute("CREATE TABLE t (x INTEGER)", ())
+        .await
+        .unwrap();
+
+    let rows = conn.query("SELECT 1", ()).await.unwrap();
+    let error = conn
+        .clone()
+        .batch(["INSERT INTO t VALUES (1)"])
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::Misuse(message) if message.contains("busy")));
+    drop(rows);
+
+    conn.batch(["INSERT INTO t VALUES (1)"]).await.unwrap();
 }
 
 #[tokio::test]

--- a/serverless/conformance/differential/README.md
+++ b/serverless/conformance/differential/README.md
@@ -22,6 +22,26 @@ harness is in [`serverless/javascript/differential`](../../javascript/differenti
 and the Rust harness in [`serverless/rust/differential`](../../rust/differential);
 harnesses for other serverless drivers join their drivers as those land.
 
+## Driver API parity
+
+The behavioral promise above rests on an API-surface requirement:
+
+* Each serverless driver exposes the same public API as the embedded
+  driver of its language. For Rust that is `turso` (`bindings/rust`,
+  whose `Connection` is also used by the sync driver) and
+  `turso_serverless` (`serverless/rust`): the same types, method
+  signatures, and semantics on both sides.
+* Serverless drivers in other languages track the JavaScript serverless
+  driver's capabilities; a feature the JavaScript driver exposes is a gap
+  in a sibling driver until it lands there too.
+
+A feature added to one side of a pair must be added to the other in the
+same change. Where a behavioral difference is unavoidable (for example,
+metadata the HTTP protocol reports per statement but a local engine only
+tracks per connection), the difference is documented on the affected API.
+This suite is the enforcement mechanism for the behavioral half of the
+contract; extend the operation vocabulary when new API lands.
+
 ## Running against `@tursodatabase/serverless`
 
 ### 1. Create a scratch database

--- a/serverless/conformance/differential/operations.md
+++ b/serverless/conformance/differential/operations.md
@@ -21,6 +21,30 @@ operation both drivers must agree on:
 When `success` is false on both sides, error messages are not compared; they
 legitimately differ between an embedded engine and an HTTP server.
 
+## Batch results
+
+For `param_batch` the drivers must agree on the whole per-statement outcome
+of one `batch()` call, not just a single result:
+
+- On success, one result per statement, each compared on the fields above.
+- On failure, the zero-based index of the failing statement must match, and
+  the per-statement results carried by the error must match entry by entry:
+  the same statements completed (with equal results, compared on the fields
+  above) and the same statements are reported as failed or never run.
+
+Because the embedded drivers execute a batch as a sequential loop that stops
+at the first error, this comparison is also the oracle for the serverless
+drivers' server-side batch: one pipeline request must behave exactly like
+sequential execution that stops at the first failure. The server-side
+execution statistics (`rows_read`, `rows_written`, `query_duration_ms`) are
+excluded from the comparison: the serverless driver reports them and the
+embedded driver does not, by design.
+
+Note that a batch is *not* equivalent to executing the statements
+sequentially without stopping: sequential execution of ten statements where
+the fourth fails would keep executing the fifth onward, while `batch()`
+skips them.
+
 ## Operations
 
 `spec/ops.json` defines the operations. They cover, roughly grouped:
@@ -38,6 +62,10 @@ legitimately differ between an embedded engine and an HTTP server.
   (a failing statement mid-transaction followed by recovery)
 - **Errors**: `invalid`, `error_check` (both drivers must agree an SQL fails),
   `batch` (multi-statement SQL)
+- **Parameterized batches**: `param_batch` — 1-4 statements through the
+  `batch()` API, each a parameterized INSERT, a SELECT, or a statement drawn
+  from `error_sqls`, optionally atomic via a `mode` of `deferred` or
+  `immediate`
 
 ## Values
 

--- a/serverless/conformance/differential/spec/ops.json
+++ b/serverless/conformance/differential/spec/ops.json
@@ -233,6 +233,14 @@
       "desc": "Structured transaction: BEGIN -> 1-5 DML/query ops -> COMMIT or ROLLBACK"
     },
     {
+      "id": "param_batch",
+      "variant": 28,
+      "sql": "batch() of 1-4 statements over t_{prefix}_{tbl}",
+      "fields": { "stmts": "batch_stmts", "mode": "optional_batch_mode" },
+      "result": "batch",
+      "desc": "Parameterized batch through the batch() API: 1-4 statements, each an INSERT INTO t_{prefix}_{tbl} VALUES (?, ?) with random values, a SELECT a, b FROM t_{prefix}_{tbl}, or an error_sql; optionally atomic via mode (deferred or immediate)."
+    },
+    {
       "id": "error_in_transaction",
       "variant": 27,
       "sql": "BEGIN; good_op; bad_sql; recovery_op; ROLLBACK",

--- a/serverless/javascript/README.md
+++ b/serverless/javascript/README.md
@@ -70,6 +70,34 @@ await conn.transaction(async () => {
 }).concurrent();
 ```
 
+The whole batch is one HTTP request, and the statements execute in order,
+stopping at the first failure. Each returned `ResultSet` carries the
+statement's `rows`, `rowsAffected`, and `lastInsertRowid`, plus the
+server-side execution statistics `rowsRead`, `rowsWritten`, and
+`queryDurationMs`:
+
+```javascript
+const results = await conn.batch([
+  { sql: "INSERT INTO users (email) VALUES (?)", args: ["carol@example.com"] },
+  "SELECT COUNT(*) AS n FROM users",
+]);
+console.log(results[0].lastInsertRowid, results[1].rows[0].n);
+console.log(results[1].rowsRead, results[1].queryDurationMs);
+```
+
+When a statement fails, the thrown error identifies it and carries the
+results of the statements that completed:
+
+```javascript
+try {
+  await conn.batch([...statements]);
+} catch (e) {
+  // e.batchIndex: zero-based index of the failing statement.
+  // e.batchResults: one entry per statement — the completed statement's
+  // ResultSet, or null for the failing statement and those never run.
+}
+```
+
 ### Custom Headers
 
 Requests can carry extra HTTP headers, e.g. for routing through a gateway:

--- a/serverless/javascript/differential/parity.test.mjs
+++ b/serverless/javascript/differential/parity.test.mjs
@@ -89,6 +89,34 @@ function typeTag(v) {
 // Cell value comparison with float epsilon and buffer equality
 // ---------------------------------------------------------------------------
 
+/** Build the statement objects passed to `batch()` for a param_batch op. */
+function batchStatements(op) {
+  return op.stmts.map(stmt => {
+    if (stmt.insert) return { sql: `INSERT INTO ${stmt.insert} VALUES (?, ?)`, args: stmt.values };
+    if (stmt.select) return { sql: `SELECT a, b FROM ${stmt.select}` };
+    return { sql: stmt.errorSql };
+  });
+}
+
+/** Normalize one per-statement ResultSet of a batch() call (raw row mode)
+ * into the comparison shape, or null for a statement that did not
+ * complete. The server-side statistics are excluded: the serverless
+ * driver reports them and the embedded driver does not, by design. */
+function normalizeBatchResultSet(rs) {
+  if (rs == null) return null;
+  const rows = (rs.rows ?? []).map(row => Array.from(row));
+  return {
+    success: true,
+    columnCount: (rs.columns ?? []).length,
+    columnNames: rs.columns ?? [],
+    rowCount: rows.length,
+    valueTypes: rows.map(row => row.map(typeTag)),
+    values: rows,
+    affectedRows: rs.rowsAffected,
+    lastInsertRowid: rs.lastInsertRowid ?? undefined,
+  };
+}
+
 function cellsEqual(a, b) {
   if (a === null || a === undefined) return b === null || b === undefined;
   if (b === null || b === undefined) return false;
@@ -351,6 +379,19 @@ function _buildOpArb(opSpec) {
     ).map(([goodOp, badSql, recoveryOp]) => ({ kind: id, goodOp, badSql, recoveryOp }));
   }
 
+  // Parameterized batch: 1-4 statements through the batch() API
+  if (fields.stmts === 'batch_stmts') {
+    const arbBatchStmt = fc.oneof(
+      fc.tuple(arbTableName, arbValue, arbValue).map(([t, a, b]) => ({ insert: t, values: [a, b] })),
+      arbTableName.map(t => ({ select: t })),
+      fc.constantFrom(..._SPEC.constants.error_sqls).map(sql => ({ errorSql: sql })),
+    );
+    return fc.tuple(
+      fc.array(arbBatchStmt, { minLength: 1, maxLength: 4 }),
+      fc.constantFrom(undefined, 'deferred', 'immediate'),
+    ).map(([stmts, mode]) => ({ kind: id, stmts, mode }));
+  }
+
   // Fallback: constant
   return fc.constant({ kind: id });
 }
@@ -474,6 +515,18 @@ async function executeOpLocal(db, op) {
       return { success: true, lastInsertRowid: rowid };
     } catch {
       return { success: false };
+    }
+  }
+  if (op.kind === 'param_batch') {
+    try {
+      const results = await db.batch(batchStatements(op), { mode: op.mode, raw: true });
+      return { success: true, batchResults: results.map(normalizeBatchResultSet) };
+    } catch (e) {
+      return {
+        success: false,
+        batchIndex: e.batchIndex,
+        batchResults: (e.batchResults ?? []).map(normalizeBatchResultSet),
+      };
     }
   }
   if (op.kind === 'batch') {
@@ -605,6 +658,16 @@ function applyPrefix(op, prefix) {
     // into a table this test case may have created).
     op.sql = op.sql.replaceAll('{prefix}', String(prefix)).replace(re, repl);
   }
+  if (op.stmts) {
+    op.stmts = op.stmts.map(stmt => ({
+      ...stmt,
+      ...(stmt.insert ? { insert: stmt.insert.replace(re, repl) } : {}),
+      ...(stmt.select ? { select: stmt.select.replace(re, repl) } : {}),
+      ...(stmt.errorSql
+        ? { errorSql: stmt.errorSql.replaceAll('{prefix}', String(prefix)).replace(re, repl) }
+        : {}),
+    }));
+  }
   if (op.innerOps) op.innerOps = op.innerOps.map(o => applyPrefix(o, prefix));
   if (op.goodOp) op.goodOp = applyPrefix(op.goodOp, prefix);
   if (op.recoveryOp) op.recoveryOp = applyPrefix(op.recoveryOp, prefix);
@@ -663,6 +726,52 @@ testFn('api parity: local vs remote produce identical results', async (t) => {
                 `    remote: ok=${remoteResult.success} cols=${remoteResult.columnCount} rows=${remoteResult.rowCount}`
               );
               const traceDump = `\n\nFull trace (prefix=${prefix}):\n${trace.join('\n')}`;
+
+              // Parameterized batch: compare the whole per-statement
+              // outcome — every completed statement's result, and on
+              // failure the failing index and the partial results.
+              if (op.kind === 'param_batch') {
+                try {
+                  if (localResult.success !== remoteResult.success) {
+                    throw new Error(
+                      `success mismatch on op #${i} ${JSON.stringify(op)}\n` +
+                      `  local:  ${JSON.stringify(localResult)}\n` +
+                      `  remote: ${JSON.stringify(remoteResult)}`
+                    );
+                  }
+                  const local = localResult.batchResults ?? [];
+                  const remote = remoteResult.batchResults ?? [];
+                  if (local.length !== remote.length) {
+                    throw new Error(
+                      `batchResults length mismatch on op #${i} ${JSON.stringify(op)}\n` +
+                      `  local:  ${JSON.stringify(localResult)}\n` +
+                      `  remote: ${JSON.stringify(remoteResult)}`
+                    );
+                  }
+                  if (!localResult.success && localResult.batchIndex !== remoteResult.batchIndex) {
+                    throw new Error(
+                      `batchIndex mismatch on op #${i} ${JSON.stringify(op)}\n` +
+                      `  local:  ${JSON.stringify(localResult)}\n` +
+                      `  remote: ${JSON.stringify(remoteResult)}`
+                    );
+                  }
+                  for (let j = 0; j < local.length; j++) {
+                    if ((local[j] === null) !== (remote[j] === null)) {
+                      throw new Error(
+                        `statement ${j} completion mismatch on op #${i} ${JSON.stringify(op)}\n` +
+                        `  local:  ${JSON.stringify(localResult)}\n` +
+                        `  remote: ${JSON.stringify(remoteResult)}`
+                      );
+                    }
+                    if (local[j] !== null) {
+                      compareResults(local[j], remote[j], `${i} statement ${j}`, op);
+                    }
+                  }
+                } catch (e) {
+                  throw new Error(e.message + traceDump);
+                }
+                continue;
+              }
 
               // ErrorCheck only compares success/failure -- error messages legitimately differ.
               if (op.kind === 'error_check') {

--- a/serverless/javascript/integration-tests/protocol.test.mjs
+++ b/serverless/javascript/integration-tests/protocol.test.mjs
@@ -175,10 +175,23 @@ test.serial('Session.batch encodes named arguments for statement objects', async
 
   globalThis.fetch = async (url, opts) => {
     requests.push(JSON.parse(opts.body));
-    return new Response(
-      `${JSON.stringify({ baton: null, base_url: null })}\n${JSON.stringify({ type: 'step_end', affected_row_count: 1 })}\n`,
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    );
+    return new Response(JSON.stringify({
+      baton: null,
+      base_url: null,
+      results: [
+        {
+          type: 'ok',
+          response: {
+            type: 'batch',
+            result: {
+              step_results: [{ cols: [], rows: [], affected_row_count: 1, last_insert_rowid: null }],
+              step_errors: [null],
+            },
+          },
+        },
+        { type: 'ok', response: { type: 'get_autocommit', is_autocommit: true } },
+      ],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   };
 
   t.teardown(() => { globalThis.fetch = originalFetch; });
@@ -187,14 +200,15 @@ test.serial('Session.batch encodes named arguments for statement objects', async
     { sql: 'INSERT INTO users(name, age) VALUES(:name, :age)', args: { name: 'alice', age: 30 } }
   ]);
 
-  t.deepEqual(requests[0].batch.steps[0].stmt.args, []);
-  t.deepEqual(requests[0].batch.steps[0].stmt.named_args, [
+  const batchRequest = requests[0].requests[0];
+  t.is(batchRequest.type, 'batch');
+  t.deepEqual(batchRequest.batch.steps[0].stmt.args, []);
+  t.deepEqual(batchRequest.batch.steps[0].stmt.named_args, [
     { name: 'name', value: { type: 'text', value: 'alice' } },
     { name: 'age', value: { type: 'integer', value: '30' } },
   ]);
-  // The trailing step is the is_autocommit transaction-state probe.
-  const probeStep = requests[0].batch.steps.at(-1);
-  t.deepEqual(probeStep.condition, { type: 'is_autocommit' });
+  // The transaction-state check rides the same pipeline request.
+  t.deepEqual(requests[0].requests.at(-1), { type: 'get_autocommit' });
 });
 
 // --- requestHeaders ---
@@ -314,17 +328,28 @@ test.serial('per-query requestHeaders apply to batch and sequence requests', asy
 
   globalThis.fetch = async (url, opts) => {
     capturedHeaders.push(opts.headers);
-    if (url.endsWith('/v3/pipeline')) {
+    const body = JSON.parse(opts.body);
+    if (body.requests?.[0]?.type === 'batch') {
       return new Response(JSON.stringify({
         baton: null,
         base_url: null,
-        results: [{ type: 'ok', response: { type: 'sequence' } }],
+        results: [{
+          type: 'ok',
+          response: {
+            type: 'batch',
+            result: {
+              step_results: [{ cols: [], rows: [], affected_row_count: 0 }],
+              step_errors: [null],
+            },
+          },
+        }],
       }), { status: 200, headers: { 'Content-Type': 'application/json' } });
     }
-    return new Response(
-      `${JSON.stringify({ baton: null, base_url: null })}\n${JSON.stringify({ type: 'step_end', affected_row_count: 0 })}\n`,
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    );
+    return new Response(JSON.stringify({
+      baton: null,
+      base_url: null,
+      results: [{ type: 'ok', response: { type: 'sequence' } }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   };
 
   t.teardown(() => { globalThis.fetch = originalFetch; });

--- a/serverless/javascript/integration-tests/protocol.test.mjs
+++ b/serverless/javascript/integration-tests/protocol.test.mjs
@@ -211,6 +211,143 @@ test.serial('Session.batch encodes named arguments for statement objects', async
   t.deepEqual(requests[0].requests.at(-1), { type: 'get_autocommit' });
 });
 
+test.serial('Session.batch rejects every transaction-control keyword before an atomic request', async t => {
+  const session = new Session({ url: 'http://fake-host' });
+  const originalFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    throw new Error('fetch must not be called');
+  };
+  t.teardown(() => { globalThis.fetch = originalFetch; });
+
+  for (const control of [
+    'BEGIN',
+    'COMMIT',
+    'END',
+    'ROLLBACK',
+    'SAVEPOINT nested',
+    'RELEASE nested',
+    '\ufeffCOMMIT',
+  ]) {
+    const error = await t.throwsAsync(
+      () => session.batch([
+        'SELECT 1',
+        ` ; \n-- leading line comment\n; /* leading block comment */ ${control}`,
+      ], 'immediate'),
+      { instanceOf: DatabaseError },
+    );
+    t.is(error.batchIndex, 1);
+    t.deepEqual(error.batchResults, []);
+  }
+  t.false(fetchCalled);
+});
+
+test.serial('Session.batch validates every argument before sending a request', async t => {
+  const session = new Session({ url: 'http://fake-host' });
+  const originalFetch = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = async () => {
+    fetchCalled = true;
+    throw new Error('fetch must not be called');
+  };
+  t.teardown(() => { globalThis.fetch = originalFetch; });
+
+  for (const invalid of [Number.POSITIVE_INFINITY, 1n << 63n]) {
+    const error = await t.throwsAsync(
+      () => session.batch([
+        { sql: 'INSERT INTO t VALUES (?)', args: [1] },
+        { sql: 'INSERT INTO t VALUES (?)', args: [invalid] },
+      ]),
+      { instanceOf: DatabaseError },
+    );
+    t.is(error.batchIndex, 1);
+    t.deepEqual(error.batchResults, []);
+  }
+  t.false(fetchCalled);
+});
+
+test.serial('Session.batch attaches a synthetic rollback failure to the primary error', async t => {
+  const session = new Session({ url: 'http://fake-host' });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    baton: null,
+    base_url: null,
+    results: [
+      {
+        type: 'ok',
+        response: {
+          type: 'batch',
+          result: {
+            step_results: [
+              { cols: [], rows: [], affected_row_count: 0, last_insert_rowid: null },
+              null,
+              null,
+              null,
+            ],
+            step_errors: [
+              null,
+              { message: 'statement failed', code: 'SQLITE_ERROR' },
+              null,
+              { message: 'rollback failed', code: 'SQLITE_IOERR' },
+            ],
+          },
+        },
+      },
+      { type: 'ok', response: { type: 'get_autocommit', is_autocommit: true } },
+    ],
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  t.teardown(() => { globalThis.fetch = originalFetch; });
+
+  const error = await t.throwsAsync(
+    () => session.batch(['SELECT * FROM missing'], 'immediate'),
+    { instanceOf: DatabaseError, message: 'statement failed' },
+  );
+  t.is(error.batchIndex, 0);
+  t.true(error.rollbackError instanceof DatabaseError);
+  t.is(error.rollbackError.message, 'rollback failed');
+  t.is(error.rollbackError.code, 'SQLITE_IOERR');
+});
+
+test.serial('Session.batch never ignores a standalone rollback error', async t => {
+  const session = new Session({ url: 'http://fake-host' });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    baton: null,
+    base_url: null,
+    results: [
+      {
+        type: 'ok',
+        response: {
+          type: 'batch',
+          result: {
+            step_results: [
+              { cols: [], rows: [], affected_row_count: 0, last_insert_rowid: null },
+              { cols: [], rows: [], affected_row_count: 0, last_insert_rowid: null },
+              { cols: [], rows: [], affected_row_count: 0, last_insert_rowid: null },
+              null,
+            ],
+            step_errors: [
+              null,
+              null,
+              null,
+              { message: 'unexpected rollback failure', code: 'SQLITE_IOERR' },
+            ],
+          },
+        },
+      },
+      { type: 'ok', response: { type: 'get_autocommit', is_autocommit: true } },
+    ],
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  t.teardown(() => { globalThis.fetch = originalFetch; });
+
+  const error = await t.throwsAsync(
+    () => session.batch(['SELECT 1'], 'immediate'),
+    { instanceOf: DatabaseError, message: 'unexpected rollback failure' },
+  );
+  t.is(error.code, 'SQLITE_IOERR');
+});
+
 // --- requestHeaders ---
 
 test.serial('Session attaches requestHeaders and lets them override Authorization', async t => {

--- a/serverless/javascript/integration-tests/serverless.test.mjs
+++ b/serverless/javascript/integration-tests/serverless.test.mjs
@@ -39,12 +39,12 @@ test.serial('prepare() method creates statement', async t => {
   const stmt = await client.prepare('SELECT * FROM test_users WHERE name = ?');
   
   const row = await stmt.get(['John Doe']);
-  t.is(row[1], 'John Doe');
-  t.is(row[2], 'john@example.com');
+  t.is(row.name, 'John Doe');
+  t.is(row.email, 'john@example.com');
   
   const rows = await stmt.all(['John Doe']);
   t.is(rows.length, 1);
-  t.is(rows[0][1], 'John Doe');
+  t.is(rows[0].name, 'John Doe');
 });
 
 test.serial('Statement.run()', async t => {
@@ -66,7 +66,7 @@ test.serial('statement iterate() method works', async t => {
   }
   
   t.true(rows.length >= 1);
-  t.is(rows[0][1], 'John Doe');
+  t.is(rows[0].name, 'John Doe');
 });
 
 test.serial('batch() method executes multiple statements', async t => {
@@ -88,11 +88,79 @@ test.serial('batch() method executes multiple statements', async t => {
   t.is(countRow.count, 3);
 });
 
+test.serial('batch() returns per-statement details and statistics', async t => {
+  await client.exec('DROP TABLE IF EXISTS test_batch_details');
+
+  const results = await client.batch([
+    'CREATE TABLE test_batch_details (id INTEGER PRIMARY KEY, name TEXT)',
+    { sql: 'INSERT INTO test_batch_details (name) VALUES (?)', args: ['Alice'] },
+    { sql: 'INSERT INTO test_batch_details (name) VALUES (?)', args: ['Bob'] },
+    'SELECT name FROM test_batch_details ORDER BY id',
+  ]);
+
+  t.is(results.length, 4);
+  t.is(results[1].rowsAffected, 1);
+  t.is(results[1].lastInsertRowid, 1);
+  t.is(results[2].lastInsertRowid, 2);
+  t.deepEqual(results[3].rows.map(row => row.name), ['Alice', 'Bob']);
+  // Server-side execution statistics are reported per statement.
+  for (const result of results) {
+    t.is(typeof result.rowsRead, 'number');
+    t.is(typeof result.rowsWritten, 'number');
+    t.is(typeof result.queryDurationMs, 'number');
+  }
+  t.true(results[1].rowsWritten >= 1);
+});
+
+test.serial('batch() failure reports the failing statement and completed results', async t => {
+  await client.exec('DROP TABLE IF EXISTS test_batch_fail');
+  await client.exec('CREATE TABLE test_batch_fail (x)');
+
+  const error = await t.throwsAsync(() =>
+    client.batch([
+      { sql: 'INSERT INTO test_batch_fail VALUES (?)', args: [1] },
+      { sql: 'INSERT INTO test_batch_missing VALUES (?)', args: [2] },
+      { sql: 'INSERT INTO test_batch_fail VALUES (?)', args: [3] },
+    ])
+  );
+  t.is(error.batchIndex, 1);
+  // One entry per statement: the completed first statement's ResultSet,
+  // null for the failing statement and the skipped statement after it.
+  t.is(error.batchResults.length, 3);
+  t.is(error.batchResults[0].rowsAffected, 1);
+  t.is(error.batchResults[1], null);
+  t.is(error.batchResults[2], null);
+
+  // Execution stopped at the failure: the first statement committed, the
+  // third never ran.
+  const countRow = await client.get('SELECT COUNT(*) as count FROM test_batch_fail');
+  t.is(countRow.count, 1);
+});
+
+test.serial('atomic batch() failure rolls back and reports the failing statement', async t => {
+  await client.exec('DROP TABLE IF EXISTS test_batch_atomic');
+  await client.exec('CREATE TABLE test_batch_atomic (x)');
+
+  const error = await t.throwsAsync(() =>
+    client.batch(
+      [
+        { sql: 'INSERT INTO test_batch_atomic VALUES (?)', args: [1] },
+        { sql: 'INSERT INTO test_batch_missing VALUES (?)', args: [2] },
+      ],
+      'immediate'
+    )
+  );
+  t.is(error.batchIndex, 1);
+  t.is(error.batchResults.length, 2);
+
+  const countRow = await client.get('SELECT COUNT(*) as count FROM test_batch_atomic');
+  t.is(countRow.count, 0);
+});
+
 test.serial('get() method queries a single value', async t => {
   const row = await client.get('SELECT 42 AS answer');
 
   t.is(row.answer, 42);
-  t.is(row[0], 42);
 });
 
 test.serial('get() method queries a single row', async t => {
@@ -109,10 +177,6 @@ test.serial('get() method queries a single row', async t => {
     ["three", 0.5],
   ]);
 
-  // Positional access is also available
-  t.is(r[0], 1);
-  t.is(r[1], "two");
-  t.is(r[2], 0.5);
 });
 
 test.serial('error handling works correctly', async t => {

--- a/serverless/javascript/src/compat.ts
+++ b/serverless/javascript/src/compat.ts
@@ -90,16 +90,12 @@ export interface ResultSet {
 /**
  * Result set returned by batch().
  */
-export interface BatchResultSet {
-  /** Column names in the result set */
-  columns: Array<string>;
-  /** Column type information */
-  columnTypes: Array<string>;
-  /** Result rows */
-  rows: Array<BatchRow>;
-  /** Number of rows affected by the statement */
-  rowsAffected: number;
-}
+/**
+ * Result set returned for each statement of `batch()`. Matches the libSQL
+ * client's `ResultSet` shape exactly, including `lastInsertRowid` and
+ * `toJSON()`.
+ */
+export type BatchResultSet = ResultSet;
 
 /**
  * libSQL-compatible error class with error codes.
@@ -267,13 +263,25 @@ class LibSQLClient implements Client {
     return resultSet;
   }
 
+  /** Wrap a batch failure in a LibsqlError, preserving the per-statement
+   * metadata batch() attaches. */
+  private wrapBatchError(error: any): LibsqlError {
+    const wrapped = mapDatabaseError(error, "BATCH_ERROR");
+    if (error?.batchIndex !== undefined) {
+      (wrapped as any).batchIndex = error.batchIndex;
+    }
+    if (error?.batchResults !== undefined) {
+      (wrapped as any).batchResults = error.batchResults.map((result: any) =>
+        result === null ? null : this.convertBatchResult(result),
+      );
+    }
+    return wrapped;
+  }
+
   private convertBatchResult(result: any): BatchResultSet {
-    return {
-      columns: result.columns || [],
-      columnTypes: result.columnTypes || [],
-      rows: result.rows || [],
-      rowsAffected: result.rowsAffected || 0,
-    };
+    // libSQL's batch() returns full ResultSets, lastInsertRowid and
+    // toJSON() included; conform exactly.
+    return this.convertResult(result);
   }
 
   private normalizeBatchOptions(options?: TransactionMode | BatchOptions): { mode?: TransactionMode; raw: boolean } {
@@ -346,7 +354,7 @@ class LibSQLClient implements Client {
       if (error instanceof LibsqlError) {
         throw error;
       }
-      throw mapDatabaseError(error, "BATCH_ERROR");
+      throw this.wrapBatchError(error);
     } finally {
       this.execLock.release();
     }
@@ -438,7 +446,10 @@ class LibSQLClient implements Client {
           );
           return results.map((result: any) => this.convertBatchResult(result));
         } catch (error: any) {
-          throw mapDatabaseError(error, "BATCH_ERROR");
+          if (error instanceof LibsqlError) {
+            throw error;
+          }
+          throw this.wrapBatchError(error);
         }
       },
       executeMultiple: async (sql: string): Promise<void> => {

--- a/serverless/javascript/src/connection.ts
+++ b/serverless/javascript/src/connection.ts
@@ -4,6 +4,7 @@ import { Statement } from './statement.js';
 import { type QueryOptions } from './protocol.js';
 import { normalizeArgs, splitBindParameters } from './args.js';
 import { createExpandedRow } from './row.js';
+import { DatabaseError } from './error.js';
 
 export type { BatchMode } from './session.js';
 
@@ -40,12 +41,32 @@ function normalizeBatchOptions(options?: BatchMode | BatchOptions): { mode?: Bat
  * libsql-js batch ResultSet shape.
  */
 function toResultSet(result: any): any {
-  return {
+  const resultSet: any = {
     columns: result.columns ?? [],
     columnTypes: result.columnTypes ?? [],
     rows: result.rows ?? [],
     rowsAffected: result.rowsAffected ?? 0,
+    rowsRead: result.rowsRead,
+    rowsWritten: result.rowsWritten,
+    queryDurationMs: result.queryDurationMs,
   };
+  // Present only for statements that inserted, like the embedded driver.
+  if (result.lastInsertRowid !== undefined) {
+    resultSet.lastInsertRowid = result.lastInsertRowid;
+  }
+  return resultSet;
+}
+
+/** Shape the per-statement results carried by a batch error into the
+ * ResultSet shape, so `error.batchResults` matches what `batch()` would
+ * have returned. */
+function shapeBatchError(error: any): any {
+  if (error instanceof DatabaseError && Array.isArray(error.batchResults)) {
+    error.batchResults = error.batchResults.map((result: any) =>
+      result === null ? null : toResultSet(result),
+    );
+  }
+  return error;
 }
 
 
@@ -256,14 +277,23 @@ export class Connection {
   /**
    * Executes a batch of SQL statements over this connection.
    *
+   * The batch is dispatched as a single request, so it always completes
+   * in one round-trip, and executes in order, stopping at the first
+   * statement that fails: the remaining statements are skipped and the
+   * thrown `DatabaseError` carries `batchIndex` (the zero-based index of
+   * the failing statement) and `batchResults` (one entry per input
+   * statement — the completed statement's `ResultSet`, or `null` for the
+   * failing statement and the statements that did not run; empty when
+   * the batch failed client-side before anything was sent).
+   *
    * By default, batch() is not transactional: each statement runs in its
    * own autocommit step, so a failure mid-batch leaves earlier successful
-   * statements committed. Pass a `mode` to make the batch atomic — the
-   * statements are wrapped in `BEGIN <mode>` / `COMMIT` (with `ROLLBACK`
-   * on failure) and dispatched as a single Hrana request, so the whole
-   * batch completes in one round-trip. When called from inside a
-   * `connection.transaction(...)` callback the `mode` argument is ignored
-   * and the surrounding transaction is reused.
+   * statements committed (their results are in `batchResults`). Pass a
+   * `mode` to make the batch atomic — the statements are wrapped in
+   * `BEGIN <mode>` / `COMMIT` (with `ROLLBACK` on failure) carried by the
+   * same request. When called from inside a `connection.transaction(...)`
+   * callback the `mode` argument is ignored and the surrounding
+   * transaction is reused.
    *
    * When `mode` is set, `batch()` owns the surrounding
    * `BEGIN`/`COMMIT`/`ROLLBACK`, so the `statements` array must not
@@ -280,7 +310,9 @@ export class Connection {
    *   inside a transaction.
    * @returns An array of `ResultSet`s — one per input statement, in order —
    *   matching the libsql-js batch contract. Each `ResultSet` carries that
-   *   statement's `columns`, `columnTypes`, `rows`, and `rowsAffected`.
+   *   statement's `columns`, `columnTypes`, `rows`, `rowsAffected`, and
+   *   `lastInsertRowid`, plus the server-side execution statistics
+   *   `rowsRead`, `rowsWritten`, and `queryDurationMs`.
    *
    * @example
    * // Plain SQL strings (non-atomic).
@@ -333,6 +365,8 @@ export class Connection {
         raw,
       );
       return results.map((result: any) => toResultSet(result));
+    } catch (error) {
+      throw shapeBatchError(error);
     } finally {
       this.execLock.release();
     }
@@ -694,14 +728,18 @@ export class Transaction {
     }
     const { raw } = normalizeBatchOptions(options);
     return await this.withGate(async () => {
-      const results = await this.session.batch(
-        statements,
-        undefined,
-        queryOptions,
-        this.defaultSafeIntegerMode,
-        raw,
-      );
-      return results.map((result: any) => toResultSet(result));
+      try {
+        const results = await this.session.batch(
+          statements,
+          undefined,
+          queryOptions,
+          this.defaultSafeIntegerMode,
+          raw,
+        );
+        return results.map((result: any) => toResultSet(result));
+      } catch (error) {
+        throw shapeBatchError(error);
+      }
     });
   }
 }

--- a/serverless/javascript/src/connection.ts
+++ b/serverless/javascript/src/connection.ts
@@ -69,7 +69,6 @@ function shapeBatchError(error: any): any {
   return error;
 }
 
-
 /**
  * A connection to a Turso database.
  *
@@ -298,10 +297,8 @@ export class Connection {
    * When `mode` is set, `batch()` owns the surrounding
    * `BEGIN`/`COMMIT`/`ROLLBACK`, so the `statements` array must not
    * contain its own transaction-control SQL (`BEGIN`, `COMMIT`,
-   * `ROLLBACK`, `SAVEPOINT`, `RELEASE`). The input is not validated
-   * for that — a user-supplied `COMMIT` will close the wrapper
-   * transaction mid-batch and leave earlier statements committed,
-   * defeating the all-or-nothing contract.
+   * `END`, `ROLLBACK`, `SAVEPOINT`, `RELEASE`). Such input is rejected
+   * before the batch starts.
    *
    * @param statements - An array of SQL strings or `{ sql, args }` objects.
    * @param mode - When set, makes the batch atomic. Accepts the same

--- a/serverless/javascript/src/error.ts
+++ b/serverless/javascript/src/error.ts
@@ -13,9 +13,11 @@ export class DatabaseError extends Error {
    * order — the completed statement's `ResultSet`, or `null` for the
    * failing statement and the statements that did not run. In a
    * non-atomic batch the completed statements' effects are committed; in
-   * an atomic batch they were rolled back. Empty when the batch failed
-   * client-side before anything was sent. */
+   * an atomic batch they were rolled back unless `rollbackError` is set.
+   * Empty when the batch failed client-side before anything was sent. */
   batchResults?: Array<any | null>;
+  /** A rollback error that occurred while handling this error. */
+  rollbackError?: Error;
 
   constructor(message: string, code?: string, rawCode?: number, cause?: Error) {
     super(message);

--- a/serverless/javascript/src/error.ts
+++ b/serverless/javascript/src/error.ts
@@ -5,6 +5,17 @@ export class DatabaseError extends Error {
   rawCode?: number;
   /** Original error that caused this error */
   declare cause?: Error;
+  /** For errors raised by `batch()`: the zero-based index of the failing
+   * statement, when a user statement (rather than the surrounding
+   * transaction control) failed. */
+  batchIndex?: number;
+  /** For errors raised by `batch()`: one entry per input statement, in
+   * order — the completed statement's `ResultSet`, or `null` for the
+   * failing statement and the statements that did not run. In a
+   * non-atomic batch the completed statements' effects are committed; in
+   * an atomic batch they were rolled back. Empty when the batch failed
+   * client-side before anything was sent. */
+  batchResults?: Array<any | null>;
 
   constructor(message: string, code?: string, rawCode?: number, cause?: Error) {
     super(message);

--- a/serverless/javascript/src/protocol.ts
+++ b/serverless/javascript/src/protocol.ts
@@ -16,6 +16,18 @@ export interface ExecuteResult {
   rows: Value[][];
   affected_row_count: number;
   last_insert_rowid?: string | number;
+  rows_read?: number;
+  rows_written?: number;
+  query_duration_ms?: number;
+}
+
+/** The result of a `batch` pipeline request (PROTOCOL.md section 6.2):
+ * one entry per step in each array. A step that executed has its result
+ * set, a step that failed has its error set, and a step skipped by its
+ * condition has both set to null. */
+export interface BatchResultData {
+  step_results: Array<ExecuteResult | null>;
+  step_errors: Array<{ message: string; code?: string; extended_code?: string } | null>;
 }
 
 export interface NamedArg {
@@ -95,7 +107,7 @@ export interface PipelineResponse {
     type: 'ok' | 'error';
     response?: {
       type: 'execute' | 'batch' | 'sequence' | 'close' | 'describe' | 'get_autocommit';
-      result?: ExecuteResult | DescribeResult;
+      result?: ExecuteResult | DescribeResult | BatchResultData;
       is_autocommit?: boolean;
     };
     error?: {

--- a/serverless/javascript/src/protocol.ts
+++ b/serverless/javascript/src/protocol.ts
@@ -137,6 +137,9 @@ export function encodeValue(value: any): Value {
   }
   
   if (typeof value === 'bigint') {
+    if (value < -(1n << 63n) || value > (1n << 63n) - 1n) {
+      throw new Error("BigInt value is outside SQLite's signed 64-bit integer range");
+    }
     return { type: 'integer', value: value.toString() };
   }
   

--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -2,6 +2,7 @@ import {
   executeCursor,
   executePipeline,
   decodeValue,
+  type BatchResultData,
   type BatchStep,
   type CursorRequest,
   type CursorResponse,
@@ -12,6 +13,7 @@ import {
   type CloseRequest,
   type DescribeRequest,
   type DescribeResult,
+  type ExecuteResult,
   type GetAutocommitRequest,
   type QueryOptions,
   type HttpContext,
@@ -432,11 +434,14 @@ export class Session {
   /**
    * Execute multiple SQL statements in a batch.
    *
-   * When `mode` is set, the batch is sent as a single Hrana request that
-   * also carries `BEGIN <mode>` / `COMMIT` / `ROLLBACK` steps using the
-   * server-side condition chain, giving atomic execution in one round-trip.
-   * When `mode` is omitted, the user statements are sent as-is and run
-   * under autocommit (or whatever transaction is already active on this
+   * The batch is sent as a single `batch` request on the pipeline
+   * endpoint (PROTOCOL.md section 6.2), so the whole batch completes in
+   * one round-trip. Each statement is gated on its predecessor
+   * succeeding, so execution stops at the first failure. When `mode` is
+   * set, the request also carries `BEGIN <mode>` / `COMMIT` / `ROLLBACK`
+   * steps using the server-side condition chain, giving atomic
+   * execution. When `mode` is omitted, the statements run under
+   * autocommit (or whatever transaction is already active on this
    * stream).
    *
    * @param statements - Array of SQL statements to execute.
@@ -447,7 +452,11 @@ export class Session {
    *   BigInt rather than Number.
    * @returns Promise resolving to an array of per-statement results — one
    *   per input statement, in order — each carrying that statement's
-   *   `columns`, `columnTypes`, `rows`, and `rowsAffected`.
+   *   `columns`, `columnTypes`, `rows`, `rowsAffected`, `lastInsertRowid`,
+   *   and the server-side execution statistics `rowsRead`, `rowsWritten`,
+   *   and `queryDurationMs`. On failure the thrown `DatabaseError` carries
+   *   `batchIndex` (the failing statement) and `batchResults` (the results
+   *   of the statements that completed).
    */
   async batch(
     statements: Array<string | { sql: string; args?: any[] | Record<string, any> }>,
@@ -456,13 +465,26 @@ export class Session {
     safeIntegers: boolean = false,
     raw: boolean = false,
   ): Promise<any> {
-    const userSteps: BatchStep[] = statements.map(statement => {
+    const userSteps: BatchStep[] = statements.map((statement, index) => {
       if (typeof statement === 'string') {
         return {
           stmt: { sql: statement, args: [], named_args: [], want_rows: true },
         };
       }
-      const encodedArgs = encodeSqlArgs(statement.args ?? []);
+      // A value that cannot be encoded fails client-side before anything
+      // is sent; report it with the statement's index like any other
+      // statement failure. Nothing has executed, so batchResults is empty.
+      let encodedArgs;
+      try {
+        encodedArgs = encodeSqlArgs(statement.args ?? []);
+      } catch (e: any) {
+        const error = new DatabaseError(
+          `batch statement ${index} failed: ${e?.message ?? e}`,
+        );
+        error.batchIndex = index;
+        error.batchResults = [];
+        throw error;
+      }
       return {
         stmt: {
           sql: statement.sql,
@@ -475,12 +497,15 @@ export class Session {
 
     let steps: BatchStep[];
     let firstUserStepIdx = 0;
-    let lastUserStepIdx = userSteps.length - 1;
     let beginIdx = -1;
     let commitIdx = -1;
-    let rollbackIdx = -1;
     if (mode === undefined) {
-      steps = userSteps;
+      // Each statement is gated on its predecessor succeeding, so
+      // execution stops at the first failure (matching the Rust and
+      // Python drivers and the `sequence` request).
+      steps = userSteps.map((step, i) =>
+        i === 0 ? step : { ...step, condition: { type: 'ok' as const, step: i - 1 } },
+      );
     } else {
       // Atomic batch: BEGIN <mode>, then each user step gated on its
       // predecessor succeeding, then COMMIT gated on the last user step
@@ -490,9 +515,8 @@ export class Session {
       // stream out of band (e.g. via session.execute("BEGIN")).
       beginIdx = 0;
       firstUserStepIdx = 1;
-      lastUserStepIdx = userSteps.length; // 1..userSteps.length inclusive
+      const lastUserStepIdx = userSteps.length; // 1..userSteps.length inclusive
       commitIdx = lastUserStepIdx + 1;
-      rollbackIdx = commitIdx + 1;
       steps = [
         { stmt: { sql: `BEGIN ${normalizeBatchMode(mode)}`, args: [], named_args: [], want_rows: false } },
         ...userSteps.map((step, i) => ({
@@ -516,121 +540,120 @@ export class Session {
       ];
     }
 
-    const probeIdx = steps.length;
-    const request: CursorRequest = {
+    const request: PipelineRequest = {
       baton: this.baton,
-      batch: { steps: [...steps, Session.autocommitProbeStep()] },
+      requests: [
+        { type: 'batch', batch: { steps } },
+        { type: 'get_autocommit' },
+      ],
     };
 
-    let batchResult;
+    let response: PipelineResponse;
     try {
-      batchResult = await executeCursor(this.httpContext(queryOptions), request, this.createAbortSignal(queryOptions));
+      response = await executePipeline(this.httpContext(queryOptions), request, this.createAbortSignal(queryOptions));
     } catch (e) {
       this.baton = null;
       this.autocommit = true;
       throw e;
     }
 
-    const { response, entries } = batchResult;
     this.baton = response.baton;
     if (response.base_url) {
       this.baseUrl = normalizeUrl(response.base_url);
     }
+    this.updateAutocommit(response);
 
-    // One result per user statement, in input order.
-    const results = userSteps.map(() => ({
-      columns: [] as string[],
-      columnTypes: [] as string[],
-      rows: [] as any[],
-      rowsAffected: 0,
-    }));
-    let deferredError: DatabaseError | null = null;
+    const first = response.results?.[0];
+    if (!first) {
+      throw new DatabaseError('missing batch result in pipeline response');
+    }
+    if (first.type === 'error') {
+      throw new DatabaseError(first.error?.message || 'Batch execution failed', first.error?.code);
+    }
+    if (first.response?.type !== 'batch') {
+      throw new DatabaseError(`expected batch result in pipeline response, got ${first.response?.type}`);
+    }
+    const batchResult = first.response.result as BatchResultData | undefined;
+    const stepResults = batchResult?.step_results;
+    const stepErrors = batchResult?.step_errors;
+    if (
+      !Array.isArray(stepResults) ||
+      !Array.isArray(stepErrors) ||
+      stepResults.length !== steps.length ||
+      stepErrors.length !== steps.length
+    ) {
+      throw new DatabaseError('batch response does not have one result and one error per step');
+    }
 
-    // step_end / row entries don't carry a step index on the wire; the Hrana
-    // server only puts `step` on step_begin / step_error. Track the current
-    // step via step_begin so we know which user statement a row or step_end
-    // belongs to. Maps the wire step index to a slot in `results`, or
-    // undefined for the synthetic BEGIN/COMMIT/ROLLBACK steps.
-    let currentResultIdx: number | undefined;
-    // Fallback for responses that omit step_begin (e.g. simplified mocks):
-    // in non-atomic mode every step_end advances to the next user statement.
-    let nextNonAtomicIdx = 0;
-    const stepToResultIdx = (step: number | undefined): number | undefined => {
-      if (mode === undefined) {
-        // Non-atomic batch: every step is a user step, in order.
-        return step ?? nextNonAtomicIdx;
+    // One result per user statement, in input order; null for statements
+    // that did not complete.
+    const results: Array<any | null> = statements.map((_, i) => {
+      const stepResult = stepResults[firstUserStepIdx + i];
+      return stepResult ? this.decodeBatchStepResult(stepResult, safeIntegers, raw) : null;
+    });
+
+    // Surface the failing step: BEGIN first, then the user statements
+    // (with their index), then COMMIT. Errors on the synthetic ROLLBACK
+    // step are suppressed — by the time it runs the transaction has
+    // already been undone and surfacing a ROLLBACK error would mask the
+    // real cause.
+    const throwStepError = (error: { message?: string; code?: string } | null, batchIndex?: number): never => {
+      const e = new DatabaseError(error?.message || 'Batch execution failed', error?.code);
+      if (batchIndex !== undefined) {
+        e.batchIndex = batchIndex;
       }
-      if (step !== undefined && step >= firstUserStepIdx && step <= lastUserStepIdx) {
-        return step - firstUserStepIdx;
-      }
-      return undefined;
+      e.batchResults = results;
+      throw e;
     };
-
-    for await (const entry of this.trackAutocommit(entries, probeIdx, queryOptions)) {
-      // Once a step has errored the whole batch will throw, so stop
-      // decoding and buffering later steps' results while draining the
-      // rest of the stream for the probe. Fatal stream errors still
-      // surface below.
-      if (deferredError !== null && entry.type !== 'error') {
-        continue;
-      }
-      switch (entry.type) {
-        case 'step_begin':
-          currentResultIdx = stepToResultIdx(entry.step);
-          if (currentResultIdx !== undefined && currentResultIdx < results.length && entry.cols) {
-            results[currentResultIdx].columns = entry.cols.map(col => col.name);
-            results[currentResultIdx].columnTypes = entry.cols.map(col => col.decltype || '');
-          }
-          break;
-        case 'row':
-          if (currentResultIdx !== undefined && currentResultIdx < results.length && entry.row) {
-            const decodedRow = entry.row.map(value => decodeValue(value, safeIntegers));
-            const row = raw
-              ? decodedRow
-              : this.createObjectRow(decodedRow, results[currentResultIdx].columns);
-            results[currentResultIdx].rows.push(row);
-          }
-          break;
-        case 'step_end': {
-          let idx = currentResultIdx;
-          if (idx === undefined && mode === undefined) {
-            idx = nextNonAtomicIdx;
-          }
-          if (idx !== undefined && idx < results.length) {
-            if (entry.affected_row_count !== undefined) {
-              results[idx].rowsAffected = results[idx].columns.length > 0
-                ? 0
-                : entry.affected_row_count;
-            }
-          }
-          if (mode === undefined && idx !== undefined) {
-            nextNonAtomicIdx = idx + 1;
-          }
-          currentResultIdx = undefined;
-          break;
-        }
-        case 'step_error':
-          // Capture the first error from BEGIN, any user step, or COMMIT
-          // and keep draining so the trailing probe (and, in atomic mode,
-          // ROLLBACK) is still observed. Errors on the synthetic ROLLBACK
-          // step are suppressed — by the time it runs the transaction has
-          // already been undone and surfacing a ROLLBACK error would mask
-          // the real cause we already captured.
-          if (deferredError === null && entry.step !== rollbackIdx) {
-            deferredError = new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
-          }
-          currentResultIdx = undefined;
-          break;
-        case 'error':
-          throw new DatabaseError(entry.error?.message || 'Batch execution failed', entry.error?.code);
+    if (beginIdx >= 0 && stepErrors[beginIdx]) {
+      throwStepError(stepErrors[beginIdx]);
+    }
+    for (let i = 0; i < userSteps.length; i++) {
+      const stepError = stepErrors[firstUserStepIdx + i];
+      if (stepError) {
+        throwStepError(stepError, i);
       }
     }
-
-    if (deferredError !== null) {
-      throw deferredError;
+    if (commitIdx >= 0 && stepErrors[commitIdx]) {
+      throwStepError(stepErrors[commitIdx]);
     }
 
+    if (results.some(result => result === null)) {
+      throw new DatabaseError('batch response is missing statement results');
+    }
     return results;
+  }
+
+  /** Decode one statement result of a batch response (section 8.4) into
+   * the per-statement result shape returned by `batch()`. */
+  private decodeBatchStepResult(stepResult: ExecuteResult, safeIntegers: boolean, raw: boolean): any {
+    const columns = (stepResult.cols ?? []).map(col => col.name ?? '');
+    const columnTypes = (stepResult.cols ?? []).map(col => col.decltype || '');
+    const rows = (stepResult.rows ?? []).map(row => {
+      const decoded = row.map(value => decodeValue(value, safeIntegers));
+      return raw ? decoded : this.createObjectRow(decoded, columns);
+    });
+    let lastInsertRowid: number | undefined;
+    if (stepResult.last_insert_rowid !== undefined && stepResult.last_insert_rowid !== null) {
+      lastInsertRowid = typeof stepResult.last_insert_rowid === 'number'
+        ? stepResult.last_insert_rowid
+        : parseInt(stepResult.last_insert_rowid, 10);
+    }
+    const resultSet: any = {
+      columns,
+      columnTypes,
+      rows,
+      rowsAffected: columns.length > 0 ? 0 : (stepResult.affected_row_count ?? 0),
+      rowsRead: stepResult.rows_read,
+      rowsWritten: stepResult.rows_written,
+      queryDurationMs: stepResult.query_duration_ms,
+    };
+    // Only statements that inserted carry the key, so callers can use
+    // `"lastInsertRowid" in resultSet` to detect an insert.
+    if (lastInsertRowid !== undefined) {
+      resultSet.lastInsertRowid = lastInsertRowid;
+    }
+    return resultSet;
   }
 
   /**

--- a/serverless/javascript/src/session.ts
+++ b/serverless/javascript/src/session.ts
@@ -27,6 +27,15 @@ import { encodeSqlArgs } from './args.js';
  */
 export type BatchMode = 'write' | 'read' | 'deferred' | 'immediate' | 'exclusive' | 'concurrent' | string;
 
+const TRANSACTION_CONTROL_KEYWORDS = new Set([
+  'BEGIN',
+  'COMMIT',
+  'END',
+  'ROLLBACK',
+  'SAVEPOINT',
+  'RELEASE',
+]);
+
 function normalizeBatchMode(mode: BatchMode): string {
   switch (String(mode).toLowerCase()) {
     case 'write':
@@ -43,6 +52,37 @@ function normalizeBatchMode(mode: BatchMode): string {
     default:
       return String(mode).toUpperCase();
   }
+}
+
+function firstSqlKeyword(sql: string): string | undefined {
+  let offset = 0;
+  while (offset < sql.length) {
+    if (/\s/.test(sql[offset]) || sql[offset] === ';') {
+      offset++;
+      continue;
+    }
+    if (sql.startsWith('--', offset)) {
+      const newline = sql.indexOf('\n', offset + 2);
+      if (newline < 0) return undefined;
+      offset = newline + 1;
+      continue;
+    }
+    if (sql.startsWith('/*', offset)) {
+      const end = sql.indexOf('*/', offset + 2);
+      if (end < 0) return undefined;
+      offset = end + 2;
+      continue;
+    }
+    break;
+  }
+  return /^[A-Za-z]+/.exec(sql.slice(offset))?.[0].toUpperCase();
+}
+
+function batchInputError(index: number, message: string): DatabaseError {
+  const error = new DatabaseError(`batch statement ${index} failed: ${message}`);
+  error.batchIndex = index;
+  error.batchResults = [];
+  return error;
 }
 
 /**
@@ -478,12 +518,7 @@ export class Session {
       try {
         encodedArgs = encodeSqlArgs(statement.args ?? []);
       } catch (e: any) {
-        const error = new DatabaseError(
-          `batch statement ${index} failed: ${e?.message ?? e}`,
-        );
-        error.batchIndex = index;
-        error.batchResults = [];
-        throw error;
+        throw batchInputError(index, e?.message ?? String(e));
       }
       return {
         stmt: {
@@ -495,10 +530,22 @@ export class Session {
       };
     });
 
+    if (mode !== undefined) {
+      for (let index = 0; index < statements.length; index++) {
+        const statement = statements[index];
+        const sql = typeof statement === 'string' ? statement : statement.sql;
+        const keyword = firstSqlKeyword(sql);
+        if (keyword !== undefined && TRANSACTION_CONTROL_KEYWORDS.has(keyword)) {
+          throw batchInputError(index, `${keyword} is not allowed in an atomic batch`);
+        }
+      }
+    }
+
     let steps: BatchStep[];
     let firstUserStepIdx = 0;
     let beginIdx = -1;
     let commitIdx = -1;
+    let rollbackIdx = -1;
     if (mode === undefined) {
       // Each statement is gated on its predecessor succeeding, so
       // execution stops at the first failure (matching the Rust and
@@ -517,6 +564,7 @@ export class Session {
       firstUserStepIdx = 1;
       const lastUserStepIdx = userSteps.length; // 1..userSteps.length inclusive
       commitIdx = lastUserStepIdx + 1;
+      rollbackIdx = commitIdx + 1;
       steps = [
         { stmt: { sql: `BEGIN ${normalizeBatchMode(mode)}`, args: [], named_args: [], want_rows: false } },
         ...userSteps.map((step, i) => ({
@@ -593,16 +641,20 @@ export class Session {
     });
 
     // Surface the failing step: BEGIN first, then the user statements
-    // (with their index), then COMMIT. Errors on the synthetic ROLLBACK
-    // step are suppressed — by the time it runs the transaction has
-    // already been undone and surfacing a ROLLBACK error would mask the
-    // real cause.
+    // (with their index), then COMMIT.
+    const rollbackError = rollbackIdx >= 0 ? stepErrors[rollbackIdx] : null;
     const throwStepError = (error: { message?: string; code?: string } | null, batchIndex?: number): never => {
       const e = new DatabaseError(error?.message || 'Batch execution failed', error?.code);
       if (batchIndex !== undefined) {
         e.batchIndex = batchIndex;
       }
       e.batchResults = results;
+      if (rollbackError) {
+        e.rollbackError = new DatabaseError(
+          rollbackError.message || 'Batch rollback failed',
+          rollbackError.code,
+        );
+      }
       throw e;
     };
     if (beginIdx >= 0 && stepErrors[beginIdx]) {
@@ -616,6 +668,14 @@ export class Session {
     }
     if (commitIdx >= 0 && stepErrors[commitIdx]) {
       throwStepError(stepErrors[commitIdx]);
+    }
+    if (rollbackError) {
+      const error = new DatabaseError(
+        rollbackError.message || 'Batch rollback failed',
+        rollbackError.code,
+      );
+      error.batchResults = results;
+      throw error;
     }
 
     if (results.some(result => result === null)) {

--- a/serverless/python/differential/test_parity.py
+++ b/serverless/python/differential/test_parity.py
@@ -168,6 +168,22 @@ def _build_op_strategy(op_spec, dml_ops=None):  # noqa: C901
             dml_ops,
         )
 
+    if fields.get("stmts") == "batch_stmts":
+        batch_stmt = st.one_of(
+            st.fixed_dictionaries(
+                {"insert": table_names, "values": st.tuples(values, values)}
+            ),
+            st.fixed_dictionaries({"select": table_names}),
+            st.fixed_dictionaries(
+                {"error_sql": st.sampled_from(_SPEC["constants"]["error_sqls"])}
+            ),
+        )
+        return st.builds(
+            lambda stmts, mode: {"kind": oid, "stmts": stmts, "mode": mode},
+            st.lists(batch_stmt, min_size=1, max_size=4),
+            st.sampled_from([None, "deferred", "immediate"]),
+        )
+
     d = {"kind": st.just(oid)}
 
     if "table" in fields:
@@ -279,6 +295,25 @@ def results_equal(a, b):  # noqa: C901
     return True
 
 
+def _batch_outcomes_equal(a, b):
+    """Compare two param_batch outcomes: success, the failing statement's
+    index, and the per-statement results entry by entry."""
+    if a.get("success") != b.get("success"):
+        return False
+    if not a.get("success") and a.get("batch_index") != b.get("batch_index"):
+        return False
+    a_results = a.get("batch_results") or []
+    b_results = b.get("batch_results") or []
+    if len(a_results) != len(b_results):
+        return False
+    for entry_a, entry_b in zip(a_results, b_results):
+        if (entry_a is None) != (entry_b is None):
+            return False
+        if entry_a is not None and not results_equal(entry_a, entry_b):
+            return False
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Result structure
 # ---------------------------------------------------------------------------
@@ -315,6 +350,41 @@ def _query_result(cur):
         "value_types": types,
         "values": vals,
     }
+
+
+def _batch_result_dict(result):
+    """Normalize one per-statement BatchResult, or None for a statement
+    that did not complete. The server-side statistics are excluded: the
+    serverless driver reports them and the embedded driver does not, by
+    design."""
+    if result is None:
+        return None
+    col_names = [d[0] for d in result.description] if result.description else []
+    return {
+        "success": True,
+        "column_count": len(col_names),
+        "column_names": col_names,
+        "row_count": len(result.rows),
+        "value_types": [[value_type_tag(v) for v in row] for row in result.rows],
+        "values": [list(row) for row in result.rows],
+        "rowcount": result.rowcount,
+        "lastrowid": result.lastrowid,
+    }
+
+
+def _batch_statements(op):
+    """Build the statement list passed to `batch()` for a param_batch op."""
+    statements = []
+    for stmt in op["stmts"]:
+        if "insert" in stmt:
+            statements.append(
+                (f"INSERT INTO {stmt['insert']} VALUES (?, ?)", tuple(stmt["values"]))
+            )
+        elif "select" in stmt:
+            statements.append(f"SELECT a, b FROM {stmt['select']}")
+        else:
+            statements.append(stmt["error_sql"])
+    return statements
 
 
 def execute_op(conn, op):  # noqa: C901
@@ -491,6 +561,23 @@ def execute_op(conn, op):  # noqa: C901
             cur = conn.execute(f"SELECT * FROM {audit} ORDER BY rowid")
             return _query_result(cur)
 
+        elif kind == "param_batch":
+            try:
+                results = conn.batch(_batch_statements(op), mode=op["mode"])
+            except Exception as exc:
+                return {
+                    "success": False,
+                    "batch_index": getattr(exc, "batch_index", None),
+                    "batch_results": [
+                        _batch_result_dict(r)
+                        for r in getattr(exc, "batch_results", [])
+                    ],
+                }
+            return {
+                "success": True,
+                "batch_results": [_batch_result_dict(r) for r in results],
+            }
+
         elif kind == "transaction_workflow":
             conn.execute("BEGIN")
             for inner in op["inner_ops"]:
@@ -538,7 +625,22 @@ def _apply_prefix(op, prefix):
             op[key] = _apply_prefix(op[key], prefix)
     if "bad_sql" in op:
         op["bad_sql"] = _TABLE_RE.sub(repl, op["bad_sql"])
+    if "stmts" in op:
+        op["stmts"] = [_apply_stmt_prefix(stmt, repl, prefix) for stmt in op["stmts"]]
     return op
+
+
+def _apply_stmt_prefix(stmt, repl, prefix):
+    stmt = dict(stmt)
+    if "insert" in stmt:
+        stmt["insert"] = _TABLE_RE.sub(repl, stmt["insert"])
+    if "select" in stmt:
+        stmt["select"] = _TABLE_RE.sub(repl, stmt["select"])
+    if "error_sql" in stmt:
+        stmt["error_sql"] = _TABLE_RE.sub(
+            repl, stmt["error_sql"].replace("{prefix}", str(prefix))
+        )
+    return stmt
 
 
 # ---------------------------------------------------------------------------
@@ -615,6 +717,23 @@ def test_api_parity(data):
                 f"    remote: ok={remote_result.get('success')} rows={remote_result.get('row_count')}"
             )
             trace_dump = "\n".join(trace)
+
+            # Parameterized batch: compare the whole per-statement
+            # outcome — every completed statement's result, and on
+            # failure the failing index and the partial results.
+            if op["kind"] == "param_batch":
+                assert _batch_outcomes_equal(local_result, remote_result), (
+                    f"Batch parity violation on op #{i} {op}:\n"
+                    f"  local:  {local_result}\n"
+                    f"  remote: {remote_result}\n\n"
+                    f"Full trace (prefix={prefix}):\n{trace_dump}"
+                )
+                # Unlike a generic failed op, an agreed batch failure leaves
+                # well-defined state (execution stops at the first error), so
+                # later operations must still agree — this is what catches an
+                # atomic batch that reports the right index but fails to roll
+                # back.
+                continue
 
             # ErrorCheck only compares success/failure — error messages differ.
             if op["kind"] == "error_check":

--- a/serverless/python/tests/test_serverless.py
+++ b/serverless/python/tests/test_serverless.py
@@ -314,6 +314,75 @@ class TestBatchValidation:
         with pytest.raises(ProgrammingError, match="batch statement 1"):
             conn.batch(["SELECT 1", 42])
 
+    @pytest.mark.parametrize("mode", [None, "immediate"])
+    def test_every_parameter_is_validated_before_the_request(self, monkeypatch, mode):
+        conn = self._offline_conn()
+
+        def fail_if_requested(_steps):
+            pytest.fail("parameter validation must finish before the request")
+
+        monkeypatch.setattr(conn._session, "execute_batch", fail_if_requested)
+        with pytest.raises(TypeError, match="batch statement 1 failed") as excinfo:
+            conn.batch(
+                [
+                    ("INSERT INTO t VALUES (?)", (1,)),
+                    ("INSERT INTO t VALUES (?)", (object(),)),
+                ],
+                mode=mode,
+            )
+        assert excinfo.value.batch_index == 1
+        assert excinfo.value.batch_results == []
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "BEGIN",
+            "COMMIT",
+            "END",
+            "ROLLBACK",
+            "SAVEPOINT batch_savepoint",
+            "RELEASE batch_savepoint",
+            "; /* empty statement */ COMMIT",
+            "\ufeffCOMMIT",
+        ],
+    )
+    def test_transaction_control_is_rejected_before_the_request(self, monkeypatch, sql):
+        conn = self._offline_conn()
+
+        def fail_if_requested(_steps):
+            pytest.fail("transaction-control SQL must be rejected before the request")
+
+        monkeypatch.setattr(conn._session, "execute_batch", fail_if_requested)
+        with pytest.raises(
+            ProgrammingError, match="transaction-control SQL is not allowed"
+        ) as excinfo:
+            conn.batch([sql], mode="immediate")
+        assert excinfo.value.batch_index == 0
+        assert excinfo.value.batch_results == []
+
+    def test_rollback_failure_is_attached_to_the_statement_error(self):
+        response = {
+            "step_results": [{}, None, None, None],
+            "step_errors": [
+                None,
+                {"message": "statement failed", "code": "SQLITE_ERROR"},
+                None,
+                {"message": "rollback failed", "code": "SQLITE_ERROR"},
+            ],
+        }
+        with pytest.raises(OperationalError, match="batch statement 0 failed") as excinfo:
+            Connection._decode_batch_result(
+                response,
+                [("INSERT INTO t VALUES (?)", (1,))],
+                offset=1,
+                commit_index=2,
+                total_steps=4,
+            )
+        assert excinfo.value.batch_index == 0
+        assert excinfo.value.batch_results == [None]
+        assert isinstance(excinfo.value.rollback_error, OperationalError)
+        assert str(excinfo.value.rollback_error) == "rollback failed"
+
 
 @needs_server
 class TestBatch:

--- a/serverless/python/tests/test_serverless.py
+++ b/serverless/python/tests/test_serverless.py
@@ -12,7 +12,7 @@ import os
 import urllib.request
 
 import pytest
-from turso_serverless import IntegrityError, OperationalError, connect
+from turso_serverless import IntegrityError, OperationalError, ProgrammingError, connect
 from turso_serverless.connection import Connection, _classify_error
 from turso_serverless.protocol import ProtocolError, ServerError, decode_value, encode_value
 from turso_serverless.session import Session, _server_error, normalize_url
@@ -284,6 +284,159 @@ class TestExecuteScript:
         )
         cur2 = conn.execute("SELECT SUM(a) FROM t_batch_tx_py")
         assert cur2.fetchone() == (31,)
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Parameterized batches
+# ---------------------------------------------------------------------------
+
+
+class TestBatchValidation:
+    """Input validation happens before any HTTP request, so these tests
+    need no server."""
+
+    def _offline_conn(self):
+        return connect("http://localhost:0")
+
+    def test_empty_batch_returns_no_results(self):
+        conn = self._offline_conn()
+        assert conn.batch([]) == []
+        assert conn.batch([], mode="immediate") == []
+
+    def test_invalid_mode_is_rejected(self):
+        conn = self._offline_conn()
+        with pytest.raises(ProgrammingError, match="batch mode"):
+            conn.batch(["SELECT 1"], mode="bogus")
+
+    def test_invalid_statement_is_rejected_with_index(self):
+        conn = self._offline_conn()
+        with pytest.raises(ProgrammingError, match="batch statement 1"):
+            conn.batch(["SELECT 1", 42])
+
+
+@needs_server
+class TestBatch:
+    def test_batch_executes_parameterized_statements_in_order(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_batch_py")
+        results = conn.batch(
+            [
+                "CREATE TABLE t_batch_py (id INTEGER PRIMARY KEY, name TEXT)",
+                ("INSERT INTO t_batch_py (name) VALUES (?)", ("Alice",)),
+                ("INSERT INTO t_batch_py (name) VALUES (:name)", {"name": "Bob"}),
+                "SELECT name FROM t_batch_py ORDER BY id",
+            ]
+        )
+        assert len(results) == 4
+        assert results[1].rowcount == 1
+        assert results[1].lastrowid == 1
+        assert results[2].lastrowid == 2
+        select = results[3]
+        assert select.description is not None
+        assert select.description[0][0] == "name"
+        assert select.rows == [("Alice",), ("Bob",)]
+        assert select.rowcount == -1
+        # Server-side execution statistics are reported per statement
+        # (PROTOCOL.md section 8.4).
+        for result in results:
+            assert isinstance(result.rows_read, int)
+            assert isinstance(result.rows_written, int)
+            assert isinstance(result.query_duration_ms, (int, float))
+        assert results[1].rows_written >= 1
+        conn.close()
+
+    def test_batch_error_identifies_the_failing_statement(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_batcherr_py")
+        conn.execute("CREATE TABLE t_batcherr_py (x)")
+        with pytest.raises(OperationalError, match="batch statement 1 failed") as excinfo:
+            conn.batch(
+                [
+                    ("INSERT INTO t_batcherr_py VALUES (?)", (1,)),
+                    ("INSERT INTO no_such_table_py VALUES (?)", (2,)),
+                    ("INSERT INTO t_batcherr_py VALUES (?)", (3,)),
+                ]
+            )
+        assert excinfo.value.batch_index == 1
+        # One entry per statement: the completed first statement's result,
+        # None for the failing and skipped ones.
+        partial = excinfo.value.batch_results
+        assert len(partial) == 3
+        assert partial[0].rowcount == 1
+        assert partial[1] is None
+        assert partial[2] is None
+        # The batch is not transactional: the statement before the failing
+        # one keeps its effect, and the one after it never ran.
+        cur = conn.execute("SELECT COUNT(*) FROM t_batcherr_py")
+        assert cur.fetchone() == (1,)
+        conn.close()
+
+    def test_batch_joins_an_open_transaction(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_batchtx_py")
+        conn.execute("CREATE TABLE t_batchtx_py (x)")
+        conn.execute("BEGIN")
+        conn.batch(
+            [
+                ("INSERT INTO t_batchtx_py VALUES (?)", (1,)),
+                ("INSERT INTO t_batchtx_py VALUES (?)", (2,)),
+            ]
+        )
+        assert conn.in_transaction
+        conn.rollback()
+        cur = conn.execute("SELECT COUNT(*) FROM t_batchtx_py")
+        assert cur.fetchone() == (0,)
+        conn.close()
+
+    def test_batch_mode_commits_atomically(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_tbatch_py")
+        conn.execute("CREATE TABLE t_tbatch_py (x)")
+        results = conn.batch(
+            [
+                ("INSERT INTO t_tbatch_py VALUES (?)", (1,)),
+                ("INSERT INTO t_tbatch_py VALUES (?)", (2,)),
+            ],
+            mode="immediate",
+        )
+        assert len(results) == 2
+        assert not conn.in_transaction
+        cur = conn.execute("SELECT COUNT(*) FROM t_tbatch_py")
+        assert cur.fetchone() == (2,)
+        conn.close()
+
+    def test_batch_mode_rolls_back_on_failure(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_tbatcherr_py")
+        conn.execute("CREATE TABLE t_tbatcherr_py (x)")
+        with pytest.raises(OperationalError) as excinfo:
+            conn.batch(
+                [
+                    ("INSERT INTO t_tbatcherr_py VALUES (?)", (1,)),
+                    ("INSERT INTO no_such_table_py VALUES (?)", (2,)),
+                ],
+                mode="immediate",
+            )
+        assert excinfo.value.batch_index == 1
+        assert not conn.in_transaction
+        # The ROLLBACK step undid the first insert.
+        cur = conn.execute("SELECT COUNT(*) FROM t_tbatcherr_py")
+        assert cur.fetchone() == (0,)
+        conn.close()
+
+    def test_batch_constraint_error_preserves_exception_class(self):
+        conn = make_conn()
+        conn.execute("DROP TABLE IF EXISTS t_batchuniq_py")
+        conn.execute("CREATE TABLE t_batchuniq_py (x UNIQUE)")
+        with pytest.raises(IntegrityError) as excinfo:
+            conn.batch(
+                [
+                    ("INSERT INTO t_batchuniq_py VALUES (?)", (1,)),
+                    ("INSERT INTO t_batchuniq_py VALUES (?)", (1,)),
+                ]
+            )
+        assert excinfo.value.batch_index == 1
         conn.close()
 
 

--- a/serverless/python/turso_serverless/__init__.py
+++ b/serverless/python/turso_serverless/__init__.py
@@ -12,7 +12,7 @@ Usage:
     conn.close()
 """
 
-from .connection import Connection, Cursor, connect
+from .connection import BatchResult, Connection, Cursor, connect
 from .dbapi import (
     # Exception classes
     DatabaseError,
@@ -36,6 +36,7 @@ paramstyle = "qmark"
 
 __all__ = [
     "connect",
+    "BatchResult",
     "Connection",
     "Cursor",
     "Row",

--- a/serverless/python/turso_serverless/connection.py
+++ b/serverless/python/turso_serverless/connection.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, TypeVar
 
 from .dbapi import (
     DatabaseError,
@@ -38,12 +38,12 @@ class BatchResult:
     (PROTOCOL.md section 8.4); the embedded driver reports None for them."""
 
     rows: list[tuple]
-    description: Optional[tuple[tuple[str, None, None, None, None, None, None], ...]]
+    description: tuple[tuple[str, None, None, None, None, None, None], ...] | None
     rowcount: int
-    lastrowid: Optional[int]
-    rows_read: Optional[int] = None
-    rows_written: Optional[int] = None
-    query_duration_ms: Optional[float] = None
+    lastrowid: int | None
+    rows_read: int | None = None
+    rows_written: int | None = None
+    query_duration_ms: float | None = None
 
 
 # Accepted values for the `mode` argument of Connection.batch and the
@@ -65,7 +65,7 @@ _TRANSACTION_CONTROL_KEYWORDS = {
 }
 
 
-def _batch_begin_sql(mode: Optional[str]) -> Optional[str]:
+def _batch_begin_sql(mode: str | None) -> str | None:
     if mode is None:
         return None
     begin_sql = _BATCH_MODES.get(str(mode).lower())
@@ -113,7 +113,7 @@ def _reject_transaction_control_statements(
 def _batch_statement_error(
     index: int,
     error: Exception,
-    results: Optional[list] = None,
+    results: list | None = None,
 ) -> Exception:
     """Wrap a statement failure so the raised exception identifies which
     statement failed, preserving the DB-API exception class. The zero-based
@@ -163,7 +163,7 @@ class Connection:
         self,
         session: Session,
         *,
-        isolation_level: Optional[str] = "DEFERRED",
+        isolation_level: str | None = "DEFERRED",
     ) -> None:
         self._session = session
         self.isolation_level = isolation_level
@@ -179,8 +179,8 @@ class Connection:
     def _execute_stmt(
         self,
         sql: str,
-        params: Optional[list] = None,
-        named_params: Optional[list[tuple[str, Any]]] = None,
+        params: list | None = None,
+        named_params: list[tuple[str, Any]] | None = None,
         want_rows: bool = True,
     ) -> StmtResult:
         self._ensure_open()
@@ -227,7 +227,7 @@ class Connection:
         if self.in_transaction:
             self._execute_stmt("ROLLBACK", want_rows=False)
 
-    def cursor(self, factory: Optional[Callable[[Connection], _DBCursorT]] = None) -> _DBCursorT | Cursor:
+    def cursor(self, factory: Callable[[Connection], _DBCursorT] | None = None) -> _DBCursorT | Cursor:
         self._ensure_open()
         if factory is None:
             return Cursor(self)
@@ -251,7 +251,7 @@ class Connection:
     def batch(
         self,
         statements: Iterable[str | tuple[str, Sequence[Any] | Mapping[str, Any]]],
-        mode: Optional[str] = None,
+        mode: str | None = None,
     ) -> list[BatchResult]:
         """Execute multiple parameterized statements in a single HTTP
         request.
@@ -352,7 +352,7 @@ class Connection:
         result: dict,
         stmts: list[tuple[str, Any]],
         offset: int,
-        commit_index: Optional[int],
+        commit_index: int | None,
         total_steps: int,
     ) -> list[BatchResult]:
         """Decode a wire-level batch result into per-statement results, or
@@ -372,7 +372,7 @@ class Connection:
             )
         # Decode the results of the statements that executed before looking
         # at the errors, so a failure can still report what completed.
-        results: list[Optional[BatchResult]] = [
+        results: list[BatchResult | None] = [
             Connection._decode_batch_statement_result(step_results[offset + i], sql)
             for i, (sql, _parameters) in enumerate(stmts)
         ]
@@ -393,7 +393,7 @@ class Connection:
         return results
 
     @staticmethod
-    def _decode_batch_statement_result(step_result: Any, sql: str) -> Optional[BatchResult]:
+    def _decode_batch_statement_result(step_result: Any, sql: str) -> BatchResult | None:
         """Decode one statement result of a batch response (section 8.4),
         or None when the statement did not complete."""
         if not isinstance(step_result, dict):
@@ -428,7 +428,7 @@ class Connection:
         step_errors: list,
         statement_count: int,
         offset: int,
-        commit_index: Optional[int],
+        commit_index: int | None,
         results: list,
     ) -> None:
         """Raise the error of the batch step that failed, if any: the
@@ -471,8 +471,8 @@ class Cursor:
         self.row_factory: Callable | type[Row] | None = connection.row_factory
         self._rows: list[tuple] = []
         self._row_index = 0
-        self._description: Optional[tuple[tuple[str, None, None, None, None, None, None], ...]] = None
-        self._lastrowid: Optional[int] = None
+        self._description: tuple[tuple[str, None, None, None, None, None, None], ...] | None = None
+        self._lastrowid: int | None = None
         self._rowcount: int = -1
         self._closed = False
 
@@ -503,7 +503,7 @@ class Cursor:
     @staticmethod
     def _convert_params(
         parameters: Sequence[Any] | Mapping[str, Any],
-    ) -> tuple[Optional[list], Optional[list[tuple[str, Any]]]]:
+    ) -> tuple[list | None, list[tuple[str, Any]] | None]:
         """Convert DB-API parameters to protocol args/named_args."""
         if isinstance(parameters, Mapping):
             named = []
@@ -611,7 +611,7 @@ class Cursor:
         self._row_index += 1
         return self._apply_row_factory(row)
 
-    def fetchmany(self, size: Optional[int] = None) -> list[Any]:
+    def fetchmany(self, size: int | None = None) -> list[Any]:
         self._ensure_open()
         if size is None:
             size = self.arraysize
@@ -652,9 +652,9 @@ class Cursor:
 def connect(
     url: str,
     *,
-    auth_token: Optional[str] = None,
-    remote_encryption_key: Optional[str] = None,
-    isolation_level: Optional[str] = "DEFERRED",
+    auth_token: str | None = None,
+    remote_encryption_key: str | None = None,
+    isolation_level: str | None = "DEFERRED",
 ) -> Connection:
     """Open a remote connection to a Turso database.
 

--- a/serverless/python/turso_serverless/connection.py
+++ b/serverless/python/turso_serverless/connection.py
@@ -18,6 +18,7 @@ from .dbapi import (
     ProgrammingError,
     Row,
     Warning,
+    _first_keyword,
     _is_dml,
     _is_insert_or_replace,
 )
@@ -52,6 +53,15 @@ _BATCH_MODES = {
     "immediate": "BEGIN IMMEDIATE",
     "exclusive": "BEGIN EXCLUSIVE",
     "concurrent": "BEGIN CONCURRENT",
+}
+
+_TRANSACTION_CONTROL_KEYWORDS = {
+    "BEGIN",
+    "COMMIT",
+    "END",
+    "ROLLBACK",
+    "SAVEPOINT",
+    "RELEASE",
 }
 
 
@@ -89,6 +99,17 @@ def _normalize_batch_statements(
     return normalized
 
 
+def _reject_transaction_control_statements(
+    statements: list[tuple[str, Sequence[Any] | Mapping[str, Any]]],
+) -> None:
+    for index, (sql, _parameters) in enumerate(statements):
+        if _first_keyword(sql) in _TRANSACTION_CONTROL_KEYWORDS:
+            error = ProgrammingError(
+                "transaction-control SQL is not allowed in a batch with a transaction mode"
+            )
+            raise _batch_statement_error(index, error) from error
+
+
 def _batch_statement_error(
     index: int,
     error: Exception,
@@ -97,9 +118,9 @@ def _batch_statement_error(
     """Wrap a statement failure so the raised exception identifies which
     statement failed, preserving the DB-API exception class. The zero-based
     index is available as the `batch_index` attribute, and `batch_results`
-    carries one entry per statement: the completed statement's
-    `BatchResult`, or None for the failing statement and the statements
-    that did not run."""
+    is empty when validation fails before execution. Otherwise it carries
+    one entry per statement: the completed statement's `BatchResult`, or
+    None for the failing statement and the statements that did not run."""
     wrapped = type(error)(f"batch statement {index} failed: {error}")
     wrapped.batch_index = index
     wrapped.batch_results = results if results is not None else []
@@ -241,17 +262,20 @@ class Connection:
         stops at the first statement that fails: the remaining statements
         are skipped and the raised exception identifies the failing
         statement by its zero-based index (the `batch_index` attribute)
-        and carries the per-statement results (the `batch_results`
-        attribute: one entry per statement — the completed statement's
-        `BatchResult`, or None for the failing statement and the
-        statements that did not run).
+        and carries the per-statement results in the `batch_results`
+        attribute. It is empty when parameter validation fails before
+        execution; otherwise it has one entry per statement — the completed
+        statement's `BatchResult`, or None for the failing statement and
+        the statements that did not run.
 
         With `mode` set to "deferred", "immediate", "exclusive", or
         "concurrent", the statements are wrapped in `BEGIN <mode>` /
         `COMMIT`, with a `ROLLBACK` on failure, all carried by the same
         request: either every statement commits or none does. The
         statements must not contain their own transaction-control SQL in
-        that case. With `mode` unset the batch is not transactional: each
+        that case. If `ROLLBACK` itself fails, the primary exception has a
+        `rollback_error` attribute and the stream's transaction state is
+        unknown. With `mode` unset the batch is not transactional: each
         statement commits as it executes.
 
         Unlike `execute()`, `batch()` never opens a legacy implicit
@@ -268,25 +292,27 @@ class Connection:
         if self.in_transaction:
             begin_sql = None
 
+        user_steps = []
+        for i, (sql, parameters) in enumerate(stmts):
+            try:
+                args, named_args = Cursor._convert_params(parameters)
+                user_steps.append(
+                    build_batch_step(sql, args=args, named_args=named_args, want_rows=True)
+                )
+            except Exception as e:
+                raise _batch_statement_error(i, e) from e
+
+        if begin_sql is not None:
+            _reject_transaction_control_statements(stmts)
+
         steps = []
         offset = 0
         if begin_sql is not None:
             steps.append(build_batch_step(begin_sql, want_rows=False))
             offset = 1
-        for i, (sql, parameters) in enumerate(stmts):
-            condition = None
+        for i, step in enumerate(user_steps):
             if offset + i > 0:
-                condition = {"type": "ok", "step": offset + i - 1}
-            # Value encoding can fail client-side (e.g. an unsupported
-            # type); report it with the statement's index like any other
-            # statement failure.
-            try:
-                args, named_args = Cursor._convert_params(parameters)
-                step = build_batch_step(
-                    sql, args=args, named_args=named_args, want_rows=True, condition=condition
-                )
-            except Exception as e:
-                raise _batch_statement_error(i, e) from e
+                step["condition"] = {"type": "ok", "step": offset + i - 1}
             steps.append(step)
         commit_index = None
         if begin_sql is not None:
@@ -331,9 +357,8 @@ class Connection:
     ) -> list[BatchResult]:
         """Decode a wire-level batch result into per-statement results, or
         raise the error of the step that failed. Failures of the synthetic
-        BEGIN/COMMIT steps surface as-is; a ROLLBACK failure is ignored
-        because it only runs after a failure that is already being
-        reported."""
+        BEGIN/COMMIT steps surface as-is. A ROLLBACK failure is attached to
+        that primary error as `rollback_error`."""
         step_results = result.get("step_results")
         step_errors = result.get("step_errors")
         if (
@@ -351,7 +376,17 @@ class Connection:
             Connection._decode_batch_statement_result(step_results[offset + i], sql)
             for i, (sql, _parameters) in enumerate(stmts)
         ]
-        Connection._raise_batch_step_error(step_errors, len(stmts), offset, commit_index, results)
+        rollback_error = None
+        if commit_index is not None and step_errors[commit_index + 1] is not None:
+            rollback_error = _classify_error(_server_error(step_errors[commit_index + 1]))
+        try:
+            Connection._raise_batch_step_error(step_errors, len(stmts), offset, commit_index, results)
+        except Exception as primary_error:
+            if rollback_error is not None:
+                primary_error.rollback_error = rollback_error
+            raise
+        if rollback_error is not None:
+            raise rollback_error
         for i, result in enumerate(results):
             if result is None:
                 raise ProtocolError(f"batch response is missing the result for statement {i}")

--- a/serverless/python/turso_serverless/connection.py
+++ b/serverless/python/turso_serverless/connection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, Callable, Optional, TypeVar
 
 from .dbapi import (
@@ -20,9 +21,89 @@ from .dbapi import (
     _is_dml,
     _is_insert_or_replace,
 )
+from .protocol import ProtocolError, build_batch_step, decode_value
 from .session import Session, StmtResult, _server_error
 
 _DBCursorT = TypeVar("_DBCursorT", bound="Cursor")
+
+
+@dataclass
+class BatchResult:
+    """The result of one statement of a [`Connection.batch`] call, in
+    DB-API vocabulary: `description` and `rows` for statements that return
+    rows, `rowcount` for DML (−1 when the statement returned rows), and
+    `lastrowid` for INSERT/REPLACE. `rows_read`, `rows_written`, and
+    `query_duration_ms` are the server-side execution statistics
+    (PROTOCOL.md section 8.4); the embedded driver reports None for them."""
+
+    rows: list[tuple]
+    description: Optional[tuple[tuple[str, None, None, None, None, None, None], ...]]
+    rowcount: int
+    lastrowid: Optional[int]
+    rows_read: Optional[int] = None
+    rows_written: Optional[int] = None
+    query_duration_ms: Optional[float] = None
+
+
+# Accepted values for the `mode` argument of Connection.batch and the
+# BEGIN statement each maps to.
+_BATCH_MODES = {
+    "deferred": "BEGIN DEFERRED",
+    "immediate": "BEGIN IMMEDIATE",
+    "exclusive": "BEGIN EXCLUSIVE",
+    "concurrent": "BEGIN CONCURRENT",
+}
+
+
+def _batch_begin_sql(mode: Optional[str]) -> Optional[str]:
+    if mode is None:
+        return None
+    begin_sql = _BATCH_MODES.get(str(mode).lower())
+    if begin_sql is None:
+        raise ProgrammingError(
+            f"batch mode must be one of {sorted(_BATCH_MODES)} or None, got {mode!r}"
+        )
+    return begin_sql
+
+
+def _normalize_batch_statements(
+    statements: Iterable[Any],
+) -> list[tuple[str, Sequence[Any] | Mapping[str, Any]]]:
+    """Normalize batch input to (sql, parameters) pairs. Accepts SQL
+    strings and (sql, parameters) pairs, like the JavaScript driver."""
+    normalized = []
+    for index, statement in enumerate(statements):
+        if isinstance(statement, str):
+            normalized.append((statement, ()))
+            continue
+        if (
+            isinstance(statement, (tuple, list))
+            and len(statement) == 2
+            and isinstance(statement[0], str)
+        ):
+            normalized.append((statement[0], statement[1]))
+            continue
+        raise ProgrammingError(
+            f"batch statement {index} must be a SQL string or a (sql, parameters) pair"
+        )
+    return normalized
+
+
+def _batch_statement_error(
+    index: int,
+    error: Exception,
+    results: Optional[list] = None,
+) -> Exception:
+    """Wrap a statement failure so the raised exception identifies which
+    statement failed, preserving the DB-API exception class. The zero-based
+    index is available as the `batch_index` attribute, and `batch_results`
+    carries one entry per statement: the completed statement's
+    `BatchResult`, or None for the failing statement and the statements
+    that did not run."""
+    wrapped = type(error)(f"batch statement {index} failed: {error}")
+    wrapped.batch_index = index
+    wrapped.batch_results = results if results is not None else []
+    return wrapped
 
 
 def _classify_error(e: Exception) -> Exception:
@@ -145,6 +226,187 @@ class Connection:
         cur = self.cursor()
         cur.executescript(sql_script)
         return cur
+
+    def batch(
+        self,
+        statements: Iterable[str | tuple[str, Sequence[Any] | Mapping[str, Any]]],
+        mode: Optional[str] = None,
+    ) -> list[BatchResult]:
+        """Execute multiple parameterized statements in a single HTTP
+        request.
+
+        The statements — SQL strings or (sql, parameters) pairs, with the
+        same parameter forms as `execute()` — are sent as one batch
+        request (PROTOCOL.md section 6.2) and execute in order. Execution
+        stops at the first statement that fails: the remaining statements
+        are skipped and the raised exception identifies the failing
+        statement by its zero-based index (the `batch_index` attribute)
+        and carries the per-statement results (the `batch_results`
+        attribute: one entry per statement — the completed statement's
+        `BatchResult`, or None for the failing statement and the
+        statements that did not run).
+
+        With `mode` set to "deferred", "immediate", "exclusive", or
+        "concurrent", the statements are wrapped in `BEGIN <mode>` /
+        `COMMIT`, with a `ROLLBACK` on failure, all carried by the same
+        request: either every statement commits or none does. The
+        statements must not contain their own transaction-control SQL in
+        that case. With `mode` unset the batch is not transactional: each
+        statement commits as it executes.
+
+        Unlike `execute()`, `batch()` never opens a legacy implicit
+        transaction. If a transaction is already open on this connection,
+        the statements join it (and `mode` is ignored).
+
+        Returns one `BatchResult` per statement, in order.
+        """
+        self._ensure_open()
+        begin_sql = _batch_begin_sql(mode)
+        stmts = _normalize_batch_statements(statements)
+        if not stmts:
+            return []
+        if self.in_transaction:
+            begin_sql = None
+
+        steps = []
+        offset = 0
+        if begin_sql is not None:
+            steps.append(build_batch_step(begin_sql, want_rows=False))
+            offset = 1
+        for i, (sql, parameters) in enumerate(stmts):
+            condition = None
+            if offset + i > 0:
+                condition = {"type": "ok", "step": offset + i - 1}
+            # Value encoding can fail client-side (e.g. an unsupported
+            # type); report it with the statement's index like any other
+            # statement failure.
+            try:
+                args, named_args = Cursor._convert_params(parameters)
+                step = build_batch_step(
+                    sql, args=args, named_args=named_args, want_rows=True, condition=condition
+                )
+            except Exception as e:
+                raise _batch_statement_error(i, e) from e
+            steps.append(step)
+        commit_index = None
+        if begin_sql is not None:
+            commit_index = offset + len(stmts)
+            steps.append(
+                build_batch_step(
+                    "COMMIT",
+                    want_rows=False,
+                    condition={"type": "ok", "step": commit_index - 1},
+                )
+            )
+            # ROLLBACK runs only when BEGIN succeeded and COMMIT did not.
+            # The ok(BEGIN) guard prevents it from aborting a transaction
+            # opened on the stream out of band.
+            steps.append(
+                build_batch_step(
+                    "ROLLBACK",
+                    want_rows=False,
+                    condition={
+                        "type": "and",
+                        "conds": [
+                            {"type": "ok", "step": 0},
+                            {"type": "not", "cond": {"type": "ok", "step": commit_index}},
+                        ],
+                    },
+                )
+            )
+
+        try:
+            result = self._session.execute_batch(steps)
+        except RuntimeError as e:
+            raise _classify_error(e) from None
+        return self._decode_batch_result(result, stmts, offset, commit_index, len(steps))
+
+    @staticmethod
+    def _decode_batch_result(
+        result: dict,
+        stmts: list[tuple[str, Any]],
+        offset: int,
+        commit_index: Optional[int],
+        total_steps: int,
+    ) -> list[BatchResult]:
+        """Decode a wire-level batch result into per-statement results, or
+        raise the error of the step that failed. Failures of the synthetic
+        BEGIN/COMMIT steps surface as-is; a ROLLBACK failure is ignored
+        because it only runs after a failure that is already being
+        reported."""
+        step_results = result.get("step_results")
+        step_errors = result.get("step_errors")
+        if (
+            not isinstance(step_results, list)
+            or not isinstance(step_errors, list)
+            or len(step_results) != total_steps
+            or len(step_errors) != total_steps
+        ):
+            raise ProtocolError(
+                f"batch response does not have one result and one error per step: {result}"
+            )
+        # Decode the results of the statements that executed before looking
+        # at the errors, so a failure can still report what completed.
+        results: list[Optional[BatchResult]] = [
+            Connection._decode_batch_statement_result(step_results[offset + i], sql)
+            for i, (sql, _parameters) in enumerate(stmts)
+        ]
+        Connection._raise_batch_step_error(step_errors, len(stmts), offset, commit_index, results)
+        for i, result in enumerate(results):
+            if result is None:
+                raise ProtocolError(f"batch response is missing the result for statement {i}")
+        return results
+
+    @staticmethod
+    def _decode_batch_statement_result(step_result: Any, sql: str) -> Optional[BatchResult]:
+        """Decode one statement result of a batch response (section 8.4),
+        or None when the statement did not complete."""
+        if not isinstance(step_result, dict):
+            return None
+        columns = [c.get("name") or "" for c in step_result.get("cols") or []]
+        rows = [tuple(decode_value(v) for v in row) for row in step_result.get("rows") or []]
+        if columns:
+            description = tuple((name, None, None, None, None, None, None) for name in columns)
+            rowcount = -1
+        else:
+            description = None
+            rowcount = step_result.get("affected_row_count") or 0
+        lastrowid = None
+        raw_rowid = step_result.get("last_insert_rowid")
+        if raw_rowid is not None and _is_insert_or_replace(sql):
+            try:
+                lastrowid = int(raw_rowid)
+            except (TypeError, ValueError) as e:
+                raise ProtocolError(f"invalid rowid in server response: {e}") from None
+        return BatchResult(
+            rows=rows,
+            description=description,
+            rowcount=rowcount,
+            lastrowid=lastrowid,
+            rows_read=step_result.get("rows_read"),
+            rows_written=step_result.get("rows_written"),
+            query_duration_ms=step_result.get("query_duration_ms"),
+        )
+
+    @staticmethod
+    def _raise_batch_step_error(
+        step_errors: list,
+        statement_count: int,
+        offset: int,
+        commit_index: Optional[int],
+        results: list,
+    ) -> None:
+        """Raise the error of the batch step that failed, if any: the
+        synthetic BEGIN first, then the user statements (with their index
+        and the per-statement results), then the synthetic COMMIT."""
+        if offset and step_errors[0] is not None:
+            raise _classify_error(_server_error(step_errors[0]))
+        for i in range(statement_count):
+            error = step_errors[offset + i]
+            if error is not None:
+                raise _batch_statement_error(i, _classify_error(_server_error(error)), results)
+        if commit_index is not None and step_errors[commit_index] is not None:
+            raise _classify_error(_server_error(step_errors[commit_index]))
 
     def _maybe_implicit_begin(self, sql: str) -> None:
         """Legacy implicit transaction behavior."""

--- a/serverless/python/turso_serverless/dbapi.py
+++ b/serverless/python/turso_serverless/dbapi.py
@@ -51,8 +51,8 @@ class NotSupportedError(DatabaseError):
 
 def _first_keyword(sql: str) -> str:
     """
-    Return the first SQL keyword (uppercased) ignoring leading whitespace
-    and single-line and multi-line comments.
+    Return the first SQL keyword (uppercased) ignoring leading whitespace,
+    empty statements, and single-line and multi-line comments.
 
     This is intentionally minimal and only used to detect DML for implicit
     transaction handling. It may not handle all edge cases (e.g. complex WITH).
@@ -61,7 +61,7 @@ def _first_keyword(sql: str) -> str:
     n = len(sql)
     while i < n:
         c = sql[i]
-        if c.isspace():
+        if c.isspace() or c in (";", "\ufeff"):
             i += 1
             continue
         if c == "-" and i + 1 < n and sql[i + 1] == "-":

--- a/serverless/python/turso_serverless/session.py
+++ b/serverless/python/turso_serverless/session.py
@@ -316,6 +316,20 @@ class Session:
             raise decoder.step_error
         return decoder.result
 
+    def execute_batch(self, steps: list[dict]) -> dict:
+        """Execute a batch request on the pipeline endpoint (section 6.2)
+        and return its raw result: `step_results` and `step_errors` arrays
+        with one entry per step. Step failures are reported in those
+        arrays, not raised here."""
+        results = self.execute_pipeline([{"type": "batch", "batch": {"steps": steps}}])
+        result = results[0]
+        if result.get("type") == "error":
+            raise _server_error(result.get("error"))
+        response = result.get("response") or {}
+        if response.get("type") != "batch" or not isinstance(response.get("result"), dict):
+            raise ProtocolError(f"expected batch result in pipeline response, got {response}")
+        return response["result"]
+
     def close(self) -> None:
         """Close the stream (section 6.8). Errors are ignored: the stream
         may already have expired."""

--- a/serverless/rust/batch.rs
+++ b/serverless/rust/batch.rs
@@ -201,7 +201,13 @@ pub(crate) struct BatchLayout {
     user_count: usize,
     begin: Option<usize>,
     commit: Option<usize>,
+    rollback: Option<usize>,
     total_steps: usize,
+}
+
+pub(crate) struct DecodedBatch {
+    pub(crate) outcome: Result<Vec<BatchResult>>,
+    pub(crate) last_insert_rowid: Option<i64>,
 }
 
 /// Build the wire-level batch for the given statements.
@@ -259,72 +265,172 @@ pub(crate) fn build_batch(
         });
         commit
     });
+    let rollback = commit.map(|commit| commit + 1);
     let layout = BatchLayout {
         user_offset,
         user_count,
         begin: wrap.map(|_| 0),
         commit,
+        rollback,
         total_steps: steps.len(),
     };
     (Batch { steps }, layout)
 }
 
 /// Decode a wire-level batch result into per-statement results, or the
-/// error of the step that failed.
+/// error of the step that failed. The decoded rowid is kept separate from
+/// the outcome so the connection cache can still advance when a synthetic
+/// `COMMIT` or `ROLLBACK` step fails after user statements completed.
 ///
 /// A failing user statement is reported as
 /// [`Error::BatchStatementFailed`] with its zero-based index. Failures of
-/// the synthetic `BEGIN`/`COMMIT` steps surface as the underlying error.
-/// The synthetic `ROLLBACK` step's error, if any, is ignored: it only runs
-/// after a failure that is already being reported, and surfacing it would
-/// mask the cause.
+/// the synthetic `BEGIN`/`COMMIT` steps surface as the underlying error. If
+/// the automatic rollback also fails, both errors are preserved in
+/// [`Error::BatchRollbackFailed`].
 pub(crate) fn decode_batch_result(
     result: crate::protocol::BatchResult,
     layout: &BatchLayout,
-) -> Result<Vec<BatchResult>> {
+) -> DecodedBatch {
     if result.step_results.len() != layout.total_steps
         || result.step_errors.len() != layout.total_steps
     {
-        return Err(Error::Http(format!(
-            "batch response has {} results and {} errors for {} steps",
-            result.step_results.len(),
-            result.step_errors.len(),
-            layout.total_steps
-        )));
+        return DecodedBatch {
+            outcome: Err(Error::Http(format!(
+                "batch response has {} results and {} errors for {} steps",
+                result.step_results.len(),
+                result.step_errors.len(),
+                layout.total_steps
+            ))),
+            last_insert_rowid: None,
+        };
     }
     let mut step_results = result.step_results;
     let mut step_errors = result.step_errors;
+    if let Some(step) = step_results
+        .iter()
+        .zip(&step_errors)
+        .position(|(result, error)| result.is_some() && error.is_some())
+    {
+        return DecodedBatch {
+            outcome: Err(Error::Http(format!(
+                "batch response step {step} has both a result and an error"
+            ))),
+            last_insert_rowid: None,
+        };
+    }
     // Decode the results of the statements that executed before looking
     // at the errors, so a failure can still report what completed.
     let mut outputs = Vec::with_capacity(layout.user_count);
+    let mut last_insert_rowid = None;
     for i in 0..layout.user_count {
-        outputs.push(
-            step_results[layout.user_offset + i]
-                .take()
-                .map(BatchResult::from_stmt_result)
-                .transpose()?,
-        );
+        let output = match step_results[layout.user_offset + i]
+            .take()
+            .map(BatchResult::from_stmt_result)
+            .transpose()
+        {
+            Ok(output) => output,
+            Err(error) => {
+                return DecodedBatch {
+                    outcome: Err(error),
+                    last_insert_rowid,
+                };
+            }
+        };
+        if let Some(rowid) = output.as_ref().and_then(BatchResult::last_insert_rowid) {
+            last_insert_rowid = Some(rowid);
+        }
+        outputs.push(output);
     }
-    if let Some(begin) = layout.begin {
-        if let Some(error) = step_errors[begin].take() {
-            return Err(error.into());
+
+    enum Failure {
+        Synthetic(Error),
+        Statement { index: usize, error: Error },
+    }
+
+    let mut failure = layout
+        .begin
+        .and_then(|begin| step_errors[begin].take().map(Error::from))
+        .map(Failure::Synthetic);
+    if failure.is_none() {
+        for i in 0..layout.user_count {
+            if let Some(statement_error) = step_errors[layout.user_offset + i].take() {
+                failure = Some(Failure::Statement {
+                    index: i,
+                    error: statement_error.into(),
+                });
+                break;
+            }
         }
     }
-    for i in 0..layout.user_count {
-        if let Some(error) = step_errors[layout.user_offset + i].take() {
-            return Err(Error::BatchStatementFailed {
-                index: i,
-                error: Box::new(error.into()),
-                results: outputs,
-            });
+    if failure.is_none() {
+        failure = layout
+            .commit
+            .and_then(|commit| step_errors[commit].take().map(Error::from))
+            .map(Failure::Synthetic);
+    }
+    let failure_into_error = |failure, results| match failure {
+        Failure::Synthetic(error) => error,
+        Failure::Statement { index, error } => Error::BatchStatementFailed {
+            index,
+            error: Box::new(error),
+            results,
+        },
+    };
+    if let Some(rollback_error) = layout
+        .rollback
+        .and_then(|rollback| step_errors[rollback].take())
+    {
+        let cause = failure.map_or_else(
+            || Error::Http("batch rollback failed without a preceding batch failure".to_string()),
+            |failure| failure_into_error(failure, outputs),
+        );
+        return DecodedBatch {
+            outcome: Err(Error::BatchRollbackFailed {
+                error: Box::new(cause),
+                rollback_error: Box::new(rollback_error.into()),
+            }),
+            last_insert_rowid,
+        };
+    }
+    if let Some(failure) = failure {
+        return DecodedBatch {
+            outcome: Err(failure_into_error(failure, outputs)),
+            last_insert_rowid,
+        };
+    }
+
+    if let Some(begin) = layout.begin {
+        if step_results[begin].is_none() {
+            return DecodedBatch {
+                outcome: Err(Error::Http(
+                    "batch response is missing the BEGIN result".to_string(),
+                )),
+                last_insert_rowid,
+            };
         }
     }
     if let Some(commit) = layout.commit {
-        if let Some(error) = step_errors[commit].take() {
-            return Err(error.into());
+        if step_results[commit].is_none() {
+            return DecodedBatch {
+                outcome: Err(Error::Http(
+                    "batch response is missing the COMMIT result".to_string(),
+                )),
+                last_insert_rowid,
+            };
         }
     }
-    outputs
+    if let Some(rollback) = layout.rollback {
+        if step_results[rollback].is_some() {
+            return DecodedBatch {
+                outcome: Err(Error::Http(
+                    "batch response ran ROLLBACK after a successful COMMIT".to_string(),
+                )),
+                last_insert_rowid,
+            };
+        }
+    }
+
+    let outcome = outputs
         .into_iter()
         .enumerate()
         .map(|(i, output)| {
@@ -334,7 +440,11 @@ pub(crate) fn decode_batch_result(
                 ))
             })
         })
-        .collect()
+        .collect();
+    DecodedBatch {
+        outcome,
+        last_insert_rowid,
+    }
 }
 
 #[cfg(test)]
@@ -411,6 +521,7 @@ mod tests {
         assert_eq!(layout.user_offset, 1);
         assert_eq!(layout.begin, Some(0));
         assert_eq!(layout.commit, Some(3));
+        assert_eq!(layout.rollback, Some(4));
         assert_eq!(layout.total_steps, 5);
     }
 
@@ -432,7 +543,9 @@ mod tests {
             ],
             step_errors: vec![None, None],
         };
-        let outputs = decode_batch_result(result, &layout).unwrap();
+        let decoded = decode_batch_result(result, &layout);
+        assert_eq!(decoded.last_insert_rowid, Some(42));
+        let outputs = decoded.outcome.unwrap();
         assert_eq!(outputs.len(), 2);
         assert_eq!(
             outputs[0].rows()[0].get_value(0).unwrap(),
@@ -449,7 +562,7 @@ mod tests {
             step_results: vec![Some(stmt_result(1)), None, None],
             step_errors: vec![None, Some(proto_error("boom")), None],
         };
-        let error = decode_batch_result(result, &layout).unwrap_err();
+        let error = decode_batch_result(result, &layout).outcome.unwrap_err();
         match error {
             Error::BatchStatementFailed {
                 index,
@@ -482,7 +595,7 @@ mod tests {
             ],
             step_errors: vec![None, None, Some(proto_error("second failed")), None, None],
         };
-        let error = decode_batch_result(result, &layout).unwrap_err();
+        let error = decode_batch_result(result, &layout).outcome.unwrap_err();
         match error {
             Error::BatchStatementFailed { index, .. } => assert_eq!(index, 1),
             other => panic!("expected BatchStatementFailed, got {other:?}"),
@@ -490,40 +603,70 @@ mod tests {
     }
 
     #[test]
-    fn decode_surfaces_commit_failure_without_an_index() {
+    fn decode_surfaces_commit_failure_and_the_latest_user_rowid() {
         let (_, layout) = build_batch(user_stmts(1), Some(TransactionBehavior::Deferred));
         let result = ProtoBatchResult {
             step_results: vec![
                 Some(stmt_result(0)),
-                Some(stmt_result(1)),
+                Some(StmtResult {
+                    last_insert_rowid: Some("41".to_string()),
+                    ..stmt_result(1)
+                }),
                 None,
                 Some(stmt_result(0)),
             ],
             step_errors: vec![None, None, Some(proto_error("commit failed")), None],
         };
-        let error = decode_batch_result(result, &layout).unwrap_err();
+        let decoded = decode_batch_result(result, &layout);
+        assert_eq!(decoded.last_insert_rowid, Some(41));
+        let error = decoded.outcome.unwrap_err();
         assert!(matches!(error, Error::Error(ref m) if m == "commit failed"));
     }
 
     #[test]
-    fn decode_ignores_rollback_errors_in_favor_of_the_cause() {
-        let (_, layout) = build_batch(user_stmts(1), Some(TransactionBehavior::Deferred));
+    fn decode_preserves_the_cause_and_rollback_error() {
+        let (_, layout) = build_batch(user_stmts(2), Some(TransactionBehavior::Deferred));
         let result = ProtoBatchResult {
-            step_results: vec![Some(stmt_result(0)), None, None, None],
+            step_results: vec![
+                Some(stmt_result(0)),
+                Some(StmtResult {
+                    last_insert_rowid: Some("40".to_string()),
+                    ..stmt_result(1)
+                }),
+                None,
+                None,
+                None,
+            ],
             step_errors: vec![
+                None,
                 None,
                 Some(proto_error("the real cause")),
                 None,
                 Some(proto_error("cannot rollback")),
             ],
         };
-        let error = decode_batch_result(result, &layout).unwrap_err();
+        let decoded = decode_batch_result(result, &layout);
+        assert_eq!(decoded.last_insert_rowid, Some(40));
+        let error = decoded.outcome.unwrap_err();
         match error {
-            Error::BatchStatementFailed { index, error, .. } => {
-                assert_eq!(index, 0);
-                assert!(matches!(*error, Error::Error(ref m) if m == "the real cause"));
+            Error::BatchRollbackFailed {
+                error,
+                rollback_error,
+            } => {
+                assert!(matches!(
+                    *error,
+                    Error::BatchStatementFailed {
+                        index: 1,
+                        error,
+                        ..
+                    } if matches!(*error, Error::Error(ref m) if m == "the real cause")
+                ));
+                assert!(matches!(
+                    *rollback_error,
+                    Error::Error(ref m) if m == "cannot rollback"
+                ));
             }
-            other => panic!("expected BatchStatementFailed, got {other:?}"),
+            other => panic!("expected BatchRollbackFailed, got {other:?}"),
         }
     }
 
@@ -534,7 +677,7 @@ mod tests {
             step_results: vec![Some(stmt_result(0)), None],
             step_errors: vec![None, None],
         };
-        let error = decode_batch_result(result, &layout).unwrap_err();
+        let error = decode_batch_result(result, &layout).outcome.unwrap_err();
         assert!(matches!(error, Error::Http(_)));
     }
 
@@ -545,7 +688,29 @@ mod tests {
             step_results: vec![Some(stmt_result(0))],
             step_errors: vec![None],
         };
-        let error = decode_batch_result(result, &layout).unwrap_err();
+        let error = decode_batch_result(result, &layout).outcome.unwrap_err();
         assert!(matches!(error, Error::Http(_)));
+    }
+
+    #[test]
+    fn decode_rejects_a_step_with_a_result_and_an_error() {
+        let (_, layout) = build_batch(user_stmts(1), None);
+        let result = ProtoBatchResult {
+            step_results: vec![Some(stmt_result(0))],
+            step_errors: vec![Some(proto_error("impossible"))],
+        };
+        let error = decode_batch_result(result, &layout).outcome.unwrap_err();
+        assert!(matches!(error, Error::Http(ref message) if message.contains("both")));
+    }
+
+    #[test]
+    fn decode_rejects_a_missing_commit_result() {
+        let (_, layout) = build_batch(user_stmts(1), Some(TransactionBehavior::Deferred));
+        let result = ProtoBatchResult {
+            step_results: vec![Some(stmt_result(0)), Some(stmt_result(1)), None, None],
+            step_errors: vec![None, None, None, None],
+        };
+        let error = decode_batch_result(result, &layout).outcome.unwrap_err();
+        assert!(matches!(error, Error::Http(ref message) if message.contains("COMMIT")));
     }
 }

--- a/serverless/rust/batch.rs
+++ b/serverless/rust/batch.rs
@@ -1,0 +1,551 @@
+//! Parameterized statement batches.
+//!
+//! A batch sends multiple statements — each with its own bind parameters —
+//! to the server as a single batch request (section 6.2 of the protocol
+//! specification), so the whole batch completes in one HTTP round trip.
+//! See [`Connection::batch`](crate::Connection::batch) and
+//! [`Connection::transactional_batch`](crate::Connection::transactional_batch).
+
+use crate::{
+    params::{IntoParams, Params},
+    protocol::{decode_value_owned, Batch, BatchCond, BatchStep, Stmt},
+    rows::Row,
+    transaction::TransactionBehavior,
+    Column, Error, Result,
+};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+use sealed::Sealed;
+
+/// One statement of a batch, with its bind parameters.
+///
+/// Usually built implicitly from a SQL string or a `(sql, params)` pair
+/// (see [`IntoBatchStatement`]). Build `BatchStatement`s explicitly to mix
+/// parameter shapes in one batch, since the elements of a single array or
+/// `Vec` must share one type:
+///
+/// ```rust
+/// # fn build() -> turso_serverless::Result<Vec<turso_serverless::BatchStatement>> {
+/// use turso_serverless::BatchStatement;
+/// Ok(vec![
+///     BatchStatement::new("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())?,
+///     BatchStatement::new("INSERT INTO t (v) VALUES (?1)", ("x",))?,
+/// ])
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct BatchStatement {
+    pub(crate) sql: String,
+    pub(crate) params: Params,
+}
+
+impl BatchStatement {
+    /// Create a batch statement from SQL text and parameters, accepting the
+    /// same parameter forms as [`Connection::execute`](crate::Connection::execute).
+    pub fn new(sql: impl Into<String>, params: impl IntoParams) -> Result<Self> {
+        Ok(Self {
+            sql: sql.into(),
+            params: params.into_params()?,
+        })
+    }
+}
+
+/// Converts some type into one statement of a batch.
+///
+/// Implemented for:
+///
+/// - SQL strings without parameters: `"DELETE FROM t"`.
+/// - `(sql, params)` pairs, with the same parameter forms as
+///   [`Connection::execute`](crate::Connection::execute):
+///   `("INSERT INTO t (v) VALUES (?1)", ("x",))`.
+/// - [`BatchStatement`], for batches that mix parameter shapes.
+pub trait IntoBatchStatement: Sealed {
+    #[doc(hidden)]
+    fn into_batch_statement(self) -> Result<BatchStatement>;
+}
+
+impl Sealed for BatchStatement {}
+impl IntoBatchStatement for BatchStatement {
+    fn into_batch_statement(self) -> Result<BatchStatement> {
+        Ok(self)
+    }
+}
+
+impl Sealed for &str {}
+impl IntoBatchStatement for &str {
+    fn into_batch_statement(self) -> Result<BatchStatement> {
+        BatchStatement::new(self, ())
+    }
+}
+
+impl Sealed for String {}
+impl IntoBatchStatement for String {
+    fn into_batch_statement(self) -> Result<BatchStatement> {
+        BatchStatement::new(self, ())
+    }
+}
+
+impl<S: Into<String>, P: IntoParams> Sealed for (S, P) {}
+impl<S: Into<String>, P: IntoParams> IntoBatchStatement for (S, P) {
+    fn into_batch_statement(self) -> Result<BatchStatement> {
+        BatchStatement::new(self.0, self.1)
+    }
+}
+
+/// The result of one statement of a batch.
+#[derive(Debug)]
+pub struct BatchResult {
+    columns: Vec<Column>,
+    rows: Vec<Row>,
+    rows_affected: u64,
+    last_insert_rowid: Option<i64>,
+    rows_read: Option<u64>,
+    rows_written: Option<u64>,
+    query_duration_ms: Option<f64>,
+}
+
+impl BatchResult {
+    /// Returns the columns of the statement's result set.
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    /// Returns the rows returned by the statement.
+    pub fn rows(&self) -> &[Row] {
+        &self.rows
+    }
+
+    /// Returns the number of rows changed by the statement.
+    pub fn rows_affected(&self) -> u64 {
+        self.rows_affected
+    }
+
+    /// Returns the rowid inserted by the statement, when the statement was
+    /// an INSERT into a table with a rowid.
+    pub fn last_insert_rowid(&self) -> Option<i64> {
+        self.last_insert_rowid
+    }
+
+    /// Returns the number of rows read while executing the statement, as
+    /// reported by the server (section 8.4).
+    pub fn rows_read(&self) -> Option<u64> {
+        self.rows_read
+    }
+
+    /// Returns the number of rows written while executing the statement,
+    /// as reported by the server (section 8.4).
+    pub fn rows_written(&self) -> Option<u64> {
+        self.rows_written
+    }
+
+    /// Returns the server-side execution time of the statement in
+    /// milliseconds (section 8.4).
+    pub fn query_duration_ms(&self) -> Option<f64> {
+        self.query_duration_ms
+    }
+
+    fn from_stmt_result(result: crate::protocol::StmtResult) -> Result<Self> {
+        let columns: Vec<Column> = result
+            .cols
+            .into_iter()
+            .map(|c| Column {
+                name: c.name.unwrap_or_default(),
+                decl_type: c.decltype,
+            })
+            .collect();
+        let rows = result
+            .rows
+            .into_iter()
+            .map(|row| {
+                row.into_iter()
+                    .map(decode_value_owned)
+                    .collect::<Result<Vec<_>>>()
+                    .map(Row::new)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let last_insert_rowid = result
+            .last_insert_rowid
+            .map(|rowid| {
+                rowid
+                    .parse::<i64>()
+                    .map_err(|e| Error::Error(format!("invalid rowid in server response: {e}")))
+            })
+            .transpose()?;
+        // Row-returning statements (e.g. INSERT ... RETURNING) report 0,
+        // matching the embedded drivers.
+        let rows_affected = if columns.is_empty() {
+            result.affected_row_count
+        } else {
+            0
+        };
+        Ok(Self {
+            columns,
+            rows,
+            rows_affected,
+            last_insert_rowid,
+            rows_read: result.rows_read,
+            rows_written: result.rows_written,
+            query_duration_ms: result.query_duration_ms,
+        })
+    }
+}
+
+/// Where the user's statements sit among the steps of a batch on the wire:
+/// an atomic batch surrounds them with synthetic `BEGIN`/`COMMIT`/`ROLLBACK`
+/// steps.
+pub(crate) struct BatchLayout {
+    user_offset: usize,
+    user_count: usize,
+    begin: Option<usize>,
+    commit: Option<usize>,
+    total_steps: usize,
+}
+
+/// Build the wire-level batch for the given statements.
+///
+/// Each statement is gated on its predecessor succeeding, so execution
+/// stops at the first failure. With `wrap` set, the statements are
+/// additionally surrounded by `BEGIN <behavior>`, a `COMMIT` gated on the
+/// last statement succeeding, and a `ROLLBACK` gated on `BEGIN` having
+/// succeeded and `COMMIT` not having succeeded. The extra ok(BEGIN) guard
+/// prevents the ROLLBACK from aborting a transaction the caller opened on
+/// the stream out of band.
+pub(crate) fn build_batch(
+    stmts: Vec<Stmt>,
+    wrap: Option<TransactionBehavior>,
+) -> (Batch, BatchLayout) {
+    let user_count = stmts.len();
+    let mut steps = Vec::with_capacity(user_count + if wrap.is_some() { 3 } else { 0 });
+    let user_offset = match wrap {
+        None => 0,
+        Some(behavior) => {
+            steps.push(BatchStep {
+                condition: None,
+                stmt: Stmt::new(behavior.begin_sql(), false),
+            });
+            1
+        }
+    };
+    for (i, stmt) in stmts.into_iter().enumerate() {
+        let prev = (user_offset + i).checked_sub(1);
+        steps.push(BatchStep {
+            condition: prev.map(|prev| BatchCond::Ok { step: prev as u32 }),
+            stmt,
+        });
+    }
+    let commit = wrap.map(|_| {
+        let commit = user_offset + user_count;
+        steps.push(BatchStep {
+            condition: Some(BatchCond::Ok {
+                step: (commit - 1) as u32,
+            }),
+            stmt: Stmt::new("COMMIT", false),
+        });
+        steps.push(BatchStep {
+            condition: Some(BatchCond::And {
+                conds: vec![
+                    BatchCond::Ok { step: 0 },
+                    BatchCond::Not {
+                        cond: Box::new(BatchCond::Ok {
+                            step: commit as u32,
+                        }),
+                    },
+                ],
+            }),
+            stmt: Stmt::new("ROLLBACK", false),
+        });
+        commit
+    });
+    let layout = BatchLayout {
+        user_offset,
+        user_count,
+        begin: wrap.map(|_| 0),
+        commit,
+        total_steps: steps.len(),
+    };
+    (Batch { steps }, layout)
+}
+
+/// Decode a wire-level batch result into per-statement results, or the
+/// error of the step that failed.
+///
+/// A failing user statement is reported as
+/// [`Error::BatchStatementFailed`] with its zero-based index. Failures of
+/// the synthetic `BEGIN`/`COMMIT` steps surface as the underlying error.
+/// The synthetic `ROLLBACK` step's error, if any, is ignored: it only runs
+/// after a failure that is already being reported, and surfacing it would
+/// mask the cause.
+pub(crate) fn decode_batch_result(
+    result: crate::protocol::BatchResult,
+    layout: &BatchLayout,
+) -> Result<Vec<BatchResult>> {
+    if result.step_results.len() != layout.total_steps
+        || result.step_errors.len() != layout.total_steps
+    {
+        return Err(Error::Http(format!(
+            "batch response has {} results and {} errors for {} steps",
+            result.step_results.len(),
+            result.step_errors.len(),
+            layout.total_steps
+        )));
+    }
+    let mut step_results = result.step_results;
+    let mut step_errors = result.step_errors;
+    // Decode the results of the statements that executed before looking
+    // at the errors, so a failure can still report what completed.
+    let mut outputs = Vec::with_capacity(layout.user_count);
+    for i in 0..layout.user_count {
+        outputs.push(
+            step_results[layout.user_offset + i]
+                .take()
+                .map(BatchResult::from_stmt_result)
+                .transpose()?,
+        );
+    }
+    if let Some(begin) = layout.begin {
+        if let Some(error) = step_errors[begin].take() {
+            return Err(error.into());
+        }
+    }
+    for i in 0..layout.user_count {
+        if let Some(error) = step_errors[layout.user_offset + i].take() {
+            return Err(Error::BatchStatementFailed {
+                index: i,
+                error: Box::new(error.into()),
+                results: outputs,
+            });
+        }
+    }
+    if let Some(commit) = layout.commit {
+        if let Some(error) = step_errors[commit].take() {
+            return Err(error.into());
+        }
+    }
+    outputs
+        .into_iter()
+        .enumerate()
+        .map(|(i, output)| {
+            output.ok_or_else(|| {
+                Error::Http(format!(
+                    "batch response is missing the result for statement {i}"
+                ))
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{BatchResult as ProtoBatchResult, ProtoError, ProtoValue, StmtResult};
+    use crate::Value;
+    use serde_json::json;
+
+    fn user_stmts(n: usize) -> Vec<Stmt> {
+        (0..n)
+            .map(|i| Stmt::new(format!("SELECT {i}"), true))
+            .collect()
+    }
+
+    fn stmt_result(rows_affected: u64) -> StmtResult {
+        StmtResult {
+            cols: Vec::new(),
+            rows: Vec::new(),
+            affected_row_count: rows_affected,
+            last_insert_rowid: None,
+            rows_read: None,
+            rows_written: None,
+            query_duration_ms: None,
+        }
+    }
+
+    fn proto_error(message: &str) -> ProtoError {
+        ProtoError {
+            message: message.to_string(),
+            code: None,
+            extended_code: None,
+        }
+    }
+
+    #[test]
+    fn plain_batch_chains_each_step_on_its_predecessor() {
+        let (batch, layout) = build_batch(user_stmts(3), None);
+        let json = serde_json::to_value(&batch).unwrap();
+        let steps = json["steps"].as_array().unwrap();
+        assert_eq!(steps.len(), 3);
+        assert_eq!(steps[0].get("condition"), None);
+        assert_eq!(steps[1]["condition"], json!({"type": "ok", "step": 0}));
+        assert_eq!(steps[2]["condition"], json!({"type": "ok", "step": 1}));
+        assert_eq!(layout.user_offset, 0);
+        assert_eq!(layout.total_steps, 3);
+    }
+
+    #[test]
+    fn transactional_batch_wraps_statements_in_begin_commit_rollback() {
+        let (batch, layout) = build_batch(user_stmts(2), Some(TransactionBehavior::Immediate));
+        let json = serde_json::to_value(&batch).unwrap();
+        let steps = json["steps"].as_array().unwrap();
+        assert_eq!(steps.len(), 5);
+
+        assert_eq!(steps[0]["stmt"]["sql"], "BEGIN IMMEDIATE");
+        assert_eq!(steps[0].get("condition"), None);
+        assert_eq!(steps[1]["condition"], json!({"type": "ok", "step": 0}));
+        assert_eq!(steps[2]["condition"], json!({"type": "ok", "step": 1}));
+        assert_eq!(steps[3]["stmt"]["sql"], "COMMIT");
+        assert_eq!(steps[3]["condition"], json!({"type": "ok", "step": 2}));
+        assert_eq!(steps[4]["stmt"]["sql"], "ROLLBACK");
+        assert_eq!(
+            steps[4]["condition"],
+            json!({
+                "type": "and",
+                "conds": [
+                    {"type": "ok", "step": 0},
+                    {"type": "not", "cond": {"type": "ok", "step": 3}},
+                ],
+            })
+        );
+
+        assert_eq!(layout.user_offset, 1);
+        assert_eq!(layout.begin, Some(0));
+        assert_eq!(layout.commit, Some(3));
+        assert_eq!(layout.total_steps, 5);
+    }
+
+    #[test]
+    fn decode_maps_results_per_statement_in_order() {
+        let (_, layout) = build_batch(user_stmts(2), None);
+        let result = ProtoBatchResult {
+            step_results: vec![
+                Some(StmtResult {
+                    rows: vec![vec![ProtoValue::Integer {
+                        value: "7".to_string(),
+                    }]],
+                    ..stmt_result(0)
+                }),
+                Some(StmtResult {
+                    last_insert_rowid: Some("42".to_string()),
+                    ..stmt_result(1)
+                }),
+            ],
+            step_errors: vec![None, None],
+        };
+        let outputs = decode_batch_result(result, &layout).unwrap();
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(
+            outputs[0].rows()[0].get_value(0).unwrap(),
+            Value::Integer(7)
+        );
+        assert_eq!(outputs[1].rows_affected(), 1);
+        assert_eq!(outputs[1].last_insert_rowid(), Some(42));
+    }
+
+    #[test]
+    fn decode_reports_the_failing_statement_index() {
+        let (_, layout) = build_batch(user_stmts(3), None);
+        let result = ProtoBatchResult {
+            step_results: vec![Some(stmt_result(1)), None, None],
+            step_errors: vec![None, Some(proto_error("boom")), None],
+        };
+        let error = decode_batch_result(result, &layout).unwrap_err();
+        match error {
+            Error::BatchStatementFailed {
+                index,
+                error,
+                results,
+            } => {
+                assert_eq!(index, 1);
+                assert!(matches!(*error, Error::Error(ref m) if m == "boom"));
+                // One entry per statement: the completed first statement's
+                // result, None for the failing and skipped ones.
+                assert_eq!(results.len(), 3);
+                assert_eq!(results[0].as_ref().unwrap().rows_affected(), 1);
+                assert!(results[1].is_none());
+                assert!(results[2].is_none());
+            }
+            other => panic!("expected BatchStatementFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_indexes_user_statements_past_the_synthetic_begin() {
+        let (_, layout) = build_batch(user_stmts(2), Some(TransactionBehavior::Deferred));
+        let result = ProtoBatchResult {
+            step_results: vec![
+                Some(stmt_result(0)),
+                Some(stmt_result(1)),
+                None,
+                None,
+                Some(stmt_result(0)),
+            ],
+            step_errors: vec![None, None, Some(proto_error("second failed")), None, None],
+        };
+        let error = decode_batch_result(result, &layout).unwrap_err();
+        match error {
+            Error::BatchStatementFailed { index, .. } => assert_eq!(index, 1),
+            other => panic!("expected BatchStatementFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_surfaces_commit_failure_without_an_index() {
+        let (_, layout) = build_batch(user_stmts(1), Some(TransactionBehavior::Deferred));
+        let result = ProtoBatchResult {
+            step_results: vec![
+                Some(stmt_result(0)),
+                Some(stmt_result(1)),
+                None,
+                Some(stmt_result(0)),
+            ],
+            step_errors: vec![None, None, Some(proto_error("commit failed")), None],
+        };
+        let error = decode_batch_result(result, &layout).unwrap_err();
+        assert!(matches!(error, Error::Error(ref m) if m == "commit failed"));
+    }
+
+    #[test]
+    fn decode_ignores_rollback_errors_in_favor_of_the_cause() {
+        let (_, layout) = build_batch(user_stmts(1), Some(TransactionBehavior::Deferred));
+        let result = ProtoBatchResult {
+            step_results: vec![Some(stmt_result(0)), None, None, None],
+            step_errors: vec![
+                None,
+                Some(proto_error("the real cause")),
+                None,
+                Some(proto_error("cannot rollback")),
+            ],
+        };
+        let error = decode_batch_result(result, &layout).unwrap_err();
+        match error {
+            Error::BatchStatementFailed { index, error, .. } => {
+                assert_eq!(index, 0);
+                assert!(matches!(*error, Error::Error(ref m) if m == "the real cause"));
+            }
+            other => panic!("expected BatchStatementFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_rejects_a_skipped_statement_with_no_error() {
+        let (_, layout) = build_batch(user_stmts(2), None);
+        let result = ProtoBatchResult {
+            step_results: vec![Some(stmt_result(0)), None],
+            step_errors: vec![None, None],
+        };
+        let error = decode_batch_result(result, &layout).unwrap_err();
+        assert!(matches!(error, Error::Http(_)));
+    }
+
+    #[test]
+    fn decode_rejects_a_result_count_mismatch() {
+        let (_, layout) = build_batch(user_stmts(2), None);
+        let result = ProtoBatchResult {
+            step_results: vec![Some(stmt_result(0))],
+            step_errors: vec![None],
+        };
+        let error = decode_batch_result(result, &layout).unwrap_err();
+        assert!(matches!(error, Error::Http(_)));
+    }
+}

--- a/serverless/rust/conformance/tests/driver.rs
+++ b/serverless/rust/conformance/tests/driver.rs
@@ -568,6 +568,59 @@ async fn transactional_batch_rolls_back_on_failure() {
 }
 
 #[tokio::test]
+async fn transactional_batch_updates_rowid_when_commit_fails() {
+    let config = config_or_skip!();
+    let conn = connect(&config.url, &config.auth_token).await;
+    let parent = unique_name("t_rowid_parent");
+    let child = unique_name("t_rowid_child");
+
+    conn.execute("PRAGMA foreign_keys = ON", ()).await.unwrap();
+    conn.execute(
+        format!("CREATE TABLE {parent} (id INTEGER PRIMARY KEY)"),
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        format!(
+            "CREATE TABLE {child} (\
+                id INTEGER PRIMARY KEY, \
+                parent_id INTEGER REFERENCES {parent}(id) DEFERRABLE INITIALLY DEFERRED\
+            )"
+        ),
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(format!("INSERT INTO {parent} VALUES (5)"), ())
+        .await
+        .unwrap();
+    assert_eq!(conn.last_insert_rowid(), 5);
+
+    let error = conn
+        .transactional_batch(
+            [format!("INSERT INTO {child} VALUES (9, 999)")],
+            TransactionBehavior::Deferred,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::Constraint(_)), "{error}");
+    assert_eq!(conn.last_insert_rowid(), 9);
+
+    let mut rows = conn
+        .query(format!("SELECT count(*) FROM {child}"), ())
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+        0
+    );
+
+    drop_table(&conn, &child).await;
+    drop_table(&conn, &parent).await;
+}
+
+#[tokio::test]
 async fn transactional_batch_joins_an_open_transaction() {
     let config = config_or_skip!();
     let mut conn = connect(&config.url, &config.auth_token).await;

--- a/serverless/rust/conformance/tests/driver.rs
+++ b/serverless/rust/conformance/tests/driver.rs
@@ -7,7 +7,7 @@
 use turso_serverless::{
     named_params,
     transaction::{DropBehavior, TransactionBehavior},
-    Builder, Connection, Error, Value,
+    BatchStatement, Builder, Connection, Error, Value,
 };
 use turso_serverless_conformance::{config_or_skip, unique_name};
 
@@ -298,6 +298,303 @@ async fn execute_batch_stops_at_first_error() {
         .unwrap();
     let row = rows.next().await.unwrap().unwrap();
     assert_eq!(row.get::<i64>(0).unwrap(), 1);
+
+    drop_table(&conn, &table).await;
+}
+
+#[tokio::test]
+async fn batch_executes_parameterized_statements_in_order() {
+    let config = config_or_skip!();
+    let conn = connect(&config.url, &config.auth_token).await;
+    let table = unique_name("t_pbatch");
+
+    let results = conn
+        .batch(vec![
+            BatchStatement::new(
+                format!("CREATE TABLE {table} (id INTEGER PRIMARY KEY, name TEXT)"),
+                (),
+            )
+            .unwrap(),
+            BatchStatement::new(
+                format!("INSERT INTO {table} (name) VALUES (?1)"),
+                ("Alice",),
+            )
+            .unwrap(),
+            BatchStatement::new(
+                format!("INSERT INTO {table} (name) VALUES (:name)"),
+                named_params![":name": "Bob"],
+            )
+            .unwrap(),
+            BatchStatement::new(format!("SELECT name FROM {table} ORDER BY id"), ()).unwrap(),
+        ])
+        .await
+        .unwrap();
+
+    // One result per statement, in order.
+    assert_eq!(results.len(), 4);
+    assert_eq!(results[1].rows_affected(), 1);
+    assert_eq!(results[1].last_insert_rowid(), Some(1));
+    assert_eq!(results[2].last_insert_rowid(), Some(2));
+    let select = &results[3];
+    assert_eq!(select.columns()[0].name(), "name");
+    assert_eq!(select.rows().len(), 2);
+    assert_eq!(
+        select.rows()[0].get_value(0).unwrap(),
+        Value::Text("Alice".to_string())
+    );
+    assert_eq!(
+        select.rows()[1].get_value(0).unwrap(),
+        Value::Text("Bob".to_string())
+    );
+    assert_eq!(conn.last_insert_rowid(), 2);
+
+    // Server-side execution statistics are reported per statement
+    // (section 8.4).
+    for result in &results {
+        assert!(result.rows_read().is_some());
+        assert!(result.rows_written().is_some());
+        assert!(result.query_duration_ms().is_some());
+    }
+    assert!(results[1].rows_written().unwrap() >= 1);
+
+    drop_table(&conn, &table).await;
+}
+
+#[tokio::test]
+async fn batch_accepts_strings_and_pairs() {
+    let config = config_or_skip!();
+    let conn = connect(&config.url, &config.auth_token).await;
+    let table = unique_name("t_pbatchforms");
+
+    conn.execute(format!("CREATE TABLE {table} (x INTEGER)"), ())
+        .await
+        .unwrap();
+
+    conn.batch([
+        format!("INSERT INTO {table} VALUES (1)"),
+        format!("INSERT INTO {table} VALUES (2)"),
+    ])
+    .await
+    .unwrap();
+    conn.batch([
+        (format!("INSERT INTO {table} VALUES (?1)"), (3,)),
+        (format!("INSERT INTO {table} VALUES (?1)"), (4,)),
+    ])
+    .await
+    .unwrap();
+
+    let mut rows = conn
+        .query(format!("SELECT count(*), sum(x) FROM {table}"), ())
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 4);
+    assert_eq!(row.get::<i64>(1).unwrap(), 10);
+
+    drop_table(&conn, &table).await;
+}
+
+#[tokio::test]
+async fn batch_error_identifies_the_failing_statement() {
+    let config = config_or_skip!();
+    let conn = connect(&config.url, &config.auth_token).await;
+    let table = unique_name("t_pbatcherr");
+
+    conn.execute(format!("CREATE TABLE {table} (x INTEGER)"), ())
+        .await
+        .unwrap();
+
+    let error = conn
+        .batch(vec![
+            BatchStatement::new(format!("INSERT INTO {table} VALUES (?1)"), (1,)).unwrap(),
+            BatchStatement::new(
+                format!("INSERT INTO no_such_table_{table} VALUES (?1)"),
+                (2,),
+            )
+            .unwrap(),
+            BatchStatement::new(format!("INSERT INTO {table} VALUES (?1)"), (3,)).unwrap(),
+        ])
+        .await
+        .unwrap_err();
+    match error {
+        Error::BatchStatementFailed {
+            index,
+            error,
+            results,
+        } => {
+            assert_eq!(index, 1);
+            assert!(error.to_string().contains("no_such_table"), "{error}");
+            // One entry per statement: the completed first statement's
+            // result, None for the failing and skipped ones.
+            assert_eq!(results.len(), 3);
+            assert_eq!(results[0].as_ref().unwrap().rows_affected(), 1);
+            assert!(results[1].is_none());
+            assert!(results[2].is_none());
+        }
+        other => panic!("expected BatchStatementFailed, got {other:?}"),
+    }
+
+    // The batch is not transactional: the statement before the failing one
+    // keeps its effect, and the one after it never ran.
+    let mut rows = conn
+        .query(format!("SELECT count(*) FROM {table}"), ())
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 1);
+
+    drop_table(&conn, &table).await;
+}
+
+#[tokio::test]
+async fn batch_joins_an_open_transaction() {
+    let config = config_or_skip!();
+    let mut conn = connect(&config.url, &config.auth_token).await;
+    let table = unique_name("t_pbatchtx");
+
+    conn.execute(format!("CREATE TABLE {table} (x INTEGER)"), ())
+        .await
+        .unwrap();
+
+    let tx = conn.transaction().await.unwrap();
+    tx.batch([
+        (format!("INSERT INTO {table} VALUES (?1)"), (1,)),
+        (format!("INSERT INTO {table} VALUES (?1)"), (2,)),
+    ])
+    .await
+    .unwrap();
+    // The batch ran inside the transaction rather than starting a stream
+    // of its own.
+    assert!(!tx.is_autocommit().unwrap());
+    tx.rollback().await.unwrap();
+
+    let mut rows = conn
+        .query(format!("SELECT count(*) FROM {table}"), ())
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 0);
+
+    drop_table(&conn, &table).await;
+}
+
+#[tokio::test]
+async fn empty_batch_returns_no_results() {
+    let config = config_or_skip!();
+    let conn = connect(&config.url, &config.auth_token).await;
+
+    let results = conn.batch(Vec::<BatchStatement>::new()).await.unwrap();
+    assert!(results.is_empty());
+    let results = conn
+        .transactional_batch(Vec::<BatchStatement>::new(), TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn transactional_batch_commits_atomically() {
+    let config = config_or_skip!();
+    let conn = connect(&config.url, &config.auth_token).await;
+    let table = unique_name("t_tbatch");
+
+    conn.execute(format!("CREATE TABLE {table} (x INTEGER)"), ())
+        .await
+        .unwrap();
+
+    let results = conn
+        .transactional_batch(
+            [
+                (format!("INSERT INTO {table} VALUES (?1)"), (1,)),
+                (format!("INSERT INTO {table} VALUES (?1)"), (2,)),
+            ],
+            TransactionBehavior::Immediate,
+        )
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(conn.is_autocommit().unwrap());
+
+    // The committed rows are visible from a fresh connection.
+    let other = connect(&config.url, &config.auth_token).await;
+    let mut rows = other
+        .query(format!("SELECT count(*) FROM {table}"), ())
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 2);
+
+    drop_table(&conn, &table).await;
+}
+
+#[tokio::test]
+async fn transactional_batch_rolls_back_on_failure() {
+    let config = config_or_skip!();
+    let conn = connect(&config.url, &config.auth_token).await;
+    let table = unique_name("t_tbatcherr");
+
+    conn.execute(format!("CREATE TABLE {table} (x INTEGER)"), ())
+        .await
+        .unwrap();
+
+    let error = conn
+        .transactional_batch(
+            [
+                (format!("INSERT INTO {table} VALUES (?1)"), (1,)),
+                (
+                    format!("INSERT INTO no_such_table_{table} VALUES (?1)"),
+                    (2,),
+                ),
+            ],
+            TransactionBehavior::Immediate,
+        )
+        .await
+        .unwrap_err();
+    match error {
+        Error::BatchStatementFailed { index, .. } => assert_eq!(index, 1),
+        other => panic!("expected BatchStatementFailed, got {other:?}"),
+    }
+    assert!(conn.is_autocommit().unwrap());
+
+    // The ROLLBACK step undid the first insert.
+    let mut rows = conn
+        .query(format!("SELECT count(*) FROM {table}"), ())
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 0);
+
+    drop_table(&conn, &table).await;
+}
+
+#[tokio::test]
+async fn transactional_batch_joins_an_open_transaction() {
+    let config = config_or_skip!();
+    let mut conn = connect(&config.url, &config.auth_token).await;
+    let table = unique_name("t_tbatchtx");
+
+    conn.execute(format!("CREATE TABLE {table} (x INTEGER)"), ())
+        .await
+        .unwrap();
+
+    // With a transaction already open the wrapping is skipped and the
+    // statements join it, so the outer rollback undoes them.
+    let tx = conn.transaction().await.unwrap();
+    tx.transactional_batch(
+        [(format!("INSERT INTO {table} VALUES (?1)"), (1,))],
+        TransactionBehavior::Immediate,
+    )
+    .await
+    .unwrap();
+    assert!(!tx.is_autocommit().unwrap());
+    tx.rollback().await.unwrap();
+
+    let mut rows = conn
+        .query(format!("SELECT count(*) FROM {table}"), ())
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 0);
 
     drop_table(&conn, &table).await;
 }

--- a/serverless/rust/conformance/tests/protocol.rs
+++ b/serverless/rust/conformance/tests/protocol.rs
@@ -404,6 +404,78 @@ async fn atomic_batch_rolls_back_on_failure() {
 }
 
 #[tokio::test]
+async fn batch_steps_carry_bind_parameters_in_one_pipeline_post() {
+    let config = config_or_skip!();
+    let table = unique_name("t_batchargs");
+    exec(
+        &config,
+        &[&format!(
+            "CREATE TABLE {table} (id INTEGER PRIMARY KEY, v TEXT)"
+        )],
+    )
+    .await;
+
+    // A single POST to /v3/pipeline carries a whole parameterized batch:
+    // every step has its own `args` / `named_args` (section 6.2).
+    let (status, response) = pipeline(
+        &config,
+        json!({
+            "baton": null,
+            "requests": [
+                {"type": "batch", "batch": {"steps": [
+                    {
+                        "stmt": {
+                            "sql": format!("INSERT INTO {table} (v) VALUES (?)"),
+                            "args": [{"type": "text", "value": "a"}],
+                            "want_rows": false,
+                        },
+                    },
+                    {
+                        "condition": {"type": "ok", "step": 0},
+                        "stmt": {
+                            "sql": format!("INSERT INTO {table} (v) VALUES (:v)"),
+                            "named_args": [
+                                {"name": "v", "value": {"type": "text", "value": "b"}},
+                            ],
+                            "want_rows": false,
+                        },
+                    },
+                    {
+                        "condition": {"type": "ok", "step": 1},
+                        "stmt": {
+                            "sql": format!("SELECT v FROM {table} ORDER BY id"),
+                            "want_rows": true,
+                        },
+                    },
+                ]}},
+                {"type": "close"},
+            ],
+        }),
+    )
+    .await;
+
+    assert_eq!(status, 200);
+    let result = &response["results"][0];
+    assert_eq!(result["type"], "ok", "batch failed: {result}");
+    let batch_result = &result["response"]["result"];
+    let step_results = batch_result["step_results"].as_array().unwrap();
+    let step_errors = batch_result["step_errors"].as_array().unwrap();
+    assert_eq!(step_results.len(), 3);
+    assert_eq!(step_errors, &vec![Value::Null; 3]);
+
+    assert_eq!(step_results[0]["affected_row_count"], 1);
+    assert_eq!(step_results[0]["last_insert_rowid"], "1");
+    assert_eq!(step_results[1]["affected_row_count"], 1);
+    assert_eq!(step_results[1]["last_insert_rowid"], "2");
+    let rows = step_results[2]["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0][0], json!({"type": "text", "value": "a"}));
+    assert_eq!(rows[1][0], json!({"type": "text", "value": "b"}));
+
+    exec(&config, &[&format!("DROP TABLE {table}")]).await;
+}
+
+#[tokio::test]
 async fn sequence_stops_at_first_failing_statement() {
     let config = config_or_skip!();
     let table = unique_name("p_seq");

--- a/serverless/rust/connection.rs
+++ b/serverless/rust/connection.rs
@@ -188,11 +188,11 @@ impl Connection {
     ///
     /// This method owns the surrounding transaction, so the statements
     /// must not contain their own transaction-control SQL (`BEGIN`,
-    /// `COMMIT`, `ROLLBACK`, `SAVEPOINT`, `RELEASE`); a user-supplied
+    /// `COMMIT`, `END`, `ROLLBACK`, `SAVEPOINT`, `RELEASE`); a user-supplied
     /// `COMMIT` would close the wrapper transaction mid-batch and leave
-    /// earlier statements committed, defeating the all-or-nothing
-    /// contract. If a transaction is already open on this connection, the
-    /// wrapping is skipped and the statements join it, exactly as with
+    /// earlier statements committed, defeating the all-or-nothing contract.
+    /// If a transaction is already open on this connection, the wrapping is
+    /// skipped and the statements join it, exactly as with
     /// [`batch`](Connection::batch).
     ///
     /// # Example
@@ -237,19 +237,7 @@ impl Connection {
         I: IntoIterator,
         I::Item: IntoBatchStatement,
     {
-        let stmts = stmts
-            .into_iter()
-            .enumerate()
-            .map(|(index, stmt)| {
-                stmt.into_batch_statement()
-                    .and_then(|stmt| Self::build_stmt(&stmt.sql, stmt.params, true))
-                    .map_err(|error| Error::BatchStatementFailed {
-                        index,
-                        error: Box::new(error),
-                        results: Vec::new(),
-                    })
-            })
-            .collect::<Result<Vec<_>>>()?;
+        let stmts = Self::build_batch_stmts(stmts)?;
         if stmts.is_empty() {
             return Ok(Vec::new());
         }
@@ -263,6 +251,9 @@ impl Connection {
         } else {
             None
         };
+        if wrap.is_some() {
+            Self::validate_managed_batch(&stmts)?;
+        }
         let (batch, layout) = build_batch(stmts, wrap);
         let results = session
             .pipeline(vec![StreamRequest::Batch { batch }], true)
@@ -271,40 +262,60 @@ impl Connection {
             Some(StreamResult::Ok {
                 response: StreamResponse::Batch { result },
             }) => {
-                let update_rowid = |outputs: &[Option<BatchResult>]| {
-                    if let Some(rowid) = outputs
-                        .iter()
-                        .rev()
-                        .find_map(|o| o.as_ref().and_then(|o| o.last_insert_rowid()))
-                    {
-                        session
-                            .shared
-                            .last_insert_rowid
-                            .store(rowid, Ordering::Relaxed);
-                    }
-                };
-                match decode_batch_result(result, &layout) {
-                    Ok(outputs) => {
-                        let outputs: Vec<Option<BatchResult>> =
-                            outputs.into_iter().map(Some).collect();
-                        update_rowid(&outputs);
-                        Ok(outputs.into_iter().flatten().collect())
-                    }
-                    Err(error) => {
-                        // A statement that completed before the failure still
-                        // moved the connection's rowid server-side.
-                        if let Error::BatchStatementFailed { results, .. } = &error {
-                            update_rowid(results);
-                        }
-                        Err(error)
-                    }
+                let decoded = decode_batch_result(result, &layout);
+                if let Some(rowid) = decoded.last_insert_rowid {
+                    session
+                        .shared
+                        .last_insert_rowid
+                        .store(rowid, Ordering::Relaxed);
                 }
+                decoded.outcome
             }
             Some(StreamResult::Error { error }) => Err(error.into()),
             _ => Err(Error::Http(
                 "missing batch result in pipeline response".to_string(),
             )),
         }
+    }
+
+    fn build_batch_stmts<I>(stmts: I) -> Result<Vec<Stmt>>
+    where
+        I: IntoIterator,
+        I::Item: IntoBatchStatement,
+    {
+        stmts
+            .into_iter()
+            .enumerate()
+            .map(|(index, stmt)| {
+                stmt.into_batch_statement()
+                    .and_then(|stmt| Self::build_stmt(&stmt.sql, stmt.params, true))
+                    .map_err(|error| Error::BatchStatementFailed {
+                        index,
+                        error: Box::new(error),
+                        results: Vec::new(),
+                    })
+            })
+            .collect()
+    }
+
+    fn validate_managed_batch(stmts: &[Stmt]) -> Result<()> {
+        for (index, stmt) in stmts.iter().enumerate() {
+            if stmt
+                .sql
+                .as_deref()
+                .is_some_and(is_transaction_control_statement)
+            {
+                return Err(Error::BatchStatementFailed {
+                    index,
+                    error: Box::new(Error::Misuse(
+                        "transaction-control SQL is not allowed in a managed transactional batch"
+                            .to_string(),
+                    )),
+                    results: Vec::new(),
+                });
+            }
+        }
+        Ok(())
     }
 
     /// Prepare a SQL statement.
@@ -496,7 +507,7 @@ impl Connection {
                 None => {
                     return Err(Error::Http(
                         "missing execute result in pipeline response".to_string(),
-                    ))
+                    ));
                 }
             }
         }
@@ -526,5 +537,109 @@ impl Connection {
             }
         }
         Ok(stmt)
+    }
+}
+
+fn is_transaction_control_statement(sql: &str) -> bool {
+    let mut sql = sql;
+    loop {
+        sql = sql.trim_start_matches(|c: char| c.is_whitespace() || c == '\u{feff}' || c == ';');
+        if let Some(comment) = sql.strip_prefix("--") {
+            sql = comment.split_once('\n').map_or("", |(_, rest)| rest);
+        } else if let Some(comment) = sql.strip_prefix("/*") {
+            let Some((_, rest)) = comment.split_once("*/") else {
+                return false;
+            };
+            sql = rest;
+        } else {
+            break;
+        }
+    }
+    let keyword_end = sql
+        .find(|c: char| !c.is_ascii_alphabetic())
+        .unwrap_or(sql.len());
+    matches!(
+        &sql[..keyword_end].to_ascii_uppercase()[..],
+        "BEGIN" | "COMMIT" | "END" | "ROLLBACK" | "SAVEPOINT" | "RELEASE"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{named_params, BatchStatement};
+
+    #[test]
+    fn batch_preflight_reports_late_infinite_positional_param() {
+        let statements = vec![
+            BatchStatement::new("SELECT ?1", (1.0,)).unwrap(),
+            BatchStatement::new("SELECT ?1", (f64::INFINITY,)).unwrap(),
+        ];
+        let error = Connection::build_batch_stmts(statements).unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::BatchStatementFailed {
+                index: 1,
+                error,
+                results,
+            } if matches!(*error, Error::ToSqlConversionFailure(_)) && results.is_empty()
+        ));
+    }
+
+    #[test]
+    fn batch_preflight_reports_infinite_named_param() {
+        let stmt =
+            BatchStatement::new("SELECT :x", named_params![":x": f64::NEG_INFINITY]).unwrap();
+        let error = Connection::build_batch_stmts([stmt]).unwrap_err();
+        assert!(matches!(
+            error,
+            Error::BatchStatementFailed {
+                index: 0,
+                error,
+                results,
+            } if matches!(*error, Error::ToSqlConversionFailure(_)) && results.is_empty()
+        ));
+    }
+
+    #[test]
+    fn transaction_control_detection_skips_space_and_comments() {
+        for sql in [
+            "BEGIN",
+            "  -- why\ncommit transaction",
+            "/* first */ SAVEPOINT s",
+            "; /* empty statement */ COMMIT",
+            "\u{feff}release s",
+            "END",
+        ] {
+            assert!(is_transaction_control_statement(sql), "{sql:?}");
+        }
+        for sql in [
+            "SELECT 'COMMIT'",
+            "CREATE TABLE rollback_log (x)",
+            "BEGINNING",
+            "/* unterminated",
+        ] {
+            assert!(!is_transaction_control_statement(sql), "{sql:?}");
+        }
+    }
+
+    #[test]
+    fn managed_batch_rejects_transaction_control_with_its_user_index() {
+        let stmts = Connection::build_batch_stmts([
+            "SELECT 1",
+            "; /* empty statement */ COMMIT",
+            "SELECT 2",
+        ])
+        .unwrap();
+        let error = Connection::validate_managed_batch(&stmts).unwrap_err();
+        assert!(matches!(
+            error,
+            Error::BatchStatementFailed {
+                index: 1,
+                error,
+                results,
+            } if matches!(*error, Error::Misuse(_)) && results.is_empty()
+        ));
     }
 }

--- a/serverless/rust/connection.rs
+++ b/serverless/rust/connection.rs
@@ -9,6 +9,7 @@ use std::{
 use tokio::sync::Mutex;
 
 use crate::{
+    batch::{build_batch, decode_batch_result, BatchResult, IntoBatchStatement},
     params::{IntoParams, Params},
     protocol::{encode_value, NamedArg, Stmt, StreamRequest, StreamResponse, StreamResult},
     rows::{Row, Rows},
@@ -120,6 +121,188 @@ impl Connection {
             Some(StreamResult::Error { error }) => Err(error.into()),
             None => Err(Error::Http(
                 "missing sequence result in pipeline response".to_string(),
+            )),
+        }
+    }
+
+    /// Execute multiple parameterized statements in a single HTTP request.
+    ///
+    /// The statements are sent as one batch (section 6.2 of the protocol
+    /// specification) and execute in order. Execution stops at the first
+    /// statement that fails: the remaining statements are skipped and the
+    /// returned [`Error::BatchStatementFailed`] carries the zero-based
+    /// index of the failing statement together with the underlying error.
+    ///
+    /// The batch is not transactional: each statement commits as it
+    /// executes, so statements that ran before a failure stay committed.
+    /// For all-or-nothing execution use
+    /// [`transactional_batch`](Connection::transactional_batch). If a
+    /// transaction is open on this connection — including when calling
+    /// through a [`Transaction`] — the statements join it instead of
+    /// committing individually.
+    ///
+    /// Accepts plain SQL strings, `(sql, params)` pairs, and
+    /// [`crate::BatchStatement`]s (see [`IntoBatchStatement`]). Returns one
+    /// [`BatchResult`] per statement, in order.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # async fn run(conn: turso_serverless::Connection) -> turso_serverless::Result<()> {
+    /// // Statements whose parameters have the same type can be passed
+    /// // as (sql, params) pairs.
+    /// conn.batch([
+    ///     ("INSERT INTO users (name) VALUES (?1)", ("Alice",)),
+    ///     ("INSERT INTO users (name) VALUES (?1)", ("Bob",)),
+    /// ])
+    /// .await?;
+    ///
+    /// // Batches mixing parameter shapes use `BatchStatement`.
+    /// use turso_serverless::BatchStatement;
+    /// let results = conn
+    ///     .batch(vec![
+    ///         BatchStatement::new("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)", ())?,
+    ///         BatchStatement::new("INSERT INTO t (v) VALUES (?1)", ("x",))?,
+    ///     ])
+    ///     .await?;
+    /// assert_eq!(results[1].rows_affected(), 1);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn batch<I>(&self, stmts: I) -> Result<Vec<BatchResult>>
+    where
+        I: IntoIterator,
+        I::Item: IntoBatchStatement,
+    {
+        self.run_batch(stmts, None).await
+    }
+
+    /// Execute multiple parameterized statements atomically, in a single
+    /// HTTP request.
+    ///
+    /// Like [`batch`](Connection::batch), but the statements are wrapped
+    /// in `BEGIN <behavior>` / `COMMIT`, with a `ROLLBACK` on failure, all
+    /// carried by the same request: either every statement commits or none
+    /// does. On failure the returned [`Error::BatchStatementFailed`]
+    /// carries the zero-based index of the failing statement.
+    ///
+    /// This method owns the surrounding transaction, so the statements
+    /// must not contain their own transaction-control SQL (`BEGIN`,
+    /// `COMMIT`, `ROLLBACK`, `SAVEPOINT`, `RELEASE`); a user-supplied
+    /// `COMMIT` would close the wrapper transaction mid-batch and leave
+    /// earlier statements committed, defeating the all-or-nothing
+    /// contract. If a transaction is already open on this connection, the
+    /// wrapping is skipped and the statements join it, exactly as with
+    /// [`batch`](Connection::batch).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # async fn run(conn: turso_serverless::Connection) -> turso_serverless::Result<()> {
+    /// use turso_serverless::{BatchStatement, TransactionBehavior};
+    /// // A schema migration as one atomic round trip: DDL plus a
+    /// // parameterized bookkeeping INSERT.
+    /// conn.transactional_batch(
+    ///     vec![
+    ///         BatchStatement::new("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)", ())?,
+    ///         BatchStatement::new(
+    ///             "INSERT INTO migrations (version, applied_at) VALUES (?1, ?2)",
+    ///             (3, "2026-08-27"),
+    ///         )?,
+    ///     ],
+    ///     TransactionBehavior::Immediate,
+    /// )
+    /// .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn transactional_batch<I>(
+        &self,
+        stmts: I,
+        behavior: TransactionBehavior,
+    ) -> Result<Vec<BatchResult>>
+    where
+        I: IntoIterator,
+        I::Item: IntoBatchStatement,
+    {
+        self.run_batch(stmts, Some(behavior)).await
+    }
+
+    async fn run_batch<I>(
+        &self,
+        stmts: I,
+        wrap: Option<TransactionBehavior>,
+    ) -> Result<Vec<BatchResult>>
+    where
+        I: IntoIterator,
+        I::Item: IntoBatchStatement,
+    {
+        let stmts = stmts
+            .into_iter()
+            .enumerate()
+            .map(|(index, stmt)| {
+                stmt.into_batch_statement()
+                    .and_then(|stmt| Self::build_stmt(&stmt.sql, stmt.params, true))
+                    .map_err(|error| Error::BatchStatementFailed {
+                        index,
+                        error: Box::new(error),
+                        results: Vec::new(),
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        if stmts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut session = self.session.lock().await;
+        self.maybe_handle_dangling_tx(&mut session).await?;
+        // With a transaction already open on the connection, another BEGIN
+        // would fail; the statements join the open transaction instead
+        // (matching the JavaScript driver).
+        let wrap = if self.shared.autocommit.load(Ordering::Relaxed) {
+            wrap
+        } else {
+            None
+        };
+        let (batch, layout) = build_batch(stmts, wrap);
+        let results = session
+            .pipeline(vec![StreamRequest::Batch { batch }], true)
+            .await?;
+        match results.into_iter().next() {
+            Some(StreamResult::Ok {
+                response: StreamResponse::Batch { result },
+            }) => {
+                let update_rowid = |outputs: &[Option<BatchResult>]| {
+                    if let Some(rowid) = outputs
+                        .iter()
+                        .rev()
+                        .find_map(|o| o.as_ref().and_then(|o| o.last_insert_rowid()))
+                    {
+                        session
+                            .shared
+                            .last_insert_rowid
+                            .store(rowid, Ordering::Relaxed);
+                    }
+                };
+                match decode_batch_result(result, &layout) {
+                    Ok(outputs) => {
+                        let outputs: Vec<Option<BatchResult>> =
+                            outputs.into_iter().map(Some).collect();
+                        update_rowid(&outputs);
+                        Ok(outputs.into_iter().flatten().collect())
+                    }
+                    Err(error) => {
+                        // A statement that completed before the failure still
+                        // moved the connection's rowid server-side.
+                        if let Error::BatchStatementFailed { results, .. } = &error {
+                            update_rowid(results);
+                        }
+                        Err(error)
+                    }
+                }
+            }
+            Some(StreamResult::Error { error }) => Err(error.into()),
+            _ => Err(Error::Http(
+                "missing batch result in pipeline response".to_string(),
             )),
         }
     }

--- a/serverless/rust/differential/lib.rs
+++ b/serverless/rust/differential/lib.rs
@@ -177,6 +177,21 @@ pub enum Op {
         bad_sql: String,
         recovery_op: Box<Op>,
     },
+    /// Parameterized batch through the batch() API (spec op param_batch).
+    ParamBatch {
+        stmts: Vec<BatchStmt>,
+        /// None runs non-transactionally; "deferred"/"immediate" wrap the
+        /// batch in a transaction.
+        mode: Option<String>,
+    },
+}
+
+/// One statement of a [`Op::ParamBatch`].
+#[derive(Debug, Clone)]
+pub enum BatchStmt {
+    Insert { table: String, values: Vec<Val> },
+    Select { table: String },
+    ErrorSql { sql: String },
 }
 
 #[derive(Debug, Clone)]
@@ -433,7 +448,81 @@ pub fn gen_op(tc: &TestCase, table_cols: &mut HashMap<String, usize>, prefix: u3
         },
         "transaction_workflow" => gen_transaction_workflow(tc, table_cols, prefix),
         "error_in_transaction" => gen_error_in_transaction(tc, table_cols, prefix),
+        "param_batch" => {
+            let count: u8 = tc.draw(gs::integers::<u8>());
+            let count = (count % 4) + 1;
+            let stmts = (0..count)
+                .map(|_| {
+                    let pick: u8 = tc.draw(gs::integers::<u8>());
+                    match pick % 3 {
+                        0 => BatchStmt::Insert {
+                            table: table_name(tc, prefix),
+                            values: vec![gen_value(tc), gen_value(tc)],
+                        },
+                        1 => BatchStmt::Select {
+                            table: table_name(tc, prefix),
+                        },
+                        _ => BatchStmt::ErrorSql {
+                            sql: gen_error_sql(tc, prefix),
+                        },
+                    }
+                })
+                .collect();
+            let mode: u8 = tc.draw(gs::integers::<u8>());
+            let mode = match mode % 3 {
+                0 => None,
+                1 => Some("deferred".to_string()),
+                _ => Some("immediate".to_string()),
+            };
+            Op::ParamBatch { stmts, mode }
+        }
         other => panic!("unknown op id in ops.json: {other}"),
+    }
+}
+
+/// Every op id this harness implements. A spec op outside this list fails
+/// the suite deterministically instead of panicking mid-case.
+const SUPPORTED_OP_IDS: &[&str] = &[
+    "create",
+    "create_dynamic",
+    "insert",
+    "insert_returning",
+    "delete_returning",
+    "update_returning",
+    "select",
+    "select_value",
+    "begin",
+    "commit",
+    "rollback",
+    "invalid",
+    "param",
+    "named_param",
+    "numbered_param",
+    "insert_affected",
+    "delete_affected",
+    "update_affected",
+    "insert_rowid",
+    "batch",
+    "select_limit",
+    "select_count",
+    "select_expr",
+    "error_check",
+    "prepared_reuse",
+    "create_trigger",
+    "transaction_workflow",
+    "error_in_transaction",
+    "param_batch",
+];
+
+/// Panics with an actionable message when ops.json contains an operation
+/// this harness does not implement. Call once at suite start.
+pub fn assert_spec_ops_supported() {
+    for op in spec()["ops"].as_array().unwrap() {
+        let id = op["id"].as_str().unwrap();
+        assert!(
+            SUPPORTED_OP_IDS.contains(&id),
+            "op '{id}' in ops.json has no Rust harness support; implement it in gen_op and the parity executors"
+        );
     }
 }
 

--- a/serverless/rust/differential/tests/parity.rs
+++ b/serverless/rust/differential/tests/parity.rs
@@ -16,7 +16,8 @@ use hegel::{generators as gs, TestCase};
 
 use turso_serverless_conformance::{config, TestConfig};
 use turso_serverless_differential::{
-    create_table_sql, gen_error_sql, gen_ops, spec_num_tables, Op, Val,
+    assert_spec_ops_supported, create_table_sql, gen_error_sql, gen_ops, spec_num_tables,
+    BatchStmt, Op, Val,
 };
 
 // ---------------------------------------------------------------------------
@@ -123,6 +124,16 @@ fn value_type_tag(v: &NormalizedValue) -> &'static str {
 // Structural result — compared across drivers
 // ---------------------------------------------------------------------------
 
+/// The whole per-statement outcome of one batch() call: the failing
+/// statement's index (when a user statement failed) and one entry per
+/// statement — the completed statement's result, or None for the failing
+/// statement and the statements that did not run.
+#[derive(Debug, Default)]
+struct BatchOutcome {
+    failed_index: Option<usize>,
+    entries: Vec<Option<OpResult>>,
+}
+
 #[derive(Debug, Default)]
 struct OpResult {
     success: bool,
@@ -134,6 +145,7 @@ struct OpResult {
     column_decltypes: Option<Vec<Option<String>>>,
     affected_rows: Option<u64>,
     last_insert_rowid: Option<i64>,
+    batch: Option<BatchOutcome>,
 }
 
 fn fail_result() -> OpResult {
@@ -272,6 +284,89 @@ async fn query_remote(
 // ---------------------------------------------------------------------------
 // Execute operations against each driver
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Parameterized batch (spec op param_batch)
+// ---------------------------------------------------------------------------
+
+fn local_batch_statements(stmts: &[BatchStmt]) -> Vec<turso::BatchStatement> {
+    stmts
+        .iter()
+        .map(|stmt| match stmt {
+            BatchStmt::Insert { table, values } => turso::BatchStatement::new(
+                format!("INSERT INTO {table} VALUES (?, ?)"),
+                values.iter().map(val_to_local).collect::<Vec<_>>(),
+            ),
+            BatchStmt::Select { table } => {
+                turso::BatchStatement::new(format!("SELECT a, b FROM {table}"), ())
+            }
+            BatchStmt::ErrorSql { sql } => turso::BatchStatement::new(sql.clone(), ()),
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .expect("generated batch values always convert")
+}
+
+fn remote_batch_statements(stmts: &[BatchStmt]) -> Vec<turso_serverless::BatchStatement> {
+    stmts
+        .iter()
+        .map(|stmt| match stmt {
+            BatchStmt::Insert { table, values } => turso_serverless::BatchStatement::new(
+                format!("INSERT INTO {table} VALUES (?, ?)"),
+                values.iter().map(val_to_remote).collect::<Vec<_>>(),
+            ),
+            BatchStmt::Select { table } => {
+                turso_serverless::BatchStatement::new(format!("SELECT a, b FROM {table}"), ())
+            }
+            BatchStmt::ErrorSql { sql } => turso_serverless::BatchStatement::new(sql.clone(), ()),
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .expect("generated batch values always convert")
+}
+
+/// Normalize one per-statement result of a batch() call. The server-side
+/// execution statistics are excluded: the serverless driver reports them
+/// and the embedded driver does not, by design.
+macro_rules! normalize_batch_entry {
+    ($result:expr, $normalize:ident) => {{
+        let result = $result;
+        let column_names: Vec<String> = result
+            .columns()
+            .iter()
+            .map(|c| c.name().to_string())
+            .collect();
+        let column_decltypes: Vec<Option<String>> = result
+            .columns()
+            .iter()
+            .map(|c| c.decl_type().map(|s| s.to_string()))
+            .collect();
+        let values: Vec<Vec<NormalizedValue>> = result
+            .rows()
+            .iter()
+            .map(|row| {
+                (0..row.column_count())
+                    .map(|i| $normalize(&row.get_value(i).expect("row value")))
+                    .collect()
+            })
+            .collect();
+        OpResult {
+            success: true,
+            column_count: Some(column_names.len()),
+            row_count: Some(values.len()),
+            value_types: Some(
+                values
+                    .iter()
+                    .map(|row| row.iter().map(|v| value_type_tag(v).to_string()).collect())
+                    .collect(),
+            ),
+            values: Some(values),
+            column_names: Some(column_names),
+            column_decltypes: Some(column_decltypes),
+            affected_rows: Some(result.rows_affected()),
+            last_insert_rowid: result.last_insert_rowid(),
+            batch: None,
+        }
+    }};
+}
 
 fn execute_op_local<'a>(
     conn: &'a turso::Connection,
@@ -517,6 +612,58 @@ async fn execute_op_local_inner(conn: &turso::Connection, op: &Op) -> OpResult {
             match conn.execute("ROLLBACK", ()).await {
                 Ok(_) => exec_ok(),
                 Err(_) => fail_result(),
+            }
+        }
+        Op::ParamBatch { stmts, mode } => {
+            let statements = local_batch_statements(stmts);
+            let result = match mode.as_deref() {
+                None => conn.batch(statements).await,
+                Some("immediate") => {
+                    conn.transactional_batch(
+                        statements,
+                        turso::transaction::TransactionBehavior::Immediate,
+                    )
+                    .await
+                }
+                Some(_) => {
+                    conn.transactional_batch(
+                        statements,
+                        turso::transaction::TransactionBehavior::Deferred,
+                    )
+                    .await
+                }
+            };
+            match result {
+                Ok(results) => OpResult {
+                    success: true,
+                    batch: Some(BatchOutcome {
+                        failed_index: None,
+                        entries: results
+                            .iter()
+                            .map(|r| Some(normalize_batch_entry!(r, normalize_local)))
+                            .collect(),
+                    }),
+                    ..OpResult::default()
+                },
+                Err(turso::Error::BatchStatementFailed { index, results, .. }) => OpResult {
+                    success: false,
+                    batch: Some(BatchOutcome {
+                        failed_index: Some(index),
+                        entries: results
+                            .iter()
+                            .map(|r| {
+                                r.as_ref()
+                                    .map(|r| normalize_batch_entry!(r, normalize_local))
+                            })
+                            .collect(),
+                    }),
+                    ..OpResult::default()
+                },
+                Err(_) => OpResult {
+                    success: false,
+                    batch: Some(BatchOutcome::default()),
+                    ..OpResult::default()
+                },
             }
         }
     }
@@ -769,6 +916,60 @@ async fn execute_op_remote_inner(conn: &turso_serverless::Connection, op: &Op) -
                 Err(_) => fail_result(),
             }
         }
+        Op::ParamBatch { stmts, mode } => {
+            let statements = remote_batch_statements(stmts);
+            let result = match mode.as_deref() {
+                None => conn.batch(statements).await,
+                Some("immediate") => {
+                    conn.transactional_batch(
+                        statements,
+                        turso_serverless::TransactionBehavior::Immediate,
+                    )
+                    .await
+                }
+                Some(_) => {
+                    conn.transactional_batch(
+                        statements,
+                        turso_serverless::TransactionBehavior::Deferred,
+                    )
+                    .await
+                }
+            };
+            match result {
+                Ok(results) => OpResult {
+                    success: true,
+                    batch: Some(BatchOutcome {
+                        failed_index: None,
+                        entries: results
+                            .iter()
+                            .map(|r| Some(normalize_batch_entry!(r, normalize_remote)))
+                            .collect(),
+                    }),
+                    ..OpResult::default()
+                },
+                Err(turso_serverless::Error::BatchStatementFailed { index, results, .. }) => {
+                    OpResult {
+                        success: false,
+                        batch: Some(BatchOutcome {
+                            failed_index: Some(index),
+                            entries: results
+                                .iter()
+                                .map(|r| {
+                                    r.as_ref()
+                                        .map(|r| normalize_batch_entry!(r, normalize_remote))
+                                })
+                                .collect(),
+                        }),
+                        ..OpResult::default()
+                    }
+                }
+                Err(_) => OpResult {
+                    success: false,
+                    batch: Some(BatchOutcome::default()),
+                    ..OpResult::default()
+                },
+            }
+        }
     }
 }
 
@@ -829,6 +1030,60 @@ fn assert_values_match(
     }
 }
 
+/// Compare the whole per-statement outcome of a param_batch op: the
+/// failing statement's index and every entry, field by field.
+fn assert_batch_outcomes_match(local: &OpResult, remote: &OpResult, i: usize, op: &Op) {
+    let (Some(lb), Some(rb)) = (&local.batch, &remote.batch) else {
+        panic!(
+            "batch outcome presence mismatch on op #{i} {op:?}\n  local:  {local:?}\n  remote: {remote:?}"
+        );
+    };
+    assert_eq!(
+        lb.failed_index, rb.failed_index,
+        "batch failed_index mismatch on op #{i} {op:?}\n  local:  {local:?}\n  remote: {remote:?}"
+    );
+    assert_eq!(
+        lb.entries.len(),
+        rb.entries.len(),
+        "batch entry count mismatch on op #{i} {op:?}\n  local:  {local:?}\n  remote: {remote:?}"
+    );
+    for (j, (le, re)) in lb.entries.iter().zip(rb.entries.iter()).enumerate() {
+        match (le, re) {
+            (None, None) => {}
+            (Some(le), Some(re)) => {
+                assert_eq!(
+                    le.column_names, re.column_names,
+                    "batch entry {j} column_names mismatch on op #{i} {op:?}\n  local:  {le:?}\n  remote: {re:?}"
+                );
+                assert_eq!(
+                    le.row_count, re.row_count,
+                    "batch entry {j} row_count mismatch on op #{i} {op:?}\n  local:  {le:?}\n  remote: {re:?}"
+                );
+                assert_eq!(
+                    le.value_types, re.value_types,
+                    "batch entry {j} value_types mismatch on op #{i} {op:?}\n  local:  {le:?}\n  remote: {re:?}"
+                );
+                assert_values_match(&le.values, &re.values, i, op);
+                assert_eq!(
+                    le.column_decltypes, re.column_decltypes,
+                    "batch entry {j} column_decltypes mismatch on op #{i} {op:?}\n  local:  {le:?}\n  remote: {re:?}"
+                );
+                assert_eq!(
+                    le.affected_rows, re.affected_rows,
+                    "batch entry {j} affected_rows mismatch on op #{i} {op:?}\n  local:  {le:?}\n  remote: {re:?}"
+                );
+                assert_eq!(
+                    le.last_insert_rowid, re.last_insert_rowid,
+                    "batch entry {j} last_insert_rowid mismatch on op #{i} {op:?}\n  local:  {le:?}\n  remote: {re:?}"
+                );
+            }
+            _ => panic!(
+                "batch entry {j} completion mismatch on op #{i} {op:?}\n  local:  {local:?}\n  remote: {remote:?}"
+            ),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // The property test
 // ---------------------------------------------------------------------------
@@ -838,6 +1093,7 @@ fn api_parity(tc: TestCase) {
     let Some(config) = config_or_skip() else {
         return;
     };
+    assert_spec_ops_supported();
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
         // Fresh connections per test case — no stale transaction state.
@@ -876,6 +1132,18 @@ fn api_parity(tc: TestCase) {
                 remote_result.success, remote_result.column_count, remote_result.row_count, remote_result.affected_rows,
             ));
             let trace_dump = || trace.join("\n");
+
+            // Parameterized batch: compare the whole per-statement outcome.
+            // An agreed batch failure leaves well-defined state (execution
+            // stops at the first error), so keep comparing later operations.
+            if matches!(op, Op::ParamBatch { .. }) {
+                assert_eq!(
+                    local_result.success, remote_result.success,
+                    "success mismatch on op #{i} {op:?}\n  local:  {local_result:?}\n  remote: {remote_result:?}\n\nFull trace (prefix={prefix}):\n{}", trace_dump()
+                );
+                assert_batch_outcomes_match(&local_result, &remote_result, i, op);
+                continue;
+            }
 
             // ErrorCheck only compares success/failure — error messages legitimately differ.
             if matches!(op, Op::ErrorCheck { .. }) {

--- a/serverless/rust/error.rs
+++ b/serverless/rust/error.rs
@@ -1,3 +1,4 @@
+use crate::batch::BatchResult;
 use crate::protocol::ProtoError;
 
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
@@ -46,6 +47,21 @@ pub enum Error {
     /// non-200 response from the server (section 9.3).
     #[error("{0}")]
     Http(String),
+    /// A statement of a [`batch`](crate::Connection::batch) failed.
+    /// Carries the zero-based index of the failing statement within the
+    /// batch, the underlying error, and the per-statement results.
+    #[error("batch statement {index} failed: {error}")]
+    BatchStatementFailed {
+        index: usize,
+        error: Box<Error>,
+        /// One entry per statement of the batch, in order: the result of
+        /// each statement that completed, or `None` for the failing
+        /// statement and the statements that did not run. In a
+        /// non-transactional batch the completed statements' effects are
+        /// committed; in a transactional batch they were rolled back.
+        /// Empty when the batch failed before reaching the database.
+        results: Vec<Option<BatchResult>>,
+    },
 }
 
 impl From<ProtoError> for Error {

--- a/serverless/rust/error.rs
+++ b/serverless/rust/error.rs
@@ -58,9 +58,19 @@ pub enum Error {
         /// each statement that completed, or `None` for the failing
         /// statement and the statements that did not run. In a
         /// non-transactional batch the completed statements' effects are
-        /// committed; in a transactional batch they were rolled back.
+        /// committed; in a transactional batch they were rolled back unless
+        /// this error is wrapped in [`Error::BatchRollbackFailed`].
         /// Empty when the batch failed before reaching the database.
         results: Vec<Option<BatchResult>>,
+    },
+    /// A managed transactional batch failed and its automatic rollback
+    /// failed too. `error` is the failure that caused the rollback; when a
+    /// user statement failed, it is a
+    /// [`BatchStatementFailed`](Self::BatchStatementFailed).
+    #[error("batch rollback failed after {error}: {rollback_error}")]
+    BatchRollbackFailed {
+        error: Box<Error>,
+        rollback_error: Box<Error>,
     },
 }
 

--- a/serverless/rust/lib.rs
+++ b/serverless/rust/lib.rs
@@ -23,9 +23,29 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Batches
+//!
+//! Multiple parameterized statements can be sent in a single HTTP request
+//! with [`Connection::batch`], or atomically with
+//! [`Connection::transactional_batch`]:
+//!
+//! ```rust,no_run
+//! # async fn run(conn: turso_serverless::Connection) -> turso_serverless::Result<()> {
+//! let results = conn
+//!     .batch([
+//!         ("INSERT INTO users (name) VALUES (?1)", ("Alice",)),
+//!         ("INSERT INTO users (name) VALUES (?1)", ("Bob",)),
+//!     ])
+//!     .await?;
+//! assert_eq!(results.len(), 2);
+//! # Ok(())
+//! # }
+//! ```
 
 use std::{future::Future, pin::Pin, sync::Arc};
 
+pub mod batch;
 mod column;
 pub mod connection;
 mod error;
@@ -37,6 +57,7 @@ mod statement;
 pub mod transaction;
 pub mod value;
 
+pub use batch::{BatchResult, BatchStatement, IntoBatchStatement};
 pub use column::Column;
 pub use connection::Connection;
 pub use error::{BoxError, Error, Result};

--- a/serverless/rust/protocol.rs
+++ b/serverless/rust/protocol.rs
@@ -53,6 +53,18 @@ pub fn encode_value(value: &Value) -> Result<ProtoValue> {
     })
 }
 
+/// Like [`decode_value`], but consumes the protocol value so text is moved
+/// rather than cloned. Preferred when the response is owned.
+pub fn decode_value_owned(value: ProtoValue) -> Result<Value> {
+    Ok(match value {
+        ProtoValue::Text { value } => Value::Text(value),
+        ProtoValue::Blob { .. } | ProtoValue::Null | ProtoValue::Integer { .. } => {
+            decode_value(&value)?
+        }
+        ProtoValue::Float { value } => Value::Real(value.unwrap_or(f64::NAN)),
+    })
+}
+
 pub fn decode_value(value: &ProtoValue) -> Result<Value> {
     Ok(match value {
         ProtoValue::Null => Value::Null,
@@ -181,6 +193,12 @@ pub struct StmtResult {
     pub affected_row_count: u64,
     #[serde(default)]
     pub last_insert_rowid: Option<String>,
+    #[serde(default)]
+    pub rows_read: Option<u64>,
+    #[serde(default)]
+    pub rows_written: Option<u64>,
+    #[serde(default)]
+    pub query_duration_ms: Option<f64>,
 }
 
 /// A batch result (section 6.2).

--- a/serverless/rust/transaction.rs
+++ b/serverless/rust/transaction.rs
@@ -23,7 +23,7 @@ pub enum TransactionBehavior {
 }
 
 impl TransactionBehavior {
-    fn begin_sql(self) -> &'static str {
+    pub(crate) fn begin_sql(self) -> &'static str {
         match self {
             TransactionBehavior::Deferred => "BEGIN DEFERRED",
             TransactionBehavior::Immediate => "BEGIN IMMEDIATE",

--- a/testing/conformance/javascript/__test__/async.test.js
+++ b/testing/conformance/javascript/__test__/async.test.js
@@ -116,6 +116,9 @@ test.serial("Database.exec() after close()", async (t) => {
 //   - rows is an Array<Row>. By default rows match Statement.all() object
 //     rows; pass { raw: true } to receive arrays.
 //   - rowsAffected is the per-statement change count (0 for SELECT).
+//   - lastInsertRowid is present only on entries whose statement inserted
+//     a row (Turso drivers; the serverless driver also reports rowsRead,
+//     rowsWritten, and queryDurationMs per statement).
 // ==========================================================================
 
 // Assert the ResultSet invariants shared by every batch entry, regardless
@@ -126,7 +129,13 @@ const assertResultSetShape = (t, rs) => {
   t.is(rs.columnTypes.length, rs.columns.length, "columnTypes parallels columns");
   t.true(Array.isArray(rs.rows), "rows is an array");
   t.is(typeof rs.rowsAffected, "number", "rowsAffected is a number");
-  t.false("lastInsertRowid" in rs, "batch ResultSet does not expose lastInsertRowid");
+  if ("lastInsertRowid" in rs) {
+    t.is(
+      typeof rs.lastInsertRowid,
+      "number",
+      "lastInsertRowid, present only for statements that inserted, is a number",
+    );
+  }
   t.is(rs.toJSON, undefined, "batch ResultSet does not expose toJSON");
 };
 
@@ -143,10 +152,14 @@ test.serial("Database.batch() [returns one ResultSet per statement, in order]", 
   t.is(results.length, 3, "one ResultSet per input statement");
   results.forEach((rs) => assertResultSetShape(t, rs));
 
-  // INSERT: no result rows, one row affected.
+  // INSERT: no result rows, one row affected. Turso drivers report the
+  // inserted rowid per statement.
   t.deepEqual(results[0].columns, []);
   t.deepEqual(results[0].rows, []);
   t.is(results[0].rowsAffected, 1);
+  if (process.env.PROVIDER === "turso" || process.env.PROVIDER === "serverless") {
+    t.is(typeof results[0].lastInsertRowid, "number", "INSERT entry reports its rowid");
+  }
 
   // SELECT: rows surfaced, nothing affected.
   t.deepEqual(results[1].columns, ["id", "name"]);


### PR DESCRIPTION
Ever since the libSQL days, the batch API has had the same complaint: you
could not get the result of each individual statement, and when a batch
failed you could not tell which statement failed — or what had already
taken effect. With Turso we have a blank slate, and it turns out the
protocol never was the limitation: a batch response carries complete
per-statement information (results, last insert rowid, error codes, and
the execution statistics `rows_read`, `rows_written`,
`query_duration_ms`; PROTOCOL.md §6.2, §8.4, §9.1). The drivers just
dropped it. This PR takes the opportunity to do it right.

Every driver now exposes one `batch()` API that returns everything the
protocol reports, per statement, in one HTTP round trip:

- **Per-statement results**: rows, affected row count, last insert
  rowid, and the server-side execution statistics.
- **Failure visibility**: statements execute in order and stop at the
  first failure; the error identifies the failing statement by index
  *and* carries one entry per statement — the completed statement's
  result, or null/None for the failing statement and the ones that never
  ran. In a non-atomic batch the completed statements are committed, and
  the caller can finally see exactly what took effect.
- **Atomic mode**: the transactional variant wraps the statements in
  `BEGIN <mode>` / `COMMIT` with a conditional `ROLLBACK`, carried by the
  same single request.

Per driver:

- **JavaScript** (`serverless/javascript`, existing public API — extended
  compatibly): each `ResultSet` gains `lastInsertRowid`, `rowsRead`,
  `rowsWritten`, `queryDurationMs`; the thrown `DatabaseError` gains
  `batchIndex` and `batchResults`. `batch()` moves from the cursor
  endpoint to a pipeline batch request because the cursor stream's
  `step_end` does not carry the statistics. Non-atomic batches are now
  gated on the previous statement succeeding — previously statements
  after a failure kept executing server-side.
- **Rust** (new API, `bindings/rust` + `serverless/rust` in one commit
  per the driver-parity rule): `Connection::batch` /
  `Connection::transactional_batch`, `BatchStatement`/`IntoBatchStatement`
  inputs, `BatchResult` with stats accessors, and
  `Error::BatchStatementFailed { index, error, results }`. The sync
  driver shares the embedded `Connection`, so all three backends expose
  the same API.
- **Python** (new API, `bindings/python` + `serverless/python` in one
  commit): `Connection.batch(statements, mode=None)` on the DB-API
  surface (sync, aio, and the sync-database driver via inheritance),
  raising the classified DB-API exception with `batch_index` and
  `batch_results` attributes.

The parity requirement itself is codified first, in
`serverless/conformance/differential/README.md` ("Driver API parity")
with a pointer from the AGENTS.md core principles.

**Deliberately skipped: Go.** The Go serverless driver is a plain
`database/sql` driver, and `database/sql` has no batch surface, so it is
less obvious what to do there: libsql-client-go's precedent is splitting
multi-statement SQL client-side (with a vendored ANTLR SQLite parser)
inside `Exec`, while the alternative is a driver-specific `Batch` API
outside the standard interface. That trade-off deserves its own
discussion and PR.

The batch behavior is property-tested: a `param_batch` operation in the
shared differential vocabulary (`spec/ops.json`) generates 1-4
parameterized statements — including planted failures and atomic modes —
and all three language harnesses (fast-check, hypothesis, hegel) assert
that the embedded and serverless drivers agree on every statement's
result, the failing index, and the partial results carried by the error.
Building those harnesses caught two real driver bugs before the tests
ever ran: the embedded JS driver had no batch error surface at all, and
the embedded Rust driver reported the connection's stale change counter
for row-returning statements inside a batch.

Follow-ups, out of scope here:

- Whether the JS `compat` (libsql-compat) layer should surface the new
  per-statement `ResultSet` fields on success; it is kept libsql-shaped
  here (the error path does preserve `batchIndex`/`batchResults`).
- Driver-wide preservation of `extended_code` on errors (today only the
  Python serverless `ServerError` keeps it).
- A batch entry containing multi-statement SQL ("a; b") errors on the
  embedded drivers but the server prepares only the first statement — an
  embedded/serverless divergence worth its own discussion.

Also rides along in the JS commit: four env-gated integration tests still
asserted positional access on expanded rows, which f52724d45 removed on
purpose; CI never runs those tests, so they had drifted.

Tested against a live libsql-server and against Turso Cloud: Rust 44
unit + 58 conformance tests plus the hegel parity property, Python 73
serverless + 236 embedded plus the hypothesis parity property,
JavaScript 42 integration tests plus the fast-check parity property, and
protocol-level coverage asserting a parameterized multi-statement batch
in a single pipeline POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)