### PR TITLE
bindings/dotnet: complete ADO.NET compatibility and stream recovery

### DIFF
--- a/bindings/dotnet/src/Turso.Data/TursoConnection.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoConnection.cs
@@ -8,6 +8,7 @@ namespace Turso;
 
 public class TursoConnection : DbConnection
 {
+    internal static Func<HttpMessageHandler?>? RemoteMessageHandlerFactory { get; set; }
     internal static Func<HttpClient?>? SyncHttpClientFactory { get; set; }
 
     private TursoDatabaseHandle? _turso;
@@ -28,6 +29,7 @@ public class TursoConnection : DbConnection
     private bool _closing;
     private bool _readUncommitted;
     private bool _remoteTransactionActive;
+    private System.Runtime.ExceptionServices.ExceptionDispatchInfo? _remoteTransactionFailure;
 
     [AllowNull]
     public override string ConnectionString
@@ -280,20 +282,33 @@ public class TursoConnection : DbConnection
         CancellationToken cancellationToken)
     {
         var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
+        ThrowIfRemoteTransactionFaulted();
         var closeAfter = !_connectionOptions.ReadYourWrites && !_remoteTransactionActive;
-        try
+        for (var attempt = 0; ; attempt++)
         {
-            return await remoteClient.ExecuteAsync(sql, parameters, wantRows, commandTimeout, closeAfter, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch (TursoRemoteSqlException)
-        {
-            throw;
-        }
-        catch
-        {
-            InvalidateRemoteSession();
-            throw;
+            try
+            {
+                return await remoteClient.ExecuteAsync(sql, parameters, wantRows, commandTimeout, closeAfter, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (TursoRemoteSqlException exception) when (
+                !_remoteTransactionActive && attempt == 0 && exception.IsStreamExpired)
+            {
+                remoteClient.ResetSession();
+            }
+            catch (TursoRemoteSqlException exception)
+            {
+                if (_remoteTransactionActive && exception.IsStreamExpired)
+                    _remoteTransactionFailure = System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception);
+                else if (exception.IsStreamExpired)
+                    remoteClient.ResetSession();
+                throw;
+            }
+            catch
+            {
+                InvalidateRemoteSession();
+                throw;
+            }
         }
     }
 
@@ -304,6 +319,7 @@ public class TursoConnection : DbConnection
         CancellationToken cancellationToken)
     {
         var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
+        ThrowIfRemoteTransactionFaulted();
         var closeAfter = !_connectionOptions.ReadYourWrites && !_remoteTransactionActive;
         try
         {
@@ -328,24 +344,34 @@ public class TursoConnection : DbConnection
         }
     }
 
-    internal void BeginRemoteTransaction(IsolationLevel isolationLevel)
+    internal void BeginRemoteTransaction(IsolationLevel isolationLevel, bool deferred = true)
     {
-        _ = isolationLevel;
         var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
         if (_remoteTransactionActive)
             throw new InvalidOperationException("A transaction is already active on this connection.");
 
+        _remoteTransactionFailure = null;
         _remoteTransactionActive = true;
         try
         {
             remoteClient
-                .ExecuteAsync("BEGIN", new TursoParameterCollection(), wantRows: false, DefaultTimeout, closeAfter: false, CancellationToken.None)
+                .ExecuteAsync(
+                    isolationLevel == IsolationLevel.Serializable && !deferred
+                        ? "BEGIN IMMEDIATE"
+                        : "BEGIN",
+                    new TursoParameterCollection(),
+                    wantRows: false,
+                    DefaultTimeout,
+                    closeAfter: false,
+                    CancellationToken.None)
                 .GetAwaiter()
                 .GetResult();
         }
-        catch (TursoRemoteSqlException)
+        catch (TursoRemoteSqlException exception)
         {
             _remoteTransactionActive = false;
+            if (exception.IsStreamExpired)
+                remoteClient.ResetSession();
             throw;
         }
         catch
@@ -360,6 +386,7 @@ public class TursoConnection : DbConnection
         var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
         if (!_remoteTransactionActive)
             throw new InvalidOperationException("No remote transaction is active on this connection.");
+        ThrowIfRemoteTransactionFaulted();
 
         try
         {
@@ -368,8 +395,10 @@ public class TursoConnection : DbConnection
                 .GetAwaiter()
                 .GetResult();
         }
-        catch (TursoRemoteSqlException)
+        catch (TursoRemoteSqlException exception)
         {
+            if (exception.IsStreamExpired)
+                _remoteTransactionFailure = System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception);
             throw;
         }
         catch
@@ -386,6 +415,7 @@ public class TursoConnection : DbConnection
         var remoteClient = _remoteClient ?? throw new InvalidOperationException("Turso database is closed.");
         if (!_remoteTransactionActive)
             throw new InvalidOperationException("No remote transaction is active on this connection.");
+        ThrowIfRemoteTransactionFaulted();
 
         try
         {
@@ -400,6 +430,15 @@ public class TursoConnection : DbConnection
             InvalidateRemoteSession();
             throw;
         }
+    }
+
+    internal bool RemoteTransactionFaulted => _remoteTransactionFailure is not null;
+
+    internal void CompleteFaultedRemoteTransaction()
+    {
+        _remoteClient?.ResetSession();
+        _remoteTransactionActive = false;
+        _remoteTransactionFailure = null;
     }
 
     internal void CloseRemoteSessionIfStateless()
@@ -433,7 +472,14 @@ public class TursoConnection : DbConnection
         if (_connectionOptions.GetEncryptionCipher().HasValue || !string.IsNullOrWhiteSpace(_connectionOptions["Encryption Key"]))
             throw new InvalidOperationException("Encryption Cipher and Encryption Key are local database options and cannot be used with remote Turso URLs.");
 
-        _remoteClient = new TursoRemoteClient(_connectionOptions.GetRemoteUri(), _connectionOptions.AuthToken);
+        var handler = RemoteMessageHandlerFactory?.Invoke();
+        _remoteClient = handler is null
+            ? new TursoRemoteClient(_connectionOptions.GetRemoteUri(), _connectionOptions.AuthToken)
+            : new TursoRemoteClient(
+                new HttpClient(handler),
+                _connectionOptions.GetRemoteUri(),
+                _connectionOptions.AuthToken,
+                disposeHttpClient: true);
     }
 
     private void OpenReplica()
