### PR TITLE
postgres: support quit and exit commands in tursopg cli

### DIFF
--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -525,7 +525,7 @@ Upgrade is not supported.
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| psql-style REPL | 🟡 Partial | `tursopg` (not psql itself); supports `\d[+]`, `\dt[+]`, `\di`, `\dv`, `\dn`, `\dT`, `\du`/`\dg`, `\df`, `\l`, `\x`, `\timing`, `\echo`, `\conninfo`, `\?`, `\q`; no `\copy`, `\i`, `\e`, `\set`, `\pset`, `\g`, `\watch` |
+| psql-style REPL | 🟡 Partial | `tursopg` (not psql itself); supports `\d[+]`, `\dt[+]`, `\di`, `\dv`, `\dn`, `\dT`, `\du`/`\dg`, `\df`, `\l`, `\x`, `\timing`, `\echo`, `\conninfo`, `\?`, `\q`, and interactive `quit`/`exit`; no `\copy`, `\i`, `\e`, `\set`, `\pset`, `\g`, `\watch` |
 | pgbench | ❌ Not supported | |
 | pg_combinebackup | ❌ Not supported | |
 | pg_createsubscriber | ❌ Not supported | |

--- a/postgres/cli/main.rs
+++ b/postgres/cli/main.rs
@@ -942,6 +942,10 @@ impl Repl {
             let prompt = self.prompt().to_string();
             match rl.readline(&prompt) {
                 Ok(line) => {
+                    if self.input_buf.trim().is_empty() && is_exit_command(&line) {
+                        break;
+                    }
+
                     self.interrupt_count.store(0, Ordering::Release);
                     self.read_state.process(&line);
                     self.input_buf.push_str(&line);
@@ -985,6 +989,12 @@ impl Repl {
             self.consume(false);
         }
     }
+}
+
+fn is_exit_command(line: &str) -> bool {
+    let line = line.trim_end();
+    let line = line.strip_suffix(';').unwrap_or(line).trim_end();
+    line.eq_ignore_ascii_case("exit") || line.eq_ignore_ascii_case("quit")
 }
 
 // ---------------------------------------------------------------------------
@@ -1044,4 +1054,40 @@ fn main() -> anyhow::Result<()> {
         std::process::exit(1);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_successful_exit_commands() {
+        for command in [
+            "exit", "quit", "EXIT", "QuIt", "exit;", "quit;", "EXIT;", "exit ;  ", "quit ;  ",
+        ] {
+            assert!(
+                is_exit_command(command),
+                "expected {command:?} to be an exit command"
+            );
+        }
+    }
+
+    #[test]
+    fn test_unsuccessful_exit_commands() {
+        for command in [
+            "",
+            " quit ",
+            "exit;;",
+            "exit now",
+            "quitter",
+            "some_exit",
+            "SELECT 'quit';",
+            "quit;;",
+        ] {
+            assert!(
+                !is_exit_command(command),
+                "expected {command:?} not to be an exit command"
+            );
+        }
+    }
 }


### PR DESCRIPTION

<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

This PR adds support for using `quit` and `exit` (and their variants) to leave the tursopg cli in interactive mode. This matches the psql behavior for exiting in interactive mode.

## Motivation and context

I have muscle memory for exiting psql by typing "quit", so I kept noticing that tursopg didn't have the same behavior here. I figured I would add this to tursopg as a small quality-of-life improvement.

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

AI helped me verify psql's exact behavior and with the tests since I wasn't sure where to place them. I ended up adding the tests directly to `postgres/cli/main.rs` since the existing cli tests in `postgres/cli/tests/tursopg.rs` use stdin rather than interactive mode.
