### PR TITLE
postgres: reject filesystem COPY FROM on the wire listener

### DIFF
--- a/postgres/COMPAT.md
+++ b/postgres/COMPAT.md
@@ -341,7 +341,7 @@ Upgrade is not supported.
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| COPY table FROM 'file' (text format) | ✅ Supported | DELIMITER, NULL string, HEADER, column lists, backslash escapes, `\.` end-of-data marker; atomic (rolls back on malformed rows) |
+| COPY table FROM 'file' (text format) | 🟡 Partial | Embedded and CLI connections: DELIMITER, NULL string, HEADER, column lists, backslash escapes, `\.` end-of-data marker; atomic (rolls back on malformed rows). The `tursopg --server` listener rejects filesystem `COPY FROM`. |
 | COPY from/to STDIN/STDOUT | ❌ Not supported | Rejected with an error; no wire-level COPY sub-protocol |
 | COPY FROM ... WHERE | ❌ Not supported | |
 | COPY ... ON_ERROR | ❌ Not supported | |

--- a/postgres/cli/tests/tursopg.rs
+++ b/postgres/cli/tests/tursopg.rs
@@ -1253,34 +1253,39 @@ fn extract_command_tags(data: &[u8]) -> Vec<String> {
 }
 
 #[test]
-fn wire_copy_from_returns_copy_n() {
+fn wire_copy_from_file_is_rejected() {
     let (mut server, port) = start_tursopg_server();
 
     let path = write_temp_copy_file("wire", "1\tAlice\n2\tBob\n3\tCharlie\n");
 
     let mut client = PgTestClient::connect(port);
 
-    // Create table
     let tags = client.query_command_tags("CREATE TABLE users(id INT, name TEXT)");
     assert!(
         tags.iter().any(|t| t.contains("CREATE")),
         "expected CREATE tag, got: {tags:?}"
     );
 
-    // COPY FROM
     let copy_sql = format!("COPY users FROM '{}'", path.display());
-    let tags = client.query_command_tags(&copy_sql);
+    client.send_query(&copy_sql);
+    let response = client.read_until_ready();
+    let text = String::from_utf8_lossy(&response);
     assert!(
-        tags.iter().any(|t| t == "COPY 3"),
-        "expected 'COPY 3' tag, got: {tags:?}"
+        text.contains("not allowed on this connection"),
+        "expected filesystem COPY FROM to be rejected, got: {text}"
+    );
+    assert!(
+        !extract_command_tags(&response)
+            .iter()
+            .any(|t| t.starts_with("COPY")),
+        "COPY must not complete on the wire listener"
     );
 
-    // Verify data via SELECT
-    let tags = client.query_command_tags("SELECT id, name FROM users ORDER BY id");
-    // SELECT produces a CommandComplete like "SELECT 3"
+    let tags = client.query_command_tags("SELECT id, name FROM users");
     assert!(
-        tags.iter().any(|t| t.starts_with("SELECT")),
-        "expected SELECT tag, got: {tags:?}"
+        tags.iter()
+            .any(|t| t == "SELECT 0" || t.starts_with("SELECT")),
+        "expected empty table after rejected COPY, got: {tags:?}"
     );
 
     std::fs::remove_file(&path).ok();

--- a/postgres/frontend/session.rs
+++ b/postgres/frontend/session.rs
@@ -1,5 +1,6 @@
 use std::num::NonZero;
 use std::str;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::aliases;
@@ -22,6 +23,7 @@ pub struct PgConnection {
 struct PgConnectionInner {
     conn: Arc<Connection>,
     session_state: Mutex<SessionState>,
+    allow_filesystem_copy: AtomicBool,
 }
 
 impl PgConnectionInner {
@@ -79,8 +81,19 @@ impl PgConnection {
             inner: Arc::new(PgConnectionInner {
                 conn,
                 session_state: Mutex::new(SessionState::default()),
+                allow_filesystem_copy: AtomicBool::new(true),
             }),
         }
+    }
+
+    /// Allow `COPY ... FROM 'path'` to read the host filesystem.
+    ///
+    /// The unauthenticated wire server turns this off. Embedded and CLI
+    /// connections keep the default (on).
+    pub fn set_allow_filesystem_copy(&self, allow: bool) {
+        self.inner
+            .allow_filesystem_copy
+            .store(allow, Ordering::Relaxed);
     }
 
     pub fn inner(&self) -> &Arc<Connection> {
@@ -282,7 +295,7 @@ fn try_prepare_special(pg_conn: &Arc<PgConnectionInner>, sql: &str) -> Result<Op
     }
 
     if let Some(stmt) = try_extract_copy_from(&parse_result) {
-        let rows_inserted = handle_pg_copy_from(&pg_conn.conn, &stmt)?;
+        let rows_inserted = handle_pg_copy_from(pg_conn, &stmt)?;
         let stmt = noop_statement(&pg_conn.conn)?;
         stmt.set_n_change(rows_inserted as i64);
         return Ok(Some(stmt));
@@ -405,7 +418,13 @@ fn drop_all_tables_in_schema(conn: &Arc<Connection>, schema_name: &str) -> Resul
     Ok(())
 }
 
-fn handle_pg_copy_from(conn: &Arc<Connection>, stmt: &PgCopyFromStmt) -> Result<usize> {
+fn handle_pg_copy_from(pg_conn: &Arc<PgConnectionInner>, stmt: &PgCopyFromStmt) -> Result<usize> {
+    if !pg_conn.allow_filesystem_copy.load(Ordering::Relaxed) {
+        return Err(LimboError::ParseError(
+            "COPY FROM a filesystem path is not allowed on this connection".to_string(),
+        ));
+    }
+    let conn = &pg_conn.conn;
     let data = std::fs::read_to_string(&stmt.filename).map_err(|e| {
         LimboError::ParseError(format!("COPY FROM: cannot read '{}': {}", stmt.filename, e))
     })?;

--- a/postgres/server/lib.rs
+++ b/postgres/server/lib.rs
@@ -39,6 +39,7 @@ impl TursoPgServer {
         conn: Connection,
         interrupt_count: Arc<AtomicUsize>,
     ) -> Self {
+        conn.set_allow_filesystem_copy(false);
         Self {
             address,
             db_file,

--- a/postgres/tests/integration/postgres/copy.rs
+++ b/postgres/tests/integration/postgres/copy.rs
@@ -133,6 +133,25 @@ fn test_copy_from_file_not_found(db: TempDatabase) {
 }
 
 #[turso_macros::test(mvcc)]
+fn test_copy_from_file_rejected_when_disabled(db: TempDatabase) {
+    let conn = db.connect_postgres();
+    conn.set_allow_filesystem_copy(false);
+
+    conn.execute("CREATE TABLE t (a INTEGER)").unwrap();
+
+    let tsv = write_temp_file("1\n");
+    let sql = format!("COPY t FROM '{}'", tsv.path().display());
+    let err = conn.execute(&sql).unwrap_err().to_string();
+    assert!(
+        err.contains("not allowed on this connection"),
+        "unexpected error: {err}"
+    );
+
+    let rows = query_all(&conn, "SELECT a FROM t");
+    assert!(rows.is_empty());
+}
+
+#[turso_macros::test(mvcc)]
 fn test_copy_from_wrong_column_count(db: TempDatabase) {
     let conn = db.connect_postgres();
 


### PR DESCRIPTION
# NOTICE:
<!--
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.
-->

## Description

`tursopg --server` now rejects `COPY ... FROM 'path'`. Embedded `PgConnection` and the interactive CLI still allow filesystem COPY FROM.

The wire listener does not authenticate (`NoopHandler`). Reading a client-supplied path on that path is not appropriate.

## Motivation and context

COMPAT.md already lists COPY FROM file as supported for local use. This change keeps that for embedded and CLI connections, and turns it off for the network listener.

Related: open [#8199](https://github.com/tursodatabase/turso/pull/8199) adds COPY TO file; this PR does not change COPY TO.

## Description of AI Usage

Assisted with implementation and tests. I reviewed the change and the test results.
