### PR TITLE
core/translate: refuse ALTER TABLE RENAME onto an existing view name

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1565,17 +1565,18 @@ pub fn translate_alter_table(
             let normalized_new_name = normalize_ident(new_name);
             let mut temp_triggers_to_rewrite: Vec<(String, String, bool)> = Vec::new();
 
-            if resolver.with_schema(database_id, |s| {
-                s.get_table(new_name).is_some()
-                    || s.indexes
-                        .values()
-                        .flatten()
-                        .any(|index| index.name == normalize_ident(new_name))
-            }) {
+            // Views whose SQL failed to load are absent from the schema maps
+            // but their rows are still in sqlite_schema, so the name is taken.
+            let new_name_taken = resolver.with_schema(database_id, |s| {
+                s.get_object_type(&normalized_new_name).is_some()
+                    || s.broken_views.contains(&normalized_new_name)
+                    || s.incompatible_views.contains(&normalized_new_name)
+            });
+            if new_name_taken {
                 return Err(LimboError::ParseError(format!(
                     "there is already another table or index with this name: {new_name}"
                 )));
-            };
+            }
 
             for trigger_entry in collect_triggers_for_alter_target(resolver, database_id) {
                 if let Some(missing_table) = validate_trigger_table_refs_after_rename(

--- a/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
@@ -582,6 +582,28 @@ test fail-alter-table-rename-to-existing-table {
 expect error {
 }
 
+@skip-if mvcc "views not supported in MVCC mode"
+@cross-check-integrity
+test fail-alter-table-rename-to-existing-view {
+    CREATE TABLE x (a);
+    CREATE VIEW y AS SELECT 1;
+    ALTER TABLE x RENAME TO y;
+}
+expect error {
+    there is already another table or index with this name: y
+}
+
+@skip-if mvcc "views not supported in MVCC mode"
+@cross-check-integrity
+test fail-alter-table-rename-to-existing-view-different-case {
+    CREATE TABLE x (a);
+    CREATE VIEW y AS SELECT 1;
+    ALTER TABLE x RENAME TO Y;
+}
+expect error {
+    there is already another table or index with this name: Y
+}
+
 @cross-check-integrity
 test alter-table-rename-to-quoted-identifier {
     CREATE TABLE t (a);


### PR DESCRIPTION
The rename check in `translate_alter_table` only looked at tables and indexes, so `ALTER TABLE t RENAME TO v` went through when `v` was a view. You end up with two `sqlite_schema` rows called `v` and the file won't open anymore, neither in sqlite3 nor in turso.

Switched it to `Schema::get_object_type`, same thing CREATE TABLE / CREATE VIEW already use. Also covers views that didn't load (`broken_views` / `incompatible_views`), their rows are still in sqlite_schema so the name is still taken.

Fixes #8579
