### PR TITLE
core/fts: merge segments on the write path past a threshold

### DIFF
--- a/core/benches/fts_benchmark.rs
+++ b/core/benches/fts_benchmark.rs
@@ -484,29 +484,40 @@ fn bench_fts_single_row_commit_churn(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("FTS Single Row Commit Churn");
     group.sample_size(10);
 
-    for commit_count in [64, 256] {
-        group.bench_function(BenchmarkId::new("committed_rows", commit_count), |b| {
-            iter_custom_or_iter!(b, |iters| {
-                let mut total = std::time::Duration::ZERO;
-                for repetition in 0..iters {
-                    let temp_dir = tempfile::tempdir().unwrap();
-                    let db = setup_fts_db(&temp_dir, 0);
-                    let conn = db.connect().unwrap();
-                    let start = std::time::Instant::now();
-                    for id in 0..commit_count {
-                        let id = id as u64 + repetition * commit_count as u64;
-                        conn.execute(format!(
-                            "INSERT INTO docs (id, title, body) VALUES \
+    // merge_threshold 0 disables the write-path auto-merge; the default (32)
+    // pays for merges past the threshold. The pair isolates what B1's
+    // auto-merge costs a single-row-commit workload.
+    for (commit_count, merge_threshold) in [(64, 0), (64, 32), (256, 0), (256, 32)] {
+        group.bench_function(
+            BenchmarkId::new(
+                "committed_rows",
+                format!("{commit_count}_merge_threshold_{merge_threshold}"),
+            ),
+            |b| {
+                iter_custom_or_iter!(b, |iters| {
+                    let mut total = std::time::Duration::ZERO;
+                    for repetition in 0..iters {
+                        let temp_dir = tempfile::tempdir().unwrap();
+                        let db = setup_fts_db(&temp_dir, 0);
+                        let conn = db.connect().unwrap();
+                        conn.execute(format!("PRAGMA fts_merge_threshold = {merge_threshold}"))
+                            .unwrap();
+                        let start = std::time::Instant::now();
+                        for id in 0..commit_count {
+                            let id = id as u64 + repetition * commit_count as u64;
+                            conn.execute(format!(
+                                "INSERT INTO docs (id, title, body) VALUES \
                                  ({id}, 'commit {id}', \
                                  'independently committed database document {id}')"
-                        ))
-                        .unwrap();
+                            ))
+                            .unwrap();
+                        }
+                        total += start.elapsed();
                     }
-                    total += start.elapsed();
-                }
-                total
-            });
-        });
+                    total
+                });
+            },
+        );
     }
 
     group.finish();

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -441,6 +441,10 @@ pub struct Connection {
     /// PRAGMA count_changes: when ON, each INSERT, UPDATE and DELETE returns
     /// one row with the number of rows it changed.
     pub(super) count_changes: AtomicBool,
+    /// PRAGMA fts_merge_threshold: number of visible FTS index segments a
+    /// statement flush may leave behind before the write path merges them.
+    /// 0 disables write-path merging.
+    pub(super) fts_merge_threshold: AtomicI64,
     /// SQLite DQS misfeature: when ON (default), unresolved double-quoted identifiers
     /// in DML statements fall back to string literals instead of raising an error.
     pub(super) dqs_dml: AtomicBool,
@@ -3924,6 +3928,14 @@ impl Connection {
 
     pub fn get_dml_require_where(&self) -> bool {
         self.dml_require_where.load(Ordering::SeqCst)
+    }
+
+    pub fn get_fts_merge_threshold(&self) -> i64 {
+        self.fts_merge_threshold.load(Ordering::SeqCst)
+    }
+
+    pub fn set_fts_merge_threshold(&self, value: i64) {
+        self.fts_merge_threshold.store(value, Ordering::SeqCst);
     }
 
     pub fn set_dml_require_where(&self, value: bool) {

--- a/core/database.rs
+++ b/core/database.rs
@@ -2391,6 +2391,7 @@ impl Database {
             vdbe_trace: AtomicBool::new(false),
             dml_require_where: AtomicBool::new(false),
             count_changes: AtomicBool::new(false),
+            fts_merge_threshold: AtomicI64::new(crate::index_method::DEFAULT_FTS_MERGE_THRESHOLD),
             dqs_dml: AtomicBool::new(true),
             sequence_inner_retries: AtomicU64::new(0),
             mv_tx: RwLock::new(None),

--- a/core/index_method/fts/mod.rs
+++ b/core/index_method/fts/mod.rs
@@ -486,6 +486,13 @@ struct FtsShared {
     /// Throwaway index used only to mint `SegmentMeta` values for
     /// synthesized `meta.json` content.
     scratch: Mutex<Option<Index>>,
+    /// Heuristic count of visible segments: bumped by segment-appending
+    /// publishes, reset by merges, reconciled by every full registry scan.
+    /// Only used to decide whether the write-path auto-merge should pay for
+    /// the real scan — never for correctness (the merge recomputes the true
+    /// visible set from its own snapshot). May drift on rollbacks or across
+    /// processes; the next scan or merge corrects it.
+    visible_segment_estimate: AtomicUsize,
     stats: FtsRuntimeStats,
 }
 
@@ -1050,6 +1057,11 @@ pub struct FtsCursor {
     pending_tombstone_rows: Vec<(SegmentId, u32)>,
     /// Row publication in flight (statement flush, control row, or merge).
     publish: Option<PendingPublish>,
+    /// Set when a statement flush published a new segment; tells
+    /// `stage_statement_commit` to consider a write-path merge once the
+    /// flush publication completes. Survives IO yields so the auto-merge
+    /// check resumes exactly once per flushed statement.
+    auto_merge_pending: bool,
     /// Segment ids this transaction published into the shared byte cache;
     /// purged on rollback.
     own_published: Vec<SegmentId>,
@@ -1119,6 +1131,7 @@ impl FtsCursor {
             doc_buffer: Vec::new(),
             pending_tombstone_rows: Vec::new(),
             publish: None,
+            auto_merge_pending: false,
             own_published: Vec::new(),
             state: FtsState::Init,
             opening_for_write: false,
@@ -1848,6 +1861,11 @@ impl FtsCursor {
                             );
                         }
                         self.snapshot_loaded = true;
+                        // A full scan is ground truth for the auto-merge
+                        // trigger heuristic; reconcile any drift.
+                        self.shared
+                            .visible_segment_estimate
+                            .store(self.segments.len(), Ordering::Relaxed);
                     }
                     self.ensure_searcher()?;
                     self.state = FtsState::Ready;
@@ -2114,11 +2132,17 @@ impl FtsCursor {
             PublishApply::AppendSegment(new_segment) => {
                 if let Some(segment) = new_segment {
                     self.segments.push(segment);
+                    self.shared
+                        .visible_segment_estimate
+                        .fetch_add(1, Ordering::Relaxed);
                 }
                 self.invalidate_snapshot_view();
             }
             PublishApply::ReplaceSegments(segments) => {
                 self.segments = segments;
+                self.shared
+                    .visible_segment_estimate
+                    .store(self.segments.len(), Ordering::Relaxed);
                 self.invalidate_snapshot_view();
             }
         }
@@ -2233,6 +2257,132 @@ impl FtsCursor {
         Ok(())
     }
 
+    /// Which visible segments the write-path merge should rewrite (B2):
+    /// - a segment at least half tombstoned is always a candidate —
+    ///   rewriting reclaims its dead space no matter how big it is;
+    /// - otherwise candidates are every clean segment at or below the
+    ///   smallest size layer holding at least two of them, so one huge
+    ///   segment is not rewritten on every trigger.
+    ///
+    /// Returns an empty set when nothing is worth rewriting (no pair of
+    /// mergeable clean segments and no tombstone-heavy segment).
+    fn auto_merge_candidates(&self) -> HashSet<SegmentId> {
+        /// ParadeDB-style size layers. Segments at or past the last
+        /// boundary never merge on size grounds.
+        const FTS_MERGE_LAYER_BYTES: [u64; 4] = [100 << 10, 1 << 20, 100 << 20, 1 << 30];
+        fn segment_bytes(segment: &LoadedSegment) -> u64 {
+            segment.descriptor.files.iter().map(|file| file.size).sum()
+        }
+
+        let mut candidates: HashSet<SegmentId> = self
+            .segments
+            .iter()
+            .filter(|segment| {
+                segment.descriptor.max_doc > 0
+                    && segment.deleted.len() as u64 * 2 >= u64::from(segment.descriptor.max_doc)
+            })
+            .map(LoadedSegment::id)
+            .collect();
+        for ceiling in FTS_MERGE_LAYER_BYTES {
+            let group: Vec<SegmentId> = self
+                .segments
+                .iter()
+                .filter(|segment| {
+                    !candidates.contains(&segment.id()) && segment_bytes(segment) <= ceiling
+                })
+                .map(LoadedSegment::id)
+                .collect();
+            if group.len() >= 2 {
+                candidates.extend(group);
+                return candidates;
+            }
+        }
+        // No clean tier is mergeable; rewriting only pays off if a
+        // tombstone-heavy segment reclaims space.
+        candidates
+    }
+
+    /// After a statement flush published a new segment, merge the visible
+    /// set down if it exceeds the connection's `fts_merge_threshold`. Runs
+    /// inside the same transaction, under the same lease and admissibility
+    /// rules as OPTIMIZE — so a refused lease (`Busy` /
+    /// `WriteWriteConflict`) skips the merge silently: a writer must never
+    /// fail because maintenance was contended.
+    fn try_auto_merge(&mut self) -> Result<IOResult<()>> {
+        // Re-entry after an IO yield inside the merge publication: the
+        // pending flag was already cleared when the merge was staged, so
+        // this only handles yields from the snapshot scan below.
+        let Some(conn) = self.connection.as_ref().and_then(Weak::upgrade) else {
+            self.auto_merge_pending = false;
+            return Ok(IOResult::Done(()));
+        };
+        let threshold = conn.get_fts_merge_threshold();
+        if threshold <= 0 {
+            self.auto_merge_pending = false;
+            return Ok(IOResult::Done(()));
+        }
+        // Cheap pre-check: below the threshold, a flushed statement must pay
+        // nothing beyond this load — the estimate keeps the insert fast path
+        // scan-free. Over-estimates cost one wasted scan; under-estimates
+        // delay the merge until the next reconciling scan.
+        if self
+            .shared
+            .visible_segment_estimate
+            .load(Ordering::Relaxed)
+            .max(self.segments.len())
+            <= threshold as usize
+        {
+            self.auto_merge_pending = false;
+            return Ok(IOResult::Done(()));
+        }
+        // The insert fast path stops after format detection; counting the
+        // visible set needs the full registry scan (resumable on IO).
+        return_if_io!(self.ensure_snapshot_loaded());
+        if self.segments.len() <= threshold as usize {
+            self.auto_merge_pending = false;
+            return Ok(IOResult::Done(()));
+        }
+        match self.acquire_mvcc_maintenance_lease() {
+            Ok(()) => {}
+            Err(LimboError::Busy | LimboError::WriteWriteConflict) => {
+                tracing::debug!("FTS auto-merge: lease contended, skipping");
+                self.auto_merge_pending = false;
+                return Ok(IOResult::Done(()));
+            }
+            Err(err) => return Err(err),
+        }
+        if let Some((mv_store, tx_id, index_id)) = self.mvcc_index_id(
+            &conn,
+            self.database_id
+                .ok_or_else(|| LimboError::InternalError("FTS database id not set".into()))?,
+        )? {
+            match mv_store.check_index_method_merge_admissible(tx_id, index_id) {
+                Ok(()) => {}
+                Err(LimboError::Busy | LimboError::WriteWriteConflict) => {
+                    tracing::debug!("FTS auto-merge: deleter overlap, skipping");
+                    self.auto_merge_pending = false;
+                    return Ok(IOResult::Done(()));
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        // Tiered candidacy: rewrite the small tier and tombstone-heavy
+        // segments, never a big clean segment on every trigger.
+        let candidates = self.auto_merge_candidates();
+        if candidates.is_empty() {
+            tracing::debug!("FTS auto-merge: no tier is worth rewriting, skipping");
+            self.auto_merge_pending = false;
+            return Ok(IOResult::Done(()));
+        }
+        self.stage_merge_of_segments(&candidates)?;
+        // Clear before driving: a yield inside the publication resumes
+        // through `stage_statement_commit`'s is_publishing branch, which
+        // must not evaluate the trigger again.
+        self.auto_merge_pending = false;
+        return_if_io!(self.drive_publish());
+        Ok(IOResult::Done(()))
+    }
+
     /// Complete any in-flight or due batch publication before a mutation.
     /// The VDBE retries the current instruction when an operation returns
     /// `IOResult::IO`, so this must finish before Tantivy state changes.
@@ -2340,6 +2490,7 @@ impl FtsCursor {
         self.doc_buffer.clear();
         self.pending_tombstone_rows.clear();
         self.publish = None;
+        self.auto_merge_pending = false;
         self.segments.clear();
         self.snapshot_loaded = false;
         self.scan_descriptors.clear();
@@ -3212,7 +3363,14 @@ impl IndexMethodCursor for FtsCursor {
                 self.pending_op_count()
             );
             self.stage_flush()?;
+            self.auto_merge_pending = matches!(
+                self.publish.as_ref().map(|publish| &publish.apply),
+                Some(PublishApply::AppendSegment(Some(_)))
+            );
             return_if_io!(self.drive_publish());
+        }
+        if self.auto_merge_pending {
+            return_if_io!(self.try_auto_merge());
         }
         // This cursor's statement-scope writes are staged; it never flushes
         // again, so a later statement's cursor may write this index.

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -27,6 +27,12 @@ pub mod toy_vector_sparse_ivf;
 pub const BACKING_BTREE_INDEX_METHOD_NAME: &str = "backing_btree";
 pub const TOY_VECTOR_SPARSE_IVF_INDEX_METHOD_NAME: &str = "toy_vector_sparse_ivf";
 
+/// Default for `PRAGMA fts_merge_threshold`: the number of visible FTS
+/// segments a statement flush may leave behind before the write path merges
+/// them. Lives here (not in the feature-gated `fts` module) because the
+/// connection setting exists regardless of the feature.
+pub const DEFAULT_FTS_MERGE_THRESHOLD: i64 = 32;
+
 /// index method "entry point" which can create attachment of the method to the table with given configuration
 /// (this trait acts like a "factory")
 pub trait IndexMethod: std::fmt::Debug + Send + Sync {

--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -190,6 +190,10 @@ pub fn pragma_for(pragma: &PragmaName) -> Pragma {
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["mvcc_group_commit"],
         ),
+        PragmaName::FtsMergeThreshold => Pragma::new(
+            PragmaFlags::NoColumns1 | PragmaFlags::Result0,
+            &["fts_merge_threshold"],
+        ),
         ForeignKeys => Pragma::new(
             PragmaFlags::NoColumns1 | PragmaFlags::Result0,
             &["foreign_keys"],

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -696,6 +696,16 @@ fn update_pragma(
             connection.set_mvcc_group_commit(parse_pragma_enabled(&value))?;
             Ok(TransactionMode::None)
         }
+        PragmaName::FtsMergeThreshold => {
+            let threshold = match parse_signed_number(&value)? {
+                Value::Numeric(Numeric::Integer(size)) if size >= 0 => size,
+                _ => bail_parse_error!(
+                    "fts_merge_threshold must be 0 (disabled) or a positive integer"
+                ),
+            };
+            connection.set_fts_merge_threshold(threshold);
+            Ok(TransactionMode::None)
+        }
         PragmaName::ForeignKeys => {
             let enabled = parse_pragma_enabled(&value);
             connection.set_foreign_keys_enabled(enabled);
@@ -1635,6 +1645,14 @@ fn query_pragma(
             let enabled = connection.mvcc_group_commit()?;
             let register = program.alloc_register();
             program.emit_int(enabled as i64, register);
+            program.emit_result_row(register, 1);
+            program.add_pragma_result_column(pragma.to_string());
+            Ok(TransactionMode::None)
+        }
+        PragmaName::FtsMergeThreshold => {
+            let threshold = connection.get_fts_merge_threshold();
+            let register = program.alloc_register();
+            program.emit_int(threshold, register);
             program.emit_result_row(register, 1);
             program.add_pragma_result_column(pragma.to_string());
             Ok(TransactionMode::None)

--- a/sqlite/parser/src/ast.rs
+++ b/sqlite/parser/src/ast.rs
@@ -1963,6 +1963,10 @@ pub enum PragmaName {
     /// Sets or queries whether concurrent MVCC commits batch their logical-log
     /// appends behind a single fsync.
     MvccGroupCommit,
+    /// Sets or queries the number of visible FTS index segments a statement
+    /// flush may leave behind before the write path merges them. 0 disables
+    /// write-path merging.
+    FtsMergeThreshold,
     /// List all available types (built-in and custom)
     ListTypes,
     /// Deprecated no-op: control whether callback is invoked for empty result sets

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -6237,3 +6237,374 @@ fn multiprocess_shared_cache_serves_snapshot_consistent_pages() {
         );
     }
 }
+
+/// B1 write-path auto-merge: single-row autocommit inserts must not let the
+/// visible segment set grow past `PRAGMA fts_merge_threshold` by more than
+/// the one segment the triggering statement itself appends. Runs in both
+/// WAL and MVCC modes (the maintenance lease is a no-op in WAL).
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_auto_merge_bounds_segment_count() {
+    for mvcc in [false, true] {
+        let tmp_db = TempDatabase::builder()
+            .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+            .with_mvcc(mvcc)
+            .build();
+        let conn = tmp_db.connect_limbo();
+        conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+            .unwrap();
+        conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+            .unwrap();
+        conn.execute("PRAGMA fts_merge_threshold = 4").unwrap();
+        assert_eq!(
+            limbo_exec_rows(&conn, "PRAGMA fts_merge_threshold"),
+            vec![vec![rusqlite::types::Value::Integer(4)]]
+        );
+
+        const ROWS: i64 = 30;
+        for id in 0..ROWS {
+            conn.execute(format!("INSERT INTO docs VALUES ({id}, 'common doc {id}')"))
+                .unwrap();
+        }
+
+        let stats = fts_stats_in_txn(&tmp_db, &conn, "docs", "docs_fts");
+        let segment_count = stats.segment_count.expect("snapshot must be loaded");
+        assert!(
+            segment_count <= 5,
+            "auto-merge must keep the visible set at threshold + 1 at most, \
+             got {segment_count} segments (mvcc={mvcc})"
+        );
+
+        // Every document still matches exactly once through the merged view.
+        assert_eq!(
+            limbo_exec_rows(
+                &conn,
+                "SELECT count(*) FROM docs WHERE fts_match(body, 'common')"
+            ),
+            vec![vec![rusqlite::types::Value::Integer(ROWS)]],
+            "mvcc={mvcc}"
+        );
+    }
+}
+
+/// B1: a merge-threshold of 0 disables the write path merge entirely — each
+/// autocommit insert keeps appending its own segment.
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_auto_merge_disabled_by_zero_threshold() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    conn.execute("PRAGMA fts_merge_threshold = 0").unwrap();
+    for id in 0..12 {
+        conn.execute(format!("INSERT INTO docs VALUES ({id}, 'plain doc {id}')"))
+            .unwrap();
+    }
+    assert_eq!(
+        fts_stats_in_txn(&tmp_db, &conn, "docs", "docs_fts").segment_count,
+        Some(12),
+        "threshold 0 must leave one segment per single-row insert"
+    );
+    assert!(
+        conn.execute("PRAGMA fts_merge_threshold = -1").is_err(),
+        "negative thresholds must be rejected"
+    );
+}
+
+/// B1: a concurrent transaction holding the maintenance lease makes the
+/// write-path merge skip silently — the writer's inserts must succeed, and
+/// the deferred merge happens on a later, uncontended insert.
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_auto_merge_skips_when_lease_contended() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .with_mvcc(true)
+        .build();
+    let writer = tmp_db.connect_limbo();
+    let merger = tmp_db.connect_limbo();
+
+    writer
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    writer
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    writer.execute("PRAGMA fts_merge_threshold = 2").unwrap();
+    for id in 0..3 {
+        writer
+            .execute(format!("INSERT INTO docs VALUES ({id}, 'early doc {id}')"))
+            .unwrap();
+    }
+
+    // The merger's open transaction holds the maintenance lease.
+    merger.execute("BEGIN CONCURRENT").unwrap();
+    merger.execute("OPTIMIZE INDEX docs_fts").unwrap();
+
+    // Every insert is past the threshold, so each one attempts the merge;
+    // the held lease must make it skip, never fail the writer.
+    for id in 10..16 {
+        writer
+            .execute(format!("INSERT INTO docs VALUES ({id}, 'later doc {id}')"))
+            .unwrap_or_else(|e| {
+                panic!("a contended auto-merge must skip, not fail the writer: {e}")
+            });
+    }
+    merger.execute("COMMIT").unwrap();
+
+    // The lease is free again: the next insert merges everything down.
+    writer
+        .execute("INSERT INTO docs VALUES (100, 'final doc')")
+        .unwrap();
+    let fresh = tmp_db.connect_limbo();
+    let stats = fts_stats_in_txn(&tmp_db, &fresh, "docs", "docs_fts");
+    let segment_count = stats.segment_count.expect("snapshot must be loaded");
+    assert!(
+        segment_count <= 3,
+        "the deferred merge must collapse the backlog, got {segment_count} segments"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &fresh,
+            "SELECT count(*) FROM docs WHERE fts_match(body, 'doc')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(10)]],
+        "every document must match exactly once after skipped and deferred merges"
+    );
+}
+
+/// B2 helper: build one large (>100KB) merged segment from `rows` documents
+/// with wide vocabulary, then return the connection. The follow-up OPTIMIZE
+/// compacts the batch flushes into a single segment.
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+fn fts_build_large_segment(conn: &Arc<turso_core::Connection>, rows: usize) {
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    let mut sql = String::from("INSERT INTO docs VALUES ");
+    for id in 0..rows {
+        if id > 0 {
+            sql.push(',');
+        }
+        sql.push_str(&format!(
+            "({id}, 'bulk document number{id} vocab{} vocab{} filler{} extra{} common corpus text')",
+            id * 7 % 3000,
+            id * 13 % 3000,
+            id * 17 % 3000,
+            id * 19 % 3000,
+        ));
+    }
+    conn.execute(sql).unwrap();
+    conn.execute("OPTIMIZE INDEX docs_fts").unwrap();
+}
+
+/// B2 tiered candidacy: the write-path merge must only rewrite the small
+/// tier — one large segment plus many single-row segments merge down to
+/// exactly two segments (the untouched large one and the merged smalls),
+/// not one.
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_auto_merge_spares_large_segments() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+    fts_build_large_segment(&conn, 3000);
+    let stats = fts_stats_in_txn(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(stats.segment_count, Some(1));
+    assert!(
+        stats.cached_bytes.unwrap() > 100 * 1024,
+        "premise: the merged segment must exceed the smallest merge layer \
+         (100KB), got {} bytes",
+        stats.cached_bytes.unwrap()
+    );
+
+    conn.execute("PRAGMA fts_merge_threshold = 2").unwrap();
+    for id in 10_000..10_006 {
+        conn.execute(format!("INSERT INTO docs VALUES ({id}, 'tiny doc {id}')"))
+            .unwrap();
+    }
+
+    let stats = fts_stats_in_txn(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(
+        stats.segment_count,
+        Some(2),
+        "the large segment must not be rewritten by the small-tier merge"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT count(*) FROM docs WHERE fts_match(body, 'tiny')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(6)]]
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT count(*) FROM docs WHERE fts_match(body, 'corpus')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(3000)]]
+    );
+}
+
+/// B2 dead-space awareness: a segment that is at least half tombstoned is
+/// picked by the write-path merge even when its size tier would spare it.
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_auto_merge_rewrites_tombstone_heavy_segments() {
+    let tmp_db = TempDatabase::builder()
+        .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+        .build();
+    let conn = tmp_db.connect_limbo();
+    fts_build_large_segment(&conn, 3000);
+    let stats = fts_stats_in_txn(&tmp_db, &conn, "docs", "docs_fts");
+    assert!(
+        stats.cached_bytes.unwrap() > 100 * 1024,
+        "premise: large segment"
+    );
+
+    // Tombstone 60% of the large segment, then trigger the write-path merge
+    // exactly once (the second small insert pushes the count past the
+    // threshold).
+    conn.execute("DELETE FROM docs WHERE id < 1800").unwrap();
+    conn.execute("PRAGMA fts_merge_threshold = 2").unwrap();
+    for id in 10_000..10_002 {
+        conn.execute(format!("INSERT INTO docs VALUES ({id}, 'tiny doc {id}')"))
+            .unwrap();
+    }
+
+    let stats = fts_stats_in_txn(&tmp_db, &conn, "docs", "docs_fts");
+    assert_eq!(
+        stats.segment_count,
+        Some(1),
+        "a >=50% tombstoned segment must be rewritten regardless of its size tier"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT count(*) FROM docs WHERE fts_match(body, 'corpus')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(1200)]],
+        "only the live documents survive the compaction"
+    );
+    assert_eq!(
+        limbo_exec_rows(
+            &conn,
+            "SELECT count(*) FROM docs WHERE fts_match(body, 'tiny')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(2)]]
+    );
+}
+
+/// B3 starvation probe: under a loop of concurrent single-row UPDATEs
+/// (each one a short-lived deleter transaction), an OPTIMIZE issued
+/// repeatedly from another connection must succeed within a bounded number
+/// of attempts — contention refusals are fine, permanent starvation is not.
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_optimize_succeeds_under_concurrent_update_churn() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let tmp_db = Arc::new(
+        TempDatabase::builder()
+            .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
+            .with_mvcc(true)
+            .build(),
+    );
+    let setup = tmp_db.connect_limbo();
+    setup
+        .execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    setup
+        .execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+    for id in 0..40 {
+        setup
+            .execute(format!("INSERT INTO docs VALUES ({id}, 'seed doc {id}')"))
+            .unwrap();
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let mut updaters = Vec::new();
+    // Two updaters on disjoint id ranges: they contend with OPTIMIZE via
+    // deleter registration, never with each other on base rows.
+    for (lo, hi) in [(0i64, 20i64), (20, 40)] {
+        let tmp_db = Arc::clone(&tmp_db);
+        let stop = Arc::clone(&stop);
+        updaters.push(std::thread::spawn(move || {
+            let conn = tmp_db.connect_limbo();
+            // Keep the churn manual-OPTIMIZE-shaped: no write-path merges.
+            conn.execute("PRAGMA fts_merge_threshold = 0").unwrap();
+            let mut round = 0i64;
+            while !stop.load(Ordering::Acquire) {
+                for id in lo..hi {
+                    if stop.load(Ordering::Acquire) {
+                        break;
+                    }
+                    match conn.execute(format!(
+                        "UPDATE docs SET body = 'round {round} doc {id}' WHERE id = {id}"
+                    )) {
+                        Ok(_) => {}
+                        Err(
+                            turso_core::LimboError::Busy
+                            | turso_core::LimboError::WriteWriteConflict
+                            | turso_core::LimboError::SchemaUpdated,
+                        ) => {}
+                        Err(e) => panic!("updater failed abnormally: {e}"),
+                    }
+                }
+                round += 1;
+            }
+        }));
+    }
+
+    // Give the churn a moment to be genuinely concurrent.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let optimizer = tmp_db.connect_limbo();
+    const MAX_ATTEMPTS: usize = 500;
+    let mut attempts = 0;
+    let succeeded = loop {
+        attempts += 1;
+        match optimizer.execute("OPTIMIZE INDEX docs_fts") {
+            Ok(_) => break true,
+            Err(
+                turso_core::LimboError::Busy
+                | turso_core::LimboError::WriteWriteConflict
+                | turso_core::LimboError::SchemaUpdated,
+            ) => {
+                if attempts >= MAX_ATTEMPTS {
+                    break false;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(2));
+            }
+            Err(e) => panic!("OPTIMIZE failed abnormally: {e}"),
+        }
+    };
+
+    stop.store(true, Ordering::Release);
+    for updater in updaters {
+        updater.join().unwrap();
+    }
+    assert!(
+        succeeded,
+        "OPTIMIZE was starved for {MAX_ATTEMPTS} attempts under concurrent UPDATE churn"
+    );
+    println!("OPTIMIZE succeeded after {attempts} attempt(s)");
+
+    // The index is still coherent after the churn + merge.
+    let check = tmp_db.connect_limbo();
+    assert_eq!(
+        limbo_exec_rows(
+            &check,
+            "SELECT count(*) FROM docs WHERE fts_match(body, 'doc')"
+        ),
+        vec![vec![rusqlite::types::Value::Integer(40)]]
+    );
+}


### PR DESCRIPTION
## Why

In the segment-registry design (#8517) every flushed statement publishes one
immutable segment, so without write-path maintenance N single-row commits
leave N segments behind and read cost degrades without bound. Manual
`OPTIMIZE INDEX` exists, but an index should not need babysitting to stay
queryable.

## What

After a statement flush publishes a segment, if the visible segment set
exceeds `PRAGMA fts_merge_threshold` (default 32, 0 disables, per
connection) the cursor takes the maintenance lease and stages a merge **in
the same transaction**. A `Busy` / `WriteWriteConflict` refusal skips the
merge silently: a writer must never fail because maintenance was contended —
the merge simply re-arms on the next flushed statement.

Below the threshold a flushed statement pays exactly one atomic load of a
shared segment-count estimate, so the insert fast path stays scan-free. The
estimate is a heuristic only (bumped by publishes, reset by merges,
reconciled by every full registry scan); the merge itself always recomputes
the true visible set from its own snapshot.

Candidacy is tiered, ParadeDB-style (layers at 100KB / 1MB / 100MB / 1GB):

- clean segments merge only within the smallest layer holding at least two
  of them, so one huge clean segment is not rewritten on every trigger;
- a segment at least half tombstoned is always a candidate — rewriting it
  reclaims dead space no matter its size.

`OPTIMIZE INDEX` keeps its "compact everything now" semantics, with no tier
exemptions.

## Concurrency

The merge runs under the existing per-index lease (the merge mutex from
#8517) and the same deleter-admissibility rules as OPTIMIZE, so concurrent
appenders are unaffected and concurrent deleters are never lost. The
auto-merge's own transaction's deleter registration is exempt from the
admissibility check, so single-connection UPDATE traffic still merges
itself. The `auto_merge_pending` flag survives I/O yields, so the check
resumes exactly once per flushed statement and a yield inside the merge
publication resumes through the ordinary publish path without re-evaluating
the trigger.

OPTIMIZE under sustained deleter churn is live but contended (7–159 retries
measured); the docs layer of this stack records the retry guidance.
