### PR TITLE
testing/js: update vulnerable conformance dependencies

### DIFF
--- a/testing/conformance/javascript/package-lock.json
+++ b/testing/conformance/javascript/package-lock.json
@@ -18,10 +18,10 @@
     },
     "../../../bindings/javascript/packages/native": {
       "name": "@tursodatabase/database",
-      "version": "0.8.0-pre.1",
+      "version": "0.8.0-pre.7",
       "license": "MIT",
       "dependencies": {
-        "@tursodatabase/database-common": "^0.8.0-pre.1"
+        "@tursodatabase/database-common": "^0.8.0-pre.7"
       },
       "devDependencies": {
         "@napi-rs/cli": "^3.1.5",
@@ -35,7 +35,7 @@
     },
     "../../../serverless/javascript": {
       "name": "@tursodatabase/serverless",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.13",
@@ -718,9 +718,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1502,9 +1502,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2420,7 +2420,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
## Summary
- update tar, brace-expansion, and js-yaml in the JavaScript conformance lockfile

## Validation
- `npm ci --ignore-scripts`
- `npm audit --package-lock-only`

## Stack
6 of 6. Based on the serverless JavaScript dependency PR.