### PR TITLE
core/json: fix json_each/json_tree over null column

### DIFF
--- a/core/json/vtab.rs
+++ b/core/json/vtab.rs
@@ -253,7 +253,7 @@ impl InternalVirtualTableCursor for JsonEachCursor {
         self.traversal_states.clear();
         self.rowid = 0;
 
-        if args.is_empty() {
+        if args.is_empty() || args[0] == Value::Null {
             return Ok(false);
         }
         if args.len() == 2 && matches!(self.traversal_mode, JsonTraversalMode::Tree) {

--- a/sqlite/conformance/sqlite-sqltests/json/default.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/json/default.sqltest
@@ -3461,3 +3461,23 @@ test jsonb-oversized-child-remove {
 }
 expect {
 }
+
+test json_each_over_null_column {
+    WITH t(id, tags) AS (
+        VALUES (1, '["x"]'), (2, NULL)
+    )
+    SELECT COUNT(*) FROM t, json_each(t.tags);
+}
+expect {
+    1
+}
+
+test json_tree_over_null_column {
+    WITH t(id, tags) AS (
+        VALUES (1, '["x"]'), (2, NULL)
+    )
+    SELECT COUNT(*) FROM t, json_tree(t.tags);
+}
+expect {
+    2
+}


### PR DESCRIPTION
Prevents `json_each` and `json_tree` from producing phantom rows for `NULL` column values.
Added regression tests for both functions.
Fixes #8576.