### PR TITLE
bindings/c: implement sqlite3_strnicmp

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -750,8 +750,8 @@ Modifiers:
 | sqlite3_create_collation16  | ❌ No      |         |
 | sqlite3_collation_needed    | ❌ No      |         |
 | sqlite3_collation_needed16  | ❌ No      |         |
-| sqlite3_stricmp             | ❌ No      | Stub    |
-| sqlite3_strnicmp            | ❌ No      |         |
+| sqlite3_stricmp             | ✅ Yes     |         |
+| sqlite3_strnicmp            | ✅ Yes     |         |
 
 ### Backup API
 

--- a/bindings/c/include/sqlite3.h
+++ b/bindings/c/include/sqlite3.h
@@ -352,6 +352,8 @@ int sqlite3_blob_close(void *_blob);
 
 int sqlite3_stricmp(const char *_a, const char *_b);
 
+int sqlite3_strnicmp(const char *_a, const char *_b, int _n);
+
 int sqlite3_create_collation_v2(sqlite3 *_db,
                                 const char *_name,
                                 int _enc,

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -3058,15 +3058,40 @@ pub unsafe extern "C" fn sqlite3_stricmp(
     a: *const ffi::c_char,
     b: *const ffi::c_char,
 ) -> ffi::c_int {
-    let a = std::ffi::CStr::from_ptr(a).to_bytes();
-    let b = std::ffi::CStr::from_ptr(b).to_bytes();
-    for (x, y) in a.iter().zip(b.iter()) {
-        let diff = x.to_ascii_lowercase() as ffi::c_int - y.to_ascii_lowercase() as ffi::c_int;
-        if diff != 0 {
-            return diff;
-        }
+    sqlite3_strnicmp(a, b, ffi::c_int::MAX)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sqlite3_strnicmp(
+    a: *const ffi::c_char,
+    b: *const ffi::c_char,
+    n: ffi::c_int,
+) -> ffi::c_int {
+    if a.is_null() {
+        return if b.is_null() { 0 } else { -1 };
+    } else if b.is_null() {
+        return 1;
     }
-    a.len() as ffi::c_int - b.len() as ffi::c_int
+    if n <= 0 {
+        return 0;
+    }
+
+    let mut p_a = a as *const u8;
+    let mut p_b = b as *const u8;
+    let mut rem = n;
+
+    while rem > 0 && *p_a != 0 && p_a.read().eq_ignore_ascii_case(&p_b.read()) {
+        p_a = p_a.add(1);
+        p_b = p_b.add(1);
+        rem -= 1;
+    }
+
+    if rem <= 0 {
+        0
+    } else {
+        (p_a.read().to_ascii_lowercase() as ffi::c_int)
+            - (p_b.read().to_ascii_lowercase() as ffi::c_int)
+    }
 }
 
 #[no_mangle]

--- a/bindings/c/tests/compat/mod.rs
+++ b/bindings/c/tests/compat/mod.rs
@@ -173,6 +173,8 @@ extern "C" {
         tail: *mut *const libc::c_char,
     ) -> i32;
     fn sqlite3_db_handle(stmt: *mut sqlite3_stmt) -> *mut sqlite3;
+    fn sqlite3_stricmp(a: *const libc::c_char, b: *const libc::c_char) -> i32;
+    fn sqlite3_strnicmp(a: *const libc::c_char, b: *const libc::c_char, n: i32) -> i32;
     fn sqlite3_value_int(value: *mut libc::c_void) -> i32;
     fn sqlite3_result_int(context: *mut libc::c_void, val: i32);
     fn sqlite3_initialize() -> i32;
@@ -3768,6 +3770,57 @@ mod tests {
             assert!(null_handle.is_null());
 
             assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
+    fn test_sqlite3_stricmp_and_strnicmp() {
+        unsafe {
+            // NULL handling
+            assert_eq!(sqlite3_stricmp(ptr::null(), ptr::null()), 0);
+            assert_eq!(sqlite3_stricmp(ptr::null(), c"abc".as_ptr()), -1);
+            assert_eq!(sqlite3_stricmp(c"abc".as_ptr(), ptr::null()), 1);
+
+            // NULL precedence over N <= 0 in strnicmp
+            assert_eq!(sqlite3_strnicmp(ptr::null(), c"abc".as_ptr(), 0), -1);
+            assert_eq!(sqlite3_strnicmp(c"abc".as_ptr(), ptr::null(), 0), 1);
+            assert_eq!(sqlite3_strnicmp(ptr::null(), ptr::null(), 0), 0);
+
+            // N <= 0 returns 0 for non-null strings
+            assert_eq!(sqlite3_strnicmp(c"abc".as_ptr(), c"xyz".as_ptr(), 0), 0);
+            assert_eq!(sqlite3_strnicmp(c"abc".as_ptr(), c"xyz".as_ptr(), -1), 0);
+
+            // Case-insensitivity (unbounded vs bounded)
+            assert_eq!(sqlite3_stricmp(c"Hello".as_ptr(), c"hello".as_ptr()), 0);
+            assert_eq!(sqlite3_strnicmp(c"HELLO".as_ptr(), c"hello".as_ptr(), 5), 0);
+
+            // Bounded prefix matching and exact difference on mismatch
+            assert_eq!(
+                sqlite3_strnicmp(c"abcdef".as_ptr(), c"ABCXYZ".as_ptr(), 3),
+                0
+            );
+            assert_eq!(
+                sqlite3_strnicmp(c"abcdef".as_ptr(), c"ABCXYZ".as_ptr(), 4),
+                (b'd' as i32) - (b'x' as i32)
+            );
+            assert_eq!(sqlite3_strnicmp(c"abc".as_ptr(), c"abcd".as_ptr(), 3), 0);
+
+            // Length mismatch return value ('\0' difference)
+            assert_eq!(
+                sqlite3_stricmp(c"abc".as_ptr(), c"abcd".as_ptr()),
+                -(b'd' as i32)
+            );
+            assert_eq!(
+                sqlite3_strnicmp(c"abcd".as_ptr(), c"abc".as_ptr(), 4),
+                b'd' as i32
+            );
+
+            // Non-ASCII byte comparisons (raw byte difference without folding)
+            assert_eq!(sqlite3_stricmp(c"\x80".as_ptr(), c"\x81".as_ptr()), -1);
+            assert_eq!(
+                sqlite3_strnicmp(c"\xc3\xa9".as_ptr(), c"\xc3\x89".as_ptr(), 2),
+                (0xa9_i32) - (0x89_i32)
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

Implement `sqlite3_strnicmp` in the C API and use it as the shared implementation for `sqlite3_stricmp`.

This also fixes `sqlite3_stricmp` compatibility for case-insensitive comparison semantics, including exact mismatch return values, NULL pointer handling, and ASCII-only case folding.

* Add `sqlite3_strnicmp` to the public C header.
* Implement SQLite-compatible comparison semantics for both APIs.
* Update `COMPAT.md` to mark both APIs as supported.
* Add differential compatibility coverage for NULL inputs, comparison bounds, NUL termination, exact byte differences, and non-ASCII bytes.

## Testing

* `cargo fmt --check`
* `cargo test -p turso_sqlite3`
* `cargo test -p turso_sqlite3 --test compat --features sqlite3`
* `cargo clippy -p turso_sqlite3 --all-targets -- --deny warnings`
* `git diff --check`