@@ -618,10 +664,13 @@ public class TursoConnection : DbConnection
         {
             if (_remoteTransactionActive)
             {
-                remoteClient
-                    .ExecuteAsync("ROLLBACK", new TursoParameterCollection(), wantRows: false, DefaultTimeout, closeAfter: true, CancellationToken.None)
-                    .GetAwaiter()
-                    .GetResult();
+                if (_remoteTransactionFailure is null)
+                {
+                    remoteClient
+                        .ExecuteAsync("ROLLBACK", new TursoParameterCollection(), wantRows: false, DefaultTimeout, closeAfter: true, CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult();
+                }
             }
             else
             {
@@ -637,6 +686,7 @@ public class TursoConnection : DbConnection
             remoteClient.Dispose();
             _remoteClient = null;
             _remoteTransactionActive = false;
+            _remoteTransactionFailure = null;
             _readUncommitted = false;
         }
 
@@ -649,6 +699,7 @@ public class TursoConnection : DbConnection
         _remoteClient?.Dispose();
         _remoteClient = null;
         _remoteTransactionActive = false;
+        _remoteTransactionFailure = null;
         _readUncommitted = false;
     }
 
@@ -760,6 +811,11 @@ public class TursoConnection : DbConnection
 
         foreach (var reader in readers)
             reader.Dispose();
+    }
+
+    private void ThrowIfRemoteTransactionFaulted()
+    {
+        _remoteTransactionFailure?.Throw();
     }
 
     private sealed record AutomaticSyncNotification(

--- a/bindings/dotnet/src/Turso.Data/TursoDataReader.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoDataReader.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Data.Common;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Turso.Raw.Public;
 using Turso.Raw.Public.Handles;
 using Turso.Raw.Public.Value;
@@ -15,6 +16,7 @@ public class TursoDataReader : DbDataReader
     private readonly TursoCommand _command;
     private readonly TursoStatementHandle _statement;
     private readonly CommandBehavior _behavior;
+    private readonly Type?[] _fieldTypes;
     private IDisposable? _syncOperation;
     private TursoConnection? _syncConnection;
     private bool _isClosed;
@@ -34,6 +36,7 @@ public class TursoDataReader : DbDataReader
         _statement = statement;
         _behavior = behavior;
         _syncOperation = syncOperation;
+        _fieldTypes = new Type?[TursoBindings.GetFieldCount(statement)];
         if (syncOperation is not null && command.Connection is TursoConnection connection)
         {
             _syncConnection = connection;
@@ -74,6 +77,12 @@ public class TursoDataReader : DbDataReader
 
     public override string GetDataTypeName(int ordinal)
     {
+        EnsureOpen();
+        ValidateOrdinal(ordinal);
+        var declaredType = TursoBindings.GetDeclaredTypeName(_statement, ordinal);
+        if (!string.IsNullOrWhiteSpace(declaredType))
+            return declaredType;
+
         var value = TursoBindings.GetValue(_statement, ordinal);
         return GetTypeName(value.ValueType);
     }
@@ -102,8 +111,20 @@ public class TursoDataReader : DbDataReader
 
     public override Type GetFieldType(int ordinal)
     {
+        EnsureOpen();
+        ValidateOrdinal(ordinal);
+        if (_fieldTypes[ordinal] is { } fieldType)
+            return fieldType;
+
+        var declaredType = TursoBindings.GetDeclaredTypeName(_statement, ordinal);
+        if (DataReaderCompatibility.TryGetClrTypeFromDeclaredType(declaredType, out fieldType))
+        {
+            _fieldTypes[ordinal] = fieldType;
+            return fieldType;
+        }
+
         var value = TursoBindings.GetValue(_statement, ordinal);
-        return value.ValueType switch
+        fieldType = value.ValueType switch
         {
             TursoValueType.Integer => typeof(long),
             TursoValueType.Real => typeof(double),
@@ -111,6 +132,11 @@ public class TursoDataReader : DbDataReader
             TursoValueType.Blob => typeof(byte[]),
             _ => typeof(object)
         };
+
+        if (value.ValueType is not TursoValueType.Null and not TursoValueType.Empty)
+            _fieldTypes[ordinal] = fieldType;
+
+        return fieldType;
     }
 
     public override float GetFloat(int ordinal)
@@ -120,7 +146,7 @@ public class TursoDataReader : DbDataReader
 
     public override Guid GetGuid(int ordinal)
     {
-        return Guid.Parse(TursoBindings.GetValue(_statement, ordinal).StringValue);
+        return DataReaderCompatibility.ToGuid(GetValue(ordinal));
     }
 
     public override short GetInt16(int ordinal)
@@ -193,6 +219,12 @@ public class TursoDataReader : DbDataReader
     }
 
     public override int FieldCount => TursoBindings.GetFieldCount(_statement);
+
+    public override DataTable GetSchemaTable()
+    {
+        EnsureOpen();
+        return DataReaderCompatibility.CreateSchemaTable(this);
+    }
 
     public override object this[int ordinal] => GetValue(ordinal)!;
 
@@ -293,5 +325,133 @@ public class TursoDataReader : DbDataReader
     private void RunExternalIo()
     {
         _syncConnection?.RunExternalIo();
+    }
+
+    private void ValidateOrdinal(int ordinal)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(ordinal);
+        if (ordinal >= FieldCount)
+            throw new IndexOutOfRangeException($"column ordinal {ordinal} is out of range");
+    }
+}
+
+internal static class DataReaderCompatibility
+{
+    public static DataTable CreateSchemaTable(DbDataReader reader)
+    {
+        var schema = new DataTable("SchemaTable");
+        schema.Columns.Add(SchemaTableColumn.ColumnName, typeof(string));
+        schema.Columns.Add(SchemaTableColumn.ColumnOrdinal, typeof(int));
+        schema.Columns.Add(SchemaTableColumn.ColumnSize, typeof(int));
+        schema.Columns.Add(SchemaTableColumn.NumericPrecision, typeof(short));
+        schema.Columns.Add(SchemaTableColumn.NumericScale, typeof(short));
+        schema.Columns.Add(SchemaTableColumn.IsUnique, typeof(bool));
+        schema.Columns.Add(SchemaTableColumn.IsKey, typeof(bool));
+        schema.Columns.Add("BaseServerName", typeof(string));
+        schema.Columns.Add("BaseCatalogName", typeof(string));
+        schema.Columns.Add(SchemaTableColumn.BaseColumnName, typeof(string));
+        schema.Columns.Add(SchemaTableColumn.BaseSchemaName, typeof(string));
+        schema.Columns.Add(SchemaTableColumn.BaseTableName, typeof(string));
+        schema.Columns.Add(SchemaTableColumn.DataType, typeof(Type));
+        schema.Columns.Add("DataTypeName", typeof(string));
+        schema.Columns.Add(SchemaTableColumn.AllowDBNull, typeof(bool));
+        schema.Columns.Add(SchemaTableColumn.IsAliased, typeof(bool));
+        schema.Columns.Add(SchemaTableColumn.IsExpression, typeof(bool));
+        schema.Columns.Add(SchemaTableOptionalColumn.IsAutoIncrement, typeof(bool));
+        schema.Columns.Add(SchemaTableOptionalColumn.IsHidden, typeof(bool));
+        schema.Columns.Add(SchemaTableOptionalColumn.IsReadOnly, typeof(bool));
+        schema.Columns.Add(SchemaTableOptionalColumn.IsRowVersion, typeof(bool));
+        schema.Columns.Add(SchemaTableColumn.IsLong, typeof(bool));
+        schema.Columns.Add(SchemaTableColumn.ProviderType, typeof(int));
+        schema.Columns.Add(SchemaTableColumn.NonVersionedProviderType, typeof(int));
+        schema.Columns.Add(SchemaTableOptionalColumn.ProviderSpecificDataType, typeof(Type));
+
+        for (var ordinal = 0; ordinal < reader.FieldCount; ordinal++)
+        {
+            var fieldType = reader.GetFieldType(ordinal);
+            var row = schema.NewRow();
+            row[SchemaTableColumn.ColumnName] = reader.GetName(ordinal);
+            row[SchemaTableColumn.ColumnOrdinal] = ordinal;
+            row[SchemaTableColumn.ColumnSize] = -1;
+            row[SchemaTableColumn.NumericPrecision] = DBNull.Value;
+            row[SchemaTableColumn.NumericScale] = DBNull.Value;
+            row[SchemaTableColumn.IsUnique] = false;
+            row[SchemaTableColumn.IsKey] = false;
+            row["BaseServerName"] = "";
+            row["BaseCatalogName"] = "";
+            row[SchemaTableColumn.BaseColumnName] = reader.GetName(ordinal);
+            row[SchemaTableColumn.BaseSchemaName] = "";
+            row[SchemaTableColumn.BaseTableName] = "";
+            row[SchemaTableColumn.DataType] = fieldType;
+            row["DataTypeName"] = reader.GetDataTypeName(ordinal);
+            row[SchemaTableColumn.AllowDBNull] = true;
+            row[SchemaTableColumn.IsAliased] = false;
+            row[SchemaTableColumn.IsExpression] = false;
+            row[SchemaTableOptionalColumn.IsAutoIncrement] = false;
+            row[SchemaTableOptionalColumn.IsHidden] = false;
+            row[SchemaTableOptionalColumn.IsReadOnly] = false;
+            row[SchemaTableOptionalColumn.IsRowVersion] = false;
+            row[SchemaTableColumn.IsLong] = fieldType == typeof(byte[]);
+            var providerType = (int)GetDbType(fieldType);
+            row[SchemaTableColumn.ProviderType] = providerType;
+            row[SchemaTableColumn.NonVersionedProviderType] = providerType;
+            row[SchemaTableOptionalColumn.ProviderSpecificDataType] = fieldType;
+            schema.Rows.Add(row);
+        }
+
+        return schema;
+    }
+
+    public static bool TryGetClrTypeFromDeclaredType(string? declaredType, out Type fieldType)
+    {
+        fieldType = typeof(object);
+        if (string.IsNullOrWhiteSpace(declaredType))
+            return false;
+
+        var normalized = declaredType.Trim().ToUpperInvariant();
+        if (normalized.Contains("INT", StringComparison.Ordinal))
+            fieldType = typeof(long);
+        else if (normalized.Contains("REAL", StringComparison.Ordinal)
+                 || normalized.Contains("FLOA", StringComparison.Ordinal)
+                 || normalized.Contains("DOUB", StringComparison.Ordinal))
+            fieldType = typeof(double);
+        else if (normalized.Contains("TEXT", StringComparison.Ordinal)
+                 || normalized.Contains("CHAR", StringComparison.Ordinal)
+                 || normalized.Contains("CLOB", StringComparison.Ordinal))
+            fieldType = typeof(string);
+        else if (normalized.Contains("BLOB", StringComparison.Ordinal))
+            fieldType = typeof(byte[]);
+        else
+            return false;
+
+        return true;
+    }
+
+    public static Guid ToGuid(object value)
+    {
+        return value switch
+        {
+            Guid guid => guid,
+            string text => Guid.Parse(text),
+            byte[] bytes when bytes.Length == 16 => new Guid(bytes),
+            byte[] bytes => Guid.Parse(Encoding.UTF8.GetString(bytes)),
+            _ => throw new InvalidCastException($"Cannot convert {value.GetType()} value to Guid.")
+        };
+    }
+
+    private static DbType GetDbType(Type fieldType)
+    {
+        if (fieldType == typeof(long))
+            return DbType.Int64;
+        if (fieldType == typeof(double))
+            return DbType.Double;
+        if (fieldType == typeof(string))
+            return DbType.String;
+        if (fieldType == typeof(byte[]))
+            return DbType.Binary;
+        if (fieldType == typeof(Guid))
+            return DbType.Guid;
+
+        return DbType.Object;
     }
 }

