### PR TITLE
serverless/js: fix broken README links and add repository field

### DIFF
--- a/serverless/javascript/README.md
+++ b/serverless/javascript/README.md
@@ -176,7 +176,7 @@ Check out the `examples/` directory for complete usage examples.
 
 ## API Reference
 
-For complete API documentation, see [JavaScript API Reference](../../docs/javascript-api-reference.md).
+For complete API documentation, see [JavaScript API Reference](https://github.com/tursodatabase/turso/blob/main/docs/javascript-api-reference.md).
 
 ## Related Packages
 
@@ -185,7 +185,7 @@ For complete API documentation, see [JavaScript API Reference](../../docs/javasc
 
 ## License
 
-This project is licensed under the [MIT license](../../LICENSE.md).
+This project is licensed under the [MIT license](https://github.com/tursodatabase/turso/blob/main/LICENSE.md).
 
 ## Support
 

--- a/serverless/javascript/package.json
+++ b/serverless/javascript/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@tursodatabase/serverless",
   "version": "1.4.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tursodatabase/turso"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
Fixes #7592.

This updates the published `@tursodatabase/serverless` package metadata and README links:

- Replace the broken relative JavaScript API reference link with the repository's canonical GitHub URL.
- Replace the broken relative license link with the repository's canonical GitHub URL.
- Add the missing npm `repository` field, matching the format used by sibling JavaScript packages.

Validation:
- `npm pack --dry-run`
- `npm pack`
- inspected the generated package metadata
- `git diff --check`

No source code or unrelated files were changed.