### PR TITLE
examples/js: update vulnerable Vite dependencies

### DIFF
--- a/examples/javascript/database-wasm-vite/package-lock.json
+++ b/examples/javascript/database-wasm-vite/package-lock.json
@@ -12,24 +12,24 @@
         "@tursodatabase/database-wasm": "../../../bindings/javascript/packages/wasm"
       },
       "devDependencies": {
-        "vite": "^7.3.2"
+        "vite": "^7.3.5"
       }
     },
     "../../../bindings/javascript/packages/wasm": {
       "name": "@tursodatabase/database-wasm",
-      "version": "0.6.0-pre.26",
+      "version": "0.8.0-pre.7",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.0-pre.26",
-        "@tursodatabase/database-wasm-common": "^0.6.0-pre.26"
+        "@tursodatabase/database-common": "^0.8.0-pre.7",
+        "@tursodatabase/database-wasm-common": "^0.8.0-pre.7"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
-        "@vitest/browser": "^3.2.4",
+        "@vitest/browser": "^3.2.7",
         "playwright": "^1.55.0",
         "typescript": "^5.9.2",
-        "vite": "^7.3.2",
-        "vitest": "^3.2.4"
+        "vite": "^7.3.5",
+        "vitest": "^3.2.7"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -911,9 +911,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -950,9 +950,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -970,7 +970,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1051,13 +1051,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",

--- a/examples/javascript/database-wasm-vite/package.json
+++ b/examples/javascript/database-wasm-vite/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "vite": "^7.3.2"
+    "vite": "^7.3.5"
   },
   "dependencies": {
     "@tursodatabase/database-wasm": "../../../bindings/javascript/packages/wasm"

--- a/examples/javascript/sync-wasm-vite/package-lock.json
+++ b/examples/javascript/sync-wasm-vite/package-lock.json
@@ -12,25 +12,25 @@
         "@tursodatabase/sync-wasm": "../../../bindings/javascript/sync/packages/wasm"
       },
       "devDependencies": {
-        "vite": "^7.3.2"
+        "vite": "^7.3.5"
       }
     },
     "../../../bindings/javascript/sync/packages/wasm": {
       "name": "@tursodatabase/sync-wasm",
-      "version": "0.6.0-pre.24",
+      "version": "0.8.0-pre.7",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.6.0-pre.24",
-        "@tursodatabase/database-wasm-common": "^0.6.0-pre.24",
-        "@tursodatabase/sync-common": "^0.6.0-pre.24"
+        "@tursodatabase/database-common": "^0.8.0-pre.7",
+        "@tursodatabase/database-wasm-common": "^0.8.0-pre.7",
+        "@tursodatabase/sync-common": "^0.8.0-pre.7"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
-        "@vitest/browser": "^3.2.4",
+        "@vitest/browser": "^3.2.7",
         "playwright": "^1.57.0",
         "typescript": "^5.9.2",
-        "vite": "^7.3.2",
-        "vitest": "^3.2.4"
+        "vite": "^7.3.5",
+        "vitest": "^3.2.7"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -912,9 +912,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -951,9 +951,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -971,7 +971,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1052,13 +1052,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",

--- a/examples/javascript/sync-wasm-vite/package.json
+++ b/examples/javascript/sync-wasm-vite/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "vite": "^7.3.2"
+    "vite": "^7.3.5"
   },
   "dependencies": {
     "@tursodatabase/sync-wasm": "../../../bindings/javascript/sync/packages/wasm"


### PR DESCRIPTION
## Summary
- raise the Vite minimum version in both WASM examples
- refresh Vite, nanoid, and postcss lockfile resolutions

## Validation
- `npm ci --ignore-scripts`
- `npm audit --package-lock-only`

The example production builds still require the linked WASM packages to be built first.

## Stack
4 of 6. Based on the React Native dependency PR. The next PR targets this branch and updates serverless JavaScript dependencies.