--- a/bindings/dotnet/src/Turso.Data/TursoParameter.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoParameter.cs
@@ -90,13 +90,20 @@ public class TursoParameter : DbParameter
         if (Value is null)
             return new TursoValue { ValueType = TursoValueType.Null };
 
-        var valueType = Value.GetType();
+        var value = Value;
+        var valueType = value.GetType();
+        if (valueType.IsEnum)
+        {
+            valueType = Enum.GetUnderlyingType(valueType);
+            value = Convert.ChangeType(value, valueType, CultureInfo.InvariantCulture);
+        }
+
         if (!TursoTypeMapping.TryGetValue(valueType, out var tursoValueType))
         {
             throw new ArgumentException($"Parameter type {valueType} is not supported");
         }
 
-        return GetTursoValue(Value, tursoValueType);
+        return GetTursoValue(value, tursoValueType);
     }
 
     public override int Size

--- a/bindings/dotnet/src/Turso.Data/TursoRemoteClient.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoRemoteClient.cs
@@ -584,25 +584,29 @@ internal sealed class RemoteError
     public string? Code { get; init; }
 }
 
-internal sealed class TursoRemoteSqlException(
+public sealed class TursoRemoteSqlException(
     string message,
     string? remoteErrorCode,
     string? remoteErrorMessage) : TursoException(message)
 {
+    public string? RemoteErrorCode { get; } = remoteErrorCode;
+
+    public string? RemoteErrorMessage { get; } = remoteErrorMessage;
+
     public bool IsStreamExpired
-        => remoteErrorCode is not null
-               && (remoteErrorCode.Equals("STREAM_EXPIRED", StringComparison.OrdinalIgnoreCase)
-                   || remoteErrorCode.Equals("STREAM_NOT_FOUND", StringComparison.OrdinalIgnoreCase)
-                   || remoteErrorCode.Equals("BATON_EXPIRED", StringComparison.OrdinalIgnoreCase)
-                   || remoteErrorCode.Equals("HRANA_STREAM_EXPIRED", StringComparison.OrdinalIgnoreCase)
-                   || remoteErrorCode.Equals("HRANA_STREAM_NOT_FOUND", StringComparison.OrdinalIgnoreCase)
-                   || remoteErrorCode.Equals("BA_STREAM_EXPIRED", StringComparison.OrdinalIgnoreCase)
-                   || remoteErrorCode.Equals("BA_STREAM_NOT_FOUND", StringComparison.OrdinalIgnoreCase))
-           || remoteErrorMessage is not null
-               && (remoteErrorMessage.Contains("stream expired", StringComparison.OrdinalIgnoreCase)
-                   || remoteErrorMessage.Contains("stream has expired", StringComparison.OrdinalIgnoreCase)
-                   || remoteErrorMessage.Contains("stream not found", StringComparison.OrdinalIgnoreCase)
-                   || remoteErrorMessage.Contains("baton expired", StringComparison.OrdinalIgnoreCase));
+        => !string.IsNullOrWhiteSpace(RemoteErrorCode)
+            ? RemoteErrorCode.Equals("STREAM_EXPIRED", StringComparison.OrdinalIgnoreCase)
+              || RemoteErrorCode.Equals("STREAM_NOT_FOUND", StringComparison.OrdinalIgnoreCase)
+              || RemoteErrorCode.Equals("BATON_EXPIRED", StringComparison.OrdinalIgnoreCase)
+              || RemoteErrorCode.Equals("HRANA_STREAM_EXPIRED", StringComparison.OrdinalIgnoreCase)
+              || RemoteErrorCode.Equals("HRANA_STREAM_NOT_FOUND", StringComparison.OrdinalIgnoreCase)
+              || RemoteErrorCode.Equals("BA_STREAM_EXPIRED", StringComparison.OrdinalIgnoreCase)
+              || RemoteErrorCode.Equals("BA_STREAM_NOT_FOUND", StringComparison.OrdinalIgnoreCase)
+            : RemoteErrorMessage is not null
+              && (RemoteErrorMessage.Contains("stream expired", StringComparison.OrdinalIgnoreCase)
+                  || RemoteErrorMessage.Contains("stream has expired", StringComparison.OrdinalIgnoreCase)
+                  || RemoteErrorMessage.Contains("stream not found", StringComparison.OrdinalIgnoreCase)
+                  || RemoteErrorMessage.Contains("baton expired", StringComparison.OrdinalIgnoreCase));
 }
 
 internal sealed class RemoteBatchResult

--- a/bindings/dotnet/src/Turso.Data/TursoRemoteDataReader.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoRemoteDataReader.cs
@@ -80,13 +80,17 @@ internal sealed class TursoRemoteDataReader : DbDataReader
 
     public override string GetDataTypeName(int ordinal)
     {
-        var value = HasCurrentRow ? CurrentValue(ordinal) : null;
-        if (value is not null)
-            return GetTypeName(value.Type);
+        EnsureOpen();
+        ValidateOrdinal(ordinal);
 
-        return ordinal >= 0 && ordinal < CurrentResult.Columns.Count
-            ? CurrentResult.Columns[ordinal].DeclType ?? string.Empty
-            : string.Empty;
+        var declaredType = ordinal < CurrentResult.Columns.Count
+            ? CurrentResult.Columns[ordinal].DeclType
+            : null;
+        if (!string.IsNullOrWhiteSpace(declaredType))
+            return declaredType;
+
+        var value = FirstNonNullValue(ordinal);
+        return value is null ? string.Empty : GetTypeName(value.Type);
     }
 
     public override DateTime GetDateTime(int ordinal)
@@ -112,18 +116,14 @@ internal sealed class TursoRemoteDataReader : DbDataReader
         EnsureOpen();
         ValidateOrdinal(ordinal);
 
-        if (HasCurrentRow)
-            return GetClrType(CurrentResult.Rows[_rowIndex][ordinal].Type);
-
         if (ordinal < CurrentResult.Columns.Count
-            && TryGetClrTypeFromDeclaredType(CurrentResult.Columns[ordinal].DeclType, out var declaredType))
+            && DataReaderCompatibility.TryGetClrTypeFromDeclaredType(CurrentResult.Columns[ordinal].DeclType, out var declaredType))
         {
             return declaredType;
         }
 
