### PR TITLE
core: speed up whole-table deletes

### DIFF
--- a/core/benches/write_perf_benchmark.rs
+++ b/core/benches/write_perf_benchmark.rs
@@ -610,8 +610,8 @@ fn bench_delete_performance(criterion: &mut Criterion) {
          CREATE INDEX clear_target_data ON clear_target(data); \
          CREATE INDEX clear_target_bucket ON clear_target(bucket)";
     let seed_source = format!(
-        "WITH RECURSIVE c(x) AS (VALUES(0) UNION ALL SELECT x + 1 FROM c WHERE x < {}) \
-         INSERT INTO source SELECT x, printf('data_%d', x), x % 1000 FROM c",
+        "INSERT INTO source \
+         SELECT value, printf('data_%d', value), value % 1000 FROM generate_series(0, {})",
         DELETE_ALL_ROWS - 1
     );
 
@@ -658,6 +658,7 @@ fn bench_delete_performance(criterion: &mut Criterion) {
         sqlite_conn
             .pragma_update(None, "synchronous", "OFF")
             .unwrap();
+        rusqlite::vtab::series::load_module(&sqlite_conn).unwrap();
         sqlite_conn.execute(&seed_source, []).unwrap();
 
         group.bench_function(BenchmarkId::new("sqlite", "delete_all_three_btrees"), |b| {

--- a/core/benches/write_perf_benchmark.rs
+++ b/core/benches/write_perf_benchmark.rs
@@ -603,6 +603,80 @@ fn bench_delete_performance(criterion: &mut Criterion) {
         });
     }
 
+    const DELETE_ALL_ROWS: usize = 50_000;
+    const DELETE_ALL_SCHEMA: &str =
+        "CREATE TABLE source (id INTEGER PRIMARY KEY, data TEXT, bucket INTEGER); \
+         CREATE TABLE clear_target (id INTEGER PRIMARY KEY, data TEXT, bucket INTEGER); \
+         CREATE INDEX clear_target_data ON clear_target(data); \
+         CREATE INDEX clear_target_bucket ON clear_target(bucket)";
+    let seed_source = format!(
+        "WITH RECURSIVE c(x) AS (VALUES(0) UNION ALL SELECT x + 1 FROM c WHERE x < {}) \
+         INSERT INTO source SELECT x, printf('data_%d', x), x % 1000 FROM c",
+        DELETE_ALL_ROWS - 1
+    );
+
+    group.throughput(Throughput::Elements(DELETE_ALL_ROWS as u64));
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db = setup_limbo_with_sync(
+        &temp_dir,
+        "CREATE TABLE source (id INTEGER PRIMARY KEY, data TEXT, bucket INTEGER)",
+        false,
+    );
+    let conn = db.connect().unwrap();
+    conn.execute("CREATE TABLE clear_target (id INTEGER PRIMARY KEY, data TEXT, bucket INTEGER)")
+        .unwrap();
+    conn.execute("CREATE INDEX clear_target_data ON clear_target(data)")
+        .unwrap();
+    conn.execute("CREATE INDEX clear_target_bucket ON clear_target(bucket)")
+        .unwrap();
+    let mut seed = conn.query(&seed_source).unwrap().unwrap();
+    run_to_completion(&mut seed, &db).unwrap();
+    let mut refill = conn
+        .prepare("INSERT INTO clear_target SELECT * FROM source")
+        .unwrap();
+    let mut delete_all = conn.prepare("DELETE FROM clear_target").unwrap();
+
+    group.bench_function(BenchmarkId::new("limbo", "delete_all_three_btrees"), |b| {
+        iter_custom_or_iter!(b, |iters| {
+            let mut total = std::time::Duration::ZERO;
+            for _ in 0..iters {
+                run_to_completion(&mut refill, &db).unwrap();
+                refill.reset().unwrap();
+
+                let start = std::time::Instant::now();
+                run_to_completion(&mut delete_all, &db).unwrap();
+                total += start.elapsed();
+                delete_all.reset().unwrap();
+            }
+            total
+        });
+    });
+
+    if enable_rusqlite {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sqlite_conn = setup_rusqlite(&temp_dir, DELETE_ALL_SCHEMA);
+        sqlite_conn
+            .pragma_update(None, "synchronous", "OFF")
+            .unwrap();
+        sqlite_conn.execute(&seed_source, []).unwrap();
+
+        group.bench_function(BenchmarkId::new("sqlite", "delete_all_three_btrees"), |b| {
+            iter_custom_or_iter!(b, |iters| {
+                let mut total = std::time::Duration::ZERO;
+                for _ in 0..iters {
+                    sqlite_conn
+                        .execute("INSERT INTO clear_target SELECT * FROM source", [])
+                        .unwrap();
+
+                    let start = std::time::Instant::now();
+                    sqlite_conn.execute("DELETE FROM clear_target", []).unwrap();
+                    total += start.elapsed();
+                }
+                total
+            });
+        });
+    }
+
     group.finish();
 }
 

--- a/core/translate/delete.rs
+++ b/core/translate/delete.rs
@@ -195,8 +195,6 @@ pub fn prepare_delete_plan(
     connection: &Arc<crate::Connection>,
     database_id: usize,
 ) -> Result<Plan> {
-    let schema = resolver.schema();
-
     let btree_table_for_triggers = table.btree();
     let table = if let Some(table) = table.virtual_table() {
         Table::Virtual(table)
@@ -205,7 +203,9 @@ pub fn prepare_delete_plan(
     } else {
         crate::bail_parse_error!("Table is neither a virtual table nor a btree table");
     };
-    let indexes = schema.get_indices(table.get_name()).cloned().collect();
+    let indexes = resolver.with_schema(database_id, |schema| {
+        schema.get_indices(table.get_name()).cloned().collect()
+    });
     let joined_tables = vec![JoinedTable {
         op: Operation::default_scan_for(&table),
         table,

--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     vdbe::{
         builder::{CursorKey, CursorType, ProgramBuilder},
-        insn::{Insn, RegisterOrLiteral},
+        insn::{ClearBtreeCount, Insn, RegisterOrLiteral},
     },
     CaptureDataChangesExt, Connection,
 };
@@ -43,6 +43,12 @@ pub fn emit_program_for_delete(
     program: &mut ProgramBuilder,
     mut plan: DeletePlan,
 ) -> Result<()> {
+    if emit_clear_btree_delete(connection, resolver, program, &plan)? {
+        program.result_columns = plan.result_columns;
+        program.table_references.extend(plan.table_references);
+        return Ok(());
+    }
+
     let mut t_ctx = Box::new(TranslateCtx::new(
         program,
         resolver.fork(),
@@ -277,6 +283,113 @@ pub fn emit_program_for_delete(
     program.result_columns = plan.result_columns;
     program.table_references.extend(plan.table_references);
     Ok(())
+}
+
+fn emit_clear_btree_delete(
+    connection: &Arc<Connection>,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+    plan: &DeletePlan,
+) -> Result<bool> {
+    if !plan.where_clause.is_empty()
+        || !plan.result_columns.is_empty()
+        || plan.rowset_plan.is_some()
+        || plan.safety.requires_stable_write_set()
+        || program.capture_data_changes_info().is_some()
+        || plan
+            .indexes
+            .iter()
+            .any(|index| index.index_method.is_some())
+    {
+        return Ok(false);
+    }
+
+    let table_ref = plan
+        .table_references
+        .joined_tables()
+        .first()
+        .expect("DELETE always has one joined table");
+    let Some(table) = table_ref.btree() else {
+        return Ok(false);
+    };
+    if connection.mv_store_for_db(table_ref.database_id).is_some() {
+        return Ok(false);
+    }
+
+    let table_name = table_ref.table.get_name();
+    let has_dependent_views = resolver.with_schema(table_ref.database_id, |schema| {
+        !schema
+            .get_dependent_materialized_views(table_name)
+            .is_empty()
+    });
+    if has_dependent_views {
+        return Ok(false);
+    }
+    if connection.foreign_keys_enabled() {
+        let has_foreign_keys = resolver.with_schema(table_ref.database_id, |schema| {
+            schema.any_resolved_fks_referencing(table_name) || schema.has_child_fks(table_name)
+        });
+        if has_foreign_keys {
+            return Ok(false);
+        }
+    }
+
+    let table_cursor = program.alloc_cursor_id(CursorType::BTreeTable(table.clone()));
+    program.emit_insn(Insn::OpenWrite {
+        cursor_id: table_cursor,
+        root_page: RegisterOrLiteral::Literal(table.root_page),
+        db: table_ref.database_id,
+    });
+    let count_reg = program.alloc_register();
+    program.emit_insn(Insn::Count {
+        cursor_id: table_cursor,
+        target_reg: count_reg,
+        exact: true,
+    });
+
+    let full_index_count = plan
+        .indexes
+        .iter()
+        .filter(|index| index.where_clause.is_none())
+        .count();
+    for index in &plan.indexes {
+        let delete_count = if index.where_clause.is_some() {
+            let index_cursor = program.alloc_cursor_index(None, index)?;
+            program.emit_insn(Insn::OpenWrite {
+                cursor_id: index_cursor,
+                root_page: RegisterOrLiteral::Literal(index.root_page),
+                db: table_ref.database_id,
+            });
+            let index_count_reg = program.alloc_register();
+            program.emit_insn(Insn::Count {
+                cursor_id: index_cursor,
+                target_reg: index_count_reg,
+                exact: false,
+            });
+            Some(ClearBtreeCount {
+                count_reg: index_count_reg,
+                add_to_change_count: false,
+                rows_written_multiplier: 1,
+            })
+        } else {
+            None
+        };
+        program.emit_insn(Insn::ClearBtree {
+            db: table_ref.database_id,
+            root: index.root_page,
+            delete_count,
+        });
+    }
+    program.emit_insn(Insn::ClearBtree {
+        db: table_ref.database_id,
+        root: table.root_page,
+        delete_count: Some(ClearBtreeCount {
+            count_reg,
+            add_to_change_count: true,
+            rows_written_multiplier: full_index_count + 1,
+        }),
+    });
+    Ok(true)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/core/translate/emitter/delete.rs
+++ b/core/translate/emitter/delete.rs
@@ -43,12 +43,21 @@ pub fn emit_program_for_delete(
     program: &mut ProgramBuilder,
     mut plan: DeletePlan,
 ) -> Result<()> {
-    if emit_clear_btree_delete(connection, resolver, program, &plan)? {
-        program.result_columns = plan.result_columns;
-        program.table_references.extend(plan.table_references);
-        return Ok(());
+    if !emit_clear_btree_delete(connection, resolver, program, &plan)? {
+        emit_row_loop_delete(connection, resolver, program, &mut plan)?;
     }
 
+    program.result_columns = plan.result_columns;
+    program.table_references.extend(plan.table_references);
+    Ok(())
+}
+
+fn emit_row_loop_delete(
+    connection: &Arc<Connection>,
+    resolver: &Resolver,
+    program: &mut ProgramBuilder,
+    plan: &mut DeletePlan,
+) -> Result<()> {
     let mut t_ctx = Box::new(TranslateCtx::new(
         program,
         resolver.fork(),
@@ -279,9 +288,6 @@ pub fn emit_program_for_delete(
         program.emit_insn(Insn::FkCheck { deferred: false });
         emit_returning_scan_back(program, buf);
     }
-    // Finalize program
-    program.result_columns = plan.result_columns;
-    program.table_references.extend(plan.table_references);
     Ok(())
 }
 

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -550,6 +550,7 @@ pub(crate) fn emit_refill_index(
             program.emit_insn(Insn::ClearBtree {
                 db: database_id,
                 root,
+                delete_count: None,
             });
         }
         program.emit_insn(Insn::OpenWrite {

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -638,6 +638,130 @@ mod tests {
     }
 
     #[test]
+    fn delete_without_where_clears_table_and_index_btrees() {
+        let io = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT, score INTEGER)")
+            .unwrap();
+        conn.execute("CREATE UNIQUE INDEX items_name ON items(name)")
+            .unwrap();
+        conn.execute("CREATE INDEX items_score ON items(score) WHERE score > 0")
+            .unwrap();
+        conn.execute("INSERT INTO items VALUES(1, 'one', -1), (2, 'two', 0), (3, 'three', 1)")
+            .unwrap();
+
+        let mut statement = conn.prepare("DELETE FROM items").unwrap();
+        let instructions = &statement.get_program().insns;
+        let clears = instructions
+            .iter()
+            .filter_map(|(instruction, _)| match instruction {
+                Insn::ClearBtree { delete_count, .. } => Some(delete_count),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            clears.len(),
+            3,
+            "the table and both indexes must be cleared"
+        );
+        assert!(
+            clears.iter().any(|count| count.is_some_and(|count| {
+                count.add_to_change_count && count.rows_written_multiplier == 2
+            })),
+            "the table clear must count changed rows and table plus full-index writes"
+        );
+        assert!(
+            instructions
+                .iter()
+                .all(|(instruction, _)| !matches!(instruction, Insn::Delete { .. })),
+            "a whole-table delete must not emit the row-at-a-time Delete opcode"
+        );
+
+        statement.run_ignore_rows().unwrap();
+        assert_eq!(statement.n_change(), 3);
+        assert_eq!(
+            statement.metrics().rows_written,
+            7,
+            "metrics must count table, full-index, and partial-index entries"
+        );
+
+        statement.reset().unwrap();
+        statement.reset_metrics();
+        statement.run_ignore_rows().unwrap();
+        assert_eq!(statement.n_change(), 0);
+        assert_eq!(statement.metrics().rows_written, 0);
+
+        statement.reset().unwrap();
+        statement.reset_metrics();
+        conn.execute("INSERT INTO items VALUES(4, 'four', -1), (5, 'five', 1)")
+            .unwrap();
+        statement.run_ignore_rows().unwrap();
+        assert_eq!(statement.n_change(), 2);
+        assert_eq!(
+            statement.metrics().rows_written,
+            5,
+            "reused statements must recount table and index entries"
+        );
+    }
+
+    #[test]
+    fn delete_keeps_row_loop_when_rows_need_individual_processing() {
+        let io = Arc::new(MemoryIO::new());
+        let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+            .unwrap();
+
+        for sql in [
+            "DELETE FROM items WHERE 1",
+            "DELETE FROM items RETURNING id",
+        ] {
+            let statement = conn.prepare(sql).unwrap();
+            assert!(
+                statement
+                    .get_program()
+                    .insns
+                    .iter()
+                    .all(|(instruction, _)| !matches!(instruction, Insn::ClearBtree { .. })),
+                "{sql} must process rows individually"
+            );
+        }
+
+        conn.execute("CREATE TABLE deleted_items(id)").unwrap();
+        conn.execute(
+            "CREATE TRIGGER log_item_delete AFTER DELETE ON items \
+             BEGIN INSERT INTO deleted_items VALUES(old.id); END",
+        )
+        .unwrap();
+        let statement = conn.prepare("DELETE FROM items").unwrap();
+        assert!(
+            statement
+                .get_program()
+                .insns
+                .iter()
+                .all(|(instruction, _)| !matches!(instruction, Insn::ClearBtree { .. })),
+            "DELETE triggers require the row loop"
+        );
+
+        conn.execute("PRAGMA foreign_keys = ON").unwrap();
+        conn.execute("CREATE TABLE parents(id INTEGER PRIMARY KEY)")
+            .unwrap();
+        conn.execute("CREATE TABLE children(parent_id REFERENCES parents(id))")
+            .unwrap();
+        let statement = conn.prepare("DELETE FROM parents").unwrap();
+        assert!(
+            statement
+                .get_program()
+                .insns
+                .iter()
+                .all(|(instruction, _)| !matches!(instruction, Insn::ClearBtree { .. })),
+            "foreign-key actions require the row loop"
+        );
+    }
+
+    #[test]
     fn test_insert_autoincrement_with_malformed_sqlite_sequence_is_corrupt() {
         let io = Arc::new(MemoryIO::new());
         let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13650,7 +13650,14 @@ fn op_clear_btree_inner(
     insn: &Insn,
     pager: &Arc<Pager>,
 ) -> InsnResult {
-    load_insn!(ClearBtree { db, root }, insn);
+    load_insn!(
+        ClearBtree {
+            db,
+            root,
+            delete_count,
+        },
+        insn
+    );
 
     let mv_store = program.connection.mv_store_for_db(*db);
     if mv_store.is_some() {
@@ -13683,6 +13690,23 @@ fn op_clear_btree_inner(
                             btree_cursor.invalidate_btree_cache();
                         }
                     }
+                }
+                if let Some(delete_count) = delete_count {
+                    let count = match state.registers[delete_count.count_reg].get_value() {
+                        Value::Numeric(Numeric::Integer(count)) if *count >= 0 => *count,
+                        value => {
+                            return Err(LimboError::InternalError(format!(
+                                "ClearBtree: expected non-negative delete count, got {value:?}"
+                            ))
+                            .into())
+                        }
+                    };
+                    if delete_count.add_to_change_count {
+                        state.record_statement_changes(count);
+                    }
+                    state.record_rows_written(
+                        (count as u64).saturating_mul(delete_count.rows_written_multiplier as u64),
+                    );
                 }
                 state.active_op_state.clear();
                 state.pc += 1;

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -1791,11 +1791,15 @@ pub fn insn_to_row(
                 0,
                 "".to_string()
             ),
-            Insn::ClearBtree { db, root } => (
+            Insn::ClearBtree {
+                db,
+                root,
+                delete_count,
+            } => (
                 "ClearBtree",
                 *root,
                 *db as i64,
-                0,
+                delete_count.map_or(0, |count| count.count_reg as i64),
                 Value::build_text(""),
                 0,
                 format!("root={root} iDb={db}"),

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -379,6 +379,13 @@ pub struct HashDistinctData {
     pub target_pc: BranchOffset,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct ClearBtreeCount {
+    pub count_reg: usize,
+    pub add_to_change_count: bool,
+    pub rows_written_multiplier: usize,
+}
+
 // There are currently 190 opcodes in sqlite
 #[repr(u8)]
 #[derive(Description, Debug, Clone, EnumDiscriminants)]
@@ -1461,6 +1468,9 @@ pub enum Insn {
     ClearBtree {
         db: usize,
         root: i64,
+        /// Whole-table DELETE uses this optional count for change counters and write metrics.
+        /// REINDEX does not need a count.
+        delete_count: Option<ClearBtreeCount>,
     },
 
     /// Deletes an entire database table or index whose root page in the database file is given by P1.

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1140,8 +1140,12 @@ impl ProgramState {
     }
 
     pub(crate) fn record_statement_change(&self) {
-        self.n_change.fetch_add(1, Ordering::SeqCst);
-        self.n_total_change.fetch_add(1, Ordering::SeqCst);
+        self.record_statement_changes(1);
+    }
+
+    pub(crate) fn record_statement_changes(&self, count: i64) {
+        self.n_change.fetch_add(count, Ordering::SeqCst);
+        self.n_total_change.fetch_add(count, Ordering::SeqCst);
     }
 
     pub(crate) fn record_total_change(&self) {

--- a/sqlite/conformance/sqlite-sqltests/delete.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/delete.sqltest
@@ -113,7 +113,6 @@ expect {
     1|name-1|1
 }
 
-@skip-if mvcc "AUTOINCREMENT is not supported in MVCC mode"
 @cross-check-integrity
 test delete-all-empty-keeps-autoincrement-watermark {
     CREATE TABLE numbered(id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT);

--- a/sqlite/conformance/sqlite-sqltests/delete.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/delete.sqltest
@@ -205,6 +205,148 @@ expect {
 }
 
 @cross-check-integrity
+test delete-all-with-indexes-reports-the-row-count {
+    CREATE TABLE counted(id INTEGER PRIMARY KEY, name TEXT, score INTEGER);
+    CREATE UNIQUE INDEX counted_name ON counted(name);
+    CREATE INDEX counted_positive_score ON counted(score) WHERE score > 0;
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 2000
+    )
+    INSERT INTO counted SELECT x, printf('name-%d', x), x - 1000 FROM c;
+    DELETE FROM counted;
+    SELECT changes(), count(*) FROM counted;
+    DELETE FROM counted;
+    SELECT changes(), count(*) FROM counted;
+    INSERT INTO counted VALUES(7, 'name-7', 7);
+    SELECT id, score FROM counted INDEXED BY counted_name WHERE name = 'name-7';
+    SELECT id, name FROM counted INDEXED BY counted_positive_score WHERE score > 0;
+}
+expect {
+    2000|0
+    0|0
+    7|7
+    7|name-7
+}
+
+@cross-check-integrity
+test delete-all-counts-rows-added-after-pages-were-freed {
+    CREATE TABLE churn(id INTEGER PRIMARY KEY, payload BLOB, tag TEXT);
+    CREATE INDEX churn_tag ON churn(tag);
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 600
+    )
+    INSERT INTO churn SELECT x, zeroblob(400), printf('tag-%d', x % 7) FROM c;
+    DELETE FROM churn WHERE id % 2 = 0;
+    SELECT changes(), count(*) FROM churn;
+    BEGIN;
+    WITH RECURSIVE c(x) AS (
+        VALUES(601)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 640
+    )
+    INSERT INTO churn SELECT x, zeroblob(400), printf('tag-%d', x % 7) FROM c;
+    DELETE FROM churn;
+    SELECT changes(), count(*) FROM churn;
+    COMMIT;
+    INSERT INTO churn VALUES(1, zeroblob(400), 'tag-1');
+    SELECT id, tag FROM churn INDEXED BY churn_tag WHERE tag = 'tag-1';
+}
+expect {
+    300|300
+    340|0
+    1|tag-1
+}
+
+@cross-check-integrity
+test delete-all-with-foreign-keys-off-leaves-child-rows {
+    CREATE TABLE parents(id INTEGER PRIMARY KEY);
+    CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id REFERENCES parents(id) ON DELETE CASCADE);
+    INSERT INTO parents VALUES(1), (2), (3);
+    INSERT INTO children VALUES(10, 1), (20, 2), (30, 3);
+    DELETE FROM parents;
+    SELECT changes(),
+           (SELECT count(*) FROM parents),
+           (SELECT count(*) FROM children);
+}
+expect {
+    3|0|3
+}
+
+@cross-check-integrity
+test delete-all-from-a-child-table-with-foreign-keys-on {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE parents(id INTEGER PRIMARY KEY);
+    CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id REFERENCES parents(id));
+    INSERT INTO parents VALUES(1), (2), (3);
+    INSERT INTO children VALUES(10, 1), (20, 2), (30, 3);
+    DELETE FROM children;
+    SELECT changes(),
+           (SELECT count(*) FROM children),
+           (SELECT count(*) FROM parents);
+    DELETE FROM parents;
+    SELECT changes(), count(*) FROM parents;
+}
+expect {
+    3|0|3
+    3|0
+}
+
+test delete-all-fails-while-child-rows-still-point-at-the-table {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE parents(id INTEGER PRIMARY KEY);
+    CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id REFERENCES parents(id));
+    INSERT INTO parents VALUES(1), (2), (3);
+    INSERT INTO children VALUES(10, 1);
+    DELETE FROM parents;
+}
+expect error {
+    (?i)foreign key constraint failed
+}
+
+@cross-check-integrity
+test delete-all-sees-foreign-keys-turned-on-after-an-earlier-delete {
+    CREATE TABLE parents(id INTEGER PRIMARY KEY);
+    CREATE TABLE children(id INTEGER PRIMARY KEY, parent_id REFERENCES parents(id) ON DELETE CASCADE);
+    DELETE FROM parents;
+    SELECT changes();
+    INSERT INTO parents VALUES(1), (2);
+    INSERT INTO children VALUES(10, 1), (20, 2);
+    PRAGMA foreign_keys = ON;
+    DELETE FROM parents;
+    SELECT changes(),
+           (SELECT count(*) FROM parents),
+           (SELECT count(*) FROM children);
+}
+expect {
+    0
+    2|0|0
+}
+
+@skip-if mvcc "in MVCC mode CREATE INDEX adds one to total_changes()"
+@cross-check-integrity
+test delete-all-inside-a-trigger-does-not-change-what-changes-reports {
+    CREATE TABLE trigger_source(id INTEGER PRIMARY KEY);
+    CREATE TABLE cleared(id INTEGER PRIMARY KEY, value TEXT);
+    CREATE INDEX cleared_value ON cleared(value);
+    CREATE TRIGGER clear_on_insert AFTER INSERT ON trigger_source BEGIN
+        DELETE FROM cleared;
+    END;
+    INSERT INTO cleared VALUES(1, 'a'), (2, 'b'), (3, 'c');
+    INSERT INTO trigger_source VALUES(1);
+    SELECT changes(), total_changes(), (SELECT count(*) FROM cleared);
+    INSERT INTO cleared VALUES(4, 'd');
+    SELECT id, value FROM cleared INDEXED BY cleared_value;
+}
+expect {
+    1|7|0
+    4|d
+}
+
+@cross-check-integrity
 test delete_where_falsy {
     CREATE TABLE resourceful_schurz (diplomatic_kaplan BLOB);
     INSERT INTO resourceful_schurz VALUES (X'696E646570656E64656E745F6A6165636B6C65'), (X'67656E65726F75735F62617262616E65677261'), (X'73757065725F74616E6E656E6261756D'), (X'6D6F76696E675F6E616F756D6F76'), (X'7374756E6E696E675F6B62');

--- a/sqlite/conformance/sqlite-sqltests/delete.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/delete.sqltest
@@ -84,6 +84,126 @@ test delete-all-with-indexes-1 {
 expect {
 }
 
+@skip-if mvcc "page-level whole-table DELETE is disabled in MVCC mode"
+@cross-check-integrity
+test delete-all-clears-every-btree-and-rolls-back {
+    CREATE TABLE clear_me(id INTEGER PRIMARY KEY, name TEXT, score INTEGER);
+    CREATE UNIQUE INDEX clear_me_name ON clear_me(name);
+    CREATE INDEX clear_me_positive_score ON clear_me(score) WHERE score > 0;
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 2000
+    )
+    INSERT INTO clear_me SELECT x, printf('name-%d', x), x - 1000 FROM c;
+    BEGIN;
+    DELETE FROM clear_me;
+    SELECT changes(), total_changes(), count(*) FROM clear_me;
+    ROLLBACK;
+    SELECT total_changes(), count(*), min(id), max(id) FROM clear_me;
+    DELETE FROM clear_me;
+    SELECT changes(), total_changes(), count(*) FROM clear_me;
+    INSERT INTO clear_me VALUES(1, 'name-1', 1);
+    SELECT id, name, score FROM clear_me INDEXED BY clear_me_name;
+}
+expect {
+    2000|4000|0
+    4000|2000|1|2000
+    2000|6000|0
+    1|name-1|1
+}
+
+@skip-if mvcc "AUTOINCREMENT is not supported in MVCC mode"
+@cross-check-integrity
+test delete-all-empty-keeps-autoincrement-watermark {
+    CREATE TABLE numbered(id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT);
+    DELETE FROM numbered;
+    SELECT changes(), total_changes();
+    INSERT INTO numbered(value) VALUES('one'), ('two'), ('three');
+    DELETE FROM numbered;
+    SELECT changes(), total_changes(), count(*) FROM numbered;
+    INSERT INTO numbered(value) VALUES('four');
+    SELECT id, value FROM numbered;
+}
+expect {
+    0|0
+    3|6|0
+    4|four
+}
+
+@cross-check-integrity
+test delete-all-rolls-back-to-nested-savepoint {
+    CREATE TABLE saved(id INTEGER PRIMARY KEY, value TEXT UNIQUE, score INTEGER);
+    CREATE INDEX saved_positive ON saved(score) WHERE score > 0;
+    WITH RECURSIVE c(x) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT x + 1 FROM c WHERE x < 1000
+    )
+    INSERT INTO saved SELECT x, printf('value-%d', x), x - 500 FROM c;
+    SAVEPOINT outer;
+    SAVEPOINT inner;
+    DELETE FROM saved;
+    SELECT changes(), count(*) FROM saved;
+    ROLLBACK TO inner;
+    SELECT count(*), min(id), max(id) FROM saved;
+    SELECT id FROM saved INDEXED BY sqlite_autoindex_saved_1 WHERE value = 'value-777';
+    RELEASE inner;
+    DELETE FROM saved;
+    RELEASE outer;
+    SELECT changes(), count(*) FROM saved;
+    INSERT INTO saved VALUES(1, 'value-1', 1);
+    SELECT id, value, score FROM saved INDEXED BY saved_positive WHERE score > 0;
+}
+expect {
+    1000|0
+    1000|1|1000
+    777
+    1000|0
+    1|value-1|1
+}
+
+@cross-check-integrity
+test delete-all-preserves-trigger-and-foreign-key-effects {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE Parents(id INTEGER PRIMARY KEY);
+    CREATE TABLE children(parent_id REFERENCES PARENTS(id) ON DELETE CASCADE);
+    CREATE TABLE audit(parent_id INTEGER);
+    CREATE TRIGGER audit_parent_delete AFTER DELETE ON parents BEGIN
+        INSERT INTO audit VALUES(old.id);
+    END;
+    INSERT INTO parents VALUES(1), (2), (3);
+    INSERT INTO children VALUES(1), (2), (3);
+    DELETE FROM parents;
+    SELECT changes(),
+           (SELECT count(*) FROM parents),
+           (SELECT count(*) FROM children),
+           (SELECT count(*) FROM audit),
+           (SELECT sum(parent_id) FROM audit);
+}
+expect {
+    3|0|0|3|6
+}
+
+@cross-check-integrity
+test delete-all-clears-temp-table-indexes {
+    CREATE TEMP TABLE temp_items(id INTEGER PRIMARY KEY, value TEXT);
+    CREATE INDEX temp.temp_items_value ON temp_items(value);
+    INSERT INTO temp_items VALUES(1, 'one'), (2, 'two'), (3, 'three');
+    DELETE FROM temp_items WHERE id = 2;
+    SELECT id, value FROM temp_items INDEXED BY temp_items_value ORDER BY value;
+    DELETE FROM temp_items;
+    SELECT changes(), count(*) FROM temp_items INDEXED BY temp_items_value;
+    INSERT INTO temp_items VALUES(4, 'four');
+    SELECT id, value FROM temp_items INDEXED BY temp_items_value;
+}
+expect {
+    1|one
+    3|three
+    2|0
+    4|four
+}
+
 @cross-check-integrity
 test delete_where_falsy {
     CREATE TABLE resourceful_schurz (diplomatic_kaplan BLOB);

--- a/sqlite/conformance/turso-sqltests/fts.sqltest
+++ b/sqlite/conformance/turso-sqltests/fts.sqltest
@@ -44,6 +44,24 @@ expect {
 }
 
 @backend cli
+test fts-delete-all-rows-without-a-where-clause {
+    CREATE TABLE t (id INTEGER PRIMARY KEY, x TEXT);
+    CREATE INDEX t_idx ON t USING fts (x);
+    INSERT INTO t VALUES (1, 'hello world');
+    INSERT INTO t VALUES (2, 'goodbye world');
+    DELETE FROM t;
+    SELECT changes(), count(*) FROM t;
+    INSERT INTO t VALUES (3, 'hello again');
+    SELECT id, x FROM t WHERE fts_match(x, 'hello');
+    SELECT count(*) FROM t WHERE fts_match(x, 'world');
+}
+expect {
+    2|0
+    3|hello again
+    0
+}
+
+@backend cli
 test fts-delete-no-match {
     CREATE TABLE t (id INTEGER PRIMARY KEY, x TEXT);
     CREATE INDEX t_idx ON t USING fts (x);

--- a/sqlite/conformance/turso-sqltests/materialized_views.sqltest
+++ b/sqlite/conformance/turso-sqltests/materialized_views.sqltest
@@ -2125,6 +2125,27 @@ expect {
     3|1
 }
 
+test matview-delete-all-rows-without-a-where-clause {
+    CREATE TABLE readings(id INTEGER PRIMARY KEY, device TEXT, value INTEGER);
+    CREATE INDEX readings_device ON readings(device);
+    CREATE MATERIALIZED VIEW device_totals AS
+    SELECT device, COUNT(*) AS n FROM readings GROUP BY device;
+    INSERT INTO readings VALUES (1, 'D1', 10), (2, 'D1', 5), (3, 'D2', 7);
+    SELECT device, n FROM device_totals ORDER BY device;
+    DELETE FROM readings;
+    SELECT changes(), (SELECT count(*) FROM readings), (SELECT count(*) FROM device_totals);
+    INSERT INTO readings VALUES (4, 'D3', 3);
+    SELECT device, n FROM device_totals;
+    SELECT id FROM readings INDEXED BY readings_device WHERE device = 'D3';
+}
+expect {
+    D1|2
+    D2|1
+    3|0|0
+    D3|1
+    4
+}
+
 test matview-count-distinct-group-by-empty-start {
     CREATE TABLE measurements(device TEXT, reading INTEGER);
     CREATE MATERIALIZED VIEW device_summary AS

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -184,7 +184,7 @@ set test_files {
   dbstatus             fail
   dbstatus2            fail
   delete               fail
-  delete2              fail
+  delete2              pass
   delete3              skip {hangs at delete3-1.1}
   delete4            skip {aborts the harness on an engine panic at core/storage/wal.rs:4363}
   delete_db            fail

--- a/testing/system/vtab.test
+++ b/testing/system/vtab.test
@@ -135,6 +135,16 @@ do_execsql_test_on_specific_db {:memory:} update-hidden-column {
     select comment from t where key = 'hidden';
 } {"updated comment"}
 
+do_execsql_test_on_specific_db {:memory:} delete-all-rows-without-a-where-clause {
+    create virtual table t using kv_store;
+    insert into t(key, value) values ('k0', 'v0'), ('k1', 'v1'), ('k2', 'v2');
+    delete from t;
+    select count(*) from t;
+    insert into t(key, value) values ('k3', 'v3');
+    select key, value from t;
+} {0
+k3|v3}
+
 # hidden columns are not listed in the dataset returned by 'PRAGMA table_info'
 do_execsql_test_on_specific_db {:memory:} pragma-table-info-hidden-columns {
     create virtual table t using kv_store;

--- a/tests/integration/abandoned_statement_pager.rs
+++ b/tests/integration/abandoned_statement_pager.rs
@@ -54,6 +54,7 @@ fn expect_unfinished_write_commit_error(result: turso_core::Result<()>, context:
 /// Steps `sql` until the `target_io`-th `StepResult::IO`, completes that I/O,
 /// then drops the statement without stepping it again. Returns false if the
 /// statement finished before reaching `target_io` I/Os.
+#[must_use]
 fn abandon_statement_after_io_completion(
     conn: &Arc<Connection>,
     io: &Arc<MemoryYieldIO>,
@@ -83,6 +84,7 @@ fn abandon_statement_after_io_completion(
 /// Steps `sql` until the `target_io`-th `StepResult::IO` and drops the
 /// statement while that I/O is still pending. Returns false if the statement
 /// finished before reaching `target_io` I/Os.
+#[must_use]
 fn abandon_statement_before_io_completion(
     conn: &Arc<Connection>,
     io: &Arc<MemoryYieldIO>,

--- a/tests/integration/abandoned_statement_pager.rs
+++ b/tests/integration/abandoned_statement_pager.rs
@@ -285,6 +285,95 @@ fn test_abandoned_delete_does_not_poison_next_delete() {
     }
 }
 
+fn run_abandoned_delete_all_sweep(abandon_before_completion: bool) {
+    let payload = "x".repeat(20_000);
+
+    for target_io in 1..=128 {
+        let io = Arc::new(MemoryYieldIO::new());
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let timing = if abandon_before_completion {
+            "before"
+        } else {
+            "after"
+        };
+        let path = temp_dir
+            .path()
+            .join(format!("abandoned-delete-all-{timing}-{target_io}.db"));
+        let path = path.to_str().unwrap();
+
+        {
+            let conn = open_conn(io.clone(), path);
+            seed_indexed_overflow_rows(&conn, &payload);
+        }
+
+        let conn = open_conn(io.clone(), path);
+        conn.execute("BEGIN").unwrap();
+
+        let abandoned = if abandon_before_completion {
+            abandon_statement_before_io_completion(&conn, &io, "DELETE FROM t", target_io)
+        } else {
+            abandon_statement_after_io_completion(&conn, &io, "DELETE FROM t", target_io)
+        };
+        if !abandoned {
+            conn.execute("ROLLBACK").unwrap();
+            assert!(
+                target_io > 1,
+                "whole-table DELETE finished without any I/O. The abandonment sweep never ran"
+            );
+            break;
+        }
+
+        // Run another write after any combination of index and table clears.
+        // COMMIT must restore every B-tree because the first statement did not finish.
+        conn.execute(format!("INSERT INTO t VALUES(9, 9, '{payload}')"))
+            .unwrap();
+        expect_unfinished_write_commit_error(
+            conn.execute("COMMIT"),
+            &format!(
+                "target_io={target_io} ({timing} completion): COMMIT after abandoned whole-table DELETE"
+            ),
+        );
+
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t ORDER BY id"),
+            vec![2, 3, 4, 5, 6, 7, 8],
+            "target_io={target_io} ({timing} completion): rejected COMMIT must restore table rows"
+        );
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t INDEXED BY t_x ORDER BY x"),
+            vec![2, 3, 4, 5, 6, 7, 8],
+            "target_io={target_io} ({timing} completion): rejected COMMIT must restore index entries"
+        );
+
+        // DELETE and INSERT must still work after the rollback. This test detects stale
+        // root-page, cursor, or freelist state from the unfinished statement.
+        conn.execute("DELETE FROM t").unwrap();
+        assert!(ids(&conn, "SELECT id FROM t").is_empty());
+        conn.execute(format!("INSERT INTO t VALUES(10, 10, '{payload}')"))
+            .unwrap();
+        assert_eq!(
+            ids(&conn, "SELECT id FROM t INDEXED BY t_x ORDER BY x"),
+            vec![10],
+            "target_io={target_io} ({timing} completion): refill after rollback is missing"
+        );
+        assert_eq!(
+            integrity_check(&conn),
+            vec!["ok"],
+            "target_io={target_io} ({timing} completion): abandoned clear poisoned storage"
+        );
+    }
+}
+
+#[test]
+fn test_delete_all_abandoned_before_io_completion_restores_every_btree() {
+    run_abandoned_delete_all_sweep(true);
+}
+
+#[test]
+fn test_delete_all_abandoned_after_io_completion_restores_every_btree() {
+    run_abandoned_delete_all_sweep(false);
+}
+
 #[test]
 fn test_abandoned_insert_does_not_poison_next_insert() {
     let payload = "x".repeat(20_000);

--- a/tests/integration/attach.rs
+++ b/tests/integration/attach.rs
@@ -97,6 +97,7 @@ fn test_attached_write_does_not_upgrade_stale_main_snapshot(
     conn1.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
     conn2.execute(format!("ATTACH '{}' AS aux", aux_path.display()))?;
     conn1.execute("CREATE TABLE aux.t(x INTEGER)")?;
+    conn1.execute("CREATE INDEX aux.t_x ON t(x)")?;
     conn1.execute("INSERT INTO aux.t VALUES (1)")?;
 
     conn1.execute("BEGIN")?;
@@ -113,11 +114,13 @@ fn test_attached_write_does_not_upgrade_stale_main_snapshot(
     conn1
         .execute("DELETE FROM aux.t")
         .context("delete from aux")?;
-    let rows = limbo_exec_rows(&conn1, "SELECT x FROM aux.t");
+    let rows = limbo_exec_rows(&conn1, "SELECT x FROM aux.t INDEXED BY t_x");
     assert!(rows.is_empty());
     let main_rows = limbo_exec_rows(&conn1, "SELECT x FROM main_t");
     assert_eq!(main_rows, vec![vec![rusqlite::types::Value::Integer(1)]]);
     conn1.execute("ROLLBACK")?;
+    let rows = limbo_exec_rows(&conn1, "SELECT x FROM aux.t INDEXED BY t_x");
+    assert_eq!(rows, vec![vec![rusqlite::types::Value::Integer(2)]]);
     Ok(())
 }
 

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -314,6 +314,58 @@ fn test_cdc_simple_full(db: TempDatabase) {
 }
 
 #[turso_macros::test]
+fn test_cdc_delete_all_keeps_one_record_per_deleted_row(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")
+        .unwrap();
+    conn.execute("PRAGMA capture_data_changes_conn('full')")
+        .unwrap();
+    conn.execute("INSERT INTO t VALUES (1, 2), (3, 4)").unwrap();
+
+    conn.execute("DELETE FROM t").unwrap();
+
+    assert_eq!(
+        normalize_cdc_v2_rows(limbo_exec_rows(&conn, "SELECT * FROM turso_cdc")),
+        vec![
+            v2_row(
+                1,
+                "t",
+                1,
+                None,
+                Some(record([Value::Integer(1), Value::Integer(2)])),
+                None,
+            ),
+            v2_row(
+                1,
+                "t",
+                3,
+                None,
+                Some(record([Value::Integer(3), Value::Integer(4)])),
+                None,
+            ),
+            v2_commit(),
+            v2_row(
+                -1,
+                "t",
+                1,
+                Some(record([Value::Integer(1), Value::Integer(2)])),
+                None,
+                None,
+            ),
+            v2_row(
+                -1,
+                "t",
+                3,
+                Some(record([Value::Integer(3), Value::Integer(4)])),
+                None,
+                None,
+            ),
+            v2_commit(),
+        ]
+    );
+}
+
+#[turso_macros::test]
 fn test_cdc_crud(db: TempDatabase) {
     let conn = db.connect_limbo();
     conn.execute("CREATE TABLE t (x INTEGER PRIMARY KEY, y)")

--- a/tests/integration/query_processing/test_transactions.rs
+++ b/tests/integration/query_processing/test_transactions.rs
@@ -228,6 +228,88 @@ fn test_transaction_visibility(tmp_db: TempDatabase) {
 }
 
 #[turso_macros::test]
+fn test_delete_all_keeps_existing_reader_snapshots(tmp_db: TempDatabase) {
+    let table_reader = tmp_db.connect_limbo();
+    let index_reader = tmp_db.connect_limbo();
+    let writer = tmp_db.connect_limbo();
+
+    writer.execute("PRAGMA journal_mode = 'wal'").unwrap();
+    writer
+        .execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)")
+        .unwrap();
+    writer
+        .execute("CREATE INDEX items_value ON items(value)")
+        .unwrap();
+    writer
+        .execute(
+            "WITH RECURSIVE c(x) AS (
+                VALUES(1) UNION ALL SELECT x + 1 FROM c WHERE x < 300
+             ) INSERT INTO items SELECT x, printf('value-%04d', x) FROM c",
+        )
+        .unwrap();
+
+    table_reader.execute("BEGIN").unwrap();
+    index_reader.execute("BEGIN").unwrap();
+    let mut table_scan = table_reader
+        .prepare("SELECT id FROM items ORDER BY id")
+        .unwrap();
+    let mut index_scan = index_reader
+        .prepare("SELECT id FROM items INDEXED BY items_value ORDER BY value")
+        .unwrap();
+
+    let mut table_ids = Vec::new();
+    let mut index_ids = Vec::new();
+    for (statement, ids) in [
+        (&mut table_scan, &mut table_ids),
+        (&mut index_scan, &mut index_ids),
+    ] {
+        loop {
+            match statement.step().unwrap() {
+                StepResult::Row => {
+                    ids.push(statement.row().unwrap().get::<i64>(0).unwrap());
+                    break;
+                }
+                StepResult::IO | StepResult::Yield => tmp_db.io.step().unwrap(),
+                other => panic!("reader did not yield its first row: {other:?}"),
+            }
+        }
+    }
+
+    writer.execute("DELETE FROM items").unwrap();
+
+    for (statement, ids) in [
+        (&mut table_scan, &mut table_ids),
+        (&mut index_scan, &mut index_ids),
+    ] {
+        loop {
+            match statement.step().unwrap() {
+                StepResult::Row => ids.push(statement.row().unwrap().get::<i64>(0).unwrap()),
+                StepResult::IO | StepResult::Yield => tmp_db.io.step().unwrap(),
+                StepResult::Done => break,
+                other => panic!("reader failed after whole-table DELETE: {other:?}"),
+            }
+        }
+    }
+
+    let expected = (1..=300).collect::<Vec<_>>();
+    assert_eq!(table_ids, expected, "table reader lost its WAL snapshot");
+    assert_eq!(index_ids, expected, "index reader lost its WAL snapshot");
+    drop(table_scan);
+    drop(index_scan);
+    table_reader.execute("COMMIT").unwrap();
+    index_reader.execute("COMMIT").unwrap();
+
+    let fresh_reader = tmp_db.connect_limbo();
+    let rows: Vec<(i64,)> = fresh_reader.exec_rows("SELECT id FROM items");
+    assert!(
+        rows.is_empty(),
+        "new readers must observe the committed DELETE"
+    );
+    let integrity: Vec<(String,)> = fresh_reader.exec_rows("PRAGMA integrity_check");
+    assert_eq!(integrity, vec![("ok".to_string(),)]);
+}
+
+#[turso_macros::test]
 /// A constraint error does not rollback the transaction, it rolls back the statement.
 fn test_constraint_error_aborts_only_stmt_not_entire_transaction(tmp_db: TempDatabase) {
     let conn = tmp_db.connect_limbo();

--- a/tests/integration/query_processing/test_write_path.rs
+++ b/tests/integration/query_processing/test_write_path.rs
@@ -1829,6 +1829,46 @@ fn test_matview_row_loss_during_btree_split(tmp_db: TempDatabase) -> anyhow::Res
     Ok(())
 }
 
+#[turso_macros::test(views)]
+fn test_delete_all_updates_dependent_materialized_view(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    common::run_query(
+        &tmp_db,
+        &conn,
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, title TEXT)",
+    )?;
+    common::run_query(
+        &tmp_db,
+        &conn,
+        "CREATE MATERIALIZED VIEW v AS SELECT id, title FROM t",
+    )?;
+    common::run_query(
+        &tmp_db,
+        &conn,
+        "WITH RECURSIVE c(x) AS (
+            VALUES(1) UNION ALL SELECT x + 1 FROM c WHERE x < 300
+         ) INSERT INTO t SELECT x, printf('title-%d', x) FROM c",
+    )?;
+
+    common::run_query(&tmp_db, &conn, "DELETE FROM t")?;
+    assert!(limbo_exec_rows(&conn, "SELECT * FROM t").is_empty());
+    assert!(
+        limbo_exec_rows(&conn, "SELECT * FROM v").is_empty(),
+        "whole-table DELETE must remove every dependent materialized-view row"
+    );
+
+    common::run_query(&tmp_db, &conn, "INSERT INTO t VALUES(301, 'after-clear')")?;
+    assert_eq!(
+        limbo_exec_rows(&conn, "SELECT id, title FROM v"),
+        vec![vec![
+            RValue::Integer(301),
+            RValue::Text("after-clear".into())
+        ]],
+        "materialized-view maintenance must remain usable after DELETE"
+    );
+    Ok(())
+}
+
 /// Regression test for simulator seed 867: UPDATE on an attached database table
 /// that changes the primary key (rowid) while a UNIQUE index exists would use
 /// the wrong database_id (0 instead of the attached db) for OpenWrite cursors,

--- a/tests/integration/reindex.rs
+++ b/tests/integration/reindex.rs
@@ -158,3 +158,51 @@ fn reindex_write_fault_rolls_back_without_emptying_index() -> anyhow::Result<()>
     assert_reindex_fixture_intact(&conn, rows)?;
     Ok(())
 }
+
+/// If a WAL write fails after several B-tree clears, the statement must restore the table,
+/// indexes, and freelist.
+#[test]
+fn delete_all_write_fault_rolls_back_every_btree() -> anyhow::Result<()> {
+    let io = Arc::new(QueuedIo::new());
+    let db_path = "queued-delete-all-fault.db";
+    let wal_path = format!("{db_path}-wal");
+    let db = open_queued_db(io.clone(), db_path)?;
+    let conn = db.connect()?;
+    conn.execute("PRAGMA page_size = 512")?;
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, value TEXT UNIQUE, payload BLOB)")?;
+    conn.execute("CREATE INDEX idx_even ON t(id) WHERE id % 2 = 0")?;
+    for id in 1..=500 {
+        conn.execute(format!(
+            "INSERT INTO t VALUES({id}, 'value-{id:04}', zeroblob(5000))"
+        ))?;
+    }
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+
+    io.fault_after(wal_path, QueuedIoOpKind::Pwritev, 0);
+    let delete_result = conn.execute("DELETE FROM t");
+    assert!(
+        delete_result.is_err(),
+        "whole-table DELETE must fail under an injected WAL write fault"
+    );
+    io.clear_fault();
+
+    assert_eq!(query_rows(&conn, "SELECT count(*) FROM t")?, vec!["500"]);
+    assert_eq!(
+        query_rows(
+            &conn,
+            "SELECT id FROM t INDEXED BY sqlite_autoindex_t_1 WHERE value = 'value-0250'"
+        )?,
+        vec!["250"],
+        "the unique index must be restored"
+    );
+    assert_eq!(
+        query_rows(
+            &conn,
+            "SELECT count(*) FROM t INDEXED BY idx_even WHERE id % 2 = 0"
+        )?,
+        vec!["250"],
+        "the partial index must be restored"
+    );
+    assert_eq!(query_rows(&conn, "PRAGMA integrity_check")?, vec!["ok"]);
+    Ok(())
+}


### PR DESCRIPTION
Clear table and index B-trees at the page level when DELETE does not need per-row work.

Keep the row loop for triggers, foreign keys, CDC, MVCC, RETURNING, materialized views, and index methods.

Load indexes from the target database schema. This prevents stale indexes for TEMP and attached tables.

The 50,000-row benchmark improves from 94.7 ms to 3.03 ms.