### PR TITLE
  Fix attached database paths that incorrectly use main database state

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3832,25 +3832,19 @@ impl Connection {
         }
     }
 
-    /// Clone the *shared* schema of `database_id` (main or attached), bypassing
-    /// the per-connection schema cache. Falls back to the main DB's shared
-    /// schema when `database_id` does not name an attached database — callers
-    /// in error paths get something usable instead of a panic.
+    /// Clone the shared schema for `database_id`, bypassing the connection-local cache.
     ///
-    /// MVCC checkpoint specifically must call this rather than [`Self::with_schema`]:
-    /// it writes from the mv store to the pager, so the schema it uses must
-    /// match the pager being checkpointed and cannot be a stale per-connection
-    /// copy.
+    /// Panics if `database_id` is neither main nor an attached database.
     pub(crate) fn clone_shared_schema(&self, database_id: usize) -> Arc<Schema> {
         if database_id == crate::MAIN_DB_ID {
             self.db.clone_schema()
         } else {
-            self.attached_databases
-                .read()
+            let attached_databases = self.attached_databases.read();
+            let (db, _) = attached_databases
                 .index_to_data
                 .get(&database_id)
-                .map(|(db, _)| db.schema.lock().clone())
-                .unwrap_or_else(|| self.db.clone_schema())
+                .expect("shared schema requested for unknown attached database");
+            db.clone_schema()
         }
     }
 

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3192,11 +3192,11 @@ impl Connection {
                 let mut schemas = self.database_schemas.write();
                 let schema_arc = schemas.entry(database_id).or_insert_with(|| {
                     let attached_dbs = self.attached_databases.read();
-                    let (db, _pager) = attached_dbs
+                    let entry = attached_dbs
                         .index_to_data
                         .get(&database_id)
                         .expect("Database ID should be valid");
-                    let schema = db.schema.lock().clone();
+                    let schema = entry.db.schema.lock().clone();
                     schema
                 });
                 let schema = Schema::try_make_mut(schema_arc)?;
@@ -3227,7 +3227,15 @@ impl Connection {
                     .map(|temp_db| temp_db.pager.clone())
                     .expect("temp database should be initialized after ensure_temp_database"))
             }
-            _ => Ok(self.attached_databases.read().get_pager_by_index(index)),
+            _ => self
+                .attached_databases
+                .read()
+                .get_pager_by_index(index)
+                .ok_or_else(|| {
+                    LimboError::InternalError(format!(
+                        "database index {index} is missing from the attached catalog"
+                    ))
+                }),
         }
     }
 
