### PR TITLE
Add per-seed timeouts to differential_fuzzer CI runs so pathological queries fail faster

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -375,6 +375,8 @@ jobs:
   differential-fuzzer:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
+    env:
+      DIFFERENTIAL_FUZZER_TIMEOUT_SECONDS: 180
     strategy:
       fail-fast: false
       matrix:
@@ -390,14 +392,26 @@ jobs:
         with:
           prefix-key: "v1-rust"
           cache-on-failure: true
+      - name: Build differential_fuzzer
+        run: cargo build -p differential-fuzzer --bin differential_fuzzer
       - name: Run differential_fuzzer on a fixed set of seeds
         run: |
           # Reproduce a failure locally with:
           #   cargo run -p differential-fuzzer --bin differential_fuzzer -- \
           #     --seed <seed> --profile ${{ matrix.profile }} -n 1000
           for seed in 1 2 3 4 5 6; do
-            cargo run -p differential-fuzzer --bin differential_fuzzer -- \
-              --seed "$seed" --profile ${{ matrix.profile }} -n 1000
+            exit_code=0
+            # One slow statement must not consume the complete CI job.
+            timeout --kill-after=10s "${DIFFERENTIAL_FUZZER_TIMEOUT_SECONDS}s" \
+              target/debug/differential_fuzzer \
+                --seed "$seed" --profile ${{ matrix.profile }} -n 1000 \
+              || exit_code=$?
+            if [ "$exit_code" -eq 124 ] || [ "$exit_code" -eq 137 ]; then
+              echo "::error::Differential fuzzer timed out after ${DIFFERENTIAL_FUZZER_TIMEOUT_SECONDS} seconds. Seed: $seed. Profile: ${{ matrix.profile }}."
+            fi
+            if [ "$exit_code" -ne 0 ]; then
+              exit "$exit_code"
+            fi
           done
 
   # Random seeds keep discovering new divergences. Run them only on pushes to
@@ -407,6 +421,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
+    env:
+      DIFFERENTIAL_FUZZER_TIMEOUT_SECONDS: 180
     strategy:
       fail-fast: false
       matrix:
@@ -420,13 +436,30 @@ jobs:
         with:
           prefix-key: "v1-rust"
           cache-on-failure: true
+      - name: Build differential_fuzzer
+        run: cargo build -p differential-fuzzer --bin differential_fuzzer
       - name: Run differential_fuzzer with random seeds
         run: |
           # A failure prints its seed and profile; reproduce with
           #   cargo run -p differential-fuzzer --bin differential_fuzzer -- \
           #     --seed <seed> --profile ${{ matrix.profile }} -n 1000
-          cargo run -p differential-fuzzer --bin differential_fuzzer -- \
-            --profile ${{ matrix.profile }} -n 1000 loop 10
+          for run_number in {1..10}; do
+            # Select the seed first so a timeout still reports it.
+            seed=$(od -An -N8 -tu8 /dev/urandom | tr -d ' ')
+            echo "Starting random fuzzer run $run_number of 10. Seed: $seed. Profile: ${{ matrix.profile }}."
+            exit_code=0
+            # One slow statement must not consume the complete CI job.
+            timeout --kill-after=10s "${DIFFERENTIAL_FUZZER_TIMEOUT_SECONDS}s" \
+              target/debug/differential_fuzzer \
+                --seed "$seed" --profile ${{ matrix.profile }} -n 1000 \
+              || exit_code=$?
+            if [ "$exit_code" -eq 124 ] || [ "$exit_code" -eq 137 ]; then
+              echo "::error::Differential fuzzer timed out after ${DIFFERENTIAL_FUZZER_TIMEOUT_SECONDS} seconds. Seed: $seed. Profile: ${{ matrix.profile }}."
+            fi
+            if [ "$exit_code" -ne 0 ]; then
+              exit "$exit_code"
+            fi
+          done
 
   test-limbo:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
Add timeout to differential_fuzzer CI runs so pathological queries fail faster. Otherwise a single bad case can consume the entire allotted CI time for no benefit.