### PR TITLE
  core: ignore rowid-less tables and prevent stale rowids or duplicate FULL JOIN rows

### DIFF
--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -174,10 +174,12 @@ fn pragma_vtabs() -> Vec<Arc<VirtualTable>> {
     PragmaVirtualTable::functions()
         .into_iter()
         .map(|(tab, schema_sql)| {
+            let (columns, has_visible_rowid) = VirtualTable::resolve_schema(schema_sql)
+                .expect("pragma table-valued function schema resolution should not fail");
             Arc::new(VirtualTable {
                 name: format!("pragma_{}", tab.pragma_name),
-                columns: VirtualTable::resolve_columns(schema_sql)
-                    .expect("pragma table-valued function schema resolution should not fail"),
+                columns,
+                has_visible_rowid,
                 kind: VTabKind::TableValuedFunction,
                 vtab_type: VirtualTableType::Pragma(tab),
                 vtab_id: 0,

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2701,6 +2701,7 @@ impl TryClone for VirtualTable {
         Ok(Self {
             name: self.name.clone(),
             columns: self.columns.try_clone()?,
+            has_visible_rowid: self.has_visible_rowid,
             kind: self.kind,
             vtab_type: self.vtab_type.clone(),
             vtab_id: self.vtab_id,

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -1,11 +1,14 @@
 use super::*;
+use crate::translate::planner::ROWID_STRS;
 
 /// The precedence of binding identifiers to columns.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BindingBehavior {
     /// `TryResultColumnsFirst` means that result columns (e.g. SELECT x AS y, ...) take precedence over canonical columns (e.g. SELECT x, y AS z, ...). This is the default behavior.
     TryResultColumnsFirst,
-    /// `TryCanonicalColumnsFirst` means that canonical columns take precedence over result columns. This is used for e.g. WHERE clauses.
+    /// `TryCanonicalColumnsFirst` checks columns in the current query before result aliases.
+    /// Result aliases still take precedence over columns from enclosing queries.
+    /// This is used for e.g. WHERE clauses.
     TryCanonicalColumnsFirst,
     /// `ResultColumnsNotAllowed` means that referring to result columns is not allowed. This is used e.g. for DML statements.
     ResultColumnsNotAllowed,
@@ -60,7 +63,7 @@ pub(super) fn resolve_qualified_on_ref(
     }
 
     if let Table::BTree(btree) = table {
-        if parse_row_id(normalized_id, internal_id, || false)?.is_some() {
+        if parse_row_id(normalized_id, internal_id).is_some() {
             if !btree.has_rowid {
                 crate::bail_parse_error!("no such column: {}", normalized_id);
             }
@@ -110,6 +113,9 @@ pub fn bind_and_rewrite_expr<'a>(
                     }
                     let mut match_result = None;
                     let joined_tables = referenced_tables.joined_tables();
+                    let is_rowid_name = ROWID_STRS
+                        .iter()
+                        .any(|name| name.eq_ignore_ascii_case(&normalized_id));
 
                     // First check joined tables
                     for joined_table in joined_tables.iter() {
@@ -145,72 +151,27 @@ pub fn bind_and_rewrite_expr<'a>(
                                     col.is_rowid_alias(),
                                 ));
                             }
-                        // only if we haven't found a match, check for explicit rowid reference
-                        } else if let Table::BTree(btree) = &joined_table.table {
-                            if let Some(row_id_expr) =
-                                parse_row_id(&normalized_id, joined_tables[0].internal_id, || {
-                                    joined_tables.len() != 1
-                                })?
-                            {
-                                if !btree.has_rowid {
-                                    crate::bail_parse_error!("no such column: {}", id.as_str());
-                                }
-                                *expr = row_id_expr;
-                                return Ok(WalkControl::Continue);
-                            }
                         }
                     }
 
-                    // Then check outer query references, if we still didn't find something.
-                    // Normally finding multiple matches for a non-qualified column is an error (column x is ambiguous)
-                    // but in the case of subqueries, the inner query takes precedence.
-                    // For example:
-                    // SELECT * FROM t WHERE x = (SELECT x FROM t2)
-                    // In this case, there is no ambiguity:
-                    // - x in the outer query refers to t.x,
-                    // - x in the inner query refers to t2.x.
-                    //
-                    // Ambiguity is only checked within the same scope depth. Once a match
-                    // is found at depth N, deeper scopes (N+1, N+2, ...) are not checked.
-                    if match_result.is_none() {
-                        let mut matched_scope_depth = None;
-                        for outer_ref in referenced_tables.outer_query_refs().iter() {
-                            // Definition-only entries let a FROM clause find a CTE by
-                            // name; the CTE's columns are visible only after a FROM
-                            // clause actually adds the table. Every other outer ref is
-                            // a real table in an enclosing scope, including CTEs and
-                            // the recursive self-reference, and its columns can be
-                            // referenced without qualification.
-                            if outer_ref.cte_definition_only {
-                                continue;
+                    if match_result.is_none() && is_rowid_name {
+                        let mut rowid_candidates = joined_tables
+                            .iter()
+                            .filter(|table| is_implicit_rowid_candidate(&table.table));
+                        if let Some(rowid_candidate) = rowid_candidates.next() {
+                            if rowid_candidates.next().is_some() {
+                                crate::bail_parse_error!("ambiguous column name: {}", id.as_str());
                             }
-                            // Skip refs from deeper scopes once we found a match
-                            if let Some(depth) = matched_scope_depth {
-                                if outer_ref.scope_depth > depth {
-                                    continue;
-                                }
+                            let table_id = rowid_candidate.internal_id;
+                            if !matches!(&rowid_candidate.table, Table::BTree(_)) {
+                                crate::bail_parse_error!("no such column: {}", id.as_str());
                             }
-                            let col_idx = outer_ref.table.columns().iter().position(|c| {
-                                c.name
-                                    .as_ref()
-                                    .is_some_and(|name| name.eq_ignore_ascii_case(&normalized_id))
-                            });
-                            if col_idx.is_some() {
-                                let col_idx = col_idx.unwrap();
-                                if outer_ref.using_dedup_hidden_cols.get(col_idx) {
-                                    continue;
-                                }
-                                if match_result.is_some() {
-                                    crate::bail_parse_error!(
-                                        "ambiguous column name: {}",
-                                        id.as_str()
-                                    );
-                                }
-                                let col = outer_ref.table.columns().get(col_idx).unwrap();
-                                match_result =
-                                    Some((outer_ref.internal_id, col_idx, col.is_rowid_alias()));
-                                matched_scope_depth = Some(outer_ref.scope_depth);
-                            }
+                            *expr = Expr::RowId {
+                                database: None,
+                                table: table_id,
+                            };
+                            referenced_tables.mark_rowid_referenced(table_id);
+                            return Ok(WalkControl::Continue);
                         }
                     }
 
@@ -236,6 +197,105 @@ pub fn bind_and_rewrite_expr<'a>(
                                 }
                             }
                         }
+                    }
+
+                    // Then check outer query references, if we still didn't find something.
+                    // Normally finding multiple matches for a non-qualified column is an error (column x is ambiguous)
+                    // but in the case of subqueries, the inner query takes precedence.
+                    // For example:
+                    // SELECT * FROM t WHERE x = (SELECT x FROM t2)
+                    // In this case, there is no ambiguity:
+                    // - x in the outer query refers to t.x,
+                    // - x in the inner query refers to t2.x.
+                    //
+                    // Ambiguity is only checked within the same scope depth. Once a match
+                    // is found at depth N, deeper scopes (N+1, N+2, ...) are not checked.
+                    let mut matched_scope_depth = None;
+                    let mut outer_column_match = None;
+                    let mut outer_column_is_ambiguous = false;
+                    let mut outer_rowid_match = None;
+                    let mut outer_rowid_is_ambiguous = false;
+
+                    for outer_ref in referenced_tables.outer_query_refs().iter() {
+                        if outer_ref.cte_definition_only {
+                            continue;
+                        }
+                        let column_match = outer_ref
+                            .table
+                            .columns()
+                            .iter()
+                            .enumerate()
+                            .find(|(col_idx, column)| {
+                                !outer_ref.using_dedup_hidden_cols.get(*col_idx)
+                                    && column.name.as_ref().is_some_and(|name| {
+                                        name.eq_ignore_ascii_case(&normalized_id)
+                                    })
+                            })
+                            .map(|(col_idx, column)| (col_idx, column.is_rowid_alias()));
+                        let is_rowid_candidate =
+                            is_rowid_name && is_implicit_rowid_candidate(&outer_ref.table);
+                        if column_match.is_none() && !is_rowid_candidate {
+                            continue;
+                        }
+
+                        match matched_scope_depth {
+                            Some(depth) if outer_ref.scope_depth > depth => continue,
+                            Some(depth) if outer_ref.scope_depth < depth => {
+                                outer_column_match = None;
+                                outer_column_is_ambiguous = false;
+                                outer_rowid_match = None;
+                                outer_rowid_is_ambiguous = false;
+                                matched_scope_depth = Some(outer_ref.scope_depth);
+                            }
+                            Some(_) => {}
+                            None => matched_scope_depth = Some(outer_ref.scope_depth),
+                        }
+
+                        if let Some((col_idx, is_rowid_alias)) = column_match {
+                            if outer_column_match.is_some() {
+                                outer_column_is_ambiguous = true;
+                            } else {
+                                outer_column_match =
+                                    Some((outer_ref.internal_id, col_idx, is_rowid_alias));
+                            }
+                        } else if is_rowid_candidate {
+                            if outer_rowid_match.is_some() {
+                                outer_rowid_is_ambiguous = true;
+                            } else {
+                                outer_rowid_match = Some((
+                                    outer_ref.internal_id,
+                                    matches!(&outer_ref.table, Table::BTree(_)),
+                                ));
+                            }
+                        }
+                    }
+
+                    if outer_column_is_ambiguous {
+                        crate::bail_parse_error!("ambiguous column name: {}", id.as_str());
+                    }
+                    if let Some((table_id, col_idx, is_rowid_alias)) = outer_column_match {
+                        *expr = Expr::Column {
+                            database: None, // TODO: support different databases
+                            table: table_id,
+                            column: col_idx,
+                            is_rowid_alias,
+                        };
+                        referenced_tables.mark_column_used(table_id, col_idx);
+                        return Ok(WalkControl::Continue);
+                    }
+                    if outer_rowid_is_ambiguous {
+                        crate::bail_parse_error!("ambiguous column name: {}", id.as_str());
+                    }
+                    if let Some((table_id, can_bind_rowid)) = outer_rowid_match {
+                        if !can_bind_rowid {
+                            crate::bail_parse_error!("no such column: {}", id.as_str());
+                        }
+                        *expr = Expr::RowId {
+                            database: None,
+                            table: table_id,
+                        };
+                        referenced_tables.mark_rowid_referenced(table_id);
+                        return Ok(WalkControl::Continue);
                     }
 
                     // SQLite DQS misfeature: double-quoted identifiers fall back to string literals
@@ -693,6 +753,14 @@ pub fn bind_and_rewrite_expr<'a>(
         },
     )?;
     Ok(())
+}
+
+fn is_implicit_rowid_candidate(table: &Table) -> bool {
+    match table {
+        Table::BTree(table) => table.has_rowid,
+        Table::Virtual(table) => table.has_visible_rowid,
+        Table::FromClauseSubquery(_) | Table::RecursiveCteInput(_) => false,
+    }
 }
 
 /// Extract a string literal value from an expression that has already been

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -769,6 +769,7 @@ impl<'a, 'plan> HashProbeSetupEmitter<'a, 'plan> {
             num_keys: to_u32(num_keys),
             dest_reg: to_u32(match_reg),
             target_pc: hash_probe_miss_label,
+            pc_if_deferred: self.next,
             payload_dest_reg: payload_dest_reg.map(to_u32),
             num_payload: to_u32(num_payload),
             // Main probe loop always carries the probe rowid so spilled build
@@ -1065,6 +1066,11 @@ impl<'a, 'plan> HashProbeCloseEmitter<'a, 'plan> {
                 decrement_by: 0,
             });
 
+            self.program.emit_insn(Insn::Null {
+                dest: self.hash_ctx.match_reg,
+                dest_end: None,
+            });
+
             if let Some(cursor_id) = self.hash_ctx.build_cursor_id {
                 self.program.emit_insn(Insn::NullRow { cursor_id });
             }
@@ -1316,6 +1322,7 @@ impl GraceHashLoop {
             num_keys: to_u32(hash_ctx.num_keys),
             dest_reg: to_u32(match_reg),
             target_pc: grace_outer_check,
+            pc_if_deferred: grace_probe_top,
             payload_dest_reg: payload_dest_reg.map(to_u32),
             num_payload: to_u32(num_payload),
             probe_rowid_reg: None, // grace-only: HashGraceLoadPartition already loaded this partition
@@ -1361,6 +1368,11 @@ impl GraceHashLoop {
                     decrement_by: 0,
                 });
             }
+
+            program.emit_insn(Insn::Null {
+                dest: match_reg,
+                dest_end: None,
+            });
 
             // Set build cursor to NULL row
             if let Some(cursor_id) = hash_ctx.build_cursor_id {

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -2823,28 +2823,17 @@ pub fn break_predicate_at_and_boundaries<T: From<Expr>>(
     }
 }
 
-pub fn parse_row_id<F>(
-    column_name: &str,
-    table_id: TableInternalId,
-    fn_check: F,
-) -> Result<Option<Expr>>
-where
-    F: FnOnce() -> bool,
-{
+pub fn parse_row_id(column_name: &str, table_id: TableInternalId) -> Option<Expr> {
     if ROWID_STRS
         .iter()
         .any(|s| s.eq_ignore_ascii_case(column_name))
     {
-        if fn_check() {
-            crate::bail_parse_error!("ROWID is ambiguous");
-        }
-
-        return Ok(Some(Expr::RowId {
+        return Some(Expr::RowId {
             database: None, // TODO: support different databases
             table: table_id,
-        }));
+        });
     }
-    Ok(None)
+    None
 }
 
 #[allow(clippy::type_complexity)]

--- a/core/util.rs
+++ b/core/util.rs
@@ -515,7 +515,7 @@ pub fn simple_bind_expr(
                     let is_btree_table = matches!(joined_table.table, Table::BTree(_));
                     if is_btree_table {
                         if let Some(rowid) =
-                            parse_row_id(&normalize_ident(id.as_str()), internal_id, || false)?
+                            parse_row_id(&normalize_ident(id.as_str()), internal_id)
                         {
                             *expr = rowid;
                         }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1760,7 +1760,14 @@ impl ProgramBuilder {
                 Insn::NotFound { target_pc, .. } => resolve(target_pc, "NotFound")?,
                 Insn::FkIfZero { target_pc, .. } => resolve(target_pc, "FkIfZero")?,
                 Insn::Filter { target_pc, .. } => resolve(target_pc, "Filter")?,
-                Insn::HashProbe { target_pc, .. } => resolve(target_pc, "HashProbe")?,
+                Insn::HashProbe {
+                    target_pc,
+                    pc_if_deferred,
+                    ..
+                } => {
+                    resolve(target_pc, "HashProbe")?;
+                    resolve(pc_if_deferred, "HashProbe")?;
+                }
                 Insn::HashNext { target_pc, .. } => resolve(target_pc, "HashNext")?,
                 Insn::HashDistinct { data } => resolve(&mut data.target_pc, "HashDistinct")?,
                 Insn::HashScanUnmatched { target_pc, .. } => {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -17231,6 +17231,7 @@ pub fn op_hash_probe(
             num_keys,
             dest_reg,
             target_pc,
+            pc_if_deferred,
             payload_dest_reg,
             num_payload,
             probe_rowid_reg,
@@ -17291,7 +17292,7 @@ pub fn op_hash_probe(
         // Main probe loop: buffer probe rows targeting spilled build partitions.
         if let Some(rowid_reg) = probe_rowid_reg {
             if probe_buffered {
-                state.pc = target_pc.as_offset_int();
+                state.pc = pc_if_deferred.as_offset_int();
                 state.active_op_state.clear();
                 return Ok(InsnFunctionStepResult::Step);
             }
@@ -17317,8 +17318,7 @@ pub fn op_hash_probe(
                         return Ok(InsnFunctionStepResult::IO(io));
                     }
                 }
-                // Jump to target_pc: this row is deferred to grace processing.
-                state.pc = target_pc.as_offset_int();
+                state.pc = pc_if_deferred.as_offset_int();
                 state.active_op_state.clear();
                 return Ok(InsnFunctionStepResult::Step);
             }
@@ -18930,6 +18930,8 @@ mod tests {
     use crate::alloc::vec;
     use crate::translate::collate::CollationSeq;
     use crate::vdbe::BranchOffset;
+    #[cfg(feature = "io_memory_yield")]
+    use crate::MemoryYieldIO;
     use crate::SqliteDialect;
     use crate::{Database, DatabaseOpts, MemoryIO, IO};
 
@@ -18950,6 +18952,12 @@ mod tests {
 
     fn make_spilled_hash_table() -> (HashTable, crate::alloc::Vec<Value>, usize) {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
+        make_spilled_hash_table_with_io(io)
+    }
+
+    fn make_spilled_hash_table_with_io(
+        io: Arc<dyn IO>,
+    ) -> (HashTable, crate::alloc::Vec<Value>, usize) {
         let config = HashTableConfig {
             initial_buckets: 4,
             mem_budget: 1024,
@@ -18959,21 +18967,33 @@ mod tests {
             track_matched: false,
             ..Default::default()
         };
-        let mut ht = HashTable::new(config, io).unwrap();
+        let mut ht = HashTable::new(config, io.clone()).unwrap();
 
         for i in 0..1024 {
-            match ht
-                .insert(vec![Value::from_i64(i)], i, vec![], None)
-                .unwrap()
-            {
-                IOResult::Done(()) => {}
-                IOResult::IO(_) => panic!("memory IO should complete synchronously"),
+            let mut pending = PendingHashInsert {
+                key_values: vec![Value::from_i64(i)],
+                rowid: i,
+                payload_values: vec![],
+            };
+            loop {
+                match ht.insert_pending(pending, None).unwrap() {
+                    HashInsertResult::Done => break,
+                    HashInsertResult::IO {
+                        pending: next_pending,
+                        ..
+                    } => {
+                        io.step().unwrap();
+                        pending = next_pending;
+                    }
+                }
             }
         }
 
-        match ht.finalize_build(None).unwrap() {
-            IOResult::Done(()) => {}
-            IOResult::IO(_) => panic!("memory IO should complete synchronously"),
+        loop {
+            match ht.finalize_build(None).unwrap() {
+                IOResult::Done(()) => break,
+                IOResult::IO(_) => io.step().unwrap(),
+            }
         }
         assert!(ht.has_spilled(), "test requires spilled hash table");
 
@@ -19257,6 +19277,7 @@ mod tests {
             num_keys: 1,
             dest_reg: 1,
             target_pc: BranchOffset::Offset(99),
+            pc_if_deferred: BranchOffset::Offset(77),
             payload_dest_reg: None,
             num_payload: 0,
             probe_rowid_reg: None,
@@ -19278,6 +19299,91 @@ mod tests {
             state.active_op_state.hash_probe().is_none(),
             "HashProbe should not stash resumable state for the removed fallback path"
         );
+    }
+
+    #[test]
+    fn test_hash_probe_deferred_row_uses_deferred_target() {
+        let stmt = prepare_test_statement();
+        let (ht, probe_key, _) = make_spilled_hash_table();
+
+        let mut state = ProgramState::new(3, 0);
+        state.hash_tables.insert(7, ht);
+        state.set_register(0, Register::Value(probe_key[0].clone()));
+        state.set_register(2, Register::Value(Value::from_i64(123)));
+
+        let insn = Insn::HashProbe {
+            hash_table_id: 7,
+            key_start_reg: 0,
+            num_keys: 1,
+            dest_reg: 1,
+            target_pc: BranchOffset::Offset(99),
+            pc_if_deferred: BranchOffset::Offset(77),
+            payload_dest_reg: None,
+            num_payload: 0,
+            probe_rowid_reg: Some(2),
+        };
+
+        let step = op_hash_probe(stmt.get_program(), &mut state, &insn, stmt.get_pager())
+            .expect("buffering a probe row should succeed");
+        assert!(matches!(step, InsnFunctionStepResult::Step));
+        assert_eq!(state.pc, 77, "deferred rows must skip the miss path");
+        assert_eq!(state.metrics.hash_join.grace_probe_rows_buffered, 1);
+        assert!(state.active_op_state.hash_probe().is_none());
+    }
+
+    #[cfg(feature = "io_memory_yield")]
+    #[test]
+    fn test_hash_probe_io_reentry_uses_deferred_target_without_rebuffering() {
+        let stmt = prepare_test_statement();
+        let io = Arc::new(MemoryYieldIO::new());
+        let (ht, _, _) = make_spilled_hash_table_with_io(io.clone());
+        let padding = "x".repeat(1024);
+        let probe_key = (0..4096)
+            .map(|i| vec![Value::build_text(format!("{i}-{padding}"))])
+            .find(|key| {
+                let partition_idx = ht.partition_for_keys(key).unwrap();
+                !ht.is_partition_loaded(partition_idx)
+            })
+            .expect("expected a large key for an unloaded spilled partition");
+
+        let mut state = ProgramState::new(3, 0);
+        state.hash_tables.insert(7, ht);
+        state.set_register(0, Register::Value(probe_key[0].clone()));
+        state.set_register(2, Register::Value(Value::from_i64(123)));
+
+        let insn = Insn::HashProbe {
+            hash_table_id: 7,
+            key_start_reg: 0,
+            num_keys: 1,
+            dest_reg: 1,
+            target_pc: BranchOffset::Offset(99),
+            pc_if_deferred: BranchOffset::Offset(77),
+            payload_dest_reg: None,
+            num_payload: 0,
+            probe_rowid_reg: Some(2),
+        };
+
+        let step = op_hash_probe(stmt.get_program(), &mut state, &insn, stmt.get_pager())
+            .expect("buffering should yield on MemoryYieldIO");
+        assert!(matches!(step, InsnFunctionStepResult::IO(_)));
+        assert_eq!(state.pc, 0, "pc must not advance before I/O completes");
+        assert_eq!(state.metrics.hash_join.grace_probe_rows_buffered, 1);
+        assert!(state
+            .active_op_state
+            .hash_probe()
+            .as_ref()
+            .is_some_and(|state| state.probe_buffered));
+
+        io.step().unwrap();
+        let step = op_hash_probe(stmt.get_program(), &mut state, &insn, stmt.get_pager())
+            .expect("resuming after probe buffering I/O should succeed");
+        assert!(matches!(step, InsnFunctionStepResult::Step));
+        assert_eq!(state.pc, 77, "resumed rows must skip the miss path");
+        assert_eq!(
+            state.metrics.hash_join.grace_probe_rows_buffered, 1,
+            "re-entry must not buffer the same probe row again"
+        );
+        assert!(state.active_op_state.hash_probe().is_none());
     }
 
     #[test]
@@ -19311,6 +19417,7 @@ mod tests {
             num_keys: 1,
             dest_reg: 1,
             target_pc: BranchOffset::Offset(99),
+            pc_if_deferred: BranchOffset::Offset(77),
             payload_dest_reg: None,
             num_payload: 0,
             probe_rowid_reg: None,
@@ -19325,6 +19432,45 @@ mod tests {
             &Value::from_i64(expected_rowid),
             "HashProbe should return the matching build rowid"
         );
+    }
+
+    #[test]
+    fn test_hash_probe_true_miss_uses_miss_target() {
+        let stmt = prepare_test_statement();
+        let (mut ht, _, partition_idx) = make_spilled_hash_table();
+        let missing_key = (1024..)
+            .take(4096)
+            .map(|i| vec![Value::from_i64(i)])
+            .find(|key| ht.partition_for_keys(key).unwrap() == partition_idx)
+            .expect("expected a missing key in the spilled partition");
+
+        loop {
+            match ht.load_spilled_partition(partition_idx, None).unwrap() {
+                IOResult::Done(()) => break,
+                IOResult::IO(_) => continue,
+            }
+        }
+
+        let mut state = ProgramState::new(2, 0);
+        state.hash_tables.insert(7, ht);
+        state.set_register(0, Register::Value(missing_key[0].clone()));
+
+        let insn = Insn::HashProbe {
+            hash_table_id: 7,
+            key_start_reg: 0,
+            num_keys: 1,
+            dest_reg: 1,
+            target_pc: BranchOffset::Offset(99),
+            pc_if_deferred: BranchOffset::Offset(77),
+            payload_dest_reg: None,
+            num_payload: 0,
+            probe_rowid_reg: None,
+        };
+
+        let step = op_hash_probe(stmt.get_program(), &mut state, &insn, stmt.get_pager())
+            .expect("probing a loaded partition should succeed");
+        assert!(matches!(step, InsnFunctionStepResult::Step));
+        assert_eq!(state.pc, 99, "a true miss must use the miss target");
     }
 
     #[test]

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -2556,7 +2556,7 @@ pub fn insn_to_row(
             0,
             String::new(),
         ),
-        Insn::HashProbe{hash_table_id: hash_table_reg, key_start_reg, num_keys, dest_reg, target_pc, payload_dest_reg, num_payload, probe_rowid_reg: _} => {
+        Insn::HashProbe{hash_table_id: hash_table_reg, key_start_reg, num_keys, dest_reg, target_pc, pc_if_deferred, payload_dest_reg, num_payload, probe_rowid_reg: _} => {
             let payload_info = if let Some(p_reg) = payload_dest_reg {
                 format!(" payload=r[{}]..r[{}]", p_reg, p_reg + num_payload - 1)
             } else {
@@ -2567,7 +2567,13 @@ pub fn insn_to_row(
                 *hash_table_reg as i64,
                 *key_start_reg as i64,
                 *num_keys as i64,
-                Value::build_text(format!("r[{}]={}{}", dest_reg, target_pc.as_debug_int(), payload_info)),
+                Value::build_text(format!(
+                    "r[{}]={} deferred={}{}",
+                    dest_reg,
+                    target_pc.as_debug_int(),
+                    pc_if_deferred.as_debug_int(),
+                    payload_info
+                )),
                 0,
                 String::new(),
             )

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -1966,13 +1966,15 @@ pub enum Insn {
     /// For each match, load the build-side rowid into dest_reg and continue.
     /// If payload columns were stored during build, they are written to
     /// payload_dest_reg..payload_dest_reg+num_payload-1.
-    /// If no matches, jump to target_pc.
+    /// If no matches, jump to target_pc. If the probe row is buffered for
+    /// grace processing, jump to pc_if_deferred instead.
     HashProbe {
         hash_table_id: u32,
         key_start_reg: u32,
         num_keys: u32,
         dest_reg: u32,
         target_pc: BranchOffset,
+        pc_if_deferred: BranchOffset,
         /// Starting register to write payload columns from hash entry.
         payload_dest_reg: Option<u32>,
         /// Number of payload columns expected

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -20,6 +20,8 @@ pub(crate) enum VirtualTableType {
 pub struct VirtualTable {
     pub(crate) name: String,
     pub(crate) columns: Vec<Column>,
+    /// Derived from the declared schema; `WITHOUT ROWID` removes implicit rowid lookup.
+    pub(crate) has_visible_rowid: bool,
     pub(crate) kind: VTabKind,
     pub(crate) vtab_type: VirtualTableType,
     // identifier to tie a cursor to a specific instantiated virtual table instance
@@ -73,9 +75,11 @@ impl VirtualTable {
         kind: VTabKind,
         table: Arc<RwLock<dyn InternalVirtualTable>>,
     ) -> crate::Result<Self> {
+        let (columns, has_visible_rowid) = Self::resolve_schema(sql)?;
         Ok(VirtualTable {
             name,
-            columns: Self::resolve_columns(sql)?,
+            columns,
+            has_visible_rowid,
             kind,
             vtab_type: VirtualTableType::Internal(table),
             vtab_id: 0,
@@ -95,9 +99,11 @@ impl VirtualTable {
             )));
         };
 
+        let (columns, has_visible_rowid) = Self::resolve_schema(schema)?;
         let vtab = VirtualTable {
             name: name.to_owned(),
-            columns: Self::resolve_columns(schema)?,
+            columns,
+            has_visible_rowid,
             kind: VTabKind::TableValuedFunction,
             vtab_type,
             vtab_id: 0,
@@ -116,9 +122,11 @@ impl VirtualTable {
         let module = syms.vtab_modules.get(module_name);
         let (table, schema) =
             ExtVirtualTable::create(module_name, module, args, VTabKind::VirtualTable)?;
+        let (columns, has_visible_rowid) = Self::resolve_schema(schema)?;
         let vtab = VirtualTable {
             name: tbl_name.unwrap_or(module_name).to_owned(),
-            columns: Self::resolve_columns(schema)?,
+            columns,
+            has_visible_rowid,
             kind: VTabKind::VirtualTable,
             vtab_type: VirtualTableType::External(table),
             vtab_id: VTAB_ID_COUNTER.fetch_add(1, Ordering::Acquire),
@@ -128,7 +136,7 @@ impl VirtualTable {
         Ok(Arc::new(vtab))
     }
 
-    pub(crate) fn resolve_columns(schema: String) -> crate::Result<Vec<Column>> {
+    pub(crate) fn resolve_schema(schema: String) -> crate::Result<(Vec<Column>, bool)> {
         let mut parser = Parser::new(schema.as_bytes());
         if let ast::Cmd::Stmt(ast::Stmt::CreateTable { body, .. }) =
             parser.next_cmd()?.ok_or_else(|| {
@@ -137,7 +145,13 @@ impl VirtualTable {
                 )
             })?
         {
-            columns_from_create_table_body(&body)
+            let has_visible_rowid = match &body {
+                ast::CreateTableBody::ColumnsAndConstraints { options, .. } => {
+                    !options.contains_without_rowid()
+                }
+                ast::CreateTableBody::AsSelect(_) => true,
+            };
+            Ok((columns_from_create_table_body(&body)?, has_visible_rowid))
         } else {
             Err(LimboError::ParseError(
                 "Failed to parse schema from virtual table module".to_string(),
@@ -634,6 +648,7 @@ mod tests {
     #[derive(Debug)]
     struct StaticTable {
         name: &'static str,
+        without_rowid: bool,
     }
 
     impl InternalVirtualTable for StaticTable {
@@ -641,7 +656,14 @@ mod tests {
             self.name.to_string()
         }
         fn sql(&self) -> String {
-            format!("CREATE TABLE {}(key TEXT, value INTEGER)", self.name)
+            if self.without_rowid {
+                format!(
+                    "CREATE TABLE {}(key TEXT PRIMARY KEY, value INTEGER) WITHOUT ROWID",
+                    self.name
+                )
+            } else {
+                format!("CREATE TABLE {}(key TEXT, value INTEGER)", self.name)
+            }
         }
         fn open(
             &self,
@@ -723,6 +745,7 @@ mod tests {
         let name = db
             .register_internal_vtab(StaticTable {
                 name: "external_metadata",
+                without_rowid: false,
             })
             .unwrap();
         assert_eq!(name, "external_metadata");
@@ -767,6 +790,7 @@ mod tests {
         let name = db
             .register_internal_vtab(StaticTable {
                 name: "External_ΔΥΣ",
+                without_rowid: false,
             })
             .unwrap();
         assert_eq!(name, "External_ΔΥΣ");
@@ -777,5 +801,66 @@ mod tests {
         assert_eq!(rows.len(), 2);
 
         assert!(conn.prepare("SELECT key, value FROM external_δυσ").is_err());
+    }
+
+    #[test]
+    fn virtual_table_rowid_visibility_affects_unqualified_resolution() {
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let db = Database::open_file_with_flags(
+            io,
+            crate::util::MEMORY_PATH,
+            OpenFlags::Create,
+            DatabaseOpts::new(),
+            None,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        db.register_internal_vtab(StaticTable {
+            name: "with_rowid",
+            without_rowid: false,
+        })
+        .unwrap();
+        db.register_internal_vtab(StaticTable {
+            name: "without_rowid",
+            without_rowid: true,
+        })
+        .unwrap();
+
+        let conn = db.connect().unwrap();
+        assert!(conn
+            .prepare("SELECT v.rowid FROM without_rowid AS v")
+            .is_err());
+
+        let rows = conn
+            .prepare(
+                "SELECT key AS rowid FROM without_rowid \
+                 WHERE rowid = 'alpha'",
+            )
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(rows, vec![vec![Value::build_text("alpha")]]);
+
+        conn.execute("CREATE TABLE outer_rows(value); INSERT INTO outer_rows VALUES(1), (2)")
+            .unwrap();
+        let err = conn
+            .prepare("SELECT rowid FROM outer_rows, with_rowid")
+            .unwrap_err();
+        assert!(err.to_string().contains("ambiguous column name: rowid"));
+        let rows = conn
+            .prepare(
+                "SELECT rowid, (SELECT rowid FROM without_rowid LIMIT 1) \
+                 FROM outer_rows ORDER BY rowid",
+            )
+            .unwrap()
+            .run_collect_rows()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec![Value::from_i64(1), Value::from_i64(1)],
+                vec![Value::from_i64(2), Value::from_i64(2)],
+            ]
+        );
     }
 }

--- a/sqlite/conformance/sqlite-sqltests/join/outer_hash_join.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/join/outer_hash_join.sqltest
@@ -178,6 +178,21 @@ expect {
 }
 
 @cross-check-integrity
+test full-outer-join-null-extends-rowid {
+    CREATE TABLE t1(a);
+    CREATE TABLE t2(c);
+    INSERT INTO t1(rowid, a) VALUES (7, 9);
+    INSERT INTO t2 VALUES (9);
+    SELECT quote(t1.rowid), quote(t1.a), quote(t2.c)
+      FROM t1 FULL OUTER JOIN t2 ON t1.a = t2.c AND t1.a + t2.c = 0
+     ORDER BY t2.c IS NOT NULL;
+}
+expect {
+    7|9|NULL
+    NULL|NULL|9
+}
+
+@cross-check-integrity
 test full-outer-join-all-match {
     CREATE TABLE t1(a, b);
     CREATE TABLE t2(c, d);
@@ -766,6 +781,27 @@ test full-outer-join-spill {
 }
 expect {
     600|500|201
+}
+
+# Probe rows for spilled partitions must wait for grace processing instead of
+# being emitted as unmatched rows by the main probe loop.
+@cross-check-integrity
+test full-outer-join-spill-defers-probe-misses {
+    CREATE TABLE spill_left(a, b);
+    CREATE TABLE spill_right(c, d);
+    INSERT INTO spill_left SELECT value, 'left-' || value FROM generate_series(1, 5000);
+    INSERT INTO spill_right SELECT value, 'right-' || value FROM generate_series(1, 5000);
+    SELECT count(*),
+           count(spill_left.rowid),
+           count(spill_right.rowid),
+           sum(spill_left.a),
+           sum(spill_right.c)
+      FROM spill_left FULL OUTER JOIN spill_right
+        ON spill_left.a = spill_right.c
+       AND spill_left.a + spill_right.c < 0;
+}
+expect {
+    10000|5000|5000|12502500|12502500
 }
 
 # Multi-table LEFT JOIN with spill: inner loop must be iterated via Gosub

--- a/sqlite/conformance/sqlite-sqltests/select/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/select/memory.sqltest
@@ -1129,6 +1129,93 @@ expect {
     100
 }
 
+@skip-if mvcc "WITHOUT ROWID tables are not supported in MVCC mode"
+@cross-check-integrity
+test unqualified-rowid-uses-real-column-or-only-rowid-table {
+    CREATE TABLE t(a);
+    CREATE TABLE w(k PRIMARY KEY) WITHOUT ROWID;
+    CREATE TABLE explicit_rowid(rowid PRIMARY KEY) WITHOUT ROWID;
+    CREATE VIEW v AS SELECT a FROM t;
+    INSERT INTO t VALUES(9);
+    INSERT INTO w VALUES(9);
+    INSERT INTO explicit_rowid VALUES(99);
+    SELECT rowid FROM t, w, v;
+    SELECT rowid FROM v, w, t;
+    SELECT rowid FROM t, explicit_rowid;
+    SELECT rowid FROM explicit_rowid, t;
+    SELECT quote(rowid), quote(t.a), quote(w.k)
+      FROM t FULL JOIN w ON t.a = w.k AND t.a + w.k = 0
+     ORDER BY w.k IS NOT NULL;
+}
+expect {
+    1
+    1
+    99
+    99
+    1|9|NULL
+    NULL|NULL|9
+}
+
+@skip-if mvcc "WITHOUT ROWID tables are not supported in MVCC mode"
+@cross-check-integrity
+test unqualified-rowid-uses-nearest-outer-scope {
+    CREATE TABLE grandparent(rowid);
+    CREATE TABLE parent(value);
+    CREATE TABLE inner_table(key PRIMARY KEY) WITHOUT ROWID;
+    INSERT INTO grandparent VALUES(10);
+    INSERT INTO parent VALUES(20), (21);
+    INSERT INTO inner_table VALUES(30);
+    SELECT (SELECT rowid) FROM parent ORDER BY rowid;
+    SELECT (SELECT (SELECT rowid FROM inner_table)
+              FROM parent ORDER BY rowid DESC LIMIT 1)
+      FROM grandparent;
+    SELECT (SELECT rowid FROM inner_table)
+      FROM grandparent, parent ORDER BY parent.rowid;
+    SELECT (SELECT rowid FROM inner_table)
+      FROM parent, grandparent ORDER BY parent.rowid;
+}
+expect {
+    1
+    2
+    2
+    10
+    10
+    10
+    10
+}
+
+@skip-if mvcc "WITHOUT ROWID tables are not supported in MVCC mode"
+test unqualified-rowid-ambiguity-stops-at-nearest-outer-scope {
+    CREATE TABLE grandparent(rowid);
+    CREATE TABLE parent_a(value);
+    CREATE TABLE parent_b(value);
+    CREATE TABLE inner_table(key PRIMARY KEY) WITHOUT ROWID;
+    INSERT INTO grandparent VALUES(10);
+    INSERT INTO parent_a VALUES(20);
+    INSERT INTO parent_b VALUES(30);
+    INSERT INTO inner_table VALUES(40);
+    SELECT (SELECT (SELECT rowid FROM inner_table) FROM parent_a, parent_b)
+      FROM grandparent;
+}
+expect error {
+    ambiguous column name: rowid
+}
+
+@skip-if mvcc "WITHOUT ROWID tables are not supported in MVCC mode"
+@cross-check-integrity
+test result-alias-shadows-outer-columns {
+    CREATE TABLE outer_table(rowid, other_name);
+    CREATE TABLE inner_table(key PRIMARY KEY) WITHOUT ROWID;
+    INSERT INTO outer_table VALUES(10, 20);
+    INSERT INTO inner_table VALUES(30);
+    SELECT (SELECT 123 AS rowid FROM inner_table WHERE rowid = 123) FROM outer_table;
+    SELECT (SELECT 456 AS other_name FROM inner_table WHERE other_name = 456) FROM outer_table;
+}
+expect {
+    123
+    456
+}
+
 @cross-check-integrity
 test null-in-search {
     CREATE TABLE t_x_asc (id INTEGER PRIMARY KEY, x);


### PR DESCRIPTION
 ## todo:
 open pre-existing bugs claude found during adversial review as issues. , seperate into multiple commits perhaps(?)
 - look at the failed snapshot tests - i did not run them locally.
 
 ## what
 
 
  Unqualified rowid references were treated as ambiguous whenever multiple tables appeared in the FROM clause, even if only one table had a visible rowid:

```sql
  CREATE TABLE t(a);
  CREATE TABLE w(k PRIMARY KEY) WITHOUT ROWID;
  INSERT INTO t VALUES(9);
  INSERT INTO w VALUES(9);

  SELECT rowid FROM t, w;
```
  SQLite returns 1. Turso returned ROWID is ambiguous.

  Rowid lookup also missed eligible tables in outer query scopes, and outer columns could incorrectly take precedence over result aliases.

  FULL OUTER hash joins had a related problem. Null-extending the build side left the previous rowid cached, so unmatched rows could expose a stale rowid. When the hash table spilled, deferred probe rows also took the normal miss path before grace processing and could be emitted twice.

  ## Fix

  Resolve real columns first, then consider only tables with a visible implicit rowid in the nearest query scope. Check result aliases before outer scopes, and derive virtual-table rowid visibility from their
  declared schema.

 Give HashProbe separate branches for true misses and rows deferred to grace processing. Clear the cached build rowid before emitting unmatched FULL JOIN rows.


  ## AI disclosure

used claude for review and tests

