### PR TITLE
core/optimizer: keep required sorts across hash joins

### DIFF
--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -252,12 +252,17 @@ pub fn plan_satisfies_order_target(
         if let AccessMethodParams::HashJoin {
             build_table_idx,
             join_type,
+            materialize_build_input,
             ..
         } = &access_method.params
         {
             hash_join_build_tables
                 .set(*build_table_idx)
                 .expect("a plan cannot contain more than the table limit");
+            // Materialization can absorb and prune every loop before the probe.
+            if *materialize_build_input {
+                return false;
+            }
             // Outer hash joins emit unmatched rows in hash-bucket order, not scan order.
             if matches!(join_type, HashJoinType::LeftOuter | HashJoinType::FullOuter) {
                 return false;

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -246,10 +246,19 @@ pub fn plan_satisfies_order_target(
     order_target: &OrderTarget,
     schema: &Schema,
 ) -> bool {
-    // Outer hash joins emit unmatched rows in hash-bucket order, not scan order.
+    let mut hash_join_build_tables = TableMask::default();
     for (_, access_method_index) in plan.data.iter() {
         let access_method = &access_methods_arena[*access_method_index];
-        if let AccessMethodParams::HashJoin { join_type, .. } = &access_method.params {
+        if let AccessMethodParams::HashJoin {
+            build_table_idx,
+            join_type,
+            ..
+        } = &access_method.params
+        {
+            hash_join_build_tables
+                .set(*build_table_idx)
+                .expect("a plan cannot contain more than the table limit");
+            // Outer hash joins emit unmatched rows in hash-bucket order, not scan order.
             if matches!(join_type, HashJoinType::LeftOuter | HashJoinType::FullOuter) {
                 return false;
             }
@@ -262,6 +271,12 @@ pub fn plan_satisfies_order_target(
     for (loop_pos, (table_index, access_method_index)) in plan.data.iter().enumerate() {
         let access_method = &access_methods_arena[*access_method_index];
         let table_ref = &joined_tables[*table_index];
+
+        // A hash build is consumed into an unordered hash table and omitted
+        // from the execution loop order. Its scan order cannot order output.
+        if hash_join_build_tables.get(*table_index) {
+            return false;
+        }
 
         // Outer joins can emit an extra row with NULLs on the right-hand side
         // when no match is found. Because that row is produced after the scan or

--- a/core/translate/optimizer/order.rs
+++ b/core/translate/optimizer/order.rs
@@ -259,7 +259,12 @@ pub fn plan_satisfies_order_target(
             hash_join_build_tables
                 .set(*build_table_idx)
                 .expect("a plan cannot contain more than the table limit");
-            // Materialization can absorb and prune every loop before the probe.
+            // We bail out early because as soon as there's a hash join that materializes its
+            // build side, we can't rely on any of the relations to the left of its probe table
+            // in the join order. This is because translation retransforms the join order later on
+            // (see `prune_join_order_for_materialized_inputs`)
+            // Eventually, we could narrow down this check to consider the ordering of the relations
+            // at, or to the right of, the rightmost probe table, but for now this'll do.
             if *materialize_build_input {
                 return false;
             }

--- a/sqlite/conformance/sqlite-sqltests/join/hash_join_order_by.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/join/hash_join_order_by.sqltest
@@ -45,6 +45,7 @@ expect {
 }
 
 @setup hash_join_order_by
+@skip-if sqlite "query plan explanation output is different in sqlite"
 test hash-join-order-by-build-table-uses-sorter {
     EXPLAIN QUERY PLAN
     SELECT a.id
@@ -66,6 +67,7 @@ setup hash_join_with_outer_table {
 }
 
 @setup hash_join_with_outer_table
+@skip-if sqlite "query plan explanation output is different in sqlite"
 test hash-join-keeps-outer-table-order-elision {
     EXPLAIN QUERY PLAN
     SELECT c.id, a.id
@@ -124,6 +126,7 @@ expect {
 }
 
 @setup materialized_hash_join_order_by
+@skip-if sqlite "query plan explanation output is different in sqlite"
 test hash-join-materialized-prefix-uses-sorter {
     EXPLAIN QUERY PLAN
     SELECT c.id

--- a/sqlite/conformance/sqlite-sqltests/join/hash_join_order_by.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/join/hash_join_order_by.sqltest
@@ -1,0 +1,77 @@
+@database :memory:
+
+setup hash_join_order_by {
+    CREATE TABLE a(id INTEGER PRIMARY KEY, k INTEGER);
+    INSERT INTO a VALUES (1, 10), (2, 20), (3, 30);
+    CREATE TABLE b(k INTEGER);
+    INSERT INTO b VALUES (30), (10), (20);
+}
+
+@setup hash_join_order_by
+test hash-join-order-by-build-table-ascending {
+    SELECT a.id
+    FROM a JOIN b ON b.k = a.k
+    WHERE a.id > 0
+    ORDER BY a.id;
+}
+expect {
+    1
+    2
+    3
+}
+
+@setup hash_join_order_by
+test hash-join-order-by-build-table-descending-page {
+    SELECT a.id
+    FROM a JOIN b ON b.k = a.k
+    WHERE a.id > 0
+    ORDER BY a.id DESC
+    LIMIT 1 OFFSET 1;
+}
+expect {
+    2
+}
+
+@setup hash_join_order_by
+test hash-join-window-order-by-build-table {
+    SELECT a.id, row_number() OVER (ORDER BY a.id)
+    FROM a JOIN b ON b.k = a.k
+    WHERE a.id > 0;
+}
+expect {
+    1|1
+    2|2
+    3|3
+}
+
+@setup hash_join_order_by
+test hash-join-order-by-build-table-uses-sorter {
+    EXPLAIN QUERY PLAN
+    SELECT a.id
+    FROM a JOIN b ON b.k = a.k
+    WHERE a.id > 0
+    ORDER BY a.id;
+}
+expect pattern {
+    (?s)HASH JOIN b.*SEARCH a USING INTEGER PRIMARY KEY.*USE SORTER FOR ORDER BY
+}
+
+setup hash_join_with_outer_table {
+    CREATE TABLE c(id INTEGER PRIMARY KEY);
+    CREATE TABLE a(id INTEGER PRIMARY KEY, k INTEGER);
+    CREATE TABLE b(k INTEGER);
+}
+
+@setup hash_join_with_outer_table
+test hash-join-keeps-outer-table-order-elision {
+    EXPLAIN QUERY PLAN
+    SELECT c.id, a.id
+    FROM c, a JOIN b ON b.k = a.k
+    WHERE c.id > 0
+    ORDER BY c.id;
+}
+expect {
+    1|0|0|SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
+    2|0|0|HASH JOIN b
+    3|0|0|SCAN a
+}

--- a/sqlite/conformance/sqlite-sqltests/join/hash_join_order_by.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/join/hash_join_order_by.sqltest
@@ -58,8 +58,11 @@ expect pattern {
 
 setup hash_join_with_outer_table {
     CREATE TABLE c(id INTEGER PRIMARY KEY);
+    INSERT INTO c VALUES (3), (1), (2);
     CREATE TABLE a(id INTEGER PRIMARY KEY, k INTEGER);
+    INSERT INTO a VALUES (1, 10), (2, 20), (3, 30);
     CREATE TABLE b(k INTEGER);
+    INSERT INTO b VALUES (30), (10), (20);
 }
 
 @setup hash_join_with_outer_table
@@ -74,4 +77,62 @@ expect {
     1|0|0|SEARCH c USING INTEGER PRIMARY KEY (rowid=?)
     2|0|0|HASH JOIN b
     3|0|0|SCAN a
+}
+
+@setup hash_join_with_outer_table
+test hash-join-keeps-outer-table-runtime-order {
+    SELECT c.id
+    FROM c, a JOIN b ON b.k = a.k
+    WHERE c.id > 0
+    ORDER BY c.id;
+}
+expect {
+    1
+    1
+    1
+    2
+    2
+    2
+    3
+    3
+    3
+}
+
+setup materialized_hash_join_order_by {
+    CREATE TABLE c(id INTEGER PRIMARY KEY);
+    INSERT INTO c VALUES (1), (2), (3);
+    CREATE TABLE a(id INTEGER PRIMARY KEY, c_id INTEGER, k INTEGER);
+    INSERT INTO a VALUES (1, 1, 10), (2, 2, 20), (3, 3, 30);
+    CREATE INDEX a_c_id ON a(c_id);
+    CREATE TABLE b(k INTEGER);
+    INSERT INTO b VALUES (30), (10), (20);
+}
+
+@setup materialized_hash_join_order_by
+test hash-join-materialized-prefix-keeps-order {
+    SELECT c.id
+    FROM c
+    JOIN a ON a.c_id = c.id
+    JOIN b ON b.k = a.k
+    WHERE c.id > 0
+    ORDER BY c.id;
+}
+expect {
+    1
+    2
+    3
+}
+
+@setup materialized_hash_join_order_by
+test hash-join-materialized-prefix-uses-sorter {
+    EXPLAIN QUERY PLAN
+    SELECT c.id
+    FROM c
+    JOIN a ON a.c_id = c.id
+    JOIN b ON b.k = a.k
+    WHERE c.id > 0
+    ORDER BY c.id;
+}
+expect pattern {
+    (?s)MATERIALIZE hash build input for a.*HASH JOIN b.*USE SORTER FOR ORDER BY
 }


### PR DESCRIPTION
<!-- 
In order to streamline the contribution process, please check the "allow edits from maintainers" checkbox on your PR. If needed, this allows us to push tweaks to your PR and avoid a potentially lengthy back-and-forth. Your original commits will stay on the branch, and you will keep authorship of those commits.

(i ran out of pangram credits lol, unlike the previous pr)
-->


## Description
fixes #8574

updated `plan_satisfies_order_target` to the ff
these can no longer supply final order:
- table used to build hash lokup
- if hash prep captures and removes an earlier group of loops

also made sure a separate ordered outer loop can avoid a sorter when it survives unchanges and supplies the complete requested order

<!-- 
Please include a summary of the changes and the related issue. 
-->

## Motivation and context

<!-- 
Please include relevant motivation and context.
Link relevant issues here.
-->
tried other approaches:
- disabling hash joins (throws away fast plans)
- adding a sorter everywhere (causes unnecessary sorts)

there is a case tho where the build side is proven to contain one fixed value will still sort unnecessarily which can be skipped but i think its negligible to account for because i don't think the benefits outweigh the risk also the perf is negligible (~13ms)

perf-wise (apple m2):

| Case | Before | After | Change |
|---|---:|---:|---:|
| Affected `ORDER BY ... LIMIT 100`, 100k rows | 1123.78 ms | 2713.00 ms | +141.4% |
| No-`ORDER BY` hash-join control | 22.395 ms/query | 21.626 ms/query | -3.4% |
| Safe outer-order planning, 300 statements | 195.98 ms | 197.12 ms | +0.6% |
| Constant-key ordered control | 4.928 ms/query | 4.915 ms/query | -0.3% |
| Affected query peak RSS | 35.72 MiB | 50.91 MiB | +42.5% |
| No-`ORDER BY` control peak RSS | 38.72 MiB | 38.75 MiB | +0.1% |

before patch was faster because it skipped the required work to give the correct order

## Description of AI Usage

<!-- 
Please disclose how AI was used to help create this PR. For example, you can share prompts,
specific tools, or ways of working that you took advantage of. You can also share whether the
creation of the PR was mainly driven by AI, or whether it was used for assistance.

This is a good way of sharing knowledge to other contributors about how we can work more efficiently with
AI tools. Note that the use of AI is encouraged, but the committer is still fully responsible for understanding
and reviewing the output.
-->
used ai to help understand the issue further, and to help with debugging, doing benchmarking performance and a bit of implementation, implementation + refining was steered by me