### PR TITLE
postgres: support WITHIN GROUP aggregates

### DIFF
--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -198,7 +198,7 @@ INTEGER. Unknown type names pass through as custom types.
 | unnest/array_agg | 🟡 Partial | array_agg works; unnest is not implemented |
 | Upsert (INSERT ... ON CONFLICT DO ...) | ✅ Supported | DO NOTHING and DO UPDATE SET ... (with EXCLUDED and conflict targets) |
 | Window functions | 🟡 Partial | Aggregate window functions (COUNT/SUM/AVG/MIN/MAX OVER), row_number, PARTITION BY/ORDER BY, frame clauses, and named WINDOW clauses work; rank, dense_rank, lag, lead, etc. are not implemented |
-| WITHIN GROUP clause | ❌ Not supported | Silently dropped; ordered-set aggregates (percentile_cont) missing |
+| WITHIN GROUP clause | 🟡 Partial | Supports mode(), percentile_cont(), and percentile_disc() with one ORDER BY expression; DESC and explicit NULLS ordering are not supported |
 | WITH ORDINALITY clause | ❌ Not supported | |
 | WITH queries (Common Table Expressions) | ✅ Supported | Including WITH RECURSIVE; MATERIALIZED hints accepted |
 | Writable WITH queries (Common Table Expressions) | ❌ Not supported | "CTE query is not a SELECT statement" |

--- a/postgres/conformance/pg-sqltests/functions.sqltest
+++ b/postgres/conformance/pg-sqltests/functions.sqltest
@@ -210,3 +210,21 @@ test pg-get-expr-check-constraint {
 expect {
     val > 0
 }
+
+test percentile-cont-within-group {
+    CREATE TABLE demo (value int);
+    INSERT INTO demo (value) VALUES (1), (2);
+    SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY value) FROM demo;
+}
+expect {
+    1.5
+}
+
+test mode-within-group {
+    CREATE TABLE demo (value int);
+    INSERT INTO demo VALUES (2), (2), (1), (1);
+    SELECT mode() WITHIN GROUP (ORDER BY value) FROM demo;
+}
+expect {
+    1
+}

--- a/postgres/parser/translator.rs
+++ b/postgres/parser/translator.rs
@@ -3196,12 +3196,19 @@ impl PostgreSQLTranslator {
             }
         }
 
+        let translated_order = self.translate_order_by(&func_call.agg_order)?;
+        let (order_by, within_group) = if func_call.agg_within_group {
+            (vec![], translated_order)
+        } else {
+            (translated_order, vec![])
+        };
+
         Ok(ast::Expr::FunctionCall {
             name: ast::Name::from_string(func_name),
             distinctness,
             args,
-            order_by: vec![],
-            within_group: vec![],
+            order_by,
+            within_group,
             filter_over,
         })
     }
@@ -6563,6 +6570,76 @@ mod tests {
         } else {
             panic!("Expected CreateView");
         }
+    }
+
+    #[test]
+    fn test_function_within_group_order_is_translated() {
+        let translator = PostgreSQLTranslator::new();
+        let sql = "SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY x) FROM test";
+        let parsed = crate::parse(sql).unwrap();
+        let translated = translator.translate(&parsed).unwrap();
+
+        let ast::Stmt::Select(select) = translated else {
+            panic!("expected select statement");
+        };
+        let ast::OneSelect::Select { columns, .. } = &select.body.select else {
+            panic!("expected select body");
+        };
+        let ast::ResultColumn::Expr(expr, _) = &columns[0] else {
+            panic!("expected result column");
+        };
+        let ast::Expr::FunctionCall {
+            order_by,
+            within_group,
+            ..
+        } = expr.as_ref()
+        else {
+            panic!("expected function call");
+        };
+        let [sorted_column] = within_group.as_slice() else {
+            panic!("expected single sorted column");
+        };
+        let ast::Expr::Id(name) = sorted_column.expr.as_ref() else {
+            panic!("expected id");
+        };
+
+        assert_eq!(name.as_str(), "x");
+        assert!(order_by.is_empty());
+    }
+
+    #[test]
+    fn test_function_argument_order_is_translated() {
+        let translator = PostgreSQLTranslator::new();
+        let sql = "SELECT array_agg(x ORDER BY y) FROM test";
+        let parsed = crate::parse(sql).unwrap();
+        let translated = translator.translate(&parsed).unwrap();
+
+        let ast::Stmt::Select(select) = translated else {
+            panic!("expected select statement");
+        };
+        let ast::OneSelect::Select { columns, .. } = &select.body.select else {
+            panic!("expected select body");
+        };
+        let ast::ResultColumn::Expr(expr, _) = &columns[0] else {
+            panic!("expected result column");
+        };
+        let ast::Expr::FunctionCall {
+            order_by,
+            within_group,
+            ..
+        } = expr.as_ref()
+        else {
+            panic!("expected function call");
+        };
+        let [sorted_column] = order_by.as_slice() else {
+            panic!("expected single sorted column");
+        };
+        let ast::Expr::Id(name) = sorted_column.expr.as_ref() else {
+            panic!("expected id");
+        };
+
+        assert_eq!(name.as_str(), "y");
+        assert!(within_group.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

<!-- 
Please include a summary of the changes and the related issue. 
-->

Fixes the wiring for `WITHIN GROUP` in the Postgres translator. This enables Tursopg to use Turso's existing support for the functions `mode`, `percentile_cont` and `percentile_disc`.

Demonstration of the fix in action:
<img width="1921" height="511" alt="Image" src="https://github.com/user-attachments/assets/4b6035cf-2dbb-41ea-82ec-8340b7957206" />

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->

Queries with `WITHIN GROUP` were previously failing with the error "Parse error: no such function: percentile_cont" because the translator did not pass the necessary values into Turso's `within_group` AST field.

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->

Used GPT 5.6 sol to help with finding the gap for `WITHIN GROUP`. The AI guided my implementation but I wrote the code (other than the `COMPAT.md` changes since I don't know the nuances between Turso's WITHIN GROUP versus Postgres's)
