### PR TITLE
reset table-valued PRAGMA rowids for each scan

### DIFF
--- a/core/pragma.rs
+++ b/core/pragma.rs
@@ -443,6 +443,9 @@ impl PragmaVirtualTableCursor {
         };
 
         self.arg = arg;
+        // VFilter starts a new scan. Reset the position so repeated scans
+        // return the same rowids, as SQLite does.
+        self.pos = 0;
 
         if let Some(schema) = schema {
             // Schema-qualified PRAGMA statements are not supported yet
@@ -469,6 +472,38 @@ impl PragmaVirtualTableCursor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Database, MemoryIO, SqliteDialect};
+
+    #[test]
+    fn filter_starts_each_pragma_scan_at_rowid_one() {
+        let io: Arc<dyn crate::IO> = Arc::new(MemoryIO::new());
+        let db =
+            Database::open_file(io, crate::util::MEMORY_PATH, Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("CREATE TABLE scan_target(first, second)")
+            .unwrap();
+
+        let pragma_vtab = PragmaVirtualTable {
+            pragma_name: "table_info".to_string(),
+            visible_column_count: 6,
+            max_arg_count: 2,
+            has_pragma_arg: true,
+        };
+        let mut cursor = pragma_vtab.open(conn).unwrap();
+
+        assert!(cursor
+            .filter(crate::alloc::vec![Value::from_text("scan_target")])
+            .unwrap());
+        assert_eq!(cursor.rowid(), 1);
+        assert!(cursor.next().unwrap());
+        assert_eq!(cursor.rowid(), 2);
+        assert!(!cursor.next().unwrap());
+
+        assert!(cursor
+            .filter(crate::alloc::vec![Value::from_text("scan_target")])
+            .unwrap());
+        assert_eq!(cursor.rowid(), 1);
+    }
 
     #[test]
     fn test_best_index_argv_order_both_hidden_constraints() {


### PR DESCRIPTION
A nested-loop join starts a new table-valued PRAGMA scan for each outer row. Turso kept the row counter between scans. For a two-column table, the second scan returned rowids 3 and 4 instead of 1 and 2.

Reset the counter in VFilter so every scan starts at rowid 1, matching SQLite.
The regression test on this PR uses the cursor API because Turso does not expose table-valued PRAGMA rowids in SQL.

### Background for this bugfix

There's an upcoming RIGHT JOIN / FULL OUTER JOIN pr. That one surfaced the bug fixed here, and the PR will include a *.sqltest case.

RIGHT JOIN reads a virtual table on its right twice: first to find matches, then to return rows that had no match. It uses rowids to identify the same rows in both scans. Pragma virtual tables kept incrementing their rowids across VFilter calls. The same row therefore received a different rowid in the second scan.