### PR TITLE
core/functions: fix datetime rounding

### DIFF
--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -928,12 +928,11 @@ where
     match func_type {
         "julianday" => Value::from_f64(p.i_jd as f64 / 86400000.0),
         "unixepoch" => {
-            let unix = (p.i_jd - 210866760000000) / 1000;
+            let unix = (p.i_jd - 210866760000000) as f64 / 1000.0;
             if p.use_subsec {
-                let ms = (p.i_jd - 210866760000000) as f64 / 1000.0;
-                Value::from_f64(ms)
+                Value::from_f64(unix)
             } else {
-                Value::from_i64(unix)
+                Value::from_i64(unix.floor() as i64)
             }
         }
         _ => {
@@ -1379,10 +1378,11 @@ where
             Some('P') => write!(res, "{}", if p.h >= 12 { "pm" } else { "am" }).unwrap(),
             Some('R') => write!(res, "{:02}:{:02}", p.h, p.min).unwrap(),
             Some('s') => {
+                let s = (p.i_jd - 210866760000000) as f64 / 1000.0;
                 if p.use_subsec {
-                    write!(res, "{:.3}", (p.i_jd - 210866760000000) as f64 / 1000.0).unwrap();
+                    write!(res, "{s:.3}").unwrap();
                 } else {
-                    write!(res, "{}", (p.i_jd - 210866760000000) / 1000).unwrap();
+                    write!(res, "{}", s.floor()).unwrap();
                 }
             }
             Some('S') => write!(res, "{:02}", p.s as i32).unwrap(),

--- a/sqlite/conformance/sqlite-sqltests/scalar-functions-datetime.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/scalar-functions-datetime.sqltest
@@ -29,6 +29,13 @@ expect {
     2023-05-18
 }
 
+test date-unixepoch-at-1-millisecond-before-epochtime {
+    SELECT date(unixepoch('1969-12-31T23:59:59.999Z'), 'unixepoch');
+}
+expect {
+    1969-12-31
+}
+
 test date-with-milliseconds {
     SELECT date('2023-05-18 15:30:45.123');
 }
@@ -634,6 +641,13 @@ expect {
 
 test unixepoch-at-1-second-before-epochtime {
     SELECT unixepoch('1969-12-31 23:59:59');
+}
+expect {
+    -1
+}
+
+test unixepoch-at-1-millisecond-before-epochtime {
+    SELECT unixepoch('1969-12-31 23:59:59.999');
 }
 expect {
     -1
@@ -1554,6 +1568,13 @@ test strftime-seconds-since-epoch {
 }
 expect {
     1737638070
+}
+
+test strftime-at-1-millisecond-before-epochtime {
+    SELECT strftime('%s', '1969-12-31T23:59:59.999');
+}
+expect {
+    -1
 }
 
 test strftime-with-subsec {


### PR DESCRIPTION
Since integer division is truncating, and the integer value is always rounded to 0, rounded the value down.
Closes #8549.