@@ -3646,9 +3654,11 @@ impl Connection {
                     };
                 }
                 AttachDatabaseState::Publish { alias, db, pager } => {
-                    self.attached_databases
-                        .write()
-                        .insert(alias.as_str(), (db.clone(), pager.clone()));
+                    self.attached_databases.write().insert(
+                        alias.as_str(),
+                        db.clone(),
+                        pager.clone(),
+                    );
                     self.bump_prepare_context_generation();
                     *state = AttachDatabaseState::Done;
                     return Ok(IOResult::Done(()));
@@ -3755,8 +3765,8 @@ impl Connection {
         }
         {
             let catalog = self.attached_databases.read();
-            for (&idx, (_db, pager)) in catalog.index_to_data.iter() {
-                pagers.push((idx, pager.clone()));
+            for (&idx, entry) in catalog.index_to_data.iter() {
+                pagers.push((idx, entry.pager.clone()));
             }
         }
         f(&pagers)
@@ -3785,11 +3795,11 @@ impl Connection {
         }
 
         let attached_dbs = self.attached_databases.read();
-        let (db, _pager) = attached_dbs
+        let entry = attached_dbs
             .index_to_data
             .get(&database_id)
             .expect("Database ID should be valid after resolve_database_id");
-        let schema = db.schema.lock().clone();
+        let schema = entry.db.schema.lock().clone();
         schema
     }
 
@@ -3807,8 +3817,8 @@ impl Connection {
         let mut schemas = self.database_schemas.write();
         if let Some(local_schema) = schemas.remove(&database_id) {
             let attached_dbs = self.attached_databases.read();
-            if let Some((db, _pager)) = attached_dbs.index_to_data.get(&database_id) {
-                *db.schema.lock() = local_schema;
+            if let Some(entry) = attached_dbs.index_to_data.get(&database_id) {
+                *entry.db.schema.lock() = local_schema;
             }
             self.bump_prepare_context_generation();
         }
@@ -3840,11 +3850,11 @@ impl Connection {
             self.db.clone_schema()
         } else {
             let attached_databases = self.attached_databases.read();
-            let (db, _) = attached_databases
+            let entry = attached_databases
                 .index_to_data
                 .get(&database_id)
                 .expect("shared schema requested for unknown attached database");
-            db.clone_schema()
+            entry.db.clone_schema()
         }
     }
 
@@ -3881,9 +3891,8 @@ impl Connection {
         // Add attached databases
         let attached_dbs = self.attached_databases.read();
         for (alias, &seq_number) in attached_dbs.name_to_index.iter() {
-            let file_path = if let Some((db, _pager)) = attached_dbs.index_to_data.get(&seq_number)
-            {
-                Self::get_canonical_path_for_database(db)
+            let file_path = if let Some(entry) = attached_dbs.index_to_data.get(&seq_number) {
+                Self::get_canonical_path_for_database(&entry.db)
             } else {
                 String::new()
             };
@@ -3966,6 +3975,50 @@ impl Connection {
     pub fn set_sync_mode(&self, mode: SyncMode) {
         self.sync_mode.set(mode);
         self.bump_prepare_context_generation();
+    }
+
+    pub(crate) fn get_sync_mode_for_database(&self, database_id: usize) -> Result<SyncMode> {
+        match database_id {
+            MAIN_DB_ID => Ok(self.get_sync_mode()),
+            TEMP_DB_ID => Ok(SyncMode::Off),
+            _ => self
+                .attached_databases
+                .read()
+                .index_to_data
+                .get(&database_id)
+                .map(|entry| entry.sync_mode)
+                .ok_or_else(|| {
+                    LimboError::InternalError(format!(
+                        "database index {database_id} is missing from the attached catalog"
+                    ))
+                }),
+        }
+    }
+
+    pub(crate) fn set_sync_mode_for_database(
+        &self,
+        database_id: usize,
+        mode: SyncMode,
+    ) -> Result<()> {
+        match database_id {
+            MAIN_DB_ID => self.sync_mode.set(mode),
+            // SQLite fixes temp databases at synchronous=OFF.
+            TEMP_DB_ID => return Ok(()),
+            _ => {
+                let mut attached_databases = self.attached_databases.write();
+                let entry = attached_databases
+                    .index_to_data
+                    .get_mut(&database_id)
+                    .ok_or_else(|| {
+                        LimboError::InternalError(format!(
+                            "database index {database_id} is missing from the attached catalog"
+                        ))
+                    })?;
+                entry.sync_mode = mode;
+            }
+        }
+        self.bump_prepare_context_generation();
+        Ok(())
     }
 
     pub fn get_temp_store(&self) -> crate::TempStore {
@@ -5228,7 +5281,7 @@ impl Connection {
                 catalog
                     .index_to_data
                     .get(&db)
-                    .and_then(|(db, _)| db.get_mv_store().as_ref().cloned())
+                    .and_then(|entry| entry.db.get_mv_store().as_ref().cloned())
             }
         }
     }
@@ -5459,7 +5512,8 @@ mod tests {
     fn attached_entry(conn: &Connection, alias: &str) -> (Arc<Database>, Arc<Pager>) {
         let catalog = conn.attached_databases.read();
         let index = *catalog.name_to_index.get(alias).unwrap();
-        catalog.index_to_data.get(&index).unwrap().clone()
+        let entry = catalog.index_to_data.get(&index).unwrap();
+        (entry.db.clone(), entry.pager.clone())
     }
 
     #[test]

--- a/core/database.rs
+++ b/core/database.rs
@@ -3231,11 +3231,17 @@ impl Database {
     }
 }
 
+pub(crate) struct AttachedDatabase {
+    pub(crate) db: Arc<Database>,
+    pub(crate) pager: Arc<Pager>,
+    pub(crate) sync_mode: SyncMode,
+}
+
 // Optimized for fast get() operations and supports unlimited attached databases.
 pub(crate) struct DatabaseCatalog {
     pub(crate) name_to_index: HashMap<String, usize>,
     allocated: Vec<u64>,
-    pub(crate) index_to_data: HashMap<usize, (Arc<Database>, Arc<Pager>)>,
+    pub(crate) index_to_data: HashMap<usize, AttachedDatabase>,
 }
 
 #[allow(unused)]
@@ -3249,9 +3255,7 @@ impl DatabaseCatalog {
     }
 
     pub(crate) fn get_database_by_index(&self, index: usize) -> Option<Arc<Database>> {
-        self.index_to_data
-            .get(&index)
-            .map(|(db, _pager)| db.clone())
+        self.index_to_data.get(&index).map(|entry| entry.db.clone())
     }
 
     pub(crate) fn get_name_by_index(&self, index: usize) -> Option<String> {
@@ -3267,16 +3271,12 @@ impl DatabaseCatalog {
             Some(idx) => self
                 .index_to_data
                 .get(idx)
-                .map(|(db, _pager)| (*idx, db.clone())),
+                .map(|entry| (*idx, entry.db.clone())),
         }
     }
 
-    pub(crate) fn get_pager_by_index(&self, idx: &usize) -> Arc<Pager> {
-        let (_db, pager) = self
-            .index_to_data
-            .get(idx)
-            .expect("If we are looking up a database by index, it must exist.");
-        pager.clone()
+    pub(crate) fn get_pager_by_index(&self, idx: &usize) -> Option<Arc<Pager>> {
+        self.index_to_data.get(idx).map(|entry| entry.pager.clone())
     }
 
     fn add(&mut self, s: &str) -> usize {
@@ -3291,9 +3291,16 @@ impl DatabaseCatalog {
         index
     }
 
-    pub(crate) fn insert(&mut self, s: &str, data: (Arc<Database>, Arc<Pager>)) -> usize {
+    pub(crate) fn insert(&mut self, s: &str, db: Arc<Database>, pager: Arc<Pager>) -> usize {
         let idx = self.add(s);
-        self.index_to_data.insert(idx, data);
+        self.index_to_data.insert(
+            idx,
+            AttachedDatabase {
+                db,
+                pager,
+                sync_mode: SyncMode::Full,
+            },
+        );
         idx
     }
 

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -737,8 +737,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         mode: CheckpointMode,
     ) -> Self {
         assert!(
-            !matches!(mode, CheckpointMode::Passive { .. })
-                || connection.experimental_mvcc_passive_checkpoint_enabled(),
+            !matches!(mode, CheckpointMode::Passive { .. }) || mvstore.uses_passive_checkpoint(),
             "passive checkpoint mode requires experimental_mvcc_passive_checkpoint"
         );
         // MVCC supports only Passive (no blocking lock, requires the experimental flag) and
@@ -756,7 +755,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         // mode, MVCC checkpoint writes from the mv store back to the pager —
         // so the schema must match the pager being checkpointed.
         let schema = connection.clone_shared_schema(database_id);
-        let index_id_to_index = if connection.experimental_mvcc_passive_checkpoint_enabled() {
+        let index_id_to_index = if mvstore.uses_passive_checkpoint() {
             HashMap::default()
         } else {
             schema
@@ -1955,9 +1954,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     fn step_inner(&mut self, _context: &()) -> Result<TransitionResult<CheckpointResult>> {
         match &self.state {
             CheckpointState::PrepareCheckpoint => {
-                let passive = self
-                    .connection
-                    .experimental_mvcc_passive_checkpoint_enabled();
+                let passive = self.mvstore.uses_passive_checkpoint();
                 if passive {
                     // The passive checkpoint acquires the blocking lock only after
                     // collection, so it needs an explicit single-orchestrator gate. The
@@ -2100,9 +2097,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 }
                 tracing::debug!("Collected {} index row changes", self.index_write_set.len());
 
-                let passive = self
-                    .connection
-                    .experimental_mvcc_passive_checkpoint_enabled();
+                let passive = self.mvstore.uses_passive_checkpoint();
                 if passive {
                     inject_transition_yield!(self, CheckpointYieldPoint::BeforeAcquireLock);
                     // Passive path: collection AND the btree write phase run without the

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -24,8 +24,8 @@ use crate::types::IOResultOr;
 use crate::types::{IOCompletions, IOResult, ImmutableRecord, ImmutableRecordRef};
 use crate::{turso_assert, turso_assert_eq};
 use crate::{
-    CheckpointResult, Completion, Connection, IOExt, LimboError, Numeric, Pager, Result, SyncMode,
-    TransactionState, Value, ValueRef,
+    CheckpointResult, Completion, Connection, Database, IOExt, LimboError, Numeric, Pager, Result,
+    SyncMode, TransactionState, Value, ValueRef,
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::num::NonZeroU64;
@@ -184,6 +184,7 @@ pub struct CheckpointStateMachine<Clock: LogicalClock, A: ConcurrentAllocator = 
     /// Connection to the database
     connection: Arc<Connection>,
     /// Database whose pager and schema this checkpoint is writing.
+    database: Arc<Database>,
     database_id: usize,
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
@@ -724,7 +725,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             )
         });
         self.durable_mvcc_metadata =
-            !self.connection.db.is_in_memory_db() && self.mvcc_meta_table.is_some();
+            !self.database.is_in_memory_db() && self.mvcc_meta_table.is_some();
     }
 
     pub fn new(
@@ -750,6 +751,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             },
         };
         let checkpoint_lock = mvstore.blocking_checkpoint_lock.clone();
+        let database = connection.get_source_database(database_id);
         // Use the shared DB schema (not the per-connection cache, which may be
         // stale) for the database whose pager we're checkpointing. Unlike WAL
         // mode, MVCC checkpoint writes from the mv store back to the pager —
@@ -783,7 +785,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 table.columns().len(),
             )
         });
-        let durable_mvcc_metadata = !connection.db.is_in_memory_db() && mvcc_meta_table.is_some();
+        let durable_mvcc_metadata = !database.is_in_memory_db() && mvcc_meta_table.is_some();
         let durable_tx_max = mvstore.durable_txid_max.load(Ordering::SeqCst);
         let durable_txid_max_old = NonZeroU64::new(durable_tx_max);
         #[cfg(any(test, injected_yields))]
@@ -800,6 +802,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             durable_txid_max_new: durable_tx_max,
             mvstore,
             connection,
+            database,
             database_id,
             #[cfg(any(test, injected_yields))]
             yield_instance_id,
@@ -1502,7 +1505,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     }
 
     fn has_unpublished_schema_changes(&self) -> bool {
-        let schema = self.connection.db.schema.lock();
+        let schema = self.database.schema.lock();
         if !schema.dropped_root_pages.is_empty() {
             return true;
         }
@@ -1587,7 +1590,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         // Patch the live db.schema (not local_schema, the checkpoint's private snapshot) so
         // clone_schema() propagates real root pages; negative placeholders would orphan the
         // new btree pages.
-        let mut schema_ref = self.connection.db.schema.lock();
+        let mut schema_ref = self.database.schema.lock();
         let schema = Schema::try_make_mut(&mut schema_ref)?;
         for (name, table) in schema.tables.iter_mut() {
             #[cfg(not(feature = "conn_raw_api"))]
@@ -1649,7 +1652,15 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             .dropped_root_pages
             .extend(std::mem::take(&mut self.ended_created_roots));
         drop(schema_ref);
-        *self.connection.schema.write() = self.connection.db.clone_schema();
+        let schema = self.database.clone_schema();
+        if self.database_id == crate::MAIN_DB_ID {
+            *self.connection.schema.write() = schema;
+        } else {
+            self.connection
+                .database_schemas()
+                .write()
+                .insert(self.database_id, schema);
+        }
         self.connection.bump_prepare_context_generation();
         self.mvstore.bump_schema_generation();
         Ok(())
@@ -2734,7 +2745,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                                 )
                             })?;
                         checkpoint_header.schema_cookie =
-                            self.connection.db.schema.lock().schema_version.into();
+                            self.database.schema.lock().schema_version.into();
                         let staged_header = self.pager.io.block(|| {
                             self.pager.with_header_mut(|header| {
                                 // Keep pager-maintained fields (for example database_size/change_counter)
@@ -2756,10 +2767,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     // On commit_tx failure the `?` rolls back the pager txn; durable_txid_max and
                     // the log offset stay put, so a retry re-stages from the previous boundary.
                     tracing::debug!("Committing pager transaction");
-                    match self
-                        .pager
-                        .commit_tx(&self.connection, self.update_transaction_state)?
-                    {
+                    match self.pager.commit_tx(
+                        &self.connection,
+                        self.sync_mode,
+                        self.update_transaction_state,
+                    )? {
                         IOResult::Done(_) => {
                             self.pager_commit_done = true;
                         }

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3663,10 +3663,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)?;
                 inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                 if appended_to_log && mvcc_store.storage.should_checkpoint() {
-                    let auto_checkpoint_mode = if self
-                        .connection
-                        .experimental_mvcc_passive_checkpoint_enabled()
-                    {
+                    let auto_checkpoint_mode = if mvcc_store.uses_passive_checkpoint() {
                         crate::storage::wal::CheckpointMode::Passive {
                             upper_bound_inclusive: None,
                         }
@@ -7691,6 +7688,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             snapshot_ts = last_committed.min(inflight_floor.saturating_sub(1));
         });
         snapshot_ts
+    }
+
+    pub(crate) fn uses_passive_checkpoint(&self) -> bool {
+        self.experimental_mvcc_passive_checkpoint
     }
 
     /// Try to enter the passive publish window. Returns false if another publish is in flight.

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -1720,7 +1720,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn new(
         state: CommitState<Clock, A>,
         tx_id: TxID,
@@ -1729,9 +1728,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         db_id: usize,
         commit_coordinator: Arc<CommitCoordinator>,
         header: Arc<RwLock<Option<DatabaseHeader>>>,
-        sync_mode: SyncMode,
-    ) -> Self {
-        let pager = connection.pager.load().clone();
+    ) -> Result<Self> {
+        let pager = connection.get_pager_from_database_index(&db_id)?;
+        let sync_mode = connection.get_sync_mode_for_database(db_id)?;
         // Use the connection's tx-level schema_did_change flag as the
         // single source of truth.  This flag is set by SetCookie(SchemaVersion)
         // which every DDL emits, so it covers all schema-changing operations
@@ -1743,7 +1742,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 schema_did_change: true
             }
         );
-        Self {
+        Ok(Self {
             state,
             is_finalized: false,
             #[cfg(any(test, injected_yields))]
@@ -1761,7 +1760,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             wrote_logical_log: false,
             sync_mode,
             _phantom: PhantomData,
-        }
+        })
     }
 
     fn release_group_claim(&mut self) {
@@ -3677,7 +3676,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                         mvcc_store.clone(),
                         self.connection.clone(),
                         false,
-                        self.connection.get_sync_mode(),
+                        self.sync_mode,
                         self.db_id,
                         auto_checkpoint_mode,
                     ));
@@ -7092,8 +7091,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             db_id,
             self.commit_coordinator.clone(),
             self.global_header.clone(),
-            connection.get_sync_mode(),
-        ));
+        )?);
         let state_machine = StateMachine::new(state);
         Ok(state_machine)
     }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9578,7 +9578,11 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
         )
         .unwrap();
     }
