### PR TITLE
Fix clone_test_db.sh to clone the real testing database path

### DIFF
--- a/scripts/clone_test_db.sh
+++ b/scripts/clone_test_db.sh
@@ -7,5 +7,5 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 "$PROJECT_ROOT/scripts/install-sqlite3.sh"
 SQLITE3_BIN="$PROJECT_ROOT/.sqlite3/sqlite3"
 
-rm -f testing/testing_clone.db*
-"$SQLITE3_BIN" testing/testing/db '.clone testing/testing_clone.db' > /dev/null
+rm -f testing/system/testing_clone.db*
+"$SQLITE3_BIN" testing/system/testing.db '.clone testing/system/testing_clone.db' > /dev/null


### PR DESCRIPTION
Fixes #8551.

The script was cloning `testing/testing/db` (which has never existed) into `testing/testing_clone.db`, but the C compat tests actually open `testing/system/testing_clone.db` (see `bindings/c/tests/compat/mod.rs:258`). The source should be `testing/system/testing.db`.

Because sqlite3 silently opens a missing source as an empty database and `.clone` exits 0, the reset silently produced an empty clone, so `make test-sqlite3` ran against an empty database.

Both paths updated to the correct `testing/system` location, and the stale-clone `rm -f` now targets the right file.