### PR TITLE
core/translate: enforce 2,000 max columns limit on tables

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1268,6 +1268,13 @@ pub fn translate_alter_table(
             let constraints = col_def.constraints.clone();
             let mut column = Column::try_from(&col_def)?;
 
+            if btree.columns().len() >= crate::types::MAX_COLUMN {
+                return Err(LimboError::ParseError(format!(
+                    "too many columns on {}",
+                    btree.name
+                )));
+            }
+
             let new_column_name = column.name.clone().ok_or_else(|| {
                 LimboError::ParseError(
                     "column name is missing in ALTER TABLE ADD COLUMN".to_string(),

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1,5 +1,6 @@
 use crate::sync::Arc;
 use crate::HashMap;
+use crate::LimboError;
 
 use crate::ext::VTabImpl;
 use crate::function::{Deterministic, Func, MathFunc, ScalarFunc};
@@ -733,6 +734,11 @@ fn validate(
         constraints,
     } = &body
     {
+        if columns.len() > crate::types::MAX_COLUMN {
+            return Err(LimboError::ParseError(format!(
+                "too many columns on {table_name}"
+            )));
+        }
         let column_names: Vec<&str> = columns.iter().map(|c| c.col_name.as_str()).collect();
         for i in 0..columns.len() {
             let col_i = &columns[i];

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -30,10 +30,6 @@ use turso_parser::ast::ResultColumn;
 use turso_parser::ast::SortOrder;
 use turso_parser::ast::{self, CompoundSelect, Expr};
 
-/// Maximum number of columns in a result set.
-/// SQLite's default SQLITE_MAX_COLUMN is 2000, with a hard upper limit of 32767.
-const SQLITE_MAX_COLUMN: usize = 2000;
-
 #[turso_macros::trace_stack]
 pub fn translate_select(
     select: ast::Select,
@@ -618,7 +614,7 @@ fn prepare_one_select_plan(
                 }
             }
 
-            if plan.result_columns.len() > SQLITE_MAX_COLUMN {
+            if plan.result_columns.len() > crate::types::MAX_COLUMN {
                 crate::bail_parse_error!("too many columns in result set");
             }
 
@@ -866,7 +862,7 @@ fn prepare_one_select_plan(
                 crate::bail_parse_error!("LIMIT clause is not allowed with VALUES clause");
             }
             let len = values[0].len();
-            if len > SQLITE_MAX_COLUMN {
+            if len > crate::types::MAX_COLUMN {
                 crate::bail_parse_error!("too many columns in result set");
             }
             let mut result_columns = Vec::with_capacity(len);

--- a/core/types.rs
+++ b/core/types.rs
@@ -35,7 +35,7 @@ use std::task::{Poll, Waker};
 /// SQLite by default uses 2000 as maximum numbers in a row.
 /// It controlld by the constant called SQLITE_MAX_COLUMN
 /// But the hard limit of number of columns is 32,767 columns i16::MAX
-/// const MAX_COLUMN: usize = 2000;
+pub const MAX_COLUMN: usize = 2000;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ValueType {


### PR DESCRIPTION
CREATE TABLE and ALTER TABLE ... ADD COLUMN should reject operations that result in a table having more than 2,000 columns to prevent violating the SQLite max columns constraint.

Exported MAX_COLUMN from types.rs and applied it in translation validation.

Fixes #8572

