### PR TITLE
Fix documentation typos (committed/occurred)

### DIFF
--- a/bindings/go/go-bindings-db-tests.mdx
+++ b/bindings/go/go-bindings-db-tests.mdx
@@ -29,7 +29,7 @@ Generate tests which will cover generic use of SQL.
 - Subqueries
 - INSERT ... RETURNING ...
     * Make additional test case for scenario, where multiple values were inserted, but only one row were fetch
-    * Make sure that in this case transaction will be properly commited even when not all rows were consumed
+    * Make sure that in this case transaction will be properly committed even when not all rows were consumed
 - CONFLICT clauses (and how driver inform caller about conflict)
 - Basic DDL statements (CREATE/DELETE)
 - More complex DDL statements (ALTER TABLE)

--- a/bindings/python/py-bindings-db-aio.mdx
+++ b/bindings/python/py-bindings-db-aio.mdx
@@ -100,7 +100,7 @@ Pay additional attention to the following aspects:
     - MAKE SURE this logic implemented properly
 * Implement .rowcount property correctly, be careful with `executemany(...)` methods as it must return rowcount of all executed statements (not just last statement)
 * Convert exceptions from rust layer to appropriate exceptions documented in the sqlite3 db-api2 docs
-* BE CAREFUL with implementation of transaction control. Make sure that in LEGACY_TRANSACTION_CONTROL mode implicit transaction will be properly commited in case of cursor close
+* BE CAREFUL with implementation of transaction control. Make sure that in LEGACY_TRANSACTION_CONTROL mode implicit transaction will be properly committed in case of cursor close
 
 Also, make types and API compatible with aiosqlite (note, that aiosqlite implements some other methods, which can be omitted now, like interrupt)
 

--- a/bindings/python/py-bindings-db.mdx
+++ b/bindings/python/py-bindings-db.mdx
@@ -106,7 +106,7 @@ Pay additional attention to the following aspects:
     - MAKE SURE this logic implemented properly
 * Implement .rowcount property correctly, be careful with `executemany(...)` methods as it must return rowcount of all executed statements (not just last statement)
 * Convert exceptions from rust layer to appropriate exceptions documented in the sqlite3 db-api2 docs
-* BE CAREFUL with implementation of transaction control. Make sure that in LEGACY_TRANSACTION_CONTROL mode implicit transaction will be properly commited in case of cursor close
+* BE CAREFUL with implementation of transaction control. Make sure that in LEGACY_TRANSACTION_CONTROL mode implicit transaction will be properly committed in case of cursor close
 
 <Shell 
     cmd="curl https://docs.python.org/3/library/sqlite3.html | pandoc --from html --to markdown" 

--- a/bindings/python/py-bindings-tests-aio.mdx
+++ b/bindings/python/py-bindings-tests-aio.mdx
@@ -37,7 +37,7 @@ Generate tests which will cover generic use of SQL.
 - Subqueries
 - INSERT ... RETURNING ...
     * Make additional test case for scenario, where multiple values were inserted, but only one row were fetch
-    * Make sure that in this case transaction will be properly commited even when not all rows were consumed
+    * Make sure that in this case transaction will be properly committed even when not all rows were consumed
 - CONFLICT clauses (and how driver inform caller about conflict)
 - Basic DDL statements (CREATE/DELETE)
 - More complex DDL statements (ALTER TABLE)

--- a/bindings/python/py-bindings-tests.mdx
+++ b/bindings/python/py-bindings-tests.mdx
@@ -34,7 +34,7 @@ Generate tests which will cover generic use of SQL.
 - Subqueries
 - INSERT ... RETURNING ...
     * Make additional test case for scenario, where multiple values were inserted, but only one row were fetch
-    * Make sure that in this case transaction will be properly commited even when not all rows were consumed
+    * Make sure that in this case transaction will be properly committed even when not all rows were consumed
 - CONFLICT clauses (and how driver inform caller about conflict)
 - Basic DDL statements (CREATE/DELETE)
 - More complex DDL statements (ALTER TABLE)

--- a/cli/sync_server.mdx
+++ b/cli/sync_server.mdx
@@ -134,7 +134,7 @@ The main database API is in the lib.rs:
     * pub const WAL_FRAME_HEADER_SIZE: usize = 24;
     * Do not forget to cut this meta to get page content
 - sync server must work only with page_size = 4096 (4kb)
-- If server_revision is not set - take latest commited frame offset
+- If server_revision is not set - take latest committed frame offset
 - If client_revision is not set - use zero for this
 - Pull updates logic should take all frames between [client_revision..server_revision] and send latest versions of unique pages changed in this range
     * Iterates backward and maintain HashSet of changes pages in memory during request execution

--- a/testing/antithesis/README.md
+++ b/testing/antithesis/README.md
@@ -58,7 +58,7 @@ using [sqlite-viz](https://github.com/LeMikaelF/sqlite-viz). SQLite (and possibl
 can also dump information about certain pages in a human-readable form (see the `dump` command and the `-p` flag for
 pages, or `-t` for trees), so that you can either reason better about them, or pass them to an LLM.
 
-You might also try binary-searching for the time that the corruption occured. The resolution of `rewind()` is
+You might also try binary-searching for the time that the corruption occurred. The resolution of `rewind()` is
 only one millisecond, but that will at least give you an idea:
 
 ```js


### PR DESCRIPTION
Rebased doc-only version of the earlier #7615. Focuses only on documentation files (`.mdx`/`.md`) that have no conflict risk — the source-file changes were dropped since those have diverged on main.

Fixes several `commited` → `committed` and `occured` → `occurred` typos across the Go/Python bindings docs, the sync server doc, and the Antithesis README.