### PR TITLE
core/translate: materialize a GROUP BY key that a larger expression wraps

### DIFF
--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -416,23 +416,30 @@ fn collect_non_aggregate_expressions<'a>(
         Option<turso_parser::ast::NullsOrder>,
     )],
 ) -> Result<()> {
-    let mut result_columns = Vec::new();
-    for expr in root_result_columns
+    let output_exprs: Vec<&'a ast::Expr> = root_result_columns
         .iter()
         .map(|col| &col.expr)
         .chain(order_by.iter().map(|(e, _, _)| e.as_ref()))
         .chain(group_by.having.iter().flatten())
-    {
+        .collect();
+
+    let mut result_columns = Vec::new();
+    for expr in &output_exprs {
         collect_result_columns(expr, plan, &mut result_columns)?;
     }
 
     for group_expr in &group_by.exprs {
-        let expr_appears_in_result_columns = result_columns
+        let mut expr_appears_in_result_columns = result_columns
             .iter()
-            .any(|expr| exprs_are_equivalent(expr, group_expr))
-            || root_result_columns
-                .iter()
-                .any(|rc| exprs_are_equivalent(&rc.expr, group_expr));
+            .any(|expr| exprs_are_equivalent(expr, group_expr));
+        if !expr_appears_in_result_columns {
+            for expr in &output_exprs {
+                if expr_contains_equivalent(expr, group_expr)? {
+                    expr_appears_in_result_columns = true;
+                    break;
+                }
+            }
+        }
         non_aggregate_expressions.push((group_expr, expr_appears_in_result_columns));
     }
     for expr in result_columns {
@@ -522,6 +529,20 @@ fn collect_result_columns<'a>(
         Ok(WalkControl::Continue)
     })?;
     Ok(())
+}
+
+/// Whether `needle` occurs anywhere inside `haystack`, either as the whole
+/// expression or as a sub-expression.
+fn expr_contains_equivalent(haystack: &ast::Expr, needle: &ast::Expr) -> Result<bool> {
+    let mut found = false;
+    walk_expr(haystack, &mut |expr: &ast::Expr| -> Result<WalkControl> {
+        if exprs_are_equivalent(expr, needle) {
+            found = true;
+            return Ok(WalkControl::SkipChildren);
+        }
+        Ok(WalkControl::Continue)
+    })?;
+    Ok(found)
 }
 
 /// In case sorting is needed for GROUP BY, creates a pseudo table that matches

--- a/sqlite/conformance/sqlite-sqltests/groupby/expression-key.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/groupby/expression-key.sqltest
@@ -1,0 +1,183 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE t(a, b);
+    INSERT INTO t VALUES (1, 10), (2, 20), (2, 30);
+}
+
+@setup schema
+test select-is-exactly-the-group-by-expression {
+    SELECT a+0, count(*) FROM t GROUP BY a+0 ORDER BY 1;
+}
+expect {
+    1|1
+    2|2
+}
+
+@setup schema
+test select-calls-a-function-on-the-group-by-expression {
+    SELECT abs(a+0), count(*) FROM t GROUP BY a+0 ORDER BY 1;
+}
+expect {
+    1|1
+    2|2
+}
+
+@setup schema
+test select-does-arithmetic-on-the-group-by-expression {
+    SELECT (a+0)*2, count(*) FROM t GROUP BY a+0 ORDER BY 1;
+}
+expect {
+    2|1
+    4|2
+}
+
+@setup schema
+test select-negates-the-group-by-expression {
+    SELECT -(a+0), count(*) FROM t GROUP BY a+0 ORDER BY 1;
+}
+expect {
+    -2|2
+    -1|1
+}
+
+@setup schema
+test select-casts-the-group-by-expression {
+    SELECT CAST(a+0 AS TEXT), count(*) FROM t GROUP BY a+0 ORDER BY 1;
+}
+expect {
+    1|1
+    2|2
+}
+
+@setup schema
+test select-uses-the-group-by-expression-in-a-case {
+    SELECT CASE WHEN (a+0) > 1 THEN 'big' ELSE 'small' END, count(*) FROM t GROUP BY a+0 ORDER BY 1;
+}
+expect {
+    big|2
+    small|1
+}
+
+@setup schema
+test select-tests-the-group-by-expression-for-null {
+    SELECT (a+0) IS NULL, count(*) FROM t GROUP BY a+0 ORDER BY 2;
+}
+expect {
+    0|1
+    0|2
+}
+
+@setup schema
+test select-takes-the-type-of-the-group-by-expression {
+    SELECT typeof(a+0), count(*) FROM t GROUP BY a+0 ORDER BY 2;
+}
+expect {
+    integer|1
+    integer|2
+}
+
+@setup schema
+test select-nests-the-group-by-expression-two-functions-deep {
+    SELECT abs(abs(a+0)), count(*) FROM t GROUP BY a+0 ORDER BY 1;
+}
+expect {
+    1|1
+    2|2
+}
+
+@setup schema
+test group-by-a-function-and-wrap-it-in-the-select {
+    SELECT abs(abs(a)), count(*) FROM t GROUP BY abs(a) ORDER BY 1;
+}
+expect {
+    1|1
+    2|2
+}
+
+@setup schema
+test group-by-a-concatenation-and-wrap-it-in-the-select {
+    SELECT length(a||'x'), count(*) FROM t GROUP BY a||'x' ORDER BY 1;
+}
+expect {
+    2|1
+    2|2
+}
+
+@setup schema
+test having-wraps-the-group-by-expression {
+    SELECT count(*) FROM t GROUP BY a+0 HAVING abs(a+0) > 1;
+}
+expect {
+    2
+}
+
+@setup schema
+test having-wraps-the-group-by-expression-with-no-select-reference {
+    SELECT count(*) FROM t GROUP BY a+0 HAVING (a+0)*2 IS NOT NULL ORDER BY 1;
+}
+expect {
+    1
+    2
+}
+
+@setup schema
+test order-by-wraps-the-group-by-expression {
+    SELECT count(*) FROM t GROUP BY a+0 ORDER BY -(a+0);
+}
+expect {
+    2
+    1
+}
+
+@setup schema
+test select-wraps-the-group-by-expression-alongside-a-bare-column {
+    SELECT abs(a+0), b FROM t GROUP BY a+0 ORDER BY 1;
+}
+expect {
+    1|10
+    2|20
+}
+
+@setup schema
+test select-wraps-two-group-by-expressions {
+    SELECT abs(a+0), abs(b+0) FROM t GROUP BY a+0, b+0 ORDER BY 1, 2;
+}
+expect {
+    1|10
+    2|20
+    2|30
+}
+
+@setup schema
+test distinct-over-a-wrapped-group-by-expression {
+    SELECT DISTINCT abs(a+0) FROM t GROUP BY a+0 ORDER BY 1;
+}
+expect {
+    1
+    2
+}
+
+@setup schema
+test subquery-selects-a-wrapped-group-by-expression {
+    SELECT g FROM (SELECT abs(a+0) AS g FROM t GROUP BY a+0) ORDER BY 1;
+}
+expect {
+    1
+    2
+}
+
+setup nulls {
+    CREATE TABLE t(a, b);
+    INSERT INTO t VALUES (1, 10), (2, 20), (2, 30), (NULL, 40);
+}
+
+@setup nulls
+test select-wraps-the-group-by-expression-with-a-null-group {
+    SELECT abs(a+0), count(*) FROM t GROUP BY a+0 ORDER BY 1;
+}
+expect {
+    |1
+    1|1
+    2|2
+}


