### PR TITLE
core/mvcc: fix MVCC begin race with blocking checkpoint

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -85,6 +85,19 @@ pub mod tests;
 /// Sentinel value for `MvStore::exclusive_tx` indicating no exclusive transaction is active.
 const NO_EXCLUSIVE_TX: u64 = 0;
 
+/// Whether a caller already holds the blocking checkpoint read guard.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CheckpointReadLockState {
+    NotHeld,
+    Held,
+}
+
+impl CheckpointReadLockState {
+    fn is_held(self) -> bool {
+        matches!(self, Self::Held)
+    }
+}
+
 /// Convert a sequence backing-table row into the exclusive upper bound used by
 /// sync scans. This is intentionally tailored to ascending non-CYCLE sequences,
 /// which is the shape used by AUTOINCREMENT CDC ids.
@@ -5914,8 +5927,81 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         connection: &Connection,
         expected_schema_generation: Option<u64>,
     ) -> Result<TxID> {
+        self.begin_exclusive_tx_with_checkpoint_read_guard(
+            pager,
+            maybe_existing_tx_id,
+            connection,
+            expected_schema_generation,
+            CheckpointReadLockState::NotHeld,
+        )
+    }
+
+    /// Try to acquire the blocking checkpoint read guard for a fresh MVCC
+    /// begin.
+    ///
+    /// Use this only for a fresh MVCC begin that must preserve this order:
+    /// checkpoint gate, pager read mark, MVCC transaction. If this returns
+    /// `CheckpointReadLockState::Held` and the caller fails before handing the
+    /// guard to a `begin_*_with_checkpoint_read_guard` helper, call
+    /// `release_unadopted_checkpoint_read_guard`.
+    ///
+    /// Do not use this for read-to-write upgrades. An existing MVCC
+    /// transaction already owns its checkpoint guard.
+    pub(crate) fn try_acquire_checkpoint_read_guard_for_fresh_mvcc_begin(
+        &self,
+    ) -> Result<CheckpointReadLockState> {
+        if self.experimental_mvcc_passive_checkpoint {
+            return Ok(CheckpointReadLockState::NotHeld);
+        }
+        if !self.blocking_checkpoint_lock.read() {
+            return Err(LimboError::Busy);
+        }
+        Ok(CheckpointReadLockState::Held)
+    }
+
+    /// Release a checkpoint gate acquired by
+    /// `try_acquire_checkpoint_read_guard_for_fresh_mvcc_begin` before MVCC
+    /// has adopted it.
+    ///
+    /// Do not call this after a `begin_*_with_checkpoint_read_guard` helper
+    /// succeeds. At that point the transaction owns the guard and the normal
+    /// transaction finish path releases it.
+    pub(crate) fn release_unadopted_checkpoint_read_guard(&self, guard: CheckpointReadLockState) {
+        if guard.is_held() {
+            self.blocking_checkpoint_lock.unlock();
+        }
+    }
+
+    /// Begin or upgrade a write MVCC transaction, optionally adopting a
+    /// checkpoint gate that the VDBE already acquired.
+    ///
+    /// Ordinary MvStore callers should use `begin_exclusive_tx`. Use this
+    /// helper only when the caller is preserving the fresh-begin order itself:
+    /// checkpoint gate, pager read mark, MVCC transaction. Pass
+    /// `CheckpointReadLockState::NotHeld` for upgrades because the existing
+    /// transaction already owns the gate.
+    pub(crate) fn begin_exclusive_tx_with_checkpoint_read_guard(
+        &self,
+        pager: Arc<Pager>,
+        maybe_existing_tx_id: Option<TxID>,
+        connection: &Connection,
+        expected_schema_generation: Option<u64>,
+        checkpoint_read_guard: CheckpointReadLockState,
+    ) -> Result<TxID> {
         #[cfg(not(any(test, injected_yields)))]
         let _ = connection;
+        turso_assert!(
+            maybe_existing_tx_id.is_none() || !checkpoint_read_guard.is_held(),
+            "checkpoint read guard is only passed for fresh MVCC begins"
+        );
+        turso_assert!(
+            !checkpoint_read_guard.is_held() || !self.experimental_mvcc_passive_checkpoint,
+            "passive MVCC begin must not hold the blocking checkpoint read guard"
+        );
+        turso_assert!(
+            !checkpoint_read_guard.is_held() || pager.holds_read_lock(),
+            "checkpoint read guard must be paired with a pager read mark before MVCC begin"
+        );
         // Existing transactions already hold one blocking-checkpoint read guard
         // from begin_tx() (truncate path only). When upgrading read->write, do not acquire another one.
         let passive = self.experimental_mvcc_passive_checkpoint;
@@ -5928,7 +6014,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         } else {
             None
         };
