### PR TITLE
core: drop arc_with_non_send_sync allows in memory IO constructors

### DIFF
--- a/core/io/memory.rs
+++ b/core/io/memory.rs
@@ -30,11 +30,10 @@ struct WritePause {
 }
 
 impl MemoryIO {
-    #[allow(clippy::arc_with_non_send_sync)]
     pub fn new() -> Self {
         debug!("Using IO backend 'memory'");
         Self {
-            files: Arc::new(Mutex::new(HashMap::default())),
+            files: Arc::new(Mutex::new(HashMap::<String, Arc<MemoryFile>>::default())),
         }
     }
 }

--- a/core/io/memory_yield.rs
+++ b/core/io/memory_yield.rs
@@ -34,12 +34,11 @@ struct Deferred {
 }
 
 impl MemoryYieldIO {
-    #[allow(clippy::arc_with_non_send_sync)]
     pub fn new() -> Self {
         debug!("Using IO backend 'memory_yield'");
         Self {
-            files: Arc::new(Mutex::new(HashMap::default())),
-            pending: Arc::new(Mutex::new(VecDeque::new())),
+            files: Arc::new(Mutex::new(HashMap::<String, Arc<MemoryYieldFile>>::default())),
+            pending: Arc::new(Mutex::new(VecDeque::<Deferred>::new())),
         }
     }
 }


### PR DESCRIPTION
Part of #1750 - first slice, covering `core/io`.

The `arc_with_non_send_sync` allows in the memory IO constructors were not hiding a real Send/Sync problem: `crate::sync::Mutex` is `parking_lot::Mutex`, so `Arc<Mutex<HashMap<String, Arc<MemoryFile>>>>` is perfectly Send + Sync. The lint fired because `HashMap::default()` gave clippy unresolved type parameters at the point of the expression. Naming the map types explicitly (`HashMap::<String, Arc<MemoryFile>>::default()`, `VecDeque::<Deferred>::new()`) removes the ambiguity, and the `#[allow]` attributes are gone.

## Validation

- `cargo clippy -p turso_core`: zero warnings in `memory.rs` / `memory_yield.rs` with the allows removed
- Semantic no-op: the explicit types match the struct field declarations exactly

## Scope

~100 suppressions remain across the repo (ext, cli, benches, bindings, postgres...). I plan to keep going subsystem by subsystem in follow-up PRs - `core/ext` and `cli` next - unless maintainers would rather see bigger batches.
