### PR TITLE
core/btree: advance synchronously within a leaf page in next()

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6338,6 +6338,11 @@ impl CursorTrait for BTreeCursor {
     }
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     fn next(&mut self) -> IOResultOr<()> {
+        if self.can_advance_within_leaf() {
+            self.stack.advance();
+            self.invalidate_record();
+            return Ok(IOResult::Done(()));
+        }
         if self.valid_state == CursorValidState::Invalid {
             return Ok(IOResult::Done(()));
         }
@@ -7397,6 +7402,30 @@ impl CursorTrait for BTreeCursor {
                 }
             }
         }
+    }
+}
+
+impl BTreeCursor {
+    /// True when the next cell is on the same leaf page and no resumable
+    /// state is pending, so advancing cannot yield and `next()` can skip
+    /// its state machine. Every pending flag routes to the full path,
+    /// which owns its handling: `skip_advance` (restore landed on the
+    /// iteration target; advancing would skip a row), an abandoned
+    /// overflow read, and an in-flight spill descent.
+    fn can_advance_within_leaf(&self) -> bool {
+        if !matches!(self.advance_state, AdvanceState::Start)
+            || !matches!(self.valid_state, CursorValidState::Valid)
+            || self.needs_restore()
+            || self.skip_advance
+            || !self.has_record
+            || self.read_overflow_state.is_some()
+            || self.iteration_pending_descent.is_some()
+        {
+            return false;
+        }
+        let contents = self.stack.top_ref().get_contents();
+        let cell_idx = self.stack.current_cell_index();
+        cell_idx >= 0 && contents.is_leaf() && cell_idx as usize + 1 < contents.cell_count()
     }
 }
 


### PR DESCRIPTION
Every `next()` paid the full suspendable-cursor apparatus even when the next cell was already in memory on the same page: an `AdvanceState` state machine entered and exited per row, restore probing, and resume-state bookkeeping — all there so a row advance *could* fault a page in, paid on every row of a hot page that never will. A b-tree leaf holds hundreds of rows; the page-boundary case that can actually do I/O is the rare one, so the common advance shrinks to an index bump plus record-cache invalidation.

The fast path is gated by a single pure predicate, `can_advance_within_leaf()`: it can only read, so when any gate fails the state machine below sees the cursor exactly as it always did. Every pending flag routes to the full path, which owns its handling: `skip_advance` (a restore landed on the iteration target; advancing would skip a row), an abandoned overflow read, and an in-flight descent.

Measured with `cargo bench -p turso_core --bench scan_loop_benchmark` against current main:
- `select_one_100k`: **-9% to -15%** across three runs (all p=0.00)
- `select_star_100k`: statistically unchanged — its cost is dominated by record copy and column decode, not cursor advance

Tests: btree and vdbe unit suites; sqltest conformance; fmt and clippy (`--all-features --all-targets`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)