-    run_pager_until_done(|| pager.commit_tx(&db.conn, true), pager.as_ref()).unwrap();
+    run_pager_until_done(
+        || pager.commit_tx(&db.conn, db.conn.get_sync_mode(), true),
+        pager.as_ref(),
+    )
+    .unwrap();
 
     pager.begin_read_tx().unwrap();
     let mut interior_key = None;
@@ -9631,7 +9635,11 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
             IOResult::IO(io) => io.wait(pager.io.as_ref()).unwrap(),
         }
     }
-    run_pager_until_done(|| pager.commit_tx(&db.conn, true), pager.as_ref()).unwrap();
+    run_pager_until_done(
+        || pager.commit_tx(&db.conn, db.conn.get_sync_mode(), true),
+        pager.as_ref(),
+    )
+    .unwrap();
 
     pager.begin_read_tx().unwrap();
     let count_after = run_pager_until_done(|| cursor.write().count(), pager.as_ref()).unwrap();

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10886,7 +10886,11 @@ mod tests {
             &pager,
         )
         .unwrap();
-        run_until_done(|| pager.commit_tx(&conn, true), &pager).unwrap();
+        run_until_done(
+            || pager.commit_tx(&conn, conn.get_sync_mode(), true),
+            &pager,
+        )
+        .unwrap();
 
         let page2 = run_until_done(|| pager.allocate_page(), &pager).unwrap();
         btree_init_page(&page2, PageType::TableLeaf, 0, pager.usable_space());
