### PR TITLE
core: compare and decode records straight from the pinned page

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -305,5 +305,9 @@ name = "scan_loop_benchmark"
 harness = false
 
 [[bench]]
+name = "seek_loop_benchmark"
+harness = false
+
+[[bench]]
 name = "text_validate_benchmark"
 harness = false

--- a/core/benches/seek_loop_benchmark.rs
+++ b/core/benches/seek_loop_benchmark.rs
@@ -1,0 +1,127 @@
+//! Index-seek microbenchmark over a 100k-row table.
+//!
+//! Each iteration runs point lookups through a secondary index. The hot
+//! path is the b-tree descent, the leaf binary search, and the
+//! deferred-seek rowid fetch. There is no scan loop. This isolates
+//! per-seek overhead the same way scan_loop_benchmark isolates per-row
+//! overhead.
+//!
+//! Run:  cargo bench -p turso_core --bench seek_loop_benchmark
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
+#[cfg(not(feature = "codspeed"))]
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+use turso_core::{Connection, Database, PlatformIO, SqliteDialect, Statement, StepResult, Value};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+const NROWS: usize = 100_000;
+const LOOKUPS_PER_ITER: usize = 1000;
+
+struct Fixture {
+    _dir: TempDir,
+    db: Arc<Database>,
+    conn: Arc<Connection>,
+}
+
+fn seed_db() -> Fixture {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("seek.db");
+    #[allow(clippy::arc_with_non_send_sync)]
+    let io = Arc::new(PlatformIO::new().unwrap());
+    let db = Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+
+    conn.execute("PRAGMA cache_size=-65536").unwrap();
+    conn.execute(
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL, value INTEGER NOT NULL)",
+    )
+    .unwrap();
+
+    conn.execute("BEGIN").unwrap();
+    let mut insert = conn.prepare("INSERT INTO t VALUES (?1, ?2, ?3)").unwrap();
+    for i in 0..NROWS as i64 {
+        insert
+            .bind_at(1usize.try_into().unwrap(), Value::from_i64(i))
+            .unwrap();
+        insert
+            .bind_at(
+                2usize.try_into().unwrap(),
+                Value::build_text(format!("name_{i:07}")),
+            )
+            .unwrap();
+        insert
+            .bind_at(3usize.try_into().unwrap(), Value::from_i64(i))
+            .unwrap();
+        drive_stmt_to_completion(&db, &mut insert);
+    }
+    conn.execute("COMMIT").unwrap();
+    conn.execute("CREATE INDEX t_name ON t (name)").unwrap();
+
+    Fixture {
+        _dir: dir,
+        db,
+        conn,
+    }
+}
+
+fn drive_stmt_to_completion(db: &Database, stmt: &mut Statement) -> usize {
+    let mut rows = 0;
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                black_box(stmt.row());
+                rows += 1;
+            }
+            StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
+                db.io.step().unwrap();
+            }
+            StepResult::Done => break,
+            StepResult::Interrupt | StepResult::Busy => unreachable!(),
+        }
+    }
+    stmt.reset().unwrap();
+    rows
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_seek_loop(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("seek_loop");
+    group.sample_size(30);
+    group.measurement_time(Duration::from_secs(5));
+    group.warm_up_time(Duration::from_secs(3));
+
+    let fixture = seed_db();
+    group.bench_function("index_point_lookup_1k", |b| {
+        let mut stmt = fixture
+            .conn
+            .prepare("SELECT value FROM t WHERE name = ?1")
+            .unwrap();
+        b.iter(|| {
+            let mut rows = 0;
+            for i in 0..LOOKUPS_PER_ITER as i64 {
+                // Spread the probes across the key space. Then each lookup
+                // descends a different path instead of replaying one leaf.
+                let key = (i * 97) % NROWS as i64;
+                stmt.bind_at(
+                    1usize.try_into().unwrap(),
+                    Value::build_text(format!("name_{key:07}")),
+                )
+                .unwrap();
+                rows += drive_stmt_to_completion(&fixture.db, &mut stmt);
+            }
+            assert_eq!(rows, LOOKUPS_PER_ITER);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_seek_loop);
+criterion_main!(benches);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -708,6 +708,15 @@ pub trait CursorTrait: Any + Send + Sync {
     fn note_external_row_write(&mut self, _rowid: Option<i64>) {}
     /// Get the record of the entry the cursor is poiting to if any
     fn record(&mut self) -> IOResultOr<Option<&ImmutableRecord>>;
+    /// Like [`Self::record`], but can return the payload borrowed from the
+    /// page instead of copying it into the cursor's record buffer. The
+    /// borrow is valid only while the cursor stays on the same row. Use this
+    /// when the caller decodes or compares the payload immediately. Use
+    /// [`Self::record`] when the record must outlive cursor movement.
+    fn record_payload(&mut self) -> IOResultOr<Option<&[u8]>> {
+        let record = return_if_io!(self.record());
+        Ok(IOResult::Done(record.map(|record| record.get_payload())))
+    }
     /// Move the cursor based on the key and the type of operation (op).
     fn seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> IOResultOr<SeekResult>;
     /// Seek using registers directly without serializing them into an ImmutableRecord first.
@@ -2217,31 +2226,24 @@ impl BTreeCursor {
             .unwrap()
             .cell_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
 
-        if let Some(next_page) = first_overflow_page {
+        // Compare directly against the cell payload in the page buffer. The
+        // payload stays valid because the page stack pins the page. Only an
+        // overflow cell needs a copy into the cursor's record buffer.
+        let payload: &[u8] = if let Some(next_page) = first_overflow_page {
             let res = self.process_overflow_read(payload, next_page, payload_size)?;
             if res.is_io() {
                 return Ok(ControlFlow::Break(res));
             }
+            self.get_immutable_record()
+                .expect("overflow read must have assembled the record")
+                .get_payload()
         } else {
-            self.get_immutable_record_or_create()?
-                .as_mut()
-                .unwrap()
-                .invalidate();
-            crate::with_btree_allocation_site!(
-                RecordPayload,
-                self.get_immutable_record_or_create()?
-                    .as_mut()
-                    .unwrap()
-                    .start_serialization(payload)
-            )?;
+            payload
         };
 
         let (target_leaf_page_is_in_left_subtree, is_eq) = {
-            let record = self.get_immutable_record();
-            let record = record.as_ref().unwrap();
-
             let interior_cell_vs_index_key = record_comparer.compare(
-                record,
+                payload,
                 key_values,
                 self.index_info
                     .as_ref()
@@ -2654,26 +2656,23 @@ impl BTreeCursor {
             .unwrap()
             .cell_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
 
-        if let Some(next_page) = first_overflow_page {
+        // Compare directly against the cell payload in the page buffer. The
+        // payload stays valid because the page stack pins the page. Only an
+        // overflow cell needs a copy into the cursor's record buffer.
+        let payload: &[u8] = if let Some(next_page) = first_overflow_page {
             let res = self.process_overflow_read(payload, next_page, payload_size)?;
             if let IOResult::IO(io) = res {
                 return Ok(ControlFlow::Break(IOResult::IO(io)));
             }
+            self.get_immutable_record()
+                .expect("overflow read must have assembled the record")
+                .get_payload()
         } else {
-            self.get_immutable_record_or_create()?
-                .as_mut()
-                .unwrap()
-                .invalidate();
-            crate::with_btree_allocation_site!(
-                RecordPayload,
-                self.get_immutable_record_or_create()?
-                    .as_mut()
-                    .unwrap()
-                    .start_serialization(payload)
-            )?;
+            payload
         };
 
-        let (cmp, found) = self.compare_with_current_record(
+        let (cmp, found) = Self::compare_cell_payload_with_key(
+            payload,
             key_values,
             seek_op,
             &record_comparer,
@@ -2716,18 +2715,15 @@ impl BTreeCursor {
         Ok(ControlFlow::Continue(()))
     }
 
-    fn compare_with_current_record(
-        &self,
+    fn compare_cell_payload_with_key(
+        payload: &[u8],
         key_values: &[ValueRef],
         seek_op: SeekOp,
         record_comparer: &RecordCompare,
         index_info: &IndexInfo,
     ) -> Result<(Ordering, bool)> {
-        let record = self.get_immutable_record();
-        let record = record.as_ref().unwrap();
-
         let tie_breaker = get_tie_breaker_from_seek_op(seek_op);
-        let cmp = record_comparer.compare(record, key_values, index_info, 0, tie_breaker)?;
+        let cmp = record_comparer.compare(payload, key_values, index_info, 0, tie_breaker)?;
 
         let found = match seek_op {
             SeekOp::GT => cmp.is_gt(),
@@ -6510,6 +6506,33 @@ impl CursorTrait for BTreeCursor {
         };
 
         Ok(IOResult::Done(self.reusable_immutable_record.as_ref()))
+    }
+
+    #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
+    fn record_payload(&mut self) -> IOResultOr<Option<&[u8]>> {
+        if self.needs_restore() {
+            return_if_io!(self.restore_context());
+        }
+        if !self.has_record() {
+            return Ok(IOResult::Done(None));
+        }
+
+        let page = self.stack.top_ref();
+        let contents = page.get_contents();
+        let cell_idx = self.stack.current_cell_index();
+        let (payload, payload_size, first_overflow_page) =
+            contents.cell_read_payload_ptr(cell_idx as usize, self.usable_space())?;
+        if let Some(next_page) = first_overflow_page {
+            return_if_io!(self.process_overflow_read(payload, next_page, payload_size));
+            Ok(IOResult::Done(
+                self.get_immutable_record()
+                    .map(|record| record.get_payload()),
+            ))
+        } else {
+            // The payload borrows from the page buffer. The buffer stays
+            // valid because the page stack pins the page.
+            Ok(IOResult::Done(Some(payload)))
+        }
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]

--- a/core/translate/collate.rs
+++ b/core/translate/collate.rs
@@ -152,25 +152,36 @@ impl CollationSeq {
     #[inline(always)]
     pub fn compare_strings(&self, lhs: &str, rhs: &str) -> Ordering {
         match *self {
-            Self::Unset | Self::Binary => Self::binary_cmp(lhs, rhs),
-            Self::NoCase => Self::nocase_cmp(lhs, rhs),
-            Self::Rtrim => Self::rtrim_cmp(lhs, rhs),
             Self::Locale(id) => LocaleCollationRegistry::global().compare(id, lhs, rhs),
+            _ => self.compare_bytes(lhs.as_bytes(), rhs.as_bytes()),
+        }
+    }
+
+    /// True when this collation orders text by its bytes alone. For these
+    /// collations a raw byte comparison needs no UTF-8 validation. Only
+    /// locale collations need a validated `&str`.
+    #[inline(always)]
+    pub const fn is_byte_ordered(&self) -> bool {
+        !matches!(self, Self::Locale(_))
+    }
+
+    /// Compare text as raw bytes. Callers must check `is_byte_ordered()` first.
+    #[inline(always)]
+    pub fn compare_bytes(&self, lhs: &[u8], rhs: &[u8]) -> Ordering {
+        match *self {
             // Immutable comparison paths have no connection to fetch the external
             // callback from. Runtime VDBE paths dispatch custom collations via
-            // `Connection`; schema/index paths reject them before storage.
-            Self::Custom(_) => Self::binary_cmp(lhs, rhs),
+            // `Connection`. Schema/index paths reject them before storage.
+            Self::Unset | Self::Binary | Self::Custom(_) => lhs.cmp(rhs),
+            Self::NoCase => Self::nocase_cmp(lhs, rhs),
+            Self::Rtrim => Self::rtrim_cmp(lhs, rhs),
+            Self::Locale(_) => unreachable!("locale collations require validated text"),
         }
     }
 
     #[inline(always)]
-    fn binary_cmp(lhs: &str, rhs: &str) -> Ordering {
-        lhs.cmp(rhs)
-    }
-
-    #[inline(always)]
-    fn nocase_cmp(lhs: &str, rhs: &str) -> Ordering {
-        for (left, right) in lhs.bytes().zip(rhs.bytes()) {
+    fn nocase_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        for (left, right) in lhs.iter().zip(rhs.iter()) {
             let left = left.to_ascii_lowercase();
             let right = right.to_ascii_lowercase();
             if left != right {
@@ -184,8 +195,18 @@ impl CollationSeq {
     }
 
     #[inline(always)]
-    fn rtrim_cmp(lhs: &str, rhs: &str) -> Ordering {
-        lhs.trim_end_matches(' ').cmp(rhs.trim_end_matches(' '))
+    fn rtrim_cmp(lhs: &[u8], rhs: &[u8]) -> Ordering {
+        // In valid UTF-8, a trailing 0x20 byte is always an ASCII space. As a
+        // result, byte trimming matches str::trim_end_matches(' ').
+        let mut lhs_end = lhs.len();
+        while lhs_end > 0 && lhs[lhs_end - 1] == b' ' {
+            lhs_end -= 1;
+        }
+        let mut rhs_end = rhs.len();
+        while rhs_end > 0 && rhs[rhs_end - 1] == b' ' {
+            rhs_end -= 1;
+        }
+        lhs[..lhs_end].cmp(&rhs[..rhs_end])
     }
 
     pub fn hash_key(&self, text: &str) -> Vec<u8> {

--- a/core/types.rs
+++ b/core/types.rs
@@ -2565,7 +2565,7 @@ pub enum RecordCompare {
 impl RecordCompare {
     pub fn compare<V, E, I>(
         &self,
-        serialized: &ImmutableRecord,
+        payload: &[u8],
         unpacked: I,
         index_info: &IndexInfo,
         skip: usize,
@@ -2578,14 +2578,12 @@ impl RecordCompare {
     {
         let unpacked = unpacked.into_iter();
         match self {
-            RecordCompare::Int => {
-                compare_records_int(serialized, unpacked, index_info, tie_breaker)
-            }
+            RecordCompare::Int => compare_records_int(payload, unpacked, index_info, tie_breaker),
             RecordCompare::String => {
-                compare_records_string(serialized, unpacked, index_info, tie_breaker)
+                compare_records_string(payload, unpacked, index_info, tie_breaker)
             }
             RecordCompare::Generic => {
-                compare_records_generic(serialized, unpacked, index_info, skip, tie_breaker)
+                compare_records_generic(payload, unpacked, index_info, skip, tie_breaker)
             }
         }
     }
@@ -2650,7 +2648,7 @@ pub fn get_tie_breaker_from_seek_op(seek_op: SeekOp) -> std::cmp::Ordering {
 ///
 /// # Arguments
 ///
-/// * `serialized` - The left-hand side record in serialized format
+/// * `payload` - The left-hand side record payload (serialized record bytes)
 /// * `unpacked` - The right-hand side record as an array of parsed values
 /// * `index_info` - Contains sort order information for each field
 /// * `collations` - Array of collation sequences (unused for integers)
@@ -2667,7 +2665,7 @@ pub fn get_tie_breaker_from_seek_op(seek_op: SeekOp) -> std::cmp::Ordering {
 /// 5. **Remaining fields**: If first field is equal and more fields exist,
 ///    delegates to `compare_records_generic()` with `skip=1`
 fn compare_records_int<V, I>(
-    serialized: &ImmutableRecord,
+    payload: &[u8],
     unpacked: I,
     index_info: &IndexInfo,
     tie_breaker: std::cmp::Ordering,
@@ -2676,9 +2674,8 @@ where
     V: AsValueRef,
     I: ExactSizeIterator<Item = V>,
 {
-    let payload = serialized.get_payload();
     if payload.len() < 2 {
-        return compare_records_generic(serialized, unpacked, index_info, 0, tie_breaker);
+        return compare_records_generic(payload, unpacked, index_info, 0, tie_breaker);
     }
 
     let (header_size, offset_1st_serialtype) = read_varint(payload)?;
@@ -2696,7 +2693,7 @@ where
 
     let serialtype_is_integer = matches!(first_serial_type, 1..=6 | 8 | 9);
     if !serialtype_is_integer {
-        return compare_records_generic(serialized, unpacked, index_info, 0, tie_breaker);
+        return compare_records_generic(payload, unpacked, index_info, 0, tie_breaker);
     }
 
     let data_start = header_size;
@@ -2706,7 +2703,7 @@ where
     // Do not consume iterator here
     let ValueRef::Numeric(Numeric::Integer(rhs_int)) = unpacked.peek().unwrap().as_value_ref()
     else {
-        return compare_records_generic(serialized, unpacked, index_info, 0, tie_breaker);
+        return compare_records_generic(payload, unpacked, index_info, 0, tie_breaker);
     };
     let comparison = match index_info.key_info[0].sort_order {
         SortOrder::Asc => lhs_int.cmp(&rhs_int),
@@ -2716,7 +2713,7 @@ where
         std::cmp::Ordering::Equal => {
             // First fields equal, compare remaining fields if any
             if unpacked.len() > 1 {
-                return compare_records_generic(serialized, unpacked, index_info, 1, tie_breaker);
+                return compare_records_generic(payload, unpacked, index_info, 1, tie_breaker);
             }
             Ok(tie_breaker)
         }
@@ -2746,7 +2743,7 @@ where
 ///
 /// # Arguments
 ///
-/// * `serialized` - The left-hand side record in serialized format
+/// * `payload` - The left-hand side record payload (serialized record bytes)
 /// * `unpacked` - The right-hand side record as an array of parsed values
 /// * `index_info` - Contains sort order information for each field
 /// * `collations` - Array of collation sequences for string comparisons
@@ -2763,7 +2760,7 @@ where
 /// 5. **Remaining fields**: If first field is equal and more fields exist,
 ///    delegates to `compare_records_generic()` with `skip=1`
 fn compare_records_string<V, I>(
-    serialized: &ImmutableRecord,
+    payload: &[u8],
     unpacked: I,
     index_info: &IndexInfo,
     tie_breaker: std::cmp::Ordering,
@@ -2772,9 +2769,8 @@ where
     V: AsValueRef,
     I: ExactSizeIterator<Item = V>,
 {
-    let payload = serialized.get_payload();
     if payload.len() < 2 {
-        return compare_records_generic(serialized, unpacked, index_info, 0, tie_breaker);
+        return compare_records_generic(payload, unpacked, index_info, 0, tie_breaker);
     }
 
     let (header_size, offset_1st_serialtype) = read_varint(payload)?;
@@ -2792,29 +2788,47 @@ where
 
     let serialtype_is_string = first_serial_type >= 13 && (first_serial_type & 1) == 1;
     if !serialtype_is_string {
-        return compare_records_generic(serialized, unpacked, index_info, 0, tie_breaker);
+        return compare_records_generic(payload, unpacked, index_info, 0, tie_breaker);
     }
 
     let mut unpacked = unpacked.peekable();
 
     let ValueRef::Text(rhs_text) = unpacked.peek().unwrap().as_value_ref() else {
-        return compare_records_generic(serialized, unpacked, index_info, 0, tie_breaker);
+        return compare_records_generic(payload, unpacked, index_info, 0, tie_breaker);
     };
 
     let string_len = (first_serial_type as usize - 13) / 2;
     let data_start = header_size;
 
-    turso_debug_assert!(data_start + string_len <= payload.len());
-
-    let serial_type = SerialType::try_from(first_serial_type)?;
-    let (lhs_value, _) = read_value(&payload[data_start..], serial_type)?;
-
-    let ValueRef::Text(lhs_text) = lhs_value else {
-        return compare_records_generic(serialized, unpacked, index_info, 0, tie_breaker);
-    };
+    if payload.len() < data_start + string_len {
+        return Err(LimboError::Corrupt(format!(
+            "Record payload too short: text field needs {} bytes but payload only has {}",
+            data_start + string_len,
+            payload.len()
+        )));
+    }
 
     let collation = index_info.key_info[0].collation;
-    let comparison = collation.compare_strings(&lhs_text, &rhs_text);
+    // SQLite compares record text without UTF-8 validation. Only locale
+    // collations need a validated &str.
+    let (comparison, lhs_len) = if collation.is_byte_ordered() {
+        let lhs_bytes = &payload[data_start..data_start + string_len];
+        (
+            collation.compare_bytes(lhs_bytes, rhs_text.as_str().as_bytes()),
+            lhs_bytes.len(),
+        )
+    } else {
+        let serial_type = SerialType::try_from(first_serial_type)?;
+        let (lhs_value, _) = read_value(&payload[data_start..], serial_type)?;
+
+        let ValueRef::Text(lhs_text) = lhs_value else {
+            return compare_records_generic(payload, unpacked, index_info, 0, tie_breaker);
+        };
+        (
+            collation.compare_strings(&lhs_text, &rhs_text),
+            lhs_text.len(),
+        )
+    };
 
     let final_comparison = match index_info.key_info[0].sort_order {
         SortOrder::Asc => comparison,
@@ -2823,7 +2837,7 @@ where
 
     match final_comparison {
         std::cmp::Ordering::Equal => {
-            let len_cmp = lhs_text.len().cmp(&rhs_text.len());
+            let len_cmp = lhs_len.cmp(&rhs_text.len());
             if len_cmp != std::cmp::Ordering::Equal {
                 let adjusted = match index_info.key_info[0].sort_order {
                     SortOrder::Asc => len_cmp,
@@ -2833,7 +2847,7 @@ where
             }
 
             if unpacked.len() > 1 {
-                return compare_records_generic(serialized, unpacked, index_info, 1, tie_breaker);
+                return compare_records_generic(payload, unpacked, index_info, 1, tie_breaker);
             }
             Ok(tie_breaker)
         }
@@ -2848,13 +2862,13 @@ where
 /// or `Greater` if the serialized record is less than, equal to, or greater than
 /// the unpacked record.
 ///
-/// The `serialized` record must be a blob created by the record serialization
+/// The `payload` must be a blob created by the record serialization
 /// process (equivalent to SQLite's OP_MakeRecord opcode). The `unpacked` record
 /// must be a parsed key array of `RefValue` objects.
 ///
 /// # Arguments
 ///
-/// * `serialized` - The left-hand side record in serialized format
+/// * `payload` - The left-hand side record payload (serialized record bytes)
 /// * `unpacked` - The right-hand side record as an array of parsed values
 /// * `index_info` - Contains sort order information for each field
 /// * `skip` - Number of initial fields to skip (assumes caller verified equality)
@@ -2873,7 +2887,7 @@ where
 /// of fields. If all fields that appear in both records are equal, then
 /// `tie_breaker` is returned.
 pub fn compare_records_generic<V, I>(
-    serialized: &ImmutableRecord,
+    payload: &[u8],
     unpacked: I,
     index_info: &IndexInfo,
     skip: usize,
@@ -2883,7 +2897,6 @@ where
     V: AsValueRef,
     I: ExactSizeIterator<Item = V>,
 {
-    let payload = serialized.get_payload();
     if payload.is_empty() {
         return Ok(std::cmp::Ordering::Less);
     }
@@ -2925,6 +2938,41 @@ where
         header_pos += bytes_read;
 
         let serial_type = SerialType::try_from(serial_type_raw)?;
+        let key_info = &index_info.key_info[field_idx];
+
+        // TEXT vs TEXT under a byte-ordered collation compares the raw payload
+        // bytes. SQLite does not validate UTF-8 on compare. Only locale
+        // collations need a validated &str.
+        if matches!(serial_type.kind(), SerialTypeKind::Text)
+            && key_info.collation.is_byte_ordered()
+        {
+            if let ValueRef::Text(rhs_text) = *rhs_value {
+                let field_size = serial_type.size();
+                if payload.len() < data_pos + field_size {
+                    return Err(LimboError::Corrupt(format!(
+                        "Record payload too short: text field needs {} bytes but payload only has {}",
+                        data_pos + field_size,
+                        payload.len()
+                    )));
+                }
+                let lhs_bytes = &payload[data_pos..data_pos + field_size];
+                data_pos += field_size;
+
+                let comparison = key_info
+                    .collation
+                    .compare_bytes(lhs_bytes, rhs_text.as_str().as_bytes());
+                // Neither side is NULL, so cmp_with_sort reduces to sort order.
+                let final_comparison = match key_info.sort_order {
+                    SortOrder::Asc => comparison,
+                    SortOrder::Desc => comparison.reverse(),
+                };
+                if final_comparison != std::cmp::Ordering::Equal {
+                    return Ok(final_comparison);
+                }
+                field_idx += 1;
+                continue;
+            }
+        }
 
         let lhs_value = match serial_type.kind() {
             SerialTypeKind::ConstInt0 => ValueRef::Numeric(Numeric::Integer(0)),
@@ -2937,7 +2985,6 @@ where
             }
         };
 
-        let key_info = &index_info.key_info[field_idx];
         let comparison = match (&lhs_value, rhs_value) {
             (ValueRef::Text(lhs_text), ValueRef::Text(rhs_text)) => {
                 key_info.collation.compare_strings(lhs_text, rhs_text)
@@ -3954,7 +4001,13 @@ mod tests {
 
         let comparer = find_compare(unpacked_values.iter().peekable(), index_info);
         let optimized_result = comparer
-            .compare(&serialized, &unpacked_values, index_info, 0, tie_breaker)
+            .compare(
+                serialized.get_payload(),
+                &unpacked_values,
+                index_info,
+                0,
+                tie_breaker,
+            )
             .unwrap();
 
         assert_eq!(
@@ -3963,7 +4016,7 @@ mod tests {
         );
 
         let generic_result = compare_records_generic(
-            &serialized,
+            serialized.get_payload(),
             unpacked_values.iter(),
             index_info,
             0,
@@ -4371,12 +4424,22 @@ mod tests {
         ];
 
         let tie_breaker = std::cmp::Ordering::Equal;
-        let result_skip_0 =
-            compare_records_generic(&serialized, unpacked.iter(), &index_info, 0, tie_breaker)
-                .unwrap();
-        let result_skip_1 =
-            compare_records_generic(&serialized, unpacked.iter(), &index_info, 1, tie_breaker)
-                .unwrap();
+        let result_skip_0 = compare_records_generic(
+            serialized.get_payload(),
+            unpacked.iter(),
+            &index_info,
+            0,
+            tie_breaker,
+        )
+        .unwrap();
+        let result_skip_1 = compare_records_generic(
+            serialized.get_payload(),
+            unpacked.iter(),
+            &index_info,
+            1,
+            tie_breaker,
+        )
+        .unwrap();
 
         assert_eq!(result_skip_0, std::cmp::Ordering::Less);
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2081,8 +2081,8 @@ fn op_column_fetch(
                     return Ok(InsnFunctionStepResult::Step);
                 }
 
-                let record_result = return_if_io!(cursor.record());
-                let Some(record) = record_result else {
+                let payload_result = return_if_io!(cursor.record_payload());
+                let Some(payload) = payload_result else {
                     // Cursor is not positioned on a valid row (e.g., empty table).
                     // Return NULL, not the column's default value.
                     // DEFAULT handling below is for when record exists
@@ -2091,7 +2091,7 @@ fn op_column_fetch(
                     return Ok(InsnFunctionStepResult::Step);
                 };
 
-                let mut payload_iterator = record.iter()?;
+                let mut payload_iterator = ValueIterator::new(payload)?;
 
                 // Parse the header for serial types incrementally until we have the target column
                 // Use nth_into_register to write directly to the register without
@@ -2242,15 +2242,15 @@ fn op_column_range_fetch(
                     return Ok(InsnFunctionStepResult::Step);
                 }
 
-                let record_result = return_if_io!(cursor.record());
-                let Some(record) = record_result else {
+                let payload_result = return_if_io!(cursor.record_payload());
+                let Some(payload) = payload_result else {
                     for reg in &mut state.registers[dest..dest + count] {
                         reg.set_null();
                     }
                     return Ok(InsnFunctionStepResult::Step);
                 };
 
-                record.iter()?.decode_into_registers_after(
+                ValueIterator::new(payload)?.decode_into_registers_after(
                     start_column,
                     &mut state.registers[dest..dest + count],
                 )?
@@ -6633,13 +6633,13 @@ pub fn op_idx_ge(
         let cursor = cursor.as_btree_mut();
         let index_info = cursor.get_index_info().clone();
 
-        let pc = if let Some(idx_record) = return_if_io!(cursor.record()) {
+        let pc = if let Some(idx_payload) = return_if_io!(cursor.record_payload()) {
             // Create the comparison record from registers
             let values =
                 registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
             let tie_breaker = get_tie_breaker_from_idx_comp_op(insn);
             let ord = compare_records_generic(
-                idx_record,  // The serialized record from the index
+                idx_payload, // The serialized record from the index
                 values,      // The record built from registers
                 &index_info, // Sort order flags
                 0,
@@ -6703,11 +6703,11 @@ pub fn op_idx_le(
         let cursor = cursor.as_btree_mut();
         let index_info = cursor.get_index_info().clone();
 
-        let pc = if let Some(idx_record) = return_if_io!(cursor.record()) {
+        let pc = if let Some(idx_payload) = return_if_io!(cursor.record_payload()) {
             let values =
                 registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
             let tie_breaker = get_tie_breaker_from_idx_comp_op(insn);
-            let ord = compare_records_generic(idx_record, values, &index_info, 0, tie_breaker)?;
+            let ord = compare_records_generic(idx_payload, values, &index_info, 0, tie_breaker)?;
 
             if ord.is_le() {
                 target_pc.as_offset_int()
@@ -6750,11 +6750,11 @@ pub fn op_idx_gt(
         let cursor = cursor.as_btree_mut();
         let index_info = cursor.get_index_info().clone();
 
-        let pc = if let Some(idx_record) = return_if_io!(cursor.record()) {
+        let pc = if let Some(idx_payload) = return_if_io!(cursor.record_payload()) {
             let values =
                 registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
             let tie_breaker = get_tie_breaker_from_idx_comp_op(insn);
-            let ord = compare_records_generic(idx_record, values, &index_info, 0, tie_breaker)?;
+            let ord = compare_records_generic(idx_payload, values, &index_info, 0, tie_breaker)?;
 
             if ord.is_gt() {
                 target_pc.as_offset_int()
@@ -6797,12 +6797,12 @@ pub fn op_idx_lt(
         let cursor = cursor.as_btree_mut();
         let index_info = cursor.get_index_info().clone();
 
-        let pc = if let Some(idx_record) = return_if_io!(cursor.record()) {
+        let pc = if let Some(idx_payload) = return_if_io!(cursor.record_payload()) {
             let values =
                 registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
 
             let tie_breaker = get_tie_breaker_from_idx_comp_op(insn);
-            let ord = compare_records_generic(idx_record, values, &index_info, 0, tie_breaker)?;
+            let ord = compare_records_generic(idx_payload, values, &index_info, 0, tie_breaker)?;
 
             if ord.is_lt() {
                 target_pc.as_offset_int()


### PR DESCRIPTION
Index seeks copied every probed cell payload into the cursor's record buffer, and the comparators then only called get_payload() on it. Every Column and IdxGE opcode paid the same full-row copy through record(). The page under a cursor is pinned on its page stack, so the payload is safe to borrow in place.

The record comparators now take the raw payload slice. Seek probes compare directly against the page buffer. A new
CursorTrait::record_payload() lets Column, ColumnRange and the IdxGT/GE/LT/LE opcodes decode without a copy of the record. Byte-ordered collations (BINARY, NOCASE, RTRIM) skip UTF-8 validation during compares. SQLite also does not validate text on compare. Locale collations keep the validated path.

Index point lookups improve ~14% and full SELECT * table scans ~11% on the seek/scan loop microbenchmarks.

Tests: sqltest conformance, core unit tests, fuzz_tests. A new seek_loop_benchmark covers the index point-lookup path.