### PR TITLE
core/io: link completions to their group before submitting them

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2183,16 +2183,17 @@ impl Connection {
         frame_watermark: Option<u64>,
     ) -> Result<Option<(Arc<Page>, Completion)>> {
         let pager = self.pager.load();
-        let (page_ref, c) = match pager.read_page_no_cache(page_idx as i64, frame_watermark, true) {
-            Ok(result) => result,
-            // on windows, zero read will trigger UnexpectedEof
-            #[cfg(target_os = "windows")]
-            Err(LimboError::CompletionError(crate::error::CompletionError::IOError(
-                std::io::ErrorKind::UnexpectedEof,
-                _,
-            ))) => return Ok(None),
-            Err(err) => return Err(err),
-        };
+        let (page_ref, c) =
+            match pager.read_page_no_cache(page_idx as i64, frame_watermark, true, None) {
+                Ok(result) => result,
+                // on windows, zero read will trigger UnexpectedEof
+                #[cfg(target_os = "windows")]
+                Err(LimboError::CompletionError(crate::error::CompletionError::IOError(
+                    std::io::ErrorKind::UnexpectedEof,
+                    _,
+                ))) => return Ok(None),
+                Err(err) => return Err(err),
+            };
 
         Ok(Some((page_ref, c)))
     }