### PR DESCRIPTION
## Description

A GROUP BY key that is an expression comes back NULL whenever the SELECT item is not *exactly* that expression. Wrapping it in anything at all breaks it.

```sql
CREATE TABLE t(a); INSERT INTO t VALUES(1),(2),(2);

SELECT a+0,      count(*) FROM t GROUP BY a+0;   -- 1|1  2|2   correct
SELECT abs(a+0), count(*) FROM t GROUP BY a+0;   --  |1   |2   should be 1|1 2|2
SELECT (a+0)*2,  count(*) FROM t GROUP BY a+0;   --  |1   |2   should be 2|1 4|2

SELECT count(*) FROM t GROUP BY a+0 HAVING abs(a+0) > 1;  -- no rows, should be 2
SELECT count(*) FROM t GROUP BY a+0 ORDER BY -(a+0);      -- wrong order
```

`collect_non_aggregate_expressions` decides whether a key has to be read back out of the sorter by comparing it against each result column *as a whole*. `abs(a+0)` is not `a+0`, so the key was never cached, and `a` was re-read from the base cursor, which is exhausted by the time the group row is emitted. `collect_result_columns` had meanwhile stopped descending into `a+0`, on the assumption the key covered it, so nothing else materialized `a` either. HAVING and ORDER BY were never checked for the key at all.

Now I look for the key anywhere inside the SELECT list, HAVING and ORDER BY instead of only at the top level. Nothing downstream needed changing, because `translate_expr` already consults the register cache at every node.

The EXPLAIN diff states it most plainly. For `SELECT abs(a+0) FROM t GROUP BY a+0`, sqlite puts two columns in the group-by sorter and reads `a` back from the pseudo cursor:

```
MakeRecord     8     2     10          r[10]=mkrec(r[8..9])
...
Column         2     1     7           r[7]=t.a          <- pseudo cursor
```

turso put one in, then read the table cursor:

```
MakeRecord     8     1     7           r[7]=mkrec(r[8..8])
...
Column         2     0     14          r[14]=t.a         <- table cursor, exhausted
```

## Motivation and context

I found this running generated SQL against sqlite3 and turso and diffing the output.

The oracle is sqlite3 3.51.0: same SQL to both engines, results compared exactly, error text normalised to "did it error at all". I ran 5935 scalar-expression cases and 3373 statement-level cases, then built 670 cases around this specific shape once I understood it. Those 670 went from 559 mismatches to 0. The other two corpora are unchanged by this patch, so nothing regressed; their remaining mismatches are unrelated and I have not touched them.

Scope: this covers keys appearing anywhere in the SELECT list, HAVING and ORDER BY expressions themselves. A key referenced from inside a *subquery* in HAVING or ORDER BY is still wrong, but that is a different bug and already filed as #8221, where the subquery reads the base cursor while the group-output subroutine runs. I tried covering it here by descending into subquery bodies as well and it changed nothing, which is what made me go and find #8221, so I left that path alone.

Also run: 14317 conformance tests pass, 2401 `turso_core` unit tests, 1286 integration tests, `cargo clippy --all-features --all-targets` clean, `cargo fmt` clean.

The new tests fail 18/19 with the source change reverted and the test file kept. The one that still passes is the deliberate guard for `SELECT a+0 ... GROUP BY a+0`, which already worked and should stay working. Every expected value in the .sqltest was taken from real sqlite3 output, not from turso.

## Description of AI Usage

Written with Claude Code: it ran the differential harness, narrowed the failure to the top-level-only comparison in `collect_non_aggregate_expressions`, and drafted the patch and the test file. I directed it, checked the bytecode evidence against sqlite, and verified the before/after by reverting only the source and re-running.