-        return CurrentResult.Rows.Count > 0 && ordinal < CurrentResult.Rows[0].Count
-            ? GetClrType(CurrentResult.Rows[0][ordinal].Type)
-            : typeof(object);
+        var value = FirstNonNullValue(ordinal);
+        return value is null ? typeof(object) : GetClrType(value.Type);
     }
 
     public override float GetFloat(int ordinal)
@@ -133,7 +133,7 @@ internal sealed class TursoRemoteDataReader : DbDataReader
 
     public override Guid GetGuid(int ordinal)
     {
-        return Guid.Parse(GetString(ordinal));
+        return DataReaderCompatibility.ToGuid(GetValue(ordinal));
     }
 
     public override short GetInt16(int ordinal)
@@ -208,6 +208,12 @@ internal sealed class TursoRemoteDataReader : DbDataReader
         : CurrentResult.Rows.Count > 0
             ? CurrentResult.Rows[0].Count
             : 0;
+
+    public override DataTable GetSchemaTable()
+    {
+        EnsureOpen();
+        return DataReaderCompatibility.CreateSchemaTable(this);
+    }
 
     public override object this[int ordinal] => GetValue(ordinal);
 
@@ -364,32 +370,19 @@ internal sealed class TursoRemoteDataReader : DbDataReader
             "float" => typeof(double),
             "text" => typeof(string),
             "blob" => typeof(byte[]),
-            "null" => typeof(DBNull),
             _ => typeof(object),
         };
     }
 
-    private static bool TryGetClrTypeFromDeclaredType(string? declaredType, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Type? clrType)
+    private RemoteResponseValue? FirstNonNullValue(int ordinal)
     {
-        clrType = null;
-        if (string.IsNullOrWhiteSpace(declaredType))
-            return false;
+        foreach (var row in CurrentResult.Rows)
+        {
+            if (ordinal < row.Count && row[ordinal].Type != "null")
+                return row[ordinal];
+        }
 
-        var normalized = declaredType.Trim().ToUpperInvariant();
-        if (normalized.Contains("INT", StringComparison.Ordinal))
-            clrType = typeof(long);
-        else if (normalized.Contains("REAL", StringComparison.Ordinal)
-                 || normalized.Contains("FLOA", StringComparison.Ordinal)
-                 || normalized.Contains("DOUB", StringComparison.Ordinal))
-            clrType = typeof(double);
-        else if (normalized.Contains("TEXT", StringComparison.Ordinal)
-                 || normalized.Contains("CHAR", StringComparison.Ordinal)
-                 || normalized.Contains("CLOB", StringComparison.Ordinal))
-            clrType = typeof(string);
-        else if (normalized.Contains("BLOB", StringComparison.Ordinal))
-            clrType = typeof(byte[]);
-
-        return clrType is not null;
+        return null;
     }
 
     private void EnsureOpen()

--- a/bindings/dotnet/src/Turso.Data/TursoTransaction.cs
+++ b/bindings/dotnet/src/Turso.Data/TursoTransaction.cs
@@ -10,6 +10,14 @@ public class TursoTransaction : DbTransaction
     private bool _completed;
 
     public TursoTransaction(TursoConnection connection, IsolationLevel isolationLevel)