@@ -11209,7 +11213,10 @@ mod tests {
                     pager.deref(),
                 )
                 .unwrap();
-                pager.io.block(|| pager.commit_tx(&conn, true)).unwrap();
+                pager
+                    .io
+                    .block(|| pager.commit_tx(&conn, conn.get_sync_mode(), true))
+                    .unwrap();
                 pager.begin_read_tx().unwrap();
                 // FIXME: add sorted vector instead, should be okay for small amounts of keys for now :P, too lazy to fix right now
                 let _c = cursor.move_to_root().unwrap();
@@ -11348,7 +11355,10 @@ mod tests {
                 if let Some(c) = c {
                     pager.io.wait_for_completion(c).unwrap();
                 }
-                pager.io.block(|| pager.commit_tx(&conn, true)).unwrap();
+                pager
+                    .io
+                    .block(|| pager.commit_tx(&conn, conn.get_sync_mode(), true))
+                    .unwrap();
             }
 
             // Check that all keys can be found by seeking
@@ -11580,7 +11590,10 @@ mod tests {
                 if let Some(c) = c {
                     pager.io.wait_for_completion(c).unwrap();
                 }
-                pager.io.block(|| pager.commit_tx(&conn, true)).unwrap();
+                pager
+                    .io
+                    .block(|| pager.commit_tx(&conn, conn.get_sync_mode(), true))
+                    .unwrap();
             }
 
             // Final validation
