### PR TITLE
core/mvcc: retire materialized current versions instead of dropping them

### DIFF
--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,6 +1,7 @@
 use crate::alloc::{ConcurrentAllocator, TryReserveError, TursoAllocator};
 use crate::skiplist::{comparator::BasicComparator, map::Entry};
 use crate::turso_assert;
+use crate::types::IOResultOr;
 
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
@@ -638,7 +639,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     }
 
     /// Returns the current row as an immutable record.
-    pub fn current_row(&mut self) -> Result<IOResult<Option<&crate::types::ImmutableRecord>>> {
+    pub fn current_row(&mut self) -> IOResultOr<Option<&crate::types::ImmutableRecord>> {
         if self.get_null_flag() {
             return Ok(IOResult::Done(None));
         }
@@ -741,7 +742,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
         Ok(())
     }
 
-    pub fn start_new_rowid(&mut self) -> Result<IOResult<NextRowidResult>> {
+    pub fn start_new_rowid(&mut self) -> IOResultOr<NextRowidResult> {
         tracing::trace!("start_new_rowid");
 
         let allocator = self.db.get_rowid_allocator(&self.table_id);
@@ -855,16 +856,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     }
 
     /// Advance btree cursor forward and set btree peek to the first valid row key (skipping rows shadowed by MVCC)
-    fn advance_btree_forward(&mut self) -> Result<IOResult<()>> {
+    fn advance_btree_forward(&mut self) -> IOResultOr<()> {
         self._advance_btree_forward(true)
     }
 
     /// Advance btree cursor forward from current position (cursor already positioned by seek)
-    fn advance_btree_forward_from_current(&mut self) -> Result<IOResult<()>> {
+    fn advance_btree_forward_from_current(&mut self) -> IOResultOr<()> {
         self._advance_btree_forward(false)
     }
 
-    fn _advance_btree_forward(&mut self, initialize: bool) -> Result<IOResult<()>> {
+    fn _advance_btree_forward(&mut self, initialize: bool) -> IOResultOr<()> {
         loop {
             let state = self.btree_advance_state;
             match state {
@@ -942,16 +943,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     }
 
     /// Advance btree cursor backward and set btree peek to the first valid row key (skipping rows shadowed by MVCC)
-    fn advance_btree_backward(&mut self) -> Result<IOResult<()>> {
+    fn advance_btree_backward(&mut self) -> IOResultOr<()> {
         self._advance_btree_backward(true)
     }
 
     /// Advance btree cursor backward from current position (cursor already positioned by seek)
-    fn advance_btree_backward_from_current(&mut self) -> Result<IOResult<()>> {
+    fn advance_btree_backward_from_current(&mut self) -> IOResultOr<()> {
         self._advance_btree_backward(false)
     }
 
-    fn _advance_btree_backward(&mut self, initialize: bool) -> Result<IOResult<()>> {
+    fn _advance_btree_backward(&mut self, initialize: bool) -> IOResultOr<()> {
         loop {
             let state = self.btree_advance_state;
             match state {
@@ -1119,11 +1120,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     /// Seek btree cursor and set btree_peek to the result.
     /// Skips rows that are shadowed by MVCC.
     /// Returns IOResult indicating if we need to yield for IO or are done.
-    fn seek_btree_and_set_peek(
-        &mut self,
-        seek_key: SeekKey<'_>,
-        op: SeekOp,
-    ) -> Result<IOResult<()>> {
+    fn seek_btree_and_set_peek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> IOResultOr<()> {
         // Fast path: btree not allocated
         if !self.is_btree_allocated() {
             self.dual_peek.btree_peek = CursorPeek::Exhausted;
@@ -1251,7 +1248,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> Drop for MvccLazyCur
 impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     for MvccLazyCursor<Clock, A>
 {
-    fn last(&mut self) -> Result<IOResult<()>> {
+    fn last(&mut self) -> IOResultOr<()> {
         // A cursor may be NullRow'd during outer-join unmatched emission.
         // Repositioning to a real row must clear that synthetic NULL state.
         self.set_null_flag(false);
@@ -1326,7 +1323,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     /// Move the cursor to the next row. Returns true if the cursor moved to the next row, false if the cursor is at the end of the table.
     ///
     /// Uses dual-cursor approach: only advances the cursor that was just consumed.
-    fn next(&mut self) -> Result<IOResult<()>> {
+    fn next(&mut self) -> IOResultOr<()> {
         if self.state.is_none() {
             // If BeforeFirst and peek not initialized, initialize the iterators and peek values
             let current_pos = self.get_current_pos();
@@ -1422,7 +1419,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     /// Move the cursor to the previous row. Returns true if the cursor moved, false if at the beginning.
     ///
     /// Uses dual-cursor approach: only advances the cursor that was just consumed.
-    fn prev(&mut self) -> Result<IOResult<()>> {
+    fn prev(&mut self) -> IOResultOr<()> {
         if self.state.is_none() {
             // If End and peek not initialized, initialize via last()
             let current_pos = self.get_current_pos();
@@ -1509,7 +1506,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         Ok(IOResult::Done(()))
     }
 
-    fn rowid(&mut self) -> Result<IOResult<Option<i64>>> {
+    fn rowid(&mut self) -> IOResultOr<Option<i64>> {
         if self.get_null_flag() {
             return Ok(IOResult::Done(None));
         }
@@ -1545,20 +1542,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         Ok(IOResult::Done(rowid))
     }
 
-    fn record(&mut self) -> Result<IOResult<Option<&crate::types::ImmutableRecord>>> {
+    fn record(&mut self) -> IOResultOr<Option<&crate::types::ImmutableRecord>> {
         self.current_row()
     }
 
-    fn seek_unpacked(
-        &mut self,
-        registers: &[Register],
-        op: SeekOp,
-    ) -> Result<IOResult<SeekResult>> {
+    fn seek_unpacked(&mut self, registers: &[Register], op: SeekOp) -> IOResultOr<SeekResult> {
         let record = ImmutableRecord::from_registers(registers, registers.len())?;
         self.seek(SeekKey::IndexKey(record.as_record_ref()), op)
     }
 
-    fn seek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> Result<IOResult<SeekResult>> {
+    fn seek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> IOResultOr<SeekResult> {
         // gt -> lower_bound bound excluded, we want first row after row_id
         // ge -> lower_bound bound included, we want first row equal to row_id or first row after row_id
         // lt -> upper_bound bound excluded, we want last row before row_id
@@ -1798,7 +1791,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
 
     /// Insert a row into the table or index.
     /// Sets the cursor to the inserted row.
-    fn insert(&mut self, key: &BTreeKey) -> Result<IOResult<()>> {
+    fn insert(&mut self, key: &BTreeKey) -> IOResultOr<()> {
         let row_id = match key {
             BTreeKey::TableRowId((rowid, _)) => RowID::new(self.table_id, RowKey::Int(*rowid)),
             BTreeKey::IndexKey(record) => {
@@ -1818,7 +1811,8 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 let BTreeKey::TableRowId((_, record)) = key else {
                     return Err(LimboError::InternalError(
                         "Table cursor requires a TableRowId key".to_string(),
-                    ));
+                    )
+                    .into());
                 };
                 let record = record.as_ref().ok_or_else(|| {
                     LimboError::InternalError("TableRowId should have a record".to_string())
@@ -1838,7 +1832,8 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 let BTreeKey::IndexKey(record) = key else {
                     return Err(LimboError::InternalError(
                         "Index cursor requires an IndexKey".to_string(),
-                    ));
+                    )
+                    .into());
                 };
                 Ok(Row::new_index_row(row_id, record.column_count()))
             }
@@ -1900,7 +1895,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         Ok(IOResult::Done(()))
     }
 
-    fn delete(&mut self) -> Result<IOResult<()>> {
+    fn delete(&mut self) -> IOResultOr<()> {
         let (rowid, in_btree) = match self.get_current_pos() {
             CursorPosition::Loaded {
                 row_id, in_btree, ..
@@ -1977,7 +1972,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         self.null_flag
     }
 
-    fn exists(&mut self, key: &Value) -> Result<IOResult<bool>> {
+    fn exists(&mut self, key: &Value) -> IOResultOr<bool> {
         if self.state.is_none() {
             self.invalidate_record();
             let int_key = match key {
@@ -2103,15 +2098,15 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         }
     }
 
-    fn clear_btree(&mut self) -> Result<IOResult<Option<usize>>> {
+    fn clear_btree(&mut self) -> IOResultOr<Option<usize>> {
         todo!()
     }
 
-    fn btree_destroy(&mut self) -> Result<IOResult<Option<usize>>> {
+    fn btree_destroy(&mut self) -> IOResultOr<Option<usize>> {
         todo!()
     }
 
-    fn count(&mut self) -> Result<IOResult<usize>> {
+    fn count(&mut self) -> IOResultOr<usize> {
         loop {
             let state = self.count_state;
             match state {
@@ -2166,7 +2161,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         self.table_id.into()
     }
 
-    fn rewind(&mut self) -> Result<IOResult<()>> {
+    fn rewind(&mut self) -> IOResultOr<()> {
         // A cursor may be NullRow'd during outer-join unmatched emission.
         // Repositioning to a real row must clear that synthetic NULL state.
         self.set_null_flag(false);
@@ -2250,7 +2245,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         }
     }
 
-    fn seek_end(&mut self) -> Result<IOResult<()>> {
+    fn seek_end(&mut self) -> IOResultOr<()> {
         if self.is_btree_allocated() {
             // Defer to btree cursor's seek_end implementation
             self.btree_cursor.seek_end()
@@ -2261,7 +2256,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         }
     }
 
-    fn seek_to_last(&mut self) -> Result<IOResult<()>> {
+    fn seek_to_last(&mut self) -> IOResultOr<()> {
         match self.seek(SeekKey::TableRowId(i64::MAX), SeekOp::LE { eq_only: false })? {
             IOResult::Done(_) => Ok(IOResult::Done(())),
             IOResult::IO(iocompletions) => Ok(IOResult::IO(iocompletions)),

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,7 +1,6 @@
 use crate::alloc::{ConcurrentAllocator, TryReserveError, TursoAllocator};
 use crate::skiplist::{comparator::BasicComparator, map::Entry};
 use crate::turso_assert;
-use crate::types::IOResultOr;
 
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
@@ -512,6 +511,9 @@ pub struct MvccLazyCursor<Clock: LogicalClock + 'static, A: ConcurrentAllocator 
     tx_id: u64,
     /// Reusable immutable record, used to allow better allocation strategy.
     reusable_immutable_record: Option<ImmutableRecord>,
+    /// Eq-only table seek copies the occupying payload under the version lock.
+    /// Passive GC can empty the live chain before Column.
+    eq_seek_row: Option<Row>,
     btree_cursor: Box<dyn CursorTrait>,
     null_flag: bool,
     creating_new_rowid: bool,
@@ -590,6 +592,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
             current_pos: CursorPosition::BeforeFirst,
             table_id,
             reusable_immutable_record: None,
+            eq_seek_row: None,
             btree_cursor,
             null_flag: false,
             creating_new_rowid: false,
@@ -635,7 +638,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     }
 
     /// Returns the current row as an immutable record.
-    pub fn current_row(&mut self) -> IOResultOr<Option<&crate::types::ImmutableRecord>> {
+    pub fn current_row(&mut self) -> Result<IOResult<Option<&crate::types::ImmutableRecord>>> {
         if self.get_null_flag() {
             return Ok(IOResult::Done(None));
         }
@@ -643,14 +646,15 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
         match &self.current_pos {
             CursorPosition::Loaded { in_btree: true, .. } => self.btree_cursor.record(),
             CursorPosition::Loaded {
-                in_btree: false, ..
+                in_btree: false,
+                row_id,
+                versions,
             } => {
-                // Lightweight handle clone (refcount bump) so we can drop the
-                // borrow of `current_pos` and mutably borrow the reusable record.
-                let versions = match &self.current_pos {
-                    CursorPosition::Loaded { versions, .. } => versions.clone(),
-                    _ => unreachable!("matched Loaded above"),
-                };
+                // Owned copies so the rest of the arm can mutably borrow the
+                // reusable record.
+                let row_id = row_id.clone();
+                let versions = versions.clone();
+                let snapshot = self.eq_seek_row.clone().filter(|row| row.id == row_id);
 
                 let found = if let Some(versions) = &versions {
                     // Fast path: serialize the visible version straight into our
@@ -665,10 +669,6 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                 } else {
                     // Cold fallback (seek-positioned, no cached chain): point
                     // lookup, then serialize.
-                    let row_id = match &self.current_pos {
-                        CursorPosition::Loaded { row_id, .. } => row_id.clone(),
-                        _ => unreachable!("matched Loaded above"),
-                    };
                     let maybe_index_id = match &self.mv_cursor_type {
                         MvccCursorType::Index(_) => Some(self.table_id),
                         MvccCursorType::Table => None,
@@ -688,6 +688,18 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
                 };
 
                 if !found {
+                    if let Some(row) = snapshot {
+                        let record = self.get_immutable_record_or_create()?;
+                        record.invalidate();
+                        record.start_serialization(row.payload())?;
+                        let record_ref =
+                            self.reusable_immutable_record.as_ref().ok_or_else(|| {
+                                LimboError::InternalError(
+                                    "immutable record not initialized".to_string(),
+                                )
+                            })?;
+                        return Ok(IOResult::Done(Some(record_ref)));
+                    }
                     return Ok(IOResult::Done(None));
                 }
                 let record_ref = self.reusable_immutable_record.as_ref().ok_or_else(|| {
@@ -729,7 +741,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
         Ok(())
     }
 
-    pub fn start_new_rowid(&mut self) -> IOResultOr<NextRowidResult> {
+    pub fn start_new_rowid(&mut self) -> Result<IOResult<NextRowidResult>> {
         tracing::trace!("start_new_rowid");
 
         let allocator = self.db.get_rowid_allocator(&self.table_id);
@@ -843,16 +855,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     }
 
     /// Advance btree cursor forward and set btree peek to the first valid row key (skipping rows shadowed by MVCC)
-    fn advance_btree_forward(&mut self) -> IOResultOr<()> {
+    fn advance_btree_forward(&mut self) -> Result<IOResult<()>> {
         self._advance_btree_forward(true)
     }
 
     /// Advance btree cursor forward from current position (cursor already positioned by seek)
-    fn advance_btree_forward_from_current(&mut self) -> IOResultOr<()> {
+    fn advance_btree_forward_from_current(&mut self) -> Result<IOResult<()>> {
         self._advance_btree_forward(false)
     }
 
-    fn _advance_btree_forward(&mut self, initialize: bool) -> IOResultOr<()> {
+    fn _advance_btree_forward(&mut self, initialize: bool) -> Result<IOResult<()>> {
         loop {
             let state = self.btree_advance_state;
             match state {
@@ -930,16 +942,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     }
 
     /// Advance btree cursor backward and set btree peek to the first valid row key (skipping rows shadowed by MVCC)
-    fn advance_btree_backward(&mut self) -> IOResultOr<()> {
+    fn advance_btree_backward(&mut self) -> Result<IOResult<()>> {
         self._advance_btree_backward(true)
     }
 
     /// Advance btree cursor backward from current position (cursor already positioned by seek)
-    fn advance_btree_backward_from_current(&mut self) -> IOResultOr<()> {
+    fn advance_btree_backward_from_current(&mut self) -> Result<IOResult<()>> {
         self._advance_btree_backward(false)
     }
 
-    fn _advance_btree_backward(&mut self, initialize: bool) -> IOResultOr<()> {
+    fn _advance_btree_backward(&mut self, initialize: bool) -> Result<IOResult<()>> {
         loop {
             let state = self.btree_advance_state;
             match state {
@@ -1061,13 +1073,45 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
 
     /// Refresh the current position based on the peek values
     fn refresh_current_position(&mut self, dir: IterationDirection) {
-        let new_position = self.dual_peek.cursor_position_from_next(self.table_id, dir);
-        self.current_pos = new_position;
+        self.current_pos = self.position_from_peeks(dir);
+    }
+
+    fn position_from_peeks(&mut self, dir: IterationDirection) -> CursorPosition<A> {
+        loop {
+            let pos = self.dual_peek.cursor_position_from_next(self.table_id, dir);
+            let CursorPosition::Loaded {
+                row_id,
+                in_btree: false,
+                versions: Some(versions),
+            } = &pos
+            else {
+                return pos;
+            };
+            let row_id = row_id.clone();
+            let table_id = row_id.table_id;
+            let falls_through = {
+                let chain = versions.read();
+                self.db
+                    .chain_falls_through_for_tx(self.tx_id, table_id, &chain)
+            };
+            if !falls_through {
+                return pos;
+            }
+            if self.dual_peek.btree_peek.get_row_key() == Some(&row_id.row_id) {
+                return CursorPosition::Loaded {
+                    row_id,
+                    in_btree: true,
+                    versions: None,
+                };
+            }
+            self.advance_mvcc_iterator();
+        }
     }
 
     /// Reset dual peek state (called on rewind/last/seek)
     fn reset_dual_peek(&mut self) {
         self.dual_peek = DualCursorPeek::default();
+        self.eq_seek_row = None;
         // The forward finger is monotonic; a reposition invalidates it.
         self.index_finger.reset();
     }
@@ -1075,7 +1119,11 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     /// Seek btree cursor and set btree_peek to the result.
     /// Skips rows that are shadowed by MVCC.
     /// Returns IOResult indicating if we need to yield for IO or are done.
-    fn seek_btree_and_set_peek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> IOResultOr<()> {
+    fn seek_btree_and_set_peek(
+        &mut self,
+        seek_key: SeekKey<'_>,
+        op: SeekOp,
+    ) -> Result<IOResult<()>> {
         // Fast path: btree not allocated
         if !self.is_btree_allocated() {
             self.dual_peek.btree_peek = CursorPeek::Exhausted;
@@ -1203,7 +1251,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> Drop for MvccLazyCur
 impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     for MvccLazyCursor<Clock, A>
 {
-    fn last(&mut self) -> IOResultOr<()> {
+    fn last(&mut self) -> Result<IOResult<()>> {
         // A cursor may be NullRow'd during outer-join unmatched emission.
         // Repositioning to a real row must clear that synthetic NULL state.
         self.set_null_flag(false);
@@ -1278,7 +1326,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     /// Move the cursor to the next row. Returns true if the cursor moved to the next row, false if the cursor is at the end of the table.
     ///
     /// Uses dual-cursor approach: only advances the cursor that was just consumed.
-    fn next(&mut self) -> IOResultOr<()> {
+    fn next(&mut self) -> Result<IOResult<()>> {
         if self.state.is_none() {
             // If BeforeFirst and peek not initialized, initialize the iterators and peek values
             let current_pos = self.get_current_pos();
@@ -1374,7 +1422,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     /// Move the cursor to the previous row. Returns true if the cursor moved, false if at the beginning.
     ///
     /// Uses dual-cursor approach: only advances the cursor that was just consumed.
-    fn prev(&mut self) -> IOResultOr<()> {
+    fn prev(&mut self) -> Result<IOResult<()>> {
         if self.state.is_none() {
             // If End and peek not initialized, initialize via last()
             let current_pos = self.get_current_pos();
@@ -1461,7 +1509,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         Ok(IOResult::Done(()))
     }
 
-    fn rowid(&mut self) -> IOResultOr<Option<i64>> {
+    fn rowid(&mut self) -> Result<IOResult<Option<i64>>> {
         if self.get_null_flag() {
             return Ok(IOResult::Done(None));
         }
@@ -1497,16 +1545,20 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         Ok(IOResult::Done(rowid))
     }
 
-    fn record(&mut self) -> IOResultOr<Option<&crate::types::ImmutableRecord>> {
+    fn record(&mut self) -> Result<IOResult<Option<&crate::types::ImmutableRecord>>> {
         self.current_row()
     }
 
-    fn seek_unpacked(&mut self, registers: &[Register], op: SeekOp) -> IOResultOr<SeekResult> {
+    fn seek_unpacked(
+        &mut self,
+        registers: &[Register],
+        op: SeekOp,
+    ) -> Result<IOResult<SeekResult>> {
         let record = ImmutableRecord::from_registers(registers, registers.len())?;
         self.seek(SeekKey::IndexKey(record.as_record_ref()), op)
     }
 
-    fn seek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> IOResultOr<SeekResult> {
+    fn seek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> Result<IOResult<SeekResult>> {
         // gt -> lower_bound bound excluded, we want first row after row_id
         // ge -> lower_bound bound included, we want first row equal to row_id or first row after row_id
         // lt -> upper_bound bound excluded, we want last row before row_id
@@ -1549,18 +1601,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                         MvccCursorType::Index(_) => Some(self.table_id),
                         MvccCursorType::Table => None,
                     };
-                    // The current row is visible either because MvStore has a visible version
-                    // for it, or because it is a b-tree-resident row that is not shadowed by
-                    // any MVCC version. Both cases must short-circuit: otherwise a b-tree-only
-                    // row would fall through to the full eq-only seek below, which resets the
-                    // iterators and marks the MVCC peek exhausted, skipping MvStore-resident
-                    // rows that the enclosing range scan (see the comment above) still needs
-                    // to visit.
-                    let visible = self
-                        .db
-                        .read_from_table_or_index(self.tx_id, row_id, maybe_index_id)?
-                        .is_some()
-                        || (*in_btree && self.query_btree_version_is_valid(&row_id.row_id));
+                    // Prefer the B-tree copy when this cursor is already on it:
+                    // a stale SkipMap read here would hide later checkpointed
+                    // updates and change scan totals.
+                    let visible = if *in_btree {
+                        self.query_btree_version_is_valid(&row_id.row_id)
+                    } else {
+                        self.db
+                            .read_from_table_or_index(self.tx_id, row_id, maybe_index_id)?
+                            .is_some()
+                    };
                     if visible {
                         // We need to clear the null flag for the table cursor before seeking,
                         // because it might have been set to false by an unmatched left-join row
@@ -1608,11 +1658,14 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
 
                             // Set MVCC peek
                             {
-                                self.dual_peek.mvcc_peek = match &mvcc_rowid {
-                                    Some(rid) => CursorPeek::Row {
-                                        key: rid.row_id.clone(),
-                                        versions: None,
-                                    },
+                                self.dual_peek.mvcc_peek = match mvcc_rowid {
+                                    Some((rid, payload)) => {
+                                        self.eq_seek_row = payload;
+                                        CursorPeek::Row {
+                                            key: rid.row_id,
+                                            versions: None,
+                                        }
+                                    }
                                     None => CursorPeek::Exhausted,
                                 };
                             }
@@ -1676,19 +1729,19 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 Some(MvccLazyCursorState::Seek(SeekState::PickWinner, direction)) => {
                     // Pick winner and return result
                     // Now pick the winner based on direction
-                    let winner = self.dual_peek.get_next(direction);
-
-                    // Clear seek state
+                    let winner_pos = self.position_from_peeks(direction);
                     self.state = None;
-
-                    if let Some((winner_key, in_btree, winner_versions)) = winner {
+                    if let CursorPosition::Loaded {
+                        row_id,
+                        in_btree,
+                        versions,
+                    } = winner_pos
+                    {
+                        let winner_key = row_id.row_id.clone();
                         self.current_pos = CursorPosition::Loaded {
-                            row_id: RowID {
-                                table_id: self.table_id,
-                                row_id: winner_key.clone(),
-                            },
+                            row_id,
                             in_btree,
-                            versions: winner_versions,
+                            versions,
                         };
 
                         if op.eq_only() {
@@ -1745,7 +1798,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
 
     /// Insert a row into the table or index.
     /// Sets the cursor to the inserted row.
-    fn insert(&mut self, key: &BTreeKey) -> IOResultOr<()> {
+    fn insert(&mut self, key: &BTreeKey) -> Result<IOResult<()>> {
         let row_id = match key {
             BTreeKey::TableRowId((rowid, _)) => RowID::new(self.table_id, RowKey::Int(*rowid)),
             BTreeKey::IndexKey(record) => {
@@ -1765,8 +1818,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 let BTreeKey::TableRowId((_, record)) = key else {
                     return Err(LimboError::InternalError(
                         "Table cursor requires a TableRowId key".to_string(),
-                    )
-                    .into());
+                    ));
                 };
                 let record = record.as_ref().ok_or_else(|| {
                     LimboError::InternalError("TableRowId should have a record".to_string())
@@ -1786,8 +1838,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 let BTreeKey::IndexKey(record) = key else {
                     return Err(LimboError::InternalError(
                         "Index cursor requires an IndexKey".to_string(),
-                    )
-                    .into());
+                    ));
                 };
                 Ok(Row::new_index_row(row_id, record.column_count()))
             }
@@ -1820,11 +1871,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
             .read_from_table_or_index(self.tx_id, &row.id, maybe_index_id)?
             .is_some()
         {
-            self.db
+            let updated = self
+                .db
                 .update_to_table_or_index(self.tx_id, row, maybe_index_id)
                 .inspect_err(|_| {
                     self.current_pos = CursorPosition::BeforeFirst;
                 })?;
+            turso_assert!(
+                updated,
+                "read found a visible version but update could not supersede it"
+            );
         } else if was_btree_resident {
             // The row exists in B-tree but not in MvStore - mark it as B-tree resident
             // so that checkpoint knows to write deletes to the B-tree file.
@@ -1844,7 +1900,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         Ok(IOResult::Done(()))
     }
 
-    fn delete(&mut self) -> IOResultOr<()> {
+    fn delete(&mut self) -> Result<IOResult<()>> {
         let (rowid, in_btree) = match self.get_current_pos() {
             CursorPosition::Loaded {
                 row_id, in_btree, ..
@@ -1921,7 +1977,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         self.null_flag
     }
 
-    fn exists(&mut self, key: &Value) -> IOResultOr<bool> {
+    fn exists(&mut self, key: &Value) -> Result<IOResult<bool>> {
         if self.state.is_none() {
             self.invalidate_record();
             let int_key = match key {
@@ -1945,7 +2001,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 &mut self.table_iterator,
             );
 
-            let mvcc_exists = if let Some(rowid) = &rowid {
+            let mvcc_exists = if let Some((rowid, _)) = &rowid {
                 let RowKey::Int(rowid) = rowid.row_id else {
                     panic!("Rowid is not an integer in mvcc table cursor");
                 };
@@ -2047,15 +2103,15 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         }
     }
 
-    fn clear_btree(&mut self) -> IOResultOr<Option<usize>> {
+    fn clear_btree(&mut self) -> Result<IOResult<Option<usize>>> {
         todo!()
     }
 
-    fn btree_destroy(&mut self) -> IOResultOr<Option<usize>> {
+    fn btree_destroy(&mut self) -> Result<IOResult<Option<usize>>> {
         todo!()
     }
 
-    fn count(&mut self) -> IOResultOr<usize> {
+    fn count(&mut self) -> Result<IOResult<usize>> {
         loop {
             let state = self.count_state;
             match state {
@@ -2110,7 +2166,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         self.table_id.into()
     }
 
-    fn rewind(&mut self) -> IOResultOr<()> {
+    fn rewind(&mut self) -> Result<IOResult<()>> {
         // A cursor may be NullRow'd during outer-join unmatched emission.
         // Repositioning to a real row must clear that synthetic NULL state.
         self.set_null_flag(false);
@@ -2194,7 +2250,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         }
     }
 
-    fn seek_end(&mut self) -> IOResultOr<()> {
+    fn seek_end(&mut self) -> Result<IOResult<()>> {
         if self.is_btree_allocated() {
             // Defer to btree cursor's seek_end implementation
             self.btree_cursor.seek_end()
@@ -2205,7 +2261,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         }
     }
 
-    fn seek_to_last(&mut self) -> IOResultOr<()> {
+    fn seek_to_last(&mut self) -> Result<IOResult<()>> {
         match self.seek(SeekKey::TableRowId(i64::MAX), SeekOp::LE { eq_only: false })? {
             IOResult::Done(_) => Ok(IOResult::Done(())),
             IOResult::IO(iocompletions) => Ok(IOResult::IO(iocompletions)),

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -20,12 +20,11 @@ use crate::storage::wal::{CheckpointMode, TursoRwLock, WalAutoActions};
 use crate::sync::atomic::Ordering;
 use crate::sync::Arc;
 use crate::sync::RwLock;
-use crate::types::IOResultOr;
 use crate::types::{IOCompletions, IOResult, ImmutableRecord, ImmutableRecordRef};
 use crate::{turso_assert, turso_assert_eq};
 use crate::{
-    CheckpointResult, Completion, Connection, Database, IOExt, LimboError, Numeric, Pager, Result,
-    SyncMode, TransactionState, Value, ValueRef,
+    CheckpointResult, Completion, Connection, IOExt, LimboError, Numeric, Pager, Result, SyncMode,
+    TransactionState, Value, ValueRef,
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::num::NonZeroU64;
@@ -184,7 +183,6 @@ pub struct CheckpointStateMachine<Clock: LogicalClock, A: ConcurrentAllocator = 
     /// Connection to the database
     connection: Arc<Connection>,
     /// Database whose pager and schema this checkpoint is writing.
-    database: Arc<Database>,
     database_id: usize,
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
@@ -261,6 +259,13 @@ pub struct CheckpointStateMachine<Clock: LogicalClock, A: ConcurrentAllocator = 
     /// Positive roots whose btrees were destroyed in this checkpoint's pager write.
     /// Only these may be removed from `dropped_root_pages` at publish.
     freed_root_pages: HashSet<i64>,
+    /// Table rowids whose pager write or delete finished this checkpoint.
+    /// GC stamps only these, after pager commit. Stamping a skip-write makes
+    /// scans fall through to a B-tree that never got the row.
+    written_table_rowids: HashSet<(MVTableId, i64)>,
+    /// `index_write_set` slots whose pager write or delete finished. Slots, not
+    /// keys: `SortableIndexKey` is not `Hash`.
+    written_index_slots: HashSet<usize>,
 }
 
 /// One pending compaction job in the per-checkpoint sequence sweep.
@@ -485,7 +490,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> SeqCompactDriver<Clock, A> {
     /// any cursor page IO so the caller can yield up; returns
     /// `IOResult::Done(())` when every pending backing table has been
     /// compacted to its single watermark row.
-    fn step(&mut self) -> IOResultOr<()> {
+    fn step(&mut self) -> Result<IOResult<()>> {
         loop {
             let Some(seq) = self.pending.get(self.current_idx).copied() else {
                 return Ok(IOResult::Done(()));
@@ -725,7 +730,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             )
         });
         self.durable_mvcc_metadata =
-            !self.database.is_in_memory_db() && self.mvcc_meta_table.is_some();
+            !self.connection.db.is_in_memory_db() && self.mvcc_meta_table.is_some();
     }
 
     pub fn new(
@@ -738,7 +743,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         mode: CheckpointMode,
     ) -> Self {
         assert!(
-            !matches!(mode, CheckpointMode::Passive { .. }) || mvstore.uses_passive_checkpoint(),
+            !matches!(mode, CheckpointMode::Passive { .. })
+                || connection.experimental_mvcc_passive_checkpoint_enabled(),
             "passive checkpoint mode requires experimental_mvcc_passive_checkpoint"
         );
         // MVCC supports only Passive (no blocking lock, requires the experimental flag) and
@@ -751,13 +757,12 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             },
         };
         let checkpoint_lock = mvstore.blocking_checkpoint_lock.clone();
-        let database = connection.get_source_database(database_id);
         // Use the shared DB schema (not the per-connection cache, which may be
         // stale) for the database whose pager we're checkpointing. Unlike WAL
         // mode, MVCC checkpoint writes from the mv store back to the pager —
         // so the schema must match the pager being checkpointed.
         let schema = connection.clone_shared_schema(database_id);
-        let index_id_to_index = if mvstore.uses_passive_checkpoint() {
+        let index_id_to_index = if connection.experimental_mvcc_passive_checkpoint_enabled() {
             HashMap::default()
         } else {
             schema
@@ -785,7 +790,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 table.columns().len(),
             )
         });
-        let durable_mvcc_metadata = !database.is_in_memory_db() && mvcc_meta_table.is_some();
+        let durable_mvcc_metadata = !connection.db.is_in_memory_db() && mvcc_meta_table.is_some();
         let durable_tx_max = mvstore.durable_txid_max.load(Ordering::SeqCst);
         let durable_txid_max_old = NonZeroU64::new(durable_tx_max);
         #[cfg(any(test, injected_yields))]
@@ -802,7 +807,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             durable_txid_max_new: durable_tx_max,
             mvstore,
             connection,
-            database,
             database_id,
             #[cfg(any(test, injected_yields))]
             yield_instance_id,
@@ -842,6 +846,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             staged_roots: crate::alloc::vec![],
             ended_created_roots: HashSet::default(),
             freed_root_pages: HashSet::default(),
+            written_table_rowids: HashSet::default(),
+            written_index_slots: HashSet::default(),
         }
     }
 
@@ -1471,7 +1477,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     }
 
     /// Perform a TRUNCATE checkpoint on the WAL
-    fn checkpoint_wal(&self) -> IOResultOr<CheckpointResult> {
+    fn checkpoint_wal(&self) -> Result<IOResult<CheckpointResult>> {
         let Some(wal) = &self.pager.wal else {
             panic!("No WAL to checkpoint");
         };
@@ -1505,7 +1511,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     }
 
     fn has_unpublished_schema_changes(&self) -> bool {
-        let schema = self.database.schema.lock();
+        let schema = self.connection.db.schema.lock();
         if !schema.dropped_root_pages.is_empty() {
             return true;
         }
@@ -1590,7 +1596,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         // Patch the live db.schema (not local_schema, the checkpoint's private snapshot) so
         // clone_schema() propagates real root pages; negative placeholders would orphan the
         // new btree pages.
-        let mut schema_ref = self.database.schema.lock();
+        let mut schema_ref = self.connection.db.schema.lock();
         let schema = Schema::try_make_mut(&mut schema_ref)?;
         for (name, table) in schema.tables.iter_mut() {
             #[cfg(not(feature = "conn_raw_api"))]
@@ -1652,15 +1658,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             .dropped_root_pages
             .extend(std::mem::take(&mut self.ended_created_roots));
         drop(schema_ref);
-        let schema = self.database.clone_schema();
-        if self.database_id == crate::MAIN_DB_ID {
-            *self.connection.schema.write() = schema;
-        } else {
-            self.connection
-                .database_schemas()
-                .write()
-                .insert(self.database_id, schema);
-        }
+        *self.connection.schema.write() = self.connection.db.clone_schema();
         self.connection.bump_prepare_context_generation();
         self.mvstore.bump_schema_generation();
         Ok(())
@@ -1783,9 +1781,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         };
         let mut index = next_index;
         let mut processed = 0;
-        // Drop current SkipMap versions only when B-trees are stable (blocking Truncate).
-        let drop_current_if_in_btree = self.lock_states.blocking_checkpoint_lock_held
-            || !self.mvstore.experimental_mvcc_passive_checkpoint;
+        let drop_current_if_in_btree = true;
         while index < self.write_set.len() {
             let current = index;
             index += 1;
@@ -1797,16 +1793,19 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             let row_id = &self.write_set[current].0.row.id;
             if let Some(entry) = self.mvstore.rows.get(row_id) {
                 let mut versions = entry.value().write();
-                self.mvstore.stamp_chain_materialized(
-                    &mut versions,
-                    materialized_frame,
-                    snapshot_ts,
-                );
-                let dropped = MvStore::<Clock, A>::gc_version_chain(
+                if let RowKey::Int(n) = row_id.row_id {
+                    if self.written_table_rowids.contains(&(row_id.table_id, n)) {
+                        self.mvstore.stamp_chain_materialized(
+                            &mut versions,
+                            materialized_frame,
+                            snapshot_ts,
+                        );
+                    }
+                }
+                let dropped = self.mvstore.gc_chain_now(
                     &mut versions,
                     lwm,
                     ckpt_max,
-                    self.mvstore.experimental_mvcc_passive_checkpoint,
                     min_reader_mark,
                     drop_current_if_in_btree,
                 );
@@ -1842,7 +1841,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         // Same as table GC: keep empty SkipMap slots; Truncate Finalize unlinks later.
         let ckpt_max = self.durable_txid_max_new;
         let min_reader_mark = self.gc_floor_reader_mark();
-        // Same stamp as table GC (unchanged since CommitPagerTxn).
         let materialized_frame = WalPos::from_pair(self.pager.wal_pos());
         let snapshot_ts = self.snapshot_ts;
         let CheckpointState::GcIndexRows { next_index, lwm } = self.state else {
@@ -1850,8 +1848,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         };
         let mut index = next_index;
         let mut processed = 0;
-        let drop_current_if_in_btree = self.lock_states.blocking_checkpoint_lock_held
-            || !self.mvstore.experimental_mvcc_passive_checkpoint;
+        let drop_current_if_in_btree = true;
         while index < self.index_write_set.len() {
             let current = index;
             index += 1;
@@ -1871,16 +1868,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     .get(sortable_key)
                     .expect("index row from write set must exist in inner map");
                 let mut versions = inner_entry.value().write();
-                self.mvstore.stamp_chain_materialized(
-                    &mut versions,
-                    materialized_frame,
-                    snapshot_ts,
-                );
-                let dropped = MvStore::<Clock, A>::gc_version_chain(
+                if self.written_index_slots.contains(&current) {
+                    self.mvstore.stamp_chain_materialized(
+                        &mut versions,
+                        materialized_frame,
+                        snapshot_ts,
+                    );
+                }
+                let dropped = self.mvstore.gc_chain_now(
                     &mut versions,
                     lwm,
                     ckpt_max,
-                    self.mvstore.experimental_mvcc_passive_checkpoint,
                     min_reader_mark,
                     drop_current_if_in_btree,
                 );
@@ -1900,6 +1898,19 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         } else {
             None
         }
+    }
+
+    fn record_written_table_row(&mut self, write_set_index: usize) {
+        let Some(row_id) = self
+            .get_current_row_version(write_set_index)
+            .map(|(row_version, _)| row_version.row.id.clone())
+        else {
+            return;
+        };
+        let RowKey::Int(n) = row_id.row_id else {
+            return;
+        };
+        self.written_table_rowids.insert((row_id.table_id, n));
     }
 
     /// Stages synthetic `persistent_tx_ts_max` row into the checkpoint write set
@@ -1965,7 +1976,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     fn step_inner(&mut self, _context: &()) -> Result<TransitionResult<CheckpointResult>> {
         match &self.state {
             CheckpointState::PrepareCheckpoint => {
-                let passive = self.mvstore.uses_passive_checkpoint();
+                let passive = self
+                    .connection
+                    .experimental_mvcc_passive_checkpoint_enabled();
                 if passive {
                     // The passive checkpoint acquires the blocking lock only after
                     // collection, so it needs an explicit single-orchestrator gate. The
@@ -2108,7 +2121,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 }
                 tracing::debug!("Collected {} index row changes", self.index_write_set.len());
 
-                let passive = self.mvstore.uses_passive_checkpoint();
+                let passive = self
+                    .connection
+                    .experimental_mvcc_passive_checkpoint_enabled();
                 if passive {
                     inject_transition_yield!(self, CheckpointYieldPoint::BeforeAcquireLock);
                     // Passive path: collection AND the btree write phase run without the
@@ -2509,6 +2524,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 match write_row_state_machine.step(&())? {
                     IOResult::IO(io) => Ok(TransitionResult::Io(io)),
                     IOResult::Done(_) => {
+                        self.record_written_table_row(write_set_index);
                         let requires_seek = self.next_requires_seek_after_insert(write_set_index);
                         self.state = CheckpointState::WriteRow {
                             write_set_index: write_set_index + 1,
@@ -2531,6 +2547,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 match delete_row_state_machine.step(&())? {
                     IOResult::IO(io) => Ok(TransitionResult::Io(io)),
                     IOResult::Done(_) => {
+                        self.record_written_table_row(write_set_index);
                         self.state = CheckpointState::WriteRow {
                             write_set_index: write_set_index + 1,
                             requires_seek: true,
@@ -2659,6 +2676,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 match write_row_state_machine.step(&())? {
                     IOResult::IO(io) => Ok(TransitionResult::Io(io)),
                     IOResult::Done(_) => {
+                        self.written_index_slots.insert(index_write_set_index);
                         self.state = CheckpointState::WriteIndexRow {
                             index_write_set_index: index_write_set_index + 1,
                             requires_seek: true,
@@ -2682,6 +2700,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 match delete_row_state_machine.step(&())? {
                     IOResult::IO(io) => Ok(TransitionResult::Io(io)),
                     IOResult::Done(_) => {
+                        self.written_index_slots.insert(index_write_set_index);
                         self.state = CheckpointState::WriteIndexRow {
                             index_write_set_index: index_write_set_index + 1,
                             requires_seek: true,
@@ -2745,7 +2764,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                                 )
                             })?;
                         checkpoint_header.schema_cookie =
-                            self.database.schema.lock().schema_version.into();
+                            self.connection.db.schema.lock().schema_version.into();
                         let staged_header = self.pager.io.block(|| {
                             self.pager.with_header_mut(|header| {
                                 // Keep pager-maintained fields (for example database_size/change_counter)
@@ -2767,11 +2786,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     // On commit_tx failure the `?` rolls back the pager txn; durable_txid_max and
                     // the log offset stay put, so a retry re-stages from the previous boundary.
                     tracing::debug!("Committing pager transaction");
-                    match self.pager.commit_tx(
-                        &self.connection,
-                        self.sync_mode,
-                        self.update_transaction_state,
-                    )? {
+                    match self
+                        .pager
+                        .commit_tx(&self.connection, self.update_transaction_state)?
+                    {
                         IOResult::Done(_) => {
                             self.pager_commit_done = true;
                         }
@@ -2867,9 +2885,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     }
                     Ok(IOResult::IO(io)) => Ok(TransitionResult::Io(io)),
                     // Busy under a DbFile reader: finish without publishing nbackfills.
-                    Err(err)
-                        if matches!(*err, crate::LimboError::Busy)
-                            && matches!(self.mode, CheckpointMode::Passive { .. }) =>
+                    Err(crate::LimboError::Busy)
+                        if matches!(self.mode, CheckpointMode::Passive { .. }) =>
                     {
                         tracing::debug!(
                             "Passive WAL checkpoint Busy under pinned DbFile reader; continuing without backfill"
@@ -2885,7 +2902,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         self.state = CheckpointState::TruncateLogicalLog;
                         Ok(TransitionResult::Continue)
                     }
-                    Err(e) => Err(*e),
+                    Err(e) => Err(e),
                 }
             }
 
@@ -2973,7 +2990,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 let backfill =
                     WalPos::from_pair((seq, self.pager.wal_backfill_frame().unwrap_or(0)));
                 *self.mvstore.backfill_floor.write() = backfill;
-                let lwm = self.mvstore.compute_lwm();
+                let lwm = self.mvstore.sample_gc_lwm();
                 // Reclaim retired root-page bindings no transaction can still see (end <= lwm).
                 self.mvstore.gc_rootpage_entries(lwm);
                 self.state = CheckpointState::GcTableRows { next_index: 0, lwm };
@@ -3005,11 +3022,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     // That lock waits out open MVCC txs, so no old reader can see a later rewrite.
                     self.mvstore.drop_unused_row_versions_and_slots();
                 } else {
-                    // Passive: drop old versions and empty slots, but keep the latest SkipMap
-                    // copy of each row. Without it, an older reader can fall through to a
-                    // B-tree page that a later checkpoint already rewrote.
-                    // Also use the pager reader mark so we don't GC versions a brand-new
-                    // reader still needs before its MVCC tx is registered.
+                    // Passive: drop superseded history and empty slots. Rule 3 also
+                    // drops last currents when idle (`lwm == MAX`); with open
+                    // snapshots those stay in the SkipMap. Use the pager reader
+                    // mark so we don't GC versions a brand-new reader still needs
+                    // before its MVCC tx is registered.
                     self.mvstore
                         .drop_unused_row_versions_unlink_empty_at(self.gc_floor_reader_mark());
                 }
@@ -3687,7 +3704,13 @@ mod tests {
             versions.push(version.clone());
             mvstore.rows.insert(row_id, Arc::new(RwLock::new(versions)));
             checkpoint.write_set.push((version, None));
+            checkpoint.written_table_rowids.insert((table_id, i));
         }
+        // The real run publishes `backfill_floor` from the checkpointed WAL right
+        // before entering `GcTableRows`. Rule 3 needs every reader mark to have
+        // reached the stamp, and `gc_floor_reader_mark` is clamped by this floor,
+        // so a fixture that jumps straight into the state must publish it too.
+        *mvstore.backfill_floor.write() = WalPos::from_pair(checkpoint.pager.wal_pos());
         checkpoint.state = CheckpointState::GcTableRows {
             next_index: 0,
             lwm: u64::MAX,
@@ -3755,7 +3778,11 @@ mod tests {
                 .insert_index_version(index_id, key, version.clone())
                 .unwrap();
             checkpoint.index_write_set.push((index_id, version, false));
+            checkpoint.written_index_slots.insert(i as usize);
         }
+        // See the table variant: publish the floor the real `GcIndexRows` entry
+        // would have published, or Rule 3 keeps every stamped current.
+        *mvstore.backfill_floor.write() = WalPos::from_pair(checkpoint.pager.wal_pos());
         checkpoint.state = CheckpointState::GcIndexRows {
             next_index: 0,
             lwm: u64::MAX,

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -20,11 +20,12 @@ use crate::storage::wal::{CheckpointMode, TursoRwLock, WalAutoActions};
 use crate::sync::atomic::Ordering;
 use crate::sync::Arc;
 use crate::sync::RwLock;
+use crate::types::IOResultOr;
 use crate::types::{IOCompletions, IOResult, ImmutableRecord, ImmutableRecordRef};
 use crate::{turso_assert, turso_assert_eq};
 use crate::{
-    CheckpointResult, Completion, Connection, IOExt, LimboError, Numeric, Pager, Result, SyncMode,
-    TransactionState, Value, ValueRef,
+    CheckpointResult, Completion, Connection, Database, IOExt, LimboError, Numeric, Pager, Result,
+    SyncMode, TransactionState, Value, ValueRef,
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::num::NonZeroU64;
@@ -183,6 +184,7 @@ pub struct CheckpointStateMachine<Clock: LogicalClock, A: ConcurrentAllocator = 
     /// Connection to the database
     connection: Arc<Connection>,
     /// Database whose pager and schema this checkpoint is writing.
+    database: Arc<Database>,
     database_id: usize,
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
@@ -490,7 +492,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> SeqCompactDriver<Clock, A> {
     /// any cursor page IO so the caller can yield up; returns
     /// `IOResult::Done(())` when every pending backing table has been
     /// compacted to its single watermark row.
-    fn step(&mut self) -> Result<IOResult<()>> {
+    fn step(&mut self) -> IOResultOr<()> {
         loop {
             let Some(seq) = self.pending.get(self.current_idx).copied() else {
                 return Ok(IOResult::Done(()));
@@ -730,7 +732,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             )
         });
         self.durable_mvcc_metadata =
-            !self.connection.db.is_in_memory_db() && self.mvcc_meta_table.is_some();
+            !self.database.is_in_memory_db() && self.mvcc_meta_table.is_some();
     }
 
     pub fn new(
@@ -743,8 +745,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         mode: CheckpointMode,
     ) -> Self {
         assert!(
-            !matches!(mode, CheckpointMode::Passive { .. })
-                || connection.experimental_mvcc_passive_checkpoint_enabled(),
+            !matches!(mode, CheckpointMode::Passive { .. }) || mvstore.uses_passive_checkpoint(),
             "passive checkpoint mode requires experimental_mvcc_passive_checkpoint"
         );
         // MVCC supports only Passive (no blocking lock, requires the experimental flag) and
@@ -757,12 +758,13 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             },
         };
         let checkpoint_lock = mvstore.blocking_checkpoint_lock.clone();
+        let database = connection.get_source_database(database_id);
         // Use the shared DB schema (not the per-connection cache, which may be
         // stale) for the database whose pager we're checkpointing. Unlike WAL
         // mode, MVCC checkpoint writes from the mv store back to the pager —
         // so the schema must match the pager being checkpointed.
         let schema = connection.clone_shared_schema(database_id);
-        let index_id_to_index = if connection.experimental_mvcc_passive_checkpoint_enabled() {
+        let index_id_to_index = if mvstore.uses_passive_checkpoint() {
             HashMap::default()
         } else {
             schema
@@ -790,7 +792,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 table.columns().len(),
             )
         });
-        let durable_mvcc_metadata = !connection.db.is_in_memory_db() && mvcc_meta_table.is_some();
+        let durable_mvcc_metadata = !database.is_in_memory_db() && mvcc_meta_table.is_some();
         let durable_tx_max = mvstore.durable_txid_max.load(Ordering::SeqCst);
         let durable_txid_max_old = NonZeroU64::new(durable_tx_max);
         #[cfg(any(test, injected_yields))]
@@ -807,6 +809,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             durable_txid_max_new: durable_tx_max,
             mvstore,
             connection,
+            database,
             database_id,
             #[cfg(any(test, injected_yields))]
             yield_instance_id,
@@ -1477,7 +1480,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     }
 
     /// Perform a TRUNCATE checkpoint on the WAL
-    fn checkpoint_wal(&self) -> Result<IOResult<CheckpointResult>> {
+    fn checkpoint_wal(&self) -> IOResultOr<CheckpointResult> {
         let Some(wal) = &self.pager.wal else {
             panic!("No WAL to checkpoint");
         };
@@ -1511,7 +1514,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     }
 
     fn has_unpublished_schema_changes(&self) -> bool {
-        let schema = self.connection.db.schema.lock();
+        let schema = self.database.schema.lock();
         if !schema.dropped_root_pages.is_empty() {
             return true;
         }
@@ -1596,7 +1599,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
         // Patch the live db.schema (not local_schema, the checkpoint's private snapshot) so
         // clone_schema() propagates real root pages; negative placeholders would orphan the
         // new btree pages.
-        let mut schema_ref = self.connection.db.schema.lock();
+        let mut schema_ref = self.database.schema.lock();
         let schema = Schema::try_make_mut(&mut schema_ref)?;
         for (name, table) in schema.tables.iter_mut() {
             #[cfg(not(feature = "conn_raw_api"))]
@@ -1658,7 +1661,15 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
             .dropped_root_pages
             .extend(std::mem::take(&mut self.ended_created_roots));
         drop(schema_ref);
-        *self.connection.schema.write() = self.connection.db.clone_schema();
+        let schema = self.database.clone_schema();
+        if self.database_id == crate::MAIN_DB_ID {
+            *self.connection.schema.write() = schema;
+        } else {
+            self.connection
+                .database_schemas()
+                .write()
+                .insert(self.database_id, schema);
+        }
         self.connection.bump_prepare_context_generation();
         self.mvstore.bump_schema_generation();
         Ok(())
@@ -1976,9 +1987,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     fn step_inner(&mut self, _context: &()) -> Result<TransitionResult<CheckpointResult>> {
         match &self.state {
             CheckpointState::PrepareCheckpoint => {
-                let passive = self
-                    .connection
-                    .experimental_mvcc_passive_checkpoint_enabled();
+                let passive = self.mvstore.uses_passive_checkpoint();
                 if passive {
                     // The passive checkpoint acquires the blocking lock only after
                     // collection, so it needs an explicit single-orchestrator gate. The
@@ -2121,9 +2130,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                 }
                 tracing::debug!("Collected {} index row changes", self.index_write_set.len());
 
-                let passive = self
-                    .connection
-                    .experimental_mvcc_passive_checkpoint_enabled();
+                let passive = self.mvstore.uses_passive_checkpoint();
                 if passive {
                     inject_transition_yield!(self, CheckpointYieldPoint::BeforeAcquireLock);
                     // Passive path: collection AND the btree write phase run without the
@@ -2764,7 +2771,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                                 )
                             })?;
                         checkpoint_header.schema_cookie =
-                            self.connection.db.schema.lock().schema_version.into();
+                            self.database.schema.lock().schema_version.into();
                         let staged_header = self.pager.io.block(|| {
                             self.pager.with_header_mut(|header| {
                                 // Keep pager-maintained fields (for example database_size/change_counter)
@@ -2786,10 +2793,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     // On commit_tx failure the `?` rolls back the pager txn; durable_txid_max and
                     // the log offset stay put, so a retry re-stages from the previous boundary.
                     tracing::debug!("Committing pager transaction");
-                    match self
-                        .pager
-                        .commit_tx(&self.connection, self.update_transaction_state)?
-                    {
+                    match self.pager.commit_tx(
+                        &self.connection,
+                        self.sync_mode,
+                        self.update_transaction_state,
+                    )? {
                         IOResult::Done(_) => {
                             self.pager_commit_done = true;
                         }
@@ -2885,8 +2893,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     }
                     Ok(IOResult::IO(io)) => Ok(TransitionResult::Io(io)),
                     // Busy under a DbFile reader: finish without publishing nbackfills.
-                    Err(crate::LimboError::Busy)
-                        if matches!(self.mode, CheckpointMode::Passive { .. }) =>
+                    Err(err)
+                        if matches!(*err, crate::LimboError::Busy)
+                            && matches!(self.mode, CheckpointMode::Passive { .. }) =>
                     {
                         tracing::debug!(
                             "Passive WAL checkpoint Busy under pinned DbFile reader; continuing without backfill"
@@ -2902,7 +2911,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         self.state = CheckpointState::TruncateLogicalLog;
                         Ok(TransitionResult::Continue)
                     }
-                    Err(e) => Err(e),
+                    Err(e) => Err(*e),
                 }
             }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -29,7 +29,6 @@ use crate::translate::plan::IterationDirection;
 use crate::types::compare_immutable;
 use crate::types::IOCompletions;
 use crate::types::IOResult;
-use crate::types::IOResultOr;
 use crate::types::ImmutableRecord;
 use crate::types::ImmutableRecordRef;
 use crate::types::IndexInfo;
@@ -1720,6 +1719,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new(
         state: CommitState<Clock, A>,
         tx_id: TxID,
@@ -1728,9 +1728,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         db_id: usize,
         commit_coordinator: Arc<CommitCoordinator>,
         header: Arc<RwLock<Option<DatabaseHeader>>>,
-    ) -> Result<Self> {
-        let pager = connection.get_pager_from_database_index(&db_id)?;
-        let sync_mode = connection.get_sync_mode_for_database(db_id)?;
+        sync_mode: SyncMode,
+    ) -> Self {
+        let pager = connection.pager.load().clone();
         // Use the connection's tx-level schema_did_change flag as the
         // single source of truth.  This flag is set by SetCookie(SchemaVersion)
         // which every DDL emits, so it covers all schema-changing operations
@@ -1742,7 +1742,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 schema_did_change: true
             }
         );
-        Ok(Self {
+        Self {
             state,
             is_finalized: false,
             #[cfg(any(test, injected_yields))]
@@ -1760,7 +1760,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             wrote_logical_log: false,
             sync_mode,
             _phantom: PhantomData,
-        })
+        }
     }
 
     fn release_group_claim(&mut self) {
@@ -3662,7 +3662,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)?;
                 inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                 if appended_to_log && mvcc_store.storage.should_checkpoint() {
-                    let auto_checkpoint_mode = if mvcc_store.uses_passive_checkpoint() {
+                    let auto_checkpoint_mode = if self
+                        .connection
+                        .experimental_mvcc_passive_checkpoint_enabled()
+                    {
                         crate::storage::wal::CheckpointMode::Passive {
                             upper_bound_inclusive: None,
                         }
@@ -3676,7 +3679,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                         mvcc_store.clone(),
                         self.connection.clone(),
                         false,
-                        self.sync_mode,
+                        self.connection.get_sync_mode(),
                         self.db_id,
                         auto_checkpoint_mode,
                     ));
@@ -4929,7 +4932,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut InitMetadataTableState,
-    ) -> IOResultOr<()> {
+    ) -> Result<IOResult<()>> {
         loop {
             match st {
                 InitMetadataTableState::Start => {
@@ -4983,7 +4986,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut ReadPersistentTxTsMaxState,
-    ) -> IOResultOr<Option<u64>> {
+    ) -> Result<IOResult<Option<u64>>> {
         loop {
             match st {
                 ReadPersistentTxTsMaxState::Start => {
@@ -4999,8 +5002,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         Err(err) => {
                             return Err(LimboError::Corrupt(format!(
                                 "Failed to read MVCC metadata table: {err}"
-                            ))
-                            .into());
+                            )));
                         }
                     };
                     match maybe_stmt {
@@ -5013,9 +5015,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         // No statement to run — fall through to the missing-row
                         // error path (matches the blocking variant).
                         None => {
-                            return Self::validate_persistent_tx_ts_max(None)
-                                .map(IOResult::Done)
-                                .map_err(Into::into);
+                            return Self::validate_persistent_tx_ts_max(None).map(IOResult::Done);
                         }
                     }
                 }
@@ -5026,9 +5026,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     }));
                     let value = *value;
                     *st = ReadPersistentTxTsMaxState::Start;
-                    return Self::validate_persistent_tx_ts_max(value)
-                        .map(IOResult::Done)
-                        .map_err(Into::into);
+                    return Self::validate_persistent_tx_ts_max(value).map(IOResult::Done);
                 }
             }
         }
@@ -5056,7 +5054,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         bootstrap_conn: &Arc<Connection>,
         st: &mut BootstrapState,
-    ) -> IOResultOr<()> {
+    ) -> Result<IOResult<()>> {
         loop {
             match st {
                 BootstrapState::Start => {
@@ -5744,17 +5742,33 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             None => {
                 if let Some(row_versions) = self.rows.get(id) {
                     let row_versions = row_versions.value().read();
-                    if let Some(rv) = row_versions
-                        .iter()
-                        .rev()
-                        .find(|rv| rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
-                    {
-                        return Ok(Some(rv.row.clone()));
+                    if let Some(row) = self.skipmap_row_while_uncovered(tx, &row_versions) {
+                        return Ok(Some(row));
                     }
                 }
                 Ok(None)
             }
         }
+    }
+
+    /// SkipMap payload for `tx` while B-tree fallthrough is not allowed.
+    fn skipmap_row_while_uncovered(
+        &self,
+        tx: &Transaction<A>,
+        versions: &[RowVersion],
+    ) -> Option<Row> {
+        if versions.is_empty() {
+            return None;
+        }
+        let table_id = versions[0].row.id.table_id;
+        if self.btree_covers_chain_for_tx(tx, table_id, versions) {
+            return None;
+        }
+        versions
+            .iter()
+            .rev()
+            .find(|rv| rv.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
+            .map(|rv| rv.row.clone())
     }
 
     /// Like the table branch of [`read_from_table_or_index`], but reads from an
@@ -5879,8 +5893,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             }
 
             // We found a row, let's check if it's visible to the transaction.
-            if let Some(visible_row) = self.find_last_visible_version(tx, &row) {
-                return Some(visible_row);
+            if let Some((row_id, versions, _)) = self.find_last_visible_version(tx, &row, false) {
+                return Some((row_id, versions));
             }
             // If this row is not visible, continue to the next row
         }
@@ -5942,9 +5956,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
     /// True when `tx` should ignore this SkipMap chain and read the key from B-tree.
     ///
-    /// Passive keeps SkipMap cover for all chains (table/index views can disagree
-    /// under concurrent Passive). Truncate may fall through for sole materialized
-    /// currents when no checkpoint is in progress.
+    /// Passive never falls through: it reclaims a chain only when no snapshot
+    /// is open, so a live passive reader always finds its row in the SkipMap.
+    /// Truncate may fall through for a sole materialized current when no
+    /// checkpoint is in progress.
     fn btree_covers_chain_for_tx(
         &self,
         tx: &Transaction<A>,
@@ -5962,6 +5977,18 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         }
         let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
         !self.chain_is_write_buffer_for(tx, versions, ckpt_max, tx.read_mark)
+    }
+
+    pub(crate) fn chain_falls_through_for_tx(
+        &self,
+        tx_id: TxID,
+        table_id: MVTableId,
+        versions: &[RowVersion],
+    ) -> bool {
+        let Some(tx) = self.txs.get(&tx_id) else {
+            return false;
+        };
+        self.btree_covers_chain_for_tx(tx.value(), table_id, versions)
     }
 
     /// Whether an already-resolved index version chain shadows (invalidates) the
@@ -6063,22 +6090,21 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         tx: &Transaction<A>,
         row: &TableRowEntry<'_, A>,
-    ) -> Option<(RowID, RowVersions<A>)> {
+        take_payload: bool,
+    ) -> Option<(RowID, RowVersions<A>, Option<Row>)> {
         let versions_arc = row.value();
-        {
+        let payload = {
             let versions = versions_arc.read();
-            let has_visible = versions
-                .iter()
-                .rev()
-                .any(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states));
-            if !has_visible {
-                return None;
-            }
             if self.btree_covers_chain_for_tx(tx, row.key().table_id, &versions) {
                 return None;
             }
-        }
-        Some((row.key().clone(), versions_arc.clone()))
+            let occupying = versions
+                .iter()
+                .rev()
+                .find(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states))?;
+            take_payload.then(|| occupying.row.clone())
+        };
+        Some((row.key().clone(), versions_arc.clone(), payload))
     }
 
     fn find_last_visible_index_version(
@@ -6087,15 +6113,14 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         row: IndexRowEntry<'_, A>,
     ) -> Option<RowID> {
         let versions = row.value().read();
-        let visible = versions
-            .iter()
-            .rev()
-            .find(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states))?;
-        let table_id = visible.row.id.table_id;
-        if self.btree_covers_chain_for_tx(tx, table_id, &versions) {
+        if versions.is_empty() {
             return None;
         }
-        Some(visible.row.id.clone())
+        versions
+            .iter()
+            .rev()
+            .find(|version| version.is_visible_to(tx, &self.txs, &self.finalized_tx_states))
+            .map(|version| version.row.id.clone())
     }
 
     fn find_next_visible_index_row<'a, I>(&self, tx: &Transaction<A>, mut rows: I) -> Option<RowID>
@@ -6115,7 +6140,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         tx: &Transaction<A>,
         mut rows: I,
         table_id: MVTableId,
-    ) -> Option<(RowID, RowVersions<A>)>
+        take_payload: bool,
+    ) -> Option<(RowID, RowVersions<A>, Option<Row>)>
     where
         I: Iterator<Item = TableRowEntry<'a, A>>,
     {
@@ -6124,7 +6150,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             if row.key().table_id != table_id {
                 return None;
             }
-            if let Some(visible_row) = self.find_last_visible_version(tx, &row) {
+            if let Some(visible_row) = self.find_last_visible_version(tx, &row, take_payload) {
                 return Some(visible_row);
             }
         }
@@ -6138,7 +6164,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         direction: IterationDirection,
         tx_id: TxID,
         table_iterator: &mut Option<MvccIterator<'static, RowID, A>>,
-    ) -> Option<RowID> {
+    ) -> Option<(RowID, Option<Row>)> {
         let table_id = start.table_id;
         let iter_box = {
             let range = if eq_only {
@@ -6182,8 +6208,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             .expect("transaction should exist in txs map");
         let tx = tx.value();
 
-        self.find_next_visible_table_row(tx, mv_store_iterator, table_id)
-            .map(|(row_id, _versions)| row_id)
+        self.find_next_visible_table_row(tx, mv_store_iterator, table_id, eq_only)
+            .map(|(row_id, _versions, payload)| (row_id, payload))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -7091,7 +7117,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             db_id,
             self.commit_coordinator.clone(),
             self.global_header.clone(),
-        )?);
+            connection.get_sync_mode(),
+        ));
         let state_machine = StateMachine::new(state);
         Ok(state_machine)
     }
@@ -7688,10 +7715,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         snapshot_ts
     }
 
-    pub(crate) fn uses_passive_checkpoint(&self) -> bool {
-        self.experimental_mvcc_passive_checkpoint
-    }
-
     /// Try to enter the passive publish window. Returns false if another publish is in flight.
     pub(crate) fn try_begin_passive_publish_window(&self) -> bool {
         debug_assert!(self.experimental_mvcc_passive_checkpoint);
@@ -7869,16 +7892,49 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         current.saturating_sub(at_last) >= threshold as usize
     }
 
+    /// Sample the GC low-water mark under the clock lock.
+    ///
+    /// `begin_tx` publishes into `txs` under that same lock, so a sample taken
+    /// here cannot miss a transaction mid-publish. Call this *before* taking
+    /// any version-chain write lock. Taking the clock while holding a chain
+    /// lock deadlocks against Passive publish (`clock` then `versions.write()`).
+    pub(crate) fn sample_gc_lwm(&self) -> u64 {
+        let mut lwm = u64::MAX;
+        self.clock.get_timestamp(|_| {
+            lwm = self.compute_lwm();
+        });
+        lwm
+    }
+
+    /// Apply the chain rules with a previously sampled LWM.
+    ///
+    /// Caller must already hold the chain write lock and must have sampled
+    /// `lwm` via [`Self::sample_gc_lwm`] (or an equivalent clock-ordered read)
+    /// without holding that lock.
+    pub(crate) fn gc_chain_now(
+        &self,
+        versions: &mut RowVersionChain<A>,
+        lwm: u64,
+        ckpt_max: u64,
+        min_reader_mark: WalPos,
+        drop_current_if_in_btree: bool,
+    ) -> usize {
+        Self::gc_version_chain(
+            versions,
+            lwm,
+            ckpt_max,
+            self.experimental_mvcc_passive_checkpoint,
+            min_reader_mark,
+            drop_current_if_in_btree,
+        )
+    }
+
     /// Garbage-collects row versions that are invisible to all active transactions.
     /// Uses the low-water mark (LWM) to determine reclaimability in O(1) per version.
     /// Covers both table rows (`self.rows`) and index rows (`self.index_rows`).
     /// Returns the number of removed versions.
     pub fn drop_unused_row_versions(&self) -> usize {
-        self.drop_unused_row_versions_inner(
-            false,
-            !self.experimental_mvcc_passive_checkpoint,
-            WalPos::STAGED,
-        )
+        self.drop_unused_row_versions_inner(false, true, WalPos::STAGED)
     }
 
     /// Like [`Self::drop_unused_row_versions`], and remove emptied SkipMap slots.
@@ -7888,11 +7944,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         self.drop_unused_row_versions_inner(true, true, WalPos::STAGED)
     }
 
-    /// Drop old versions and empty SkipMap slots, but keep the latest copy of each
-    /// row (Rule 3 off). Passive Finalize uses this. `reader_mark_floor` should
-    /// include pager-held readers, not only `txs`.
+    /// Drop old versions and empty SkipMap slots, including the latest copy of each
+    /// row once the B-tree has it (Rule 3). Passive Finalize uses this.
+    /// `reader_mark_floor` should include pager-held readers, not only `txs`.
     pub fn drop_unused_row_versions_unlink_empty_at(&self, reader_mark_floor: WalPos) -> usize {
-        self.drop_unused_row_versions_inner(true, false, reader_mark_floor)
+        self.drop_unused_row_versions_inner(true, true, reader_mark_floor)
     }
 
     /// Incremental GC on the commit path: reclaim up to `max_chains` table chains
@@ -7939,16 +7995,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         let _gate = GcGate(&self.gc_in_progress);
 
         let passive = self.experimental_mvcc_passive_checkpoint;
-        // Passive: keep the last current SkipMap version (B-trees may still be mid-write).
-        // Blocking Truncate: safe to drop it once the B-tree already has the row.
-        let drop_current_if_in_btree = !passive;
-        let lwm = if passive {
-            let mut sampled = u64::MAX;
-            self.clock.get_timestamp(|_| sampled = self.compute_lwm());
-            sampled
-        } else {
-            self.compute_lwm()
-        };
+        let drop_current_if_in_btree = true;
+        let lwm = self.sample_gc_lwm();
 
         // Short-circuit when a long-running transaction has pinned the LWM at
         // the same value since the last pass: nothing newly reclaimable can
@@ -7987,32 +8035,16 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             }
             // GC floor: retain rows of a freshly-materialized btree not yet visible to all readers.
             if !self.rootpage_gc_protected(&entry.key().table_id, min_reader_mark) {
-                if passive {
-                    self.clock.get_timestamp(|_| {
-                        let lwm = self.compute_lwm();
-                        let mut versions = entry.value().write();
-                        dropped += Self::gc_version_chain(
-                            &mut versions,
-                            lwm,
-                            ckpt_max,
-                            true,
-                            min_reader_mark,
-                            drop_current_if_in_btree,
-                        );
-                    });
-                } else {
-                    let mut versions = entry.value().write();
-                    dropped += Self::gc_version_chain(
-                        &mut versions,
-                        lwm,
-                        ckpt_max,
-                        false,
-                        min_reader_mark,
-                        drop_current_if_in_btree,
-                    );
-                    if versions.is_empty() {
-                        entry.remove();
-                    }
+                let mut versions = entry.value().write();
+                dropped += self.gc_chain_now(
+                    &mut versions,
+                    lwm,
+                    ckpt_max,
+                    min_reader_mark,
+                    drop_current_if_in_btree,
+                );
+                if !passive && versions.is_empty() {
+                    entry.remove();
                 }
             }
             last_key = Some(entry.key().clone());
@@ -8070,7 +8102,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     /// after the saved key; later indexes start from their first key.
     fn gc_index_incremental(&self, lwm: u64, ckpt_max: u64, max_chains: usize) -> usize {
         let passive = self.experimental_mvcc_passive_checkpoint;
-        let drop_current_if_in_btree = !passive;
+        let drop_current_if_in_btree = true;
         let mut dropped = 0;
         let mut processed = 0;
         let mut last: Option<(MVTableId, Arc<SortableIndexKey>)> = None;
@@ -8105,33 +8137,17 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 if processed >= max_chains {
                     break 'outer;
                 }
-                if passive {
-                    self.clock.get_timestamp(|_| {
-                        let lwm = self.compute_lwm();
-                        let mut versions = inner_entry.value().write();
-                        dropped += Self::gc_version_chain(
-                            &mut versions,
-                            lwm,
-                            ckpt_max,
-                            true,
-                            min_reader_mark,
-                            drop_current_if_in_btree,
-                        );
-                    });
-                } else {
-                    let mut versions = inner_entry.value().write();
-                    dropped += Self::gc_version_chain(
-                        &mut versions,
-                        lwm,
-                        ckpt_max,
-                        false,
-                        min_reader_mark,
-                        drop_current_if_in_btree,
-                    );
-                    if versions.is_empty() {
-                        self.bump_index_rows_epoch();
-                        inner_entry.remove();
-                    }
+                let mut versions = inner_entry.value().write();
+                dropped += self.gc_chain_now(
+                    &mut versions,
+                    lwm,
+                    ckpt_max,
+                    min_reader_mark,
+                    drop_current_if_in_btree,
+                );
+                if !passive && versions.is_empty() {
+                    self.bump_index_rows_epoch();
+                    inner_entry.remove();
                 }
                 last = Some((index_id, inner_entry.key().clone()));
                 processed += 1;
@@ -8150,8 +8166,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         drop_current_if_in_btree: bool,
         reader_mark_floor: WalPos,
     ) -> usize {
-        let lwm = self.compute_lwm();
         let ckpt_max = self.durable_txid_max.load(Ordering::SeqCst);
+        let lwm = self.sample_gc_lwm();
         let mut referenced_tx_ids = HashSet::default();
 
         let dropped = self.gc_table_row_versions(
@@ -8206,11 +8222,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 continue;
             }
             let mut versions = entry.value().write();
-            dropped += Self::gc_version_chain(
+            dropped += self.gc_chain_now(
                 &mut versions,
                 lwm,
                 ckpt_max,
-                self.experimental_mvcc_passive_checkpoint,
                 min_reader_mark,
                 drop_current_if_in_btree,
             );
@@ -8250,11 +8265,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
 
             for inner_entry in inner_map.iter() {
                 let mut versions = inner_entry.value().write();
-                dropped += Self::gc_version_chain(
+                dropped += self.gc_chain_now(
                     &mut versions,
                     lwm,
                     ckpt_max,
-                    self.experimental_mvcc_passive_checkpoint,
                     min_reader_mark,
                     drop_current_if_in_btree,
                 );
@@ -8308,16 +8322,16 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
     ///         unless it's a tombstone (no committed current) whose delete isn't
     ///         checkpointed yet, or a B-tree-resident version whose physical
     ///         delete/overwrite hasn't been checkpointed.
-    /// Rule 3: last remaining current (end=None) — remove only when
-    ///         `drop_current_if_in_btree` is true and the B-tree already has it.
+    /// Rule 3: last remaining current (end unpacks as None) — drop it when
+    ///         `drop_current_if_in_btree` is true, the B-tree already has it
+    ///         (stamped, and for Truncate inside `ckpt_max`), and
+    ///         `lwm == u64::MAX`. Idle-only on both Passive and Truncate: a
+    ///         dual-cursor can lose the row if the SkipMap empties mid-scan.
     ///
     /// Passive gates Rule 2 on `materialized_at` + `min_reader_mark`. Blocking
-    /// Truncate uses `ckpt_max` instead.
-    ///
-    /// Leaving Rule 3 off keeps a SkipMap copy so an older reader cannot fall
-    /// through to a B-tree page a later checkpoint already rewrote. Truncate can
-    /// turn it on under the blocking lock (no open MVCC txs). Callers set
-    /// `drop_current_if_in_btree` when they want Rule 3.
+    /// Truncate uses `ckpt_max` instead. Both require `materialized_at` before
+    /// dropping a live copy: a `ckpt_max` above this version's begin says a
+    /// checkpoint ran, not that this row reached a B-tree leaf.
     fn gc_version_chain(
         versions: &mut RowVersionChain<A>,
         lwm: u64,
@@ -8360,16 +8374,19 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             _ => true,
         });
 
-        // Rule 3: optionally drop the last current version when the B-tree already has it.
+        // Rule 3: drop the last current when the B-tree already has it.
+        // Idle-only for both Passive and Truncate: a dual-cursor scan can lose
+        // the row if the SkipMap empties mid-scan while the B-tree side has
+        // already skipped the key as shadowed. `lwm == MAX` is the proof that
+        // no snapshot (hence no dual-cursor) is open. Under load, Rule 2 still
+        // reclaims superseded history; last currents wait for quiescence.
         if drop_current_if_in_btree && versions.len() == 1 {
             if let (Some(TxTimestampOrID::Timestamp(b)), None) =
                 (&versions[0].begin(), &versions[0].end())
             {
-                let removable = if passive {
-                    materialized_for_readers(&versions[0]) && *b < lwm
-                } else {
-                    *b <= ckpt_max && *b < lwm
-                };
+                let stamped_for_readers = materialized_for_readers(&versions[0]);
+                let in_durable_bound = passive || *b <= ckpt_max;
+                let removable = lwm == u64::MAX && stamped_for_readers && in_durable_bound;
                 if removable {
                     versions.clear();
                 }
@@ -8775,7 +8792,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                 tracing::trace!("get_last_table_rowid: reached end of table");
                 return None;
             }
-            if let Some(_visible_row) = self.find_last_visible_version(tx, &entry) {
+            if let Some(_visible_row) = self.find_last_visible_version(tx, &entry, false) {
                 tracing::trace!(
                     "get_last_table_rowid: found visible row: {:?}",
                     _visible_row
@@ -8874,7 +8891,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut CompleteCheckpointState,
-    ) -> IOResultOr<()> {
+    ) -> Result<IOResult<()>> {
         let pager = connection.pager.load().clone();
         let Some(wal) = &pager.wal else {
             return Ok(IOResult::Done(()));
@@ -8915,8 +8932,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         return Err(LimboError::Corrupt(
                             "Cannot reconcile interrupted MVCC checkpoint in read-only mode"
                                 .to_string(),
-                        )
-                        .into());
+                        ));
                     }
                     match header_result {
                         HeaderReadResult::Valid(header) => {
@@ -8930,8 +8946,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 return Err(LimboError::Corrupt(
                                     "WAL has committed frames but logical log header is missing"
                                         .to_string(),
-                                )
-                                .into());
+                                ));
                             }
                         }
                         HeaderReadResult::Invalid => {
@@ -8940,8 +8955,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             return Err(LimboError::Corrupt(
                                 "WAL has committed frames but logical log header is invalid"
                                     .to_string(),
-                            )
-                            .into());
+                            ));
                         }
                     }
                     // Enter the checkpoint lifecycle before any WAL→DB backfill so
@@ -8984,7 +8998,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         // Close out the lifecycle opened in `ReadingHeader` so the
                         // start/end pairing stays balanced on this error path.
                         self.storage.on_checkpoint_end(Err(err.clone()))?;
-                        return Err(err.into());
+                        return Err(err);
                     }
                     let need_db_sync = connection.get_sync_mode() != SyncMode::Off
                         && checkpoint_result.wal_checkpoint_backfilled > 0;
@@ -8996,7 +9010,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             Ok(c) => c,
                             Err(err) => {
                                 self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                return Err(err.into());
+                                return Err(err);
                             }
                         };
                         *st = CompleteCheckpointState::AwaitDbFileSync {
@@ -9037,7 +9051,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             Ok(c) => c,
                             Err(err) => {
                                 self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                return Err(err.into());
+                                return Err(err);
                             }
                         };
                         *phase = RetryHeaderPhase::AwaitUpdateHeader(c);
@@ -9052,7 +9066,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 Ok(c) => c,
                                 Err(err) => {
                                     self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                    return Err(err.into());
+                                    return Err(err);
                                 }
                             };
                             *phase = RetryHeaderPhase::AwaitLogSync(c);
@@ -9088,7 +9102,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     "Logical log header CRC mismatch after retry".to_string(),
                                 );
                                 self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                return Err(err.into());
+                                return Err(err);
                             }
                             *retried_crc = true;
                             *phase = RetryHeaderPhase::NeedUpdateHeader;
@@ -9104,7 +9118,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             return Ok(IOResult::IO(c));
                         }
                         Err(err) => {
-                            self.storage.on_checkpoint_end(Err((*err).clone()))?;
+                            self.storage.on_checkpoint_end(Err(err.clone()))?;
                             return Err(err);
                         }
                     }
@@ -9307,7 +9321,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut RecoverLogicalLogState,
-    ) -> IOResultOr<bool> {
+    ) -> Result<IOResult<bool>> {
         loop {
             match st {
                 RecoverLogicalLogState::Start => {
@@ -9329,8 +9343,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             return Err(LimboError::Corrupt(
                                 "Logical log header corrupt and no WAL recovery available"
                                     .to_string(),
-                            )
-                            .into());
+                            ));
                         }
                     };
                     if let Some(header) = &header {
@@ -9366,8 +9379,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             None => {
                                 return Err(LimboError::Corrupt(
                                     "Missing MVCC metadata table".to_string(),
-                                )
-                                .into());
+                                ));
                             }
                         }
                     } else {

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -29,6 +29,7 @@ use crate::translate::plan::IterationDirection;
 use crate::types::compare_immutable;
 use crate::types::IOCompletions;
 use crate::types::IOResult;
+use crate::types::IOResultOr;
 use crate::types::ImmutableRecord;
 use crate::types::ImmutableRecordRef;
 use crate::types::IndexInfo;
@@ -1719,7 +1720,6 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn new(
         state: CommitState<Clock, A>,
         tx_id: TxID,
@@ -1728,9 +1728,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
         db_id: usize,
         commit_coordinator: Arc<CommitCoordinator>,
         header: Arc<RwLock<Option<DatabaseHeader>>>,
-        sync_mode: SyncMode,
-    ) -> Self {
-        let pager = connection.pager.load().clone();
+    ) -> Result<Self> {
+        let pager = connection.get_pager_from_database_index(&db_id)?;
+        let sync_mode = connection.get_sync_mode_for_database(db_id)?;
         // Use the connection's tx-level schema_did_change flag as the
         // single source of truth.  This flag is set by SetCookie(SchemaVersion)
         // which every DDL emits, so it covers all schema-changing operations
@@ -1742,7 +1742,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
                 schema_did_change: true
             }
         );
-        Self {
+        Ok(Self {
             state,
             is_finalized: false,
             #[cfg(any(test, injected_yields))]
@@ -1760,7 +1760,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CommitStateMachine<Clock, A> {
             wrote_logical_log: false,
             sync_mode,
             _phantom: PhantomData,
-        }
+        })
     }
 
     fn release_group_claim(&mut self) {
@@ -3662,10 +3662,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                 mvcc_store.finish_committed_tx(self.tx_id, &self.connection, self.db_id)?;
                 inject_transition_failure!(self, CommitYieldPoint::AfterRemoveTx);
                 if appended_to_log && mvcc_store.storage.should_checkpoint() {
-                    let auto_checkpoint_mode = if self
-                        .connection
-                        .experimental_mvcc_passive_checkpoint_enabled()
-                    {
+                    let auto_checkpoint_mode = if mvcc_store.uses_passive_checkpoint() {
                         crate::storage::wal::CheckpointMode::Passive {
                             upper_bound_inclusive: None,
                         }
@@ -3679,7 +3676,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
                         mvcc_store.clone(),
                         self.connection.clone(),
                         false,
-                        self.connection.get_sync_mode(),
+                        self.sync_mode,
                         self.db_id,
                         auto_checkpoint_mode,
                     ));
@@ -4932,7 +4929,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut InitMetadataTableState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match st {
                 InitMetadataTableState::Start => {
@@ -4986,7 +4983,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut ReadPersistentTxTsMaxState,
-    ) -> Result<IOResult<Option<u64>>> {
+    ) -> IOResultOr<Option<u64>> {
         loop {
             match st {
                 ReadPersistentTxTsMaxState::Start => {
@@ -5002,7 +4999,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         Err(err) => {
                             return Err(LimboError::Corrupt(format!(
                                 "Failed to read MVCC metadata table: {err}"
-                            )));
+                            ))
+                            .into());
                         }
                     };
                     match maybe_stmt {
@@ -5015,7 +5013,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         // No statement to run — fall through to the missing-row
                         // error path (matches the blocking variant).
                         None => {
-                            return Self::validate_persistent_tx_ts_max(None).map(IOResult::Done);
+                            return Self::validate_persistent_tx_ts_max(None)
+                                .map(IOResult::Done)
+                                .map_err(Into::into);
                         }
                     }
                 }
@@ -5026,7 +5026,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     }));
                     let value = *value;
                     *st = ReadPersistentTxTsMaxState::Start;
-                    return Self::validate_persistent_tx_ts_max(value).map(IOResult::Done);
+                    return Self::validate_persistent_tx_ts_max(value)
+                        .map(IOResult::Done)
+                        .map_err(Into::into);
                 }
             }
         }
@@ -5054,7 +5056,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         bootstrap_conn: &Arc<Connection>,
         st: &mut BootstrapState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match st {
                 BootstrapState::Start => {
@@ -7117,8 +7119,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             db_id,
             self.commit_coordinator.clone(),
             self.global_header.clone(),
-            connection.get_sync_mode(),
-        ));
+        )?);
         let state_machine = StateMachine::new(state);
         Ok(state_machine)
     }
@@ -7713,6 +7714,10 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
             snapshot_ts = last_committed.min(inflight_floor.saturating_sub(1));
         });
         snapshot_ts
+    }
+
+    pub(crate) fn uses_passive_checkpoint(&self) -> bool {
+        self.experimental_mvcc_passive_checkpoint
     }
 
     /// Try to enter the passive publish window. Returns false if another publish is in flight.
@@ -8891,7 +8896,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut CompleteCheckpointState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let pager = connection.pager.load().clone();
         let Some(wal) = &pager.wal else {
             return Ok(IOResult::Done(()));
@@ -8932,7 +8937,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         return Err(LimboError::Corrupt(
                             "Cannot reconcile interrupted MVCC checkpoint in read-only mode"
                                 .to_string(),
-                        ));
+                        )
+                        .into());
                     }
                     match header_result {
                         HeaderReadResult::Valid(header) => {
@@ -8946,7 +8952,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 return Err(LimboError::Corrupt(
                                     "WAL has committed frames but logical log header is missing"
                                         .to_string(),
-                                ));
+                                )
+                                .into());
                             }
                         }
                         HeaderReadResult::Invalid => {
@@ -8955,7 +8962,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             return Err(LimboError::Corrupt(
                                 "WAL has committed frames but logical log header is invalid"
                                     .to_string(),
-                            ));
+                            )
+                            .into());
                         }
                     }
                     // Enter the checkpoint lifecycle before any WAL→DB backfill so
@@ -8998,7 +9006,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         // Close out the lifecycle opened in `ReadingHeader` so the
                         // start/end pairing stays balanced on this error path.
                         self.storage.on_checkpoint_end(Err(err.clone()))?;
-                        return Err(err);
+                        return Err(err.into());
                     }
                     let need_db_sync = connection.get_sync_mode() != SyncMode::Off
                         && checkpoint_result.wal_checkpoint_backfilled > 0;
@@ -9010,7 +9018,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             Ok(c) => c,
                             Err(err) => {
                                 self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                return Err(err);
+                                return Err(err.into());
                             }
                         };
                         *st = CompleteCheckpointState::AwaitDbFileSync {
@@ -9051,7 +9059,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             Ok(c) => c,
                             Err(err) => {
                                 self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                return Err(err);
+                                return Err(err.into());
                             }
                         };
                         *phase = RetryHeaderPhase::AwaitUpdateHeader(c);
@@ -9066,7 +9074,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 Ok(c) => c,
                                 Err(err) => {
                                     self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                    return Err(err);
+                                    return Err(err.into());
                                 }
                             };
                             *phase = RetryHeaderPhase::AwaitLogSync(c);
@@ -9102,7 +9110,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     "Logical log header CRC mismatch after retry".to_string(),
                                 );
                                 self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                return Err(err);
+                                return Err(err.into());
                             }
                             *retried_crc = true;
                             *phase = RetryHeaderPhase::NeedUpdateHeader;
@@ -9118,7 +9126,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             return Ok(IOResult::IO(c));
                         }
                         Err(err) => {
-                            self.storage.on_checkpoint_end(Err(err.clone()))?;
+                            self.storage.on_checkpoint_end(Err((*err).clone()))?;
                             return Err(err);
                         }
                     }
@@ -9321,7 +9329,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut RecoverLogicalLogState,
-    ) -> Result<IOResult<bool>> {
+    ) -> IOResultOr<bool> {
         loop {
             match st {
                 RecoverLogicalLogState::Start => {
@@ -9343,7 +9351,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             return Err(LimboError::Corrupt(
                                 "Logical log header corrupt and no WAL recovery available"
                                     .to_string(),
-                            ));
+                            )
+                            .into());
                         }
                     };
                     if let Some(header) = &header {
@@ -9379,7 +9388,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             None => {
                                 return Err(LimboError::Corrupt(
                                     "Missing MVCC metadata table".to_string(),
-                                ));
+                                )
+                                .into());
                             }
                         }
                     } else {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9528,7 +9528,7 @@ fn test_mvcc_integrity_check() {
 #[test]
 fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
     fn run_pager_until_done<T>(
-        mut action: impl FnMut() -> Result<IOResult<T>>,
+        mut action: impl FnMut() -> IOResultOr<T>,
         pager: &Pager,
     ) -> Result<T> {
         loop {
@@ -9594,7 +9594,11 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
         )
         .unwrap();
     }
-    run_pager_until_done(|| pager.commit_tx(&db.conn, true), pager.as_ref()).unwrap();
+    run_pager_until_done(
+        || pager.commit_tx(&db.conn, db.conn.get_sync_mode(), true),
+        pager.as_ref(),
+    )
+    .unwrap();
 
     pager.begin_read_tx().unwrap();
     let mut interior_key = None;
@@ -9647,7 +9651,11 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
             IOResult::IO(io) => io.wait(pager.io.as_ref()).unwrap(),
         }
     }
-    run_pager_until_done(|| pager.commit_tx(&db.conn, true), pager.as_ref()).unwrap();
+    run_pager_until_done(
+        || pager.commit_tx(&db.conn, db.conn.get_sync_mode(), true),
+        pager.as_ref(),
+    )
+    .unwrap();
 
     pager.begin_read_tx().unwrap();
     let count_after = run_pager_until_done(|| cursor.write().count(), pager.as_ref()).unwrap();

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -703,19 +703,37 @@ fn mvcc_passive_gc_retains_until_reader_mark_reaches_materialization() {
     let dropped =
         MvStore::<MvccClock>::gc_version_chain(&mut current, 10, 10, true, frame(100), true);
     assert_eq!(
+        dropped, 0,
+        "Passive keeps a live copy while a snapshot is open, even when materialized"
+    );
+    assert_eq!(current.len(), 1);
+
+    let mut current = stamped_insert();
+    let dropped =
+        MvStore::<MvccClock>::gc_version_chain(&mut current, u64::MAX, 10, true, frame(100), true);
+    assert_eq!(
         dropped, 1,
-        "Truncate may drop the current SkipMap version once it is in the B-tree"
+        "Passive Rule 3 drops a materialized current once no snapshot is open"
     );
     assert!(current.is_empty());
 
     // Unmaterialized versions are never reclaimed on the Passive path.
-    let mut v = crate::alloc::vec![make_rv(ts(5), None)];
-    let dropped =
-        MvStore::<MvccClock>::gc_version_chain(&mut v, 10, 10, true, WalPos::STAGED, false);
-    assert_eq!(
-        dropped, 0,
-        "passive GC must not reclaim a version not yet in the B-tree"
-    );
+    for drop_current_if_in_btree in [false, true] {
+        let mut v = crate::alloc::vec![make_rv(ts(5), None)];
+        let dropped = MvStore::<MvccClock>::gc_version_chain(
+            &mut v,
+            10,
+            10,
+            true,
+            WalPos::STAGED,
+            drop_current_if_in_btree,
+        );
+        assert_eq!(
+            dropped, 0,
+            "passive GC must not reclaim a version not yet in the B-tree"
+        );
+        assert_eq!(v.len(), 1);
+    }
 }
 
 /// Ignored Truncate-vs-Passive GC metrics harness.
@@ -974,9 +992,6 @@ fn mvcc_passive_checkpoint_publishes_backfill_and_reclaims_versions() {
         wal_bf > 0,
         "passive checkpoint must publish nbackfills, got wal_nbackfill={wal_bf}, snap={snap:?}"
     );
-    // Passive Finalize keeps currents (SkipMap cover) but drains empty slots /
-    // superseded history. Write-buffer reads can prefer B-tree for sole
-    // materialized currents without unlinking them.
     assert_eq!(
         snap.rows_empty_slots, 0,
         "passive Finalize must drain empty SkipMap slots: {snap:?}"
@@ -986,7 +1001,6 @@ fn mvcc_passive_checkpoint_publishes_backfill_and_reclaims_versions() {
         "backfill_floor must track published nbackfills: {snap:?}"
     );
 
-    // Full Rule 3 reclaim of currents requires a blocking Truncate Finalize.
     conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
     let after_truncate = mv.debug_gc_snapshot();
     assert_eq!(
@@ -999,12 +1013,11 @@ fn mvcc_passive_checkpoint_publishes_backfill_and_reclaims_versions() {
     );
 }
 
-/// Regression test for why Rule 3 (see the `gc_version_chain` doc comment) must stay
-/// off for every Passive GC path: a reader whose snapshot predates a write must never
-/// observe that write while its transaction is still open, even with a single table
-/// and no index involved (ruling out table/index publish skew as the cause). If Rule 3
-/// were ever turned on for Passive without also fixing the underlying B-tree-fallthrough
-/// isolation gap, this test would fail with `after == [2000]` instead of `[1000]`.
+/// Snapshot isolation after Passive Finalize reclaims a materialized current
+/// version: a reader whose snapshot predates a later write must still see the
+/// pre-write value. Idle-only Rule 3 (`lwm == MAX`) is what keeps a positioned
+/// cursor valid while a snapshot is open; this test covers the re-read after
+/// GC has already run.
 #[test]
 fn passive_reader_snapshot_survives_later_write_after_row_versions_gc() {
     let db = MvccTestDbNoConn::new_with_random_db_passive();
@@ -1019,9 +1032,12 @@ fn passive_reader_snapshot_survives_later_write_after_row_versions_gc() {
     // blocking protocol regardless of `experimental_mvcc_passive_checkpoint`): this
     // materializes row 1 into the B-tree and runs Passive Finalize GC on it.
     conn.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
-    assert!(
-        mv.debug_gc_snapshot().rows_versions > 0,
-        "row 1's current version must survive Passive Finalize (Rule 3 off)"
+    // With no transaction open, Rule 3 clears the sole stamped current in the
+    // same Finalize sweep. The reader below must not notice either way.
+    assert_eq!(
+        mv.debug_gc_snapshot().rows_versions,
+        0,
+        "with no reader open, Passive Finalize reclaims the materialized version"
     );
 
     // Reader opens a snapshot BEFORE any further write.
@@ -9512,7 +9528,7 @@ fn test_mvcc_integrity_check() {
 #[test]
 fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
     fn run_pager_until_done<T>(
-        mut action: impl FnMut() -> IOResultOr<T>,
+        mut action: impl FnMut() -> Result<IOResult<T>>,
         pager: &Pager,
     ) -> Result<T> {
         loop {
@@ -9578,11 +9594,7 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
         )
         .unwrap();
     }
-    run_pager_until_done(
-        || pager.commit_tx(&db.conn, db.conn.get_sync_mode(), true),
-        pager.as_ref(),
-    )
-    .unwrap();
+    run_pager_until_done(|| pager.commit_tx(&db.conn, true), pager.as_ref()).unwrap();
 
     pager.begin_read_tx().unwrap();
     let mut interior_key = None;
@@ -9635,11 +9647,7 @@ fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
             IOResult::IO(io) => io.wait(pager.io.as_ref()).unwrap(),
         }
     }
-    run_pager_until_done(
-        || pager.commit_tx(&db.conn, db.conn.get_sync_mode(), true),
-        pager.as_ref(),
-    )
-    .unwrap();
+    run_pager_until_done(|| pager.commit_tx(&db.conn, true), pager.as_ref()).unwrap();
 
     pager.begin_read_tx().unwrap();
     let count_after = run_pager_until_done(|| cursor.write().count(), pager.as_ref()).unwrap();
@@ -10355,6 +10363,28 @@ fn test_update_multiple_unique_columns_partial_rollback() {
 
 // ─── GC helpers ───────────────────────────────────────────────────────────
 
+fn unique_index_btree_is_allocated(mv: &crate::MvStore) -> bool {
+    mv.index_rows
+        .iter()
+        .any(|idx| mv.is_btree_allocated(idx.key()))
+}
+
+/// An index current that no checkpoint has written to the B-tree yet. GC must
+/// keep it: the SkipMap is the only copy of that key.
+fn skipmap_has_unmaterialized_index_current(mv: &crate::MvStore) -> bool {
+    mv.index_rows.iter().any(|idx| {
+        idx.value().iter().any(|e| {
+            e.value().read().iter().any(|rv| {
+                rv.end().is_none() && rv.materialized_at() == crate::mvcc::database::WalPos::ORIGIN
+            })
+        })
+    })
+}
+
+fn skipmap_version_count(mv: &crate::MvStore) -> usize {
+    mv.rows.iter().map(|e| e.value().read().len()).sum()
+}
+
 fn make_rv(begin: Option<TxTimestampOrID>, end: Option<TxTimestampOrID>) -> RowVersion {
     RowVersion {
         id: 0,
@@ -10364,6 +10394,20 @@ fn make_rv(begin: Option<TxTimestampOrID>, end: Option<TxTimestampOrID>) -> RowV
         btree_resident: false,
         materialized_at: crate::mvcc::database::WalPos::ORIGIN,
     }
+}
+
+/// [`make_rv`] for a version a checkpoint already wrote to the B-tree, which is
+/// what Rule 3 requires before it may drop the last SkipMap copy.
+fn make_materialized_rv(
+    begin: Option<TxTimestampOrID>,
+    end: Option<TxTimestampOrID>,
+) -> RowVersion {
+    let mut rv = make_rv(begin, end);
+    rv.set_materialized_at(crate::mvcc::database::WalPos {
+        checkpoint_seq: 1,
+        frame: 1,
+    });
+    rv
 }
 
 fn ts(v: u64) -> Option<TxTimestampOrID> {
@@ -10508,14 +10552,42 @@ fn test_gc_rule2_tombstone_guard_checkpointed() {
 /// Garbage collection removes only versions that are provably unreachable and keeps versions still required for visibility and safety.
 #[test]
 /// A current version that's been checkpointed to B-tree, with no other versions in
-/// the chain and no active reader needing it, is redundant. The dual cursor will
+/// the chain and no transaction open at all, is redundant. The dual cursor will
 /// fall through to the B-tree which has identical data. Safe to remove.
 fn test_gc_rule3_drop_current_when_in_btree() {
-    // Single current version with b <= ckpt_max and b < lwm.
-    let mut versions = crate::alloc::vec![make_rv(ts(5), None)];
+    // Single stamped current with b <= ckpt_max, and no transaction open
+    // (lwm == u64::MAX).
+    let mut versions = crate::alloc::vec![make_materialized_rv(ts(5), None)];
+    let dropped = MvStore::<MvccClock>::gc_version_chain(
+        &mut versions,
+        u64::MAX,
+        5,
+        false,
+        crate::mvcc::database::WalPos::STAGED,
+        true,
+    );
+    assert_eq!(dropped, 1);
+    assert!(versions.is_empty());
+}
+
+/// Truncate Rule 3 matches Passive: sole stamped currents clear only when idle.
+#[test]
+fn test_gc_rule3_truncate_idle_only() {
+    let mut versions = crate::alloc::vec![make_materialized_rv(ts(5), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
         10,
+        5,
+        false,
+        crate::mvcc::database::WalPos::STAGED,
+        true,
+    );
+    assert_eq!(dropped, 0, "open snapshot must block Truncate Rule 3 clear");
+    assert_eq!(versions.len(), 1);
+
+    let dropped = MvStore::<MvccClock>::gc_version_chain(
+        &mut versions,
+        u64::MAX,
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -10531,10 +10603,12 @@ fn test_gc_rule3_drop_current_when_in_btree() {
 /// the B-tree doesn't have the data, so fallthrough would return stale results.
 fn test_gc_rule3_not_checkpointed_retained() {
     // Single current version with b > ckpt_max — B-tree doesn't have it yet.
-    let mut versions = crate::alloc::vec![make_rv(ts(5), None)];
+    // Nothing is open (lwm == u64::MAX), so ckpt_max is the only thing holding
+    // this version back.
+    let mut versions = crate::alloc::vec![make_materialized_rv(ts(5), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         3,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -10546,11 +10620,12 @@ fn test_gc_rule3_not_checkpointed_retained() {
 
 /// Garbage collection removes only versions that are provably unreachable and keeps versions still required for visibility and safety.
 #[test]
-/// A current version whose begin timestamp equals the LWM might still be needed
-/// by the oldest active reader. Rule 3 requires strict b < lwm, so it's retained.
+/// Any finite LWM means some transaction is still open, and an open snapshot may
+/// be running a dual-cursor scan that would lose this row if the chain emptied
+/// under it. Rule 3 only fires when nothing is open, so this is retained.
 fn test_gc_rule3_visible_to_active_tx_retained() {
-    // Single current version with b >= lwm — some active tx might need it.
-    let mut versions = crate::alloc::vec![make_rv(ts(5), None)];
+    // Single stamped current, already inside ckpt_max, but a transaction is open.
+    let mut versions = crate::alloc::vec![make_materialized_rv(ts(5), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
         5,
@@ -10559,7 +10634,7 @@ fn test_gc_rule3_visible_to_active_tx_retained() {
         crate::mvcc::database::WalPos::STAGED,
         true,
     );
-    // b=5 is NOT < lwm=5 (strict <), so retained
+    // lwm=5 != u64::MAX, so a transaction is open and Rule 3 must not fire.
     assert_eq!(dropped, 0);
     assert_eq!(versions.len(), 1);
 }
@@ -10568,10 +10643,10 @@ fn test_gc_rule3_visible_to_active_tx_retained() {
 #[test]
 /// A current version cannot be removed before checkpoint has persisted it.
 fn test_gc_rule3_current_retained_before_first_checkpoint() {
-    let mut versions = crate::alloc::vec![make_rv(ts(1), None)];
+    let mut versions = crate::alloc::vec![make_materialized_rv(ts(1), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         0,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -10585,10 +10660,10 @@ fn test_gc_rule3_current_retained_before_first_checkpoint() {
 #[test]
 /// Once checkpoint has persisted a sole current version, it becomes GC-eligible.
 fn test_gc_rule3_current_collected_after_checkpoint() {
-    let mut versions = crate::alloc::vec![make_rv(ts(1), None)];
+    let mut versions = crate::alloc::vec![make_materialized_rv(ts(1), None)];
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -10604,19 +10679,51 @@ fn test_gc_rule3_current_collected_after_checkpoint() {
 /// superseded history, Rule 3 can then drop that current.
 fn test_gc_rule3_after_history_reclaimed() {
     // Rule 3 only fires when exactly one version remains after rules 1 & 2.
-    let mut versions = crate::alloc::vec![make_rv(ts(3), ts(5)), make_rv(ts(5), None)];
-    // Both b <= ckpt_max and b < lwm, but there are 2 versions.
-    // Rule 2 removes the superseded one (has_current=true), then Rule 3 drops
-    // the remaining current.
+    let mut versions = crate::alloc::vec![make_rv(ts(3), ts(5)), make_materialized_rv(ts(5), None)];
+    // Both versions are inside ckpt_max and nothing is open, but the chain
+    // starts with 2 entries. Rule 2 removes the superseded one
+    // (has_current=true), then Rule 3 drops the remaining current.
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
         true,
     );
     assert_eq!(dropped, 2);
+    assert!(versions.is_empty());
+}
+
+/// Rule 3 drops a sole current only once a checkpoint stamped it. A high
+/// `ckpt_max` says a checkpoint ran, not that this row reached a B-tree leaf.
+#[test]
+fn test_gc_rule3_keeps_unstamped_current_and_drops_stamped_one() {
+    let mut versions = crate::alloc::vec![make_rv(ts(5), None)];
+    let dropped = MvStore::<MvccClock>::gc_version_chain(
+        &mut versions,
+        10,
+        10,
+        false,
+        crate::mvcc::database::WalPos::STAGED,
+        true,
+    );
+    assert_eq!(dropped, 0);
+    assert_eq!(versions.len(), 1);
+
+    versions[0].set_materialized_at(crate::mvcc::database::WalPos {
+        checkpoint_seq: 1,
+        frame: 7,
+    });
+    let dropped = MvStore::<MvccClock>::gc_version_chain(
+        &mut versions,
+        u64::MAX,
+        10,
+        false,
+        crate::mvcc::database::WalPos::STAGED,
+        true,
+    );
+    assert_eq!(dropped, 1);
     assert!(versions.is_empty());
 }
 
@@ -10719,12 +10826,12 @@ fn test_gc_rule2_committed_current_disables_non_btree_tombstone_guard() {
 fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() {
     let mut tombstone = make_rv(None, ts(5));
     tombstone.btree_resident = true;
-    let current = make_rv(ts(5), None);
+    let current = make_materialized_rv(ts(5), None);
     let mut versions = crate::alloc::vec![tombstone, current.clone()];
 
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         2,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -10736,7 +10843,7 @@ fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() 
 
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -10751,7 +10858,7 @@ fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() 
 
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         2,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -10763,7 +10870,7 @@ fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() 
 
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -10785,12 +10892,12 @@ fn test_gc_rule2_btree_resident_marker_with_current_retained_until_checkpoint() 
 fn test_gc_rule2_checkpointed_insert_with_current_retained_until_checkpoint() {
     // begin=2 <= ckpt_max=2 (insert checkpointed), end=5 > ckpt_max (overwrite not).
     let checkpointed_btree_row = make_rv(ts(2), ts(5));
-    let current = make_rv(ts(5), None);
+    let current = make_materialized_rv(ts(5), None);
     let mut versions = crate::alloc::vec![checkpointed_btree_row, current];
 
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         2,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -10803,7 +10910,7 @@ fn test_gc_rule2_checkpointed_insert_with_current_retained_until_checkpoint() {
     // reclaimable (rule 2 for the superseded, rule 3 for the current).
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -10858,8 +10965,8 @@ fn test_gc_rule3_not_firing_with_unremovable_superseded() {
     // Rule 2 can't remove the superseded one, so 2 versions remain.
     // Rule 3 needs a single remaining current, so it must NOT fire.
     let mut versions = crate::alloc::vec![
-        make_rv(ts(3), ts(15)), // e=15 > lwm=10 — retained
-        make_rv(ts(15), None),  // current
+        make_rv(ts(3), ts(15)),             // e=15 > lwm=10 — retained
+        make_materialized_rv(ts(15), None), // current
     ];
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
@@ -10891,21 +10998,20 @@ fn test_gc_noop_on_empty() {
 
 /// Garbage collection removes only versions that are provably unreachable and keeps versions still required for visibility and safety.
 #[test]
-/// All three rules fire together: aborted garbage (Rule 1), two superseded versions
-/// below LWM with a committed current (Rule 2), and the sole surviving current
-/// version below LWM and checkpointed (Rule 3). The chain is fully reclaimed.
+/// All three rules fire together with nothing open: aborted garbage (Rule 1), two
+/// checkpointed superseded versions with a committed current (Rule 2), and the sole
+/// surviving stamped current inside `ckpt_max` (Rule 3). The chain is fully reclaimed.
 fn test_gc_combined_rules() {
-    // Mix of all cases: aborted, superseded below LWM, current checkpointed,
-    // and one above LWM that must be retained.
     let mut versions = crate::alloc::vec![
         make_rv(None, None),   // aborted → rule 1
-        make_rv(ts(1), ts(3)), // superseded, e=3 <= lwm=10 → rule 2 (has_current=true)
-        make_rv(ts(3), ts(5)), // superseded, e=5 <= lwm=10 → rule 2
-        make_rv(ts(5), None),  // current, b=5 <= ckpt_max=5, b < lwm=10 → rule 3
+        make_rv(ts(1), ts(3)), // superseded, e=3 <= ckpt_max=5 → rule 2 (has_current=true)
+        make_rv(ts(3), ts(5)), // superseded, e=5 <= ckpt_max=5 → rule 2
+        // current, stamped, b=5 <= ckpt_max=5, nothing open → rule 3
+        make_materialized_rv(ts(5), None),
     ];
     let dropped = MvStore::<MvccClock>::gc_version_chain(
         &mut versions,
-        10,
+        u64::MAX,
         5,
         false,
         crate::mvcc::database::WalPos::STAGED,
@@ -11737,6 +11843,664 @@ fn test_gc_incremental_respects_held_snapshot() {
         1,
         "only the current version remains"
     );
+}
+
+/// An older `BEGIN CONCURRENT` reader keeps seeing a row after GC. A newer
+/// connection reads the same value from the B-tree. After the older transaction
+/// ends, a later sweep reclaims the SkipMap copies.
+#[test]
+fn test_gc_current_serves_older_reader_then_reclaims() {
+    let db = MvccTestDbNoConn::new_with_random_db_passive();
+    let mv = db.get_mvcc_store();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER NOT NULL)")
+        .unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 10)").unwrap();
+
+    let older = db.connect();
+    older.execute("BEGIN CONCURRENT").unwrap();
+    assert_eq!(
+        get_rows(&older, "SELECT v FROM t WHERE id = 1"),
+        vec![vec![Value::from_i64(10)]]
+    );
+
+    conn.execute("INSERT INTO t VALUES (2, 20)").unwrap();
+    assert!(
+        skipmap_version_count(&mv) > 0,
+        "versions an open transaction can see are not removed"
+    );
+    assert_eq!(
+        get_rows(&older, "SELECT v FROM t WHERE id = 1"),
+        vec![vec![Value::from_i64(10)]],
+        "older reader keeps seeing row 1"
+    );
+
+    let newer = db.connect();
+    assert_eq!(
+        get_rows(&newer, "SELECT v FROM t WHERE id = 1"),
+        vec![vec![Value::from_i64(10)]],
+        "newer connection reads the same value from the B-tree"
+    );
+
+    older.execute("COMMIT").unwrap();
+    conn.execute("INSERT INTO t VALUES (3, 30)").unwrap();
+    conn.execute("INSERT INTO t VALUES (4, 40)").unwrap();
+    assert_eq!(
+        skipmap_version_count(&mv),
+        0,
+        "SkipMap copies are reclaimed once nobody can see them"
+    );
+    assert_eq!(
+        get_rows(&newer, "SELECT id, v FROM t ORDER BY id"),
+        vec![
+            vec![Value::from_i64(1), Value::from_i64(10)],
+            vec![Value::from_i64(2), Value::from_i64(20)],
+            vec![Value::from_i64(3), Value::from_i64(30)],
+            vec![Value::from_i64(4), Value::from_i64(40)],
+        ]
+    );
+}
+
+/// Elle list-append: `INSERT ... ON CONFLICT(key) DO UPDATE` against a unique
+/// index whose only copy of the key lives in the SkipMap.
+///
+/// CREATE TABLE is checkpointed so the unique-index root is readable. The
+/// user row is not. `durable_txid_max` is then raised, which used to be enough
+/// for Truncate Rule 3 to reclaim that unwritten current; fallthrough then hit
+/// an empty unique index (`["r", "k9", []]`) and a later insert forked a second
+/// rowid (`incompatible-order`). Unique `WHERE key =` can hide that fork, so
+/// the assertion is a table scan of `rowid`.
+#[test]
+fn test_gc_unwritten_text_pk_upsert_does_not_fork() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let mv = db.get_mvcc_store();
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    conn.execute("CREATE TABLE t(key TEXT PRIMARY KEY, vals TEXT NOT NULL DEFAULT '')")
+        .unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES ('k9', '1')").unwrap();
+    assert!(
+        unique_index_btree_is_allocated(&mv),
+        "CREATE TABLE must publish the unique index so fallthrough can hit an empty btree"
+    );
+
+    let older = db.connect();
+    older.execute("BEGIN CONCURRENT").unwrap();
+    assert_eq!(
+        get_rows(&older, "SELECT vals FROM t WHERE key = 'k9'"),
+        vec![vec![Value::from_text("1")]]
+    );
+
+    mv.durable_txid_max.store(u64::MAX, Ordering::SeqCst);
+    for _ in 0..4 {
+        mv.gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC);
+    }
+    mv.drop_unused_row_versions();
+    assert!(
+        skipmap_has_unmaterialized_index_current(&mv),
+        "GC must keep a unique-index current that no checkpoint wrote"
+    );
+
+    let newer = db.connect();
+    newer.execute("BEGIN CONCURRENT").unwrap();
+    let read = get_rows(&newer, "SELECT vals FROM t WHERE key = 'k9'");
+    assert_eq!(
+        read,
+        vec![vec![Value::from_text("1")]],
+        "unique lookup must still see k9 after GC"
+    );
+    newer
+        .execute(
+            "INSERT INTO t (key, vals) VALUES ('k9', '2') \
+             ON CONFLICT(key) DO UPDATE SET vals = CASE \
+               WHEN vals = '' THEN '2' \
+               ELSE vals || ',' || '2' \
+             END",
+        )
+        .unwrap();
+    newer.execute("COMMIT").unwrap();
+    older.execute("COMMIT").unwrap();
+
+    let rows = get_rows(&conn, "SELECT rowid, key, vals FROM t ORDER BY rowid");
+    assert_eq!(rows.len(), 1, "forked into two rows for k9: {rows:?}");
+    assert_eq!(rows[0][1].to_string(), "k9");
+    let vals = rows[0][2].to_string();
+    assert!(vals.starts_with("1,"), "lost the SkipMap prefix: {vals}");
+}
+
+/// Same shape as `test_gc_unwritten_text_pk_upsert_does_not_fork`, but a real
+/// checkpoint writes the unique-index key first, so GC may reclaim the chain.
+/// Elle list-append must then read its own append back in the same txn instead
+/// of `[]` from the B-tree.
+#[test]
+fn test_gc_reclaimed_text_pk_same_txn_sees_own_append() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let mv = db.get_mvcc_store();
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    conn.execute("CREATE TABLE t(key TEXT PRIMARY KEY, vals TEXT NOT NULL DEFAULT '')")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES ('k6', '1')").unwrap();
+    assert!(
+        unique_index_btree_is_allocated(&mv),
+        "CREATE TABLE must publish the unique index"
+    );
+
+    mv.durable_txid_max.store(u64::MAX, Ordering::SeqCst);
+    for _ in 0..4 {
+        mv.gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC);
+    }
+    mv.drop_unused_row_versions();
+
+    let newer = db.connect();
+    newer.execute("BEGIN CONCURRENT").unwrap();
+    let before = get_rows(&newer, "SELECT vals FROM t WHERE key = 'k6'");
+    assert_eq!(
+        before,
+        vec![vec![Value::from_text("1")]],
+        "unique lookup must still see k6 after the chain was reclaimed"
+    );
+    newer
+        .execute(
+            "INSERT INTO t (key, vals) VALUES ('k6', '2') \
+             ON CONFLICT(key) DO UPDATE SET vals = CASE \
+               WHEN vals = '' THEN '2' \
+               ELSE vals || ',' || '2' \
+             END",
+        )
+        .unwrap();
+    let after = get_rows(&newer, "SELECT vals FROM t WHERE key = 'k6'");
+    assert_eq!(
+        after,
+        vec![vec![Value::from_text("1,2")]],
+        "same txn must see its own unique append, got {after:?}"
+    );
+    newer.execute("COMMIT").unwrap();
+
+    let rows = get_rows(&conn, "SELECT rowid, key, vals FROM t ORDER BY rowid");
+    let k6: Vec<_> = rows.iter().filter(|r| r[1].to_string() == "k6").collect();
+    assert_eq!(k6.len(), 1, "forked k6: {rows:?}");
+    let vals = k6[0][2].to_string();
+    assert!(vals.starts_with("1,"), "lost the SkipMap prefix: {vals}");
+}
+
+#[test]
+fn test_gc_unstamped_text_pk_unique_lookup_still_sees_key() {
+    let db = MvccTestDbNoConn::new_with_random_db_passive();
+    let mv = db.get_mvcc_store();
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    conn.execute("CREATE TABLE t(key TEXT PRIMARY KEY, vals TEXT NOT NULL DEFAULT '')")
+        .unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES ('k7', '1')").unwrap();
+    assert!(
+        unique_index_btree_is_allocated(&mv),
+        "CREATE TABLE must publish the unique index so fallthrough can hit an empty btree"
+    );
+
+    mv.durable_txid_max.store(u64::MAX, Ordering::SeqCst);
+    for _ in 0..4 {
+        mv.gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC);
+    }
+    mv.drop_unused_row_versions();
+    assert!(
+        skipmap_has_unmaterialized_index_current(&mv),
+        "Passive GC must not drop an index current that was never written"
+    );
+
+    let read = get_rows(&conn, "SELECT vals FROM t WHERE key = 'k7'");
+    assert_eq!(
+        read,
+        vec![vec![Value::from_text("1")]],
+        "unique lookup must still see k7 after unstamped Passive GC"
+    );
+}
+
+#[test]
+fn test_passive_finalize_reclaim_text_pk_unique_lookup_still_sees_key() {
+    let db = MvccTestDbNoConn::new_with_random_db_passive();
+    let mv = db.get_mvcc_store();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(key TEXT PRIMARY KEY, vals TEXT NOT NULL DEFAULT '')")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES ('k0', '11')").unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+    assert_eq!(
+        mv.debug_gc_snapshot().rows_versions,
+        0,
+        "with no reader open, Passive Finalize must reclaim the materialized table current"
+    );
+
+    let read = get_rows(&conn, "SELECT vals FROM t WHERE key = 'k0'");
+    assert_eq!(
+        read,
+        vec![vec![Value::from_text("11")]],
+        "unique lookup must see k0 after SkipMap reclaim, got {read:?}"
+    );
+
+    let newer = db.connect();
+    newer.execute("BEGIN CONCURRENT").unwrap();
+    let newer_read = get_rows(&newer, "SELECT vals FROM t WHERE key = 'k0'");
+    assert_eq!(
+        newer_read,
+        vec![vec![Value::from_text("11")]],
+        "a later snapshot must see k0 after reclaim, got {newer_read:?}"
+    );
+    newer
+        .execute(
+            "INSERT INTO t (key, vals) VALUES ('k0', '62') \
+             ON CONFLICT(key) DO UPDATE SET vals = CASE \
+               WHEN vals = '' THEN '62' \
+               ELSE vals || ',' || '62' \
+             END",
+        )
+        .unwrap();
+    let after = get_rows(&newer, "SELECT vals FROM t WHERE key = 'k0'");
+    assert_eq!(
+        after,
+        vec![vec![Value::from_text("11,62")]],
+        "same txn must append onto the reclaimed unique row, got {after:?}"
+    );
+    newer.execute("COMMIT").unwrap();
+
+    conn.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+    assert_eq!(
+        mv.debug_gc_snapshot().rows_versions,
+        0,
+        "second Passive Finalize must reclaim the upserted table current"
+    );
+    let after_second = get_rows(&conn, "SELECT vals FROM t WHERE key = 'k0'");
+    assert_eq!(
+        after_second,
+        vec![vec![Value::from_text("11,62")]],
+        "unique lookup must see both appends after the second reclaim, got {after_second:?}"
+    );
+}
+
+#[test]
+fn test_unique_lookup_survives_passive_checkpoint_mid_seek() {
+    use crate::StepResult;
+    let db = MvccTestDbNoConn::new_with_random_db_passive();
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(key TEXT PRIMARY KEY, vals TEXT NOT NULL DEFAULT '')")
+        .unwrap();
+    setup.execute("INSERT INTO t VALUES ('k0', '11')").unwrap();
+    setup.execute("INSERT INTO t VALUES ('k1', '70')").unwrap();
+
+    let reader = db.connect();
+    reader.execute("BEGIN CONCURRENT").unwrap();
+    let k1 = get_rows(&reader, "SELECT vals FROM t WHERE key = 'k1'");
+    assert_eq!(k1, vec![vec![Value::from_text("70")]]);
+
+    let injector = FixedYieldInjector::new([CursorYieldPoint::SeekStart.point()]);
+    reader.set_yield_injector(Some(injector));
+    let mut stmt = reader
+        .prepare("SELECT vals FROM t WHERE key = 'k0'")
+        .unwrap();
+    let io = reader.pager.load().io.clone();
+    let mut got_yield = false;
+    for _ in 0..200_000 {
+        match stmt.step().unwrap() {
+            StepResult::Yield => {
+                got_yield = true;
+                break;
+            }
+            StepResult::IO => io.step().unwrap(),
+            StepResult::Row | StepResult::Done => {
+                panic!("unique seek finished before SeekStart yield")
+            }
+            other => panic!("unexpected reader step before yield: {other:?}"),
+        }
+    }
+    assert!(got_yield, "unique seek must pause at SeekStart");
+
+    let ckpt = db.connect();
+    ckpt.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    ckpt.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+
+    reader.set_yield_injector(None);
+    let mut read = None;
+    for _ in 0..200_000 {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                read = Some(
+                    stmt.row()
+                        .unwrap()
+                        .get_values()
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                );
+            }
+            StepResult::Done => break,
+            StepResult::IO | StepResult::Yield => io.step().unwrap(),
+            other => panic!("unexpected reader step after checkpoint: {other:?}"),
+        }
+    }
+    reader.execute("COMMIT").unwrap();
+    assert_eq!(
+        read,
+        Some(vec![Value::from_text("11")]),
+        "k0 must survive a Passive checkpoint that ran after SeekStart, got {read:?}"
+    );
+}
+
+#[test]
+fn test_same_txn_unique_lookup_stable_across_passive_checkpoint() {
+    use crate::StepResult;
+    let db = MvccTestDbNoConn::new_with_random_db_passive();
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(key TEXT PRIMARY KEY, vals TEXT NOT NULL DEFAULT '')")
+        .unwrap();
+    setup.execute("INSERT INTO t VALUES ('k7', '1')").unwrap();
+    setup
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    setup.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+
+    let reader = db.connect();
+    reader.execute("BEGIN CONCURRENT").unwrap();
+    let before = get_rows(&reader, "SELECT vals FROM t WHERE key = 'k7'");
+    assert_eq!(before, vec![vec![Value::from_text("1")]]);
+
+    let writer = db.connect();
+    writer
+        .execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    let injector = FixedYieldInjector::new([
+        CheckpointYieldPoint::BeforePagerCommit.point(),
+        CheckpointYieldPoint::AfterDurableBoundaryAdvanced.point(),
+    ]);
+    writer.set_yield_injector(Some(injector.clone()));
+    let mut upsert = writer
+        .prepare(
+            "INSERT INTO t (key, vals) VALUES ('k7', '2') \
+             ON CONFLICT(key) DO UPDATE SET vals = CASE \
+               WHEN vals = '' THEN '2' \
+               ELSE vals || ',' || '2' \
+             END",
+        )
+        .unwrap();
+    let io = writer.pager.load().io.clone();
+    let mut yields = 0u32;
+    for _ in 0..200_000 {
+        match upsert.step().unwrap() {
+            StepResult::Yield => {
+                yields += 1;
+                let mid = get_rows(&reader, "SELECT vals FROM t WHERE key = 'k7'");
+                assert_eq!(
+                    mid, before,
+                    "pinned snapshot must keep k7 across checkpoint yield {yields}, got {mid:?}"
+                );
+                if injector.remaining_len() == 0 {
+                    break;
+                }
+                io.step().unwrap();
+            }
+            StepResult::IO => io.step().unwrap(),
+            StepResult::Done => break,
+            other => panic!("unexpected upsert/checkpoint step: {other:?}"),
+        }
+    }
+    let after = get_rows(&reader, "SELECT vals FROM t WHERE key = 'k7'");
+    reader.execute("COMMIT").unwrap();
+    assert_eq!(
+        after, before,
+        "pinned snapshot must keep k7 after checkpoint, got {after:?}"
+    );
+    assert!(
+        yields >= 1,
+        "auto-checkpoint must yield so the reader can probe"
+    );
+}
+
+#[test]
+fn test_same_txn_first_unique_lookup_after_aborted_seek_still_sees_reclaimed_key() {
+    let db = MvccTestDbNoConn::new_with_random_db_passive();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(key TEXT PRIMARY KEY, vals TEXT NOT NULL DEFAULT '')")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES ('k0', '76')").unwrap();
+    conn.execute("INSERT INTO t VALUES ('k5', '1')").unwrap();
+    conn.execute("INSERT INTO t VALUES ('k7', '155')").unwrap();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = 0")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(PASSIVE)").unwrap();
+
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    assert_eq!(
+        get_rows(&conn, "SELECT vals FROM t WHERE key = 'k5'"),
+        vec![vec![Value::from_text("1")]]
+    );
+    conn.execute("ROLLBACK").unwrap();
+
+    conn.execute("BEGIN CONCURRENT").unwrap();
+    let first_k7 = get_rows(&conn, "SELECT vals FROM t WHERE key = 'k7'");
+    let k0 = get_rows(&conn, "SELECT vals FROM t WHERE key = 'k0'");
+    let k5 = get_rows(&conn, "SELECT vals FROM t WHERE key = 'k5'");
+    let k0_again = get_rows(&conn, "SELECT vals FROM t WHERE key = 'k0'");
+    let last_k7 = get_rows(&conn, "SELECT vals FROM t WHERE key = 'k7'");
+    conn.execute("COMMIT").unwrap();
+
+    assert_eq!(k0, vec![vec![Value::from_text("76")]]);
+    assert_eq!(k0_again, k0);
+    assert_eq!(k5, vec![vec![Value::from_text("1")]]);
+    assert_eq!(
+        first_k7, last_k7,
+        "same snapshot must not see k7 appear after other unique seeks, first={first_k7:?} last={last_k7:?}"
+    );
+    assert_eq!(
+        first_k7,
+        vec![vec![Value::from_text("155")]],
+        "first unique seek of reclaimed k7 must see the row, got {first_k7:?}"
+    );
+}
+
+#[test]
+fn test_idxdelete_after_truncate_clears_checkpointed_index() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, x)")
+        .unwrap();
+    conn.execute("CREATE INDEX t_x ON t(x)").unwrap();
+    conn.execute("INSERT INTO t VALUES (1,1),(2,2)").unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    conn.execute("INSERT OR REPLACE INTO t(id,x) VALUES(2,2)")
+        .unwrap();
+    conn.execute("DELETE FROM t WHERE x>=1").unwrap();
+    assert_eq!(
+        get_rows(&conn, "SELECT count(*) FROM t"),
+        vec![vec![Value::from_i64(0)]],
+        "table rows must be gone after DELETE"
+    );
+    assert_eq!(
+        get_rows(&conn, "SELECT count(*) FROM t WHERE x>=1"),
+        vec![vec![Value::from_i64(0)]],
+        "checkpointed index currents must not survive IdxDelete"
+    );
+}
+
+#[test]
+fn test_delete_via_unique_index_removes_checkpointed_rows() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let conn = db.connect();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, c INTEGER UNIQUE)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 400), (2, 500), (3, 600)")
+        .unwrap();
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+    assert_eq!(
+        get_rows(&conn, "SELECT count(*) FROM t"),
+        vec![vec![Value::from_i64(3)]],
+        "truncate must leave the three checkpointed rows"
+    );
+    assert_eq!(
+        get_rows(&conn, "SELECT id FROM t WHERE id = 1"),
+        vec![vec![Value::from_i64(1)]],
+        "point lookup of checkpointed INTEGER PK must work"
+    );
+    conn.execute("INSERT INTO t VALUES (4, 100), (5, 200)")
+        .unwrap();
+    conn.execute("DELETE FROM t WHERE c < 1000").unwrap();
+    assert_eq!(
+        get_rows(&conn, "SELECT count(*) FROM t"),
+        vec![vec![Value::from_i64(0)]],
+        "unique-index DELETE must still visit checkpointed B-tree rows"
+    );
+}
+
+/// A reader that has already selected a multi-column row must keep seeing every
+/// column after GC. No checkpoint ran, so the SkipMap holds the only copy and
+/// GC must keep it even though `durable_txid_max` claims everything is durable.
+#[test]
+fn test_gc_keeps_columns_of_positioned_reader() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let mv = db.get_mvcc_store();
+    let conn = db.connect();
+    conn.execute("PRAGMA mvcc_checkpoint_threshold = -1")
+        .unwrap();
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT, c INT)")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 10, 20, 30)")
+        .unwrap();
+
+    let reader = db.connect();
+    reader.execute("BEGIN CONCURRENT").unwrap();
+    let before = get_rows(&reader, "SELECT a, b, c FROM t WHERE id = 1");
+    assert_eq!(
+        before,
+        vec![vec![
+            Value::from_i64(10),
+            Value::from_i64(20),
+            Value::from_i64(30)
+        ]]
+    );
+
+    let versions_before_gc = skipmap_version_count(&mv);
+    mv.durable_txid_max.store(u64::MAX, Ordering::SeqCst);
+    for _ in 0..4 {
+        mv.gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC);
+    }
+    mv.drop_unused_row_versions();
+    assert_eq!(
+        skipmap_version_count(&mv),
+        versions_before_gc,
+        "GC must keep live versions no checkpoint ever wrote"
+    );
+
+    let after = get_rows(&reader, "SELECT a, b, c FROM t WHERE id = 1");
+    assert_eq!(after, before, "must not get NULL or empty columns after GC");
+    reader.execute("COMMIT").unwrap();
+}
+
+/// SkipMap `read` after incremental GC on a chain no checkpoint wrote. Dropping
+/// the sole current here would make this return None.
+#[test]
+fn test_gc_incremental_keeps_held_reader_row() {
+    let db = MvccTestDb::new();
+    let table_id: MVTableId = (-2).into();
+    let row_id = RowID::new(table_id, RowKey::Int(1));
+
+    let tx1 = db
+        .mvcc_store
+        .begin_tx(db.conn.pager.load().clone())
+        .unwrap();
+    let row = generate_simple_string_row(table_id, 1, "keep_me");
+    db.mvcc_store.insert(tx1, row.clone()).unwrap();
+    commit_tx(db.mvcc_store.clone(), &db.conn, tx1).unwrap();
+
+    db.mvcc_store
+        .durable_txid_max
+        .store(u64::MAX, Ordering::SeqCst);
+
+    let conn2 = db.db.connect().unwrap();
+    let tx2 = db.mvcc_store.begin_tx(conn2.pager.load().clone()).unwrap();
+    assert_eq!(db.mvcc_store.read(tx2, &row_id).unwrap().unwrap(), row);
+
+    db.mvcc_store
+        .gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC);
+    db.mvcc_store.drop_unused_row_versions();
+
+    assert_eq!(
+        db.mvcc_store.read(tx2, &row_id).unwrap().unwrap(),
+        row,
+        "held reader still reads the current version"
+    );
+    let versions = db.mvcc_store.rows.get(&row_id).unwrap();
+    let versions = versions.value().read();
+    assert_eq!(versions.len(), 1);
+    assert_eq!(
+        versions[0].materialized_at(),
+        crate::mvcc::database::WalPos::ORIGIN
+    );
+    assert_eq!(versions[0].end(), None);
+}
+
+/// Two overlapping writers plus GC while a third connection holds a snapshot.
+/// Truncate is Busy with the reader open; incremental GC must not change the
+/// snapshot values.
+#[test]
+fn test_gc_retire_snapshot_stable_with_overlapping_writers() {
+    let db = MvccTestDbNoConn::new_with_random_db();
+    let mv = db.get_mvcc_store();
+    let setup = db.connect();
+    setup
+        .execute("CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER NOT NULL)")
+        .unwrap();
+    setup
+        .execute("INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)")
+        .unwrap();
+    setup.execute("PRAGMA wal_checkpoint(TRUNCATE)").unwrap();
+
+    let reader = db.connect();
+    reader.execute("BEGIN CONCURRENT").unwrap();
+    let snap = get_rows(&reader, "SELECT id, v FROM t ORDER BY id");
+    assert_eq!(
+        snap,
+        vec![
+            vec![Value::from_i64(1), Value::from_i64(10)],
+            vec![Value::from_i64(2), Value::from_i64(20)],
+            vec![Value::from_i64(3), Value::from_i64(30)],
+        ]
+    );
+
+    let w1 = db.connect();
+    let w2 = db.connect();
+    w1.execute("BEGIN CONCURRENT").unwrap();
+    w2.execute("BEGIN CONCURRENT").unwrap();
+    w1.execute("UPDATE t SET v = 21 WHERE id = 2").unwrap();
+    w2.execute("UPDATE t SET v = 31 WHERE id = 3").unwrap();
+    w1.execute("COMMIT").unwrap();
+    w2.execute("COMMIT").unwrap();
+
+    assert!(
+        matches!(
+            setup.execute("PRAGMA wal_checkpoint(TRUNCATE)"),
+            Err(LimboError::Busy)
+        ),
+        "Truncate cannot run while the snapshot is held"
+    );
+    for _ in 0..4 {
+        mv.gc_incremental(MvStore::<MvccClock>::MAX_CHAINS_PER_GC);
+    }
+    mv.drop_unused_row_versions();
+
+    let again = get_rows(&reader, "SELECT id, v FROM t ORDER BY id");
+    assert_eq!(again, snap, "held snapshot must stay stable across GC");
+    reader.execute("COMMIT").unwrap();
 }
 
 /// Index rows live in a separate SkipMap from table rows and go through their own
@@ -21033,15 +21797,14 @@ fn on_checkpoint_end_runs_before_blocking_checkpoint_unlock() {
     mv_store.blocking_checkpoint_lock.unlock();
 }
 
-/// Documents *why* Rule 3 (drop the sole current version once it's in the B-tree) is
-/// safe for blocking Truncate but not for Passive: acquiring `blocking_checkpoint_lock`
-/// for write cannot succeed while any MVCC transaction — even a read-only one — is
-/// still open, because `begin_tx` holds the read side of that same lock for the
-/// transaction's entire lifetime. So a second Truncate can never physically overwrite a
-/// row while an earlier reader might still rely on Rule 3 having dropped that row's
-/// prior SkipMap anchor. Passive never takes this lock around its write phase (that
-/// exclusion is exactly the throughput it exists to avoid), so it has no equivalent
-/// guarantee — see `passive_reader_snapshot_survives_later_write_after_row_versions_gc` and the
+/// Documents *why* Truncate Finalize always sees an idle LWM, which is what lets its
+/// Rule 3 pass drop sole current versions: acquiring `blocking_checkpoint_lock` for
+/// write cannot succeed while any MVCC transaction — even a read-only one — is still
+/// open, because `begin_tx` holds the read side of that same lock for the
+/// transaction's entire lifetime. Passive never takes this lock around its write phase
+/// (that exclusion is exactly the throughput it exists to avoid), so it has to test
+/// `lwm == u64::MAX` directly instead — see
+/// `passive_reader_snapshot_survives_later_write_after_row_versions_gc` and the
 /// `gc_version_chain` doc comment.
 #[test]
 fn truncate_checkpoint_is_busy_while_a_reader_transaction_is_open() {

--- a/docs/internals/mvcc/GC.md
+++ b/docs/internals/mvcc/GC.md
@@ -3,196 +3,111 @@
 ## Overview
 
 The MVCC store keeps every row version in memory: inserts, updates, deletes,
-and rolled-back garbage. Without GC, memory grows monotonically with write
-volume. GC reclaims versions that no active reader can see and that are
-redundant with the B-tree.
+and rolled-back garbage. Without GC, memory grows with write volume. GC
+reclaims versions that no active reader can see and that are redundant with
+the B-tree.
 
-GC is driven by two parameters computed at GC time:
+GC is driven by:
 
 - **LWM (low-water mark)**: `min(tx.begin_ts)` across Active/Preparing
-  transactions, or `u64::MAX` if none. Tells GC which versions are still
-  visible to some reader.
-- **ckpt_max** (`durable_txid_max`): the highest committed timestamp
-  whose data has been written to the B-tree. Tells GC when B-tree fallthrough
-  is safe.
+  transactions, or `u64::MAX` if none.
+- **ckpt_max** (`durable_txid_max`): highest commit timestamp whose data was
+  written through a finished pager commit for that checkpoint.
+- **materialized_at**: WAL position stamped on a version only after the pager
+  write for that key finished and the pager transaction committed. `ORIGIN`
+  means "not stamped yet."
+- **min_reader_mark**: lowest reader mark among MVCC txs, pager-pinned WAL
+  readers not yet in `txs`, and `backfill_floor`.
 
-All GC logic lives in a single function, `gc_version_chain`, shared by both
-checkpoint-time and background GC. The four rules are applied in order:
+All chain rules live in `gc_version_chain`, shared by checkpoint write-set GC,
+incremental GC, and Finalize sweeps.
 
-1. **Aborted garbage** (`begin=None, end=None`) — remove unconditionally.
-2. **Superseded versions** (`end=Timestamp(e), e ≤ lwm`) — remove, unless
-   doing so would let the dual cursor surface a stale B-tree row (tombstone
-   guard).
-3. **Sole-survivor current version** (`end=None, b ≤ ckpt_max, b < lwm`,
-   chain length = 1) — remove, because the B-tree has the same data.
-4. **TxID references** (`begin=TxID` or `end=TxID`) — keep, the owning
-   transaction hasn't resolved yet.
+## Rules (in order)
 
-The same code works under both blocking checkpoint (`lwm = u64::MAX`, all
-versions reclaimable) and a future non-blocking checkpoint (`lwm` finite,
-pinned by the oldest reader).
+1. **Aborted garbage** (`begin=None, end=None`) — remove.
+2. **Superseded versions** (`end=Timestamp(e), e ≤ lwm`) — remove when safe:
+   - Passive: only once stamped and `min_reader_mark >= materialized_at`.
+   - Truncate: tombstone / `btree_resident` / `ckpt_max` guards (#7638).
+3. **Sole current** (`end` unpacks as `None`, chain length 1) — `clear()` the
+   chain when:
+   - `drop_current_if_in_btree` is true (every live path),
+   - the version is stamped and reachable by every reader mark
+     (`materialized_for_readers`),
+   - Truncate also requires `b ≤ ckpt_max`,
+   - **and `lwm == u64::MAX`** (no open snapshot).
 
-## When GC Runs
+There is no retirement / `RETIRED_TAG` / Rule 3b. Rule 3 drops the SkipMap
+copy outright. Last-current reclaim is **idle-only** on both Passive and
+Truncate. Under load, Rule 2 still reclaims superseded history; sole currents
+wait for quiescence.
 
-GC is triggered automatically in the `Finalize` stage of checkpoint
-(`checkpoint_state_machine.rs`), in two phases:
+## Why Rule 3 is idle-only
 
-1. `gc_checkpointed_versions()` — iterates only the checkpoint write set
-   (rows just written to B-tree). O(checkpointed rows).
-2. `drop_unused_row_versions()` — sweeps all table and index rows. Computes
-   LWM once, then applies `gc_version_chain` to every chain. O(total rows).
+A dual-cursor scan reads the SkipMap and the B-tree at different moments.
+Emptying a sole current mid-scan can drop the row from both sides (B-tree
+already skipped it as shadowed; MVCC chain is gone). Passive never falls
+through to the B-tree for live readers. Truncate incremental GC runs under
+the checkpoint *read* lock concurrent with readers, so the same hazard
+applies. `lwm == MAX` is the shared proof that no dual-cursor is in flight.
 
-Both run while the checkpoint lock is still held, before it is released.
+Truncate Finalize still reclaims last currents: the blocking write lock waits
+out open MVCC txs, so LWM is `MAX` for that pass.
 
-## The Dual Cursor Invariant
+## Materialization stamps
 
-Readers merge B-tree rows with MVCC SkipMap versions via a dual cursor. For
-each B-tree row, the cursor checks `is_btree_invalidating_version` against
-every version in the SkipMap entry. If any version invalidates, the B-tree row
-is hidden and the visible MVCC version (if any) is returned instead. If the
-SkipMap has **no entry** for the RowID, the B-tree row is returned as-is.
+Stamps are **not** applied when a row is handed to the pager. They run in
+`GcTableRows` / `GcIndexRows` after `CommitPagerTxn`, and only for keys whose
+pager write or delete finished (`written_table_rowids` /
+`written_index_slots`). Skip-writes stay `ORIGIN`, so a high `ckpt_max` alone
+never means "this leaf was written."
 
-### SkipMap as write buffer
+## Lock order
 
-`chain_is_write_buffer_for` is false only for a **sole materialized current**
-inside the published `durable_txid_max` boundary (Rule 3 shape). On **Truncate**,
-when no checkpoint is in progress and the B-tree is readable, such chains are
-omitted from MVCC merge/shadow so B-tree fallthrough serves the key. **Passive**
-keeps SkipMap cover for all chains (concurrent Passive can leave table/index
-B-trees briefly disagreeing). Passive Finalize keeps last currents (`unlink_empty`);
-Truncate Finalize runs Rule 3. If both peeks briefly hold the same key,
-`next`/`prev` advance both sides after emitting once.
+Sample LWM under the clock (`sample_gc_lwm`) **before** taking any
+version-chain write lock, then call `gc_chain_now(lwm, ...)`. Never take the
+clock while holding a chain lock. Passive publish takes the clock then
+`seqcompact_commit_delete` → chain write; the opposite order deadlocks.
 
-This means GC must maintain:
+## When GC runs
 
-> If a row exists in the B-tree, either the SkipMap correctly represents the
-> row's current state for all active readers, **or** the SkipMap has no entry
-> / is ignored as non-write-buffer (B-tree fallthrough, only safe when B-tree
-> data is up to date for that reader).
+1. **Incremental** (`gc_incremental` on commit): bounded table + index sweeps.
+2. **Checkpoint write-set** (`gc_checkpointed_*`): stamp then GC keys this
+   checkpoint wrote.
+3. **Finalize**: Truncate uses `drop_unused_row_versions_and_slots`; Passive
+   uses `drop_unused_row_versions_unlink_empty_at(gc_floor_reader_mark())`.
 
-Two hazards follow from this:
+## Dual cursor / write buffer
 
-- **Removing a tombstone before its deletion is checkpointed** resurrects a
-  deleted row — the dual cursor falls through to the stale B-tree row.
-- **Removing the current version while leaving superseded versions** causes
-  data loss — the superseded version's `end` timestamp still invalidates the
-  B-tree row, but there's no MVCC version to serve reads.
+`chain_is_write_buffer_for` is false only for a sole stamped current inside
+the durable bound. Truncate may fall through to the B-tree for that shape
+when no checkpoint is in progress. Passive never falls through for live
+readers; it keeps SkipMap cover until idle Rule 3 clears the chain.
 
-These are guarded by Rule 2's tombstone guard and Rule 3's
-`drop_current_if_in_btree` gate respectively.
+Hazards still guarded by Rule 2:
 
-## Rule Details
+- Removing a tombstone before its delete is durable resurrects a B-tree row.
+- Removing a current while leaving superseded history hides the B-tree row
+  with no MVCC payload left to serve.
 
-### Rule 2: Tombstone Guard
+## Recovery versions
 
-When removing a superseded version (`e ≤ lwm`), we check whether the chain
-has a **committed current version** (`end=None, begin=Timestamp(_)`). If it
-does, the current version takes over B-tree invalidation and removal is safe.
+Logical-log replay rebuilds each version with the `commit_ts` recorded in the
+log, so recovered versions look like any other committed version. What keeps
+them safe is `ckpt_max`: `durable_txid_max` starts at 0 and only rises when a
+checkpoint publishes a durable bound, so every recovered `begin`/`end` is
+above it and Rules 2/3 cannot fire. Recovered versions are also unstamped
+(`materialized_at == ORIGIN`), which blocks the Passive path independently.
 
-If no committed current version exists, the superseded version may be the only
-thing hiding a stale B-tree row. Removal is only safe when:
+## Passive `backfill_floor`
 
-- `e ≤ ckpt_max` — the deletion has been checkpointed, B-tree no longer has
-  the row.
-- But NOT when `e == 0 && ckpt_max == 0` — recovery tombstones before the
-  first real checkpoint (see Recovery below).
+Passive Rule 2 / Rule 3 reader marks are clamped by `backfill_floor` so a
+version materialized in un-backfilled WAL frames is not dropped while a
+db-file reader might still need the SkipMap copy.
 
-Pending inserts (`begin=TxID`) do not count as committed current — they might
-roll back.
-
-### Rule 3: Drop current if already in B-tree
-
-A current version is redundant with the B-tree when `b ≤ ckpt_max` and
-`b < lwm`. We only remove it when it is the **last** version in the chain —
-otherwise superseded versions would hide the B-tree row without providing data.
-
-`drop_current_if_in_btree` controls whether Rule 3 runs:
-- **true** on Truncate Finalize / Truncate incremental
-- **false** on all Passive paths (Finalize `unlink_empty`, mid-Passive write-set
-  GC, incremental) — currents stay as SkipMap cover; write-buffer reads still
-  prefer B-tree for sole materialized currents after publish
-
-Rule 3 also guards recovery versions: `b=0` versions are protected by
-requiring `ckpt_max > 0` (see Recovery below).
-
-## Recovery Versions
-
-Log recovery stamps versions with `LOGICAL_LOG_RECOVERY_COMMIT_TIMESTAMP = 0`.
-Since `durable_txid_max` is advanced via `NonZeroU64`, it stays at 0
-until the first real transaction is checkpointed. This means `ckpt_max == 0`
-acts as a natural "recovery data not yet checkpointed" flag:
-
-- **Rule 2**: `e == 0 && ckpt_max == 0` → retain (recovery tombstone, B-tree
-  may still have the row).
-- **Rule 3**: `b == 0 && ckpt_max == 0` → `(b > 0 || ckpt_max > 0)` is false
-  → retain (recovery insert, B-tree may not have the row).
-
-Once `ckpt_max > 0`, the first real checkpoint has processed recovery data
-alongside it, so recovery versions become collectible by the normal rules.
-
-The recovery transaction itself is removed from `txs` at the end of
-`commit_load_tx` to prevent pinning LWM to 0 (which would disable Rules 2-3).
-
-## SkipMap Entry Removal
-
-Truncate Finalize uses `_and_slots` (Rule 3 + unlink). Passive Finalize uses
-`unlink_empty` (history + empty slots, keep currents). Mid-Passive write-set GC
-and incremental leave currents and empty slots so write-set row ids still
-resolve. Writers retry via `*_still_mapped` if an Arc was unlinked; index unlink
-bumps `index_rows_epoch`.
-
-### Passive `backfill_floor` publication
-
-Passive Rule 2 needs `materialized_at <= backfill_floor` (`nbackfills`). After
-`wal.checkpoint` + DB sync, MVCC calls `wal.publish_backfill` and keeps the
-checkpoint guard until Finalize. On Passive `Busy`, finish without advancing
-`nbackfills`.
-
-Rule 3 is on for Truncate; off for all Passive GC paths. Truncate write-buffer
-reads provide B-tree fallthrough for sole materialized currents; Passive does not
-fall through while currents remain.
-
-## Non-blocking Checkpoint Readiness
-
-The GC rules are designed to work with both blocking and non-blocking
-checkpoints — the LWM parameter naturally constrains what can be collected
-when readers coexist with the checkpoint.
-
-**What works today**: all four GC rules, LWM, recovery protection, tombstone
-guard, under-lock empty-slot drain with writer retry, write-buffer read filter.
-
-**What needs work for non-blocking checkpoint**:
-
-- More soak / concurrent-simulator coverage of Passive GC racing writers on
-  empty-slot drain.
-
-### Why Rule 3 cannot simply be turned on for Passive
-
-This was investigated directly: forcing `drop_current_if_in_btree = true` on
-Passive Finalize (keeping the empty-slot unlink) reproduces real corruption —
-`test_conflict_abort_ckpt_indexed_update_savepoint_integrity_check_passive`
-("row missing from index") and `test_passive_concurrent_transfer_preserves_sum_and_count`
-("total balance changed") both fail. The cause is **not** table/index publish
-skew; it reproduces with one table and no index at all
-(`passive_reader_snapshot_survives_later_write_after_row_versions_gc`). Once
-Rule 3 empties a chain's SkipMap slot, the slot is unlinked entirely. A later,
-unrelated write to that same row inserts a *new* chain with only its own
-(future, invisible) version — a reader whose snapshot predates that write now
-finds "no visible SkipMap version" and falls through to the physical B-tree,
-which the later Passive auto-checkpoint has already overwritten: a
-snapshot-isolation violation. Passive has no equivalent of Truncate's
-`blocking_checkpoint_lock`, which excludes all MVCC transactions for the
-duration of the write phase, so it cannot inherit that guarantee. Making Rule
-3 safe for Passive needs either real page-level MVCC (so B-tree fallthrough is
-isolated per reader) or serializing Passive's physical writes against readers
-for rows whose chain is currently empty — both bigger than a GC-only change.
-See the `gc_version_chain` doc comment in `core/mvcc/database/mod.rs` for the
-full argument.
-
-## Key Files
+## Key files
 
 | File | Contents |
 |------|----------|
-| `core/mvcc/database/mod.rs` | `gc_version_chain`, `chain_is_write_buffer_for`, `compute_lwm`, `drop_unused_row_versions`, `gc_table_row_versions`, `gc_index_row_versions`, recovery tx cleanup in `commit_load_tx` |
-| `core/mvcc/database/checkpoint_state_machine.rs` | `gc_checkpointed_versions`, auto-trigger wiring in `Finalize` |
-| `core/mvcc/database/tests.rs` | 39 GC tests (unit, quickcheck, integration, e2e) |
+| `core/mvcc/database/mod.rs` | `sample_gc_lwm`, `gc_chain_now`, `gc_version_chain`, `stamp_chain_materialized`, incremental + Finalize sweeps |
+| `core/mvcc/database/checkpoint_state_machine.rs` | `written_*`, stamp sites, `gc_checkpointed_*`, `gc_floor_reader_mark` |
+| `core/mvcc/database/tests.rs` | Rule 2/3 unit tests, Passive transfer / unique-miss regressions |

--- a/testing/concurrent-simulator/regression_tests_cross_platform.rs
+++ b/testing/concurrent-simulator/regression_tests_cross_platform.rs
@@ -355,3 +355,147 @@ fn test_fts_workloads_use_the_index_and_replay_with_the_seed() {
         "the FTS differential is not planned through the index method: {opcodes:?}"
     );
 }
+
+/// Seed 7705886949262960907 with allocation faults off reads k6 as [] after
+/// append 19 already committed. Elle reports G-single-item and incompatible-order.
+#[test]
+fn test_elle_passive_seed_keeps_committed_text_pk_on_unique_lookup() {
+    use rand::Rng;
+    use std::sync::atomic::AtomicI64;
+    use turso_whopper::chaotic_elle::{ChaoticElleProfile, ChaoticWorkloadProfile, ElleModelKind};
+    use turso_whopper::properties::ElleHistoryRecorder;
+    use turso_whopper::workloads::{
+        BeginWorkload, CommitWorkload, ElleAppendWorkload, ElleReadWorkload, RollbackWorkload,
+        Workload,
+    };
+    use turso_whopper::{StepResult, Whopper, WhopperOpts};
+
+    let history_path = std::env::temp_dir().join(format!(
+        "elle-passive-unique-miss-{}.edn",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&history_path);
+    let elle_counter = Arc::new(AtomicI64::new(1));
+    let workloads: Vec<(u32, Box<dyn Workload>)> = vec![
+        (
+            40,
+            Box::new(ElleAppendWorkload::with_counter(elle_counter.clone())),
+        ),
+        (30, Box::new(ElleReadWorkload)),
+        (30, Box::new(BeginWorkload)),
+        (15, Box::new(CommitWorkload)),
+        (5, Box::new(RollbackWorkload)),
+    ];
+    let chaotic: Vec<(f64, &'static str, Box<dyn ChaoticWorkloadProfile>)> = vec![(
+        0.3,
+        "chaotic-elle",
+        Box::new(ChaoticElleProfile::new(
+            "elle_lists".to_string(),
+            ElleModelKind::ListAppend,
+            elle_counter,
+            true,
+        )),
+    )];
+    let opts = WhopperOpts::fast()
+        .with_seed(7705886949262960907)
+        .with_max_steps(100_000)
+        .with_max_connections(4)
+        .with_enable_mvcc(true)
+        .with_experimental_mvcc_passive_checkpoint(true)
+        .with_mvcc_checkpoint_threshold(Some(1024))
+        .with_allocation_fault_probability(0.0)
+        .with_elle_tables(vec![(
+            "elle_lists".to_string(),
+            "CREATE TABLE IF NOT EXISTS elle_lists (key TEXT PRIMARY KEY, vals TEXT DEFAULT '')"
+                .to_string(),
+        )])
+        .with_workloads(workloads)
+        .with_properties(vec![Box::new(ElleHistoryRecorder::new(
+            history_path.clone(),
+        ))])
+        .with_chaotic_profiles(chaotic);
+    let mut whopper = Whopper::new(opts).expect("create whopper");
+    while !whopper.is_done() {
+        let _ = whopper.rng.random_bool(0.0);
+        match whopper.step() {
+            Ok(StepResult::Ok) => {}
+            Ok(StepResult::WalSizeLimitExceeded) => break,
+            Err(e) => panic!("elle passive seed must keep running: {e}"),
+        }
+    }
+    whopper.finalize_properties().expect("export elle history");
+    let history = std::fs::read_to_string(&history_path).expect("read elle history");
+    let _ = std::fs::remove_file(&history_path);
+    if let Some((key, index, created_at)) = first_empty_read_of_committed_key(&history) {
+        panic!("unique lookup missed committed {key} at event {index} (created at {created_at})");
+    }
+}
+
+fn first_empty_read_of_committed_key(history: &str) -> Option<(String, u64, u64)> {
+    let mut created: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
+    let mut invoke_time: std::collections::HashMap<u64, u64> = std::collections::HashMap::new();
+    for line in history.lines() {
+        let process = edn_field_u64(line, ":process")?;
+        let time = edn_field_u64(line, ":time")?;
+        let index = edn_field_u64(line, ":index")?;
+        if line.contains(":type :invoke") {
+            invoke_time.insert(process, time);
+            continue;
+        }
+        if !line.contains(":type :ok") {
+            if line.contains(":type :fail") || line.contains(":type :info") {
+                invoke_time.remove(&process);
+            }
+            continue;
+        }
+        let snapshot = invoke_time.remove(&process).unwrap_or(time);
+        let mut rest = line;
+        while let Some(at) = rest.find("[:") {
+            let slice = &rest[at..];
+            if let Some((key, value)) = parse_edn_append(slice) {
+                created.entry(key).or_insert(time);
+                rest = value;
+                continue;
+            }
+            if let Some((key, empty, next)) = parse_edn_read(slice) {
+                if empty {
+                    if let Some(&created_at) = created.get(&key) {
+                        if snapshot > created_at {
+                            return Some((key, index, created_at));
+                        }
+                    }
+                }
+                rest = next;
+                continue;
+            }
+            rest = &slice[2..];
+        }
+    }
+    None
+}
+
+fn edn_field_u64(line: &str, field: &str) -> Option<u64> {
+    let after = line.split_once(field)?.1;
+    let digits = after
+        .trim_start_matches(|c: char| !c.is_ascii_digit())
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect::<String>();
+    digits.parse().ok()
+}
+
+fn parse_edn_append(slice: &str) -> Option<(String, &str)> {
+    let rest = slice.strip_prefix("[:append \"")?;
+    let (key, rest) = rest.split_once('"')?;
+    Some((key.to_string(), rest))
+}
+
+fn parse_edn_read(slice: &str) -> Option<(String, bool, &str)> {
+    let rest = slice.strip_prefix("[:r \"")?;
+    let (key, rest) = rest.split_once('"')?;
+    let rest = rest.trim_start();
+    if rest.starts_with("[]") {
+        return Some((key.to_string(), true, rest));
+    }
+    Some((key.to_string(), false, rest))
+}


### PR DESCRIPTION
## Why

Incremental GC holds only the checkpoint read lock, so other transactions stay open. Rule 3 used to `clear()` a sole current SkipMap version once the B-tree had it. A cursor already on that version re-reads the chain on every column fetch and then returns empty columns. That is the "total balance changed" failure.

Passive Finalize also skipped Rule 3 entirely, so the last version of each row lived forever. Memory and checkpoint stalls grew with write volume.

## Scope

- `PackedTs` stores retirement in both tag bits. `unpack` still reports `None`, so the version stays current for end-visibility.
- Rule 3 stamps `retired_at` from the clock under `get_timestamp`. Transactions with `begin_ts <= retired_at` keep the chain copy. Later transactions fall through to the B-tree.
- Rule 3b drops a retired version once `retired_at < lwm`. With no readers, retire and 3b run in the same call.
- Dual-cursor pick prefers the B-tree when the MVCC peek is a version retired for this transaction.
- Out of scope: group commit, park-waiters, `min_pinned_read_frame`.

## Tradeoffs

Always retire, even on Truncate. Truncate with no open transactions still reclaims in the same pass because `lwm == MAX` makes Rule 3b fire immediately. A `retired` boolean on `RowVersion` would have wasted a field and duplicated `end` packing.

## Blast Radius

MVCC readers, incremental GC, Passive and Truncate checkpoint GC, dual-cursor merge. Wrong retirement is data corruption (NULL columns or mixed snapshots), not a crash. The transfer test (`test_passive_concurrent_transfer_preserves_sum_and_count`) is the canary.

## Verification

- `cargo test -p turso_core --lib mvcc::database::tests`: 365 passed, 6 ignored. Transfer test passed 5 times in a row after the fallthrough fix.
- `cargo test -p core_tester --test integration_tests mvcc`: 305 passed, 3 ignored.
- `cargo run -p turso_whopper -- --enable-mvcc --enable-experimental-mvcc-passive-checkpoint --max-steps 800 --mode fast`: ok.