### PR TITLE
core/vdbe: remember column positions for rows read column by column

### DIFF
--- a/core/benches/select_star_benchmark.rs
+++ b/core/benches/select_star_benchmark.rs
@@ -52,7 +52,7 @@ struct Fixture {
     conn: Arc<Connection>,
 }
 
-fn seed_db(mode: Mode) -> Fixture {
+fn seed_db(mode: Mode, tables: &[(&str, usize, usize)]) -> Fixture {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("columns.db");
     #[allow(clippy::arc_with_non_send_sync)]
@@ -65,7 +65,7 @@ fn seed_db(mode: Mode) -> Fixture {
     }
     conn.execute("PRAGMA cache_size=-65536").unwrap(); //negative means kibibytes (https://sqlite.org/pragma.html#pragma_cache_size)
 
-    for (table, ncols, nrows) in TABLES {
+    for (table, ncols, nrows) in tables {
         let cols = (0..*ncols)
             .map(|c| {
                 if c % 2 == 0 {
@@ -135,7 +135,7 @@ fn bench_select_star(criterion: &mut Criterion) {
     group.warm_up_time(Duration::from_secs(3));
 
     for mode in [Mode::Wal, Mode::Mvcc] {
-        let fixture = seed_db(mode);
+        let fixture = seed_db(mode, TABLES);
         for (table, ncols, nrows) in TABLES {
             let label = format!("select_star_{ncols}_{}", mode.suffix());
             group.bench_with_input(BenchmarkId::new(label, nrows), nrows, |b, _| {
@@ -155,5 +155,58 @@ fn bench_select_star(criterion: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_select_star);
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_column_shapes(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("column_fetch");
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(10));
+    group.warm_up_time(Duration::from_secs(3));
+
+    let wide_table = &TABLES[0];
+    let (table, _, nrows) = *wide_table;
+
+    let sum_32_of_one_column = format!(
+        "SELECT {} FROM {table}",
+        (0..32)
+            .map(|k| format!("SUM(c90 + {k})"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let select_32_descending = format!(
+        "SELECT {} FROM {table}",
+        (74..106)
+            .rev()
+            .map(|c| format!("c{c}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    let select_sparse_4 = format!("SELECT c90, c2, c50, c7 FROM {table}");
+    let select_single_late = format!("SELECT c101 FROM {table}");
+
+    let shapes = [
+        ("sum_32_of_one_column_106", sum_32_of_one_column, 1),
+        ("select_32_descending_106", select_32_descending, nrows),
+        ("select_sparse_4_of_106", select_sparse_4, nrows),
+        ("select_single_late_106", select_single_late, nrows),
+    ];
+
+    for mode in [Mode::Wal, Mode::Mvcc] {
+        let fixture = seed_db(mode, std::slice::from_ref(wide_table));
+        for (name, sql, expected_rows) in &shapes {
+            let label = format!("{name}_{}", mode.suffix());
+            group.bench_with_input(BenchmarkId::new(label, nrows), &nrows, |b, _| {
+                let mut stmt = fixture.conn.prepare(sql.as_str()).unwrap();
+                assert_eq!(
+                    drive_stmt_to_completion(&fixture.db, &mut stmt),
+                    *expected_rows,
+                    "{sql} should return {expected_rows} rows"
+                );
+                b.iter(|| drive_stmt_to_completion(&fixture.db, &mut stmt));
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_select_star, bench_column_shapes);
 criterion_main!(benches);

--- a/core/types.rs
+++ b/core/types.rs
@@ -1156,6 +1156,16 @@ impl<'a> TryFrom<ValueRef<'a>> for &'a str {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnPosition {
+    Found {
+        header_offset: usize,
+        data_offset: usize,
+    },
+    NoSuchColumn,
+    Unusable,
+}
+
 mod immutable_record {
     use super::*;
 
@@ -1170,6 +1180,7 @@ mod immutable_record {
         //
         // payload is the std::vec::Vec<u8> but in order to use Register which holds ImmutableRecord as a Value - we store std::vec::Vec<u8> as Value::Blob
         payload: Value,
+        column_positions: Cell<Option<Box<ColumnPositionCache>>>,
     }
 
     // SAFETY: all ImmutableRecord instances are intended to be used in a single thread
@@ -1181,6 +1192,7 @@ mod immutable_record {
         fn clone(&self) -> Self {
             Self {
                 payload: self.payload.clone(),
+                column_positions: Cell::new(None),
             }
         }
     }
@@ -1557,6 +1569,31 @@ mod immutable_record {
         }
 
         #[inline]
+        pub fn column_position(
+            &self,
+            header: &[u8],
+            column: usize,
+            cache_wanted: impl FnOnce() -> bool,
+        ) -> Result<ColumnPosition> {
+            let mut slot = self.column_positions.take();
+            let cache =
+                slot.get_or_insert_with(|| Box::new(ColumnPositionCache::new(cache_wanted())));
+            let position = cache.position_of(header, column);
+            self.column_positions.set(slot);
+            position
+        }
+
+        #[cfg(test)]
+        pub fn cached_column_count(&self) -> usize {
+            let slot = self.column_positions.take();
+            let count = slot
+                .as_ref()
+                .map_or(0, |cache| cache.column_starts.len().saturating_sub(1));
+            self.column_positions.set(slot);
+            count
+        }
+
+        #[inline]
         /// Returns true if the record contains any NULL values.
         /// This is an optimization that only examines the header (serial types)
         /// without deserializing the data section.
@@ -1646,6 +1683,7 @@ mod immutable_record {
             payload.try_reserve_exact(payload_capacity)?;
             Ok(Self {
                 payload: Value::Blob(payload),
+                column_positions: Cell::new(None),
             })
         }
 
@@ -1660,6 +1698,7 @@ mod immutable_record {
         pub fn from_buf(buf: RecordBuf) -> Self {
             Self {
                 payload: Value::Blob(buf.0),
+                column_positions: Cell::new(None),
             }
         }
 
@@ -1670,12 +1709,14 @@ mod immutable_record {
             buf.try_extend(payload.iter().copied())?;
             Ok(Self {
                 payload: Value::Blob(buf),
+                column_positions: Cell::new(None),
             })
         }
 
         pub const fn from_bin_record(payload: ValueBlob) -> Self {
             Self {
                 payload: Value::Blob(payload),
+                column_positions: Cell::new(None),
             }
         }
 
@@ -1791,6 +1832,7 @@ mod immutable_record {
             writer.assert_finish_capacity();
             Ok(Self {
                 payload: Value::Blob(buf),
+                column_positions: Cell::new(None),
             })
         }
 
@@ -1811,10 +1853,17 @@ mod immutable_record {
         }
 
         #[inline]
-        pub const fn as_blob_mut(&mut self) -> &mut ValueBlob {
+        const fn as_blob_mut(&mut self) -> &mut ValueBlob {
             match &mut self.payload {
                 Value::Blob(b) => b,
                 _ => panic!("payload must be a blob"),
+            }
+        }
+
+        #[inline]
+        fn forget_column_positions(&mut self) {
+            if let Some(cache) = self.column_positions.get_mut() {
+                cache.forget_row();
             }
         }
 
@@ -1826,6 +1875,7 @@ mod immutable_record {
         #[inline]
         #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::RecordCopy)]
         pub fn start_serialization(&mut self, payload: &[u8]) -> Result<()> {
+            self.forget_column_positions();
             let blob = self.as_blob_mut();
             blob.try_reserve(payload.len())?;
             blob.extend_from_slice(payload);
@@ -1834,7 +1884,17 @@ mod immutable_record {
 
         #[inline]
         pub fn invalidate(&mut self) {
+            self.forget_column_positions();
             self.as_blob_mut().clear();
+        }
+
+        #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::CloneFrom)]
+        pub fn replace_payload(&mut self, payload: &[u8]) -> Result<(), TryReserveError> {
+            self.forget_column_positions();
+            let blob = self.as_blob_mut();
+            blob.clear();
+            blob.try_extend(payload.iter().copied())?;
+            Ok(())
         }
 
         #[inline]
@@ -1887,6 +1947,77 @@ mod immutable_record {
             ImmutableRecordRef {
                 payload: ImmutableRecordRefPayload::Borrowed(self.get_payload()),
             }
+        }
+    }
+
+    struct ColumnPositionCache {
+        column_starts: crate::alloc::Vec<ColumnStart>,
+        usable: bool,
+    }
+
+    #[derive(Clone, Copy)]
+    struct ColumnStart {
+        header_offset: u32,
+        data_offset: u32,
+    }
+
+    impl ColumnStart {
+        const FIRST: Self = Self {
+            header_offset: 0,
+            data_offset: 0,
+        };
+    }
+
+    impl ColumnPositionCache {
+        fn new(usable: bool) -> Self {
+            Self {
+                column_starts: crate::alloc::vec![],
+                usable,
+            }
+        }
+
+        fn forget_row(&mut self) {
+            self.column_starts.clear();
+        }
+
+        fn position_of(&mut self, header: &[u8], column: usize) -> Result<ColumnPosition> {
+            if !self.usable {
+                return Ok(ColumnPosition::Unusable);
+            }
+            if self.column_starts.is_empty() {
+                let column_count_upper_bound = header.len() + 1;
+                self.column_starts.try_reserve(column_count_upper_bound)?;
+                self.column_starts.push(ColumnStart::FIRST);
+            }
+            while self.column_starts.len() <= column + 1 {
+                let last = *self
+                    .column_starts
+                    .last()
+                    .expect("column_starts starts with ColumnStart::FIRST");
+                if last.header_offset as usize >= header.len() {
+                    return Ok(ColumnPosition::NoSuchColumn);
+                }
+                let (serial_type, varint_len) =
+                    read_varint(&header[last.header_offset as usize..])?;
+                let value_len = get_serial_type_size(serial_type)?;
+                let (Ok(header_offset), Ok(data_offset)) = (
+                    u32::try_from(last.header_offset as usize + varint_len),
+                    u32::try_from(last.data_offset as usize + value_len),
+                ) else {
+                    self.column_starts.clear();
+                    self.usable = false;
+                    return Ok(ColumnPosition::Unusable);
+                };
+                self.column_starts.push(ColumnStart {
+                    header_offset,
+                    data_offset,
+                });
+            }
+            let start = self.column_starts[column];
+            Ok(ColumnPosition::Found {
+                header_offset: start.header_offset as usize,
+                data_offset: start.data_offset as usize,
+            })
         }
     }
 }
@@ -4860,5 +4991,193 @@ mod tests {
         for value in values {
             assert_eq!(value.try_clone().unwrap(), value);
         }
+    }
+}
+
+#[cfg(test)]
+mod column_position_cache_tests {
+    use super::*;
+
+    fn record_of_alternating_ints_and_texts(column_count: usize) -> ImmutableRecord {
+        let values: std::vec::Vec<Value> = (0..column_count)
+            .map(|c| {
+                if c % 2 == 0 {
+                    Value::from_i64(c as i64)
+                } else {
+                    Value::build_text(format!("s{c}"))
+                }
+            })
+            .collect();
+        ImmutableRecord::from_values(values.iter(), column_count).unwrap()
+    }
+
+    fn read_through_cache(record: &ImmutableRecord, column: usize) -> Option<String> {
+        let mut iter = record.iter().unwrap();
+        let header = iter.header_section_ref();
+        let data = iter.data_section_ref();
+        let ColumnPosition::Found {
+            header_offset,
+            data_offset,
+        } = record.column_position(header, column, || true).unwrap()
+        else {
+            return None;
+        };
+        iter.set_header_section(&header[header_offset..]);
+        iter.set_data_section(&data[data_offset..]);
+        let value = iter.next().unwrap().unwrap();
+        Some(format!("{:?}", value.to_owned().unwrap()))
+    }
+
+    #[test]
+    fn cached_reads_match_uncached_reads_in_any_order() {
+        let column_count = 40;
+        let record = record_of_alternating_ints_and_texts(column_count);
+
+        let expected: std::vec::Vec<String> = record
+            .iter()
+            .unwrap()
+            .map(|v| format!("{:?}", v.unwrap().to_owned().unwrap()))
+            .collect();
+        assert_eq!(expected.len(), column_count);
+
+        let jumping_order = [39usize, 0, 17, 1, 38, 17, 5, 39, 2];
+        for &c in &jumping_order {
+            assert_eq!(
+                read_through_cache(&record, c).as_deref(),
+                Some(expected[c].as_str()),
+                "column {c} read through the cache differs"
+            );
+        }
+
+        for (c, want) in expected.iter().enumerate() {
+            assert_eq!(
+                read_through_cache(&record, c).as_deref(),
+                Some(want.as_str())
+            );
+        }
+    }
+
+    #[test]
+    fn reading_past_the_end_of_a_record_reports_no_column() {
+        let record = record_of_alternating_ints_and_texts(3);
+        assert!(read_through_cache(&record, 2).is_some());
+        assert_eq!(read_through_cache(&record, 3), None);
+        assert_eq!(read_through_cache(&record, 400), None);
+    }
+
+    #[test]
+    fn parsing_stops_at_the_column_that_was_asked_for() {
+        let record = record_of_alternating_ints_and_texts(100);
+
+        assert!(read_through_cache(&record, 3).is_some());
+        assert_eq!(record.cached_column_count(), 4);
+
+        assert!(read_through_cache(&record, 9).is_some());
+        assert_eq!(record.cached_column_count(), 10);
+
+        assert!(read_through_cache(&record, 2).is_some());
+        assert_eq!(record.cached_column_count(), 10);
+    }
+
+    #[test]
+    fn the_first_call_decides_caching_for_the_life_of_the_record() {
+        let record = record_of_alternating_ints_and_texts(8);
+        let iter = record.iter().unwrap();
+        let header = iter.header_section_ref();
+
+        assert_eq!(
+            record.column_position(header, 0, || false).unwrap(),
+            ColumnPosition::Unusable
+        );
+        assert_eq!(
+            record
+                .column_position(header, 0, || panic!("asked the gate again"))
+                .unwrap(),
+            ColumnPosition::Unusable
+        );
+    }
+
+    #[test]
+    fn a_clone_starts_cold_and_decides_for_itself() {
+        let record = record_of_alternating_ints_and_texts(8);
+        assert!(read_through_cache(&record, 7).is_some());
+        assert_eq!(record.cached_column_count(), 8);
+
+        let clone = record.clone();
+        assert_eq!(clone.cached_column_count(), 0);
+        assert!(read_through_cache(&clone, 7).is_some());
+        assert_eq!(record.cached_column_count(), 8);
+    }
+
+    #[test]
+    fn replacing_the_payload_forgets_the_old_positions() {
+        let mut reused = record_of_alternating_ints_and_texts(20);
+        let second = {
+            let values: std::vec::Vec<Value> = (0..20)
+                .map(|c| {
+                    if c % 2 == 0 {
+                        Value::build_text(format!("long-text-value-{c}"))
+                    } else {
+                        Value::from_i64(c as i64 * 1000)
+                    }
+                })
+                .collect();
+            ImmutableRecord::from_values(values.iter(), 20).unwrap()
+        };
+
+        for c in 0..20 {
+            assert!(read_through_cache(&reused, c).is_some());
+        }
+
+        reused.replace_payload(second.get_payload()).unwrap();
+
+        for c in 0..20 {
+            assert_eq!(
+                read_through_cache(&reused, c),
+                read_through_cache(&second, c),
+                "column {c} still reads at the previous row's offset"
+            );
+        }
+    }
+
+    #[test]
+    fn the_cursor_reuse_cycle_forgets_the_previous_row() {
+        let mut record = record_of_alternating_ints_and_texts(12);
+        for c in 0..12 {
+            assert!(read_through_cache(&record, c).is_some());
+        }
+
+        record.invalidate();
+        assert!(record.is_invalidated());
+
+        let next = {
+            let values: std::vec::Vec<Value> = (0..12)
+                .map(|c| {
+                    if c % 2 == 0 {
+                        Value::build_text(format!("much-longer-text-{c}"))
+                    } else {
+                        Value::from_i64(c as i64 * 7777)
+                    }
+                })
+                .collect();
+            ImmutableRecord::from_values(values.iter(), 12).unwrap()
+        };
+        record.start_serialization(next.get_payload()).unwrap();
+
+        for c in 0..12 {
+            assert_eq!(
+                read_through_cache(&record, c),
+                read_through_cache(&next, c),
+                "column {c} still reads at the previous row's offset"
+            );
+        }
+    }
+
+    #[test]
+    fn the_cache_slot_costs_one_word_per_record() {
+        assert_eq!(
+            std::mem::size_of::<ImmutableRecord>(),
+            std::mem::size_of::<Value>() + std::mem::size_of::<usize>()
+        );
     }
 }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -2264,6 +2264,9 @@ impl ProgramBuilder {
             && self.flags.is_multi_write()
             && self.may_abort();
 
+        let cursors_worth_caching_column_positions =
+            pick_cursors_worth_caching_column_positions(&self.insns)?;
+
         let prepared = PreparedProgram {
             max_registers: self.next_free_register,
             insns: self.insns,
@@ -2284,6 +2287,7 @@ impl ProgramBuilder {
             prepare_context,
             write_databases: self.write_databases,
             read_databases: self.read_databases,
+            cursors_worth_caching_column_positions,
         };
         Ok(prepared)
     }
@@ -2314,5 +2318,136 @@ impl CursorTypeExt for CursorType {
                 | CursorType::Pseudo(_)
                 | CursorType::Sorter
         )
+    }
+}
+
+fn pick_cursors_worth_caching_column_positions(insns: &[(Insn, usize)]) -> crate::Result<BitSet> {
+    let mut walk_costs_per_cursor: HashMap<CursorID, HeaderWalkCosts> = HashMap::default();
+    for (insn, _) in insns {
+        if let Insn::Column {
+            cursor_id, column, ..
+        } = insn
+        {
+            walk_costs_per_cursor
+                .entry(*cursor_id)
+                .or_default()
+                .count_read_of(*column);
+        }
+    }
+    let mut worth_caching = BitSet::default();
+    for (cursor_id, walk_costs) in walk_costs_per_cursor {
+        if walk_costs.caching_wins() {
+            worth_caching.set(cursor_id)?;
+        }
+    }
+    Ok(worth_caching)
+}
+
+const CACHED_FILL_COST_IN_DECODES_PER_COLUMN: usize = 4;
+const CACHED_BREAK_EVEN_SLACK_IN_DECODES: usize = 16;
+
+#[derive(Default)]
+struct HeaderWalkCosts {
+    decodes_without_cache: usize,
+    columns_one_shared_walk_must_fill: usize,
+}
+
+impl HeaderWalkCosts {
+    fn count_read_of(&mut self, column: usize) {
+        let decodes_to_walk_from_the_front = column + 1;
+        self.decodes_without_cache += decodes_to_walk_from_the_front;
+        self.columns_one_shared_walk_must_fill = self
+            .columns_one_shared_walk_must_fill
+            .max(decodes_to_walk_from_the_front);
+    }
+
+    fn caching_wins(&self) -> bool {
+        let decodes_with_cache = self.columns_one_shared_walk_must_fill
+            * CACHED_FILL_COST_IN_DECODES_PER_COLUMN
+            + CACHED_BREAK_EVEN_SLACK_IN_DECODES;
+        self.decodes_without_cache > decodes_with_cache
+    }
+}
+
+#[cfg(test)]
+mod column_position_cache_gating_tests {
+    use super::*;
+
+    fn column_read(cursor_id: CursorID, column: usize) -> (Insn, usize) {
+        (
+            Insn::Column {
+                cursor_id,
+                column,
+                dest: 0,
+                default: None,
+            },
+            0,
+        )
+    }
+
+    fn worth_caching(insns: &[(Insn, usize)]) -> BitSet {
+        pick_cursors_worth_caching_column_positions(insns).unwrap()
+    }
+
+    #[test]
+    fn one_read_of_a_late_column_walks_exactly_as_far_as_the_fill_would() {
+        assert!(!worth_caching(&[column_read(0, 9)]).get(0));
+    }
+
+    #[test]
+    fn two_early_columns_cost_too_few_decodes_to_repay_a_fill() {
+        assert!(!worth_caching(&[column_read(0, 0), column_read(0, 1)]).get(0));
+    }
+
+    #[test]
+    fn select_star_over_a_wide_table_repays_the_fill_many_times() {
+        let insns: Vec<_> = (0..106).map(|c| column_read(0, c)).collect();
+        assert!(worth_caching(&insns).get(0));
+    }
+
+    #[test]
+    fn select_star_over_a_narrow_table_decodes_single_byte_varints_faster_than_any_fill() {
+        let insns: Vec<_> = (0..10).map(|c| column_read(0, c)).collect();
+        assert!(!worth_caching(&insns).get(0));
+    }
+
+    #[test]
+    fn select_star_crossover_sits_between_ten_and_twenty_one_columns() {
+        let insns: Vec<_> = (0..21).map(|c| column_read(0, c)).collect();
+        assert!(worth_caching(&insns).get(0));
+    }
+
+    #[test]
+    fn reading_one_column_under_many_aggregates_walks_once_instead_of_once_per_aggregate() {
+        let insns: Vec<_> = (0..32).map(|_| column_read(0, 4)).collect();
+        assert!(worth_caching(&insns).get(0));
+    }
+
+    #[test]
+    fn a_few_far_apart_columns_cost_less_to_walk_than_to_fill() {
+        let insns = [
+            column_read(0, 90),
+            column_read(0, 2),
+            column_read(0, 50),
+            column_read(0, 7),
+        ];
+        assert!(!worth_caching(&insns).get(0));
+    }
+
+    #[test]
+    fn many_columns_read_out_of_order_share_one_walk_no_fusion_could_provide() {
+        let insns: Vec<_> = (0..40)
+            .map(|i| column_read(0, if i % 2 == 0 { 39 - i } else { i }))
+            .collect();
+        assert!(worth_caching(&insns).get(0));
+    }
+
+    #[test]
+    fn each_cursor_is_judged_on_its_own_columns() {
+        let mut insns: Vec<_> = (0..40).map(|c| column_read(0, c)).collect();
+        insns.push(column_read(1, 1));
+        let worth_caching = worth_caching(&insns);
+        assert!(worth_caching.get(0));
+        assert!(!worth_caching.get(1));
     }
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -25,8 +25,9 @@ use crate::storage::pager::{default_page1, CreateBTreeFlags, PageRef, SavepointR
 use crate::storage::sqlite3_ondisk::{DatabaseHeader, PageSize, RawVersion};
 use crate::translate::collate::CollationSeq;
 use crate::types::{
-    compare_immutable, compare_immutable_single, compare_records_generic, AsValueRef, Extendable,
-    IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekResult, Text, ValueIterator,
+    compare_immutable, compare_immutable_single, compare_records_generic, AsValueRef,
+    ColumnPosition, Extendable, IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekResult,
+    Text, ValueIterator,
 };
 use crate::util::{
     escape_sql_string_literal, normalize_ident, rename_identifiers,
@@ -2085,11 +2086,37 @@ fn op_column_fetch(
 
                 let mut payload_iterator = record.iter()?;
 
-                // Parse the header for serial types incrementally until we have the target column
-                // Use nth_into_register to write directly to the register without
-                // creating intermediate ValueRef allocations
+                let position = record.column_position(
+                    payload_iterator.header_section_ref(),
+                    column,
+                    || program.cursor_caches_column_positions(cursor_id),
+                )?;
 
-                match payload_iterator.nth_into_register(column, &mut state.registers[dest]) {
+                let decoded = match position {
+                    ColumnPosition::Found {
+                        header_offset,
+                        data_offset,
+                    } => {
+                        let header = payload_iterator.header_section_ref();
+                        let data = payload_iterator.data_section_ref();
+                        if unlikely(header_offset > header.len() || data_offset > data.len()) {
+                            return Err(LimboError::Corrupt(
+                                "Data section too small for indicated serial type size".into(),
+                            ));
+                        }
+                        payload_iterator.set_header_section(&header[header_offset..]);
+                        payload_iterator.set_data_section(&data[data_offset..]);
+                        payload_iterator.nth_into_register(0, &mut state.registers[dest])
+                    }
+                    // Parse the header for serial types incrementally until we have the target column
+                    // Use nth_into_register to write directly to the register without
+                    // creating intermediate ValueRef allocations
+                    ColumnPosition::NoSuchColumn | ColumnPosition::Unusable => {
+                        payload_iterator.nth_into_register(column, &mut state.registers[dest])
+                    }
+                };
+
+                match decoded {
                     Some(result) => {
                         result?;
                         return Ok(InsnFunctionStepResult::Step);

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! https://www.sqlite.org/opcode.html
 
-use crate::alloc::{TryReserveError, TursoFromIterator};
+use crate::alloc::TryReserveError;
 use crate::translate::plan::BitSet;
 use crate::types::{Extendable, Text, ValueBlob};
 use crate::{turso_assert, turso_assert_ne, turso_debug_assert, NonNan};
@@ -294,9 +294,7 @@ impl TryClone for Register {
         match (self, source) {
             (Register::Value(dst), Register::Value(src)) => dst.try_clone_from(src)?,
             (Register::Record(dst), Register::Record(src)) => {
-                let buf = dst.as_blob_mut();
-                buf.clear();
-                buf.try_extend(src.get_payload().iter().copied())?;
+                dst.replace_payload(src.get_payload())?;
             }
             (dst, Register::Value(src)) => {
                 let mut value = Value::Null;
@@ -1623,6 +1621,14 @@ pub struct PreparedProgram {
     pub write_databases: BitSet,
     /// Set of attached database indices that need read transactions.
     pub read_databases: BitSet,
+    pub cursors_worth_caching_column_positions: BitSet,
+}
+
+impl PreparedProgram {
+    #[inline(always)]
+    pub fn cursor_caches_column_positions(&self, cursor_id: usize) -> bool {
+        self.cursors_worth_caching_column_positions.get(cursor_id)
+    }
 }
 
 #[derive(Clone)]

--- a/sqlite/conformance/sqlite-sqltests/select/column-access.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/select/column-access.sqltest
@@ -1,0 +1,216 @@
+# Column reads over wide rows, short records and out-of-order
+# projections. These pin the values a row's columns decode to no matter
+# how many columns a statement reads or what order it reads them in,
+# which is what any record-header caching has to preserve.
+
+@database :memory:
+
+setup wide {
+    CREATE TABLE wide(c0 INTEGER, c1 TEXT, c2 REAL, c3 INTEGER, c4 TEXT, c5 REAL, c6 INTEGER, c7 TEXT, c8 REAL, c9 INTEGER, c10 TEXT, c11 REAL, c12 INTEGER, c13 TEXT, c14 REAL, c15 INTEGER, c16 TEXT, c17 REAL, c18 INTEGER, c19 TEXT, c20 REAL, c21 INTEGER, c22 TEXT, c23 REAL);
+    INSERT INTO wide VALUES (NULL, 't0_1', 0.2, 3, 't0_4', 0.5, 6, 't0_7', 0.8, NULL, 't0_10', 0.11, 12, 't0_13', 0.14, 15, 't0_16', 0.17, NULL, 't0_19', 0.20, 21, 't0_22', 0.23);
+    INSERT INTO wide VALUES (100, 't1_1', 1.2, 103, 't1_4', 1.5, 106, 't1_7', NULL, 109, 't1_10', 1.11, 112, 't1_13', 1.14, 115, 't1_16', NULL, 118, 't1_19', 1.20, 121, 't1_22', 1.23);
+    INSERT INTO wide VALUES (200, 't2_1', 2.2, 203, 't2_4', 2.5, 206, NULL, 2.8, 209, 't2_10', 2.11, 212, 't2_13', 2.14, 215, NULL, 2.17, 218, 't2_19', 2.20, 221, 't2_22', 2.23);
+    INSERT INTO wide VALUES (300, 't3_1', 3.2, 303, 't3_4', 3.5, NULL, 't3_7', 3.8, 309, 't3_10', 3.11, 312, 't3_13', 3.14, NULL, 't3_16', 3.17, 318, 't3_19', 3.20, 321, 't3_22', 3.23);
+    CREATE TABLE lookup(k INTEGER PRIMARY KEY, label TEXT);
+    INSERT INTO lookup VALUES (0,'zero'),(100,'hundred'),(200,'two-hundred'),(300,'three-hundred');
+}
+
+setup grown {
+    CREATE TABLE grown(a INTEGER, b TEXT);
+    INSERT INTO grown VALUES (1,'one'),(2,'two'),(3,'three');
+    ALTER TABLE grown ADD COLUMN c INTEGER DEFAULT 42;
+    ALTER TABLE grown ADD COLUMN d TEXT DEFAULT 'dflt';
+    INSERT INTO grown VALUES (4,'four',400,'dee');
+}
+
+@setup wide
+test column-wide-select-star {
+    SELECT * FROM wide ORDER BY c0
+}
+expect {
+    |t0_1|0.2|3|t0_4|0.5|6|t0_7|0.8||t0_10|0.11|12|t0_13|0.14|15|t0_16|0.17||t0_19|0.2|21|t0_22|0.23
+    100|t1_1|1.2|103|t1_4|1.5|106|t1_7||109|t1_10|1.11|112|t1_13|1.14|115|t1_16||118|t1_19|1.2|121|t1_22|1.23
+    200|t2_1|2.2|203|t2_4|2.5|206||2.8|209|t2_10|2.11|212|t2_13|2.14|215||2.17|218|t2_19|2.2|221|t2_22|2.23
+    300|t3_1|3.2|303|t3_4|3.5||t3_7|3.8|309|t3_10|3.11|312|t3_13|3.14||t3_16|3.17|318|t3_19|3.2|321|t3_22|3.23
+}
+
+@setup wide
+test column-wide-descending-order {
+    SELECT c23, c11, c2, c17 FROM wide ORDER BY c0
+}
+expect {
+    0.23|0.11|0.2|0.17
+    1.23|1.11|1.2|
+    2.23|2.11|2.2|2.17
+    3.23|3.11|3.2|3.17
+}
+
+@setup wide
+test column-wide-scattered {
+    SELECT c15, c0, c22, c7, c3 FROM wide ORDER BY c0
+}
+expect {
+    15||t0_22|t0_7|3
+    115|100|t1_22|t1_7|103
+    215|200|t2_22||203
+    |300|t3_22|t3_7|303
+}
+
+@setup wide
+test column-wide-same-column-repeated {
+    SELECT c12, c12, c12, c12, c12, c12 FROM wide ORDER BY c0
+}
+expect {
+    12|12|12|12|12|12
+    112|112|112|112|112|112
+    212|212|212|212|212|212
+    312|312|312|312|312|312
+}
+
+@setup wide
+test column-wide-repeated-in-aggregates {
+    SELECT SUM(c0), SUM(c0 + 1), SUM(c0 + 2), SUM(c0 + 3), SUM(c0 + 4) FROM wide
+}
+expect {
+    600|603|606|609|612
+}
+
+@setup wide
+test column-wide-single-late-column {
+    SELECT c23 FROM wide ORDER BY c0
+}
+expect {
+    0.23
+    1.23
+    2.23
+    3.23
+}
+
+@setup wide
+test column-wide-single-early-column {
+    SELECT c1 FROM wide ORDER BY c0
+}
+expect {
+    t0_1
+    t1_1
+    t2_1
+    t3_1
+}
+
+@setup wide
+test column-wide-first-and-last {
+    SELECT c0, c23 FROM wide ORDER BY c0
+}
+expect {
+    |0.23
+    100|1.23
+    200|2.23
+    300|3.23
+}
+
+@setup wide
+test column-wide-nulls-interleaved {
+    SELECT c0, c9, c18, c4, c13 FROM wide ORDER BY c0
+}
+expect {
+    |||t0_4|t0_13
+    100|109|118|t1_4|t1_13
+    200|209|218|t2_4|t2_13
+    300|309|318|t3_4|t3_13
+}
+
+@setup wide
+test column-wide-filter-late-project-early {
+    SELECT c1, c2 FROM wide WHERE c21 IS NOT NULL ORDER BY c0
+}
+expect {
+    t0_1|0.2
+    t1_1|1.2
+    t2_1|2.2
+    t3_1|3.2
+}
+
+@setup wide
+test column-wide-order-by-late-column {
+    SELECT c2, c1, c0 FROM wide ORDER BY c22 DESC, c0
+}
+expect {
+    3.2|t3_1|300
+    2.2|t2_1|200
+    1.2|t1_1|100
+    0.2|t0_1|
+}
+
+@setup wide
+test column-wide-group-by {
+    SELECT c0 % 2, COUNT(*), SUM(c3) FROM wide GROUP BY c0 % 2 ORDER BY 1
+}
+expect {
+    |1|3
+    0|3|609
+}
+
+@setup wide
+test column-wide-distinct {
+    SELECT DISTINCT c0 % 2, c6 % 3 FROM wide ORDER BY 1, 2
+}
+expect {
+    |0
+    0|
+    0|1
+    0|2
+}
+
+@setup wide
+test column-wide-join {
+    SELECT w.c0, w.c14, w.c21, l.label FROM wide w JOIN lookup l ON l.k = w.c0 ORDER BY w.c0
+}
+expect {
+    100|1.14|121|hundred
+    200|2.14|221|two-hundred
+    300|3.14|321|three-hundred
+}
+
+@setup wide
+test column-wide-subquery {
+    SELECT c0, (SELECT label FROM lookup WHERE k = wide.c0) FROM wide ORDER BY c0
+}
+expect {
+    |
+    100|hundred
+    200|two-hundred
+    300|three-hundred
+}
+
+@setup grown
+test column-short-record-select-star {
+    SELECT * FROM grown ORDER BY a
+}
+expect {
+    1|one|42|dflt
+    2|two|42|dflt
+    3|three|42|dflt
+    4|four|400|dee
+}
+
+@setup grown
+test column-short-record-defaults-out-of-order {
+    SELECT a, d, c, b FROM grown ORDER BY a
+}
+expect {
+    1|dflt|42|one
+    2|dflt|42|two
+    3|dflt|42|three
+    4|dee|400|four
+}
+
+@setup grown
+test column-short-record-only-added-column {
+    SELECT d FROM grown ORDER BY a
+}
+expect {
+    dflt
+    dflt
+    dflt
+    dee
+}


### PR DESCRIPTION
## Description

Reintroduces record header caching: records carry a pointer-sized slot for a `ColumnPositionCache` that remembers each parsed column's header and data offsets, so a row read through many separate `Column` instructions walks the header once instead of once per instruction.

The first commit adds `column_fetch` benchmark shapes and value-pinning conformance tests for the territory instruction fusion cannot reach; the second adds the cache. Landing the benchmarks first produced a CodSpeed baseline run on unmodified code, so the new shapes have a comparison too (see the run links in the comments).

Record header caching is on its third life here, and each earlier removal names a shortcoming this design has to answer:

1. `RecordCursor` (written July 2025) was removed by #4465 in favor of the zero-allocation `ValueIterator`. **This cache costs one pointer per record, allocates only on cursors a compile-time cost model armed, and reuses that allocation across rows** — steady-state scans allocate nothing.
2. #4472 restored caching to fix a 50–200% regression on ClickBench's 90-aggregate query, but parsed whole headers on first touch, which made narrow reads of the 105-column `hits` table slower than no cache at all; #4739 reverted it within the hour. **This cache parses incrementally: reading column 3 of a 106-column row parses 4 serial types, not 106.**
3. A later unmerged attempt (see #8059's history) gated per cursor but asked a per-program bitset on every executed `Column`, measuring +0.4% to +1.2% on the narrow reads the gate declines. **Here the first `Column` on a record stamps the decision into the record's own cache slot, so steady-state reads consult only data they already hold.**

The cost model (`pick_cursors_worth_caching_column_positions`) counts, per cursor, the serial-type decodes a row costs with and without a cache, and arms only cursors where caching wins. Fusion consumes the `Column` instructions the model counts, so `ColumnRange` and the cache stay off each other's territory, matching the measurement that combining them on one shape is uniformly worse than letting each keep its own.

Correctness rests on one invariant: every payload mutation flows through `invalidate`, `start_serialization` or `replace_payload`, which drop the remembered positions; `as_blob_mut` is no longer reachable from outside the record. Clones start cold.

## Motivation and context

`SELECT SUM(ResolutionWidth), SUM(ResolutionWidth + 1), … FROM hits` re-parses the record header once per aggregate: fusion gets nothing (there is no ascending run), so this is still O(N²) per row on main. The same holds for out-of-order projections such as `SELECT c90, c2, c50`. Prior measurement of this cache design by instruction count: −64.9% on 32 aggregates over one column, −50% on unfused wide reads, at ≤ +1.2% on declined narrow reads — and the per-record stamp in this version removes most of that remaining cost.

CodSpeed on this PR covers both directions: `sum_32_of_one_column` and `select_32_descending` measure the win; `select_sparse_4`, `select_single_late` and the existing `select_star_*` shapes guard the declined and fused paths against exactly the kind of broad regression that sank #4472.

Validation so far: 2367 core unit tests, the full sqltest conformance suite with the gate forced on for every cursor (12,000+ tests through the cached path), clippy with `--all-features --all-targets --deny=warnings`, and a smoke run of all 14 benchmark shapes.

History: #4465 (first removal), #4472 (restore), #4739 (second removal), #8059 (ColumnRange fusion).

## Description of AI Usage

This PR was researched, implemented, and validated by Claude Code from the prompt "add the record header cache back in a way that mitigates its previous shortcomings". The git history of the two previous removals was mined for the failure modes listed above, the design was ported from an earlier unmerged branch with the per-read gate cost removed, and CodSpeed runs were triggered and compared by the agent to validate the result. A human reviewed the final diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2qVaE1Ti2CNyeVrbgNGJz)_