### PR TITLE
core: accept UUID blobs in STRICT tables

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -820,7 +820,7 @@ fn bootstrap_builtin_types(registry: &mut HashMap<String, Arc<TypeDef>>) -> crat
 
     let type_sqls: &[&str] = &[
         #[cfg(feature = "uuid")]
-        "CREATE TYPE uuid(value text) BASE blob ENCODE uuid_blob(value) DECODE uuid_str(value) DEFAULT uuid4_str() OPERATOR '<'",
+        "CREATE TYPE uuid(value any) BASE blob ENCODE CASE WHEN typeof(value) = 'blob' AND length(value) = 16 THEN value ELSE uuid_blob(value) END DECODE uuid_str(value) DEFAULT uuid4_str() OPERATOR '<'",
         "CREATE TYPE boolean(value any) BASE integer ENCODE boolean_to_int(value) DECODE CASE WHEN value THEN 1 ELSE 0 END OPERATOR '<'",
         #[cfg(feature = "json")]
         "CREATE TYPE json(value text) BASE text ENCODE json(value) DECODE value",

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -820,7 +820,7 @@ fn bootstrap_builtin_types(registry: &mut HashMap<String, Arc<TypeDef>>) -> crat
 
     let type_sqls: &[&str] = &[
         #[cfg(feature = "uuid")]
-        "CREATE TYPE uuid(value any) BASE blob ENCODE CASE WHEN typeof(value) = 'blob' AND length(value) = 16 THEN value ELSE uuid_blob(value) END DECODE uuid_str(value) DEFAULT uuid4_str() OPERATOR '<'",
+        "CREATE TYPE uuid(value any) BASE blob ENCODE CASE WHEN value IS NULL THEN NULL WHEN typeof(value) = 'blob' AND length(value) = 16 THEN value ELSE coalesce(uuid_blob(value), RAISE(ABORT, 'invalid UUID value')) END DECODE uuid_str(value) DEFAULT uuid4_str() OPERATOR '<'",
         "CREATE TYPE boolean(value any) BASE integer ENCODE boolean_to_int(value) DECODE CASE WHEN value THEN 1 ELSE 0 END OPERATOR '<'",
         #[cfg(feature = "json")]
         "CREATE TYPE json(value text) BASE text ENCODE json(value) DECODE value",

--- a/sqlite/conformance/turso-sqltests/custom_types.sqltest
+++ b/sqlite/conformance/turso-sqltests/custom_types.sqltest
@@ -318,7 +318,7 @@ expect {
     time(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN time (value) IS NULL THEN RAISE (ABORT, 'invalid time value') ELSE rtrim (rtrim (strftime ('%H:%M:%f', value), '0'), '.') END|value||'<'
     timestamp(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE rtrim (rtrim (strftime ('%Y-%m-%d %H:%M:%f', value), '0'), '.') END|value||'<'
     timestamptz(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE rtrim (rtrim (strftime ('%Y-%m-%d %H:%M:%f', value), '0'), '.') END|value||'<'
-    uuid(value text)|blob|uuid_blob (value)|uuid_str (value)|uuid4_str ()|'<'
+    uuid(value any)|blob|CASE WHEN typeof (value) = 'blob' AND length (value) = 16 THEN value ELSE uuid_blob (value) END|uuid_str (value)|uuid4_str ()|'<'
     varchar(value text, maxlen integer)|text|CASE WHEN length (value) <= maxlen THEN value ELSE RAISE (ABORT, 'value too long for varchar') END|value||'<'
 }
 
@@ -353,7 +353,7 @@ expect {
     time(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN time (value) IS NULL THEN RAISE (ABORT, 'invalid time value') ELSE rtrim (rtrim (strftime ('%H:%M:%f', value), '0'), '.') END|value||'<'
     timestamp(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE rtrim (rtrim (strftime ('%Y-%m-%d %H:%M:%f', value), '0'), '.') END|value||'<'
     timestamptz(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE rtrim (rtrim (strftime ('%Y-%m-%d %H:%M:%f', value), '0'), '.') END|value||'<'
-    uuid(value text)|blob|uuid_blob (value)|uuid_str (value)|uuid4_str ()|'<'
+    uuid(value any)|blob|CASE WHEN typeof (value) = 'blob' AND length (value) = 16 THEN value ELSE uuid_blob (value) END|uuid_str (value)|uuid4_str ()|'<'
     varchar(value text, maxlen integer)|text|CASE WHEN length (value) <= maxlen THEN value ELSE RAISE (ABORT, 'value too long for varchar') END|value||'<'
 }
 
@@ -365,6 +365,48 @@ test encode-null-rejects-primary-key {
 }
 expect error {
     NOT NULL constraint failed
+}
+
+@requires strict "uses STRICT tables"
+test strict-uuid-accepts-generated-blobs {
+    CREATE TABLE t1(id uuid PRIMARY KEY) STRICT;
+    INSERT INTO t1 VALUES (uuid4());
+    INSERT INTO t1 VALUES (uuid7());
+    SELECT count(*), min(length(id)), max(length(id)) FROM t1;
+}
+expect {
+    2|36|36
+}
+
+@requires strict "uses STRICT tables"
+test strict-uuid-rejects-invalid-blob {
+    CREATE TABLE t1(id uuid PRIMARY KEY) STRICT;
+    INSERT INTO t1 VALUES (X'0102');
+}
+expect error {
+    NOT NULL constraint failed
+}
+
+@requires strict "uses STRICT tables"
+test strict-uuid-rejects-invalid-text {
+    CREATE TABLE t1(id uuid PRIMARY KEY) STRICT;
+    INSERT INTO t1 VALUES ('not a uuid');
+}
+expect error {
+    NOT NULL constraint failed
+}
+
+@requires strict "uses STRICT tables"
+test strict-uuid-foreign-key-matches-text-and-blob {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE t1(id uuid PRIMARY KEY) STRICT;
+    CREATE TABLE t2(parent_id uuid REFERENCES t1(id)) STRICT;
+    INSERT INTO t1 VALUES ('01945ca0-3189-76c0-9a8f-caf310fc8b8e');
+    INSERT INTO t2 VALUES (X'01945ca0318976c09a8fcaf310fc8b8e');
+    SELECT parent_id FROM t2;
+}
+expect {
+    01945ca0-3189-76c0-9a8f-caf310fc8b8e
 }
 
 @requires strict "uses STRICT tables"

--- a/sqlite/conformance/turso-sqltests/custom_types.sqltest
+++ b/sqlite/conformance/turso-sqltests/custom_types.sqltest
@@ -318,7 +318,7 @@ expect {
     time(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN time (value) IS NULL THEN RAISE (ABORT, 'invalid time value') ELSE rtrim (rtrim (strftime ('%H:%M:%f', value), '0'), '.') END|value||'<'
     timestamp(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE rtrim (rtrim (strftime ('%Y-%m-%d %H:%M:%f', value), '0'), '.') END|value||'<'
     timestamptz(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE rtrim (rtrim (strftime ('%Y-%m-%d %H:%M:%f', value), '0'), '.') END|value||'<'
-    uuid(value any)|blob|CASE WHEN typeof (value) = 'blob' AND length (value) = 16 THEN value ELSE uuid_blob (value) END|uuid_str (value)|uuid4_str ()|'<'
+    uuid(value any)|blob|CASE WHEN value IS NULL THEN NULL WHEN typeof (value) = 'blob' AND length (value) = 16 THEN value ELSE coalesce (uuid_blob (value), RAISE (ABORT, 'invalid UUID value')) END|uuid_str (value)|uuid4_str ()|'<'
     varchar(value text, maxlen integer)|text|CASE WHEN length (value) <= maxlen THEN value ELSE RAISE (ABORT, 'value too long for varchar') END|value||'<'
 }
 
@@ -353,7 +353,7 @@ expect {
     time(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN time (value) IS NULL THEN RAISE (ABORT, 'invalid time value') ELSE rtrim (rtrim (strftime ('%H:%M:%f', value), '0'), '.') END|value||'<'
     timestamp(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE rtrim (rtrim (strftime ('%Y-%m-%d %H:%M:%f', value), '0'), '.') END|value||'<'
     timestamptz(value text)|text|CASE WHEN value IS NULL THEN NULL WHEN datetime (value) IS NULL THEN RAISE (ABORT, 'invalid timestamp value') ELSE rtrim (rtrim (strftime ('%Y-%m-%d %H:%M:%f', value), '0'), '.') END|value||'<'
-    uuid(value any)|blob|CASE WHEN typeof (value) = 'blob' AND length (value) = 16 THEN value ELSE uuid_blob (value) END|uuid_str (value)|uuid4_str ()|'<'
+    uuid(value any)|blob|CASE WHEN value IS NULL THEN NULL WHEN typeof (value) = 'blob' AND length (value) = 16 THEN value ELSE coalesce (uuid_blob (value), RAISE (ABORT, 'invalid UUID value')) END|uuid_str (value)|uuid4_str ()|'<'
     varchar(value text, maxlen integer)|text|CASE WHEN length (value) <= maxlen THEN value ELSE RAISE (ABORT, 'value too long for varchar') END|value||'<'
 }
 
@@ -367,7 +367,6 @@ expect error {
     NOT NULL constraint failed
 }
 
-@requires strict "uses STRICT tables"
 test strict-uuid-accepts-generated-blobs {
     CREATE TABLE t1(id uuid PRIMARY KEY) STRICT;
     INSERT INTO t1 VALUES (uuid4());
@@ -378,25 +377,152 @@ expect {
     2|36|36
 }
 
-@requires strict "uses STRICT tables"
 test strict-uuid-rejects-invalid-blob {
     CREATE TABLE t1(id uuid PRIMARY KEY) STRICT;
     INSERT INTO t1 VALUES (X'0102');
 }
 expect error {
-    NOT NULL constraint failed
+    invalid UUID value
 }
 
-@requires strict "uses STRICT tables"
 test strict-uuid-rejects-invalid-text {
     CREATE TABLE t1(id uuid PRIMARY KEY) STRICT;
     INSERT INTO t1 VALUES ('not a uuid');
 }
 expect error {
-    NOT NULL constraint failed
+    invalid UUID value
 }
 
-@requires strict "uses STRICT tables"
+setup nullable-uuid {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b uuid) STRICT;
+}
+
+@setup nullable-uuid
+test strict-uuid-nullable-rejects-integer {
+    INSERT INTO t1 VALUES (1, 42);
+}
+expect error {
+    invalid UUID value
+}
+
+@setup nullable-uuid
+test strict-uuid-nullable-rejects-real {
+    INSERT INTO t1 VALUES (1, 3.5);
+}
+expect error {
+    invalid UUID value
+}
+
+@setup nullable-uuid
+test strict-uuid-nullable-rejects-short-blob {
+    INSERT INTO t1 VALUES (1, X'0102');
+}
+expect error {
+    invalid UUID value
+}
+
+@setup nullable-uuid
+test strict-uuid-nullable-rejects-malformed-text {
+    INSERT INTO t1 VALUES (1, 'not a uuid');
+}
+expect error {
+    invalid UUID value
+}
+
+setup uuid-row {
+    INSERT INTO t1 VALUES (1, '01945ca0-3189-76c0-9a8f-caf310fc8b8e');
+}
+
+@setup nullable-uuid
+@setup uuid-row
+test strict-uuid-update-rejects-integer {
+    UPDATE t1 SET b = 42;
+}
+expect error {
+    invalid UUID value
+}
+
+@setup nullable-uuid
+@setup uuid-row
+test strict-uuid-update-rejects-real {
+    UPDATE t1 SET b = 3.5;
+}
+expect error {
+    invalid UUID value
+}
+
+@setup nullable-uuid
+@setup uuid-row
+test strict-uuid-update-rejects-short-blob {
+    UPDATE t1 SET b = X'0102';
+}
+expect error {
+    invalid UUID value
+}
+
+@setup nullable-uuid
+@setup uuid-row
+test strict-uuid-update-rejects-malformed-text {
+    UPDATE t1 SET b = 'not a uuid';
+}
+expect error {
+    invalid UUID value
+}
+
+test strict-uuid-not-null-update-rejects-short-blob {
+    CREATE TABLE t1(b uuid NOT NULL) STRICT;
+    INSERT INTO t1 VALUES ('01945ca0-3189-76c0-9a8f-caf310fc8b8e');
+    UPDATE t1 SET b = X'0102';
+}
+expect error {
+    invalid UUID value
+}
+
+@setup nullable-uuid
+@setup uuid-row
+test strict-uuid-upsert-rejects-integer {
+    INSERT INTO t1 VALUES (1, '01945ca0-3189-76c0-9a8f-caf310fc8b8e')
+        ON CONFLICT(a) DO UPDATE SET b = 42;
+}
+expect error {
+    invalid UUID value
+}
+
+@setup nullable-uuid
+test strict-uuid-valid-inputs {
+    INSERT INTO t1 VALUES (1, '01945ca0-3189-76c0-9a8f-caf310fc8b8e'),
+        (2, X'01945ca0318976c09a8fcaf310fc8b8e'), (3, NULL);
+    SELECT a, quote(b) FROM t1 ORDER BY a;
+    UPDATE t1 SET b = X'01945ca0318976c09a8fcaf310fc8b8e' WHERE a = 1;
+    UPDATE t1 SET b = '01945ca0-3189-76c0-9a8f-caf310fc8b8e' WHERE a = 2;
+    UPDATE t1 SET b = NULL WHERE a = 3;
+    SELECT a, quote(b) FROM t1 ORDER BY a;
+}
+expect {
+    1|'01945ca0-3189-76c0-9a8f-caf310fc8b8e'
+    2|'01945ca0-3189-76c0-9a8f-caf310fc8b8e'
+    3|NULL
+    1|'01945ca0-3189-76c0-9a8f-caf310fc8b8e'
+    2|'01945ca0-3189-76c0-9a8f-caf310fc8b8e'
+    3|NULL
+}
+
+test strict-uuid-cast-null {
+    SELECT CAST(NULL AS uuid) IS NULL;
+}
+expect {
+    1
+}
+
+test uuid-blob-invalid-inputs-remain-null {
+    SELECT uuid_blob(42) IS NULL, uuid_blob(3.5) IS NULL,
+        uuid_blob(X'0102') IS NULL, uuid_blob('not a uuid') IS NULL,
+        uuid_blob(NULL) IS NULL;
+}
+expect {
+    1|1|1|1|1
+}
+
 test strict-uuid-foreign-key-matches-text-and-blob {
     PRAGMA foreign_keys = ON;
     CREATE TABLE t1(id uuid PRIMARY KEY) STRICT;

--- a/tests/integration/custom_types.rs
+++ b/tests/integration/custom_types.rs
@@ -3,6 +3,93 @@ mod tests {
     use crate::common::{ExecRows, TempDatabase};
     use tempfile::TempDir;
 
+    #[test]
+    fn test_uuid_invalid_update_and_upsert_preserve_rows() {
+        for mvcc in [false, true] {
+            let opts = turso_core::DatabaseOpts::new()
+                .with_custom_types(true)
+                .with_encryption(true);
+            let db = TempDatabase::builder()
+                .with_opts(opts)
+                .with_mvcc(mvcc)
+                .build();
+            let conn = db.connect_limbo();
+            let mode: Vec<(String,)> = conn.exec_rows("PRAGMA journal_mode");
+            assert_eq!(mode, vec![(if mvcc { "mvcc" } else { "wal" }.to_string(),)]);
+
+            let uuid = "01945ca0-3189-76c0-9a8f-caf310fc8b8e";
+            conn.execute("CREATE TABLE t1(a INTEGER PRIMARY KEY, b uuid) STRICT")
+                .unwrap();
+            conn.execute(format!("INSERT INTO t1 VALUES (1, '{uuid}')"))
+                .unwrap();
+
+            for sql in [
+                "UPDATE t1 SET b = 42 WHERE a = 1",
+                "INSERT INTO t1 VALUES (1, '01945ca0-3189-76c0-9a8f-caf310fc8b8e') \
+                 ON CONFLICT(a) DO UPDATE SET b = 42",
+            ] {
+                let err = conn.execute(sql).unwrap_err();
+                assert!(
+                    err.to_string().contains("invalid UUID value"),
+                    "mvcc={mvcc}, {sql}: {err}"
+                );
+                let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM t1 ORDER BY a");
+                assert_eq!(rows, vec![(1, uuid.to_string())], "mvcc={mvcc}, {sql}");
+            }
+            conn.close().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_uuid_invalid_multirow_writes_preserve_transaction() {
+        for mvcc in [false, true] {
+            let opts = turso_core::DatabaseOpts::new()
+                .with_custom_types(true)
+                .with_encryption(true);
+            let db = TempDatabase::builder()
+                .with_opts(opts)
+                .with_mvcc(mvcc)
+                .build();
+            let conn = db.connect_limbo();
+            let mode: Vec<(String,)> = conn.exec_rows("PRAGMA journal_mode");
+            assert_eq!(mode, vec![(if mvcc { "mvcc" } else { "wal" }.to_string(),)]);
+
+            let uuid = "01945ca0-3189-76c0-9a8f-caf310fc8b8e";
+            conn.execute("CREATE TABLE t1(a INTEGER PRIMARY KEY, b uuid) STRICT")
+                .unwrap();
+            conn.execute(format!(
+                "INSERT INTO t1 VALUES (1, '{uuid}'), (2, '{uuid}')"
+            ))
+            .unwrap();
+            conn.execute("BEGIN").unwrap();
+            conn.execute(format!("INSERT INTO t1 VALUES (3, '{uuid}')"))
+                .unwrap();
+            let expected = vec![
+                (1, uuid.to_string()),
+                (2, uuid.to_string()),
+                (3, uuid.to_string()),
+            ];
+
+            for sql in [
+                "INSERT INTO t1 VALUES (4, '01945ca0-3189-76c0-9a8f-caf310fc8b8e'), (5, 42)",
+                "UPDATE t1 SET b = CASE WHEN a = 1 THEN '550e8400-e29b-41d4-a716-446655440000' \
+                 ELSE 42 END WHERE a < 3",
+            ] {
+                let err = conn.execute(sql).unwrap_err();
+                assert!(
+                    err.to_string().contains("invalid UUID value"),
+                    "mvcc={mvcc}, {sql}: {err}"
+                );
+                let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM t1 ORDER BY a");
+                assert_eq!(rows, expected, "mvcc={mvcc}, {sql}");
+            }
+            conn.execute("COMMIT").unwrap();
+            let rows: Vec<(i64, String)> = conn.exec_rows("SELECT a, b FROM t1 ORDER BY a");
+            assert_eq!(rows, expected, "mvcc={mvcc}, after COMMIT");
+            conn.close().unwrap();
+        }
+    }
+
     /// Custom types must be loaded from __turso_internal_types when reopening
     /// a database. Without this, SELECT returns raw encoded values and PRAGMA
     /// list_types omits user-defined types.


### PR DESCRIPTION

<!-- 
# NOTICE:
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.

for maintainers:
this pr description was based off my understanding, and ai wasn't used in the process. see:
https://www.pangram.com/history/cb0e595c-1648-43ad-8c44-348a8c573c92?ucc=8YMatFMs9ac 
-->

## Description

update the built-in uuid custom type to accept both text and binary at the first type check before the encoder to fix #6221 and added regression tests as usual

## Motivation and context

so i did a bit of digging to understand how this work and i've run it down to it being literally a type mismatch in the first check before the encoder.

i've decided to take a look at #7031 and #7139 as starting points but both changed `uuid_blob()` to accept BLOB input and while that just happens to works functionally, it also changes documented behavior for a problem that belongs to the type definition, additionally it runs it through `uuid_blob` causing unnecessary copies. 

side note: for #6221, the table isn't strict and blob only means arbitrary binary so it doesn't really validate the uuids. however, in strict tables it can require the blob storage class but wont know whether said blob contains a uuid or arbitrary bytes which made me lean towards the correct semantic type being `uuid` and not raw blob for both pk and fk.

side side note: i've also looked into #7550 which seems to address something broader, however it increases blast-radius and accepts wrong-length/malformed blobs (though it avoids the previously stated unnecessary copy situation)

this change just makes a cheap type/length check while being properly scoped and has fewer blob copies and in my opinion, looks better because its effectively a one liner change

edit: fixed typos, and also fixed me inverting the first check and the encoder (oops) and removed brain fart

edit 2: regarding `any` usage, it only applies at first check before encoding, it does **not** apply to stored data for what i believe should be obvious reasons, removed brain fart.

## Description of AI Usage

ai was used to help debug and explain stuff and help with testing, implementation + refining was done on my end after reading rust docs (uuid) and the turso docs (create type) to help me understand better