### PR TITLE
core/translate: set the column collation in DML index expressions

### DIFF
--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -2243,7 +2243,11 @@ pub fn translate_expr(
                             resolver,
                         )
                     }
-                    Some(SelfTableContext::ForDML { dml_ctx, .. }) => {
+                    Some(SelfTableContext::ForDML { dml_ctx, table }) => {
+                        let Some(table_column) = table.columns().get(*column) else {
+                            crate::bail_parse_error!("column index out of bounds");
+                        };
+                        program.set_collation(Some((table_column.collation(), false)));
                         let src_reg = dml_ctx.to_column_reg(*column);
                         program.emit_insn(Insn::Copy {
                             src_reg,

--- a/sqlite/conformance/sqlite-sqltests/partial_idx.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/partial_idx.sqltest
@@ -60,6 +60,86 @@ expect error {
 }
 
 @cross-check-integrity
+test partial-index-where-nocase-column-refuses-duplicate {
+    CREATE TABLE t (s TEXT COLLATE NOCASE);
+    CREATE UNIQUE INDEX i ON t(s) WHERE s = 'a';
+    INSERT INTO t VALUES ('A');
+    INSERT INTO t VALUES ('a');
+}
+expect error {
+    UNIQUE constraint failed: t.s
+}
+
+@cross-check-integrity
+test partial-index-where-rtrim-column-refuses-duplicate {
+    CREATE TABLE t (s TEXT COLLATE RTRIM);
+    CREATE UNIQUE INDEX i ON t(s) WHERE s = 'a';
+    INSERT INTO t VALUES ('a  ');
+    INSERT INTO t VALUES ('a');
+}
+expect error {
+    UNIQUE constraint failed: t.s
+}
+
+@cross-check-integrity
+test partial-index-where-nocase-column-other-than-indexed {
+    CREATE TABLE t (k INTEGER, s TEXT COLLATE NOCASE);
+    CREATE UNIQUE INDEX i ON t(k) WHERE s = 'a';
+    INSERT INTO t VALUES (1, 'A');
+    INSERT INTO t VALUES (1, 'a');
+}
+expect error {
+    UNIQUE constraint failed: t.k
+}
+
+@cross-check-integrity
+test partial-index-where-nocase-column-update-into-predicate {
+    CREATE TABLE t (s TEXT COLLATE NOCASE);
+    CREATE UNIQUE INDEX i ON t(s) WHERE s = 'a';
+    INSERT INTO t VALUES ('z');
+    UPDATE t SET s = 'A';
+    SELECT s FROM t WHERE s = 'a';
+}
+expect {
+    A
+}
+
+@cross-check-integrity
+test partial-index-where-binary-column-keeps-binary {
+    CREATE TABLE t (s TEXT);
+    CREATE UNIQUE INDEX i ON t(s) WHERE s = 'a';
+    INSERT INTO t VALUES ('A');
+    INSERT INTO t VALUES ('a');
+    SELECT count(*) FROM t;
+}
+expect {
+    2
+}
+
+@cross-check-integrity
+test partial-index-where-explicit-collate-beats-column {
+    CREATE TABLE t (s TEXT COLLATE NOCASE);
+    CREATE UNIQUE INDEX i ON t(s) WHERE s = 'a' COLLATE BINARY;
+    INSERT INTO t VALUES ('A');
+    INSERT INTO t VALUES ('a');
+    SELECT count(*) FROM t;
+}
+expect {
+    2
+}
+
+@cross-check-integrity
+test expression-index-nocase-column-refuses-duplicate {
+    CREATE TABLE t (s TEXT COLLATE NOCASE);
+    CREATE UNIQUE INDEX i ON t(s = 'a');
+    INSERT INTO t VALUES ('A');
+    INSERT INTO t VALUES ('a');
+}
+expect error {
+    UNIQUE constraint failed
+}
+
+@cross-check-integrity
 test partial-index-expensive-violation-update {
     CREATE TABLE products (id INTEGER PRIMARY KEY, sku TEXT, price INTEGER);
     CREATE UNIQUE INDEX idx_expensive ON products(sku) WHERE price > 100;


### PR DESCRIPTION
When translating a column reference inside the ForDML self-table context, translate_expr was not setting the collation. Because of this, partial index predicates were always compared with BINARY, ignoring the collation declared on the column.
With a NOCASE column and a partial unique index on WHERE s='a', inserting 'A' did not add the row to the index. But integrity_check uses the column collation, so it reported the row as missing. A second insert with 'a' was also accepted, when SQLite rejects it.

I fixed it by setting the collation in the ForDML arm, the same as the normal column path already does. This arm is also used for expression indexes and for UPDATE, so those cases are fixed too.
Fixes #8578