### PR TITLE
eqp: mark left-join table scans

### DIFF
--- a/core/translate/eqp.rs
+++ b/core/translate/eqp.rs
@@ -299,7 +299,9 @@ impl Display for EqpDetail {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::ConstantRow => write!(f, "SCAN CONSTANT ROW"),
-            Self::Scan { table, index, .. } => {
+            Self::Scan {
+                table, index, join, ..
+            } => {
                 write!(f, "SCAN {}", table.name_with_alias())?;
                 if let Some(index) = index {
                     if index.covering {
@@ -307,6 +309,9 @@ impl Display for EqpDetail {
                     } else {
                         write!(f, " USING INDEX {}", index.name)?;
                     }
+                }
+                if join.is_some_and(|join| join.shows_left_join_suffix()) {
+                    write!(f, " LEFT-JOIN")?;
                 }
                 Ok(())
             }

--- a/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-left-join-on-predicate-can-prove-index-eqp.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-left-join-on-predicate-can-prove-index-eqp.snap
@@ -17,5 +17,5 @@ info:
 ---
 QUERY PLAN
 |--SCAN left_items
-|--SCAN right_items USING INDEX right_marker_null_idx
+|--SCAN right_items USING INDEX right_marker_null_idx LEFT-JOIN
 `--USE SORTER FOR ORDER BY

--- a/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-left-join-where-predicate-cannot-prove-index-eqp.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshots/partial_idx__partial-index-left-join-where-predicate-cannot-prove-index-eqp.snap
@@ -16,4 +16,4 @@ info:
 ---
 QUERY PLAN
 |--SCAN left_items
-`--SCAN right_items
+`--SCAN right_items LEFT-JOIN


### PR DESCRIPTION
SQLite labels both table scans and index searches on the nullable side of a LEFT JOIN as LEFT-JOIN in EXPLAIN QUERY PLAN. We only labeled index searches.

This keeps the join type when Turso reports a table scan and updates the affected snapshots.

Tests: focused EQP snapshot tests