### PR TITLE
core/vdbe: check for interrupts every 64 instructions instead of every one

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -299,3 +299,7 @@ harness = false
 [[bench]]
 name = "select_star_benchmark"
 harness = false
+
+[[bench]]
+name = "scan_loop_benchmark"
+harness = false

--- a/core/benches/scan_loop_benchmark.rs
+++ b/core/benches/scan_loop_benchmark.rs
@@ -1,0 +1,117 @@
+//! Scan-loop microbenchmark over a 100k-row table.
+//!
+//! `SELECT 1 FROM t` is the scan analogue of the existing `SELECT 1`
+//! benchmark: the loop body is just ResultRow + Next, so it isolates
+//! per-instruction dispatch and cursor-advance overhead with no decode
+//! work. `SELECT * FROM t` adds column decoding on top.
+//!
+//! Run:  cargo bench -p turso_core --bench scan_loop_benchmark
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
+#[cfg(not(feature = "codspeed"))]
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+use turso_core::{Connection, Database, PlatformIO, SqliteDialect, Statement, StepResult, Value};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+const NROWS: usize = 100_000;
+
+struct Fixture {
+    _dir: TempDir,
+    db: Arc<Database>,
+    conn: Arc<Connection>,
+}
+
+fn seed_db() -> Fixture {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("scan.db");
+    #[allow(clippy::arc_with_non_send_sync)]
+    let io = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("PRAGMA cache_size=-65536").unwrap(); //negative means kibibytes (https://sqlite.org/pragma.html#pragma_cache_size)
+    conn.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL, value INTEGER NOT NULL)",
+    )
+    .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    let mut insert = conn.prepare("INSERT INTO t VALUES (?1, ?2, ?3)").unwrap();
+    for i in 0..NROWS as i64 {
+        insert
+            .bind_at(1usize.try_into().unwrap(), Value::from_i64(i))
+            .unwrap();
+        insert
+            .bind_at(
+                2usize.try_into().unwrap(),
+                Value::build_text(format!("name_{i}")),
+            )
+            .unwrap();
+        insert
+            .bind_at(3usize.try_into().unwrap(), Value::from_i64(i))
+            .unwrap();
+        drive_stmt_to_completion(&db, &mut insert);
+    }
+    conn.execute("COMMIT").unwrap();
+
+    Fixture {
+        _dir: dir,
+        db,
+        conn,
+    }
+}
+
+fn drive_stmt_to_completion(db: &Database, stmt: &mut Statement) -> usize {
+    let mut rows = 0;
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                black_box(stmt.row());
+                rows += 1;
+            }
+            StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
+                db.io.step().unwrap();
+            }
+            StepResult::Done => break,
+            StepResult::Interrupt | StepResult::Busy => unreachable!(),
+        }
+    }
+    stmt.reset().unwrap();
+    rows
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_scan_loop(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("scan_loop");
+    group.sample_size(30);
+    group.measurement_time(Duration::from_secs(5));
+    group.warm_up_time(Duration::from_secs(3));
+
+    let fixture = seed_db();
+    for (label, sql) in [
+        ("select_one_100k", "SELECT 1 FROM t"),
+        ("select_star_100k", "SELECT * FROM t"),
+    ] {
+        group.bench_function(label, |b| {
+            let mut stmt = fixture.conn.prepare(sql).unwrap();
+            assert_eq!(
+                drive_stmt_to_completion(&fixture.db, &mut stmt),
+                NROWS,
+                "t should have been seeded with {NROWS} rows"
+            );
+            b.iter(|| drive_stmt_to_completion(&fixture.db, &mut stmt));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_scan_loop);
+criterion_main!(benches);

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -4755,9 +4755,15 @@ impl Connection {
         self.progress_handler.set(ops, handler);
     }
 
-    /// Returns true when the step-based progress handler requests interruption.
-    pub fn should_interrupt_for_progress(&self, vm_steps: u64) -> bool {
-        self.progress_handler.should_interrupt(vm_steps)
+    /// Configured progress-handler interval in VM steps; 0 when disabled.
+    pub fn progress_ops(&self) -> u64 {
+        self.progress_handler.ops()
+    }
+
+    /// Returns true when the step-based progress handler requests interruption
+    /// for the VM steps executed in `(prev_steps, vm_steps]`.
+    pub fn should_interrupt_for_progress(&self, prev_steps: u64, vm_steps: u64) -> bool {
+        self.progress_handler.should_interrupt(prev_steps, vm_steps)
     }
 
     /// Request interruption of currently running root statements on this connection.

--- a/core/progress.rs
+++ b/core/progress.rs
@@ -52,14 +52,17 @@ impl ProgressHandler {
         self.ops() != 0
     }
 
-    /// Returns true when the callback requests interruption at this VM step.
+    /// Returns true when the callback requests interruption for the VM steps
+    /// executed in `(prev_steps, vm_steps]`.
     ///
     /// The cadence is approximate by design, matching SQLite's documentation:
-    /// the callback is consulted only when the current VM-step count crosses a
-    /// configured multiple of `ops`.
-    pub(crate) fn should_interrupt(&self, vm_steps: u64) -> bool {
+    /// the callback is consulted only when the VM-step count crosses a
+    /// configured multiple of `ops`. Callers that consult this once per step
+    /// pass `prev_steps = vm_steps - 1`; callers that batch several steps per
+    /// consultation pass the count from the previous consultation.
+    pub(crate) fn should_interrupt(&self, prev_steps: u64, vm_steps: u64) -> bool {
         let ops = self.ops();
-        if ops == 0 || vm_steps % ops != 0 {
+        if ops == 0 || prev_steps / ops == vm_steps / ops {
             return false;
         }
         let callback = self.callback.read();
@@ -81,7 +84,7 @@ mod tests {
     #[test]
     fn disabled_handler_never_interrupts() {
         let handler = ProgressHandler::new();
-        assert!(!handler.should_interrupt(1));
+        assert!(!handler.should_interrupt(0, 1));
         assert!(!handler.is_enabled());
     }
 
@@ -98,15 +101,15 @@ mod tests {
             })),
         );
 
-        assert!(!handler.should_interrupt(1));
+        assert!(!handler.should_interrupt(0, 1));
         assert_eq!(calls.load(Ordering::SeqCst), 0);
-        assert!(!handler.should_interrupt(2));
+        assert!(!handler.should_interrupt(1, 2));
         assert_eq!(calls.load(Ordering::SeqCst), 0);
-        assert!(!handler.should_interrupt(3));
+        assert!(!handler.should_interrupt(2, 3));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
-        assert!(!handler.should_interrupt(4));
+        assert!(!handler.should_interrupt(3, 4));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
-        assert!(!handler.should_interrupt(6));
+        assert!(!handler.should_interrupt(5, 6));
         assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 
@@ -115,8 +118,8 @@ mod tests {
         let handler = ProgressHandler::new();
         handler.set(2, Some(Box::new(|| true)));
 
-        assert!(!handler.should_interrupt(1));
-        assert!(handler.should_interrupt(2));
+        assert!(!handler.should_interrupt(0, 1));
+        assert!(handler.should_interrupt(1, 2));
     }
 
     #[test]
@@ -131,11 +134,11 @@ mod tests {
                 true
             })),
         );
-        assert!(handler.should_interrupt(1));
+        assert!(handler.should_interrupt(0, 1));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
 
         handler.set(0, None);
-        assert!(!handler.should_interrupt(2));
+        assert!(!handler.should_interrupt(1, 2));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1711,8 +1711,10 @@ impl Program {
         self.connection.get_pager_from_database_index(idx)
     }
 
+    // `prev_steps` is the vm_steps value at the previous consultation, so the
+    // progress handler sees every crossed multiple of its interval.
     #[inline]
-    fn maybe_request_interrupt<I>(&self, state: &mut ProgramState, io: &I) -> bool
+    fn maybe_request_interrupt<I>(&self, state: &mut ProgramState, io: &I, prev_steps: u64) -> bool
     where
         I: crate::IO + ?Sized,
     {
@@ -1729,7 +1731,7 @@ impl Program {
             .is_some_and(|deadline| io.current_time_monotonic() >= deadline);
         let progress_interrupt = self
             .connection
-            .should_interrupt_for_progress(state.metrics.vm_steps);
+            .should_interrupt_for_progress(prev_steps, state.metrics.vm_steps);
         if connection_interrupt || hit_query_deadline || progress_interrupt {
             state.interrupt();
         }
@@ -1780,7 +1782,11 @@ impl Program {
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
 
-        if self.maybe_request_interrupt(state, pager.io.as_ref()) {
+        if self.maybe_request_interrupt(
+            state,
+            pager.io.as_ref(),
+            state.metrics.vm_steps.saturating_sub(1),
+        ) {
             return Ok(StepResult::Interrupt);
         }
 
@@ -1875,7 +1881,11 @@ impl Program {
                 return Err(LimboError::InternalError("Connection closed".to_string()));
             }
 
-            if self.maybe_request_interrupt(state, pager.io.as_ref()) {
+            if self.maybe_request_interrupt(
+                state,
+                pager.io.as_ref(),
+                state.metrics.vm_steps.saturating_sub(1),
+            ) {
                 return Ok(StepResult::Interrupt);
             }
 
@@ -1921,7 +1931,11 @@ impl Program {
             }
             return Err(LimboError::InternalError("Connection closed".to_string()));
         }
-        if self.maybe_request_interrupt(state, pager.io.as_ref()) {
+        if self.maybe_request_interrupt(
+            state,
+            pager.io.as_ref(),
+            state.metrics.vm_steps.saturating_sub(1),
+        ) {
             return Ok(StepResult::Interrupt);
         }
         // The single row has already been returned when pc is non-zero.
@@ -1947,6 +1961,14 @@ impl Program {
         waker: Option<&Waker>,
     ) -> Result<StepResult> {
         let enable_tracing = tracing::enabled!(tracing::Level::TRACE);
+        let vdbe_trace = self.connection.get_vdbe_trace();
+        // A progress handler with a small interval narrows the check gate so
+        // its cadence is honored; without one the gate stays at the maximum.
+        let progress_ops = self.connection.progress_ops();
+        // Reborrow the instruction list once: reloading it through `self`
+        // every iteration defeats LLVM's hoisting because the opcode call
+        // below is opaque to it.
+        let insns = self.insns.as_slice();
         // Invalidate the previous result row once per step call: rows are only
         // handed out between step calls, and ResultRow returns immediately
         // after setting a fresh one.
@@ -1988,24 +2010,45 @@ impl Program {
                 state.io_completions = None;
             }
             loop {
-                if self.connection.is_closed() {
-                    // Connection is closed for whatever reason, rollback the transaction.
-                    let state = self.connection.get_tx_state();
-                    if let TransactionState::Write { .. } = state {
-                        pager.rollback_tx(&self.connection);
+                // Closed/interrupt/deadline/progress checks run once every
+                // CHECK_INTERVAL instructions instead of on each one (SQLite
+                // similarly only checks at jump opcodes). vm_steps persists
+                // across step calls, so the cadence spans the whole statement;
+                // callers regain control at every returned row regardless.
+                // The interval must stay a power of two so this gate is a
+                // mask test, never a division, in the interpreter hot loop.
+                const CHECK_INTERVAL: u64 = 64;
+                const _: () = assert!(CHECK_INTERVAL.is_power_of_two());
+                let check_mask = if progress_ops == 0 {
+                    CHECK_INTERVAL - 1
+                } else {
+                    progress_ops.next_power_of_two().min(CHECK_INTERVAL) - 1
+                };
+                if state.metrics.vm_steps & check_mask == 0 {
+                    if self.connection.is_closed() {
+                        // Connection is closed for whatever reason, rollback the transaction.
+                        let state = self.connection.get_tx_state();
+                        if let TransactionState::Write { .. } = state {
+                            pager.rollback_tx(&self.connection);
+                        }
+                        return Err(LimboError::InternalError("Connection closed".to_string()));
                     }
-                    return Err(LimboError::InternalError("Connection closed".to_string()));
-                }
-                if self.maybe_request_interrupt(state, pager.io.as_ref()) {
-                    self.abort(pager, None, state, true)?;
-                    return Ok(StepResult::Interrupt);
+                    let prev_steps = state.metrics.vm_steps.saturating_sub(check_mask + 1);
+                    if self.maybe_request_interrupt(state, pager.io.as_ref(), prev_steps) {
+                        self.abort(pager, None, state, true)?;
+                        return Ok(StepResult::Interrupt);
+                    }
                 }
 
                 // A trigger can return FAIL before the parent program reaches
                 // Halt. FAIL keeps changes made by earlier rows, so their
                 // index-method writes must finish before abort() releases the
                 // statement savepoint and commits those partial changes.
-                if let Some(fail_error) = state.pending_fail_prepare_error.take() {
+                if state.pending_fail_prepare_error.is_some() {
+                    let fail_error = state
+                        .pending_fail_prepare_error
+                        .take()
+                        .expect("checked is_some above");
                     match execute::index_method_stage_statement_all(state) {
                         Ok(IOResult::Done(())) => {
                             if let Err(abort_err) =
@@ -2051,13 +2094,13 @@ impl Program {
                         }
                     }
                 }
-                let (insn, _) = &self.insns[state.pc as usize];
+                let (insn, _) = &insns[state.pc as usize];
                 let insn_function = insn.to_function();
                 if enable_tracing {
                     trace_insn(self, state.pc as InsnReference, insn);
                     crate::stack::trace_remaining("program_step:opcode");
                 }
-                if self.connection.get_vdbe_trace() {
+                if vdbe_trace {
                     // Diff registers from PREVIOUS opcode
                     // The last opcode (Halt) won't have its diff printed, but Halt
                     // doesn't write to any registers


### PR DESCRIPTION
The interpreter loop checked connection-closed, interrupt, query deadline, and the progress handler on every executed instruction, several of them SeqCst atomic loads. SQLite only checks at jump opcodes. Gate the checks on the vm_steps counter so they run once every 64 instructions. A progress handler with a smaller interval narrows the gate to honor its cadence; the handler is consulted with (prev, current) step counts so no multiple of its interval is missed.

Also hoists the instruction slice and vdbe_trace flag out of the loop, and probes pending_fail_prepare_error without the unconditional Option write-back.

The first commit adds a scan-loop microbenchmark: `SELECT 1 FROM t` over 100k rows is the scan analogue of the existing `SELECT 1` benchmark — the loop body is just ResultRow and Next, so it isolates per-instruction dispatch and cursor-advance overhead.

Measured on the new benchmark: **select_one_100k -5.4%, select_star_100k -9.4%** (criterion, p = 0.00 on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)