### PR TITLE
Update SQLITE_MAX_COLUMN to 32767

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -32,7 +32,7 @@ use turso_parser::ast::{self, CompoundSelect, Expr};
 
 /// Maximum number of columns in a result set.
 /// SQLite's default SQLITE_MAX_COLUMN is 2000, with a hard upper limit of 32767.
-const SQLITE_MAX_COLUMN: usize = 2000;
+const SQLITE_MAX_COLUMN: usize = 32767;
 
 #[turso_macros::trace_stack]
 pub fn translate_select(


### PR DESCRIPTION
Increased the maximum number of columns in a result set from 2000 to 32767 to match SQLite's upper limit.

# NOTICE:

In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.



## Description


Increased `SQLITE_MAX_COLUMN` in `core/translate/select.rs` from `2000` to `32767`.


## Motivation and context

Sets the maximum column limit to SQLite's upper hard limit (`32767`), allowing queries with larger result sets and broader schema compatibility.



## Description of AI Usage

AI was used to locate the constant definition and assist with navigating the GitHub PR workflow. All code changes were reviewed before committing.

