### PR TITLE
fix dead Discord invite links

### DIFF
--- a/.github/workflows/fossier.yml
+++ b/.github/workflows/fossier.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           registry-api-key: ${{ secrets.FOSSIER_REGISTRY_API_KEY }}
-          contact-url: "https://discord.gg/CnXmpukt4"
+          contact-url: "https://discord.gg/jgjmyYgHwB"

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -242,4 +242,4 @@ MIT
 ## Support
 
 - [GitHub Issues](https://github.com/tursodatabase/turso/issues)
-- [Discord Community](https://discord.gg/turso)
+- [Discord Community](https://tur.so/discord)

--- a/packages/turso-cli/README.md
+++ b/packages/turso-cli/README.md
@@ -147,7 +147,7 @@ Inside the interactive shell, use `.commands` for database operations:
 
 - [GitHub](https://github.com/tursodatabase/turso)
 - [Documentation](https://docs.turso.tech)
-- [Discord](https://discord.gg/turso)
+- [Discord](https://tur.so/discord)
 
 ## License
 


### PR DESCRIPTION
Three Discord links in the repo no longer resolve. Verified against Discord's invite API:

| Link | Location | Status |
| --- | --- | --- |
| `discord.gg/CnXmpukt4` | `.github/workflows/fossier.yml` | `Unknown Invite` |
| `discord.gg/turso` | `bindings/rust/README.md`, `packages/turso-cli/README.md` | `Unknown Invite` |

### The Fossier appeal link

The first one is the more useful fix. Fossier prints `contact-url` to contributors it auto-closes, telling them they can reach the maintainers there to appeal — so the people handed the dead link are exactly the ones with no other way in, and the ones least likely to be in a position to report it.

This points it at the core developers invite already advertised by the badge in the top-level README. That invite is configured never to expire, which matters because `3a0e6f1d7` ("update discord link in fossier workflow") shows this link has already had to be refreshed once; a non-expiring code stops it recurring.

I used the developers server rather than the users community since an appeal should land in front of maintainers.

### The README community links

`discord.gg/turso` looks like a vanity invite that lapsed. Every other README in the repo already links the users community through the `tur.so/discord` redirect, which the project controls and can repoint without another sweep through the docs — so this just brings the last two stragglers in line. No new convention, and the remaining `tur.so/discord` links were confirmed live.

Split into two commits since the appeal path and the docs links are independent concerns.