+        : this(connection, isolationLevel, deferred: true)
+    {
+    }
+
+    internal TursoTransaction(
+        TursoConnection connection,
+        IsolationLevel isolationLevel,
+        bool deferred)
     {
         _connection = connection;
         _isolationLevel = NormalizeIsolationLevel(isolationLevel);
@@ -18,16 +26,23 @@ public class TursoTransaction : DbTransaction
             connection.ReadUncommitted = true;
 
         if (connection.IsRemote)
-            connection.BeginRemoteTransaction(_isolationLevel);
+            connection.BeginRemoteTransaction(_isolationLevel, deferred);
         else
-            connection.ExecuteNonQuery("BEGIN");
+            connection.ExecuteNonQuery(
+                _isolationLevel == IsolationLevel.Serializable && !deferred
+                    ? "BEGIN IMMEDIATE"
+                    : "BEGIN");
     }
 
     protected override void Dispose(bool disposing)
     {
         if (!_completed)
         {
-            if (_connection.State == System.Data.ConnectionState.Closed)
+            if (_connection.RemoteTransactionFaulted)
+            {
+                CompleteTransaction();
+            }
+            else if (_connection.State == System.Data.ConnectionState.Closed)
                 CompleteTransaction();
             else
                 Rollback();
@@ -53,6 +68,8 @@ public class TursoTransaction : DbTransaction
             }
             catch (TursoRemoteSqlException)
             {
+                if (_connection.RemoteTransactionFaulted)
+                    CompleteTransaction();
                 throw;
             }
             catch
@@ -104,6 +121,8 @@ public class TursoTransaction : DbTransaction
     {
         if (_isolationLevel == IsolationLevel.ReadUncommitted)
             _connection.ReadUncommitted = false;
+        if (_connection.RemoteTransactionFaulted)
+            _connection.CompleteFaultedRemoteTransaction();
         _completed = true;
     }
 
@@ -120,6 +139,7 @@ public class TursoTransaction : DbTransaction
             IsolationLevel.Unspecified => IsolationLevel.Serializable,
             IsolationLevel.Serializable => IsolationLevel.Serializable,
             IsolationLevel.ReadCommitted => IsolationLevel.Serializable,
+            IsolationLevel.RepeatableRead => IsolationLevel.Serializable,
             IsolationLevel.ReadUncommitted => IsolationLevel.ReadUncommitted,
             _ => throw new NotSupportedException($"Isolation level {isolationLevel} is not supported.")
         };

--- a/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
+++ b/bindings/dotnet/src/Turso.Raw/Public/TursoBindings.cs
@@ -242,6 +242,25 @@ public static class TursoBindings
         }
     }
 
