### PR TITLE
core/translate: remove formatting allocation in schema

### DIFF
--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1450,10 +1450,19 @@ pub fn translate_create_table(
         p5: 0,
     });
 
-    // TODO: remove format, it sucks for performance but is convenient
     let escaped_tbl_name = escape_sql_string_literal(&normalized_tbl_name);
-    let mut parse_schema_where_clause =
-        format!("tbl_name = '{escaped_tbl_name}' AND type != 'trigger'");
+    let mut parse_schema_where_clause = String::with_capacity(
+        "tbl_name = '' AND type != 'trigger'".len()
+            + escaped_tbl_name.len()
+            + if created_sequence_table {
+                " OR tbl_name = 'sqlite_sequence'".len()
+            } else {
+                0
+            },
+    );
+    parse_schema_where_clause.push_str("tbl_name = '");
+    parse_schema_where_clause.push_str(&escaped_tbl_name);
+    parse_schema_where_clause.push_str("' AND type != 'trigger'");
     if created_sequence_table {
         parse_schema_where_clause.push_str(" OR tbl_name = 'sqlite_sequence'");
     }


### PR DESCRIPTION
This replaces a format! macro with String::with_capacity and push_str to avoid allocating and formatting overhead.

<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->


## Description

This PR addresses a specific `TODO` left in `core/translate/schema.rs` during schema parsing:
`// TODO: remove format, it sucks for performance but is convenient`

It replaces the expensive `format!(...)` macro with a pre-calculated `String::with_capacity(...)` and subsequent `.push_str(...)` calls. 



