### PR TITLE
core/btree: parse cells once per row and share across rowid and record reads

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -19,7 +19,7 @@ use crate::{
     io_yield_one,
     schema::{BTreeTable, Index},
     storage::{
-        pager::{BtreePageAllocMode, Pager},
+        pager::{BtreePageAllocMode, Pager, ParsedCell},
         sqlite3_ondisk::{
             payload_overflows, read_u32, read_varint, write_varint, BTreeCell, DatabaseHeader,
             PageContent, PageSize, PageType, TableInteriorCell, CELL_PTR_SIZE_BYTES,
@@ -798,6 +798,15 @@ pub struct BTreeCursor {
     stack: PageStack,
     /// Reusable immutable record, used to allow better allocation strategy.
     reusable_immutable_record: Option<ImmutableRecord>,
+    /// Cell metadata parsed at most once per cursor position and shared by
+    /// `rowid()` and `record()`. Cleared by
+    /// `invalidate_record()` whenever the cursor moves, alongside the record
+    /// cache above. Mirrors SQLite's cached cell info (btree.c getCellInfo).
+    /// Holding the page-backed payload slice is sound for the same reason
+    /// using it within one opcode is: the page stack pins the page while the
+    /// cursor is positioned on it, and every path that moves the cursor or
+    /// marks it for restore invalidates this cache before the next read.
+    cached_cell: Option<ParsedCell>,
     /// Information about the index key structure (sort order, collation, etc)
     pub index_info: Option<Arc<IndexInfo>>,
     /// Maintain count of the number of records in the btree. Used for the `Count` opcode
@@ -1096,6 +1105,7 @@ impl BTreeCursor {
                 stack: [const { None }; BTCURSOR_MAX_DEPTH + 1],
             },
             reusable_immutable_record: None,
+            cached_cell: None,
             index_info: None,
             count: 0,
             context: None,
@@ -2211,11 +2221,13 @@ impl BTreeCursor {
         let cur_cell_idx = (min + max) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
         self.stack.set_cell_index(cur_cell_idx as i32);
 
-        let (payload, payload_size, first_overflow_page) = self
+        let cell = self
             .stack
             .get_page_contents_at_level(old_top_idx)
             .unwrap()
             .cell_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
+        let (payload, payload_size, first_overflow_page) =
+            (cell.payload, cell.payload_size, cell.first_overflow_page);
 
         if let Some(next_page) = first_overflow_page {
             let res = self.process_overflow_read(payload, next_page, payload_size)?;
@@ -2648,11 +2660,13 @@ impl BTreeCursor {
         let cur_cell_idx = (min + max) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
         self.stack.set_cell_index(cur_cell_idx as i32);
 
-        let (payload, payload_size, first_overflow_page) = self
+        let cell = self
             .stack
             .get_page_contents_at_level(old_top_idx)
             .unwrap()
             .cell_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
+        let (payload, payload_size, first_overflow_page) =
+            (cell.payload, cell.payload_size, cell.first_overflow_page);
 
         if let Some(next_page) = first_overflow_page {
             let res = self.process_overflow_read(payload, next_page, payload_size)?;
@@ -6040,6 +6054,23 @@ impl BTreeCursor {
         self.reusable_immutable_record.as_ref()
     }
 
+    /// Parses the cell the cursor is positioned on, at most once per
+    /// position (SQLite's getCellInfo). Callers must have handled
+    /// `needs_restore()` and checked `has_record()` first.
+    fn parsed_cell(&mut self) -> Result<ParsedCell> {
+        if let Some(cell) = self.cached_cell {
+            return Ok(cell);
+        }
+        let cell = {
+            let page = self.stack.top_ref();
+            let contents = page.get_contents();
+            let cell_idx = self.stack.current_cell_index();
+            contents.cell_read_payload_ptr(cell_idx as usize, self.usable_space())?
+        };
+        self.cached_cell = Some(cell);
+        Ok(cell)
+    }
+
     pub fn is_write_in_progress(&self) -> bool {
         matches!(self.state, CursorState::Write(_))
     }
@@ -6418,17 +6449,17 @@ impl CursorTrait for BTreeCursor {
             return Ok(IOResult::Done(None));
         }
         if self.has_record() {
-            let page = self.stack.top_ref();
-            let contents = page.get_contents();
-            let page_type = contents.page_type()?;
-            if page_type.is_table() {
-                let cell_idx = self.stack.current_cell_index();
-                let rowid = contents.cell_table_leaf_read_rowid(cell_idx as usize)?;
-                Ok(IOResult::Done(Some(rowid)))
-            } else {
-                let _ = return_if_io!(self.record());
-                Ok(IOResult::Done(self.get_index_rowid_from_record()))
+            if let Some(rowid) = self.parsed_cell()?.rowid {
+                return Ok(IOResult::Done(Some(rowid)));
             }
+            // Index cell: the rowid lives inside the record. Cache it in the
+            // parsed cell so repeated reads skip the record walk.
+            let _ = return_if_io!(self.record());
+            let rowid = self.get_index_rowid_from_record();
+            if let Some(cell) = self.cached_cell.as_mut() {
+                cell.rowid = rowid;
+            }
+            Ok(IOResult::Done(rowid))
         } else {
             Ok(IOResult::Done(None))
         }
@@ -6488,12 +6519,9 @@ impl CursorTrait for BTreeCursor {
             return Ok(IOResult::Done(self.reusable_immutable_record.as_ref()));
         }
 
-        let page = self.stack.top_ref();
-        let contents = page.get_contents();
-        let cell_idx = self.stack.current_cell_index();
-        let (payload, payload_size, first_overflow_page) =
-            contents.cell_read_payload_ptr(cell_idx as usize, self.usable_space())?;
-        if let Some(next_page) = first_overflow_page {
+        let cell = self.parsed_cell()?;
+        let (payload, payload_size) = (cell.payload, cell.payload_size);
+        if let Some(next_page) = cell.first_overflow_page {
             return_if_io!(self.process_overflow_read(payload, next_page, payload_size))
         } else {
             self.get_immutable_record_or_create()?
@@ -6518,6 +6546,7 @@ impl CursorTrait for BTreeCursor {
         // saveAllCursors at the head of sqlite3BtreeInsert (btree.c:9348).
         return_if_io!(self.drive_pending_peer_save(key.maybe_rowid()));
         return_if_io!(self.insert_into_page(key));
+        self.cached_cell = None;
         self.invalidate_count_cache();
         if key.maybe_rowid().is_some() {
             self.set_has_record(true);
@@ -6545,6 +6574,7 @@ impl CursorTrait for BTreeCursor {
             // blob cursors whether the deletion hits their pinned row.
             let deleted_rowid = self.current_table_leaf_rowid();
             return_if_io!(self.drive_pending_peer_save(deleted_rowid));
+            self.cached_cell = None;
             self.invalidate_count_cache();
             self.state = CursorState::Delete(DeleteState::Start);
         }
@@ -7178,6 +7208,7 @@ impl CursorTrait for BTreeCursor {
 
     #[inline]
     fn invalidate_record(&mut self) {
+        self.cached_cell = None;
         if let Some(record) = self.reusable_immutable_record.as_mut() {
             record.invalidate();
         }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -109,6 +109,22 @@ impl HeaderRefMut {
     }
 }
 
+/// Everything one parse of a b-tree cell yields: the record payload location
+/// plus, for table-leaf cells, the rowid. Mirrors SQLite's `btreeParseCell`
+/// into `BtCursor.info`, so one parse per row serves both `RowId` and
+/// `Column` opcodes.
+#[derive(Clone, Copy)]
+pub struct ParsedCell {
+    /// Record payload bytes local to the page. Valid as long as the page is
+    /// alive and unmodified.
+    pub payload: &'static [u8],
+    /// Total record payload size, including any overflow-page part.
+    pub payload_size: u64,
+    pub first_overflow_page: Option<u32>,
+    /// Rowid, for table-leaf cells only.
+    pub rowid: Option<i64>,
+}
+
 pub struct PageInner {
     pub flags: AtomicUsize,
     pub id: usize,
@@ -450,20 +466,19 @@ impl PageInner {
     /// This bypasses the full `cell_get()` to `read_btree_cell()` path for
     /// record reads and index binary-search hot loops.
     /// The returned slice is valid as long as the page is alive.
-    ///
-    /// Returns: (payload_slice, payload_size, first_overflow_page)
     #[inline(always)]
     pub fn cell_read_payload_ptr(
         &self,
         idx: usize,
         usable_size: usize,
-    ) -> crate::Result<(&'static [u8], u64, Option<u32>)> {
+    ) -> crate::Result<ParsedCell> {
         let buf = self.as_ptr();
         let cell_pointer_array_start = self.header_size();
         let cell_pointer = cell_pointer_array_start + (idx * CELL_PTR_SIZE_BYTES);
         let cell_offset = self.read_u16(cell_pointer) as usize;
 
         let page_type = self.page_type()?;
+        let mut rowid = None;
         let (payload_size, payload_start) = match page_type {
             PageType::IndexInterior => {
                 let (size, len) =
@@ -479,8 +494,9 @@ impl PageInner {
                 let (size, payload_size_len) =
                     read_varint(crate::slice_in_bounds_or_corrupt!(buf, cell_offset..))?;
                 let rowid_start = cell_offset + payload_size_len;
-                let (_, rowid_len) =
+                let (rowid_value, rowid_len) =
                     read_varint(crate::slice_in_bounds_or_corrupt!(buf, rowid_start..))?;
+                rowid = Some(rowid_value as i64);
                 (size, rowid_start + rowid_len)
             }
             PageType::TableInterior => {
@@ -540,7 +556,12 @@ impl PageInner {
             (slice, None)
         };
 
-        Ok((payload_slice, payload_size, first_overflow))
+        Ok(ParsedCell {
+            payload: payload_slice,
+            payload_size,
+            first_overflow_page: first_overflow,
+            rowid,
+        })
     }
 
     #[inline]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2081,8 +2081,7 @@ fn op_column_fetch(
                     return Ok(InsnFunctionStepResult::Step);
                 }
 
-                let record_result = return_if_io!(cursor.record());
-                let Some(record) = record_result else {
+                let Some(record) = return_if_io!(cursor.record()) else {
                     // Cursor is not positioned on a valid row (e.g., empty table).
                     // Return NULL, not the column's default value.
                     // DEFAULT handling below is for when record exists
@@ -2242,8 +2241,7 @@ fn op_column_range_fetch(
                     return Ok(InsnFunctionStepResult::Step);
                 }
 
-                let record_result = return_if_io!(cursor.record());
-                let Some(record) = record_result else {
+                let Some(record) = return_if_io!(cursor.record()) else {
                     for reg in &mut state.registers[dest..dest + count] {
                         reg.set_null();
                     }
@@ -5847,6 +5845,16 @@ pub fn op_row_id(
     _pager: &Arc<Pager>,
 ) -> InsnResult {
     load_insn!(RowId { cursor_id, dest }, insn);
+    // Fast path: no deferred seek pending and no suspended state machine, so
+    // the op-state slot (enum write + drop per transition) is bypassed
+    // entirely. On IO resume the slot is still idle and this path re-executes.
+    if state.active_op_state.is_idle() && state.deferred_seeks[*cursor_id].is_none() {
+        let result = read_rowid_into_register(state, *cursor_id, *dest)?;
+        if matches!(result, InsnFunctionStepResult::Step) {
+            state.pc += 1;
+        }
+        return Ok(result);
+    }
     loop {
         match *state.active_op_state.row_id() {
             OpRowIdState::Start => {
@@ -5904,60 +5912,9 @@ pub fn op_row_id(
                 *state.active_op_state.row_id() = OpRowIdState::GetRowid;
             }
             OpRowIdState::GetRowid => {
-                let cursors = &mut state.cursors;
-                if let Some(Cursor::NullRow) = cursors
-                    .get_mut(*cursor_id)
-                    .expect("cursor_id should be valid")
-                {
-                    state.registers[*dest].set_null();
-                } else if let Some(Cursor::BTree(btree_cursor)) = cursors
-                    .get_mut(*cursor_id)
-                    .expect("cursor_id should be valid")
-                {
-                    if btree_cursor.get_null_flag() {
-                        state.registers[*dest].set_null();
-                        break;
-                    }
-                    if let Some(ref rowid) = return_if_io!(btree_cursor.rowid()) {
-                        state.registers[*dest].set_int(*rowid);
-                    } else {
-                        state.registers[*dest].set_null();
-                    }
-                } else if let Some(Cursor::Virtual(virtual_cursor)) = cursors
-                    .get_mut(*cursor_id)
-                    .expect("cursor_id should be valid")
-                {
-                    let rowid = virtual_cursor.rowid();
-                    if rowid != 0 {
-                        state.registers[*dest].set_int(rowid);
-                    } else {
-                        state.registers[*dest].set_null();
-                    }
-                } else if let Some(Cursor::MaterializedView(mv_cursor)) = cursors
-                    .get_mut(*cursor_id)
-                    .expect("cursor_id should be valid")
-                {
-                    if let Some(rowid) = return_if_io!(mv_cursor.rowid()) {
-                        state.registers[*dest].set_int(rowid);
-                    } else {
-                        state.registers[*dest].set_null();
-                    }
-                } else if let Some(Cursor::IndexMethod(cursor)) = cursors
-                    .get_mut(*cursor_id)
-                    .expect("cursor_id should be valid")
-                {
-                    if let Some(rowid) = return_if_io!(cursor.query_rowid()) {
-                        state.registers[*dest].set_int(rowid);
-                    } else {
-                        state.registers[*dest].set_null();
-                    }
-                } else {
-                    mark_unlikely();
-                    return Err(LimboError::InternalError(
-                        "RowId: cursor is not a table, virtual, or materialized view cursor"
-                            .to_string(),
-                    )
-                    .into());
+                let result = read_rowid_into_register(state, *cursor_id, *dest)?;
+                if !matches!(result, InsnFunctionStepResult::Step) {
+                    return Ok(result);
                 }
                 break;
             }
@@ -5966,6 +5923,67 @@ pub fn op_row_id(
 
     state.active_op_state.clear();
     state.pc += 1;
+    Ok(InsnFunctionStepResult::Step)
+}
+
+/// Writes the rowid of the row `cursor_id` is positioned on into register
+/// `dest` (NULL when there is no row). Shared by op_row_id's fast path and
+/// its resumable state machine.
+fn read_rowid_into_register(state: &mut ProgramState, cursor_id: usize, dest: usize) -> InsnResult {
+    let cursors = &mut state.cursors;
+    if let Some(Cursor::NullRow) = cursors
+        .get_mut(cursor_id)
+        .expect("cursor_id should be valid")
+    {
+        state.registers[dest].set_null();
+    } else if let Some(Cursor::BTree(btree_cursor)) = cursors
+        .get_mut(cursor_id)
+        .expect("cursor_id should be valid")
+    {
+        if btree_cursor.get_null_flag() {
+            state.registers[dest].set_null();
+            return Ok(InsnFunctionStepResult::Step);
+        }
+        if let Some(ref rowid) = return_if_io!(btree_cursor.rowid()) {
+            state.registers[dest].set_int(*rowid);
+        } else {
+            state.registers[dest].set_null();
+        }
+    } else if let Some(Cursor::Virtual(virtual_cursor)) = cursors
+        .get_mut(cursor_id)
+        .expect("cursor_id should be valid")
+    {
+        let rowid = virtual_cursor.rowid();
+        if rowid != 0 {
+            state.registers[dest].set_int(rowid);
+        } else {
+            state.registers[dest].set_null();
+        }
+    } else if let Some(Cursor::MaterializedView(mv_cursor)) = cursors
+        .get_mut(cursor_id)
+        .expect("cursor_id should be valid")
+    {
+        if let Some(rowid) = return_if_io!(mv_cursor.rowid()) {
+            state.registers[dest].set_int(rowid);
+        } else {
+            state.registers[dest].set_null();
+        }
+    } else if let Some(Cursor::IndexMethod(cursor)) = cursors
+        .get_mut(cursor_id)
+        .expect("cursor_id should be valid")
+    {
+        if let Some(rowid) = return_if_io!(cursor.query_rowid()) {
+            state.registers[dest].set_int(rowid);
+        } else {
+            state.registers[dest].set_null();
+        }
+    } else {
+        mark_unlikely();
+        return Err(LimboError::InternalError(
+            "RowId: cursor is not a table, virtual, or materialized view cursor".to_string(),
+        )
+        .into());
+    }
     Ok(InsnFunctionStepResult::Step)
 }
 


### PR DESCRIPTION
A positioned cell was being walked twice per row: `cell_read_payload_ptr` found the record payload but threw away the rowid varint it had already read, and `rowid()` re-read the cell pointer and both varints on its own. `cell_read_payload_ptr` now returns a `ParsedCell` (payload slice + size + overflow + table-leaf rowid) that the cursor caches for the current position, shared by `rowid()`, `record()`, and `record_payload()`. Invalidation rides the existing record-cache points plus insert/delete. This mirrors SQLite's `getCellInfo` pattern, where OP_Rowid and OP_Column both reuse `BtCursor.info`.

Also gives `op_row_id` the same idle-slot fast path `op_column_impl` already has, bypassing the ActiveOpState big-enum transitions when no deferred seek or suspended state machine is pending.

## Measurement

Interleaved binary protocol: bench binaries built from clean main and from this commit, then run alternately (main, port, main, port, ...) for 7 rounds of `scan_loop_benchmark`, comparing median of medians. This avoids the baseline drift that criterion saved baselines exhibit when captured hours apart.

- `select_star_100k`: **-4.3%** (7.98 ms -> 7.64 ms), ported binary faster in 6 of 7 adjacent pairs
- `select_one_100k`: unchanged within noise (adjacent pairs flip sign), as expected — it exercises no per-row column/rowid work

## Tests

- `cargo test -p turso_core btree` (109 passed) and `cargo test -p turso_core vdbe` (271 passed)
- sqltest conformance suite: 1589 passed, 341 skipped
- `cargo fmt --check` and `cargo clippy --all-features --all-targets -- --deny=warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)