### PR TITLE
core/vdbe: dispatch through a direct match with register-sized results

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -10,6 +10,7 @@ use crate::sync::{
     },
     Arc, Mutex, RwLock,
 };
+use crate::types::IOResultOr;
 #[cfg(all(feature = "fs", feature = "conn_raw_api"))]
 use crate::types::{WalFrameInfo, WalState};
 #[cfg(feature = "fs")]
@@ -1414,7 +1415,7 @@ impl Connection {
     pub(crate) fn reparse_schema_nonblock(
         self: &Arc<Connection>,
         state: &mut ReparseSchemaState,
-    ) -> Result<crate::types::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         use crate::types::IOResult;
         if matches!(state, ReparseSchemaState::Start) {
             // read cookie before consuming statement program - otherwise we can
@@ -1498,7 +1499,7 @@ impl Connection {
     fn drive_reparse_building(
         self: &Arc<Connection>,
         state: &mut ReparseSchemaState,
-    ) -> Result<crate::types::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         use crate::types::IOResult;
         loop {
             let ReparseSchemaState::Building(inner) = state else {
@@ -1661,7 +1662,7 @@ impl Connection {
                 }
                 ReparsePhase::LoadTypes { stmt, type_rows } => {
                     // Type loading is best-effort: log and continue on error.
-                    let scan = (|| -> Result<IOResult<()>> {
+                    let scan = (|| -> IOResultOr<()> {
                         crate::return_if_io!(stmt.run_with_row_callback_nonblock(|row| {
                             type_rows.push(row.get::<&str>(1)?.to_string());
                             Ok(())
@@ -1727,9 +1728,7 @@ impl Connection {
     /// Non-blocking variant of [`Self::read_current_schema_cookie`]. The MVCC
     /// path reads an in-memory header (never yields); the pager path may yield
     /// while reading page 1. Idempotent across re-entry.
-    pub(crate) fn read_current_schema_cookie_nonblock(
-        &self,
-    ) -> Result<crate::types::IOResult<u32>> {
+    pub(crate) fn read_current_schema_cookie_nonblock(&self) -> crate::types::IOResultOr<u32> {
         use crate::types::IOResult;
         if let Some(mv_store) = self.mv_store().as_ref() {
             let tx_id = self.get_mv_tx_id();
@@ -3433,7 +3432,7 @@ impl Connection {
         _path: &str,
         _alias: &str,
         _state: &mut AttachDatabaseState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         Err(LimboError::InvalidArgument(
             "attach not available in this build (no-fs)".to_string(),
         ))
@@ -3446,7 +3445,7 @@ impl Connection {
         _alias: &str,
         _reserved_space: Option<u8>,
         _state: &mut AttachDatabaseState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         // File-backed ATTACH is unavailable without `fs`, so pre-initialization
         // page-layout overrides are also unsupported in this build.
         self.attach_database(_path, _alias, _state)
@@ -3459,7 +3458,7 @@ impl Connection {
         path: &str,
         alias: &str,
         state: &mut AttachDatabaseState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         self.attach_database_with_config(path, alias, None, state)
     }
 
@@ -3472,30 +3471,35 @@ impl Connection {
         alias: &str,
         reserved_space: Option<u8>,
         state: &mut AttachDatabaseState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match state {
                 AttachDatabaseState::Start => {
                     if self.is_closed() {
-                        return Err(LimboError::InternalError("Connection closed".to_string()));
+                        return Err(
+                            LimboError::InternalError("Connection closed".to_string()).into()
+                        );
                     }
 
                     if self.is_attached(alias) {
                         return Err(LimboError::InvalidArgument(format!(
                             "database {alias} is already in use"
-                        )));
+                        ))
+                        .into());
                     }
 
                     if alias.eq_ignore_ascii_case("main") || alias.eq_ignore_ascii_case("temp") {
                         return Err(LimboError::InvalidArgument(format!(
                             "reserved name {alias} is already in use"
-                        )));
+                        ))
+                        .into());
                     }
                     if self.pager.load().has_external_page_codec() {
                         return Err(LimboError::InvalidArgument(
                             "ATTACH is unsupported for connections using an external page codec"
                                 .to_string(),
-                        ));
+                        )
+                        .into());
                     }
 
                     let db_opts = DatabaseOpts::new()
@@ -3624,7 +3628,8 @@ impl Connection {
                     let Some(mv_store) = mv_store_guard.as_ref() else {
                         return Err(LimboError::InternalError(
                             "fresh MVCC attach missing MV store".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     crate::return_if_io!(mv_store.bootstrap_nonblock(
                         bootstrap
@@ -3651,7 +3656,8 @@ impl Connection {
                 AttachDatabaseState::Done => {
                     return Err(LimboError::InternalError(
                         "attach_database called after completion".to_string(),
-                    ));
+                    )
+                    .into());
                 }
             }
         }
@@ -4055,7 +4061,7 @@ impl Connection {
     pub(crate) fn load_sequence_descriptors_via_sql_nonblock(
         self: &Arc<Connection>,
         state: &mut LoadSequenceDescriptorsState,
-    ) -> Result<crate::types::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         use crate::types::IOResult;
         loop {
             match state {
@@ -4165,7 +4171,7 @@ impl Connection {
         seq_name: &str,
         stmt: &mut Option<Box<Statement>>,
         meta: &mut Option<(i64, i64, i64, i64, bool)>,
-    ) -> Result<crate::types::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         use crate::types::IOResult;
         if stmt.is_none() {
             let escaped = backing_table_name.replace('"', "\"\"");
@@ -4198,7 +4204,8 @@ impl Connection {
             Err(err) => Err(LimboError::Corrupt(format!(
                 "internal sequence backing table \"{backing_table_name}\" for sequence \
                  \"{seq_name}\": descriptor row read failed: {err}"
-            ))),
+            ))
+            .into()),
         }
     }
 
@@ -4242,7 +4249,7 @@ impl Connection {
         seq: &crate::schema::Sequence,
         stmt: &mut Option<Box<Statement>>,
         row: &mut Option<(i64, bool)>,
-    ) -> Result<crate::types::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         use crate::types::IOResult;
         if stmt.is_none() {
             let escaped = backing_table_name.replace('"', "\"\"");
@@ -4273,7 +4280,8 @@ impl Connection {
                 "internal sequence backing table \"{backing_table_name}\" for sequence \
                  \"{}\": watermark row read failed: {err}",
                 seq.name
-            ))),
+            ))
+            .into()),
         }
     }
 
@@ -4326,7 +4334,7 @@ impl Connection {
     pub(crate) fn sync_autoincrement_backing_tables_from_sqlite_sequence_nonblock(
         self: &Arc<Connection>,
         state: &mut SyncAutoincrementState,
-    ) -> Result<crate::types::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         use crate::schema::{autoincrement_sequence_name, SQLITE_SEQUENCE_TABLE_NAME};
         use crate::translate::sequence::sequence_backing_table_name;
         use crate::types::IOResult;

--- a/core/database.rs
+++ b/core/database.rs
@@ -3,6 +3,7 @@
 //! keeps a single `Database` per file, and the per-connection catalog of
 //! attached databases.
 
+use crate::types::IOResultOr;
 use crate::util::IOExt;
 #[cfg(feature = "io_memory_yield")]
 use crate::MemoryYieldIO;
@@ -1163,13 +1164,14 @@ impl Database {
         io: Arc<dyn IO>,
         path: &str,
         options: &OpenOptions,
-    ) -> Result<IOResult<Arc<Database>>> {
+    ) -> IOResultOr<Arc<Database>> {
         Self::reject_wal_path_for_registry_open(options)?;
         Self::validate_open_options(options)?;
         let Some(storage) = options.storage.clone() else {
             return Err(LimboError::InvalidArgument(
                 "OpenOptions::storage is required for Database::open_async".to_string(),
-            ));
+            )
+            .into());
         };
         // Re-derive lock-mode flags from opts: multiprocess WAL must open the
         // WAL file with NoLock or the second process fails to lock `-wal`.
@@ -1203,7 +1205,8 @@ impl Database {
                                 return Err(LimboError::InvalidArgument(
                                     "Database is encrypted but no encryption options provided"
                                         .to_string(),
-                                ));
+                                )
+                                .into());
                             }
                             db.validate_page_codec(options.page_codec.as_deref())?;
                             Self::check_registry_dialect(&db, options.dialect.as_ref())?;
@@ -1300,12 +1303,13 @@ impl Database {
         io: Arc<dyn IO>,
         path: &str,
         options: &OpenOptions,
-    ) -> Result<IOResult<Arc<Database>>> {
+    ) -> IOResultOr<Arc<Database>> {
         Self::validate_open_options(options)?;
         let Some(storage) = options.storage.clone() else {
             return Err(LimboError::InvalidArgument(
                 "OpenOptions::storage is required for Database::do_open_async".to_string(),
-            ));
+            )
+            .into());
         };
         Self::do_open_async_guarded(
             state,
@@ -1340,12 +1344,13 @@ impl Database {
         page_codec: Option<Arc<dyn PageCodec>>,
         allocator: alloc::DynAllocator,
         dialect: Arc<dyn Dialect>,
-    ) -> Result<IOResult<Arc<Database>>> {
+    ) -> IOResultOr<Arc<Database>> {
         Self::validate_external_page_codec_options(opts, page_codec.is_some())?;
         if encryption_opts.is_some() && page_codec.is_some() {
             return Err(LimboError::InvalidArgument(
                 "built-in encryption cannot be combined with an external page codec".to_string(),
-            ));
+            )
+            .into());
         }
         let result = Self::do_open_async_internal(
             state,
@@ -1381,7 +1386,7 @@ impl Database {
         page_codec: Option<Arc<dyn PageCodec>>,
         allocator: alloc::DynAllocator,
         dialect: Arc<dyn Dialect>,
-    ) -> Result<IOResult<Arc<Database>>> {
+    ) -> IOResultOr<Arc<Database>> {
         loop {
             tracing::debug!("do_open_async_internal: state.phase={:?}", state.phase);
             match &state.phase {
@@ -1536,7 +1541,10 @@ impl Database {
                             // Release the schema lock
                             state.schema_guard = None;
                         }
-                        Err(LimboError::ExtensionError(e)) => {
+                        Err(err) if matches!(*err, LimboError::ExtensionError(_)) => {
+                            let LimboError::ExtensionError(e) = *err else {
+                                unreachable!()
+                            };
                             // this means that a vtab exists and we no longer have the module loaded.
                             // we print a warning to the user to load the module
                             state.schema_guard = None;
@@ -1650,11 +1658,12 @@ impl Database {
         st: &mut InitState,
         encryption_key: Option<&EncryptionKey>,
         page_codec: Option<&Arc<dyn PageCodec>>,
-    ) -> Result<IOResult<Pager>> {
+    ) -> IOResultOr<Pager> {
         if encryption_key.is_some() && page_codec.is_some() {
             return Err(LimboError::InvalidArgument(
                 "built-in encryption cannot be combined with an external page codec".to_string(),
-            ));
+            )
+            .into());
         }
         loop {
             match st {
@@ -1690,11 +1699,11 @@ impl Database {
                             Err(LimboError::Busy) => {
                                 read_tx_attempts += 1;
                                 if read_tx_attempts > 1 {
-                                    return Err(LimboError::Busy);
+                                    return Err(LimboError::Busy.into());
                                 }
                                 pager.io.yield_now();
                             }
-                            Err(err) => return Err(err),
+                            Err(err) => return Err(err.into()),
                         }
                     }
 
@@ -1750,7 +1759,7 @@ impl Database {
                             };
                             if let Err(err) = validate_codec_header() {
                                 pager.end_read_tx();
-                                return Err(err);
+                                return Err(err.into());
                             }
                             if header.vacuum_mode_largest_root_page.get() > 0 {
                                 if header.incremental_vacuum_enabled.get() > 0 {
@@ -1795,7 +1804,7 @@ impl Database {
         st: &mut HeaderValidationState,
         encryption_key: Option<&EncryptionKey>,
         page_codec: Option<&Arc<dyn PageCodec>>,
-    ) -> Result<IOResult<Arc<Pager>>> {
+    ) -> IOResultOr<Arc<Pager>> {
         loop {
             match st {
                 HeaderValidationState::Start { init } => {
@@ -1842,7 +1851,8 @@ impl Database {
                     if !header_mut.text_encoding.is_utf8() {
                         return Err(LimboError::UnsupportedEncoding(
                             header_mut.text_encoding.to_string(),
-                        ));
+                        )
+                        .into());
                     }
 
                     let (read_version, write_version) =
@@ -1853,7 +1863,7 @@ impl Database {
                             "invalid value of database header magic bytes: {:?}",
                             header_mut.magic
                         );
-                        return Err(LimboError::NotADB);
+                        return Err(LimboError::NotADB.into());
                     }
                     // when we open fresh db with encryption params - header will be SQLite at this point
                     if encryption_key.is_some()
@@ -1864,7 +1874,7 @@ impl Database {
                             "invalid value of database header magic bytes: {:?}",
                             header_mut.magic
                         );
-                        return Err(LimboError::NotADB);
+                        return Err(LimboError::NotADB.into());
                     }
 
                     // TODO: right now we don't support READ ONLY and no READ or WRITE in the Version header
@@ -1872,7 +1882,7 @@ impl Database {
                     if read_version != write_version {
                         return Err(LimboError::Corrupt(format!(
                             "Read version `{read_version:?}` is not equal to Write version `{write_version:?} in database header`"
-                        )));
+                        )).into());
                     }
 
                     let (read_version, _write_version) = (
@@ -1889,26 +1899,30 @@ impl Database {
                         return Err(LimboError::Corrupt(format!(
                             "Invalid max_embed_frac: expected 64, got {}",
                             header_mut.max_embed_frac
-                        )));
+                        ))
+                        .into());
                     }
                     if header_mut.min_embed_frac != 32 {
                         return Err(LimboError::Corrupt(format!(
                             "Invalid min_embed_frac: expected 32, got {}",
                             header_mut.min_embed_frac
-                        )));
+                        ))
+                        .into());
                     }
                     if header_mut.leaf_frac != 32 {
                         return Err(LimboError::Corrupt(format!(
                             "Invalid leaf_frac: expected 32, got {}",
                             header_mut.leaf_frac
-                        )));
+                        ))
+                        .into());
                     }
                     let schema_format = header_mut.schema_format.get();
                     // If the database is completely empty, if it has no schema, then the schema format number can be zero.
                     if !(0..=4).contains(&schema_format) {
                         return Err(LimboError::Corrupt(format!(
                             "Invalid schema_format: expected 1-4, got {schema_format}"
-                        )));
+                        ))
+                        .into());
                     }
                     if !matches!(
                         header_mut.text_encoding,
@@ -1920,7 +1934,8 @@ impl Database {
                         return Err(LimboError::Corrupt(format!(
                             "Invalid text_encoding: {}",
                             header_mut.text_encoding
-                        )));
+                        ))
+                        .into());
                     }
                     if !matches!(
                         header_mut.text_encoding,
@@ -1929,7 +1944,8 @@ impl Database {
                         return Err(LimboError::Corrupt(format!(
                             "Only utf8 text_encoding is supported by tursodb: got={}",
                             header_mut.text_encoding
-                        )));
+                        ))
+                        .into());
                     }
 
                     // Determine if we should open in MVCC mode based on the database header version
@@ -1939,7 +1955,8 @@ impl Database {
                         return Err(LimboError::InvalidArgument(
                             "external page codecs are not supported with MVCC databases"
                                 .to_string(),
-                        ));
+                        )
+                        .into());
                     }
 
                     // MVCC has no cross-process coordination: commit
@@ -1951,7 +1968,7 @@ impl Database {
                         return Err(LimboError::InvalidArgument(format!(
                             "cannot open MVCC database '{}' with experimental multiprocess WAL: MVCC does not support multiprocess access",
                             self.path
-                        )));
+                        )).into());
                     }
 
                     // Now check the Header Version to see which mode the DB file really is on
@@ -1982,7 +1999,7 @@ impl Database {
                         return Err(LimboError::Corrupt(format!(
                             "MVCC logical log file exists for database {}, but database header indicates WAL mode. The database may be corrupted.",
                             self.path
-                        )));
+                        )).into());
                     }
 
                     let page = header.page().clone();
@@ -2439,7 +2456,7 @@ impl Database {
     /// Non-blocking read of the 512-byte database file header (page 1's
     /// header region). Yields the read completion via the supplied state until
     /// it finishes, then returns the filled buffer.
-    fn read_db_header_buf(&self, st: &mut DbHeaderReadState) -> Result<IOResult<Arc<Buffer>>> {
+    fn read_db_header_buf(&self, st: &mut DbHeaderReadState) -> IOResultOr<Arc<Buffer>> {
         loop {
             match st {
                 DbHeaderReadState::Start => {
@@ -2910,7 +2927,7 @@ impl Database {
         requested_page_size: Option<usize>,
         hdr_st: &mut DbHeaderReadState,
         page_codec: Option<&Arc<dyn PageCodec>>,
-    ) -> Result<IOResult<Pager>> {
+    ) -> IOResultOr<Pager> {
         let cipher = self.encryption_cipher_mode.get();
 
         // For an existing (initialized) database, read the 512-byte header
@@ -2930,14 +2947,16 @@ impl Database {
                     return Err(LimboError::InvalidArgument(format!(
                         "page codec reported invalid page size {}",
                         header_info.page_size
-                    )));
+                    ))
+                    .into());
                 };
                 if !page_size.has_valid_reserved_space(header_info.reserved_space) {
                     return Err(LimboError::InvalidArgument(format!(
                         "page codec reported invalid reserved space {} for page size {}",
                         header_info.reserved_space,
                         page_size.get()
-                    )));
+                    ))
+                    .into());
                 }
                 (Some(header_info.reserved_space), Some(page_size))
             } else {
@@ -2954,7 +2973,7 @@ impl Database {
             if reserved_bytes != required_reserved_bytes {
                 return Err(LimboError::InvalidArgument(format!(
                     "page codec requires exactly {required_reserved_bytes} reserved bytes, but database provides {reserved_bytes}"
-                )));
+                )).into());
             }
         }
 
@@ -4152,7 +4171,7 @@ mod database_tests {
         };
 
         assert!(matches!(
-            err,
+            *err,
             LimboError::InvalidArgument(ref message)
                 if message
                     == "external page codecs are not supported with experimental multiprocess WAL"

--- a/core/error.rs
+++ b/core/error.rs
@@ -22,9 +22,11 @@ pub enum LimboError {
     DatabaseFull(String),
     #[error("Parse error: {0}")]
     ParseError(String),
+    /// Boxed: the parser error is ~96 bytes inline and would dominate
+    /// `LimboError`'s size, which rides in every hot-path `Result`.
     #[error(transparent)]
     #[diagnostic(transparent)]
-    LexerError(#[from] turso_parser::error::Error),
+    LexerError(#[from] Box<turso_parser::error::Error>),
     #[error("Conversion error: {0}")]
     ConversionError(String),
     #[error("Env variable error: {0}")]
@@ -123,6 +125,39 @@ pub enum LimboError {
     UnsupportedEncoding(String),
     #[error("Out of memory")]
     OutOfMemory,
+}
+
+/// `?` in functions returning boxed errors (see `InsnResult`) composes
+/// `From<X> for LimboError` with the boxing. One impl per source error type
+/// that crosses that boundary; a blanket impl would overlap std's
+/// `From<T> for Box<T>`.
+macro_rules! boxed_from {
+    ($ty:ty) => {
+        impl From<$ty> for Box<LimboError> {
+            fn from(err: $ty) -> Self {
+                Box::new(LimboError::from(err))
+            }
+        }
+    };
+}
+boxed_from!(crate::alloc::TryReserveError);
+boxed_from!(std::collections::TryReserveError);
+boxed_from!(turso_parser::error::Error);
+boxed_from!(CompletionError);
+boxed_from!(CacheError);
+boxed_from!(bumpalo::AllocErr);
+boxed_from!(crate::alloc::AllocError);
+
+impl From<Box<LimboError>> for LimboError {
+    fn from(err: Box<LimboError>) -> Self {
+        *err
+    }
+}
+
+impl From<turso_parser::error::Error> for LimboError {
+    fn from(err: turso_parser::error::Error) -> Self {
+        LimboError::LexerError(Box::new(err))
+    }
 }
 
 impl LimboError {
@@ -258,14 +293,14 @@ pub(crate) const fn cold_return<T>(v: T) -> T {
 #[macro_export]
 macro_rules! bail_parse_error {
     ($($arg:tt)*) => {
-        return $crate::error::cold_return(Err($crate::error::LimboError::ParseError(format!($($arg)*))))
+        return $crate::error::cold_return(Err($crate::error::LimboError::ParseError(format!($($arg)*)).into()))
     };
 }
 
 #[macro_export]
 macro_rules! bail_corrupt_error {
     ($($arg:tt)*) => {
-        return $crate::error::cold_return(Err($crate::error::LimboError::Corrupt(format!($($arg)*))))
+        return $crate::error::cold_return(Err($crate::error::LimboError::Corrupt(format!($($arg)*)).into()))
     };
 }
 
@@ -301,7 +336,7 @@ macro_rules! assert_or_bail_corrupt {
 #[macro_export]
 macro_rules! bail_constraint_error {
     ($($arg:tt)*) => {
-        return $crate::error::cold_return(Err($crate::error::LimboError::Constraint(format!($($arg)*))))
+        return $crate::error::cold_return(Err($crate::error::LimboError::Constraint(format!($($arg)*)).into()))
     };
 }
 

--- a/core/incremental/aggregate_operator.rs
+++ b/core/incremental/aggregate_operator.rs
@@ -12,6 +12,7 @@ use crate::storage::btree::CursorTrait;
 use crate::sync::Arc;
 use crate::sync::Mutex;
 use crate::translate::plan::ColumnMask;
+use crate::types::IOResultOr;
 use crate::types::{
     IOResult, ImmutableRecord, ImmutableRecordRef, SeekKey, SeekOp, SeekResult, ValueRef,
 };
@@ -503,7 +504,7 @@ impl AggregateEvalState {
         &mut self,
         operator: &mut AggregateOperator,
         cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<(Delta, ComputedStates)>> {
+    ) -> IOResultOr<(Delta, ComputedStates)> {
         loop {
             match self {
                 AggregateEvalState::FetchKey {
@@ -1451,7 +1452,7 @@ impl AggregateOperator {
         &mut self,
         state: &mut EvalState,
         cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<(Delta, ComputedStates)>> {
+    ) -> IOResultOr<(Delta, ComputedStates)> {
         match state {
             EvalState::Uninitialized => {
                 panic!("Cannot eval AggregateOperator with Uninitialized state");
@@ -1770,11 +1771,7 @@ impl AggregateOperator {
 }
 
 impl IncrementalOperator for AggregateOperator {
-    fn eval(
-        &mut self,
-        state: &mut EvalState,
-        cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    fn eval(&mut self, state: &mut EvalState, cursors: &mut DbspStateCursors) -> IOResultOr<Delta> {
         let (delta, _) = return_if_io!(self.eval_internal(state, cursors));
         Ok(IOResult::Done(delta))
     }
@@ -1783,7 +1780,7 @@ impl IncrementalOperator for AggregateOperator {
         &mut self,
         mut deltas: DeltaPair,
         cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         // Aggregate operator only uses left delta, right must be empty
         assert!(
             deltas.right.is_empty(),
@@ -2111,7 +2108,7 @@ impl RecomputeMinMax {
         existing_groups: &mut HashMap<String, AggregateState>,
         operator: &AggregateOperator,
         cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match self {
                 RecomputeMinMax::ProcessElements {
@@ -2299,7 +2296,7 @@ impl ScanState {
         seek_op: SeekOp,
         storage_id: i64,
         zset_hash: Hash128,
-    ) -> Result<IOResult<Option<Value>>> {
+    ) -> IOResultOr<Option<Value>> {
         let seek_result = return_if_io!(cursors
             .index_cursor
             .seek(SeekKey::IndexKey(index_record.as_record_ref()), seek_op));
@@ -2373,10 +2370,7 @@ impl ScanState {
         }
     }
 
-    pub fn find_new_value(
-        &mut self,
-        cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Option<Value>>> {
+    pub fn find_new_value(&mut self, cursors: &mut DbspStateCursors) -> IOResultOr<Option<Value>> {
         loop {
             match self {
                 ScanState::CheckCandidate {
@@ -2638,7 +2632,7 @@ impl FetchDistinctState {
         cursors: &mut DbspStateCursors,
         generate_group_hash: impl Fn(&str) -> Hash128,
         is_plain_distinct: bool,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match self {
                 FetchDistinctState::Init { groups_to_fetch } => {
@@ -2884,7 +2878,7 @@ impl DistinctPersistState {
         operator_id: i64,
         cursors: &mut DbspStateCursors,
         generate_group_hash: impl Fn(&str) -> Hash128,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match self {
                 DistinctPersistState::Init {
@@ -3040,7 +3034,7 @@ impl MinMaxPersistState {
         column_min_max: &HashMap<usize, AggColumnInfo>,
         cursors: &mut DbspStateCursors,
         generate_group_hash: impl Fn(&str) -> Hash128,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match self {
                 MinMaxPersistState::Init {

--- a/core/incremental/compiler.rs
+++ b/core/incremental/compiler.rs
@@ -14,6 +14,7 @@ use crate::incremental::operator::{
 };
 use crate::schema::Type;
 use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
+use crate::types::IOResultOr;
 use crate::SqliteDialect;
 // Note: logical module must be made pub(crate) in translate/mod.rs
 use crate::numeric::Numeric;
@@ -69,7 +70,7 @@ impl WriteRowView {
         key: SeekKey,
         build_record: impl Fn(isize) -> Vec<Value>,
         weight: isize,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match self {
                 WriteRowView::GetRecord => {
@@ -94,13 +95,15 @@ impl WriteRowView {
                                 _ => {
                                     return Err(LimboError::InternalError(format!(
                                         "Invalid weight value in storage for key {key:?}"
-                                    )))
+                                    ))
+                                    .into())
                                 }
                             },
                             None => {
                                 return Err(LimboError::InternalError(format!(
                                     "No weight value found in storage for key {key:?}"
-                                )))
+                                ))
+                                .into())
                             }
                         };
 
@@ -129,7 +132,8 @@ impl WriteRowView {
                         _ => {
                             return Err(LimboError::InternalError(
                                 "Expected TableRowId for storage".to_string(),
-                            ))
+                            )
+                            .into())
                         }
                     };
 
@@ -366,7 +370,7 @@ impl DbspNode {
         eval_state: &mut EvalState,
         commit_operators: bool,
         cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         // Process delta using the executable operator
         let op = &mut self.executable;
 
@@ -477,7 +481,7 @@ impl DbspCircuit {
         pager: &Arc<Pager>,
         state_cursors: &mut DbspStateCursors,
         commit_operators: bool,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         if let Some(root_id) = self.root {
             self.execute_node(
                 root_id,
@@ -487,9 +491,7 @@ impl DbspCircuit {
                 state_cursors,
             )
         } else {
-            Err(LimboError::ParseError(
-                "Circuit has no root node".to_string(),
-            ))
+            Err(LimboError::ParseError("Circuit has no root node".to_string()).into())
         }
     }
 
@@ -503,7 +505,7 @@ impl DbspCircuit {
         &mut self,
         pager: Arc<Pager>,
         execute_state: &mut ExecuteState,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         if let Some(root_id) = self.root {
             // Create temporary cursors for execute (non-commit) operations
             let table_cursor =
@@ -518,9 +520,7 @@ impl DbspCircuit {
             let mut cursors = DbspStateCursors::new(table_cursor, index_cursor);
             self.execute_node(root_id, pager, execute_state, false, &mut cursors)
         } else {
-            Err(LimboError::ParseError(
-                "Circuit has no root node".to_string(),
-            ))
+            Err(LimboError::ParseError("Circuit has no root node".to_string()).into())
         }
     }
 
@@ -534,7 +534,7 @@ impl DbspCircuit {
         &mut self,
         input_data: HashMap<String, Delta>,
         pager: Arc<Pager>,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         // No root means nothing to commit
         if self.root.is_none() {
             return Ok(IOResult::Done(Delta::new()));
@@ -676,7 +676,7 @@ impl DbspCircuit {
         execute_state: &mut ExecuteState,
         commit_operators: bool,
         cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         loop {
             match execute_state {
                 ExecuteState::Uninitialized => {

--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -1,6 +1,7 @@
 use crate::numeric::Numeric;
 use crate::sync::Arc;
 use crate::sync::Mutex;
+use crate::types::IOResultOr;
 use crate::{
     incremental::{
         compiler::{DeltaSet, ExecuteState},
@@ -91,7 +92,7 @@ impl MaterializedViewCursor {
     }
 
     /// Compute transaction changes lazily on first access
-    fn ensure_tx_changes_computed(&mut self) -> Result<IOResult<()>> {
+    fn ensure_tx_changes_computed(&mut self) -> IOResultOr<()> {
         // Check if we've already processed the current state
         let current_len = self.tx_state.len();
         if current_len == self.last_tx_state_len {
@@ -120,7 +121,7 @@ impl MaterializedViewCursor {
     }
 
     // Read the current btree entry as a vector (empty if no current position)
-    fn read_btree_delta_entry(&mut self) -> Result<IOResult<Vec<(HashableRow, isize)>>> {
+    fn read_btree_delta_entry(&mut self) -> IOResultOr<Vec<(HashableRow, isize)>> {
         let btree_rowid = return_if_io!(self.btree_cursor.rowid());
         let rowid = match btree_rowid {
             None => return Ok(IOResult::Done(Vec::new())),
@@ -147,14 +148,15 @@ impl MaterializedViewCursor {
             _ => {
                 return Err(crate::LimboError::InternalError(format!(
                     "Invalid data in materialized view: expected integer weight, found {weight_value:?}"
-                )))
+                )).into())
             }
         };
 
         if weight <= 0 {
             return Err(crate::LimboError::InternalError(format!(
                 "Invalid data in materialized view: expected a positive weight, found {weight}"
-            )));
+            ))
+            .into());
         }
 
         // TODO: std boundary conversion; adjust once incremental uses the
@@ -173,7 +175,7 @@ impl MaterializedViewCursor {
         target_rowid: i64,
         op: SeekOp,
         changes: Vec<(HashableRow, isize)>,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let mut btree_entries = Delta { changes };
         let changes = self.uncommitted.seek(target, op);
 
@@ -227,7 +229,7 @@ impl MaterializedViewCursor {
     }
 
     /// Internal seek implementation that doesn't check preconditions
-    fn do_seek(&mut self, target_rowid: i64, op: SeekOp) -> Result<IOResult<SeekResult>> {
+    fn do_seek(&mut self, target_rowid: i64, op: SeekOp) -> IOResultOr<SeekResult> {
         loop {
             // Process state machine - need to handle mutable borrow carefully
             match &mut self.seek_state {
@@ -306,7 +308,7 @@ impl MaterializedViewCursor {
         }
     }
 
-    pub fn seek(&mut self, key: SeekKey, op: SeekOp) -> Result<IOResult<SeekResult>> {
+    pub fn seek(&mut self, key: SeekKey, op: SeekOp) -> IOResultOr<SeekResult> {
         // Ensure transaction changes are computed
         return_if_io!(self.ensure_tx_changes_computed());
 
@@ -315,14 +317,15 @@ impl MaterializedViewCursor {
             SeekKey::IndexKey(_) => {
                 return Err(LimboError::ParseError(
                     "Cannot search a materialized view with an index key".to_string(),
-                ));
+                )
+                .into());
             }
         };
 
         self.do_seek(target_rowid, op)
     }
 
-    pub fn next(&mut self) -> Result<IOResult<bool>> {
+    pub fn next(&mut self) -> IOResultOr<bool> {
         // If there's a pending seek operation (due to IO), complete it first.
         // SeekState::Seek or SeekState::Advancing means IO was interrupted mid-seek and we need to resume.
         // SeekState::Init means cursor was never positioned - don't resume, fall through to check current_row.
@@ -346,7 +349,7 @@ impl MaterializedViewCursor {
         Ok(IOResult::Done(result == SeekResult::Found))
     }
 
-    pub fn column(&mut self, col: usize) -> Result<IOResult<Value>> {
+    pub fn column(&mut self, col: usize) -> IOResultOr<Value> {
         if let Some((_, ref values)) = self.current_row {
             Ok(IOResult::Done(
                 values.get(col).cloned().unwrap_or(Value::Null),
@@ -356,11 +359,11 @@ impl MaterializedViewCursor {
         }
     }
 
-    pub fn rowid(&self) -> Result<IOResult<Option<i64>>> {
+    pub fn rowid(&self) -> IOResultOr<Option<i64>> {
         Ok(IOResult::Done(self.current_row.as_ref().map(|(id, _)| *id)))
     }
 
-    pub fn rewind(&mut self) -> Result<IOResult<()>> {
+    pub fn rewind(&mut self) -> IOResultOr<()> {
         return_if_io!(self.ensure_tx_changes_computed());
         // Seek GT from i64::MIN to find the first row using internal do_seek
         let _result = return_if_io!(self.do_seek(i64::MIN, SeekOp::GT));
@@ -1777,7 +1780,7 @@ mod tests {
         }
 
         impl CursorTrait for MockBTreeCursor {
-            fn seek(&mut self, _key: SeekKey<'_>, _op: SeekOp) -> Result<IOResult<SeekResult>> {
+            fn seek(&mut self, _key: SeekKey<'_>, _op: SeekOp) -> IOResultOr<SeekResult> {
                 let count = self.seek_count.fetch_add(1, Ordering::SeqCst);
                 if count == 0 {
                     // First seek returns TryAdvance
@@ -1793,12 +1796,12 @@ mod tests {
                 &mut self,
                 _registers: &[Register],
                 _op: SeekOp,
-            ) -> Result<IOResult<SeekResult>> {
+            ) -> IOResultOr<SeekResult> {
                 // Not used in these tests
                 Ok(IOResult::Done(SeekResult::NotFound))
             }
 
-            fn next(&mut self) -> Result<IOResult<()>> {
+            fn next(&mut self) -> IOResultOr<()> {
                 let count = self.next_count.fetch_add(1, Ordering::SeqCst);
                 if count == 0 {
                     // First call returns IO (pending)
@@ -1810,7 +1813,7 @@ mod tests {
                 }
             }
 
-            fn prev(&mut self) -> Result<IOResult<()>> {
+            fn prev(&mut self) -> IOResultOr<()> {
                 let count = self.prev_count.fetch_add(1, Ordering::SeqCst);
                 if count == 0 {
                     // First call returns IO (pending)
@@ -1822,23 +1825,23 @@ mod tests {
                 }
             }
 
-            fn rowid(&mut self) -> Result<IOResult<Option<i64>>> {
+            fn rowid(&mut self) -> IOResultOr<Option<i64>> {
                 Ok(IOResult::Done(self.current_rowid))
             }
 
-            fn record(&mut self) -> Result<IOResult<Option<&ImmutableRecord>>> {
+            fn record(&mut self) -> IOResultOr<Option<&ImmutableRecord>> {
                 Ok(IOResult::Done(Some(&self.record)))
             }
 
-            fn last(&mut self) -> Result<IOResult<()>> {
+            fn last(&mut self) -> IOResultOr<()> {
                 Ok(IOResult::Done(()))
             }
 
-            fn insert(&mut self, _key: &BTreeKey) -> Result<IOResult<()>> {
+            fn insert(&mut self, _key: &BTreeKey) -> IOResultOr<()> {
                 Ok(IOResult::Done(()))
             }
 
-            fn delete(&mut self) -> Result<IOResult<()>> {
+            fn delete(&mut self) -> IOResultOr<()> {
                 Ok(IOResult::Done(()))
             }
 
@@ -1848,19 +1851,19 @@ mod tests {
                 false
             }
 
-            fn exists(&mut self, _key: &Value) -> Result<IOResult<bool>> {
+            fn exists(&mut self, _key: &Value) -> IOResultOr<bool> {
                 Ok(IOResult::Done(false))
             }
 
-            fn clear_btree(&mut self) -> Result<IOResult<Option<usize>>> {
+            fn clear_btree(&mut self) -> IOResultOr<Option<usize>> {
                 Ok(IOResult::Done(None))
             }
 
-            fn btree_destroy(&mut self) -> Result<IOResult<Option<usize>>> {
+            fn btree_destroy(&mut self) -> IOResultOr<Option<usize>> {
                 Ok(IOResult::Done(None))
             }
 
-            fn count(&mut self) -> Result<IOResult<usize>> {
+            fn count(&mut self) -> IOResultOr<usize> {
                 Ok(IOResult::Done(0))
             }
 
@@ -1872,7 +1875,7 @@ mod tests {
                 1
             }
 
-            fn rewind(&mut self) -> Result<IOResult<()>> {
+            fn rewind(&mut self) -> IOResultOr<()> {
                 Ok(IOResult::Done(()))
             }
 
@@ -1886,11 +1889,11 @@ mod tests {
                 &self.index_info
             }
 
-            fn seek_end(&mut self) -> Result<IOResult<()>> {
+            fn seek_end(&mut self) -> IOResultOr<()> {
                 Ok(IOResult::Done(()))
             }
 
-            fn seek_to_last(&mut self) -> Result<IOResult<()>> {
+            fn seek_to_last(&mut self) -> IOResultOr<()> {
                 Ok(IOResult::Done(()))
             }
 

--- a/core/incremental/filter_operator.rs
+++ b/core/incremental/filter_operator.rs
@@ -9,7 +9,8 @@ use crate::incremental::operator::{
 use crate::sync::Arc;
 use crate::sync::Mutex;
 use crate::types::IOResult;
-use crate::{Result, Value};
+use crate::types::IOResultOr;
+use crate::Value;
 use std::cmp::Ordering;
 
 /// Filter predicate for filtering rows
@@ -176,7 +177,7 @@ impl IncrementalOperator for FilterOperator {
         &mut self,
         state: &mut EvalState,
         _cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         let delta = match state {
             EvalState::Init { deltas } => {
                 // Filter operators only use left_delta, right_delta must be empty
@@ -211,11 +212,7 @@ impl IncrementalOperator for FilterOperator {
         Ok(IOResult::Done(output_delta))
     }
 
-    fn commit(
-        &mut self,
-        deltas: DeltaPair,
-        _cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    fn commit(&mut self, deltas: DeltaPair, _cursors: &mut DbspStateCursors) -> IOResultOr<Delta> {
         // Filter operator only uses left delta, right must be empty
         assert!(
             deltas.right.is_empty(),

--- a/core/incremental/input_operator.rs
+++ b/core/incremental/input_operator.rs
@@ -8,7 +8,7 @@ use crate::incremental::operator::{
 use crate::sync::Arc;
 use crate::sync::Mutex;
 use crate::types::IOResult;
-use crate::Result;
+use crate::types::IOResultOr;
 
 /// Input operator - source of data for the circuit
 /// Represents base relations/tables that receive external updates
@@ -29,7 +29,7 @@ impl IncrementalOperator for InputOperator {
         &mut self,
         state: &mut EvalState,
         _cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         match state {
             EvalState::Init { deltas } => {
                 // Input operators only use left_delta, right_delta must be empty
@@ -47,11 +47,7 @@ impl IncrementalOperator for InputOperator {
         }
     }
 
-    fn commit(
-        &mut self,
-        deltas: DeltaPair,
-        _cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    fn commit(&mut self, deltas: DeltaPair, _cursors: &mut DbspStateCursors) -> IOResultOr<Delta> {
         // Input operator only uses left delta, right must be empty
         assert!(
             deltas.right.is_empty(),

--- a/core/incremental/join_operator.rs
+++ b/core/incremental/join_operator.rs
@@ -10,6 +10,7 @@ use crate::numeric::Numeric;
 use crate::storage::btree::CursorTrait;
 use crate::sync::Arc;
 use crate::sync::Mutex;
+use crate::types::IOResultOr;
 use crate::types::{IOResult, ImmutableRecord, ImmutableRecordRef, SeekKey, SeekOp, SeekResult};
 use crate::{return_and_restore_if_io, return_if_io, Result, Value};
 
@@ -28,7 +29,7 @@ fn read_next_join_row(
     join_key: &HashableRow,
     last_element_hash: Option<Hash128>,
     cursors: &mut DbspStateCursors,
-) -> Result<IOResult<Option<(Hash128, HashableRow, isize)>>> {
+) -> IOResultOr<Option<(Hash128, HashableRow, isize)>> {
     // Build the index key: (storage_id, zset_id, element_id)
     // zset_id is the hash of the join key
     let zset_hash = join_key.cached_hash();
@@ -192,7 +193,7 @@ impl JoinEvalState {
         right_key_indices: &[usize],
         left_storage_id: i64,
         right_storage_id: i64,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         loop {
             match self {
                 JoinEvalState::ProcessDeltaJoin { deltas, output } => {
@@ -462,7 +463,7 @@ impl JoinOperator {
         &mut self,
         state: &mut EvalState,
         cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         // Get the join state out of the enum
         match state {
             EvalState::Join(js) => js.process_join_state(
@@ -480,7 +481,7 @@ impl JoinOperator {
         &mut self,
         state: &mut EvalState,
         cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         loop {
             let loop_state = std::mem::replace(state, EvalState::Uninitialized);
             match loop_state {
@@ -584,20 +585,12 @@ fn serialize_hashable_row(row: &HashableRow) -> Result<crate::ValueBlob> {
 }
 
 impl IncrementalOperator for JoinOperator {
-    fn eval(
-        &mut self,
-        state: &mut EvalState,
-        cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    fn eval(&mut self, state: &mut EvalState, cursors: &mut DbspStateCursors) -> IOResultOr<Delta> {
         let delta = return_if_io!(self.eval_internal(state, cursors));
         Ok(IOResult::Done(delta))
     }
 
-    fn commit(
-        &mut self,
-        deltas: DeltaPair,
-        cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    fn commit(&mut self, deltas: DeltaPair, cursors: &mut DbspStateCursors) -> IOResultOr<Delta> {
         loop {
             let mut state = std::mem::replace(&mut self.commit_state, JoinCommitState::Invalid);
             match &mut state {

--- a/core/incremental/merge_operator.rs
+++ b/core/incremental/merge_operator.rs
@@ -8,7 +8,7 @@ use crate::incremental::operator::{
 use crate::sync::Arc;
 use crate::sync::Mutex;
 use crate::types::IOResult;
-use crate::Result;
+use crate::types::IOResultOr;
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
@@ -134,7 +134,7 @@ impl IncrementalOperator for MergeOperator {
         &mut self,
         input: &mut EvalState,
         _cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         match input {
             EvalState::Init { deltas } => {
                 // Extract deltas from the evaluation state
@@ -165,11 +165,7 @@ impl IncrementalOperator for MergeOperator {
         }
     }
 
-    fn commit(
-        &mut self,
-        deltas: DeltaPair,
-        _cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    fn commit(&mut self, deltas: DeltaPair, _cursors: &mut DbspStateCursors) -> IOResultOr<Delta> {
         // Transform deltas based on union mode
         let left_transformed = self.transform_delta(deltas.left, true);
         let right_transformed = self.transform_delta(deltas.right, false);

--- a/core/incremental/operator.rs
+++ b/core/incremental/operator.rs
@@ -17,8 +17,7 @@ use crate::schema::{Index, IndexColumn};
 use crate::storage::btree::BTreeCursor;
 use crate::sync::Arc;
 use crate::sync::Mutex;
-use crate::types::IOResult;
-use crate::Result;
+use crate::types::IOResultOr;
 use std::fmt::Debug;
 
 /// Struct to hold both table and index cursors for DBSP state operations
@@ -214,21 +213,13 @@ pub trait IncrementalOperator: Debug + Send {
     ///
     /// # Returns
     /// The output delta from the evaluation
-    fn eval(
-        &mut self,
-        state: &mut EvalState,
-        cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>>;
+    fn eval(&mut self, state: &mut EvalState, cursors: &mut DbspStateCursors) -> IOResultOr<Delta>;
 
     /// Commit deltas to the operator's internal state and return the output
     /// This is called when a transaction commits, making changes permanent
     /// Returns the output delta (what downstream operators should see)
     /// The cursors parameter is for operators that need to persist state
-    fn commit(
-        &mut self,
-        deltas: DeltaPair,
-        cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>>;
+    fn commit(&mut self, deltas: DeltaPair, cursors: &mut DbspStateCursors) -> IOResultOr<Delta>;
 
     /// Set computation tracker
     fn set_tracker(&mut self, tracker: Arc<Mutex<ComputationTracker>>);
@@ -236,6 +227,7 @@ pub trait IncrementalOperator: Debug + Send {
 
 #[cfg(test)]
 mod tests {
+    use crate::types::IOResult;
     use crate::SqliteDialect;
     use rustc_hash::FxHashSet as HashSet;
 
@@ -300,8 +292,8 @@ mod tests {
             // Get the record at this position
             let record = loop {
                 match cursors.table_cursor.record().unwrap() {
-                    IOResult::Done(r) => break r,
-                    IOResult::IO(io) => io.wait(&*pager.io).unwrap(),
+                    crate::types::IOResult::Done(r) => break r,
+                    crate::types::IOResult::IO(io) => io.wait(&*pager.io).unwrap(),
                 }
             }
             .unwrap()
@@ -3748,7 +3740,7 @@ mod tests {
         // Evaluate merge
         let result = merge_op.commit(delta_pair, &mut cursors).unwrap();
 
-        if let IOResult::Done(merged) = result {
+        if let crate::types::IOResult::Done(merged) = result {
             // Should have all 4 entries
             assert_eq!(merged.len(), 4);
 

--- a/core/incremental/persistence.rs
+++ b/core/incremental/persistence.rs
@@ -1,8 +1,9 @@
 use crate::incremental::operator::{AggregateState, DbspStateCursors};
 use crate::numeric::Numeric;
 use crate::storage::btree::{BTreeCursor, BTreeKey, CursorTrait};
+use crate::types::IOResultOr;
 use crate::types::{IOResult, ImmutableRecord, SeekKey, SeekOp, SeekResult};
-use crate::{return_if_io, LimboError, Result, Value};
+use crate::{return_if_io, LimboError, Value};
 
 #[derive(Debug, Default)]
 pub enum ReadRecord {
@@ -22,7 +23,7 @@ impl ReadRecord {
         &mut self,
         key: SeekKey,
         cursor: &mut BTreeCursor,
-    ) -> Result<IOResult<Option<AggregateState>>> {
+    ) -> IOResultOr<Option<AggregateState>> {
         loop {
             match self {
                 ReadRecord::GetRecord => {
@@ -111,7 +112,7 @@ impl WriteRow {
         index_key: Vec<Value>,
         record_values: Vec<Value>,
         weight: isize,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match self {
                 WriteRow::GetRecord => {
@@ -147,7 +148,8 @@ impl WriteRow {
                         if !matches!(table_res, SeekResult::Found) {
                             return Err(LimboError::InternalError(
                                 "Index points to non-existent table row".to_string(),
-                            ));
+                            )
+                            .into());
                         }
 
                         let existing_record = return_if_io!(cursors.table_cursor.record());
@@ -165,13 +167,15 @@ impl WriteRow {
                                 _ => {
                                     return Err(LimboError::InternalError(
                                         "Invalid weight value in storage".to_string(),
-                                    ))
+                                    )
+                                    .into())
                                 }
                             },
                             None => {
                                 return Err(LimboError::InternalError(
                                     "No weight value found in storage".to_string(),
-                                ))
+                                )
+                                .into())
                             }
                         };
 
@@ -213,7 +217,8 @@ impl WriteRow {
                             None => {
                                 return Err(LimboError::InternalError(
                                     "Table cursor has rows but no valid rowid".to_string(),
-                                ))
+                                )
+                                .into())
                             }
                         }
                     };

--- a/core/incremental/project_operator.rs
+++ b/core/incremental/project_operator.rs
@@ -9,8 +9,9 @@ use crate::incremental::operator::{
 use crate::sync::Mutex;
 use crate::sync::{atomic::Ordering, Arc};
 use crate::types::IOResult;
+use crate::types::IOResultOr;
 use crate::SqliteDialect;
-use crate::{Connection, Database, Result, Value};
+use crate::{Connection, Database, Value};
 
 #[derive(Debug, Clone)]
 pub struct ProjectColumn {
@@ -104,7 +105,7 @@ impl IncrementalOperator for ProjectOperator {
         &mut self,
         state: &mut EvalState,
         _cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    ) -> IOResultOr<Delta> {
         let delta = match state {
             EvalState::Init { deltas } => {
                 // Project operators only use left_delta, right_delta must be empty
@@ -135,11 +136,7 @@ impl IncrementalOperator for ProjectOperator {
         Ok(IOResult::Done(output_delta))
     }
 
-    fn commit(
-        &mut self,
-        deltas: DeltaPair,
-        _cursors: &mut DbspStateCursors,
-    ) -> Result<IOResult<Delta>> {
+    fn commit(&mut self, deltas: DeltaPair, _cursors: &mut DbspStateCursors) -> IOResultOr<Delta> {
         // Project operator only uses left delta, right must be empty
         assert!(
             deltas.right.is_empty(),

--- a/core/incremental/view.rs
+++ b/core/incremental/view.rs
@@ -7,6 +7,7 @@ use crate::storage::btree::CursorTrait;
 use crate::sync::Arc;
 use crate::sync::Mutex;
 use crate::translate::logical::LogicalPlanBuilder;
+use crate::types::IOResultOr;
 use crate::types::{IOResult, Value};
 use crate::util::{extract_view_columns, ViewColumnSchema};
 use crate::{return_if_io, LimboError, Pager, Result, Statement};
@@ -419,7 +420,7 @@ impl IncrementalView {
         uncommitted: DeltaSet,
         pager: Arc<Pager>,
         execute_state: &mut crate::incremental::compiler::ExecuteState,
-    ) -> crate::Result<crate::types::IOResult<Delta>> {
+    ) -> crate::types::IOResultOr<Delta> {
         // Initialize execute_state with the input data
         *execute_state = crate::incremental::compiler::ExecuteState::Init {
             input_data: uncommitted,
@@ -1148,7 +1149,7 @@ impl IncrementalView {
         conn: &crate::sync::Arc<crate::Connection>,
         pager: &crate::sync::Arc<crate::Pager>,
         _btree_cursor: &mut dyn CursorTrait,
-    ) -> crate::Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         // Assert that this is a materialized view with a root page
         assert!(
             self.root_page != 0,
@@ -1170,7 +1171,7 @@ impl IncrementalView {
         conn: &crate::sync::Arc<crate::Connection>,
         pager: &crate::sync::Arc<crate::Pager>,
         _btree_cursor: &mut dyn CursorTrait,
-    ) -> crate::Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         'outer: loop {
             match std::mem::replace(&mut self.populate_state, PopulateState::Done) {
                 PopulateState::Start => {
@@ -1324,7 +1325,7 @@ impl IncrementalView {
                                     rows_processed,
                                     pending_row: None, // No pending row when interrupted between rows
                                 };
-                                return Err(LimboError::Busy);
+                                return Err(LimboError::Busy.into());
                             }
 
                             crate::vdbe::StepResult::IO
@@ -1360,7 +1361,7 @@ impl IncrementalView {
         values: Vec<Value>,
         table_idx: usize,
         pager: Arc<crate::Pager>,
-    ) -> crate::Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         // Create a single-row delta
         let mut single_row_delta = Delta::new();
         single_row_delta.insert(rowid, values);
@@ -1401,11 +1402,7 @@ impl IncrementalView {
     }
 
     /// Merge a delta set of changes into the view's current state
-    pub fn merge_delta(
-        &mut self,
-        delta_set: DeltaSet,
-        pager: Arc<crate::Pager>,
-    ) -> crate::Result<IOResult<()>> {
+    pub fn merge_delta(&mut self, delta_set: DeltaSet, pager: Arc<crate::Pager>) -> IOResultOr<()> {
         // Early return if all deltas are empty
         if delta_set.is_empty() {
             return Ok(IOResult::Done(()));

--- a/core/index_method/fts/mod.rs
+++ b/core/index_method/fts/mod.rs
@@ -14,6 +14,7 @@
 //! degenerate concurrency: the pager write lock serializes writers.
 
 use crate::sync::{Arc, Weak};
+use crate::types::IOResultOr;
 use crate::{
     index_method::{
         open_index_cursor, parse_patterns, IndexMethod, IndexMethodAttachment,
@@ -812,7 +813,7 @@ impl NestedDdl {
 
     /// Drive the statements to completion in order, handing their I/O to
     /// the caller; re-enter after each yield until `Done`.
-    fn step(&mut self) -> Result<IOResult<()>> {
+    fn step(&mut self) -> IOResultOr<()> {
         let conn = self.connection.upgrade().ok_or_else(|| {
             LimboError::InternalError("FTS nested DDL outlived its connection".into())
         })?;
@@ -1448,7 +1449,7 @@ impl FtsCursor {
     /// with no control row is either empty or was written by the
     /// pre-registry FTS implementation; the latter is refused with a
     /// rebuild hint, since that layout is not readable by this code.
-    fn drive_open(&mut self) -> Result<IOResult<()>> {
+    fn drive_open(&mut self) -> IOResultOr<()> {
         let conn = self
             .connection
             .as_ref()
@@ -1544,7 +1545,8 @@ impl FtsCursor {
                                  and cannot be written; rebuild it with `DROP INDEX {name}` \
                                  followed by `CREATE INDEX ... USING fts`",
                                 name = self.index_name
-                            )));
+                            ))
+                            .into());
                         }
                         self.segments.clear();
                         self.snapshot_loaded = true;
@@ -1561,7 +1563,8 @@ impl FtsCursor {
                         // found.
                         return Err(LimboError::Corrupt(
                             "FTS v2 store has rows but no control record".into(),
-                        ));
+                        )
+                        .into());
                     }
                     // Rows without the `fts2/` prefix were written by the
                     // pre-registry FTS implementation (a whole Tantivy
@@ -1574,7 +1577,8 @@ impl FtsCursor {
                          and its storage format is no longer supported; rebuild it \
                          with `DROP INDEX {name}` followed by `CREATE INDEX ... USING fts`",
                         name = self.index_name
-                    )));
+                    ))
+                    .into());
                 }
                 FtsState::ScanSegments {
                     seeked,
@@ -1629,7 +1633,8 @@ impl FtsCursor {
                         if !path.starts_with(FTS2_TOMB_PREFIX) {
                             return Err(LimboError::Corrupt(format!(
                                 "FTS registry scan hit an unrecognized row: {path}"
-                            )));
+                            ))
+                            .into());
                         }
                         self.state = FtsState::ScanTombs {
                             seeked: false,
@@ -1707,7 +1712,8 @@ impl FtsCursor {
                         // would resurrect every deleted doc after it.
                         return Err(LimboError::Corrupt(format!(
                             "FTS tombstone scan hit an unrecognized row: {path}"
-                        )));
+                        ))
+                        .into());
                     };
                     let segment_id = parse_segment_id(uuid)?;
                     let doc_id = u32::try_from(doc_id).map_err(|_| {
@@ -1771,7 +1777,8 @@ impl FtsCursor {
                                 {
                                     return Err(LimboError::Corrupt(format!(
                                         "duplicate FTS chunk {path}:{chunk_no}"
-                                    )));
+                                    ))
+                                    .into());
                                 }
                                 *advance_pending = true;
                             }
@@ -1877,7 +1884,7 @@ impl FtsCursor {
 
     /// Load the snapshot view if this cursor skipped it (the insert fast
     /// path). Needed before the first delete or same-transaction query.
-    fn ensure_snapshot_loaded(&mut self) -> Result<IOResult<()>> {
+    fn ensure_snapshot_loaded(&mut self) -> IOResultOr<()> {
         if self.snapshot_loaded {
             return Ok(IOResult::Done(()));
         }
@@ -1900,7 +1907,7 @@ impl FtsCursor {
         &mut self,
         conn: &Arc<Connection>,
         database_id: usize,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         if let Some(ddl) = self.pending_ddl.as_mut() {
             return_if_io!(ddl.step());
             self.pending_ddl = None;
@@ -1943,7 +1950,7 @@ impl FtsCursor {
 
     /// Step freshly prepared nested DDL; park it on the cursor if it
     /// yields so the next entry resumes it.
-    fn drive_nested_ddl(&mut self, mut ddl: NestedDdl) -> Result<IOResult<()>> {
+    fn drive_nested_ddl(&mut self, mut ddl: NestedDdl) -> IOResultOr<()> {
         let result = ddl.step();
         if matches!(result, Ok(IOResult::IO(_))) {
             self.pending_ddl = Some(ddl);
@@ -2085,7 +2092,7 @@ impl FtsCursor {
 
     /// Drive the in-flight publication (row deletions, then row inserts,
     /// then in-memory effects exactly once).
-    fn drive_publish(&mut self) -> Result<IOResult<()>> {
+    fn drive_publish(&mut self) -> IOResultOr<()> {
         let Some(publish) = self.publish.as_mut() else {
             return Ok(IOResult::Done(()));
         };
@@ -2229,7 +2236,7 @@ impl FtsCursor {
     /// Complete any in-flight or due batch publication before a mutation.
     /// The VDBE retries the current instruction when an operation returns
     /// `IOResult::IO`, so this must finish before Tantivy state changes.
-    fn flush_gate(&mut self) -> Result<IOResult<()>> {
+    fn flush_gate(&mut self) -> IOResultOr<()> {
         if self.is_publishing() {
             return_if_io!(self.drive_publish());
         }
@@ -2559,7 +2566,7 @@ impl FtsBackingRowWiper {
         })
     }
 
-    pub fn step(&mut self) -> Result<IOResult<()>> {
+    pub fn step(&mut self) -> IOResultOr<()> {
         self.deleter.step(self.cursor.as_mut())
     }
 }
@@ -2600,7 +2607,7 @@ impl FtsBackingRowDumper {
         })
     }
 
-    pub fn step(&mut self) -> Result<IOResult<()>> {
+    pub fn step(&mut self) -> IOResultOr<()> {
         loop {
             if !self.started {
                 return_if_io!(self.cursor.rewind());
@@ -2649,7 +2656,7 @@ impl Drop for FtsCursor {
 impl IndexMethodCursor for FtsCursor {
     /// Creates the FTS index storage (internal BTree table for segment
     /// rows) and stages the v2 control row.
-    fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn create(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
         let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
@@ -2682,7 +2689,7 @@ impl IndexMethodCursor for FtsCursor {
     }
 
     /// Destroys the FTS index, dropping all storage and clearing caches.
-    fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn destroy(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
         let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
@@ -2737,7 +2744,7 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Opens the index for reading: scan the visible registry rows at this
     /// snapshot and assemble a searcher over exactly those segments.
-    fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn open_read(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
         let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
@@ -2752,7 +2759,7 @@ impl IndexMethodCursor for FtsCursor {
     /// Opens the index for writing. Pure inserts only need to know the
     /// store's format — they append segments without reading the index —
     /// so this stops after format detection.
-    fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn open_write(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
         let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);
@@ -2775,7 +2782,7 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Buffers a document for the next segment build. Values are text
     /// columns followed by rowid.
-    fn insert(&mut self, values: &[Register]) -> Result<IOResult<()>> {
+    fn insert(&mut self, values: &[Register]) -> IOResultOr<()> {
         self.claim_writer_slot()?;
         return_if_io!(self.flush_gate());
 
@@ -2786,9 +2793,7 @@ impl IndexMethodCursor for FtsCursor {
         let rowid = match rowid_reg {
             Register::Value(Value::Numeric(crate::numeric::Numeric::Integer(i))) => *i,
             _ => {
-                return Err(LimboError::InternalError(
-                    "FTS rowid must be integer".into(),
-                ));
+                return Err(LimboError::InternalError("FTS rowid must be integer".into()).into());
             }
         };
 
@@ -2820,7 +2825,7 @@ impl IndexMethodCursor for FtsCursor {
     /// Deletes a document by rowid: drop it from the buffer if it has not
     /// been serialized yet, and tombstone every live posting it has in the
     /// visible segment set.
-    fn delete(&mut self, values: &[Register]) -> Result<IOResult<()>> {
+    fn delete(&mut self, values: &[Register]) -> IOResultOr<()> {
         self.claim_writer_slot()?;
         // Announce this transaction as a tombstone writer before any
         // tombstone exists, so a concurrent merge cannot retire the
@@ -2838,9 +2843,7 @@ impl IndexMethodCursor for FtsCursor {
         let rowid = match rowid_reg {
             Register::Value(Value::Numeric(crate::numeric::Numeric::Integer(i))) => *i,
             _ => {
-                return Err(LimboError::InternalError(
-                    "FTS rowid must be integer".into(),
-                ));
+                return Err(LimboError::InternalError("FTS rowid must be integer".into()).into());
             }
         };
 
@@ -2868,7 +2871,7 @@ impl IndexMethodCursor for FtsCursor {
 
     /// Starts an FTS query. Parses the query string and executes the search.
     /// Returns true if there are results, false otherwise.
-    fn query_start(&mut self, values: &[Register]) -> Result<IOResult<bool>> {
+    fn query_start(&mut self, values: &[Register]) -> IOResultOr<bool> {
         self.ensure_searcher()?;
         let searcher = self
             .searcher
@@ -2877,7 +2880,8 @@ impl IndexMethodCursor for FtsCursor {
         if values.len() < 2 {
             return Err(LimboError::InternalError(
                 "FTS query_start: expected pattern id and query string".into(),
-            ));
+            )
+            .into());
         }
 
         // values[0] = pattern index
@@ -2890,7 +2894,7 @@ impl IndexMethodCursor for FtsCursor {
         // values[1] = query string
         let query_str = match &values[1] {
             Register::Value(Value::Text(t)) => t.as_str().to_string(),
-            _ => return Err(LimboError::InternalError("FTS query must be text".into())),
+            _ => return Err(LimboError::InternalError("FTS query must be text".into()).into()),
         };
 
         // Determine the optional SQL LIMIT captured by the selected pattern.
@@ -2929,12 +2933,14 @@ impl IndexMethodCursor for FtsCursor {
                 return Err(LimboError::InternalError(
                     "FTS query_start: LIMIT pattern selected but no limit value captured"
                         .to_string(),
-                ));
+                )
+                .into());
             }),
             _ => {
                 return Err(LimboError::InternalError(format!(
                     "FTS query_start: unknown pattern {pattern_idx}"
-                )));
+                ))
+                .into());
             }
         };
 
@@ -2952,7 +2958,8 @@ impl IndexMethodCursor for FtsCursor {
             return Err(LimboError::InternalError(format!(
                 "FTS query is too long ({} bytes; the limit is {FTS_MAX_QUERY_BYTES})",
                 query_str.len()
-            )));
+            ))
+            .into());
         }
         let mut depth = 0usize;
         for byte in query_str.bytes() {
@@ -2962,7 +2969,8 @@ impl IndexMethodCursor for FtsCursor {
                     if depth > FTS_MAX_QUERY_NESTING {
                         return Err(LimboError::InternalError(format!(
                             "FTS query nests deeper than {FTS_MAX_QUERY_NESTING} parentheses"
-                        )));
+                        ))
+                        .into());
                     }
                 }
                 b')' => depth = depth.saturating_sub(1),
@@ -2971,9 +2979,7 @@ impl IndexMethodCursor for FtsCursor {
         }
         let (query, parse_errors) = parser.parse_query_lenient(&query_str);
         if let Some(error) = parse_errors.first() {
-            return Err(LimboError::InternalError(format!(
-                "FTS parse error: {error:?}"
-            )));
+            return Err(LimboError::InternalError(format!("FTS parse error: {error:?}")).into());
         }
 
         // TopDocs keeps a heap proportional to its limit. Cap that heap at the
@@ -3116,7 +3122,7 @@ impl IndexMethodCursor for FtsCursor {
     }
 
     /// Advances to the next query result. Returns true if more results exist.
-    fn query_next(&mut self) -> Result<IOResult<bool>> {
+    fn query_next(&mut self) -> IOResultOr<bool> {
         if let Some(stream) = &mut self.streaming_hits {
             return Ok(IOResult::Done(stream.advance()?));
         }
@@ -3128,12 +3134,10 @@ impl IndexMethodCursor for FtsCursor {
     }
 
     /// Returns the column value for the current result (score or match indicator).
-    fn query_column(&mut self, idx: usize) -> Result<IOResult<Value>> {
+    fn query_column(&mut self, idx: usize) -> IOResultOr<Value> {
         // Column 0 = score for fts_score, or 1 (true) for fts_match
         if idx != 0 {
-            return Err(LimboError::InternalError(
-                "FTS: only column 0 supported".into(),
-            ));
+            return Err(LimboError::InternalError("FTS: only column 0 supported".into()).into());
         }
 
         match self.current_pattern {
@@ -3146,7 +3150,8 @@ impl IndexMethodCursor for FtsCursor {
                 {
                     return Err(LimboError::InternalError(
                         "FTS: query_column out of bounds".into(),
-                    ));
+                    )
+                    .into());
                 }
                 // For fts_match patterns, return 1 (true) - indicates this row matches
                 Ok(IOResult::Done(Value::from_i64(1)))
@@ -3182,7 +3187,7 @@ impl IndexMethodCursor for FtsCursor {
     }
 
     /// Returns the rowid for the current query result.
-    fn query_rowid(&mut self) -> Result<IOResult<Option<i64>>> {
+    fn query_rowid(&mut self) -> IOResultOr<Option<i64>> {
         if let Some(stream) = &self.streaming_hits {
             return Ok(IOResult::Done(stream.current.map(|(_, rowid)| rowid)));
         }
@@ -3198,7 +3203,7 @@ impl IndexMethodCursor for FtsCursor {
     /// new segment and the visible set exceeds `PRAGMA fts_merge_threshold`,
     /// merges it down in the same transaction (skipped silently on
     /// maintenance contention).
-    fn stage_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn stage_statement_commit(&mut self, _context: &IndexMethodContext) -> IOResultOr<()> {
         if self.is_publishing() {
             return_if_io!(self.drive_publish());
         } else if self.pending_op_count() > 0 {
@@ -3259,7 +3264,7 @@ impl IndexMethodCursor for FtsCursor {
     /// Merge the visible segments into one, compacting tombstones away.
     /// Call via `OPTIMIZE INDEX idx_name`. The only operation that touches
     /// other transactions' rows; serialized by the per-index merge mutex.
-    fn optimize(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn optimize(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
         let conn = context.connection()?;
         let database_id = context.database().id;
         self.database_id = Some(database_id);

--- a/core/index_method/fts/rows.rs
+++ b/core/index_method/fts/rows.rs
@@ -12,6 +12,7 @@
 //! * [`RowDeleter`] — delete every row matching a list of path targets.
 //!   Only merge/OPTIMIZE deletes rows.
 
+use crate::types::IOResultOr;
 use crate::{
     numeric::Numeric,
     return_if_io,
@@ -159,7 +160,7 @@ impl RowInserter {
         }
     }
 
-    pub fn step(&mut self, cursor: &mut dyn CursorTrait) -> Result<IOResult<()>> {
+    pub fn step(&mut self, cursor: &mut dyn CursorTrait) -> IOResultOr<()> {
         loop {
             match &mut self.phase {
                 None => {
@@ -275,7 +276,7 @@ impl RowDeleter {
         self.phase = DeletePhase::Seeking;
     }
 
-    pub fn step(&mut self, cursor: &mut dyn CursorTrait) -> Result<IOResult<()>> {
+    pub fn step(&mut self, cursor: &mut dyn CursorTrait) -> IOResultOr<()> {
         loop {
             let Some(target) = self.targets.get(self.idx) else {
                 return Ok(IOResult::Done(()));

--- a/core/index_method/mod.rs
+++ b/core/index_method/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, Weak};
 
+use crate::types::IOResultOr;
 use rustc_hash::FxHashMap as HashMap;
 #[cfg(any(test, injected_yields))]
 use strum::EnumCount;
@@ -542,23 +543,23 @@ pub struct IndexMethodTestStats {
 /// skipping `stage_statement_commit` silently loses writes.
 pub trait IndexMethodCursor: Send {
     /// create necessary components for index method (usually, this is a bunch of btree-s)
-    fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
+    fn create(&mut self, context: &IndexMethodContext) -> IOResultOr<()>;
     /// destroy components created in the create(...) call for index method
-    fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
+    fn destroy(&mut self, context: &IndexMethodContext) -> IOResultOr<()>;
 
     /// open necessary components for reading the index
-    fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
+    fn open_read(&mut self, context: &IndexMethodContext) -> IOResultOr<()>;
     /// open necessary components for writing the index
-    fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>>;
+    fn open_write(&mut self, context: &IndexMethodContext) -> IOResultOr<()>;
 
     /// handle insert action
     /// "values" argument contains registers with values for index columns followed by rowid Integer register
     /// (e.g. for "CREATE INDEX i ON t USING method (x, z)" insert(...) call will have 3 registers in values: [x, z, rowid])
-    fn insert(&mut self, values: &[Register]) -> Result<IOResult<()>>;
+    fn insert(&mut self, values: &[Register]) -> IOResultOr<()>;
     /// handle delete action
     /// "values" argument contains registers with values for index columns followed by rowid Integer register
     /// (e.g. for "CREATE INDEX i ON t USING method (x, z)" insert(...) call will have 3 registers in values: [x, z, rowid])
-    fn delete(&mut self, values: &[Register]) -> Result<IOResult<()>>;
+    fn delete(&mut self, values: &[Register]) -> IOResultOr<()>;
 
     /// initialize query to the index method
     /// first element of "values" slice is the Integer register which holds index of the chosen [IndexMethodDefinition::patterns] by query planner
@@ -569,14 +570,14 @@ pub trait IndexMethodCursor: Send {
     /// - [Integer(1), Text("turso")] - pattern "SELECT * FROM {table} WHERE x = ?" was chosen with equality comparison equals to "turso"
     ///
     /// Returns false if query will produce no rows (similar to VFilter/Rewind op codes)
-    fn query_start(&mut self, values: &[Register]) -> Result<IOResult<bool>>;
+    fn query_start(&mut self, values: &[Register]) -> IOResultOr<bool>;
 
     /// Moves cursor to the next response row
     /// Returns false if query exhausted all rows
-    fn query_next(&mut self) -> Result<IOResult<bool>>;
+    fn query_next(&mut self) -> IOResultOr<bool>;
 
     /// Return column with given idx (zero-based) from current row
-    fn query_column(&mut self, idx: usize) -> Result<IOResult<Value>>;
+    fn query_column(&mut self, idx: usize) -> IOResultOr<Value>;
 
     /// Return rowid of the original table row which corresponds to the current cursor row
     ///
@@ -592,11 +593,11 @@ pub trait IndexMethodCursor: Send {
     /// In this case query planner will execute index method query first, and then
     /// enrich its result with name, comment, rating columns from original table accessing original row by its rowid
     /// returned from query_rowid(...) method
-    fn query_rowid(&mut self) -> Result<IOResult<Option<i64>>>;
+    fn query_rowid(&mut self) -> IOResultOr<Option<i64>>;
 
     /// Stage all pending index changes before the statement savepoint is
     /// released. Any fallible work or I/O belongs in this phase.
-    fn stage_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn stage_statement_commit(&mut self, _context: &IndexMethodContext) -> IOResultOr<()> {
         Ok(IOResult::Done(()))
     }
 
@@ -624,7 +625,7 @@ pub trait IndexMethodCursor: Send {
     fn close(&mut self, _context: &IndexMethodContext) {}
 
     /// Optimize the index by merging segments or performing other maintenance.
-    fn optimize(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn optimize(&mut self, _context: &IndexMethodContext) -> IOResultOr<()> {
         Ok(IOResult::Done(()))
     }
 

--- a/core/index_method/toy_vector_sparse_ivf.rs
+++ b/core/index_method/toy_vector_sparse_ivf.rs
@@ -3,6 +3,7 @@ use std::{
     sync::atomic::Ordering,
 };
 
+use crate::types::IOResultOr;
 use turso_parser::ast::{self, SortOrder};
 
 use crate::numeric::Numeric;
@@ -404,7 +405,7 @@ fn key_info() -> KeyInfo {
 }
 
 impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
-    fn create(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn create(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
         // we need to properly track subprograms and propagate result to the root program to make this execution async
         let connection = context.connection()?;
         let database_id = context.database().id;
@@ -450,7 +451,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         Ok(IOResult::Done(()))
     }
 
-    fn destroy(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn destroy(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
         let connection = context.connection()?;
         let database_id = context.database().id;
         let db_prefix = connection
@@ -477,7 +478,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         Ok(IOResult::Done(()))
     }
 
-    fn open_read(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn open_read(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
         self.inverted_index_cursor = Some(context.open_index_cursor(
             &self.configuration.table_name,
             &self.inverted_index_btree,
@@ -494,7 +495,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         Ok(IOResult::Done(()))
     }
 
-    fn open_write(&mut self, context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn open_write(&mut self, context: &IndexMethodContext) -> IOResultOr<()> {
         self.inverted_index_cursor = Some(context.open_index_cursor(
             &self.configuration.table_name,
             &self.inverted_index_btree,
@@ -510,7 +511,7 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         Ok(IOResult::Done(()))
     }
 
-    fn stage_statement_commit(&mut self, _context: &IndexMethodContext) -> Result<IOResult<()>> {
+    fn stage_statement_commit(&mut self, _context: &IndexMethodContext) -> IOResultOr<()> {
         Ok(IOResult::Done(()))
     }
 
@@ -528,16 +529,16 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         self.main_btree = None;
     }
 
-    fn insert(&mut self, values: &[Register]) -> Result<IOResult<()>> {
+    fn insert(&mut self, values: &[Register]) -> IOResultOr<()> {
         let Some(inverted_cursor) = &mut self.inverted_index_cursor else {
-            return Err(LimboError::InternalError(
-                "inverted cursor must be opened".to_string(),
-            ));
+            return Err(
+                LimboError::InternalError("inverted cursor must be opened".to_string()).into(),
+            );
         };
         let Some(stats_cursor) = &mut self.stats_cursor else {
-            return Err(LimboError::InternalError(
-                "stats cursor must be opened".to_string(),
-            ));
+            return Err(
+                LimboError::InternalError("stats cursor must be opened".to_string()).into(),
+            );
         };
         loop {
             tracing::debug!("insert_state: {:?}", self.insert_state);
@@ -546,18 +547,21 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(vector) = values[0].get_value().to_blob() else {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let vector = Vector::from_slice_owned(vector)?;
                     if !matches!(vector.vector_type, VectorType::Float32Sparse) {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
-                        ));
+                        )
+                        .into());
                     }
                     let Some(rowid) = values[1].get_value().as_int() else {
                         return Err(LimboError::InternalError(
                             "second value must be i64 rowid".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let sum = vector.as_f32_sparse().values.iter().sum::<f32>() as f64;
                     self.insert_state = VectorSparseInvertedIndexInsertState::Prepare {
@@ -576,7 +580,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(v) = vector.as_ref() else {
                         return Err(LimboError::InternalError(
                             "vector must be present in Prepare state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     if *idx == v.as_f32_sparse().idx.len() {
                         self.insert_state = VectorSparseInvertedIndexInsertState::Init;
@@ -615,7 +620,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(k) = key.as_ref() else {
                         return Err(LimboError::InternalError(
                             "key must be present in SeekInverted state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let result = return_if_io!(inverted_cursor.seek(
                         SeekKey::IndexKey(k.as_record_ref()),
@@ -640,14 +646,16 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(k) = key.as_ref() else {
                         return Err(LimboError::InternalError(
                             "key must be present in InsertInverted state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     return_if_io!(inverted_cursor.insert(&BTreeKey::IndexKey(k.as_record_ref())));
 
                     let Some(v) = vector.as_ref() else {
                         return Err(LimboError::InternalError(
                             "vector must be present in InsertInverted state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let position = v.as_f32_sparse().idx[*idx];
                     let key = ImmutableRecord::from_values(&[Value::from_i64(position as i64)], 1)?;
@@ -669,7 +677,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(k) = key.as_ref() else {
                         return Err(LimboError::InternalError(
                             "key must be present in SeekStats state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let result = return_if_io!(stats_cursor.seek(
                         SeekKey::IndexKey(k.as_record_ref()),
@@ -688,7 +697,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             let Some(v) = vector.as_ref() else {
                                 return Err(LimboError::InternalError(
                                     "vector must be present in SeekStats state".to_string(),
-                                ));
+                                )
+                                .into());
                             };
                             let position = v.as_f32_sparse().idx[*idx];
                             let value = v.as_f32_sparse().values[*idx] as f64;
@@ -729,7 +739,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(v) = vector.as_ref() else {
                         return Err(LimboError::InternalError(
                             "vector must be present in ReadStats state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let position = v.as_f32_sparse().idx[*idx];
                     let value = v.as_f32_sparse().values[*idx] as f64;
@@ -767,7 +778,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(k) = key.as_ref() else {
                         return Err(LimboError::InternalError(
                             "key must be present in UpdateStats state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     return_if_io!(stats_cursor.insert(&BTreeKey::IndexKey(k.as_record_ref())));
 
@@ -782,16 +794,14 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         }
     }
 
-    fn delete(&mut self, values: &[Register]) -> Result<IOResult<()>> {
+    fn delete(&mut self, values: &[Register]) -> IOResultOr<()> {
         let Some(cursor) = &mut self.inverted_index_cursor else {
-            return Err(LimboError::InternalError(
-                "cursor must be opened".to_string(),
-            ));
+            return Err(LimboError::InternalError("cursor must be opened".to_string()).into());
         };
         let Some(stats_cursor) = &mut self.stats_cursor else {
-            return Err(LimboError::InternalError(
-                "stats cursor must be opened".to_string(),
-            ));
+            return Err(
+                LimboError::InternalError("stats cursor must be opened".to_string()).into(),
+            );
         };
         loop {
             tracing::debug!("delete_state: {:?}", self.delete_state);
@@ -800,18 +810,21 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(vector) = values[0].get_value().to_blob() else {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let vector = Vector::from_slice_owned(vector)?;
                     if !matches!(vector.vector_type, VectorType::Float32Sparse) {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
-                        ));
+                        )
+                        .into());
                     }
                     let Some(rowid) = values[1].get_value().as_int() else {
                         return Err(LimboError::InternalError(
                             "second value must be i64 rowid".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let sum = vector.as_f32_sparse().values.iter().sum::<f32>() as f64;
                     self.delete_state = VectorSparseInvertedIndexDeleteState::Prepare {
@@ -830,7 +843,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(v) = vector.as_ref() else {
                         return Err(LimboError::InternalError(
                             "vector must be present in Prepare state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     if *idx == v.as_f32_sparse().idx.len() {
                         self.delete_state = VectorSparseInvertedIndexDeleteState::Init;
@@ -877,7 +891,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(k) = key.as_ref() else {
                         return Err(LimboError::InternalError(
                             "key must be present in SeekInverted state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let result = return_if_io!(cursor.seek(
                         SeekKey::IndexKey(k.as_record_ref()),
@@ -905,7 +920,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         SeekResult::NotFound => {
                             return Err(LimboError::Corrupt(
                                 "inverted index corrupted".to_string(),
-                            ));
+                            )
+                            .into());
                         }
                     }
                 }
@@ -917,7 +933,9 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                 } => {
                     return_if_io!(cursor.next());
                     if !cursor.has_record() {
-                        return Err(LimboError::Corrupt("inverted index corrupted".to_string()));
+                        return Err(
+                            LimboError::Corrupt("inverted index corrupted".to_string()).into()
+                        );
                     }
                     self.delete_state = VectorSparseInvertedIndexDeleteState::DeleteInverted {
                         vector: vector.take(),
@@ -936,7 +954,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(v) = vector.as_ref() else {
                         return Err(LimboError::InternalError(
                             "vector must be present in DeleteInverted state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let position = v.as_f32_sparse().idx[*idx];
                     let key = ImmutableRecord::from_values(&[Value::from_i64(position as i64)], 1)?;
@@ -958,7 +977,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(k) = key.as_ref() else {
                         return Err(LimboError::InternalError(
                             "key must be present in SeekStats state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let result = return_if_io!(stats_cursor.seek(
                         SeekKey::IndexKey(k.as_record_ref()),
@@ -976,7 +996,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         SeekResult::NotFound | SeekResult::TryAdvance => {
                             return Err(LimboError::Corrupt(
                                 "stats index corrupted: can't find component row".to_string(),
-                            ));
+                            )
+                            .into());
                         }
                     }
                 }
@@ -991,7 +1012,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(v) = vector.as_ref() else {
                         return Err(LimboError::InternalError(
                             "vector must be present in ReadStats state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let position = v.as_f32_sparse().idx[*idx];
                     tracing::debug!(
@@ -1028,7 +1050,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(k) = key.as_ref() else {
                         return Err(LimboError::InternalError(
                             "key must be present in UpdateStats state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     return_if_io!(stats_cursor.insert(&BTreeKey::IndexKey(k.as_record_ref())));
 
@@ -1043,21 +1066,15 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         }
     }
 
-    fn query_start(&mut self, values: &[Register]) -> Result<IOResult<bool>> {
+    fn query_start(&mut self, values: &[Register]) -> IOResultOr<bool> {
         let Some(inverted) = &mut self.inverted_index_cursor else {
-            return Err(LimboError::InternalError(
-                "cursor must be opened".to_string(),
-            ));
+            return Err(LimboError::InternalError("cursor must be opened".to_string()).into());
         };
         let Some(stats) = &mut self.stats_cursor else {
-            return Err(LimboError::InternalError(
-                "cursor must be opened".to_string(),
-            ));
+            return Err(LimboError::InternalError("cursor must be opened".to_string()).into());
         };
         let Some(main) = &mut self.main_btree else {
-            return Err(LimboError::InternalError(
-                "cursor must be opened".to_string(),
-            ));
+            return Err(LimboError::InternalError("cursor must be opened".to_string()).into());
         };
         loop {
             tracing::debug!("query_state: {:?}", self.search_state);
@@ -1066,18 +1083,21 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(vector) = values[1].get_value().to_blob() else {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let Some(limit) = values[2].get_value().as_int() else {
                         return Err(LimboError::InternalError(
                             "second value must be i64 limit parameter".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let vector = Vector::from_slice_owned(vector)?;
                     if !matches!(vector.vector_type, VectorType::Float32Sparse) {
                         return Err(LimboError::InternalError(
                             "first value must be sparse vector".to_string(),
-                        ));
+                        )
+                        .into());
                     }
                     let sparse = vector.as_f32_sparse();
                     let sum = sparse.values.iter().sum::<f32>() as f64;
@@ -1102,7 +1122,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(v) = vector.as_ref() else {
                         return Err(LimboError::InternalError(
                             "vector must be present in CollectComponentsSeek state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let p = &v.as_f32_sparse().idx[*idx..];
                     if p.is_empty() && key.is_none() {
@@ -1110,7 +1131,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             return Err(LimboError::InternalError(
                                 "components must be present in CollectComponentsSeek state"
                                     .to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         match self.scan_order {
                             ScanOrder::DatasetFrequencyAsc => {
@@ -1153,7 +1175,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         let Some(v) = vector.as_ref() else {
                             return Err(LimboError::InternalError(
                                 "vector must be present in CollectComponentsSeek state".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         let position = v.as_f32_sparse().idx[*idx];
                         *key = Some(ImmutableRecord::from_values(
@@ -1164,7 +1187,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(k) = key.as_ref() else {
                         return Err(LimboError::InternalError(
                             "key must be present in CollectComponentsSeek state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let result = return_if_io!(stats.seek(
                         SeekKey::IndexKey(k.as_record_ref()),
@@ -1205,14 +1229,16 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(v) = vector.as_ref() else {
                         return Err(LimboError::InternalError(
                             "vector must be present in CollectComponentsRead state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let value = v.as_f32_sparse().values[*idx];
                     let component = parse_stat_row(record)?;
                     let Some(comps) = components.as_mut() else {
                         return Err(LimboError::InternalError(
                             "components must be present in CollectComponentsRead state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     comps.push((component, value));
                     self.search_state =
@@ -1238,13 +1264,15 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(c) = components.as_ref() else {
                         return Err(LimboError::InternalError(
                             "components must be present in Seek state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     if c.is_empty() && key.is_none() {
                         let Some(distances) = distances.take() else {
                             return Err(LimboError::InternalError(
                                 "distances must be present in Seek state".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         self.search_result = distances.iter().map(|(d, i)| (*i, d.0)).collect();
                         return Ok(IOResult::Done(!self.search_result.is_empty()));
@@ -1263,7 +1291,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         let Some(dists) = distances.as_ref() else {
                             return Err(LimboError::InternalError(
                                 "distances must be present in Seek state".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         if dists.len() >= *limit as usize {
                             if let Some((max_threshold, _)) = dists.last() {
@@ -1295,12 +1324,14 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         let Some(comps) = components.as_mut() else {
                             return Err(LimboError::InternalError(
                                 "components must be present in Seek state".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         let Some(c) = comps.pop_front() else {
                             return Err(LimboError::InternalError(
                                 "components queue must not be empty in Seek state".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         *key = Some(ImmutableRecord::from_values(
                             &[Value::from_i64(c.position as i64)],
@@ -1311,7 +1342,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(k) = key.as_ref() else {
                         return Err(LimboError::InternalError(
                             "key must be present in Seek state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let result = return_if_io!(inverted.seek(
                         SeekKey::IndexKey(k.as_record_ref()),
@@ -1322,7 +1354,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             let Some(comp) = component.take() else {
                                 return Err(LimboError::InternalError(
                                     "component must be present in Seek state".to_string(),
-                                ));
+                                )
+                                .into());
                             };
                             self.search_state = VectorSparseInvertedIndexSearchState::Read {
                                 sum: *sum,
@@ -1339,7 +1372,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                             let Some(comp) = component.take() else {
                                 return Err(LimboError::InternalError(
                                     "component must be present in Seek state".to_string(),
-                                ));
+                                )
+                                .into());
                             };
                             self.search_state = VectorSparseInvertedIndexSearchState::Next {
                                 sum: *sum,
@@ -1378,7 +1412,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         let Some(mut current) = current.take() else {
                             return Err(LimboError::InternalError(
                                 "current must be present in Read state".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         current.sort_unstable();
 
@@ -1396,13 +1431,15 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(coll) = collected.as_mut() else {
                         return Err(LimboError::InternalError(
                             "collected must be present in Read state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     if coll.insert(row.rowid) {
                         let Some(curr) = current.as_mut() else {
                             return Err(LimboError::InternalError(
                                 "current must be present in Read state".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         curr.push(row.rowid);
                     }
@@ -1433,7 +1470,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         let Some(mut current) = current.take() else {
                             return Err(LimboError::InternalError(
                                 "current must be present in Next state".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         current.sort_unstable();
 
@@ -1471,7 +1509,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(c) = current.as_ref() else {
                         return Err(LimboError::InternalError(
                             "current must be present in EvaluateSeek state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     if c.is_empty() && rowid.is_none() {
                         self.search_state = VectorSparseInvertedIndexSearchState::Seek {
@@ -1490,7 +1529,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         let Some(curr) = current.as_mut() else {
                             return Err(LimboError::InternalError(
                                 "current must be present in EvaluateSeek state".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         *rowid = Some(curr.pop_front().ok_or_else(|| {
                             LimboError::InternalError(
@@ -1502,7 +1542,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                     let Some(rid) = rowid.as_ref() else {
                         return Err(LimboError::InternalError(
                             "rowid must be present in EvaluateSeek state".to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let rowid = *rid;
                     let k = SeekKey::TableRowId(rowid);
@@ -1511,7 +1552,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         return Err(LimboError::Corrupt(
                             "vector_sparse_ivf corrupted: unable to find rowid in main table"
                                 .to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     self.search_state = VectorSparseInvertedIndexSearchState::EvaluateRead {
                         sum: *sum,
@@ -1538,24 +1580,28 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         let ValueRef::Blob(data) = record.get_value(column_idx)? else {
                             return Err(LimboError::InternalError(
                                 "table column value must be sparse vector".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         let data = Vector::from_slice_owned(data)?;
                         if !matches!(data.vector_type, VectorType::Float32Sparse) {
                             return Err(LimboError::InternalError(
                                 "table column value must be sparse vector".to_string(),
-                            ));
+                            )
+                            .into());
                         }
                         let Some(arg) = values[1].get_value().to_blob() else {
                             return Err(LimboError::InternalError(
                                 "first value must be sparse vector".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         let arg = Vector::from_slice_owned(arg)?;
                         if !matches!(arg.vector_type, VectorType::Float32Sparse) {
                             return Err(LimboError::InternalError(
                                 "first value must be sparse vector".to_string(),
-                            ));
+                            )
+                            .into());
                         }
                         tracing::debug!(
                             "vector: {:?}, query: {:?}",
@@ -1566,7 +1612,8 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
                         let Some(dists) = distances.as_mut() else {
                             return Err(LimboError::InternalError(
                                 "distances must be present in EvaluateRead state".to_string(),
-                            ));
+                            )
+                            .into());
                         };
                         dists.insert((FloatOrd(distance), *rowid));
                         if dists.len() > *limit as usize {
@@ -1588,25 +1635,27 @@ impl IndexMethodCursor for VectorSparseInvertedIndexMethodCursor {
         }
     }
 
-    fn query_rowid(&mut self) -> Result<IOResult<Option<i64>>> {
+    fn query_rowid(&mut self) -> IOResultOr<Option<i64>> {
         let Some(result) = self.search_result.front() else {
             return Err(LimboError::InternalError(
                 "search_result must not be empty when query_rowid is called".to_string(),
-            ));
+            )
+            .into());
         };
         Ok(IOResult::Done(Some(result.0)))
     }
 
-    fn query_column(&mut self, _: usize) -> Result<IOResult<Value>> {
+    fn query_column(&mut self, _: usize) -> IOResultOr<Value> {
         let Some(result) = self.search_result.front() else {
             return Err(LimboError::InternalError(
                 "search_result must not be empty when query_column is called".to_string(),
-            ));
+            )
+            .into());
         };
         Ok(IOResult::Done(Value::from_f64(result.1)))
     }
 
-    fn query_next(&mut self) -> Result<IOResult<bool>> {
+    fn query_next(&mut self) -> IOResultOr<bool> {
         let _ = self.search_result.pop_front();
         Ok(IOResult::Done(!self.search_result.is_empty()))
     }

--- a/core/io/memory_yield.rs
+++ b/core/io/memory_yield.rs
@@ -271,7 +271,7 @@ mod tests {
 
     fn drive_guarded_io<T>(
         io: &StepGuardedIO,
-        mut action: impl FnMut() -> Result<IOResult<T>>,
+        mut action: impl FnMut() -> crate::types::IOResultOr<T>,
     ) -> (T, usize) {
         let mut io_yields = 0usize;
         loop {

--- a/core/json/error.rs
+++ b/core/json/error.rs
@@ -61,3 +61,10 @@ impl From<Error> for crate::LimboError {
         }
     }
 }
+
+/// Composes with the boxing used by `InsnResult` (see core/error.rs).
+impl From<Error> for Box<crate::LimboError> {
+    fn from(err: Error) -> Self {
+        Box::new(crate::LimboError::from(err))
+    }
+}

--- a/core/mvcc/cursor.rs
+++ b/core/mvcc/cursor.rs
@@ -1,6 +1,7 @@
 use crate::alloc::{ConcurrentAllocator, TryReserveError, TursoAllocator};
 use crate::skiplist::{comparator::BasicComparator, map::Entry};
 use crate::turso_assert;
+use crate::types::IOResultOr;
 
 use crate::mvcc::clock::LogicalClock;
 use crate::mvcc::database::{
@@ -634,7 +635,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     }
 
     /// Returns the current row as an immutable record.
-    pub fn current_row(&mut self) -> Result<IOResult<Option<&crate::types::ImmutableRecord>>> {
+    pub fn current_row(&mut self) -> IOResultOr<Option<&crate::types::ImmutableRecord>> {
         if self.get_null_flag() {
             return Ok(IOResult::Done(None));
         }
@@ -728,7 +729,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
         Ok(())
     }
 
-    pub fn start_new_rowid(&mut self) -> Result<IOResult<NextRowidResult>> {
+    pub fn start_new_rowid(&mut self) -> IOResultOr<NextRowidResult> {
         tracing::trace!("start_new_rowid");
 
         let allocator = self.db.get_rowid_allocator(&self.table_id);
@@ -842,16 +843,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     }
 
     /// Advance btree cursor forward and set btree peek to the first valid row key (skipping rows shadowed by MVCC)
-    fn advance_btree_forward(&mut self) -> Result<IOResult<()>> {
+    fn advance_btree_forward(&mut self) -> IOResultOr<()> {
         self._advance_btree_forward(true)
     }
 
     /// Advance btree cursor forward from current position (cursor already positioned by seek)
-    fn advance_btree_forward_from_current(&mut self) -> Result<IOResult<()>> {
+    fn advance_btree_forward_from_current(&mut self) -> IOResultOr<()> {
         self._advance_btree_forward(false)
     }
 
-    fn _advance_btree_forward(&mut self, initialize: bool) -> Result<IOResult<()>> {
+    fn _advance_btree_forward(&mut self, initialize: bool) -> IOResultOr<()> {
         loop {
             let state = self.btree_advance_state;
             match state {
@@ -929,16 +930,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     }
 
     /// Advance btree cursor backward and set btree peek to the first valid row key (skipping rows shadowed by MVCC)
-    fn advance_btree_backward(&mut self) -> Result<IOResult<()>> {
+    fn advance_btree_backward(&mut self) -> IOResultOr<()> {
         self._advance_btree_backward(true)
     }
 
     /// Advance btree cursor backward from current position (cursor already positioned by seek)
-    fn advance_btree_backward_from_current(&mut self) -> Result<IOResult<()>> {
+    fn advance_btree_backward_from_current(&mut self) -> IOResultOr<()> {
         self._advance_btree_backward(false)
     }
 
-    fn _advance_btree_backward(&mut self, initialize: bool) -> Result<IOResult<()>> {
+    fn _advance_btree_backward(&mut self, initialize: bool) -> IOResultOr<()> {
         loop {
             let state = self.btree_advance_state;
             match state {
@@ -1074,11 +1075,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> MvccLazyCursor<Clock
     /// Seek btree cursor and set btree_peek to the result.
     /// Skips rows that are shadowed by MVCC.
     /// Returns IOResult indicating if we need to yield for IO or are done.
-    fn seek_btree_and_set_peek(
-        &mut self,
-        seek_key: SeekKey<'_>,
-        op: SeekOp,
-    ) -> Result<IOResult<()>> {
+    fn seek_btree_and_set_peek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> IOResultOr<()> {
         // Fast path: btree not allocated
         if !self.is_btree_allocated() {
             self.dual_peek.btree_peek = CursorPeek::Exhausted;
@@ -1206,7 +1203,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> Drop for MvccLazyCur
 impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     for MvccLazyCursor<Clock, A>
 {
-    fn last(&mut self) -> Result<IOResult<()>> {
+    fn last(&mut self) -> IOResultOr<()> {
         // A cursor may be NullRow'd during outer-join unmatched emission.
         // Repositioning to a real row must clear that synthetic NULL state.
         self.set_null_flag(false);
@@ -1281,7 +1278,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     /// Move the cursor to the next row. Returns true if the cursor moved to the next row, false if the cursor is at the end of the table.
     ///
     /// Uses dual-cursor approach: only advances the cursor that was just consumed.
-    fn next(&mut self) -> Result<IOResult<()>> {
+    fn next(&mut self) -> IOResultOr<()> {
         if self.state.is_none() {
             // If BeforeFirst and peek not initialized, initialize the iterators and peek values
             let current_pos = self.get_current_pos();
@@ -1377,7 +1374,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
     /// Move the cursor to the previous row. Returns true if the cursor moved, false if at the beginning.
     ///
     /// Uses dual-cursor approach: only advances the cursor that was just consumed.
-    fn prev(&mut self) -> Result<IOResult<()>> {
+    fn prev(&mut self) -> IOResultOr<()> {
         if self.state.is_none() {
             // If End and peek not initialized, initialize via last()
             let current_pos = self.get_current_pos();
@@ -1464,7 +1461,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         Ok(IOResult::Done(()))
     }
 
-    fn rowid(&mut self) -> Result<IOResult<Option<i64>>> {
+    fn rowid(&mut self) -> IOResultOr<Option<i64>> {
         if self.get_null_flag() {
             return Ok(IOResult::Done(None));
         }
@@ -1500,20 +1497,16 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         Ok(IOResult::Done(rowid))
     }
 
-    fn record(&mut self) -> Result<IOResult<Option<&crate::types::ImmutableRecord>>> {
+    fn record(&mut self) -> IOResultOr<Option<&crate::types::ImmutableRecord>> {
         self.current_row()
     }
 
-    fn seek_unpacked(
-        &mut self,
-        registers: &[Register],
-        op: SeekOp,
-    ) -> Result<IOResult<SeekResult>> {
+    fn seek_unpacked(&mut self, registers: &[Register], op: SeekOp) -> IOResultOr<SeekResult> {
         let record = ImmutableRecord::from_registers(registers, registers.len())?;
         self.seek(SeekKey::IndexKey(record.as_record_ref()), op)
     }
 
-    fn seek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> Result<IOResult<SeekResult>> {
+    fn seek(&mut self, seek_key: SeekKey<'_>, op: SeekOp) -> IOResultOr<SeekResult> {
         // gt -> lower_bound bound excluded, we want first row after row_id
         // ge -> lower_bound bound included, we want first row equal to row_id or first row after row_id
         // lt -> upper_bound bound excluded, we want last row before row_id
@@ -1752,7 +1745,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
 
     /// Insert a row into the table or index.
     /// Sets the cursor to the inserted row.
-    fn insert(&mut self, key: &BTreeKey) -> Result<IOResult<()>> {
+    fn insert(&mut self, key: &BTreeKey) -> IOResultOr<()> {
         let row_id = match key {
             BTreeKey::TableRowId((rowid, _)) => RowID::new(self.table_id, RowKey::Int(*rowid)),
             BTreeKey::IndexKey(record) => {
@@ -1772,7 +1765,8 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 let BTreeKey::TableRowId((_, record)) = key else {
                     return Err(LimboError::InternalError(
                         "Table cursor requires a TableRowId key".to_string(),
-                    ));
+                    )
+                    .into());
                 };
                 let record = record.as_ref().ok_or_else(|| {
                     LimboError::InternalError("TableRowId should have a record".to_string())
@@ -1792,7 +1786,8 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
                 let BTreeKey::IndexKey(record) = key else {
                     return Err(LimboError::InternalError(
                         "Index cursor requires an IndexKey".to_string(),
-                    ));
+                    )
+                    .into());
                 };
                 Ok(Row::new_index_row(row_id, record.column_count()))
             }
@@ -1849,7 +1844,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         Ok(IOResult::Done(()))
     }
 
-    fn delete(&mut self) -> Result<IOResult<()>> {
+    fn delete(&mut self) -> IOResultOr<()> {
         let (rowid, in_btree) = match self.get_current_pos() {
             CursorPosition::Loaded {
                 row_id, in_btree, ..
@@ -1926,7 +1921,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         self.null_flag
     }
 
-    fn exists(&mut self, key: &Value) -> Result<IOResult<bool>> {
+    fn exists(&mut self, key: &Value) -> IOResultOr<bool> {
         if self.state.is_none() {
             self.invalidate_record();
             let int_key = match key {
@@ -2052,15 +2047,15 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         }
     }
 
-    fn clear_btree(&mut self) -> Result<IOResult<Option<usize>>> {
+    fn clear_btree(&mut self) -> IOResultOr<Option<usize>> {
         todo!()
     }
 
-    fn btree_destroy(&mut self) -> Result<IOResult<Option<usize>>> {
+    fn btree_destroy(&mut self) -> IOResultOr<Option<usize>> {
         todo!()
     }
 
-    fn count(&mut self) -> Result<IOResult<usize>> {
+    fn count(&mut self) -> IOResultOr<usize> {
         loop {
             let state = self.count_state;
             match state {
@@ -2115,7 +2110,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         self.table_id.into()
     }
 
-    fn rewind(&mut self) -> Result<IOResult<()>> {
+    fn rewind(&mut self) -> IOResultOr<()> {
         // A cursor may be NullRow'd during outer-join unmatched emission.
         // Repositioning to a real row must clear that synthetic NULL state.
         self.set_null_flag(false);
@@ -2199,7 +2194,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         }
     }
 
-    fn seek_end(&mut self) -> Result<IOResult<()>> {
+    fn seek_end(&mut self) -> IOResultOr<()> {
         if self.is_btree_allocated() {
             // Defer to btree cursor's seek_end implementation
             self.btree_cursor.seek_end()
@@ -2210,7 +2205,7 @@ impl<Clock: LogicalClock + 'static, A: ConcurrentAllocator> CursorTrait
         }
     }
 
-    fn seek_to_last(&mut self) -> Result<IOResult<()>> {
+    fn seek_to_last(&mut self) -> IOResultOr<()> {
         match self.seek(SeekKey::TableRowId(i64::MAX), SeekOp::LE { eq_only: false })? {
             IOResult::Done(_) => Ok(IOResult::Done(())),
             IOResult::IO(iocompletions) => Ok(IOResult::IO(iocompletions)),

--- a/core/mvcc/database/checkpoint_state_machine.rs
+++ b/core/mvcc/database/checkpoint_state_machine.rs
@@ -20,6 +20,7 @@ use crate::storage::wal::{CheckpointMode, TursoRwLock, WalAutoActions};
 use crate::sync::atomic::Ordering;
 use crate::sync::Arc;
 use crate::sync::RwLock;
+use crate::types::IOResultOr;
 use crate::types::{IOCompletions, IOResult, ImmutableRecord, ImmutableRecordRef};
 use crate::{turso_assert, turso_assert_eq};
 use crate::{
@@ -483,7 +484,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> SeqCompactDriver<Clock, A> {
     /// any cursor page IO so the caller can yield up; returns
     /// `IOResult::Done(())` when every pending backing table has been
     /// compacted to its single watermark row.
-    fn step(&mut self) -> Result<IOResult<()>> {
+    fn step(&mut self) -> IOResultOr<()> {
         loop {
             let Some(seq) = self.pending.get(self.current_idx).copied() else {
                 return Ok(IOResult::Done(()));
@@ -1468,7 +1469,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
     }
 
     /// Perform a TRUNCATE checkpoint on the WAL
-    fn checkpoint_wal(&self) -> Result<IOResult<CheckpointResult>> {
+    fn checkpoint_wal(&self) -> IOResultOr<CheckpointResult> {
         let Some(wal) = &self.pager.wal else {
             panic!("No WAL to checkpoint");
         };
@@ -2859,8 +2860,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                     }
                     Ok(IOResult::IO(io)) => Ok(TransitionResult::Io(io)),
                     // Busy under a DbFile reader: finish without publishing nbackfills.
-                    Err(crate::LimboError::Busy)
-                        if matches!(self.mode, CheckpointMode::Passive { .. }) =>
+                    Err(err)
+                        if matches!(*err, crate::LimboError::Busy)
+                            && matches!(self.mode, CheckpointMode::Passive { .. }) =>
                     {
                         tracing::debug!(
                             "Passive WAL checkpoint Busy under pinned DbFile reader; continuing without backfill"
@@ -2876,7 +2878,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> CheckpointStateMachine<Clock, 
                         self.state = CheckpointState::TruncateLogicalLog;
                         Ok(TransitionResult::Continue)
                     }
-                    Err(e) => Err(e),
+                    Err(e) => Err(*e),
                 }
             }
 

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -29,6 +29,7 @@ use crate::translate::plan::IterationDirection;
 use crate::types::compare_immutable;
 use crate::types::IOCompletions;
 use crate::types::IOResult;
+use crate::types::IOResultOr;
 use crate::types::ImmutableRecord;
 use crate::types::ImmutableRecordRef;
 use crate::types::IndexInfo;
@@ -4932,7 +4933,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut InitMetadataTableState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match st {
                 InitMetadataTableState::Start => {
@@ -4986,7 +4987,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut ReadPersistentTxTsMaxState,
-    ) -> Result<IOResult<Option<u64>>> {
+    ) -> IOResultOr<Option<u64>> {
         loop {
             match st {
                 ReadPersistentTxTsMaxState::Start => {
@@ -5002,7 +5003,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         Err(err) => {
                             return Err(LimboError::Corrupt(format!(
                                 "Failed to read MVCC metadata table: {err}"
-                            )));
+                            ))
+                            .into());
                         }
                     };
                     match maybe_stmt {
@@ -5015,7 +5017,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         // No statement to run — fall through to the missing-row
                         // error path (matches the blocking variant).
                         None => {
-                            return Self::validate_persistent_tx_ts_max(None).map(IOResult::Done);
+                            return Self::validate_persistent_tx_ts_max(None)
+                                .map(IOResult::Done)
+                                .map_err(Into::into);
                         }
                     }
                 }
@@ -5026,7 +5030,9 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                     }));
                     let value = *value;
                     *st = ReadPersistentTxTsMaxState::Start;
-                    return Self::validate_persistent_tx_ts_max(value).map(IOResult::Done);
+                    return Self::validate_persistent_tx_ts_max(value)
+                        .map(IOResult::Done)
+                        .map_err(Into::into);
                 }
             }
         }
@@ -5054,7 +5060,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         bootstrap_conn: &Arc<Connection>,
         st: &mut BootstrapState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             match st {
                 BootstrapState::Start => {
@@ -8869,7 +8875,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut CompleteCheckpointState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let pager = connection.pager.load().clone();
         let Some(wal) = &pager.wal else {
             return Ok(IOResult::Done(()));
@@ -8910,7 +8916,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         return Err(LimboError::Corrupt(
                             "Cannot reconcile interrupted MVCC checkpoint in read-only mode"
                                 .to_string(),
-                        ));
+                        )
+                        .into());
                     }
                     match header_result {
                         HeaderReadResult::Valid(header) => {
@@ -8924,7 +8931,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 return Err(LimboError::Corrupt(
                                     "WAL has committed frames but logical log header is missing"
                                         .to_string(),
-                                ));
+                                )
+                                .into());
                             }
                         }
                         HeaderReadResult::Invalid => {
@@ -8933,7 +8941,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             return Err(LimboError::Corrupt(
                                 "WAL has committed frames but logical log header is invalid"
                                     .to_string(),
-                            ));
+                            )
+                            .into());
                         }
                     }
                     // Enter the checkpoint lifecycle before any WAL→DB backfill so
@@ -8976,7 +8985,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                         // Close out the lifecycle opened in `ReadingHeader` so the
                         // start/end pairing stays balanced on this error path.
                         self.storage.on_checkpoint_end(Err(err.clone()))?;
-                        return Err(err);
+                        return Err(err.into());
                     }
                     let need_db_sync = connection.get_sync_mode() != SyncMode::Off
                         && checkpoint_result.wal_checkpoint_backfilled > 0;
@@ -8988,7 +8997,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             Ok(c) => c,
                             Err(err) => {
                                 self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                return Err(err);
+                                return Err(err.into());
                             }
                         };
                         *st = CompleteCheckpointState::AwaitDbFileSync {
@@ -9029,7 +9038,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             Ok(c) => c,
                             Err(err) => {
                                 self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                return Err(err);
+                                return Err(err.into());
                             }
                         };
                         *phase = RetryHeaderPhase::AwaitUpdateHeader(c);
@@ -9044,7 +9053,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                 Ok(c) => c,
                                 Err(err) => {
                                     self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                    return Err(err);
+                                    return Err(err.into());
                                 }
                             };
                             *phase = RetryHeaderPhase::AwaitLogSync(c);
@@ -9080,7 +9089,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                                     "Logical log header CRC mismatch after retry".to_string(),
                                 );
                                 self.storage.on_checkpoint_end(Err(err.clone()))?;
-                                return Err(err);
+                                return Err(err.into());
                             }
                             *retried_crc = true;
                             *phase = RetryHeaderPhase::NeedUpdateHeader;
@@ -9096,7 +9105,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             return Ok(IOResult::IO(c));
                         }
                         Err(err) => {
-                            self.storage.on_checkpoint_end(Err(err.clone()))?;
+                            self.storage.on_checkpoint_end(Err((*err).clone()))?;
                             return Err(err);
                         }
                     }
@@ -9299,7 +9308,7 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
         &self,
         connection: &Arc<Connection>,
         st: &mut RecoverLogicalLogState,
-    ) -> Result<IOResult<bool>> {
+    ) -> IOResultOr<bool> {
         loop {
             match st {
                 RecoverLogicalLogState::Start => {
@@ -9321,7 +9330,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             return Err(LimboError::Corrupt(
                                 "Logical log header corrupt and no WAL recovery available"
                                     .to_string(),
-                            ));
+                            )
+                            .into());
                         }
                     };
                     if let Some(header) = &header {
@@ -9357,7 +9367,8 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
                             None => {
                                 return Err(LimboError::Corrupt(
                                     "Missing MVCC metadata table".to_string(),
-                                ));
+                                )
+                                .into());
                             }
                         }
                     } else {

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -9512,7 +9512,7 @@ fn test_mvcc_integrity_check() {
 #[test]
 fn test_checkpoint_index_writer_overwrites_existing_interior_key() {
     fn run_pager_until_done<T>(
-        mut action: impl FnMut() -> Result<IOResult<T>>,
+        mut action: impl FnMut() -> IOResultOr<T>,
         pager: &Pager,
     ) -> Result<T> {
         loop {

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -235,6 +235,7 @@ use crate::io::{FileSyncType, SharedBufferData};
 use crate::sync::Arc;
 use crate::sync::RwLock;
 use crate::turso_assert;
+use crate::types::IOResultOr;
 use crate::{
     alloc::{ConcurrentAllocator, TursoAllocator},
     io::{CompletionGroup, ReadComplete},
@@ -1760,7 +1761,7 @@ impl StreamingLogicalLogReader {
         io.block(|| self.try_read_header_nonblock())
     }
 
-    pub(crate) fn try_read_header_nonblock(&mut self) -> Result<IOResult<HeaderReadResult>> {
+    pub(crate) fn try_read_header_nonblock(&mut self) -> IOResultOr<HeaderReadResult> {
         self.file_size = self.file.size()? as usize;
         if self.file_size < LOG_HDR_SIZE {
             return Ok(IOResult::Done(HeaderReadResult::NoLog));
@@ -1793,7 +1794,7 @@ impl StreamingLogicalLogReader {
                 self.set_invalid_header_state();
                 Ok(IOResult::Done(HeaderReadResult::Invalid))
             }
-            Err(err) => Err(err),
+            Err(err) => Err(err.into()),
         }
     }
 
@@ -1821,7 +1822,7 @@ impl StreamingLogicalLogReader {
     /// Recovery needs the whole frame so it can decide which schema snapshot should decode each
     /// index op. Empty parsed frames are skipped, so callers that receive Some(frame) can
     /// rely on `frame` being non-empty.
-    pub(crate) fn next_frame(&mut self) -> Result<IOResult<Option<Vec<ParsedOp>>>> {
+    pub(crate) fn next_frame(&mut self) -> IOResultOr<Option<Vec<ParsedOp>>> {
         loop {
             match self.state {
                 StreamingState::NeedTransactionStart => {
@@ -1907,7 +1908,7 @@ impl StreamingLogicalLogReader {
     /// Empty payloads are returned because internal-only commits still
     /// advance the logical-log offset even though clients have no operation to
     /// apply.
-    pub fn next_portable_change_frame(&mut self) -> Result<IOResult<Option<PortableChangeFrame>>> {
+    pub fn next_portable_change_frame(&mut self) -> IOResultOr<Option<PortableChangeFrame>> {
         self.file_size = self.file.size()? as usize;
         match return_if_io!(self.parse_next_portable_changes_frame()) {
             ParseResult::Frame(frame) => Ok(IOResult::Done(Some(PortableChangeFrame {
@@ -1925,7 +1926,7 @@ impl StreamingLogicalLogReader {
     ///
     /// Empty payloads are valid: internal-only commits still need recovery
     /// log frames, but they do not produce client-visible logical operations.
-    pub fn next_portable_changes(&mut self) -> Result<IOResult<Option<PortableChangeFrame>>> {
+    pub fn next_portable_changes(&mut self) -> IOResultOr<Option<PortableChangeFrame>> {
         loop {
             let Some(frame) = return_if_io!(self.next_portable_change_frame()) else {
                 return Ok(IOResult::Done(None));
@@ -2002,7 +2003,7 @@ impl StreamingLogicalLogReader {
         payload_ctx: &EncryptedPayloadReadContext,
         chunk_index: usize,
         running_crc: u32,
-    ) -> Result<IOResult<EncryptedChunkReadResult>> {
+    ) -> IOResultOr<EncryptedChunkReadResult> {
         // first we gotta figure out, how many bytes to read off the disk, its either
         // `self.encrypted_payload_chunk_size` or the remainder in the last chunk
         let plaintext_len = encrypted_chunk_plaintext_len(
@@ -2060,7 +2061,7 @@ impl StreamingLogicalLogReader {
         if decrypted_plaintext_len != plaintext_len {
             return Err(LimboError::Corrupt(format!(
                 "decrypted chunk length mismatch: expected {plaintext_len}, got {decrypted_plaintext_len}"
-            )));
+            )).into());
         }
 
         Ok(IOResult::Done(EncryptedChunkReadResult::Ok {
@@ -2173,7 +2174,7 @@ impl StreamingLogicalLogReader {
         payload_size: usize,
         commit_ts: u64,
         running_crc: u32,
-    ) -> Result<IOResult<PayloadParseResult>> {
+    ) -> IOResultOr<PayloadParseResult> {
         let (nonce_size, tag_size) = {
             let enc = self
                 .encryption_ctx
@@ -2230,7 +2231,7 @@ impl StreamingLogicalLogReader {
                 if parsed_ops.len() == op_count as usize {
                     return Err(LimboError::Corrupt(format!(
                         "encrypted payload has trailing carried bytes after parsing all {op_count} ops"
-                    )));
+                    )).into());
                 }
                 // carry holds the prefix of an op that was split by the previous chunk boundary.
                 // Try to finish that carried op using bytes from the current decrypted chunk.
@@ -2249,7 +2250,8 @@ impl StreamingLogicalLogReader {
                     Err(e) => {
                         return Err(LimboError::Corrupt(format!(
                             "encrypted carried-op parse error: {e}"
-                        )));
+                        ))
+                        .into());
                     }
                 }
             }
@@ -2282,7 +2284,8 @@ impl StreamingLogicalLogReader {
             return Err(LimboError::Corrupt(format!(
                 "encrypted payload ended after {} parsed ops, expected {op_count}",
                 parsed_ops.len()
-            )));
+            ))
+            .into());
         }
 
         // once we have parsed the full payload, carry must be empty
@@ -2290,7 +2293,8 @@ impl StreamingLogicalLogReader {
             return Err(LimboError::Corrupt(format!(
                 "encrypted payload has {} trailing plaintext bytes after parsing all ops",
                 carry.len()
-            )));
+            ))
+            .into());
         }
 
         Ok(IOResult::Done(PayloadParseResult::Ok(
@@ -2305,7 +2309,7 @@ impl StreamingLogicalLogReader {
         op_count: u32,
         commit_ts: u64,
         running_crc: u32,
-    ) -> Result<IOResult<ReadEncryptedResult>> {
+    ) -> IOResultOr<ReadEncryptedResult> {
         let (nonce_size, tag_size) = {
             let enc = self
                 .encryption_ctx
@@ -2345,7 +2349,8 @@ impl StreamingLogicalLogReader {
             return Err(LimboError::Corrupt(format!(
                 "encrypted plaintext size mismatch: expected {plaintext_size}, got {}",
                 plaintext.len()
-            )));
+            ))
+            .into());
         }
         Ok(IOResult::Done(Some((plaintext, running_crc))))
     }
@@ -2358,7 +2363,7 @@ impl StreamingLogicalLogReader {
     /// mid-op IO yield re-parses only the in-flight op on re-entry and the buffer
     /// compacts as ops are consumed. Corruption is reported as
     /// `Err(LimboError::Corrupt(..))`; the caller maps it to an invalid frame.
-    fn parse_streaming_payload(&mut self) -> Result<IOResult<PayloadOutcome>> {
+    fn parse_streaming_payload(&mut self) -> IOResultOr<PayloadOutcome> {
         loop {
             let (op_index, op_count, commit_ts) = {
                 let fip = self
@@ -2379,7 +2384,8 @@ impl StreamingLogicalLogReader {
                 if payload_size as u64 != payload_bytes_read {
                     return Err(LimboError::Corrupt(format!(
                         "payload_size ({payload_size}) != payload_bytes_read ({payload_bytes_read})"
-                    )));
+                    ))
+                    .into());
                 }
                 return Ok(IOResult::Done(PayloadOutcome::Ok));
             }
@@ -2412,7 +2418,8 @@ impl StreamingLogicalLogReader {
                     if flags & !OP_ALLOWED_FLAGS != 0 || table_id_i32 >= 0 {
                         return Err(LimboError::Corrupt(format!(
                             "invalid op flags={flags:#x} or table_id={table_id_i32} for tag={tag}"
-                        )));
+                        ))
+                        .into());
                     }
                     Some(MVTableId::from(table_id_i32 as i64))
                 }
@@ -2420,12 +2427,12 @@ impl StreamingLogicalLogReader {
                     if flags != 0 || table_id_i32 != 0 {
                         return Err(LimboError::Corrupt(format!(
                             "OP_UPDATE_HEADER has non-zero flags={flags:#x} or table_id={table_id_i32}"
-                        )));
+                        )).into());
                     }
                     None
                 }
                 _ => {
-                    return Err(LimboError::Corrupt(format!("unknown op tag {tag}")));
+                    return Err(LimboError::Corrupt(format!("unknown op tag {tag}")).into());
                 }
             };
             let btree_resident = (flags & OP_FLAG_BTREE_RESIDENT) != 0;
@@ -2488,7 +2495,8 @@ impl StreamingLogicalLogReader {
                     if rowid_len > payload.len() {
                         return Err(LimboError::Corrupt(
                             "upsert op rowid varint extends beyond payload".to_string(),
-                        ));
+                        )
+                        .into());
                     }
                     let mut payload = payload;
                     let record_bytes = payload.split_off(rowid_len);
@@ -2512,7 +2520,8 @@ impl StreamingLogicalLogReader {
                         return Err(LimboError::Corrupt(format!(
                             "delete op rowid varint len {rowid_len} > payload len {}",
                             payload.len()
-                        )));
+                        ))
+                        .into());
                     }
                     let rowid_i64 = rowid_u64 as i64;
                     let mut payload = payload;
@@ -2558,7 +2567,8 @@ impl StreamingLogicalLogReader {
                             "OP_UPDATE_HEADER payload len {} != DatabaseHeader::SIZE {}",
                             payload.len(),
                             DatabaseHeader::SIZE
-                        )));
+                        ))
+                        .into());
                     }
                     let mut bytes = [0u8; DatabaseHeader::SIZE];
                     bytes.copy_from_slice(&payload);
@@ -2566,14 +2576,15 @@ impl StreamingLogicalLogReader {
                     if header.magic != *b"SQLite format 3\0" {
                         return Err(LimboError::Corrupt(
                             "OP_UPDATE_HEADER has invalid SQLite magic".to_string(),
-                        ));
+                        )
+                        .into());
                     }
                     ParsedOp::UpdateHeader { header, commit_ts }
                 }
                 _ => {
-                    return Err(LimboError::Corrupt(format!(
-                        "unknown op tag {tag} in payload"
-                    )));
+                    return Err(
+                        LimboError::Corrupt(format!("unknown op tag {tag} in payload")).into(),
+                    );
                 }
             };
 
@@ -2604,7 +2615,7 @@ impl StreamingLogicalLogReader {
     /// `buffer_offset` to `frame_anchor` and re-runs just the in-flight unit from
     /// local state. `frame_start` is captured once at frame open (never
     /// recomputed) so an invalid frame reports the correct `last_valid_offset`.
-    fn parse_next_transaction(&mut self) -> Result<IOResult<ParseResult>> {
+    fn parse_next_transaction(&mut self) -> IOResultOr<ParseResult> {
         loop {
             if self.frame_in_progress.is_none() {
                 // Start a fresh frame at the current consume cursor.
@@ -2677,7 +2688,7 @@ impl StreamingLogicalLogReader {
                             tracing::warn!("corrupt extension block: {msg}");
                             return self.invalidate_frame();
                         }
-                        Err(e) => return Err(e),
+                        Err(e) => return Err(e.into()),
                     };
                     {
                         let fip = self.frame_in_progress.as_mut().expect("frame in progress");
@@ -2697,8 +2708,8 @@ impl StreamingLogicalLogReader {
                     }
                     Ok(IOResult::Done(PayloadOutcome::Eof)) => return self.abort_frame_eof(),
                     Ok(IOResult::IO(io)) => return Ok(IOResult::IO(io)),
-                    Err(LimboError::Corrupt(msg)) => {
-                        tracing::warn!("corrupt payload: {msg}");
+                    Err(err) if matches!(*err, LimboError::Corrupt(_)) => {
+                        tracing::warn!("corrupt payload: {err}");
                         return self.invalidate_frame();
                     }
                     Err(e) => return Err(e),
@@ -2745,7 +2756,7 @@ impl StreamingLogicalLogReader {
     /// re-entry. The chained CRC is seeded from `self.running_crc` and folded
     /// over the header bytes. Field/structural problems return `Invalid`; the
     /// caller sets `last_valid_offset` from the captured `frame_start`.
-    fn parse_frame_header(&mut self) -> Result<IOResult<HeaderParseOutcome>> {
+    fn parse_frame_header(&mut self) -> IOResultOr<HeaderParseOutcome> {
         // TX HEADER v2 layout (24 bytes):
         // FRAME_MAGIC(4) | payload_size(8) | op_count(4) | commit_ts(8)
         //
@@ -2880,7 +2891,7 @@ impl StreamingLogicalLogReader {
     /// and store their result into `frame_in_progress` once complete. Corruption
     /// propagates as `Err(LimboError::Corrupt(..))` for the caller to map to an
     /// invalid frame.
-    fn parse_payload_phase(&mut self) -> Result<IOResult<PayloadOutcome>> {
+    fn parse_payload_phase(&mut self) -> IOResultOr<PayloadOutcome> {
         let (payload_size, op_count, commit_ts, extension_size, extension_record_count, header_crc) = {
             let fip = self.frame_in_progress.as_ref().expect("frame in progress");
             (
@@ -2970,7 +2981,7 @@ impl StreamingLogicalLogReader {
     /// it without advancing the chain — `last_valid_offset`/`running_crc` stay at
     /// the last fully committed frame. EOF is terminal for a recovery pass
     /// (`file_size` is fixed once recovery starts).
-    fn abort_frame_eof(&mut self) -> Result<IOResult<ParseResult>> {
+    fn abort_frame_eof(&mut self) -> IOResultOr<ParseResult> {
         self.frame_in_progress = None;
         Ok(IOResult::Done(ParseResult::Eof))
     }
@@ -2979,7 +2990,7 @@ impl StreamingLogicalLogReader {
     /// Set `last_valid_offset` to the captured frame start so the writer
     /// overwrites the torn frame on the next append, and drop the frame without
     /// advancing the chain.
-    fn invalidate_frame(&mut self) -> Result<IOResult<ParseResult>> {
+    fn invalidate_frame(&mut self) -> IOResultOr<ParseResult> {
         let frame_start = self
             .frame_in_progress
             .as_ref()
@@ -2993,7 +3004,7 @@ impl StreamingLogicalLogReader {
     /// Commit a fully validated frame: advance `last_valid_offset` to the byte
     /// past the trailer, carry this frame's CRC as the seed for the next frame,
     /// and move the frame anchor past the trailer.
-    fn commit_frame(&mut self) -> Result<IOResult<ParseResult>> {
+    fn commit_frame(&mut self) -> IOResultOr<ParseResult> {
         let fip = self.frame_in_progress.take().expect("frame in progress");
         self.last_valid_offset = self.offset.saturating_sub(self.bytes_can_read());
         self.running_crc = fip.running_crc;
@@ -3012,7 +3023,7 @@ impl StreamingLogicalLogReader {
         &mut self,
         mut amount: usize,
         mut running_crc: u32,
-    ) -> Result<IOResult<Option<u32>>> {
+    ) -> IOResultOr<Option<u32>> {
         const CHUNK_SIZE: usize = 64 * 1024;
         while amount > 0 {
             let chunk_len = amount.min(CHUNK_SIZE);
@@ -3051,7 +3062,7 @@ impl StreamingLogicalLogReader {
         Ok(on_disk_size)
     }
 
-    fn parse_next_portable_changes_frame(&mut self) -> Result<IOResult<ParseResult>> {
+    fn parse_next_portable_changes_frame(&mut self) -> IOResultOr<ParseResult> {
         // See `parse_next_transaction`: rewind to the frame anchor so a mid-frame
         // IO yield resumes correctly on re-entry.
         self.buffer_offset = self.frame_anchor;
@@ -3195,7 +3206,7 @@ impl StreamingLogicalLogReader {
                 self.last_valid_offset = frame_start;
                 return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
-            Err(e) => return Err(e),
+            Err(e) => return Err(e.into()),
         };
         let (portable_changes, running_crc) = if encrypted_extension_size > 0 {
             let plaintext_size = payload_size
@@ -3222,7 +3233,7 @@ impl StreamingLogicalLogReader {
                     self.last_valid_offset = frame_start;
                     return Ok(IOResult::Done(ParseResult::InvalidFrame));
                 }
-                Err(e) => return Err(e),
+                Err(e) => return Err(e.into()),
             };
             (portable_changes, running_crc)
         } else {
@@ -3241,7 +3252,7 @@ impl StreamingLogicalLogReader {
                                 self.last_valid_offset = frame_start;
                                 return Ok(IOResult::Done(ParseResult::InvalidFrame));
                             }
-                            Err(e) => return Err(e),
+                            Err(e) => return Err(e.into()),
                         };
                         (portable_changes, running_crc)
                     }
@@ -3404,7 +3415,7 @@ impl StreamingLogicalLogReader {
         bytes_in_buffer + bytes_in_file
     }
 
-    fn try_consume_bytes(&mut self, amount: usize) -> Result<IOResult<Option<crate::ValueBlob>>> {
+    fn try_consume_bytes(&mut self, amount: usize) -> IOResultOr<Option<crate::ValueBlob>> {
         if self.remaining_bytes() < amount {
             return Ok(IOResult::Done(None));
         }
@@ -3417,7 +3428,7 @@ impl StreamingLogicalLogReader {
         Ok(IOResult::Done(Some(bytes)))
     }
 
-    fn try_consume_fixed<const N: usize>(&mut self) -> Result<IOResult<Option<[u8; N]>>> {
+    fn try_consume_fixed<const N: usize>(&mut self) -> IOResultOr<Option<[u8; N]>> {
         if self.remaining_bytes() < N {
             return Ok(IOResult::Done(None));
         }
@@ -3431,7 +3442,7 @@ impl StreamingLogicalLogReader {
         Ok(IOResult::Done(Some(out)))
     }
 
-    fn try_consume_u8(&mut self) -> Result<IOResult<Option<u8>>> {
+    fn try_consume_u8(&mut self) -> IOResultOr<Option<u8>> {
         if self.remaining_bytes() == 0 {
             return Ok(IOResult::Done(None));
         }
@@ -3448,7 +3459,7 @@ impl StreamingLogicalLogReader {
     /// this reads byte-by-byte via `try_consume_u8` to handle streaming I/O where
     /// the varint may span a buffer boundary. Returns `None` on EOF (short read).
     #[allow(clippy::type_complexity)]
-    fn consume_varint_bytes(&mut self) -> Result<IOResult<Option<(u64, [u8; 9], usize)>>> {
+    fn consume_varint_bytes(&mut self) -> IOResultOr<Option<(u64, [u8; 9], usize)>> {
         let mut v: u64 = 0;
         let mut bytes = [0u8; 9];
         let mut len = 0usize;
@@ -3469,7 +3480,7 @@ impl StreamingLogicalLogReader {
         bytes[len] = c;
         len += 1;
         if (v >> 48) == 0 {
-            return Err(LimboError::Corrupt("Invalid varint".to_string()));
+            return Err(LimboError::Corrupt("Invalid varint".to_string()).into());
         }
         v = (v << 8) + c as u64;
         Ok(IOResult::Done(Some((v, bytes, len))))
@@ -3482,7 +3493,7 @@ impl StreamingLogicalLogReader {
     /// issue a fresh pread, stash it in `self.in_flight_read`, and either
     /// yield the completion (when not synchronously done) or loop to take
     /// the resume branch.
-    fn read_exact_at(&mut self, pos: u64, len: usize) -> Result<IOResult<Vec<u8>>> {
+    fn read_exact_at(&mut self, pos: u64, len: usize) -> IOResultOr<Vec<u8>> {
         loop {
             if let Some(InFlightRead::Exact { completion, .. }) = &self.in_flight_read {
                 if !completion.succeeded() {
@@ -3500,7 +3511,8 @@ impl StreamingLogicalLogReader {
                     return Err(LimboError::Corrupt(format!(
                         "Logical log short read: expected {expected_len}, got {}",
                         result.len()
-                    )));
+                    ))
+                    .into());
                 }
                 return Ok(IOResult::Done(result));
             }
@@ -3543,7 +3555,7 @@ impl StreamingLogicalLogReader {
     /// Non-blocking: a pread in flight is tracked in `self.in_flight_read`
     /// and the method yields its completion until done. Re-entry picks up
     /// where it left off without re-issuing the read.
-    pub fn read_more_data(&mut self, need: usize) -> Result<IOResult<()>> {
+    pub fn read_more_data(&mut self, need: usize) -> IOResultOr<()> {
         loop {
             // Resume hook: a pread that was issued by a previous call to
             // this method completed; observe its result and advance.
@@ -3561,7 +3573,8 @@ impl StreamingLogicalLogReader {
                     return Err(LimboError::Corrupt(format!(
                         "Expected to read more bytes but read 0 bytes at offset {}",
                         self.offset
-                    )));
+                    ))
+                    .into());
                 }
                 self.offset += bytes_read;
             }
@@ -3619,7 +3632,8 @@ impl StreamingLogicalLogReader {
                 return Err(LimboError::Corrupt(format!(
                     "Expected to read {still_need} bytes more but reached end of file at offset {}",
                     self.offset
-                )));
+                ))
+                .into());
             }
 
             let header_buf = Arc::new(Buffer::new_temporary(to_read));

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -14,6 +14,7 @@ use crate::translate::expr::{
 };
 use crate::translate::index::{resolve_index_method_parameters, resolve_sorted_columns};
 use crate::translate::planner::ROWID_STRS;
+use crate::types::IOResultOr;
 use crate::types::{IOResult, ImmutableRecord};
 use crate::util::{exprs_are_equivalent, normalize_ident};
 use crate::vdbe::affinity::Affinity;
@@ -1543,7 +1544,7 @@ impl Schema {
     }
 
     /// Update [Schema] by scanning the first root page (sqlite_schema)
-    /// Returns Result<IOResult<()>> to allow async operation with external IO loop
+    /// Returns IOResultOr<()> to allow async operation with external IO loop
     pub fn make_from_btree(
         &mut self,
         state: &mut MakeFromBtreeState,
@@ -1551,7 +1552,7 @@ impl Schema {
         pager: &Arc<Pager>,
         syms: &SymbolTable,
         dialect: &dyn crate::dialect::Dialect,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let result = self.make_from_btree_internal(state, mv_cursor, pager, syms, dialect);
         if result.is_err() {
             state.cleanup(pager);
@@ -1571,7 +1572,7 @@ impl Schema {
         pager: &Arc<Pager>,
         syms: &SymbolTable,
         dialect: &dyn crate::dialect::Dialect,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             tracing::debug!("make_from_btree: state.phase={:?}", state.phase);
             match &state.phase {
@@ -1579,7 +1580,8 @@ impl Schema {
                     if mv_cursor.is_some() {
                         return Err(crate::LimboError::ParseError(
                             "MVCC is not supported for make_from_btree schema recovery".to_string(),
-                        ));
+                        )
+                        .into());
                     }
 
                     state.cursor = Some(BTreeCursor::new_table(Arc::clone(pager), 1, 10));
@@ -1633,20 +1635,28 @@ impl Schema {
                     // sqlite schema table has 5 columns: type, name, tbl_name, rootpage, sql
                     let ty_value = row.get_value(0)?;
                     let ValueRef::Text(ty) = ty_value else {
-                        return Err(LimboError::ConversionError("Expected text value".into()));
+                        return Err(
+                            LimboError::ConversionError("Expected text value".into()).into()
+                        );
                     };
                     let ValueRef::Text(name) = row.get_value(1)? else {
-                        return Err(LimboError::ConversionError("Expected text value".into()));
+                        return Err(
+                            LimboError::ConversionError("Expected text value".into()).into()
+                        );
                     };
                     let table_name_value = row.get_value(2)?;
                     let ValueRef::Text(table_name) = table_name_value else {
-                        return Err(LimboError::ConversionError("Expected text value".into()));
+                        return Err(
+                            LimboError::ConversionError("Expected text value".into()).into()
+                        );
                     };
                     let root_page_value = row.get_value(3)?;
                     let ValueRef::Numeric(crate::numeric::Numeric::Integer(root_page)) =
                         root_page_value
                     else {
-                        return Err(LimboError::ConversionError("Expected integer value".into()));
+                        return Err(
+                            LimboError::ConversionError("Expected integer value".into()).into()
+                        );
                     };
                     let sql_value = row.get_value(4)?;
                     let sql_textref = match sql_value {

--- a/core/state_machine.rs
+++ b/core/state_machine.rs
@@ -1,3 +1,4 @@
+use crate::types::IOResultOr;
 use crate::{
     types::{IOCompletions, IOResult},
     Result,
@@ -62,7 +63,7 @@ impl<State: StateTransition> StateMachine<State> {
         }
     }
 
-    pub fn step(&mut self, context: &State::Context) -> Result<IOResult<State::SMResult>> {
+    pub fn step(&mut self, context: &State::Context) -> IOResultOr<State::SMResult> {
         loop {
             if self.is_finalized {
                 unreachable!("StateMachine::transition: state machine is finalized");

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -335,7 +335,7 @@ impl std::fmt::Debug for Statement {
 }
 
 impl Statement {
-    pub(crate) fn prepare_index_methods(&mut self) -> Result<crate::IOResult<()>> {
+    pub(crate) fn prepare_index_methods(&mut self) -> crate::types::IOResultOr<()> {
         crate::vdbe::execute::index_method_stage_statement_all(&mut self.state)
     }
 
@@ -617,7 +617,7 @@ impl Statement {
             .step(&mut self.state, &self.pager, self.query_mode, waker);
         for attempt in 0..MAX_SCHEMA_RETRY {
             // Only reprepare if we still need to update schema
-            if !matches!(res, Err(LimboError::SchemaUpdated)) {
+            if !matches!(&res, Err(err) if matches!(**err, LimboError::SchemaUpdated)) {
                 break;
             }
             // In a write transaction, reprepare may not help (e.g. cross-process
@@ -721,7 +721,9 @@ impl Statement {
             self.cleanup_orphaned_seq_inner_tx();
         }
 
-        res
+        // The interpreter chain carries a boxed error to keep per-row returns
+        // register-sized; unbox once at the public boundary.
+        res.map_err(|err| *err)
     }
 
     #[inline]
@@ -741,6 +743,7 @@ impl Statement {
     pub fn step_subprogram(&mut self) -> Result<StepResult> {
         self.program
             .step(&mut self.state, &self.pager, self.query_mode, None)
+            .map_err(|err| *err)
     }
 
     pub fn run_ignore_rows(&mut self) -> Result<()> {
@@ -807,7 +810,7 @@ impl Statement {
     /// Used by engine-internal callers that must stay non-blocking (MVCC
     /// bootstrap/recovery) so they don't call `io.step()` on backends that have
     /// no synchronous IO pump (e.g. WASM).
-    pub fn run_ignore_rows_nonblock(&mut self) -> Result<crate::IOResult<()>> {
+    pub fn run_ignore_rows_nonblock(&mut self) -> crate::types::IOResultOr<()> {
         loop {
             match self.step()? {
                 vdbe::StepResult::Done => return Ok(crate::IOResult::Done(())),
@@ -818,8 +821,8 @@ impl Statement {
                     });
                     return Ok(crate::IOResult::IO(io));
                 }
-                vdbe::StepResult::Interrupt => return Err(LimboError::Interrupt),
-                vdbe::StepResult::Busy => return Err(LimboError::Busy),
+                vdbe::StepResult::Interrupt => return Err(LimboError::Interrupt.into()),
+                vdbe::StepResult::Busy => return Err(LimboError::Busy.into()),
             }
         }
     }
@@ -838,7 +841,7 @@ impl Statement {
     pub fn run_with_row_callback_nonblock(
         &mut self,
         mut func: impl FnMut(&Row) -> Result<()>,
-    ) -> Result<crate::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         loop {
             match self.step()? {
                 vdbe::StepResult::Done => return Ok(crate::IOResult::Done(())),
@@ -851,8 +854,8 @@ impl Statement {
                     });
                     return Ok(crate::IOResult::IO(io));
                 }
-                vdbe::StepResult::Interrupt => return Err(LimboError::Interrupt),
-                vdbe::StepResult::Busy => return Err(LimboError::Busy),
+                vdbe::StepResult::Interrupt => return Err(LimboError::Interrupt.into()),
+                vdbe::StepResult::Busy => return Err(LimboError::Busy.into()),
             }
         }
     }
@@ -1528,7 +1531,7 @@ impl Statement {
                         Err(e) => {
                             capture_reset_error(
                                 &mut reset_error,
-                                e,
+                                *e,
                                 "Error halting statement during reset",
                             );
                             break;

--- a/core/stats.rs
+++ b/core/stats.rs
@@ -1,4 +1,5 @@
 use crate::sync::Arc;
+use crate::types::IOResultOr;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::alloc::TursoVecExt;
@@ -149,7 +150,7 @@ pub enum RefreshAnalyzeStatsState {
 pub fn refresh_analyze_stats_nonblock(
     conn: &Arc<Connection>,
     st: &mut RefreshAnalyzeStatsState,
-) -> Result<IOResult<()>> {
+) -> IOResultOr<()> {
     loop {
         match st {
             RefreshAnalyzeStatsState::Start => {
@@ -207,7 +208,7 @@ fn load_sqlite_stat1_rows_nonblock(
     stmt: &mut Statement,
     schema: &Schema,
     stats: &mut AnalyzeStats,
-) -> Result<crate::types::IOResult<()>> {
+) -> crate::types::IOResultOr<()> {
     crate::return_if_io!(
         stmt.run_with_row_callback_nonblock(|row| { load_sqlite_stat1_row(row, schema, stats) })
     );

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1,3 +1,4 @@
+use crate::types::IOResultOr;
 use branches::{mark_unlikely, unlikely};
 use rustc_hash::FxHashMap as HashMap;
 #[cfg(debug_assertions)]
@@ -662,13 +663,13 @@ pub enum SavePositionResult {
 
 pub trait CursorTrait: Any + Send + Sync {
     /// Move cursor to last entry.
-    fn last(&mut self) -> Result<IOResult<()>>;
+    fn last(&mut self) -> IOResultOr<()>;
     /// Move cursor to next entry.
-    fn next(&mut self) -> Result<IOResult<()>>;
+    fn next(&mut self) -> IOResultOr<()>;
     /// Move cursor to previous entry.
-    fn prev(&mut self) -> Result<IOResult<()>>;
+    fn prev(&mut self) -> IOResultOr<()>;
     /// Get the rowid of the entry the cursor is poiting to if any
-    fn rowid(&mut self) -> Result<IOResult<Option<i64>>>;
+    fn rowid(&mut self) -> IOResultOr<Option<i64>>;
 
     /// Incremental blob I/O — read `len` bytes at `off` within column `column`'s value
     /// into `out`. Only table (rowid) b-tree cursors support this; the default errors.
@@ -678,28 +679,26 @@ pub trait CursorTrait: Any + Send + Sync {
         _off: usize,
         _len: usize,
         _out: &mut crate::ValueBlob,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         Err(LimboError::InternalError(
             "incremental blob I/O is only supported on table rows".to_string(),
-        ))
+        )
+        .into())
     }
     /// Incremental blob I/O — write `data` at `off` within column `column`'s value.
-    fn blob_write_column(
-        &mut self,
-        _column: usize,
-        _off: usize,
-        _data: &[u8],
-    ) -> Result<IOResult<()>> {
+    fn blob_write_column(&mut self, _column: usize, _off: usize, _data: &[u8]) -> IOResultOr<()> {
         Err(LimboError::InternalError(
             "incremental blob I/O is only supported on table rows".to_string(),
-        ))
+        )
+        .into())
     }
     /// Byte length of column `column`'s value on the current row, validating that
     /// the value is byte-addressable (TEXT or BLOB).
-    fn blob_column_len(&mut self, _column: usize) -> Result<IOResult<usize>> {
+    fn blob_column_len(&mut self, _column: usize) -> IOResultOr<usize> {
         Err(LimboError::InternalError(
             "incremental blob I/O is only supported on table rows".to_string(),
-        ))
+        )
+        .into())
     }
     /// Notification, delivered during a peer's saveAllCursors pass, that the peer is
     /// about to write the row `rowid` in this cursor's b-tree (`None` when the rowid
@@ -708,38 +707,37 @@ pub trait CursorTrait: Any + Send + Sync {
     /// invalidateIncrblobCursors — while surviving writes to other rows. Default no-op.
     fn note_external_row_write(&mut self, _rowid: Option<i64>) {}
     /// Get the record of the entry the cursor is poiting to if any
-    fn record(&mut self) -> Result<IOResult<Option<&ImmutableRecord>>>;
+    fn record(&mut self) -> IOResultOr<Option<&ImmutableRecord>>;
     /// Move the cursor based on the key and the type of operation (op).
-    fn seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> Result<IOResult<SeekResult>>;
+    fn seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> IOResultOr<SeekResult>;
     /// Seek using registers directly without serializing them into an ImmutableRecord first.
     /// This avoids heap allocation and serialization overhead in hot paths like index lookups.
-    fn seek_unpacked(&mut self, registers: &[Register], op: SeekOp)
-        -> Result<IOResult<SeekResult>>;
+    fn seek_unpacked(&mut self, registers: &[Register], op: SeekOp) -> IOResultOr<SeekResult>;
     /// Insert a record in the position the cursor is at.
-    fn insert(&mut self, key: &BTreeKey) -> Result<IOResult<()>>;
+    fn insert(&mut self, key: &BTreeKey) -> IOResultOr<()>;
     /// Delete a record in the position the cursor is at.
-    fn delete(&mut self) -> Result<IOResult<()>>;
+    fn delete(&mut self) -> IOResultOr<()>;
     fn set_null_flag(&mut self, flag: bool);
     fn get_null_flag(&self) -> bool;
     /// Check if a key exists.
-    fn exists(&mut self, key: &Value) -> Result<IOResult<bool>>;
-    fn clear_btree(&mut self) -> Result<IOResult<Option<usize>>>;
-    fn btree_destroy(&mut self) -> Result<IOResult<Option<usize>>>;
+    fn exists(&mut self, key: &Value) -> IOResultOr<bool>;
+    fn clear_btree(&mut self) -> IOResultOr<Option<usize>>;
+    fn btree_destroy(&mut self) -> IOResultOr<Option<usize>>;
     /// Count the number of entries in the b-tree
     ///
     /// Only supposed to be used in the context of a simple Count Select Statement
-    fn count(&mut self) -> Result<IOResult<usize>>;
+    fn count(&mut self) -> IOResultOr<usize>;
     fn is_empty(&self) -> bool;
     fn root_page(&self) -> i64;
     /// Move cursor at the start.
-    fn rewind(&mut self) -> Result<IOResult<()>>;
+    fn rewind(&mut self) -> IOResultOr<()>;
     /// Check if cursor is poiting at a valid entry with a record.
     fn has_record(&self) -> bool;
     fn set_has_record(&mut self, has_record: bool);
     fn get_index_info(&self) -> &Arc<IndexInfo>;
 
-    fn seek_end(&mut self) -> Result<IOResult<()>>;
-    fn seek_to_last(&mut self) -> Result<IOResult<()>>;
+    fn seek_end(&mut self) -> IOResultOr<()>;
+    fn seek_to_last(&mut self) -> IOResultOr<()>;
 
     /// Returns true if this cursor operates in MVCC mode.
     fn is_mvcc(&self) -> bool {
@@ -765,7 +763,7 @@ pub trait CursorTrait: Any + Send + Sync {
     /// [`SavePositionResult::MustInvalidate`] when the position can't be
     /// represented (MVCC cursors, stale page stack); the caller falls back to
     /// invalidate_btree_cache.
-    fn try_save_position_for_external_balance(&mut self) -> Result<IOResult<SavePositionResult>> {
+    fn try_save_position_for_external_balance(&mut self) -> IOResultOr<SavePositionResult> {
         Ok(IOResult::Done(SavePositionResult::MustInvalidate))
     }
     // --- end: BTreeCursor specific functions ----
@@ -1197,7 +1195,7 @@ impl BTreeCursor {
     /// Check if the table is empty.
     /// This is done by checking if the root page has no cells.
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn is_empty_table(&mut self) -> Result<IOResult<bool>> {
+    fn is_empty_table(&mut self) -> IOResultOr<bool> {
         loop {
             let state = self.is_empty_table_state.clone();
             match state {
@@ -1224,7 +1222,7 @@ impl BTreeCursor {
     /// Move the cursor to the previous record and return it.
     /// Used in backwards iteration.
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG, name = "prev"))]
-    pub fn get_prev_record(&mut self) -> Result<IOResult<()>> {
+    pub fn get_prev_record(&mut self) -> IOResultOr<()> {
         let mut inner = || {
             loop {
                 // Resume hook: if a previous backwards-iteration call yielded
@@ -1285,7 +1283,7 @@ impl BTreeCursor {
                     let should_visit_internal_node = is_index && self.going_upwards; // we are going upwards, this means we still need to visit divider cell in an index
                     if should_visit_internal_node {
                         self.going_upwards = false;
-                        return Ok(IOResult::Done(true));
+                        return Ok::<_, Box<crate::LimboError>>(IOResult::Done(true));
                     } else if matches!(
                         page_type,
                         PageType::IndexLeaf | PageType::TableLeaf | PageType::TableInterior
@@ -1374,7 +1372,7 @@ impl BTreeCursor {
         payload: &'static [u8],
         start_next_page: u32,
         payload_size: u64,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             if self.read_overflow_state.is_none() {
                 let remaining_to_read =
@@ -1471,7 +1469,8 @@ impl BTreeCursor {
                 );
                 return Err(LimboError::Corrupt(
                     "inconsistent overflow chain observed during payload read".to_string(),
-                ));
+                )
+                .into());
             }
             // Take the whole state before the fallible record allocations below,
             // like the inconsistent-chain branch above: an error must not leave
@@ -1510,12 +1509,12 @@ impl BTreeCursor {
     /// Move the cursor to the next record and return it.
     /// Used in forwards iteration, which is the default.
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG, name = "next"))]
-    pub fn get_next_record(&mut self) -> Result<IOResult<()>> {
+    pub fn get_next_record(&mut self) -> IOResultOr<()> {
         let mut inner = || {
             if self.stack.current_page == -1 {
                 // This can happen in nested left joins. See:
                 // https://github.com/tursodatabase/turso/issues/2924
-                return Ok(IOResult::Done(false));
+                return Ok::<_, Box<crate::LimboError>>(IOResult::Done(false));
             }
             loop {
                 // Resume hook: if a previous call yielded for spill IO mid-
@@ -1663,7 +1662,7 @@ impl BTreeCursor {
     /// This may be used to seek to a specific record in a point query (e.g. SELECT * FROM table WHERE col = 10)
     /// or e.g. find the first record greater than the seek key in a range query (e.g. SELECT * FROM table WHERE col > 10).
     /// We don't include the rowid in the comparison and that's why the last value from the record is not included.
-    fn do_seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> Result<IOResult<SeekResult>> {
+    fn do_seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> IOResultOr<SeekResult> {
         let ret = return_if_io!(match &key {
             SeekKey::TableRowId(rowid) => self.tablebtree_seek(*rowid, op),
             SeekKey::IndexKey(index_key) => {
@@ -1674,11 +1673,7 @@ impl BTreeCursor {
         Ok(IOResult::Done(ret))
     }
 
-    fn do_seek_unpacked(
-        &mut self,
-        registers: &[Register],
-        op: SeekOp,
-    ) -> Result<IOResult<SeekResult>> {
+    fn do_seek_unpacked(&mut self, registers: &[Register], op: SeekOp) -> IOResultOr<SeekResult> {
         let ret = return_if_io!(self.indexbtree_seek_unpacked(registers, op));
         self.valid_state = CursorValidState::Valid;
         Ok(IOResult::Done(ret))
@@ -1726,7 +1721,7 @@ impl BTreeCursor {
     /// the caller to yield itself, matching the contract of the legacy
     /// `move_to_root`.
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn move_to_root_nonblock(&mut self) -> Result<IOResult<Option<Completion>>> {
+    fn move_to_root_nonblock(&mut self) -> IOResultOr<Option<Completion>> {
         self.seek_state = CursorSeekState::Start;
         self.going_upwards = false;
         tracing::trace!(root_page = self.root_page);
@@ -1738,7 +1733,7 @@ impl BTreeCursor {
 
     /// Move the cursor to the rightmost record in the btree.
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
-    fn move_to_rightmost(&mut self) -> Result<IOResult<bool>> {
+    fn move_to_rightmost(&mut self) -> IOResultOr<bool> {
         loop {
             let (move_to_right_state, rightmost_page_id) = &self.move_to_right_state;
             match *move_to_right_state {
@@ -1801,7 +1796,7 @@ impl BTreeCursor {
 
     /// Specialized version of move_to() for table btrees.
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
-    fn tablebtree_move_to(&mut self, rowid: i64, seek_op: SeekOp) -> Result<IOResult<()>> {
+    fn tablebtree_move_to(&mut self, rowid: i64, seek_op: SeekOp) -> IOResultOr<()> {
         loop {
             let (old_top_idx, is_leaf, cell_count) = {
                 let page = self.stack.top_ref();
@@ -1979,7 +1974,7 @@ impl BTreeCursor {
         &mut self,
         index_key: &ImmutableRecordRef<'_>,
         cmp: SeekOp,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let key_values = index_key.get_values()?;
         let record_comparer = {
             let index_info = self
@@ -1998,7 +1993,7 @@ impl BTreeCursor {
         &mut self,
         registers: &[Register],
         cmp: SeekOp,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         if matches!(
             self.seek_state,
             CursorSeekState::LeafPageBinarySearch { .. } | CursorSeekState::FoundLeaf { .. }
@@ -2030,7 +2025,7 @@ impl BTreeCursor {
         cmp: SeekOp,
         record_comparer: RecordCompare,
         key_values: &[ValueRef<'_>],
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         tracing::debug!("Using record comparison strategy: {:?}", record_comparer);
         let tie_breaker = get_tie_breaker_from_seek_op(cmp);
 
@@ -2312,7 +2307,7 @@ impl BTreeCursor {
     /// Specialized version of do_seek() for table btrees that uses binary search instead
     /// of iterating cells in order.
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn tablebtree_seek(&mut self, rowid: i64, seek_op: SeekOp) -> Result<IOResult<SeekResult>> {
+    fn tablebtree_seek(&mut self, rowid: i64, seek_op: SeekOp) -> IOResultOr<SeekResult> {
         if matches!(
             self.seek_state,
             CursorSeekState::Start
@@ -2476,7 +2471,7 @@ impl BTreeCursor {
         &mut self,
         key: &ImmutableRecordRef<'_>,
         seek_op: SeekOp,
-    ) -> Result<IOResult<SeekResult>> {
+    ) -> IOResultOr<SeekResult> {
         let key_values = key.get_values()?;
         let record_comparer = {
             let index_info = self
@@ -2501,7 +2496,7 @@ impl BTreeCursor {
         &mut self,
         registers: &[Register],
         seek_op: SeekOp,
-    ) -> Result<IOResult<SeekResult>> {
+    ) -> IOResultOr<SeekResult> {
         let index_info = self
             .index_info
             .as_ref()
@@ -2525,7 +2520,7 @@ impl BTreeCursor {
         seek_op: SeekOp,
         record_comparer: RecordCompare,
         key_values: &[ValueRef<'_>],
-    ) -> Result<IOResult<SeekResult>> {
+    ) -> IOResultOr<SeekResult> {
         if matches!(
             self.seek_state,
             CursorSeekState::Start
@@ -2746,7 +2741,7 @@ impl BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    pub fn move_to(&mut self, key: SeekKey<'_>, cmp: SeekOp) -> Result<IOResult<()>> {
+    pub fn move_to(&mut self, key: SeekKey<'_>, cmp: SeekOp) -> IOResultOr<()> {
         tracing::trace!(?key, ?cmp);
         // For a table with N rows, we can find any row by row id in O(log(N)) time by starting at the root page and following the B-tree pointers.
         // B-trees consist of interior pages and leaf pages. Interior pages contain pointers to other pages, while leaf pages contain the actual row data.
@@ -2809,7 +2804,7 @@ impl BTreeCursor {
     /// Insert a record into the btree.
     /// If the insert operation overflows the page, it will be split and the btree will be balanced.
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn insert_into_page(&mut self, bkey: &BTreeKey) -> Result<IOResult<()>> {
+    fn insert_into_page(&mut self, bkey: &BTreeKey) -> IOResultOr<()> {
         let record = bkey
             .get_record()
             .expect("expected record present on insert");
@@ -3037,7 +3032,7 @@ impl BTreeCursor {
     /// If `None`, balancing stops when a level is encountered that doesn't need balancing.
     /// If `Some(depth)`, the page on the stack at depth `depth` will be rebalanced after balancing the current page.
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
-    fn balance(&mut self, balance_ancestor_at_depth: Option<usize>) -> Result<IOResult<()>> {
+    fn balance(&mut self, balance_ancestor_at_depth: Option<usize>) -> IOResultOr<()> {
         loop {
             let usable_space = self.usable_space();
             let BalanceState {
@@ -3161,7 +3156,7 @@ impl BTreeCursor {
     /// 3. Update the rightmost pointer of the parent to point to the new leaf page.
     /// 4. Continue balance from the parent page (inserting the new divider cell may have overflowed the parent)
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
-    fn balance_quick(&mut self) -> Result<IOResult<()>> {
+    fn balance_quick(&mut self) -> IOResultOr<()> {
         // Since we are going to change the btree structure, let's forget our cached knowledge of the rightmost page.
         let _ = self.move_to_right_state.1.take();
 
@@ -3239,7 +3234,7 @@ impl BTreeCursor {
 
     /// Balance a non root page by trying to balance cells between a maximum of 3 siblings that should be neighboring the page that overflowed/underflowed.
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
-    fn balance_non_root(&mut self) -> Result<IOResult<()>> {
+    fn balance_non_root(&mut self) -> IOResultOr<()> {
         loop {
             let usable_space = self.usable_space();
             let BalanceState {
@@ -5045,7 +5040,7 @@ impl BTreeCursor {
     /// Balance the root page.
     /// This is done when the root page overflows, and we need to create a new root page.
     /// See e.g. https://en.wikipedia.org/wiki/B-tree
-    fn balance_root(&mut self) -> Result<IOResult<()>> {
+    fn balance_root(&mut self) -> IOResultOr<()> {
         /* todo: balance deeper, create child and copy contents of root there. Then split root */
         /* if we are in root page then we just need to create a new root and push key there */
 
@@ -5137,7 +5132,7 @@ impl BTreeCursor {
     /// Uses a state machine to keep track of it's operations so that traversal can be
     /// resumed from last point after IO interruption
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn clear_overflow_pages(&mut self, cell: &BTreeCell) -> Result<IOResult<()>> {
+    fn clear_overflow_pages(&mut self, cell: &BTreeCell) -> IOResultOr<()> {
         // `database_size` is invariant for the duration of this invocation, so
         // read the page-1 header at most once and reuse it for every overflow
         // page validation below instead of re-reading it per `ReadNext`.
@@ -5159,7 +5154,9 @@ impl BTreeCursor {
                             return_if_io!(self.overflow_database_size(&mut database_size));
                         if unlikely(!Self::valid_overflow_page_id(next_page, database_size)) {
                             self.overflow_state = OverflowState::Start;
-                            return Err(LimboError::Corrupt("Invalid overflow page number".into()));
+                            return Err(
+                                LimboError::Corrupt("Invalid overflow page number".into()).into()
+                            );
                         }
                         // No mutations precede this read in the Start branch,
                         // so a spill yield safely re-enters here.
@@ -5195,7 +5192,9 @@ impl BTreeCursor {
                         return_if_io!(self.overflow_database_size(&mut database_size));
                     if unlikely(!Self::valid_overflow_page_id(next, database_size)) {
                         self.overflow_state = OverflowState::Start;
-                        return Err(LimboError::Corrupt("Invalid overflow page number".into()));
+                        return Err(
+                            LimboError::Corrupt("Invalid overflow page number".into()).into()
+                        );
                     }
                     let (page, c) = return_if_io!(self.pager.read_page(next as i64));
                     self.overflow_state = OverflowState::ProcessPage { next_page: page };
@@ -5213,7 +5212,7 @@ impl BTreeCursor {
 
     /// Read `database_size` from the page-1 header at most once per
     /// `clear_overflow_pages` invocation, memoizing it in `cache`.
-    fn overflow_database_size(&self, cache: &mut Option<u32>) -> Result<IOResult<u32>> {
+    fn overflow_database_size(&self, cache: &mut Option<u32>) -> IOResultOr<u32> {
         if let Some(database_size) = cache {
             return Ok(IOResult::Done(*database_size));
         }
@@ -5244,7 +5243,7 @@ impl BTreeCursor {
     /// ```
     ///
     /// The destruction order would be: [4',4,5,2,6,7,3,1]
-    fn destroy_btree_contents(&mut self, keep_root: bool) -> Result<IOResult<Option<usize>>> {
+    fn destroy_btree_contents(&mut self, keep_root: bool) -> IOResultOr<Option<usize>> {
         if let CursorState::None = &self.state {
             let c = return_if_io!(self.move_to_root_nonblock());
             self.state = CursorState::Destroy(DestroyInfo {
@@ -5528,9 +5527,9 @@ impl BTreeCursor {
     /// position merely disturbed by a write to a *different* row is restored by
     /// re-seeking the pinned rowid, exactly like SQLite's restoreCursorPosition for
     /// incrblob cursors; if the row cannot be found again the handle expires too.
-    fn blob_ensure_position(&mut self) -> Result<IOResult<()>> {
+    fn blob_ensure_position(&mut self) -> IOResultOr<()> {
         if self.blob_expired {
-            return Err(LimboError::BlobHandleExpired);
+            return Err(LimboError::BlobHandleExpired.into());
         }
         if self.blob_position_is_live() {
             return Ok(IOResult::Done(()));
@@ -5540,7 +5539,7 @@ impl BTreeCursor {
         }
         if !self.blob_position_is_live() {
             self.blob_expired = true;
-            return Err(LimboError::BlobHandleExpired);
+            return Err(LimboError::BlobHandleExpired.into());
         }
         Ok(IOResult::Done(()))
     }
@@ -5549,13 +5548,13 @@ impl BTreeCursor {
     /// table-leaf cell, unless it is already cached for this (page, cell), and pin
     /// the cell's rowid for expiry tracking. Restoring a disturbed position may
     /// yield IO; the layout parse itself reads only the resident leaf page.
-    fn blob_ensure_layout(&mut self) -> Result<IOResult<()>> {
+    fn blob_ensure_layout(&mut self) -> IOResultOr<()> {
         return_if_io!(self.blob_ensure_position());
         let usable = self.pager.usable_space();
         turso_assert!(usable > 4, "usable space must exceed overflow header");
         let cell_idx = self.stack.current_cell_index();
         if cell_idx < 0 {
-            return Err(LimboError::BlobHandleExpired);
+            return Err(LimboError::BlobHandleExpired.into());
         }
         let cell_idx = cell_idx as usize;
         let leaf_id = self.stack.top_ref().get().id;
@@ -5574,7 +5573,8 @@ impl BTreeCursor {
             let BTreeCell::TableLeafCell(cell) = contents.cell_get(cell_idx, usable)? else {
                 return Err(LimboError::InternalError(
                     "incremental blob I/O requires a table (rowid) row".to_string(),
-                ));
+                )
+                .into());
             };
             (
                 cell.rowid,
@@ -5587,7 +5587,8 @@ impl BTreeCursor {
         if local_len > payload_size {
             return Err(LimboError::Corrupt(format!(
                 "cell claims {payload_size} payload bytes but holds {local_len} locally"
-            )));
+            ))
+            .into());
         }
         let c = &mut self.blob_cache;
         c.valid = false;
@@ -5613,7 +5614,7 @@ impl BTreeCursor {
     /// Fetch the `idx`-th overflow page, reusing the pinned last page on a spatial-
     /// locality hit and otherwise going through the O(1) overflow cache + pager, then
     /// pinning the result for the next access.
-    fn blob_overflow_page(&mut self, idx: usize) -> Result<IOResult<PageRef>> {
+    fn blob_overflow_page(&mut self, idx: usize) -> IOResultOr<PageRef> {
         if self.blob_cache.last_ov_idx == idx {
             if let Some(p) = &self.blob_cache.last_ov_page {
                 // Pinned while cached, so the pager can't evict it and take its
@@ -5644,7 +5645,7 @@ impl BTreeCursor {
     /// offset, length, and serial type. The header usually sits in the local payload
     /// (no IO), but a wide row on a small page can spill it into the overflow chain,
     /// in which case just the header bytes are streamed in (with IO yields).
-    fn blob_ensure_column(&mut self, column: usize) -> Result<IOResult<()>> {
+    fn blob_ensure_column(&mut self, column: usize) -> IOResultOr<()> {
         return_if_io!(self.blob_ensure_layout());
         if self.blob_cache.col_valid && self.blob_cache.col == column {
             return Ok(IOResult::Done(()));
@@ -5668,7 +5669,8 @@ impl BTreeCursor {
         {
             return Err(LimboError::Corrupt(format!(
                 "record header size {header_size} out of bounds (payload {payload_size})"
-            )));
+            ))
+            .into());
         }
         let (body_off, len, serial) = if header_size <= local_len {
             let page = self.stack.top_ref();
@@ -5726,7 +5728,7 @@ impl BTreeCursor {
     ///
     /// Idempotent and IO-reentrant: the array lives on the cursor and grows append-only,
     /// so on a yield the operation restarts and this resumes where it left off.
-    fn ensure_overflow_cached(&mut self, upto: usize) -> Result<IOResult<()>> {
+    fn ensure_overflow_cached(&mut self, upto: usize) -> IOResultOr<()> {
         loop {
             let last = {
                 let pages = &self.blob_cache.overflow_pages;
@@ -5738,7 +5740,8 @@ impl BTreeCursor {
                     None => {
                         return Err(LimboError::Corrupt(
                             "blob value needs overflow pages but has none".to_string(),
-                        ))
+                        )
+                        .into())
                     }
                 }
             };
@@ -5755,7 +5758,8 @@ impl BTreeCursor {
                     "overflow chain ends after {} pages but the record needs at least {}",
                     self.blob_cache.overflow_pages.len(),
                     upto + 1
-                )));
+                ))
+                .into());
             }
             crate::with_btree_allocation_site!(
                 OverflowRead,
@@ -5798,7 +5802,7 @@ impl BTreeCursor {
     /// Copy `buf.len()` bytes starting at payload offset `off` (0 = first byte of the
     /// value) into `buf`, spanning the leaf-local payload and the overflow chain. Uses
     /// the O(1) overflow cache to locate each page. Requires `blob_ensure_layout` first.
-    fn blob_read_range(&mut self, off: usize, buf: &mut [u8]) -> Result<IOResult<()>> {
+    fn blob_read_range(&mut self, off: usize, buf: &mut [u8]) -> IOResultOr<()> {
         let len = buf.len();
         let mut done = 0usize;
         while done < len {
@@ -5823,7 +5827,7 @@ impl BTreeCursor {
     /// Write `data` starting at payload offset `off` in place, spanning the leaf-local
     /// payload and the overflow chain. Each mutated page is registered dirty so the
     /// write is journaled. Requires `blob_ensure_layout` first.
-    fn blob_write_range(&mut self, off: usize, data: &[u8]) -> Result<IOResult<()>> {
+    fn blob_write_range(&mut self, off: usize, data: &[u8]) -> IOResultOr<()> {
         let len = data.len();
         let mut done = 0usize;
         while done < len {
@@ -5851,7 +5855,7 @@ impl BTreeCursor {
     /// column tier of the cache up to date and confirm the value is byte-addressable
     /// (TEXT or BLOB). Reads/writes/length all funnel through here so the type rule
     /// is enforced in exactly one place.
-    fn blob_typed_column(&mut self, column: usize) -> Result<IOResult<()>> {
+    fn blob_typed_column(&mut self, column: usize) -> IOResultOr<()> {
         return_if_io!(self.blob_ensure_column(column));
         self.blob_require_text_or_blob()?;
         Ok(IOResult::Done(()))
@@ -5860,17 +5864,13 @@ impl BTreeCursor {
     /// Validate the byte range `[off, off+len)` against column `column`'s value and
     /// return its payload-relative start offset (for `blob_read_range` /
     /// `blob_write_range`). One bounds check backs both read and write.
-    fn blob_resolve_range(
-        &mut self,
-        column: usize,
-        off: usize,
-        len: usize,
-    ) -> Result<IOResult<usize>> {
+    fn blob_resolve_range(&mut self, column: usize, off: usize, len: usize) -> IOResultOr<usize> {
         return_if_io!(self.blob_typed_column(column));
         if off.saturating_add(len) > self.blob_cache.col_len {
             return Err(LimboError::InternalError(
                 "blob access past end of column value".to_string(),
-            ));
+            )
+            .into());
         }
         Ok(IOResult::Done(self.blob_cache.col_body_off + off))
     }
@@ -5878,7 +5878,7 @@ impl BTreeCursor {
     /// Total byte length of column `column`'s value in the current row, validating
     /// that the value is byte-addressable (TEXT or BLOB). This backs
     /// `sqlite3_blob_open`, so the type error surfaces at open time.
-    pub fn blob_column_len_inherent(&mut self, column: usize) -> Result<IOResult<usize>> {
+    pub fn blob_column_len_inherent(&mut self, column: usize) -> IOResultOr<usize> {
         return_if_io!(self.blob_typed_column(column));
         Ok(IOResult::Done(self.blob_cache.col_len))
     }
@@ -5894,7 +5894,7 @@ impl BTreeCursor {
         off: usize,
         len: usize,
         out: &mut crate::ValueBlob,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let payload_off = return_if_io!(self.blob_resolve_range(column, off, len));
         crate::with_btree_allocation_site!(
             OverflowRead,
@@ -5921,7 +5921,7 @@ impl BTreeCursor {
         column: usize,
         off: usize,
         data: &[u8],
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let payload_off = return_if_io!(self.blob_resolve_range(column, off, data.len()));
         if data.is_empty() {
             return Ok(IOResult::Done(()));
@@ -5936,7 +5936,7 @@ impl BTreeCursor {
         cell_idx: usize,
         record: &ImmutableRecordRef<'_>,
         state: &mut OverwriteCellState,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             turso_assert!(page.is_loaded(), "page is not loaded", { "page_id": page.get().id });
             match state {
@@ -6093,7 +6093,7 @@ impl BTreeCursor {
     /// written (`None` when unknown); peers backing incremental blob handles use it
     /// to expire exactly when their own row is hit (sqlite3's
     /// invalidateIncrblobCursors, btree.c:672).
-    fn drive_pending_peer_save(&mut self, written_rowid: Option<i64>) -> Result<IOResult<()>> {
+    fn drive_pending_peer_save(&mut self, written_rowid: Option<i64>) -> IOResultOr<()> {
         if self.pending_peer_save.is_none() && matches!(self.state, CursorState::None) {
             // BTCF_Multiple fast path (sqlite3 btree.c:9348).
             if !self.has_peers.load(crate::sync::atomic::Ordering::Relaxed) {
@@ -6158,7 +6158,7 @@ impl BTreeCursor {
     /// peer-deleted cursor is still recoverable via Rewind/Seek, whereas our
     /// Invalid is reserved for cursors that can never be repositioned.
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn restore_context(&mut self) -> Result<IOResult<()>> {
+    fn restore_context(&mut self) -> IOResultOr<()> {
         if !self.needs_restore() {
             return Ok(IOResult::Done(()));
         }
@@ -6216,11 +6216,11 @@ impl BTreeCursor {
         self.pager.io.block(|| self.pager.read_page(page_idx))
     }
 
-    pub fn read_page(&self, page_idx: i64) -> Result<IOResult<(PageRef, Option<Completion>)>> {
+    pub fn read_page(&self, page_idx: i64) -> IOResultOr<(PageRef, Option<Completion>)> {
         self.pager.read_page(page_idx)
     }
 
-    pub fn allocate_page(&self, page_type: PageType, offset: usize) -> Result<IOResult<PageRef>> {
+    pub fn allocate_page(&self, page_type: PageType, offset: usize) -> IOResultOr<PageRef> {
         self.pager
             .do_allocate_page(page_type, offset, BtreePageAllocMode::Any)
     }
@@ -6327,22 +6327,17 @@ impl CursorTrait for BTreeCursor {
         off: usize,
         len: usize,
         out: &mut crate::ValueBlob,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         self.blob_read_column_inherent(column, off, len, out)
     }
-    fn blob_write_column(
-        &mut self,
-        column: usize,
-        off: usize,
-        data: &[u8],
-    ) -> Result<IOResult<()>> {
+    fn blob_write_column(&mut self, column: usize, off: usize, data: &[u8]) -> IOResultOr<()> {
         self.blob_write_column_inherent(column, off, data)
     }
-    fn blob_column_len(&mut self, column: usize) -> Result<IOResult<usize>> {
+    fn blob_column_len(&mut self, column: usize) -> IOResultOr<usize> {
         self.blob_column_len_inherent(column)
     }
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn next(&mut self) -> Result<IOResult<()>> {
+    fn next(&mut self) -> IOResultOr<()> {
         if self.valid_state == CursorValidState::Invalid {
             return Ok(IOResult::Done(()));
         }
@@ -6383,7 +6378,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn last(&mut self) -> Result<IOResult<()>> {
+    fn last(&mut self) -> IOResultOr<()> {
         self.set_null_flag(false);
         if self.valid_state == CursorValidState::Invalid {
             return Ok(IOResult::Done(()));
@@ -6397,7 +6392,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn prev(&mut self) -> Result<IOResult<()>> {
+    fn prev(&mut self) -> IOResultOr<()> {
         loop {
             match self.advance_state {
                 AdvanceState::Start => {
@@ -6415,7 +6410,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
-    fn rowid(&mut self) -> Result<IOResult<Option<i64>>> {
+    fn rowid(&mut self) -> IOResultOr<Option<i64>> {
         if self.needs_restore() {
             return_if_io!(self.restore_context());
         }
@@ -6440,7 +6435,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip(self, key), level = Level::DEBUG))]
-    fn seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> Result<IOResult<SeekResult>> {
+    fn seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> IOResultOr<SeekResult> {
         self.skip_advance = false;
         // Empty trace to capture the span information
         tracing::trace!("");
@@ -6458,11 +6453,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip(self, registers), level = Level::DEBUG))]
-    fn seek_unpacked(
-        &mut self,
-        registers: &[Register],
-        op: SeekOp,
-    ) -> Result<IOResult<SeekResult>> {
+    fn seek_unpacked(&mut self, registers: &[Register], op: SeekOp) -> IOResultOr<SeekResult> {
         self.skip_advance = false;
         // Empty trace to capture the span information
         tracing::trace!("");
@@ -6480,7 +6471,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
-    fn record(&mut self) -> Result<IOResult<Option<&ImmutableRecord>>> {
+    fn record(&mut self) -> IOResultOr<Option<&ImmutableRecord>> {
         // Mirrors sqlite3BtreeRestoreCursorPosition called at btree read
         // entry points (btree.c:5315, etc).
         if self.needs_restore() {
@@ -6522,7 +6513,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn insert(&mut self, key: &BTreeKey) -> Result<IOResult<()>> {
+    fn insert(&mut self, key: &BTreeKey) -> IOResultOr<()> {
         tracing::debug!(valid_state = ?self.valid_state, cursor_state = ?self.state, is_write_in_progress = self.is_write_in_progress());
         // saveAllCursors at the head of sqlite3BtreeInsert (btree.c:9348).
         return_if_io!(self.drive_pending_peer_save(key.maybe_rowid()));
@@ -6547,7 +6538,7 @@ impl CursorTrait for BTreeCursor {
     /// 8. PostInteriorNodeReplacement -> if an interior node was replaced, we need to advance the cursor once.
     /// 9. SeekAfterBalancing -> adjust the cursor to a node that is closer to the deleted value. go to Finish
     /// 10. Finish -> Delete operation is done. Return CursorResult(Ok())
-    fn delete(&mut self) -> Result<IOResult<()>> {
+    fn delete(&mut self) -> IOResultOr<()> {
         if let CursorState::None = &self.state {
             // saveAllCursors at the head of sqlite3BtreeDelete (btree.c:9841). The
             // cursor is positioned on the row being deleted, so its rowid tells peer
@@ -6938,7 +6929,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn exists(&mut self, key: &Value) -> Result<IOResult<bool>> {
+    fn exists(&mut self, key: &Value) -> IOResultOr<bool> {
         let int_key = match key {
             Value::Numeric(Numeric::Integer(i)) => i,
             _ => unreachable!("btree tables are indexed by integers!"),
@@ -6955,7 +6946,7 @@ impl CursorTrait for BTreeCursor {
     /// Unlike [`btree_destroy`], which frees all pages including the root,
     /// this method only clears the tree’s contents. The root page remains
     /// allocated and is reset to an empty leaf page.
-    fn clear_btree(&mut self) -> Result<IOResult<Option<usize>>> {
+    fn clear_btree(&mut self) -> IOResultOr<Option<usize>> {
         // First entry only — destroy_btree_contents yields IO and resumes
         // through this method, so guard with the same state==None gate it
         // uses for its own state machine. Every page in this btree is about
@@ -6980,7 +6971,7 @@ impl CursorTrait for BTreeCursor {
     ///
     /// For cases where the B-Tree should remain allocated but emptied, see [`btree_clear`].
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
-    fn btree_destroy(&mut self) -> Result<IOResult<Option<usize>>> {
+    fn btree_destroy(&mut self) -> IOResultOr<Option<usize>> {
         // See clear_btree for the state==None gate rationale.
         if matches!(self.state, CursorState::None) {
             self.pager.invalidate_peer_cursors(self);
@@ -6992,7 +6983,7 @@ impl CursorTrait for BTreeCursor {
     /// Count the number of entries in the b-tree
     ///
     /// Only supposed to be used in the context of a simple Count Select Statement
-    fn count(&mut self) -> Result<IOResult<usize>> {
+    fn count(&mut self) -> IOResultOr<usize> {
         let mut mem_page;
         let mut contents;
 
@@ -7151,7 +7142,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn rewind(&mut self) -> Result<IOResult<()>> {
+    fn rewind(&mut self) -> IOResultOr<()> {
         self.set_null_flag(false);
         if self.valid_state == CursorValidState::Invalid {
             return Ok(IOResult::Done(()));
@@ -7247,7 +7238,7 @@ impl CursorTrait for BTreeCursor {
     /// sentinel/dirty state we can't save from — has_record can lag the stack
     /// across an in-flight Insert/Delete — in which case the caller falls back
     /// to invalidate_btree_cache.
-    fn try_save_position_for_external_balance(&mut self) -> Result<IOResult<SavePositionResult>> {
+    fn try_save_position_for_external_balance(&mut self) -> IOResultOr<SavePositionResult> {
         // The peer is about to modify this btree's structure, so any cached
         // knowledge of the tree shape goes stale: the rightmost page id
         // (move_to_rightmost's skip-a-seek optimization) and the memoized
@@ -7338,7 +7329,7 @@ impl CursorTrait for BTreeCursor {
         self.index_info.as_ref().unwrap()
     }
 
-    fn seek_end(&mut self) -> Result<IOResult<()>> {
+    fn seek_end(&mut self) -> IOResultOr<()> {
         if self.valid_state == CursorValidState::Invalid {
             return Ok(IOResult::Done(()));
         }
@@ -7380,7 +7371,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
-    fn seek_to_last(&mut self) -> Result<IOResult<()>> {
+    fn seek_to_last(&mut self) -> IOResultOr<()> {
         loop {
             match self.seek_to_last_state {
                 SeekToLastState::Start => {
@@ -7649,7 +7640,7 @@ pub fn integrity_check(
     errors: &mut crate::alloc::Vec<IntegrityCheckError>,
     pager: &Arc<Pager>,
     mv_store: Option<&Arc<MvStore>>,
-) -> Result<IOResult<()>> {
+) -> IOResultOr<()> {
     if let Some(mv_store) = mv_store {
         let Some(IntegrityCheckPageEntry {
             page_idx: root_page,
@@ -9794,7 +9785,7 @@ fn fill_cell_payload(
     usable_space: usize,
     pager: Arc<Pager>,
     fill_cell_payload_state: &mut FillCellPayloadState,
-) -> Result<IOResult<()>> {
+) -> IOResultOr<()> {
     let overflow_page_pointer_size = 4;
     let overflow_page_data_size = usable_space - overflow_page_pointer_size;
     let result = loop {
@@ -13509,7 +13500,7 @@ mod tests {
         }
     }
 
-    fn run_until_done<T>(action: impl FnMut() -> Result<IOResult<T>>, pager: &Pager) -> Result<T> {
+    fn run_until_done<T>(action: impl FnMut() -> IOResultOr<T>, pager: &Pager) -> Result<T> {
         pager.io.block(action)
     }
 

--- a/core/storage/mod.rs
+++ b/core/storage/mod.rs
@@ -34,6 +34,6 @@ pub(crate) mod wal;
 #[macro_export]
 macro_rules! return_corrupt {
     ($($arg:tt)*) => {
-        return Err(LimboError::Corrupt(format!($($arg)*)));
+        return Err(LimboError::Corrupt(format!($($arg)*)).into());
     };
 }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -21,6 +21,7 @@ use crate::sync::atomic::{
 };
 use crate::sync::Arc;
 use crate::sync::{Mutex, RwLock};
+use crate::types::IOResultOr;
 use crate::types::{IOCompletions, WalState};
 use crate::util::IOExt as _;
 use crate::{
@@ -75,7 +76,7 @@ use ptrmap::*;
 pub struct HeaderRef(PageRef);
 
 impl HeaderRef {
-    pub fn from_pager(pager: &Pager) -> Result<IOResult<Self>> {
+    pub fn from_pager(pager: &Pager) -> IOResultOr<Self> {
         let page = return_if_io!(pager.read_header_page());
         Ok(IOResult::Done(Self(page)))
     }
@@ -91,7 +92,7 @@ impl HeaderRef {
 pub struct HeaderRefMut(PageRef);
 
 impl HeaderRefMut {
-    pub fn from_pager(pager: &Pager) -> Result<IOResult<Self>> {
+    pub fn from_pager(pager: &Pager) -> IOResultOr<Self> {
         let page = return_if_io!(pager.read_header_page());
         pager.add_dirty(&page)?;
         Ok(IOResult::Done(Self(page)))
@@ -1825,7 +1826,7 @@ impl Pager {
 
     /// Read page 1 (the database header page) using the header_ref_state state machine.
     /// Used by HeaderRef and HeaderRefMut to avoid duplicating the page-loading logic.
-    fn read_header_page(&self) -> Result<IOResult<PageRef>> {
+    fn read_header_page(&self) -> IOResultOr<PageRef> {
         loop {
             let state = self.header_ref_state.read().clone();
             tracing::trace!("read_header_page - {:?}", state);
@@ -2357,7 +2358,7 @@ impl Pager {
 
     /// Set the maximum page count for this database
     /// Returns the new maximum page count (may be clamped to current database size)
-    pub fn set_max_page_count(&self, new_max: u32) -> crate::Result<IOResult<u32>> {
+    pub fn set_max_page_count(&self, new_max: u32) -> IOResultOr<u32> {
         // Get current database size
         let current_page_count =
             return_if_io!(self.with_header(|header| header.database_size.get()));
@@ -2413,7 +2414,7 @@ impl Pager {
     /// `target_page_num` (1-indexed) is the page whose entry is sought.
     /// Returns `Ok(None)` if the page is not supposed to have a ptrmap entry (e.g. header, or a ptrmap page itself).
     #[cfg(feature = "autovacuum")]
-    pub fn ptrmap_get(&self, target_page_num: u32) -> Result<IOResult<Option<PtrmapEntry>>> {
+    pub fn ptrmap_get(&self, target_page_num: u32) -> IOResultOr<Option<PtrmapEntry>> {
         loop {
             let ptrmap_get_state = {
                 let vacuum_state = self.vacuum_state.read();
@@ -2472,7 +2473,8 @@ impl Pager {
                             "Ptrmap page {} has unexpected internal offset {}",
                             ptrmap_pg_no,
                             page_content.offset()
-                        )));
+                        ))
+                        .into());
                     }
                     let ptrmap_page_data_slice: &[u8] = &full_buffer_slice[page_content.offset()..];
                     let actual_data_length = ptrmap_page_data_slice.len();
@@ -2481,7 +2483,7 @@ impl Pager {
                     if offset_in_ptrmap_page + PTRMAP_ENTRY_SIZE > actual_data_length {
                         return Err(LimboError::InternalError(format!(
                         "Ptrmap offset {offset_in_ptrmap_page} + entry size {PTRMAP_ENTRY_SIZE} out of bounds for page {ptrmap_pg_no} (actual data len {actual_data_length})"
-                    )));
+                    )).into());
                     }
 
                     let entry_slice = &ptrmap_page_data_slice
@@ -2491,7 +2493,7 @@ impl Pager {
                         Some(entry) => Ok(IOResult::Done(Some(entry))),
                         None => Err(LimboError::Corrupt(format!(
                             "Failed to deserialize ptrmap entry for page {target_page_num} from ptrmap page {ptrmap_pg_no}"
-                        ))),
+                        )).into()),
                     };
                 }
             }
@@ -2507,7 +2509,7 @@ impl Pager {
         db_page_no_to_update: u32,
         entry_type: PtrmapType,
         parent_page_no: u32,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         tracing::trace!(
             "ptrmap_put(page_idx = {}, entry_type = {:?}, parent_page_no = {})",
             db_page_no_to_update,
@@ -2530,7 +2532,7 @@ impl Pager {
                         turso_soft_unreachable!("Cannot set ptrmap entry for header/ptrmap page or invalid page", { "page": db_page_no_to_update });
                         return Err(LimboError::InternalError(format!(
                         "Cannot set ptrmap entry for page {db_page_no_to_update}: it's a header/ptrmap page or invalid."
-                    )));
+                    )).into());
                     }
 
                     let ptrmap_pg_no =
@@ -2575,7 +2577,7 @@ impl Pager {
                         PTRMAP_ENTRY_SIZE,
                         ptrmap_pg_no,
                         full_buffer_slice.len()
-                    )));
+                    )).into());
                     }
 
                     let entry = PtrmapEntry {
@@ -2601,7 +2603,7 @@ impl Pager {
     /// This method is used to allocate a new root page for a btree, both for tables and indexes
     /// FIXME: handle no room in page cache
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn btree_create(&self, flags: &CreateBTreeFlags) -> Result<IOResult<u32>> {
+    pub fn btree_create(&self, flags: &CreateBTreeFlags) -> IOResultOr<u32> {
         let page_type = match flags {
             _ if flags.is_table() => PageType::TableLeaf,
             _ if flags.is_index() => PageType::IndexLeaf,
@@ -2707,7 +2709,8 @@ impl Pager {
                 AutoVacuumMode::Incremental => {
                     return Err(LimboError::InternalError(
                         "Incremental auto-vacuum is not supported".to_string(),
-                    ));
+                    )
+                    .into());
                 }
             }
         }
@@ -2716,7 +2719,7 @@ impl Pager {
     /// Allocate a new overflow page.
     /// This is done when a cell overflows and new space is needed.
     // FIXME: handle no room in page cache
-    pub fn allocate_overflow_page(&self) -> Result<IOResult<PageRef>> {
+    pub fn allocate_overflow_page(&self) -> IOResultOr<PageRef> {
         let page = return_if_io!(self.allocate_page());
         tracing::debug!("Pager::allocate_overflow_page(id={})", page.get().id);
 
@@ -2736,7 +2739,7 @@ impl Pager {
         page_type: PageType,
         offset: usize,
         _alloc_mode: BtreePageAllocMode,
-    ) -> Result<IOResult<PageRef>> {
+    ) -> IOResultOr<PageRef> {
         let page = return_if_io!(self.allocate_page());
         #[cfg(debug_assertions)]
         turso_assert_eq!(
@@ -2937,7 +2940,7 @@ impl Pager {
     }
 
     /// Get the schema cookie, using the cached value if available to avoid reading page 1.
-    pub fn get_schema_cookie(&self) -> Result<IOResult<u32>> {
+    pub fn get_schema_cookie(&self) -> IOResultOr<u32> {
         // Try to use cached value first
         if let Some(cookie) = self.get_schema_cookie_cached() {
             return Ok(IOResult::Done(cookie));
@@ -3000,7 +3003,7 @@ impl Pager {
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn maybe_allocate_page1(&self) -> Result<IOResult<()>> {
+    pub fn maybe_allocate_page1(&self) -> IOResultOr<()> {
         if !self.db_initialized() {
             if let Some(_lock) = self.init_lock.try_lock() {
                 return Ok(self.allocate_page1()?.map(|_| ()));
@@ -3019,7 +3022,7 @@ impl Pager {
     /// `try_restart_log_before_write`. Callers managing WAL state externally
     /// (sync engine) must not pass `Restart` because rotating the WAL header
     /// behind their back invalidates watermarks they have already published.
-    pub fn begin_write_tx(&self, allowed_auto_actions: WalAutoActions) -> Result<IOResult<()>> {
+    pub fn begin_write_tx(&self, allowed_auto_actions: WalAutoActions) -> IOResultOr<()> {
         // TODO(Diego): The only possibly allocate page1 here is because OpenEphemeral needs a write transaction
         // we should have a unique API to begin transactions, something like sqlite3BtreeBeginTrans
         return_if_io!(self.maybe_allocate_page1());
@@ -3060,11 +3063,11 @@ impl Pager {
     ///
     /// VACUUM runs on an existing database, so page 1 must already be allocated
     /// and a WAL must be present.
-    pub fn begin_vacuum_blocking_tx(&self) -> Result<IOResult<()>> {
+    pub fn begin_vacuum_blocking_tx(&self) -> IOResultOr<()> {
         if !self.db_initialized() {
             return Err(LimboError::InternalError(
                 "begin_vacuum_blocking_tx can be done on an initialized database (page 1 must already be allocated)".into(),
-            ));
+            ).into());
         }
         let wal = self.wal.as_ref().ok_or_else(|| {
             LimboError::InternalError("begin_vacuum_blocking_tx requires WAL mode".into())
@@ -3085,7 +3088,7 @@ impl Pager {
         &self,
         connection: &Connection,
         update_transaction_state: bool,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         if connection.is_nested_stmt() {
             // Parent statement will handle the transaction commit.
             return Ok(IOResult::Done(()));
@@ -3332,7 +3335,7 @@ impl Pager {
     /// `pending_reads` corresponds to a single outstanding disk read; the
     /// entry is removed exactly when this method returns `Done`.
     #[tracing::instrument(skip_all, level = Level::TRACE)]
-    pub fn read_page(&self, page_idx: i64) -> Result<IOResult<(PageRef, Option<Completion>)>> {
+    pub fn read_page(&self, page_idx: i64) -> IOResultOr<(PageRef, Option<Completion>)> {
         self.read_page_into(page_idx, None)
     }
 
@@ -3342,7 +3345,7 @@ impl Pager {
         &self,
         page_idx: i64,
         group: Option<&mut CompletionGroup>,
-    ) -> Result<IOResult<(PageRef, Option<Completion>)>> {
+    ) -> IOResultOr<(PageRef, Option<Completion>)> {
         turso_assert_greater_than_or_equal!(page_idx, 0, "pages in pager should be positive, negative might indicate unallocated pages from mvcc or any other nasty bug");
         tracing::debug!("read_page_nonblock(page_idx = {})", page_idx);
         #[cfg(test)]
@@ -3436,7 +3439,7 @@ impl Pager {
     /// evicted, the page is admitted over capacity rather than failing the
     /// read (mirroring SQLite, where `cache_size` may be exceeded while all
     /// pages are in use); later inserts drain the excess.
-    fn cache_insert(&self, page_idx: usize, page: PageRef) -> Result<IOResult<()>> {
+    fn cache_insert(&self, page_idx: usize, page: PageRef) -> IOResultOr<()> {
         {
             let mut page_cache = self.page_cache.write();
             let page_key = PageCacheKey::new(page_idx);
@@ -3555,7 +3558,7 @@ impl Pager {
     /// Flush all dirty pages to disk (async/re-entrant).
     /// Unlike commit_wal, this function does not commit, checkpoint nor sync the WAL/Database.
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn cacheflush(&self) -> Result<IOResult<Vec<Completion>>> {
+    pub fn cacheflush(&self) -> IOResultOr<Vec<Completion>> {
         let wal = self
             .wal
             .as_ref()
@@ -3834,7 +3837,7 @@ impl Pager {
     /// then mark them as spilled so they can be evicted even while dirty.
     /// For ephemeral tables: writes pages directly to the temp database file.
     #[instrument(skip_all, level = Level::DEBUG)]
-    fn try_spill_dirty_pages(&self) -> Result<IOResult<()>> {
+    fn try_spill_dirty_pages(&self) -> IOResultOr<()> {
         loop {
             let state = self.spill_state.read().clone();
             match state {
@@ -3990,7 +3993,7 @@ impl Pager {
     /// `SpillState::WritingToWal` and yields the write completion. The WAL
     /// must already be initialized (callers route through `PreparingWal*`
     /// first).
-    fn spill_append_frames_to_wal(&self, pages: Vec<PinGuard>) -> Result<IOResult<()>> {
+    fn spill_append_frames_to_wal(&self, pages: Vec<PinGuard>) -> IOResultOr<()> {
         let wal = self
             .wal
             .as_ref()
@@ -4032,7 +4035,7 @@ impl Pager {
 
     /// Wait for any in-flight spill writes to finish.
     /// This prevents publishing WAL metadata that references frames that are not yet durable.
-    fn wait_for_spill_completions(&self) -> Result<IOResult<()>> {
+    fn wait_for_spill_completions(&self) -> IOResultOr<()> {
         loop {
             let state = self.spill_state.read().clone();
             if matches!(state, SpillState::Idle) {
@@ -4082,7 +4085,7 @@ impl Pager {
 
     /// Check if the cache needs spilling and attempt to spill if necessary.
     /// This should be called before inserting new pages into the cache.
-    fn ensure_cache_space(&self) -> Result<IOResult<()>> {
+    fn ensure_cache_space(&self) -> IOResultOr<()> {
         let needs_spill = {
             let cache = self.page_cache.read();
             cache.needs_spill()
@@ -4122,7 +4125,7 @@ impl Pager {
         allowed_auto_actions: WalAutoActions,
         sync_mode: SyncMode,
         data_sync_retry: bool,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         {
             let mut commit_info = self.commit_info.write();
             if commit_info.state == CommitState::PrepareWal {
@@ -4153,12 +4156,10 @@ impl Pager {
         allowed_auto_actions: WalAutoActions,
         sync_mode: SyncMode,
         data_sync_retry: bool,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let Some(wal) = self.wal.as_ref() else {
             turso_soft_unreachable!("commit_wal() called without WAL");
-            return Err(LimboError::InternalError(
-                "commit_wal() called without WAL".into(),
-            ));
+            return Err(LimboError::InternalError("commit_wal() called without WAL".into()).into());
         };
 
         loop {
@@ -4247,7 +4248,8 @@ impl Pager {
                     if !reads.succeeded() {
                         return Err(LimboError::CompletionError(reads.get_error().unwrap_or(
                             CompletionError::IOError(std::io::ErrorKind::Other, "read"),
-                        )));
+                        ))
+                        .into());
                     }
                     // All reads complete and successful, proceed to frame preparation
                     commit_info.completion_group = None;
@@ -4285,7 +4287,8 @@ impl Pager {
                             return Err(LimboError::InternalError(format!(
                                 "dirty page {} has no buffer loaded at commit time",
                                 page.get().id
-                            )));
+                            ))
+                            .into());
                         }
                         turso_assert!(
                             page.get().overflow_cells.is_empty(),
@@ -4337,7 +4340,8 @@ impl Pager {
                         return Err(LimboError::CompletionError(CompletionError::IOError(
                             std::io::ErrorKind::Other,
                             "write",
-                        )));
+                        ))
+                        .into());
                     }
                     commit_info.completion_group = None;
                     // All writes complete; WaitSync submits the WAL fsync if
@@ -4387,7 +4391,8 @@ impl Pager {
                             return Err(LimboError::CompletionError(CompletionError::IOError(
                                 std::io::ErrorKind::Other,
                                 "sync",
-                            )));
+                            ))
+                            .into());
                         }
                         commit_info.pending_sync = None;
                     }
@@ -4620,7 +4625,7 @@ impl Pager {
         mode: CheckpointMode,
         sync_mode: crate::SyncMode,
         clear_page_cache: bool,
-    ) -> Result<IOResult<CheckpointResult>> {
+    ) -> IOResultOr<CheckpointResult> {
         self.checkpoint_inner(
             mode,
             sync_mode,
@@ -4633,7 +4638,7 @@ impl Pager {
         &self,
         sync_mode: crate::SyncMode,
         clear_page_cache: bool,
-    ) -> Result<IOResult<CheckpointResult>> {
+    ) -> IOResultOr<CheckpointResult> {
         self.checkpoint_inner(
             CheckpointMode::Truncate {
                 upper_bound_inclusive: None,
@@ -4651,12 +4656,13 @@ impl Pager {
         sync_mode: crate::SyncMode,
         clear_page_cache: bool,
         lock_source: CheckpointLockSource,
-    ) -> Result<IOResult<CheckpointResult>> {
+    ) -> IOResultOr<CheckpointResult> {
         let Some(wal) = self.wal.as_ref() else {
             turso_soft_unreachable!("checkpoint() called on database without WAL");
             return Err(LimboError::InternalError(
                 "checkpoint() called on database without WAL".to_string(),
-            ));
+            )
+            .into());
         };
         loop {
             // Clone the phase to check what state we're in, but keep result in place
@@ -4881,7 +4887,8 @@ impl Pager {
                     if bytes_read < DatabaseHeader::SIZE {
                         return Err(LimboError::Corrupt(
                             "database header unreadable after checkpoint sync".into(),
-                        ));
+                        )
+                        .into());
                     }
                     let (db_size_pages, db_header_crc32c) =
                         super::wal::database_identity_from_header_bytes(
@@ -5148,7 +5155,7 @@ impl Pager {
     // Providing a page is optional, if provided it will be used to avoid reading the page from disk.
     // This is implemented in accordance with sqlite freepage2() function.
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn free_page(&self, mut page: Option<PageRef>, page_id: usize) -> Result<IOResult<()>> {
+    pub fn free_page(&self, mut page: Option<PageRef>, page_id: usize) -> IOResultOr<()> {
         tracing::trace!("free_page(page_id={})", page_id);
         // Number of reserved slots in trunk header (next pointer + leaf count)
         const RESERVED_SLOTS: usize = 2;
@@ -5164,7 +5171,8 @@ impl Pager {
                     if page_id < 2 || page_id > header.database_size.get() as usize {
                         return Err(LimboError::Corrupt(format!(
                             "Invalid page number {page_id} for free operation"
-                        )));
+                        ))
+                        .into());
                     }
 
                     // The first yield point is the `HeaderRefMut::from_pager`
@@ -5286,7 +5294,7 @@ impl Pager {
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn allocate_page1(&self) -> Result<IOResult<PageRef>> {
+    pub fn allocate_page1(&self) -> IOResultOr<PageRef> {
         let state = self.allocate_page1_state.read().clone();
         match state {
             AllocatePage1State::Start => {
@@ -5379,7 +5387,7 @@ impl Pager {
     /// Final step of [Pager::allocate_page1]: page 1 is written (and, for
     /// WAL-backed databases, fsync'd) to the main database file; publish it
     /// in the page cache and mark the database initialized.
-    fn finish_allocate_page1(&self, page: PageRef) -> Result<IOResult<PageRef>> {
+    fn finish_allocate_page1(&self, page: PageRef) -> IOResultOr<PageRef> {
         let page_key = PageCacheKey::new(page.get().id);
         let mut cache = self.page_cache.write();
         cache.insert(page_key, page.clone()).map_err(|e| {
@@ -5408,7 +5416,7 @@ impl Pager {
     ///        or allocate a new page.
     #[allow(clippy::readonly_write_lock)]
     #[instrument(skip_all, level = Level::DEBUG)]
-    pub fn allocate_page(&self) -> Result<IOResult<PageRef>> {
+    pub fn allocate_page(&self) -> IOResultOr<PageRef> {
         // Ensure cache has room before allocating (we may spill dirty pages first)
         return_if_io!(self.ensure_cache_space());
 
@@ -5629,7 +5637,8 @@ impl Pager {
                     if new_db_size > max_page_count {
                         return Err(LimboError::DatabaseFull(
                             "database or disk is full".to_string(),
-                        ));
+                        )
+                        .into());
                     }
 
                     // FIXME: should reserve page cache entry before modifying the database
@@ -5752,7 +5761,7 @@ impl Pager {
         *self.header_ref_state.write() = HeaderRefState::Start;
     }
 
-    pub fn with_header<T>(&self, f: impl Fn(&DatabaseHeader) -> T) -> Result<IOResult<T>> {
+    pub fn with_header<T>(&self, f: impl Fn(&DatabaseHeader) -> T) -> IOResultOr<T> {
         let header_ref = return_if_io!(HeaderRef::from_pager(self));
         let header = header_ref.borrow();
         // Update cached schema cookie when reading header
@@ -5760,7 +5769,7 @@ impl Pager {
         Ok(IOResult::Done(f(header)))
     }
 
-    pub fn with_header_mut<T>(&self, f: impl Fn(&mut DatabaseHeader) -> T) -> Result<IOResult<T>> {
+    pub fn with_header_mut<T>(&self, f: impl Fn(&mut DatabaseHeader) -> T) -> IOResultOr<T> {
         let header_ref = return_if_io!(HeaderRefMut::from_pager(self));
         let header = header_ref.borrow_mut();
         let result = f(header);
@@ -6278,7 +6287,7 @@ mod tests {
 
         let err = pager.cacheflush().unwrap_err();
         assert!(matches!(
-            err,
+            *err,
             LimboError::CompletionError(CompletionError::PageCodecError { page_idx: 2 })
         ));
         assert!(matches!(
@@ -6328,7 +6337,7 @@ mod ptrmap_tests {
     use arc_swap::ArcSwapOption;
 
     pub fn run_until_done<T>(
-        mut action: impl FnMut() -> Result<IOResult<T>>,
+        mut action: impl FnMut() -> IOResultOr<T>,
         pager: &Pager,
     ) -> Result<T> {
         loop {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -43,6 +43,7 @@
 
 #![allow(clippy::arc_with_non_send_sync)]
 
+use crate::types::IOResultOr;
 use crate::{
     io_yield_one, turso_assert, turso_assert_eq, turso_assert_greater_than,
     types::{IOCompletions, IOResult},
@@ -1559,7 +1560,7 @@ impl BuildSharedWal {
     /// Drive the recovery state machine. Yields the in-flight read completion
     /// when it must wait; returns `Done(wal_file_shared)` once the full WAL
     /// has been scanned (or recovery short-circuited).
-    pub fn poll(&mut self) -> Result<IOResult<Arc<RwLock<WalFileShared>>>> {
+    pub fn poll(&mut self) -> IOResultOr<Arc<RwLock<WalFileShared>>> {
         loop {
             match self.phase.clone() {
                 BuildSharedWalPhase::NeedHeaderRead => {

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -3,6 +3,7 @@
 use crate::io::FileSyncType;
 use crate::sync::Mutex;
 use crate::sync::OnceLock;
+use crate::types::IOResultOr;
 use crate::{turso_assert, turso_assert_greater_than, turso_debug_assert};
 use branches::mark_unlikely;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -748,7 +749,7 @@ pub trait Wal: Debug + Send + Sync {
         pager: &Pager,
         mode: CheckpointMode,
         sync_mode: SyncMode,
-    ) -> Result<IOResult<CheckpointResult>>;
+    ) -> IOResultOr<CheckpointResult>;
     fn install_durable_backfill_proof(
         &self,
         max_frame: u64,
@@ -805,7 +806,7 @@ pub trait Wal: Debug + Send + Sync {
         &self,
         result: &mut CheckpointResult,
         sync_type: FileSyncType,
-    ) -> Result<IOResult<()>>;
+    ) -> IOResultOr<()>;
 
     /// Try to acquire the checkpoint serialization lock. Returns `Busy` if
     /// another checkpointer or VACUUM already holds it. Used by plain VACUUM
@@ -838,7 +839,7 @@ pub trait Wal: Debug + Send + Sync {
         &self,
         pager: &Pager,
         sync_mode: SyncMode,
-    ) -> Result<IOResult<CheckpointResult>>;
+    ) -> IOResultOr<CheckpointResult>;
 
     /// Release the exclusive VACUUM lock acquired by `begin_vacuum_blocking_tx`.
     /// VACUUM calls this once done, after which new
@@ -2860,7 +2861,7 @@ pub enum OpenSharedWal {
 }
 
 impl OpenSharedWal {
-    pub fn poll(&mut self) -> Result<IOResult<Arc<RwLock<WalFileShared>>>> {
+    pub fn poll(&mut self) -> IOResultOr<Arc<RwLock<WalFileShared>>> {
         match self {
             OpenSharedWal::Noop(wal) => Ok(IOResult::Done(wal.clone())),
             OpenSharedWal::Build(driver) => driver.poll(),
@@ -3972,7 +3973,7 @@ impl Wal for WalFile {
         pager: &Pager,
         mode: CheckpointMode,
         sync_mode: SyncMode,
-    ) -> Result<IOResult<CheckpointResult>> {
+    ) -> IOResultOr<CheckpointResult> {
         self.checkpoint_inner(pager, mode, CheckpointLockSource::Acquire, sync_mode)
             .inspect_err(|e| {
                 tracing::debug!("WAL checkpoint failed: {e}");
@@ -3985,7 +3986,7 @@ impl Wal for WalFile {
         &self,
         pager: &Pager,
         sync_mode: SyncMode,
-    ) -> Result<IOResult<CheckpointResult>> {
+    ) -> IOResultOr<CheckpointResult> {
         self.checkpoint_inner(
             pager,
             CheckpointMode::Truncate {
@@ -4647,7 +4648,7 @@ impl Wal for WalFile {
         &self,
         result: &mut CheckpointResult,
         sync_type: FileSyncType,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         self.truncate_log(result, sync_type)
     }
 }
@@ -4794,7 +4795,7 @@ impl WalFile {
         mode: CheckpointMode,
         lock_source: CheckpointLockSource,
         sync_mode: SyncMode,
-    ) -> Result<IOResult<CheckpointResult>> {
+    ) -> IOResultOr<CheckpointResult> {
         loop {
             let state = self.ongoing_checkpoint.read().state.clone();
             tracing::debug!(?state);
@@ -4834,7 +4835,7 @@ impl WalFile {
                             tracing::debug!(
                                 "abort checkpoint because latest frame in WAL is greater than upper_bound in TRUNCATE mode: {max_frame} != {upper_bound}"
                             );
-                            return Err(LimboError::Busy);
+                            return Err(LimboError::Busy.into());
                         }
                     }
                     if let CheckpointMode::Passive {
@@ -4936,7 +4937,7 @@ impl WalFile {
                             .collect();
                         pager.io.cancel(&to_cancel)?;
                         pager.io.drain_completions(&to_cancel)?;
-                        return Err(LimboError::CompletionError(e));
+                        return Err(LimboError::CompletionError(e).into());
                     }
                     let epoch = self.coordination.checkpoint_epoch();
                     // Issue reads until we hit limits
@@ -5003,7 +5004,8 @@ impl WalFile {
                         mark_unlikely();
                         return Err(LimboError::InternalError(
                             "checkpoint stuck: no inflight completions but not complete".into(),
-                        ));
+                        )
+                        .into());
                     }
                 }
                 // All eligible frames copied to the db file.
@@ -5030,7 +5032,7 @@ impl WalFile {
                     );
                     tracing::debug!("checkpoint_result={:?}, mode={:?}", checkpoint_result, mode);
                     if mode.require_all_backfilled() && !checkpoint_result.everything_backfilled() {
-                        return Err(LimboError::Busy);
+                        return Err(LimboError::Busy.into());
                     }
                     if mode.should_restart_log() {
                         turso_assert!(
@@ -5203,7 +5205,7 @@ impl WalFile {
         &self,
         result: &mut CheckpointResult,
         sync_type: FileSyncType,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let file = self.coordination.prepare_truncate()?;
 
         if !result.wal_truncate_sent {
@@ -9880,7 +9882,7 @@ pub mod test {
                 }
                 e => {
                     assert!(
-                        matches!(e, Err(LimboError::Busy)),
+                        matches!(&e, Err(err) if matches!(**err, LimboError::Busy)),
                         "reader is holding readmark0 we should return Busy"
                     );
                     break;
@@ -9911,7 +9913,7 @@ pub mod test {
                 }
                 Err(e) => {
                     assert!(
-                        matches!(e, LimboError::Busy),
+                        matches!(*e, LimboError::Busy),
                         "should return busy if we have readers"
                     );
                     break;
@@ -10075,7 +10077,7 @@ pub mod test {
         };
 
         assert!(
-            matches!(result, Err(LimboError::Busy)),
+            matches!(&result, Err(err) if matches!(**err, LimboError::Busy)),
             "Restart checkpoint should fail when write lock is held"
         );
 
@@ -10422,7 +10424,7 @@ pub mod test {
             let result = wal.checkpoint(&pager, CheckpointMode::Restart, SyncMode::Full);
 
             assert!(
-                matches!(result, Err(LimboError::Busy)),
+                matches!(&result, Err(err) if matches!(**err, LimboError::Busy)),
                 "RESTART checkpoint should fail when a reader is using slot 0"
             );
         }
@@ -10532,7 +10534,7 @@ pub mod test {
                         // Drive any pending IO (should quickly become Busy or Done)
                         io.wait(db.io.as_ref()).unwrap();
                     }
-                    Err(LimboError::Busy) => {
+                    Err(err) if matches!(*err, LimboError::Busy) => {
                         break;
                     }
                     other => panic!("expected Busy from FULL with old reader, got {other:?}"),

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -67,7 +67,9 @@ fn validate_delete(
             views.iter().fold(String::new(), |_, s| s.to_string() + ", "),
         );
     }
-    Ok(())
+    // Pins the closure's error type: bail_parse_error! is polymorphic over
+    // boxed and unboxed LimboError since the InsnResult migration.
+    Ok::<(), crate::LimboError>(())
     })?;
     Ok(table)
 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -3459,6 +3459,12 @@ impl IOCompletions {
     }
 }
 
+/// Return type for storage-layer functions that may suspend for I/O.
+/// The boxed error keeps the whole value register-sized for small `T`
+/// (a bare `LimboError` is 40 bytes and forces a memory return on every
+/// call in cursor and pager hot paths); `?` boxes automatically.
+pub type IOResultOr<T> = std::result::Result<IOResult<T>, Box<crate::LimboError>>;
+
 #[derive(Debug)]
 #[must_use]
 pub enum IOResult<T> {
@@ -3489,7 +3495,7 @@ impl<T> IOResult<T> {
     }
 }
 
-/// Evaluate a Result<IOResult<T>>, if IO return IO.
+/// Evaluate a IOResultOr<T>, if IO return IO.
 #[macro_export]
 macro_rules! return_if_io {
     ($expr:expr) => {
@@ -3498,7 +3504,8 @@ macro_rules! return_if_io {
             Ok(IOResult::IO(io)) => return Ok(IOResult::IO(io)),
             Err(err) => {
                 branches::mark_unlikely();
-                return Err(err);
+                // Polymorphic over boxed and unboxed LimboError contexts.
+                return Err(err.into());
             }
         }
     };

--- a/core/util.rs
+++ b/core/util.rs
@@ -6,6 +6,7 @@ use crate::translate::expr::{walk_expr, walk_expr_mut, WalkControl};
 use crate::translate::plan::{BitSet, JoinedTable};
 use crate::translate::planner::parse_row_id;
 use crate::types::IOResult;
+use crate::types::IOResultOr;
 use crate::IO;
 use crate::{
     schema::{Column, Schema, Table, Type},
@@ -80,15 +81,15 @@ macro_rules! ends_with_ignore_ascii_case {
 }
 
 pub trait IOExt {
-    fn block<T>(&self, f: impl FnMut() -> Result<IOResult<T>>) -> Result<T>;
+    fn block<T>(&self, f: impl FnMut() -> IOResultOr<T>) -> Result<T>;
     fn wait<T, F>(&self, f: F) -> impl Future<Output = Result<T>> + Send
     where
-        F: FnMut() -> Result<IOResult<T>> + Send,
+        F: FnMut() -> IOResultOr<T> + Send,
         T: Send;
 }
 
 impl<I: ?Sized + IO> IOExt for I {
-    fn block<T>(&self, mut f: impl FnMut() -> Result<IOResult<T>>) -> Result<T> {
+    fn block<T>(&self, mut f: impl FnMut() -> IOResultOr<T>) -> Result<T> {
         Ok(loop {
             match f()? {
                 IOResult::Done(v) => break v,
@@ -99,7 +100,7 @@ impl<I: ?Sized + IO> IOExt for I {
 
     async fn wait<T, F>(&self, mut f: F) -> Result<T>
     where
-        F: FnMut() -> Result<IOResult<T>> + Send,
+        F: FnMut() -> IOResultOr<T> + Send,
         T: Send,
     {
         Ok(loop {
@@ -257,7 +258,7 @@ pub fn parse_schema_rows(
     syms: &SymbolTable,
     resolve_attached_db: &dyn Fn(&str) -> Option<usize>,
     dialect: &dyn crate::dialect::Dialect,
-) -> Result<IOResult<()>> {
+) -> IOResultOr<()> {
     {
         let inner = state
             .inner

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -26,6 +26,7 @@ use crate::storage::page_cache::PageCache;
 use crate::storage::pager::{default_page1, CreateBTreeFlags, PageRef, SavepointResult};
 use crate::storage::sqlite3_ondisk::{DatabaseHeader, PageSize, RawVersion};
 use crate::translate::collate::CollationSeq;
+use crate::types::IOResultOr;
 use crate::types::{
     compare_immutable, compare_immutable_single, compare_records_generic, AsValueRef, Extendable,
     IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekResult, Text, ValueIterator,
@@ -192,7 +193,7 @@ macro_rules! return_if_io {
             Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
             Err(err) => {
                 mark_unlikely();
-                return Err(err);
+                return Err(err.into());
             }
         }
     };
@@ -204,13 +205,18 @@ macro_rules! check_arg_count {
             return Err(LimboError::InternalError(format!(
                 "expected {} argument(s), got {}",
                 $expected, $actual
-            )));
+            ))
+            .into());
         }
     };
 }
 
-pub type InsnFunction =
-    fn(&Program, &mut ProgramState, &Insn, &Arc<Pager>) -> Result<InsnFunctionStepResult>;
+/// Errors are boxed so an op's whole return value stays small: a LimboError
+/// is 40 bytes and would otherwise be copied through memory on every executed
+/// instruction. `?` boxes automatically via `From`; explicit `Err` sites box
+/// at the point the error is created.
+pub type InsnResult = Result<InsnFunctionStepResult, Box<LimboError>>;
+pub type InsnFunction = fn(&Program, &mut ProgramState, &Insn, &Arc<Pager>) -> InsnResult;
 
 /// Parse a Value (text, int, float, or blob) into a BigDecimal.
 fn value_to_bigdecimal(val: &Value) -> Result<bigdecimal::BigDecimal> {
@@ -413,7 +419,7 @@ pub fn op_init(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Init { target_pc }, insn);
     if unlikely(!target_pc.is_offset()) {
         crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
@@ -427,7 +433,7 @@ pub fn op_add(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Add { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -443,7 +449,7 @@ pub fn op_subtract(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Subtract { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -459,7 +465,7 @@ pub fn op_multiply(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Multiply { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -475,7 +481,7 @@ pub fn op_divide(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Divide { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -491,7 +497,7 @@ pub fn op_drop_index(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(DropIndex { index, db }, insn);
     let conn = program.connection.clone();
     let is_mvcc = conn.mv_store_for_db(*db).is_some();
@@ -513,7 +519,7 @@ pub fn op_remainder(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Remainder { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -529,7 +535,7 @@ pub fn op_bit_and(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(BitAnd { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -545,7 +551,7 @@ pub fn op_bit_or(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(BitOr { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -561,7 +567,7 @@ pub fn op_bit_not(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(BitNot { reg, dest }, insn);
     state.registers[*dest].set_value(state.registers[*reg].get_value().exec_bit_not());
     state.pc += 1;
@@ -573,7 +579,7 @@ pub fn op_checkpoint(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     fn set_not_in_wal_result(state: &mut ProgramState, dest: usize) {
         // Match SQLite for databases that are not in WAL mode.
         state.registers[dest].set_int(0);
@@ -594,7 +600,7 @@ pub fn op_checkpoint(
         // when a checkpoint is attempted. We don't have table locks, so return TableLocked for any
         // attempt to checkpoint in an interactive transaction. This does not end the transaction,
         // however.
-        return Err(LimboError::TableLocked);
+        return Err(LimboError::TableLocked.into());
     }
     if *database == crate::TEMP_DB_ID && program.connection.temp.database.read().is_none() {
         set_not_in_wal_result(state, *dest);
@@ -662,10 +668,10 @@ pub fn op_checkpoint(
                 Ok(TransitionResult::Io(iocompletions)) => {
                     if let Err(err) = iocompletions.wait(pager.io.as_ref()) {
                         ckpt_sm.cleanup_after_external_io_error(err.clone())?;
-                        return Err(err);
+                        return Err(err.into());
                     }
                 }
-                Err(err) => return Err(err),
+                Err(err) => return Err(err.into()),
             }
         };
         // https://sqlite.org/pragma.html#pragma_wal_checkpoint
@@ -716,7 +722,7 @@ pub fn op_null(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     match insn {
         Insn::Null { dest, dest_end } | Insn::BeginSubrtn { dest, dest_end } => {
             if let Some(dest_end) = dest_end {
@@ -747,7 +753,7 @@ pub fn op_null_row(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(NullRow { cursor_id }, insn);
     // NullRow can target a never-opened cursor slot (e.g. a Once-guarded
     // OpenAutoindex in a loop body that never ran); install a permanently
@@ -779,7 +785,7 @@ pub fn op_compare(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Compare {
             start_reg_a,
@@ -794,9 +800,7 @@ pub fn op_compare(
     let count = *count;
 
     if unlikely(start_reg_a + count > start_reg_b) {
-        return Err(LimboError::InternalError(
-            "Compare registers overlap".to_string(),
-        ));
+        return Err(LimboError::InternalError("Compare registers overlap".to_string()).into());
     }
 
     // (https://github.com/tursodatabase/turso/issues/2304): reusing logic from compare_immutable().
@@ -817,7 +821,7 @@ pub fn op_jump(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Jump {
             target_pc_lt,
@@ -831,9 +835,7 @@ pub fn op_jump(
     assert!(target_pc_gt.is_offset());
     let cmp = state.last_compare.take();
     if unlikely(cmp.is_none()) {
-        return Err(LimboError::InternalError(
-            "Jump without compare".to_string(),
-        ));
+        return Err(LimboError::InternalError("Jump without compare".to_string()).into());
     }
     let target_pc = match cmp.expect("comparison should succeed for valid operands") {
         std::cmp::Ordering::Less => *target_pc_lt,
@@ -849,7 +851,7 @@ pub fn op_move(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Move {
             source_reg,
@@ -876,7 +878,7 @@ pub fn op_if_pos(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         IfPos {
             reg,
@@ -902,7 +904,8 @@ pub fn op_if_pos(
             mark_unlikely();
             return Err(LimboError::InternalError(
                 "IfPos: the value in the register is not an integer".into(),
-            ));
+            )
+            .into());
         }
     }
     Ok(InsnFunctionStepResult::Step)
@@ -913,7 +916,7 @@ pub fn op_not_null(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(NotNull { reg, target_pc }, insn);
     if !target_pc.is_offset() {
         crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
@@ -936,7 +939,7 @@ pub fn op_comparison(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     let (lhs, rhs, target_pc, flags, collation, op) = match insn {
         Insn::Eq {
             lhs,
@@ -1139,7 +1142,7 @@ pub fn op_if(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         If {
             reg,
@@ -1167,7 +1170,7 @@ pub fn op_if_not(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         IfNot {
             reg,
@@ -1217,7 +1220,7 @@ pub fn op_open_read(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         OpenRead {
             cursor_id,
@@ -1329,7 +1332,8 @@ pub fn op_open_read(
             if !table.has_rowid && program.connection.get_mv_tx_id_for_db(*db).is_some() {
                 return Err(LimboError::ParseError(
                     "WITHOUT ROWID tables are not supported in MVCC mode".to_string(),
-                ));
+                )
+                .into());
             }
             let btree_cursor: Box<dyn CursorTrait> = if table.has_rowid {
                 Box::new(BTreeCursor::new_table(
@@ -1392,7 +1396,7 @@ pub fn op_vopen(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(VOpen { cursor_id }, insn);
     let (_, cursor_type) = program
         .cursor_ref
@@ -1416,7 +1420,7 @@ pub fn op_vcreate(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         VCreate {
             module_name,
@@ -1434,9 +1438,9 @@ pub fn op_vcreate(
                 .collect::<Result<_, _>>()?
         } else {
             mark_unlikely();
-            return Err(LimboError::InternalError(
-                "VCreate: args_reg is not a record".to_string(),
-            ));
+            return Err(
+                LimboError::InternalError("VCreate: args_reg is not a record".to_string()).into(),
+            );
         }
     } else {
         vec![]
@@ -1456,7 +1460,7 @@ pub fn op_vfilter(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         VFilter {
             cursor_id,
@@ -1499,7 +1503,7 @@ pub fn op_vcolumn(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         VColumn {
             cursor_id,
@@ -1523,7 +1527,7 @@ pub fn op_vupdate(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     #[cfg(not(feature = "cli_only"))]
     let _ = pager;
     load_insn!(
@@ -1555,13 +1559,14 @@ pub fn op_vupdate(
         }
     };
     if virtual_table.readonly() && !allow_dbpage_write {
-        return Err(LimboError::ReadOnly);
+        return Err(LimboError::ReadOnly.into());
     }
 
     if unlikely(*arg_count < 2) {
         return Err(LimboError::InternalError(
             "VUpdate: arg_count must be at least 2 (rowid and insert_rowid)".to_string(),
-        ));
+        )
+        .into());
     }
     let mut argv = crate::alloc::Vec::try_with_capacity_ext(*arg_count)?;
     for i in 0..*arg_count {
@@ -1573,7 +1578,8 @@ pub fn op_vupdate(
             return Err(LimboError::InternalError(format!(
                 "VUpdate: register out of bounds at {}",
                 *start_reg + i
-            )));
+            ))
+            .into());
         }
     }
     let result = if allow_dbpage_write {
@@ -1605,9 +1611,9 @@ pub fn op_vupdate(
         Err(e) => {
             // virtual table update failed
             mark_unlikely();
-            return Err(LimboError::ExtensionError(format!(
-                "Virtual table update failed: {e}"
-            )));
+            return Err(
+                LimboError::ExtensionError(format!("Virtual table update failed: {e}")).into(),
+            );
         }
     }
     Ok(InsnFunctionStepResult::Step)
@@ -1618,7 +1624,7 @@ pub fn op_vnext(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         VNext {
             cursor_id,
@@ -1646,7 +1652,7 @@ pub fn op_vdestroy(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(VDestroy { db: _, table_name }, insn);
     let conn = program.connection.clone();
     {
@@ -1654,7 +1660,8 @@ pub fn op_vdestroy(
             mark_unlikely();
             return Err(crate::LimboError::InternalError(
                 "Could not find Virtual Table to Destroy".to_string(),
-            ));
+            )
+            .into());
         };
         vtab.destroy()?;
     }
@@ -1668,7 +1675,7 @@ pub fn op_vbegin(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(VBegin { cursor_id }, insn);
     let cursor = state.get_cursor(*cursor_id);
     let cursor = cursor.as_virtual_mut();
@@ -1694,7 +1701,7 @@ pub fn op_vrename(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         VRename {
             cursor_id,
@@ -1724,7 +1731,7 @@ pub fn op_open_pseudo(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         OpenPseudo {
             cursor_id,
@@ -1750,7 +1757,7 @@ pub fn op_rewind(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Rewind {
             cursor_id,
@@ -1793,7 +1800,7 @@ pub fn op_last(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Last {
             cursor_id,
@@ -1837,7 +1844,7 @@ pub fn op_column(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Column {
             cursor_id,
@@ -1859,12 +1866,16 @@ pub fn op_column(
     )
 }
 
+// Not in test builds: inline(always) makes fn-item coercions produce
+// per-site copies in debug, breaking test_make_sure_correct_insn_table's
+// pointer-identity check.
+#[cfg_attr(not(test), inline(always))]
 pub fn op_column_range(
     program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         ColumnRange {
             cursor_id,
@@ -1916,12 +1927,7 @@ impl ColumnFetch<'_> {
         }
     }
 
-    fn fetch(
-        &self,
-        program: &Program,
-        state: &mut ProgramState,
-        cursor_id: usize,
-    ) -> Result<InsnFunctionStepResult> {
+    fn fetch(&self, program: &Program, state: &mut ProgramState, cursor_id: usize) -> InsnResult {
         match *self {
             ColumnFetch::Single {
                 column,
@@ -1943,7 +1949,7 @@ fn op_column_impl(
     state: &mut ProgramState,
     cursor_id: usize,
     fetch: ColumnFetch<'_>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     // Fast path: no deferred seek pending and no suspended state machine. The
     // column fetch either completes or yields IO with nothing persisted, so the
     // op-state slot (enum write + drop on clear) is bypassed entirely. On IO
@@ -2038,7 +2044,7 @@ fn op_column_fetch(
     column: usize,
     dest: usize,
     default: &Option<Value>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     // First check if this is a MaterializedViewCursor
     {
         let cursor = state.get_cursor(cursor_id);
@@ -2198,7 +2204,7 @@ fn op_column_range_fetch(
     start_column: usize,
     dest: usize,
     defaults: &[Option<Value>],
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     let (_, cursor_type) = program
         .cursor_ref
         .get(cursor_id)
@@ -2285,7 +2291,7 @@ fn op_column_range_fetch(
                 return Err(LimboError::InternalError(format!(
                     "ColumnRange: pseudo-cursor content register {content_reg} must not overlap destination registers {dest}..{}",
                     dest + count
-                )));
+                )).into());
             }
             let (content, dest_regs) = if content_reg < dest {
                 let (left, right) = state.registers.split_at_mut(dest);
@@ -2320,7 +2326,7 @@ pub fn op_column_has_field(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         ColumnHasField {
             cursor_id,
@@ -2375,7 +2381,7 @@ pub fn op_type_check(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         TypeCheck {
             start_reg,
@@ -2401,7 +2407,9 @@ pub fn op_type_check(
                 )
             } else if col.is_rowid_alias() && matches!(reg.get_value(), Value::Null) {
                 // Handle INTEGER PRIMARY KEY for null as usual (Rowid will be auto-assigned)
-                return Ok(());
+                // (Turbofish pins the closure's error type; the bail macros are
+                // polymorphic over boxed and unboxed LimboError.)
+                return Ok::<(), LimboError>(());
             } else if matches!(reg.get_value(), Value::Null) {
                 // STRICT only enforces type affinity on non-NULL values.
                 // NULL is valid in any column without NOT NULL constraint.
@@ -2453,7 +2461,7 @@ pub fn op_array_encode(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ArrayEncode { data }, insn);
     let ArrayEncodeData {
         reg,
@@ -2569,7 +2577,7 @@ pub fn op_array_decode(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ArrayDecode { reg }, insn);
 
     let val = state.registers[*reg].get_value();
@@ -2599,7 +2607,7 @@ pub fn op_array_element(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         ArrayElement {
             array_reg,
@@ -2650,7 +2658,7 @@ pub fn op_array_length(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ArrayLength { reg, dest }, insn);
 
     let val = state.registers[*reg].get_value();
@@ -2668,7 +2676,7 @@ pub fn op_make_array(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         MakeArray {
             start_reg,
@@ -2687,7 +2695,8 @@ pub fn op_make_array(
             start_reg,
             end,
             state.registers.len()
-        )));
+        ))
+        .into());
     }
     state.registers[*dest].set_value(make_array_from_registers(
         &state.registers,
@@ -2705,7 +2714,7 @@ pub fn op_make_array_dynamic(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         MakeArrayDynamic {
             start_reg,
@@ -2729,7 +2738,8 @@ pub fn op_make_array_dynamic(
             start_reg,
             end,
             state.registers.len()
-        )));
+        ))
+        .into());
     }
 
     state.registers[*dest].set_value(make_array_from_registers(
@@ -2751,7 +2761,7 @@ pub fn op_struct_field(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         StructField {
             src_reg,
@@ -2786,7 +2796,7 @@ pub fn op_union_pack(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         UnionPack {
             tag_index,
@@ -2818,7 +2828,7 @@ pub fn op_union_tag(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         UnionTag {
             src_reg,
@@ -2856,7 +2866,7 @@ pub fn op_union_extract(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         UnionExtract {
             src_reg,
@@ -2911,7 +2921,7 @@ pub fn op_reg_copy_offset(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         RegCopyOffset {
             src,
@@ -2931,7 +2941,8 @@ pub fn op_reg_copy_offset(
             "RegCopyOffset: destination register {} out of bounds (max {})",
             dest,
             state.registers.len()
-        )));
+        ))
+        .into());
     }
     if dest != *src {
         // try_clone_from reuses the destination register's allocation.
@@ -2952,7 +2963,7 @@ pub fn op_array_concat(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ArrayConcat { lhs, rhs, dest }, insn);
 
     // Check NULL before cloning to avoid unnecessary allocation
@@ -3011,7 +3022,7 @@ pub fn op_array_set_element(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         ArraySetElement {
             array_reg,
@@ -3042,9 +3053,9 @@ pub fn op_array_set_element(
     let new_val = state.registers[*value_reg].get_value().clone();
 
     let Value::Blob(blob) = arr_val else {
-        return Err(LimboError::InternalError(
-            "ArraySetElement: expected blob array".into(),
-        ));
+        return Err(
+            LimboError::InternalError("ArraySetElement: expected blob array".into()).into(),
+        );
     };
     let mut elements = array_values_from_blob(blob)?;
     if idx >= elements.len() {
@@ -3065,7 +3076,7 @@ pub fn op_array_slice(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         ArraySlice {
             array_reg,
@@ -3092,7 +3103,7 @@ pub fn op_make_record(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         MakeRecord {
             start_reg,
@@ -3114,7 +3125,8 @@ pub fn op_make_record(
                 "MakeRecord: the length of affinity string ({}) does not match the count ({})",
                 affinity_str.len(),
                 count
-            )));
+            ))
+            .into());
         }
         for (i, affinity_ch) in affinity_str.chars().enumerate().take(count) {
             let reg_index = start_reg + i;
@@ -3127,7 +3139,8 @@ pub fn op_make_record(
         return Err(LimboError::InternalError(format!(
             "MakeRecord: destination register {dest_reg} overlaps its source range {start_reg}..{}",
             start_reg + count
-        )));
+        ))
+        .into());
     }
 
     // Serialize into the destination register's spent record buffer: per-row
@@ -3145,7 +3158,7 @@ pub fn op_mem_max(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(MemMax { dest_reg, src_reg }, insn);
 
     let dest_val = state.registers[*dest_reg].get_value();
@@ -3203,7 +3216,7 @@ pub fn op_blob_read(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         BlobRead {
             cursor,
@@ -3224,7 +3237,9 @@ pub fn op_blob_read(
     {
         Ok(IOResult::Done(())) => {}
         Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
-        Err(LimboError::BlobHandleExpired) => return Ok(blob_expired_ack(state, *dest)),
+        Err(err) if matches!(*err, LimboError::BlobHandleExpired) => {
+            return Ok(blob_expired_ack(state, *dest))
+        }
         Err(err) => return Err(err),
     }
     state.registers[*dest].set_value(Value::Blob(out));
@@ -3240,7 +3255,7 @@ pub fn op_blob_len(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         BlobLen {
             cursor,
@@ -3264,7 +3279,7 @@ pub fn op_blob_write(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         BlobWrite {
             cursor,
@@ -3281,13 +3296,16 @@ pub fn op_blob_write(
         other => {
             return Err(LimboError::InternalError(format!(
                 "BlobWrite: source register must hold a blob, got {other:?}"
-            )));
+            ))
+            .into());
         }
     };
     match blob_btree_cursor(state, *cursor, "BlobWrite")?.blob_write_column(*column, off, &data) {
         Ok(IOResult::Done(())) => {}
         Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
-        Err(LimboError::BlobHandleExpired) => return Ok(blob_expired_ack(state, *dest)),
+        Err(err) if matches!(*err, LimboError::BlobHandleExpired) => {
+            return Ok(blob_expired_ack(state, *dest))
+        }
         Err(err) => return Err(err),
     }
     state.registers[*dest].set_value(Value::Numeric(Numeric::Integer(1)));
@@ -3295,12 +3313,16 @@ pub fn op_blob_write(
     Ok(InsnFunctionStepResult::Step)
 }
 
+// Not in test builds: inline(always) makes fn-item coercions produce
+// per-site copies in debug, breaking test_make_sure_correct_insn_table's
+// pointer-identity check.
+#[cfg_attr(not(test), inline(always))]
 pub fn op_result_row(
     _program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ResultRow { start_reg, count }, insn);
     let row = Row {
         values: &state.registers[*start_reg] as *const Register,
@@ -3311,12 +3333,16 @@ pub fn op_result_row(
     Ok(InsnFunctionStepResult::Row)
 }
 
+// Not in test builds: inline(always) makes fn-item coercions produce
+// per-site copies in debug, breaking test_make_sure_correct_insn_table's
+// pointer-identity check.
+#[cfg_attr(not(test), inline(always))]
 pub fn op_next(
     program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Next {
             cursor_id,
@@ -3382,7 +3408,7 @@ pub fn op_prev(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Prev {
             cursor_id,
@@ -3435,7 +3461,7 @@ pub fn halt(
     err_code: usize,
     description: &str,
     on_error: Option<ResolveType>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     state.halt_in_progress = true;
     let mv_store = program.connection.mv_store();
     let auto_commit = program.connection.auto_commit.load(Ordering::SeqCst);
@@ -3450,7 +3476,7 @@ pub fn halt(
         match program.commit_txn(pager.clone(), state, mv_store.as_ref(), false)? {
             IOResult::Done(_) => {
                 index_method_on_transaction_committed_all(state, &program.connection);
-                return Err(pending_error);
+                return Err(pending_error.into());
             }
             IOResult::IO(io) => {
                 state.pending_fail_error = Some(pending_error); // put it back and wait
@@ -3474,7 +3500,7 @@ pub fn halt(
             if program.is_trigger_subprogram() {
                 return_if_io!(index_method_stage_statement_all(state));
             }
-            return Err(LimboError::RaiseIgnore);
+            return Err(LimboError::RaiseIgnore.into());
         }
         if err_code > 0 {
             let error = match resolve_type {
@@ -3488,10 +3514,10 @@ pub fn halt(
             // Trigger subprograms must not commit — just propagate the error.
             // The parent program's abort() handles transaction state.
             if program.is_trigger_subprogram() {
-                return Err(error);
+                return Err(error.into());
             }
 
-            return Err(error);
+            return Err(error.into());
         }
     }
 
@@ -3536,7 +3562,8 @@ pub fn halt(
             {
                 return Err(LimboError::ForeignKeyConstraint(
                     "immediate foreign key constraint failed".to_string(),
-                ));
+                )
+                .into());
             }
 
             // Stage every custom index before releasing the statement
@@ -3555,7 +3582,7 @@ pub fn halt(
             match program.commit_txn(pager.clone(), state, mv_store.as_ref(), false)? {
                 IOResult::Done(_) => {
                     index_method_on_transaction_committed_all(state, &program.connection);
-                    return Err(error);
+                    return Err(error.into());
                 }
                 IOResult::IO(io) => {
                     // store the error for reentrancy
@@ -3574,13 +3601,13 @@ pub fn halt(
         // as-is.
         if program.resolve_type == ResolveType::Fail {
             if let LimboError::Constraint(msg) = error {
-                return Err(LimboError::Raise(ResolveType::Fail, msg));
+                return Err(LimboError::Raise(ResolveType::Fail, msg).into());
             }
         }
 
         // For non-FAIL modes (or non-autocommit), just return the error.
         // abort() will handle rollback based on resolve_type.
-        return Err(error);
+        return Err(error.into());
     }
 
     tracing::trace!(
@@ -3596,7 +3623,8 @@ pub fn halt(
     {
         return Err(LimboError::ForeignKeyConstraint(
             "immediate foreign key constraint failed".to_string(),
-        ));
+        )
+        .into());
     }
 
     if program.is_trigger_subprogram() {
@@ -3629,7 +3657,8 @@ pub fn halt(
                 program.connection.set_tx_state(TransactionState::None);
                 return Err(LimboError::ForeignKeyConstraint(
                     "deferred foreign key constraint failed".to_string(),
-                ));
+                )
+                .into());
             }
         }
         if can_autocommit_now {
@@ -3747,9 +3776,7 @@ pub(crate) fn vtab_commit_all(conn: &Connection) -> crate::Result<()> {
 /// Stage pending writes on every index-method cursor before releasing the
 /// statement savepoint. Cursor order is bytecode cursor order, which is stable
 /// across resumptions and avoids attachment-order ambiguity.
-pub(crate) fn index_method_stage_statement_all(
-    state: &mut ProgramState,
-) -> crate::Result<IOResult<()>> {
+pub(crate) fn index_method_stage_statement_all(state: &mut ProgramState) -> IOResultOr<()> {
     if state.index_methods_finalized {
         return Ok(IOResult::Done(()));
     }
@@ -3763,7 +3790,8 @@ pub(crate) fn index_method_stage_statement_all(
             let Some(context) = state.index_method_contexts[cursor_id].clone() else {
                 return Err(LimboError::InternalError(format!(
                     "index-method cursor {cursor_id} has no execution context"
-                )));
+                ))
+                .into());
             };
             crate::mvcc::yield_points::inject_io_yield!(
                 context,
@@ -3949,7 +3977,7 @@ pub fn op_halt(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Halt {
             err_code,
@@ -3974,7 +4002,7 @@ pub fn op_halt_if_null(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         HaltIfNull {
             target_reg,
@@ -4024,7 +4052,7 @@ pub fn op_transaction(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     let result = op_transaction_inner(program, state, insn, pager);
     tracing::debug!(
         "op_transaction: end: state={:?}, tx_state={:?}",
@@ -4125,10 +4153,10 @@ fn begin_fresh_mvcc_tx(
     }
 }
 
-fn pager_db_size_for_named_savepoint(pager: &Arc<Pager>) -> Result<IOResult<u32>> {
+fn pager_db_size_for_named_savepoint(pager: &Arc<Pager>) -> IOResultOr<u32> {
     match pager.with_header(|header| header.database_size.get()) {
         Ok(result) => Ok(result),
-        Err(LimboError::Page1NotAlloc) => Ok(IOResult::Done(0)),
+        Err(err) if matches!(*err, LimboError::Page1NotAlloc) => Ok(IOResult::Done(0)),
         Err(err) => Err(err),
     }
 }
@@ -4136,7 +4164,7 @@ fn pager_db_size_for_named_savepoint(pager: &Arc<Pager>) -> Result<IOResult<u32>
 fn open_named_savepoint_frames_on_wal_pager(
     pager: &Arc<Pager>,
     frames: &[crate::connection::NamedSavepointFrame],
-) -> Result<IOResult<()>> {
+) -> IOResultOr<()> {
     if frames.is_empty() {
         return Ok(IOResult::Done(()));
     }
@@ -4160,7 +4188,7 @@ fn open_connection_named_savepoints_for_db(
     conn: &Connection,
     db: usize,
     pager: &Arc<Pager>,
-) -> Result<IOResult<()>> {
+) -> IOResultOr<()> {
     conn.with_named_savepoints(|frames| {
         if frames.is_empty() {
             return Ok(IOResult::Done(()));
@@ -4185,7 +4213,7 @@ fn open_connection_named_savepoints_for_db(
     })
 }
 
-fn load_active_non_main_wal_headers_for_named_savepoint(conn: &Connection) -> Result<IOResult<()>> {
+fn load_active_non_main_wal_headers_for_named_savepoint(conn: &Connection) -> IOResultOr<()> {
     conn.with_all_attached_pagers_with_index(|pagers| {
         for (db_id, pager) in pagers {
             if conn.mv_store_for_db(*db_id).is_some() || !pager.holds_read_lock() {
@@ -4282,7 +4310,7 @@ pub fn op_transaction_inner(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Transaction {
             db,
@@ -4319,7 +4347,7 @@ pub fn op_transaction_inner(
                 let conn = program.connection.clone();
                 let mut started_secondary_tx = false;
                 if write && conn.is_readonly(*db) {
-                    return Err(LimboError::ReadOnly);
+                    return Err(LimboError::ReadOnly.into());
                 }
                 let active_writers = conn.n_active_writes.load(Ordering::SeqCst);
                 turso_assert!(
@@ -4340,9 +4368,9 @@ pub fn op_transaction_inner(
                     && !state.is_active_write
                     && active_writers > 0
                 {
-                    return Err(LimboError::StatementsInProgress(
-                        "cannot start a write statement",
-                    ));
+                    return Err(
+                        LimboError::StatementsInProgress("cannot start a write statement").into(),
+                    );
                 }
 
                 // Fast path: if checkpoint root publication already replaced the
@@ -4354,7 +4382,7 @@ pub fn op_transaction_inner(
                     tracing::debug!(
                         "MVCC shared schema changed without a schema-cookie change; force reprepare"
                     );
-                    return Err(LimboError::SchemaUpdated);
+                    return Err(LimboError::SchemaUpdated.into());
                 }
                 #[cfg(any(test, injected_yields))]
                 {
@@ -4440,7 +4468,8 @@ pub fn op_transaction_inner(
                                 return Err(LimboError::TxError(
                                     "Cannot start CONCURRENT transaction after BEGIN DEFERRED"
                                         .to_string(),
-                                ));
+                                )
+                                .into());
                             }
                             // Use the same tx_mode as the main DB's active
                             // transaction when available, so BEGIN CONCURRENT
@@ -4474,7 +4503,7 @@ pub fn op_transaction_inner(
                                         state.auto_txn_cleanup = TxnCleanup::RollbackTxn;
                                     }
                                 }
-                                Err(err) => return Err(err),
+                                Err(err) => return Err(err.into()),
                             }
                         } else if write {
                             // Upgrade: attached DB has a Read/Concurrent tx but the
@@ -4529,7 +4558,8 @@ pub fn op_transaction_inner(
                             return Err(LimboError::TxError(
                                 "Cannot start CONCURRENT transaction after BEGIN DEFERRED"
                                     .to_string(),
-                            ));
+                            )
+                            .into());
                         }
 
                         if !has_existing_mv_tx {
@@ -4549,7 +4579,7 @@ pub fn op_transaction_inner(
                                             conn.set_tx_state(TransactionState::None);
                                             state.auto_txn_cleanup = TxnCleanup::None;
                                         }
-                                        return Err(err);
+                                        return Err(err.into());
                                     }
                                 };
                             #[cfg(any(test, injected_yields))]
@@ -4585,7 +4615,7 @@ pub fn op_transaction_inner(
                                         conn.set_tx_state(TransactionState::None);
                                         state.auto_txn_cleanup = TxnCleanup::None;
                                     }
-                                    return Err(err);
+                                    return Err(err.into());
                                 }
                             }
                         } else if updated {
@@ -4614,7 +4644,7 @@ pub fn op_transaction_inner(
                                         conn.set_tx_state(TransactionState::None);
                                         state.auto_txn_cleanup = TxnCleanup::None;
                                     }
-                                    return Err(err);
+                                    return Err(err.into());
                                 }
                             }
                         }
@@ -4625,7 +4655,8 @@ pub fn op_transaction_inner(
                         return Err(LimboError::TxError(
                             "Concurrent transaction mode is only supported when MVCC is enabled"
                                 .to_string(),
-                        ));
+                        )
+                        .into());
                     }
                     // For attached databases without MVCC, always start read/write
                     // transactions on the attached pager, since the connection-level
@@ -4687,8 +4718,8 @@ pub fn op_transaction_inner(
                         );
                         let begin_w_tx_res = pager.begin_write_tx(conn.wal_auto_actions());
                         if matches!(
-                            begin_w_tx_res,
-                            Err(LimboError::Busy | LimboError::BusySnapshot)
+                            &begin_w_tx_res,
+                            Err(err) if matches!(**err, LimboError::Busy | LimboError::BusySnapshot)
                         ) {
                             // We failed to upgrade to write transaction so put the transaction into its original state.
                             // That is, if the transaction had not started, end the read transaction so that next time we
@@ -4780,12 +4811,12 @@ pub fn op_transaction_inner(
                                 header_schema_cookie,
                                 *schema_cookie
                             );
-                            return Err(LimboError::SchemaUpdated);
+                            return Err(LimboError::SchemaUpdated.into());
                         }
                     }
                     Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
                     // This means we are starting a read_tx and we do not have a page 1 yet, so we just continue execution
-                    Err(LimboError::Page1NotAlloc) => {}
+                    Err(err) if matches!(*err, LimboError::Page1NotAlloc) => {}
                     Err(err) => {
                         return Err(err);
                     }
@@ -4890,7 +4921,7 @@ pub fn op_auto_commit(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         AutoCommit {
             auto_commit,
@@ -4957,7 +4988,8 @@ pub fn op_auto_commit(
         (false, true) => {
             return Err(LimboError::InternalError(
                 "Insn::AutoCommit {{ auto_commit: false, rollback: true }} is not valid".into(),
-            ));
+            )
+            .into());
         }
     };
 
@@ -4976,7 +5008,8 @@ pub fn op_auto_commit(
                 TxOp::Commit => "cannot commit transaction",
                 TxOp::Rollback => "cannot rollback transaction",
                 TxOp::Begin => unreachable!("guard only matches Commit | Rollback"),
-            }));
+            })
+            .into());
         }
 
         match tx_op {
@@ -5007,7 +5040,8 @@ pub fn op_auto_commit(
                     conn.rollback_manual_txn_cleanup(pager, true);
                     return Err(LimboError::TxError(
                         "cannot commit - an unfinished write statement was abandoned".to_string(),
-                    ));
+                    )
+                    .into());
                 }
                 // Pre-check deferred FKs; leave tx open and do NOT clear violations
                 check_deferred_fk_on_commit(&conn)?;
@@ -5027,13 +5061,16 @@ pub fn op_auto_commit(
         return match &tx_op {
             TxOp::Begin => Err(LimboError::TxError(
                 "cannot start a transaction within a transaction".to_string(),
-            )),
+            )
+            .into()),
             TxOp::Commit => Err(LimboError::TxError(
                 "cannot commit - no transaction is active".to_string(),
-            )),
+            )
+            .into()),
             TxOp::Rollback => Err(LimboError::TxError(
                 "cannot rollback - no transaction is active".to_string(),
-            )),
+            )
+            .into()),
         };
     }
 
@@ -5096,7 +5133,7 @@ pub fn op_savepoint(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Savepoint { op, name }, insn);
     let conn = program.connection.clone();
     let mv_store = conn.mv_store();
@@ -5116,7 +5153,8 @@ pub fn op_savepoint(
             SavepointOp::Begin => "cannot open savepoint",
             SavepointOp::Release => "cannot release savepoint",
             SavepointOp::RollbackTo => "cannot rollback savepoint",
-        }));
+        })
+        .into());
     }
 
     match *op {
@@ -5246,6 +5284,7 @@ pub fn op_savepoint(
                     Ok(InsnFunctionStepResult::Step)
                 },
             )
+            .map_err(Into::into)
         }
         SavepointOp::Release => {
             let release_result = if let Some(mv_store) = mv_store.as_ref() {
@@ -5259,7 +5298,7 @@ pub fn op_savepoint(
             match release_result {
                 SavepointResult::NotFound => {
                     mark_unlikely();
-                    return Err(LimboError::TxError(format!("no such savepoint: {name}")));
+                    return Err(LimboError::TxError(format!("no such savepoint: {name}")).into());
                 }
                 SavepointResult::Release => {
                     let _ = conn.release_named_savepoint_frame(name);
@@ -5298,7 +5337,7 @@ pub fn op_savepoint(
 
             let Some(deferred_fk_snapshot) = deferred_fk_snapshot else {
                 mark_unlikely();
-                return Err(LimboError::TxError(format!("no such savepoint: {name}")));
+                return Err(LimboError::TxError(format!("no such savepoint: {name}")).into());
             };
             let frame_info = conn.rollback_named_savepoint_frame(name);
             mirror_named_savepoint_to_active_non_main_databases(
@@ -5371,7 +5410,7 @@ pub fn op_goto(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Goto { target_pc }, insn);
     if !target_pc.is_offset() {
         crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
@@ -5385,7 +5424,7 @@ pub fn op_gosub(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Gosub {
             target_pc,
@@ -5406,7 +5445,7 @@ pub fn op_return(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Return {
             return_reg,
@@ -5421,9 +5460,9 @@ pub fn op_return(
         state.pc = pc;
     } else {
         if unlikely(!*can_fallthrough) {
-            return Err(LimboError::InternalError(
-                "Return register is not an integer".to_string(),
-            ));
+            return Err(
+                LimboError::InternalError("Return register is not an integer".to_string()).into(),
+            );
         }
         state.pc += 1;
     }
@@ -5435,7 +5474,7 @@ pub fn op_integer(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Integer { value, dest }, insn);
     state.registers[*dest].set_int(*value);
     state.pc += 1;
@@ -5500,7 +5539,7 @@ pub fn op_reset_count(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     if !matches!(insn, Insn::ResetCount) {
         panic!("Expected Insn::ResetCount, got {insn:?}");
     }
@@ -5518,7 +5557,7 @@ pub fn op_change_count(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ChangeCount { dest }, insn);
     let nchange = state.n_change.load(Ordering::SeqCst);
     state.registers[*dest].set_int(nchange);
@@ -5533,7 +5572,7 @@ pub fn op_program(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Program {
             param_registers,
@@ -5630,7 +5669,7 @@ pub fn op_program(
                                     saved_last_insert_rowid,
                                     saved_changes_value: saved_last_changes_value,
                                 };
-                                return Err(LimboError::Busy);
+                                return Err(LimboError::Busy.into());
                             }
                         },
                         Err(LimboError::Constraint(constraint_err)) => {
@@ -5644,7 +5683,7 @@ pub fn op_program(
                                     saved_last_insert_rowid,
                                     saved_last_changes_value,
                                 );
-                                return Err(LimboError::Constraint(constraint_err));
+                                return Err(LimboError::Constraint(constraint_err).into());
                             }
                             subprogram_aborted = true;
                             break;
@@ -5664,7 +5703,7 @@ pub fn op_program(
                                 saved_last_insert_rowid,
                                 saved_last_changes_value,
                             );
-                            return Err(err);
+                            return Err(err.into());
                         }
                     }
                 }
@@ -5703,7 +5742,7 @@ pub fn op_real(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Real { value, dest }, insn);
     state.registers[*dest]
         .set_float(NonNan::new(*value).expect("f64 passed to op_real should be a valid NonNan"));
@@ -5716,7 +5755,7 @@ pub fn op_real_affinity(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(RealAffinity { register }, insn);
     if let Value::Numeric(Numeric::Integer(i)) = &state.registers[*register].get_value() {
         state.registers[*register].set_float(
@@ -5733,7 +5772,7 @@ pub fn op_string8(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(String8 { value, dest }, insn);
     state.registers[*dest].set_text(Text::new(value.clone()))?;
     state.pc += 1;
@@ -5745,7 +5784,7 @@ pub fn op_blob(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Blob { value, dest }, insn);
     state.registers[*dest].set_blob(value.clone())?;
     state.pc += 1;
@@ -5757,7 +5796,7 @@ pub fn op_row_data(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(RowData { cursor_id, dest }, insn);
 
     // Copy the row into the destination register's spent record buffer: one
@@ -5797,12 +5836,16 @@ pub enum OpRowIdState {
     GetRowid,
 }
 
+// Not in test builds: inline(always) makes fn-item coercions produce
+// per-site copies in debug, breaking test_make_sure_correct_insn_table's
+// pointer-identity check.
+#[cfg_attr(not(test), inline(always))]
 pub fn op_row_id(
     _program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(RowId { cursor_id, dest }, insn);
     loop {
         match *state.active_op_state.row_id() {
@@ -5913,7 +5956,8 @@ pub fn op_row_id(
                     return Err(LimboError::InternalError(
                         "RowId: cursor is not a table, virtual, or materialized view cursor"
                             .to_string(),
-                    ));
+                    )
+                    .into());
                 }
                 break;
             }
@@ -5930,7 +5974,7 @@ pub fn op_idx_row_id(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(IdxRowId { cursor_id, dest }, insn);
     let cursors = &mut state.cursors;
     let cursor = cursors
@@ -5958,7 +6002,7 @@ pub fn op_seek_rowid(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SeekRowid {
             cursor_id,
@@ -6048,7 +6092,7 @@ pub fn op_deferred_seek(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         DeferredSeek {
             index_cursor_id,
@@ -6093,7 +6137,7 @@ pub fn op_seek(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     let (cursor_id, is_index, start_reg, num_regs, target_pc) = match insn {
         Insn::SeekGE {
             cursor_id,
@@ -6194,7 +6238,7 @@ pub fn op_seek(
             Ok(InsnFunctionStepResult::Step)
         }
         Ok(SeekInternalResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
-        Err(e) => Err(e),
+        Err(e) => Err(e.into()),
     }
 }
 
@@ -6570,7 +6614,7 @@ pub fn op_idx_ge(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         IdxGE {
             cursor_id,
@@ -6623,7 +6667,7 @@ pub fn op_seek_end(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(SeekEnd { cursor_id }, *insn);
     {
         let cursor = state.get_cursor(cursor_id);
@@ -6640,7 +6684,7 @@ pub fn op_idx_le(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         IdxLE {
             cursor_id,
@@ -6687,7 +6731,7 @@ pub fn op_idx_gt(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         IdxGT {
             cursor_id,
@@ -6734,7 +6778,7 @@ pub fn op_idx_lt(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         IdxLT {
             cursor_id,
@@ -6781,7 +6825,7 @@ pub fn op_decr_jump_zero(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(DecrJumpZero { reg, target_pc }, insn);
     if !target_pc.is_offset() {
         crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
@@ -6802,7 +6846,8 @@ pub fn op_decr_jump_zero(
             mark_unlikely();
             return Err(LimboError::InternalError(
                 "DecrJumpZero: unexpected aggregate register".into(),
-            ));
+            )
+            .into());
         }
     }
     Ok(InsnFunctionStepResult::Step)
@@ -7602,7 +7647,7 @@ fn op_window_step(
     acc_reg: usize,
     arg_reg: usize,
     func: &WindowFunc,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     match func {
         WindowFunc::RowNumber => {
             if let Register::Value(Value::Null) = state.registers[acc_reg] {
@@ -7730,7 +7775,8 @@ fn op_window_step(
             if !coerce_register_to_integer(state, arg_reg + 1) {
                 return Err(LimboError::InvalidArgument(
                     "second argument to nth_value must be a positive integer".into(),
-                ));
+                )
+                .into());
             }
             let Value::Numeric(Numeric::Integer(n)) = state.registers[arg_reg + 1].get_value()
             else {
@@ -7740,7 +7786,8 @@ fn op_window_step(
             if n <= 0 {
                 return Err(LimboError::InvalidArgument(
                     "second argument to nth_value must be a positive integer".into(),
-                ));
+                )
+                .into());
             }
             if let Register::Value(Value::Null) = state.registers[acc_reg] {
                 state.registers[acc_reg] =
@@ -7848,7 +7895,8 @@ fn op_window_step(
                 if nparam <= 0 {
                     return Err(LimboError::InvalidArgument(
                         "argument of ntile must be a positive integer".into(),
-                    ));
+                    )
+                    .into());
                 }
                 state.registers[acc_reg] =
                     Register::Aggregate(AggContext::Builtin(crate::alloc::try_vec![
@@ -7869,7 +7917,8 @@ fn op_window_step(
         other => {
             return Err(LimboError::InternalError(format!(
                 "window function {other} reached runtime dispatch but has no handler"
-            )));
+            ))
+            .into());
         }
     }
     state.pc += 1;
@@ -7882,14 +7931,15 @@ fn op_window_value(
     acc_reg: usize,
     dest_reg: usize,
     func: &WindowFunc,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     let value = match func {
         WindowFunc::RowNumber => match &state.registers[acc_reg] {
             Register::Aggregate(AggContext::Builtin(payload)) => payload[0].clone(),
             other => {
                 return Err(LimboError::InternalError(format!(
                     "row_number accumulator in unexpected register state: {other:?}"
-                )));
+                ))
+                .into());
             }
         },
         WindowFunc::Rank => {
@@ -7900,7 +7950,8 @@ fn op_window_value(
                 return Err(LimboError::InternalError(format!(
                     "rank accumulator in unexpected register state: {:?}",
                     state.registers[acc_reg]
-                )));
+                ))
+                .into());
             };
             std::mem::replace(&mut payload[0], Value::from_i64(0))
         }
@@ -7913,7 +7964,8 @@ fn op_window_value(
                 return Err(LimboError::InternalError(format!(
                     "dense_rank accumulator in unexpected register state: {:?}",
                     state.registers[acc_reg]
-                )));
+                ))
+                .into());
             };
             let Value::Numeric(Numeric::Integer(pending)) = &mut payload[1] else {
                 unreachable!("dense_rank pending flag must be Integer");
@@ -7941,7 +7993,8 @@ fn op_window_value(
                 other => {
                     return Err(LimboError::InternalError(format!(
                         "{func} accumulator in unexpected register state: {other:?}"
-                    )));
+                    ))
+                    .into());
                 }
             }
         }
@@ -7961,7 +8014,8 @@ fn op_window_value(
                 other => {
                     return Err(LimboError::InternalError(format!(
                         "last_value accumulator in unexpected register state: {other:?}"
-                    )));
+                    ))
+                    .into());
                 }
             }
         }
@@ -7974,7 +8028,8 @@ fn op_window_value(
                 return Err(LimboError::InternalError(format!(
                     "percent_rank accumulator in unexpected register state: {:?}",
                     state.registers[acc_reg]
-                )));
+                ))
+                .into());
             };
             let Value::Numeric(Numeric::Integer(ntotal)) = &payload[0] else {
                 unreachable!("percent_rank nTotal must be Integer");
@@ -7999,7 +8054,8 @@ fn op_window_value(
                 return Err(LimboError::InternalError(format!(
                     "cume_dist accumulator in unexpected register state: {:?}",
                     state.registers[acc_reg]
-                )));
+                ))
+                .into());
             };
             let Value::Numeric(Numeric::Integer(ntotal)) = &payload[0] else {
                 unreachable!("cume_dist nTotal must be Integer");
@@ -8055,7 +8111,8 @@ fn op_window_value(
         other => {
             return Err(LimboError::InternalError(format!(
                 "window function {other} reached runtime dispatch but has no handler"
-            )));
+            ))
+            .into());
         }
     };
     state.registers[dest_reg].set_value(value);
@@ -8071,7 +8128,7 @@ fn op_window_inverse(
     acc_reg: usize,
     _arg_reg: usize,
     func: &WindowFunc,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     match func {
         // percent_rank / cume_dist xInverse — increment nStep, the
         // count of rows that have dropped off the start of the frame.
@@ -8083,7 +8140,7 @@ fn op_window_inverse(
                 return Err(LimboError::InternalError(format!(
                     "percent_rank/cume_dist accumulator in unexpected register state at inverse: {:?}",
                     state.registers[acc_reg]
-                )));
+                )).into());
             };
             let Value::Numeric(Numeric::Integer(nstep)) = &mut payload[1] else {
                 unreachable!("percent_rank/cume_dist nStep must be Integer");
@@ -8120,7 +8177,8 @@ fn op_window_inverse(
                 return Err(LimboError::InternalError(format!(
                     "last_value accumulator in unexpected register state at inverse: {:?}",
                     state.registers[acc_reg]
-                )));
+                ))
+                .into());
             };
             let Value::Numeric(Numeric::Integer(count)) = &mut payload[1] else {
                 unreachable!("last_value frame-row count must be Integer");
@@ -8151,7 +8209,7 @@ pub fn op_agg_inverse(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         AggInverse {
             acc_reg,
@@ -8176,7 +8234,8 @@ pub fn op_agg_inverse(
         return Err(LimboError::InternalError(format!(
             "AggInverse: acc_reg {} not initialized — xStep should have run first",
             *acc_reg
-        )));
+        ))
+        .into());
     };
     let payload = agg.payload_mut();
     inverse_agg_payload(func, arg, payload)?;
@@ -8477,7 +8536,7 @@ pub fn op_agg_step(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(AggStep { data }, insn);
     let AggStepData {
         acc_reg,
@@ -8586,7 +8645,7 @@ pub fn op_agg_step(
                     unsafe { aggregate_destructor(state_ptr as usize) };
                 }
                 state.registers[*acc_reg].set_value(Value::Null);
-                return Err(err);
+                return Err(err.into());
             }
         }
         _ => {
@@ -8619,7 +8678,8 @@ pub fn op_agg_step(
                 return Err(LimboError::InternalError(format!(
                     "AggStep: register {} does not hold an aggregate accumulator",
                     *acc_reg
-                )));
+                ))
+                .into());
             };
             let payload = agg.payload_vec_mut();
             update_agg_payload(
@@ -8642,7 +8702,7 @@ pub fn op_agg_final(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     let (acc_reg, dest_reg, func) = match insn {
         Insn::AggFinal { register, func } => (*register, *register, func),
         Insn::AggValue {
@@ -8748,7 +8808,7 @@ pub fn op_sorter_open(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(SorterOpen { data }, insn);
     let SorterOpenData {
         cursor_id,
@@ -8821,7 +8881,7 @@ pub fn op_sorter_data(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SorterData {
             cursor_id,
@@ -8840,7 +8900,7 @@ pub fn op_sorter_data(
         if content_reg != *dest_reg {
             return Err(LimboError::InternalError(format!(
                 "SorterData: destination register {dest_reg} must be pseudo-cursor {pseudo_cursor}'s content register {content_reg}"
-            )));
+            )).into());
         }
     }
     {
@@ -8870,7 +8930,7 @@ pub fn op_sorter_insert(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SorterInsert {
             cursor_id,
@@ -8896,7 +8956,7 @@ pub fn op_sorter_sort(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SorterSort {
             cursor_id,
@@ -8931,7 +8991,7 @@ pub fn op_sorter_next(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SorterNext {
             cursor_id,
@@ -8960,7 +9020,7 @@ pub fn op_sorter_compare(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SorterCompare {
             cursor_id,
@@ -8974,9 +9034,9 @@ pub fn op_sorter_compare(
     let previous_sorter_values = {
         let Register::Record(record) = &state.registers[*sorted_record_reg] else {
             mark_unlikely();
-            return Err(LimboError::InternalError(
-                "Sorted record must be a record".to_string(),
-            ));
+            return Err(
+                LimboError::InternalError("Sorted record must be a record".to_string()).into(),
+            );
         };
         &record.get_values_range(0..*num_regs)?
     };
@@ -8992,9 +9052,7 @@ pub fn op_sorter_compare(
     let cursor = cursor.as_sorter_mut();
     let Some(current_sorter_record) = cursor.record() else {
         mark_unlikely();
-        return Err(LimboError::InternalError(
-            "Sorter must have a record".to_string(),
-        ));
+        return Err(LimboError::InternalError("Sorter must have a record".to_string()).into());
     };
 
     let current_sorter_values = &current_sorter_record.get_values_range(0..*num_regs)?;
@@ -9024,7 +9082,7 @@ pub fn op_rowset_add(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         RowSetAdd {
             rowset_reg,
@@ -9038,9 +9096,9 @@ pub fn op_rowset_add(
         Value::Numeric(Numeric::Integer(i)) => *i,
         _ => {
             mark_unlikely();
-            return Err(LimboError::InternalError(
-                "RowSetAdd: P2 must be an integer".to_string(),
-            ));
+            return Err(
+                LimboError::InternalError("RowSetAdd: P2 must be an integer".to_string()).into(),
+            );
         }
     };
 
@@ -9059,7 +9117,7 @@ pub fn op_rowset_read(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         RowSetRead {
             rowset_reg,
@@ -9110,7 +9168,7 @@ pub fn op_rowset_test(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         RowSetTest {
             rowset_reg,
@@ -9127,9 +9185,9 @@ pub fn op_rowset_test(
         Value::Numeric(Numeric::Integer(i)) => *i,
         _ => {
             mark_unlikely();
-            return Err(LimboError::InternalError(
-                "RowSetTest: P3 must be an integer".to_string(),
-            ));
+            return Err(
+                LimboError::InternalError("RowSetTest: P3 must be an integer".to_string()).into(),
+            );
         }
     };
 
@@ -9179,7 +9237,7 @@ pub fn op_function(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Function {
             constant_mask: _,
@@ -9199,7 +9257,7 @@ pub fn op_function(
                 let json_str = get_json(json_value.get_value(), None);
                 match json_str {
                     Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
 
@@ -9208,7 +9266,7 @@ pub fn op_function(
                 let json_blob = jsonb(json_value.get_value(), &state.json_cache);
                 match json_blob {
                     Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
 
@@ -9230,7 +9288,7 @@ pub fn op_function(
 
                 match json_result {
                     Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
             JsonFunc::JsonExtract => {
@@ -9248,7 +9306,7 @@ pub fn op_function(
 
                 match result {
                     Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
             JsonFunc::JsonbExtract => {
@@ -9266,7 +9324,7 @@ pub fn op_function(
 
                 match result {
                     Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
 
@@ -9282,7 +9340,7 @@ pub fn op_function(
                 let json_str = json_func(json.get_value(), path.get_value(), &state.json_cache);
                 match json_str {
                     Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
             JsonFunc::JsonArrayLength | JsonFunc::JsonType => {
@@ -9306,14 +9364,14 @@ pub fn op_function(
 
                 match func_result {
                     Ok(result) => state.registers[*dest].set_value(result),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
             JsonFunc::JsonErrorPosition => {
                 let json_value = &state.registers[*start_reg];
                 match json_error_position(json_value.get_value()) {
                     Ok(pos) => state.registers[*dest].set_value(pos),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
             JsonFunc::JsonValid => {
@@ -9460,7 +9518,7 @@ pub fn op_function(
 
                 match json_result {
                     Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
             JsonFunc::JsonbSet => {
@@ -9474,7 +9532,7 @@ pub fn op_function(
 
                 match json_result {
                     Ok(json) => state.registers[*dest].set_value(json),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
             JsonFunc::JsonQuote => {
@@ -9482,7 +9540,7 @@ pub fn op_function(
 
                 match json_quote(json_value.get_value()) {
                     Ok(result) => state.registers[*dest].set_value(result),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
         },
@@ -9531,7 +9589,8 @@ pub fn op_function(
                     mark_unlikely();
                     return Err(LimboError::ParseError(
                         "wrong number of arguments to function GLOB()".to_string(),
-                    ));
+                    )
+                    .into());
                 }
                 let pattern_reg = &state.registers[*start_reg];
                 let match_reg = &state.registers[*start_reg + 1];
@@ -9610,7 +9669,8 @@ pub fn op_function(
                                 if c.is_none() || chars.next().is_some() {
                                     return Err(LimboError::Constraint(
                                         "ESCAPE expression must be a single character".to_string(),
-                                    ));
+                                    )
+                                    .into());
                                 }
                                 escape_char = c;
                             }
@@ -9652,7 +9712,8 @@ pub fn op_function(
                     "ScalarFunc::NextVal handler should be unreachable under \
                      the disk-only sequence design"
                         .to_string(),
-                ));
+                )
+                .into());
             }
             ScalarFunc::CurrVal => {
                 let seq_name = match state.registers[*start_reg].get_value() {
@@ -9660,7 +9721,8 @@ pub fn op_function(
                     _ => {
                         return Err(crate::LimboError::ParseError(
                             "currval() requires a text argument".to_string(),
-                        ));
+                        )
+                        .into());
                     }
                 };
                 // The connection's currval session map persists across
@@ -9676,7 +9738,8 @@ pub fn op_function(
                     None => {
                         return Err(crate::LimboError::ParseError(format!(
                             "currval of sequence \"{seq_name}\" is not yet defined in this session",
-                        )));
+                        ))
+                        .into());
                     }
                 }
             }
@@ -9700,7 +9763,8 @@ pub fn op_function(
                     _ => {
                         return Err(crate::LimboError::ParseError(
                             "setval() requires a text argument".to_string(),
-                        ));
+                        )
+                        .into());
                     }
                 };
                 let value = match state.registers[*start_reg + 1].get_value().as_int() {
@@ -9708,7 +9772,8 @@ pub fn op_function(
                     None => {
                         return Err(crate::LimboError::ParseError(
                             "setval() requires an integer value".to_string(),
-                        ));
+                        )
+                        .into());
                     }
                 };
                 if arg_count > 2
@@ -9719,14 +9784,16 @@ pub fn op_function(
                 {
                     return Err(crate::LimboError::ParseError(
                         "setval() requires an integer is_called argument".to_string(),
-                    ));
+                    )
+                    .into());
                 }
                 let seq = program.connection.find_sequence(&seq_name)?;
                 if value < seq.min_value || value > seq.max_value {
                     return Err(crate::LimboError::ParseError(format!(
                         "setval: value {} is out of bounds for sequence \"{}\" ({}..{})",
                         value, seq.name, seq.min_value, seq.max_value
-                    )));
+                    ))
+                    .into());
                 }
                 state.registers[*dest].set_value(Value::from_i64(value));
             }
@@ -10013,7 +10080,8 @@ pub fn op_function(
                         return Err(LimboError::InvalidArgument(
                             "table_columns_json_array: function argument must be of type TEXT"
                                 .to_string(),
-                        ));
+                        )
+                        .into());
                     };
                     let table = {
                         let schema = program.connection.schema.read();
@@ -10022,7 +10090,8 @@ pub fn op_function(
                             None => {
                                 return Err(LimboError::InvalidArgument(format!(
                                     "table_columns_json_array: table {table} doesn't exists"
-                                )));
+                                ))
+                                .into());
                             }
                         }
                     };
@@ -10066,7 +10135,7 @@ pub fn op_function(
                     let Value::Text(columns_str) = columns_str else {
                         return Err(LimboError::InvalidArgument(
                             "bin_record_json_object: function arguments must be of type TEXT and BLOB correspondingly".to_string()
-                        ));
+                        ).into());
                     };
 
                     if let Value::Null = bin_record {
@@ -10077,7 +10146,7 @@ pub fn op_function(
                     let Value::Blob(bin_record) = bin_record else {
                         return Err(LimboError::InvalidArgument(
                             "bin_record_json_object: function arguments must be of type TEXT and BLOB correspondingly".to_string()
-                        ));
+                        ).into());
                     };
                     let mut columns_json_array =
                         json::jsonb::Jsonb::from_str(columns_str.as_str())?;
@@ -10101,18 +10170,18 @@ pub fn op_function(
 
                         let val = match payload_iterator.next() {
                             Some(Ok(v)) => v,
-                            Some(Err(e)) => return Err(e),
+                            Some(Err(e)) => return Err(e.into()),
                             None => {
                                 return Err(LimboError::InvalidArgument(
                                     "bin_record_json_object: binary record has fewer columns than specified in the columns argument".to_string()
-                                ));
+                                ).into());
                             }
                         };
 
                         if let ValueRef::Blob(..) = val {
                             return Err(LimboError::InvalidArgument(
                                 "bin_record_json_object: formatting of BLOB values stored in binary record is not supported".to_string()
-                            ));
+                            ).into());
                         }
                         let val_json =
                             json::convert_ref_dbtype_to_jsonb(val, json::Conv::NotStrict)?;
@@ -10136,13 +10205,15 @@ pub fn op_function(
                 let Value::Text(filename_str) = filename else {
                     return Err(LimboError::InvalidArgument(
                         "attach: filename argument must be text".to_string(),
-                    ));
+                    )
+                    .into());
                 };
 
                 let Value::Text(dbname_str) = dbname else {
                     return Err(LimboError::InvalidArgument(
                         "attach: database name argument must be text".to_string(),
-                    ));
+                    )
+                    .into());
                 };
 
                 return_if_io!(program.connection.attach_database(
@@ -10168,7 +10239,8 @@ pub fn op_function(
                 let Value::Text(dbname_str) = dbname else {
                     return Err(LimboError::InvalidArgument(
                         "detach: database name argument must be text".to_string(),
-                    ));
+                    )
+                    .into());
                 };
 
                 // Call the detach_database method on the connection
@@ -10271,7 +10343,8 @@ pub fn op_function(
                     _ => {
                         return Err(LimboError::InternalError(
                             "sequence_watermark_experimental() argument must be TEXT".to_string(),
-                        ));
+                        )
+                        .into());
                     }
                 };
                 let (db_id, sequence_key) =
@@ -10302,7 +10375,8 @@ pub fn op_function(
                         if *i < 0 {
                             return Err(LimboError::InternalError(
                                 "test_uint_encode: negative value".to_string(),
-                            ));
+                            )
+                            .into());
                         }
                         Value::build_text(i.to_string())
                     }
@@ -10310,7 +10384,8 @@ pub fn op_function(
                         if *f < 0.0 || f.fract() != 0.0 {
                             return Err(LimboError::InternalError(
                                 "test_uint_encode: not a non-negative integer".to_string(),
-                            ));
+                            )
+                            .into());
                         }
                         Value::build_text((f64::from(*f) as u64).to_string())
                     }
@@ -10326,7 +10401,8 @@ pub fn op_function(
                     _ => {
                         return Err(LimboError::InternalError(
                             "test_uint_encode: unsupported type".to_string(),
-                        ));
+                        )
+                        .into());
                     }
                 };
                 state.registers[*dest].set_value(result);
@@ -10367,7 +10443,8 @@ pub fn op_function(
                             None => {
                                 return Err(LimboError::InternalError(
                                     "test_uint arithmetic overflow/underflow".to_string(),
-                                ));
+                                )
+                                .into());
                             }
                         }
                     }
@@ -10461,7 +10538,8 @@ pub fn op_function(
                         _ => {
                             return Err(LimboError::Constraint(format!(
                                 "invalid input for type boolean: \"{i}\""
-                            )));
+                            ))
+                            .into());
                         }
                     },
                     Value::Text(t) => {
@@ -10472,14 +10550,16 @@ pub fn op_function(
                             _ => {
                                 return Err(LimboError::Constraint(format!(
                                     "invalid input for type boolean: \"{v}\""
-                                )));
+                                ))
+                                .into());
                             }
                         }
                     }
                     other => {
                         return Err(LimboError::Constraint(format!(
                             "invalid input for type boolean: \"{other}\""
-                        )));
+                        ))
+                        .into());
                     }
                 };
                 state.registers[*dest].set_value(result);
@@ -10509,7 +10589,8 @@ pub fn op_function(
                     other => {
                         return Err(LimboError::Constraint(format!(
                             "invalid input for type inet: \"{other}\""
-                        )));
+                        ))
+                        .into());
                     }
                 };
                 state.registers[*dest].set_value(result);
@@ -10533,7 +10614,8 @@ pub fn op_function(
                             _ => {
                                 return Err(LimboError::Constraint(
                                     "numeric_encode: precision must be an integer".to_string(),
-                                ));
+                                )
+                                .into());
                             }
                         };
                         let scale = match scale_reg.get_value() {
@@ -10541,7 +10623,8 @@ pub fn op_function(
                             _ => {
                                 return Err(LimboError::Constraint(
                                     "numeric_encode: scale must be an integer".to_string(),
-                                ));
+                                )
+                                .into());
                             }
                         };
                         let text = match other {
@@ -10551,7 +10634,8 @@ pub fn op_function(
                             _ => {
                                 return Err(LimboError::Constraint(format!(
                                     "invalid input for type numeric: \"{other}\""
-                                )));
+                                ))
+                                .into());
                             }
                         };
                         let bd = BigDecimal::from_str(&text).map_err(|_| {
@@ -10577,7 +10661,8 @@ pub fn op_function(
                     other => {
                         return Err(LimboError::Constraint(format!(
                             "numeric_decode: expected blob, got \"{other}\""
-                        )));
+                        ))
+                        .into());
                     }
                 };
                 state.registers[*dest].set_value(result);
@@ -10603,7 +10688,8 @@ pub fn op_function(
                                 if b.is_zero() {
                                     return Err(LimboError::Constraint(
                                         "division by zero".to_string(),
-                                    ));
+                                    )
+                                    .into());
                                 }
                                 a / b
                             }
@@ -10742,7 +10828,8 @@ pub fn op_function(
             | ScalarFunc::UnionExtractFunc => {
                 return Err(LimboError::InternalError(format!(
                     "{scalar_func} should be desugared to a dedicated instruction, not Function"
-                )));
+                ))
+                .into());
             }
         },
         crate::function::Func::Vector(vector_func) => {
@@ -10978,7 +11065,8 @@ pub fn op_function(
                             return Err(LimboError::InternalError(
                                 "Unexpected command during ALTER TABLE RENAME processing"
                                     .to_string(),
-                            ));
+                            )
+                            .into());
                         };
 
                         match stmt {
@@ -11029,7 +11117,8 @@ pub fn op_function(
                                     return Err(LimboError::InternalError(
                                         "CREATE TABLE AS SELECT schemas cannot be altered"
                                             .to_string(),
-                                    ));
+                                    )
+                                    .into());
                                 };
 
                                 let mut any_change = false;
@@ -11268,7 +11357,8 @@ pub fn op_function(
                             return Err(LimboError::InternalError(
                                 "Unexpected command during ALTER TABLE RENAME COLUMN processing"
                                     .to_string(),
-                            ));
+                            )
+                            .into());
                         };
 
                         match stmt {
@@ -11331,7 +11421,8 @@ pub fn op_function(
                                     return Err(LimboError::InternalError(
                                         "CREATE TABLE AS SELECT schemas cannot be altered"
                                             .to_string(),
-                                    ));
+                                    )
+                                    .into());
                                 };
 
                                 let normalized_tbl_name = normalize_ident(tbl_name.name.as_str());
@@ -11366,7 +11457,7 @@ pub fn op_function(
                                                     let (ast::Expr::Name(ref name)
                                                     | ast::Expr::Id(ref name)) = *col.expr
                                                     else {
-                                                        return Err(LimboError::ParseError("Unexpected expression in PRIMARY KEY constraint".to_string()));
+                                                        return Err(LimboError::ParseError("Unexpected expression in PRIMARY KEY constraint".to_string()).into());
                                                     };
                                                     if normalize_ident(name.as_str()) == rename_from
                                                     {
@@ -11384,7 +11475,7 @@ pub fn op_function(
                                                     let (ast::Expr::Name(ref name)
                                                     | ast::Expr::Id(ref name)) = *col.expr
                                                     else {
-                                                        return Err(LimboError::ParseError("Unexpected expression in UNIQUE constraint".to_string()));
+                                                        return Err(LimboError::ParseError("Unexpected expression in UNIQUE constraint".to_string()).into());
                                                     };
                                                     if normalize_ident(name.as_str()) == rename_from
                                                     {
@@ -11546,7 +11637,8 @@ pub fn op_function(
                     if arg_count < 2 {
                         return Err(LimboError::InvalidArgument(
                             "fts_match requires at least 2 arguments: text, query".to_string(),
-                        ));
+                        )
+                        .into());
                     }
 
                     // Last arg is the query, first N-1 args are text columns
@@ -11584,7 +11676,7 @@ pub fn op_function(
                         return Err(LimboError::InvalidArgument(
                             "fts_highlight requires at least 4 arguments: text, before_tag, after_tag, query"
                                 .to_string(),
-                        ));
+                        ).into());
                     }
 
                     // Last 3 args are: before_tag, after_tag, query
@@ -11646,7 +11738,7 @@ pub fn op_sequence(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Sequence {
             cursor_id,
@@ -11670,7 +11762,7 @@ pub fn op_sequence_test(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SequenceTest {
             cursor_id,
@@ -11698,7 +11790,7 @@ pub fn op_init_coroutine(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         InitCoroutine {
             yield_reg,
@@ -11725,7 +11817,7 @@ pub fn op_end_coroutine(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(EndCoroutine { yield_reg }, insn);
 
     if let Value::Numeric(Numeric::Integer(pc)) = state.registers[*yield_reg].get_value() {
@@ -11745,7 +11837,7 @@ pub fn op_yield(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Yield {
             yield_reg,
@@ -11834,7 +11926,7 @@ pub fn op_insert(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Insert {
             cursor: cursor_id,
@@ -12099,7 +12191,7 @@ pub fn op_insert(
                         return Err(LimboError::ParseError(
                             "WITHOUT ROWID tables with dependent materialized views are not supported"
                                 .to_string(),
-                        ));
+                        ).into());
                     }
                     state.active_op_state.insert().sub_state = OpInsertSubState::ApplyViewChange;
                     continue;
@@ -12178,7 +12270,7 @@ pub fn op_int_64(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Int64 {
             _p1,
@@ -12213,7 +12305,7 @@ pub fn op_delete(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Delete {
             cursor_id,
@@ -12319,7 +12411,7 @@ pub fn op_idx_delete(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         IdxDelete {
             cursor_id,
@@ -12364,14 +12456,14 @@ pub fn op_idx_delete(
                     Ok(SeekInternalResult::Found) => true,
                     Ok(SeekInternalResult::NotFound) => false,
                     Ok(SeekInternalResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 };
 
                 if !found {
                     // If we didn't find it because a txn we depended on was aborted, then it means it isn't really corrupt, we simply
                     // might have found some garbage data because other tx trashed all row versions we depended on (basically it sets begin: None, end: None).
                     if program.connection.mvcc_tx_should_abort() {
-                        return Err(LimboError::CommitDependencyAborted);
+                        return Err(LimboError::CommitDependencyAborted.into());
                     }
                     // If P5 is not zero, then raise an SQLITE_CORRUPT_INDEX error if no matching index entry is found
                     // Also, do not raise this (self-correcting and non-critical) error if in writable_schema mode.
@@ -12382,7 +12474,7 @@ pub fn op_idx_delete(
                             .collect::<Vec<_>>();
                         return Err(LimboError::Corrupt(format!(
                             "IdxDelete: no matching index entry found for key {reg_values:?} while seeking"
-                        )));
+                        )).into());
                     }
                     state.pc += 1;
                     state.active_op_state.clear();
@@ -12403,7 +12495,7 @@ pub fn op_idx_delete(
                         .collect::<Vec<_>>();
                     return Err(LimboError::Corrupt(format!(
                         "IdxDelete: no matching index entry found for key while verifying: {reg_values:?}"
-                    )));
+                    )).into());
                 }
                 *state.active_op_state.idx_delete() = OpIdxDeleteState::Deleting;
             }
@@ -12438,7 +12530,7 @@ pub fn op_idx_insert(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         IdxInsert {
             cursor_id,
@@ -12455,12 +12547,14 @@ pub fn op_idx_insert(
         let Some(start) = unpacked_start else {
             return Err(LimboError::InternalError(
                 "IndexMethod must receive unpacked values".to_string(),
-            ));
+            )
+            .into());
         };
         let Some(count) = unpacked_count else {
             return Err(LimboError::InternalError(
                 "IndexMethod must receive unpacked values".to_string(),
-            ));
+            )
+            .into());
         };
         return_if_io!(cursor.insert(&state.registers[start..start + count as usize]));
         state.record_rows_written(1);
@@ -12471,9 +12565,7 @@ pub fn op_idx_insert(
     let record_to_insert = match &state.registers[record_reg] {
         Register::Record(ref r) => r,
         o => {
-            return Err(LimboError::InternalError(format!(
-                "expected record, got {o:?}"
-            )));
+            return Err(LimboError::InternalError(format!("expected record, got {o:?}")).into());
         }
     };
 
@@ -12556,7 +12648,8 @@ pub fn op_idx_insert(
                     }
                     return Err(LimboError::Constraint(
                         "UNIQUE constraint failed: duplicate key".into(),
-                    ));
+                    )
+                    .into());
                 }
 
                 false
@@ -12613,7 +12706,7 @@ pub fn op_new_rowid(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     new_rowid_inner(program, state, insn, pager).inspect_err(|_| {
         // In case of error we need to unlock rowid lock from mvcc cursor
         load_insn!(
@@ -12640,7 +12733,7 @@ fn new_rowid_inner(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         NewRowid {
             cursor,
@@ -12785,7 +12878,7 @@ fn new_rowid_inner(
 
             OpNewRowidState::GeneratingRandom { attempts } => {
                 if attempts >= MAX_ATTEMPTS {
-                    return Err(LimboError::DatabaseFull("Unable to find an unused rowid after 100 attempts - database is probably full".to_string()));
+                    return Err(LimboError::DatabaseFull("Unable to find an unused rowid after 100 attempts - database is probably full".to_string()).into());
                 }
 
                 // Generate a random i64 and constrain it to the lower half of the rowid range.
@@ -12883,7 +12976,7 @@ pub fn op_must_be_int(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(MustBeInt { reg, target_pc }, insn);
     if !coerce_register_to_integer(state, *reg) {
         if let Some(target_pc) = target_pc {
@@ -12901,7 +12994,7 @@ pub fn op_soft_null(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(SoftNull { reg }, insn);
     state.registers[*reg].set_null();
     state.pc += 1;
@@ -12921,7 +13014,7 @@ pub fn op_no_conflict(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         NoConflict {
             cursor_id,
@@ -12952,7 +13045,8 @@ pub fn op_no_conflict(
                         let Register::Record(record) = &state.registers[*record_reg] else {
                             return Err(LimboError::InternalError(
                                 "NoConflict: expected a record in the register".into(),
-                            ));
+                            )
+                            .into());
                         };
                         record.iter()?.any(|val| matches!(val, Ok(ValueRef::Null)))
                     }
@@ -13008,7 +13102,7 @@ pub fn op_not_exists(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         NotExists {
             cursor,
@@ -13034,7 +13128,7 @@ pub fn op_offset_limit(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         OffsetLimit {
             limit_reg,
@@ -13048,7 +13142,8 @@ pub fn op_offset_limit(
         _ => {
             return Err(LimboError::InternalError(
                 "OffsetLimit: the value in limit_reg is not an integer".into(),
-            ));
+            )
+            .into());
         }
     };
     let offset_val = match state.registers[*offset_reg].get_value() {
@@ -13057,7 +13152,8 @@ pub fn op_offset_limit(
         _ => {
             return Err(LimboError::InternalError(
                 "OffsetLimit: the value in offset_reg is not an integer".into(),
-            ));
+            )
+            .into());
         }
     };
 
@@ -13078,7 +13174,7 @@ pub fn op_open_write(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         OpenWrite {
             cursor_id,
@@ -13089,7 +13185,7 @@ pub fn op_open_write(
     );
     invalidate_deferred_seeks_for_cursor(state, *cursor_id);
     if program.connection.is_readonly(*db) {
-        return Err(LimboError::ReadOnly);
+        return Err(LimboError::ReadOnly.into());
     }
     let pager = program.get_pager_from_database_index(db)?;
     let mv_store = program.connection.mv_store_for_db(*db);
@@ -13122,7 +13218,8 @@ pub fn op_open_write(
             _ => {
                 return Err(LimboError::InternalError(
                     "OpenWrite: the value in root_page is not an integer".into(),
-                ));
+                )
+                .into());
             }
         },
     };
@@ -13134,12 +13231,13 @@ pub fn op_open_write(
             let Some(tx_id) = program.connection.get_mv_tx_id_for_db(*db) else {
                 return Err(LimboError::InternalError(
                     "Schema changes in MVCC mode require an exclusive MVCC transaction".to_string(),
-                ));
+                )
+                .into());
             };
             if !mv_store.is_exclusive_tx(&tx_id) {
                 return Err(LimboError::TxError(
                     "DDL statements require an exclusive transaction (use BEGIN instead of BEGIN CONCURRENT)".to_string(),
-                ));
+                ).into());
             }
         }
     }
@@ -13216,7 +13314,8 @@ pub fn op_open_write(
             {
                 return Err(LimboError::ParseError(
                     "WITHOUT ROWID tables are not supported in MVCC mode".to_string(),
-                ));
+                )
+                .into());
             }
             let num_columns = match cursor_type {
                 CursorType::BTreeTable(table_rc) => table_rc.columns().len(),
@@ -13263,7 +13362,7 @@ pub fn op_copy(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Copy {
             src_reg,
@@ -13309,11 +13408,11 @@ pub fn op_create_btree(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(CreateBtree { db, root, flags }, insn);
 
     if program.connection.is_readonly(*db) {
-        return Err(LimboError::ReadOnly);
+        return Err(LimboError::ReadOnly.into());
     }
     let mv_store = program.connection.mv_store_for_db(*db);
 
@@ -13336,10 +13435,10 @@ pub fn op_index_method_create(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(IndexMethodCreate { db, cursor_id }, insn);
     if program.connection.is_readonly(*db) {
-        return Err(LimboError::ReadOnly);
+        return Err(LimboError::ReadOnly.into());
     }
     let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] else {
         unreachable!("IndexMethodCreate emitted against a non-index-method cursor {cursor_id}");
@@ -13370,10 +13469,10 @@ pub fn op_index_method_destroy(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(IndexMethodDestroy { db, cursor_id }, insn);
     if program.connection.is_readonly(*db) {
-        return Err(LimboError::ReadOnly);
+        return Err(LimboError::ReadOnly.into());
     }
     let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) else {
         unreachable!("IndexMethodDestroy emitted against a non-index-method cursor {cursor_id}");
@@ -13402,10 +13501,10 @@ pub fn op_index_method_optimize(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(IndexMethodOptimize { db, cursor_id }, insn);
     if program.connection.is_readonly(*db) {
-        return Err(LimboError::ReadOnly);
+        return Err(LimboError::ReadOnly.into());
     }
     let Some((_, CursorType::IndexMethod(module))) = program.cursor_ref.get(*cursor_id) else {
         unreachable!("IndexMethodOptimize emitted against a non-index-method cursor {cursor_id}");
@@ -13434,7 +13533,7 @@ pub fn op_index_method_query(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         IndexMethodQuery {
             db: _,
@@ -13478,7 +13577,7 @@ pub fn op_destroy(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Destroy {
             db,
@@ -13533,11 +13632,11 @@ pub fn op_clear_btree(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     match op_clear_btree_inner(program, state, insn, pager) {
         Ok(result) => Ok(result),
         Err(err) => {
-            if !matches!(err, LimboError::Busy | LimboError::BusySnapshot) {
+            if !matches!(*err, LimboError::Busy | LimboError::BusySnapshot) {
                 state.active_op_state.clear();
             }
             Err(err)
@@ -13550,14 +13649,15 @@ fn op_clear_btree_inner(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ClearBtree { db, root }, insn);
 
     let mv_store = program.connection.mv_store_for_db(*db);
     if mv_store.is_some() {
         return Err(LimboError::InternalError(
             "ClearBtree is not supported in MVCC mode".to_string(),
-        ));
+        )
+        .into());
     }
 
     let clear_pager = if *db != MAIN_DB_ID {
@@ -13597,7 +13697,7 @@ pub fn op_reset_sorter(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ResetSorter { cursor_id }, insn);
 
     let (_, cursor_type) = program
@@ -13614,12 +13714,14 @@ pub fn op_reset_sorter(
         CursorType::Sorter => {
             return Err(LimboError::InternalError(
                 "ResetSorter is not supported for sorter cursors".to_string(),
-            ));
+            )
+            .into());
         }
         _ => {
             return Err(LimboError::InternalError(format!(
                 "ResetSorter is not supported for {cursor_type:?}"
-            )));
+            ))
+            .into());
         }
     }
 
@@ -13632,7 +13734,7 @@ pub fn op_drop_table(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(DropTable { db, table_name, .. }, insn);
     let conn = program.connection.clone();
     let is_mvcc = conn.mv_store_for_db(*db).is_some();
@@ -13686,7 +13788,7 @@ pub fn op_drop_view(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(DropView { db, view_name }, insn);
     let conn = program.connection.clone();
     conn.with_database_schema_mut(*db, |schema| {
@@ -13702,7 +13804,7 @@ pub fn op_drop_type(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(DropType { db, type_name }, insn);
     let conn = program.connection.clone();
     conn.with_database_schema_mut(*db, |schema| {
@@ -13717,7 +13819,7 @@ pub fn op_add_sequence(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(AddSequence { data }, insn);
     let AddSequenceData {
         db,
@@ -13751,7 +13853,7 @@ pub fn op_drop_sequence(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(DropSequence { db, seq_name }, insn);
     let conn = program.connection.clone();
     conn.with_database_schema_mut(*db, |schema| {
@@ -13773,7 +13875,7 @@ pub fn op_add_type(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(AddType { db, sql }, insn);
     let conn = program.connection.clone();
     conn.with_database_schema_mut(*db, |schema| schema.add_type_from_sql(sql))??;
@@ -13798,7 +13900,7 @@ pub fn op_sequence_compute_next(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SequenceComputeNext {
             db,
@@ -13816,7 +13918,8 @@ pub fn op_sequence_compute_next(
         _ => {
             return Err(crate::LimboError::ParseError(
                 "SequenceComputeNext: seq_name_reg must be text".to_string(),
-            ));
+            )
+            .into());
         }
     };
 
@@ -13884,7 +13987,8 @@ pub fn op_sequence_compute_next(
                     // or any other autoinc path.
                     return Err(crate::LimboError::DatabaseFull(
                         "database or disk is full".to_string(),
-                    ));
+                    )
+                    .into());
                 } else {
                     return Err(crate::LimboError::DatabaseFull(format!(
                         "nextval: reached {} value of sequence \"{}\"",
@@ -13894,7 +13998,8 @@ pub fn op_sequence_compute_next(
                             "minimum"
                         },
                         seq.name
-                    )));
+                    ))
+                    .into());
                 }
             } else {
                 current + seq.increment_by
@@ -13918,7 +14023,7 @@ pub fn op_set_sequence_currval(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SetSequenceCurrval {
             seq_name_reg,
@@ -13932,7 +14037,8 @@ pub fn op_set_sequence_currval(
         _ => {
             return Err(crate::LimboError::ParseError(
                 "SetSequenceCurrval: seq_name_reg must be text".to_string(),
-            ));
+            )
+            .into());
         }
     };
     let value = state.registers[*value_reg]
@@ -13960,7 +14066,7 @@ pub fn op_sequence_track_allocation(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SequenceTrackAllocation {
             db,
@@ -13975,7 +14081,8 @@ pub fn op_sequence_track_allocation(
         _ => {
             return Err(crate::LimboError::ParseError(
                 "SequenceTrackAllocation: seq_name_reg must be text".to_string(),
-            ));
+            )
+            .into());
         }
     };
     let value = state.registers[*value_reg]
@@ -14038,7 +14145,7 @@ pub fn op_sequence_register_allocation(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SequenceRegisterAllocation {
             db,
@@ -14067,7 +14174,8 @@ pub fn op_sequence_register_allocation(
         _ => {
             return Err(crate::LimboError::ParseError(
                 "SequenceRegisterAllocation: seq_name_reg must be text".to_string(),
-            ));
+            )
+            .into());
         }
     };
     let value = state.registers[*value_reg]
@@ -14174,7 +14282,7 @@ pub fn op_sequence_begin_inner_tx(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SequenceBeginInnerTx {
             db,
@@ -14248,7 +14356,7 @@ pub fn op_sequence_commit_inner_tx(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SequenceCommitInnerTx {
             db,
@@ -14287,7 +14395,8 @@ pub fn op_sequence_commit_inner_tx(
         _ => {
             return Err(LimboError::InternalError(
                 "SequenceCommitInnerTx: saved_outer_reg must be blob".to_string(),
-            ));
+            )
+            .into());
         }
     };
 
@@ -14302,7 +14411,8 @@ pub fn op_sequence_commit_inner_tx(
                 return Err(LimboError::InternalError(
                     "SequenceCommitInnerTx: connection has no mv_tx but path was Wrapped"
                         .to_string(),
-                ));
+                )
+                .into());
             }
         };
         state.sequence_inner_commit = Some(mv_store.commit_tx(inner_tx_id, &conn, *db)?);
@@ -14321,11 +14431,12 @@ pub fn op_sequence_commit_inner_tx(
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
-        Err(
-            err @ (LimboError::WriteWriteConflict
-            | LimboError::BusySnapshot
-            | LimboError::Conflict(_)),
-        ) => {
+        Err(err)
+            if matches!(
+                *err,
+                LimboError::WriteWriteConflict | LimboError::BusySnapshot | LimboError::Conflict(_)
+            ) =>
+        {
             state.sequence_inner_commit = None;
             // Inner tx may already be in a state where rollback is a
             // no-op (e.g. self-aborted); `is_tx_rollbackable` guards.
@@ -14354,7 +14465,7 @@ pub fn op_sequence_commit_inner_tx(
             if state.sequence_inner_retry_count > SEQUENCE_INNER_TX_RETRY_BUDGET {
                 state.sequence_inner_retry_count = 0;
                 let _ = err;
-                return Err(LimboError::Busy);
+                return Err(LimboError::Busy.into());
             }
             // Re-export the specific class via the status register —
             // the translator-emitted retry uses it to decide whether
@@ -14384,7 +14495,7 @@ pub fn op_drop_trigger(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(DropTrigger { db, trigger_name }, insn);
 
     let conn = program.connection.clone();
@@ -14400,7 +14511,7 @@ pub fn op_close(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Close { cursor_id }, insn);
     if let Some(Cursor::IndexMethod(cursor)) = state.cursors[*cursor_id].as_mut() {
         let context = state.index_method_contexts[*cursor_id]
@@ -14438,7 +14549,7 @@ pub fn op_is_null(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(IsNull { reg, target_pc }, insn);
     if matches!(state.registers[*reg], Register::Value(Value::Null)) {
         state.pc = target_pc.as_offset_int();
@@ -14453,7 +14564,7 @@ pub fn op_page_count(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(PageCount { db, dest }, insn);
     let pager = program.get_pager_from_database_index(db)?;
     let mv_store = program.connection.mv_store_for_db(*db);
@@ -14501,7 +14612,7 @@ pub fn op_parse_schema(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         ParseSchema {
             db,
@@ -14569,7 +14680,8 @@ pub fn op_parse_schema(
                     .store(previous_auto_commit, Ordering::SeqCst);
                 return Err(LimboError::InternalError(format!(
                     "stale reference to detached database (index {db})"
-                )));
+                ))
+                .into());
             };
             let schema = db_inst.schema.lock().clone();
             schema
@@ -14605,10 +14717,7 @@ pub fn op_parse_schema(
 /// Drive the inner schema statement one step at a time.
 /// Returns IO to the outer VDBE loop when the inner statement needs it,
 /// preserving all intermediate parsing state for resumption.
-fn op_parse_schema_step(
-    state: &mut ProgramState,
-    conn: &Arc<Connection>,
-) -> Result<InsnFunctionStepResult> {
+fn op_parse_schema_step(state: &mut ProgramState, conn: &Arc<Connection>) -> InsnResult {
     loop {
         let inner = state.active_op_state.parse_schema().as_mut().unwrap();
         match inner.stmt.step()? {
@@ -14740,7 +14849,7 @@ fn op_parse_schema_step(
                 drop(stmt);
                 conn.auto_commit
                     .store(previous_auto_commit, Ordering::SeqCst);
-                return Err(LimboError::Interrupt);
+                return Err(LimboError::Interrupt.into());
             }
             StepResult::Busy => {
                 let OpParseSchemaInner {
@@ -14755,7 +14864,7 @@ fn op_parse_schema_step(
                 drop(stmt);
                 conn.auto_commit
                     .store(previous_auto_commit, Ordering::SeqCst);
-                return Err(LimboError::Busy);
+                return Err(LimboError::Busy.into());
             }
         }
     }
@@ -14803,7 +14912,7 @@ pub fn op_init_cdc_version(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         InitCdcVersion {
             cdc_table_name,
@@ -14874,7 +14983,7 @@ fn drive_init_cdc_version(
     cdc_mode: &str,
     cdc_table_name: &str,
     escaped_cdc_table_name: &str,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     loop {
         let inner = state.active_op_state.init_cdc_version().as_mut().unwrap();
         match inner.stmt.step()? {
@@ -14965,8 +15074,8 @@ fn drive_init_cdc_version(
             },
             // Interrupt/Busy fall through to the caller, which clears the
             // parked state machine on error.
-            StepResult::Interrupt => return Err(LimboError::Interrupt),
-            StepResult::Busy => return Err(LimboError::Busy),
+            StepResult::Interrupt => return Err(LimboError::Interrupt.into()),
+            StepResult::Busy => return Err(LimboError::Busy.into()),
         }
     }
 }
@@ -14976,7 +15085,7 @@ pub fn op_populate_materialized_views(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(PopulateMaterializedViews { cursors }, insn);
 
     let conn = program.connection.clone();
@@ -14999,7 +15108,8 @@ pub fn op_populate_materialized_views(
                 _ => {
                     return Err(LimboError::InternalError(
                         "Expected BTree cursor for materialized view".into(),
-                    ));
+                    )
+                    .into());
                 }
             };
 
@@ -15033,7 +15143,8 @@ pub fn op_populate_materialized_views(
                 _ => {
                     return Err(LimboError::InternalError(
                         "Expected BTree cursor for materialized view population".into(),
-                    ));
+                    )
+                    .into());
                 }
             };
 
@@ -15052,7 +15163,7 @@ pub fn op_read_cookie(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ReadCookie { db, dest, cookie }, insn);
     let pager = program.get_pager_from_database_index(db)?;
     let mv_store = program.connection.mv_store_for_db(*db);
@@ -15095,7 +15206,7 @@ pub fn op_set_cookie(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         SetCookie {
             db,
@@ -15111,14 +15222,15 @@ pub fn op_set_cookie(
         let Some(tx_id) = program.connection.get_mv_tx_id_for_db(*db) else {
             return Err(LimboError::InternalError(
                 "Header updates in MVCC mode require an active transaction".to_string(),
-            ));
+            )
+            .into());
         };
         if !mv_store.is_exclusive_tx(&tx_id) {
             // Header cookies are global metadata with no row-level conflict keys; require
             // SQLite-style single-writer semantics (same policy as DDL in MVCC).
             return Err(LimboError::TxError(
                 "Header updates require an exclusive transaction (use BEGIN instead of BEGIN CONCURRENT)".to_string(),
-            ));
+            ).into());
         }
     }
 
@@ -15194,7 +15306,7 @@ pub fn op_shift_right(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ShiftRight { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -15210,7 +15322,7 @@ pub fn op_shift_left(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ShiftLeft { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -15226,7 +15338,7 @@ pub fn op_add_imm(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(AddImm { register, value }, insn);
 
     let current = &state.registers[*register];
@@ -15258,7 +15370,7 @@ pub fn op_variable(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Variable { index, dest }, insn);
     state.registers[*dest].set_value(state.get_parameter(*index));
     state.pc += 1;
@@ -15270,7 +15382,7 @@ pub fn op_zero_or_null(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ZeroOrNull { rg1, rg2, dest }, insn);
     if state.registers[*rg1].is_null() || state.registers[*rg2].is_null() {
         state.registers[*dest].set_null()
@@ -15286,7 +15398,7 @@ pub fn op_not(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Not { reg, dest }, insn);
     match state.registers[*reg].get_value().exec_boolean_not() {
         Value::Numeric(Numeric::Integer(i)) => state.registers[*dest].set_int(i),
@@ -15305,7 +15417,7 @@ pub fn op_is_true(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         IsTrue {
             reg,
@@ -15346,7 +15458,7 @@ pub fn op_concat(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Concat { lhs, rhs, dest }, insn);
     let value = state.registers[*lhs]
         .get_value()
@@ -15361,7 +15473,7 @@ pub fn op_and(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(And { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -15377,7 +15489,7 @@ pub fn op_or(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Or { lhs, rhs, dest }, insn);
     state.registers[*dest].set_value(
         state.registers[*lhs]
@@ -15393,7 +15505,7 @@ pub fn op_noop(
     state: &mut ProgramState,
     _insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     // Do nothing
     // Advance the program counter for the next opcode
     state.pc += 1;
@@ -15428,7 +15540,7 @@ pub fn op_open_ephemeral(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     let (cursor_id, is_table) = match insn {
         Insn::OpenEphemeral {
             cursor_id,
@@ -15625,7 +15737,7 @@ pub fn op_open_dup(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         OpenDup {
             new_cursor_id,
@@ -15658,7 +15770,8 @@ pub fn op_open_dup(
             if !table.has_rowid && program.connection.get_mv_tx_id().is_some() {
                 return Err(LimboError::ParseError(
                     "WITHOUT ROWID tables are not supported in MVCC mode".to_string(),
-                ));
+                )
+                .into());
             }
             let cursor: Box<dyn CursorTrait> = if table.has_rowid {
                 Box::new(BTreeCursor::new_table(
@@ -15703,12 +15816,14 @@ pub fn op_open_dup(
         CursorType::BTreeIndex(_) => {
             return Err(LimboError::InternalError(
                 "OpenDup is not supported for BTreeIndex".to_string(),
-            ));
+            )
+            .into());
         }
         _ => {
             return Err(LimboError::InternalError(format!(
                 "OpenDup is not supported for {cursor_type:?}"
-            )));
+            ))
+            .into());
         }
     }
 
@@ -15725,7 +15840,7 @@ pub fn op_once(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Once {
             target_pc_when_reentered,
@@ -15753,7 +15868,7 @@ pub fn op_reset_once(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(ResetOnce { region_end }, insn);
     assert!(region_end.is_offset());
     let start = state.pc;
@@ -15768,7 +15883,7 @@ pub fn op_found(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     let (cursor_id, target_pc, record_reg, num_regs) = match insn {
         Insn::NotFound {
             cursor_id,
@@ -15809,7 +15924,7 @@ pub fn op_found(
         Ok(SeekInternalResult::Found) => SeekResult::Found,
         Ok(SeekInternalResult::NotFound) => SeekResult::NotFound,
         Ok(SeekInternalResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
-        Err(e) => return Err(e),
+        Err(e) => return Err(e.into()),
     };
 
     let found = matches!(seek_result, SeekResult::Found);
@@ -15828,7 +15943,7 @@ pub fn op_affinity(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Affinity {
             start_reg,
@@ -15841,7 +15956,8 @@ pub fn op_affinity(
     if affinities.len() != count.get() {
         return Err(LimboError::InternalError(
             "Affinity: the length of affinities does not match the count".into(),
-        ));
+        )
+        .into());
     }
 
     for (i, affinity_char) in affinities.chars().enumerate().take(count.get()) {
@@ -15861,7 +15977,7 @@ pub fn op_count(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Count {
             cursor_id,
@@ -15932,7 +16048,7 @@ pub fn op_integrity_check(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(IntegrityCk { data }, insn);
     let IntegrityCkData {
         db,
@@ -16109,7 +16225,7 @@ pub fn op_cast(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Cast { reg, affinity }, insn);
 
     let value = state.registers[*reg].get_value().clone();
@@ -16239,7 +16355,7 @@ pub fn op_rename_table(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(RenameTable { db, from, to }, insn);
 
     let normalized_from = normalize_ident(from.as_str());
@@ -16440,7 +16556,7 @@ pub fn op_drop_column(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         DropColumn {
             db,
@@ -16565,7 +16681,7 @@ pub fn op_add_column(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(AddColumn { data }, insn);
 
     let conn = program.connection.clone();
@@ -16606,7 +16722,7 @@ pub fn op_alter_column(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         AlterColumn {
             db,
@@ -16903,7 +17019,7 @@ pub fn op_if_neg(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(IfNeg { reg, target_pc }, insn);
 
     match &state.registers[*reg] {
@@ -17003,7 +17119,7 @@ pub fn op_fk_counter(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         FkCounter {
             increment_value,
@@ -17029,7 +17145,7 @@ pub fn op_fk_if_zero(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         FkIfZero {
             deferred,
@@ -17066,7 +17182,7 @@ pub fn op_fk_check(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(FkCheck { deferred }, insn);
     if !program.connection.foreign_keys_enabled() {
         state.pc += 1;
@@ -17080,7 +17196,8 @@ pub fn op_fk_check(
     if v > 0 {
         return Err(LimboError::ForeignKeyConstraint(
             "immediate foreign key constraint failed".to_string(),
-        ));
+        )
+        .into());
     }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -17091,7 +17208,7 @@ pub fn op_hash_build(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(HashBuild { data }, insn);
 
     let mut op_state = match state.active_op_state.hash_build().take().filter(|s| {
@@ -17183,7 +17300,8 @@ pub fn op_hash_build(
             _ => {
                 return Err(LimboError::InternalError(
                     "HashBuild: unsupported cursor type".to_string(),
-                ));
+                )
+                .into());
             }
         };
         op_state.rowid = Some(rowid_val);
@@ -17219,7 +17337,7 @@ pub fn op_hash_distinct(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(HashDistinct { data }, insn);
 
     let temp_store = program.connection.get_temp_store();
@@ -17289,7 +17407,7 @@ pub fn op_hash_build_finalize(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(HashBuildFinalize { hash_table_id }, insn);
     if let Some(ht) = state.hash_tables.get_mut(hash_table_id) {
         // Finalize the build phase, may flush remaining partitions to disk if spilled
@@ -17326,7 +17444,7 @@ pub fn op_hash_probe(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         HashProbe {
             hash_table_id,
@@ -17434,7 +17552,7 @@ pub fn op_hash_probe(
         } else if unlikely(!hash_table.is_partition_loaded(partition_idx)) {
             return Err(LimboError::InternalError(format!(
                 "HashProbe reached spilled partition {partition_idx} without a preloaded build partition; probe_rowid_reg=None is grace-only"
-            )));
+            )).into());
         }
 
         // Probe the loaded partition
@@ -17490,7 +17608,7 @@ pub fn op_hash_next(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         HashNext {
             hash_table_id,
@@ -17530,7 +17648,7 @@ pub fn op_hash_close(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(HashClose { hash_table_id }, insn);
     if let Some(mut hash_table) = state.hash_tables.remove(hash_table_id) {
         hash_table.close();
@@ -17544,7 +17662,7 @@ pub fn op_hash_clear(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(HashClear { hash_table_id }, insn);
     if let Some(hash_table) = state.hash_tables.get_mut(hash_table_id) {
         hash_table.clear()?;
@@ -17558,7 +17676,7 @@ pub fn op_hash_reset_matched(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(HashResetMatched { hash_table_id }, insn);
     if let Some(hash_table) = state.hash_tables.get_mut(hash_table_id) {
         hash_table.reset_matched_bits();
@@ -17572,7 +17690,7 @@ pub fn op_hash_mark_matched(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(HashMarkMatched { hash_table_id }, insn);
     if let Some(hash_table) = state.hash_tables.get_mut(hash_table_id) {
         hash_table.mark_current_matched();
@@ -17586,7 +17704,7 @@ pub fn op_hash_scan_unmatched(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         HashScanUnmatched {
             hash_table_id,
@@ -17621,7 +17739,7 @@ pub fn op_hash_next_unmatched(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         HashNextUnmatched {
             hash_table_id,
@@ -17661,7 +17779,7 @@ fn advance_unmatched_scan(
     payload_dest_reg: Option<usize>,
     num_payload: usize,
     metrics: &mut HashJoinMetrics,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     if hash_table.has_spilled() {
         if let Some(partition_idx) = hash_table.unmatched_scan_current_partition() {
             if !hash_table.is_partition_loaded(partition_idx) {
@@ -17708,7 +17826,7 @@ pub fn op_hash_grace_init(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         HashGraceInit {
             hash_table_id,
@@ -17752,7 +17870,7 @@ pub fn op_hash_grace_load_partition(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         HashGraceLoadPartition {
             hash_table_id,
@@ -17784,7 +17902,7 @@ pub fn op_hash_grace_next_probe(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         HashGraceNextProbe {
             hash_table_id,
@@ -17831,7 +17949,7 @@ pub fn op_hash_grace_advance_partition(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         HashGraceAdvancePartition {
             hash_table_id,
@@ -18044,7 +18162,7 @@ pub fn op_max_pgcnt(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(MaxPgcnt { db, dest, new_max }, insn);
 
     let pager = program.get_pager_from_database_index(db)?;
@@ -18163,7 +18281,7 @@ pub fn op_journal_mode(
     state: &mut ProgramState,
     insn: &Insn,
     pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     match op_journal_mode_inner(program, state, insn, pager) {
         Ok(result) => {
             if !matches!(result, InsnFunctionStepResult::IO(_)) {
@@ -18185,7 +18303,7 @@ fn op_journal_mode_inner(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     use crate::storage::sqlite3_ondisk::begin_write_btree_page;
 
     load_insn!(JournalMode { db, dest, new_mode }, insn);
@@ -18247,7 +18365,7 @@ fn op_journal_mode_inner(
 
                 // Check if database is readonly - cannot change journal mode on readonly databases
                 if program.connection.is_readonly(*db) {
-                    return Err(LimboError::ReadOnly);
+                    return Err(LimboError::ReadOnly.into());
                 }
 
                 // CDC capture is connection-level state that feeds off the
@@ -18265,7 +18383,7 @@ fn op_journal_mode_inner(
                         "cannot change journal_mode (from {prev} to {new}) while CDC capture is active: \
                          capture would silently stop; disable capture first with \
                          PRAGMA capture_data_changes_conn('off')"
-                    )));
+                    )).into());
                 }
 
                 // MVCC has no cross-process coordination: commit
@@ -18282,14 +18400,15 @@ fn op_journal_mode_inner(
                     return Err(LimboError::InvalidArgument(
                         "journal_mode=mvcc is not supported with experimental multiprocess WAL: MVCC does not support multiprocess access"
                             .to_string(),
-                    ));
+                    ).into());
                 }
                 if matches!(new_mode, journal_mode::JournalMode::Mvcc)
                     && pager.has_external_page_codec()
                 {
                     return Err(LimboError::InvalidArgument(
                         "external page codecs are not supported with MVCC databases".to_string(),
-                    ));
+                    )
+                    .into());
                 }
 
                 state.active_op_state.journal_mode().new_mode = Some(new_mode);
@@ -18441,7 +18560,8 @@ fn op_journal_mode_inner(
                 let Some(mv_store) = mv_store_guard.as_ref() else {
                     return Err(LimboError::InternalError(
                         "MVCC journal mode bootstrap missing MV store".to_string(),
-                    ));
+                    )
+                    .into());
                 };
                 return_if_io!(mv_store.bootstrap_nonblock(
                     &program.connection,
@@ -18474,7 +18594,7 @@ pub fn op_filter(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         Filter {
             cursor_id,
@@ -18524,7 +18644,7 @@ pub fn op_filter_add(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(
         FilterAdd {
             cursor_id,
@@ -18619,7 +18739,7 @@ pub fn op_vacuum_into(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     match op_vacuum_into_inner(program, state, insn) {
         Ok(InsnFunctionStepResult::Step) => {
             // Instruction complete, reset state
@@ -18687,11 +18807,7 @@ fn cleanup_op_vacuum_into(
     Ok(())
 }
 
-fn op_vacuum_into_inner(
-    program: &Program,
-    state: &mut ProgramState,
-    insn: &Insn,
-) -> Result<InsnFunctionStepResult> {
+fn op_vacuum_into_inner(program: &Program, state: &mut ProgramState, insn: &Insn) -> InsnResult {
     load_insn!(
         VacuumInto {
             schema_name,
@@ -18719,7 +18835,8 @@ fn op_vacuum_into_inner(
     let VacuumOpState::IntoFile(vacuum_state) = &mut state.op_vacuum_state else {
         return Err(LimboError::InternalError(
             "VACUUM INTO resumed with incompatible VACUUM state".to_string(),
-        ));
+        )
+        .into());
     };
     let escaped_schema_name = &vacuum_state.escaped_schema_name;
     let source_db_id = vacuum_state.source_db_id;
@@ -18734,7 +18851,8 @@ fn op_vacuum_into_inner(
                 if !program.connection.auto_commit.load(Ordering::SeqCst) {
                     return Err(LimboError::TxError(
                         "cannot VACUUM INTO from within a transaction".to_string(),
-                    ));
+                    )
+                    .into());
                 }
                 // This VACUUM INTO statement itself is the one active root
                 // statement. Any count other than 1 means some other
@@ -18747,14 +18865,16 @@ fn op_vacuum_into_inner(
                 {
                     return Err(LimboError::TxError(
                         "cannot VACUUM - SQL statements in progress".to_string(),
-                    ));
+                    )
+                    .into());
                 }
 
                 // we always vacuum into a new file, so check if it exists
                 if std::path::Path::new(dest_path).exists() {
                     return Err(LimboError::ParseError(format!(
                         "output file already exists: {dest_path}"
-                    )));
+                    ))
+                    .into());
                 }
 
                 // Pin source metadata before building the output database. The
@@ -18915,7 +19035,7 @@ pub fn op_vacuum(
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
-) -> Result<InsnFunctionStepResult> {
+) -> InsnResult {
     load_insn!(Vacuum { db }, insn);
 
     if matches!(state.op_vacuum_state, VacuumOpState::None) {
@@ -18925,7 +19045,8 @@ pub fn op_vacuum(
     let VacuumOpState::InPlace(vacuum_state) = &mut state.op_vacuum_state else {
         return Err(LimboError::InternalError(
             "VACUUM resumed with incompatible VACUUM state".to_string(),
-        ));
+        )
+        .into());
     };
 
     match vacuum_state.step(&program.connection) {
@@ -18965,13 +19086,16 @@ fn with_header<T, F>(
     program: &Program,
     db: usize,
     f: F,
-) -> Result<IOResult<T>>
+) -> IOResultOr<T>
 where
     F: Fn(&DatabaseHeader) -> T,
 {
     if let Some(mv_store) = mv_store {
         let tx_id = program.connection.get_mv_tx_id_for_db(db);
-        mv_store.with_header(f, tx_id.as_ref()).map(IOResult::Done)
+        mv_store
+            .with_header(f, tx_id.as_ref())
+            .map(IOResult::Done)
+            .map_err(Into::into)
     } else {
         pager.with_header(&f)
     }
@@ -18983,7 +19107,7 @@ pub fn with_header_mut<T, F>(
     program: &Program,
     db: usize,
     f: F,
-) -> Result<IOResult<T>>
+) -> IOResultOr<T>
 where
     F: Fn(&mut DatabaseHeader) -> T,
 {
@@ -18992,6 +19116,7 @@ where
         mv_store
             .with_header_mut(f, tx_id.as_ref())
             .map(IOResult::Done)
+            .map_err(Into::into)
     } else {
         pager.with_header_mut(&f)
     }
@@ -19002,12 +19127,13 @@ fn get_schema_cookie(
     mv_store: Option<&Arc<MvStore>>,
     program: &Program,
     db: usize,
-) -> Result<IOResult<u32>> {
+) -> IOResultOr<u32> {
     if let Some(mv_store) = mv_store {
         let tx_id = program.connection.get_mv_tx_id_for_db(db);
         mv_store
             .with_header(|header| header.schema_cookie.get(), tx_id.as_ref())
             .map(IOResult::Done)
+            .map_err(Into::into)
     } else {
         pager.get_schema_cookie()
     }
@@ -19373,7 +19499,7 @@ mod tests {
         };
 
         assert!(
-            matches!(err, LimboError::InternalError(ref message) if message.contains("probe_rowid_reg=None is grace-only")),
+            matches!(*err, LimboError::InternalError(ref message) if message.contains("probe_rowid_reg=None is grace-only")),
             "unexpected error: {err:?}"
         );
         assert_eq!(state.pc, 0, "pc should not advance on invariant violation");
@@ -19446,7 +19572,7 @@ mod tests {
             Ok(_) => panic!("non-integer register must fail"),
             Err(err) => err,
         };
-        assert!(matches!(err, LimboError::Constraint(message) if message == "datatype mismatch"));
+        assert!(matches!(*err, LimboError::Constraint(message) if message == "datatype mismatch"));
         assert_eq!(state.pc, 0);
     }
 
@@ -19471,7 +19597,7 @@ mod tests {
             Err(err) => err,
         };
         assert!(
-            matches!(err, LimboError::InternalError(ref message) if message.contains("overlaps its source range")),
+            matches!(*err, LimboError::InternalError(ref message) if message.contains("overlaps its source range")),
             "unexpected error: {err:?}"
         );
     }
@@ -19494,7 +19620,7 @@ mod tests {
             Err(err) => err,
         };
         assert!(
-            matches!(err, LimboError::InternalError(ref message) if message.contains("content register")),
+            matches!(*err, LimboError::InternalError(ref message) if message.contains("content register")),
             "unexpected error: {err:?}"
         );
     }

--- a/core/vdbe/hash_table.rs
+++ b/core/vdbe/hash_table.rs
@@ -1,6 +1,7 @@
 use crate::alloc::vec;
 use crate::alloc::*;
 use crate::turso_assert;
+use crate::types::IOResultOr;
 use crate::{
     error::LimboError,
     io::{Buffer, Completion, TempFile, IO},
@@ -1147,7 +1148,7 @@ impl HashTable {
         rowid: i64,
         payload_values: Vec<Value>,
         metrics: Option<&mut HashJoinMetrics>,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let pending = PendingHashInsert {
             key_values,
             rowid,
@@ -1263,7 +1264,7 @@ impl HashTable {
         key_values: &[Value],
         key_refs: &[ValueRef],
         mut metrics: Option<&mut HashJoinMetrics>,
-    ) -> Result<IOResult<bool>> {
+    ) -> IOResultOr<bool> {
         turso_assert!(
             self.state == HashTableState::Building || self.state == HashTableState::Spilled,
             "Cannot insert_distinct into hash table in unexpected state",
@@ -1803,10 +1804,7 @@ impl HashTable {
 
     /// Finalize the build phase and prepare for probing.
     /// If spilled, flushes remaining in-memory partition entries to disk.
-    pub fn finalize_build(
-        &mut self,
-        metrics: Option<&mut HashJoinMetrics>,
-    ) -> Result<IOResult<()>> {
+    pub fn finalize_build(&mut self, metrics: Option<&mut HashJoinMetrics>) -> IOResultOr<()> {
         let mut metrics = metrics;
         turso_assert!(
             self.state == HashTableState::Building || self.state == HashTableState::Spilled,
@@ -2273,7 +2271,7 @@ impl HashTable {
         &mut self,
         partition_idx: usize,
         mut metrics: Option<&mut HashJoinMetrics>,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         loop {
             // to avoid holding mut borrows, split this into two phases.
             let action = {
@@ -2289,9 +2287,9 @@ impl HashTable {
                 let io_state = spilled.io_state.get();
 
                 if unlikely(matches!(io_state, SpillIOState::Error)) {
-                    return Err(LimboError::InternalError(
-                        "hash join spill I/O failure".into(),
-                    ));
+                    return Err(
+                        LimboError::InternalError("hash join spill I/O failure".into()).into(),
+                    );
                 }
                 // Already fully loaded
                 if spilled.is_loaded() {
@@ -2694,7 +2692,7 @@ impl HashTable {
         key_values: Vec<Value>,
         probe_rowid: i64,
         metrics: Option<&mut HashJoinMetrics>,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let spill_state = self
             .spill_state
             .as_ref()
@@ -2849,7 +2847,7 @@ impl HashTable {
     pub fn finalize_probe_spill(
         &mut self,
         metrics: Option<&mut HashJoinMetrics>,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let mut metrics = metrics;
         let Some(probe_state) = self.probe_spill_state.as_ref() else {
             return Ok(IOResult::Done(()));
@@ -2943,7 +2941,7 @@ impl HashTable {
     pub fn grace_load_current_partition(
         &mut self,
         mut metrics: Option<&mut HashJoinMetrics>,
-    ) -> Result<IOResult<bool>> {
+    ) -> IOResultOr<bool> {
         loop {
             let grace = self.grace_state.as_ref().expect("grace state must exist");
             if grace.partition_list_idx >= grace.partitions_to_process.len() {
@@ -2980,7 +2978,7 @@ impl HashTable {
     }
 
     /// Advance to next probe entry. Returns keys+rowid or None when exhausted.
-    pub fn grace_next_probe_entry(&mut self) -> Result<IOResult<Option<GraceProbeEntry>>> {
+    pub fn grace_next_probe_entry(&mut self) -> IOResultOr<Option<GraceProbeEntry>> {
         loop {
             let grace = self.grace_state.as_ref().expect("grace state must exist");
             if grace.probe_entry_cursor < grace.probe_entries.len() {
@@ -3010,7 +3008,7 @@ impl HashTable {
 
     /// Try to load the next probe chunk for the given partition.
     /// Returns true if more probe entries were loaded, false if exhausted.
-    fn grace_try_load_next_probe_chunk(&mut self, partition_idx: usize) -> Result<IOResult<bool>> {
+    fn grace_try_load_next_probe_chunk(&mut self, partition_idx: usize) -> IOResultOr<bool> {
         loop {
             let Some(probe_state) = self.probe_spill_state.as_ref() else {
                 return Ok(IOResult::Done(false));
@@ -3084,7 +3082,7 @@ impl HashTable {
 
     /// Load probe entries for a given partition into grace_state.probe_entries.
     /// Loads from in-memory buffers or from the first spill chunk.
-    fn grace_load_probe_entries(&mut self, partition_idx: usize) -> Result<IOResult<()>> {
+    fn grace_load_probe_entries(&mut self, partition_idx: usize) -> IOResultOr<()> {
         {
             let grace = self.grace_state.as_mut().expect("grace state");
             grace.probe_entries.clear();
@@ -3116,7 +3114,7 @@ impl HashTable {
     }
 
     /// Load the next probe spill chunk into grace_state.probe_entries.
-    fn grace_load_next_probe_chunk(&mut self, partition_idx: usize) -> Result<IOResult<bool>> {
+    fn grace_load_next_probe_chunk(&mut self, partition_idx: usize) -> IOResultOr<bool> {
         loop {
             let action = {
                 let probe_state = self.probe_spill_state.as_mut().expect("probe spill state");
@@ -3126,9 +3124,9 @@ impl HashTable {
                 let io_state = spilled.io_state.get();
 
                 if unlikely(matches!(io_state, SpillIOState::Error)) {
-                    return Err(LimboError::InternalError(
-                        "grace probe spill I/O failure".into(),
-                    ));
+                    return Err(
+                        LimboError::InternalError("grace probe spill I/O failure".into()).into(),
+                    );
                 }
 
                 if matches!(io_state, SpillIOState::WaitingForRead) {

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -2127,6 +2127,273 @@ const fn get_insn_virtual_table() -> [InsnFunction; InsnVariants::COUNT] {
 
 const INSN_VTABLE: [InsnFunction; InsnVariants::COUNT] = get_insn_virtual_table();
 
+/// Dispatches one instruction through a direct, exhaustive match: every arm
+/// is a direct call the branch predictor resolves per call site, and LLVM
+/// may inline hot opcodes into their arms, folding the `load_insn!` re-match
+/// inside them. Viable as a full match (not tiered) because `InsnResult`
+/// returns in registers; with the old 40-byte-error result each arm carried
+/// its own return-slot plumbing and the match blew past inlining thresholds.
+#[inline(always)]
+pub(crate) fn dispatch_insn(
+    program: &super::Program,
+    state: &mut super::ProgramState,
+    insn: &Insn,
+    pager: &std::sync::Arc<crate::Pager>,
+) -> execute::InsnResult {
+    match insn {
+        Insn::Eq { .. }
+        | Insn::Ne { .. }
+        | Insn::Lt { .. }
+        | Insn::Le { .. }
+        | Insn::Gt { .. }
+        | Insn::Ge { .. } => execute::op_comparison(program, state, insn, pager),
+        Insn::SeekGE { .. } | Insn::SeekGT { .. } | Insn::SeekLE { .. } | Insn::SeekLT { .. } => {
+            execute::op_seek(program, state, insn, pager)
+        }
+        Insn::AggFinal { .. } | Insn::AggValue { .. } => {
+            execute::op_agg_final(program, state, insn, pager)
+        }
+        Insn::OpenEphemeral { .. } | Insn::OpenAutoindex { .. } => {
+            execute::op_open_ephemeral(program, state, insn, pager)
+        }
+        Insn::Found { .. } | Insn::NotFound { .. } => {
+            execute::op_found(program, state, insn, pager)
+        }
+        Insn::Init { .. } => execute::op_init(program, state, insn, pager),
+        Insn::Null { .. } => execute::op_null(program, state, insn, pager),
+        Insn::BeginSubrtn { .. } => execute::op_null(program, state, insn, pager),
+        Insn::NullRow { .. } => execute::op_null_row(program, state, insn, pager),
+        Insn::Add { .. } => execute::op_add(program, state, insn, pager),
+        Insn::Subtract { .. } => execute::op_subtract(program, state, insn, pager),
+        Insn::Multiply { .. } => execute::op_multiply(program, state, insn, pager),
+        Insn::Divide { .. } => execute::op_divide(program, state, insn, pager),
+        Insn::DropIndex { .. } => execute::op_drop_index(program, state, insn, pager),
+        Insn::Compare { .. } => execute::op_compare(program, state, insn, pager),
+        Insn::BitAnd { .. } => execute::op_bit_and(program, state, insn, pager),
+        Insn::BitOr { .. } => execute::op_bit_or(program, state, insn, pager),
+        Insn::BitNot { .. } => execute::op_bit_not(program, state, insn, pager),
+        Insn::Checkpoint { .. } => execute::op_checkpoint(program, state, insn, pager),
+        Insn::Remainder { .. } => execute::op_remainder(program, state, insn, pager),
+        Insn::Jump { .. } => execute::op_jump(program, state, insn, pager),
+        Insn::Move { .. } => execute::op_move(program, state, insn, pager),
+        Insn::IfPos { .. } => execute::op_if_pos(program, state, insn, pager),
+        Insn::NotNull { .. } => execute::op_not_null(program, state, insn, pager),
+        Insn::If { .. } => execute::op_if(program, state, insn, pager),
+        Insn::IfNot { .. } => execute::op_if_not(program, state, insn, pager),
+        Insn::OpenRead { .. } => execute::op_open_read(program, state, insn, pager),
+        Insn::VOpen { .. } => execute::op_vopen(program, state, insn, pager),
+        Insn::VCreate { .. } => execute::op_vcreate(program, state, insn, pager),
+        Insn::VFilter { .. } => execute::op_vfilter(program, state, insn, pager),
+        Insn::VColumn { .. } => execute::op_vcolumn(program, state, insn, pager),
+        Insn::VUpdate { .. } => execute::op_vupdate(program, state, insn, pager),
+        Insn::VNext { .. } => execute::op_vnext(program, state, insn, pager),
+        Insn::VDestroy { .. } => execute::op_vdestroy(program, state, insn, pager),
+        Insn::OpenPseudo { .. } => execute::op_open_pseudo(program, state, insn, pager),
+        Insn::Rewind { .. } => execute::op_rewind(program, state, insn, pager),
+        Insn::Last { .. } => execute::op_last(program, state, insn, pager),
+        Insn::Column { .. } => execute::op_column(program, state, insn, pager),
+        Insn::ColumnRange { .. } => execute::op_column_range(program, state, insn, pager),
+        Insn::ColumnHasField { .. } => execute::op_column_has_field(program, state, insn, pager),
+        Insn::TypeCheck { .. } => execute::op_type_check(program, state, insn, pager),
+        Insn::ArrayEncode { .. } => execute::op_array_encode(program, state, insn, pager),
+        Insn::ArrayDecode { .. } => execute::op_array_decode(program, state, insn, pager),
+        Insn::ArrayElement { .. } => execute::op_array_element(program, state, insn, pager),
+        Insn::ArrayLength { .. } => execute::op_array_length(program, state, insn, pager),
+        Insn::MakeArray { .. } => execute::op_make_array(program, state, insn, pager),
+        Insn::MakeArrayDynamic { .. } => {
+            execute::op_make_array_dynamic(program, state, insn, pager)
+        }
+        Insn::StructField { .. } => execute::op_struct_field(program, state, insn, pager),
+        Insn::UnionPack { .. } => execute::op_union_pack(program, state, insn, pager),
+        Insn::UnionTag { .. } => execute::op_union_tag(program, state, insn, pager),
+        Insn::UnionExtract { .. } => execute::op_union_extract(program, state, insn, pager),
+        Insn::RegCopyOffset { .. } => execute::op_reg_copy_offset(program, state, insn, pager),
+        Insn::BlobRead { .. } => execute::op_blob_read(program, state, insn, pager),
+        Insn::BlobWrite { .. } => execute::op_blob_write(program, state, insn, pager),
+        Insn::BlobLen { .. } => execute::op_blob_len(program, state, insn, pager),
+        Insn::ArrayConcat { .. } => execute::op_array_concat(program, state, insn, pager),
+        Insn::ArraySetElement { .. } => execute::op_array_set_element(program, state, insn, pager),
+        Insn::ArraySlice { .. } => execute::op_array_slice(program, state, insn, pager),
+        Insn::MakeRecord { .. } => execute::op_make_record(program, state, insn, pager),
+        Insn::ResultRow { .. } => execute::op_result_row(program, state, insn, pager),
+        Insn::Next { .. } => execute::op_next(program, state, insn, pager),
+        Insn::Prev { .. } => execute::op_prev(program, state, insn, pager),
+        Insn::Halt { .. } => execute::op_halt(program, state, insn, pager),
+        Insn::HaltIfNull { .. } => execute::op_halt_if_null(program, state, insn, pager),
+        Insn::Transaction { .. } => execute::op_transaction(program, state, insn, pager),
+        Insn::AutoCommit { .. } => execute::op_auto_commit(program, state, insn, pager),
+        Insn::Savepoint { .. } => execute::op_savepoint(program, state, insn, pager),
+        Insn::Goto { .. } => execute::op_goto(program, state, insn, pager),
+        Insn::Gosub { .. } => execute::op_gosub(program, state, insn, pager),
+        Insn::Return { .. } => execute::op_return(program, state, insn, pager),
+        Insn::Integer { .. } => execute::op_integer(program, state, insn, pager),
+        Insn::Program { .. } => execute::op_program(program, state, insn, pager),
+        Insn::ResetCount => execute::op_reset_count(program, state, insn, pager),
+        Insn::ChangeCount { .. } => execute::op_change_count(program, state, insn, pager),
+        Insn::Real { .. } => execute::op_real(program, state, insn, pager),
+        Insn::RealAffinity { .. } => execute::op_real_affinity(program, state, insn, pager),
+        Insn::String8 { .. } => execute::op_string8(program, state, insn, pager),
+        Insn::Blob { .. } => execute::op_blob(program, state, insn, pager),
+        Insn::RowData { .. } => execute::op_row_data(program, state, insn, pager),
+        Insn::RowId { .. } => execute::op_row_id(program, state, insn, pager),
+        Insn::IdxRowId { .. } => execute::op_idx_row_id(program, state, insn, pager),
+        Insn::SeekRowid { .. } => execute::op_seek_rowid(program, state, insn, pager),
+        Insn::DeferredSeek { .. } => execute::op_deferred_seek(program, state, insn, pager),
+        Insn::SeekEnd { .. } => execute::op_seek_end(program, state, insn, pager),
+        Insn::IdxGE { .. } => execute::op_idx_ge(program, state, insn, pager),
+        Insn::IdxGT { .. } => execute::op_idx_gt(program, state, insn, pager),
+        Insn::IdxLE { .. } => execute::op_idx_le(program, state, insn, pager),
+        Insn::IdxLT { .. } => execute::op_idx_lt(program, state, insn, pager),
+        Insn::DecrJumpZero { .. } => execute::op_decr_jump_zero(program, state, insn, pager),
+        Insn::AggStep { .. } => execute::op_agg_step(program, state, insn, pager),
+        Insn::AggInverse { .. } => execute::op_agg_inverse(program, state, insn, pager),
+        Insn::SorterOpen { .. } => execute::op_sorter_open(program, state, insn, pager),
+        Insn::SorterInsert { .. } => execute::op_sorter_insert(program, state, insn, pager),
+        Insn::SorterSort { .. } => execute::op_sorter_sort(program, state, insn, pager),
+        Insn::SorterData { .. } => execute::op_sorter_data(program, state, insn, pager),
+        Insn::SorterNext { .. } => execute::op_sorter_next(program, state, insn, pager),
+        Insn::SorterCompare { .. } => execute::op_sorter_compare(program, state, insn, pager),
+        Insn::RowSetAdd { .. } => execute::op_rowset_add(program, state, insn, pager),
+        Insn::RowSetRead { .. } => execute::op_rowset_read(program, state, insn, pager),
+        Insn::RowSetTest { .. } => execute::op_rowset_test(program, state, insn, pager),
+        Insn::Function { .. } => execute::op_function(program, state, insn, pager),
+        Insn::Cast { .. } => execute::op_cast(program, state, insn, pager),
+        Insn::InitCoroutine { .. } => execute::op_init_coroutine(program, state, insn, pager),
+        Insn::EndCoroutine { .. } => execute::op_end_coroutine(program, state, insn, pager),
+        Insn::Yield { .. } => execute::op_yield(program, state, insn, pager),
+        Insn::Insert { .. } => execute::op_insert(program, state, insn, pager),
+        Insn::Int64 { .. } => execute::op_int_64(program, state, insn, pager),
+        Insn::IdxInsert { .. } => execute::op_idx_insert(program, state, insn, pager),
+        Insn::Delete { .. } => execute::op_delete(program, state, insn, pager),
+        Insn::NewRowid { .. } => execute::op_new_rowid(program, state, insn, pager),
+        Insn::MustBeInt { .. } => execute::op_must_be_int(program, state, insn, pager),
+        Insn::SoftNull { .. } => execute::op_soft_null(program, state, insn, pager),
+        Insn::NoConflict { .. } => execute::op_no_conflict(program, state, insn, pager),
+        Insn::NotExists { .. } => execute::op_not_exists(program, state, insn, pager),
+        Insn::OffsetLimit { .. } => execute::op_offset_limit(program, state, insn, pager),
+        Insn::OpenWrite { .. } => execute::op_open_write(program, state, insn, pager),
+        Insn::Copy { .. } => execute::op_copy(program, state, insn, pager),
+        Insn::CreateBtree { .. } => execute::op_create_btree(program, state, insn, pager),
+        Insn::IndexMethodCreate { .. } => {
+            execute::op_index_method_create(program, state, insn, pager)
+        }
+        Insn::IndexMethodDestroy { .. } => {
+            execute::op_index_method_destroy(program, state, insn, pager)
+        }
+        Insn::IndexMethodOptimize { .. } => {
+            execute::op_index_method_optimize(program, state, insn, pager)
+        }
+        Insn::IndexMethodQuery { .. } => {
+            execute::op_index_method_query(program, state, insn, pager)
+        }
+        Insn::ClearBtree { .. } => execute::op_clear_btree(program, state, insn, pager),
+        Insn::Destroy { .. } => execute::op_destroy(program, state, insn, pager),
+        Insn::ResetSorter { .. } => execute::op_reset_sorter(program, state, insn, pager),
+        Insn::DropTable { .. } => execute::op_drop_table(program, state, insn, pager),
+        Insn::DropTrigger { .. } => execute::op_drop_trigger(program, state, insn, pager),
+        Insn::DropType { .. } => execute::op_drop_type(program, state, insn, pager),
+        Insn::AddSequence { .. } => execute::op_add_sequence(program, state, insn, pager),
+        Insn::DropSequence { .. } => execute::op_drop_sequence(program, state, insn, pager),
+        Insn::SequenceComputeNext { .. } => {
+            execute::op_sequence_compute_next(program, state, insn, pager)
+        }
+        Insn::SetSequenceCurrval { .. } => {
+            execute::op_set_sequence_currval(program, state, insn, pager)
+        }
+        Insn::SequenceTrackAllocation { .. } => {
+            execute::op_sequence_track_allocation(program, state, insn, pager)
+        }
+        Insn::SequenceRegisterAllocation { .. } => {
+            execute::op_sequence_register_allocation(program, state, insn, pager)
+        }
+        Insn::SequenceBeginInnerTx { .. } => {
+            execute::op_sequence_begin_inner_tx(program, state, insn, pager)
+        }
+        Insn::SequenceCommitInnerTx { .. } => {
+            execute::op_sequence_commit_inner_tx(program, state, insn, pager)
+        }
+        Insn::AddType { .. } => execute::op_add_type(program, state, insn, pager),
+        Insn::DropView { .. } => execute::op_drop_view(program, state, insn, pager),
+        Insn::Close { .. } => execute::op_close(program, state, insn, pager),
+        Insn::IsNull { .. } => execute::op_is_null(program, state, insn, pager),
+        Insn::ParseSchema { .. } => execute::op_parse_schema(program, state, insn, pager),
+        Insn::PopulateMaterializedViews { .. } => {
+            execute::op_populate_materialized_views(program, state, insn, pager)
+        }
+        Insn::ShiftRight { .. } => execute::op_shift_right(program, state, insn, pager),
+        Insn::ShiftLeft { .. } => execute::op_shift_left(program, state, insn, pager),
+        Insn::AddImm { .. } => execute::op_add_imm(program, state, insn, pager),
+        Insn::Variable { .. } => execute::op_variable(program, state, insn, pager),
+        Insn::ZeroOrNull { .. } => execute::op_zero_or_null(program, state, insn, pager),
+        Insn::Not { .. } => execute::op_not(program, state, insn, pager),
+        Insn::IsTrue { .. } => execute::op_is_true(program, state, insn, pager),
+        Insn::Concat { .. } => execute::op_concat(program, state, insn, pager),
+        Insn::And { .. } => execute::op_and(program, state, insn, pager),
+        Insn::Or { .. } => execute::op_or(program, state, insn, pager),
+        Insn::Noop => execute::op_noop(program, state, insn, pager),
+        Insn::PageCount { .. } => execute::op_page_count(program, state, insn, pager),
+        Insn::ReadCookie { .. } => execute::op_read_cookie(program, state, insn, pager),
+        Insn::SetCookie { .. } => execute::op_set_cookie(program, state, insn, pager),
+        Insn::Once { .. } => execute::op_once(program, state, insn, pager),
+        Insn::ResetOnce { .. } => execute::op_reset_once(program, state, insn, pager),
+        Insn::Affinity { .. } => execute::op_affinity(program, state, insn, pager),
+        Insn::IdxDelete { .. } => execute::op_idx_delete(program, state, insn, pager),
+        Insn::Count { .. } => execute::op_count(program, state, insn, pager),
+        Insn::IntegrityCk { .. } => execute::op_integrity_check(program, state, insn, pager),
+        Insn::RenameTable { .. } => execute::op_rename_table(program, state, insn, pager),
+        Insn::DropColumn { .. } => execute::op_drop_column(program, state, insn, pager),
+        Insn::AddColumn { .. } => execute::op_add_column(program, state, insn, pager),
+        Insn::AlterColumn { .. } => execute::op_alter_column(program, state, insn, pager),
+        Insn::MaxPgcnt { .. } => execute::op_max_pgcnt(program, state, insn, pager),
+        Insn::JournalMode { .. } => execute::op_journal_mode(program, state, insn, pager),
+        Insn::IfNeg { .. } => execute::op_if_neg(program, state, insn, pager),
+        Insn::Explain { .. } => execute::op_noop(program, state, insn, pager),
+        Insn::OpenDup { .. } => execute::op_open_dup(program, state, insn, pager),
+        Insn::MemMax { .. } => execute::op_mem_max(program, state, insn, pager),
+        Insn::Sequence { .. } => execute::op_sequence(program, state, insn, pager),
+        Insn::SequenceTest { .. } => execute::op_sequence_test(program, state, insn, pager),
+        Insn::FkCounter { .. } => execute::op_fk_counter(program, state, insn, pager),
+        Insn::FkIfZero { .. } => execute::op_fk_if_zero(program, state, insn, pager),
+        Insn::FkCheck { .. } => execute::op_fk_check(program, state, insn, pager),
+        Insn::VBegin { .. } => execute::op_vbegin(program, state, insn, pager),
+        Insn::VRename { .. } => execute::op_vrename(program, state, insn, pager),
+        Insn::FilterAdd { .. } => execute::op_filter_add(program, state, insn, pager),
+        Insn::Filter { .. } => execute::op_filter(program, state, insn, pager),
+        Insn::HashBuild { .. } => execute::op_hash_build(program, state, insn, pager),
+        Insn::HashDistinct { .. } => execute::op_hash_distinct(program, state, insn, pager),
+        Insn::HashBuildFinalize { .. } => {
+            execute::op_hash_build_finalize(program, state, insn, pager)
+        }
+        Insn::HashProbe { .. } => execute::op_hash_probe(program, state, insn, pager),
+        Insn::HashNext { .. } => execute::op_hash_next(program, state, insn, pager),
+        Insn::HashClose { .. } => execute::op_hash_close(program, state, insn, pager),
+        Insn::HashClear { .. } => execute::op_hash_clear(program, state, insn, pager),
+        Insn::HashMarkMatched { .. } => execute::op_hash_mark_matched(program, state, insn, pager),
+        Insn::HashResetMatched { .. } => {
+            execute::op_hash_reset_matched(program, state, insn, pager)
+        }
+        Insn::HashScanUnmatched { .. } => {
+            execute::op_hash_scan_unmatched(program, state, insn, pager)
+        }
+        Insn::HashNextUnmatched { .. } => {
+            execute::op_hash_next_unmatched(program, state, insn, pager)
+        }
+        Insn::HashGraceInit { .. } => execute::op_hash_grace_init(program, state, insn, pager),
+        Insn::HashGraceLoadPartition { .. } => {
+            execute::op_hash_grace_load_partition(program, state, insn, pager)
+        }
+        Insn::HashGraceNextProbe { .. } => {
+            execute::op_hash_grace_next_probe(program, state, insn, pager)
+        }
+        Insn::HashGraceAdvancePartition { .. } => {
+            execute::op_hash_grace_advance_partition(program, state, insn, pager)
+        }
+        Insn::VacuumInto { .. } => execute::op_vacuum_into(program, state, insn, pager),
+        Insn::Vacuum { .. } => execute::op_vacuum(program, state, insn, pager),
+        Insn::InitCdcVersion { .. } => execute::op_init_cdc_version(program, state, insn, pager),
+    }
+}
+
 impl InsnVariants {
     // This function is used for testing
     #[allow(dead_code)]
@@ -2472,5 +2739,20 @@ mod tests {
             "Insn grew to {} bytes",
             std::mem::size_of::<super::Insn>()
         );
+    }
+}
+
+#[cfg(test)]
+mod error_size_tests {
+    /// `LimboError` rides in the `Result` of every opcode call and every
+    /// cursor operation, so its size is copied around once per executed
+    /// instruction. A fat new variant (see the boxed `LexerError`) silently
+    /// taxes the whole hot path.
+    #[test]
+    fn limbo_error_stays_small() {
+        assert!(std::mem::size_of::<crate::LimboError>() <= 40);
+        // The niche-packed boxed-error result returns in registers; anything
+        // past 16 bytes goes back through memory on every executed insn.
+        assert!(std::mem::size_of::<super::execute::InsnResult>() <= 16);
     }
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -19,6 +19,7 @@
 
 use crate::alloc::{TryReserveError, TursoFromIterator};
 use crate::translate::plan::BitSet;
+use crate::types::IOResultOr;
 use crate::types::{Extendable, Text, ValueBlob};
 use crate::{turso_assert, turso_assert_ne, turso_debug_assert, NonNan};
 pub mod affinity;
@@ -777,6 +778,9 @@ pub struct SequenceInnerTxState {
 }
 
 pub struct ProgramState {
+    /// Interrupt/progress-check gate mask for normal_step; re-derived from
+    /// the progress handler's interval each time the gate fires.
+    check_mask: u64,
     pub io_completions: Option<IOCompletions>,
     pub pc: InsnReference,
     pub(crate) cursors: Vec<Option<Cursor>>,
@@ -930,6 +934,7 @@ impl ProgramState {
         let cursor_seqs = vec![0i64; max_cursors];
         let registers = vec![Register::Value(Value::Null); max_registers].into_boxed_slice();
         Self {
+            check_mask: 63,
             io_completions: None,
             pc: 0,
             cursors,
@@ -1307,7 +1312,7 @@ impl ProgramState {
         connection: &Connection,
         pager: &Arc<Pager>,
         write: bool,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let in_explicit_txn = !connection.auto_commit.load(Ordering::SeqCst);
         if write && in_explicit_txn {
             // Check if MVCC is active - if so, use MVCC savepoints instead of pager savepoints
@@ -1745,7 +1750,7 @@ impl Program {
         pager: &Arc<Pager>,
         query_mode: QueryMode,
         waker: Option<&Waker>,
-    ) -> Result<StepResult> {
+    ) -> Result<StepResult, Box<LimboError>> {
         state.execution_state = ProgramExecutionState::Running;
         let result = match query_mode {
             QueryMode::Normal => self.normal_step(state, pager, waker),
@@ -1772,14 +1777,18 @@ impl Program {
         result
     }
 
-    fn explain_step(&self, state: &mut ProgramState, pager: &Arc<Pager>) -> Result<StepResult> {
+    fn explain_step(
+        &self,
+        state: &mut ProgramState,
+        pager: &Arc<Pager>,
+    ) -> Result<StepResult, Box<LimboError>> {
         turso_debug_assert!(state.column_count() == EXPLAIN_COLUMNS.len());
         if self.connection.is_closed() {
             let tx_state = self.connection.get_tx_state();
             if let TransactionState::Write { .. } = tx_state {
                 pager.rollback_tx(&self.connection);
             }
-            return Err(LimboError::InternalError("Connection closed".to_string()));
+            return Err(LimboError::InternalError("Connection closed".to_string()).into());
         }
 
         if self.maybe_request_interrupt(
@@ -1869,7 +1878,7 @@ impl Program {
         &self,
         state: &mut ProgramState,
         pager: &Arc<Pager>,
-    ) -> Result<StepResult> {
+    ) -> Result<StepResult, Box<LimboError>> {
         turso_debug_assert!(state.column_count() == EXPLAIN_QUERY_PLAN_COLUMNS.len());
         loop {
             if self.connection.is_closed() {
@@ -1878,7 +1887,7 @@ impl Program {
                 if let TransactionState::Write { .. } = state {
                     pager.rollback_tx(&self.connection);
                 }
-                return Err(LimboError::InternalError("Connection closed".to_string()));
+                return Err(LimboError::InternalError("Connection closed".to_string()).into());
             }
 
             if self.maybe_request_interrupt(
@@ -1921,7 +1930,7 @@ impl Program {
         &self,
         state: &mut ProgramState,
         pager: &Arc<Pager>,
-    ) -> Result<StepResult> {
+    ) -> Result<StepResult, Box<LimboError>> {
         turso_debug_assert!(state.column_count() == EXPLAIN_QUERY_PLAN_JSON_COLUMNS.len());
         if self.connection.is_closed() {
             // Connection is closed for whatever reason, rollback the transaction.
@@ -1929,7 +1938,7 @@ impl Program {
             if let TransactionState::Write { .. } = tx_state {
                 pager.rollback_tx(&self.connection);
             }
-            return Err(LimboError::InternalError("Connection closed".to_string()));
+            return Err(LimboError::InternalError("Connection closed".to_string()).into());
         }
         if self.maybe_request_interrupt(
             state,
@@ -1954,17 +1963,17 @@ impl Program {
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]
+    // inline(always): called once per returned row from step(); outlined it
+    // costs a call plus a 40-byte memory-returned Result per row.
+    #[inline(always)]
     fn normal_step(
         &self,
         state: &mut ProgramState,
         pager: &Arc<Pager>,
         waker: Option<&Waker>,
-    ) -> Result<StepResult> {
+    ) -> Result<StepResult, Box<LimboError>> {
         let enable_tracing = tracing::enabled!(tracing::Level::TRACE);
         let vdbe_trace = self.connection.get_vdbe_trace();
-        // A progress handler with a small interval narrows the check gate so
-        // its cadence is honored; without one the gate stays at the maximum.
-        let progress_ops = self.connection.progress_ops();
         // Reborrow the instruction list once: reloading it through `self`
         // every iteration defeats LLVM's hoisting because the opcode call
         // below is opaque to it.
@@ -1999,13 +2008,13 @@ impl Program {
                             );
                         }
                         pager.cleanup_after_checkpoint_failure();
-                        return Err(checkpoint_err);
+                        return Err(checkpoint_err.into());
                     }
                     let err = err.into();
                     if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
                         tracing::error!("Abort failed during error handling: {abort_err}");
                     }
-                    return Err(err);
+                    return Err(err.into());
                 }
                 state.io_completions = None;
             }
@@ -2017,23 +2026,32 @@ impl Program {
                 // callers regain control at every returned row regardless.
                 // The interval must stay a power of two so this gate is a
                 // mask test, never a division, in the interpreter hot loop.
+                // The gate mask lives in ProgramState and is re-derived from the
+                // progress handler's interval only when the gate fires, so the
+                // steady-state cost is one mask test with no atomics. A handler
+                // with interval N < 64 narrows the mask at the next firing (a
+                // one-time lag of at most CHECK_INTERVAL instructions; the
+                // cadence is approximate by contract).
                 const CHECK_INTERVAL: u64 = 64;
                 const _: () = assert!(CHECK_INTERVAL.is_power_of_two());
-                let check_mask = if progress_ops == 0 {
-                    CHECK_INTERVAL - 1
-                } else {
-                    progress_ops.next_power_of_two().min(CHECK_INTERVAL) - 1
-                };
-                if state.metrics.vm_steps & check_mask == 0 {
+                if state.metrics.vm_steps & state.check_mask == 0 {
+                    let progress_ops = self.connection.progress_ops();
+                    state.check_mask = if progress_ops == 0 || progress_ops >= CHECK_INTERVAL {
+                        CHECK_INTERVAL - 1
+                    } else {
+                        progress_ops.next_power_of_two() - 1
+                    };
                     if self.connection.is_closed() {
                         // Connection is closed for whatever reason, rollback the transaction.
                         let state = self.connection.get_tx_state();
                         if let TransactionState::Write { .. } = state {
                             pager.rollback_tx(&self.connection);
                         }
-                        return Err(LimboError::InternalError("Connection closed".to_string()));
+                        return Err(
+                            LimboError::InternalError("Connection closed".to_string()).into()
+                        );
                     }
-                    let prev_steps = state.metrics.vm_steps.saturating_sub(check_mask + 1);
+                    let prev_steps = state.metrics.vm_steps.saturating_sub(state.check_mask + 1);
                     if self.maybe_request_interrupt(state, pager.io.as_ref(), prev_steps) {
                         self.abort(pager, None, state, true)?;
                         return Ok(StepResult::Interrupt);
@@ -2058,7 +2076,7 @@ impl Program {
                                     "Abort failed after preparing FAIL index methods: {abort_err}"
                                 );
                             }
-                            return Err(fail_error);
+                            return Err(fail_error.into());
                         }
                         Ok(IOResult::IO(io)) => {
                             state.pending_fail_prepare_error = Some(fail_error);
@@ -2095,7 +2113,6 @@ impl Program {
                     }
                 }
                 let (insn, _) = &insns[state.pc as usize];
-                let insn_function = insn.to_function();
                 if enable_tracing {
                     trace_insn(self, state.pc as InsnReference, insn);
                     crate::stack::trace_remaining("program_step:opcode");
@@ -2139,7 +2156,7 @@ impl Program {
                 // Always increment VM steps for every loop iteration
                 state.metrics.vm_steps = state.metrics.vm_steps.saturating_add(1);
 
-                match insn_function(self, state, insn, pager) {
+                match insn::dispatch_insn(self, state, insn, pager) {
                     Ok(InsnFunctionStepResult::Step) => {
                         // Instruction completed, moving to next
                         state.metrics.insn_executed = state.metrics.insn_executed.saturating_add(1);
@@ -2176,32 +2193,34 @@ impl Program {
                         state.metrics.insn_executed = state.metrics.insn_executed.saturating_add(1);
                         return Ok(StepResult::Row);
                     }
-                    Err(LimboError::Busy) => {
-                        // Instruction blocked - will retry at same PC
-                        return Ok(StepResult::Busy);
-                    }
-                    Err(LimboError::BusySnapshot)
-                        if self.connection.transaction_state.get() == TransactionState::None =>
-                    {
-                        // For interactive transactions that are already in a read transaction, retrying BusySnapshot is pointless
-                        // because the snapshot will continue to be stale no matter how many times we retry.
-                        // However, for auto-commits or BEGIN IMMEDIATE, failing to promote to write transaction means it was rolled
-                        // back, so auto-retrying can be useful.
-                        return Ok(StepResult::Busy);
-                    }
-                    Err(err)
-                        if (matches!(err, LimboError::Constraint(_))
+                    Err(boxed_err) => match *boxed_err {
+                        LimboError::Busy => {
+                            // Instruction blocked - will retry at same PC
+                            return Ok(StepResult::Busy);
+                        }
+                        LimboError::BusySnapshot
+                            if self.connection.transaction_state.get()
+                                == TransactionState::None =>
+                        {
+                            // For interactive transactions that are already in a read transaction, retrying BusySnapshot is pointless
+                            // because the snapshot will continue to be stale no matter how many times we retry.
+                            // However, for auto-commits or BEGIN IMMEDIATE, failing to promote to write transaction means it was rolled
+                            // back, so auto-retrying can be useful.
+                            return Ok(StepResult::Busy);
+                        }
+                        err if (matches!(err, LimboError::Constraint(_))
                             && self.resolve_type == ResolveType::Fail)
                             || matches!(err, LimboError::Raise(ResolveType::Fail, _)) =>
-                    {
-                        state.pending_fail_prepare_error = Some(err);
-                    }
-                    Err(err) => {
-                        if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
-                            tracing::error!("Abort failed during error handling: {abort_err}");
+                        {
+                            state.pending_fail_prepare_error = Some(err);
                         }
-                        return Err(err);
-                    }
+                        err => {
+                            if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
+                                tracing::error!("Abort failed during error handling: {abort_err}");
+                            }
+                            return Err(err.into());
+                        }
+                    },
                 }
             }
         }
@@ -2213,7 +2232,7 @@ impl Program {
         state: &mut ProgramState,
         rollback: bool,
         pager: &Arc<Pager>,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         use crate::types::IOResult;
 
         loop {
@@ -2317,7 +2336,7 @@ impl Program {
         program_state: &mut ProgramState,
         mv_store: Option<&Arc<MvStore>>,
         rollback: bool,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         if !rollback {
             turso_assert!(
                 !matches!(
@@ -2398,7 +2417,7 @@ impl Program {
         pager: Arc<Pager>,
         program_state: &mut ProgramState,
         rollback: bool,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let connection = self.connection.clone();
         let auto_commit = connection.auto_commit.load(Ordering::SeqCst);
         let tx_state = connection.get_tx_state();
@@ -2495,7 +2514,7 @@ impl Program {
         program_state: &mut ProgramState,
         mv_store: &Arc<MvStore>,
         rollback: bool,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let conn = self.connection.clone();
         let auto_commit = conn.auto_commit.load(Ordering::SeqCst);
         if !auto_commit {
@@ -2585,7 +2604,7 @@ impl Program {
                     // Rollback remaining uncommitted attached MVCC transactions
                     // so they don't block checkpointing until connection close.
                     conn.rollback_attached_mvcc_txs(true);
-                    return Err(e);
+                    return Err(e.into());
                 }
             };
             match state_machine.step(&attached_mv_store)? {
@@ -2644,7 +2663,7 @@ impl Program {
         connection: &Connection,
         program_state: &mut ProgramState,
         rollback: bool,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         let commit_state = &mut program_state.commit_state;
         if matches!(commit_state, CommitState::CommittingAttached) {
             // Resume committing attached pagers after IO yield.
@@ -2698,11 +2717,7 @@ impl Program {
     /// because in explicit transactions, the COMMIT statement's program may differ
     /// from the statement that acquired the attached write lock.
     /// On IO yield, already-committed pagers are skipped on re-entry via holds_write_lock().
-    fn end_attached_write_txns(
-        &self,
-        connection: &Connection,
-        rollback: bool,
-    ) -> Result<IOResult<()>> {
+    fn end_attached_write_txns(&self, connection: &Connection, rollback: bool) -> IOResultOr<()> {
         connection.with_all_attached_pagers_with_index(|pagers| {
             for (db_id, attached_pager) in pagers {
                 let db_id = *db_id;
@@ -2771,7 +2786,7 @@ impl Program {
         &self,
         commit_state: &mut StateMachine<Box<MvccCommitStateMachine>>,
         mv_store: &Arc<MvStore>,
-    ) -> Result<IOResult<()>> {
+    ) -> IOResultOr<()> {
         commit_state.step(mv_store)
     }
 
@@ -3095,7 +3110,7 @@ impl Program {
                                         Err(e) => {
                                             capture_abort_error(
                                                 &mut abort_error,
-                                                e,
+                                                *e,
                                                 "commit_txn failed during FAIL abort",
                                             );
                                             break;

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1,3 +1,4 @@
+use crate::types::IOResultOr;
 use crate::{turso_assert, turso_assert_eq};
 use branches::mark_unlikely;
 use turso_parser::ast::SortOrder;
@@ -256,7 +257,7 @@ impl Sorter {
     }
 
     // We do the sorting here since this is what is called by the SorterSort instruction
-    pub fn sort(&mut self) -> Result<IOResult<()>> {
+    pub fn sort(&mut self) -> IOResultOr<()> {
         loop {
             match self.sort_state {
                 SortState::Start => {
@@ -309,7 +310,7 @@ impl Sorter {
     }
 
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Result<IOResult<()>> {
+    pub fn next(&mut self) -> IOResultOr<()> {
         if self.chunks.is_empty() {
             match self.records.pop() {
                 Some(ptr) => {
@@ -338,7 +339,7 @@ impl Sorter {
             match return_if_io!(self.next_from_chunk_heap()) {
                 Some(boxed_record) => {
                     if let Some(ref error) = boxed_record.deserialization_error {
-                        return Err(error.clone());
+                        return Err(error.clone().into());
                     }
                     let payload = boxed_record.record.get_payload();
                     match &mut self.current {
@@ -372,7 +373,7 @@ impl Sorter {
         current
     }
 
-    pub fn insert(&mut self, record: &ImmutableRecord) -> Result<IOResult<()>> {
+    pub fn insert(&mut self, record: &ImmutableRecord) -> IOResultOr<()> {
         let payload_size = record.get_payload().len();
         loop {
             match self.insert_state {
@@ -417,7 +418,7 @@ impl Sorter {
         }
     }
 
-    fn init_chunk_heap(&mut self) -> Result<IOResult<()>> {
+    fn init_chunk_heap(&mut self) -> IOResultOr<()> {
         match self.init_chunk_heap_state {
             InitChunkHeapState::Start => {
                 let mut group = CompletionGroup::new(|_| {});
@@ -426,7 +427,7 @@ impl Sorter {
                         tracing::error!("Failed to read chunk: {e}");
                         group.cancel();
                         self.io.drain_completions(group.completions())?;
-                        return Err(e);
+                        return Err(e.into());
                     }
                 }
                 self.init_chunk_heap_state = InitChunkHeapState::PushChunk;
@@ -465,7 +466,7 @@ impl Sorter {
     /// from that chunk. If IO is needed, we store it in `pending_completion` and wait for it
     /// on the next call before popping again - this ensures all non-exhausted chunks have
     /// a record in the heap before we decide which is smallest.
-    fn next_from_chunk_heap(&mut self) -> Result<IOResult<Option<Box<BoxedSortableRecord>>>> {
+    fn next_from_chunk_heap(&mut self) -> IOResultOr<Option<Box<BoxedSortableRecord>>> {
         // If there is a pending IO, we must wait for it before popping from the heap,
         // otherwise we might return records out of order.
         while let Some((completion, chunk_idx)) = self.pending_completion.take() {

--- a/core/vdbe/statement_lifecycle_tests.rs
+++ b/core/vdbe/statement_lifecycle_tests.rs
@@ -58,67 +58,66 @@ impl crate::index_method::IndexMethodCursor for FailingPrepareCursor {
     fn create(
         &mut self,
         _context: &crate::index_method::IndexMethodContext,
-    ) -> Result<crate::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         Ok(crate::IOResult::Done(()))
     }
 
     fn destroy(
         &mut self,
         _context: &crate::index_method::IndexMethodContext,
-    ) -> Result<crate::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         Ok(crate::IOResult::Done(()))
     }
 
     fn open_read(
         &mut self,
         _context: &crate::index_method::IndexMethodContext,
-    ) -> Result<crate::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         Ok(crate::IOResult::Done(()))
     }
 
     fn open_write(
         &mut self,
         _context: &crate::index_method::IndexMethodContext,
-    ) -> Result<crate::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         Ok(crate::IOResult::Done(()))
     }
 
-    fn insert(&mut self, _values: &[crate::vdbe::Register]) -> Result<crate::IOResult<()>> {
+    fn insert(&mut self, _values: &[crate::vdbe::Register]) -> crate::types::IOResultOr<()> {
         self.dirty = true;
         Ok(crate::IOResult::Done(()))
     }
 
-    fn delete(&mut self, _values: &[crate::vdbe::Register]) -> Result<crate::IOResult<()>> {
+    fn delete(&mut self, _values: &[crate::vdbe::Register]) -> crate::types::IOResultOr<()> {
         self.dirty = true;
         Ok(crate::IOResult::Done(()))
     }
 
-    fn query_start(&mut self, _values: &[crate::vdbe::Register]) -> Result<crate::IOResult<bool>> {
+    fn query_start(&mut self, _values: &[crate::vdbe::Register]) -> crate::types::IOResultOr<bool> {
         Ok(crate::IOResult::Done(false))
     }
 
-    fn query_next(&mut self) -> Result<crate::IOResult<bool>> {
+    fn query_next(&mut self) -> crate::types::IOResultOr<bool> {
         Ok(crate::IOResult::Done(false))
     }
 
-    fn query_column(&mut self, _idx: usize) -> Result<crate::IOResult<Value>> {
-        Err(LimboError::InternalError(
-            "failing_prepare has no query rows".to_string(),
-        ))
+    fn query_column(&mut self, _idx: usize) -> crate::types::IOResultOr<Value> {
+        Err(LimboError::InternalError("failing_prepare has no query rows".to_string()).into())
     }
 
-    fn query_rowid(&mut self) -> Result<crate::IOResult<Option<i64>>> {
+    fn query_rowid(&mut self) -> crate::types::IOResultOr<Option<i64>> {
         Ok(crate::IOResult::Done(None))
     }
 
     fn stage_statement_commit(
         &mut self,
         _context: &crate::index_method::IndexMethodContext,
-    ) -> Result<crate::IOResult<()>> {
+    ) -> crate::types::IOResultOr<()> {
         if self.dirty {
             return Err(LimboError::InternalError(
                 "forced index-method preparation failure".to_string(),
-            ));
+            )
+            .into());
         }
         Ok(crate::IOResult::Done(()))
     }

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -1,3 +1,4 @@
+use crate::types::IOResultOr;
 use rustc_hash::FxHashMap;
 use std::sync::{atomic::Ordering, Arc};
 
@@ -344,12 +345,13 @@ pub(crate) fn open_vacuum_temp_db(
 fn finalize_vacuum_target_header(
     target_conn: &Arc<Connection>,
     header_meta: &VacuumDbHeaderMeta,
-) -> Result<crate::IOResult<()>> {
+) -> crate::types::IOResultOr<()> {
     if let Some(mv_store) = target_conn.mv_store_for_db(crate::MAIN_DB_ID) {
         let tx_id = target_conn.get_mv_tx_id_for_db(crate::MAIN_DB_ID);
         return mv_store
             .with_header_mut(|header| header_meta.apply_to(header), tx_id.as_ref())
-            .map(crate::IOResult::Done);
+            .map(crate::IOResult::Done)
+            .map_err(Into::into);
     }
     let pager = target_conn.pager.load();
     pager.with_header_mut(|header| header_meta.apply_to(header))
@@ -547,7 +549,7 @@ pub(crate) enum VacuumTargetBuildPhase {
 pub(crate) fn vacuum_target_build_step(
     config: &VacuumTargetBuildConfig,
     state: &mut VacuumTargetBuildContext,
-) -> Result<crate::IOResult<()>> {
+) -> crate::types::IOResultOr<()> {
     loop {
         let current_phase = std::mem::take(&mut state.phase);
 
@@ -670,7 +672,7 @@ pub(crate) fn vacuum_target_build_step(
                         return Ok(crate::IOResult::IO(io));
                     }
                     crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                        return Err(LimboError::Busy);
+                        return Err(LimboError::Busy.into());
                     }
                 }
             }
@@ -736,7 +738,7 @@ pub(crate) fn vacuum_target_build_step(
                     return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                    return Err(LimboError::Busy);
+                    return Err(LimboError::Busy.into());
                 }
             },
 
@@ -873,7 +875,7 @@ pub(crate) fn vacuum_target_build_step(
                     return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                    return Err(LimboError::Busy);
+                    return Err(LimboError::Busy.into());
                 }
             },
 
@@ -908,7 +910,7 @@ pub(crate) fn vacuum_target_build_step(
                     return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                    return Err(LimboError::Busy);
+                    return Err(LimboError::Busy.into());
                 }
             },
 
@@ -958,7 +960,7 @@ pub(crate) fn vacuum_target_build_step(
                     return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                    return Err(LimboError::Busy);
+                    return Err(LimboError::Busy.into());
                 }
             },
 
@@ -1004,7 +1006,7 @@ pub(crate) fn vacuum_target_build_step(
                     return Ok(crate::IOResult::IO(io));
                 }
                 crate::StepResult::Busy | crate::StepResult::Interrupt => {
-                    return Err(LimboError::Busy);
+                    return Err(LimboError::Busy.into());
                 }
             },
 
@@ -1369,7 +1371,7 @@ impl VacuumInPlaceOpContext {
         }
     }
 
-    pub(crate) fn step(&mut self, connection: &Arc<Connection>) -> Result<IOResult<()>> {
+    pub(crate) fn step(&mut self, connection: &Arc<Connection>) -> IOResultOr<()> {
         vacuum_in_place_step(
             connection,
             self.db,
@@ -1703,7 +1705,7 @@ fn vacuum_in_place_step(
     temp_db: &mut Option<Box<VacuumTempDb>>,
     committed_image: &mut Option<VacuumCommittedImageMeta>,
     cleanup_state: &mut VacuumInPlaceCleanupState,
-) -> Result<IOResult<()>> {
+) -> IOResultOr<()> {
     let source_pager = connection.get_pager_from_database_index(&db)?;
 
     loop {
@@ -1713,17 +1715,19 @@ fn vacuum_in_place_step(
                 if !connection.auto_commit.load(Ordering::SeqCst) {
                     return Err(LimboError::TxError(
                         "cannot VACUUM from within a transaction".to_string(),
-                    ));
+                    )
+                    .into());
                 }
                 // 2. No other active root statements on this connection.
                 if connection.n_active_root_statements.load(Ordering::SeqCst) != 1 {
                     return Err(LimboError::TxError(
                         "cannot VACUUM - SQL statements in progress".to_string(),
-                    ));
+                    )
+                    .into());
                 }
                 // 3. Reject readonly database, well you cannot edit a readonly db ^_^
                 if connection.is_readonly(db) {
-                    return Err(LimboError::ReadOnly);
+                    return Err(LimboError::ReadOnly.into());
                 }
                 // 4. Resolve source database mode.
                 let source_db = connection.get_source_database(db);
@@ -1732,7 +1736,8 @@ fn vacuum_in_place_step(
                 if source_db.is_in_memory_db() {
                     return Err(LimboError::InternalError(
                         "cannot VACUUM an in-memory database".to_string(),
-                    ));
+                    )
+                    .into());
                 }
                 reject_unsupported_vacuum_auto_vacuum_mode(source_pager.get_auto_vacuum_mode())?;
                 // 6. Reject non-WAL pagers.
@@ -1754,7 +1759,7 @@ fn vacuum_in_place_step(
                     if mv_store.has_uncheckpointed_log()? {
                         return Err(LimboError::TxError(
                             "cannot VACUUM an MVCC database with uncheckpointed changes; run PRAGMA wal_checkpoint(TRUNCATE) first".to_string(),
-                        ));
+                        ).into());
                     }
                     if connection.get_mv_tx_id_for_db(db).is_some() {
                         turso_assert!(
@@ -1764,7 +1769,7 @@ fn vacuum_in_place_step(
                         return Err(LimboError::InternalError(
                             "VACUUM acquired MVCC gate while this connection has an MVCC transaction"
                                 .to_string(),
-                        ));
+                        ).into());
                     }
                     guard.demote_connection();
                     // After demotion this connection stops reading schema-cookie state from the
@@ -1977,7 +1982,7 @@ fn vacuum_in_place_step(
                     return Ok(IOResult::IO(IOCompletions(completion.clone())));
                 }
                 if !completion.succeeded() {
-                    return Err(vacuum_completion_error(completion, "WAL header init"));
+                    return Err(vacuum_completion_error(completion, "WAL header init").into());
                 }
 
                 if !*fsync_phase {
@@ -2044,7 +2049,7 @@ fn vacuum_in_place_step(
                     return Ok(IOResult::IO(IOCompletions(read_completion.clone())));
                 }
                 if !read_completion.succeeded() {
-                    return Err(vacuum_completion_error(read_completion, "temp batch read"));
+                    return Err(vacuum_completion_error(read_completion, "temp batch read").into());
                 }
 
                 // All pages in this batch are loaded. Prepare WAL frames.
@@ -2123,7 +2128,7 @@ fn vacuum_in_place_step(
                 // Check for write errors.
                 for c in completions.iter() {
                     if !c.succeeded() {
-                        return Err(vacuum_completion_error(c, "WAL write"));
+                        return Err(vacuum_completion_error(c, "WAL write").into());
                     }
                 }
 
@@ -2196,7 +2201,7 @@ fn vacuum_in_place_step(
                     return Ok(IOResult::IO(IOCompletions(sync_completion.clone())));
                 }
                 if !sync_completion.succeeded() {
-                    return Err(vacuum_completion_error(sync_completion, "WAL fsync"));
+                    return Err(vacuum_completion_error(sync_completion, "WAL fsync").into());
                 }
                 *phase = VacuumInPlacePhase::PublishWalCommit;
                 continue;

--- a/sdk-kit/src/rsapi.rs
+++ b/sdk-kit/src/rsapi.rs
@@ -725,6 +725,12 @@ pub fn c_string_to_str(ptr: *const std::ffi::c_char) -> std::ffi::CString {
     unsafe { std::ffi::CString::from_raw(ptr as *mut std::ffi::c_char) }
 }
 
+impl From<Box<LimboError>> for TursoError {
+    fn from(value: Box<LimboError>) -> Self {
+        (*value).into()
+    }
+}
+
 impl From<LimboError> for TursoError {
     fn from(value: LimboError) -> Self {
         match value {

--- a/sync/engine/src/errors.rs
+++ b/sync/engine/src/errors.rs
@@ -14,6 +14,12 @@ pub enum Error {
     IoError(String),
 }
 
+impl From<Box<turso_core::LimboError>> for Error {
+    fn from(value: Box<turso_core::LimboError>) -> Self {
+        (*value).into()
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
         Error::JsonDecode(e.to_string())

--- a/tests/integration/database.rs
+++ b/tests/integration/database.rs
@@ -225,7 +225,7 @@ fn test_open_async_requires_storage() {
     )
     .expect_err("open_async without storage must fail");
     assert!(
-        matches!(err, turso_core::LimboError::InvalidArgument(ref m) if m.contains("storage")),
+        matches!(*err, turso_core::LimboError::InvalidArgument(ref m) if m.contains("storage")),
         "expected InvalidArgument about missing storage, got {err:?}"
     );
 }

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -19,7 +19,7 @@ use turso_core::{
 
 use crate::common::{limbo_exec_rows, limbo_exec_rows_fallible, ExecRows, TempDatabase};
 
-fn run<T>(db: &TempDatabase, mut f: impl FnMut() -> Result<IOResult<T>>) -> Result<T> {
+fn run<T>(db: &TempDatabase, mut f: impl FnMut() -> turso_core::types::IOResultOr<T>) -> Result<T> {
     loop {
         match f()? {
             IOResult::Done(value) => return Ok(value),


### PR DESCRIPTION
Opcode functions returned Result<InsnFunctionStepResult, LimboError>,
a 40-byte value returned through memory on every executed instruction.
The same shape repeated at the step level and across ~350 storage
functions that may suspend for I/O, and LimboError itself was 96 bytes
because one variant stores a parser error inline.

Box the errors so hot results fit in registers:
- LimboError's parser error is boxed (96 -> 40 bytes), with a size
  test pinning it there.
- Opcode functions return InsnResult, 16 bytes, register-returned.
  Errors are boxed where they are created; ? boxes via From.
- The interpreter dispatches through one exhaustive match instead of
  the function-pointer table, with the per-row opcodes inlined into
  their arms. With the old 40-byte results a full match regressed --
  every arm carried its own return-slot plumbing -- but with
  register-sized results it is the fastest shape.
- normal_step and step carry the boxed error too, unboxed once at the
  public Statement boundary.
- Storage-layer functions return IOResultOr<T>, which is 16 bytes and
  register-returned for most payloads.

scan_loop benchmark: select_one_100k -5.7%, select_star_100k -11.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)