### PR TITLE
vdbe: skip decoding column values for null checks

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -216,6 +216,10 @@ name = "count_benchmark"
 harness = false
 
 [[bench]]
+name = "count_null_peek_benchmark"
+harness = false
+
+[[bench]]
 name = "mvcc_benchmark"
 harness = false
 

--- a/core/benches/count_null_peek_benchmark.rs
+++ b/core/benches/count_null_peek_benchmark.rs
@@ -37,7 +37,10 @@ const DENSITIES: &[(&str, u64)] = &[
 const QUERY_SHAPES: &[(&str, &str)] = &[
     ("count_col", "SELECT COUNT({col}) FROM t"),
     ("where_is_null", "SELECT id FROM t WHERE {col} IS NULL"),
-    ("where_is_not_null", "SELECT id FROM t WHERE {col} IS NOT NULL"),
+    (
+        "where_is_not_null",
+        "SELECT id FROM t WHERE {col} IS NOT NULL",
+    ),
     (
         "filter_is_null",
         "SELECT COUNT(*) FILTER (WHERE {col} IS NULL) FROM t",
@@ -64,9 +67,7 @@ fn seed_db(n: usize, label: &str, k: u64) -> TempDir {
     let tx = conn.unchecked_transaction().unwrap();
     {
         let mut ins = tx
-            .prepare(
-                "INSERT INTO t(id, g, nullable_text, nullable_blob) VALUES (?1, ?2, ?3, ?4)",
-            )
+            .prepare("INSERT INTO t(id, g, nullable_text, nullable_blob) VALUES (?1, ?2, ?3, ?4)")
             .unwrap();
         for i in 1..=n as i64 {
             let g = format!("group-{:02}", i % 16);
@@ -82,13 +83,8 @@ fn seed_db(n: usize, label: &str, k: u64) -> TempDir {
                 let blob = vec![(i % 251) as u8; 64];
                 ins.execute((i, &g, Some(text), Some(blob))).unwrap();
             } else {
-                ins.execute((
-                    i,
-                    &g,
-                    Option::<String>::None,
-                    Option::<Vec<u8>>::None,
-                ))
-                .unwrap();
+                ins.execute((i, &g, Option::<String>::None, Option::<Vec<u8>>::None))
+                    .unwrap();
             }
         }
     }

--- a/core/benches/count_null_peek_benchmark.rs
+++ b/core/benches/count_null_peek_benchmark.rs
@@ -1,0 +1,153 @@
+//! Microbenchmark for the peek-only NULL-check opcode (tursodatabase/turso#4921):
+//! compares COUNT(col), WHERE col IS [NOT] NULL, and FILTER (WHERE col IS NULL)
+//! across a NULL-density sweep, for both a TEXT and a BLOB column (to separate
+//! UTF-8 validation cost from allocation cost). Densities are deterministic via
+//! id % k, not RANDOM(), so runs are reproducible and diffable across builds.
+//!
+//! Run:  cargo bench -p turso_core --bench count_null_peek_benchmark
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion,
+};
+#[cfg(not(feature = "codspeed"))]
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::TempDir;
+use turso_core::{Database, PlatformIO, SqliteDialect, StepResult};
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+const N: usize = 1_000_000;
+
+// NULL density expressed as "1 in K rows is non-NULL" so that 0% density is exactly
+// representable (k = 0 => always NULL) alongside the sparser end of the sweep.
+const DENSITIES: &[(&str, u64)] = &[
+    ("d00", 0),   // 0% non-null (always NULL)
+    ("d10", 10),  // 10% non-null (id % 10 == 0)
+    ("d50", 2),   // 50% non-null (id % 2 == 0)
+    ("d90", 10),  // 90% non-null (id % 10 != 0)
+    ("d99", 100), // 99% non-null (id % 100 != 0)
+];
+
+const QUERY_SHAPES: &[(&str, &str)] = &[
+    ("count_col", "SELECT COUNT({col}) FROM t"),
+    ("where_is_null", "SELECT id FROM t WHERE {col} IS NULL"),
+    ("where_is_not_null", "SELECT id FROM t WHERE {col} IS NOT NULL"),
+    (
+        "filter_is_null",
+        "SELECT COUNT(*) FILTER (WHERE {col} IS NULL) FROM t",
+    ),
+];
+
+const COLUMNS: &[&str] = &["nullable_text", "nullable_blob"];
+
+/// d90/d99 flip to != 0 since k alone can't express >50% non-null with == 0.
+fn seed_db(n: usize, label: &str, k: u64) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("count_null_peek.db");
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    conn.execute_batch(
+        "PRAGMA journal_mode=DELETE;
+         CREATE TABLE t(
+             id INTEGER PRIMARY KEY,
+             g TEXT,
+             nullable_text TEXT,
+             nullable_blob BLOB
+         );",
+    )
+    .unwrap();
+    let tx = conn.unchecked_transaction().unwrap();
+    {
+        let mut ins = tx
+            .prepare(
+                "INSERT INTO t(id, g, nullable_text, nullable_blob) VALUES (?1, ?2, ?3, ?4)",
+            )
+            .unwrap();
+        for i in 1..=n as i64 {
+            let g = format!("group-{:02}", i % 16);
+            let is_non_null = if label == "d00" {
+                false
+            } else if label == "d90" || label == "d99" {
+                (i as u64) % k != 0
+            } else {
+                (i as u64) % k == 0
+            };
+            if is_non_null {
+                let text = format!("row-text-payload-{i}");
+                let blob = vec![(i % 251) as u8; 64];
+                ins.execute((i, &g, Some(text), Some(blob))).unwrap();
+            } else {
+                ins.execute((
+                    i,
+                    &g,
+                    Option::<String>::None,
+                    Option::<Vec<u8>>::None,
+                ))
+                .unwrap();
+            }
+        }
+    }
+    tx.commit().unwrap();
+    dir
+}
+
+fn drain_turso(db: &Database, stmt: &mut turso_core::Statement) {
+    loop {
+        match stmt.step().unwrap() {
+            StepResult::Row => {
+                black_box(stmt.row());
+            }
+            StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
+                db.io.step().unwrap();
+            }
+            StepResult::Done => break,
+            StepResult::Interrupt | StepResult::Busy => unreachable!(),
+        }
+    }
+    stmt.reset().unwrap();
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_count_null_peek(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("count_null_peek");
+    group.sample_size(30);
+    group.measurement_time(Duration::from_secs(8));
+    group.warm_up_time(Duration::from_secs(2));
+
+    for (density_label, k) in DENSITIES {
+        let dir = seed_db(N, density_label, *k);
+        let path = dir.path().join("count_null_peek.db");
+
+        for col in COLUMNS {
+            #[allow(clippy::arc_with_non_send_sync)]
+            let io = Arc::new(PlatformIO::new().unwrap());
+            let db =
+                Database::open_file(io, path.to_str().unwrap(), Arc::new(SqliteDialect)).unwrap();
+            let conn = db.connect().unwrap();
+            {
+                let mut p = conn.prepare("PRAGMA cache_size=-65536").unwrap();
+                while !matches!(p.step().unwrap(), StepResult::Done) {
+                    db.io.step().unwrap();
+                }
+            }
+
+            for (shape_label, sql_template) in QUERY_SHAPES {
+                let sql = sql_template.replace("{col}", col);
+                let bench_id = format!("{shape_label}/{col}/{density_label}");
+                group.bench_with_input(BenchmarkId::new(bench_id, N), &N, |b, _| {
+                    let mut stmt = conn.prepare(&sql).unwrap();
+                    b.iter(|| drain_turso(&db, &mut stmt));
+                });
+            }
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_count_null_peek);
+criterion_main!(benches);

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -16,7 +16,7 @@ use super::{
     emitter::{OperationMode, Resolver, TranslateCtx},
     expr::{
         resolve_expr, translate_condition_expr, translate_expr, translate_expr_no_constant_opt,
-        ConditionMetadata, NoConstantOptReason,
+        try_resolve_peek_target, ConditionMetadata, NoConstantOptReason,
     },
     plan::{
         Aggregate, Distinctness, NonFromClauseSubquery, SelectPlan, SubqueryEvalPhase,
@@ -252,6 +252,32 @@ pub fn handle_distinct(
     });
 }
 
+/// Skips DISTINCT: a placeholder peek would collapse every distinct non-null
+/// value into the same value, breaking the distinct count.
+fn try_count_col_peek(
+    program: &mut ProgramBuilder,
+    referenced_tables: &TableReferences,
+    resolver: &Resolver,
+    agg_arg_source: &AggArgumentSource,
+) -> Result<Option<usize>> {
+    let AggArgumentSource::Expression {
+        args, distinctness, ..
+    } = agg_arg_source
+    else {
+        return Ok(None);
+    };
+    if !matches!(distinctness, Distinctness::NonDistinct) {
+        return Ok(None);
+    }
+    let Some(target) = try_resolve_peek_target(program, referenced_tables, resolver, &args[0])?
+    else {
+        return Ok(None);
+    };
+    let dest = program.alloc_register();
+    program.emit_column_is_null_to_reg(target.cursor_id, target.column, dest);
+    Ok(Some(dest))
+}
+
 /// Source of aggregate function arguments during bytecode emission.
 ///
 /// * `Register`: arguments were pre-computed into contiguous registers
@@ -401,7 +427,10 @@ pub fn translate_aggregation_step(
             if num_args != 1 {
                 crate::bail_parse_error!("count bad number of arguments");
             }
-            let expr_reg = agg_arg_source.translate(program, referenced_tables, resolver, 0)?;
+            let expr_reg = match try_count_col_peek(program, referenced_tables, resolver, &agg_arg_source)? {
+                Some(reg) => reg,
+                None => agg_arg_source.translate(program, referenced_tables, resolver, 0)?,
+            };
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             program.emit_insn(Insn::AggStep {
                 data: Box::new(AggStepData {

--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -427,10 +427,11 @@ pub fn translate_aggregation_step(
             if num_args != 1 {
                 crate::bail_parse_error!("count bad number of arguments");
             }
-            let expr_reg = match try_count_col_peek(program, referenced_tables, resolver, &agg_arg_source)? {
-                Some(reg) => reg,
-                None => agg_arg_source.translate(program, referenced_tables, resolver, 0)?,
-            };
+            let expr_reg =
+                match try_count_col_peek(program, referenced_tables, resolver, &agg_arg_source)? {
+                    Some(reg) => reg,
+                    None => agg_arg_source.translate(program, referenced_tables, resolver, 0)?,
+                };
             handle_distinct(program, agg_arg_source.distinctness(), expr_reg);
             program.emit_insn(Insn::AggStep {
                 data: Box::new(AggStepData {

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -208,6 +208,7 @@ pub struct Resolver<'a> {
     /// that its own action program is already being built.
     pub(super) fk_action_compile_stack: FkActionCompileStack,
     unqualified_database_search_path: Option<Vec<String>>,
+    pub(crate) peek_eligible_columns: std::rc::Rc<HashSet<(TableInternalId, usize)>>,
 }
 
 #[derive(Clone)]
@@ -324,6 +325,7 @@ impl<'a> Resolver<'a> {
             has_temp_schema,
             fk_action_compile_stack: FkActionCompileStack::default(),
             unqualified_database_search_path: unqualified_database_search_path.clone(),
+            peek_eligible_columns: std::rc::Rc::new(HashSet::default()),
         }
     }
 
@@ -369,6 +371,7 @@ impl<'a> Resolver<'a> {
             has_temp_schema: self.has_temp_schema,
             fk_action_compile_stack: self.fk_action_compile_stack.clone(),
             unqualified_database_search_path: self.unqualified_database_search_path.clone(),
+            peek_eligible_columns: self.peek_eligible_columns.clone(),
         }
     }
 
@@ -396,6 +399,7 @@ impl<'a> Resolver<'a> {
             has_temp_schema: self.has_temp_schema,
             fk_action_compile_stack: self.fk_action_compile_stack.clone(),
             unqualified_database_search_path: self.unqualified_database_search_path.clone(),
+            peek_eligible_columns: self.peek_eligible_columns.clone(),
         }
     }
 
@@ -617,6 +621,12 @@ impl<'a> Resolver<'a> {
         } else {
             None
         }
+    }
+
+    /// A cached register (e.g. a hash-join build-side register) may not reflect the cursor's
+    /// current row; peeking the cursor directly in that case reads the wrong row.
+    pub fn column_value_is_register_cached(&self, expr: &ast::Expr) -> bool {
+        self.resolve_cached_expr_reg(expr).is_some()
     }
 
     /// Access schema for a database using a closure pattern to avoid cloning

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -18,7 +18,7 @@ use crate::{
             Operation, QueryDestination, Scan, Search, SeekKeyComponent, SelectPlan,
             SimpleAggregate,
         },
-        planner::table_mask_from_expr,
+        planner::{compute_peek_eligible_columns, table_mask_from_expr},
         select::emit_simple_count,
         subquery::{emit_from_clause_subqueries, emit_non_from_clause_subqueries_for_eval_at},
         values::emit_values,
@@ -82,6 +82,9 @@ pub fn emit_query<'a>(
 ) -> Result<usize> {
     let after_main_loop_label = program.allocate_label();
     t_ctx.label_main_loop_end = Some(after_main_loop_label);
+
+    t_ctx.resolver.peek_eligible_columns =
+        std::rc::Rc::new(compute_peek_eligible_columns(plan));
 
     // Register parameters from EXISTS subquery result columns that were dropped
     // during semi/anti-join unnesting. No code is emitted for these, but the

--- a/core/translate/emitter/select.rs
+++ b/core/translate/emitter/select.rs
@@ -83,8 +83,7 @@ pub fn emit_query<'a>(
     let after_main_loop_label = program.allocate_label();
     t_ctx.label_main_loop_end = Some(after_main_loop_label);
 
-    t_ctx.resolver.peek_eligible_columns =
-        std::rc::Rc::new(compute_peek_eligible_columns(plan));
+    t_ctx.resolver.peek_eligible_columns = std::rc::Rc::new(compute_peek_eligible_columns(plan));
 
     // Register parameters from EXISTS subquery result columns that were dropped
     // during semi/anti-join unnesting. No code is emitted for these, but the

--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -230,7 +230,12 @@ fn try_translate_null_check_peek(
         (false, true) => (false, condition_metadata.jump_target_when_true),
         (false, false) => (true, condition_metadata.jump_target_when_false),
     };
-    program.emit_column_is_null_jump(target.cursor_id, target.column, target_pc, jump_if_column_is_null);
+    program.emit_column_is_null_jump(
+        target.cursor_id,
+        target.column,
+        target_pc,
+        jump_if_column_is_null,
+    );
     Ok(true)
 }
 

--- a/core/translate/expr/condition.rs
+++ b/core/translate/expr/condition.rs
@@ -209,6 +209,31 @@ pub(super) fn translate_in_list(
     Ok(())
 }
 
+fn try_translate_null_check_peek(
+    program: &mut ProgramBuilder,
+    referenced_tables: &TableReferences,
+    resolver: &Resolver,
+    operand: &ast::Expr,
+    is_null_semantics: bool,
+    condition_metadata: ConditionMetadata,
+) -> Result<bool> {
+    let Some(target) = try_resolve_peek_target(program, referenced_tables, resolver, operand)?
+    else {
+        return Ok(false);
+    };
+    let (jump_if_column_is_null, target_pc) = match (
+        is_null_semantics,
+        condition_metadata.jump_if_condition_is_true,
+    ) {
+        (true, true) => (true, condition_metadata.jump_target_when_true),
+        (true, false) => (false, condition_metadata.jump_target_when_false),
+        (false, true) => (false, condition_metadata.jump_target_when_true),
+        (false, false) => (true, condition_metadata.jump_target_when_false),
+    };
+    program.emit_column_is_null_jump(target.cursor_id, target.column, target_pc, jump_if_column_is_null);
+    Ok(true)
+}
+
 #[instrument(skip(program, referenced_tables, expr, resolver), level = Level::DEBUG)]
 pub fn translate_condition_expr(
     program: &mut ProgramBuilder,
@@ -361,35 +386,53 @@ pub fn translate_condition_expr(
         ast::Expr::Binary(e1, ast::Operator::Is, e2)
             if matches!(e2.as_ref(), ast::Expr::Literal(ast::Literal::Null)) =>
         {
-            let cur_reg = program.alloc_register();
-            translate_expr(program, Some(referenced_tables), e1, cur_reg, resolver)?;
-            if condition_metadata.jump_if_condition_is_true {
-                program.emit_insn(Insn::IsNull {
-                    reg: cur_reg,
-                    target_pc: condition_metadata.jump_target_when_true,
-                });
-            } else {
-                program.emit_insn(Insn::NotNull {
-                    reg: cur_reg,
-                    target_pc: condition_metadata.jump_target_when_false,
-                });
+            if !try_translate_null_check_peek(
+                program,
+                referenced_tables,
+                resolver,
+                e1,
+                true,
+                condition_metadata,
+            )? {
+                let cur_reg = program.alloc_register();
+                translate_expr(program, Some(referenced_tables), e1, cur_reg, resolver)?;
+                if condition_metadata.jump_if_condition_is_true {
+                    program.emit_insn(Insn::IsNull {
+                        reg: cur_reg,
+                        target_pc: condition_metadata.jump_target_when_true,
+                    });
+                } else {
+                    program.emit_insn(Insn::NotNull {
+                        reg: cur_reg,
+                        target_pc: condition_metadata.jump_target_when_false,
+                    });
+                }
             }
         }
         ast::Expr::Binary(e1, ast::Operator::IsNot, e2)
             if matches!(e2.as_ref(), ast::Expr::Literal(ast::Literal::Null)) =>
         {
-            let cur_reg = program.alloc_register();
-            translate_expr(program, Some(referenced_tables), e1, cur_reg, resolver)?;
-            if condition_metadata.jump_if_condition_is_true {
-                program.emit_insn(Insn::NotNull {
-                    reg: cur_reg,
-                    target_pc: condition_metadata.jump_target_when_true,
-                });
-            } else {
-                program.emit_insn(Insn::IsNull {
-                    reg: cur_reg,
-                    target_pc: condition_metadata.jump_target_when_false,
-                });
+            if !try_translate_null_check_peek(
+                program,
+                referenced_tables,
+                resolver,
+                e1,
+                false,
+                condition_metadata,
+            )? {
+                let cur_reg = program.alloc_register();
+                translate_expr(program, Some(referenced_tables), e1, cur_reg, resolver)?;
+                if condition_metadata.jump_if_condition_is_true {
+                    program.emit_insn(Insn::NotNull {
+                        reg: cur_reg,
+                        target_pc: condition_metadata.jump_target_when_true,
+                    });
+                } else {
+                    program.emit_insn(Insn::IsNull {
+                        reg: cur_reg,
+                        target_pc: condition_metadata.jump_target_when_false,
+                    });
+                }
             }
         }
         ast::Expr::Binary(e1, op, e2) => {
@@ -515,33 +558,51 @@ pub fn translate_condition_expr(
             }
         }
         ast::Expr::NotNull(expr) => {
-            let cur_reg = program.alloc_register();
-            translate_expr(program, Some(referenced_tables), expr, cur_reg, resolver)?;
-            if condition_metadata.jump_if_condition_is_true {
-                program.emit_insn(Insn::NotNull {
-                    reg: cur_reg,
-                    target_pc: condition_metadata.jump_target_when_true,
-                });
-            } else {
-                program.emit_insn(Insn::IsNull {
-                    reg: cur_reg,
-                    target_pc: condition_metadata.jump_target_when_false,
-                });
+            if !try_translate_null_check_peek(
+                program,
+                referenced_tables,
+                resolver,
+                expr,
+                false,
+                condition_metadata,
+            )? {
+                let cur_reg = program.alloc_register();
+                translate_expr(program, Some(referenced_tables), expr, cur_reg, resolver)?;
+                if condition_metadata.jump_if_condition_is_true {
+                    program.emit_insn(Insn::NotNull {
+                        reg: cur_reg,
+                        target_pc: condition_metadata.jump_target_when_true,
+                    });
+                } else {
+                    program.emit_insn(Insn::IsNull {
+                        reg: cur_reg,
+                        target_pc: condition_metadata.jump_target_when_false,
+                    });
+                }
             }
         }
         ast::Expr::IsNull(expr) => {
-            let cur_reg = program.alloc_register();
-            translate_expr(program, Some(referenced_tables), expr, cur_reg, resolver)?;
-            if condition_metadata.jump_if_condition_is_true {
-                program.emit_insn(Insn::IsNull {
-                    reg: cur_reg,
-                    target_pc: condition_metadata.jump_target_when_true,
-                });
-            } else {
-                program.emit_insn(Insn::NotNull {
-                    reg: cur_reg,
-                    target_pc: condition_metadata.jump_target_when_false,
-                });
+            if !try_translate_null_check_peek(
+                program,
+                referenced_tables,
+                resolver,
+                expr,
+                true,
+                condition_metadata,
+            )? {
+                let cur_reg = program.alloc_register();
+                translate_expr(program, Some(referenced_tables), expr, cur_reg, resolver)?;
+                if condition_metadata.jump_if_condition_is_true {
+                    program.emit_insn(Insn::IsNull {
+                        reg: cur_reg,
+                        target_pc: condition_metadata.jump_target_when_true,
+                    });
+                } else {
+                    program.emit_insn(Insn::NotNull {
+                        reg: cur_reg,
+                        target_pc: condition_metadata.jump_target_when_false,
+                    });
+                }
             }
         }
         ast::Expr::Unary(_, _) => {

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -104,6 +104,7 @@ pub use metadata::ConditionMetadata;
 pub use translator::{
     resolve_expr, translate_expr, translate_expr_no_constant_opt, NoConstantOptReason,
 };
+pub(crate) use translator::try_resolve_peek_target;
 pub use utils::{
     as_binary_components, maybe_apply_affinity, sanitize_string, truth_test_rhs, unwrap_parens,
     unwrap_parens_owned,

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -101,10 +101,10 @@ pub(crate) use emission::{
     seed_returning_row_image_in_cache,
 };
 pub use metadata::ConditionMetadata;
+pub(crate) use translator::try_resolve_peek_target;
 pub use translator::{
     resolve_expr, translate_expr, translate_expr_no_constant_opt, NoConstantOptReason,
 };
-pub(crate) use translator::try_resolve_peek_target;
 pub use utils::{
     as_binary_components, maybe_apply_affinity, sanitize_string, truth_test_rhs, unwrap_parens,
     unwrap_parens_owned,

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -89,6 +89,157 @@ pub fn resolve_expr(
     translate_expr(program, referenced_tables, expr, dest_reg, resolver)
 }
 
+pub(crate) struct ColumnPeekTarget {
+    pub cursor_id: CursorID,
+    pub column: usize,
+}
+
+/// Resolves the cursor and index-remapped column position to read column of table_ref_id.
+/// column_is_virtual must be true for a VIRTUAL generated column: it has a slot in a
+/// non-covering index, but the value is only materialized there when the index is covering.
+fn resolve_column_read_target(
+    program: &ProgramBuilder,
+    table_ref_id: TableInternalId,
+    column: usize,
+    index: Option<&Arc<crate::schema::Index>>,
+    use_covering_index: bool,
+    is_from_outer_query_scope: bool,
+    column_is_virtual: bool,
+) -> Option<(CursorID, usize, bool)> {
+    let (table_cursor_id, index_cursor_id) = if is_from_outer_query_scope {
+        // Due to a limitation of our translation system, a subquery that references an outer
+        // query table cannot know whether a table cursor, index cursor, or both were opened for
+        // that table reference. Hence: currently we first try to resolve a table cursor, and if
+        // that fails, we resolve an index cursor.
+        if let Some(table_cursor_id) =
+            program.resolve_cursor_id_safe(&CursorKey::table(table_ref_id))
+        {
+            (Some(table_cursor_id), None)
+        } else {
+            (
+                None,
+                Some(program.resolve_any_index_cursor_id_for_table(table_ref_id)),
+            )
+        }
+    } else {
+        let table_cursor_id = if use_covering_index {
+            program.resolve_cursor_id_safe(&CursorKey::table(table_ref_id))
+        } else {
+            Some(program.resolve_cursor_id(&CursorKey::table(table_ref_id)))
+        };
+        let index_cursor_id = index
+            .map(|index| program.resolve_cursor_id(&CursorKey::index(table_ref_id, index.clone())));
+        (table_cursor_id, index_cursor_id)
+    };
+
+    let is_btree_index = index_cursor_id
+        .is_some_and(|cid| program.get_cursor_type(cid).is_some_and(|ct| ct.is_index()));
+    let read_from_index = if is_from_outer_query_scope {
+        is_btree_index
+    } else if is_btree_index {
+        let column_is_in_index =
+            index.is_some_and(|idx| idx.column_table_pos_to_index_pos(column).is_some());
+        column_is_in_index && (!column_is_virtual || use_covering_index)
+    } else {
+        false
+    };
+
+    if read_from_index {
+        let index_cursor_id = index_cursor_id?;
+        let index = program.resolve_index_for_cursor_id(index_cursor_id);
+        let index_pos = index.column_table_pos_to_index_pos(column)?;
+        Some((index_cursor_id, index_pos, true))
+    } else {
+        Some((table_cursor_id.or(index_cursor_id)?, column, false))
+    }
+}
+
+/// Excludes rowid-alias columns: an INTEGER PRIMARY KEY column's record payload
+/// stores NULL even though the column itself is never NULL in SQL.
+pub(crate) fn try_resolve_column_peek(
+    program: &ProgramBuilder,
+    referenced_tables: Option<&TableReferences>,
+    resolver: &Resolver,
+    table_ref_id: TableInternalId,
+    column: usize,
+    is_rowid_alias: bool,
+) -> Result<Option<ColumnPeekTarget>> {
+    if is_rowid_alias || program.has_cursor_override(table_ref_id) {
+        return Ok(None);
+    }
+    let Some(referenced_tables) = referenced_tables else {
+        return Ok(None);
+    };
+    let Some(table_reference) = referenced_tables.find_joined_table_by_internal_id(table_ref_id)
+    else {
+        return Ok(None);
+    };
+    if matches!(table_reference.op, Operation::IndexMethodQuery(_)) {
+        return Ok(None);
+    }
+    let index = table_reference.op.index();
+    let use_covering_index = table_reference.utilizes_covering_index();
+
+    let table = &table_reference.table;
+    let Table::BTree(_) = table else {
+        return Ok(None);
+    };
+    let Some(table_column) = table.get_column_at(column) else {
+        return Ok(None);
+    };
+    if table_column.is_generated() {
+        return Ok(None);
+    }
+    // A custom type's DECODE could map a non-null payload to NULL, or vice versa, so raw
+    // record NULL-ness wouldn't reflect the decoded value.
+    if resolver
+        .schema()
+        .get_type_def(&table_column.ty_str, table.is_strict())
+        .is_some()
+    {
+        return Ok(None);
+    }
+
+    let Some((cursor_id, column, _)) =
+        resolve_column_read_target(program, table_ref_id, column, index, use_covering_index, false, false)
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(ColumnPeekTarget { cursor_id, column }))
+}
+
+pub(crate) fn try_resolve_peek_target(
+    program: &ProgramBuilder,
+    referenced_tables: &TableReferences,
+    resolver: &Resolver,
+    expr: &ast::Expr,
+) -> Result<Option<ColumnPeekTarget>> {
+    let ast::Expr::Column {
+        table,
+        column,
+        is_rowid_alias,
+        ..
+    } = expr
+    else {
+        return Ok(None);
+    };
+    if resolver.column_value_is_register_cached(expr) {
+        return Ok(None);
+    }
+    if !resolver.peek_eligible_columns.contains(&(*table, *column)) {
+        return Ok(None);
+    }
+    try_resolve_column_peek(
+        program,
+        Some(referenced_tables),
+        resolver,
+        *table,
+        *column,
+        *is_rowid_alias,
+    )
+}
+
 /// Translate an expression into bytecode.
 #[turso_macros::trace_stack]
 pub fn translate_expr(
@@ -2374,36 +2525,21 @@ pub fn translate_expr(
                             unreachable!("Either index or table cursor must be opened");
                         }
                     } else {
-                        let is_btree_index = index_cursor_id.is_some_and(|cid| {
-                            program.get_cursor_type(cid).is_some_and(|ct| ct.is_index())
-                        });
-                        // For non-outer-scope reads: an index can supply a
-                        // column's value only when the index actually
-                        // stores it. Presence in the index's column list
-                        // (`column_table_pos_to_index_pos`) is necessary
-                        // but not sufficient for VIRTUAL generated
-                        // columns — the index has a slot but the value
-                        // is only materialized when the index is
-                        // covering. For stored columns the slot implies
-                        // the value, so any in-index hit is fine.
-                        let read_from_index = if is_from_outer_query_scope {
-                            is_btree_index
-                        } else if is_btree_index {
-                            let column_is_in_index = index.as_ref().is_some_and(|idx| {
-                                idx.column_table_pos_to_index_pos(*column).is_some()
-                            });
-                            let column_is_virtual = matches!(
-                                table.get_column_at(*column).map(|c| c.generated_type()),
-                                Some(GeneratedType::Virtual { .. })
-                            );
-                            column_is_in_index && (!column_is_virtual || use_covering_index)
-                        } else {
-                            false
-                        };
-
                         let Some(table_column) = table.get_column_at(*column) else {
                             crate::bail_parse_error!("column index out of bounds");
                         };
+                        let column_is_virtual =
+                            matches!(table_column.generated_type(), GeneratedType::Virtual { .. });
+                        let resolved = resolve_column_read_target(
+                            program,
+                            *table_ref_id,
+                            *column,
+                            index,
+                            use_covering_index,
+                            is_from_outer_query_scope,
+                            column_is_virtual,
+                        );
+                        let read_from_index = resolved.is_some_and(|(_, _, r)| r);
                         match table_column.generated_type() {
                             // if we're reading from an index that contains this virtual column,
                             // the index already has the computed value, so read it from the index
@@ -2433,28 +2569,8 @@ pub fn translate_expr(
                                 program.set_collation(Some((table_column.collation(), false)));
                             }
                             _ => {
-                                let read_cursor = if read_from_index {
-                                    index_cursor_id.expect("index cursor should be opened")
-                                } else {
-                                    table_cursor_id
-                                        .or(index_cursor_id)
-                                        .expect("cursor should be opened")
-                                };
-                                let column = if read_from_index {
-                                    let index = program.resolve_index_for_cursor_id(
-                                        index_cursor_id.expect("index cursor should be opened"),
-                                    );
-                                    index
-                                        .column_table_pos_to_index_pos(*column)
-                                        .unwrap_or_else(|| {
-                                            panic!(
-                                                "index {} does not contain column number {} of table {}",
-                                                index.name, column, table_ref_id
-                                            )
-                                        })
-                                } else {
-                                    *column
-                                };
+                                let (read_cursor, column, _) =
+                                    resolved.expect("cursor should be opened");
 
                                 // For custom type columns with ENCODE/DECODE and a
                                 // default, suppress the Column instruction's default.

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -200,9 +200,15 @@ pub(crate) fn try_resolve_column_peek(
         return Ok(None);
     }
 
-    let Some((cursor_id, column, _)) =
-        resolve_column_read_target(program, table_ref_id, column, index, use_covering_index, false, false)
-    else {
+    let Some((cursor_id, column, _)) = resolve_column_read_target(
+        program,
+        table_ref_id,
+        column,
+        index,
+        use_covering_index,
+        false,
+        false,
+    ) else {
         return Ok(None);
     };
 

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -16,7 +16,9 @@ fn try_translate_filter_null_check_peek(
     skip_label: BranchOffset,
 ) -> Result<bool> {
     let (is_null_semantics, operand) = match filter_expr {
-        Expr::Binary(e1, Operator::Is, e2) if matches!(e2.as_ref(), Expr::Literal(Literal::Null)) => {
+        Expr::Binary(e1, Operator::Is, e2)
+            if matches!(e2.as_ref(), Expr::Literal(Literal::Null)) =>
+        {
             (true, e1.as_ref())
         }
         Expr::Binary(e1, Operator::IsNot, e2)

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -8,6 +8,42 @@ use crate::vdbe::insn::AggStepData;
 
 use super::*;
 
+fn try_translate_filter_null_check_peek(
+    program: &mut ProgramBuilder,
+    referenced_tables: &TableReferences,
+    resolver: &Resolver,
+    filter_expr: &Expr,
+    skip_label: BranchOffset,
+) -> Result<bool> {
+    let (is_null_semantics, operand) = match filter_expr {
+        Expr::Binary(e1, Operator::Is, e2) if matches!(e2.as_ref(), Expr::Literal(Literal::Null)) => {
+            (true, e1.as_ref())
+        }
+        Expr::Binary(e1, Operator::IsNot, e2)
+            if matches!(e2.as_ref(), Expr::Literal(Literal::Null)) =>
+        {
+            (false, e1.as_ref())
+        }
+        Expr::IsNull(e) => (true, e.as_ref()),
+        Expr::NotNull(e) => (false, e.as_ref()),
+        _ => return Ok(false),
+    };
+    let Some(target) = try_resolve_peek_target(program, referenced_tables, resolver, operand)?
+    else {
+        return Ok(false);
+    };
+    // Skip the AggStep when the filter is false: for IS NULL that's column NOT
+    // null; for IS NOT NULL, column IS null.
+    let jump_if_column_is_null = !is_null_semantics;
+    program.emit_column_is_null_jump(
+        target.cursor_id,
+        target.column,
+        skip_label,
+        jump_if_column_is_null,
+    );
+    Ok(true)
+}
+
 /// SQLite (and so Turso) processes joins as a nested loop.
 /// The loop may emit rows to various destinations depending on the query:
 /// - a GROUP BY sorter (grouping is done by sorting based on the GROUP BY keys and aggregating while the GROUP BY keys match)
@@ -289,19 +325,27 @@ fn emit_loop_source<'a>(
                 // FILTER: skip AggStep if filter condition is false
                 let filter_skip_label = if let Some(filter_expr) = &agg.filter_expr {
                     let label = program.allocate_label();
-                    let filter_reg = program.alloc_register();
-                    translate_expr(
+                    if !try_translate_filter_null_check_peek(
                         program,
-                        Some(&plan.table_references),
-                        filter_expr,
-                        filter_reg,
+                        &plan.table_references,
                         &t_ctx.resolver,
-                    )?;
-                    program.emit_insn(Insn::IfNot {
-                        reg: filter_reg,
-                        target_pc: label,
-                        jump_if_null: true,
-                    });
+                        filter_expr,
+                        label,
+                    )? {
+                        let filter_reg = program.alloc_register();
+                        translate_expr(
+                            program,
+                            Some(&plan.table_references),
+                            filter_expr,
+                            filter_reg,
+                            &t_ctx.resolver,
+                        )?;
+                        program.emit_insn(Insn::IfNot {
+                            reg: filter_reg,
+                            target_pc: label,
+                            jump_if_null: true,
+                        });
+                    }
                     Some(label)
                 } else {
                     None

--- a/core/translate/main_loop/mod.rs
+++ b/core/translate/main_loop/mod.rs
@@ -1,4 +1,4 @@
-use turso_parser::ast::{Expr, SortOrder, TableInternalId};
+use turso_parser::ast::{Expr, Literal, Operator, SortOrder, TableInternalId};
 
 use super::{
     aggregation::{translate_aggregation_step, AggArgumentSource},
@@ -8,8 +8,8 @@ use super::{
     },
     expr::{
         expr_references_outer_query, expr_references_subquery_id, translate_condition_expr,
-        translate_expr, translate_expr_no_constant_opt, walk_expr, ConditionMetadata,
-        NoConstantOptReason, WalkControl,
+        translate_expr, translate_expr_no_constant_opt, try_resolve_peek_target, walk_expr,
+        ConditionMetadata, NoConstantOptReason, WalkControl,
     },
     group_by::{group_by_agg_phase, GroupByMetadata, GroupByRowSource},
     optimizer::{constraints::BinaryExprSide, Optimizable},

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -7,7 +7,7 @@ use super::{
     plan::{
         Aggregate, ColumnMask, ColumnUsedMask, Distinctness, EvalAt, IterationDirection, JoinInfo,
         JoinOrderMember, JoinType as PlanJoinType, JoinedTable, Operation, OuterQueryReference,
-        Plan, QueryDestination, ResultSetColumn, Scan, TableReferences, WhereTerm,
+        Plan, QueryDestination, ResultSetColumn, Scan, SelectPlan, TableReferences, WhereTerm,
     },
     select::{prepare_select_plan, prepare_select_plan_from_arms},
 };
@@ -487,6 +487,67 @@ fn collect_subquery_table_refs_in_expr(expr: &Expr, out: &mut Vec<String>) {
 
 /// Valid ways to refer to the rowid of a btree table.
 pub const ROWID_STRS: [&str; 3] = ["rowid", "_rowid_", "oid"];
+
+/// Profitability heuristic only; correctness (cursor type, rowid alias, generated
+/// columns, DISTINCT, ...) is enforced independently at each call site.
+pub(crate) fn compute_peek_eligible_columns(
+    plan: &SelectPlan,
+) -> rustc_hash::FxHashSet<(TableInternalId, usize)> {
+    let mut counts: rustc_hash::FxHashMap<(TableInternalId, usize), usize> =
+        rustc_hash::FxHashMap::default();
+    // Skip aggregate args (e.g. val in COUNT(val)); counted separately via plan.aggregates.
+    let is_extracted_aggregate_call = |e: &Expr| {
+        matches!(e, Expr::FunctionCall { .. } | Expr::FunctionCallStar { .. })
+            && plan
+                .aggregates
+                .iter()
+                .any(|agg| exprs_are_equivalent(e, &agg.original_expr))
+    };
+    let mut count_top_level_expr = |expr: &Expr| {
+        let _ = walk_expr(expr, &mut |e: &Expr| -> Result<WalkControl> {
+            if is_extracted_aggregate_call(e) {
+                return Ok(WalkControl::SkipChildren);
+            }
+            if let Expr::Column { table, column, .. } = e {
+                *counts.entry((*table, *column)).or_insert(0) += 1;
+            }
+            Ok(WalkControl::Continue)
+        });
+    };
+
+    for result_column in &plan.result_columns {
+        count_top_level_expr(&result_column.expr);
+    }
+    for where_term in &plan.where_clause {
+        count_top_level_expr(&where_term.expr);
+    }
+    if let Some(group_by) = &plan.group_by {
+        for expr in &group_by.exprs {
+            count_top_level_expr(expr);
+        }
+        if let Some(having) = &group_by.having {
+            for expr in having {
+                count_top_level_expr(expr);
+            }
+        }
+    }
+    for (expr, _, _) in &plan.order_by {
+        count_top_level_expr(expr);
+    }
+    for aggregate in &plan.aggregates {
+        for arg in &aggregate.args {
+            count_top_level_expr(arg);
+        }
+        if let Some(filter_expr) = &aggregate.filter_expr {
+            count_top_level_expr(filter_expr);
+        }
+    }
+
+    counts
+        .into_iter()
+        .filter_map(|(key, count)| (count == 1).then_some(key))
+        .collect()
+}
 
 /// This function walks the expression tree and identifies aggregate
 /// and window functions.

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1751,6 +1751,9 @@ impl ProgramBuilder {
                     resolve(pc_if_empty, "IndexMethodQuery")?;
                 }
                 Insn::IsNull { reg: _, target_pc } => resolve(target_pc, "IsNull")?,
+                Insn::ColumnIsNullJump { target_pc, .. } => {
+                    resolve(target_pc, "ColumnIsNullJump")?;
+                }
                 Insn::VNext { pc_if_next, .. } => resolve(pc_if_next, "VNext")?,
                 Insn::VFilter { pc_if_empty, .. } => resolve(pc_if_empty, "VFilter")?,
                 Insn::RowSetRead { pc_if_empty, .. } => resolve(pc_if_empty, "RowSetRead")?,
@@ -2165,6 +2168,24 @@ impl ProgramBuilder {
     }
 
     fn emit_column(&mut self, cursor_id: CursorID, column: usize, out: usize) {
+        let (physical_column, default) = self.resolve_column_physical_and_default(cursor_id, column);
+
+        self.emit_insn(Insn::Column {
+            cursor_id,
+            column: physical_column,
+            dest: out,
+            default,
+        });
+    }
+
+    /// Resolves a logical column index to its physical position (BTreeTable cursors only,
+    /// due to ALTER TABLE DROP COLUMN) and computes the short-record DEFAULT, consuming the
+    /// one-shot suppress_column_default flag.
+    fn resolve_column_physical_and_default(
+        &mut self,
+        cursor_id: CursorID,
+        column: usize,
+    ) -> (usize, Option<Value>) {
         let (_, cursor_type) = self.cursor_ref.get(cursor_id).expect("cursor_id is valid");
 
         if let CursorType::BTreeTable(btree) = cursor_type {
@@ -2237,10 +2258,38 @@ impl ProgramBuilder {
             default
         };
 
-        self.emit_insn(Insn::Column {
+        (physical_column, default)
+    }
+
+    /// Emits Insn::ColumnIsNullJump without decoding the column. Callers are responsible
+    /// for the peek-eligibility gates (rowid alias, generated columns, custom types, cursor
+    /// type).
+    pub fn emit_column_is_null_jump(
+        &mut self,
+        cursor_id: CursorID,
+        column: usize,
+        target_pc: BranchOffset,
+        jump_if_column_is_null: bool,
+    ) {
+        let (physical_column, default) = self.resolve_column_physical_and_default(cursor_id, column);
+        self.emit_insn(Insn::ColumnIsNullJump {
             cursor_id,
             column: physical_column,
-            dest: out,
+            target_pc,
+            jump_if_column_is_null,
+            default,
+        });
+    }
+
+    /// Emits Insn::ColumnIsNullToReg, writing a value derived from the column's nullness to
+    /// dest without decoding the payload. See emit_column_is_null_jump for the eligibility
+    /// caveat.
+    pub fn emit_column_is_null_to_reg(&mut self, cursor_id: CursorID, column: usize, dest: usize) {
+        let (physical_column, default) = self.resolve_column_physical_and_default(cursor_id, column);
+        self.emit_insn(Insn::ColumnIsNullToReg {
+            cursor_id,
+            column: physical_column,
+            dest,
             default,
         });
     }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -2168,7 +2168,8 @@ impl ProgramBuilder {
     }
 
     fn emit_column(&mut self, cursor_id: CursorID, column: usize, out: usize) {
-        let (physical_column, default) = self.resolve_column_physical_and_default(cursor_id, column);
+        let (physical_column, default) =
+            self.resolve_column_physical_and_default(cursor_id, column);
 
         self.emit_insn(Insn::Column {
             cursor_id,
@@ -2271,7 +2272,8 @@ impl ProgramBuilder {
         target_pc: BranchOffset,
         jump_if_column_is_null: bool,
     ) {
-        let (physical_column, default) = self.resolve_column_physical_and_default(cursor_id, column);
+        let (physical_column, default) =
+            self.resolve_column_physical_and_default(cursor_id, column);
         self.emit_insn(Insn::ColumnIsNullJump {
             cursor_id,
             column: physical_column,
@@ -2285,7 +2287,8 @@ impl ProgramBuilder {
     /// dest without decoding the payload. See emit_column_is_null_jump for the eligibility
     /// caveat.
     pub fn emit_column_is_null_to_reg(&mut self, cursor_id: CursorID, column: usize, dest: usize) {
-        let (physical_column, default) = self.resolve_column_physical_and_default(cursor_id, column);
+        let (physical_column, default) =
+            self.resolve_column_physical_and_default(cursor_id, column);
         self.emit_insn(Insn::ColumnIsNullToReg {
             cursor_id,
             column: physical_column,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -52,8 +52,8 @@ use crate::vdbe::vacuum::VacuumInPlaceOpContext;
 use crate::vdbe::value::ComparisonOp;
 use crate::vdbe::ValueIteratorExt;
 use crate::vdbe::{
-    registers_to_ref_values, DeferredSeekState, EndStatement, OpHashBuildState, OpHashProbeState,
-    StepResult, TxnCleanup, VacuumOpState,
+    registers_to_ref_values, BranchOffset, DeferredSeekState, EndStatement, OpHashBuildState,
+    OpHashProbeState, StepResult, TxnCleanup, VacuumOpState,
 };
 use crate::vector::{
     vector1bit, vector32, vector32_sparse, vector64, vector8, vector_concat, vector_distance_cos,
@@ -1897,6 +1897,65 @@ pub fn op_column_range(
     )
 }
 
+pub fn op_column_is_null_to_reg(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> InsnResult {
+    load_insn!(
+        ColumnIsNullToReg {
+            cursor_id,
+            column,
+            dest,
+            default,
+        },
+        insn
+    );
+    op_column_impl(
+        program,
+        state,
+        *cursor_id,
+        ColumnFetch::ProbeToReg {
+            column: *column,
+            dest: *dest,
+            default,
+        },
+    )
+}
+
+pub fn op_column_is_null_jump(
+    program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> InsnResult {
+    load_insn!(
+        ColumnIsNullJump {
+            cursor_id,
+            column,
+            target_pc,
+            jump_if_column_is_null,
+            default,
+        },
+        insn
+    );
+    if !target_pc.is_offset() {
+        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+    }
+    op_column_impl(
+        program,
+        state,
+        *cursor_id,
+        ColumnFetch::ProbeJump {
+            column: *column,
+            target_pc: *target_pc,
+            jump_if_column_is_null: *jump_if_column_is_null,
+            default,
+        },
+    )
+}
+
 /// What a Column-family instruction fetches once the cursor is positioned.
 #[derive(Clone, Copy)]
 enum ColumnFetch<'a> {
@@ -1912,10 +1971,21 @@ enum ColumnFetch<'a> {
         dest: usize,
         defaults: &'a [Option<Value>],
     },
+    ProbeToReg {
+        column: usize,
+        dest: usize,
+        default: &'a Option<Value>,
+    },
+    ProbeJump {
+        column: usize,
+        target_pc: BranchOffset,
+        jump_if_column_is_null: bool,
+        default: &'a Option<Value>,
+    },
 }
 
 impl ColumnFetch<'_> {
-    /// Writes NULL to every destination register of this fetch.
+    /// Row-not-found is treated as NULL; ProbeJump resolves its jump here instead of writing a register.
     fn write_null_regs(&self, state: &mut ProgramState) {
         match *self {
             ColumnFetch::Single { dest, .. } => state.registers[dest].set_null(),
@@ -1924,7 +1994,25 @@ impl ColumnFetch<'_> {
                     .iter_mut()
                     .for_each(|reg| reg.set_null());
             }
+            ColumnFetch::ProbeToReg { dest, .. } => {
+                state.registers[dest].set_null();
+            }
+            ColumnFetch::ProbeJump {
+                target_pc,
+                jump_if_column_is_null,
+                ..
+            } => {
+                state.pc = if jump_if_column_is_null {
+                    target_pc.as_offset_int()
+                } else {
+                    state.pc + 1
+                };
+            }
         }
+    }
+
+    fn handles_own_pc(&self) -> bool {
+        matches!(self, ColumnFetch::ProbeJump { .. })
     }
 
     fn fetch(&self, program: &Program, state: &mut ProgramState, cursor_id: usize) -> InsnResult {
@@ -1939,6 +2027,25 @@ impl ColumnFetch<'_> {
                 dest,
                 defaults,
             } => op_column_range_fetch(program, state, cursor_id, start_column, dest, defaults),
+            ColumnFetch::ProbeToReg {
+                column,
+                dest,
+                default,
+            } => op_column_probe_to_reg(program, state, cursor_id, column, dest, default),
+            ColumnFetch::ProbeJump {
+                column,
+                target_pc,
+                jump_if_column_is_null,
+                default,
+            } => op_column_probe_jump(
+                program,
+                state,
+                cursor_id,
+                column,
+                target_pc,
+                jump_if_column_is_null,
+                default,
+            ),
         }
     }
 }
@@ -1956,7 +2063,7 @@ fn op_column_impl(
     // resume the slot is still idle and this path re-executes.
     if state.active_op_state.is_idle() && state.deferred_seeks[cursor_id].is_none() {
         let result = fetch.fetch(program, state, cursor_id)?;
-        if matches!(result, InsnFunctionStepResult::Step) {
+        if matches!(result, InsnFunctionStepResult::Step) && !fetch.handles_own_pc() {
             state.pc += 1;
         }
         return Ok(result);
@@ -2032,7 +2139,9 @@ fn op_column_impl(
     }
 
     state.active_op_state.clear();
-    state.pc += 1;
+    if !fetch.handles_own_pc() {
+        state.pc += 1;
+    }
     Ok(InsnFunctionStepResult::Step)
 }
 
@@ -2174,6 +2283,127 @@ fn op_column_fetch(
         CursorType::VirtualTable(_) => {
             panic!("Insn:Column on virtual table cursor, use Insn:VColumn instead");
         }
+    }
+    Ok(InsnFunctionStepResult::Step)
+}
+
+/// Whether a short record's missing column would read as NULL, per its
+/// DEFAULT. Mirrors apply_column_default's nullness outcome.
+fn is_default_null(default: &Option<Value>) -> bool {
+    !matches!(default, Some(v) if !matches!(v, Value::Null))
+}
+
+fn column_probe_is_null(
+    program: &Program,
+    state: &mut ProgramState,
+    cursor_id: usize,
+    column: usize,
+    default: &Option<Value>,
+    opcode_name: &'static str,
+) -> Result<IOResult<bool>> {
+    let (_, cursor_type) = program
+        .cursor_ref
+        .get(cursor_id)
+        .expect("cursor_id should exist in cursor_ref");
+    match cursor_type {
+        CursorType::BTreeTable(_) | CursorType::BTreeIndex(_) => {
+            let cursor_ref = must_be_btree_cursor!(cursor_id, program.cursor_ref, state, opcode_name);
+            if matches!(cursor_ref, Cursor::NullRow) {
+                Ok(IOResult::Done(true))
+            } else {
+                let cursor = cursor_ref.as_btree_mut();
+                if cursor.get_null_flag() {
+                    Ok(IOResult::Done(true))
+                } else {
+                    let record = match cursor.record()? {
+                        IOResult::IO(io) => return Ok(IOResult::IO(io)),
+                        IOResult::Done(record) => record,
+                    };
+                    let is_null = match record {
+                        None => true,
+                        Some(record) => {
+                            let mut payload_iterator = record.iter()?;
+                            match payload_iterator.nth_is_null(column) {
+                                Some(result) => result?,
+                                None => is_default_null(default),
+                            }
+                        }
+                    };
+                    Ok(IOResult::Done(is_null))
+                }
+            }
+        }
+        CursorType::Pseudo(_) => {
+            let content_reg = crate::get_cursor!(state, cursor_id)
+                .as_pseudo_mut()
+                .content_reg();
+            let is_null = match &state.registers[content_reg] {
+                Register::Record(record) => {
+                    let mut payload_iterator = record.iter()?;
+                    match payload_iterator.nth_is_null(column) {
+                        Some(result) => result?,
+                        None => {
+                            turso_debug_assert!(
+                                false,
+                                "pseudo-cursor column out of range for record",
+                                { "column": column }
+                            );
+                            is_default_null(default)
+                        }
+                    }
+                }
+                _ => true,
+            };
+            Ok(IOResult::Done(is_null))
+        }
+        other => unreachable!(
+            "{opcode_name} emitted for unsupported cursor type {other:?}; the translator's peek-eligibility gate should have excluded it"
+        ),
+    }
+}
+
+fn op_column_probe_to_reg(
+    program: &Program,
+    state: &mut ProgramState,
+    cursor_id: usize,
+    column: usize,
+    dest: usize,
+    default: &Option<Value>,
+) -> InsnResult {
+    let is_null = return_if_io!(column_probe_is_null(
+        program,
+        state,
+        cursor_id,
+        column,
+        default,
+        "ColumnIsNullToReg",
+    ));
+    let value = if is_null { Value::Null } else { Value::from_i64(0) };
+    state.registers[dest].set_value(value);
+    Ok(InsnFunctionStepResult::Step)
+}
+
+fn op_column_probe_jump(
+    program: &Program,
+    state: &mut ProgramState,
+    cursor_id: usize,
+    column: usize,
+    target_pc: BranchOffset,
+    jump_if_column_is_null: bool,
+    default: &Option<Value>,
+) -> InsnResult {
+    let is_null = return_if_io!(column_probe_is_null(
+        program,
+        state,
+        cursor_id,
+        column,
+        default,
+        "ColumnIsNullJump",
+    ));
+    if is_null == jump_if_column_is_null {
+        state.pc = target_pc.as_offset_int();
+    } else {
+        state.pc += 1;
     }
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2378,7 +2378,11 @@ fn op_column_probe_to_reg(
         default,
         "ColumnIsNullToReg",
     ));
-    let value = if is_null { Value::Null } else { Value::from_i64(0) };
+    let value = if is_null {
+        Value::Null
+    } else {
+        Value::from_i64(0)
+    };
     state.registers[dest].set_value(value);
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -688,6 +688,66 @@ pub fn insn_to_row(
                     ),
                 )
             }
+            Insn::ColumnIsNullToReg {
+                cursor_id,
+                column,
+                dest,
+                default,
+            } => {
+                let cursor_type = &program.cursor_ref[*cursor_id].1;
+                let column_name: Option<&String> = match cursor_type {
+                    CursorType::BTreeTable(table) => {
+                        table.columns().get(*column).and_then(|v| v.name.as_ref())
+                    }
+                    CursorType::BTreeIndex(index) => index.columns.get(*column).map(|c| &c.name),
+                    _ => None,
+                };
+                (
+                    "ColumnIsNullToReg",
+                    *cursor_id as i64,
+                    *column as i64,
+                    *dest as i64,
+                    default.clone().unwrap_or_else(|| Value::build_text("")),
+                    0,
+                    format!(
+                        "r[{}]=({}.{} IS NULL) (peek, no decode)",
+                        dest,
+                        get_table_or_index_name(*cursor_id),
+                        column_name.map_or_else(|| format!("column {}", *column), |name| name.to_string()),
+                    ),
+                )
+            }
+            Insn::ColumnIsNullJump {
+                cursor_id,
+                column,
+                target_pc,
+                jump_if_column_is_null,
+                default,
+            } => {
+                let cursor_type = &program.cursor_ref[*cursor_id].1;
+                let column_name: Option<&String> = match cursor_type {
+                    CursorType::BTreeTable(table) => {
+                        table.columns().get(*column).and_then(|v| v.name.as_ref())
+                    }
+                    CursorType::BTreeIndex(index) => index.columns.get(*column).map(|c| &c.name),
+                    _ => None,
+                };
+                (
+                    "ColumnIsNullJump",
+                    *cursor_id as i64,
+                    *column as i64,
+                    target_pc.as_debug_int().into(),
+                    default.clone().unwrap_or_else(|| Value::build_text("")),
+                    0,
+                    format!(
+                        "if {}.{} IS {}NULL goto {} (peek, no decode)",
+                        get_table_or_index_name(*cursor_id),
+                        column_name.map_or_else(|| format!("column {}", *column), |name| name.to_string()),
+                        if *jump_if_column_is_null { "" } else { "NOT " },
+                        target_pc.as_debug_int(),
+                    ),
+                )
+            }
             Insn::ColumnHasField {
                 cursor_id,
                 column,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -702,6 +702,23 @@ pub enum Insn {
         defaults: Vec<Option<Value>>,
     },
 
+    ColumnIsNullJump {
+        cursor_id: CursorID,
+        column: usize,
+        target_pc: BranchOffset,
+        jump_if_column_is_null: bool,
+        /// Same role as Column's default field.
+        default: Option<Value>,
+    },
+
+    /// dest gets Value::Null or a placeholder, never the real value; safe only if the caller checks solely for Value::Null.
+    ColumnIsNullToReg {
+        cursor_id: CursorID,
+        column: usize,
+        dest: usize,
+        default: Option<Value>,
+    },
+
     /// Jump to `target_pc` if the cursor's current record contains a field at
     /// the given column index.  Falls through when the record has fewer fields
     /// (a "short record" from before ALTER TABLE ADD COLUMN).
@@ -2194,6 +2211,12 @@ pub(crate) fn dispatch_insn(
         Insn::Column { .. } => execute::op_column(program, state, insn, pager),
         Insn::ColumnRange { .. } => execute::op_column_range(program, state, insn, pager),
         Insn::ColumnHasField { .. } => execute::op_column_has_field(program, state, insn, pager),
+        Insn::ColumnIsNullJump { .. } => {
+            execute::op_column_is_null_jump(program, state, insn, pager)
+        }
+        Insn::ColumnIsNullToReg { .. } => {
+            execute::op_column_is_null_to_reg(program, state, insn, pager)
+        }
         Insn::TypeCheck { .. } => execute::op_type_check(program, state, insn, pager),
         Insn::ArrayEncode { .. } => execute::op_array_encode(program, state, insn, pager),
         Insn::ArrayDecode { .. } => execute::op_array_decode(program, state, insn, pager),
@@ -2446,6 +2469,8 @@ impl InsnVariants {
             InsnVariants::Last => execute::op_last,
             InsnVariants::Column => execute::op_column,
             InsnVariants::ColumnRange => execute::op_column_range,
+            InsnVariants::ColumnIsNullJump => execute::op_column_is_null_jump,
+            InsnVariants::ColumnIsNullToReg => execute::op_column_is_null_to_reg,
             InsnVariants::ColumnHasField => execute::op_column_has_field,
             InsnVariants::TypeCheck => execute::op_type_check,
             InsnVariants::ArrayEncode => execute::op_array_encode,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3395,6 +3395,9 @@ pub trait ValueIteratorExt {
     /// has fewer elements; registers past the returned count are left untouched.
     fn decode_into_registers_after(&mut self, skip: usize, dests: &mut [Register])
         -> Result<usize>;
+
+    /// None means a short record (e.g. pre-dating an ALTER TABLE ADD COLUMN); caller must then fall back to a full decode, since nullness there depends on the schema default.
+    fn nth_is_null(&mut self, n: usize) -> Option<Result<bool>>;
 }
 
 impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
@@ -3610,6 +3613,65 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
         Some(Ok(()))
     }
 
+    #[inline(always)]
+    fn nth_is_null(&mut self, n: usize) -> Option<Result<bool>> {
+        use crate::storage::sqlite3_ondisk::read_varint;
+        use crate::types::get_serial_type_size;
+
+        let mut header = self.header_section_ref();
+        let mut data = self.data_section_ref();
+
+        let mut data_sum = 0;
+        for _ in 0..n {
+            if header.is_empty() {
+                return None;
+            }
+
+            let (serial_type, bytes_read) = match read_varint(header) {
+                Ok(v) => v,
+                Err(e) => return Some(Err(e)),
+            };
+            header = &header[bytes_read..];
+
+            data_sum += match get_serial_type_size(serial_type) {
+                Ok(size) => size,
+                Err(e) => return Some(Err(e)),
+            };
+        }
+
+        if data_sum > data.len() {
+            return Some(Err(LimboError::Corrupt(
+                "Data section too small for indicated serial type size".into(),
+            )));
+        }
+        data = &data[data_sum..];
+
+        // Serial type 0 alone determines NULL-ness; payload bytes are never touched.
+        if header.is_empty() {
+            return None;
+        }
+
+        let (serial_type, bytes_read) = match read_varint(header) {
+            Ok(v) => v,
+            Err(e) => return Some(Err(e)),
+        };
+        self.set_header_section(&header[bytes_read..]);
+
+        // Skip past the element by size, without reading it, so the iterator stays valid.
+        let elem_size = match get_serial_type_size(serial_type) {
+            Ok(size) => size,
+            Err(e) => return Some(Err(e)),
+        };
+        if elem_size > data.len() {
+            return Some(Err(LimboError::Corrupt(
+                "Data section too small for indicated serial type size".into(),
+            )));
+        }
+        self.set_data_section(&data[elem_size..]);
+
+        Some(Ok(serial_type == 0))
+    }
+
     #[inline]
     fn decode_into_registers_after(
         &mut self,
@@ -3664,6 +3726,56 @@ mod tests {
             ),
             "unexpected result: {result:?}"
         );
+    }
+
+    #[test]
+    fn nth_is_null_matches_nth_into_register_across_every_serial_type() {
+        use crate::types::Record;
+
+        let values = std::vec![
+            Value::Null,
+            Value::from_i64(5),                // I8
+            Value::from_i64(1_000),             // I16
+            Value::from_i64(100_000),           // I24
+            Value::from_i64(10_000_000),        // I32
+            Value::from_i64(1_i64 << 40),        // I48
+            Value::from_i64(i64::MAX),          // I64
+            Value::from_f64(1.5),               // F64
+            Value::from_i64(0),                 // CONST_INT0
+            Value::from_i64(1),                 // CONST_INT1
+            Value::Text(Text::new("hello")),
+            Value::from_slice(&[1, 2, 3]).unwrap(),
+            Value::Null,
+        ];
+
+        let mut buf = std::vec::Vec::new();
+        Record::new(values.clone()).serialize(&mut buf);
+
+        for (i, v) in values.iter().enumerate() {
+            let mut peek_iter = crate::types::ValueIterator::new(&buf).unwrap();
+            let is_null = peek_iter
+                .nth_is_null(i)
+                .unwrap_or_else(|| panic!("index {i} should be present"))
+                .unwrap_or_else(|e| panic!("index {i}: unexpected parse error: {e:?}"));
+
+            let mut decode_iter = crate::types::ValueIterator::new(&buf).unwrap();
+            let mut dest = Register::Value(Value::Null);
+            decode_iter
+                .nth_into_register(i, &mut dest)
+                .unwrap_or_else(|| panic!("index {i} should be present"))
+                .unwrap_or_else(|e| panic!("index {i}: unexpected decode error: {e:?}"));
+            let fully_decoded_is_null = matches!(dest, Register::Value(Value::Null));
+
+            assert_eq!(
+                is_null, fully_decoded_is_null,
+                "index {i} ({v:?}): nth_is_null disagreed with a full decode"
+            );
+            assert_eq!(is_null, matches!(v, Value::Null), "index {i}: {v:?}");
+        }
+
+        // Short record must report None (not assume NULL); a schema DEFAULT can be non-null.
+        let mut iter = crate::types::ValueIterator::new(&buf).unwrap();
+        assert!(iter.nth_is_null(values.len()).is_none());
     }
 
     #[test]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3730,19 +3730,20 @@ mod tests {
 
     #[test]
     fn nth_is_null_matches_nth_into_register_across_every_serial_type() {
+        use crate::alloc::vec;
         use crate::types::Record;
 
-        let values = std::vec![
+        let values = vec![
             Value::Null,
-            Value::from_i64(5),                // I8
-            Value::from_i64(1_000),             // I16
-            Value::from_i64(100_000),           // I24
-            Value::from_i64(10_000_000),        // I32
-            Value::from_i64(1_i64 << 40),        // I48
-            Value::from_i64(i64::MAX),          // I64
-            Value::from_f64(1.5),               // F64
-            Value::from_i64(0),                 // CONST_INT0
-            Value::from_i64(1),                 // CONST_INT1
+            Value::from_i64(5),           // I8
+            Value::from_i64(1_000),       // I16
+            Value::from_i64(100_000),     // I24
+            Value::from_i64(10_000_000),  // I32
+            Value::from_i64(1_i64 << 40), // I48
+            Value::from_i64(i64::MAX),    // I64
+            Value::from_f64(1.5),         // F64
+            Value::from_i64(0),           // CONST_INT0
+            Value::from_i64(1),           // CONST_INT1
             Value::Text(Text::new("hello")),
             Value::from_slice(&[1, 2, 3]).unwrap(),
             Value::Null,

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-column.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-column.snap
@@ -13,17 +13,17 @@ QUERY PLAN
 `--SCAN t1
 
 BYTECODE
-addr  opcode       p1  p2  p3  p4      p5  comment
-   0  Init          0  11   0           0  Start at 11
-   1  Null          0   2   0           0  r[2]=NULL
-   2  OpenRead      0   2   0  k(2,B)   0  table=t1, root=2, iDb=0
-   3  Rewind        0   7   0           0  Rewind table t1
-   4    Column      0   0   3           0  r[3]=t1.x
-   5    AggStep     0   3   2  count    0  accum=r[2] step(r[3])
-   6  Next          0   4   0           1
-   7  AggFinal      0   2   0  count    0  accum=r[2]
-   8  Copy          2   1   0           0  r[1]=r[2]
-   9  ResultRow     1   1   0           0  output=r[1]
-  10  Halt          0   0   0           0
-  11  Transaction   0   1   1           0  iDb=0 tx_mode=Read
-  12  Goto          0   1   0           0
+addr  opcode               p1  p2  p3  p4      p5  comment
+   0  Init                  0  11   0           0  Start at 11
+   1  Null                  0   2   0           0  r[2]=NULL
+   2  OpenRead              0   2   0  k(2,B)   0  table=t1, root=2, iDb=0
+   3  Rewind                0   7   0           0  Rewind table t1
+   4    ColumnIsNullToReg   0   0   3           0  r[3]=(t1.x IS NULL) (peek, no decode)
+   5    AggStep             0   3   2  count    0  accum=r[2] step(r[3])
+   6  Next                  0   4   0           1
+   7  AggFinal              0   2   0  count    0  accum=r[2]
+   8  Copy                  2   1   0           0  r[1]=r[2]
+   9  ResultRow             1   1   0           0  output=r[1]
+  10  Halt                  0   0   0           0
+  11  Transaction           0   1   1           0  iDb=0 tx_mode=Read
+  12  Goto                  0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/null_peek/null_peek.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/null_peek/null_peek.sqltest
@@ -1,0 +1,31 @@
+# tursodatabase/turso#4921: pins presence of the peek-only opcodes
+# (ColumnIsNullToReg/ColumnIsNullJump) in EXPLAIN output for the four call
+# sites below. If a future change regresses the optimization, these snapshots
+# fail with a diff showing Column/IsNull/NotNull instead.
+
+@database :memory:
+@skip-file-if mvcc "mvcc has slightly different cursor ids, so skipping it for now"
+
+setup t {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, val TEXT);
+}
+
+@setup t
+snapshot count-col-peek {
+    SELECT count(val) FROM t;
+}
+
+@setup t
+snapshot where-is-null-peek {
+    SELECT id FROM t WHERE val IS NULL;
+}
+
+@setup t
+snapshot where-is-not-null-peek {
+    SELECT id FROM t WHERE val IS NOT NULL;
+}
+
+@setup t
+snapshot filter-is-null-peek {
+    SELECT count(*) FILTER (WHERE val IS NULL) FROM t;
+}

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/null_peek/snapshots/null_peek__count-col-peek.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/null_peek/snapshots/null_peek__count-col-peek.snap
@@ -1,0 +1,29 @@
+---
+source: null_peek.sqltest
+expression: SELECT count(val) FROM t;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - t
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t
+
+BYTECODE
+addr  opcode               p1  p2  p3  p4          p5  comment
+   0  Init                  0  11   0               0  Start at 11
+   1  Null                  0   2   0               0  r[2]=NULL
+   2  OpenRead              0   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
+   3  Rewind                0   7   0               0  Rewind table t
+   4    ColumnIsNullToReg   0   2   3               0  r[3]=(t.val IS NULL) (peek, no decode)
+   5    AggStep             0   3   2  count        0  accum=r[2] step(r[3])
+   6  Next                  0   4   0               1
+   7  AggFinal              0   2   0  count        0  accum=r[2]
+   8  Copy                  2   1   0               0  r[1]=r[2]
+   9  ResultRow             1   1   0               0  output=r[1]
+  10  Halt                  0   0   0               0
+  11  Transaction           0   1   1               0  iDb=0 tx_mode=Read
+  12  Goto                  0   1   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/null_peek/snapshots/null_peek__filter-is-null-peek.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/null_peek/snapshots/null_peek__filter-is-null-peek.snap
@@ -1,0 +1,30 @@
+---
+source: null_peek.sqltest
+expression: SELECT count(*) FILTER (WHERE val IS NULL) FROM t;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - t
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t
+
+BYTECODE
+addr  opcode              p1  p2  p3  p4          p5  comment
+   0  Init                 0  11   0               0  Start at 11
+   1  Null                 0   2   0               0  r[2]=NULL
+   2  OpenRead             0   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
+   3  Rewind               0   7   0               0  Rewind table t
+   4    ColumnIsNullJump   0   2   6               0  if t.val IS NOT NULL goto 6 (peek, no decode)
+   5    AggStep            0   3   2  count        0  accum=r[2] step(r[3])
+   6  Next                 0   4   0               1
+   7  AggFinal             0   2   0  count        0  accum=r[2]
+   8  Copy                 2   1   0               0  r[1]=r[2]
+   9  ResultRow            1   1   0               0  output=r[1]
+  10  Halt                 0   0   0               0
+  11  Transaction          0   1   1               0  iDb=0 tx_mode=Read
+  12  Integer              1   3   0               0  r[3]=1
+  13  Goto                 0   1   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/null_peek/snapshots/null_peek__where-is-not-null-peek.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/null_peek/snapshots/null_peek__where-is-not-null-peek.snap
@@ -1,0 +1,26 @@
+---
+source: null_peek.sqltest
+expression: SELECT id FROM t WHERE val IS NOT NULL;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - t
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t
+
+BYTECODE
+addr  opcode              p1  p2  p3  p4          p5  comment
+   0  Init                 0   8   0               0  Start at 8
+   1  OpenRead             0   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
+   2  Rewind               0   7   0               0  Rewind table t
+   3    ColumnIsNullJump   0   2   6               0  if t.val IS NULL goto 6 (peek, no decode)
+   4    RowId              0   1   0               0  r[1]=t.rowid
+   5    ResultRow          1   1   0               0  output=r[1]
+   6  Next                 0   3   0               1
+   7  Halt                 0   0   0               0
+   8  Transaction          0   1   1               0  iDb=0 tx_mode=Read
+   9  Goto                 0   1   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/null_peek/snapshots/null_peek__where-is-null-peek.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/null_peek/snapshots/null_peek__where-is-null-peek.snap
@@ -1,0 +1,26 @@
+---
+source: null_peek.sqltest
+expression: SELECT id FROM t WHERE val IS NULL;
+info:
+  statement_type: SELECT
+  tables:
+  - t
+  setup_blocks:
+  - t
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t
+
+BYTECODE
+addr  opcode              p1  p2  p3  p4          p5  comment
+   0  Init                 0   8   0               0  Start at 8
+   1  OpenRead             0   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
+   2  Rewind               0   7   0               0  Rewind table t
+   3    ColumnIsNullJump   0   2   6               0  if t.val IS NOT NULL goto 6 (peek, no decode)
+   4    RowId              0   1   0               0  r[1]=t.rowid
+   5    ResultRow          1   1   0               0  output=r[1]
+   6  Next                 0   3   0               1
+   7  Halt                 0   0   0               0
+   8  Transaction          0   1   1               0  iDb=0 tx_mode=Read
+   9  Goto                 0   1   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__subquery-within-cte.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__subquery-within-cte.snap
@@ -30,54 +30,53 @@ QUERY PLAN
 `--USE SORTER FOR ORDER BY
 
 BYTECODE
-addr  opcode             p1  p2  p3  p4              p5  comment
-   0  Init                0  47   0                   0  Start at 47
-   1  InitCoroutine       1  29   2                   0
-   2  Once               12   0   0                   0  goto 12
-   3  OpenEphemeral       0   0   0                   0  cursor=0 is_table=false
-   4  OpenRead            1   3   0  k(3,B,B,B)       0  table=categories, root=3, iDb=0
-   5  Rewind              1  12   0                   0  Rewind table categories
-   6    Column            1   2   3                   0  r[3]=categories.parent_id
-   7    NotNull           3  11   0                   0  r[3]!=NULL -> goto 11
-   8    RowId             1   2   0                   0  r[2]=categories.rowid
-   9    MakeRecord        2   1   4                   0  r[4]=mkrec(r[2..2]); for ephemeral_index_where_sub_t2
-  10    IdxInsert         0   4   0                   8  key=r[4]
-  11  Next                1   6   0                   1
-  12  OpenRead            2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
-  13  OpenRead            3   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
-  14  NullRow             0   0   0                   0  Set cursor 0 to a (pseudo) NULL row
-  15  Rewind              0  28   0                   0  Rewind  ephemeral(ephemeral_index_where_sub_t2)
-  16    Column            0   0   8                   0  r[8]=ephemeral(ephemeral_index_where_sub_t2).id
-  17    IsNull            8  27   0                   0  if (r[8]==NULL) goto 27
-  18    SeekGE            3  27   8                   0  key=[8..8]
-  19      IdxGT           3  27   8                   0  key=[8..8]
-  20      DeferredSeek    3   2   0                   0
-  21      IdxRowId        3   5   0                   0  r[5]=cursor 3 for index idx_products_category.rowid
-  22      Column          2   1   6                   0  r[6]=products.name
-  23      Column          2   3   7                   0  r[7]=products.price
-  24      RealAffinity    7   0   0                   0
-  25      Yield           1   0   0                   0
-  26    Next              3  19   0                   0
-  27  Next                0  16   0                   0
-  28  EndCoroutine        1   0   0                   0
-  29  SorterOpen          4   1   0  k(1,-B)          0  cursor=4
-  30  InitCoroutine       1   0   2                   0
-  31    Yield             1  39   0                   0
-  32    Copy              7  13   0                   0  r[13]=r[7]
-  33    Le               13  14  38  Binary           0  if r[13]<=r[14] goto 38
-  34    Copy              7  15   0                   0  r[15]=r[7]
-  35    Copy              6  16   0                   0  r[16]=r[6]
-  36    MakeRecord       15   2  11                   0  r[11]=mkrec(r[15..16])
-  37    SorterInsert      4  11   0  0                0  key=r[11]
-  38  Goto                0  31   0                   0
-  39  OpenPseudo          5  11   2                   0  2 columns in r[11]
-  40  SorterSort          4  46   0                   0
-  41    SorterData        4  11   5                   0  r[11]=data
-  42    Column            5   1   9                   0  r[9]=pseudo.column 1
-  43    Column            5   0  10                   0  r[10]=pseudo.column 0
-  44    ResultRow         9   2   0                   0  output=r[9..10]
-  45  SorterNext          4  41   0                   0
-  46  Halt                0   0   0                   0
-  47  Transaction         0   1  11                   0  iDb=0 tx_mode=Read
-  48  Integer           100  14   0                   0  r[14]=100
-  49  Goto                0   1   0                   0
+addr  opcode               p1  p2  p3  p4              p5  comment
+   0  Init                  0  46   0                   0  Start at 46
+   1  InitCoroutine         1  28   2                   0
+   2  Once                 11   0   0                   0  goto 11
+   3  OpenEphemeral         0   0   0                   0  cursor=0 is_table=false
+   4  OpenRead              1   3   0  k(3,B,B,B)       0  table=categories, root=3, iDb=0
+   5  Rewind                1  11   0                   0  Rewind table categories
+   6    ColumnIsNullJump    1   2  10                   0  if categories.parent_id IS NOT NULL goto 10 (peek, no decode)
+   7    RowId               1   2   0                   0  r[2]=categories.rowid
+   8    MakeRecord          2   1   3                   0  r[3]=mkrec(r[2..2]); for ephemeral_index_where_sub_t2
+   9    IdxInsert           0   3   0                   8  key=r[3]
+  10  Next                  1   6   0                   1
+  11  OpenRead              2   2   0  k(5,B,B,B,B,B)   0  table=products, root=2, iDb=0
+  12  OpenRead              3   8   0  k(2,B)           0  index=idx_products_category, root=8, iDb=0
+  13  NullRow               0   0   0                   0  Set cursor 0 to a (pseudo) NULL row
+  14  Rewind                0  27   0                   0  Rewind  ephemeral(ephemeral_index_where_sub_t2)
+  15    Column              0   0   7                   0  r[7]=ephemeral(ephemeral_index_where_sub_t2).id
+  16    IsNull              7  26   0                   0  if (r[7]==NULL) goto 26
+  17    SeekGE              3  26   7                   0  key=[7..7]
+  18      IdxGT             3  26   7                   0  key=[7..7]
+  19      DeferredSeek      3   2   0                   0
+  20      IdxRowId          3   4   0                   0  r[4]=cursor 3 for index idx_products_category.rowid
+  21      Column            2   1   5                   0  r[5]=products.name
+  22      Column            2   3   6                   0  r[6]=products.price
+  23      RealAffinity      6   0   0                   0
+  24      Yield             1   0   0                   0
+  25    Next                3  18   0                   0
+  26  Next                  0  15   0                   0
+  27  EndCoroutine          1   0   0                   0
+  28  SorterOpen            4   1   0  k(1,-B)          0  cursor=4
+  29  InitCoroutine         1   0   2                   0
+  30    Yield               1  38   0                   0
+  31    Copy                6  12   0                   0  r[12]=r[6]
+  32    Le                 12  13  37  Binary           0  if r[12]<=r[13] goto 37
+  33    Copy                6  14   0                   0  r[14]=r[6]
+  34    Copy                5  15   0                   0  r[15]=r[5]
+  35    MakeRecord         14   2  10                   0  r[10]=mkrec(r[14..15])
+  36    SorterInsert        4  10   0  0                0  key=r[10]
+  37  Goto                  0  30   0                   0
+  38  OpenPseudo            5  10   2                   0  2 columns in r[10]
+  39  SorterSort            4  45   0                   0
+  40    SorterData          4  10   5                   0  r[10]=data
+  41    Column              5   1   8                   0  r[8]=pseudo.column 1
+  42    Column              5   0   9                   0  r[9]=pseudo.column 0
+  43    ResultRow           8   2   0                   0  output=r[8..9]
+  44  SorterNext            4  40   0                   0
+  45  Halt                  0   0   0                   0
+  46  Transaction           0   1  11                   0  iDb=0 tx_mode=Read
+  47  Integer             100  13   0                   0  r[13]=100
+  48  Goto                  0   1   0                   0

--- a/sqlite/conformance/turso-sqltests/count-null-peek.sqltest
+++ b/sqlite/conformance/turso-sqltests/count-null-peek.sqltest
@@ -1,0 +1,277 @@
+@database :memory:
+
+# tursodatabase/turso#4921: COUNT(col), WHERE col IS [NOT] NULL, and
+# FILTER (WHERE col IS NULL) can determine the answer from a column's NULL-ness
+# alone, without decoding its payload. These tests pin correctness for the
+# peek path, plus every case that must always fall back to full decode.
+
+test count-col-with-nulls {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, val TEXT);
+    INSERT INTO t VALUES (1, 'a', 'x'), (2, 'a', NULL), (3, 'b', 'y'), (4, 'b', NULL), (5, 'b', NULL);
+
+    SELECT count(val) FROM t;
+}
+expect {
+    2
+}
+
+test count-col-grouped-with-nulls {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, val TEXT);
+    INSERT INTO t VALUES (1, 'a', 'x'), (2, 'a', NULL), (3, 'b', 'y'), (4, 'b', NULL), (5, 'b', NULL);
+
+    SELECT g, count(val) FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    a|1
+    b|1
+}
+
+test count-col-all-null {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO t VALUES (1, NULL), (2, NULL), (3, NULL);
+
+    SELECT count(val) FROM t;
+}
+expect {
+    0
+}
+
+test count-col-blob-with-nulls {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val BLOB);
+    INSERT INTO t VALUES (1, X'0102'), (2, NULL), (3, X'0304');
+
+    SELECT count(val) FROM t;
+}
+expect {
+    2
+}
+
+test where-is-null-basic {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, val TEXT);
+    INSERT INTO t VALUES (1, 'a', 'x'), (2, 'a', NULL), (3, 'b', 'y'), (4, 'b', NULL);
+
+    SELECT id FROM t WHERE val IS NULL ORDER BY id;
+}
+expect {
+    2
+    4
+}
+
+test where-is-not-null {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, val TEXT);
+    INSERT INTO t VALUES (1, 'a', 'x'), (2, 'a', NULL), (3, 'b', 'y'), (4, 'b', NULL);
+
+    SELECT id FROM t WHERE val IS NOT NULL ORDER BY id;
+}
+expect {
+    1
+    3
+}
+
+test where-isnull-notnull-keyword-syntax {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO t VALUES (1, 'x'), (2, NULL), (3, 'y'), (4, NULL);
+
+    SELECT id FROM t WHERE val ISNULL ORDER BY id;
+    SELECT id FROM t WHERE val NOTNULL ORDER BY id;
+}
+expect {
+    2
+    4
+    1
+    3
+}
+
+# max(val) is a function call, not a bare column, so this never reaches the
+# peek path; it pins that peek must not incorrectly fire on a non-column
+# HAVING operand.
+test having-is-null-on-non-column-operand {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, val TEXT);
+    INSERT INTO t VALUES (1, 'a', 'x'), (2, 'a', NULL), (3, 'b', NULL), (4, 'b', NULL);
+
+    SELECT g FROM t GROUP BY g HAVING max(val) IS NULL ORDER BY g;
+}
+expect {
+    b
+}
+
+# A bare column in HAVING that also appears in GROUP BY is register-cached
+# for the group comparison, so peek is skipped in favor of the cached value
+# even though it would otherwise be peek-eligible.
+test having-is-null-bare-column-register-cached-not-peeked {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, val TEXT);
+    INSERT INTO t VALUES (1, 'a', 'x'), (2, 'a', 'y'), (3, NULL, 'z');
+
+    SELECT count(*) FROM t GROUP BY g HAVING g IS NULL;
+}
+expect {
+    1
+}
+
+test filter-count-is-null {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, val TEXT);
+    INSERT INTO t VALUES (1, 'a', 'x'), (2, 'a', NULL), (3, 'b', 'y'), (4, 'b', NULL), (5, 'b', NULL);
+
+    SELECT count(*) FILTER (WHERE val IS NULL) FROM t;
+}
+expect {
+    3
+}
+
+test filter-count-is-not-null-grouped {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, val TEXT);
+    INSERT INTO t VALUES (1, 'a', 'x'), (2, 'a', NULL), (3, 'b', 'y'), (4, 'b', NULL), (5, 'b', NULL);
+
+    SELECT g, count(*) FILTER (WHERE val IS NOT NULL) FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    a|1
+    b|1
+}
+
+# Short records: a row written before ALTER TABLE ADD COLUMN has no byte
+# for the new column at all. The peek path must decide nullness from the
+# column's DEFAULT, not from the absence of a payload byte.
+
+test count-and-is-null-short-record-non-null-default {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT);
+    INSERT INTO t VALUES (1, 'a'), (2, 'b');
+    ALTER TABLE t ADD COLUMN w TEXT DEFAULT 'hello';
+    INSERT INTO t VALUES (3, 'c', 'world');
+
+    SELECT count(w) FROM t;
+    SELECT id FROM t WHERE w IS NULL ORDER BY id;
+}
+expect {
+    3
+}
+
+test count-and-is-null-short-record-null-default {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT);
+    INSERT INTO t VALUES (1, 'a'), (2, 'b');
+    ALTER TABLE t ADD COLUMN w TEXT;
+    INSERT INTO t VALUES (3, 'c', 'present');
+
+    SELECT count(w) FROM t;
+    SELECT id FROM t WHERE w IS NULL ORDER BY id;
+}
+expect {
+    1
+    1
+    2
+}
+
+# Hard exclusions: these must always fall back to full column decode.
+
+# A custom type's DECODE can map a non-null stored payload to a NULL logical
+# value (here, 42 decodes to NULL), so peeking the raw record NULL-ness would
+# answer wrong.
+@requires strict "uses STRICT tables"
+test custom-type-decode-never-peeked {
+    CREATE TYPE tricky BASE integer
+        ENCODE value
+        DECODE CASE WHEN value = 42 THEN NULL ELSE value END;
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val tricky) STRICT;
+    INSERT INTO t VALUES (1, 10), (2, 42), (3, 99);
+
+    SELECT count(val) FROM t;
+    SELECT id FROM t WHERE val IS NULL ORDER BY id;
+}
+expect {
+    2
+    2
+}
+
+# An INTEGER PRIMARY KEY column's value lives in the btree key, not the record
+# payload (the payload slot is NULL), so it must never be peeked, or
+# COUNT(int_pk) / int_pk IS NULL would be silently wrong.
+test rowid-alias-column-never-peeked {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO t VALUES (1, 'x'), (2, 'y'), (3, 'z');
+
+    SELECT count(id) FROM t;
+    SELECT count(*) FROM t WHERE id IS NULL;
+    SELECT count(*) FROM t WHERE id IS NOT NULL;
+    SELECT count(*) FILTER (WHERE id IS NULL) FROM t;
+}
+expect {
+    3
+    0
+    3
+    0
+}
+
+# On a single table, the optimizer constant-folds "rowid_alias IS NULL" to
+# false before peek code ever runs, so the test above never actually
+# exercises the rowid-alias exclusion at runtime. Under a LEFT JOIN,
+# a matched right-hand row still has a NULL payload slot for its rowid-alias
+# column (the value lives in the rowid, not the payload) while an unmatched,
+# null-extended row is genuinely NULL; only checking the exclusion at
+# runtime tells these two cases apart.
+test rowid-alias-column-never-peeked-under-left-join {
+    CREATE TABLE l(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE TABLE r(id INTEGER PRIMARY KEY, lid INTEGER);
+    INSERT INTO l VALUES (1, 'a'), (2, 'b'), (3, 'c');
+    INSERT INTO r VALUES (1, 1), (2, 3);
+
+    SELECT l.id FROM l LEFT JOIN r ON r.lid = l.id WHERE r.id IS NULL ORDER BY l.id;
+}
+expect {
+    2
+}
+
+# COUNT(DISTINCT col) hashes the actual decoded value; the peek's placeholder
+# value would collapse every non-null value into one bucket.
+test count-distinct-col-never-peeked {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO t VALUES (1, 'x'), (2, 'x'), (3, 'y'), (4, NULL), (5, 'z');
+
+    SELECT count(DISTINCT val) FROM t;
+}
+expect {
+    3
+}
+
+# A column read through a covering index must remap to the index-column
+# ordinal before peeking, exactly like the existing Column opcode does.
+test covering-index-count-col {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+    CREATE INDEX t_val ON t(val);
+    INSERT INTO t VALUES (1, 'x'), (2, NULL), (3, 'y'), (4, NULL), (5, 'z');
+
+    SELECT count(val) FROM t;
+    SELECT id FROM t WHERE val IS NULL ORDER BY id;
+}
+expect {
+    3
+    2
+    4
+}
+
+# A VIRTUAL generated column is computed from its expression, not read from
+# the record payload at all; it must never be peeked.
+test virtual-generated-column-never-peeked {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER GENERATED ALWAYS AS (a * 2) VIRTUAL);
+    INSERT INTO t VALUES (1, 5), (2, NULL), (3, 10);
+
+    SELECT count(b) FROM t;
+    SELECT id FROM t WHERE b IS NULL ORDER BY id;
+}
+expect {
+    2
+    2
+}
+
+# A column referenced more than once in the statement is not profitable to
+# peek (the decoded value is still needed elsewhere); correctness must hold
+# either way.
+test column-referenced-elsewhere-not-peeked-but-correct {
+    CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+    INSERT INTO t VALUES (1, 'x'), (2, NULL), (3, 'y'), (4, NULL);
+
+    SELECT count(val), val FROM t WHERE val IS NOT NULL GROUP BY val ORDER BY val;
+}
+expect {
+    1|x
+    1|y
+}

--- a/sqlite/conformance/turso-sqltests/hash-join-stale-cursor-peek.sqltest
+++ b/sqlite/conformance/turso-sqltests/hash-join-stale-cursor-peek.sqltest
@@ -1,0 +1,41 @@
+@database :memory:
+
+# Regression coverage for a hash-join stale-cursor bug in the peek-only opcodes
+# (tursodatabase/turso#4921): a FULL OUTER JOIN's hash join copies the build
+# side into payload registers rather than leaving a live positioned cursor, so
+# peeking the cursor directly (instead of using the cached register) would
+# silently read whatever row it was last left on. t1.a is nullable (no NOT
+# NULL constraint), so this is independent of the constant-fold optimization.
+
+test full-outer-join-is-null-does-not-peek-stale-hash-join-cursor {
+    CREATE TABLE t1 (id INTEGER PRIMARY KEY, k, a TEXT);
+    CREATE TABLE t2 (id INTEGER PRIMARY KEY, k, b TEXT);
+    INSERT INTO t1 VALUES (1, 10, 'x'), (2, 20, NULL);
+    INSERT INTO t2 VALUES (1, 10, 'm'), (2, 20, 'n');
+
+    SELECT t2.k FROM t1 FULL OUTER JOIN t2 ON t1.k = t2.k WHERE t1.a IS NULL ORDER BY t2.k;
+}
+expect {
+    20
+}
+
+# Distinct from the FULL OUTER case above: for INNER/LEFT hash joins,
+# push_where_filters_to_build evaluates build-only WHERE predicates inside
+# the build loop, while the build table's cursor is redirected via a cursor
+# override (build_t is read through the shared hash-build cursor, not its
+# own table cursor). Peek must not fire for a table with an active cursor
+# override, since an index cursor for that table (if any) is deliberately
+# left unredirected. This pins that the join still answers correctly.
+test inner-join-hash-build-where-pushdown-skips-peek-under-cursor-override {
+    CREATE TABLE build_t (id INTEGER PRIMARY KEY, k INTEGER, val TEXT);
+    CREATE TABLE probe_t (id INTEGER PRIMARY KEY, k INTEGER);
+    INSERT INTO build_t VALUES (1, 1, 'x'), (2, 1, NULL), (3, 2, 'y');
+    INSERT INTO probe_t VALUES (1, 1), (2, 2);
+
+    SELECT probe_t.id FROM probe_t JOIN build_t ON probe_t.k = build_t.k
+        WHERE build_t.val IS NOT NULL ORDER BY probe_t.id;
+}
+expect {
+    1
+    2
+}


### PR DESCRIPTION
Fixes #4921

it's the first part of the fix, more on that later.

rn Turso decodes column values to check if they're null, but for  the following cases: col IS NULL, col IS NOT NULL, COUNT(col), FILTER (WHERE col IS NULL), we can just check the varints in the header instead to see if they carry a null flag. 
So add two VDBE opcodes, ColumnIsNullJump and ColumnIsNullToReg, that will be doing it to skip decoding the payload, but only when the column is referenced only once in the query (i.e. when we don't care about the actual value itself). Benchmarks say that  COUNT query will be 1.08x faster, for the IS NULL numbers are 1.16x, for the IS NOT NULL it is 1.18x, and for the WHERE filter is 1.57x, all approximately ofc.

Currently testing another part of the fix that for NOT NULL (in schema) cols will skip the peek at plan time, already shows way better performance growth (sometimes up to 200000x for IS NULL cases, but need to confirm).
