### PR TITLE
core/translate: propagate rowid use through nested subqueries

### DIFF
--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1152,6 +1152,7 @@ fn update_column_used_masks(
                 outer_query_ref
                     .col_used_mask
                     .union_with(&child_outer_query_ref.col_used_mask)?;
+                outer_query_ref.rowid_referenced |= child_outer_query_ref.rowid_referenced;
             }
         }
 

--- a/sqlite/conformance/sqlite-sqltests/select/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/select/memory.sqltest
@@ -1950,3 +1950,23 @@ test where-variable-predicate {
 }
 expect {
 }
+
+@cross-check-integrity
+test nested-correlated-rowid-propagates-through-intermediate-subqueries {
+    CREATE TABLE t(a);
+    INSERT INTO t VALUES(7), (8);
+    SELECT 'scalar', a FROM t
+      WHERE (SELECT (SELECT t.rowid=2))
+      ORDER BY a;
+    SELECT 'exists', a FROM t
+      WHERE EXISTS(SELECT 1 WHERE EXISTS(SELECT 1 WHERE t.rowid=2))
+      ORDER BY a;
+    SELECT 'in', a FROM t
+      WHERE 1 IN (SELECT 1 WHERE 1 IN (SELECT 1 WHERE t.rowid=2))
+      ORDER BY a;
+}
+expect {
+    scalar|8
+    exists|8
+    in|8
+}


### PR DESCRIPTION
 Nested correlated subqueries could lose their dependency on an outer table when they referenced only its rowid:

  ```sql
  CREATE TABLE t(a);
  INSERT INTO t VALUES(7), (8);

  SELECT a FROM t
  WHERE (SELECT (SELECT t.rowid = 2));
```
  SQLite returns 8. Turso returned no rows. Nested IN queries could also panic because they were evaluated before their cursor was opened.

  We already propagate normal column usage through intermediate subqueries, but rowid usage is tracked separately in rowid_referenced. That flag was not propagated, so the planner incorrectly treated the
  subquery as independent of t.

  ## Fix

  Propagate rowid_referenced together with the existing column-used mask.


  ## AI disclosure

  used claude for review 
  
  
  ## todo: 
   open pre-existing bugs claude found during adversial review as issues.