--- a/core/database.rs
+++ b/core/database.rs
@@ -2021,7 +2021,7 @@ impl Database {
                     // WAL / clear the cache (must hit the DB file, not the WAL).
                     let c = match completion.take() {
                         Some(c) => c,
-                        None => storage::sqlite3_ondisk::begin_write_btree_page(pager, page)?,
+                        None => storage::sqlite3_ondisk::begin_write_btree_page(pager, page, None)?,
                     };
                     if !c.succeeded() {
                         *completion = Some(c.clone());

--- a/core/io/completions.rs
+++ b/core/io/completions.rs
@@ -1,4 +1,4 @@
-use crate::turso_assert_eq;
+use crate::{turso_assert, turso_assert_eq};
 use core::fmt::{self, Debug};
 use std::{
     future::Future,
@@ -107,8 +107,14 @@ pub(super) struct CompletionInner {
     // Thread safe with OnceLock
     pub(super) result: crate::sync::OnceLock<Option<CompletionError>>,
     context: Context,
-    /// Optional parent group this completion belongs to
-    parent: OnceLock<Arc<GroupCompletionInner>>,
+    /// The group this completion belongs to, if any. Set exactly once, by
+    /// whichever side gets there first: `CompletionGroup::build` sets it to
+    /// the group when it links the completion, and `Completion::callback`
+    /// sets it to `None` when the completion finishes with no group linked
+    /// yet. The loser counts the completion into the group: the callback
+    /// counts it if `build` linked first, and `build` counts it if the
+    /// completion finished first.
+    parent: OnceLock<Option<Arc<GroupCompletionInner>>>,
     /// Keeps the write buffer alive for async I/O backends (io_uring, VFS)
     /// where pwrite returns before the kernel has consumed the buffer.
     write_buffer: OnceLock<Arc<Buffer>>,
@@ -118,7 +124,7 @@ impl fmt::Debug for CompletionInner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CompletionInner")
             .field("completion_type", &self.completion_type)
-            .field("parent", &self.parent.get().is_some())
+            .field("parent", &matches!(self.parent.get(), Some(Some(_))))
             .finish()
     }
 }
@@ -166,35 +172,34 @@ impl CompletionGroup {
         let group = Completion::new(CompletionType::Group(group_completion));
 
         // Store the group completion reference for later callback
-        if let CompletionType::Group(ref g) = group.get_inner().completion_type {
-            let _ = g.inner.self_completion.set(group.clone());
-        }
+        let group_inner = match &group.get_inner().completion_type {
+            CompletionType::Group(g) => {
+                let _ = g.inner.self_completion.set(group.clone());
+                g.inner.clone()
+            }
+            _ => unreachable!(),
+        };
 
-        for mut c in self.completions {
-            // If the completion has not completed, link it to the group.
-            if !c.finished() {
-                c.link_internal(&group);
+        for c in self.completions {
+            // Link the child to the group. If that fails, the child already
+            // finished (its callback claimed the slot before we could), or it
+            // was already linked to a group and finished since. Either way it
+            // is finished and its callback will not count it, so count it
+            // here. Checking `finished()` before linking left a window where
+            // the child finished in between, and nobody counted it.
+            if c.get_inner().parent.set(Some(group_inner.clone())).is_ok() {
                 continue;
             }
-            let group_inner = match &group.get_inner().completion_type {
-                CompletionType::Group(g) => &g.inner,
-                _ => unreachable!(),
-            };
-            // Return early if there was an error.
+            turso_assert!(c.finished(), "completion can only be linked once");
             if let Some(err) = c.get_error() {
                 let _ = group_inner.result.set(Some(err));
                 group_inner.outstanding.store(0, Ordering::SeqCst);
                 (group_inner.complete)(Err(err));
                 return group;
             }
-            // Mark the successful completion as done.
             group_inner.outstanding.fetch_sub(1, Ordering::SeqCst);
         }
 
-        let group_inner = match &group.get_inner().completion_type {
-            CompletionType::Group(g) => &g.inner,
-            _ => unreachable!(),
-        };
         if group_inner.outstanding.load(Ordering::SeqCst) == 0 {
             // Set result to Some(None) on success so succeeded() returns true
             let _ = group_inner.result.set(None);
@@ -373,7 +378,7 @@ impl Completion {
     /// drains the CQ, the resubmitted chunks pile up and the task deadlocks.
     pub fn wake_progress(&self) {
         if let Some(inner) = &self.inner {
-            if let Some(group) = inner.parent.get() {
+            if let Some(Some(group)) = inner.parent.get() {
                 if let Some(group_completion) = group.self_completion.get() {
                     group_completion.wake();
                 }
@@ -463,7 +468,9 @@ impl Completion {
 
     fn callback(&self, result: Result<i32, CompletionError>) {
         let inner = self.get_inner();
+        let mut first = false;
         inner.result.get_or_init(|| {
+            first = true;
             // Run the type-specific callback. For ReadCompletion, this returns
             // an optional error detected by the callback (e.g., short read).
             let callback_error = match &inner.completion_type {
@@ -488,12 +495,17 @@ impl Completion {
             };
 
             // Use callback error if present, otherwise use the original IO error
-            let final_error = callback_error.or_else(|| result.err());
-
-            if let Some(group) = inner.parent.get() {
-                // Capture first error in group
-                if let Some(err) = final_error {
-                    let _ = group.result.set(Some(err));
+            callback_error.or_else(|| result.err())
+        });
+        // Only the call that finished this completion may count it into a
+        // group. If a group was linked before we got here, count into it.
+        // Otherwise claim the slot with `None`: `CompletionGroup::build` then
+        // fails to link, sees the completion is finished, and counts it.
+        if first {
+            if let Some(group) = inner.parent.get_or_init(|| None) {
+                if let Some(Some(err)) = inner.result.get() {
+                    // Capture first error in group
+                    let _ = group.result.set(Some(*err));
                 }
                 let prev = group.outstanding.fetch_sub(1, Ordering::SeqCst);
                 if prev > 1 {
@@ -514,9 +526,7 @@ impl Completion {
                     }
                 }
             }
-
-            final_error
-        });
+        }
         // call the waker regardless
         inner.context.wake();
     }
@@ -528,19 +538,6 @@ impl Completion {
         match inner.completion_type {
             CompletionType::Read(ref r) => r,
             _ => unreachable!(),
-        }
-    }
-
-    /// Link this completion to a group completion (internal use only)
-    fn link_internal(&mut self, group: &Completion) {
-        let group_inner = match &group.get_inner().completion_type {
-            CompletionType::Group(g) => &g.inner,
-            _ => panic!("link_internal() requires a group completion"),
-        };
-
-        // Set the parent (can only be set once)
-        if self.get_inner().parent.set(group_inner.clone()).is_err() {
-            panic!("completion can only be linked once");
         }
     }
 }
@@ -615,6 +612,52 @@ mod tests {
     use crate::CompletionError;
 
     use super::*;
+
+    #[test]
+    fn group_build_racing_with_child_completion_on_another_thread() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::thread;
+        for i in 0..20_000 {
+            let child = Completion::new_write(|_| {});
+            let go = Arc::new(AtomicBool::new(false));
+            let (c2, go2) = (child.clone(), go.clone());
+            let t = thread::spawn(move || {
+                while !go2.load(Ordering::Acquire) {
+                    std::hint::spin_loop();
+                }
+                c2.complete(0);
+            });
+            let mut group = CompletionGroup::new(|_| {});
+            group.add(&child);
+            go.store(true, Ordering::Release);
+            let g = group.build();
+            t.join().unwrap();
+            assert!(child.finished());
+            assert!(
+                g.finished(),
+                "iteration {i}: child is finished but the group never will be"
+            );
+        }
+    }
+
+    #[test]
+    fn group_callback_fires_once_when_children_finished_before_build() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c1 = Completion::new_write(|_| {});
+        let c2 = Completion::new_write(|_| {});
+        c1.complete(0);
+        c2.complete(0);
+        let calls2 = calls.clone();
+        let mut group = CompletionGroup::new(move |_| {
+            calls2.fetch_add(1, Ordering::SeqCst);
+        });
+        group.add(&c1);
+        group.add(&c2);
+        let g = group.build();
+        assert!(g.finished());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
 
     #[test]
     fn test_completion_group_empty() {

--- a/core/io/completions.rs
+++ b/core/io/completions.rs
@@ -107,14 +107,11 @@ pub(super) struct CompletionInner {
     // Thread safe with OnceLock
     pub(super) result: crate::sync::OnceLock<Option<CompletionError>>,
     context: Context,
-    /// The group this completion belongs to, if any. Set exactly once, by
-    /// whichever side gets there first: `CompletionGroup::build` sets it to
-    /// the group when it links the completion, and `Completion::callback`
-    /// sets it to `None` when the completion finishes with no group linked
-    /// yet. The loser counts the completion into the group: the callback
-    /// counts it if `build` linked first, and `build` counts it if the
-    /// completion finished first.
-    parent: OnceLock<Option<Arc<GroupCompletionInner>>>,
+    /// The group this completion belongs to, if any. `CompletionGroup::add`
+    /// sets it before the completion is submitted, so by the time the
+    /// completion finishes and its callback counts it into the group, the
+    /// link is already there.
+    parent: OnceLock<Arc<GroupCompletionInner>>,
     /// Keeps the write buffer alive for async I/O backends (io_uring, VFS)
     /// where pwrite returns before the kernel has consumed the buffer.
     write_buffer: OnceLock<Arc<Buffer>>,
@@ -124,7 +121,7 @@ impl fmt::Debug for CompletionInner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CompletionInner")
             .field("completion_type", &self.completion_type)
-            .field("parent", &matches!(self.parent.get(), Some(Some(_))))
+            .field("parent", &self.parent.get().is_some())
             .finish()
     }
 }
@@ -178,20 +175,19 @@ impl CompletionGroup {
     }
 
     /// Add a child. Call this before the child is submitted to the IO
-    /// backend, so it is linked to the group before it can finish.
+    /// backend. The child's own callback is what counts it into the group,
+    /// so the link has to be there before the child can finish.
     pub fn add(&mut self, c: &Completion) {
         self.completions.push(c.clone());
         self.inner.outstanding.fetch_add(1, Ordering::SeqCst);
-        // Link the child. If that fails, the child already finished (its
-        // callback claimed the slot before we could), or it was linked to a
-        // group earlier and has finished since. Either way its callback will
-        // not count it, so count it here. The builder's token keeps the
-        // group from finishing on this count.
-        if c.get_inner().parent.set(Some(self.inner.clone())).is_ok() {
-            return;
-        }
-        turso_assert!(c.finished(), "completion can only be linked once");
-        self.inner.one_done(c.get_error());
+        turso_assert!(
+            c.get_inner().parent.set(self.inner.clone()).is_ok(),
+            "completion can only be linked once"
+        );
+        turso_assert!(
+            !c.finished(),
+            "completion was added to a group after it finished"
+        );
     }
 
     /// The children added so far. Used by error paths that need to
@@ -407,7 +403,7 @@ impl Completion {
     /// drains the CQ, the resubmitted chunks pile up and the task deadlocks.
     pub fn wake_progress(&self) {
         if let Some(inner) = &self.inner {
-            if let Some(Some(group)) = inner.parent.get() {
+            if let Some(group) = inner.parent.get() {
                 if let Some(group_completion) = group.self_completion.get() {
                     group_completion.wake();
                 }
@@ -526,12 +522,10 @@ impl Completion {
             // Use callback error if present, otherwise use the original IO error
             callback_error.or_else(|| result.err())
         });
-        // Only the call that finished this completion may count it into a
-        // group. If a group was linked before we got here, count into it.
-        // Otherwise claim the slot with `None`: `CompletionGroup::build` then
-        // fails to link, sees the completion is finished, and counts it.
+        // Only the call that finished this completion counts it into its
+        // group.
         if first {
-            if let Some(group) = inner.parent.get_or_init(|| None) {
+            if let Some(group) = inner.parent.get() {
                 group.one_done(inner.result.get().and_then(|e| *e));
             }
         }
@@ -621,7 +615,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn group_build_racing_with_child_completion_on_another_thread() {
+    fn group_finishes_when_child_completes_on_another_thread_during_build() {
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::thread;
         for i in 0..20_000 {
@@ -642,7 +636,7 @@ mod tests {
             assert!(child.finished());
             assert!(
                 g.finished(),
-                "iteration {i}: child is finished but the group never will be"
+                "iteration {i}: child finished but the group did not"
             );
         }
     }
@@ -653,17 +647,26 @@ mod tests {
         let calls = Arc::new(AtomicUsize::new(0));
         let c1 = Completion::new_write(|_| {});
         let c2 = Completion::new_write(|_| {});
-        c1.complete(0);
-        c2.complete(0);
         let calls2 = calls.clone();
         let mut group = CompletionGroup::new(move |_| {
             calls2.fetch_add(1, Ordering::SeqCst);
         });
         group.add(&c1);
         group.add(&c2);
+        c1.complete(0);
+        c2.complete(0);
         let g = group.build();
         assert!(g.finished());
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "added to a group after it finished")]
+    fn adding_a_finished_completion_panics() {
+        let c = Completion::new_write(|_| {});
+        c.complete(0);
+        let mut group = CompletionGroup::new(|_| {});
+        group.add(&c);
     }
 
     #[test]
@@ -816,12 +819,12 @@ mod tests {
         let c1 = Completion::new_write(|_| {});
         let c2 = Completion::new_write(|_| {});
 
-        // Complete both before adding to group
-        c1.complete(0);
-        c2.complete(0);
-
         group.add(&c1);
         group.add(&c2);
+
+        // Complete both before build()
+        c1.complete(0);
+        c2.complete(0);
 
         let group = group.build();
 
@@ -846,14 +849,14 @@ mod tests {
         let c3 = Completion::new_write(|_| {});
         let c4 = Completion::new_write(|_| {});
 
-        // Complete c1 and c3 before adding to group
-        c1.complete(0);
-        c3.complete(0);
-
         group.add(&c1);
         group.add(&c2);
         group.add(&c3);
         group.add(&c4);
+
+        // Complete c1 and c3 before build()
+        c1.complete(0);
+        c3.complete(0);
 
         let group = group.build();
 
@@ -878,11 +881,11 @@ mod tests {
         let c1 = Completion::new_write(|_| {});
         let c2 = Completion::new_write(|_| {});
 
-        // Complete c1 with error before adding to group
-        c1.error(CompletionError::Aborted);
-
         group.add(&c1);
         group.add(&c2);
+
+        // Fail c1 before build()
+        c1.error(CompletionError::Aborted);
 
         let group = group.build();
 
@@ -894,101 +897,6 @@ mod tests {
         assert!(group.finished());
         assert!(!group.succeeded());
         assert_eq!(group.get_error(), Some(CompletionError::Aborted));
-    }
-
-    #[test]
-    fn test_completion_group_tracks_all_completions() {
-        // This test verifies the fix for the bug where CompletionGroup::add()
-        // would skip successfully-finished completions. This caused problems
-        // when code used drain() to move completions into a group, because
-        // finished completions would be removed from the source but not tracked
-        // by the group, effectively losing them.
-        use crate::sync::atomic::{AtomicUsize, Ordering};
-
-        let callback_count = Arc::new(AtomicUsize::new(0));
-        let callback_count_clone = callback_count.clone();
-
-        // Simulate the pattern: create multiple completions, complete some,
-        // then add ALL of them to a group (like drain() would do)
-        let mut completions = Vec::new();
-
-        // Create 4 completions
-        for _ in 0..4 {
-            completions.push(Completion::new_write(|_| {}));
-        }
-
-        // Complete 2 of them before adding to group (simulate async completion)
-        completions[0].complete(0);
-        completions[2].complete(0);
-
-        // Now create a group and add ALL completions (like drain() would do)
-        let mut group = CompletionGroup::new(move |_| {
-            callback_count_clone.fetch_add(1, Ordering::SeqCst);
-        });
-
-        // Add all completions to the group
-        for c in &completions {
-            group.add(c);
-        }
-
-        let group = group.build();
-
-        // The group should track all 4 completions:
-        // - c[0] and c[2] are already finished
-        // - c[1] and c[3] are still pending
-        // So the group should not be finished yet
-        assert!(!group.finished());
-        assert_eq!(callback_count.load(Ordering::SeqCst), 0);
-
-        // Complete the first pending completion
-        completions[1].complete(0);
-        assert!(!group.finished());
-        assert_eq!(callback_count.load(Ordering::SeqCst), 0);
-
-        // Complete the last pending completion - now group should finish
-        completions[3].complete(0);
-        assert!(group.finished());
-        assert!(group.succeeded());
-        assert_eq!(callback_count.load(Ordering::SeqCst), 1);
-
-        // Verify no errors
-        assert!(group.get_error().is_none());
-    }
-
-    #[test]
-    fn test_completion_group_with_all_finished_successfully() {
-        // Edge case: all completions are already successfully finished
-        // when added to the group. The group should complete immediately.
-        use crate::sync::atomic::{AtomicBool, Ordering};
-
-        let callback_called = Arc::new(AtomicBool::new(false));
-        let callback_called_clone = callback_called.clone();
-
-        let mut completions = Vec::new();
-
-        // Create and immediately complete 3 completions
-        for _ in 0..3 {
-            let c = Completion::new_write(|_| {});
-            c.complete(0);
-            completions.push(c);
-        }
-
-        // Add all already-completed completions to group
-        let mut group = CompletionGroup::new(move |_| {
-            callback_called_clone.store(true, Ordering::SeqCst);
-        });
-
-        for c in &completions {
-            group.add(c);
-        }
-
-        let group = group.build();
-
-        // Group should be immediately finished since all completions were done
-        assert!(group.finished());
-        assert!(group.succeeded());
-        assert!(callback_called.load(Ordering::SeqCst));
-        assert!(group.get_error().is_none());
     }
 
     #[test]

--- a/core/io/completions.rs
+++ b/core/io/completions.rs
@@ -129,9 +129,18 @@ impl fmt::Debug for CompletionInner {
     }
 }
 
+/// Waits for a set of child completions. The group finishes when every
+/// child has finished and `build` has been called.
+///
+/// The group counts how many things are still outstanding. It starts at 1:
+/// a token held by the builder, released by `build`. Each `add` counts one
+/// more. That token keeps the group from finishing while children are still
+/// being added, even if the ones added so far finish right away.
 pub struct CompletionGroup {
     completions: Vec<Completion>,
-    callback: Box<dyn Fn(Result<i32, CompletionError>) + Send + Sync>,
+    /// The group's own completion, handed out by `build`.
+    completion: Completion,
+    inner: Arc<GroupCompletionInner>,
 }
 
 impl CompletionGroup {
@@ -139,14 +148,38 @@ impl CompletionGroup {
     where
         F: Fn(Result<i32, CompletionError>) + Send + Sync + 'static,
     {
+        let inner = Arc::new(GroupCompletionInner {
+            outstanding: AtomicUsize::new(1),
+            complete: Box::new(callback),
+            result: OnceLock::new(),
+            self_completion: OnceLock::new(),
+        });
+        let completion = Completion::new(CompletionType::Group(GroupCompletion {
+            inner: inner.clone(),
+        }));
+        let _ = inner.self_completion.set(completion.clone());
         Self {
             completions: Vec::new(),
-            callback: Box::new(callback),
+            completion,
+            inner,
         }
     }
 
-    pub fn add(&mut self, completion: &Completion) {
-        self.completions.push(completion.clone());
+    /// Add a child. Call this before the child is submitted to the IO
+    /// backend, so it is linked to the group before it can finish.
+    pub fn add(&mut self, c: &Completion) {
+        self.completions.push(c.clone());
+        self.inner.outstanding.fetch_add(1, Ordering::SeqCst);
+        // Link the child. If that fails, the child already finished (its
+        // callback claimed the slot before we could), or it was linked to a
+        // group earlier and has finished since. Either way its callback will
+        // not count it, so count it here. The builder's token keeps the
+        // group from finishing on this count.
+        if c.get_inner().parent.set(Some(self.inner.clone())).is_ok() {
+            return;
+        }
+        turso_assert!(c.finished(), "completion can only be linked once");
+        self.inner.one_done(c.get_error());
     }
 
     /// The children added so far. Used by error paths that need to
@@ -162,50 +195,11 @@ impl CompletionGroup {
         }
     }
 
+    /// Release the builder's token. The group finishes now if every child
+    /// has already finished, or later when the last one does.
     pub fn build(self) -> Completion {
-        let total = self.completions.len();
-        if total == 0 {
-            (self.callback)(Ok(0));
-            return Completion::new_yield();
-        }
-        let group_completion = GroupCompletion::new(self.callback, total);
-        let group = Completion::new(CompletionType::Group(group_completion));
-
-        // Store the group completion reference for later callback
-        let group_inner = match &group.get_inner().completion_type {
-            CompletionType::Group(g) => {
-                let _ = g.inner.self_completion.set(group.clone());
-                g.inner.clone()
-            }
-            _ => unreachable!(),
-        };
-
-        for c in self.completions {
-            // Link the child to the group. If that fails, the child already
-            // finished (its callback claimed the slot before we could), or it
-            // was already linked to a group and finished since. Either way it
-            // is finished and its callback will not count it, so count it
-            // here. Checking `finished()` before linking left a window where
-            // the child finished in between, and nobody counted it.
-            if c.get_inner().parent.set(Some(group_inner.clone())).is_ok() {
-                continue;
-            }
-            turso_assert!(c.finished(), "completion can only be linked once");
-            if let Some(err) = c.get_error() {
-                let _ = group_inner.result.set(Some(err));
-                group_inner.outstanding.store(0, Ordering::SeqCst);
-                (group_inner.complete)(Err(err));
-                return group;
-            }
-            group_inner.outstanding.fetch_sub(1, Ordering::SeqCst);
-        }
-
-        if group_inner.outstanding.load(Ordering::SeqCst) == 0 {
-            // Set result to Some(None) on success so succeeded() returns true
-            let _ = group_inner.result.set(None);
-            (group_inner.complete)(Ok(0));
-        }
-        group
+        self.inner.one_done(None);
+        self.completion
     }
 }
 
@@ -236,20 +230,6 @@ struct GroupCompletionInner {
 }
 
 impl GroupCompletion {
-    pub fn new<F>(complete: F, outstanding: usize) -> Self
-    where
-        F: Fn(Result<i32, CompletionError>) + Send + Sync + 'static,
-    {
-        Self {
-            inner: Arc::new(GroupCompletionInner {
-                outstanding: AtomicUsize::new(outstanding),
-                complete: Box::new(complete),
-                result: OnceLock::new(),
-                self_completion: OnceLock::new(),
-            }),
-        }
-    }
-
     pub fn callback(&self, result: Result<i32, CompletionError>) {
         turso_assert_eq!(
             self.inner.outstanding.load(Ordering::SeqCst),
@@ -257,6 +237,35 @@ impl GroupCompletion {
             "callback called before all completions finished"
         );
         (self.inner.complete)(result);
+    }
+}
+
+impl GroupCompletionInner {
+    /// One outstanding count is done: a child finished with `err`, or
+    /// `build` released the builder's token. Fires the group's callback
+    /// when this was the last one.
+    fn one_done(&self, err: Option<CompletionError>) {
+        if let Some(err) = err {
+            // Keep the first error.
+            let _ = self.result.set(Some(err));
+        }
+        let prev = self.outstanding.fetch_sub(1, Ordering::SeqCst);
+        turso_assert!(prev > 0, "completion group counted below zero");
+        let group_completion = self
+            .self_completion
+            .get()
+            .expect("group completion is set in CompletionGroup::new");
+        if prev > 1 {
+            // Progress wake so the waiter keeps driving io.step.
+            group_completion.wake();
+            return;
+        }
+        // Set result to Some(None) on success so succeeded() returns true.
+        let _ = self.result.set(None);
+        let result = self.result.get().and_then(|e| *e);
+        // This runs Completion::callback on the group's own completion,
+        // which in turn counts the group into its parent, if it has one.
+        group_completion.callback(result.map_or(Ok(0), Err));
     }
 }
 
@@ -503,31 +512,9 @@ impl Completion {
         // fails to link, sees the completion is finished, and counts it.
         if first {
             if let Some(group) = inner.parent.get_or_init(|| None) {
-                if let Some(Some(err)) = inner.result.get() {
-                    // Capture first error in group
-                    let _ = group.result.set(Some(*err));
-                }
-                let prev = group.outstanding.fetch_sub(1, Ordering::SeqCst);
-                if prev > 1 {
-                    // progress wake so the waiter keeps driving io.step,
-                    // If prev > 1, there are still children outstanding after this one.
-                    if let Some(group_completion) = group.self_completion.get() {
-                        group_completion.wake();
-                    }
-                }
-                // If this was the last completion in the group, trigger the group's callback
-                // which will recursively call this same callback() method to notify parents
-                if prev == 1 {
-                    // Set result to Some(None) on success so succeeded() returns true
-                    let _ = group.result.set(None);
-                    if let Some(group_completion) = group.self_completion.get() {
-                        let group_result = group.result.get().and_then(|e| *e);
-                        group_completion.callback(group_result.map_or(Ok(0), Err));
-                    }
-                }
+                group.one_done(inner.result.get().and_then(|e| *e));
             }
         }
-        // call the waker regardless
         inner.context.wake();
     }
 
@@ -879,7 +866,11 @@ mod tests {
 
         let group = group.build();
 
-        // Group should immediately fail with the error
+        // The group waits for c2 even though c1 already failed: a waiter
+        // must not carry on while a child's IO is still in flight.
+        assert!(!group.finished());
+
+        c2.complete(0);
         assert!(group.finished());
         assert!(!group.succeeded());
         assert_eq!(group.get_error(), Some(CompletionError::Aborted));

--- a/core/io/completions.rs
+++ b/core/io/completions.rs
@@ -143,6 +143,18 @@ pub struct CompletionGroup {
     inner: Arc<GroupCompletionInner>,
 }
 
+impl fmt::Debug for CompletionGroup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CompletionGroup")
+            .field("children", &self.completions.len())
+            .field(
+                "outstanding",
+                &self.inner.outstanding.load(Ordering::SeqCst),
+            )
+            .finish()
+    }
+}
+
 impl CompletionGroup {
     pub fn new<F>(callback: F) -> Self
     where
@@ -187,6 +199,14 @@ impl CompletionGroup {
     /// cancelling the group.
     pub fn completions(&self) -> &[Completion] {
         &self.completions
+    }
+
+    pub fn len(&self) -> usize {
+        self.completions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.completions.is_empty()
     }
 
     pub fn cancel(&self) {

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -554,9 +554,10 @@ impl<'a> WriteBatch<'a> {
             .sum()
     }
 
-    /// Submit all writes. Returns completions caller must wait on.
+    /// Submit all writes. Returns completions caller must wait on. Each
+    /// write is added to `group`, when given, before it is submitted.
     #[inline]
-    pub fn submit(self) -> Result<Vec<Completion>> {
+    pub fn submit(self, mut group: Option<&mut CompletionGroup>) -> Result<Vec<Completion>> {
         let mut completions = Vec::with_capacity(self.ops.len());
         for WriteOp { pos, bufs } in self.ops {
             let total_len = bufs.iter().map(|b| b.len()).sum::<usize>() as i32;
@@ -569,6 +570,9 @@ impl<'a> WriteBatch<'a> {
                     "pwritev wrote {bytes_written} bytes, expected {total_len}"
                 );
             });
+            if let Some(group) = group.as_deref_mut() {
+                group.add(&c);
+            }
             completions.push(self.file.pwritev(pos, bufs.to_vec(), c)?);
         }
         Ok(completions)

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -925,7 +925,7 @@ impl LogicalLog {
             header.clone()
         };
 
-        Ok(Some(self.write_header(upgraded_header)?))
+        Ok(Some(self.write_header(upgraded_header, None)?))
     }
 
     /// Writes a transaction to the log but does NOT advance the writer offset.
@@ -986,7 +986,13 @@ impl LogicalLog {
     }
 
     #[aristo::intent("the in-memory log header is published only after the on-disk header pwrite has completed durably", id = "aristos:logical_log_header_publish_after_fsync", verify = "full")]
-    fn write_header(&mut self, mut header: LogHeader) -> Result<Completion> {
+    /// Writes the header. The write is added to `group`, when given,
+    /// before it is submitted.
+    fn write_header(
+        &mut self,
+        mut header: LogHeader,
+        group: Option<&mut CompletionGroup>,
+    ) -> Result<Completion> {
         let header_bytes = header.encode();
         header.hdr_crc32c = u32::from_le_bytes([
             header_bytes[LOG_HDR_CRC_START],
@@ -1009,12 +1015,15 @@ impl LogicalLog {
                 );
             }
         });
+        if let Some(group) = group {
+            group.add(&c);
+        }
         self.file.pwrite(0, buffer, c)
     }
 
     pub fn update_header(&mut self) -> Result<Completion> {
         let header = self.current_or_new_header()?;
-        self.write_header(header)
+        self.write_header(header, None)
     }
 
     #[aristo::intent("the running CRC of the log is reseeded only after the truncate operation has completed durably", id = "aristos:logical_log_truncate_crc_reseed_after_completion", verify = "full")]
@@ -1071,20 +1080,16 @@ impl LogicalLog {
         self.pending_running_crc = None;
         self.header = Some(header.clone());
 
-        let header_c = self.write_header(header)?;
-        let truncate_c = self.file.truncate(
-            LOG_HDR_SIZE as u64,
-            Completion::new_trunc(move |result| {
-                if let Err(err) = result {
-                    tracing::error!("logical_log_truncate failed: {}", err);
-                }
-            }),
-        )?;
-        self.offset = 0;
-
         let mut group = CompletionGroup::new(|_| {});
-        group.add(&header_c);
-        group.add(&truncate_c);
+        let _header_c = self.write_header(header, Some(&mut group))?;
+        let c = Completion::new_trunc(move |result| {
+            if let Err(err) = result {
+                tracing::error!("logical_log_truncate failed: {}", err);
+            }
+        });
+        group.add(&c);
+        let _truncate_c = self.file.truncate(LOG_HDR_SIZE as u64, c)?;
+        self.offset = 0;
         Ok(group.build())
     }
 }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -318,15 +318,12 @@ struct BalanceState {
     /// Reusable Vec for CellArray cell_payloads to avoid per-balance allocation.
     /// Cleared before each use; grows as needed and retains capacity across operations.
     reusable_cell_payloads: crate::alloc::Vec<&'static mut [u8]>,
-    /// Disk-read completions accumulated during the sibling-load loop in
-    /// `NonRootPickSiblings`. We persist them in `BalanceState` (rather than
-    /// in a local `CompletionGroup`) so that when the loop yields for spill
-    /// IO and is re-entered, completions from earlier iterations are not
-    /// lost — they would otherwise leak: the IO is still in flight, but we
-    /// would no longer have a handle to wait on them before reading page
-    /// contents in `NonRootDoBalancing`. Cleared when the loop completes
-    /// and transitions to `NonRootDoBalancing`.
-    pending_sibling_load_completions: crate::alloc::Vec<Completion>,
+    /// Group for the sibling page reads issued by `NonRootPickSiblings`.
+    /// It lives in `BalanceState` rather than on the stack so that when
+    /// the loop yields for spill IO and is re-entered, reads from earlier
+    /// iterations are still waited on before `NonRootDoBalancing` looks at
+    /// page contents. Taken and built when the loop completes.
+    sibling_load_group: Option<CompletionGroup>,
 }
 
 impl Default for BalanceState {
@@ -336,7 +333,7 @@ impl Default for BalanceState {
             balance_info: None,
             reusable_divider_buffers: std::array::from_fn(|_| crate::alloc::vec![]),
             reusable_cell_payloads: crate::alloc::vec![],
-            pending_sibling_load_completions: crate::alloc::vec![],
+            sibling_load_group: None,
         }
     }
 }
@@ -3250,7 +3247,7 @@ impl BTreeCursor {
                 balance_info,
                 reusable_divider_buffers,
                 reusable_cell_payloads,
-                pending_sibling_load_completions,
+                sibling_load_group,
             } = &mut self.balance_state;
             tracing::debug!(?sub_state);
 
@@ -3403,8 +3400,10 @@ impl BTreeCursor {
                     let mut pgno: u32 =
                         unsafe { right_pointer.cast::<u32>().read_unaligned().swap_bytes() };
                     let current_sibling = sibling_pointer;
+                    let group =
+                        sibling_load_group.get_or_insert_with(|| CompletionGroup::new(|_| {}));
                     for i in (0..=current_sibling).rev() {
-                        match self.pager.read_page(pgno as i64) {
+                        match self.pager.read_page_into(pgno as i64, Some(group)) {
                             Err(e) => {
                                 mark_unlikely();
                                 tracing::error!("error reading page {}: {}", pgno, e);
@@ -3412,30 +3411,21 @@ impl BTreeCursor {
                                 // across previous iterations / yields so the
                                 // IO scheduler can finalize them before we
                                 // bail out.
-                                self.pager
-                                    .io
-                                    .drain_completions(pending_sibling_load_completions)?;
-                                pending_sibling_load_completions.clear();
+                                self.pager.io.drain_completions(group.completions())?;
+                                *sibling_load_group = None;
                                 return Err(e);
                             }
-                            Ok(IOResult::Done((page, c))) => {
+                            Ok(IOResult::Done((page, _))) => {
                                 pages_to_balance[i].replace(PinGuard::new(page));
-                                if let Some(c) = c {
-                                    // Accumulate in `BalanceState` rather
-                                    // than a local group: a spill yield
-                                    // later in this loop drops local state
-                                    // but the persistent vec survives.
-                                    pending_sibling_load_completions.push(c);
-                                }
                             }
                             Ok(IOResult::IO(IOCompletions(spill_c))) => {
                                 // Spill yield. The loop is fully re-entrant:
                                 // on re-entry we re-execute from the top of
                                 // `NonRootPickSiblings`, the pager's
                                 // `pending_reads` returns the same PageRef
-                                // for the in-flight sibling, and cache hits
-                                // for previously-loaded siblings yield
-                                // `c=None` so we don't double-add them.
+                                // for the in-flight sibling (its read is
+                                // already in the group), and cache hits for
+                                // previously-loaded siblings need no read.
                                 io_yield_one!(spill_c);
                             }
                         }
@@ -3506,15 +3496,13 @@ impl BTreeCursor {
                         reusable_divider_cell: crate::alloc::vec![],
                     });
                     *sub_state = BalanceSubState::NonRootDoBalancing;
-                    // Build the wait-group from the accumulated completions
-                    // collected across (possibly multiple) calls. Drain so
-                    // a subsequent balance operation starts fresh.
-                    let mut group = CompletionGroup::new(|_| {});
-                    let completions = take_vec(pending_sibling_load_completions);
-                    for c in &completions {
-                        group.add(c);
-                    }
-                    let completion = group.build();
+                    // Wait for the sibling reads issued across (possibly
+                    // multiple) entries into this state. Take the group so
+                    // the next balance starts fresh.
+                    let completion = sibling_load_group
+                        .take()
+                        .expect("the sibling loop above created the group")
+                        .build();
                     if !completion.finished() {
                         io_yield_one!(completion);
                     }
@@ -10344,7 +10332,6 @@ mod tests {
         let balance = BalanceState::default();
         assert_alloc_vec(&balance.reusable_divider_buffers[0]);
         assert_alloc_vec(&balance.reusable_cell_payloads);
-        assert_alloc_vec(&balance.pending_sibling_load_completions);
         let integrity_check = IntegrityCheckState::new(0);
         assert_alloc_vec(&integrity_check.page_stack);
         let op_integrity_check =

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3862,17 +3862,14 @@ impl Pager {
                                 for page in &pages {
                                     page.set_write_pending();
                                 }
-                                let completions = self.spill_pages_to_disk(&pages)?;
+                                let completions = self.spill_pages_to_disk(&pages, &mut group)?;
                                 if completions.is_empty() {
                                     self.finish_ephemeral_spill(&pages);
                                     return Ok(IOResult::Done(()));
                                 }
-                                for completion in &completions {
-                                    group.add(completion);
-                                }
                                 *self.spill_state.write() = SpillState::WritingToDisk {
                                     pages,
-                                    completions: completions.clone(),
+                                    completions,
                                 };
                                 io_yield_one!(group.build());
                             }
@@ -4036,10 +4033,16 @@ impl Pager {
     }
     /// Write a set of pages directly to the database file (for ephemeral tables without WAL).
     /// This is used by try_spill_dirty_pages for ephemeral tables/indexes.
-    fn spill_pages_to_disk(&self, pages: &[PinGuard]) -> Result<Vec<Completion>> {
+    /// Writes `pages` to the database file. Each write is added to `group`
+    /// before it is submitted.
+    fn spill_pages_to_disk(
+        &self,
+        pages: &[PinGuard],
+        group: &mut CompletionGroup,
+    ) -> Result<Vec<Completion>> {
         let mut completions: Vec<Completion> = Vec::with_capacity(pages.len());
         for page in pages {
-            match begin_write_btree_page(self, &page.to_page()) {
+            match begin_write_btree_page(self, &page.to_page(), Some(group)) {
                 Ok(c) => completions.push(c),
                 Err(e) => {
                     self.io.cancel(&completions)?;
@@ -5345,7 +5348,7 @@ impl Pager {
                     (default_header.page_size.get() - default_header.reserved_space as u32)
                         as usize,
                 );
-                let c = begin_write_btree_page(self, &page1)?;
+                let c = begin_write_btree_page(self, &page1, None)?;
 
                 // Pin page1 to prevent eviction while stored in state machine
                 page1.pin();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1105,8 +1105,13 @@ pub enum BtreePageAllocMode {
 
 /// This will keep track of the state of current cache commit in order to not repeat work
 struct CommitInfo {
-    completions: Vec<Completion>,
+    /// Group the reads or writes of the current step are added to. Taken
+    /// and built by `commit_completion` when the step waits on it.
+    group: Option<CompletionGroup>,
+    /// The built `group`, cached so re-entries wait on the same completion.
     completion_group: Option<Completion>,
+    /// The fsync in flight, if `WaitSync` has submitted one.
+    pending_sync: Option<Completion>,
     state: CommitState,
     collected_pages: Vec<PageRef>,
     page_sources: Vec<PageSource>,
@@ -1124,8 +1129,9 @@ enum PageSource {
 
 impl CommitInfo {
     fn reset(&mut self) {
-        self.completions.clear();
+        self.group = None;
         self.completion_group = None;
+        self.pending_sync = None;
         self.state = CommitState::PrepareWal;
         self.collected_pages.clear();
         self.page_sources.clear();
@@ -1137,8 +1143,7 @@ impl CommitInfo {
     fn initialize(&mut self, n: usize) {
         self.page_sources.clear();
         self.page_sources.reserve(n.min(IOV_MAX));
-        self.completions.clear();
-        self.completions.reserve(n / 4);
+        self.group = Some(CompletionGroup::new(|_| {}));
         self.completion_group = None;
         self.collected_pages.reserve(n.min(IOV_MAX));
     }
@@ -1662,8 +1667,9 @@ impl Pager {
             subjournal: RwLock::new(None),
             savepoints: Arc::new(RwLock::new(Vec::new())),
             commit_info: RwLock::new(CommitInfo {
-                completions: Vec::new(),
+                group: None,
                 completion_group: None,
+                pending_sync: None,
                 state: CommitState::PrepareWal,
                 collected_pages: Vec::new(),
                 prepared_frames: Vec::new(),
@@ -3262,11 +3268,14 @@ impl Pager {
 
     /// Reads a page from disk (either WAL or DB file) bypassing page-cache
     #[tracing::instrument(skip_all, level = Level::DEBUG)]
+    /// Reads a page without going through the page cache. The read is
+    /// added to `group`, when given, before it is submitted.
     pub fn read_page_no_cache(
         &self,
         page_idx: i64,
         frame_watermark: Option<u64>,
         allow_empty_read: bool,
+        group: Option<&mut CompletionGroup>,
     ) -> Result<(PageRef, Completion)> {
         turso_assert_greater_than_or_equal!(page_idx, 0);
         tracing::debug!("read_page_no_cache(page_idx = {})", page_idx);
@@ -3284,20 +3293,26 @@ impl Pager {
                 page.clone(),
                 allow_empty_read,
                 &io_ctx,
+                group,
             )?;
             return Ok((page, c));
         };
 
         if let Some(frame_id) = wal.find_frame(page_idx as u64, frame_watermark)? {
-            let c = wal.read_frame(frame_id, page.clone(), self.buffer_pool.clone())?;
+            let c = wal.read_frame(frame_id, page.clone(), self.buffer_pool.clone(), group)?;
             // TODO(pere) should probably first insert to page cache, and if successful,
             // read frame or page
             return Ok((page, c));
         }
 
         page.set_locked();
-        let c =
-            self.begin_read_disk_page(page_idx as usize, page.clone(), allow_empty_read, &io_ctx)?;
+        let c = self.begin_read_disk_page(
+            page_idx as usize,
+            page.clone(),
+            allow_empty_read,
+            &io_ctx,
+            group,
+        )?;
         Ok((page, c))
     }
 
@@ -3318,6 +3333,16 @@ impl Pager {
     /// entry is removed exactly when this method returns `Done`.
     #[tracing::instrument(skip_all, level = Level::TRACE)]
     pub fn read_page(&self, page_idx: i64) -> Result<IOResult<(PageRef, Option<Completion>)>> {
+        self.read_page_into(page_idx, None)
+    }
+
+    /// Like `read_page`, but the disk read, if one is needed, is added to
+    /// `group` before it is submitted.
+    pub fn read_page_into(
+        &self,
+        page_idx: i64,
+        group: Option<&mut CompletionGroup>,
+    ) -> Result<IOResult<(PageRef, Option<Completion>)>> {
         turso_assert_greater_than_or_equal!(page_idx, 0, "pages in pager should be positive, negative might indicate unallocated pages from mvcc or any other nasty bug");
         tracing::debug!("read_page_nonblock(page_idx = {})", page_idx);
         #[cfg(test)]
@@ -3361,7 +3386,7 @@ impl Pager {
             }
 
             tracing::debug!("read_page(page_idx = {page_idx}) = reading page from disk");
-            let (page, c) = self.read_page_no_cache(page_idx, None, false)?;
+            let (page, c) = self.read_page_no_cache(page_idx, None, false, group)?;
             self.pending_reads.write().insert(
                 page_idx,
                 PendingRead {
@@ -3392,6 +3417,7 @@ impl Pager {
         page: PageRef,
         allow_empty_read: bool,
         io_ctx: &IOContext,
+        group: Option<&mut CompletionGroup>,
     ) -> Result<Completion> {
         sqlite3_ondisk::begin_read_page(
             self.db_file.as_ref(),
@@ -3400,6 +3426,7 @@ impl Pager {
             page_idx,
             allow_empty_read,
             io_ctx,
+            group,
         )
     }
 
@@ -3694,7 +3721,7 @@ impl Pager {
                     // Page evicted, need async read from WAL
                     trace!("cacheflush: page {} evicted, reading from WAL", page_id);
                     let (page, completion) =
-                        self.read_page_no_cache(page_id as i64, None, false)?;
+                        self.read_page_no_cache(page_id as i64, None, false, None)?;
 
                     if !completion.succeeded() {
                         return Ok(CacheFlushStep::Yield(
@@ -3867,10 +3894,8 @@ impl Pager {
                                     self.finish_ephemeral_spill(&pages);
                                     return Ok(IOResult::Done(()));
                                 }
-                                *self.spill_state.write() = SpillState::WritingToDisk {
-                                    pages,
-                                    completions,
-                                };
+                                *self.spill_state.write() =
+                                    SpillState::WritingToDisk { pages, completions };
                                 io_yield_one!(group.build());
                             }
                         }
@@ -4189,60 +4214,42 @@ impl Pager {
                         if cache.peek(&page_key, false).is_some() {
                             commit_info.page_sources.push(PageSource::Cached(page_id));
                         } else {
-                            let (page, completion) =
-                                self.read_page_no_cache(page_id as i64, None, false)?;
-                            // If the read completed synchronously with an error,
-                            // surface it now. Otherwise we would silently drop the
-                            // failure (the completion is "finished" so we'd skip
-                            // pushing it into the wait list) and later trip the
-                            // page-buffer-not-loaded panic in prepare_frames when
-                            // it tries to read content from the evicted page.
-                            if completion.finished() && !completion.succeeded() {
-                                let err = completion.get_error().unwrap_or(
-                                    CompletionError::IOError(std::io::ErrorKind::Other, "read"),
-                                );
-                                return Err(LimboError::CompletionError(err));
-                            }
+                            let group = commit_info
+                                .group
+                                .as_mut()
+                                .expect("initialize() created the group");
+                            let (page, _completion) =
+                                self.read_page_no_cache(page_id as i64, None, false, Some(group))?;
                             commit_info.page_sources.push(PageSource::Evicted(page));
-                            if !completion.finished() {
-                                commit_info.completions.push(completion);
-                            }
                         }
                     }
                     drop(cache);
                     drop(dirty_pages);
-                    if !commit_info.completions.is_empty() {
+                    let issued_reads = !commit_info
+                        .group
+                        .as_ref()
+                        .expect("initialize() created the group")
+                        .is_empty();
+                    if issued_reads {
+                        // WaitBatchedReads also catches a read that failed
+                        // before we got here: the group keeps its error.
                         commit_info.state = CommitState::WaitBatchedReads { db_size };
-                        drop(commit_info);
-                        io_yield_one!(self.commit_completion());
+                        continue;
                     }
                     commit_info.state = CommitState::PrepareFrames { db_size };
                 }
                 CommitState::WaitBatchedReads { db_size } => {
-                    let all_done = self
-                        .commit_info
-                        .read()
-                        .completions
-                        .iter()
-                        .all(|c| c.finished());
-                    if !all_done {
-                        io_yield_one!(self.commit_completion());
+                    let reads = self.commit_completion();
+                    if !reads.finished() {
+                        io_yield_one!(reads);
                     }
-                    // Check for any read errors
                     let mut commit_info = self.commit_info.write();
-                    let failed = commit_info
-                        .completions
-                        .iter()
-                        .find(|c| !c.succeeded())
-                        .cloned();
-                    if let Some(_failed) = failed {
-                        return Err(LimboError::CompletionError(CompletionError::IOError(
-                            std::io::ErrorKind::Other,
-                            "read",
+                    if !reads.succeeded() {
+                        return Err(LimboError::CompletionError(reads.get_error().unwrap_or(
+                            CompletionError::IOError(std::io::ErrorKind::Other, "read"),
                         )));
                     }
                     // All reads complete and successful, proceed to frame preparation
-                    commit_info.completions.clear();
                     commit_info.completion_group = None;
                     commit_info.state = CommitState::PrepareFrames { db_size };
                 }
@@ -4312,32 +4319,19 @@ impl Pager {
                     for prepared in &commit_info.prepared_frames {
                         batch.writev(prepared.offset, &prepared.bufs);
                     }
-                    commit_info.completions = batch.submit()?;
+                    let mut group = CompletionGroup::new(|_| {});
+                    batch.submit(Some(&mut group))?;
+                    commit_info.group = Some(group);
                     commit_info.completion_group = None;
                     commit_info.state = CommitState::WaitWrites;
                 }
                 CommitState::WaitWrites => {
-                    if !self
-                        .commit_info
-                        .read()
-                        .completions
-                        .iter()
-                        .all(|c| c.finished())
-                    {
-                        io_yield_one!(self.commit_completion());
+                    let writes = self.commit_completion();
+                    if !writes.finished() {
+                        io_yield_one!(writes);
                     }
-                    // Check for any write errors
-                    let failed = self
-                        .commit_info
-                        .read()
-                        .completions
-                        .iter()
-                        .find(|c| !c.succeeded())
-                        .cloned();
-
                     let mut commit_info = self.commit_info.write();
-                    if let Some(_failed) = failed {
-                        commit_info.completions.clear();
+                    if !writes.succeeded() {
                         commit_info.completion_group = None;
                         commit_info.prepared_frames.clear();
                         return Err(LimboError::CompletionError(CompletionError::IOError(
@@ -4345,7 +4339,6 @@ impl Pager {
                             "write",
                         )));
                     }
-                    commit_info.completions.clear();
                     commit_info.completion_group = None;
                     // All writes complete; WaitSync submits the WAL fsync if
                     // one is owed.
@@ -4359,23 +4352,17 @@ impl Pager {
                 // to ensure durability in the case of partial writes is to ensure the pwritev
                 // completes before the fsync is submitted.
                 CommitState::WaitSync => {
-                    // A pending completion means a previous entry into this
-                    // state already submitted the fsync; wait on it instead
-                    // of submitting a second one. At most one fsync is ever in
-                    // flight, so completions holds either the pending fsync or
-                    // nothing.
-                    assert!(
-                        self.commit_info.read().completions.len() <= 1,
-                        "WaitSync expects at most one in-flight fsync completion"
-                    );
-                    let pending = self.commit_info.read().completions.first().cloned();
+                    // A pending fsync means a previous entry into this state
+                    // already submitted it; wait on it instead of submitting
+                    // a second one.
+                    let pending = self.commit_info.read().pending_sync.clone();
                     let need_fsync =
                         !self.commit_info.read().prepared_frames.is_empty() || wal.is_dirty();
                     let sync_c = match pending {
                         Some(c) => Some(c),
                         None if sync_mode == SyncMode::Full && need_fsync => {
                             let sync_c = wal.sync(self.get_sync_type())?;
-                            self.commit_info.write().completions.push(sync_c.clone());
+                            self.commit_info.write().pending_sync = Some(sync_c.clone());
                             Some(sync_c)
                         }
                         None => None,
@@ -4388,7 +4375,7 @@ impl Pager {
                         // Check for fsync error as we might need to panic on data_sync_retry=off
                         let mut commit_info = self.commit_info.write();
                         if !sync_c.succeeded() {
-                            commit_info.completions.clear();
+                            commit_info.pending_sync = None;
                             commit_info.prepared_frames.clear();
 
                             if !data_sync_retry {
@@ -4402,7 +4389,7 @@ impl Pager {
                                 "sync",
                             )));
                         }
-                        commit_info.completions.clear();
+                        commit_info.pending_sync = None;
                     }
                     let mut commit_info = self.commit_info.write();
                     if commit_info.prepared_frames.is_empty() {
@@ -4459,18 +4446,21 @@ impl Pager {
         Ok(())
     }
 
+    /// The completion for the reads or writes of the current commit step.
+    /// Builds the step's group on first use and hands out the same
+    /// completion after that.
     fn commit_completion(&self) -> Completion {
         let mut commit_info = self.commit_info.write();
-        if let Some(group) = &commit_info.completion_group {
-            return group.clone();
+        if let Some(c) = &commit_info.completion_group {
+            return c.clone();
         }
-        let mut group = CompletionGroup::new(|_| {});
-        for c in commit_info.completions.iter() {
-            group.add(c);
-        }
-        let result = group.build();
-        commit_info.completion_group = Some(result.clone());
-        result
+        let group = commit_info
+            .group
+            .take()
+            .expect("the commit step issued its IO before waiting on it");
+        let c = group.build();
+        commit_info.completion_group = Some(c.clone());
+        c
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -553,6 +553,8 @@ pub struct OverflowCell {
 /// Send read request for DB page read to the IO
 /// if allow_empty_read is set, than empty read will be raise error for the page, but will not panic
 #[instrument(skip_all, level = Level::DEBUG)]
+/// Reads one page from the database file. The read is added to `group`,
+/// when given, before it is submitted.
 pub fn begin_read_page(
     db_file: &dyn DatabaseStorage,
     buffer_pool: Arc<BufferPool>,
@@ -560,6 +562,7 @@ pub fn begin_read_page(
     page_idx: usize,
     allow_empty_read: bool,
     io_ctx: &IOContext,
+    group: Option<&mut CompletionGroup>,
 ) -> Result<Completion> {
     tracing::trace!("begin_read_btree_page(page_idx = {})", page_idx);
     let buf = buffer_pool.get_page();
@@ -604,6 +607,9 @@ pub fn begin_read_page(
         None
     });
     let c = Completion::new_read(buf, complete);
+    if let Some(group) = group {
+        group.add(&c);
+    }
     db_file.read_page(page_idx, io_ctx, c)
 }
 

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -663,15 +663,19 @@ pub fn begin_write_btree_page(pager: &Pager, page: &PageRef) -> Result<Completio
 /// [1,2,3], [6,7], [9,10,11,12]
 /// and submit each run as a `writev` call,
 /// for 3 total syscalls instead of 9.
+///
+/// Each run's write is added to `group` before it is submitted. Returns
+/// the number of runs submitted.
 pub fn write_pages_vectored(
     pager: &Pager,
     batch: BTreeMap<usize, Arc<Buffer>>,
     done_flag: Arc<AtomicBool>,
     err: Arc<crate::sync::OnceLock<CompletionError>>,
-) -> Result<Vec<Completion>> {
+    group: &mut CompletionGroup,
+) -> Result<usize> {
     if batch.is_empty() {
         done_flag.store(true, Ordering::Release);
-        return Ok(Vec::new());
+        return Ok(0);
     }
 
     let page_sz = pager.get_page_size_unchecked().get() as usize;
@@ -737,6 +741,7 @@ pub fn write_pages_vectored(
                 done_cl.store(true, Ordering::Release);
             }
         });
+        group.add(&cmp);
         let io_ctx = pager.io_ctx.read();
         let bufs = std::mem::replace(&mut run_bufs, Vec::with_capacity(EST_BUFF_CAPACITY));
         match pager
@@ -754,7 +759,7 @@ pub fn write_pages_vectored(
             }
         }
     }
-    Ok(completions)
+    Ok(completions.len())
 }
 
 #[instrument(skip_all, level = Level::DEBUG)]
@@ -1961,6 +1966,8 @@ pub fn begin_read_wal_frame_raw<F: File + ?Sized>(
     Ok(c)
 }
 
+/// Reads one WAL frame's page body. The read is added to `group`, when
+/// given, before it is submitted.
 pub fn begin_read_wal_frame<F: File + ?Sized>(
     io: &F,
     offset: u64,
@@ -1968,6 +1975,7 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
     complete: Box<ReadComplete>,
     page_idx: usize,
     io_ctx: &IOContext,
+    group: Option<&mut CompletionGroup>,
 ) -> Result<Completion> {
     tracing::trace!(
         "begin_read_wal_frame(offset={}, page_idx={})",
@@ -1977,7 +1985,7 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
     let buf = buffer_pool.get_page();
     let buf = Arc::new(buf);
 
-    match io_ctx.page_transform() {
+    let complete: Box<ReadComplete> = match io_ctx.page_transform() {
         PageTransform::Codec(ctx) => {
             let page_codec = ctx.clone();
             let original_complete = complete;
@@ -1985,76 +1993,69 @@ pub fn begin_read_wal_frame<F: File + ?Sized>(
             let decoded_buf = Arc::new(buffer_pool.get_page());
             let codec_context = PageCodecContext::from_page_idx(page_idx, PageLocation::Wal)?;
 
-            let decode_complete =
-                Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
-                    let Ok((encoded_buf, bytes_read)) = res else {
-                        return original_complete(res);
-                    };
-                    if bytes_read == 0 {
-                        return original_complete(Ok((encoded_buf, bytes_read)));
+            Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                let Ok((encoded_buf, bytes_read)) = res else {
+                    return original_complete(res);
+                };
+                if bytes_read == 0 {
+                    return original_complete(Ok((encoded_buf, bytes_read)));
+                }
+                turso_assert_greater_than!(
+                    bytes_read,
+                    0,
+                    "expected to read data for page codec page",
+                    { "page_idx": page_idx }
+                );
+                if bytes_read as usize != encoded_buf.len() {
+                    return original_complete(Ok((encoded_buf, bytes_read)));
+                }
+                match page_codec.decode_page(
+                    codec_context,
+                    encoded_buf.as_slice(),
+                    decoded_buf.as_mut_slice(),
+                ) {
+                    Ok(()) => original_complete(Ok((decoded_buf.clone(), bytes_read))),
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to decode WAL frame data for page_idx={page_idx}: {e}"
+                        );
+                        let err = page_codec_completion_error(page_codec.as_ref(), page_idx);
+                        original_complete(Err(err));
+                        Some(err)
                     }
-                    turso_assert_greater_than!(
-                        bytes_read,
-                        0,
-                        "expected to read data for page codec page",
-                        { "page_idx": page_idx }
-                    );
-                    if bytes_read as usize != encoded_buf.len() {
-                        return original_complete(Ok((encoded_buf, bytes_read)));
-                    }
-                    match page_codec.decode_page(
-                        codec_context,
-                        encoded_buf.as_slice(),
-                        decoded_buf.as_mut_slice(),
-                    ) {
-                        Ok(()) => original_complete(Ok((decoded_buf.clone(), bytes_read))),
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to decode WAL frame data for page_idx={page_idx}: {e}"
-                            );
-                            let err = page_codec_completion_error(page_codec.as_ref(), page_idx);
-                            original_complete(Err(err));
-                            Some(err)
-                        }
-                    }
-                });
-
-            let new_completion = Completion::new_read(buf, decode_complete);
-            io.pread(offset, new_completion)
+                }
+            })
         }
         PageTransform::Checksum(ctx) => {
             let checksum_ctx = ctx.clone();
             let original_c = complete;
-            let verify_complete =
-                Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
-                    let Ok((buf, bytes_read)) = res else {
-                        return original_c(res);
-                    };
-                    if bytes_read <= 0 {
-                        tracing::trace!("Read page {page_idx} with {} bytes", bytes_read);
-                        return original_c(Ok((buf, bytes_read)));
-                    }
+            Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
+                let Ok((buf, bytes_read)) = res else {
+                    return original_c(res);
+                };
+                if bytes_read <= 0 {
+                    tracing::trace!("Read page {page_idx} with {} bytes", bytes_read);
+                    return original_c(Ok((buf, bytes_read)));
+                }
 
-                    match checksum_ctx.verify_checksum(buf.as_mut_slice(), page_idx) {
-                        Ok(_) => original_c(Ok((buf, bytes_read))),
-                        Err(e) => {
-                            mark_unlikely();
-                            tracing::error!(
-                                "Failed to verify checksum for page_id={page_idx}: {e}"
-                            );
-                            original_c(Err(e));
-                            Some(e)
-                        }
+                match checksum_ctx.verify_checksum(buf.as_mut_slice(), page_idx) {
+                    Ok(_) => original_c(Ok((buf, bytes_read))),
+                    Err(e) => {
+                        mark_unlikely();
+                        tracing::error!("Failed to verify checksum for page_id={page_idx}: {e}");
+                        original_c(Err(e));
+                        Some(e)
                     }
-                });
-            let c = Completion::new_read(buf, verify_complete);
-            io.pread(offset, c)
+                }
+            })
         }
-        PageTransform::None => {
-            let c = Completion::new_read(buf, complete);
-            io.pread(offset, c)
-        }
+        PageTransform::None => complete,
+    };
+    let c = Completion::new_read(buf, complete);
+    if let Some(group) = group {
+        group.add(&c);
     }
+    io.pread(offset, c)
 }
 
 pub fn parse_wal_frame_header(frame: &[u8]) -> (WalFrameHeader, &[u8]) {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -58,7 +58,7 @@ pub use super::pager::{PageContent, PageInner};
 use super::wal::{OverflowFallbackCoverage, TursoRwLock, WalSharedMetadata, WalSharedRuntime};
 use crate::error::LimboError;
 use crate::fast_lock::SpinLock;
-use crate::io::{Buffer, Completion, FileSyncType, ReadComplete};
+use crate::io::{Buffer, Completion, CompletionGroup, FileSyncType, ReadComplete};
 use crate::numeric::Numeric;
 use crate::storage::btree::{payload_overflow_threshold_max, payload_overflow_threshold_min};
 use crate::storage::buffer_pool::BufferPool;
@@ -2134,7 +2134,13 @@ pub(crate) fn recompute_wal_frame_checksum(
     frame[20..24].copy_from_slice(&final_checksum.1.to_be_bytes());
     final_checksum
 }
-pub fn begin_write_wal_header<F: File + ?Sized>(io: &F, header: &WalHeader) -> Result<Completion> {
+/// Writes the WAL header. The write is added to `group`, when given,
+/// before it is submitted.
+pub fn begin_write_wal_header<F: File + ?Sized>(
+    io: &F,
+    header: &WalHeader,
+    group: Option<&mut CompletionGroup>,
+) -> Result<Completion> {
     tracing::trace!("begin_write_wal_header");
     let buffer = {
         let buffer = Buffer::new_temporary(WAL_HEADER_SIZE);
@@ -2164,6 +2170,9 @@ pub fn begin_write_wal_header<F: File + ?Sized>(io: &F, header: &WalHeader) -> R
     };
     #[allow(clippy::arc_with_non_send_sync)]
     let c = Completion::new_write(write_complete);
+    if let Some(group) = group {
+        group.add(&c);
+    }
     let c = io.pwrite(0, buffer, c)?;
     Ok(c)
 }
@@ -2424,7 +2433,7 @@ mod tests {
         let (c1, c2) = checksum_wal(header_prefix, &wal_header, (0, 0), use_native);
         wal_header.checksum_1 = c1;
         wal_header.checksum_2 = c2;
-        io.wait_for_completion(begin_write_wal_header(file.as_ref(), &wal_header).unwrap())
+        io.wait_for_completion(begin_write_wal_header(file.as_ref(), &wal_header, None).unwrap())
             .unwrap();
 
         let page = vec![0xAB; page_size];

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -622,7 +622,13 @@ pub fn finish_read_page(page_idx: usize, buffer: Arc<Buffer>, page: PageRef) {
 }
 
 #[instrument(skip_all, level = Level::DEBUG)]
-pub fn begin_write_btree_page(pager: &Pager, page: &PageRef) -> Result<Completion> {
+/// Writes one page to the database file. The write is added to `group`,
+/// when given, before it is submitted.
+pub fn begin_write_btree_page(
+    pager: &Pager,
+    page: &PageRef,
+    group: Option<&mut CompletionGroup>,
+) -> Result<Completion> {
     tracing::trace!("begin_write_btree_page(page={})", page.get().id);
     let page_source = &pager.db_file;
     let page_finish = page.clone();
@@ -648,6 +654,9 @@ pub fn begin_write_btree_page(pager: &Pager, page: &PageRef) -> Result<Completio
         })
     };
     let c = Completion::new_write(write_complete);
+    if let Some(group) = group {
+        group.add(&c);
+    }
     let io_ctx = pager.io_ctx.read();
     page_source.write_page(page_id, buffer, &io_ctx, c)
 }

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -672,12 +672,15 @@ pub trait Wal: Debug + Send + Sync {
     /// Otherwise a fresh temporary buffer is allocated. VACUUM passes a
     /// pre-allocated buffer to amortize the ~batch-size allocation across
     /// batches.
+    ///
+    /// The read is added to `group`, when given, before it is submitted.
     fn read_frames_batch(
         &self,
         start_frame: u64,
         pages: &[PageRef],
         buffer_pool: Arc<BufferPool>,
         scratch_buf: Option<Arc<Buffer>>,
+        group: Option<&mut CompletionGroup>,
     ) -> Result<Completion>;
 
     /// Read a raw WAL frame with its on-disk header and page body decoded by
@@ -3614,6 +3617,7 @@ impl Wal for WalFile {
         pages: &[PageRef],
         buffer_pool: Arc<BufferPool>,
         scratch_buf: Option<Arc<Buffer>>,
+        group: Option<&mut CompletionGroup>,
     ) -> Result<Completion> {
         turso_assert!(
             !pages.is_empty(),
@@ -3757,6 +3761,9 @@ impl Wal for WalFile {
         });
 
         let c = Completion::new_read(raw_buf, complete);
+        if let Some(group) = group {
+            group.add(&c);
+        }
         let file = self.coordination.wal_file()?;
         file.pread(offset, c)
     }
@@ -6635,7 +6642,7 @@ pub mod test {
             Arc::new(crate::Page::new(5)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .read_frames_batch(1, &target_pages, buffer_pool, None, None)
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -6663,7 +6670,7 @@ pub mod test {
             Arc::new(crate::Page::new(33)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .read_frames_batch(1, &target_pages, buffer_pool, None, None)
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -6707,7 +6714,7 @@ pub mod test {
 
         let target_page = Arc::new(crate::Page::new(32));
         let completion = wal
-            .read_frames_batch(1, &[target_page.clone()], buffer_pool, None)
+            .read_frames_batch(1, &[target_page.clone()], buffer_pool, None, None)
             .unwrap();
         io.wait_for_completion(completion).unwrap();
         assert_eq!(target_page.get_contents().as_ptr(), expected.as_slice());
@@ -6903,7 +6910,7 @@ pub mod test {
 
         let target_page = Arc::new(crate::Page::new(43));
         let c = wal
-            .read_frames_batch(1, &[target_page], buffer_pool, None)
+            .read_frames_batch(1, &[target_page], buffer_pool, None, None)
             .unwrap();
         let err = wait_for_completion_error(&io, c);
 
@@ -6939,7 +6946,7 @@ pub mod test {
         ];
 
         let completion = wal
-            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .read_frames_batch(1, &target_pages, buffer_pool, None, None)
             .unwrap();
         let err = wait_for_completion_error(&io, completion);
 
@@ -6972,7 +6979,7 @@ pub mod test {
             Arc::new(crate::Page::new(13)),
         ];
         let c = wal
-            .read_frames_batch(2, &target_pages, buffer_pool, None)
+            .read_frames_batch(2, &target_pages, buffer_pool, None, None)
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -7003,7 +7010,7 @@ pub mod test {
             Arc::new(crate::Page::new(9)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .read_frames_batch(1, &target_pages, buffer_pool, None, None)
             .unwrap();
         io.wait_for_completion(c).unwrap();
 
@@ -7034,7 +7041,7 @@ pub mod test {
             Arc::new(crate::Page::new(22)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .read_frames_batch(1, &target_pages, buffer_pool, None, None)
             .unwrap();
         let err = wait_for_completion_error(&io, c);
 
@@ -7072,7 +7079,7 @@ pub mod test {
             Arc::new(crate::Page::new(99)),
         ];
         let c = wal
-            .read_frames_batch(1, &target_pages, buffer_pool, None)
+            .read_frames_batch(1, &target_pages, buffer_pool, None, None)
             .unwrap();
         let err = wait_for_completion_error(&io, c);
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -3603,6 +3603,7 @@ impl Wal for WalFile {
             complete,
             page_idx,
             &self.io_ctx.read(),
+            None,
         )
     }
 
@@ -3910,6 +3911,7 @@ impl Wal for WalFile {
                 complete,
                 page_id as usize,
                 &self.io_ctx.read(),
+                None,
             )?;
             self.io.wait_for_completion(c)?;
             return if *conflict.lock() {
@@ -4955,9 +4957,11 @@ impl WalFile {
                         }
                         // Issue read if page wasn't found in the page cache or doesnt meet
                         // the frame requirements
-                        let inflight =
-                            self.issue_wal_read_into_buffer(page_id as usize, target_frame)?;
-                        group.add(&inflight.completion);
+                        let inflight = self.issue_wal_read_into_buffer(
+                            page_id as usize,
+                            target_frame,
+                            &mut group,
+                        )?;
                         nr_completions += 1;
                         ongoing_chkpt.inflight_reads.push(inflight);
                         ongoing_chkpt.current_page += 1;
@@ -4970,15 +4974,13 @@ impl WalFile {
                         let batch_map = ongoing_chkpt.pending_writes.take();
                         if !batch_map.is_empty() {
                             let new_write = InflightWriteBatch::new();
-                            for c in write_pages_vectored(
+                            nr_completions += write_pages_vectored(
                                 pager,
                                 batch_map,
                                 new_write.done.clone(),
                                 new_write.err.clone(),
-                            )? {
-                                group.add(&c);
-                                nr_completions += 1;
-                            }
+                                &mut group,
+                            )?;
                             ongoing_chkpt.inflight_writes.push(new_write);
                         }
                     }
@@ -5283,7 +5285,14 @@ impl WalFile {
         Ok(())
     }
 
-    fn issue_wal_read_into_buffer(&self, page_id: usize, frame_id: u64) -> Result<InflightRead> {
+    /// Starts reading a frame's page body for the checkpoint. The read is
+    /// added to `group` before it is submitted.
+    fn issue_wal_read_into_buffer(
+        &self,
+        page_id: usize,
+        frame_id: u64,
+        group: &mut CompletionGroup,
+    ) -> Result<InflightRead> {
         let offset = self.frame_offset(frame_id);
         let buf_slot = Arc::new(SpinLock::new(None));
         tracing::debug!(
@@ -5318,6 +5327,7 @@ impl WalFile {
             complete,
             page_id,
             &self.io_ctx.read(),
+            Some(group),
         )?;
 
         Ok(InflightRead {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -4270,7 +4270,9 @@ impl Wal for WalFile {
 
         self.max_frame.store(0, Ordering::Release);
         let file = self.coordination.wal_file()?;
-        let header_c = sqlite3_ondisk::begin_write_wal_header(file.as_ref(), &header)?;
+        let mut group = CompletionGroup::new(|_| {});
+        let _header_c =
+            sqlite3_ondisk::begin_write_wal_header(file.as_ref(), &header, Some(&mut group))?;
 
         // After a RESTART or try_restart_log_before_write the WAL file may
         // still contain orphaned frames from the previous epoch. Truncate
@@ -4285,21 +4287,15 @@ impl Wal for WalFile {
             }
         };
         if !should_skip_truncate {
-            let trunc_c = file.truncate(
-                WAL_HEADER_SIZE as u64,
-                Completion::new_trunc(|res| {
-                    if let Err(err) = res {
-                        tracing::warn!("WAL truncate of orphaned frames failed: {err}");
-                    }
-                }),
-            )?;
-            let mut group = CompletionGroup::new(|_| {});
-            group.add(&header_c);
-            group.add(&trunc_c);
-            Ok(Some(group.build()))
-        } else {
-            Ok(Some(header_c))
+            let c = Completion::new_trunc(|res| {
+                if let Err(err) = res {
+                    tracing::warn!("WAL truncate of orphaned frames failed: {err}");
+                }
+            });
+            group.add(&c);
+            let _trunc_c = file.truncate(WAL_HEADER_SIZE as u64, c)?;
         }
+        Ok(Some(group.build()))
     }
 
     #[aristo::intent(
@@ -7172,7 +7168,7 @@ pub mod test {
         wal_header.checksum_2 = header_checksum.1;
 
         io.wait_for_completion(
-            sqlite3_ondisk::begin_write_wal_header(file.as_ref(), &wal_header).unwrap(),
+            sqlite3_ondisk::begin_write_wal_header(file.as_ref(), &wal_header, None).unwrap(),
         )
         .unwrap();
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -655,12 +655,14 @@ pub trait Wal: Debug + Send + Sync {
     /// caller must guarantee, that frame_watermark must be greater than last checkpointed frame, otherwise method will panic
     fn find_frame(&self, page_id: u64, frame_watermark: Option<u64>) -> Result<Option<u64>>;
 
-    /// Read a frame from the WAL.
+    /// Read a frame from the WAL. The read is added to `group`, when
+    /// given, before it is submitted.
     fn read_frame(
         &self,
         frame_id: u64,
         page: PageRef,
         buffer_pool: Arc<BufferPool>,
+        group: Option<&mut CompletionGroup>,
     ) -> Result<Completion>;
 
     /// Read a contiguous run of WAL frames with a single `pread`.
@@ -3560,6 +3562,7 @@ impl Wal for WalFile {
         frame_id: u64,
         page: PageRef,
         buffer_pool: Arc<BufferPool>,
+        group: Option<&mut CompletionGroup>,
     ) -> Result<Completion> {
         tracing::debug!(
             "read_frame(page_idx = {}, frame_id = {})",
@@ -3606,7 +3609,7 @@ impl Wal for WalFile {
             complete,
             page_idx,
             &self.io_ctx.read(),
-            None,
+            group,
         )
     }
 
@@ -6686,7 +6689,7 @@ pub mod test {
         set_test_page_codec(&wal, Arc::new(TestPageCodec::Xor(0xa5)));
         let target_page = Arc::new(crate::Page::new(43));
 
-        let completion = wal.read_frame(1, target_page, buffer_pool).unwrap();
+        let completion = wal.read_frame(1, target_page, buffer_pool, None).unwrap();
         let error = wait_for_completion_error(&io, completion);
 
         assert!(matches!(
@@ -6874,7 +6877,9 @@ pub mod test {
             .unwrap();
 
         let target = Arc::new(crate::Page::new(44));
-        let completion = wal.read_frame(1, target.clone(), buffer_pool).unwrap();
+        let completion = wal
+            .read_frame(1, target.clone(), buffer_pool, None)
+            .unwrap();
         io.wait_for_completion(completion).unwrap();
         assert_eq!(
             &target.get_contents().as_ptr()[..page_size as usize - 8],
@@ -7288,7 +7293,7 @@ pub mod test {
 
         let page = Arc::new(crate::storage::pager::Page::new(7));
         let issued_epoch = wal.coordination.checkpoint_epoch();
-        let completion = wal.read_frame(1, page.clone(), buffer_pool).unwrap();
+        let completion = wal.read_frame(1, page.clone(), buffer_pool, None).unwrap();
 
         wal.increment_checkpoint_epoch();
         deferred_file.complete_pending_reads();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -18276,7 +18276,7 @@ fn op_journal_mode_inner(
                     .page_ref
                     .as_ref()
                     .expect("page_ref should be set");
-                let completion = begin_write_btree_page(pager, page)?;
+                let completion = begin_write_btree_page(pager, page, None)?;
                 state.active_op_state.journal_mode().sub_state = OpJournalModeSubState::Finalize;
                 return Ok(InsnFunctionStepResult::IO(IOCompletions(completion)));
             }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -422,16 +422,12 @@ impl Sorter {
             InitChunkHeapState::Start => {
                 let mut group = CompletionGroup::new(|_| {});
                 for chunk in self.chunks.iter_mut() {
-                    match chunk.read() {
-                        Err(e) => {
-                            tracing::error!("Failed to read chunk: {e}");
-                            group.cancel();
-                            self.io.drain_completions(group.completions())?;
-                            return Err(e);
-                        }
-                        Ok(Some(c)) => group.add(&c),
-                        Ok(None) => {}
-                    };
+                    if let Err(e) = chunk.read(Some(&mut group)) {
+                        tracing::error!("Failed to read chunk: {e}");
+                        group.cancel();
+                        self.io.drain_completions(group.completions())?;
+                        return Err(e);
+                    }
                 }
                 self.init_chunk_heap_state = InitChunkHeapState::PushChunk;
                 let completion = group.build();
@@ -450,9 +446,7 @@ impl Sorter {
                 // TODO: blocking will be unnecessary here with IO completions
                 let mut group = CompletionGroup::new(|_| {});
                 for chunk_idx in 0..self.chunks.len() {
-                    if let Some(c) = self.push_to_chunk_heap(chunk_idx)? {
-                        group.add(&c);
-                    };
+                    self.push_to_chunk_heap(chunk_idx, Some(&mut group))?;
                 }
                 self.init_chunk_heap_state = InitChunkHeapState::Start;
                 let completion = group.build();
@@ -481,14 +475,14 @@ impl Sorter {
                 return Ok(IOResult::IO(IOCompletions(completion)));
             }
             // IO completed - push result to heap and retry
-            if let Some(c) = self.push_to_chunk_heap(chunk_idx)? {
+            if let Some(c) = self.push_to_chunk_heap(chunk_idx, None)? {
                 self.pending_completion = Some((c, chunk_idx));
             }
         }
 
         // No pending IO - safe to pop from heap
         if let Some((next_record, chunk_idx)) = self.chunk_heap.pop() {
-            if let Some(c) = self.push_to_chunk_heap(chunk_idx)? {
+            if let Some(c) = self.push_to_chunk_heap(chunk_idx, None)? {
                 self.pending_completion = Some((c, chunk_idx));
             }
             return Ok(IOResult::Done(Some(next_record.0)));
@@ -498,10 +492,17 @@ impl Sorter {
         Ok(IOResult::Done(None))
     }
 
-    fn push_to_chunk_heap(&mut self, chunk_idx: usize) -> Result<Option<Completion>> {
+    /// Pushes the next record of chunk `chunk_idx` onto the heap. If the
+    /// chunk needs a read first, the read is added to `group` when given,
+    /// and its completion is returned.
+    fn push_to_chunk_heap(
+        &mut self,
+        chunk_idx: usize,
+        group: Option<&mut CompletionGroup>,
+    ) -> Result<Option<Completion>> {
         let chunk = &mut self.chunks[chunk_idx];
 
-        match chunk.next()? {
+        match chunk.next(group)? {
             ChunkNextResult::Done(Some(record)) => {
                 self.chunk_heap.try_push((
                     Reverse(Box::new(BoxedSortableRecord::new(
@@ -672,7 +673,7 @@ impl SortedChunk {
     /// Internally manages a two-phase state machine:
     /// - `Start`: Parse records from buffer, issue prefetch read if needed
     /// - `Finish`: Return the next parsed record
-    fn next(&mut self) -> Result<ChunkNextResult> {
+    fn next(&mut self, mut group: Option<&mut CompletionGroup>) -> Result<ChunkNextResult> {
         loop {
             match self.next_state {
                 NextState::Start => {
@@ -734,7 +735,7 @@ impl SortedChunk {
                     if self.records.len() == 1
                         && *self.io_state.read() != SortedChunkIOState::ReadEOF
                     {
-                        if let Some(c) = self.read()? {
+                        if let Some(c) = self.read(group.as_deref_mut())? {
                             if !c.succeeded() {
                                 return Ok(ChunkNextResult::IO(c));
                             }
@@ -755,7 +756,9 @@ impl SortedChunk {
     /// if there's no room in the buffer or no data left to read (no IO issued).
     ///
     /// On completion, appends data to `buffer` and updates `buffer_len` and `total_bytes_read`.
-    fn read(&mut self) -> Result<Option<Completion>> {
+    /// Reads more of the chunk file into the buffer. The read is added to
+    /// `group`, when given, before it is submitted.
+    fn read(&mut self, group: Option<&mut CompletionGroup>) -> Result<Option<Completion>> {
         let free_buffer_space = self.buffer.read().len() - self.buffer_len();
         let remaining_chunk_bytes =
             self.chunk_size - self.total_bytes_read.load(atomic::Ordering::SeqCst);
@@ -806,6 +809,9 @@ impl SortedChunk {
         });
 
         let c = Completion::new_read(read_buffer_ref, read_complete);
+        if let Some(group) = group {
+            group.add(&c);
+        }
         let c = self.file.pread(
             self.start_offset + self.total_bytes_read.load(atomic::Ordering::SeqCst) as u64,
             c,

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1560,13 +1560,13 @@ fn start_temp_batch_reads(
         } else {
             None
         };
-        let c = wal.read_frames_batch(
+        let _c = wal.read_frames_batch(
             *start_frame,
             run_pages,
             temp_pager.buffer_pool.clone(),
             run_scratch,
+            Some(&mut group),
         )?;
-        group.add(&c);
     }
     let combined = group.build();
 

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -2080,7 +2080,7 @@ fn vacuum_in_place_step(
                 let wal_file = wal.wal_file()?;
                 let mut batch = IOWriteBatch::new(wal_file);
                 batch.writev(prepared.offset, &prepared.bufs);
-                let completions = batch.submit()?;
+                let completions = batch.submit(None)?;
 
                 *phase = VacuumInPlacePhase::WriteWalBatch {
                     total_pages: *total_pages,


### PR DESCRIPTION
A completion group used to be built after the fact: submit the IO, get the completions back, add them to a group, build. That left a window where a child finished on another thread before it was linked, so nobody counted it and the group never finished. With io_uring one thread drains completions for everyone, so this is easy to hit. The txn-latency benchmark deadlocked on it every few runs on its checkpointer thread.

The first commit fixes the hang as it stands. The rest of the branch changes the interface so the bug cannot come back:

- The group is created first and works like a wait-group. It starts with a count of 1 held by the builder, `add` counts one more, `build` releases the builder's count. Whoever brings it to zero fires the callback, so it fires exactly once.
- Every place that submits IO for a group now takes the group and adds the completion before submitting it. `add` asserts the child has not finished yet.
- With that, nothing in `completions.rs` has to work out whether a child finished before or after it was linked. The child's callback is the only thing that counts it.

One behaviour change: a group whose child had already failed used to finish at once, with the other children still in flight. It now waits for all of them and keeps the first error.

Each commit compiles and passes tests on its own.