### PR TITLE
perf/tpc-h: run Q15 on Turso

### DIFF
--- a/perf/tpc-h/queries/15.sql
+++ b/perf/tpc-h/queries/15.sql
@@ -1,5 +1,3 @@
--- LIMBO_SKIP: views not supported
-
 create view revenue0 (supplier_no, total_revenue) as
 	select
 		l_suppkey,


### PR DESCRIPTION
Q15 was skipped on Turso because views were not supported when the
benchmark was added. Turso now handles CREATE VIEW with a column list,
so the query runs end to end and its output matches SQLite on the
scale-factor-1 TPC-H database.

Tests: ran the query from the benchmark runner path against TPC-H.db
with release tursodb and sqlite3; both return the same single row and
the trailing DROP VIEW leaves no view behind.