-        if acquires_checkpoint_guard && !self.blocking_checkpoint_lock.read() {
+        if acquires_checkpoint_guard
+            && !checkpoint_read_guard.is_held()
+            && !self.blocking_checkpoint_lock.read()
+        {
             // If there is a stop-the-world checkpoint in progress, we cannot begin any transaction at all.
             return Err(LimboError::Busy);
         }
@@ -6125,8 +6214,39 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         pager: Arc<Pager>,
         expected_schema_generation: Option<u64>,
     ) -> Result<TxID> {
+        self.begin_tx_with_schema_generation_and_checkpoint_read_guard(
+            pager,
+            expected_schema_generation,
+            CheckpointReadLockState::NotHeld,
+        )
+    }
+
+    /// Begin a read MVCC transaction, optionally adopting a checkpoint gate
+    /// that the VDBE already acquired.
+    ///
+    /// Ordinary MvStore callers should use `begin_tx_with_schema_generation`.
+    /// Use this helper only after
+    /// `try_acquire_checkpoint_read_guard_for_fresh_mvcc_begin` succeeds and
+    /// the caller has successfully pinned the pager read mark. On success, the
+    /// MVCC transaction owns the checkpoint guard. On error, this helper
+    /// releases the guard, but the caller still owns any pager read mark it
+    /// opened.
+    pub(crate) fn begin_tx_with_schema_generation_and_checkpoint_read_guard(
+        &self,
+        pager: Arc<Pager>,
+        expected_schema_generation: Option<u64>,
+        checkpoint_read_guard: CheckpointReadLockState,
+    ) -> Result<TxID> {
+        turso_assert!(
+            !checkpoint_read_guard.is_held() || !self.experimental_mvcc_passive_checkpoint,
+            "passive MVCC begin must not hold the blocking checkpoint read guard"
+        );
+        turso_assert!(
+            !checkpoint_read_guard.is_held() || pager.holds_read_lock(),
+            "checkpoint read guard must be paired with a pager read mark before MVCC begin"
+        );
         let passive = self.experimental_mvcc_passive_checkpoint;
-        if !passive && !self.blocking_checkpoint_lock.read() {
+        if !passive && !checkpoint_read_guard.is_held() && !self.blocking_checkpoint_lock.read() {
             // Stop-the-world truncate checkpoint in progress.
             return Err(LimboError::Busy);
         }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -136,6 +136,96 @@ impl YieldInjector for CommitWriterOnExclusiveAcquireInjector {
     }
 }
 
+struct CheckpointingDeleteAtMvccBeginInjector {
+    writer: Arc<Connection>,
+    fired: AtomicBool,
+}
+
+impl CheckpointingDeleteAtMvccBeginInjector {
+    fn new(writer: Arc<Connection>) -> Arc<Self> {
+        Arc::new(Self {
+            writer,
+            fired: AtomicBool::new(false),
+        })
+    }
+
+    fn fired(&self) -> bool {
+        self.fired.load(Ordering::Acquire)
+    }
+}
+
+impl std::fmt::Debug for CheckpointingDeleteAtMvccBeginInjector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CheckpointingDeleteAtMvccBeginInjector")
+            .field("fired", &self.fired())
+            .finish_non_exhaustive()
+    }
+}
+
+impl YieldInjector for CheckpointingDeleteAtMvccBeginInjector {
+    fn should_yield(&self, _instance_id: u64, selection_key: u64, point: YieldPoint) -> bool {
+        if point != TransactionYieldPoint::BeforeMvccBegin.point()
+            || selection_key != crate::MAIN_DB_ID as u64
+            || self.fired.swap(true, Ordering::AcqRel)
+        {
+            return false;
+        }
+
+        self.writer
+            .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+            .unwrap();
+        self.writer
+            .execute("DELETE FROM keep WHERE id = 1")
+            .unwrap();
+        false
+    }
+}
+
+struct CheckpointingInsertAtMvccBeginInjector {
+    writer: Arc<Connection>,
+    fired: AtomicBool,
+}
+
+impl CheckpointingInsertAtMvccBeginInjector {
+    fn new(writer: Arc<Connection>) -> Arc<Self> {
+        Arc::new(Self {
+            writer,
+            fired: AtomicBool::new(false),
+        })
+    }
+
+    fn fired(&self) -> bool {
+        self.fired.load(Ordering::Acquire)
+    }
+}
+
+impl std::fmt::Debug for CheckpointingInsertAtMvccBeginInjector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CheckpointingInsertAtMvccBeginInjector")
+            .field("fired", &self.fired())
+            .finish_non_exhaustive()
+    }
+}
+
+impl YieldInjector for CheckpointingInsertAtMvccBeginInjector {
+    fn should_yield(&self, _instance_id: u64, selection_key: u64, point: YieldPoint) -> bool {
+        if point != TransactionYieldPoint::BeforeMvccBegin.point()
+            || selection_key != crate::MAIN_DB_ID as u64
+            || self.fired.swap(true, Ordering::AcqRel)
+        {
+            return false;
+        }
+
+        self.writer
+            .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+            .unwrap();
+        self.writer
+            .execute("INSERT INTO keep VALUES (2, zeroblob(50000))")
+            .unwrap();
+        false
+    }
+}
+
 #[derive(Debug)]
 struct FixedFailureInjector {
     remaining: Mutex<rustc_hash::FxHashMap<YieldPoint, LimboError>>,
@@ -3927,6 +4017,415 @@ fn test_running_integrity_check_reprepares_without_schema_cookie_bump() {
         stale_integrity_check.stmt_status(StatementStatusCounter::Reprepare),
         1
     );
+}
+
+#[test]
+fn reader_does_not_pin_read_mark_until_checkpoint_gate_is_available() {
+    use crate::StepResult;
+
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    writer
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+        .unwrap();
+    writer.execute("INSERT INTO t VALUES (1, 'seed')").unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+
+    let checkpoint_injector =
+        FixedYieldInjector::new([CheckpointYieldPoint::BeforePagerCommit.point()]);
+    writer.set_yield_injector(Some(checkpoint_injector.clone()));
+    let mut checkpointing_insert = writer
+        .prepare("INSERT INTO t VALUES (2, 'checkpointed')")
+        .unwrap();
+    let checkpoint_io = checkpointing_insert.get_pager().io.clone();
+    step_until_checkpoint_before_pager_commit_yield(
+        &mut checkpointing_insert,
+        &checkpoint_injector,
+        &checkpoint_io,
+        "insert",
+    );
+
+    let reader = db.connect();
+    let read_mark_probe = FixedYieldInjector::new([TransactionYieldPoint::BeforeMvccBegin.point()]);
+    reader.set_yield_injector(Some(read_mark_probe.clone()));
+    let mut read = reader.prepare("SELECT v FROM t WHERE id = 1").unwrap();
+    assert!(
+        matches!(read.step().unwrap(), StepResult::Yield) && read_mark_probe.is_empty(),
+        "reader should yield before opening its MVCC transaction"
+    );
+    assert!(
+        !reader.get_pager().holds_read_lock(),
+        "reader must not pin a pager read mark before MVCC begin is allowed"
+    );
+
+    match read.step() {
+        Ok(StepResult::Busy) | Err(LimboError::Busy) => {}
+        other => panic!("reader should be Busy before pinning a read mark, got {other:?}"),
+    }
+    assert!(
+        !reader.get_pager().holds_read_lock(),
+        "Busy reader must not leave a pager read mark pinned"
+    );
+    drop(read);
+
+    writer.set_yield_injector(None);
+    step_until_done(&mut checkpointing_insert, &checkpoint_io, "insert");
+}
+
+#[test]
+fn integrity_check_does_not_pin_read_mark_until_checkpoint_gate_is_available() {
+    use crate::StepResult;
+
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    writer
+        .execute("CREATE TABLE keep(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    writer
+        .execute("CREATE TABLE free_me(id INTEGER PRIMARY KEY, v TEXT)")
+        .unwrap();
+    writer
+        .execute("INSERT INTO keep VALUES (1, 'seed')")
+        .unwrap();
+    writer
+        .execute("INSERT INTO free_me VALUES (1, 'soon freed')")
+        .unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+
+    let checkpoint_injector =
+        FixedYieldInjector::new([CheckpointYieldPoint::BeforePagerCommit.point()]);
+    writer.set_yield_injector(Some(checkpoint_injector.clone()));
+    let mut checkpointing_drop = writer.prepare("DROP TABLE free_me").unwrap();
+    let checkpoint_io = checkpointing_drop.get_pager().io.clone();
+    step_until_checkpoint_before_pager_commit_yield(
+        &mut checkpointing_drop,
+        &checkpoint_injector,
+        &checkpoint_io,
+        "drop-table checkpoint",
+    );
+
+    let reader = db.connect();
+    let read_mark_probe = FixedYieldInjector::new([TransactionYieldPoint::BeforeMvccBegin.point()]);
+    reader.set_yield_injector(Some(read_mark_probe.clone()));
+    let mut integrity_check = reader.prepare("PRAGMA integrity_check").unwrap();
+    assert!(
+        matches!(integrity_check.step().unwrap(), StepResult::Yield) && read_mark_probe.is_empty(),
+        "integrity_check should yield before opening its MVCC transaction"
+    );
+    assert!(
+        !reader.get_pager().holds_read_lock(),
+        "integrity_check must not pin a pager read mark before MVCC begin is allowed"
+    );
+
+    match integrity_check.step() {
+        Ok(StepResult::Busy) | Err(LimboError::Busy) => {}
+        other => panic!("integrity_check should be Busy before pinning a read mark, got {other:?}"),
+    }
+    assert!(
+        !reader.get_pager().holds_read_lock(),
+        "Busy integrity_check must not leave a pager read mark pinned"
+    );
+    drop(integrity_check);
+    reader.set_yield_injector(None);
+
+    writer.set_yield_injector(None);
+    step_until_done(
+        &mut checkpointing_drop,
+        &checkpoint_io,
+        "drop-table checkpoint",
+    );
+
+    let rows = get_rows(&reader, "PRAGMA integrity_check");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn integrity_check_does_not_report_freelist_count_mismatch_after_checkpoint_begin_race() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    writer
+        .execute("CREATE TABLE keep(id INTEGER PRIMARY KEY, payload BLOB)")
+        .unwrap();
+    writer
+        .execute("CREATE TABLE trash(id INTEGER PRIMARY KEY, payload BLOB)")
+        .unwrap();
+    writer
+        .execute("INSERT INTO keep VALUES (1, zeroblob(20000))")
+        .unwrap();
+    writer
+        .execute("INSERT INTO trash VALUES (1, zeroblob(20000))")
+        .unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    writer.execute("DELETE FROM trash WHERE id = 1").unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    let old_freelist_count = get_rows(&writer, "PRAGMA freelist_count")[0][0]
+        .as_int()
+        .unwrap();
+    assert!(
+        old_freelist_count > 0,
+        "setup should leave a materialized freelist"
+    );
+
+    let reader = db.connect();
+    let checkpointing_delete = CheckpointingDeleteAtMvccBeginInjector::new(writer.clone());
+    reader.set_yield_injector(Some(checkpointing_delete.clone()));
+    let mut integrity_check = reader.prepare("PRAGMA integrity_check").unwrap();
+    let rows = integrity_check.run_collect_rows().unwrap();
+    reader.set_yield_injector(None);
+    assert!(
+        checkpointing_delete.fired(),
+        "checkpointing delete should run at the MVCC begin boundary"
+    );
+    let new_freelist_count = get_rows(&writer, "PRAGMA freelist_count")[0][0]
+        .as_int()
+        .unwrap();
+    assert!(
+        new_freelist_count > old_freelist_count,
+        "delete checkpoint should increase freelist count: old={old_freelist_count}, new={new_freelist_count}"
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+#[test]
+fn integrity_check_does_not_report_page_never_used_after_checkpoint_begin_race() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    writer
+        .execute("CREATE TABLE keep(id INTEGER PRIMARY KEY, payload BLOB)")
+        .unwrap();
+    writer
+        .execute("INSERT INTO keep VALUES (1, zeroblob(1000))")
+        .unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    let old_page_count = get_rows(&writer, "PRAGMA page_count")[0][0]
+        .as_int()
+        .unwrap();
+
+    let reader = db.connect();
+    let checkpointing_insert = CheckpointingInsertAtMvccBeginInjector::new(writer.clone());
+    reader.set_yield_injector(Some(checkpointing_insert.clone()));
+    let mut integrity_check = reader.prepare("PRAGMA integrity_check").unwrap();
+    let rows = integrity_check.run_collect_rows().unwrap();
+    reader.set_yield_injector(None);
+    assert!(
+        checkpointing_insert.fired(),
+        "checkpointing insert should run at the MVCC begin boundary"
+    );
+    let new_page_count = get_rows(&writer, "PRAGMA page_count")[0][0]
+        .as_int()
+        .unwrap();
+    assert!(
+        new_page_count > old_page_count,
+        "checkpointed insert should grow the database: old={old_page_count}, new={new_page_count}"
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(&rows[0][0].to_string(), "ok");
+}
+
+fn step_until_checkpoint_before_pager_commit_yield(
+    stmt: &mut crate::Statement,
+    injector: &FixedYieldInjector,
+    io: &Arc<dyn IO>,
+    context: &str,
+) {
+    for _ in 0..100_000 {
+        match stmt.step().unwrap() {
+            crate::StepResult::Yield if injector.is_empty() => return,
+            crate::StepResult::IO | crate::StepResult::Yield => io.step().unwrap(),
+            crate::StepResult::Row => {}
+            crate::StepResult::Done => {
+                panic!("{context} completed before BeforePagerCommit yield")
+            }
+            other => panic!("unexpected {context} step before yield: {other:?}"),
+        }
+    }
+    panic!("checkpoint did not reach its guarded write phase");
+}
+
+fn step_until_done(stmt: &mut crate::Statement, io: &Arc<dyn IO>, context: &str) {
+    for _ in 0..100_000 {
+        match stmt.step().unwrap() {
+            crate::StepResult::Done => return,
+            crate::StepResult::Row => {}
+            crate::StepResult::IO | crate::StepResult::Yield => io.step().unwrap(),
+            other => panic!("unexpected {context} step after yield: {other:?}"),
+        }
+    }
+    panic!("{context} did not finish");
+}
+
+#[test]
+fn attached_reader_does_not_pin_read_mark_until_checkpoint_gate_is_available() {
+    use crate::StepResult;
+
+    let db = MvccTestDbNoConn::new_with_random_db_with_opts(DatabaseOpts::new().with_attach(true));
+    let aux_dir = tempfile::TempDir::new().unwrap();
+    let aux_path = aux_dir
+        .path()
+        .join(format!("aux_{}.db", rand::random::<u64>()));
+    let aux_path_str = aux_path.to_str().unwrap().to_string();
+
+    let writer = db.connect();
+    writer
+        .execute(format!("ATTACH '{aux_path_str}' AS aux"))
+        .unwrap();
+    writer
+        .execute("PRAGMA aux.journal_mode = 'experimental_mvcc'")
+        .unwrap();
+    let aux_db_id = writer.get_database_id_by_name("aux").unwrap();
+    let aux_mv_store = writer
+        .mv_store_for_db(aux_db_id)
+        .expect("attached aux database must be MVCC");
+    aux_mv_store.set_checkpoint_threshold(-1);
+    writer
+        .execute("CREATE TABLE aux.t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+        .unwrap();
+    writer
+        .execute("INSERT INTO aux.t VALUES (1, 'seed')")
+        .unwrap();
+    aux_mv_store.set_checkpoint_threshold(0);
+
+    let checkpoint_io = writer
+        .get_pager_from_database_index(&aux_db_id)
+        .unwrap()
+        .io
+        .clone();
+    let checkpoint_injector =
+        FixedYieldInjector::new([CheckpointYieldPoint::BeforePagerCommit.point()]);
+    writer.set_yield_injector(Some(checkpoint_injector.clone()));
+    let mut checkpointing_insert = writer
+        .prepare("INSERT INTO aux.t VALUES (2, 'checkpointed')")
+        .unwrap();
+    step_until_checkpoint_before_pager_commit_yield(
+        &mut checkpointing_insert,
+        &checkpoint_injector,
+        &checkpoint_io,
+        "attached insert",
+    );
+
+    let reader = db.connect();
+    reader
+        .execute(format!("ATTACH '{aux_path_str}' AS aux"))
+        .unwrap();
+    let reader_aux_db_id = reader.get_database_id_by_name("aux").unwrap();
+    let reader_aux_pager = reader
+        .get_pager_from_database_index(&reader_aux_db_id)
+        .unwrap();
+    let read_mark_probe = FixedYieldInjector::new([TransactionYieldPoint::BeforeMvccBegin.point()]);
+    reader.set_yield_injector(Some(read_mark_probe.clone()));
+    let mut read = reader.prepare("SELECT v FROM aux.t WHERE id = 1").unwrap();
+    assert!(
+        matches!(read.step().unwrap(), StepResult::Yield) && read_mark_probe.is_empty(),
+        "attached reader should yield before opening its MVCC transaction"
+    );
+    assert!(
+        !reader_aux_pager.holds_read_lock(),
+        "attached reader must not pin a pager read mark before MVCC begin is allowed"
+    );
+
+    match read.step() {
+        Ok(StepResult::Busy) | Err(LimboError::Busy) => {}
+        other => panic!("attached reader should be Busy before pinning a read mark, got {other:?}"),
+    }
+    assert!(
+        !reader_aux_pager.holds_read_lock(),
+        "Busy attached reader must not leave a pager read mark pinned"
+    );
+    drop(read);
+    reader.set_yield_injector(None);
+
+    writer.set_yield_injector(None);
+    step_until_done(&mut checkpointing_insert, &checkpoint_io, "attached insert");
+}
+
+#[test]
+fn savepoint_does_not_pin_read_mark_until_checkpoint_gate_is_available() {
+    use crate::StepResult;
+
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let writer = db.connect();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    writer
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT UNIQUE)")
+        .unwrap();
+    writer.execute("INSERT INTO t VALUES (1, 'seed')").unwrap();
+    writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+
+    let checkpoint_injector =
+        FixedYieldInjector::new([CheckpointYieldPoint::BeforePagerCommit.point()]);
+    writer.set_yield_injector(Some(checkpoint_injector.clone()));
+    let mut checkpointing_insert = writer
+        .prepare("INSERT INTO t VALUES (2, 'checkpointed')")
+        .unwrap();
+    let checkpoint_io = checkpointing_insert.get_pager().io.clone();
+    step_until_checkpoint_before_pager_commit_yield(
+        &mut checkpointing_insert,
+        &checkpoint_injector,
+        &checkpoint_io,
+        "insert",
+    );
+
+    let reader = db.connect();
+    let read_mark_probe = FixedYieldInjector::new([TransactionYieldPoint::BeforeMvccBegin.point()]);
+    reader.set_yield_injector(Some(read_mark_probe.clone()));
+    let mut savepoint = reader.prepare("SAVEPOINT s").unwrap();
+    assert!(
+        matches!(savepoint.step().unwrap(), StepResult::Yield) && read_mark_probe.is_empty(),
+        "SAVEPOINT should yield before opening its MVCC transaction"
+    );
+    assert!(
+        !reader.get_pager().holds_read_lock(),
+        "SAVEPOINT must not pin a pager read mark before MVCC begin is allowed"
+    );
+
+    match savepoint.step() {
+        Ok(StepResult::Busy) | Err(LimboError::Busy) => {}
+        other => panic!("SAVEPOINT should be Busy before pinning a read mark, got {other:?}"),
+    }
+    assert!(
+        !reader.get_pager().holds_read_lock(),
+        "Busy SAVEPOINT must not leave a pager read mark pinned"
+    );
+    drop(savepoint);
+    reader.set_yield_injector(None);
+
+    writer.set_yield_injector(None);
+    step_until_done(&mut checkpointing_insert, &checkpoint_io, "insert");
+
+    reader.execute("SAVEPOINT s").unwrap();
+    assert!(
+        reader.get_pager().holds_read_lock(),
+        "successful MVCC SAVEPOINT must pin a pager read mark"
+    );
+    reader.execute("ROLLBACK").unwrap();
 }
 
 /// What this test checks: Auto-checkpoint post-commit failure does not invalidate committed transaction visibility on restart.

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -258,9 +258,10 @@ use serializer::EncryptedPayload;
 use serializer::{
     extension_record_len, ExtensionRecord, PortableChangePayload, PortableEndOffsetCtx,
 };
+pub(crate) use serializer::{log_write, LogBufferWrite, LogChunkStream, LogSerializer};
+#[cfg(feature = "conn_raw_api")]
 pub(crate) use serializer::{
-    log_write, LogBufferWrite, LogChunkStream, LogSerializer, ProtoKey, ProtoSint64, ProtoVarint,
-    PROTO_WIRE_LENGTH_DELIMITED, PROTO_WIRE_VARINT,
+    ProtoKey, ProtoSint64, ProtoVarint, PROTO_WIRE_LENGTH_DELIMITED, PROTO_WIRE_VARINT,
 };
 
 /// Logical log size in bytes at which a committing transaction will trigger a checkpoint.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4002,15 +4002,17 @@ pub enum OpTransactionState {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum TransactionYieldPoint {
     BeforeStart,
+    BeforeMvccBegin,
 }
 
 #[cfg(any(test, injected_yields))]
 impl crate::mvcc::yield_hooks::YieldPointMarker for TransactionYieldPoint {
-    const POINT_COUNT: u8 = 1;
+    const POINT_COUNT: u8 = 2;
 
     fn ordinal(self) -> u8 {
         match self {
             TransactionYieldPoint::BeforeStart => 0,
+            TransactionYieldPoint::BeforeMvccBegin => 1,
         }
     }
 }
@@ -4389,6 +4391,19 @@ pub fn op_transaction_inner(
                             // applies to all databases uniformly.
                             let effective_mode =
                                 conn.get_mv_tx().map(|(_, mode)| mode).unwrap_or(*tx_mode);
+                            #[cfg(any(test, injected_yields))]
+                            {
+                                if let Some(IOResult::IO(io)) =
+                                    crate::mvcc::yield_hooks::maybe_inject_io_yield::<(), _>(
+                                        conn.yield_injector().as_ref(),
+                                        0,
+                                        *db as u64,
+                                        TransactionYieldPoint::BeforeMvccBegin,
+                                    )
+                                {
+                                    return Ok(InsnFunctionStepResult::IO(io));
+                                }
+                            }
                             match begin_mvcc_tx(
                                 mv_store,
                                 &pager,
@@ -4486,6 +4501,19 @@ pub fn op_transaction_inner(
                                         return Err(err);
                                     }
                                 };
+                            #[cfg(any(test, injected_yields))]
+                            {
+                                if let Some(IOResult::IO(io)) =
+                                    crate::mvcc::yield_hooks::maybe_inject_io_yield::<(), _>(
+                                        conn.yield_injector().as_ref(),
+                                        0,
+                                        *db as u64,
+                                        TransactionYieldPoint::BeforeMvccBegin,
+                                    )
+                                {
+                                    return Ok(InsnFunctionStepResult::IO(io));
+                                }
+                            }
                             match begin_mvcc_tx(
                                 mv_store,
                                 &pager,
@@ -5048,6 +5076,21 @@ pub fn op_savepoint(
             // before opening the first savepoint so an I/O yield is restartable.
             if let IOResult::IO(io) = load_active_non_main_wal_headers_for_named_savepoint(&conn)? {
                 return Ok(InsnFunctionStepResult::IO(io));
+            }
+            #[cfg(any(test, injected_yields))]
+            {
+                if mv_store.is_some() && conn.get_mv_tx_id().is_none() {
+                    if let Some(IOResult::IO(io)) =
+                        crate::mvcc::yield_hooks::maybe_inject_io_yield::<(), _>(
+                            conn.yield_injector().as_ref(),
+                            0,
+                            crate::MAIN_DB_ID as u64,
+                            TransactionYieldPoint::BeforeMvccBegin,
+                        )
+                    {
+                        return Ok(InsnFunctionStepResult::IO(io));
+                    }
+                }
             }
             conn.with_savepoint_schema_snapshot(
                 |main_schema_snapshot, temp_schema_snapshot, staged_schema_snapshot| {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7,7 +7,9 @@ use crate::error::SQLITE_CONSTRAINT_UNIQUE;
 use crate::function::{AccumulatorFunc, AlterTableFunc, WindowFunc};
 use crate::io::TempFile;
 use crate::mvcc::cursor::{MvccCursorType, NextRowidResult};
-use crate::mvcc::database::{BootstrapState, CheckpointStateMachine, TxID};
+use crate::mvcc::database::{
+    BootstrapState, CheckpointReadLockState, CheckpointStateMachine, TxID,
+};
 use crate::mvcc::MvccClock;
 use crate::numeric::Numeric;
 use crate::schema::{
@@ -4038,8 +4040,13 @@ pub fn op_transaction(
     }
 }
 
-/// Begin an MVCC transaction on the given MvStore using the specified mode.
-/// When `existing_tx_id` is `Some`, upgrades an existing transaction to exclusive.
+/// Begin an MVCC transaction after the caller has already put pager and
+/// checkpoint state in the right shape.
+///
+/// Use `begin_fresh_mvcc_tx` when no MVCC transaction exists yet; it owns the
+/// ordering between the checkpoint gate and pager read mark. Use this helper
+/// directly for read-to-write upgrades, passing the existing transaction id and
+/// `CheckpointReadLockState::NotHeld`.
 fn begin_mvcc_tx(
     mv_store: &MvStore,
     pager: &Arc<Pager>,
@@ -4047,17 +4054,74 @@ fn begin_mvcc_tx(
     existing_tx_id: Option<u64>,
     connection: &Connection,
     expected_schema_generation: Option<u64>,
+    checkpoint_read_guard: CheckpointReadLockState,
 ) -> Result<u64> {
     match mode {
-        TransactionMode::None | TransactionMode::Read | TransactionMode::Concurrent => {
-            mv_store.begin_tx_with_schema_generation(pager.clone(), expected_schema_generation)
-        }
-        TransactionMode::Write => mv_store.begin_exclusive_tx(
+        TransactionMode::None | TransactionMode::Read | TransactionMode::Concurrent => mv_store
+            .begin_tx_with_schema_generation_and_checkpoint_read_guard(
+                pager.clone(),
+                expected_schema_generation,
+                checkpoint_read_guard,
+            ),
+        TransactionMode::Write => mv_store.begin_exclusive_tx_with_checkpoint_read_guard(
             pager.clone(),
             existing_tx_id,
             connection,
             expected_schema_generation,
+            checkpoint_read_guard,
         ),
+    }
+}
+
+/// Start a brand-new MVCC transaction for one pager.
+///
+/// This is the VDBE helper to use when the connection does not already have an
+/// MVCC transaction for the database. It enforces the only safe fresh-begin
+/// order: checkpoint gate, pager read mark, MVCC transaction. That prevents a
+/// reader from pinning a WAL snapshot while a blocking MVCC checkpoint is
+/// already in progress.
+///
+/// Some public maintenance paths, such as schema reparse and raw WAL handling,
+/// enter VDBE with a caller-owned pager read mark already open. In that case
+/// this helper adopts that read mark for the MVCC begin but must leave cleanup
+/// to the caller.
+///
+/// Do not use this for read-to-write upgrades. Those keep the existing MVCC
+/// transaction and should call `begin_mvcc_tx` with `existing_tx_id = Some`.
+fn begin_fresh_mvcc_tx(
+    mv_store: &MvStore,
+    pager: &Arc<Pager>,
+    mode: &TransactionMode,
+    connection: &Connection,
+    expected_schema_generation: Option<u64>,
+) -> Result<u64> {
+    let checkpoint_read_guard =
+        mv_store.try_acquire_checkpoint_read_guard_for_fresh_mvcc_begin()?;
+    let opened_pager_read_tx = !pager.holds_read_lock();
+    if opened_pager_read_tx {
+        if let Err(err) = pager.begin_read_tx() {
+            mv_store.release_unadopted_checkpoint_read_guard(checkpoint_read_guard);
+            return Err(err);
+        }
+    }
+    // MVCC reads must refresh WAL change counters to avoid stale page-cache reads.
+    pager.mvcc_refresh_if_db_changed();
+    match begin_mvcc_tx(
+        mv_store,
+        pager,
+        mode,
+        None,
+        connection,
+        expected_schema_generation,
+        checkpoint_read_guard,
+    ) {
+        Ok(tx_id) => Ok(tx_id),
+        Err(err) => {
+            if opened_pager_read_tx {
+                pager.end_read_tx();
+            }
+            Err(err)
+        }
     }
 }
 
@@ -4357,18 +4421,10 @@ pub fn op_transaction_inner(
                 // 2. Start transaction if needed
                 if let Some(mv_store) = mv_store.as_ref() {
                     if is_secondary_db {
-                        if conn.get_auto_commit() && !conn.is_nested_stmt() {
-                            state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
-                        }
                         // Attached databases don't participate in the connection-level
-                        // transaction state machine above (phase 1), so the pager read
-                        // tx that the main DB path starts on None→Read isn't triggered
-                        // for them. We need it here to pin a consistent WAL snapshot
-                        // for the attached pager's B-tree page reads.
-                        if !pager.holds_read_lock() {
-                            pager.begin_read_tx()?;
-                        }
-                        pager.mvcc_refresh_if_db_changed();
+                        // transaction state machine above, so they must open
+                        // their own pager snapshot after passing the MVCC
+                        // checkpoint gate.
 
                         let current_mv_tx = conn.get_mv_tx_for_db(*db);
                         if current_mv_tx.is_none() {
@@ -4404,22 +4460,21 @@ pub fn op_transaction_inner(
                                     return Ok(InsnFunctionStepResult::IO(io));
                                 }
                             }
-                            match begin_mvcc_tx(
+                            match begin_fresh_mvcc_tx(
                                 mv_store,
                                 &pager,
                                 &effective_mode,
-                                None,
                                 &conn,
                                 None,
                             ) {
                                 Ok(tx_id) => {
                                     conn.set_mv_tx_for_db(*db, Some((tx_id, effective_mode)));
                                     started_secondary_tx = true;
+                                    if conn.get_auto_commit() && !conn.is_nested_stmt() {
+                                        state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
+                                    }
                                 }
-                                Err(err) => {
-                                    pager.end_read_tx();
-                                    return Err(err);
-                                }
+                                Err(err) => return Err(err),
                             }
                         } else if write {
                             // Upgrade: attached DB has a Read/Concurrent tx but the
@@ -4429,17 +4484,15 @@ pub fn op_transaction_inner(
                             if matches!(current_mode, TransactionMode::None | TransactionMode::Read)
                                 && matches!(tx_mode, TransactionMode::Write)
                             {
-                                if let Err(err) = begin_mvcc_tx(
+                                begin_mvcc_tx(
                                     mv_store,
                                     &pager,
                                     tx_mode,
                                     Some(tx_id),
                                     &conn,
                                     None,
-                                ) {
-                                    pager.end_read_tx();
-                                    return Err(err);
-                                }
+                                    CheckpointReadLockState::NotHeld,
+                                )?;
                                 conn.set_mv_tx_for_db(*db, Some((tx_id, *tx_mode)));
                             }
                         }
@@ -4452,18 +4505,16 @@ pub fn op_transaction_inner(
                                 !conn.is_nested_stmt(),
                                 "nested stmt should not begin a new read transaction"
                             );
-                            pager.begin_read_tx()?;
-                            if conn.get_auto_commit() {
-                                state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
-                            }
                         }
-                        // MVCC reads must refresh WAL change counters to avoid stale page-cache reads.
-                        pager.mvcc_refresh_if_db_changed();
                         // In MVCC we don't have write exclusivity, therefore we just need to start a transaction if needed.
                         // Programs can run Transaction twice, first with read flag and then with write flag. So a single txid is enough
                         // for both.
                         let current_mv_tx = program.connection.get_mv_tx_for_db(*db);
                         let has_existing_mv_tx = current_mv_tx.is_some();
+                        if has_existing_mv_tx {
+                            // MVCC reads must refresh WAL change counters to avoid stale page-cache reads.
+                            pager.mvcc_refresh_if_db_changed();
+                        }
 
                         let conn_has_executed_begin_deferred = !has_existing_mv_tx
                             && !program.connection.auto_commit.load(Ordering::SeqCst);
@@ -4471,9 +4522,10 @@ pub fn op_transaction_inner(
                             && *tx_mode == TransactionMode::Concurrent
                         {
                             mark_unlikely();
-                            pager.end_read_tx();
-                            conn.set_tx_state(TransactionState::None);
-                            state.auto_txn_cleanup = TxnCleanup::None;
+                            if started_read_tx {
+                                conn.set_tx_state(TransactionState::None);
+                                state.auto_txn_cleanup = TxnCleanup::None;
+                            }
                             return Err(LimboError::TxError(
                                 "Cannot start CONCURRENT transaction after BEGIN DEFERRED"
                                     .to_string(),
@@ -4494,7 +4546,6 @@ pub fn op_transaction_inner(
                                     Ok(generation) => generation,
                                     Err(err) => {
                                         if started_read_tx {
-                                            pager.end_read_tx();
                                             conn.set_tx_state(TransactionState::None);
                                             state.auto_txn_cleanup = TxnCleanup::None;
                                         }
@@ -4514,11 +4565,10 @@ pub fn op_transaction_inner(
                                     return Ok(InsnFunctionStepResult::IO(io));
                                 }
                             }
-                            match begin_mvcc_tx(
+                            match begin_fresh_mvcc_tx(
                                 mv_store,
                                 &pager,
                                 tx_mode,
-                                None,
                                 &conn,
                                 expected_schema_generation,
                             ) {
@@ -4526,13 +4576,12 @@ pub fn op_transaction_inner(
                                     program
                                         .connection
                                         .set_mv_tx_for_db(*db, Some((tx_id, *tx_mode)));
-                                    if is_secondary_db {
-                                        started_secondary_tx = true;
+                                    if started_read_tx && conn.get_auto_commit() {
+                                        state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
                                     }
                                 }
                                 Err(err) => {
                                     if started_read_tx {
-                                        pager.end_read_tx();
                                         conn.set_tx_state(TransactionState::None);
                                         state.auto_txn_cleanup = TxnCleanup::None;
                                     }
@@ -4558,6 +4607,7 @@ pub fn op_transaction_inner(
                                     Some(tx_id),
                                     &conn,
                                     None,
+                                    CheckpointReadLockState::NotHeld,
                                 ) {
                                     if started_read_tx {
                                         pager.end_read_tx();
@@ -5101,7 +5151,13 @@ pub fn op_savepoint(
                         let tx_id = if let Some(tx_id) = conn.get_mv_tx_id() {
                             tx_id
                         } else {
-                            let tx_id = mv_store.begin_tx(pager.clone())?;
+                            let tx_id = begin_fresh_mvcc_tx(
+                                mv_store,
+                                pager,
+                                &TransactionMode::Read,
+                                &conn,
+                                None,
+                            )?;
                             conn.set_mv_tx(Some((tx_id, TransactionMode::Read)));
                             if matches!(conn.get_tx_state(), TransactionState::None) {
                                 conn.set_tx_state(TransactionState::Read);


### PR DESCRIPTION
## Description

This patch fixes MVCC reader/checkpoint race bugs found by Antithesis.

## Prerequisites

MVCC reads in Turso need two different snapshots to agree with each other.

The pager owns the physical SQLite file view:

```text
pager read mark
  |
  v
which WAL frames / DB file pages this statement reads
```

The MVCC store owns the logical MVCC view:

```text
MVCC transaction
  |
  v
which MVCC versions, root pages, and other metadata this statement should see
```

So for a correct MVCC read, it needs physical B-tree view from pager read mark to match with logical MVCC/header view from MVCC transaction.


Keep in mind that MVCC checkpoint is blocking (for reads and writes), it changes the physical B-tree. It takes versions from the MVCC store and folds them into the SQLite B-tree. 

Since checkpoint is blocking, every reader needs to take a checkpoint read lock. For a fresh reader, the safe order is:

```text
fresh reader:
  acquire checkpoint read gate
  pin pager read mark
  begin MVCC transaction
```

That order means either:


- reader gets checkpoint read gate first:
  checkpoint waits, reader gets one consistent view

- checkpoint gets checkpoint write gate first:
  reader returns Busy before doing any meaningful work

## The bug

Before this patch, fresh MVCC begin did these two things in the wrong order.

Old flow:

```text
reader:
  set connection transaction state to Read
  pin pager read mark

  ... only later ...

  begin MVCC transaction
    this is where we tried to acquire the checkpoint read gate
```

That left a bad window:

```text
reader:      pin pager read mark
             |
             v
             reader now has an old physical B-tree snapshot

             reader has NOT acquired checkpoint read gate yet

checkpoint:  acquire checkpoint write gate
checkpoint:  fold MVCC versions into B-tree
checkpoint:  publish newer roots/header/freelist/database-size
checkpoint:  release checkpoint write gate

reader:      begin MVCC transaction
             |
             v
             reader now sees the newer logical MVCC/header state
```


The broken reader then had mixed state:

- pager read mark: old physical B-tree pages
- MVCC transaction: new logical roots/header/freelist/database-size/other shit

My friend, that cannot be correct.


Integrity check reads physical page layout. If its MVCC/header view says that some pages belong to the database, but its old pager snapshot cannot reach those pages from the old B-tree roots/freelist trunk, it reports those pages as never used.

## Fix

This patch moves the checkpoint gate before the pager read mark for fresh MVCC begins.

New flow:

```text
fresh MVCC begin:
  acquire checkpoint read gate
  pin pager read mark
  begin MVCC transaction
```

The MVCC transaction owns the checkpoint read gate after begin succeeds. Normal transaction cleanup releases it.

Now a checkpoint cannot come in between and change the db metadata.

This patch comes with some regression tests which match the exact antithesis errors: 

```rust

CARGO_BUILD_JOBS=1 cargo test -p turso_core does_not_pin_read_mark_until_checkpoint_gate_is_available --lib -- --nocapture
CARGO_BUILD_JOBS=1 cargo test -p turso_core integrity_check_does_not_report --lib -- --nocapture

thread 'mvcc::database::tests::integrity_check_does_not_report_page_never_used_after_checkpoint_begin_race' panicked at core/mvcc/database/tests.rs:4245:5:
assertion `left == right` failed
  left: "*** in database main ***\nPage 4: never used\nPage 5: never used\nPage 6: never used\nPage 7: never used\nPage 8: never used\nPage 9: never used\nPage 10: never used\nPage 11: never used\nPage 12: never used\nPage 13: never used\nPage 14: never used\nPage 15: never used"
 right: "ok"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test mvcc::database::tests::integrity_check_does_not_report_page_never_used_after_checkpoint_begin_race ... FAILED

thread 'mvcc::database::tests::integrity_check_does_not_report_freelist_count_mismatch_after_checkpoint_begin_race' panicked at core/mvcc/database/tests.rs:4205:5:
assertion `left == right` failed
  left: "*** in database main ***\nFreelist: size is 4 but should be 8"
 right: "ok"
test mvcc::database::tests::integrity_check_does_not_report_freelist_count_mismatch_after_checkpoint_begin_race ... FAILED

failures:

failures:
    mvcc::database::tests::integrity_check_does_not_report_freelist_count_mismatch_after_checkpoint_begin_race
    mvcc::database::tests::integrity_check_does_not_report_page_never_used_after_checkpoint_begin_race
```