+    public static string GetDeclaredTypeName(TursoStatementHandle statement, int ordinal)
+    {
+        statement.ThrowIfInvalid();
+        ArgumentOutOfRangeException.ThrowIfNegative(ordinal);
+
+        var declaredType = TursoInterop.StatementColumnDeclType(statement, ToNativeIndex(ordinal));
+        if (declaredType == IntPtr.Zero)
+            return "";
+
+        try
+        {
+            return Marshal.PtrToStringUTF8(declaredType) ?? "";
+        }
+        finally
+        {
+            TursoInterop.FreeString(declaredType);
+        }
+    }
+
     public static int GetFieldCount(TursoStatementHandle statement)
     {
         statement.ThrowIfInvalid();

--- a/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
+++ b/bindings/dotnet/src/Turso.Raw/TursoInterop.cs
@@ -166,6 +166,9 @@ internal static class TursoInterop
     [DllImport(DllName, EntryPoint = "turso_statement_column_name", CallingConvention = CallingConvention.Cdecl)]
     public static extern IntPtr StatementColumnName(TursoStatementHandle statement, UIntPtr index);
 
+    [DllImport(DllName, EntryPoint = "turso_statement_column_decltype", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr StatementColumnDeclType(TursoStatementHandle statement, UIntPtr index);
+
     [DllImport(DllName, EntryPoint = "turso_statement_row_value_kind", CallingConvention = CallingConvention.Cdecl)]
     public static extern TursoNativeValueType StatementRowValueKind(TursoStatementHandle statement, UIntPtr index);
 

--- a/bindings/dotnet/src/Turso.Tests/AdoNetCompatibilityTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/AdoNetCompatibilityTests.cs
@@ -1,0 +1,121 @@
+using System.Data;
+using System.Data.Common;
+using System.Text;
+using AwesomeAssertions;
+
+namespace Turso.Tests;
+
+public class AdoNetCompatibilityTests
+{
+    private enum LongEnum : long
+    {
+        Value = 42,
+    }
+
+    private enum ByteEnum : byte
+    {
+        Value = 7,
+    }
+
+    [Test]
+    public void EnumAndGuidParametersUseCompatibleStorageClasses()
+    {
+        var guid = Guid.Parse("00112233-4455-6677-8899-aabbccddeeff");
+
+        new TursoParameter(LongEnum.Value).ToValue().IntValue.Should().Be(42);
+        new TursoParameter(ByteEnum.Value).ToValue().IntValue.Should().Be(7);
+        var guidValue = new TursoParameter(guid).ToValue();
+        guidValue.ValueType.Should().Be(Turso.Raw.Public.Value.TursoValueType.Text);
+        guidValue.StringValue.Should().Be(guid.ToString());
+    }
+
+    [Test]
+    public void TursoUrlUsesHttps()
+    {
+        var options = TursoConnectionOptions.Parse("Data Source=turso://example.turso.io");
+
+        options.IsRemote.Should().BeTrue();
+        options.GetRemoteUri().Should().Be(new Uri("https://example.turso.io/"));
+
+        TursoConnectionOptions.Parse("Data Source=turso://example.turso.io;Tls=False")
+            .Invoking(x => x.GetRemoteUri())
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("Tls=False conflicts with the turso URL scheme.");
+    }
+
+    [Test]
+    public void RepeatableReadUsesSerializableTransactions()
+    {
+        using var connection = new TursoConnection();
+        connection.Open();
+        using var transaction = connection.BeginTransaction(IsolationLevel.RepeatableRead);
+
+        transaction.IsolationLevel.Should().Be(IsolationLevel.Serializable);
+        transaction.Rollback();
+    }
+
+    [Test]
+    public void LocalReaderExposesDeclaredTypesSchemaAndGuids()
+    {
+        var guid = Guid.Parse("00112233-4455-6677-8899-aabbccddeeff");
+        using var connection = new TursoConnection();
+        connection.Open();
+
+        using (var create = new TursoCommand(
+                   connection,
+                   "CREATE TABLE values_table(id INTEGER, name TEXT, guid_text GUID, guid_binary GUID, guid_utf8 GUID)"))
+        {
+            create.ExecuteNonQuery();
+        }
+
+        using (var insert = new TursoCommand(
+                   connection,
+                   "INSERT INTO values_table VALUES(NULL, NULL, ?, ?, ?)"))
+        {
+            insert.Parameters.Add(guid.ToString());
+            insert.Parameters.Add(guid.ToByteArray());
+            insert.Parameters.Add(Encoding.UTF8.GetBytes(guid.ToString()));
+            insert.ExecuteNonQuery();
+        }
+
+        using (var command = new TursoCommand(
+                   connection,
+                   "SELECT id, name, guid_text, guid_binary, guid_utf8 FROM values_table"))
+        using (var reader = command.ExecuteReader())
+        {
+            reader.GetFieldType(0).Should().Be(typeof(long));
+            reader.GetFieldType(1).Should().Be(typeof(string));
+            reader.GetFieldType(2).Should().Be(typeof(object));
+            reader.GetDataTypeName(2).Should().Be("GUID");
+            reader.Invoking(x => x.GetFieldType(-1)).Should().Throw<ArgumentOutOfRangeException>();
+            reader.Invoking(x => x.GetFieldType(reader.FieldCount)).Should().Throw<IndexOutOfRangeException>();
+
+            var schema = reader.GetSchemaTable();
+            schema.Should().NotBeNull();
+            schema!.Rows.Count.Should().Be(5);
+            schema.Rows[0][SchemaTableColumn.DataType].Should().Be(typeof(long));
+            schema.Rows[0][SchemaTableColumn.ProviderType].Should().Be((int)DbType.Int64);
+            schema.Rows[1][SchemaTableColumn.DataType].Should().Be(typeof(string));
+
+            reader.Read().Should().BeTrue();
+            reader.GetFieldType(0).Should().Be(typeof(long));
+            reader.GetFieldType(2).Should().Be(typeof(string));
+            reader.GetValue(0).Should().Be(DBNull.Value);
+            reader.GetValue(1).Should().Be(DBNull.Value);
+            reader.GetValue(2).Should().Be(guid.ToString());
+            reader.GetValue(3).Should().BeOfType<byte[]>();
+            reader.GetValue(4).Should().BeOfType<byte[]>();
+            reader.GetGuid(2).Should().Be(guid);
+            reader.GetGuid(3).Should().Be(guid);
+            reader.GetGuid(4).Should().Be(guid);
+        }
+
+        using var loadCommand = new TursoCommand(connection, "SELECT id, name FROM values_table");
+        using var loadReader = loadCommand.ExecuteReader();
+        var table = new DataTable();
+        table.Load(loadReader);
+        table.Rows.Count.Should().Be(1);
+        table.Columns["id"]!.DataType.Should().Be(typeof(long));
+        table.Columns["name"]!.DataType.Should().Be(typeof(string));
+    }
+}

--- a/bindings/dotnet/src/Turso.Tests/TursoRemoteStreamRecoveryTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/TursoRemoteStreamRecoveryTests.cs
@@ -1,0 +1,250 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using AwesomeAssertions;
+
+namespace Turso.Tests;
+
+public sealed class TursoRemoteStreamRecoveryTests
+{
+    [Test]
+    public async Task StatelessCommandRetriesOneExpiredStreamWithoutTheOldBaton()
+    {
+        using var handler = new ScriptedPipelineHandler(
+            ExecuteSuccess("stale", 1),
+            StreamExpired("stale stream", "stale-again"),
+            ExecuteSuccess("fresh", 2));
+        using var scope = UseRemoteHandler(handler);
+        using var connection = new TursoConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        connection.Open();
+
+        (await ExecuteScalarAsync(connection)).Should().Be(1L);
+        (await ExecuteScalarAsync(connection)).Should().Be(2L);
+
+        handler.Requests.Should().HaveCount(3);
+        handler.GetBaton(1).Should().Be("stale");
+        handler.GetBaton(2).Should().BeNull();
+    }
+
+    [Test]
+    public async Task NonExpiryRemoteErrorIsNotRetried()
+    {
+        using var handler = new ScriptedPipelineHandler(
+            ExecuteSuccess("stale", 1),
+            RemoteError("SQLITE_CONSTRAINT", "stream expired"));
+        using var scope = UseRemoteHandler(handler);
+        using var connection = new TursoConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        connection.Open();
+        await ExecuteScalarAsync(connection);
+
+        var exception = Assert.ThrowsAsync<TursoRemoteSqlException>(
+            async () => await ExecuteScalarAsync(connection));
+
+        exception!.RemoteErrorCode.Should().Be("SQLITE_CONSTRAINT");
+        exception.IsStreamExpired.Should().BeFalse();
+        handler.Requests.Should().HaveCount(2);
+    }
+
+    [Test]
+    public async Task PartiallyEvaluatedExpiredBatchIsNotRetried()
+    {
+        using var handler = new ScriptedPipelineHandler(
+            PartiallyExpiredBatch(),
+            ExecuteSuccess("fresh", 2));
+        using var scope = UseRemoteHandler(handler);
+        using var connection = new TursoConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        connection.Open();
+        await using var batch = (TursoBatch)connection.CreateBatch();
+        batch.BatchCommands.Add(new TursoBatchCommand("INSERT INTO items VALUES (1)"));
+        batch.BatchCommands.Add(new TursoBatchCommand("INSERT INTO items VALUES (2)"));
+
+        var batchAction = async () => await batch.ExecuteNonQueryAsync(CancellationToken.None);
+
+        await batchAction.Should().ThrowAsync<TursoRemoteSqlException>()
+            .Where(exception => exception.IsStreamExpired);
+        (await ExecuteScalarAsync(connection)).Should().Be(2L);
+        handler.Requests.Should().HaveCount(2);
+        handler.GetBaton(1).Should().BeNull();
+    }
+
+    [TestCase("commit")]
+    [TestCase("rollback")]
+    public void ExpiredTransactionPreservesItsRootFailure(string completion)
+    {
+        using var handler = new ScriptedPipelineHandler(
+            ExecuteSuccess("transaction", 0),
+            StreamExpired("transaction stream expired"));
+        using var scope = UseRemoteHandler(handler);
+        using var connection = new TursoConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        connection.Open();
+        using var transaction = (TursoTransaction)connection.BeginTransaction();
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "UPDATE t SET value = 1";
+
+        var rootFailure = Assert.Throws<TursoRemoteSqlException>(() => command.ExecuteNonQuery())!;
+        rootFailure.RemoteErrorCode.Should().Be("STREAM_EXPIRED");
+
+        Assert.Throws<TursoRemoteSqlException>(() => command.ExecuteNonQuery())
+            .Should().BeSameAs(rootFailure);
+        using var batch = (TursoBatch)connection.CreateBatch();
+        batch.Transaction = transaction;
+        batch.BatchCommands.Add(new TursoBatchCommand("UPDATE t SET value = 2"));
+        Assert.Throws<TursoRemoteSqlException>(() => batch.ExecuteNonQuery())
+            .Should().BeSameAs(rootFailure);
+        var completionFailure = completion == "commit"
+            ? Assert.Throws<TursoRemoteSqlException>(() => transaction.Commit())
+            : Assert.Throws<TursoRemoteSqlException>(() => transaction.Rollback());
+        completionFailure.Should().BeSameAs(rootFailure);
+        handler.Requests.Should().HaveCount(2);
+    }
+
+    [Test]
+    public void FaultedTransactionDisposalDoesNotMaskAnExceptionInFlight()
+    {
+        using var handler = new ScriptedPipelineHandler(
+            ExecuteSuccess("transaction", 0),
+            StreamExpired("transaction stream expired"));
+        using var scope = UseRemoteHandler(handler);
+        using var connection = new TursoConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        connection.Open();
+
+        var marker = Assert.Throws<MarkerException>(() =>
+        {
+            using var transaction = connection.BeginTransaction();
+            using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = "UPDATE t SET value = 1";
+            Assert.Throws<TursoRemoteSqlException>(() => command.ExecuteNonQuery());
+            throw new MarkerException();
+        });
+
+        marker.Should().NotBeNull();
+        handler.Requests.Should().HaveCount(2);
+    }
+
+    [Test]
+    public void CommitTimeExpiryIsPreservedAndCompletesTheTransaction()
+    {
+        using var handler = new ScriptedPipelineHandler(
+            ExecuteSuccess("transaction", 0),
+            StreamExpired("commit stream expired", "unusable"),
+            ExecuteSuccess("fresh", 1));
+        using var scope = UseRemoteHandler(handler);
+        using var connection = new TursoConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        connection.Open();
+        using var transaction = (TursoTransaction)connection.BeginTransaction();
+
+        var failure = Assert.Throws<TursoRemoteSqlException>(() => transaction.Commit());
+
+        failure!.RemoteErrorCode.Should().Be("STREAM_EXPIRED");
+        transaction.IsCompleted.Should().BeTrue();
+        ExecuteScalarAsync(connection).GetAwaiter().GetResult().Should().Be(1L);
+        handler.Requests.Should().HaveCount(3);
+        handler.GetBaton(2).Should().BeNull();
+    }
+
+    private static async Task<object?> ExecuteScalarAsync(TursoConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
+        return await command.ExecuteScalarAsync();
+    }
+
+    private static IDisposable UseRemoteHandler(HttpMessageHandler handler)
+    {
+        TursoConnection.RemoteMessageHandlerFactory = () => handler;
+        return new Scope(() => TursoConnection.RemoteMessageHandlerFactory = null);
+    }
+
+    private static string ExecuteSuccess(string baton, long value)
+        => """
+           {"baton":"__BATON__","results":[{"type":"ok","response":{"type":"execute","result":{"cols":[{"name":"value","decltype":"INTEGER"}],"rows":[[{"type":"integer","value":"__VALUE__"}]],"affected_row_count":0}}}]}
+           """
+            .Replace("__BATON__", baton, StringComparison.Ordinal)
+            .Replace("__VALUE__", value.ToString(System.Globalization.CultureInfo.InvariantCulture), StringComparison.Ordinal);
+
+    private static string StreamExpired(string message, string? baton = null)
+    {
+        var error = RemoteError("STREAM_EXPIRED", message);
+        return baton is null
+            ? error
+            : error.Replace("{\"results\"", $"{{\"baton\":\"{baton}\",\"results\"", StringComparison.Ordinal);
+    }
+
+    private static string RemoteError(string code, string message)
+        => """
+           {"results":[{"type":"error","error":{"message":"__MESSAGE__","code":"__CODE__"}}]}
+           """
+            .Replace("__MESSAGE__", message, StringComparison.Ordinal)
+            .Replace("__CODE__", code, StringComparison.Ordinal);
+
+    private static string PartiallyExpiredBatch()
+        => """
+           {
+             "baton":"stale",
+             "results":[{
+               "type":"ok",
+               "response":{
+                 "type":"batch",
+                 "result":{
+                   "step_results":[
+                     {"cols":[],"rows":[],"affected_row_count":1},
+                     null
+                   ],
+                   "step_errors":[
+                     null,
+                     {"message":"stream expired","code":"STREAM_EXPIRED"}
+                   ]
+                 }
+               }
+             }]
+           }
+           """;
+
+    private sealed class ScriptedPipelineHandler(params string[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<string> _responses = new(responses);
+
+        public List<JsonElement> Requests { get; } = [];
+
+        public string? GetBaton(int index)
+        {
+            var request = Requests[index];
+            return !request.TryGetProperty("baton", out var baton) || baton.ValueKind == JsonValueKind.Null
+                ? null
+                : baton.GetString();
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            using var document = JsonDocument.Parse(
+                await request.Content!.ReadAsStringAsync(cancellationToken));
+            var root = document.RootElement.Clone();
+            Requests.Add(root);
+            var requestType = root.GetProperty("requests")[0].GetProperty("type").GetString();
+            var response = requestType == "close"
+                ? """{"results":[{"type":"ok","response":{"type":"close"}}]}"""
+                : _responses.Dequeue();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(response, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+
+    private sealed class Scope(Action onDispose) : IDisposable
+    {
+        public void Dispose() => onDispose();
+    }
+
+    private sealed class MarkerException : Exception;
+}

--- a/bindings/dotnet/src/Turso.Tests/TursoRemoteTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/TursoRemoteTests.cs
@@ -1,3 +1,5 @@
+using System.Data;
+using System.Data.Common;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -142,8 +144,12 @@ public class TursoRemoteTests
         connection.Open();
 
         using var command = (TursoCommand)connection.CreateCommand();
-        command.CommandText = "SELECT ?, :name";
+        var guid = Guid.Parse("00112233-4455-6677-8899-aabbccddeeff");
+        command.CommandText = "SELECT ?, ?, ?, ?, :name";
         command.Parameters.Add(42);
+        command.Parameters.Add(guid);
+        command.Parameters.Add(DBNull.Value);
+        command.Parameters.Add(new byte[] { 1, 2, 3 });
         command.Parameters.AddWithValue(":name", "alice");
 
         using var reader = command.ExecuteReader();
@@ -160,9 +166,21 @@ public class TursoRemoteTests
         var requests = document.RootElement.GetProperty("requests");
         requests.GetArrayLength().Should().Be(2);
         requests[0].GetProperty("type").GetString().Should().Be("execute");
-        requests[0].GetProperty("stmt").GetProperty("sql").GetString().Should().Be("SELECT ?, :name");
-        requests[0].GetProperty("stmt").GetProperty("args")[0].GetProperty("value").GetString().Should().Be("42");
-        requests[0].GetProperty("stmt").GetProperty("named_args")[0].GetProperty("name").GetString().Should().Be(":name");
+        var statement = requests[0].GetProperty("stmt");
+        statement.GetProperty("sql").GetString().Should().Be("SELECT ?, ?, ?, ?, :name");
+        var args = statement.GetProperty("args");
+        args[0].GetProperty("value").GetString().Should().Be("42");
+        args[0].TryGetProperty("base64", out _).Should().BeFalse();
+        args[1].GetProperty("type").GetString().Should().Be("text");
+        args[1].GetProperty("value").GetString().Should().Be(guid.ToString());
+        args[1].TryGetProperty("base64", out _).Should().BeFalse();
+        args[2].GetProperty("type").GetString().Should().Be("null");
+        args[2].TryGetProperty("value", out _).Should().BeFalse();
+        args[2].TryGetProperty("base64", out _).Should().BeFalse();
+        args[3].GetProperty("type").GetString().Should().Be("blob");
+        args[3].GetProperty("base64").GetString().Should().Be("AQID");
+        args[3].TryGetProperty("value", out _).Should().BeFalse();
+        statement.GetProperty("named_args")[0].GetProperty("name").GetString().Should().Be(":name");
         requests[1].GetProperty("type").GetString().Should().Be("close");
     }
 
@@ -259,7 +277,7 @@ public class TursoRemoteTests
         reader.GetFieldType(0).Should().Be(typeof(string));
         reader.Read().Should().BeTrue();
         reader.IsDBNull(0).Should().BeTrue();
-        reader.GetFieldType(0).Should().Be(typeof(DBNull));
+        reader.GetFieldType(0).Should().Be(typeof(string));
         reader.GetValue(0).Should().Be(DBNull.Value);
         reader.Invoking(x => x.GetString(0))
             .Should().Throw<InvalidCastException>()
@@ -267,6 +285,101 @@ public class TursoRemoteTests
         reader.Invoking(x => x.GetDateTime(0))
             .Should().Throw<InvalidCastException>()
             .WithMessage("Cannot convert remote null value to DateTime.");
+    }
+
+    [Test]
+    public void TestRemoteReaderExposesStableSchemaGuidsAndRawValues()
+    {
+        var guid = Guid.Parse("00112233-4455-6677-8899-aabbccddeeff");
+        var binaryGuid = Convert.ToBase64String(guid.ToByteArray());
+        var utf8Guid = Convert.ToBase64String(Encoding.UTF8.GetBytes(guid.ToString()));
+        var responseJson = $$"""
+            {
+              "results": [
+                {
+                  "type": "ok",
+                  "response": {
+                    "type": "execute",
+                    "result": {
+                      "cols": [
+                        { "name": "id", "decltype": "INTEGER" },
+                        { "name": "name" },
+                        { "name": "guid_text", "decltype": "GUID" },
+                        { "name": "guid_binary", "decltype": "GUID" },
+                        { "name": "guid_utf8", "decltype": "GUID" }
+                      ],
+                      "rows": [
+                        [
+                          { "type": "null" },
+                          { "type": "null" },
+                          { "type": "null" },
+                          { "type": "null" },
+                          { "type": "null" }
+                        ],
+                        [
+                          { "type": "integer", "value": "42" },
+                          { "type": "text", "value": "alice" },
+                          { "type": "text", "value": "{{guid}}" },
+                          { "type": "blob", "base64": "{{binaryGuid}}" },
+                          { "type": "blob", "base64": "{{utf8Guid}}" }
+                        ]
+                      ],
+                      "affected_row_count": 0
+                    }
+                  }
+                },
+                {
+                  "type": "ok",
+                  "response": { "type": "close" }
+                }
+              ]
+            }
+            """;
+
+        using var server = new TestRemoteServer(responseJson, responseJson);
+        using var connection = new TursoConnection($"Data Source={server.Url};Read Your Writes=False");
+        connection.Open();
+
+        using (var command = new TursoCommand(connection, "SELECT id, name, guid_text, guid_binary, guid_utf8 FROM values_table"))
+        using (var reader = command.ExecuteReader())
+        {
+            reader.GetFieldType(0).Should().Be(typeof(long));
+            reader.GetFieldType(1).Should().Be(typeof(string));
+            reader.GetFieldType(2).Should().Be(typeof(string));
+            reader.GetFieldType(3).Should().Be(typeof(byte[]));
+            reader.GetDataTypeName(1).Should().Be("TEXT");
+            reader.GetDataTypeName(2).Should().Be("GUID");
+
+            var schema = reader.GetSchemaTable();
+            schema!.Rows[0][SchemaTableColumn.DataType].Should().Be(typeof(long));
+            schema.Rows[0][SchemaTableColumn.ProviderType].Should().Be((int)DbType.Int64);
+            schema.Rows[3][SchemaTableColumn.DataType].Should().Be(typeof(byte[]));
+
+            reader.Read().Should().BeTrue();
+            reader.GetFieldType(1).Should().Be(typeof(string));
+            reader.GetValue(0).Should().Be(DBNull.Value);
+            reader.GetValue(1).Should().Be(DBNull.Value);
+
+            reader.Read().Should().BeTrue();
+            reader.GetValue(0).Should().BeOfType<long>().Which.Should().Be(42);
+            reader.GetValue(1).Should().BeOfType<string>().Which.Should().Be("alice");
+            reader.GetValue(2).Should().BeOfType<string>().Which.Should().Be(guid.ToString());
+            reader.GetValue(3).Should().BeOfType<byte[]>();
+            reader.GetValue(4).Should().BeOfType<byte[]>();
+            reader.GetGuid(2).Should().Be(guid);
+            reader.GetGuid(3).Should().Be(guid);
+            reader.GetGuid(4).Should().Be(guid);
+        }
+
+        using var loadCommand = new TursoCommand(connection, "SELECT id, name, guid_text, guid_binary, guid_utf8 FROM values_table");
+        using var loadReader = loadCommand.ExecuteReader();
+        var table = new DataTable();
+        table.Load(loadReader);
+        table.Rows.Count.Should().Be(2);
+        table.Columns["id"]!.DataType.Should().Be(typeof(long));
+        table.Columns["name"]!.DataType.Should().Be(typeof(string));
+        table.Columns["guid_text"]!.DataType.Should().Be(typeof(string));
+        table.Columns["guid_binary"]!.DataType.Should().Be(typeof(byte[]));
     }
 
     [Test]


### PR DESCRIPTION
## Summary

This is the next regular extraction from the closed source draft #8504, built on top of the already merged .NET binding work in #8514, #8519, #8523, #8530, #8555, #8557, and #8609.

- complete `TursoDataReader` and `TursoRemoteDataReader` schema/type compatibility, including declared type metadata, stable non-null inference, `GetSchemaTable`, `DataTable.Load`, ordinal/null handling, provider types, and GUID conversion while preserving raw SQLite storage classes from `GetValue`
- add only the `turso_statement_column_decltype` raw binding needed by the reader metadata path
- convert enum parameters through their underlying integral type and serialize GUID parameters as text
- normalize supported transaction isolation levels, including `RepeatableRead` as serializable, and support deferred versus immediate transaction starts
- validate Hrana tagged values without null alternative fields and retain auth/base URL transport validation

## Stream expiry behavior

A direct stateless command retries exactly once after a recognized Hrana stream-expiry response and clears the stale baton before retrying. Error messages are used as an expiry fallback only when the server did not provide an error code, so ordinary coded SQL failures are never replayed merely because their text mentions an expired stream.

Remote batches are never replayed after a stream-expiry result, including partially applied batches; the no-replay and active-batch invalidation behavior from #8609 remains unchanged. A direct command failure inside an active transaction poisons that transaction with the first error, prevents later commands or batches from sending requests, and makes commit/rollback rethrow the same root failure before the unusable session is reset.

## Deferred layers

This deliberately leaves the managed `Turso.Data.Sqlite` remote/replica facade, EF Core integration, NativeAOT/mobile/package-consumer samples and CI, and all Rust work for later ordinary PRs. Replica pooling, automatic sync, and batch support that already landed in the prior PRs are not reintroduced here.

## Validation

- `dotnet format bindings\dotnet\Turso.slnx --no-restore --include <changed files> --verbosity quiet`
- `dotnet build bindings\dotnet\src\Turso.Raw\Turso.Raw.csproj --no-restore --verbosity minimal` (net8.0, net9.0, net10.0)
- `dotnet build bindings\dotnet\src\Turso.Data\Turso.Data.csproj --no-restore --verbosity minimal` (net8.0, net9.0, net10.0)
- focused ADO.NET/scripted Hrana tests: 43 passed
- complete .NET suite, serialized: 219 passed, 1 skipped

Live Cloud tests were not run; the recovery coverage uses scripted Hrana responses and does not require credentials.