@@ -11906,7 +11919,10 @@ mod tests {
             if let Some(c) = c {
                 pager.io.wait_for_completion(c).unwrap();
             }
-            pager.io.block(|| pager.commit_tx(&conn, true)).unwrap();
+            pager
+                .io
+                .block(|| pager.commit_tx(&conn, conn.get_sync_mode(), true))
+                .unwrap();
 
             // Full scan: every key must appear exactly once.
             pager.begin_read_tx().unwrap();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3083,10 +3083,13 @@ impl Pager {
     /// commit dirty pages from current transaction in WAL mode if this is not nested statement (for nested statements, parent will do the commit)
     /// if update_transaction_state set to false, then [Connection::transaction_state] left unchanged
     /// if update_transaction_state set to true, then [Connection::transaction_state] reset to [TransactionState::None] in case when method completes without error
+    /// `sync_mode` belongs to this pager's database because attached databases
+    /// can use a different synchronous mode from the connection's main database.
     #[instrument(skip_all, level = Level::DEBUG)]
     pub fn commit_tx(
         &self,
         connection: &Connection,
+        sync_mode: SyncMode,
         update_transaction_state: bool,
     ) -> IOResultOr<()> {
         if connection.is_nested_stmt() {
@@ -3118,7 +3121,7 @@ impl Pager {
                         CheckpointMode::Passive {
                             upper_bound_inclusive: None,
                         },
-                        connection.get_sync_mode(),
+                        sync_mode,
                         false,
                     );
                     match checkpoint_result {
@@ -3136,7 +3139,7 @@ impl Pager {
                 _ => {
                     return_if_io!(self.commit_wal(
                         connection.wal_auto_actions(),
-                        connection.get_sync_mode(),
+                        sync_mode,
                         connection.get_data_sync_retry(),
                     ));
 

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -488,11 +488,11 @@ impl<'a> Resolver<'a> {
                 }),
             _ => {
                 let attached_dbs = self.attached_databases.read();
-                let (db, _pager) = attached_dbs
+                let entry = attached_dbs
                     .index_to_data
                     .get(&database_id)
                     .expect("Database ID should be valid after resolve_database_id");
-                let schema = db.schema.lock().clone();
+                let schema = entry.db.schema.lock().clone();
                 schema
             }
         };

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -41,15 +41,13 @@ struct BoundIntegrityIndex {
 
 /// Translate PRAGMA integrity_check.
 pub fn translate_integrity_check(
-    schema: &Schema,
     program: &mut ProgramBuilder,
     resolver: &Resolver,
     database_id: usize,
     max_errors: usize,
-    connection: &std::sync::Arc<crate::Connection>,
+    connection: &crate::Connection,
 ) -> crate::Result<()> {
     translate_integrity_check_impl(
-        schema,
         program,
         resolver,
         database_id,
@@ -61,22 +59,50 @@ pub fn translate_integrity_check(
 
 /// Translate PRAGMA quick_check.
 pub fn translate_quick_check(
-    schema: &Schema,
     program: &mut ProgramBuilder,
     resolver: &Resolver,
     database_id: usize,
     max_errors: usize,
-    connection: &std::sync::Arc<crate::Connection>,
+    connection: &crate::Connection,
 ) -> crate::Result<()> {
-    translate_integrity_check_impl(
-        schema,
-        program,
-        resolver,
-        database_id,
-        max_errors,
-        true,
-        connection,
-    )
+    translate_integrity_check_impl(program, resolver, database_id, max_errors, true, connection)
+}
+
+fn translate_integrity_check_impl(
+    program: &mut ProgramBuilder,
+    resolver: &Resolver,
+    database_id: usize,
+    max_errors: usize,
+    quick: bool,
+    connection: &crate::Connection,
+) -> crate::Result<()> {
+    match connection.mv_store_for_db(database_id) {
+        Some(mv_store) => {
+            // Integrity checks read the target's physical file. Its root pages match the
+            // shared MVCC schema, not a connection's potentially older transaction snapshot.
+            let schema = connection.clone_shared_schema(database_id);
+            translate_integrity_check_for_schema(
+                &schema,
+                program,
+                resolver,
+                database_id,
+                max_errors,
+                quick,
+                Some(mv_store.as_ref()),
+            )
+        }
+        None => resolver.with_schema(database_id, |schema| {
+            translate_integrity_check_for_schema(
+                schema,
+                program,
+                resolver,
+                database_id,
+                max_errors,
+                quick,
+                None,
+            )
+        }),
+    }
 }
 
 fn emit_integrity_result_row(
@@ -149,14 +175,14 @@ fn bind_expr_for_table(
     Ok(out)
 }
 
-fn translate_integrity_check_impl(
+fn translate_integrity_check_for_schema(
     schema: &Schema,
     program: &mut ProgramBuilder,
     resolver: &Resolver,
     database_id: usize,
     max_errors: usize,
     quick: bool,
-    connection: &std::sync::Arc<crate::Connection>,
+    mv_store: Option<&crate::MvStore>,
 ) -> crate::Result<()> {
     // 1) Run low-level btree/freelist/overflow verification first. This mirrors
     // SQLite's OP_IntegrityCk front-pass and can already emit corruption errors
@@ -166,9 +192,8 @@ fn translate_integrity_check_impl(
 
     // integrity_check verifies the physical file, so a placeholder (negative) root for an
     // object a passive checkpoint has since materialized must be resolved to its real page.
-    let mv_store_guard = connection.db.get_mv_store();
     let resolve_root = |root_page: i64| -> i64 {
-        match mv_store_guard.as_ref() {
+        match mv_store {
             Some(mv) => mv.resolve_root_page(root_page),
             None => root_page,
         }
@@ -194,8 +219,7 @@ fn translate_integrity_check_impl(
         }
     }
 
-    let passive =
-        mv_store_guard.is_some() && connection.experimental_mvcc_passive_checkpoint_enabled();
+    let passive = mv_store.is_some_and(|mv_store| mv_store.uses_passive_checkpoint());
     let mut dropped_roots = Vec::new();
     for &dropped_root in &schema.dropped_root_pages {
         if live_root_pages.contains(&dropped_root) {
@@ -233,7 +257,13 @@ fn translate_integrity_check_impl(
         target_pc: no_structural_error_label,
     });
 
-    program.emit_string8("*** in database main ***\n".to_string(), scratch_reg);
+    let database_name = resolver
+        .get_database_name_by_index(database_id)
+        .expect("resolved integrity-check database must still exist");
+    program.emit_string8(
+        format!("*** in database {database_name} ***\n"),
+        scratch_reg,
+    );
     program.emit_insn(Insn::Concat {
         lhs: scratch_reg,
         rhs: message_reg,

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -1468,36 +1468,23 @@ fn query_pragma(
         }
         PragmaName::IntegrityCheck => {
             let max_errors = parse_max_errors_from_value(&value);
-            // integrity_check verifies the physical file, so for the main MVCC database use the
-            // latest shared schema (which reflects every committed+materialized object) rather
-            // than this connection's possibly-stale tx-snapshot — otherwise a table another
-            // connection just created and checkpointed is missing and its live page is
-            // mis-reported as orphaned.
-            let main_schema = (database_id == 0 && connection.mvcc_enabled())
-                .then(|| connection.db.schema.lock().clone());
-            let schema = main_schema.as_deref().unwrap_or(schema);
             translate_integrity_check(
-                schema,
                 program,
                 resolver,
                 database_id,
                 max_errors,
-                &connection,
+                connection.as_ref(),
             )?;
             Ok(TransactionMode::Read)
         }
         PragmaName::QuickCheck => {
             let max_errors = parse_max_errors_from_value(&value);
-            let main_schema = (database_id == 0 && connection.mvcc_enabled())
-                .then(|| connection.db.schema.lock().clone());
-            let schema = main_schema.as_deref().unwrap_or(schema);
             translate_quick_check(
-                schema,
                 program,
                 resolver,
                 database_id,
                 max_errors,
-                &connection,
+                connection.as_ref(),
             )?;
             Ok(TransactionMode::Read)
         }

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -906,8 +906,9 @@ fn query_pragma(
         PragmaName::WalCheckpoint => {
             // Checkpoint uses 3 registers: P1, P2, P3. Ref Insn::Checkpoint for more info.
             // Allocate two more here as one was allocated at the top.
-            let passive_allowed = connection.mv_store_for_db(database_id).is_none()
-                || connection.experimental_mvcc_passive_checkpoint_enabled();
+            let passive_allowed = connection
+                .mv_store_for_db(database_id)
+                .is_none_or(|mv_store| mv_store.uses_passive_checkpoint());
             let mode = match value {
                 Some(ast::Expr::Name(name)) => {
                     let mode_name = normalize_ident(name.as_str());

--- a/core/translate/pragma.rs
+++ b/core/translate/pragma.rs
@@ -658,7 +658,7 @@ fn update_pragma(
                     _ => SyncMode::Full,
                 })
             };
-            connection.set_sync_mode(mode);
+            connection.set_sync_mode_for_database(database_id, mode)?;
             Ok(TransactionMode::None)
         }
         PragmaName::DataSyncRetry => {
@@ -1588,7 +1588,7 @@ fn query_pragma(
             Ok(TransactionMode::None)
         }
         PragmaName::Synchronous => {
-            let mode = connection.get_sync_mode();
+            let mode = connection.get_sync_mode_for_database(database_id)?;
             let register = program.alloc_register();
             program.emit_int(mode as i64, register);
             program.emit_result_row(register, 1);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -643,6 +643,7 @@ pub fn op_checkpoint(
     // Re-fetch mv_store from connection to get the latest value.
     // This is necessary because the mv_store may have been set by a preceding JournalMode instruction
     // (e.g., when switching from WAL to MVCC mode via `PRAGMA journal_mode = "mvcc"`).
+    let sync_mode = program.connection.get_sync_mode_for_database(*database)?;
     let mv_store = program.connection.mv_store_for_db(*database);
     if let Some(mv_store) = mv_store.as_ref() {
         use crate::state_machine::{StateTransition, TransitionResult};
@@ -653,7 +654,7 @@ pub fn op_checkpoint(
             mv_store.clone(),
             program.connection.clone(),
             true,
-            program.connection.get_sync_mode(),
+            sync_mode,
             *database,
             *checkpoint_mode,
         );
@@ -686,7 +687,7 @@ pub fn op_checkpoint(
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
-    let step_result = pager.checkpoint(*checkpoint_mode, program.connection.get_sync_mode(), true);
+    let step_result = pager.checkpoint(*checkpoint_mode, sync_mode, true);
     match step_result {
         Ok(IOResult::Done(CheckpointResult {
             wal_max_frame,
@@ -14675,7 +14676,7 @@ pub fn op_parse_schema(
     } else if *db != crate::MAIN_DB_ID {
         let fallback_schema = {
             let attached_dbs = conn.attached_databases.read();
-            let Some((db_inst, _pager)) = attached_dbs.index_to_data.get(db) else {
+            let Some(entry) = attached_dbs.index_to_data.get(db) else {
                 conn.auto_commit
                     .store(previous_auto_commit, Ordering::SeqCst);
                 return Err(LimboError::InternalError(format!(
@@ -14683,7 +14684,7 @@ pub fn op_parse_schema(
                 ))
                 .into());
             };
-            let schema = db_inst.schema.lock().clone();
+            let schema = entry.db.schema.lock().clone();
             schema
         };
         let mut schemas = conn.database_schemas().write();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -16066,11 +16066,9 @@ pub fn op_integrity_check(
         program.get_pager_from_database_index(db)?
     };
     // Passive MVCC: read page-1 freelist fields from the pager; the MVCC header can lag.
-    let passive = mv_store.is_some()
-        && program
-            .connection
-            .experimental_mvcc_passive_checkpoint_enabled();
-    let physical_header_store = if passive { None } else { mv_store.as_ref() };
+    let physical_header_store = mv_store
+        .as_ref()
+        .filter(|mv_store| !mv_store.uses_passive_checkpoint());
     match state.active_op_state.integrity_check() {
         OpIntegrityCheckState::Start => {
             let (freelist_trunk_page, db_size) = return_if_io!(with_header(

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -79,8 +79,7 @@ use crate::{
     vdbe::{builder::CursorType, insn::Insn},
 };
 use crate::{
-    AtomicBool, CaptureDataChangesInfo, Connection, MvStore, Result, Statement, SyncMode,
-    TransactionState,
+    AtomicBool, CaptureDataChangesInfo, Connection, MvStore, Result, Statement, TransactionState,
 };
 use branches::{mark_unlikely, unlikely};
 use builder::{CursorKey, QueryMode};
@@ -2681,7 +2680,7 @@ impl Program {
             return Ok(IOResult::Done(()));
         }
         let txn_finish_result = if !rollback {
-            pager.commit_tx(connection, true)
+            pager.commit_tx(connection, connection.get_sync_mode(), true)
         } else {
             pager.rollback_tx(connection);
             Ok(IOResult::Done(()))
@@ -2734,8 +2733,8 @@ impl Program {
                     // the checkpoint logic can leave read locks held.
                     match attached_pager.commit_wal(
                         WalAutoActions::empty(),
-                        SyncMode::Normal,
-                        false,
+                        connection.get_sync_mode_for_database(db_id)?,
+                        connection.get_data_sync_retry(),
                     ) {
                         Ok(IOResult::Done(_)) => {}
                         Ok(IOResult::IO(io)) => {

--- a/sqlite/conformance/sqlite-sqltests/integrity_check/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/integrity_check/memory.sqltest
@@ -10,6 +10,32 @@ expect {
     ok
 }
 
+
+test integrity-check-qualified-empty-attached-database {
+    CREATE TABLE main.t(a UNIQUE);
+    ATTACH ':memory:' AS aux;
+    PRAGMA aux.user_version = 1;
+    PRAGMA main.page_count;
+    PRAGMA aux.page_count;
+    PRAGMA aux.integrity_check;
+    PRAGMA aux.quick_check;
+}
+expect {
+    3
+    1
+    ok
+    ok
+}
+
+test integrity-check-qualified-corrupt-attached-database {
+    ATTACH 'database/integrity_missing_index_entry.db' AS corrupt_aux;
+    PRAGMA corrupt_aux.integrity_check;
+}
+expect unordered {
+    wrong # of entries in index idx_b
+    row 3 missing from index idx_b
+}
+
 # Test basic quick_check on empty database
 test quick-check-empty {
     PRAGMA quick_check;
@@ -213,4 +239,3 @@ test integrity-check-table-check-constraint-null-passes {
 expect {
     ok
 }
-

--- a/sqlite/conformance/sqlite-sqltests/pragma/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/memory.sqltest
@@ -41,6 +41,19 @@ expect {
     1
 }
 
+@cross-check-integrity
+test pragma-temp-synchronous-stays-off {
+    PRAGMA temp.synchronous;
+    PRAGMA temp.synchronous=FULL;
+    PRAGMA temp.synchronous;
+    PRAGMA main.synchronous;
+}
+expect {
+    0
+    0
+    2
+}
+
 test pragma-function-cache-size {
     SELECT * FROM pragma_cache_size()
 }
@@ -310,4 +323,3 @@ test pragma-page-size-set-uninitialized-db {
 expect {
     1024
 }
-

--- a/sqlite/conformance/sqlite-sqltests/pragma/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/pragma/memory.sqltest
@@ -24,6 +24,23 @@ expect {
     -2000
 }
 
+@cross-check-integrity
+test pragma-attached-database-has-its-own-synchronous-mode {
+    PRAGMA main.synchronous=OFF;
+    ATTACH ':memory:' AS aux;
+    PRAGMA main.synchronous;
+    PRAGMA aux.synchronous;
+    PRAGMA aux.synchronous=NORMAL;
+    PRAGMA main.synchronous;
+    PRAGMA aux.synchronous;
+}
+expect {
+    0
+    2
+    0
+    1
+}
+
 test pragma-function-cache-size {
     SELECT * FROM pragma_cache_size()
 }
@@ -293,5 +310,4 @@ test pragma-page-size-set-uninitialized-db {
 expect {
     1024
 }
-
 

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -1,4 +1,5 @@
 use crate::common::{do_flush, limbo_exec_rows, sqlite_exec_rows, ExecRows, TempDatabase};
+use crate::unreliable_io::UnreliableIo;
 use anyhow::Context;
 use rusqlite::params;
 use rusqlite::Connection as RusqliteConnection;
@@ -48,6 +49,66 @@ fn checkpoint_attached_database(
 }
 
 #[test]
+fn test_attached_wal_commit_uses_attached_synchronous_mode() -> anyhow::Result<()> {
+    const MAIN_PATH: &str = "attached-wal-sync-main.db";
+    const AUX_PATH: &str = "attached-wal-sync-aux.db";
+
+    let io = Arc::new(UnreliableIo::new());
+    let conn = open_unreliable_attached_database(io.clone(), MAIN_PATH)?;
+    conn.execute("PRAGMA main.synchronous=OFF")?;
+    conn.execute(format!("ATTACH '{AUX_PATH}' AS aux"))?;
+    conn.execute("CREATE TABLE aux.t(id INTEGER PRIMARY KEY)")?;
+    io.mark_all_durable();
+
+    conn.execute("INSERT INTO aux.t VALUES (1)")?;
+
+    assert!(
+        !io.has_unsynced_writes(&format!("{AUX_PATH}-wal")),
+        "an attached WAL commit must fsync using aux.synchronous=FULL"
+    );
+
+    io.mark_all_durable();
+    conn.execute("PRAGMA main.synchronous=FULL")?;
+    conn.execute("PRAGMA aux.synchronous=OFF")?;
+    conn.execute("INSERT INTO aux.t VALUES (2)")?;
+    assert!(
+        io.has_unsynced_writes(&format!("{AUX_PATH}-wal")),
+        "aux.synchronous=OFF must not inherit main's FULL fsync"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_attached_checkpoint_uses_attached_synchronous_mode() -> anyhow::Result<()> {
+    const MAIN_PATH: &str = "attached-checkpoint-sync-main.db";
+    const AUX_PATH: &str = "attached-checkpoint-sync-aux.db";
+
+    let io = Arc::new(UnreliableIo::new());
+    let conn = open_unreliable_attached_database(io.clone(), MAIN_PATH)?;
+    conn.execute("PRAGMA main.synchronous=OFF")?;
+    conn.execute(format!("ATTACH '{AUX_PATH}' AS aux"))?;
+    conn.execute("CREATE TABLE aux.t(id INTEGER PRIMARY KEY)")?;
+    conn.execute("INSERT INTO aux.t VALUES (1)")?;
+    io.mark_all_durable();
+
+    let rows = limbo_exec_rows(&conn, "PRAGMA aux.wal_checkpoint(PASSIVE)");
+    assert!(
+        matches!(rows.as_slice(), [row]
+            if matches!(row.as_slice(), [
+                rusqlite::types::Value::Integer(0),
+                rusqlite::types::Value::Integer(_),
+                rusqlite::types::Value::Integer(backfilled),
+            ] if *backfilled > 0)),
+        "the aux checkpoint must backfill WAL frames: {rows:?}"
+    );
+    assert!(
+        !io.has_unsynced_writes(AUX_PATH),
+        "the aux checkpoint must fsync using aux.synchronous=FULL"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_attached_mvcc_checkpoint_uses_attached_passive_setting() -> anyhow::Result<()> {
     let db = TempDatabase::builder()
         .with_opts(
@@ -72,6 +133,71 @@ fn test_attached_mvcc_checkpoint_uses_attached_passive_setting() -> anyhow::Resu
         "PASSIVE checkpoint requires experimental_mvcc_passive_checkpoint"
     );
     Ok(())
+}
+
+#[test]
+fn test_attached_mvcc_auto_checkpoint_uses_attached_pager_and_sync_mode() -> anyhow::Result<()> {
+    const MAIN_PATH: &str = "attached-mvcc-checkpoint-main.db";
+    const AUX_PATH: &str = "attached-mvcc-checkpoint-aux.db";
+
+    let io = Arc::new(UnreliableIo::new());
+    let conn = open_unreliable_attached_database(io.clone(), MAIN_PATH)?;
+    conn.execute("PRAGMA journal_mode=mvcc")?;
+    conn.execute("PRAGMA main.synchronous=OFF")?;
+    conn.execute(format!("ATTACH '{AUX_PATH}' AS aux"))?;
+    conn.execute("CREATE TABLE aux.t(id INTEGER PRIMARY KEY)")?;
+    conn.execute("PRAGMA aux.wal_checkpoint(TRUNCATE)")?;
+
+    let aux_db = Database::open_file_with_flags(
+        io.clone(),
+        AUX_PATH,
+        OpenFlags::default(),
+        DatabaseOpts::new(),
+        None,
+        Arc::new(SqliteDialect),
+    )
+    .context("look up attached database")?;
+    aux_db
+        .get_mv_store()
+        .as_ref()
+        .expect("attached database must use MVCC")
+        .set_checkpoint_threshold(0);
+    io.mark_all_durable();
+    let before = io.durable_files();
+
+    conn.execute("INSERT INTO aux.t VALUES (1)")?;
+
+    let after = io.durable_files();
+    assert_eq!(
+        after.get(MAIN_PATH),
+        before.get(MAIN_PATH),
+        "an attached MVCC checkpoint must not write the main database"
+    );
+    assert_ne!(
+        after.get(AUX_PATH),
+        before.get(AUX_PATH),
+        "an attached MVCC checkpoint must write and fsync the attached database"
+    );
+    assert!(
+        !io.has_unsynced_writes(&format!("{AUX_PATH}-log")),
+        "an attached MVCC commit must fsync using aux.synchronous=FULL"
+    );
+    Ok(())
+}
+
+fn open_unreliable_attached_database(
+    io: Arc<UnreliableIo>,
+    path: &str,
+) -> anyhow::Result<Arc<turso_core::Connection>> {
+    let db = Database::open_file_with_flags(
+        io,
+        path,
+        OpenFlags::default(),
+        DatabaseOpts::new().with_attach(true),
+        None,
+        Arc::new(SqliteDialect),
+    )?;
+    Ok(db.connect()?)
 }
 
 #[turso_macros::test]

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -47,6 +47,33 @@ fn checkpoint_attached_database(
     Ok(())
 }
 
+#[test]
+fn test_attached_mvcc_checkpoint_uses_attached_passive_setting() -> anyhow::Result<()> {
+    let db = TempDatabase::builder()
+        .with_opts(
+            DatabaseOpts::new()
+                .with_attach(true)
+                .with_experimental_mvcc_passive_checkpoint(true),
+        )
+        .with_mvcc(true)
+        .build();
+    let conn = db.connect_limbo();
+    conn.execute("PRAGMA main.wal_checkpoint(PASSIVE)")?;
+
+    let aux_path = db.path.with_extension("attach_mvcc_checkpoint_mode.db");
+    conn.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
+
+    let error = conn
+        .execute("PRAGMA aux.wal_checkpoint(PASSIVE)")
+        .unwrap_err()
+        .to_string();
+    assert_eq!(
+        error,
+        "PASSIVE checkpoint requires experimental_mvcc_passive_checkpoint"
+    );
+    Ok(())
+}
+
 #[turso_macros::test]
 fn test_attached_schema_refreshes_after_other_connection_create(
     tmp_db: TempDatabase,


### PR DESCRIPTION
found in https://github.com/tursodatabase/turso/pull/8513
Fixes attached-database paths that accidentally reused state from main.

- Qualified `PRAGMA integrity_check` (aux.integrity_check) now use the selected database’s schema and, when applicable, its MVCC store.
- Each attached database now has its own synchronous setting, which is used for its WAL and MVCC commits and checkpoints.

