### PR TITLE
cli: preserve REAL type in database dumps

### DIFF
--- a/cli/app.rs
+++ b/cli/app.rs
@@ -2016,7 +2016,15 @@ impl Limbo {
         match v {
             Value::Null => out.write_all(b"NULL"),
             Value::Numeric(Numeric::Integer(i)) => out.write_all(format!("{i}").as_bytes()),
-            Value::Numeric(Numeric::Float(f)) => write!(out, "{}", f64::from(*f)).map(|_| ()),
+            Value::Numeric(Numeric::Float(_)) => {
+                // Use SQLite-compatible quoting so whole-number REAL values keep
+                // their REAL literal marker (for example, `5.0`) in a dump.
+                let quoted = v.exec_quote();
+                let text = quoted
+                    .to_text()
+                    .expect("quoting a numeric value must produce text");
+                out.write_all(text.as_bytes())
+            }
             Value::Text(s) => {
                 out.write_all(b"'")?;
                 let bytes = s.value.as_bytes();
@@ -2474,6 +2482,19 @@ mod tests {
         assert_eq!(
             normalize_db_path("foo.bar?mode=ro?mode=ro".into()),
             "file:foo.bar%3Fmode=ro?mode=ro"
+        );
+    }
+
+    #[test]
+    fn test_dump_preserves_real_literal_for_whole_number_float() {
+        let mut output = Vec::new();
+
+        Limbo::write_sql_value_from_value(&mut output, &Value::from_f64(5.0)).unwrap();
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "5.0",
+            "a REAL value must retain its REAL literal marker in a dump"
         );
     }
 }


### PR DESCRIPTION
## Description

When `.dump` serialized a REAL whose value was a whole number, the CLI used
the default float display and emitted an integer literal. Restoring that dump
could therefore change the value's storage class in an untyped table.

This change uses Turso's existing SQLite-compatible numeric quoting for REAL
values, so a whole-number REAL is emitted with its decimal marker (for example,
`5.0`). Integer, text, blob, and NULL serialization are unchanged.

## Motivation and context

The issue reproducer creates `u` with `CREATE TABLE u AS SELECT n*r FROM t`.
On the parent commit, `.dump` emitted `VALUES(5)` and a SQLite restore reported
`integer|5`; with this change it emits `VALUES(5.0)` and the restore reports
`real|5.0`, preserving the original type and value.

Fixes #8577

## Validation

- `cargo test -p turso_cli --tests` (51 + 18 + 12 + 3 passed)
- focused REAL-dump regression (1 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

The full workspace clippy invocation reaches the same pre-existing
`core/json/cache.rs:107` warning on the parent and this commit; `make test` and
hosted CI remain to be run by the project workflows.

## Description of AI Usage

Codex assisted with reproducing issue #8577, inspecting the existing numeric
formatter, drafting the focused regression test, and running the validation
commands. The patch was reviewed by the author and an independent non-author
reviewer; the contributor remains responsible for the code and the final PR.
