### PR TITLE
bindings/c: honor sqlite3_bind_blob n < 0 as a NUL-terminated blob

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -2215,8 +2215,8 @@ pub unsafe extern "C" fn sqlite3_bind_blob(
         return sqlite3_bind_result(stmt_ref, result);
     }
 
-    // SQLite: n < 0 means read until the first 0x00. A signed-to-usize cast
-    // of a negative n would form a huge slice.
+    // SQLite documents n < 0 for bind_blob as undefined. A signed-to-usize
+    // cast would form a huge slice, so treat n < 0 like bind_text.
     let slice_blob = if len < 0 {
         CStr::from_ptr(blob as *const ffi::c_char)
             .to_bytes()

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -2215,7 +2215,15 @@ pub unsafe extern "C" fn sqlite3_bind_blob(
         return sqlite3_bind_result(stmt_ref, result);
     }
 
-    let slice_blob = std::slice::from_raw_parts(blob as *const u8, len as usize).to_vec();
+    // SQLite: n < 0 means read until the first 0x00. A signed-to-usize cast
+    // of a negative n would form a huge slice.
+    let slice_blob = if len < 0 {
+        CStr::from_ptr(blob as *const ffi::c_char)
+            .to_bytes()
+            .to_vec()
+    } else {
+        std::slice::from_raw_parts(blob as *const u8, len as usize).to_vec()
+    };
 
     let val_blob = Value::from_blob(slice_blob);
 

--- a/bindings/c/tests/compat/mod.rs
+++ b/bindings/c/tests/compat/mod.rs
@@ -916,6 +916,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "sqlite3"))]
     #[test]
     fn test_sqlite3_bind_blob_negative_len_reads_to_nul() {
         unsafe {

--- a/bindings/c/tests/compat/mod.rs
+++ b/bindings/c/tests/compat/mod.rs
@@ -917,6 +917,69 @@ mod tests {
     }
 
     #[test]
+    fn test_sqlite3_bind_blob_negative_len_reads_to_nul() {
+        unsafe {
+            let temp_file = tempfile::NamedTempFile::with_suffix(".db").unwrap();
+            let path = std::ffi::CString::new(temp_file.path().to_str().unwrap()).unwrap();
+            let mut db = ptr::null_mut();
+            assert_eq!(sqlite3_open(path.as_ptr(), &mut db), SQLITE_OK);
+
+            let mut stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"CREATE TABLE test_bind_blob_nlen (data BLOB)".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_DONE);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+
+            let mut stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"INSERT INTO test_bind_blob_nlen (data) VALUES (?)".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            let data = b"abc\0def";
+            assert_eq!(
+                sqlite3_bind_blob(stmt, 1, data.as_ptr() as *const _, -1, None),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_DONE);
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+
+            let mut stmt = ptr::null_mut();
+            assert_eq!(
+                sqlite3_prepare_v2(
+                    db,
+                    c"SELECT data FROM test_bind_blob_nlen".as_ptr(),
+                    -1,
+                    &mut stmt,
+                    ptr::null_mut(),
+                ),
+                SQLITE_OK
+            );
+            assert_eq!(sqlite3_step(stmt), SQLITE_ROW);
+            let ptr = sqlite3_column_blob(stmt, 0);
+            let n = sqlite3_column_bytes(stmt, 0);
+            let got = std::slice::from_raw_parts(ptr as *const u8, n as usize);
+            assert_eq!(got, b"abc");
+
+            assert_eq!(sqlite3_finalize(stmt), SQLITE_OK);
+            assert_eq!(sqlite3_close(db), SQLITE_OK);
+        }
+    }
+
+    #[test]
     fn test_sqlite3_column_type() {
         unsafe {
             let temp_file = tempfile::NamedTempFile::with_suffix(".db").unwrap();


### PR DESCRIPTION
# NOTICE:
<!--
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->

## Description

`sqlite3_bind_blob` now treats a negative `n` the same way Turso already treats `sqlite3_bind_text`: read bytes until the first `0x00`. A positive `n` is still an exact length.

SQLite documents a negative length for `sqlite3_bind_blob` as undefined. The previous Turso path did `from_raw_parts(blob, len as usize)` with no `len < 0` check, which formed a huge slice. Sibling `sqlite3_bind_text` already branches on `len < 0`.

The regression test is Turso-only (`#[cfg(not(feature = "sqlite3"))]`). `--features sqlite3` (the second half of `make test-sqlite3`, and workspace `--all-features`) links the same compat suite against system libsqlite3, which does not match this defined behavior (macOS returns SQLITE_MISUSE; Linux stored a large static slice).

## Motivation and context

Callers that pass `-1` were hitting an oversized slice on Turso.

Related: merged [#2528](https://github.com/tursodatabase/turso/pull/2528) added `bind_blob`. `sqlite3_result_blob` already rejects `len < 0`.

## Description of AI Usage

Assisted with implementation and the regression test. I reviewed the change and the test results.
