### PR TITLE
bindings/dotnet: route sqlite facade through managed backends

### DIFF
--- a/bindings/dotnet/Readme.md
+++ b/bindings/dotnet/Readme.md
@@ -221,6 +221,34 @@ For common embedded SQLite usage, the `Turso.Data.Sqlite.Provider` package expos
 + using var connection = new SqliteConnection("Data Source=app.db");
 ```
 
+The same facade can connect directly to a remote database:
+
+```C#
+using Turso.Data.Sqlite;
+
+await using var connection = new SqliteConnection(
+    "Data Source=libsql://example-org.turso.io;Auth Token=eyJ...");
+await connection.OpenAsync();
+```
+
+Add `Replica Path` to keep queries local while syncing an embedded replica:
+
+```C#
+await using var connection = new SqliteConnection(
+    "Data Source=libsql://example-org.turso.io;"
+    + "Auth Token=eyJ...;"
+    + "Replica Path=./replica.db;"
+    + "Sync Interval=30");
+await connection.OpenAsync();
+await connection.SyncAsync();
+```
+
+Local paths continue to use the native SQLite-compatible backend. Remote URLs without
+`Replica Path` use direct remote execution; remote URLs with `Replica Path` use the
+local replica backend. Client-side functions, aggregates, collations, backup, blob,
+and extension helpers are unavailable on direct remote connections because they
+require a local database handle.
+
 Supported common connection string keywords include:
 
 | Keyword | Notes |
@@ -236,9 +264,9 @@ Supported common connection string keywords include:
 | `Encryption Cipher` | Turso local encryption cipher. |
 | `Encryption Key` | Hex-encoded encryption key used with `Encryption Cipher`. |
 | `Auth Token` | Bearer token for remote Turso/libSQL URLs. Aliases include `AuthToken` and `Authentication Token`. |
-| `Replica Path` | Reserved for embedded replicas. The .NET provider currently fails early with a clear unsupported error. |
+| `Replica Path` | Local path for an embedded replica of the remote `Data Source`. |
 | `Read Your Writes` | Keeps the remote Hrana session baton across commands. Defaults to `True`. Set `False` for stateless one-shot remote requests. |
-| `Sync Interval` | Reserved for embedded replicas. Automatic sync is not enabled yet. |
+| `Sync Interval` | Embedded replica automatic pull interval in seconds. `0` disables automatic sync. |
 | `Tls` | Optional override for `libsql://` development URLs. Conflicting values with explicit `http://` or `https://` schemes fail early. |
 
 ## SQLite-compatible facade coverage

--- a/bindings/dotnet/src/Turso.Data.Sqlite/ManagedSqliteResult.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/ManagedSqliteResult.cs
@@ -1,0 +1,14 @@
+namespace Turso.Data.Sqlite;
+
+internal sealed record ManagedSqliteColumn(string Name, string DataTypeName, Type FieldType);
+
+internal sealed record ManagedSqliteResult(
+    string Sql,
+    IReadOnlyList<ManagedSqliteColumn> Columns,
+    IReadOnlyList<object?[]> Rows,
+    int RecordsAffected);
+
+internal sealed record ManagedSqliteExecution(
+    IReadOnlyList<ManagedSqliteResult> Results,
+    int RecordsAffected,
+    bool HadResultSet);

