### PR TITLE
Interpreter benchmark and dispatch-loop optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7353,6 +7353,7 @@ dependencies = [
  "icu_locale",
  "intrusive-collections",
  "io-uring",
+ "itoa",
  "libc",
  "libloading 0.8.6",
  "libm",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -115,6 +115,7 @@ crossbeam-epoch = "0.9.18"
 crossbeam-utils = "0.8.21"
 tracing = { workspace = true }
 ryu = "1.0.19"
+itoa = "1.0"
 uncased = "0.9.10"
 strum_macros = { workspace = true }
 bitflags = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -298,3 +298,7 @@ harness = false
 [[bench]]
 name = "select_star_benchmark"
 harness = false
+
+[[bench]]
+name = "interpreter_benchmark"
+harness = false

--- a/core/benches/interpreter_benchmark.rs
+++ b/core/benches/interpreter_benchmark.rs
@@ -1,0 +1,280 @@
+//! Benchmarks for the bytecode interpreter (core/vdbe/execute.rs).
+//!
+//! Every workload runs on an in-memory database so disk I/O never shows up in
+//! the numbers, and every workload also runs on SQLite (rusqlite, in-memory)
+//! so there is a fixed reference point to compare against.
+//!
+//! Groups:
+//!
+//! - `interp/series`: expressions over `generate_series(1, N)`. The row source
+//!   is a cheap virtual table, so almost all of the time is the interpreter
+//!   loop itself: arithmetic, comparisons, branches, function calls, string
+//!   building, aggregates.
+//! - `interp/rcte`: the same count over a recursive CTE, which adds the
+//!   coroutine and ephemeral-queue opcodes to the mix.
+//! - `interp/scan`: full scans of an in-memory table, which adds cursor
+//!   stepping and record decoding (Column, Next, ResultRow).
+//! - `interp/stmt`: one tiny statement run over and over (bind, step, reset)
+//!   to measure the fixed cost of executing a statement.
+//!
+//! Run:  cargo bench -p turso_core --bench interpreter_benchmark
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{
+    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
+    Criterion,
+};
+#[cfg(not(feature = "codspeed"))]
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
+    Criterion,
+};
+
+use std::num::NonZero;
+use std::sync::Arc;
+use std::time::Duration;
+use turso_core::{Connection, Database, MemoryIO, SqliteDialect, Statement, StepResult, Value};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+/// Rows produced by the series / recursive CTE workloads.
+const SERIES_N: usize = 100_000;
+
+/// Rows in the scanned table.
+const SCAN_N: usize = 100_000;
+
+/// Expression workloads over `generate_series(1, N)`. Each one aggregates to
+/// a single row so the measurement is the per-row interpreter work, not the
+/// cost of handing rows back to the caller.
+const SERIES_QUERIES: &[(&str, &str)] = &[
+    ("count", "SELECT count(*) FROM generate_series(1, {N})"),
+    (
+        "arith",
+        "SELECT sum(value*3 + value/2 - value%7) FROM generate_series(1, {N})",
+    ),
+    (
+        "compare",
+        "SELECT count(*) FROM generate_series(1, {N}) WHERE value % 3 = 0 AND value % 5 <> 0",
+    ),
+    (
+        "case",
+        "SELECT sum(CASE WHEN value % 2 = 0 THEN 1 WHEN value % 3 = 0 THEN 2 ELSE 0 END) \
+         FROM generate_series(1, {N})",
+    ),
+    (
+        "scalar_funcs",
+        "SELECT sum(abs(value - 50000) + length(value) + max(value, 10)) FROM generate_series(1, {N})",
+    ),
+    (
+        "string_concat",
+        "SELECT sum(length('row-' || value || '-end')) FROM generate_series(1, {N})",
+    ),
+    (
+        "float_math",
+        "SELECT sum(value * 1.5 + value / 3.0) FROM generate_series(1, {N})",
+    ),
+];
+
+const RCTE_QUERIES: &[(&str, &str)] = &[(
+    "count",
+    "WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM c WHERE x < {N}) \
+     SELECT count(*) FROM c",
+)];
+
+/// Scans of table `t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, s TEXT)`.
+const SCAN_QUERIES: &[(&str, &str)] = &[
+    ("sum_two_cols", "SELECT sum(a + b) FROM t"),
+    (
+        "filter_count",
+        "SELECT count(*) FROM t WHERE b > 500 AND a % 2 = 0",
+    ),
+    (
+        "text_filter",
+        "SELECT count(*) FROM t WHERE s LIKE 'row-1%'",
+    ),
+    // Returns every row, so this one also measures ResultRow and the
+    // step() round trip back to the caller.
+    ("all_rows", "SELECT id, a, b, s FROM t"),
+];
+
+fn open_turso() -> (Arc<Database>, Arc<Connection>) {
+    #[allow(clippy::arc_with_non_send_sync)]
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+    (db, conn)
+}
+
+fn open_sqlite() -> rusqlite::Connection {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    rusqlite::vtab::series::load_module(&conn).unwrap();
+    conn
+}
+
+fn scan_table_sql(n: usize) -> Vec<String> {
+    let mut sql =
+        vec!["CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, s TEXT)".to_string()];
+    // Deterministic, low-cost values: `a` cycles 0..999, `b` cycles 0..1023.
+    sql.push(format!(
+        "INSERT INTO t(id, a, b, s) \
+         SELECT value, value % 1000, value % 1024, 'row-' || value \
+         FROM generate_series(1, {n})"
+    ));
+    sql
+}
+
+fn run_turso(db: &Database, stmt: &mut Statement) {
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                black_box(stmt.row().unwrap());
+            }
+            StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => db.io.step().unwrap(),
+            StepResult::Done => break,
+            StepResult::Interrupt | StepResult::Busy => unreachable!(),
+        }
+    }
+    stmt.reset().unwrap();
+}
+
+fn run_sqlite(stmt: &mut rusqlite::Statement) {
+    let mut rows = stmt.query([]).unwrap();
+    while let Some(row) = rows.next().unwrap() {
+        black_box(row.get_ref(0).unwrap());
+    }
+}
+
+fn bench_query_pair(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    label: &str,
+    sql: &str,
+    turso: &(Arc<Database>, Arc<Connection>),
+    sqlite: &rusqlite::Connection,
+) {
+    let (db, conn) = turso;
+    group.bench_function(BenchmarkId::new("turso", label), |b| {
+        let mut stmt = conn.prepare(sql).unwrap();
+        b.iter(|| run_turso(db, &mut stmt));
+    });
+    group.bench_function(BenchmarkId::new("sqlite", label), |b| {
+        let mut stmt = sqlite.prepare(sql).unwrap();
+        b.iter(|| run_sqlite(&mut stmt));
+    });
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_series(criterion: &mut Criterion) {
+    let turso = open_turso();
+    let sqlite = open_sqlite();
+
+    let mut group = criterion.benchmark_group("interp/series");
+    group.sample_size(30);
+    group.measurement_time(Duration::from_secs(5));
+    for (label, template) in SERIES_QUERIES {
+        let sql = template.replace("{N}", &SERIES_N.to_string());
+        bench_query_pair(&mut group, label, &sql, &turso, &sqlite);
+    }
+    group.finish();
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_rcte(criterion: &mut Criterion) {
+    let turso = open_turso();
+    let sqlite = open_sqlite();
+
+    let mut group = criterion.benchmark_group("interp/rcte");
+    group.sample_size(30);
+    group.measurement_time(Duration::from_secs(5));
+    for (label, template) in RCTE_QUERIES {
+        let sql = template.replace("{N}", &SERIES_N.to_string());
+        bench_query_pair(&mut group, label, &sql, &turso, &sqlite);
+    }
+    group.finish();
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_scan(criterion: &mut Criterion) {
+    let turso = open_turso();
+    let sqlite = open_sqlite();
+    for sql in scan_table_sql(SCAN_N) {
+        let mut stmt = turso.1.prepare(&sql).unwrap();
+        run_turso(&turso.0, &mut stmt);
+        sqlite.execute_batch(&sql).unwrap();
+    }
+
+    let mut group = criterion.benchmark_group("interp/scan");
+    group.sample_size(30);
+    group.measurement_time(Duration::from_secs(5));
+    for (label, sql) in SCAN_QUERIES {
+        bench_query_pair(&mut group, label, sql, &turso, &sqlite);
+    }
+    group.finish();
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_stmt(criterion: &mut Criterion) {
+    let turso = open_turso();
+    let sqlite = open_sqlite();
+    for sql in scan_table_sql(1000) {
+        let mut stmt = turso.1.prepare(&sql).unwrap();
+        run_turso(&turso.0, &mut stmt);
+        sqlite.execute_batch(&sql).unwrap();
+    }
+
+    let mut group = criterion.benchmark_group("interp/stmt");
+
+    // No table access at all: this is the floor for running one statement.
+    group.bench_function(BenchmarkId::new("turso", "select_param"), |b| {
+        let (db, conn) = &turso;
+        let mut stmt = conn.prepare("SELECT ?1 + 1").unwrap();
+        let mut i = 0i64;
+        b.iter(|| {
+            i += 1;
+            stmt.bind_at(NonZero::new(1).unwrap(), Value::from_i64(i))
+                .unwrap();
+            run_turso(db, &mut stmt);
+        });
+    });
+    group.bench_function(BenchmarkId::new("sqlite", "select_param"), |b| {
+        let mut stmt = sqlite.prepare("SELECT ?1 + 1").unwrap();
+        let mut i = 0i64;
+        b.iter(|| {
+            i += 1;
+            let mut rows = stmt.query([i]).unwrap();
+            while let Some(row) = rows.next().unwrap() {
+                black_box(row.get_ref(0).unwrap());
+            }
+        });
+    });
+
+    // One rowid lookup per statement.
+    group.bench_function(BenchmarkId::new("turso", "point_lookup"), |b| {
+        let (db, conn) = &turso;
+        let mut stmt = conn.prepare("SELECT b FROM t WHERE id = ?1").unwrap();
+        let mut i = 0i64;
+        b.iter(|| {
+            i = i % 1000 + 1;
+            stmt.bind_at(NonZero::new(1).unwrap(), Value::from_i64(i))
+                .unwrap();
+            run_turso(db, &mut stmt);
+        });
+    });
+    group.bench_function(BenchmarkId::new("sqlite", "point_lookup"), |b| {
+        let mut stmt = sqlite.prepare("SELECT b FROM t WHERE id = ?1").unwrap();
+        let mut i = 0i64;
+        b.iter(|| {
+            i = i % 1000 + 1;
+            let mut rows = stmt.query([i]).unwrap();
+            while let Some(row) = rows.next().unwrap() {
+                black_box(row.get_ref(0).unwrap());
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_series, bench_rcte, bench_scan, bench_stmt);
+criterion_main!(benches);

--- a/core/btree_dump.rs
+++ b/core/btree_dump.rs
@@ -3,7 +3,6 @@ use crate::storage::btree::BTreeCursor;
 use crate::storage::btree::CursorTrait;
 use crate::storage::pager::Pager;
 use crate::sync::Arc;
-use crate::sync::RwLock;
 use crate::util::IOExt;
 use crate::vtab::{InternalVirtualTable, InternalVirtualTableCursor};
 use crate::{Connection, Result, Value};
@@ -35,11 +34,11 @@ impl InternalVirtualTable for BtreeDumpTable {
         "CREATE TABLE btree_dump(record BLOB, name TEXT HIDDEN)".to_string()
     }
 
-    fn open(&self, conn: Arc<Connection>) -> Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
+    fn open(&self, conn: Arc<Connection>) -> Result<Box<dyn InternalVirtualTableCursor>> {
         let pager = conn.get_pager();
         let schema = conn.schema.read().clone();
         let cursor = BtreeDumpCursor::new(pager, schema);
-        Ok(Arc::new(RwLock::new(cursor)))
+        Ok(Box::new(cursor))
     }
 
     fn best_index(

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -4728,8 +4728,10 @@ impl Connection {
     }
 
     /// Returns true when the step-based progress handler requests interruption.
-    pub fn should_interrupt_for_progress(&self, vm_steps: u64) -> bool {
-        self.progress_handler.should_interrupt(vm_steps)
+    #[inline]
+    pub fn should_interrupt_for_progress(&self, vm_steps: u64, last_checked: &mut u64) -> bool {
+        self.progress_handler
+            .should_interrupt(vm_steps, last_checked)
     }
 
     /// Request interruption of currently running root statements on this connection.

--- a/core/dbpage.rs
+++ b/core/dbpage.rs
@@ -1,6 +1,5 @@
 use crate::storage::pager::Pager;
 use crate::sync::Arc;
-use crate::sync::RwLock;
 use crate::util::IOExt;
 use crate::vtab::{InternalVirtualTable, InternalVirtualTableCursor};
 use crate::{Connection, LimboError, Result, Value};
@@ -34,10 +33,10 @@ impl InternalVirtualTable for DbPageTable {
         "CREATE TABLE sqlite_dbpage(pgno INTEGER PRIMARY KEY, data BLOB, schema HIDDEN)".to_string()
     }
 
-    fn open(&self, conn: Arc<Connection>) -> Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
+    fn open(&self, conn: Arc<Connection>) -> Result<Box<dyn InternalVirtualTableCursor>> {
         let pager = conn.get_pager();
         let cursor = DbPageCursor::new(pager);
-        Ok(Arc::new(RwLock::new(cursor)))
+        Ok(Box::new(cursor))
     }
 
     /// TODO: sqlite does where_onerow optimization using idx_flag, we should do that eventually.. probably not needed for now.

--- a/core/dialect/mod.rs
+++ b/core/dialect/mod.rs
@@ -342,11 +342,8 @@ mod tests {
         fn open(
             &self,
             _conn: Arc<crate::Connection>,
-        ) -> crate::Result<Arc<crate::sync::RwLock<dyn crate::InternalVirtualTableCursor>>>
-        {
-            Ok(Arc::new(crate::sync::RwLock::new(TestCatalogCursor {
-                row: 0,
-            })))
+        ) -> crate::Result<Box<dyn crate::InternalVirtualTableCursor>> {
+            Ok(Box::new(TestCatalogCursor { row: 0 }))
         }
 
         fn best_index(

--- a/core/dialect/sqlite.rs
+++ b/core/dialect/sqlite.rs
@@ -158,6 +158,8 @@ pub fn register_builtin_catalog(
         schema.register_internal_vtab(crate::json::vtab::JsonVirtualTable::json_each())?;
         schema.register_internal_vtab(crate::json::vtab::JsonVirtualTable::json_tree())?;
     }
+    #[cfg(feature = "series")]
+    schema.register_internal_vtab(crate::series::GenerateSeriesTable)?;
     #[cfg(feature = "cli_only")]
     {
         schema.register_internal_vtab(crate::dbpage::DbPageTable::new())?;

--- a/core/ext/mod.rs
+++ b/core/ext/mod.rs
@@ -284,8 +284,6 @@ impl Database {
 
         #[cfg(feature = "uuid")]
         crate::uuid::register_extension(&mut ext_api);
-        #[cfg(feature = "series")]
-        crate::series::register_extension(&mut ext_api);
         #[cfg(feature = "time")]
         crate::time::register_extension(&mut ext_api);
         #[cfg(feature = "percentile")]

--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -1,4 +1,4 @@
-use crate::sync::{Arc, RwLock};
+use crate::sync::Arc;
 use std::iter::successors;
 use std::result::Result;
 
@@ -72,10 +72,8 @@ impl InternalVirtualTable for JsonVirtualTable {
     fn open(
         &self,
         _conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor + 'static>>> {
-        Ok(Arc::new(RwLock::new(JsonEachCursor::empty(
-            self.traversal_mode.clone(),
-        ))))
+    ) -> crate::Result<Box<dyn InternalVirtualTableCursor + 'static>> {
+        Ok(Box::new(JsonEachCursor::empty(self.traversal_mode.clone())))
     }
 
     fn best_index(

--- a/core/numeric/mod.rs
+++ b/core/numeric/mod.rs
@@ -47,6 +47,7 @@ pub enum Numeric {
 }
 
 impl Numeric {
+    #[inline]
     pub fn from_value<T: AsValueRef>(value: T) -> Option<Self> {
         let value = value.as_value_ref();
 

--- a/core/progress.rs
+++ b/core/progress.rs
@@ -44,6 +44,7 @@ impl ProgressHandler {
         self.ops.store(ops, Ordering::SeqCst);
     }
 
+    #[inline]
     pub(crate) fn ops(&self) -> u64 {
         self.ops.load(Ordering::SeqCst)
     }
@@ -55,13 +56,26 @@ impl ProgressHandler {
     /// Returns true when the callback requests interruption at this VM step.
     ///
     /// The cadence is approximate by design, matching SQLite's documentation:
-    /// the callback is consulted only when the current VM-step count crosses a
-    /// configured multiple of `ops`.
-    pub(crate) fn should_interrupt(&self, vm_steps: u64) -> bool {
+    /// the callback runs when the VM-step count has crossed a multiple of
+    /// `ops` since the last check. The interpreter only checks at loop
+    /// back-edges, so `last_checked` is the step count of the previous check
+    /// and a single check may cover several multiples; the callback then runs
+    /// once for all of them.
+    #[inline]
+    pub(crate) fn should_interrupt(&self, vm_steps: u64, last_checked: &mut u64) -> bool {
         let ops = self.ops();
-        if ops == 0 || vm_steps % ops != 0 {
+        if ops == 0 {
             return false;
         }
+        self.should_interrupt_at(vm_steps, ops, last_checked)
+    }
+
+    #[inline(never)]
+    fn should_interrupt_at(&self, vm_steps: u64, ops: u64, last_checked: &mut u64) -> bool {
+        if vm_steps / ops == *last_checked / ops {
+            return false;
+        }
+        *last_checked = vm_steps;
         let callback = self.callback.read();
         match callback.as_ref() {
             Some(callback) => callback(),
@@ -81,7 +95,8 @@ mod tests {
     #[test]
     fn disabled_handler_never_interrupts() {
         let handler = ProgressHandler::new();
-        assert!(!handler.should_interrupt(1));
+        let mut last = 0;
+        assert!(!handler.should_interrupt(1, &mut last));
         assert!(!handler.is_enabled());
     }
 
@@ -98,15 +113,40 @@ mod tests {
             })),
         );
 
-        assert!(!handler.should_interrupt(1));
+        let mut last = 0;
+        assert!(!handler.should_interrupt(1, &mut last));
         assert_eq!(calls.load(Ordering::SeqCst), 0);
-        assert!(!handler.should_interrupt(2));
+        assert!(!handler.should_interrupt(2, &mut last));
         assert_eq!(calls.load(Ordering::SeqCst), 0);
-        assert!(!handler.should_interrupt(3));
+        assert!(!handler.should_interrupt(3, &mut last));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
-        assert!(!handler.should_interrupt(4));
+        assert!(!handler.should_interrupt(4, &mut last));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
-        assert!(!handler.should_interrupt(6));
+        assert!(!handler.should_interrupt(6, &mut last));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn handler_runs_once_when_a_check_skips_several_intervals() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler = ProgressHandler::new();
+        let callback_calls = Arc::clone(&calls);
+        handler.set(
+            3,
+            Some(Box::new(move || {
+                callback_calls.fetch_add(1, Ordering::SeqCst);
+                false
+            })),
+        );
+
+        let mut last = 0;
+        assert!(!handler.should_interrupt(2, &mut last));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(!handler.should_interrupt(20, &mut last));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(!handler.should_interrupt(21, &mut last));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert!(!handler.should_interrupt(22, &mut last));
         assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
@@ -115,8 +155,9 @@ mod tests {
         let handler = ProgressHandler::new();
         handler.set(2, Some(Box::new(|| true)));
 
-        assert!(!handler.should_interrupt(1));
-        assert!(handler.should_interrupt(2));
+        let mut last = 0;
+        assert!(!handler.should_interrupt(1, &mut last));
+        assert!(handler.should_interrupt(2, &mut last));
     }
 
     #[test]
@@ -131,11 +172,12 @@ mod tests {
                 true
             })),
         );
-        assert!(handler.should_interrupt(1));
+        let mut last = 0;
+        assert!(handler.should_interrupt(1, &mut last));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
 
         handler.set(0, None);
-        assert!(!handler.should_interrupt(2));
+        assert!(!handler.should_interrupt(2, &mut last));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/core/series.rs
+++ b/core/series.rs
@@ -1,4 +1,4 @@
-use crate::sync::{Arc, RwLock};
+use crate::sync::Arc;
 use crate::vtab::{InternalVirtualTable, InternalVirtualTableCursor};
 use crate::{Connection, LimboError, Value};
 use turso_ext::{
@@ -18,11 +18,8 @@ impl InternalVirtualTable for GenerateSeriesTable {
         "generate_series".to_string()
     }
 
-    fn open(
-        &self,
-        _conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(GenerateSeriesCursor::new())))
+    fn open(&self, _conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(GenerateSeriesCursor::new()))
     }
 
     fn best_index(

--- a/core/series.rs
+++ b/core/series.rs
@@ -1,60 +1,32 @@
-use crate::sync::Arc;
-
+use crate::sync::{Arc, RwLock};
+use crate::vtab::{InternalVirtualTable, InternalVirtualTableCursor};
+use crate::{Connection, LimboError, Value};
 use turso_ext::{
-    Connection, ConstraintInfo, ConstraintOp, ConstraintUsage, ExtensionApi, IndexInfo,
-    OrderByInfo, ResultCode, VTabCursor, VTabKind, VTabModule, VTabModuleDerive, VTable, Value,
+    ConstraintInfo, ConstraintOp, ConstraintUsage, IndexInfo, OrderByInfo, ResultCode,
 };
 
-pub fn register_extension(ext_api: &mut ExtensionApi) {
-    // FIXME: Add macro magic to register functions automatically.
-    unsafe {
-        GenerateSeriesVTabModule::register_GenerateSeriesVTabModule(ext_api);
+/// The generate_series(start, stop, step) table-valued function.
+///
+/// It runs inside the engine rather than through the extension API, so
+/// reading a column is a plain field read instead of an FFI call and a
+/// value conversion.
+#[derive(Debug)]
+pub struct GenerateSeriesTable;
+
+impl InternalVirtualTable for GenerateSeriesTable {
+    fn name(&self) -> String {
+        "generate_series".to_string()
     }
-}
 
-macro_rules! extract_arg_integer {
-    ($args:expr, $idx:expr) => {
-        $args.get($idx).and_then(|v| v.to_integer())
-    };
-}
-
-/// A virtual table that generates a sequence of integers
-#[derive(Debug, VTabModuleDerive, Default)]
-struct GenerateSeriesVTabModule;
-
-impl VTabModule for GenerateSeriesVTabModule {
-    type Table = GenerateSeriesTable;
-    const NAME: &'static str = "generate_series";
-    const VTAB_KIND: VTabKind = VTabKind::TableValuedFunction;
-
-    fn create(_args: &[Value]) -> Result<(String, Self::Table), ResultCode> {
-        let schema = "CREATE TABLE generate_series (
-            value INTEGER,
-            start INTEGER HIDDEN,
-            stop INTEGER HIDDEN,
-            step INTEGER HIDDEN
-        )"
-        .into();
-        Ok((schema, GenerateSeriesTable {}))
-    }
-}
-
-struct GenerateSeriesTable {}
-
-impl VTable for GenerateSeriesTable {
-    type Cursor = GenerateSeriesCursor;
-    type Error = ResultCode;
-
-    fn open(&self, _conn: Option<Arc<Connection>>) -> Result<Self::Cursor, Self::Error> {
-        Ok(GenerateSeriesCursor {
-            start: 0,
-            stop: 0,
-            step: 0,
-            current: 0,
-        })
+    fn open(
+        &self,
+        _conn: Arc<Connection>,
+    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
+        Ok(Arc::new(RwLock::new(GenerateSeriesCursor::new())))
     }
 
     fn best_index(
+        &self,
         constraints: &[ConstraintInfo],
         _order_by: &[OrderByInfo],
     ) -> Result<IndexInfo, ResultCode> {
@@ -126,6 +98,16 @@ impl VTable for GenerateSeriesTable {
             ..Default::default()
         })
     }
+
+    fn sql(&self) -> String {
+        "CREATE TABLE generate_series (
+            value INTEGER,
+            start INTEGER HIDDEN,
+            stop INTEGER HIDDEN,
+            step INTEGER HIDDEN
+        )"
+        .to_string()
+    }
 }
 
 /// The cursor for iterating over the generated sequence
@@ -138,6 +120,15 @@ struct GenerateSeriesCursor {
 }
 
 impl GenerateSeriesCursor {
+    fn new() -> Self {
+        Self {
+            start: 0,
+            stop: 0,
+            step: 0,
+            current: 0,
+        }
+    }
+
     /// Returns true if this is an ascending series (positive step) but start > stop
     fn is_invalid_ascending_series(&self) -> bool {
         self.step > 0 && self.start > self.stop
@@ -157,80 +148,6 @@ impl GenerateSeriesCursor {
     fn would_exceed(&self) -> bool {
         (self.step > 0 && self.current.saturating_add(self.step) > self.stop)
             || (self.step < 0 && self.current.saturating_add(self.step) < self.stop)
-    }
-}
-
-impl VTabCursor for GenerateSeriesCursor {
-    type Error = ResultCode;
-
-    fn filter(&mut self, args: &[Value], idx_info: Option<(&str, i32)>) -> ResultCode {
-        let mut start: Option<i64> = None;
-        let mut stop: Option<i64> = None;
-        let mut step = 1;
-        // SQLite default for stop when it is omitted
-        const DEFAULT_STOP_OMITTED: Option<i64> = Some(u32::MAX as i64);
-
-        if let Some((_, idx_num)) = idx_info {
-            let mut arg_idx = 0;
-            // For the semantics of `idx_num`, see the comment in the `best_index` method.
-            if idx_num & 1 != 0 {
-                start = extract_arg_integer!(args, arg_idx);
-                arg_idx += 1;
-            }
-            if idx_num & 2 != 0 {
-                stop = extract_arg_integer!(args, arg_idx);
-                arg_idx += 1;
-            } else {
-                stop = DEFAULT_STOP_OMITTED;
-            }
-            if idx_num & 4 != 0 {
-                step = args
-                    .get(arg_idx)
-                    .map(|v| v.to_integer().unwrap_or(1))
-                    .unwrap_or(1);
-            }
-        }
-
-        if start.is_none() {
-            return ResultCode::InvalidArgs;
-        }
-        if stop.is_none() {
-            return ResultCode::EOF; // Sqlite returns an empty series for wacky args
-        }
-
-        // Convert zero step to 1, matching SQLite behavior
-        if step == 0 {
-            step = 1;
-        }
-
-        self.start = start.unwrap();
-        self.step = step;
-        self.stop = stop.unwrap();
-
-        // Set initial value based on range validity
-        // For invalid input SQLite returns an empty series
-        self.current = if self.is_invalid_range() {
-            return ResultCode::EOF;
-        } else {
-            self.start
-        };
-
-        ResultCode::OK
-    }
-
-    fn next(&mut self) -> ResultCode {
-        if self.eof() {
-            return ResultCode::EOF;
-        }
-
-        self.current = match self.current.checked_add(self.step) {
-            Some(val) => val,
-            None => {
-                return ResultCode::EOF;
-            }
-        };
-
-        ResultCode::OK
     }
 
     fn eof(&self) -> bool {
@@ -254,14 +171,83 @@ impl VTabCursor for GenerateSeriesCursor {
 
         false
     }
+}
 
-    fn column(&self, idx: u32) -> Result<Value, Self::Error> {
+impl InternalVirtualTableCursor for GenerateSeriesCursor {
+    /// Returns `Ok(true)` when the cursor is positioned on the first row and
+    /// `Ok(false)` when the series is empty.
+    fn filter(
+        &mut self,
+        args: &[Value],
+        _idx_str: Option<String>,
+        idx_num: i32,
+    ) -> Result<bool, LimboError> {
+        // SQLite default for stop when it is omitted
+        const DEFAULT_STOP_OMITTED: Option<i64> = Some(u32::MAX as i64);
+
+        let mut arg_idx = 0;
+        // For the semantics of `idx_num`, see the comment in the `best_index` method.
+        let mut start: Option<i64> = None;
+        if idx_num & 1 != 0 {
+            start = args.get(arg_idx).and_then(Value::as_int);
+            arg_idx += 1;
+        }
+        let stop = if idx_num & 2 != 0 {
+            let stop = args.get(arg_idx).and_then(Value::as_int);
+            arg_idx += 1;
+            stop
+        } else {
+            DEFAULT_STOP_OMITTED
+        };
+        let mut step = 1;
+        if idx_num & 4 != 0 {
+            step = args.get(arg_idx).and_then(Value::as_int).unwrap_or(1);
+        }
+
+        let Some(start) = start else {
+            return Err(LimboError::InvalidArgument(
+                "generate_series() requires a start value".to_string(),
+            ));
+        };
+        let Some(stop) = stop else {
+            return Ok(false); // Sqlite returns an empty series for wacky args
+        };
+
+        // Convert zero step to 1, matching SQLite behavior
+        if step == 0 {
+            step = 1;
+        }
+
+        self.start = start;
+        self.step = step;
+        self.stop = stop;
+        self.current = start;
+
+        // For invalid input SQLite returns an empty series
+        Ok(!self.is_invalid_range())
+    }
+
+    fn next(&mut self) -> Result<bool, LimboError> {
+        if self.eof() {
+            return Ok(false);
+        }
+
+        match self.current.checked_add(self.step) {
+            Some(val) => {
+                self.current = val;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    fn column(&self, idx: usize) -> Result<Value, LimboError> {
         Ok(match idx {
-            0 => Value::from_integer(self.current),
-            1 => Value::from_integer(self.start),
-            2 => Value::from_integer(self.stop),
-            3 => Value::from_integer(self.step),
-            _ => Value::null(),
+            0 => Value::from_i64(self.current),
+            1 => Value::from_i64(self.start),
+            2 => Value::from_i64(self.stop),
+            3 => Value::from_i64(self.step),
+            _ => Value::Null,
         })
     }
 
@@ -317,38 +303,33 @@ mod tests {
             Series { start, stop, step }
         }
     }
-    // Helper function to collect all values from a cursor, returns Result with error code
-    fn collect_series(series: Series) -> Result<Vec<i64>, ResultCode> {
-        let tbl = GenerateSeriesTable {};
-        let mut cursor = tbl.open(None)?;
+    // Helper function to collect all values from a cursor
+    fn collect_series(series: Series) -> crate::Result<Vec<i64>> {
+        let mut cursor = GenerateSeriesCursor::new();
 
         // Create args array for filter
         let args = vec![
-            Value::from_integer(series.start),
-            Value::from_integer(series.stop),
-            Value::from_integer(series.step),
+            Value::from_i64(series.start),
+            Value::from_i64(series.stop),
+            Value::from_i64(series.step),
         ];
 
         // Initialize cursor through filter
-        match cursor.filter(&args, Some(("idx", 1 | 2 | 4))) {
-            ResultCode::OK => (),
-            ResultCode::EOF => return Ok(vec![]),
-            err => return Err(err),
+        if !cursor.filter(&args, Some("7".to_string()), 1 | 2 | 4)? {
+            return Ok(vec![]);
         }
 
         let mut values = Vec::new();
         loop {
-            values.push(cursor.column(0)?.to_integer().unwrap());
+            values.push(cursor.column(0)?.as_int().unwrap());
             if values.len() > 1000 {
                 panic!(
                     "Generated more than 1000 values, expected this many: {:?}",
                     (series.stop - series.start) / series.step + 1
                 );
             }
-            match cursor.next() {
-                ResultCode::OK => (),
-                ResultCode::EOF => break,
-                err => return Err(err),
+            if !cursor.next()? {
+                break;
             }
         }
         Ok(values)
@@ -606,28 +587,26 @@ mod tests {
         let start = series.start;
         let stop = series.stop;
         let step = series.step;
-        let tbl = GenerateSeriesTable {};
-        let mut cursor = tbl.open(None).unwrap();
+        let mut cursor = GenerateSeriesCursor::new();
 
         let args = vec![
-            Value::from_integer(start),
-            Value::from_integer(stop),
-            Value::from_integer(step),
+            Value::from_i64(start),
+            Value::from_i64(stop),
+            Value::from_i64(step),
         ];
 
         // Initialize cursor through filter
-        cursor.filter(&args, Some(("idx", 1 | 2 | 4)));
+        cursor
+            .filter(&args, Some("7".to_string()), 1 | 2 | 4)
+            .unwrap();
 
         let mut rowids = vec![];
         while !cursor.eof() {
             let cur_rowid = cursor.rowid();
-            match cursor.next() {
-                ResultCode::OK => rowids.push(cur_rowid),
-                ResultCode::EOF => break,
-                err => {
-                    panic!("Unexpected error {err:?} for start={start}, stop={stop}, step={step}")
-                }
+            if !cursor.next().unwrap() {
+                break;
             }
+            rowids.push(cur_rowid);
         }
 
         assert!(
@@ -692,7 +671,7 @@ mod tests {
             usable_constraint(3), // step
         ];
 
-        let index_info = GenerateSeriesTable::best_index(&constraints, &[]).unwrap();
+        let index_info = GenerateSeriesTable.best_index(&constraints, &[]).unwrap();
 
         // Verify start gets argv_index 1, stop gets 2, step gets 3
         assert_eq!(index_info.constraint_usages[0].argv_index, Some(1)); // start
@@ -708,7 +687,7 @@ mod tests {
             usable_constraint(2), // stop
         ];
 
-        let index_info = GenerateSeriesTable::best_index(&constraints, &[]).unwrap();
+        let index_info = GenerateSeriesTable.best_index(&constraints, &[]).unwrap();
 
         // Verify start gets argv_index 1, stop gets 2
         assert_eq!(index_info.constraint_usages[0].argv_index, Some(1)); // start
@@ -722,7 +701,7 @@ mod tests {
             usable_constraint(1), // start
         ];
 
-        let index_info = GenerateSeriesTable::best_index(&constraints, &[]).unwrap();
+        let index_info = GenerateSeriesTable.best_index(&constraints, &[]).unwrap();
 
         // Verify start gets argv_index 1
         assert_eq!(index_info.constraint_usages[0].argv_index, Some(1)); // start
@@ -738,7 +717,7 @@ mod tests {
             usable_constraint(1), // start
         ];
 
-        let index_info = GenerateSeriesTable::best_index(&constraints, &[]).unwrap();
+        let index_info = GenerateSeriesTable.best_index(&constraints, &[]).unwrap();
 
         // Verify start still gets argv_index 1, stop gets 2, step gets 3 regardless of constraint order
         assert_eq!(index_info.constraint_usages[0].argv_index, Some(3)); // step
@@ -755,7 +734,7 @@ mod tests {
             usable_constraint(3), // step
         ];
 
-        let result = GenerateSeriesTable::best_index(&constraints, &[]);
+        let result = GenerateSeriesTable.best_index(&constraints, &[]);
 
         assert!(matches!(result, Err(ResultCode::InvalidArgs)));
     }
@@ -769,7 +748,7 @@ mod tests {
             index: 0,
         }];
 
-        let result = GenerateSeriesTable::best_index(&constraints, &[]);
+        let result = GenerateSeriesTable.best_index(&constraints, &[]);
 
         assert!(matches!(result, Err(ResultCode::ConstraintViolation)));
     }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -939,7 +939,21 @@ fn query_pragma(
             Ok(TransactionMode::None)
         }
         PragmaName::ModuleList => {
-            let modules = connection.get_syms_vtab_mods();
+            let mut modules: Vec<String> = connection.get_syms_vtab_mods().into_iter().collect();
+            // Built-in table-valued functions such as generate_series and
+            // json_each live in the schema rather than the extension module
+            // registry, but they are modules all the same.
+            for table in schema.tables.values() {
+                if let Table::Virtual(vtab) = table.as_ref() {
+                    if vtab.is_internal()
+                        && matches!(vtab.kind, turso_ext::VTabKind::TableValuedFunction)
+                    {
+                        modules.push(vtab.name.clone());
+                    }
+                }
+            }
+            modules.sort();
+            modules.dedup();
             for module in modules {
                 program.emit_string8(module.to_string(), register);
                 program.emit_result_row(register, 1);

--- a/core/turso_types_vtab.rs
+++ b/core/turso_types_vtab.rs
@@ -1,5 +1,4 @@
 use crate::sync::Arc;
-use crate::sync::RwLock;
 use crate::vtab::{InternalVirtualTable, InternalVirtualTableCursor};
 use crate::MAIN_DB_ID;
 use crate::{Connection, Result, Value};
@@ -29,9 +28,9 @@ impl InternalVirtualTable for TursoTypesTable {
         "CREATE TABLE sqlite_turso_types(name TEXT, sql TEXT)".to_string()
     }
 
-    fn open(&self, conn: Arc<Connection>) -> Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
+    fn open(&self, conn: Arc<Connection>) -> Result<Box<dyn InternalVirtualTableCursor>> {
         let cursor = TursoTypesCursor::new(conn);
-        Ok(Arc::new(RwLock::new(cursor)))
+        Ok(Box::new(cursor))
     }
 
     fn best_index(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6905,7 +6905,7 @@ fn update_agg_payload(
                         "Count: payload is not an integer".to_string(),
                     ));
                 };
-                *i = i.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+                *i = i.checked_add(1).ok_or_else(integer_overflow)?;
             }
         }
         AggFunc::Count0 => {
@@ -6916,7 +6916,7 @@ fn update_agg_payload(
                     "Count0: payload is not an integer".to_string(),
                 ));
             };
-            *i = i.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+            *i = i.checked_add(1).ok_or_else(integer_overflow)?;
         }
         AggFunc::Avg => {
             if matches!(arg, Value::Null) {
@@ -6949,7 +6949,7 @@ fn update_agg_payload(
                 NumericArg::Null => unreachable!("NULL early-returned above"),
             }
             *r_err_val = Value::from_f64(sum_state.r_err);
-            *count = count.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+            *count = count.checked_add(1).ok_or_else(integer_overflow)?;
         }
         AggFunc::Sum | AggFunc::Total => {
             // invariant as per init_agg_payload: payload[0] is acc (Null/Integer/Float),
@@ -6986,7 +6986,7 @@ fn update_agg_payload(
                 ovrfl: *ovrfl_i != 0,
             };
             if !matches!(arg, Value::Null) {
-                *count = count.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+                *count = count.checked_add(1).ok_or_else(integer_overflow)?;
             }
             if matches!(*acc, Value::Null) && sum_state.approx {
                 return Ok(());
@@ -7142,7 +7142,7 @@ fn update_agg_payload(
                         separator_lengths.try_reserve(
                             count
                                 .checked_mul(std::mem::size_of::<i64>())
-                                .ok_or(LimboError::IntegerOverflow)?,
+                                .ok_or_else(integer_overflow)?,
                         )?;
                         let bytes = first_separator_len.to_be_bytes();
                         for _ in 0..prior_separator_count {
@@ -7155,7 +7155,7 @@ fn update_agg_payload(
                 }
             }
             acc.exec_group_concat(arg)?;
-            *count = count.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+            *count = count.checked_add(1).ok_or_else(integer_overflow)?;
         }
         AggFunc::External(_) => {
             mark_unlikely();
@@ -7664,7 +7664,7 @@ fn op_window_step(
             let Value::Numeric(Numeric::Integer(step)) = &payload[1] else {
                 unreachable!("nth_value step count must be Integer");
             };
-            let step = step.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+            let step = step.checked_add(1).ok_or_else(integer_overflow)?;
             payload[1] = Value::from_i64(step);
             if step == n {
                 payload[0].try_clone_from(arg_slot.get_value())?;
@@ -8277,7 +8277,7 @@ fn inverse_agg_payload(func: &AggFunc, arg: Value, payload: &mut [Value]) -> Res
             let expected_separator_bytes = old_count
                 .saturating_sub(1)
                 .checked_mul(std::mem::size_of::<i64>())
-                .ok_or(LimboError::IntegerOverflow)?;
+                .ok_or_else(integer_overflow)?;
             if !separator_lengths.is_empty() && separator_lengths.len() != expected_separator_bytes
             {
                 return Err(LimboError::InternalError(format!(
@@ -8311,7 +8311,7 @@ fn inverse_agg_payload(func: &AggFunc, arg: Value, payload: &mut [Value]) -> Res
             };
             let remove_len = value_len
                 .checked_add(separator_len)
-                .ok_or(LimboError::IntegerOverflow)?;
+                .ok_or_else(integer_overflow)?;
             let Value::Text(text) = acc else {
                 unreachable!("GroupConcat accumulator is Text after a non-NULL xStep");
             };
@@ -8365,12 +8365,20 @@ fn inverse_agg_payload(func: &AggFunc, arg: Value, payload: &mut [Value]) -> Res
             for _ in 0..element_count {
                 end = end
                     .checked_add(raw_jsonb_element_len(data, end)?)
-                    .ok_or(LimboError::IntegerOverflow)?;
+                    .ok_or_else(integer_overflow)?;
             }
             data.drain(1..end);
         }
     }
     Ok(())
+}
+
+/// Passed to `ok_or_else` so the error is only built on the overflow path;
+/// `ok_or(LimboError::IntegerOverflow)` would construct and drop the error
+/// on every successful increment, and that runs once per row in aggregates.
+#[cold]
+fn integer_overflow() -> LimboError {
+    LimboError::IntegerOverflow
 }
 
 pub fn op_agg_step(
@@ -8394,37 +8402,13 @@ pub fn op_agg_step(
     }
     let func = func.expect_agg();
 
-    // Initialize aggregate state if not already done
+    if step_common_agg_fast(state, func, *acc_reg, *col) {
+        state.pc += 1;
+        return Ok(InsnFunctionStepResult::Step);
+    }
+
     if let Register::Value(Value::Null) = state.registers[*acc_reg] {
-        state.registers[*acc_reg] = match func {
-            AggFunc::External(ext_func) => match ext_func.as_ref() {
-                ExtFunc::Aggregate {
-                    context,
-                    init,
-                    step,
-                    finalize,
-                    argc,
-                    aggregate_destructor,
-                    value_destructor,
-                    ..
-                } => Register::Aggregate(AggContext::External(ExternalAggState {
-                    context: *context,
-                    state: unsafe { (init)(*context) },
-                    argc: (*argc).max(0) as usize,
-                    step_fn: *step,
-                    finalize_fn: *finalize,
-                    aggregate_destructor: *aggregate_destructor,
-                    value_destructor: *value_destructor,
-                })),
-                _ => unreachable!("scalar function called in aggregate context"),
-            },
-            _ => {
-                // Built-in aggregates use flat payload
-                let mut payload = crate::alloc::vec![];
-                init_agg_payload(func, &mut payload)?;
-                Register::Aggregate(AggContext::Builtin(payload))
-            }
-        };
+        state.registers[*acc_reg] = init_agg_accumulator(func)?;
     }
 
     let current_collation = collation.unwrap_or(CollationSeq::Binary);
@@ -8442,54 +8426,7 @@ pub fn op_agg_step(
 
     // Step the aggregate
     match func {
-        AggFunc::External(_) => {
-            // External aggregates use FFI and need special handling
-            let (context, step_fn, state_ptr, argc, aggregate_destructor, value_destructor) = {
-                let Register::Aggregate(agg) = &state.registers[*acc_reg] else {
-                    unreachable!();
-                };
-                let AggContext::External(agg_state) = agg else {
-                    unreachable!();
-                };
-                (
-                    agg_state.context,
-                    agg_state.step_fn,
-                    agg_state.state,
-                    agg_state.argc,
-                    agg_state.aggregate_destructor,
-                    agg_state.value_destructor,
-                )
-            };
-            let mut ext_values = Vec::with_capacity(argc);
-            if argc != 0 {
-                let register_slice = &state.registers[*col..*col + argc];
-                for ov in register_slice.iter() {
-                    ext_values.push(ov.get_value().to_ffi());
-                }
-            }
-            let argv_ptr = if ext_values.is_empty() {
-                std::ptr::null()
-            } else {
-                ext_values.as_ptr()
-            };
-            let mut result = unsafe { step_fn(context, state_ptr, argc as i32, argv_ptr) };
-            let value = Value::from_ffi_ref(&result);
-            if let Some(value_destructor) = value_destructor {
-                unsafe { value_destructor(&mut result) };
-            } else {
-                unsafe { result.__free_internal_type() };
-            }
-            for ext_value in ext_values {
-                unsafe { ext_value.__free_internal_type() };
-            }
-            if let Err(err) = value {
-                if let Some(aggregate_destructor) = aggregate_destructor {
-                    unsafe { aggregate_destructor(state_ptr as usize) };
-                }
-                state.registers[*acc_reg].set_value(Value::Null);
-                return Err(err);
-            }
-        }
+        AggFunc::External(_) => step_external_agg(state, *acc_reg, *col)?,
         _ => {
             let maybe_arg2 = match func {
                 AggFunc::GroupConcat | AggFunc::StringAgg => {
@@ -8536,6 +8473,198 @@ pub fn op_agg_step(
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
+}
+
+/// Steps count(*), count(x), and sum(x)/total(x) over integers or floats
+/// without going through the general path, which sets up a second
+/// argument, a comparator closure and a split borrow that these shapes never
+/// need. Returns false when the accumulator is not initialized yet, the
+/// arguments do not fit the fast shape, or the arithmetic would overflow or
+/// produce NaN; the general path then handles the row from scratch, since
+/// nothing was modified.
+#[inline(always)]
+fn step_common_agg_fast(
+    state: &mut ProgramState,
+    func: &AggFunc,
+    acc_reg: usize,
+    col: usize,
+) -> bool {
+    match func {
+        AggFunc::Count0 => {
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                return false;
+            };
+            let [Value::Numeric(Numeric::Integer(count)), ..] = payload.as_mut_slice() else {
+                return false;
+            };
+            let Some(next) = count.checked_add(1) else {
+                return false;
+            };
+            *count = next;
+            true
+        }
+        AggFunc::Count => {
+            let arg_is_null = matches!(&state.registers[col], Register::Value(Value::Null));
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                return false;
+            };
+            if arg_is_null {
+                return true;
+            }
+            let [Value::Numeric(Numeric::Integer(count)), ..] = payload.as_mut_slice() else {
+                return false;
+            };
+            let Some(next) = count.checked_add(1) else {
+                return false;
+            };
+            *count = next;
+            true
+        }
+        AggFunc::Sum | AggFunc::Total => {
+            let Register::Value(Value::Numeric(arg)) = &state.registers[col] else {
+                return false;
+            };
+            let arg = *arg;
+            let Register::Aggregate(AggContext::Builtin(payload)) = &mut state.registers[acc_reg]
+            else {
+                return false;
+            };
+            // Payload layout per init_agg_payload: acc, r_err, approx, ovrfl, count.
+            let [acc, Value::Numeric(Numeric::Float(r_err)), Value::Numeric(Numeric::Integer(approx)), Value::Numeric(Numeric::Integer(ovrfl)), Value::Numeric(Numeric::Integer(count))] =
+                payload.as_mut_slice()
+            else {
+                return false;
+            };
+            let Some(next_count) = count.checked_add(1) else {
+                return false;
+            };
+            match (acc, arg) {
+                (Value::Numeric(Numeric::Integer(acc)), Numeric::Integer(i)) => {
+                    let Some(sum) = acc.checked_add(i) else {
+                        return false;
+                    };
+                    *acc = sum;
+                }
+                (Value::Numeric(Numeric::Float(acc)), Numeric::Float(f)) => {
+                    // Same Kahan-Babuska-Neumaier step as apply_kbn_step.
+                    let s = f64::from(*acc);
+                    let r = f64::from(f);
+                    let t = s + r;
+                    let Some(sum) = NonNan::new(t) else {
+                        return false;
+                    };
+                    if t.is_finite() {
+                        let correction = if s.abs() > r.abs() {
+                            (s - t) + r
+                        } else {
+                            (r - t) + s
+                        };
+                        let Some(err) = NonNan::new(f64::from(*r_err) + correction) else {
+                            return false;
+                        };
+                        *r_err = err;
+                    }
+                    *acc = sum;
+                    *approx = 1;
+                    *ovrfl = 0;
+                }
+                _ => return false,
+            }
+            *count = next_count;
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Runs once per aggregate, on the first row, so it is kept out of the
+/// per-row `op_agg_step` body.
+#[inline(never)]
+fn init_agg_accumulator(func: &AggFunc) -> Result<Register> {
+    Ok(match func {
+        AggFunc::External(ext_func) => match ext_func.as_ref() {
+            ExtFunc::Aggregate {
+                context,
+                init,
+                step,
+                finalize,
+                argc,
+                aggregate_destructor,
+                value_destructor,
+                ..
+            } => Register::Aggregate(AggContext::External(ExternalAggState {
+                context: *context,
+                state: unsafe { (init)(*context) },
+                argc: (*argc).max(0) as usize,
+                step_fn: *step,
+                finalize_fn: *finalize,
+                aggregate_destructor: *aggregate_destructor,
+                value_destructor: *value_destructor,
+            })),
+            _ => unreachable!("scalar function called in aggregate context"),
+        },
+        _ => {
+            // Built-in aggregates use flat payload
+            let mut payload = crate::alloc::vec![];
+            init_agg_payload(func, &mut payload)?;
+            Register::Aggregate(AggContext::Builtin(payload))
+        }
+    })
+}
+
+/// External (extension) aggregates step through FFI. Kept out of
+/// `op_agg_step` so the built-in per-row path stays small.
+#[inline(never)]
+fn step_external_agg(state: &mut ProgramState, acc_reg: usize, col: usize) -> Result<()> {
+    // External aggregates use FFI and need special handling
+    let (context, step_fn, state_ptr, argc, aggregate_destructor, value_destructor) = {
+        let Register::Aggregate(agg) = &state.registers[acc_reg] else {
+            unreachable!();
+        };
+        let AggContext::External(agg_state) = agg else {
+            unreachable!();
+        };
+        (
+            agg_state.context,
+            agg_state.step_fn,
+            agg_state.state,
+            agg_state.argc,
+            agg_state.aggregate_destructor,
+            agg_state.value_destructor,
+        )
+    };
+    let mut ext_values = Vec::with_capacity(argc);
+    if argc != 0 {
+        let register_slice = &state.registers[col..col + argc];
+        for ov in register_slice.iter() {
+            ext_values.push(ov.get_value().to_ffi());
+        }
+    }
+    let argv_ptr = if ext_values.is_empty() {
+        std::ptr::null()
+    } else {
+        ext_values.as_ptr()
+    };
+    let mut result = unsafe { step_fn(context, state_ptr, argc as i32, argv_ptr) };
+    let value = Value::from_ffi_ref(&result);
+    if let Some(value_destructor) = value_destructor {
+        unsafe { value_destructor(&mut result) };
+    } else {
+        unsafe { result.__free_internal_type() };
+    }
+    for ext_value in ext_values {
+        unsafe { ext_value.__free_internal_type() };
+    }
+    if let Err(err) = value {
+        if let Some(aggregate_destructor) = aggregate_destructor {
+            unsafe { aggregate_destructor(state_ptr as usize) };
+        }
+        state.registers[acc_reg].set_value(Value::Null);
+        return Err(err);
+    }
+    Ok(())
 }
 
 pub fn op_agg_final(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -19020,7 +19020,7 @@ mod tests {
                 if !conn_for_progress.get_auto_commit() {
                     let calls =
                         source_txn_progress_calls_for_handler.fetch_add(1, Ordering::SeqCst);
-                    calls >= 10 && !did_interrupt_for_handler.swap(true, Ordering::SeqCst)
+                    calls >= 2 && !did_interrupt_for_handler.swap(true, Ordering::SeqCst)
                 } else {
                     false
                 }
@@ -19039,7 +19039,7 @@ mod tests {
             "progress interruption inside VACUUM INTO should surface as Busy, got {step:?}"
         );
         assert!(
-            source_txn_progress_calls.load(Ordering::SeqCst) > 10,
+            source_txn_progress_calls.load(Ordering::SeqCst) > 2,
             "test should interrupt after VACUUM INTO opens the source transaction"
         );
         assert!(

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -813,6 +813,8 @@ pub struct ProgramState {
     /// Per-execution statement deadline derived from the connection query timeout.
     /// `None` means no timeout.
     pub query_deadline: Option<crate::MonotonicInstant>,
+    /// VM step count at the last progress-handler check.
+    progress_last_checked: u64,
     /// Excludes new root statements while an explicit checkpoint is suspended.
     pub(crate) explicit_checkpoint_guard: Option<crate::connection::ExplicitCheckpointGuard>,
     pub parameters: Vec<Value>,
@@ -949,6 +951,7 @@ impl ProgramState {
             once: SmallVec::<[u32; 4]>::new(),
             execution_state: ProgramExecutionState::Init,
             query_deadline: None,
+            progress_last_checked: 0,
             explicit_checkpoint_guard: None,
             parameters: Vec::new(),
             commit_state: CommitState::Ready,
@@ -1090,6 +1093,7 @@ impl ProgramState {
         self.once.clear();
         self.execution_state = ProgramExecutionState::Init;
         self.query_deadline = None;
+        self.progress_last_checked = 0;
         self.explicit_checkpoint_guard = None;
         #[cfg(feature = "json")]
         self.json_cache.clear();
@@ -1706,7 +1710,53 @@ impl Program {
     }
 }
 
+impl ProgramState {
+    /// Checked on every instruction, so the common empty case must not
+    /// touch the 96-byte error slot at all.
+    #[inline]
+    fn take_pending_fail_prepare_error(&mut self) -> Option<LimboError> {
+        self.pending_fail_prepare_error.as_ref()?;
+        self.pending_fail_prepare_error.take()
+    }
+}
+
 impl Program {
+    /// Prints the register diff of the previous opcode and the current
+    /// opcode. Kept out of `normal_step` so the dispatch loop stays small.
+    #[cold]
+    #[inline(never)]
+    fn vdbe_trace_insn(&self, state: &mut ProgramState, insn: &Insn) {
+        // The last opcode (Halt) won't have its diff printed, but Halt
+        // doesn't write to any registers
+        if let Some(ref old) = state.pre_op_registers {
+            for (i, (old_reg, new_reg)) in old.iter().zip(state.registers.iter()).enumerate() {
+                if old_reg != new_reg {
+                    match new_reg {
+                        Register::Value(v) => eprintln!("R[{i}] = {v}"),
+                        Register::Aggregate(_) => eprintln!("R[{i}] = <aggregate>"),
+                        Register::Record(_) => eprintln!("R[{i}] = <record>"),
+                    }
+                }
+            }
+            state.pre_op_registers = None;
+        }
+
+        if matches!(insn, Insn::Init { .. }) {
+            eprintln!("VDBE Trace:");
+        }
+        eprintln!(
+            "{}",
+            explain::insn_to_str(
+                self,
+                state.pc,
+                insn,
+                String::new(),
+                self.explain.comment_at(state.pc)
+            )
+        );
+        state.pre_op_registers = Some(state.registers.clone());
+    }
+
     fn get_pager_from_database_index(&self, idx: &usize) -> Result<Arc<Pager>> {
         self.connection.get_pager_from_database_index(idx)
     }
@@ -1727,9 +1777,10 @@ impl Program {
         let hit_query_deadline = state
             .query_deadline
             .is_some_and(|deadline| io.current_time_monotonic() >= deadline);
-        let progress_interrupt = self
-            .connection
-            .should_interrupt_for_progress(state.metrics.vm_steps);
+        let progress_interrupt = self.connection.should_interrupt_for_progress(
+            state.metrics.vm_steps,
+            &mut state.progress_last_checked,
+        );
         if connection_interrupt || hit_query_deadline || progress_interrupt {
             state.interrupt();
         }
@@ -1947,6 +1998,7 @@ impl Program {
         waker: Option<&Waker>,
     ) -> Result<StepResult> {
         let enable_tracing = tracing::enabled!(tracing::Level::TRACE);
+        let vdbe_trace = self.connection.get_vdbe_trace();
         // Invalidate the previous result row once per step call: rows are only
         // handed out between step calls, and ResultRow returns immediately
         // after setting a fresh one.
@@ -1987,25 +2039,35 @@ impl Program {
                 }
                 state.io_completions = None;
             }
+            // Closed-connection, interrupt, deadline and progress checks run
+            // when a step call starts and after every backwards jump. Every
+            // loop in a program has a backwards jump, so long-running
+            // statements still notice them promptly, but straight-line code
+            // does not pay for the checks on every instruction. This is what
+            // SQLite does too: it only checks at jump opcodes.
+            let mut check_interrupt = true;
             loop {
-                if self.connection.is_closed() {
-                    // Connection is closed for whatever reason, rollback the transaction.
-                    let state = self.connection.get_tx_state();
-                    if let TransactionState::Write { .. } = state {
-                        pager.rollback_tx(&self.connection);
+                if check_interrupt {
+                    check_interrupt = false;
+                    if self.connection.is_closed() {
+                        // Connection is closed for whatever reason, rollback the transaction.
+                        let state = self.connection.get_tx_state();
+                        if let TransactionState::Write { .. } = state {
+                            pager.rollback_tx(&self.connection);
+                        }
+                        return Err(LimboError::InternalError("Connection closed".to_string()));
                     }
-                    return Err(LimboError::InternalError("Connection closed".to_string()));
-                }
-                if self.maybe_request_interrupt(state, pager.io.as_ref()) {
-                    self.abort(pager, None, state, true)?;
-                    return Ok(StepResult::Interrupt);
+                    if self.maybe_request_interrupt(state, pager.io.as_ref()) {
+                        self.abort(pager, None, state, true)?;
+                        return Ok(StepResult::Interrupt);
+                    }
                 }
 
                 // A trigger can return FAIL before the parent program reaches
                 // Halt. FAIL keeps changes made by earlier rows, so their
                 // index-method writes must finish before abort() releases the
                 // statement savepoint and commits those partial changes.
-                if let Some(fail_error) = state.pending_fail_prepare_error.take() {
+                if let Some(fail_error) = state.take_pending_fail_prepare_error() {
                     match execute::index_method_stage_statement_all(state) {
                         Ok(IOResult::Done(())) => {
                             if let Err(abort_err) =
@@ -2057,49 +2119,18 @@ impl Program {
                     trace_insn(self, state.pc as InsnReference, insn);
                     crate::stack::trace_remaining("program_step:opcode");
                 }
-                if self.connection.get_vdbe_trace() {
-                    // Diff registers from PREVIOUS opcode
-                    // The last opcode (Halt) won't have its diff printed, but Halt
-                    // doesn't write to any registers
-                    if let Some(ref old) = state.pre_op_registers {
-                        for (i, (old_reg, new_reg)) in
-                            old.iter().zip(state.registers.iter()).enumerate()
-                        {
-                            if old_reg != new_reg {
-                                match new_reg {
-                                    Register::Value(v) => eprintln!("R[{i}] = {v}"),
-                                    Register::Aggregate(_) => eprintln!("R[{i}] = <aggregate>"),
-                                    Register::Record(_) => eprintln!("R[{i}] = <record>"),
-                                }
-                            }
-                        }
-                        state.pre_op_registers = None;
-                    }
-
-                    // Print CURRENT opcode
-                    if matches!(insn, Insn::Init { .. }) {
-                        eprintln!("VDBE Trace:");
-                    }
-                    eprintln!(
-                        "{}",
-                        explain::insn_to_str(
-                            self,
-                            state.pc,
-                            insn,
-                            String::new(),
-                            self.explain.comment_at(state.pc)
-                        )
-                    );
-                    // Snapshot for next iteration
-                    state.pre_op_registers = Some(state.registers.clone());
+                if vdbe_trace {
+                    self.vdbe_trace_insn(state, insn);
                 }
                 // Always increment VM steps for every loop iteration
                 state.metrics.vm_steps = state.metrics.vm_steps.saturating_add(1);
 
+                let pc_before = state.pc;
                 match insn_function(self, state, insn, pager) {
                     Ok(InsnFunctionStepResult::Step) => {
                         // Instruction completed, moving to next
                         state.metrics.insn_executed = state.metrics.insn_executed.saturating_add(1);
+                        check_interrupt = state.pc <= pc_before;
                     }
                     Ok(InsnFunctionStepResult::Done) => {
                         // Instruction completed execution

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1159,18 +1159,30 @@ impl Value {
     }
 
     pub fn exec_add(&self, rhs: &Value) -> Value {
+        if let (Value::Numeric(lhs), Value::Numeric(rhs)) = (self, rhs) {
+            return lhs.checked_add(*rhs).into();
+        }
         (|| Numeric::from_value(self)?.checked_add(Numeric::from_value(rhs)?))().into()
     }
 
     pub fn exec_subtract(&self, rhs: &Value) -> Value {
+        if let (Value::Numeric(lhs), Value::Numeric(rhs)) = (self, rhs) {
+            return lhs.checked_sub(*rhs).into();
+        }
         (|| Numeric::from_value(self)?.checked_sub(Numeric::from_value(rhs)?))().into()
     }
 
     pub fn exec_multiply(&self, rhs: &Value) -> Value {
+        if let (Value::Numeric(lhs), Value::Numeric(rhs)) = (self, rhs) {
+            return lhs.checked_mul(*rhs).into();
+        }
         (|| Numeric::from_value(self)?.checked_mul(Numeric::from_value(rhs)?))().into()
     }
 
     pub fn exec_divide(&self, rhs: &Value) -> Value {
+        if let (Value::Numeric(lhs), Value::Numeric(rhs)) = (self, rhs) {
+            return lhs.checked_div(*rhs).into();
+        }
         (|| Numeric::from_value(self)?.checked_div(Numeric::from_value(rhs)?))().into()
     }
 
@@ -1183,6 +1195,14 @@ impl Value {
     }
 
     pub fn exec_remainder(&self, rhs: &Value) -> Value {
+        if let (Value::Numeric(Numeric::Integer(lhs)), Value::Numeric(Numeric::Integer(rhs))) =
+            (self, rhs)
+        {
+            return match NullableInteger::Integer(*lhs) % NullableInteger::Integer(*rhs) {
+                NullableInteger::Null => Value::Null,
+                NullableInteger::Integer(v) => Value::from_i64(v),
+            };
+        }
         let convert_to_float = matches!(Numeric::from_value(self), Some(Numeric::Float(_)))
             || matches!(Numeric::from_value(rhs), Some(Numeric::Float(_)));
 

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -1252,15 +1252,40 @@ impl Value {
             return Ok(Value::Blob(blob));
         }
 
-        let Some(lhs) = self.cast_text() else {
+        if matches!(self, Value::Null) || matches!(rhs, Value::Null) {
             return Ok(Value::Null);
-        };
+        }
 
-        let Some(rhs) = rhs.cast_text() else {
-            return Ok(Value::Null);
-        };
+        let mut out = String::new();
+        out.try_reserve(self.text_len_hint() + rhs.text_len_hint())?;
+        self.append_as_text(&mut out);
+        rhs.append_as_text(&mut out);
+        Ok(Value::build_text(out))
+    }
 
-        Ok(Value::build_text(lhs + &rhs))
+    /// Upper bound on the text length of this value, so concatenation can
+    /// allocate once.
+    fn text_len_hint(&self) -> usize {
+        match self {
+            Value::Null => 0,
+            Value::Numeric(_) => 24,
+            Value::Text(t) => t.as_str().len(),
+            Value::Blob(b) => b.len(),
+        }
+    }
+
+    /// Appends the text form of this value, the same one `to_string` gives,
+    /// without going through the formatting machinery or a temporary String.
+    fn append_as_text(&self, out: &mut String) {
+        match self {
+            Value::Null => {}
+            Value::Numeric(Numeric::Integer(i)) => out.push_str(itoa::Buffer::new().format(*i)),
+            Value::Numeric(Numeric::Float(f)) => {
+                out.push_str(&crate::numeric::format_float(f64::from(*f)))
+            }
+            Value::Text(t) => out.push_str(t.as_str()),
+            Value::Blob(b) => out.push_str(&String::from_utf8_lossy(b)),
+        }
     }
 
     pub fn exec_and(&self, rhs: &Value) -> Value {

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -243,7 +243,7 @@ impl VirtualTable {
 enum VirtualTableCursorInner {
     Pragma(Box<PragmaVirtualTableCursor>),
     External(ExtVirtualTableCursor),
-    Internal(Arc<RwLock<dyn InternalVirtualTableCursor>>),
+    Internal(Box<dyn InternalVirtualTableCursor>),
 }
 
 pub struct VirtualTableCursor {
@@ -268,7 +268,7 @@ impl VirtualTableCursor {
         }
     }
 
-    pub(crate) fn new_internal(cursor: Arc<RwLock<dyn InternalVirtualTableCursor>>) -> Self {
+    pub(crate) fn new_internal(cursor: Box<dyn InternalVirtualTableCursor>) -> Self {
         Self {
             inner: VirtualTableCursorInner::Internal(cursor),
             null_flag: false,
@@ -284,7 +284,7 @@ impl VirtualTableCursor {
         match &mut self.inner {
             VirtualTableCursorInner::Pragma(cursor) => cursor.next(),
             VirtualTableCursorInner::External(cursor) => cursor.next(),
-            VirtualTableCursorInner::Internal(cursor) => cursor.write().next(),
+            VirtualTableCursorInner::Internal(cursor) => cursor.next(),
         }
     }
 
@@ -292,7 +292,7 @@ impl VirtualTableCursor {
         match &self.inner {
             VirtualTableCursorInner::Pragma(cursor) => cursor.rowid(),
             VirtualTableCursorInner::External(cursor) => cursor.rowid(),
-            VirtualTableCursorInner::Internal(cursor) => cursor.read().rowid(),
+            VirtualTableCursorInner::Internal(cursor) => cursor.rowid(),
         }
     }
 
@@ -303,7 +303,7 @@ impl VirtualTableCursor {
         match &self.inner {
             VirtualTableCursorInner::Pragma(cursor) => cursor.column(column),
             VirtualTableCursorInner::External(cursor) => cursor.column(column),
-            VirtualTableCursorInner::Internal(cursor) => cursor.read().column(column),
+            VirtualTableCursorInner::Internal(cursor) => cursor.column(column),
         }
     }
 
@@ -320,9 +320,7 @@ impl VirtualTableCursor {
             VirtualTableCursorInner::External(cursor) => {
                 cursor.filter(idx_num, idx_str, arg_count, args)
             }
-            VirtualTableCursorInner::Internal(cursor) => {
-                cursor.write().filter(&args, idx_str, idx_num)
-            }
+            VirtualTableCursorInner::Internal(cursor) => cursor.filter(&args, idx_str, idx_num),
         }
     }
 
@@ -600,10 +598,7 @@ impl Drop for ExtVirtualTableCursor {
 
 pub trait InternalVirtualTable: std::fmt::Debug + Send + Sync {
     fn name(&self) -> String;
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>>;
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>>;
     /// best_index is used by the optimizer. See the comment on `Table::best_index`.
     fn best_index(
         &self,
@@ -650,11 +645,11 @@ mod tests {
         fn open(
             &self,
             _conn: Arc<Connection>,
-        ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-            Ok(Arc::new(RwLock::new(StaticCursor {
+        ) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+            Ok(Box::new(StaticCursor {
                 rows: vec![("alpha".to_string(), 1), ("beta".to_string(), 2)],
                 position: -1,
-            })))
+            }))
         }
         fn best_index(
             &self,

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -35,6 +35,10 @@ impl VirtualTable {
     pub(crate) fn id(&self) -> u64 {
         self.vtab_id
     }
+    pub(crate) fn is_internal(&self) -> bool {
+        matches!(self.vtab_type, VirtualTableType::Internal(_))
+    }
+
     pub(crate) fn readonly(&self) -> bool {
         match &self.vtab_type {
             VirtualTableType::Pragma(_) => true,

--- a/postgres/frontend/catalog.rs
+++ b/postgres/frontend/catalog.rs
@@ -294,11 +294,8 @@ impl InternalVirtualTable for PgClassTable {
         "pg_class".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgClassCursor::new(conn))))
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgClassCursor::new(conn)))
     }
 
     fn best_index(
@@ -540,11 +537,8 @@ impl InternalVirtualTable for PgNamespaceTable {
         "pg_namespace".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgNamespaceCursor::new(conn))))
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgNamespaceCursor::new(conn)))
     }
 
     fn best_index(
@@ -682,11 +676,8 @@ impl InternalVirtualTable for PgAttributeTable {
         "pg_attribute".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgAttributeCursor::new(conn))))
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgAttributeCursor::new(conn)))
     }
 
     fn best_index(
@@ -879,14 +870,11 @@ impl InternalVirtualTable for PgRolesTable {
         "pg_roles".to_string()
     }
 
-    fn open(
-        &self,
-        _conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgRolesCursor {
+    fn open(&self, _conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgRolesCursor {
             rows: Vec::new(),
             current_row: 0,
-        })))
+        }))
     }
 
     fn best_index(
@@ -983,15 +971,12 @@ impl InternalVirtualTable for PgProcTable {
         "pg_proc".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgProcCursor {
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgProcCursor {
             conn,
             rows: Vec::new(),
             current_row: 0,
-        })))
+        }))
     }
 
     fn best_index(
@@ -1204,15 +1189,12 @@ impl InternalVirtualTable for PgDatabaseTable {
         "pg_database".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgDatabaseCursor {
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgDatabaseCursor {
             conn,
             rows: Vec::new(),
             current_row: 0,
-        })))
+        }))
     }
 
     fn best_index(
@@ -1347,14 +1329,11 @@ impl InternalVirtualTable for PgAmTable {
         "pg_am".to_string()
     }
 
-    fn open(
-        &self,
-        _conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgAmCursor {
+    fn open(&self, _conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgAmCursor {
             rows: Vec::new(),
             current_row: 0,
-        })))
+        }))
     }
 
     fn best_index(
@@ -1439,11 +1418,8 @@ impl InternalVirtualTable for EmptyPgCatalogTable {
         self.name.clone()
     }
 
-    fn open(
-        &self,
-        _conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(EmptyPgCatalogCursor)))
+    fn open(&self, _conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(EmptyPgCatalogCursor))
     }
 
     fn best_index(
@@ -1527,11 +1503,8 @@ impl InternalVirtualTable for PgTablesTable {
         "pg_tables".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgTablesCursor::new(conn))))
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgTablesCursor::new(conn)))
     }
 
     fn best_index(
@@ -1953,15 +1926,12 @@ impl InternalVirtualTable for PgTypeTable {
         "pg_type".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgTypeCursor {
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgTypeCursor {
             conn,
             rows: Vec::new(),
             current_row: 0,
-        })))
+        }))
     }
 
     fn best_index(
@@ -2160,15 +2130,12 @@ impl InternalVirtualTable for PgIndexTable {
         "pg_index".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgIndexCursor {
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgIndexCursor {
             conn,
             rows: Vec::new(),
             current_row: 0,
-        })))
+        }))
     }
 
     fn best_index(
@@ -2337,15 +2304,12 @@ impl InternalVirtualTable for PgConstraintTable {
         "pg_constraint".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgConstraintCursor {
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgConstraintCursor {
             conn,
             rows: Vec::new(),
             current_row: 0,
-        })))
+        }))
     }
 
     fn best_index(
@@ -2700,15 +2664,12 @@ impl InternalVirtualTable for PgAttrdefTable {
         "pg_attrdef".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgAttrdefCursor {
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgAttrdefCursor {
             conn,
             rows: Vec::new(),
             current_row: 0,
-        })))
+        }))
     }
 
     fn best_index(
@@ -2824,15 +2785,12 @@ impl InternalVirtualTable for PgSequencesTable {
         "pg_sequences".to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgSequencesCursor {
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgSequencesCursor {
             conn,
             rows: Vec::new(),
             current_row: 0,
-        })))
+        }))
     }
 
     fn best_index(
@@ -3221,11 +3179,8 @@ impl InternalVirtualTable for PgInputErrorInfoTable {
         .to_string()
     }
 
-    fn open(
-        &self,
-        _conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgInputErrorInfoCursor::new())))
+    fn open(&self, _conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgInputErrorInfoCursor::new()))
     }
 
     fn best_index(
@@ -3440,11 +3395,8 @@ impl InternalVirtualTable for PgGetTableDefTable {
         .to_string()
     }
 
-    fn open(
-        &self,
-        conn: Arc<Connection>,
-    ) -> crate::Result<Arc<RwLock<dyn InternalVirtualTableCursor>>> {
-        Ok(Arc::new(RwLock::new(PgGetTableDefCursor::new(conn))))
+    fn open(&self, conn: Arc<Connection>) -> crate::Result<Box<dyn InternalVirtualTableCursor>> {
+        Ok(Box::new(PgGetTableDefCursor::new(conn)))
     }
 
     fn best_index(


### PR DESCRIPTION
This adds a benchmark for the bytecode interpreter and lands six optimizations found by profiling against it. Every performance commit was measured against its parent with the same benchmark binary configuration (criterion `--save-baseline` at the parent, `--baseline` at the commit, run back-to-back), and its commit message quotes the before/after medians.

## Benchmark

`cargo bench -p turso_core --bench interpreter_benchmark` — every workload runs on an in-memory database and also on SQLite (rusqlite, in-memory) as a fixed reference:

- `interp/series`: expressions over `generate_series(1, 100k)` (arithmetic, comparisons, CASE, scalar functions, string building, float math). The row source is cheap, so this is mostly the interpreter loop.
- `interp/rcte`: the same count over a recursive CTE (adds coroutine + ephemeral-queue opcodes).
- `interp/scan`: full scans of a 100k-row in-memory table (adds cursor stepping and record decoding).
- `interp/stmt`: a tiny statement run over and over (bind/step/reset) — the fixed cost per statement.

## Total improvement

Benchmark-only commit vs. the tip of this branch, criterion medians, measured back-to-back in one run; SQLite column from the same run for reference.

| Benchmark | Before | After | Change | SQLite | Gap before → after |
|---|---|---|---|---|---|
| series/count | 2.81 ms | 1.91 ms | **−31%** | 1.58 ms | 1.8× → 1.2× |
| series/arith | 24.31 ms | 12.91 ms | **−46%** | 8.17 ms | 3.0× → 1.6× |
| series/compare | 12.39 ms | 7.73 ms | **−37%** | 4.17 ms | 3.0× → 1.9× |
| series/case | 25.35 ms | 14.57 ms | **−42%** | 6.45 ms | 3.9× → 2.3× |
| series/scalar_funcs | 35.56 ms | 22.51 ms | **−37%** | 13.09 ms | 2.7× → 1.7× |
| series/string_concat | 31.19 ms | 14.43 ms | **−54%** | 9.89 ms | 3.2× → 1.5× |
| series/float_math | 16.90 ms | 9.57 ms | **−43%** | 6.70 ms | 2.5× → 1.4× |
| scan/sum_two_cols | 15.60 ms | 12.43 ms | −20% | 5.24 ms | 3.0× → 2.4× |
| scan/filter_count | 17.24 ms | 15.77 ms | −8.5% | 3.41 ms | 5.1× → 4.6× |
| scan/text_filter | 20.18 ms | 18.31 ms | −9.8% | 5.00 ms | 4.0× → 3.7× |
| scan/all_rows | 19.89 ms | 19.41 ms | −2.7% | 8.19 ms | 2.4× → 2.4× |
| stmt/select_param | 378 ns | 363 ns | −3.7% | 112 ns | 3.4× → 3.2× |
| stmt/point_lookup | 1.46 µs | 1.48 µs | ±0 | 393 ns | 3.7× → 3.8× |
| rcte/count | 175.9 ms | 168.3 ms | −4.3% | 18.1 ms | 9.7× → 9.3× |

## Commits

Each commit's message has the full per-benchmark table for that change; headline numbers:

1. **core/benches: add interpreter benchmark** — the benchmark itself.
2. **core/vdbe: check interrupts only at loop back-edges** — closed-connection, interrupt, deadline and progress-handler checks ran before every opcode (plus a trace-flag atomic load and a 96-byte `Option<LimboError>::take`). Now checked at step entry and after backwards jumps, like SQLite. The progress handler keeps a "last checked" watermark instead of needing exact multiples of N. `case` 25.9→19.3 ms (−25%), `scalar_funcs` −20%, `arith` −16%, `compare` −17%, scan −4..−7%.
3. **core/vdbe: add integer fast paths to arithmetic operators** — skip `Numeric::from_value`/`ValueRef` coercion when both operands are already numeric; `%` converted each operand twice. `arith` −9.5%, `case` −12%, `scalar_funcs` −10%.
4. **core/vdbe: build concatenation result with one allocation** — `||` did five allocations and two rounds of `core::fmt` per row. `string_concat` 30.0→17.95 ms (−39.5%).
5. **core/vdbe: add a fast path for count and sum aggregate steps** — the general AggStep path set up a second argument, a comparator closure and a split borrow per row, and the counter increment built a `LimboError` with `ok_or` on every successful row. `count` 2.94→1.89 ms (−36%), `sum_two_cols` −10.5%, `float_math` −8.8%.
6. **core: run generate_series inside the engine** — it was compiled into core but registered through the extension API, so every `VColumn` did an FFI value round trip. Now an `InternalVirtualTable`; `PRAGMA module_list` still lists it. `arith` −15%, `string_concat` −12.5%, `float_math` −11% (`count` +20% from the internal cursor's lock, removed by the next commit).
7. **core/vtab: hold internal virtual table cursors in a Box** — internal cursors were `Arc<RwLock<..>>`, so every column/next/rowid took an uncontended lock. `count` 2.26→1.90 ms (−16%), `compare` −19%, `arith` −14%, `case` −13%.

## Validation

- `cargo test -p turso_core --lib`, full sqltest conformance (1579 passed), postgres conformance (86 passed), `cargo clippy -p turso_core --all-features --all-targets` clean.
- Each intermediate commit builds and passes the vtab/series tests.
- One test changed: `test_vacuum_into_busy_after_source_begin_rolls_back_source_txn` relied on per-instruction progress-handler cadence (interrupt on the 10th call); it now interrupts on the 2nd check inside the source transaction. Its intent (interrupt while the source txn is open, verify Busy + rollback) is unchanged.

## What's left (profile-derived, not in this PR)

- **scan**: `BTreeCursor::record()` copies the payload per row, each `Column` re-parses the record header from the start, and text columns allocate an owned `String` (SQLite is zero-copy). Biggest remaining gap.
- **stmt**: per-statement lifecycle (`ProgramState::reset` walking all registers/cursors, `abort()` on reset even when Done, metrics lock, attached-pager walk with `Arc` clones).
- **rcte**: ephemeral index insert+delete per row — btree, not interpreter.
- `LimboError` is 96 bytes because `turso_parser::error::Error` is embedded by value, so every opcode returns a 96-byte `Result` through memory.
- A CASE-translator change (WHEN conditions as direct jumps + hoisting nested constants; matches SQLite's bytecode shape, roughly halves instructions per WHEN arm) is drafted but not yet validated.