--- a/bindings/dotnet/src/Turso.Data.Sqlite/ManagedSqliteStatement.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/ManagedSqliteStatement.cs
@@ -1,0 +1,309 @@
+using System.Text;
+
+namespace Turso.Data.Sqlite;
+
+internal sealed record ManagedSqliteStatement(
+    string Sql,
+    IReadOnlyList<string> ParameterNames,
+    string FirstKeyword)
+{
+    public bool IsTransactionControl
+        => FirstKeyword is "BEGIN" or "COMMIT" or "END" or "ROLLBACK" or "SAVEPOINT" or "RELEASE";
+}
+
+internal static class ManagedSqliteStatementParser
+{
+    public static IReadOnlyList<ManagedSqliteStatement> Parse(string sql)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+
+        var statements = new List<ManagedSqliteStatement>();
+        var text = new StringBuilder();
+        var parameters = new List<string>();
+        var parameterSet = new HashSet<string>(StringComparer.Ordinal);
+        var leadingKeywords = new List<string>(3);
+        var hasSql = false;
+        var isTrigger = false;
+        var triggerBodyStarted = false;
+        var triggerBodyDepth = 0;
+        var triggerStatementStart = false;
+
+        for (var index = 0; index < sql.Length; index++)
+        {
+            var current = sql[index];
+            var next = index + 1 < sql.Length ? sql[index + 1] : '\0';
+
+            if (current == '-' && next == '-')
+            {
+                var end = index + 2;
+                while (end < sql.Length && sql[end] != '\n')
+                    end++;
+
+                text.Append(sql, index, end - index);
+                index = end - 1;
+                continue;
+            }
+
+            if (current == '/' && next == '*')
+            {
+                var end = index + 2;
+                while (end + 1 < sql.Length && (sql[end] != '*' || sql[end + 1] != '/'))
+                    end++;
+
+                end = end + 1 < sql.Length ? end + 2 : sql.Length;
+                text.Append(sql, index, end - index);
+                index = end - 1;
+                continue;
+            }
+
+            if (current is '\'' or '"' or '`' or '[')
+            {
+                var end = ReadQuoted(sql, index, current);
+                text.Append(sql, index, end - index);
+                index = end - 1;
+                hasSql = true;
+                if (triggerBodyStarted)
+                    triggerStatementStart = false;
+                continue;
+            }
+
+            if (TryReadParameter(sql, index, out var parameterEnd))
+            {
+                var parameterName = sql[index..parameterEnd];
+                text.Append(parameterName);
+                if (parameterSet.Add(parameterName))
+                    parameters.Add(parameterName);
+                index = parameterEnd - 1;
+                hasSql = true;
+                if (triggerBodyStarted)
+                    triggerStatementStart = false;
+                continue;
+            }
+
+            if (IsIdentifierStart(current))
+            {
+                var end = index + 1;
+                while (end < sql.Length && IsIdentifierPart(sql[end]))
+                    end++;
+
+                var token = sql[index..end];
+                text.Append(token);
+                hasSql = true;
+                TrackKeyword(
+                    token,
+                    leadingKeywords,
+                    ref isTrigger,
+                    ref triggerBodyStarted,
+                    ref triggerBodyDepth,
+                    ref triggerStatementStart);
+                index = end - 1;
+                continue;
+            }
+
+            if (current == ';'
+                && (!isTrigger || triggerBodyStarted && triggerBodyDepth == 0))
+            {
+                AddStatement(statements, text, parameters, leadingKeywords, hasSql);
+                Reset(
+                    text,
+                    parameters,
+                    parameterSet,
+                    leadingKeywords,
+                    ref hasSql,
+                    ref isTrigger,
+                    ref triggerBodyStarted,
+                    ref triggerBodyDepth,
+                    ref triggerStatementStart);
+                continue;
+            }
+
+            text.Append(current);
+            if (!char.IsWhiteSpace(current) && current != ';')
+            {
+                hasSql = true;
+                if (triggerBodyStarted)
+                    triggerStatementStart = false;
+            }
+            else if (current == ';' && triggerBodyStarted && triggerBodyDepth > 0)
+            {
+                triggerStatementStart = true;
+            }
+        }
+
+        AddStatement(statements, text, parameters, leadingKeywords, hasSql);
+        return statements;
+    }
+
+    private static int ReadQuoted(string sql, int start, char opening)
+    {
+        var closing = opening == '[' ? ']' : opening;
+        var index = start + 1;
+        while (index < sql.Length)
+        {
+            if (sql[index] != closing)
+            {
+                index++;
+                continue;
+            }
+
+            if (index + 1 < sql.Length && sql[index + 1] == closing)
+            {
+                index += 2;
+                continue;
+            }
+
+            return index + 1;
+        }
+
+        return sql.Length;
+    }
+
+    private static bool TryReadParameter(string sql, int start, out int end)
+    {
+        end = start;
+        var prefix = sql[start];
+        if (prefix == '?')
+        {
+            end = start + 1;
+            while (end < sql.Length && char.IsAsciiDigit(sql[end]))
+                end++;
+            return true;
+        }
+
+        if (prefix is not (':' or '@' or '$')
+            || start + 1 >= sql.Length
+            || !IsParameterNamePart(sql[start + 1]))
+        {
+            return false;
+        }
+
+        end = start + 2;
+        while (end < sql.Length && IsParameterNamePart(sql[end]))
+            end++;
+
+        if (prefix != '$')
+            return true;
+
+        while (end + 2 < sql.Length
+               && sql[end] == ':'
+               && sql[end + 1] == ':'
+               && IsParameterNamePart(sql[end + 2]))
+        {
+            end += 3;
+            while (end < sql.Length && IsParameterNamePart(sql[end]))
+                end++;
+        }
+
+        if (end < sql.Length && sql[end] == '(')
+        {
+            var close = sql.IndexOf(')', end + 1);
+            if (close >= 0)
+                end = close + 1;
+        }
+
+        return true;
+    }
+
+    private static void TrackKeyword(
+        string token,
+        List<string> leadingKeywords,
+        ref bool isTrigger,
+        ref bool triggerBodyStarted,
+        ref int triggerBodyDepth,
+        ref bool triggerStatementStart)
+    {
+        var keyword = token.ToUpperInvariant();
+        if (leadingKeywords.Count < 3)
+        {
+            leadingKeywords.Add(keyword);
+            isTrigger = leadingKeywords is ["CREATE", "TRIGGER", ..]
+                or ["CREATE", "TEMP", "TRIGGER", ..]
+                or ["CREATE", "TEMPORARY", "TRIGGER", ..];
+        }
+
+        if (!isTrigger)
+            return;
+
+        if (!triggerBodyStarted)
+        {
+            if (keyword == "BEGIN")
+            {
+                triggerBodyStarted = true;
+                triggerBodyDepth = 1;
+                triggerStatementStart = true;
+            }
+
+            return;
+        }
+
+        if (keyword == "CASE")
+        {
+            triggerBodyDepth++;
+            triggerStatementStart = false;
+        }
+        else if (keyword == "END")
+        {
+            if (triggerBodyDepth > 1)
+                triggerBodyDepth--;
+            else if (triggerStatementStart)
+                triggerBodyDepth = 0;
+            triggerStatementStart = false;
+        }
+        else
+        {
+            triggerStatementStart = false;
+        }
+    }
+
+    private static void AddStatement(
+        List<ManagedSqliteStatement> statements,
+        StringBuilder text,
+        List<string> parameters,
+        List<string> leadingKeywords,
+        bool hasSql)
+    {
+        if (!hasSql)
+            return;
+
+        var statement = text.ToString().Trim();
+        if (statement.Length == 0)
+            return;
+
+        statements.Add(
+            new ManagedSqliteStatement(
+                statement,
+                parameters.ToArray(),
+                leadingKeywords.Count == 0 ? string.Empty : leadingKeywords[0]));
+    }
+
+    private static void Reset(
+        StringBuilder text,
+        List<string> parameters,
+        HashSet<string> parameterSet,
+        List<string> leadingKeywords,
+        ref bool hasSql,
+        ref bool isTrigger,
+        ref bool triggerBodyStarted,
+        ref int triggerBodyDepth,
+        ref bool triggerStatementStart)
+    {
+        text.Clear();
+        parameters.Clear();
+        parameterSet.Clear();
+        leadingKeywords.Clear();
+        hasSql = false;
+        isTrigger = false;
+        triggerBodyStarted = false;
+        triggerBodyDepth = 0;
+        triggerStatementStart = false;
+    }
+
+    private static bool IsIdentifierStart(char value)
+        => value == '_' || char.IsLetter(value);
+
+    private static bool IsIdentifierPart(char value)
+        => value == '_' || char.IsLetterOrDigit(value);
+
+    private static bool IsParameterNamePart(char value)
+        => value == '_' || char.IsLetterOrDigit(value);
+}

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteBatch.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteBatch.cs
@@ -1,0 +1,572 @@
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using Turso.Raw.Public;
+
+namespace Turso.Data.Sqlite;
+
+public sealed class SqliteBatch : DbBatch
+{
+    private readonly SqliteBatchCommandCollection _batchCommands = new();
+    private SqliteConnection? _connection;
+    private SqliteTransaction? _transaction;
+    private global::Turso.TursoBatch? _activeBatch;
+    private int _timeout = 30;
+
+    public SqliteBatch()
+    {
+    }
+
+    public SqliteBatch(SqliteConnection connection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        _connection = connection;
+        _transaction = connection.Transaction;
+        _timeout = connection.DefaultTimeout;
+    }
+
+    public new SqliteBatchCommandCollection BatchCommands => _batchCommands;
+
+    protected override DbBatchCommandCollection DbBatchCommands => _batchCommands;
+
+    protected override DbConnection? DbConnection
+    {
+        get => _connection;
+        set
+        {
+            _connection = value as SqliteConnection
+                          ?? (value is null
+                              ? null
+                              : throw new ArgumentException(
+                                  "Connection must be a SqliteConnection.",
+                                  nameof(value)));
+            if (_connection is not null)
+                _timeout = _connection.DefaultTimeout;
+        }
+    }
+
+    protected override DbTransaction? DbTransaction
+    {
+        get => _transaction;
+        set => _transaction = value as SqliteTransaction
+                             ?? (value is null
+                                 ? null
+                                 : throw new ArgumentException(
+                                     "Transaction must be a SqliteTransaction.",
+                                     nameof(value)));
+    }
+
+    public override int Timeout
+    {
+        get => _timeout;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            _timeout = value;
+        }
+    }
+
+    public override void Cancel()
+    {
+        _activeBatch?.Cancel();
+    }
+
+    public override int ExecuteNonQuery()
+    {
+        var state = BuildBatch();
+        if (state.Batch is null)
+            return SetRecordsAffected(state);
+
+        using (state.Batch)
+        {
+            WaitForOpenReader(state.Statements);
+            _activeBatch = state.Batch;
+            try
+            {
+                var recordsAffected = state.Batch.ExecuteNonQuery();
+                SetRecordsAffected(state);
+                return recordsAffected;
+            }
+            catch (TursoException ex)
+            {
+                throw SqliteCommand.ToSqliteException(ex);
+            }
+            finally
+            {
+                _activeBatch = null;
+            }
+        }
+    }
+
+    public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var state = BuildBatch();
+        if (state.Batch is null)
+            return SetRecordsAffected(state);
+
+        await using (state.Batch)
+        {
+            await WaitForOpenReaderAsync(state.Statements, cancellationToken).ConfigureAwait(false);
+            _activeBatch = state.Batch;
+            try
+            {
+                var recordsAffected = await state.Batch
+                    .ExecuteNonQueryAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                SetRecordsAffected(state);
+                return recordsAffected;
+            }
+            catch (TursoException ex)
+            {
+                throw SqliteCommand.ToSqliteException(ex);
+            }
+            finally
+            {
+                _activeBatch = null;
+            }
+        }
+    }
+
+    public override object? ExecuteScalar()
+    {
+        using var reader = ExecuteDbDataReader(CommandBehavior.Default);
+        return ReadScalar(reader);
+    }
+
+    public override async Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
+    {
+        await using var reader = await ExecuteDbDataReaderAsync(
+                CommandBehavior.Default,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return await ReadScalarAsync(reader, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override void Prepare()
+    {
+        var state = BuildBatch(preparing: true);
+        if (state.Batch is null)
+            return;
+
+        using (state.Batch)
+        {
+            try
+            {
+                state.Batch.Prepare();
+            }
+            catch (TursoException ex)
+            {
+                throw SqliteCommand.ToSqliteException(ex);
+            }
+        }
+    }
+
+    public override async Task PrepareAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var state = BuildBatch(preparing: true);
+        if (state.Batch is null)
+            return;
+
+        await using (state.Batch)
+        {
+            try
+            {
+                await state.Batch.PrepareAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (TursoException ex)
+            {
+                throw SqliteCommand.ToSqliteException(ex);
+            }
+        }
+    }
+
+    protected override DbBatchCommand CreateDbBatchCommand()
+        => new SqliteBatchCommand();
+
+    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        => ExecuteReaderAsyncCore(behavior, CancellationToken.None).GetAwaiter().GetResult();
+
+    protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(
+        CommandBehavior behavior,
+        CancellationToken cancellationToken)
+        => await ExecuteReaderAsyncCore(behavior, cancellationToken).ConfigureAwait(false);
+
+    private async Task<SqliteDataReader> ExecuteReaderAsyncCore(
+        CommandBehavior behavior,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var state = BuildBatch();
+        if (state.Batch is null)
+        {
+            SetRecordsAffected(state);
+            var emptyOwner = CreateReaderOwner();
+            var closeCallback = emptyOwner.OwnBufferedReader();
+            return new SqliteDataReader(
+                emptyOwner,
+                new ManagedSqliteExecution([], 0, HadResultSet: false),
+                behavior,
+                closeCallback);
+        }
+
+        await using (state.Batch)
+        {
+            await WaitForOpenReaderAsync(state.Statements, cancellationToken).ConfigureAwait(false);
+            _activeBatch = state.Batch;
+            try
+            {
+                await using var reader = await state.Batch
+                    .ExecuteReaderAsync(behavior & ~CommandBehavior.CloseConnection, cancellationToken)
+                    .ConfigureAwait(false);
+                var results = new List<ManagedSqliteResult>(state.Statements.Count);
+                var statementIndex = 0;
+                do
+                {
+                    if (statementIndex >= state.Statements.Count)
+                    {
+                        throw new SqliteException(
+                            Properties.Resources.SqliteNativeError(
+                                1,
+                                $"Managed batch returned more than {state.Statements.Count} results."),
+                            1);
+                    }
+
+                    var statement = state.Statements[statementIndex];
+                    var result = await SqliteCommand
+                        .BufferManagedResultAsync(reader, statement.Sql, cancellationToken)
+                        .ConfigureAwait(false);
+                    results.Add(result with
+                    {
+                        RecordsAffected = state.ManagedCommands[statementIndex].RecordsAffected,
+                    });
+                    statementIndex++;
+                }
+                while (await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+
+                if (statementIndex != state.Statements.Count)
+                {
+                    throw new SqliteException(
+                        Properties.Resources.SqliteNativeError(
+                            1,
+                            $"Managed batch returned {statementIndex} results for {state.Statements.Count} statements."),
+                        1);
+                }
+
+                var recordsAffected = SetRecordsAffected(state);
+                var owner = CreateReaderOwner();
+                var closeCallback = owner.OwnBufferedReader();
+                return new SqliteDataReader(
+                    owner,
+                    new ManagedSqliteExecution(
+                        results,
+                        recordsAffected,
+                        results.Any(static result => result.Columns.Count > 0)),
+                    behavior,
+                    closeCallback);
+            }
+            catch (TursoException ex)
+            {
+                throw SqliteCommand.ToSqliteException(ex);
+            }
+            finally
+            {
+                _activeBatch = null;
+            }
+        }
+    }
+
+    private BatchState BuildBatch(bool preparing = false)
+    {
+        var connection = ValidateBatch();
+        var managedBatch = new global::Turso.TursoBatch(connection.ManagedConnection)
+        {
+            Timeout = Timeout,
+            Transaction = _transaction?.ManagedTransaction,
+        };
+        var statements = new List<ManagedSqliteStatement>();
+        var managedCommands = new List<global::Turso.TursoBatchCommand>();
+        var mappings = new List<BatchCommandMapping>(_batchCommands.Count);
+        try
+        {
+            foreach (var batchCommand in _batchCommands.Items)
+            {
+                using var command = new SqliteCommand(batchCommand.CommandText, connection, _transaction);
+                foreach (SqliteParameter parameter in batchCommand.Parameters)
+                    command.Parameters.Add(parameter);
+                command.ValidateManagedParameterValues();
+
+                var commandStatements = ManagedSqliteStatementParser.Parse(batchCommand.CommandText);
+                if (commandStatements.Count == 0)
+                    throw new InvalidOperationException("Batch command text must contain a SQL statement.");
+                if (commandStatements.Any(static statement => statement.IsTransactionControl))
+                {
+                    throw new InvalidOperationException(
+                        "Transaction-control SQL is not supported in a SqliteBatch. "
+                        + "Use SqliteConnection.BeginTransaction and SqliteTransaction instead.");
+                }
+                if (connection.IsReadOnly
+                    && commandStatements.Any(SqliteCommand.IsWriteStatement))
+                {
+                    throw new SqliteException(
+                        Properties.Resources.SqliteNativeError(8, "attempt to write a readonly database"),
+                        8);
+                }
+
+                var firstManagedIndex = managedCommands.Count;
+                foreach (var statement in commandStatements)
+                {
+                    string sql;
+                    if (preparing)
+                    {
+                        sql = SqliteCommand.RewriteFacadeStatement(statement.Sql, connection);
+                    }
+                    else if (command.TryHandleFacadeStatement(statement.Sql, out sql))
+                    {
+                        continue;
+                    }
+
+                    using var managedCommand = command.CreateManagedCommand(statement, sql);
+                    var managedBatchCommand = new global::Turso.TursoBatchCommand(managedCommand.CommandText);
+                    foreach (global::Turso.TursoParameter parameter in managedCommand.Parameters)
+                        managedBatchCommand.Parameters.Add(parameter);
+                    managedBatch.BatchCommands.Add(managedBatchCommand);
+                    managedCommands.Add(managedBatchCommand);
+                    statements.Add(statement);
+                }
+
+                mappings.Add(
+                    new BatchCommandMapping(
+                        batchCommand,
+                        firstManagedIndex,
+                        managedCommands.Count - firstManagedIndex));
+            }
+
+            if (managedCommands.Count == 0)
+            {
+                managedBatch.Dispose();
+                return new BatchState(null, statements, managedCommands, mappings);
+            }
+
+            return new BatchState(managedBatch, statements, managedCommands, mappings);
+        }
+        catch
+        {
+            managedBatch.Dispose();
+            throw;
+        }
+    }
+
+    private SqliteConnection ValidateBatch()
+    {
+        var connection = _connection
+                         ?? throw new InvalidOperationException(
+                             "Connection must be set before executing a batch.");
+        if (!connection.IsManagedConnection)
+        {
+            throw new NotSupportedException(
+                "SQLite facade batches are available only for direct remote or embedded replica connections.");
+        }
+        if (connection.State != ConnectionState.Open)
+            throw new InvalidOperationException(Properties.Resources.CallRequiresOpenConnection("ExecuteBatch"));
+        if (_transaction is { IsCompleted: true })
+            throw new InvalidOperationException(Properties.Resources.TransactionCompleted);
+        if (_transaction is not null && !ReferenceEquals(_transaction.Connection, connection))
+            throw new InvalidOperationException(Properties.Resources.TransactionConnectionMismatch);
+        if (connection.Transaction is not null
+            && !ReferenceEquals(_transaction, connection.Transaction))
+        {
+            throw new InvalidOperationException(Properties.Resources.TransactionRequired);
+        }
+        if (_batchCommands.Count == 0)
+            throw new InvalidOperationException("Batch must contain at least one command.");
+
+        return connection;
+    }
+
+    private int SetRecordsAffected(BatchState state)
+    {
+        var total = 0;
+        foreach (var mapping in state.Mappings)
+        {
+            var commandTotal = 0;
+            for (var index = 0; index < mapping.Count; index++)
+            {
+                var recordsAffected = state.ManagedCommands[mapping.FirstIndex + index].RecordsAffected;
+                if (recordsAffected > 0)
+                    commandTotal = checked(commandTotal + recordsAffected);
+            }
+
+            mapping.Command.SetRecordsAffected(commandTotal);
+            total = checked(total + commandTotal);
+        }
+
+        return total;
+    }
+
+    private SqliteCommand CreateReaderOwner()
+        => new(_connection) { Transaction = _transaction };
+
+    private void WaitForOpenReader(IReadOnlyList<ManagedSqliteStatement> statements)
+    {
+        if (_connection?.HasOpenReader != true || !statements.Any(SqliteCommand.IsWriteStatement))
+            return;
+
+        Thread.Sleep(TimeSpan.FromSeconds(Timeout));
+        throw new SqliteException(Properties.Resources.SqliteNativeError(5, "database is locked"), 5);
+    }
+
+    private async Task WaitForOpenReaderAsync(
+        IReadOnlyList<ManagedSqliteStatement> statements,
+        CancellationToken cancellationToken)
+    {
+        if (_connection?.HasOpenReader != true || !statements.Any(SqliteCommand.IsWriteStatement))
+            return;
+
+        await Task.Delay(TimeSpan.FromSeconds(Timeout), cancellationToken).ConfigureAwait(false);
+        throw new SqliteException(Properties.Resources.SqliteNativeError(5, "database is locked"), 5);
+    }
+
+    private static object? ReadScalar(DbDataReader reader)
+    {
+        do
+        {
+            if (reader.FieldCount > 0 && reader.Read())
+                return reader.GetValue(0);
+        } while (reader.NextResult());
+
+        return null;
+    }
+
+    private static async Task<object?> ReadScalarAsync(
+        DbDataReader reader,
+        CancellationToken cancellationToken)
+    {
+        do
+        {
+            if (reader.FieldCount > 0
+                && await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return reader.GetValue(0);
+            }
+        } while (await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+
+        return null;
+    }
+
+    private sealed record BatchCommandMapping(
+        SqliteBatchCommand Command,
+        int FirstIndex,
+        int Count);
+
+    private sealed record BatchState(
+        global::Turso.TursoBatch? Batch,
+        IReadOnlyList<ManagedSqliteStatement> Statements,
+        IReadOnlyList<global::Turso.TursoBatchCommand> ManagedCommands,
+        IReadOnlyList<BatchCommandMapping> Mappings);
+}
+
+public sealed class SqliteBatchCommand : DbBatchCommand
+{
+    private readonly SqliteParameterCollection _parameters = new();
+    private string _commandText = string.Empty;
+    private int _recordsAffected = -1;
+
+    public SqliteBatchCommand()
+    {
+    }
+
+    public SqliteBatchCommand(string commandText)
+    {
+        CommandText = commandText;
+    }
+
+    [AllowNull]
+    public override string CommandText
+    {
+        get => _commandText;
+        set => _commandText = value ?? string.Empty;
+    }
+
+    public override CommandType CommandType
+    {
+        get => CommandType.Text;
+        set
+        {
+            if (value != CommandType.Text)
+                throw new ArgumentException(Properties.Resources.InvalidCommandType(value));
+        }
+    }
+
+    public new SqliteParameterCollection Parameters => _parameters;
+
+    protected override DbParameterCollection DbParameterCollection => _parameters;
+
+    public override int RecordsAffected => _recordsAffected;
+
+    public override bool CanCreateParameter => true;
+
+    public override DbParameter CreateParameter()
+        => new SqliteParameter();
+
+    internal void SetRecordsAffected(int recordsAffected)
+    {
+        _recordsAffected = recordsAffected;
+    }
+}
+
+public sealed class SqliteBatchCommandCollection : DbBatchCommandCollection
+{
+    private readonly List<SqliteBatchCommand> _commands = [];
+
+    public override int Count => _commands.Count;
+
+    public override bool IsReadOnly => false;
+
+    internal IReadOnlyList<SqliteBatchCommand> Items => _commands;
+
+    public override void Add(DbBatchCommand item)
+        => _commands.Add(RequireCommand(item));
+
+    public override void Clear()
+        => _commands.Clear();
+
+    public override bool Contains(DbBatchCommand item)
+        => item is SqliteBatchCommand command && _commands.Contains(command);
+
+    public override void CopyTo(DbBatchCommand[] array, int arrayIndex)
+    {
+        ArgumentNullException.ThrowIfNull(array);
+        for (var index = 0; index < _commands.Count; index++)
+            array[arrayIndex + index] = _commands[index];
+    }
+
+    public override IEnumerator<DbBatchCommand> GetEnumerator()
+        => _commands.GetEnumerator();
+
+    public override int IndexOf(DbBatchCommand item)
+        => item is SqliteBatchCommand command ? _commands.IndexOf(command) : -1;
+
+    public override void Insert(int index, DbBatchCommand item)
+        => _commands.Insert(index, RequireCommand(item));
+
+    public override bool Remove(DbBatchCommand item)
+        => item is SqliteBatchCommand command && _commands.Remove(command);
+
+    public override void RemoveAt(int index)
+        => _commands.RemoveAt(index);
+
+    protected override DbBatchCommand GetBatchCommand(int index)
+        => _commands[index];
+
+    protected override void SetBatchCommand(int index, DbBatchCommand batchCommand)
+        => _commands[index] = RequireCommand(batchCommand);
+
+    private static SqliteBatchCommand RequireCommand(DbBatchCommand command)
+        => command as SqliteBatchCommand
+           ?? throw new ArgumentException(
+               "Batch command must be a SqliteBatchCommand.",
+               nameof(command));
+}

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteCommand.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteCommand.cs
@@ -17,6 +17,7 @@ public class SqliteCommand : DbCommand
     private string _commandText = string.Empty;
     private int _commandTimeout = 30;
     private bool _hasOpenReader;
+    private global::Turso.TursoCommand? _activeManagedCommand;
 
     public SqliteCommand()
     {
@@ -131,6 +132,7 @@ public class SqliteCommand : DbCommand
 
     public override void Cancel()
     {
+        _activeManagedCommand?.Cancel();
     }
 
     public override int ExecuteNonQuery()
@@ -156,6 +158,12 @@ public class SqliteCommand : DbCommand
     public override void Prepare()
     {
         EnsureExecutable("Prepare");
+        if (Connection!.IsManagedConnection)
+        {
+            PrepareManagedAsync(CancellationToken.None).GetAwaiter().GetResult();
+            return;
+        }
+
         var statements = SplitStatements(CommandText);
         if (statements.Count != 1)
         {
@@ -182,6 +190,15 @@ public class SqliteCommand : DbCommand
         }
     }
 
+    public override Task PrepareAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        EnsureExecutable("Prepare");
+        return Connection!.IsManagedConnection
+            ? PrepareManagedAsync(cancellationToken)
+            : base.PrepareAsync(cancellationToken);
+    }
+
     protected override DbParameter CreateDbParameter() => new SqliteParameter();
 
     public new SqliteDataReader ExecuteReader() => Execute("ExecuteReader");
@@ -190,28 +207,61 @@ public class SqliteCommand : DbCommand
 
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => Execute("ExecuteReader", behavior);
 
-    public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+    public new Task<SqliteDataReader> ExecuteReaderAsync(CancellationToken cancellationToken = default)
+        => ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
+
+    public new async Task<SqliteDataReader> ExecuteReaderAsync(
+        CommandBehavior behavior,
+        CancellationToken cancellationToken)
+        => (SqliteDataReader)await ExecuteDbDataReaderAsync(behavior, cancellationToken).ConfigureAwait(false);
+
+    public override async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult(ExecuteNonQuery());
+        if (Connection?.IsManagedConnection != true)
+            return ExecuteNonQuery();
+
+        await using var reader = await ExecuteManagedAsync("ExecuteNonQuery", CommandBehavior.Default, cancellationToken)
+            .ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+        }
+
+        await reader.CloseAsync().ConfigureAwait(false);
+        return reader.RecordsAffected;
     }
 
-    public override Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
+    public override async Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult(ExecuteScalar());
+        if (Connection?.IsManagedConnection != true)
+            return ExecuteScalar();
+
+        await using var reader = await ExecuteManagedAsync("ExecuteScalar", CommandBehavior.Default, cancellationToken)
+            .ConfigureAwait(false);
+        return await reader.ReadAsync(cancellationToken).ConfigureAwait(false)
+            ? reader.GetValue(0)
+            : null;
     }
 
-    protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+    protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(
+        CommandBehavior behavior,
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult<DbDataReader>(Execute("ExecuteReader", behavior));
+        if (Connection?.IsManagedConnection != true)
+            return Execute("ExecuteReader", behavior);
+
+        return await ExecuteManagedAsync("ExecuteReader", behavior, cancellationToken).ConfigureAwait(false);
     }
 
     protected override void Dispose(bool disposing)
     {
         if (disposing)
+        {
+            _activeManagedCommand?.Dispose();
             _statement?.Dispose();
+        }
 
         base.Dispose(disposing);
     }
@@ -219,6 +269,13 @@ public class SqliteCommand : DbCommand
     private SqliteDataReader Execute(string method, CommandBehavior behavior = CommandBehavior.Default)
     {
         EnsureExecutable(method);
+        if (Connection!.IsManagedConnection)
+        {
+            return ExecuteManagedAsync(method, behavior, CancellationToken.None)
+                .GetAwaiter()
+                .GetResult();
+        }
+
         if (IsEmptyCommand(CommandText))
         {
             _hasOpenReader = true;
@@ -270,6 +327,252 @@ public class SqliteCommand : DbCommand
         return new SqliteDataReader(this, recordsAffected, behavior, CloseReader);
     }
 
+    private async Task PrepareManagedAsync(CancellationToken cancellationToken)
+    {
+        var statements = GetManagedStatements();
+        ValidateManagedParameterValues();
+        foreach (var statement in statements)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var sql = RewriteFacadeStatement(statement.Sql, Connection!);
+
+            using var command = CreateManagedCommand(statement, sql);
+            _activeManagedCommand = command;
+            try
+            {
+                await command.PrepareAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (TursoException ex)
+            {
+                throw ToSqliteException(ex, statement.Sql);
+            }
+            finally
+            {
+                _activeManagedCommand = null;
+            }
+        }
+    }
+
+    private async Task<SqliteDataReader> ExecuteManagedAsync(
+        string method,
+        CommandBehavior behavior,
+        CancellationToken cancellationToken)
+    {
+        EnsureExecutable(method);
+        var statements = GetManagedStatements();
+        if (Connection!.HasOpenReader && statements.Any(IsWriteStatement))
+        {
+            await Task.Delay(TimeSpan.FromSeconds(CommandTimeout), cancellationToken).ConfigureAwait(false);
+            throw new SqliteException(Properties.Resources.SqliteNativeError(5, "database is locked"), 5);
+        }
+        if (Connection!.IsReadOnly && statements.Any(IsWriteStatement))
+        {
+            throw new SqliteException(
+                Properties.Resources.SqliteNativeError(8, "attempt to write a readonly database"),
+                8);
+        }
+        if (statements.Count == 0)
+        {
+            _hasOpenReader = true;
+            Connection!.ReaderOpened();
+            return new SqliteDataReader(this, -1, behavior, CloseReader);
+        }
+
+        ValidateManagedParameterValues();
+        var results = new List<ManagedSqliteResult>();
+        var recordsAffected = 0;
+        var hadResultSet = false;
+        foreach (var statement in statements)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (TryHandleFacadeStatement(statement.Sql, out var sql))
+                continue;
+
+            using var command = CreateManagedCommand(statement, sql);
+            _activeManagedCommand = command;
+            try
+            {
+                await using var reader = await command
+                    .ExecuteReaderAsync(CommandBehavior.Default, cancellationToken)
+                    .ConfigureAwait(false);
+                var result = await BufferManagedResultAsync(reader, statement.Sql, cancellationToken)
+                    .ConfigureAwait(false);
+                if (result.Columns.Count > 0)
+                {
+                    results.Add(result);
+                    hadResultSet = true;
+                }
+
+                if (CountsRowsAffected(statement) && result.RecordsAffected > 0)
+                    recordsAffected = checked(recordsAffected + result.RecordsAffected);
+            }
+            catch (TursoException ex)
+            {
+                throw ToSqliteException(ex, statement.Sql);
+            }
+            finally
+            {
+                _activeManagedCommand = null;
+            }
+        }
+
+        _hasOpenReader = true;
+        Connection!.ReaderOpened();
+        return new SqliteDataReader(
+            this,
+            new ManagedSqliteExecution(results, recordsAffected, hadResultSet),
+            behavior,
+            CloseReader);
+    }
+
+    internal static async Task<ManagedSqliteResult> BufferManagedResultAsync(
+        DbDataReader reader,
+        string sql,
+        CancellationToken cancellationToken)
+    {
+        var columns = new List<ManagedSqliteColumn>(reader.FieldCount);
+        for (var ordinal = 0; ordinal < reader.FieldCount; ordinal++)
+        {
+            columns.Add(
+                new ManagedSqliteColumn(
+                    reader.GetName(ordinal),
+                    reader.GetDataTypeName(ordinal),
+                    reader.GetFieldType(ordinal)));
+        }
+
+        var rows = new List<object?[]>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var row = new object?[reader.FieldCount];
+            for (var ordinal = 0; ordinal < row.Length; ordinal++)
+                row[ordinal] = reader.GetValue(ordinal);
+            rows.Add(row);
+        }
+
+        return new ManagedSqliteResult(sql, columns, rows, reader.RecordsAffected);
+    }
+
+    internal global::Turso.TursoCommand CreateManagedCommand(
+        ManagedSqliteStatement statement,
+        string? sql = null)
+    {
+        var command = new global::Turso.TursoCommand(Connection!.ManagedConnection)
+        {
+            CommandText = sql ?? statement.Sql,
+            CommandTimeout = CommandTimeout,
+            Transaction = Transaction?.ManagedTransaction,
+        };
+
+        try
+        {
+            AddManagedParameters(command, statement);
+            return command;
+        }
+        catch
+        {
+            command.Dispose();
+            throw;
+        }
+    }
+
+    private IReadOnlyList<ManagedSqliteStatement> GetManagedStatements()
+    {
+        var statements = ManagedSqliteStatementParser.Parse(CommandText);
+        if (statements.Any(statement => statement.IsTransactionControl && !CanExecuteSavepointStatement(statement)))
+        {
+            throw new InvalidOperationException(
+                "Transaction-control SQL is not supported on a managed SqliteConnection. "
+                + "Use SqliteConnection.BeginTransaction and SqliteTransaction instead.");
+        }
+
+        if (statements.Count > 1
+            && Connection!.IsDirectRemote
+            && !Connection.ManagedReadYourWrites
+            && Transaction is null)
+        {
+            throw new NotSupportedException(
+                "Multi-statement SqliteCommand execution requires Read Your Writes=True "
+                + "or an explicit SqliteTransaction on a direct remote connection.");
+        }
+
+        return statements;
+    }
+
+    private bool CanExecuteSavepointStatement(ManagedSqliteStatement statement)
+    {
+        if (Transaction is null)
+            return false;
+
+        if (statement.FirstKeyword is "SAVEPOINT" or "RELEASE")
+            return true;
+
+        if (statement.FirstKeyword != "ROLLBACK")
+            return false;
+
+        var sql = statement.Sql.TrimStart();
+        if (!sql.StartsWith("ROLLBACK", StringComparison.OrdinalIgnoreCase))
+            return false;
+        sql = sql["ROLLBACK".Length..].TrimStart();
+        if (sql.StartsWith("TRANSACTION", StringComparison.OrdinalIgnoreCase))
+            sql = sql["TRANSACTION".Length..].TrimStart();
+        return sql.StartsWith("TO", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal void ValidateManagedParameterValues()
+    {
+        for (var index = 0; index < Parameters.Count; index++)
+        {
+            var parameter = Parameters[index];
+            if (string.IsNullOrEmpty(parameter.ParameterName))
+                throw new InvalidOperationException(Properties.Resources.RequiresSet(nameof(parameter.ParameterName)));
+            if (!parameter.HasValue)
+                throw new InvalidOperationException(Properties.Resources.RequiresSet(nameof(parameter.Value)));
+        }
+    }
+
+    internal void AddManagedParameters(
+        global::Turso.TursoCommand command,
+        ManagedSqliteStatement statement)
+    {
+        var mapped = new Dictionary<string, SqliteParameter>(StringComparer.Ordinal);
+        for (var index = 0; index < Parameters.Count; index++)
+        {
+            var parameter = Parameters[index];
+            var parameterName = parameter.ParameterName;
+            string? matchedName = null;
+            if (statement.ParameterNames.Contains(parameterName, StringComparer.Ordinal))
+            {
+                matchedName = parameterName;
+            }
+            else if (!IsPrefixed(parameterName))
+            {
+                foreach (var candidate in statement.ParameterNames)
+                {
+                    if (!IsPrefixed(candidate)
+                        || !candidate.AsSpan(1).Equals(parameterName.AsSpan(), StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (matchedName is not null)
+                        throw new InvalidOperationException(Properties.Resources.AmbiguousParameterName(parameterName));
+                    matchedName = candidate;
+                }
+            }
+
+            if (matchedName is not null)
+                mapped[matchedName] = parameter;
+        }
+
+        foreach (var parameterName in statement.ParameterNames)
+        {
+            if (!mapped.TryGetValue(parameterName, out var parameter))
+                throw new InvalidOperationException(Properties.Resources.MissingParameters(parameterName));
+
+            command.Parameters.Add(parameter.ToManagedParameter(parameterName));
+        }
+    }
+
     private void ThrowIfReaderOpen(string property)
     {
         if (_hasOpenReader)
@@ -300,6 +603,17 @@ public class SqliteCommand : DbCommand
     {
         _hasOpenReader = false;
         Connection?.ReaderClosed();
+    }
+
+    internal Action OwnBufferedReader()
+    {
+        _hasOpenReader = true;
+        Connection?.ReaderOpened();
+        return () =>
+        {
+            CloseReader();
+            Dispose();
+        };
     }
 
     internal TursoStatementHandle PrepareSingleStatement(string sql)
@@ -402,21 +716,41 @@ public class SqliteCommand : DbCommand
     }
 
     private static bool IsWriteCommand(string commandText)
-        => SplitStatements(commandText).Any(IsWriteStatement);
+        => ManagedSqliteStatementParser.Parse(commandText).Any(IsWriteStatement);
 
-    private static bool IsWriteStatement(string statement)
+    internal static bool IsWriteStatement(ManagedSqliteStatement statement)
+        => statement.FirstKeyword is "CREATE" or "DROP" or "ALTER"
+            or "INSERT" or "UPDATE" or "DELETE" or "REPLACE"
+            or "VACUUM" or "ATTACH" or "DETACH" or "REINDEX" or "ANALYZE"
+           || statement.FirstKeyword == "WITH" && IsWithDmlStatement(statement.Sql)
+           || statement.FirstKeyword == "PRAGMA" && IsWritablePragma(statement.Sql);
+
+    private static bool IsWritablePragma(string sql)
     {
-        var trimmed = statement.TrimStart();
-        return trimmed.StartsWith("CREATE", StringComparison.OrdinalIgnoreCase)
-               || trimmed.StartsWith("DROP", StringComparison.OrdinalIgnoreCase)
-               || trimmed.StartsWith("ALTER", StringComparison.OrdinalIgnoreCase)
-               || trimmed.StartsWith("INSERT", StringComparison.OrdinalIgnoreCase)
-               || trimmed.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase)
-               || trimmed.StartsWith("DELETE", StringComparison.OrdinalIgnoreCase)
-               || trimmed.StartsWith("REPLACE", StringComparison.OrdinalIgnoreCase)
-               || trimmed.StartsWith("VACUUM", StringComparison.OrdinalIgnoreCase)
-               || IsWithDmlStatement(trimmed);
+        if (Regex.IsMatch(sql, @"\bPRAGMA\b[\s\S]*=", RegexOptions.IgnoreCase))
+            return true;
+
+        var match = Regex.Match(
+            sql,
+            @"\bPRAGMA\s+(?:(?:[A-Za-z_][A-Za-z0-9_]*)\.)?(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+            RegexOptions.IgnoreCase);
+        return match.Success && !ReadOnlyPragmaFunctions.Contains(match.Groups["name"].Value);
     }
+
+    private static readonly HashSet<string> ReadOnlyPragmaFunctions =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "foreign_key_check",
+            "foreign_key_list",
+            "index_info",
+            "index_list",
+            "index_xinfo",
+            "integrity_check",
+            "quick_check",
+            "table_info",
+            "table_list",
+            "table_xinfo",
+        };
 
     internal bool TryHandleFacadeStatement(string sql, out string rewrittenSql)
     {
@@ -435,7 +769,7 @@ public class SqliteCommand : DbCommand
 
     private const string EmptyResultSql = "SELECT 1 WHERE 0";
 
-    private static string RewriteFacadeStatement(string sql, SqliteConnection connection)
+    internal static string RewriteFacadeStatement(string sql, SqliteConnection connection)
         => RewriteUnsupportedPragmas(NormalizeSql(sql), sql, connection);
 
     private static string RewriteUnsupportedPragmas(string normalized, string sql, SqliteConnection connection)
@@ -506,9 +840,19 @@ public class SqliteCommand : DbCommand
                || IsWithDmlStatement(trimmed);
     }
 
+    private static bool CountsRowsAffected(ManagedSqliteStatement statement)
+        => statement.FirstKeyword is "INSERT" or "UPDATE" or "DELETE" or "REPLACE"
+           || statement.FirstKeyword == "WITH"
+           && Regex.IsMatch(
+               statement.Sql,
+               @"\)\s*(INSERT|UPDATE|DELETE|REPLACE)\b",
+               RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
     private static bool IsWithDmlStatement(string trimmedStatement)
-        => trimmedStatement.StartsWith("WITH", StringComparison.OrdinalIgnoreCase)
-           && Regex.IsMatch(trimmedStatement, @"\)\s*(INSERT|UPDATE|DELETE|REPLACE)\b", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+        => Regex.IsMatch(
+            trimmedStatement,
+            @"\)(?:\s|--[^\r\n]*(?:\r?\n|$)|/\*[\s\S]*?\*/)*(INSERT|UPDATE|DELETE|REPLACE)\b",
+            RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
     private static List<string> SplitStatements(string commandText)
     {
@@ -578,6 +922,22 @@ public class SqliteCommand : DbCommand
 
     internal static SqliteException ToSqliteException(TursoException ex, string? sql = null)
     {
+        if (ex is global::Turso.TursoRemoteSqlException remoteException)
+        {
+            var (errorCode, extendedErrorCode) = GetRemoteSqliteErrorCodes(
+                remoteException.RemoteErrorCode);
+            var remoteMessage = string.IsNullOrWhiteSpace(remoteException.RemoteErrorMessage)
+                ? remoteException.Message
+                : remoteException.RemoteErrorMessage;
+            if (sql is not null)
+                remoteMessage = PreserveNoSuchTableCase(remoteMessage, sql);
+
+            return new SqliteException(
+                Properties.Resources.SqliteNativeError(errorCode, remoteMessage),
+                errorCode,
+                extendedErrorCode);
+        }
+
         var message = ex.Message;
         foreach (var prefix in new[] { "Unable to prepare statement: Parse error: ", "Parse error: " })
         {
@@ -607,6 +967,88 @@ public class SqliteCommand : DbCommand
             message = PreserveNoSuchTableCase(message, sql);
 
         return new SqliteException(Properties.Resources.SqliteNativeError(1, message), 1);
+    }
+
+    private static (int ErrorCode, int ExtendedErrorCode) GetRemoteSqliteErrorCodes(
+        string? remoteErrorCode)
+    {
+        if (string.IsNullOrWhiteSpace(remoteErrorCode))
+            return (1, 1);
+
+        var code = remoteErrorCode.ToUpperInvariant();
+        var extended = code switch
+        {
+            "SQLITE_BUSY_RECOVERY" => 261,
+            "SQLITE_BUSY_SNAPSHOT" => 517,
+            "SQLITE_BUSY_TIMEOUT" => 773,
+            "SQLITE_LOCKED_SHAREDCACHE" => 262,
+            "SQLITE_LOCKED_VTAB" => 518,
+            "SQLITE_READONLY_RECOVERY" => 264,
+            "SQLITE_READONLY_CANTLOCK" => 520,
+            "SQLITE_READONLY_ROLLBACK" => 776,
+            "SQLITE_READONLY_DBMOVED" => 1032,
+            "SQLITE_READONLY_CANTINIT" => 1288,
+            "SQLITE_READONLY_DIRECTORY" => 1544,
+            "SQLITE_CONSTRAINT_CHECK" => 275,
+            "SQLITE_CONSTRAINT_COMMITHOOK" => 531,
+            "SQLITE_CONSTRAINT_FOREIGNKEY" => 787,
+            "SQLITE_CONSTRAINT_FUNCTION" => 1043,
+            "SQLITE_CONSTRAINT_NOTNULL" => 1299,
+            "SQLITE_CONSTRAINT_PRIMARYKEY" => 1555,
+            "SQLITE_CONSTRAINT_TRIGGER" => 1811,
+            "SQLITE_CONSTRAINT_UNIQUE" => 2067,
+            "SQLITE_CONSTRAINT_VTAB" => 2323,
+            "SQLITE_CONSTRAINT_ROWID" => 2579,
+            "SQLITE_CONSTRAINT_PINNED" => 2835,
+            "SQLITE_CONSTRAINT_DATATYPE" => 3091,
+            "SQLITE_ABORT_ROLLBACK" => 516,
+            _ => 0,
+        };
+        if (extended != 0)
+            return (extended & 0xff, extended);
+
+        var primary = code switch
+        {
+            "SQLITE_OK" => 0,
+            "SQLITE_ERROR" => 1,
+            "SQLITE_INTERNAL" => 2,
+            "SQLITE_PERM" => 3,
+            "SQLITE_ABORT" => 4,
+            "SQLITE_BUSY" => 5,
+            "SQLITE_LOCKED" => 6,
+            "SQLITE_NOMEM" => 7,
+            "SQLITE_READONLY" => 8,
+            "SQLITE_INTERRUPT" => 9,
+            "SQLITE_IOERR" => 10,
+            "SQLITE_CORRUPT" => 11,
+            "SQLITE_NOTFOUND" => 12,
+            "SQLITE_FULL" => 13,
+            "SQLITE_CANTOPEN" => 14,
+            "SQLITE_PROTOCOL" => 15,
+            "SQLITE_EMPTY" => 16,
+            "SQLITE_SCHEMA" => 17,
+            "SQLITE_TOOBIG" => 18,
+            "SQLITE_CONSTRAINT" => 19,
+            "SQLITE_MISMATCH" => 20,
+            "SQLITE_MISUSE" => 21,
+            "SQLITE_NOLFS" => 22,
+            "SQLITE_AUTH" => 23,
+            "SQLITE_FORMAT" => 24,
+            "SQLITE_RANGE" => 25,
+            "SQLITE_NOTADB" => 26,
+            "SQLITE_NOTICE" => 27,
+            "SQLITE_WARNING" => 28,
+            _ when code.StartsWith("SQLITE_CONSTRAINT_", StringComparison.Ordinal) => 19,
+            _ when code.StartsWith("SQLITE_BUSY_", StringComparison.Ordinal) => 5,
+            _ when code.StartsWith("SQLITE_LOCKED_", StringComparison.Ordinal) => 6,
+            _ when code.StartsWith("SQLITE_READONLY_", StringComparison.Ordinal) => 8,
+            _ when code.StartsWith("SQLITE_IOERR_", StringComparison.Ordinal) => 10,
+            _ when code.StartsWith("SQLITE_CORRUPT_", StringComparison.Ordinal) => 11,
+            _ when code.StartsWith("SQLITE_CANTOPEN_", StringComparison.Ordinal) => 14,
+            _ when code.StartsWith("SQLITE_ABORT_", StringComparison.Ordinal) => 4,
+            _ => 1,
+        };
+        return (primary, primary);
     }
 
     private static string PreserveNoSuchTableCase(string message, string sql)

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Aggregates.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Aggregates.cs
@@ -13,19 +13,26 @@ public partial class SqliteConnection
 
     private void RegisterAggregateFunction(string name, int argc, bool isDeterministic, object? seed, Func<object?, object?[], object?>? step, Func<object?, object?> resultSelector)
     {
+        ThrowIfDirectRemote("Custom aggregate functions");
         ArgumentNullException.ThrowIfNull(name);
         if (step is null)
         {
             _aggregateFunctions.Remove(name);
-            if (_database is not null)
+            if (HasNativeCallbackHandle)
+            {
+                using var syncOperation = _managedConnection?.EnterSyncOperation();
                 TursoBindings.UnregisterFunction(DatabaseHandle, name);
+            }
             return;
         }
 
         var registration = new AggregateFunctionRegistration(name, argc, isDeterministic, seed, step, resultSelector);
         _aggregateFunctions[name] = registration;
-        if (_database is not null)
+        if (HasNativeCallbackHandle)
+        {
+            using var syncOperation = _managedConnection?.EnterSyncOperation();
             _nativeFunctionContexts.Add(registration.Register(DatabaseHandle));
+        }
     }
 
     private void RegisterAggregateFunctions()

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Collations.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Collations.cs
@@ -11,19 +11,26 @@ public partial class SqliteConnection
 
     private void RegisterCollation(string name, Func<string, string, int>? comparison)
     {
+        ThrowIfDirectRemote("Custom collations");
         ArgumentNullException.ThrowIfNull(name);
         if (comparison is null)
         {
             _collations.Remove(name);
-            if (_database is not null)
+            if (HasNativeCallbackHandle)
+            {
+                using var syncOperation = _managedConnection?.EnterSyncOperation();
                 TursoBindings.UnregisterCollation(DatabaseHandle, name);
+            }
             return;
         }
 
         var registration = new CollationRegistration(name, comparison);
         _collations[name] = registration;
-        if (_database is not null)
+        if (HasNativeCallbackHandle)
+        {
+            using var syncOperation = _managedConnection?.EnterSyncOperation();
             _nativeFunctionContexts.Add(registration.Register(DatabaseHandle));
+        }
     }
 
     private void RegisterCollations()

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Functions.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.Functions.cs
@@ -15,19 +15,26 @@ public partial class SqliteConnection
 
     private void RegisterScalarFunction(string name, int argc, bool isDeterministic, Func<object?[], object?>? function)
     {
+        ThrowIfDirectRemote("Custom scalar functions");
         ArgumentNullException.ThrowIfNull(name);
         if (function is null)
         {
             _scalarFunctions.Remove(name);
-            if (_database is not null)
+            if (HasNativeCallbackHandle)
+            {
+                using var syncOperation = _managedConnection?.EnterSyncOperation();
                 TursoBindings.UnregisterFunction(DatabaseHandle, name);
+            }
             return;
         }
 
         var registration = new ScalarFunctionRegistration(name, argc, isDeterministic, function);
         _scalarFunctions[name] = registration;
-        if (_database is not null)
+        if (HasNativeCallbackHandle)
+        {
+            using var syncOperation = _managedConnection?.EnterSyncOperation();
             _nativeFunctionContexts.Add(registration.Register(DatabaseHandle));
+        }
     }
 
     private void RegisterScalarFunctions()

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnection.cs
@@ -2,6 +2,8 @@ using System.Data;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.ExceptionServices;
+using Turso;
 using Turso.Raw.Public;
 using Turso.Raw.Public.Handles;
 
@@ -15,6 +17,9 @@ public partial class SqliteConnection : DbConnection
     private static readonly Dictionary<string, int> SharedMemoryReferences = new(StringComparer.OrdinalIgnoreCase);
 
     private TursoDatabaseHandle? _database;
+    private TursoConnection? _managedConnection;
+    private bool _ownsManagedConnection;
+    private bool _wrapsManagedConnection;
     private SqliteConnectionStringBuilder _connectionOptions = new();
     private bool _disposed;
     private int? _defaultTimeout;
@@ -36,6 +41,24 @@ public partial class SqliteConnection : DbConnection
         ConnectionString = connectionString;
     }
 
+    public SqliteConnection(TursoConnection connection, bool ownsConnection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        var options = new SqliteConnectionStringBuilder(connection.ConnectionString);
+        if (options.IsLocal)
+        {
+            throw new ArgumentException(
+                "Only direct remote and embedded replica Turso connections can be wrapped.",
+                nameof(connection));
+        }
+
+        _connectionOptions = options;
+        _managedConnection = connection;
+        _ownsManagedConnection = ownsConnection;
+        _wrapsManagedConnection = true;
+        _readOnly = options.Mode == SqliteOpenMode.ReadOnly;
+    }
+
     [AllowNull]
     public override string ConnectionString
     {
@@ -45,14 +68,22 @@ public partial class SqliteConnection : DbConnection
             if (State == ConnectionState.Open)
                 throw new InvalidOperationException(Properties.Resources.ConnectionStringRequiresClosedConnection);
 
-            _connectionOptions = new SqliteConnectionStringBuilder(value);
+            var options = new SqliteConnectionStringBuilder(value);
+            if (_wrapsManagedConnection && options.IsLocal)
+            {
+                throw new InvalidOperationException(
+                    "A SqliteConnection wrapping a TursoConnection must remain a direct remote or embedded replica connection.");
+            }
+
+            ConfigureManagedConnection(options);
+            _connectionOptions = options;
             _defaultTimeout = null;
         }
     }
 
-    public override string Database => "main";
+    public override string Database => _managedConnection?.Database ?? "main";
 
-    public override string DataSource => _dataSource ?? _connectionOptions.DataSource;
+    public override string DataSource => _managedConnection?.DataSource ?? _dataSource ?? _connectionOptions.DataSource;
 
     public int DefaultTimeout
     {
@@ -71,7 +102,27 @@ public partial class SqliteConnection : DbConnection
 
     public SqliteTransaction? Transaction { get; internal set; }
 
+    public bool IsLocal => _connectionOptions.IsLocal;
+
+    public bool IsDirectRemote => _connectionOptions.IsDirectRemote;
+
+    public bool IsRemote => _connectionOptions.IsRemote;
+
+    public bool IsReplica => _connectionOptions.IsReplica;
+
+    public bool IsManaged => IsRemote;
+
+    public TursoSyncDatabase? SyncDatabase => _managedConnection?.SyncDatabase;
+
     internal bool IsSharedCache => _connectionOptions.Cache == SqliteCacheMode.Shared;
+
+    internal bool IsManagedConnection => _managedConnection is not null;
+
+    private bool HasNativeCallbackHandle =>
+        _database is not null || IsReplica && State == ConnectionState.Open;
+
+    internal TursoConnection ManagedConnection => _managedConnection
+        ?? throw new InvalidOperationException("The connection does not use the managed Turso backend.");
 
     internal bool ReadUncommitted
     {
@@ -82,13 +133,32 @@ public partial class SqliteConnection : DbConnection
     // The SQLite version Turso tracks (SQLITE_VERSION in core/dialect/sqlite.rs).
     public override string ServerVersion => "3.50.4";
 
-    public override ConnectionState State => _database is null ? ConnectionState.Closed : ConnectionState.Open;
+    public override ConnectionState State => _managedConnection?.State
+        ?? (_database is null ? ConnectionState.Closed : ConnectionState.Open);
+
+    public override bool CanCreateBatch => _managedConnection?.CanCreateBatch == true;
 
     protected override DbProviderFactory DbProviderFactory => SqliteFactory.Instance;
 
     public override void Open()
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_managedConnection is not null)
+        {
+            var managedOriginalState = State;
+            try
+            {
+                _managedConnection.Open();
+                RegisterManagedReplicaCallbacks();
+            }
+            finally
+            {
+                NotifyManagedStateChange(managedOriginalState);
+            }
+
+            return;
+        }
+
         if (_database is not null)
             throw new InvalidOperationException("The connection is already open.");
         if (!string.IsNullOrEmpty(_connectionOptions.Password))
@@ -126,6 +196,9 @@ public partial class SqliteConnection : DbConnection
 
     public override Task OpenAsync(CancellationToken cancellationToken)
     {
+        if (_managedConnection is not null)
+            return OpenManagedAsync(cancellationToken);
+
         cancellationToken.ThrowIfCancellationRequested();
         Open();
         return Task.CompletedTask;
@@ -133,6 +206,36 @@ public partial class SqliteConnection : DbConnection
 
     public override void Close()
     {
+        if (_managedConnection is not null)
+        {
+            var managedOriginalState = State;
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo? transactionFailure = null;
+            try
+            {
+                if (Transaction is { IsCompleted: false } transaction)
+                {
+                    try
+                    {
+                        transaction.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        transactionFailure = System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex);
+                    }
+                }
+
+                FreeNativeFunctionContexts();
+                _managedConnection.Close();
+            }
+            finally
+            {
+                NotifyManagedStateChange(managedOriginalState);
+            }
+
+            transactionFailure?.Throw();
+            return;
+        }
+
         if (_database is null)
             return;
 
@@ -154,7 +257,23 @@ public partial class SqliteConnection : DbConnection
 
     public override void ChangeDatabase(string databaseName)
     {
+        if (_managedConnection is not null)
+        {
+            _managedConnection.ChangeDatabase(databaseName);
+            return;
+        }
+
         throw new NotSupportedException("Changing databases is not supported.");
+    }
+
+    public void Sync()
+    {
+        GetManagedConnectionForSync().Sync();
+    }
+
+    public Task SyncAsync(CancellationToken cancellationToken = default)
+    {
+        return GetManagedConnectionForSync().SyncAsync(cancellationToken);
     }
 
     public override DataTable GetSchema()
@@ -165,6 +284,8 @@ public partial class SqliteConnection : DbConnection
 
     public override DataTable GetSchema(string collectionName, string?[]? restrictionValues)
     {
+        ThrowIfManagedLocalOnly(nameof(GetSchema));
+
         if (string.Equals(collectionName, DbMetaDataCollectionNames.MetaDataCollections, StringComparison.OrdinalIgnoreCase))
         {
             ValidateRestrictions(collectionName, restrictionValues, 0);
@@ -330,6 +451,7 @@ public partial class SqliteConnection : DbConnection
 
     public virtual void EnableExtensions(bool enable = true)
     {
+        ThrowIfManagedLocalOnly(nameof(EnableExtensions));
         _extensionsEnabled = enable;
         if (_database is not null)
             TursoBindings.EnableLoadExtension(DatabaseHandle, enable);
@@ -337,6 +459,7 @@ public partial class SqliteConnection : DbConnection
 
     public virtual void LoadExtension(string file, string? proc = null)
     {
+        ThrowIfManagedLocalOnly(nameof(LoadExtension));
         ArgumentNullException.ThrowIfNull(file);
         if (proc is not null)
             throw new NotSupportedException("Custom extension entry points are not yet supported by the Turso SQLite-compatible provider.");
@@ -355,6 +478,7 @@ public partial class SqliteConnection : DbConnection
 
     public virtual void BackupDatabase(SqliteConnection destination, string destinationName, string sourceName)
     {
+        ThrowIfManagedLocalOnly(nameof(BackupDatabase));
         if (_database is null)
             throw new InvalidOperationException(Properties.Resources.CallRequiresOpenConnection("BackupDatabase"));
         ArgumentNullException.ThrowIfNull(destination);
@@ -374,11 +498,76 @@ public partial class SqliteConnection : DbConnection
 
     protected override DbCommand CreateDbCommand() => CreateCommand();
 
+    protected override DbBatch CreateDbBatch()
+    {
+        if (_managedConnection is null)
+        {
+            throw new NotSupportedException(
+                "SQLite facade batches are available only for direct remote or embedded replica connections.");
+        }
+
+        return new SqliteBatch(this);
+    }
+
     protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
         => BeginTransaction(isolationLevel);
 
+    protected override ValueTask<DbTransaction> BeginDbTransactionAsync(
+        IsolationLevel isolationLevel,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult<DbTransaction>(BeginTransaction(isolationLevel));
+    }
+
     protected override void Dispose(bool disposing)
     {
+        if (_managedConnection is not null)
+        {
+            ExceptionDispatchInfo? failure = null;
+            if (disposing
+                && !_disposed
+                && Transaction is { IsCompleted: false } transaction)
+            {
+                try
+                {
+                    transaction.Dispose();
+                }
+                catch (Exception exception)
+                {
+                    failure = ExceptionDispatchInfo.Capture(exception);
+                }
+            }
+
+            if (disposing && !_disposed && _ownsManagedConnection)
+            {
+                var originalState = State;
+                try
+                {
+                    FreeNativeFunctionContexts();
+                    _managedConnection.Dispose();
+                }
+                catch (Exception exception) when (failure is not null)
+                {
+                    // Preserve the transaction cleanup failure.
+                    _ = exception;
+                }
+                catch (Exception exception)
+                {
+                    failure = ExceptionDispatchInfo.Capture(exception);
+                }
+                finally
+                {
+                    NotifyManagedStateChange(originalState);
+                }
+            }
+
+            _disposed = true;
+            base.Dispose(disposing);
+            failure?.Throw();
+            return;
+        }
+
         if (disposing)
             Close();
 
@@ -386,13 +575,80 @@ public partial class SqliteConnection : DbConnection
         base.Dispose(disposing);
     }
 
-    internal TursoDatabaseHandle DatabaseHandle => _database ?? throw new InvalidOperationException("The connection is not open.");
+    public override ValueTask DisposeAsync()
+    {
+        if (_managedConnection is null)
+            return base.DisposeAsync();
+
+        return DisposeManagedAsync();
+    }
+
+    private async ValueTask DisposeManagedAsync()
+    {
+        ExceptionDispatchInfo? failure = null;
+        if (!_disposed && Transaction is { IsCompleted: false } transaction)
+        {
+            try
+            {
+                await transaction.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                failure = ExceptionDispatchInfo.Capture(exception);
+            }
+        }
+
+        if (!_disposed && _ownsManagedConnection)
+        {
+            var originalState = State;
+            try
+            {
+                FreeNativeFunctionContexts();
+                await ManagedConnection.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception) when (failure is not null)
+            {
+                // Preserve the transaction cleanup failure.
+                _ = exception;
+            }
+            catch (Exception exception)
+            {
+                failure = ExceptionDispatchInfo.Capture(exception);
+            }
+            finally
+            {
+                NotifyManagedStateChange(originalState);
+            }
+        }
+
+        _disposed = true;
+        await base.DisposeAsync().ConfigureAwait(false);
+        failure?.Throw();
+    }
+
+    internal TursoDatabaseHandle DatabaseHandle
+    {
+        get
+        {
+            if (_managedConnection is not null)
+            {
+                if (IsReplica)
+                    return ManagedConnection.Turso;
+                throw new NotSupportedException(
+                    "SQLite native handles are not available for direct remote connections.");
+            }
+
+            return _database ?? throw new InvalidOperationException("The connection is not open.");
+        }
+    }
 
     internal bool HasOpenReader => _openReaderCount > 0;
 
     internal bool IsReadOnly => _readOnly;
 
     internal bool RecursiveTriggers => _recursiveTriggers;
+
+    internal bool ManagedReadYourWrites => _connectionOptions.ReadYourWrites;
 
     internal void ReaderOpened() => _openReaderCount++;
 
@@ -526,8 +782,92 @@ public partial class SqliteConnection : DbConnection
 
     internal void EnsureOpen()
     {
-        if (_database is null)
+        if (State != ConnectionState.Open)
             throw new InvalidOperationException("The connection is not open.");
+    }
+
+    private void ConfigureManagedConnection(SqliteConnectionStringBuilder options)
+    {
+        if (options.IsLocal)
+        {
+            if (_managedConnection is not null && _ownsManagedConnection)
+                _managedConnection.Dispose();
+
+            _managedConnection = null;
+            _ownsManagedConnection = false;
+            _readOnly = false;
+            return;
+        }
+
+        var connectionString = options.GetTursoConnectionString();
+        _readOnly = options.Mode == SqliteOpenMode.ReadOnly;
+        if (_managedConnection is null)
+        {
+            _managedConnection = new TursoConnection(connectionString);
+            _ownsManagedConnection = true;
+            return;
+        }
+
+        _managedConnection.ConnectionString = connectionString;
+    }
+
+    private async Task OpenManagedAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var originalState = State;
+        try
+        {
+            await ManagedConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            RegisterManagedReplicaCallbacks();
+        }
+        finally
+        {
+            NotifyManagedStateChange(originalState);
+        }
+    }
+
+    private TursoConnection GetManagedConnectionForSync()
+    {
+        if (_managedConnection is null)
+            throw new NotSupportedException("Sync requires an embedded replica connection.");
+
+        return _managedConnection;
+    }
+
+    private void NotifyManagedStateChange(ConnectionState originalState)
+    {
+        var currentState = State;
+        if (currentState != originalState)
+            OnStateChange(new StateChangeEventArgs(originalState, currentState));
+    }
+
+    private void ThrowIfManagedLocalOnly(string operation)
+    {
+        if (_managedConnection is not null)
+        {
+            throw new NotSupportedException(
+                $"{operation} is not available for direct remote or embedded replica connections.");
+        }
+    }
+
+    private void ThrowIfDirectRemote(string operation)
+    {
+        if (IsDirectRemote)
+        {
+            throw new NotSupportedException(
+                $"{operation} is not available for direct remote connections.");
+        }
+    }
+
+    private void RegisterManagedReplicaCallbacks()
+    {
+        if (!IsReplica)
+            return;
+
+        using var syncOperation = ManagedConnection.EnterSyncOperation();
+        RegisterScalarFunctions();
+        RegisterAggregateFunctions();
+        RegisterCollations();
     }
 
     private void ApplyConnectionOptions()

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnectionStringBuilder.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteConnectionStringBuilder.cs
@@ -19,6 +19,24 @@ public class SqliteConnectionStringBuilder : DbConnectionStringBuilder
         "Default Timeout",
         "Pooling",
         "Vfs",
+        "Auth Token",
+        "Replica Path",
+        "Read Your Writes",
+        "Sync Interval",
+        "Sync Client Name",
+        "Sync Long Poll Timeout",
+        "Bootstrap If Empty",
+        "Partial Bootstrap Prefix",
+        "Partial Bootstrap Query",
+        "Partial Sync Segment Size",
+        "Partial Sync Prefetch",
+        "Remote Encryption Cipher",
+        "Remote Encryption Key",
+        "Push Operations Threshold",
+        "Pull Bytes Threshold",
+        "Force Logical MVCC Pull",
+        "Sync Experimental Features",
+        "Tls",
         "DateTimeKind",
         "DateTimeFormat",
         "BinaryGUID",
@@ -43,6 +61,44 @@ public class SqliteConnectionStringBuilder : DbConnectionStringBuilder
         ["CommandTimeout"] = "Default Timeout",
         ["Pooling"] = "Pooling",
         ["Vfs"] = "Vfs",
+        ["Auth Token"] = "Auth Token",
+        ["AuthToken"] = "Auth Token",
+        ["Authentication Token"] = "Auth Token",
+        ["AuthenticationToken"] = "Auth Token",
+        ["Replica Path"] = "Replica Path",
+        ["ReplicaPath"] = "Replica Path",
+        ["Read Your Writes"] = "Read Your Writes",
+        ["ReadYourWrites"] = "Read Your Writes",
+        ["Sync Interval"] = "Sync Interval",
+        ["SyncInterval"] = "Sync Interval",
+        ["Sync Client Name"] = "Sync Client Name",
+        ["SyncClientName"] = "Sync Client Name",
+        ["Sync Long Poll Timeout"] = "Sync Long Poll Timeout",
+        ["SyncLongPollTimeout"] = "Sync Long Poll Timeout",
+        ["Bootstrap If Empty"] = "Bootstrap If Empty",
+        ["BootstrapIfEmpty"] = "Bootstrap If Empty",
+        ["Partial Bootstrap Prefix"] = "Partial Bootstrap Prefix",
+        ["PartialBootstrapPrefix"] = "Partial Bootstrap Prefix",
+        ["Partial Bootstrap Query"] = "Partial Bootstrap Query",
+        ["PartialBootstrapQuery"] = "Partial Bootstrap Query",
+        ["Partial Sync Segment Size"] = "Partial Sync Segment Size",
+        ["PartialSyncSegmentSize"] = "Partial Sync Segment Size",
+        ["Partial Sync Prefetch"] = "Partial Sync Prefetch",
+        ["PartialSyncPrefetch"] = "Partial Sync Prefetch",
+        ["Remote Encryption Cipher"] = "Remote Encryption Cipher",
+        ["RemoteEncryptionCipher"] = "Remote Encryption Cipher",
+        ["Remote Encryption Key"] = "Remote Encryption Key",
+        ["RemoteEncryptionKey"] = "Remote Encryption Key",
+        ["Push Operations Threshold"] = "Push Operations Threshold",
+        ["PushOperationsThreshold"] = "Push Operations Threshold",
+        ["Pull Bytes Threshold"] = "Pull Bytes Threshold",
+        ["PullBytesThreshold"] = "Pull Bytes Threshold",
+        ["Force Logical MVCC Pull"] = "Force Logical MVCC Pull",
+        ["ForceLogicalMvccPull"] = "Force Logical MVCC Pull",
+        ["Sync Experimental Features"] = "Sync Experimental Features",
+        ["SyncExperimentalFeatures"] = "Sync Experimental Features",
+        ["Tls"] = "Tls",
+        ["TLS"] = "Tls",
         ["DateTimeKind"] = "DateTimeKind",
         ["Date Time Kind"] = "DateTimeKind",
         ["DateTimeFormat"] = "DateTimeFormat",
@@ -57,15 +113,169 @@ public class SqliteConnectionStringBuilder : DbConnectionStringBuilder
     {
     }
 
+    public string AuthToken
+    {
+        get => GetString("Auth Token");
+        set => SetString("Auth Token", value);
+    }
+
+    public string ReplicaPath
+    {
+        get => GetString("Replica Path");
+        set => SetString("Replica Path", value);
+    }
+
+    public bool ReadYourWrites
+    {
+        get => GetBool("Read Your Writes", true);
+        set => this["Read Your Writes"] = value;
+    }
+
+    public int SyncInterval
+    {
+        get => GetInt("Sync Interval", 0);
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            this["Sync Interval"] = value;
+        }
+    }
+
+    public string SyncClientName
+    {
+        get => GetString("Sync Client Name");
+        set => SetString("Sync Client Name", value);
+    }
+
+    public int SyncLongPollTimeout
+    {
+        get => GetInt("Sync Long Poll Timeout", 0);
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            this["Sync Long Poll Timeout"] = value;
+        }
+    }
+
+    public bool BootstrapIfEmpty
+    {
+        get => GetBool("Bootstrap If Empty", true);
+        set => this["Bootstrap If Empty"] = value;
+    }
+
+    public int PartialBootstrapPrefix
+    {
+        get => GetInt("Partial Bootstrap Prefix", 0);
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            this["Partial Bootstrap Prefix"] = value;
+        }
+    }
+
+    public string PartialBootstrapQuery
+    {
+        get => GetString("Partial Bootstrap Query");
+        set => SetString("Partial Bootstrap Query", value);
+    }
+
+    public long PartialSyncSegmentSize
+    {
+        get => GetLong("Partial Sync Segment Size", 0);
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            this["Partial Sync Segment Size"] = value;
+        }
+    }
+
+    public bool PartialSyncPrefetch
+    {
+        get => GetBool("Partial Sync Prefetch");
+        set => this["Partial Sync Prefetch"] = value;
+    }
+
+    public string RemoteEncryptionCipher
+    {
+        get => GetString("Remote Encryption Cipher");
+        set => SetString("Remote Encryption Cipher", value);
+    }
+
+    public string RemoteEncryptionKey
+    {
+        get => GetString("Remote Encryption Key");
+        set => SetString("Remote Encryption Key", value);
+    }
+
+    public long PushOperationsThreshold
+    {
+        get => GetLong("Push Operations Threshold", 0);
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            this["Push Operations Threshold"] = value;
+        }
+    }
+
+    public long PullBytesThreshold
+    {
+        get => GetLong("Pull Bytes Threshold", 0);
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            this["Pull Bytes Threshold"] = value;
+        }
+    }
+
+    public bool ForceLogicalMvccPull
+    {
+        get => GetBool("Force Logical MVCC Pull");
+        set => this["Force Logical MVCC Pull"] = value;
+    }
+
+    public string SyncExperimentalFeatures
+    {
+        get => GetString("Sync Experimental Features");
+        set => SetString("Sync Experimental Features", value);
+    }
+
+    public bool? Tls
+    {
+        get => GetNullableBool("Tls");
+        set => SetNullable("Tls", value);
+    }
+
     public SqliteConnectionStringBuilder(string? connectionString)
     {
         ConnectionString = connectionString ?? string.Empty;
     }
 
+    public bool IsLocal => !IsDirectRemote && !IsReplica;
+
+    public bool IsDirectRemote
+    {
+        get
+        {
+            var options = TursoConnectionOptions.Parse(GetTursoConnectionString());
+            return options.IsRemote && !options.IsReplica;
+        }
+    }
+
+    public bool IsRemote => IsDirectRemote || IsReplica;
+
+    public bool IsReplica => TursoConnectionOptions.Parse(GetTursoConnectionString()).IsReplica;
+
     public string DataSource
     {
         get => GetString("Data Source");
         set => SetString("Data Source", value);
+    }
+
+    private long GetLong(string keyword, long defaultValue)
+    {
+        return base.TryGetValue(keyword, out var value)
+            ? Convert.ToInt64(value, CultureInfo.InvariantCulture)
+            : defaultValue;
     }
 
     public SqliteOpenMode Mode
@@ -205,13 +415,41 @@ public class SqliteConnectionStringBuilder : DbConnectionStringBuilder
     internal string GetTursoConnectionString()
     {
         var builder = new DbConnectionStringBuilder();
-        if (!string.IsNullOrEmpty(DataSource))
-            builder["Data Source"] = DataSource;
-        if (DefaultTimeout != 30)
-            builder["Default Timeout"] = DefaultTimeout;
+        foreach (var keyword in ManagedKeywords)
+        {
+            if (base.TryGetValue(keyword, out var value))
+                builder[keyword] = value;
+        }
+        if (!string.IsNullOrWhiteSpace(ReplicaPath) && !builder.ContainsKey("Pooling"))
+            builder["Pooling"] = Pooling;
 
         return builder.ConnectionString;
     }
+
+    private static readonly string[] ManagedKeywords =
+    [
+        "Data Source",
+        "Default Timeout",
+        "Pooling",
+        "Auth Token",
+        "Replica Path",
+        "Read Your Writes",
+        "Sync Interval",
+        "Sync Client Name",
+        "Sync Long Poll Timeout",
+        "Bootstrap If Empty",
+        "Partial Bootstrap Prefix",
+        "Partial Bootstrap Query",
+        "Partial Sync Segment Size",
+        "Partial Sync Prefetch",
+        "Remote Encryption Cipher",
+        "Remote Encryption Key",
+        "Push Operations Threshold",
+        "Pull Bytes Threshold",
+        "Force Logical MVCC Pull",
+        "Sync Experimental Features",
+        "Tls",
+    ];
 
     private static string NormalizeKeyword(string keyword)
     {
@@ -294,8 +532,14 @@ public class SqliteConnectionStringBuilder : DbConnectionStringBuilder
             "Mode" => ConvertOpenMode(value),
             "Cache" => ConvertCacheMode(value),
             "Foreign Keys" => ConvertToNullableBoolean(value),
-            "Recursive Triggers" or "Pooling" or "BinaryGUID" => Convert.ToBoolean(value, CultureInfo.InvariantCulture),
-            "Default Timeout" or "Version" => Convert.ToInt32(value, CultureInfo.InvariantCulture),
+            "Recursive Triggers" or "Pooling" or "BinaryGUID"
+                or "Read Your Writes" or "Bootstrap If Empty" or "Partial Sync Prefetch"
+                or "Force Logical MVCC Pull" => Convert.ToBoolean(value, CultureInfo.InvariantCulture),
+            "Default Timeout" or "Version" or "Sync Interval" or "Sync Long Poll Timeout"
+                or "Partial Bootstrap Prefix" => Convert.ToInt32(value, CultureInfo.InvariantCulture),
+            "Partial Sync Segment Size" or "Push Operations Threshold" or "Pull Bytes Threshold"
+                => Convert.ToInt64(value, CultureInfo.InvariantCulture),
+            "Tls" => ConvertToNullableBoolean(value),
             "DateTimeKind" => ConvertDateTimeKind(value),
             _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty,
         };
@@ -326,6 +570,24 @@ public class SqliteConnectionStringBuilder : DbConnectionStringBuilder
             "Default Timeout" => 30,
             "Pooling" => true,
             "Vfs" => null!,
+            "Auth Token" => string.Empty,
+            "Replica Path" => string.Empty,
+            "Read Your Writes" => true,
+            "Sync Interval" => 0,
+            "Sync Client Name" => string.Empty,
+            "Sync Long Poll Timeout" => 0,
+            "Bootstrap If Empty" => true,
+            "Partial Bootstrap Prefix" => 0,
+            "Partial Bootstrap Query" => string.Empty,
+            "Partial Sync Segment Size" => 0L,
+            "Partial Sync Prefetch" => false,
+            "Remote Encryption Cipher" => string.Empty,
+            "Remote Encryption Key" => string.Empty,
+            "Push Operations Threshold" => 0L,
+            "Pull Bytes Threshold" => 0L,
+            "Force Logical MVCC Pull" => false,
+            "Sync Experimental Features" => string.Empty,
+            "Tls" => null!,
             "DateTimeKind" => System.DateTimeKind.Unspecified,
             "DateTimeFormat" => string.Empty,
             "BinaryGUID" => true,

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteDataReader.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteDataReader.cs
@@ -21,12 +21,15 @@ public class SqliteDataReader : DbDataReader
     private readonly List<string> _remainingSql = new();
     private readonly CommandBehavior _behavior;
     private readonly Action _closeCallback;
+    private readonly ManagedSqliteExecution? _managedExecution;
     private int _recordsAffected;
     private bool _isClosed;
     private bool _hasCurrentRow;
     private bool _hasPrefetchedRow;
     private bool _hadResultSet;
     private bool _currentStatementRowsAffectedCounted;
+    private int _managedResultIndex;
+    private int _managedRowIndex = -1;
 
     internal SqliteDataReader(SqliteCommand command, TursoStatementHandle statement, string currentSql, List<string> remainingSql, int recordsAffected, CommandBehavior behavior, Action closeCallback)
     {
@@ -48,6 +51,20 @@ public class SqliteDataReader : DbDataReader
         _closeCallback = closeCallback;
     }
 
+    internal SqliteDataReader(
+        SqliteCommand command,
+        ManagedSqliteExecution execution,
+        CommandBehavior behavior,
+        Action closeCallback)
+    {
+        _command = command;
+        _managedExecution = execution;
+        _recordsAffected = execution.RecordsAffected;
+        _hadResultSet = execution.HadResultSet;
+        _behavior = behavior;
+        _closeCallback = closeCallback;
+    }
+
     public override int Depth => 0;
 
     public override int FieldCount
@@ -55,7 +72,13 @@ public class SqliteDataReader : DbDataReader
         get
         {
             EnsureOpen();
-            return _statement is null ? 0 : TursoBindings.GetFieldCount(_statement);
+            return _managedExecution is not null
+                ? _managedExecution.Results.Count == 0
+                    ? 0
+                    : CurrentManagedResult.Columns.Count
+                : _statement is null
+                    ? 0
+                    : TursoBindings.GetFieldCount(_statement);
         }
     }
 
@@ -64,6 +87,9 @@ public class SqliteDataReader : DbDataReader
         get
         {
             EnsureOpen();
+            if (_managedExecution is not null)
+                return _managedExecution.Results.Count > 0 && CurrentManagedResult.Rows.Count > 0;
+
             return _statement is not null && !Regex.IsMatch(_currentSql, @"\bWHERE\b\s+0\s*=\s*1\b", RegexOptions.IgnoreCase);
         }
     }
@@ -74,6 +100,9 @@ public class SqliteDataReader : DbDataReader
     {
         get
         {
+            if (_managedExecution is not null)
+                return _recordsAffected > 0 ? _recordsAffected : _hadResultSet ? -1 : 0;
+
             if (_recordsAffected > 0)
                 return _recordsAffected;
 
@@ -88,6 +117,14 @@ public class SqliteDataReader : DbDataReader
     public override bool GetBoolean(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            var managedValue = GetManagedTypedValue(ordinal);
+            if (managedValue is string text && bool.TryParse(text, out var managedBoolValue))
+                return managedBoolValue;
+            return Convert.ToInt64(managedValue, CultureInfo.InvariantCulture) != 0;
+        }
+
         var value = GetTypedValue(ordinal);
         if (value.ValueType == TursoValueType.Text && bool.TryParse(value.StringValue, out var boolValue))
             return boolValue;
@@ -104,8 +141,9 @@ public class SqliteDataReader : DbDataReader
     public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
     {
         EnsureOpen();
-        var statement = GetStatement();
-        var bytes = ToBytes(GetTypedValue(ordinal));
+        var bytes = _managedExecution is not null
+            ? ToBytes(GetManagedTypedValue(ordinal))
+            : ToBytes(GetTypedValue(ordinal));
         if (buffer is null)
             return bytes.Length;
 
@@ -121,7 +159,14 @@ public class SqliteDataReader : DbDataReader
     public override char GetChar(int ordinal)
     {
         EnsureOpen();
-        var statement = GetStatement();
+        if (_managedExecution is not null)
+        {
+            var managedValue = GetManagedTypedValue(ordinal);
+            if (managedValue is string { Length: 1 } text)
+                return text[0];
+            return Convert.ToChar(managedValue, CultureInfo.InvariantCulture);
+        }
+
         var value = GetTypedValue(ordinal);
         if (value.ValueType == TursoValueType.Text && value.StringValue.Length == 1)
             return value.StringValue[0];
@@ -151,6 +196,17 @@ public class SqliteDataReader : DbDataReader
     public override string GetDataTypeName(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            ValidateOrdinal(ordinal);
+            var managedDeclaredType = CurrentManagedResult.Columns[ordinal].DataTypeName;
+            if (!string.IsNullOrWhiteSpace(managedDeclaredType))
+                return managedDeclaredType;
+
+            var value = GetFirstManagedNonNullValue(ordinal);
+            return GetDataTypeNameFromManagedValue(value);
+        }
+
         var statement = GetStatement();
         ValidateOrdinal(ordinal);
         var declaredType = GetDeclaredTypeName(ordinal);
@@ -172,6 +228,24 @@ public class SqliteDataReader : DbDataReader
     public override DateTime GetDateTime(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            var managedValue = GetManagedTypedValue(ordinal);
+            return managedValue switch
+            {
+                DateTime dateTime => dateTime,
+                DateTimeOffset dateTimeOffset => dateTimeOffset.UtcDateTime,
+                string text => ParseDateTime(text),
+                float number => DateTime.FromOADate(number - 2415018.5),
+                double number => DateTime.FromOADate(number - 2415018.5),
+                _ when IsInteger(managedValue) => DateTime.FromOADate(
+                    Convert.ToInt64(managedValue, CultureInfo.InvariantCulture) - 2415018.5),
+                _ => DateTime.Parse(
+                    Convert.ToString(managedValue, CultureInfo.InvariantCulture) ?? string.Empty,
+                    CultureInfo.InvariantCulture)
+            };
+        }
+
         var value = GetTypedValue(ordinal);
         return value.ValueType switch
         {
@@ -185,6 +259,23 @@ public class SqliteDataReader : DbDataReader
     public virtual DateTimeOffset GetDateTimeOffset(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            var managedValue = GetManagedTypedValue(ordinal);
+            return managedValue switch
+            {
+                DateTimeOffset dateTimeOffset => dateTimeOffset,
+                DateTime dateTime => new DateTimeOffset(dateTime),
+                string text => ParseDateTimeOffset(text),
+                float number => FromJulianDate(number),
+                double number => FromJulianDate(number),
+                _ when IsInteger(managedValue) => FromJulianDate(
+                    Convert.ToInt64(managedValue, CultureInfo.InvariantCulture)),
+                _ => ParseDateTimeOffset(
+                    Convert.ToString(managedValue, CultureInfo.InvariantCulture) ?? string.Empty)
+            };
+        }
+
         var value = GetTypedValue(ordinal);
         return value.ValueType switch
         {
@@ -198,6 +289,9 @@ public class SqliteDataReader : DbDataReader
     public override decimal GetDecimal(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+            return Convert.ToDecimal(GetManagedTypedValue(ordinal), CultureInfo.InvariantCulture);
+
         var value = GetTypedValue(ordinal);
         return value.ValueType switch
         {
@@ -211,6 +305,9 @@ public class SqliteDataReader : DbDataReader
     public override double GetDouble(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+            return Convert.ToDouble(GetManagedTypedValue(ordinal), CultureInfo.InvariantCulture);
+
         var value = GetTypedValue(ordinal);
         return value.ValueType switch
         {
@@ -226,6 +323,19 @@ public class SqliteDataReader : DbDataReader
     public override Type GetFieldType(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            ValidateOrdinal(ordinal);
+            var column = CurrentManagedResult.Columns[ordinal];
+            if (IsGuidType(column.DataTypeName))
+                return typeof(Guid);
+            if (column.FieldType != typeof(object))
+                return column.FieldType;
+
+            var value = GetFirstManagedNonNullValue(ordinal);
+            return value?.GetType() ?? GetClrTypeFromManagedDataType(column.DataTypeName);
+        }
+
         var statement = GetStatement();
         ValidateOrdinal(ordinal);
         var valueType = TursoBindings.GetValue(statement, ordinal).ValueType;
@@ -298,6 +408,9 @@ public class SqliteDataReader : DbDataReader
     public override Guid GetGuid(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+            return ToGuid(GetManagedTypedValue(ordinal));
+
         var value = GetTypedValue(ordinal);
         return ToGuid(value);
     }
@@ -317,6 +430,9 @@ public class SqliteDataReader : DbDataReader
     public override long GetInt64(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+            return Convert.ToInt64(GetManagedTypedValue(ordinal), CultureInfo.InvariantCulture);
+
         var value = GetTypedValue(ordinal);
         return value.ValueType switch
         {
@@ -330,6 +446,12 @@ public class SqliteDataReader : DbDataReader
     public override string GetName(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            ValidateOrdinal(ordinal);
+            return CurrentManagedResult.Columns[ordinal].Name;
+        }
+
         var statement = GetStatement();
         ValidateOrdinal(ordinal);
         return TursoBindings.GetName(statement, ordinal);
@@ -338,6 +460,15 @@ public class SqliteDataReader : DbDataReader
     public override Stream GetStream(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            var managedValue = GetManagedTypedValue(ordinal);
+            var managedBytes = ToBytes(managedValue);
+            return ShouldReturnBlobStream(ordinal, managedValue)
+                ? new SqliteBlob(managedBytes)
+                : new MemoryStream(managedBytes, writable: false);
+        }
+
         var value = GetTypedValue(ordinal);
         var bytes = ToBytes(value);
         if (ShouldReturnBlobStream(ordinal, value))
@@ -363,7 +494,8 @@ public class SqliteDataReader : DbDataReader
     {
         EnsureOpen();
         ArgumentNullException.ThrowIfNull(name);
-        _ = GetStatement();
+        if (_managedExecution is null)
+            _ = GetStatement();
         for (var i = 0; i < FieldCount; i++)
         {
             if (string.Equals(GetName(i), name, StringComparison.Ordinal))
@@ -393,6 +525,9 @@ public class SqliteDataReader : DbDataReader
     public override DataTable GetSchemaTable()
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+            return GetManagedSchemaTable();
+
         var statement = GetStatement();
         var schema = new DataTable("SchemaTable");
         schema.Columns.Add(SchemaTableColumn.ColumnName, typeof(string));
@@ -470,6 +605,17 @@ public class SqliteDataReader : DbDataReader
     public override string GetString(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            var managedValue = GetManagedTypedValue(ordinal);
+            return managedValue switch
+            {
+                string text => text,
+                byte[] bytes => Encoding.UTF8.GetString(bytes),
+                _ => Convert.ToString(managedValue, CultureInfo.InvariantCulture) ?? string.Empty
+            };
+        }
+
         var value = GetTypedValue(ordinal);
         return value.ValueType switch
         {
@@ -484,6 +630,22 @@ public class SqliteDataReader : DbDataReader
     public virtual TimeSpan GetTimeSpan(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            var managedValue = GetManagedTypedValue(ordinal);
+            return managedValue switch
+            {
+                TimeSpan timeSpan => timeSpan,
+                float number => TimeSpan.FromDays(number),
+                double number => TimeSpan.FromDays(number),
+                _ when IsInteger(managedValue) => TimeSpan.FromDays(
+                    Convert.ToInt64(managedValue, CultureInfo.InvariantCulture)),
+                _ => TimeSpan.Parse(
+                    Convert.ToString(managedValue, CultureInfo.InvariantCulture) ?? string.Empty,
+                    CultureInfo.InvariantCulture)
+            };
+        }
+
         var value = GetTypedValue(ordinal);
         return value.ValueType switch
         {
@@ -496,6 +658,9 @@ public class SqliteDataReader : DbDataReader
     public override object GetValue(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+            return GetManagedValue(ordinal);
+
         EnsureHasCurrentRow();
         var statement = GetStatement();
         var value = TursoBindings.GetValue(statement, ordinal);
@@ -516,8 +681,16 @@ public class SqliteDataReader : DbDataReader
     public override int GetValues(object[] values)
     {
         EnsureOpen();
-        _ = GetStatement();
-        EnsureHasCurrentRow();
+        if (_managedExecution is null)
+        {
+            _ = GetStatement();
+            EnsureHasCurrentRow();
+        }
+        else
+        {
+            EnsureHasManagedCurrentRow();
+        }
+
         ArgumentNullException.ThrowIfNull(values);
         if (values.Length < FieldCount)
             throw new IndexOutOfRangeException();
@@ -532,6 +705,9 @@ public class SqliteDataReader : DbDataReader
     public override bool IsDBNull(int ordinal)
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+            return GetManagedValue(ordinal) == DBNull.Value;
+
         EnsureHasCurrentRow();
         var statement = GetStatement();
         var valueType = TursoBindings.GetValue(statement, ordinal).ValueType;
@@ -541,6 +717,20 @@ public class SqliteDataReader : DbDataReader
     public override bool NextResult()
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            if (_managedResultIndex + 1 >= _managedExecution.Results.Count)
+            {
+                if (_managedExecution.Results.Count > 0)
+                    _managedRowIndex = CurrentManagedResult.Rows.Count;
+                return false;
+            }
+
+            _managedResultIndex++;
+            _managedRowIndex = -1;
+            return true;
+        }
+
         if (_statement is null)
             return false;
         while (TursoBindings.Read(_statement))
@@ -599,6 +789,20 @@ public class SqliteDataReader : DbDataReader
     public override bool Read()
     {
         EnsureOpen();
+        if (_managedExecution is not null)
+        {
+            if (_managedExecution.Results.Count == 0
+                || _managedRowIndex + 1 >= CurrentManagedResult.Rows.Count)
+            {
+                if (_managedExecution.Results.Count > 0)
+                    _managedRowIndex = CurrentManagedResult.Rows.Count;
+                return false;
+            }
+
+            _managedRowIndex++;
+            return true;
+        }
+
         if (_statement is null)
             return false;
         if (_hasPrefetchedRow)
@@ -659,6 +863,12 @@ public class SqliteDataReader : DbDataReader
     {
         if (_isClosed)
             return;
+
+        if (_managedExecution is not null)
+        {
+            FinishClose();
+            return;
+        }
 
         try
         {
@@ -745,6 +955,122 @@ public class SqliteDataReader : DbDataReader
             throw new InvalidOperationException(Properties.Resources.NoData);
     }
 
+    private ManagedSqliteResult CurrentManagedResult
+    {
+        get
+        {
+            if (_managedExecution is null || _managedExecution.Results.Count == 0)
+                throw new InvalidOperationException(Properties.Resources.NoData);
+
+            return _managedExecution.Results[_managedResultIndex];
+        }
+    }
+
+    private void EnsureHasManagedCurrentRow()
+    {
+        if (_managedExecution is null
+            || _managedExecution.Results.Count == 0
+            || _managedRowIndex < 0
+            || _managedRowIndex >= CurrentManagedResult.Rows.Count)
+        {
+            throw new InvalidOperationException(Properties.Resources.NoData);
+        }
+    }
+
+    private object GetManagedValue(int ordinal)
+    {
+        EnsureHasManagedCurrentRow();
+        ValidateOrdinal(ordinal);
+        var value = CurrentManagedResult.Rows[_managedRowIndex][ordinal] ?? DBNull.Value;
+        if (value != DBNull.Value
+            && IsGuidType(CurrentManagedResult.Columns[ordinal].DataTypeName)
+            && value is string or byte[])
+        {
+            return ToGuid(value);
+        }
+
+        return value;
+    }
+
+    private object GetManagedTypedValue(int ordinal)
+    {
+        var value = GetManagedValue(ordinal);
+        if (value == DBNull.Value)
+            throw new InvalidOperationException(Properties.Resources.CalledOnNullValue(ordinal));
+
+        return value;
+    }
+
+    private object? GetFirstManagedNonNullValue(int ordinal)
+    {
+        ValidateOrdinal(ordinal);
+        foreach (var row in CurrentManagedResult.Rows)
+        {
+            var value = row[ordinal];
+            if (value is not null && value != DBNull.Value)
+                return value;
+        }
+
+        return null;
+    }
+
+    private DataTable GetManagedSchemaTable()
+    {
+        var schema = new DataTable("SchemaTable");
+        schema.Columns.Add(SchemaTableColumn.ColumnName, typeof(string));
+        schema.Columns.Add(SchemaTableColumn.ColumnOrdinal, typeof(int));
+        schema.Columns.Add(SchemaTableColumn.ColumnSize, typeof(int));
+        schema.Columns.Add(SchemaTableColumn.NumericPrecision, typeof(short));
+        schema.Columns.Add(SchemaTableColumn.NumericScale, typeof(short));
+        schema.Columns.Add(SchemaTableColumn.IsUnique, typeof(bool));
+        schema.Columns.Add(SchemaTableColumn.IsKey, typeof(bool));
+        schema.Columns.Add("BaseServerName", typeof(string));
+        schema.Columns.Add("BaseCatalogName", typeof(string));
+        schema.Columns.Add(SchemaTableColumn.BaseColumnName, typeof(string));
+        schema.Columns.Add(SchemaTableColumn.BaseSchemaName, typeof(string));
+        schema.Columns.Add(SchemaTableColumn.BaseTableName, typeof(string));
+        schema.Columns.Add(SchemaTableColumn.DataType, typeof(Type));
+        schema.Columns.Add("DataTypeName", typeof(string));
+        schema.Columns.Add(SchemaTableColumn.AllowDBNull, typeof(bool));
+        schema.Columns.Add(SchemaTableColumn.IsAliased, typeof(bool));
+        schema.Columns.Add(SchemaTableColumn.IsExpression, typeof(bool));
+        schema.Columns.Add(SchemaTableOptionalColumn.IsAutoIncrement, typeof(bool));
+        schema.Columns.Add(SchemaTableColumn.IsLong, typeof(bool));
+        schema.Columns.Add(SchemaTableColumn.ProviderType, typeof(int));
+
+        for (var ordinal = 0; ordinal < FieldCount; ordinal++)
+        {
+            var column = CurrentManagedResult.Columns[ordinal];
+            var dataTypeName = GetDataTypeName(ordinal);
+            var dataType = GetFieldType(ordinal);
+            var isExpression = string.IsNullOrWhiteSpace(column.DataTypeName);
+            var row = schema.NewRow();
+            row[SchemaTableColumn.ColumnName] = column.Name;
+            row[SchemaTableColumn.ColumnOrdinal] = ordinal;
+            row[SchemaTableColumn.ColumnSize] = -1;
+            row[SchemaTableColumn.NumericPrecision] = DBNull.Value;
+            row[SchemaTableColumn.NumericScale] = DBNull.Value;
+            row[SchemaTableColumn.IsUnique] = DBNull.Value;
+            row[SchemaTableColumn.IsKey] = DBNull.Value;
+            row["BaseServerName"] = "";
+            row["BaseCatalogName"] = DBNull.Value;
+            row[SchemaTableColumn.BaseColumnName] = DBNull.Value;
+            row[SchemaTableColumn.BaseSchemaName] = DBNull.Value;
+            row[SchemaTableColumn.BaseTableName] = DBNull.Value;
+            row[SchemaTableColumn.DataType] = dataType;
+            row["DataTypeName"] = dataTypeName;
+            row[SchemaTableColumn.AllowDBNull] = DBNull.Value;
+            row[SchemaTableColumn.IsAliased] = isExpression;
+            row[SchemaTableColumn.IsExpression] = isExpression;
+            row[SchemaTableOptionalColumn.IsAutoIncrement] = DBNull.Value;
+            row[SchemaTableColumn.IsLong] = dataType == typeof(byte[]);
+            row[SchemaTableColumn.ProviderType] = (int)GetSqliteType(dataType, dataTypeName);
+            schema.Rows.Add(row);
+        }
+
+        return schema;
+    }
+
     private void CountCurrentStatementRowsAffected()
     {
         if (_statement is not null
@@ -758,6 +1084,12 @@ public class SqliteDataReader : DbDataReader
 
     private string GetDeclaredTypeName(int ordinal)
     {
+        if (_managedExecution is not null)
+        {
+            ValidateOrdinal(ordinal);
+            return CurrentManagedResult.Columns[ordinal].DataTypeName;
+        }
+
         if (TryGetSelectSource(out var tableName, out var selections))
         {
             var tableColumns = GetTableColumns(tableName);
@@ -1038,6 +1370,13 @@ public class SqliteDataReader : DbDataReader
         return new DateTimeOffset(DateTime.Parse(value, CultureInfo.InvariantCulture), TimeSpan.Zero);
     }
 
+    private static DateTimeOffset FromJulianDate(double value)
+        => new(
+            DateTime.SpecifyKind(
+                DateTime.FromOADate(value - 2415018.5),
+                DateTimeKind.Unspecified),
+            TimeSpan.Zero);
+
     private static bool HasOffset(string value)
     {
         var timeSeparator = value.IndexOf(':', StringComparison.Ordinal);
@@ -1060,12 +1399,130 @@ public class SqliteDataReader : DbDataReader
         };
     }
 
+    private static byte[] ToBytes(object value)
+    {
+        return value switch
+        {
+            byte[] bytes => bytes,
+            string text => Encoding.UTF8.GetBytes(text),
+            DBNull => [],
+            IFormattable formattable => Encoding.UTF8.GetBytes(
+                formattable.ToString(null, CultureInfo.InvariantCulture) ?? string.Empty),
+            _ => Encoding.UTF8.GetBytes(
+                Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty)
+        };
+    }
+
     private static Guid ToGuid(TursoValue value)
         => value.ValueType == TursoValueType.Blob
             ? value.BlobValue.Length == 16
                 ? new Guid(value.BlobValue)
                 : Guid.Parse(Encoding.UTF8.GetString(value.BlobValue))
             : Guid.Parse(value.StringValue);
+
+    private static Guid ToGuid(object value)
+    {
+        return value switch
+        {
+            Guid guid => guid,
+            byte[] bytes when bytes.Length == 16 => new Guid(bytes),
+            byte[] bytes => Guid.Parse(Encoding.UTF8.GetString(bytes)),
+            string text => Guid.Parse(text),
+            _ => Guid.Parse(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty)
+        };
+    }
+
+    private bool ShouldReturnBlobStream(int ordinal, object value)
+    {
+        if (value is byte[] && ordinal == 1)
+            return true;
+
+        for (var index = 0; index < ordinal; index++)
+        {
+            if (string.Equals(GetName(index), "rowid", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string GetDataTypeNameFromManagedValue(object? value)
+    {
+        return value switch
+        {
+            null or DBNull => "BLOB",
+            sbyte or byte or short or ushort or int or uint or long or ulong or bool => "INTEGER",
+            float or double or decimal => "REAL",
+            string or char or Guid or DateTime or DateTimeOffset or DateOnly or TimeOnly or TimeSpan => "TEXT",
+            byte[] => "BLOB",
+            _ => "BLOB"
+        };
+    }
+
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
+    private static Type GetClrTypeFromManagedDataType(string typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+            return typeof(object);
+        if (IsGuidType(typeName))
+            return typeof(Guid);
+
+        var normalized = typeName.ToUpperInvariant();
+        if (normalized.Contains("INT", StringComparison.Ordinal))
+            return typeof(long);
+        if (normalized.Contains("REAL", StringComparison.Ordinal)
+            || normalized.Contains("FLOA", StringComparison.Ordinal)
+            || normalized.Contains("DOUB", StringComparison.Ordinal))
+        {
+            return typeof(double);
+        }
+        if (normalized.Contains("CHAR", StringComparison.Ordinal)
+            || normalized.Contains("CLOB", StringComparison.Ordinal)
+            || normalized.Contains("TEXT", StringComparison.Ordinal))
+        {
+            return typeof(string);
+        }
+        if (normalized.Contains("BLOB", StringComparison.Ordinal))
+            return typeof(byte[]);
+
+        return typeof(string);
+    }
+
+    private static bool IsInteger(object value)
+        => value is sbyte or byte or short or ushort or int or uint or long or ulong;
+
+    private static SqliteType GetSqliteType(Type type, string dataTypeName)
+    {
+        if (type == typeof(byte[]) || dataTypeName.Contains("BLOB", StringComparison.OrdinalIgnoreCase))
+            return SqliteType.Blob;
+        if (type == typeof(float)
+            || type == typeof(double)
+            || type == typeof(decimal)
+            || dataTypeName.Contains("REAL", StringComparison.OrdinalIgnoreCase)
+            || dataTypeName.Contains("FLOA", StringComparison.OrdinalIgnoreCase)
+            || dataTypeName.Contains("DOUB", StringComparison.OrdinalIgnoreCase))
+        {
+            return SqliteType.Real;
+        }
+        if (type == typeof(bool)
+            || IsIntegerType(type)
+            || dataTypeName.Contains("INT", StringComparison.OrdinalIgnoreCase))
+        {
+            return SqliteType.Integer;
+        }
+
+        return SqliteType.Text;
+    }
+
+    private static bool IsIntegerType(Type type)
+        => type == typeof(sbyte)
+           || type == typeof(byte)
+           || type == typeof(short)
+           || type == typeof(ushort)
+           || type == typeof(int)
+           || type == typeof(uint)
+           || type == typeof(long)
+           || type == typeof(ulong);
 
     private void DrainRemainingStatements()
     {

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteFactory.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteFactory.cs
@@ -10,6 +10,12 @@ public sealed class SqliteFactory : DbProviderFactory
     {
     }
 
+    public override bool CanCreateBatch => true;
+
+    public override DbBatch CreateBatch() => new SqliteBatch();
+
+    public override DbBatchCommand CreateBatchCommand() => new SqliteBatchCommand();
+
     public override DbCommand CreateCommand() => new SqliteCommand();
 
     public override DbConnection CreateConnection() => new SqliteConnection();

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteParameter.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteParameter.cs
@@ -158,6 +158,25 @@ public class SqliteParameter : DbParameter
         };
     }
 
+    internal global::Turso.TursoParameter ToManagedParameter(string parameterName)
+    {
+        var value = ToTursoValue();
+        return new global::Turso.TursoParameter(parameterName, value.ValueType switch
+        {
+            TursoValueType.Null or TursoValueType.Empty => DBNull.Value,
+            TursoValueType.Integer => value.IntValue,
+            TursoValueType.Real => value.RealValue,
+            TursoValueType.Text => value.StringValue,
+            TursoValueType.Blob => value.BlobValue,
+            _ => throw new ArgumentOutOfRangeException()
+        })
+        {
+            IsNullable = IsNullable,
+            SourceColumn = SourceColumn,
+            SourceColumnNullMapping = SourceColumnNullMapping,
+        };
+    }
+
     private static SqliteType InferSqliteType(object? value)
     {
         return value switch

--- a/bindings/dotnet/src/Turso.Data.Sqlite/SqliteTransaction.cs
+++ b/bindings/dotnet/src/Turso.Data.Sqlite/SqliteTransaction.cs
@@ -7,6 +7,7 @@ public class SqliteTransaction : DbTransaction
 {
     private SqliteConnection? _connection;
     private readonly IsolationLevel _isolationLevel;
+    private readonly global::Turso.TursoTransaction? _managedTransaction;
     private bool _completed;
     private bool _externalRollback;
 
@@ -17,6 +18,23 @@ public class SqliteTransaction : DbTransaction
 
         if (_isolationLevel == IsolationLevel.ReadUncommitted)
             connection.ReadUncommitted = true;
+
+        if (connection.IsManagedConnection)
+        {
+            try
+            {
+                _managedTransaction = new global::Turso.TursoTransaction(
+                    connection.ManagedConnection,
+                    _isolationLevel,
+                    deferred);
+            }
+            catch (Turso.Raw.Public.TursoException ex)
+            {
+                throw SqliteCommand.ToSqliteException(ex);
+            }
+
+            return;
+        }
 
         Execute(_isolationLevel == IsolationLevel.Serializable && !deferred ? "BEGIN IMMEDIATE;" : "BEGIN;");
     }
@@ -33,21 +51,81 @@ public class SqliteTransaction : DbTransaction
 
     internal bool WasRolledBackExternally => _externalRollback;
 
+    internal global::Turso.TursoTransaction? ManagedTransaction => _managedTransaction;
+
     public override void Commit()
     {
         ThrowIfCompleted();
         if (_externalRollback)
             throw new InvalidOperationException(Properties.Resources.TransactionCompleted);
 
-        Execute("COMMIT;");
+        if (_managedTransaction is not null)
+        {
+            try
+            {
+                _managedTransaction.Commit();
+            }
+            catch (global::Turso.TursoRemoteSqlException ex) when (ex.IsStreamExpired)
+            {
+                Complete();
+                throw SqliteCommand.ToSqliteException(ex);
+            }
+            catch (Turso.Raw.Public.TursoException ex)
+            {
+                if (_managedTransaction.IsCompleted)
+                    Complete();
+                throw SqliteCommand.ToSqliteException(ex);
+            }
+            catch
+            {
+                if (_managedTransaction.IsCompleted)
+                    Complete();
+                throw;
+            }
+        }
+        else
+        {
+            Execute("COMMIT;");
+        }
+
         Complete();
     }
 
-    public override Task CommitAsync(CancellationToken cancellationToken = default)
+    public override async Task CommitAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        Commit();
-        return Task.CompletedTask;
+        ThrowIfCompleted();
+        if (_externalRollback)
+            throw new InvalidOperationException(Properties.Resources.TransactionCompleted);
+        if (_managedTransaction is null)
+        {
+            Commit();
+            return;
+        }
+
+        try
+        {
+            await _managedTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (global::Turso.TursoRemoteSqlException ex) when (ex.IsStreamExpired)
+        {
+            Complete();
+            throw SqliteCommand.ToSqliteException(ex);
+        }
+        catch (Turso.Raw.Public.TursoException ex)
+        {
+            if (_managedTransaction.IsCompleted)
+                Complete();
+            throw SqliteCommand.ToSqliteException(ex);
+        }
+        catch
+        {
+            if (_managedTransaction.IsCompleted)
+                Complete();
+            throw;
+        }
+
+        Complete();
     }
 
     public override void Rollback()
@@ -56,7 +134,16 @@ public class SqliteTransaction : DbTransaction
         try
         {
             if (!_externalRollback)
-                Execute("ROLLBACK;");
+            {
+                if (_managedTransaction is not null)
+                    _managedTransaction.Rollback();
+                else
+                    Execute("ROLLBACK;");
+            }
+        }
+        catch (Turso.Raw.Public.TursoException ex)
+        {
+            throw SqliteCommand.ToSqliteException(ex);
         }
         finally
         {
@@ -64,58 +151,96 @@ public class SqliteTransaction : DbTransaction
         }
     }
 
-    public override Task RollbackAsync(CancellationToken cancellationToken = default)
+    public override async Task RollbackAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        Rollback();
-        return Task.CompletedTask;
+        ThrowIfCompleted();
+        try
+        {
+            if (!_externalRollback)
+            {
+                if (_managedTransaction is not null)
+                    await _managedTransaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                else
+                    Execute("ROLLBACK;");
+            }
+        }
+        catch (Turso.Raw.Public.TursoException ex)
+        {
+            throw SqliteCommand.ToSqliteException(ex);
+        }
+        finally
+        {
+            Complete();
+        }
     }
 
     public override void Save(string savepointName)
     {
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
-        Execute("SAVEPOINT " + QuoteIdentifier(savepointName) + ";");
+        ExecuteTransactionCommand("SAVEPOINT " + QuoteIdentifier(savepointName) + ";");
     }
 
     public override Task SaveAsync(string savepointName, CancellationToken cancellationToken = default)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-        Save(savepointName);
-        return Task.CompletedTask;
+        ArgumentNullException.ThrowIfNull(savepointName);
+        ThrowIfCompleted();
+        return ExecuteTransactionCommandAsync(
+            "SAVEPOINT " + QuoteIdentifier(savepointName) + ";",
+            cancellationToken);
     }
 
     public override void Rollback(string savepointName)
     {
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
-        Execute("ROLLBACK TO SAVEPOINT " + QuoteIdentifier(savepointName) + ";");
+        ExecuteTransactionCommand("ROLLBACK TO SAVEPOINT " + QuoteIdentifier(savepointName) + ";");
     }
 
     public override Task RollbackAsync(string savepointName, CancellationToken cancellationToken = default)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-        Rollback(savepointName);
-        return Task.CompletedTask;
+        ArgumentNullException.ThrowIfNull(savepointName);
+        ThrowIfCompleted();
+        return ExecuteTransactionCommandAsync(
+            "ROLLBACK TO SAVEPOINT " + QuoteIdentifier(savepointName) + ";",
+            cancellationToken);
     }
 
     public override void Release(string savepointName)
     {
         ArgumentNullException.ThrowIfNull(savepointName);
         ThrowIfCompleted();
-        Execute("RELEASE SAVEPOINT " + QuoteIdentifier(savepointName) + ";");
+        ExecuteTransactionCommand("RELEASE SAVEPOINT " + QuoteIdentifier(savepointName) + ";");
     }
 
     public override Task ReleaseAsync(string savepointName, CancellationToken cancellationToken = default)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-        Release(savepointName);
-        return Task.CompletedTask;
+        ArgumentNullException.ThrowIfNull(savepointName);
+        ThrowIfCompleted();
+        return ExecuteTransactionCommandAsync(
+            "RELEASE SAVEPOINT " + QuoteIdentifier(savepointName) + ";",
+            cancellationToken);
     }
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing && !_completed && _connection is { State: ConnectionState.Open })
+        if (disposing && !_completed && _managedTransaction is not null)
+        {
+            try
+            {
+                _managedTransaction.Dispose();
+            }
+            catch (Turso.Raw.Public.TursoException ex)
+            {
+                throw SqliteCommand.ToSqliteException(ex);
+            }
+            finally
+            {
+                Complete();
+            }
+        }
+        else if (disposing && !_completed && _connection is { State: ConnectionState.Open })
             Rollback();
         else if (disposing && _connection is not null && ReferenceEquals(_connection.Transaction, this))
             _connection.Transaction = null;
@@ -125,6 +250,12 @@ public class SqliteTransaction : DbTransaction
 
     internal void MarkCompletedExternally(bool rolledBack)
     {
+        if (_managedTransaction is not null)
+        {
+            throw new InvalidOperationException(
+                "Managed transactions cannot be completed through raw transaction-control SQL.");
+        }
+
         if (rolledBack)
         {
             _externalRollback = true;
@@ -186,6 +317,53 @@ public class SqliteTransaction : DbTransaction
         command.CommandText = sql;
         command.Transaction = this;
         command.ExecuteNonQuery();
+    }
+
+    private void ExecuteTransactionCommand(string sql)
+    {
+        if (_managedTransaction is null)
+        {
+            Execute(sql);
+            return;
+        }
+
+        try
+        {
+            using var command = new global::Turso.TursoCommand(_connection!.ManagedConnection)
+            {
+                CommandText = sql,
+                Transaction = _managedTransaction,
+            };
+            command.ExecuteNonQuery();
+        }
+        catch (Turso.Raw.Public.TursoException ex)
+        {
+            throw SqliteCommand.ToSqliteException(ex, sql);
+        }
+    }
+
+    private async Task ExecuteTransactionCommandAsync(string sql, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_managedTransaction is null)
+        {
+            Execute(sql);
+            return;
+        }
+
+        try
+        {
+            await using var command = new global::Turso.TursoCommand(_connection!.ManagedConnection)
+            {
+                CommandText = sql,
+                Transaction = _managedTransaction,
+            };
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Turso.Raw.Public.TursoException ex)
+        {
+            throw SqliteCommand.ToSqliteException(ex, sql);
+        }
     }
 
 }

--- a/bindings/dotnet/src/Turso.Data/Properties/AssemblyInfo.cs
+++ b/bindings/dotnet/src/Turso.Data/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Turso.Tests")]
+[assembly: InternalsVisibleTo("Turso.Data.Sqlite")]

--- a/bindings/dotnet/src/Turso.Tests/SqliteFacadeTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/SqliteFacadeTests.cs
@@ -16,6 +16,9 @@ public class SqliteFacadeTests
         factory.CreateCommand().Should().BeOfType<SqliteCommand>();
         factory.CreateParameter().Should().BeOfType<SqliteParameter>();
         factory.CreateConnectionStringBuilder().Should().BeOfType<SqliteConnectionStringBuilder>();
+        factory.CanCreateBatch.Should().BeTrue();
+        factory.CreateBatch().Should().BeOfType<SqliteBatch>();
+        factory.CreateBatchCommand().Should().BeOfType<SqliteBatchCommand>();
     }
 
     [Test]
@@ -32,6 +35,148 @@ public class SqliteFacadeTests
         builder.BinaryGUID.Should().BeFalse();
         builder.Version.Should().Be(3);
         builder["DataSource"].Should().Be(":memory:");
+    }
+
+    [Test]
+    public void ConnectionStringBuilderRoundTripsManagedConnectionKeywords()
+    {
+        var builder = new SqliteConnectionStringBuilder(
+            "DataSource=libsql://example.turso.io;AuthToken=token;ReplicaPath=replica.db;"
+            + "ReadYourWrites=False;SyncInterval=5;SyncClientName=client;SyncLongPollTimeout=6;"
+            + "BootstrapIfEmpty=False;PartialBootstrapPrefix=7;PartialBootstrapQuery=SELECT 1;"
+            + "PartialSyncSegmentSize=8;PartialSyncPrefetch=True;RemoteEncryptionCipher=aes256gcm;"
+            + "RemoteEncryptionKey=key;PushOperationsThreshold=9;PullBytesThreshold=10;"
+            + "ForceLogicalMvccPull=True;SyncExperimentalFeatures=feature;TLS=True");
+
+        builder.AuthToken.Should().Be("token");
+        builder.ReplicaPath.Should().Be("replica.db");
+        builder.ReadYourWrites.Should().BeFalse();
+        builder.SyncInterval.Should().Be(5);
+        builder.SyncClientName.Should().Be("client");
+        builder.SyncLongPollTimeout.Should().Be(6);
+        builder.BootstrapIfEmpty.Should().BeFalse();
+        builder.PartialBootstrapPrefix.Should().Be(7);
+        builder.PartialBootstrapQuery.Should().Be("SELECT 1");
+        builder.PartialSyncSegmentSize.Should().Be(8);
+        builder.PartialSyncPrefetch.Should().BeTrue();
+        builder.RemoteEncryptionCipher.Should().Be("aes256gcm");
+        builder.RemoteEncryptionKey.Should().Be("key");
+        builder.PushOperationsThreshold.Should().Be(9);
+        builder.PullBytesThreshold.Should().Be(10);
+        builder.ForceLogicalMvccPull.Should().BeTrue();
+        builder.SyncExperimentalFeatures.Should().Be("feature");
+        builder.Tls.Should().BeTrue();
+        builder.IsReplica.Should().BeTrue();
+        builder.IsDirectRemote.Should().BeFalse();
+        builder.IsRemote.Should().BeTrue();
+        builder.IsLocal.Should().BeFalse();
+
+        var roundTripped = new SqliteConnectionStringBuilder(builder.ConnectionString);
+        roundTripped.ConnectionString.Should().Be(builder.ConnectionString);
+        roundTripped.ReplicaPath.Should().Be("replica.db");
+        roundTripped.PartialSyncSegmentSize.Should().Be(8);
+        roundTripped.Tls.Should().BeTrue();
+
+        using var connection = new SqliteConnection(roundTripped.ConnectionString);
+        connection.IsLocal.Should().BeFalse();
+        connection.IsDirectRemote.Should().BeFalse();
+        connection.IsRemote.Should().BeTrue();
+        connection.IsReplica.Should().BeTrue();
+        connection.IsManaged.Should().BeTrue();
+    }
+
+    [TestCase(":memory:", true, false, false)]
+    [TestCase("local.db", true, false, false)]
+    [TestCase("file:local.db", true, false, false)]
+    [TestCase("https://example.turso.io", false, true, false)]
+    [TestCase("libsql://example.turso.io", false, true, false)]
+    public void ConnectionStringBuilderClassifiesDataSource(
+        string dataSource,
+        bool isLocal,
+        bool isDirectRemote,
+        bool isReplica)
+    {
+        var builder = new SqliteConnectionStringBuilder { DataSource = dataSource };
+
+        builder.IsLocal.Should().Be(isLocal);
+        builder.IsDirectRemote.Should().Be(isDirectRemote);
+        builder.IsReplica.Should().Be(isReplica);
+
+        builder.ReplicaPath = isLocal ? "ignored.db" : "replica.db";
+        builder.IsReplica.Should().Be(!isLocal);
+    }
+
+    [Test]
+    public async Task ManagedConnectionDelegatesLifecycleAndState()
+    {
+        await using var connection = new SqliteConnection(
+            "Data Source=https://example.turso.io;Auth Token=token;Default Timeout=7");
+        var transitions = new List<(ConnectionState Original, ConnectionState Current)>();
+        connection.StateChange += (_, args) => transitions.Add((args.OriginalState, args.CurrentState));
+
+        connection.IsLocal.Should().BeFalse();
+        connection.IsDirectRemote.Should().BeTrue();
+        connection.IsRemote.Should().BeTrue();
+        connection.IsReplica.Should().BeFalse();
+        connection.IsManaged.Should().BeTrue();
+        connection.CanCreateBatch.Should().BeTrue();
+        connection.DataSource.Should().Be("https://example.turso.io");
+        connection.DefaultTimeout.Should().Be(7);
+        connection.State.Should().Be(ConnectionState.Closed);
+
+        await connection.OpenAsync();
+        connection.State.Should().Be(ConnectionState.Open);
+        connection.DataSource.Should().Be("https://example.turso.io");
+        connection.SyncDatabase.Should().BeNull();
+        Assert.Throws<NotSupportedException>(connection.Sync);
+        Assert.ThrowsAsync<NotSupportedException>(() => connection.SyncAsync());
+
+        connection.Close();
+        connection.State.Should().Be(ConnectionState.Closed);
+        connection.Open();
+        connection.Close();
+        transitions.Should().Equal(
+            (ConnectionState.Closed, ConnectionState.Open),
+            (ConnectionState.Open, ConnectionState.Closed),
+            (ConnectionState.Closed, ConnectionState.Open),
+            (ConnectionState.Open, ConnectionState.Closed));
+    }
+
+    [Test]
+    public async Task WrappedTursoConnectionHonorsExplicitOwnership()
+    {
+        var borrowed = new TursoConnection("Data Source=https://example.turso.io");
+        borrowed.Open();
+        await using (var wrapper = new SqliteConnection(borrowed, ownsConnection: false))
+        {
+            wrapper.State.Should().Be(ConnectionState.Open);
+            wrapper.IsDirectRemote.Should().BeTrue();
+        }
+
+        borrowed.State.Should().Be(ConnectionState.Open);
+        borrowed.Close();
+
+        var owned = new TursoConnection("Data Source=https://example.turso.io");
+        owned.Open();
+        var owningWrapper = new SqliteConnection(owned, ownsConnection: true);
+        await owningWrapper.DisposeAsync();
+
+        owned.State.Should().Be(ConnectionState.Closed);
+        Assert.Throws<ObjectDisposedException>(owned.Open);
+    }
+
+    [Test]
+    public void ManagedConnectionRejectsLocalOnlyFacadeApis()
+    {
+        using var connection = new SqliteConnection("Data Source=https://example.turso.io");
+
+        Assert.Throws<NotSupportedException>(() => connection.GetSchema());
+        Assert.Throws<NotSupportedException>(() => connection.EnableExtensions());
+        Assert.Throws<NotSupportedException>(() => connection.CreateFunction("custom", () => 1));
+
+        using var local = new SqliteConnection("Data Source=:memory:");
+        local.CanCreateBatch.Should().BeFalse();
+        Assert.Throws<NotSupportedException>(() => local.CreateBatch());
     }
 
     [Test]

--- a/bindings/dotnet/src/Turso.Tests/SqliteManagedExecutionTests.cs
+++ b/bindings/dotnet/src/Turso.Tests/SqliteManagedExecutionTests.cs
@@ -1,0 +1,751 @@
+using System.Data;
+using System.Data.Common;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using AwesomeAssertions;
+using Turso.Data.Sqlite;
+
+namespace Turso.Tests;
+
+[NonParallelizable]
+public sealed class SqliteManagedExecutionTests
+{
+    [Test]
+    public async Task ReplicaFacadePropagatesItsEffectivePoolingDefault()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "turso-sqlite-pooling-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var sqliteBuilder = new SqliteConnectionStringBuilder
+        {
+            DataSource = "https://example.test",
+            ReplicaPath = Path.Combine(directory, "replica.db"),
+            BootstrapIfEmpty = false,
+        };
+
+        try
+        {
+            await using var first = new SqliteConnection(sqliteBuilder.ConnectionString);
+            await using var second = new SqliteConnection(sqliteBuilder.ConnectionString);
+
+            await first.OpenAsync();
+            await second.OpenAsync();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("-- no statement")]
+    [TestCase("/* no statement */")]
+    public void DirectRemoteEmptyCommandReturnsMinusOneWithoutSendingARequest(string sql)
+    {
+        using var handler = new ScriptedPipelineHandler();
+        using var handlerScope = UseRemoteHandler(handler);
+        using var connection = new SqliteConnection("Data Source=https://example.test");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        command.ExecuteNonQuery().Should().Be(-1);
+        handler.RequestBodies.Should().BeEmpty();
+    }
+
+    [TestCase("/* leading comment */ INSERT INTO items VALUES (1)")]
+    [TestCase("PRAGMA user_version = 1")]
+    [TestCase("PRAGMA user_version(1)")]
+    [TestCase("WITH value(x) AS (SELECT 1) /* comment */ INSERT INTO items SELECT x FROM value")]
+    public async Task ReadOnlyManagedBatchRejectsWritesBeforeSendingThem(string sql)
+    {
+        await using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Mode=ReadOnly");
+        await connection.OpenAsync();
+        await using var batch = (SqliteBatch)connection.CreateBatch();
+        batch.BatchCommands.Add(new SqliteBatchCommand(sql));
+
+        var action = async () => await batch.ExecuteNonQueryAsync(CancellationToken.None);
+
+        await action.Should().ThrowAsync<SqliteException>()
+            .Where(exception => exception.SqliteErrorCode == 8);
+    }
+
+    [Test]
+    public void DirectRemoteTriggerColumnNamedEndStaysInOneStatement()
+    {
+        using var handler = new ScriptedPipelineHandler(EmptyResult(), CloseResult());
+        using var handlerScope = UseRemoteHandler(handler);
+        using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TRIGGER copy_value AFTER INSERT ON items BEGIN
+                INSERT INTO audit(end) VALUES (NEW.value);
+            END;
+            """;
+
+        command.ExecuteNonQuery();
+        connection.Close();
+
+        handler.RequestBodies.Should().HaveCount(2);
+        GetExecuteStatement(handler.RequestBodies[0]).GetProperty("sql").GetString()
+            .Should().Contain("INSERT INTO audit(end)")
+            .And.EndWith("END");
+    }
+
+    [Test]
+    public async Task DirectRemoteSplitsTriggerBodiesAndFiltersParametersPerStatement()
+    {
+        using var handler = new ScriptedPipelineHandler(
+            IntegerResult(1),
+            EmptyResult(),
+            IntegerResult(3),
+            CloseResult());
+        using var handlerScope = UseRemoteHandler(handler);
+        await using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT $first /* ; @ignored */;
+            CREATE TRIGGER update_items AFTER INSERT ON items BEGIN
+                INSERT INTO audit VALUES (':ignored', @trigger);
+                UPDATE items
+                SET value = CASE WHEN value = ';' THEN 'x' ELSE value END;
+            END;
+            -- ; $ignored
+            SELECT @second, "$ignored", `@ignored`, [@ignored];
+            """;
+        command.Parameters.AddWithValue("$first", 1);
+        command.Parameters.AddWithValue("@trigger", 2);
+        command.Parameters.AddWithValue("@second", 3);
+        command.Parameters.AddWithValue("$unused", 4);
+
+        await using var reader = (SqliteDataReader)await command.ExecuteReaderAsync();
+
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetInt64(0).Should().Be(1);
+        (await reader.ReadAsync()).Should().BeFalse();
+        (await reader.NextResultAsync()).Should().BeTrue();
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetInt64(0).Should().Be(3);
+        (await reader.NextResultAsync()).Should().BeFalse();
+        reader.RecordsAffected.Should().Be(-1);
+        await reader.CloseAsync();
+        await connection.CloseAsync();
+
+        handler.RequestBodies.Should().HaveCount(4);
+        var statements = handler.RequestBodies
+            .Take(3)
+            .Select(GetExecuteStatement)
+            .ToArray();
+        statements[0].GetProperty("sql").GetString().Should().Contain("SELECT $first");
+        GetNamedArgumentNames(statements[0]).Should().Equal("$first");
+        statements[1].GetProperty("sql").GetString().Should()
+            .Contain("INSERT INTO audit")
+            .And.Contain("UPDATE items")
+            .And.EndWith("END");
+        GetNamedArgumentNames(statements[1]).Should().Equal("@trigger");
+        statements[2].GetProperty("sql").GetString().Should().Contain("SELECT @second");
+        GetNamedArgumentNames(statements[2]).Should().Equal("@second");
+        GetRequestBaton(handler.RequestBodies[1]).Should().Be("session");
+        GetRequestBaton(handler.RequestBodies[2]).Should().Be("session");
+    }
+
+    [Test]
+    public void DirectRemoteMultiStatementRejectsStatelessExecution()
+    {
+        using var handler = new ScriptedPipelineHandler();
+        using var handlerScope = UseRemoteHandler(handler);
+        using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1; SELECT 2;";
+
+        command.Invoking(static value => value.ExecuteReader())
+            .Should().Throw<NotSupportedException>()
+            .WithMessage("*Read Your Writes=True*");
+        handler.RequestBodies.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ManagedPrepareMapsParametersWithoutExecutingAndRejectsAmbiguousNames()
+    {
+        using var handler = new ScriptedPipelineHandler();
+        using var handlerScope = UseRemoteHandler(handler);
+        await using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT :first; SELECT $second;";
+        command.Parameters.AddWithValue("first", 1);
+        command.Parameters.AddWithValue("second", 2);
+
+        await command.PrepareAsync();
+
+        handler.RequestBodies.Should().BeEmpty();
+        command.CommandText = "SELECT :value, $value";
+        command.Parameters.Clear();
+        command.Parameters.AddWithValue("value", 1);
+        await command.Invoking(value => value.PrepareAsync())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ambiguous*");
+        command.CommandText = "SELECT @missing";
+        command.Parameters.Clear();
+        await command.Invoking(value => value.PrepareAsync())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*@missing*");
+        handler.RequestBodies.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task DirectRemoteParametersAndReaderUseSqliteConversions()
+    {
+        var guid = Guid.Parse("00112233-4455-6677-8899-aabbccddeeff");
+        using var handler = new ScriptedPipelineHandler(
+            ExecuteResult(
+                """
+                {
+                  "cols": [
+                    { "name": "at", "decltype": "TEXT" },
+                    { "name": "elapsed", "decltype": "REAL" },
+                    { "name": "id", "decltype": "GUID" },
+                    { "name": "enabled", "decltype": "INTEGER" },
+                    { "name": "missing", "decltype": "TEXT" }
+                  ],
+                  "rows": [[
+                    { "type": "text", "value": "2025-01-02 03:04:05+02:00" },
+                    { "type": "float", "value": 0.5 },
+                    { "type": "text", "value": "00112233-4455-6677-8899-aabbccddeeff" },
+                    { "type": "integer", "value": "1" },
+                    { "type": "null" }
+                  ]],
+                  "affected_row_count": 0,
+                  "last_insert_rowid": null
+                }
+                """,
+                includeClose: true));
+        using var handlerScope = UseRemoteHandler(handler);
+        await using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=False");
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT $text, :amount, @blob, $id";
+        command.Parameters.Add("text", SqliteType.Text, 3).Value = "abcdef";
+        command.Parameters.Add("amount", SqliteType.Text).Value = 12.5m;
+        command.Parameters.Add("blob", SqliteType.Blob, 2).Value = new byte[] { 1, 2, 3 };
+        command.Parameters.Add("id", SqliteType.Text).Value = guid;
+
+        await using var reader = (SqliteDataReader)await command.ExecuteReaderAsync();
+
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetDateTime(0).Should().Be(
+            new DateTime(2025, 1, 2, 1, 4, 5, DateTimeKind.Utc));
+        reader.GetDateTimeOffset(0).Offset.Should().Be(TimeSpan.FromHours(2));
+        reader.GetTimeSpan(1).Should().Be(TimeSpan.FromHours(12));
+        reader.GetGuid(2).Should().Be(guid);
+        reader.GetValue(2).Should().Be(guid);
+        reader.GetBoolean(3).Should().BeTrue();
+        reader.IsDBNull(4).Should().BeTrue();
+        reader.Invoking(value => value.GetString(4))
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*ordinal 4*");
+        reader.GetDataTypeName(2).Should().Be("GUID");
+        var schema = reader.GetSchemaTable();
+        schema.Rows[2][SchemaTableColumn.DataType].Should().Be(typeof(Guid));
+        schema.Rows[2]["DataTypeName"].Should().Be("GUID");
+
+        var statement = GetExecuteStatement(handler.RequestBodies.Single());
+        var arguments = statement.GetProperty("named_args")
+            .EnumerateArray()
+            .ToDictionary(
+                argument => argument.GetProperty("name").GetString()!,
+                argument => argument.GetProperty("value"));
+        arguments.Keys.Should().Equal("$text", ":amount", "@blob", "$id");
+        arguments["$text"].GetProperty("value").GetString().Should().Be("abc");
+        arguments["$text"].TryGetProperty("base64", out _).Should().BeFalse();
+        arguments[":amount"].GetProperty("value").GetString().Should().Be("12.5");
+        arguments["@blob"].GetProperty("base64").GetString().Should().Be("AQI=");
+        arguments["@blob"].TryGetProperty("value", out _).Should().BeFalse();
+        arguments["$id"].GetProperty("value").GetString().Should()
+            .Be("00112233-4455-6677-8899-AABBCCDDEEFF");
+    }
+
+    [Test]
+    public void DirectRemoteTranslatesSqliteErrorCodes()
+    {
+        using var handler = new ScriptedPipelineHandler(
+            ErrorResult(
+                "SQLITE_CONSTRAINT_FOREIGNKEY",
+                "FOREIGN KEY constraint failed",
+                includeClose: true));
+        using var handlerScope = UseRemoteHandler(handler);
+        using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "INSERT INTO child VALUES (1)";
+
+        var exception = Assert.Throws<SqliteException>(() => command.ExecuteNonQuery());
+
+        exception!.SqliteErrorCode.Should().Be(19);
+        exception.SqliteExtendedErrorCode.Should().Be(787);
+        exception.Message.Should().Contain("FOREIGN KEY constraint failed");
+    }
+
+    [Test]
+    public void DirectRemotePreservesAbortRollbackExtendedCode()
+    {
+        using var handler = new ScriptedPipelineHandler(
+            ErrorResult(
+                "SQLITE_ABORT_ROLLBACK",
+                "transaction rolled back",
+                includeClose: true));
+        using var handlerScope = UseRemoteHandler(handler);
+        using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "UPDATE items SET value = 1";
+
+        var exception = Assert.Throws<SqliteException>(() => command.ExecuteNonQuery());
+
+        exception!.SqliteErrorCode.Should().Be(4);
+        exception.SqliteExtendedErrorCode.Should().Be(516);
+    }
+
+    [Test]
+    public async Task ManagedTransactionOwnsControlSqlAndSavepoints()
+    {
+        using var handler = new ScriptedPipelineHandler(
+            EmptyResult(),
+            EmptyResult(),
+            EmptyResult(),
+            EmptyResult(),
+            EmptyResult(),
+            CloseResult());
+        using var handlerScope = UseRemoteHandler(handler);
+        await using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=False");
+        await connection.OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
+        await using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "COMMIT";
+            await command.Invoking(value => value.ExecuteNonQueryAsync())
+                .Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("*Transaction-control SQL*");
+        }
+
+        await transaction.SaveAsync("save \" one");
+        await transaction.RollbackAsync("save \" one");
+        await transaction.ReleaseAsync("save \" one");
+        await transaction.CommitAsync();
+
+        handler.RequestBodies.Take(5).Select(GetExecuteSql).Should().Equal(
+            "BEGIN IMMEDIATE",
+            "SAVEPOINT \"save \"\" one\";",
+            "ROLLBACK TO SAVEPOINT \"save \"\" one\";",
+            "RELEASE SAVEPOINT \"save \"\" one\";",
+            "COMMIT");
+        GetRequestTypes(handler.RequestBodies[^1]).Should().Equal("close");
+    }
+
+    [Test]
+    public async Task DirectRemoteOpenReaderBlocksWritesAndHonorsCancellation()
+    {
+        using var handler = new ScriptedPipelineHandler(IntegerResult(1), CloseResult());
+        using var handlerScope = UseRemoteHandler(handler);
+        await using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        await connection.OpenAsync();
+        await using var select = connection.CreateCommand();
+        select.CommandText = "SELECT 1";
+        await using var reader = await select.ExecuteReaderAsync();
+        await using var write = connection.CreateCommand();
+        write.CommandText = "UPDATE items SET value = 2";
+        write.CommandTimeout = 30;
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+        var action = async () => await write.ExecuteNonQueryAsync(cancellation.Token);
+
+        await action.Should().ThrowAsync<OperationCanceledException>();
+        handler.RequestBodies.Should().HaveCount(1);
+    }
+
+    [Test]
+    public async Task DirectRemoteOpenReaderBlocksBatchWrites()
+    {
+        using var handler = new ScriptedPipelineHandler(IntegerResult(1), CloseResult());
+        using var handlerScope = UseRemoteHandler(handler);
+        await using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=True");
+        await connection.OpenAsync();
+        await using var select = connection.CreateCommand();
+        select.CommandText = "SELECT 1";
+        await using var reader = await select.ExecuteReaderAsync();
+        await using var batch = (SqliteBatch)connection.CreateBatch();
+        batch.Timeout = 0;
+        batch.BatchCommands.Add(new SqliteBatchCommand("UPDATE items SET value = 2"));
+
+        var action = async () => await batch.ExecuteNonQueryAsync(CancellationToken.None);
+
+        await action.Should().ThrowAsync<SqliteException>()
+            .Where(exception => exception.SqliteErrorCode == 5);
+        handler.RequestBodies.Should().HaveCount(1);
+    }
+
+    [Test]
+    public async Task DirectRemoteBatchFlattensStatementsAndPreservesResults()
+    {
+        using var handler = new ScriptedPipelineHandler(BatchResult());
+        using var handlerScope = UseRemoteHandler(handler);
+        await using var connection = new SqliteConnection(
+            "Data Source=https://example.test;Read Your Writes=False");
+        await connection.OpenAsync();
+        await using var batch = (SqliteBatch)connection.CreateBatch();
+        var insertAndSelect = new SqliteBatchCommand(
+            "INSERT INTO items VALUES ($one); SELECT $two;");
+        insertAndSelect.Parameters.AddWithValue("$one", 1);
+        insertAndSelect.Parameters.AddWithValue("$two", "two");
+        batch.BatchCommands.Add(insertAndSelect);
+        var update = new SqliteBatchCommand("UPDATE items SET value = @value");
+        update.Parameters.AddWithValue("@value", 3);
+        batch.BatchCommands.Add(update);
+
+        await using var reader = await batch.ExecuteReaderAsync();
+
+        (await reader.ReadAsync()).Should().BeFalse();
+        (await reader.NextResultAsync()).Should().BeTrue();
+        (await reader.ReadAsync()).Should().BeTrue();
+        reader.GetString(0).Should().Be("two");
+        (await reader.NextResultAsync()).Should().BeTrue();
+        (await reader.ReadAsync()).Should().BeFalse();
+        (await reader.NextResultAsync()).Should().BeFalse();
+        reader.RecordsAffected.Should().Be(3);
+        insertAndSelect.RecordsAffected.Should().Be(1);
+        update.RecordsAffected.Should().Be(2);
+
+        using var document = JsonDocument.Parse(handler.RequestBodies.Single());
+        var steps = document.RootElement.GetProperty("requests")[0]
+            .GetProperty("batch")
+            .GetProperty("steps");
+        steps.GetArrayLength().Should().Be(3);
+        GetNamedArgumentNames(steps[0].GetProperty("stmt")).Should().Equal("$one");
+        GetNamedArgumentNames(steps[1].GetProperty("stmt")).Should().Equal("$two");
+        GetNamedArgumentNames(steps[2].GetProperty("stmt")).Should().Equal("@value");
+    }
+
+    [Test]
+    public async Task DirectRemoteBatchReaderBlocksCommandWrites()
+    {
+        using var handler = new ScriptedPipelineHandler(BatchResult());
+        using var handlerScope = UseRemoteHandler(handler);
+        await using var connection = new SqliteConnection("Data Source=https://example.test");
+        await connection.OpenAsync();
+        await using var batch = (SqliteBatch)connection.CreateBatch();
+        batch.BatchCommands.Add(new SqliteBatchCommand(
+            "INSERT INTO items VALUES (1); SELECT value FROM items"));
+        batch.BatchCommands.Add(new SqliteBatchCommand("UPDATE items SET value = 2"));
+        await using var reader = await batch.ExecuteReaderAsync();
+        await using var write = connection.CreateCommand();
+        write.CommandText = "DELETE FROM items";
+        write.CommandTimeout = 0;
+
+        var action = async () => await write.ExecuteNonQueryAsync();
+
+        await action.Should().ThrowAsync<SqliteException>()
+            .Where(exception => exception.SqliteErrorCode == 5);
+        handler.RequestBodies.Should().HaveCount(1);
+    }
+
+    [Test]
+    public async Task DeferredBootstrapReplicaUsesManagedCommandsTransactionsAndBatch()
+    {
+        var directory = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            "sqlite-managed-replica-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var replicaPath = Path.Combine(directory, "replica.db");
+            var builder = new SqliteConnectionStringBuilder
+            {
+                DataSource = "https://example.test",
+                ReplicaPath = replicaPath,
+                BootstrapIfEmpty = false,
+                Pooling = false,
+            };
+            await using var connection = new SqliteConnection(builder.ConnectionString);
+            await connection.OpenAsync();
+            connection.CreateFunction<int, int>("double_value", value => value * 2);
+            using (var function = connection.CreateCommand())
+            {
+                function.CommandText = "SELECT double_value(2)";
+                function.ExecuteScalar().Should().Be(4L);
+            }
+            await using (var setup = connection.CreateCommand())
+            {
+                setup.CommandText = """
+                    CREATE TABLE items(value INTEGER);
+                    INSERT INTO items VALUES ($first);
+                    SELECT value FROM items;
+                    """;
+                setup.Parameters.AddWithValue("$first", 1);
+                await using var reader = await setup.ExecuteReaderAsync();
+                (await reader.ReadAsync()).Should().BeTrue();
+                reader.GetInt64(0).Should().Be(1);
+                reader.RecordsAffected.Should().Be(1);
+            }
+
+            await using (var transaction = (SqliteTransaction)await connection.BeginTransactionAsync())
+            {
+                await using var insert = connection.CreateCommand();
+                insert.Transaction = transaction;
+                insert.CommandText = "INSERT INTO items VALUES (2)";
+                (await insert.ExecuteNonQueryAsync()).Should().Be(1);
+                await transaction.SaveAsync("before-three");
+                insert.CommandText = "INSERT INTO items VALUES (3)";
+                (await insert.ExecuteNonQueryAsync()).Should().Be(1);
+                await transaction.RollbackAsync("before-three");
+                await transaction.ReleaseAsync("before-three");
+                await transaction.CommitAsync();
+            }
+
+            await using (var transaction = (SqliteTransaction)await connection.BeginTransactionAsync())
+            {
+                await using var insert = connection.CreateCommand();
+                insert.Transaction = transaction;
+                insert.CommandText = "INSERT INTO items VALUES (99)";
+                (await insert.ExecuteNonQueryAsync()).Should().Be(1);
+                await transaction.RollbackAsync();
+            }
+
+            await using var batch = (SqliteBatch)connection.CreateBatch();
+            batch.BatchCommands.Add(new SqliteBatchCommand("INSERT INTO items VALUES (4)"));
+            batch.BatchCommands.Add(new SqliteBatchCommand("SELECT SUM(value) FROM items"));
+            await using var batchReader = await batch.ExecuteReaderAsync();
+            (await batchReader.ReadAsync()).Should().BeFalse();
+            (await batchReader.NextResultAsync()).Should().BeTrue();
+            (await batchReader.ReadAsync()).Should().BeTrue();
+            batchReader.GetInt64(0).Should().Be(7);
+            batchReader.RecordsAffected.Should().Be(1);
+            await batchReader.DisposeAsync();
+
+            await using var scalarBatch = (SqliteBatch)connection.CreateBatch();
+            scalarBatch.BatchCommands.Add(new SqliteBatchCommand("INSERT INTO items VALUES (5)"));
+            scalarBatch.BatchCommands.Add(new SqliteBatchCommand("SELECT MAX(value) FROM items"));
+            (await scalarBatch.ExecuteScalarAsync(CancellationToken.None)).Should().Be(5L);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static IDisposable UseRemoteHandler(HttpMessageHandler handler)
+    {
+        TursoConnection.RemoteMessageHandlerFactory = () => handler;
+        return new Scope(() => TursoConnection.RemoteMessageHandlerFactory = null);
+    }
+
+    private static JsonElement GetExecuteStatement(string requestBody)
+    {
+        using var document = JsonDocument.Parse(requestBody);
+        return document.RootElement.GetProperty("requests")[0].GetProperty("stmt").Clone();
+    }
+
+    private static string GetExecuteSql(string requestBody)
+        => GetExecuteStatement(requestBody).GetProperty("sql").GetString()!;
+
+    private static string? GetRequestBaton(string requestBody)
+    {
+        using var document = JsonDocument.Parse(requestBody);
+        return document.RootElement.GetProperty("baton").GetString();
+    }
+
+    private static string[] GetRequestTypes(string requestBody)
+    {
+        using var document = JsonDocument.Parse(requestBody);
+        return document.RootElement.GetProperty("requests")
+            .EnumerateArray()
+            .Select(request => request.GetProperty("type").GetString()!)
+            .ToArray();
+    }
+
+    private static string[] GetNamedArgumentNames(JsonElement statement)
+        => statement.GetProperty("named_args")
+            .EnumerateArray()
+            .Select(argument => argument.GetProperty("name").GetString()!)
+            .ToArray();
+
+    private static string IntegerResult(long value)
+        => ExecuteResult(
+            $$"""
+            {
+              "cols": [{ "name": "value", "decltype": "INTEGER" }],
+              "rows": [[{ "type": "integer", "value": "{{value}}" }]],
+              "affected_row_count": 0,
+              "last_insert_rowid": null
+            }
+            """);
+
+    private static string EmptyResult(int affectedRows = 0)
+        => ExecuteResult(
+            $$"""
+            {
+              "cols": [],
+              "rows": [],
+              "affected_row_count": {{affectedRows}},
+              "last_insert_rowid": null
+            }
+            """);
+
+    private static string ExecuteResult(
+        string statementResult,
+        bool includeClose = false)
+    {
+        var closeResult = includeClose
+            ? """
+              ,
+              {
+                "type": "ok",
+                "response": { "type": "close" }
+              }
+              """
+            : string.Empty;
+        return $$"""
+                 {
+                   "baton": "session",
+                   "results": [
+                     {
+                       "type": "ok",
+                       "response": {
+                         "type": "execute",
+                         "result": {{statementResult}}
+                       }
+                     }{{closeResult}}
+                   ]
+                 }
+                 """;
+    }
+
+    private static string ErrorResult(
+        string code,
+        string message,
+        bool includeClose)
+    {
+        var closeResult = includeClose
+            ? """
+              ,
+              {
+                "type": "ok",
+                "response": { "type": "close" }
+              }
+              """
+            : string.Empty;
+        return $$"""
+                 {
+                   "results": [
+                     {
+                       "type": "error",
+                       "error": { "message": "{{message}}", "code": "{{code}}" }
+                     }{{closeResult}}
+                   ]
+                 }
+                 """;
+    }
+
+    private static string CloseResult()
+        => """
+           {
+             "results": [
+               {
+                 "type": "ok",
+                 "response": { "type": "close" }
+               }
+             ]
+           }
+           """;
+
+    private static string BatchResult()
+        => """
+           {
+             "results": [
+               {
+                 "type": "ok",
+                 "response": {
+                   "type": "batch",
+                   "result": {
+                     "step_results": [
+                       {
+                         "cols": [],
+                         "rows": [],
+                         "affected_row_count": 1,
+                         "last_insert_rowid": "1"
+                       },
+                       {
+                         "cols": [{ "name": "value", "decltype": "TEXT" }],
+                         "rows": [[{ "type": "text", "value": "two" }]],
+                         "affected_row_count": 0,
+                         "last_insert_rowid": null
+                       },
+                       {
+                         "cols": [],
+                         "rows": [],
+                         "affected_row_count": 2,
+                         "last_insert_rowid": null
+                       }
+                     ],
+                     "step_errors": [null, null, null]
+                   }
+                 }
+               },
+               {
+                 "type": "ok",
+                 "response": { "type": "close" }
+               }
+             ]
+           }
+           """;
+
+    private sealed class ScriptedPipelineHandler(params string[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<string> _responses = new(responses);
+
+        public List<string> RequestBodies { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestBodies.Add(
+                await request.Content!.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+            if (_responses.Count == 0)
+                throw new InvalidOperationException("No scripted pipeline response remains.");
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    _responses.Dequeue(),
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        }
+    }
+
+    private sealed class Scope(Action dispose) : IDisposable
+    {
+        public void Dispose()
+        {
+            dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This continues the focused .NET extraction from the closed source draft #8504 after #8514, #8519, #8523, #8530, #8555, #8557, #8609, and #8621.

- preserve the existing native local path while recognizing direct remote and embedded-replica connection strings in `Turso.Data.Sqlite`
- route remote and replica commands, readers, parameters, transactions, savepoints, and public `SqliteBatch` APIs through the merged `Turso.Data` backend
- parse multi-statement SQL across quotes, comments, trigger bodies, and statement-local parameters
- preserve SQLite-compatible records-affected, schema/type, `NextResult`, timeout/cancellation, read-only, active-reader locking, and error behavior
- reject client-only helpers on direct remote connections while registering supported callbacks against replica-local handles
- document facade migration and remote/replica connection strings

The only internal bridge is a narrow `InternalsVisibleTo("Turso.Data.Sqlite")` entry. It is required for replica callback registration against the managed connection's local native handle and sync-operation gate; direct remote execution otherwise uses public `Turso.Data` command and batch APIs.

## Deferred

The `Turso.EntityFrameworkCore.Sqlite` provider, EF migrations/database creator/options behavior, generated keys, package-consumer and NativeAOT/mobile samples, CI packaging jobs, and all Rust changes remain deferred to later ordinary PRs.

## Validation

- `dotnet format bindings/dotnet/Turso.slnx --no-restore --verify-no-changes` for the changed projects/files
- `dotnet build bindings/dotnet/Turso.slnx -c Debug --no-restore --nologo` (`net8.0`, `net9.0`, `net10.0`)
- focused facade tests: 92 passed
- full .NET suite: 250 passed, 1 existing skipped test
- live Cloud smoke test through `Turso.Data.Sqlite`: direct remote transaction/write plus embedded-replica sync/read passed