### PR TITLE
core: support parenthesized joins like SQLite

### DIFF
--- a/core/schema.rs
+++ b/core/schema.rs
@@ -4061,7 +4061,8 @@ pub struct FromClauseSubquery {
     pub plan: Box<Plan>,
     /// The columns of the derived table.
     pub columns: Vec<Column>,
-    /// SQLite keeps extra source names on a parenthesized join's result list.
+    /// Source names for a parenthesized join. SQLite stores these in
+    /// `ExprList_item.zEName` when `selectExpander` handles `SF_NestedFrom`.
     ///
     /// Turso keeps the same data here because outer name binding sees this
     /// derived table, not the inner result expressions. Each item describes

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -2751,6 +2751,7 @@ impl TryClone for FromClauseSubquery {
             name: self.name.clone(),
             plan: self.plan.clone(),
             columns: self.columns.try_clone()?,
+            parenthesized_join_columns: self.parenthesized_join_columns.clone(),
             result_columns_start_reg: self.result_columns_start_reg,
             materialized_cursor_id: self.materialized_cursor_id,
             cte: self.cte,
@@ -4060,6 +4061,12 @@ pub struct FromClauseSubquery {
     pub plan: Box<Plan>,
     /// The columns of the derived table.
     pub columns: Vec<Column>,
+    /// SQLite keeps extra source names on a parenthesized join's result list.
+    ///
+    /// Turso keeps the same data here because outer name binding sees this
+    /// derived table, not the inner result expressions. Each item describes
+    /// the column at the same position in `columns`.
+    pub(crate) parenthesized_join_columns: Option<Vec<ParenthesizedJoinColumn>>,
     /// The start register for the result columns of the derived table;
     /// must be set before data is read from it.
     pub result_columns_start_reg: Option<usize>,
@@ -4069,6 +4076,92 @@ pub struct FromClauseSubquery {
     /// CTE-specific materialization metadata, when this FROM-subquery is a CTE
     /// reference rather than an inline derived table.
     pub cte: Option<FromClauseSubqueryCteMetadata>,
+}
+
+/// Name data that an outer query can use through a parenthesized join.
+#[derive(Debug, Clone)]
+pub(crate) struct ParenthesizedJoinColumn {
+    /// The name that SQLite keeps for later name binding.
+    pub(crate) source: ParenthesizedJoinColumnSource,
+    /// The ways in which an outer query can use this column.
+    pub(crate) visibility: ParenthesizedJoinColumnVisibility,
+}
+
+/// The names that can use a saved parenthesized-join column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ParenthesizedJoinColumnVisibility {
+    /// Bare names, qualified names, and `*` can use this column.
+    Visible,
+    /// Only a qualified name can use this column.
+    QualifiedOnly,
+    /// Bare and qualified names can use this column, but `*` omits it.
+    HiddenFromStar,
+}
+
+/// The source name of a result column from a parenthesized join.
+#[derive(Debug, Clone)]
+pub(crate) enum ParenthesizedJoinColumnSource {
+    /// SQLite inserts one name that represents all copies merged by `USING`.
+    Using { column_name: String },
+    /// Turso keeps these names separate because quoted names can contain dots.
+    /// SQLite's dot-separated string cannot represent those names.
+    Table {
+        database_id: Option<usize>,
+        table_name: String,
+        column_name: String,
+    },
+    /// An implicit rowid keeps its table name but matches each rowid alias.
+    RowId {
+        database_id: Option<usize>,
+        table_name: String,
+    },
+}
+
+impl ParenthesizedJoinColumnSource {
+    /// Return true when this source matches the requested table qualifier.
+    pub(crate) fn matches_table(&self, database_id: Option<usize>, table_name: &str) -> bool {
+        match self {
+            Self::Using { .. } => false,
+            Self::Table {
+                database_id: saved_database,
+                table_name: saved_table,
+                ..
+            }
+            | Self::RowId {
+                database_id: saved_database,
+                table_name: saved_table,
+            } => {
+                database_id.is_none_or(|database| *saved_database == Some(database))
+                    && saved_table.eq_ignore_ascii_case(table_name)
+            }
+        }
+    }
+
+    /// Return true when this source matches the requested column name.
+    pub(crate) fn matches_column_name(&self, column_name: &str) -> bool {
+        match self {
+            Self::Using {
+                column_name: saved_column,
+            }
+            | Self::Table {
+                column_name: saved_column,
+                ..
+            } => saved_column.eq_ignore_ascii_case(column_name),
+            Self::RowId { .. } => ROWID_STRS
+                .iter()
+                .any(|name| name.eq_ignore_ascii_case(column_name)),
+        }
+    }
+
+    /// Return true for an implicit rowid entry.
+    pub(crate) fn is_rowid(&self) -> bool {
+        matches!(self, Self::RowId { .. })
+    }
+
+    /// Return true for the value that represents a `USING` column.
+    pub(crate) fn is_using(&self) -> bool {
+        matches!(self, Self::Using { .. })
+    }
 }
 
 /// The one-row table read by the recursive part of a recursive CTE.

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -93,9 +93,27 @@ pub fn bind_and_rewrite_expr<'a>(
                     let mut match_result = None;
                     let joined_tables = referenced_tables.joined_tables();
 
-                    // First check joined tables
+                    let is_rowid_name = crate::translate::planner::ROWID_STRS
+                        .iter()
+                        .any(|name| name.eq_ignore_ascii_case(&normalized_id));
+                    let has_declared_column = is_rowid_name
+                        && joined_tables.iter().try_fold(false, |found, table| {
+                            Ok::<_, LimboError>(
+                                find_unqualified_column_with_rowid(
+                                    &table.table,
+                                    &normalized_id,
+                                    false,
+                                )?
+                                .is_some()
+                                    || found,
+                            )
+                        })?;
                     for joined_table in joined_tables.iter() {
-                        let col_idx = find_unqualified_column(&joined_table.table, &normalized_id)?;
+                        let col_idx = find_unqualified_column_with_rowid(
+                            &joined_table.table,
+                            &normalized_id,
+                            !has_declared_column,
+                        )?;
                         if col_idx.is_some() {
                             if match_result.is_some() {
                                 let mut ok = false;
@@ -125,6 +143,9 @@ pub fn bind_and_rewrite_expr<'a>(
                             }
                         // only if we haven't found a match, check for explicit rowid reference
                         } else if let Table::BTree(btree) = &joined_table.table {
+                            if has_declared_column {
+                                continue;
+                            }
                             if let Some(row_id_expr) =
                                 parse_row_id(&normalized_id, joined_tables[0].internal_id, || {
                                     joined_tables.len() != 1
@@ -168,8 +189,32 @@ pub fn bind_and_rewrite_expr<'a>(
                                     continue;
                                 }
                             }
-                            let col_idx =
-                                find_unqualified_column(&outer_ref.table, &normalized_id)?;
+                            let has_declared_column = is_rowid_name
+                                && referenced_tables
+                                    .outer_query_refs()
+                                    .iter()
+                                    .filter(|candidate| {
+                                        !candidate.cte_definition_only
+                                            && candidate.scope_depth == outer_ref.scope_depth
+                                    })
+                                    .try_fold(false, |found, candidate| {
+                                        let column = find_unqualified_column_with_rowid(
+                                            &candidate.table,
+                                            &normalized_id,
+                                            false,
+                                        )?;
+                                        Ok::<_, LimboError>(
+                                            found
+                                                || column.is_some_and(|column| {
+                                                    !candidate.using_dedup_hidden_cols.get(column)
+                                                }),
+                                        )
+                                    })?;
+                            let col_idx = find_unqualified_column_with_rowid(
+                                &outer_ref.table,
+                                &normalized_id,
+                                !has_declared_column,
+                            )?;
                             if col_idx.is_some() {
                                 let col_idx = col_idx.unwrap();
                                 if outer_ref.using_dedup_hidden_cols.get(col_idx) {
@@ -587,6 +632,14 @@ pub(in crate::translate) fn find_unqualified_column(
     table: &Table,
     column_name: &str,
 ) -> Result<Option<usize>> {
+    find_unqualified_column_with_rowid(table, column_name, true)
+}
+
+fn find_unqualified_column_with_rowid(
+    table: &Table,
+    column_name: &str,
+    include_rowid: bool,
+) -> Result<Option<usize>> {
     let join_columns = match table {
         Table::FromClauseSubquery(subquery) => subquery.parenthesized_join_columns.as_ref(),
         _ => None,
@@ -605,7 +658,9 @@ pub(in crate::translate) fn find_unqualified_column(
             continue;
         }
         if join_column.source.is_rowid() {
-            rowid_is_ambiguous |= rowid_column.replace(column_index).is_some();
+            if include_rowid {
+                rowid_is_ambiguous |= rowid_column.replace(column_index).is_some();
+            }
         } else if join_column.visibility != ParenthesizedJoinColumnVisibility::QualifiedOnly
             && column.replace(column_index).is_some()
         {

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -224,16 +224,8 @@ pub fn bind_and_rewrite_expr<'a>(
                 }
                 Expr::Qualified(tbl, id) => {
                     crate::stack::trace_stack!("bind_qualified");
-                    // Resolve a `<tbl>.<id>` reference.
-                    //
-                    // Two-stage lookup with shadowing:
-                    //   1. Search the current scope's FROM tables (`joined_tables`).
-                    //   2. Fall back to enclosing scopes (`outer_query_refs`), restricted to
-                    //      the *nearest* scope whose identifier matches — so an inner alias
-                    //      shadows a same-named alias in an outer scope instead of conflicting.
-                    //
-                    // Produces either `Expr::Column` (real column) or `Expr::RowId`
-                    // (bare rowid alias like `t.rowid` on a btree with rowids).
+                    // A qualifier without the requested column does not hide
+                    // a matching column in an outer scope.
                     tracing::debug!("bind_and_rewrite_expr({:?}, {:?})", tbl, id);
                     let Some(referenced_tables) = &mut referenced_tables else {
                         if binding_behavior == BindingBehavior::AllowUnboundIdentifiers {

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -13,14 +13,12 @@ pub enum BindingBehavior {
     AllowUnboundIdentifiers,
 }
 
-/// The result of resolving the `<id>` half of a qualified `<tbl>.<id>`
-/// reference against a single candidate table whose identifier already
-/// matches `<tbl>`.
+/// The column found while resolving a qualified `<table>.<column>` name.
 #[derive(Debug, Clone, Copy)]
-pub(super) enum QualifiedMatch {
+enum QualifiedMatch {
     /// `<id>` named a real column on the candidate table.
     Column {
-        col_idx: usize,
+        column_index: usize,
         is_rowid_alias: bool,
     },
     /// `<id>` named the rowid (`rowid`/`oid`/`_rowid_`) of a btree.
@@ -29,46 +27,30 @@ pub(super) enum QualifiedMatch {
     RowId,
 }
 
-/// Resolve `<id>` against a single table reference.
-///
-/// The caller is responsible for:
-///   * filtering candidate refs down to those whose identifier matches `<tbl>`,
-///   * detecting ambiguity across multiple candidate refs,
-///   * applying any scope-specific USING/NATURAL dedup rules.
-///
-/// Returns:
-///   * `Ok(Some(Column { .. }))` — `<id>` is a real column on `table`.
-///   * `Ok(Some(RowId))` — `<id>` is a rowid alias on a rowid btree.
-///   * `Ok(None)` — `<id>` is not present on this ref.
-///   * `Err(_)` — `<id>` is a rowid alias but the btree has no rowid
-///     (definitively invalid; reported as "no such column: <id>" per SQLite).
-pub(super) fn resolve_qualified_on_ref(
-    table: &Table,
-    internal_id: TableInternalId,
-    normalized_id: &str,
-) -> Result<Option<QualifiedMatch>> {
-    if let Some(col_idx) = table.columns().iter().position(|c| {
-        c.name
-            .as_ref()
-            .is_some_and(|name| name.eq_ignore_ascii_case(normalized_id))
-    }) {
-        let col = table.columns().get(col_idx).unwrap();
-        return Ok(Some(QualifiedMatch::Column {
-            col_idx,
-            is_rowid_alias: col.is_rowid_alias(),
-        }));
-    }
+/// The result of one qualified-name search in one table reference.
+#[derive(Clone, Copy)]
+enum QualifiedTableMatch {
+    /// The qualifier does not name this table reference.
+    NoTable,
+    /// The qualifier names this table reference, but its column does not exist.
+    NoColumn,
+    /// The qualifier and column both match this table reference.
+    Found(QualifiedMatch),
+    /// More than one saved column in this table reference matches the name.
+    Ambiguous,
+}
 
-    if let Table::BTree(btree) = table {
-        if parse_row_id(normalized_id, internal_id, || false)?.is_some() {
-            if !btree.has_rowid {
-                crate::bail_parse_error!("no such column: {}", normalized_id);
-            }
-            return Ok(Some(QualifiedMatch::RowId));
-        }
-    }
-
-    Ok(None)
+/// The result of searching the current scope and its parent scopes.
+#[derive(Clone, Copy)]
+enum QualifiedNameMatch {
+    /// No visible query scope contains the requested table.
+    NoTable,
+    /// A visible table exists, but its column does not exist.
+    NoColumn,
+    /// One visible column matches the requested name.
+    Found(TableInternalId, QualifiedMatch),
+    /// More than one visible column matches the requested name.
+    Ambiguous,
 }
 
 /// Rewrite ast::Expr in place, binding Column references/rewriting Expr::Id -> Expr::Column
@@ -113,11 +95,7 @@ pub fn bind_and_rewrite_expr<'a>(
 
                     // First check joined tables
                     for joined_table in joined_tables.iter() {
-                        let col_idx = joined_table.table.columns().iter().position(|c| {
-                            c.name
-                                .as_ref()
-                                .is_some_and(|name| name.eq_ignore_ascii_case(&normalized_id))
-                        });
+                        let col_idx = find_unqualified_column(&joined_table.table, &normalized_id)?;
                         if col_idx.is_some() {
                             if match_result.is_some() {
                                 let mut ok = false;
@@ -190,11 +168,8 @@ pub fn bind_and_rewrite_expr<'a>(
                                     continue;
                                 }
                             }
-                            let col_idx = outer_ref.table.columns().iter().position(|c| {
-                                c.name
-                                    .as_ref()
-                                    .is_some_and(|name| name.eq_ignore_ascii_case(&normalized_id))
-                            });
+                            let col_idx =
+                                find_unqualified_column(&outer_ref.table, &normalized_id)?;
                             if col_idx.is_some() {
                                 let col_idx = col_idx.unwrap();
                                 if outer_ref.using_dedup_hidden_cols.get(col_idx) {
@@ -273,119 +248,15 @@ pub fn bind_and_rewrite_expr<'a>(
                     let normalized_table_name = normalize_ident(tbl.as_str());
                     let normalized_id = normalize_ident(id.as_str());
 
-                    // `resolved` holds the accepted binding (at most one).
-                    // `identifier_matched` is true once *any* scope produced a table whose
-                    // identifier equals `tbl`; it distinguishes "no such table" from
-                    // "no such column" in error reporting below.
-                    let mut resolved: Option<(TableInternalId, QualifiedMatch)> = None;
-                    let mut identifier_matched = false;
-
-                    let ambiguous = || -> LimboError {
-                        LimboError::ParseError(format!(
-                            "ambiguous column name: {}.{}",
-                            tbl.as_str(),
-                            id.as_str()
-                        ))
-                    };
-
-                    // --- Stage 1: search the current scope's FROM tables. ---
-                    for joined_table in referenced_tables
-                        .joined_tables()
-                        .iter()
-                        .filter(|t| t.identifier == normalized_table_name)
-                    {
-                        identifier_matched = true;
-                        let Some(candidate) = resolve_qualified_on_ref(
-                            &joined_table.table,
-                            joined_table.internal_id,
-                            &normalized_id,
-                        )?
-                        else {
-                            continue;
-                        };
-
-                        // Multiple FROM tables share this identifier and both contain `id`.
-                        // For column matches, a USING/NATURAL join on `id` lets the first
-                        // match stand (the duplicate side is implicitly merged). Rowid
-                        // matches never get this exception (rowid isn't a USING column).
-                        if resolved.is_some() {
-                            let allowed_by_using =
-                                matches!(candidate, QualifiedMatch::Column { .. })
-                                    && joined_table.join_info.as_ref().is_some_and(|ji| {
-                                        ji.using.iter().any(|u| {
-                                            u.as_str().eq_ignore_ascii_case(&normalized_id)
-                                        })
-                                    });
-                            if !allowed_by_using {
-                                return Err(ambiguous());
-                            }
-                            continue;
-                        }
-                        resolved = Some((joined_table.internal_id, candidate));
-                    }
-                    // --- Stage 2: fall back to enclosing scopes ---
-                    // Only attempted if no inner-scope table matched the identifier — an
-                    // inner alias of the same name shadows everything outside.
-                    //
-                    // We pick the *nearest* outer scope that contains a matching identifier
-                    // (smallest `scope_depth`) and search only refs at that depth. This lets
-                    // the same alias be reused at different nesting levels without triggering
-                    // spurious "ambiguous column" errors across unrelated scopes.
-                    //
-                    // `cte_definition_only` refs are excluded: those entries exist purely so
-                    // that a subquery's FROM clause can *look up* the CTE by name; once the
-                    // CTE is consumed into a FROM, column resolution must go through the
-                    // corresponding `joined_table`, not the definition-only ref.
-                    if !identifier_matched {
-                        let nearest_outer_scope = referenced_tables
-                            .outer_query_refs()
-                            .iter()
-                            .filter(|t| {
-                                !t.cte_definition_only && t.identifier == normalized_table_name
-                            })
-                            .map(|t| t.scope_depth)
-                            .min();
-
-                        if let Some(scope_depth) = nearest_outer_scope {
-                            identifier_matched = true;
-                            for outer_ref in
-                                referenced_tables.outer_query_refs().iter().filter(|t| {
-                                    !t.cte_definition_only
-                                        && t.scope_depth == scope_depth
-                                        && t.identifier == normalized_table_name
-                                })
-                            {
-                                let Some(candidate) = resolve_qualified_on_ref(
-                                    &outer_ref.table,
-                                    outer_ref.internal_id,
-                                    &normalized_id,
-                                )?
-                                else {
-                                    continue;
-                                };
-
-                                // When multiple outer refs share this identifier
-                                // (e.g. self-join `t1 JOIN t1 USING(a)`), a USING-hidden
-                                // column on the duplicate side lets the first match stand,
-                                // mirroring the Stage 1 logic for local-scope tables.
-                                if resolved.is_some() {
-                                    let allowed_by_using = matches!(
-                                        candidate,
-                                        QualifiedMatch::Column { col_idx, .. }
-                                            if outer_ref.using_dedup_hidden_cols.get(col_idx)
-                                    );
-                                    if !allowed_by_using {
-                                        return Err(ambiguous());
-                                    }
-                                    continue;
-                                }
-                                resolved = Some((outer_ref.internal_id, candidate));
-                            }
-                        }
-                    }
+                    let qualified_match = resolve_qualified_name(
+                        referenced_tables,
+                        None,
+                        &normalized_table_name,
+                        &normalized_id,
+                    )?;
 
                     // --- Error reporting. ---
-                    if resolved.is_none() && !identifier_matched {
+                    if matches!(qualified_match, QualifiedNameMatch::NoTable) {
                         // No scope contains a table with this identifier. Normally we
                         // report "no such table", but there is one case where SQLite
                         // reports "no such column" instead: when the identifier names a
@@ -442,34 +313,21 @@ pub fn bind_and_rewrite_expr<'a>(
                         }
                         crate::bail_parse_error!("no such table: {}", normalized_table_name);
                     }
-                    // Identifier matched somewhere but no column/rowid binding was
-                    // produced — the table exists, the column doesn't.
-                    let Some((tbl_id, binding)) = resolved else {
-                        crate::bail_parse_error!("no such column: {}", normalized_id);
-                    };
-
-                    match binding {
-                        QualifiedMatch::Column {
-                            col_idx,
-                            is_rowid_alias,
-                        } => {
-                            *expr = Expr::Column {
-                                database: None, // TODO: support different databases
-                                table: tbl_id,
-                                column: col_idx,
-                                is_rowid_alias,
-                            };
-                            tracing::debug!("rewritten to column");
-                            referenced_tables.mark_column_used(tbl_id, col_idx);
+                    match qualified_match {
+                        QualifiedNameMatch::Found(table_id, column) => {
+                            bind_qualified_name(expr, referenced_tables, None, table_id, column)
                         }
-                        QualifiedMatch::RowId => {
-                            *expr = Expr::RowId {
-                                database: None, // TODO: support different databases
-                                table: tbl_id,
-                            };
-                            tracing::debug!("rewritten to rowid");
-                            referenced_tables.mark_rowid_referenced(tbl_id);
-                        }
+                        QualifiedNameMatch::Ambiguous => crate::bail_parse_error!(
+                            "ambiguous column name: {}.{}",
+                            tbl.as_str(),
+                            id.as_str()
+                        ),
+                        QualifiedNameMatch::NoColumn => crate::bail_parse_error!(
+                            "no such column: {}.{}",
+                            tbl.as_str(),
+                            id.as_str()
+                        ),
+                        QualifiedNameMatch::NoTable => unreachable!("handled above"),
                     }
                     return Ok(WalkControl::Continue);
                 }
@@ -507,6 +365,39 @@ pub fn bind_and_rewrite_expr<'a>(
                         alias: None,
                     };
                     let db_resolution = resolver.resolve_database_id(&qualified_name);
+
+                    if let Ok(database_id) = db_resolution.as_ref() {
+                        match resolve_qualified_name(
+                            referenced_tables,
+                            Some(*database_id),
+                            &tbl_name_str,
+                            &normalized_col_name,
+                        )? {
+                            QualifiedNameMatch::Found(table_id, column) => {
+                                bind_qualified_name(
+                                    expr,
+                                    referenced_tables,
+                                    Some(*database_id),
+                                    table_id,
+                                    column,
+                                );
+                                return Ok(WalkControl::Continue);
+                            }
+                            QualifiedNameMatch::NoColumn => crate::bail_parse_error!(
+                                "no such column: {}.{}.{}",
+                                db_name_str,
+                                tbl_name_str,
+                                col_name_str
+                            ),
+                            QualifiedNameMatch::Ambiguous => crate::bail_parse_error!(
+                                "ambiguous column name: {}.{}.{}",
+                                db_name_str,
+                                tbl_name_str,
+                                col_name_str
+                            ),
+                            QualifiedNameMatch::NoTable => {}
+                        }
+                    }
 
                     // Try db.table.column interpretation first. If database resolves AND
                     // the table+column exist, use that. Otherwise fall through to
@@ -693,6 +584,253 @@ pub fn bind_and_rewrite_expr<'a>(
         },
     )?;
     Ok(())
+}
+
+/// Find one column by its unqualified name.
+///
+/// A parenthesized join can keep several source columns with the same name.
+/// Hidden source copies do not take part in an unqualified lookup. A visible
+/// column wins over an implicit rowid. Other duplicate names remain ambiguous.
+pub(in crate::translate) fn find_unqualified_column(
+    table: &Table,
+    column_name: &str,
+) -> Result<Option<usize>> {
+    let join_columns = match table {
+        Table::FromClauseSubquery(subquery) => subquery.parenthesized_join_columns.as_ref(),
+        _ => None,
+    };
+    let Some(join_columns) = join_columns else {
+        return Ok(table
+            .get_column_by_name(column_name)
+            .map(|(column_index, _)| column_index));
+    };
+
+    let mut column = None;
+    let mut rowid_column = None;
+    let mut rowid_is_ambiguous = false;
+    for (column_index, saved_column) in join_columns.iter().enumerate() {
+        if !saved_column.source.matches_column_name(column_name) {
+            continue;
+        }
+        if saved_column.source.is_rowid() {
+            rowid_is_ambiguous |= rowid_column.replace(column_index).is_some();
+        } else if saved_column.visibility != ParenthesizedJoinColumnVisibility::QualifiedOnly
+            && column.replace(column_index).is_some()
+        {
+            crate::bail_parse_error!("ambiguous column name: {}", column_name);
+        }
+    }
+    if column.is_none() && rowid_is_ambiguous {
+        crate::bail_parse_error!("ambiguous column name: {}", column_name);
+    }
+    Ok(column.or(rowid_column))
+}
+
+/// Search the current query first, then search the nearest outer query.
+fn resolve_qualified_name(
+    table_references: &TableReferences,
+    database_id: Option<usize>,
+    table_name: &str,
+    column_name: &str,
+) -> Result<QualifiedNameMatch> {
+    let mut table_found = false;
+    let mut found = None;
+    for joined_table in table_references.joined_tables() {
+        let candidate = match_qualified_name_in_table(
+            &joined_table.table,
+            joined_table.internal_id,
+            &joined_table.identifier,
+            database_id,
+            table_name,
+            column_name,
+        )?;
+        match candidate {
+            QualifiedTableMatch::NoTable => continue,
+            QualifiedTableMatch::NoColumn => table_found = true,
+            QualifiedTableMatch::Ambiguous => return Ok(QualifiedNameMatch::Ambiguous),
+            QualifiedTableMatch::Found(column) => {
+                table_found = true;
+                if found.is_some() {
+                    let duplicate_is_merged = matches!(column, QualifiedMatch::Column { .. })
+                        && joined_table
+                            .join_info
+                            .as_ref()
+                            .is_some_and(|join| join.merges_column(column_name));
+                    if !duplicate_is_merged {
+                        return Ok(QualifiedNameMatch::Ambiguous);
+                    }
+                } else {
+                    found = Some((joined_table.internal_id, column));
+                }
+            }
+        }
+    }
+    if table_found {
+        return Ok(
+            found.map_or(QualifiedNameMatch::NoColumn, |(table_id, column)| {
+                QualifiedNameMatch::Found(table_id, column)
+            }),
+        );
+    }
+
+    // An inner table name hides the same name in outer queries. If no inner
+    // table matches, only the nearest outer query can provide the column.
+    let mut nearest_scope = None;
+    let mut ambiguous = false;
+    for outer_ref in table_references.outer_query_refs() {
+        if outer_ref.cte_definition_only {
+            continue;
+        }
+        if nearest_scope.is_some_and(|scope| outer_ref.scope_depth > scope) {
+            continue;
+        }
+        let candidate = match_qualified_name_in_table(
+            &outer_ref.table,
+            outer_ref.internal_id,
+            &outer_ref.identifier,
+            database_id,
+            table_name,
+            column_name,
+        )?;
+        if matches!(candidate, QualifiedTableMatch::NoTable) {
+            continue;
+        }
+        if nearest_scope.is_none_or(|scope| outer_ref.scope_depth < scope) {
+            nearest_scope = Some(outer_ref.scope_depth);
+            found = None;
+            ambiguous = false;
+        }
+        match candidate {
+            QualifiedTableMatch::Ambiguous => ambiguous = true,
+            QualifiedTableMatch::Found(column) if found.is_some() => {
+                let duplicate_is_merged = matches!(
+                    column,
+                    QualifiedMatch::Column { column_index, .. }
+                        if outer_ref.using_dedup_hidden_cols.get(column_index)
+                );
+                ambiguous |= !duplicate_is_merged;
+            }
+            QualifiedTableMatch::Found(column) => {
+                found = Some((outer_ref.internal_id, column));
+            }
+            QualifiedTableMatch::NoTable | QualifiedTableMatch::NoColumn => {}
+        }
+    }
+
+    if ambiguous {
+        Ok(QualifiedNameMatch::Ambiguous)
+    } else if let Some((table_id, column)) = found {
+        Ok(QualifiedNameMatch::Found(table_id, column))
+    } else if nearest_scope.is_some() {
+        Ok(QualifiedNameMatch::NoColumn)
+    } else {
+        Ok(QualifiedNameMatch::NoTable)
+    }
+}
+
+/// Match a qualified name against one table reference.
+///
+/// SQLite lets a parenthesized join keep the names of its inner tables.
+/// A group alias remains available only when no saved inner name matches.
+fn match_qualified_name_in_table(
+    table: &Table,
+    table_id: TableInternalId,
+    table_reference_name: &str,
+    database_id: Option<usize>,
+    table_name: &str,
+    column_name: &str,
+) -> Result<QualifiedTableMatch> {
+    if let Table::FromClauseSubquery(subquery) = table {
+        if let Some(join_columns) = &subquery.parenthesized_join_columns {
+            let mut table_found = false;
+            let mut real_column = None;
+            let mut rowid_column = None;
+            let mut rowid_is_ambiguous = false;
+            for (column_index, saved_column) in join_columns.iter().enumerate() {
+                if !saved_column.source.matches_table(database_id, table_name) {
+                    continue;
+                }
+                table_found = true;
+                if !saved_column.source.matches_column_name(column_name) {
+                    continue;
+                }
+                if saved_column.source.is_rowid() {
+                    rowid_is_ambiguous |= rowid_column.replace(column_index).is_some();
+                } else if real_column.replace(column_index).is_some() {
+                    return Ok(QualifiedTableMatch::Ambiguous);
+                }
+            }
+            // A real column hides any implicit rowid candidate with the same
+            // name. Two rowid candidates are ambiguous only when no real column wins.
+            if real_column.is_none() && rowid_is_ambiguous {
+                return Ok(QualifiedTableMatch::Ambiguous);
+            }
+            if let Some(column_index) = real_column.or(rowid_column) {
+                let column = &table.columns()[column_index];
+                return Ok(QualifiedTableMatch::Found(QualifiedMatch::Column {
+                    column_index,
+                    is_rowid_alias: column.is_rowid_alias(),
+                }));
+            }
+            if table_found && !table_reference_name.eq_ignore_ascii_case(table_name) {
+                return Ok(QualifiedTableMatch::NoColumn);
+            }
+        }
+    }
+
+    // The normal database.table.column path uses schema metadata in the
+    // caller. Only a parenthesized join can match a saved database name here.
+    if database_id.is_some() || !table_reference_name.eq_ignore_ascii_case(table_name) {
+        return Ok(QualifiedTableMatch::NoTable);
+    }
+    if let Some((column_index, column)) = table.get_column_by_name(column_name) {
+        return Ok(QualifiedTableMatch::Found(QualifiedMatch::Column {
+            column_index,
+            is_rowid_alias: column.is_rowid_alias(),
+        }));
+    }
+    if let Table::BTree(btree) = table {
+        if parse_row_id(column_name, table_id, || false)?.is_some() {
+            if !btree.has_rowid {
+                crate::bail_parse_error!("no such column: {}", column_name);
+            }
+            return Ok(QualifiedTableMatch::Found(QualifiedMatch::RowId));
+        }
+    }
+    Ok(QualifiedTableMatch::NoColumn)
+}
+
+/// Replace a qualified name with its bound column and record the read.
+fn bind_qualified_name(
+    expr: &mut Expr,
+    table_references: &mut TableReferences,
+    database_id: Option<usize>,
+    table_id: TableInternalId,
+    column: QualifiedMatch,
+) {
+    match column {
+        QualifiedMatch::Column {
+            column_index,
+            is_rowid_alias,
+        } => {
+            *expr = Expr::Column {
+                database: database_id,
+                table: table_id,
+                column: column_index,
+                is_rowid_alias,
+            };
+            tracing::debug!("rewritten to column");
+            table_references.mark_column_used(table_id, column_index);
+        }
+        QualifiedMatch::RowId => {
+            *expr = Expr::RowId {
+                database: database_id,
+                table: table_id,
+            };
+            tracing::debug!("rewritten to rowid");
+            table_references.mark_rowid_referenced(table_id);
+        }
+    }
 }
 
 /// Extract a string literal value from an expression that has already been

--- a/core/translate/expr/binding.rs
+++ b/core/translate/expr/binding.rs
@@ -36,7 +36,7 @@ enum QualifiedTableMatch {
     NoColumn,
     /// The qualifier and column both match this table reference.
     Found(QualifiedMatch),
-    /// More than one saved column in this table reference matches the name.
+    /// More than one column in this table reference matches the name.
     Ambiguous,
 }
 
@@ -608,13 +608,13 @@ pub(in crate::translate) fn find_unqualified_column(
     let mut column = None;
     let mut rowid_column = None;
     let mut rowid_is_ambiguous = false;
-    for (column_index, saved_column) in join_columns.iter().enumerate() {
-        if !saved_column.source.matches_column_name(column_name) {
+    for (column_index, join_column) in join_columns.iter().enumerate() {
+        if !join_column.source.matches_column_name(column_name) {
             continue;
         }
-        if saved_column.source.is_rowid() {
+        if join_column.source.is_rowid() {
             rowid_is_ambiguous |= rowid_column.replace(column_index).is_some();
-        } else if saved_column.visibility != ParenthesizedJoinColumnVisibility::QualifiedOnly
+        } else if join_column.visibility != ParenthesizedJoinColumnVisibility::QualifiedOnly
             && column.replace(column_index).is_some()
         {
             crate::bail_parse_error!("ambiguous column name: {}", column_name);
@@ -640,7 +640,13 @@ fn resolve_qualified_name(
             &joined_table.table,
             joined_table.internal_id,
             &joined_table.identifier,
-            database_id,
+            if database_id == Some(joined_table.database_id)
+                && matches!(joined_table.table, Table::BTree(_) | Table::Virtual(_))
+            {
+                None
+            } else {
+                database_id
+            },
             table_name,
             column_name,
         )?;
@@ -665,16 +671,10 @@ fn resolve_qualified_name(
             }
         }
     }
-    if table_found {
-        return Ok(
-            found.map_or(QualifiedNameMatch::NoColumn, |(table_id, column)| {
-                QualifiedNameMatch::Found(table_id, column)
-            }),
-        );
+    if let Some((table_id, column)) = found {
+        return Ok(QualifiedNameMatch::Found(table_id, column));
     }
 
-    // An inner table name hides the same name in outer queries. If no inner
-    // table matches, only the nearest outer query can provide the column.
     let mut nearest_scope = None;
     let mut ambiguous = false;
     for outer_ref in table_references.outer_query_refs() {
@@ -692,6 +692,10 @@ fn resolve_qualified_name(
             table_name,
             column_name,
         )?;
+        if matches!(candidate, QualifiedTableMatch::NoColumn) {
+            table_found = true;
+            continue;
+        }
         if matches!(candidate, QualifiedTableMatch::NoTable) {
             continue;
         }
@@ -721,7 +725,7 @@ fn resolve_qualified_name(
         Ok(QualifiedNameMatch::Ambiguous)
     } else if let Some((table_id, column)) = found {
         Ok(QualifiedNameMatch::Found(table_id, column))
-    } else if nearest_scope.is_some() {
+    } else if table_found || nearest_scope.is_some() {
         Ok(QualifiedNameMatch::NoColumn)
     } else {
         Ok(QualifiedNameMatch::NoTable)
@@ -778,8 +782,6 @@ fn match_qualified_name_in_table(
         }
     }
 
-    // The normal database.table.column path uses schema metadata in the
-    // caller. Only a parenthesized join can match a saved database name here.
     if database_id.is_some() || !table_reference_name.eq_ignore_ascii_case(table_name) {
         return Ok(QualifiedTableMatch::NoTable);
     }

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -15,7 +15,8 @@ use crate::function::JsonFunc;
 use crate::function::{AggFunc, Func, FuncCtx, MathFuncArity, ScalarFunc, VectorFunc};
 use crate::functions::datetime;
 use crate::schema::{
-    BTreeTable, ColDef, Column, ColumnLayout, GeneratedType, Table, Type, TypeDef,
+    BTreeTable, ColDef, Column, ColumnLayout, GeneratedType, ParenthesizedJoinColumnVisibility,
+    Table, Type, TypeDef,
 };
 use crate::sync::Arc;
 use crate::translate::expression_index::{
@@ -86,6 +87,7 @@ pub(crate) use arrays::{
     emit_array_decode, emit_custom_type_decode_columns, emit_custom_type_encode_columns,
 };
 pub(crate) use binary::expr_is_array;
+pub(super) use binding::find_unqualified_column;
 pub use binding::{bind_and_rewrite_expr, BindingBehavior};
 pub use columns::{emit_table_column, emit_table_column_for_dml};
 pub use condition::translate_condition_expr;

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -2,13 +2,16 @@ use crate::{
     alloc::{self, TursoIteratorExt, TursoVecExt},
     function::{AccumulatorFunc, AggFunc},
     schema::{
-        BTreeTable, ColDef, Column, FromClauseSubquery, Index, PseudoCursorType, RecursiveCteInput,
-        Schema, Table, ROWID_SENTINEL,
+        BTreeTable, ColDef, Column, FromClauseSubquery, Index, ParenthesizedJoinColumnVisibility,
+        PseudoCursorType, RecursiveCteInput, Schema, Table, ROWID_SENTINEL,
     },
     translate::{
         collate::{get_collseq_from_expr, CollationSeq},
         emitter::UpdateRowSource,
-        expr::{as_binary_components, expr_data_type, get_expr_affinity, StorageClassMask},
+        expr::{
+            as_binary_components, expr_data_type, find_unqualified_column, get_expr_affinity,
+            StorageClassMask,
+        },
         expression_index::{normalize_expr_for_index_matching, single_table_column_usage},
         optimizer::constraints::{BinaryExprSide, SeekRangeConstraint},
         planner::determine_where_to_eval_term,
@@ -1005,14 +1008,15 @@ pub enum IterationDirection {
     Backwards,
 }
 
-pub fn select_star(
-    tables: &[JoinedTable],
+/// Add the columns selected by `*` and record each column read.
+pub(super) fn expand_star(
+    table_references: &mut TableReferences,
     out_columns: &mut Vec<ResultSetColumn>,
-    right_join_swapped: bool,
     long_names: bool,
 ) -> crate::Result<()> {
+    let tables = table_references.joined_tables();
     // RIGHT JOIN swapped tables; iterate in reverse to restore original column order.
-    let table_iter: Vec<&JoinedTable> = if right_join_swapped {
+    let table_iter: Vec<&JoinedTable> = if table_references.right_join_swapped() {
         tables.iter().rev().collect()
     } else {
         tables.iter().collect()
@@ -1044,7 +1048,7 @@ pub fn select_star(
                 .filter_map(|t| t.join_info.as_ref())
                 .flat_map(|ji| ji.using.iter().map(|u| u.as_str()))
                 .collect();
-            for col in table.columns().iter().filter(|c| !c.hidden()) {
+            for (_, col) in table.columns_for_star() {
                 if let Some(col_name) = &col.name {
                     let in_using = using_cols.iter().any(|u| u.eq_ignore_ascii_case(col_name));
                     if !in_using {
@@ -1059,50 +1063,179 @@ pub fn select_star(
         }
         out_columns.extend(
             table
-                .columns()
-                .iter()
-                .enumerate()
-                .filter(|(_, col)| !col.hidden())
-                .filter(|(_, col)| {
+                .columns_for_star()
+                .filter(|(_, column)| {
                     // If we are joining with USING, we need to deduplicate the columns from the right table
                     // that are also present in the USING clause.
-                    if let Some(join_info) = &table.join_info {
-                        !join_info.using.iter().any(|using_col| {
-                            col.name
-                                .as_ref()
-                                .is_some_and(|name| name.eq_ignore_ascii_case(using_col.as_str()))
-                        })
-                    } else {
-                        true
-                    }
+                    !table.join_info.as_ref().is_some_and(|join| {
+                        column
+                            .name
+                            .as_deref()
+                            .is_some_and(|name| join.merges_column(name))
+                    })
                 })
-                .map(|(i, col)| {
-                    // Like SQLite, SELECT * sets column names as aliases (ENAME_NAME),
-                    // bypassing full/short column name logic in get_column_name().
-                    // When long_names (full=ON, short=OFF), use "TABLE.COLUMN".
-                    // Otherwise, use just "COLUMN".
-                    let alias = col.name.as_ref().map(|col_name| {
-                        if long_names {
-                            format!("{}.{}", table.identifier, col_name)
-                        } else {
-                            col_name.clone()
-                        }
-                    });
-                    ResultSetColumn {
-                        alias,
-                        implicit_column_name: None,
-                        expr: ast::Expr::Column {
-                            database: None,
-                            table: table.internal_id,
-                            column: i,
-                            is_rowid_alias: col.is_rowid_alias(),
-                        },
-                        contains_aggregates: false,
-                    }
-                }),
+                .map(|(column_index, _)| star_result_column(table, column_index, long_names)),
         );
     }
+    for table in table_references.joined_tables_mut() {
+        for column_index in 0..table.columns().len() {
+            if !table.column_is_hidden_from_star(column_index) {
+                table.mark_column_used(column_index);
+            }
+        }
+    }
     Ok(())
+}
+
+/// Add the columns selected by `<table>.*` and record each column read.
+pub(super) fn expand_table_star(
+    table_references: &mut TableReferences,
+    out_columns: &mut Vec<ResultSetColumn>,
+    table_name: &str,
+    long_names: bool,
+) -> crate::Result<()> {
+    let normalized_name = crate::util::normalize_ident(table_name);
+    let tables = table_references.joined_tables();
+
+    let is_direct_match = |table: &JoinedTable| {
+        !matches!(
+            &table.table,
+            Table::FromClauseSubquery(subquery)
+                if subquery.parenthesized_join_columns.is_some()
+        ) && table.identifier == normalized_name
+    };
+    let direct_match_count = tables.iter().filter(|table| is_direct_match(table)).count();
+    let first_direct_match = tables.iter().find(|table| is_direct_match(table));
+    if direct_match_count > 1 {
+        let first_table =
+            first_direct_match.expect("the direct match count proved that this table exists");
+        let column_name = first_table
+            .columns()
+            .iter()
+            .find(|column| !column.hidden())
+            .and_then(|column| column.name.as_deref())
+            .unwrap_or("?");
+        crate::bail_parse_error!("ambiguous column name: {}.{}", table_name, column_name);
+    }
+
+    let saved_name_has_column = |column_name: &str| {
+        tables.iter().any(|table| {
+            matches!(
+                &table.table,
+                Table::FromClauseSubquery(subquery)
+                    if subquery.parenthesized_join_columns.as_ref().is_some_and(|columns| {
+                        columns.iter().any(|column| {
+                            !column.source.is_rowid()
+                                && column.source.matches_table(None, &normalized_name)
+                                && column.source.matches_column_name(column_name)
+                        })
+                    })
+            )
+        })
+    };
+    // SQLite binds each column after it expands `<table>.*`. A direct table
+    // and a saved inner name conflict only when both contain that column.
+    if let Some(column_name) = first_direct_match.and_then(|table| {
+        table
+            .columns_for_star()
+            .filter_map(|(_, column)| column.name.as_deref())
+            .find(|column_name| saved_name_has_column(column_name))
+    }) {
+        crate::bail_parse_error!("ambiguous column name: {}.{}", table_name, column_name);
+    }
+
+    let mut matching_columns = Vec::new();
+    for (table_index, table) in tables.iter().enumerate() {
+        if let Table::FromClauseSubquery(subquery) = &table.table {
+            if let Some(join_columns) = &subquery.parenthesized_join_columns {
+                // SQLite lets `<table>.*` use saved inner table names, but it
+                // does not let the alias of the generated join group qualify `*`.
+                matching_columns.extend(
+                    join_columns
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, saved_column)| {
+                            !saved_column.source.is_rowid()
+                                && saved_column.source.matches_table(None, &normalized_name)
+                        })
+                        .map(|(column_index, _)| (table_index, column_index)),
+                );
+                continue;
+            }
+        }
+        if table.identifier == normalized_name {
+            matching_columns.extend(
+                table
+                    .columns_for_star()
+                    .map(|(column_index, _)| (table_index, column_index)),
+            );
+        }
+    }
+    if matching_columns.is_empty() {
+        crate::bail_parse_error!("no such table: {}", table_name);
+    }
+
+    let mut used_columns = Vec::new();
+    for (table_index, mut column_index) in matching_columns {
+        let table = &tables[table_index];
+        // SQLite cannot add a nameless column to a qualified star result.
+        if table.columns()[column_index].name.is_none() {
+            continue;
+        }
+        if tables.len() == 1
+            && matches!(
+                &table.table,
+                Table::FromClauseSubquery(subquery)
+                    if subquery.parenthesized_join_columns.is_some()
+            )
+        {
+            // SQLite emits a bare generated name in this case. Rebinding that
+            // name can find several sources, or none after a numeric suffix.
+            let column_name = table.columns()[column_index]
+                .name
+                .as_deref()
+                .expect("the nameless-column check returned early");
+            let Some(rebound_column) = find_unqualified_column(&table.table, column_name)? else {
+                crate::bail_parse_error!("no such column: {}", column_name);
+            };
+            column_index = rebound_column;
+        }
+        out_columns.push(star_result_column(table, column_index, long_names));
+        used_columns.push((table.internal_id, column_index));
+    }
+    for (table_id, column_index) in used_columns {
+        table_references.mark_column_used(table_id, column_index);
+    }
+    Ok(())
+}
+
+/// Build one result column from a star expansion.
+fn star_result_column(
+    table: &JoinedTable,
+    column_index: usize,
+    long_names: bool,
+) -> ResultSetColumn {
+    let column = &table.columns()[column_index];
+    // SQLite gives star outputs explicit names. This bypasses the normal
+    // short-name and full-name rules for expression results.
+    let alias = column.name.as_ref().map(|column_name| {
+        if long_names {
+            format!("{}.{}", table.identifier, column_name)
+        } else {
+            column_name.clone()
+        }
+    });
+    ResultSetColumn {
+        alias,
+        implicit_column_name: None,
+        expr: ast::Expr::Column {
+            database: None,
+            table: table.internal_id,
+            column: column_index,
+            is_rowid_alias: column.is_rowid_alias(),
+        },
+        contains_aggregates: false,
+    }
 }
 
 /// The type of join between two tables.
@@ -1130,6 +1263,13 @@ pub struct JoinInfo {
 }
 
 impl JoinInfo {
+    /// Return true when `USING` or `NATURAL` merges this column.
+    pub fn merges_column(&self, column_name: &str) -> bool {
+        self.using
+            .iter()
+            .any(|name| name.as_str().eq_ignore_ascii_case(column_name))
+    }
+
     /// Whether this is an OUTER JOIN (LEFT OUTER or FULL OUTER).
     pub fn is_outer(&self) -> bool {
         matches!(self.join_type, JoinType::LeftOuter | JoinType::FullOuter)
@@ -2405,7 +2545,7 @@ impl Operation {
     }
 }
 
-fn query_output_columns(
+pub(super) fn query_output_columns(
     plan: &Plan,
     explicit_columns: Option<&[String]>,
 ) -> Result<alloc::Vec<Column>> {
@@ -2543,6 +2683,7 @@ impl JoinedTable {
             name: identifier.clone(),
             plan: Box::new(Plan::Select(Box::new(plan))),
             columns,
+            parenthesized_join_columns: None,
             result_columns_start_reg: None,
             materialized_cursor_id: None,
             cte: None,
@@ -2589,6 +2730,7 @@ impl JoinedTable {
             name: identifier.clone(),
             plan: Box::new(plan),
             columns,
+            parenthesized_join_columns: None,
             result_columns_start_reg: None,
             materialized_cursor_id: None,
             cte,
@@ -2641,6 +2783,34 @@ impl JoinedTable {
 
     pub fn columns(&self) -> &[Column] {
         self.table.columns()
+    }
+
+    /// Return the columns that an unqualified `*` can include.
+    pub(super) fn columns_for_star(&self) -> impl Iterator<Item = (usize, &Column)> {
+        self.columns()
+            .iter()
+            .enumerate()
+            .filter(|(column_index, _)| !self.column_is_hidden_from_star(*column_index))
+    }
+
+    /// Return true when `*` must omit a column from this table reference.
+    ///
+    /// Parenthesized joins keep source copies and rowids for qualified names.
+    /// SQLite does not show those extra values in an unqualified star.
+    fn column_is_hidden_from_star(&self, column_index: usize) -> bool {
+        let column = &self.columns()[column_index];
+        if column.hidden() {
+            return true;
+        }
+        let Table::FromClauseSubquery(subquery) = &self.table else {
+            return false;
+        };
+        let Some(join_columns) = &subquery.parenthesized_join_columns else {
+            return false;
+        };
+        let saved_column = &join_columns[column_index];
+        saved_column.visibility != ParenthesizedJoinColumnVisibility::Visible
+            || saved_column.source.is_rowid()
     }
 
     /// Mark a column as used in the query.

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1051,13 +1051,35 @@ pub(super) fn expand_star(
             for (_, col) in table.columns_for_star() {
                 if let Some(col_name) = &col.name {
                     let in_using = using_cols.iter().any(|u| u.eq_ignore_ascii_case(col_name));
-                    if !in_using {
+                    let matching_columns = tables
+                        .iter()
+                        .filter(|other| {
+                            other.identifier == table.identifier
+                                && other.table.get_column_by_name(col_name).is_some()
+                        })
+                        .count();
+                    if !in_using && matching_columns > 1 {
                         crate::bail_parse_error!(
                             "ambiguous column name: {}.{}",
                             table.identifier,
                             col_name
                         );
                     }
+                }
+            }
+        }
+        if let Table::FromClauseSubquery(subquery) = &table.table {
+            if let Some(join_columns) = &subquery.parenthesized_join_columns {
+                for column in join_columns
+                    .iter()
+                    .filter(|column| column.source.is_using())
+                {
+                    let crate::schema::ParenthesizedJoinColumnSource::Using { column_name } =
+                        &column.source
+                    else {
+                        unreachable!("filtered USING columns");
+                    };
+                    find_unqualified_column(&table.table, column_name)?;
                 }
             }
         }
@@ -1128,7 +1150,10 @@ pub(super) fn expand_table_star(
                             !column.source.is_rowid()
                                 && column.source.matches_table(None, &normalized_name)
                                 && column.source.matches_column_name(column_name)
-                        })
+                        }) && !tables.iter()
+                            .filter(|candidate| candidate.internal_id == table.internal_id || is_direct_match(candidate))
+                            .next_back()
+                            .is_some_and(|last| last.join_info.as_ref().is_some_and(|join| join.merges_column(column_name)))
                     })
             )
         })

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1669,8 +1669,64 @@ fn parse_from_clause_table(
             None, // table-valued functions don't support INDEXED BY
             connection,
         ),
-        ast::SelectTable::Sub(..) => {
-            crate::bail_parse_error!("Parenthesized FROM clause subqueries are not supported")
+        ast::SelectTable::Sub(from_clause, maybe_alias) if from_clause.joins.is_empty() => {
+            // SQLite unwraps a one-source group. An outer alias replaces the
+            // alias inside the parentheses, including when the outer alias is absent.
+            let table = replace_select_table_alias(*from_clause.select, maybe_alias);
+            parse_from_clause_table(
+                table,
+                resolver,
+                program,
+                table_references,
+                vtab_predicates,
+                cte_definitions,
+                connection,
+            )
+        }
+        ast::SelectTable::Sub(from_clause, maybe_alias) => {
+            // SQLite represents a parenthesized join group as a SELECT * subquery.
+            // The subquery keeps the joins inside the parentheses as one source.
+            let table_index = table_references.joined_tables().len();
+            let has_alias = maybe_alias.is_some();
+            let subselect = ast::Select {
+                with: None,
+                body: ast::SelectBody {
+                    select: ast::OneSelect::Select {
+                        distinctness: None,
+                        columns: vec![ast::ResultColumn::Star],
+                        from: Some(from_clause),
+                        where_clause: None,
+                        group_by: None,
+                        window_clause: Vec::new(),
+                    },
+                    compounds: Vec::new(),
+                },
+                order_by: Vec::new(),
+                limit: None,
+            };
+            parse_from_clause_table(
+                ast::SelectTable::Select(subselect, maybe_alias),
+                resolver,
+                program,
+                table_references,
+                vtab_predicates,
+                cte_definitions,
+                connection,
+            )?;
+            if !has_alias {
+                // SQLite names this generated source "(join-N)" in query plans.
+                let name = format!("(join-{table_index})");
+                let table = table_references
+                    .joined_tables_mut()
+                    .last_mut()
+                    .expect("the nested SELECT added one table");
+                table.identifier.clone_from(&name);
+                let Table::FromClauseSubquery(subquery) = &mut table.table else {
+                    unreachable!("the nested SELECT must produce a subquery table");
+                };
+                Arc::make_mut(subquery).name = name;
+            }
+            Ok(())
         }
     }
 }
@@ -2163,8 +2219,16 @@ pub fn parse_from(
 
     // Process FROM clause if present
     if let Some(from_owned) = from {
-        let select_owned = from_owned.select;
-        let joins_owned = from_owned.joins;
+        let mut select_owned = from_owned.select;
+        let mut joins_owned = from_owned.joins;
+        // SQLite removes an unaliased group when it starts the FROM clause.
+        // Keep the inner joins before the joins that follow the group.
+        while let ast::SelectTable::Sub(inner, None) = *select_owned {
+            select_owned = inner.select;
+            let mut inner_joins = inner.joins;
+            inner_joins.extend(joins_owned);
+            joins_owned = inner_joins;
+        }
         parse_from_clause_table(
             *select_owned,
             resolver,
@@ -2191,6 +2255,17 @@ pub fn parse_from(
 
     program.unmask_shadowed_ctes_being_defined(shadowed_outer_ctes);
     Ok(())
+}
+
+fn replace_select_table_alias(table: ast::SelectTable, alias: Option<ast::As>) -> ast::SelectTable {
+    match table {
+        ast::SelectTable::Table(name, _, indexed) => ast::SelectTable::Table(name, alias, indexed),
+        ast::SelectTable::TableCall(name, args, _) => {
+            ast::SelectTable::TableCall(name, args, alias)
+        }
+        ast::SelectTable::Select(select, _) => ast::SelectTable::Select(select, alias),
+        ast::SelectTable::Sub(from, _) => ast::SelectTable::Sub(from, alias),
+    }
 }
 
 #[turso_macros::trace_stack]

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -2504,11 +2504,7 @@ pub fn parse_from(
 /// Replace the alias inside a one-source group with its outer alias.
 fn replace_select_table_alias(table: ast::SelectTable, alias: Option<ast::As>) -> ast::SelectTable {
     match table {
-        ast::SelectTable::Table(name, _, indexed) => {
-            // SQLite removes the inner index choice when the group has an outer alias.
-            let indexed = if alias.is_some() { None } else { indexed };
-            ast::SelectTable::Table(name, alias, indexed)
-        }
+        ast::SelectTable::Table(name, _, indexed) => ast::SelectTable::Table(name, alias, indexed),
         ast::SelectTable::TableCall(name, args, _) => {
             ast::SelectTable::TableCall(name, args, alias)
         }

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1774,9 +1774,9 @@ fn keep_parenthesized_join_columns(table: &mut JoinedTable) -> Result<()> {
         // sides of `USING`. Outer unqualified names find this value first.
         for using_name in next_using {
             let column_name = using_name.as_str();
-            let (expr, source_column) =
+            let (expr, source_columns) =
                 resolve_parenthesized_using_column(source_tables, table_index, column_name);
-            used_columns.push(source_column);
+            used_columns.extend(source_columns);
             result_columns.push(parenthesized_join_result_column(expr, column_name));
             join_columns.push(ParenthesizedJoinColumn {
                 source: ParenthesizedJoinColumnSource::Using {
@@ -1906,6 +1906,15 @@ fn keep_parenthesized_join_columns(table: &mut JoinedTable) -> Result<()> {
     }
 
     plan.result_columns = result_columns;
+    for source_table in plan.table_references.joined_tables_mut() {
+        if let Some(join) = &mut source_table.join_info {
+            if join.is_full_outer() {
+                // The equality predicates and merged outputs now express USING
+                // completely. Treat it as ON so the hash join planner can use it.
+                join.using.clear();
+            }
+        }
+    }
     for (table_id, column_index) in used_columns {
         plan.table_references
             .mark_column_used(table_id, column_index);
@@ -1964,29 +1973,50 @@ fn parenthesized_join_result_column(expr: Expr, column_name: &str) -> ResultSetC
     }
 }
 
-/// Find the first source column for an INNER or LEFT `USING` join.
-///
-/// These joins preserve the first source. RIGHT and FULL require a merged value.
 fn resolve_parenthesized_using_column(
     tables: &[JoinedTable],
     last_table_index: usize,
     column_name: &str,
-) -> (Expr, (TableInternalId, usize)) {
-    for table in &tables[..=last_table_index] {
+) -> (Expr, Vec<(TableInternalId, usize)>) {
+    let mut expr = None;
+    let mut used_columns = Vec::new();
+    for table in tables.iter().take(last_table_index + 2) {
         let Some((column_index, column)) = table.table.get_column_by_name(column_name) else {
             continue;
         };
-        return (
-            Expr::Column {
-                database: None,
-                table: table.internal_id,
-                column: column_index,
-                is_rowid_alias: column.is_rowid_alias(),
-            },
-            (table.internal_id, column_index),
-        );
+        let source = Expr::Column {
+            database: None,
+            table: table.internal_id,
+            column: column_index,
+            is_rowid_alias: column.is_rowid_alias(),
+        };
+        if expr.is_none() {
+            expr = Some(source);
+        } else if table
+            .join_info
+            .as_ref()
+            .is_some_and(|join| join.is_full_outer() && join.merges_column(column_name))
+        {
+            expr = Some(Expr::FunctionCall {
+                name: ast::Name::exact("coalesce".to_string()),
+                distinctness: None,
+                args: vec![Box::new(expr.take().unwrap()), Box::new(source)],
+                order_by: vec![],
+                within_group: vec![],
+                filter_over: ast::FunctionTail {
+                    filter_clause: None,
+                    over_clause: None,
+                },
+            });
+        } else {
+            continue;
+        }
+        used_columns.push((table.internal_id, column_index));
     }
-    unreachable!("USING already proved that the column exists");
+    (
+        expr.expect("USING already proved that the column exists"),
+        used_columns,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1754,12 +1754,21 @@ fn keep_parenthesized_join_columns(table: &mut JoinedTable) -> Result<()> {
     let mut join_columns = crate::alloc::vec![];
     let mut used_columns = Vec::new();
 
-    for (table_index, source_table) in source_tables.iter().enumerate() {
-        let next_using = source_tables
-            .get(table_index + 1)
-            .and_then(|next| next.join_info.as_ref())
-            .map(|join| join.using.as_slice())
-            .unwrap_or_default();
+    let right_join_swapped = plan.table_references.right_join_swapped();
+    let source_order: Vec<_> = if right_join_swapped {
+        source_tables.iter().enumerate().rev().collect()
+    } else {
+        source_tables.iter().enumerate().collect()
+    };
+    for (table_index, source_table) in source_order {
+        let next_using = if right_join_swapped {
+            (table_index == 1).then_some(source_table)
+        } else {
+            source_tables.get(table_index + 1)
+        }
+        .and_then(|next| next.join_info.as_ref())
+        .map(|join| join.using.as_slice())
+        .unwrap_or_default();
 
         // SQLite stores one canonical value before the source columns on both
         // sides of `USING`. Outer unqualified names find this value first.
@@ -1782,6 +1791,11 @@ fn keep_parenthesized_join_columns(table: &mut JoinedTable) -> Result<()> {
                 .join_info
                 .as_ref()
                 .is_some_and(|join| join.merges_column(column_name))
+                || (right_join_swapped
+                    && source_tables[1]
+                        .join_info
+                        .as_ref()
+                        .is_some_and(|join| join.merges_column(column_name)))
                 || next_using
                     .iter()
                     .any(|name| name.as_str().eq_ignore_ascii_case(column_name))

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -5,9 +5,10 @@ use super::plan::NamedWindowBound;
 use super::{
     expr::{walk_expr, walk_expr_mut},
     plan::{
-        Aggregate, ColumnMask, ColumnUsedMask, Distinctness, EvalAt, IterationDirection, JoinInfo,
-        JoinOrderMember, JoinType as PlanJoinType, JoinedTable, Operation, OuterQueryReference,
-        Plan, QueryDestination, ResultSetColumn, Scan, TableReferences, WhereTerm,
+        query_output_columns, Aggregate, ColumnMask, ColumnUsedMask, Distinctness, EvalAt,
+        IterationDirection, JoinInfo, JoinOrderMember, JoinType as PlanJoinType, JoinedTable,
+        Operation, OuterQueryReference, Plan, QueryDestination, ResultSetColumn, Scan,
+        TableReferences, WhereTerm,
     },
     select::{prepare_select_plan, prepare_select_plan_from_arms},
 };
@@ -23,7 +24,10 @@ use crate::translate::{
 use crate::{
     ast::Limit,
     function::Func,
-    schema::Table,
+    schema::{
+        ParenthesizedJoinColumn, ParenthesizedJoinColumnSource, ParenthesizedJoinColumnVisibility,
+        Table,
+    },
     util::{exprs_are_equivalent, normalize_ident},
     Result,
 };
@@ -1686,9 +1690,10 @@ fn parse_from_clause_table(
         ast::SelectTable::Sub(from_clause, maybe_alias) => {
             // SQLite represents a parenthesized join group as a SELECT * subquery.
             // The subquery keeps the joins inside the parentheses as one source.
-            let table_index = table_references.joined_tables().len();
-            let has_alias = maybe_alias.is_some();
-            let subselect = ast::Select {
+            let generated_name = maybe_alias
+                .is_none()
+                .then(|| format!("(join-{})", table_references.joined_tables().len()));
+            let join_select = ast::Select {
                 with: None,
                 body: ast::SelectBody {
                     select: ast::OneSelect::Select {
@@ -1705,7 +1710,7 @@ fn parse_from_clause_table(
                 limit: None,
             };
             parse_from_clause_table(
-                ast::SelectTable::Select(subselect, maybe_alias),
+                ast::SelectTable::Select(join_select, maybe_alias),
                 resolver,
                 program,
                 table_references,
@@ -1713,22 +1718,261 @@ fn parse_from_clause_table(
                 cte_definitions,
                 connection,
             )?;
-            if !has_alias {
+            let table = table_references
+                .joined_tables_mut()
+                .last_mut()
+                .expect("the nested SELECT added one table");
+            if let Some(name) = generated_name {
                 // SQLite names this generated source "(join-N)" in query plans.
-                let name = format!("(join-{table_index})");
-                let table = table_references
-                    .joined_tables_mut()
-                    .last_mut()
-                    .expect("the nested SELECT added one table");
                 table.identifier.clone_from(&name);
                 let Table::FromClauseSubquery(subquery) = &mut table.table else {
                     unreachable!("the nested SELECT must produce a subquery table");
                 };
                 Arc::make_mut(subquery).name = name;
             }
+            keep_parenthesized_join_columns(table)?;
             Ok(())
         }
     }
+}
+
+/// Keep the source columns that SQLite stores for a parenthesized join.
+///
+/// A normal `SELECT *` removes duplicate `USING` columns and all rowids.
+/// SQLite keeps those values because an outer query can use qualified names.
+fn keep_parenthesized_join_columns(table: &mut JoinedTable) -> Result<()> {
+    let Table::FromClauseSubquery(subquery) = &mut table.table else {
+        unreachable!("a parenthesized join must produce a subquery table");
+    };
+    let subquery = Arc::make_mut(subquery);
+    let Plan::Select(plan) = subquery.plan.as_mut() else {
+        unreachable!("a parenthesized join must produce one SELECT plan");
+    };
+
+    let source_tables = plan.table_references.joined_tables();
+    let mut result_columns = Vec::new();
+    let mut join_columns = crate::alloc::vec![];
+    let mut used_columns = Vec::new();
+
+    for (table_index, source_table) in source_tables.iter().enumerate() {
+        let next_using = source_tables
+            .get(table_index + 1)
+            .and_then(|next| next.join_info.as_ref())
+            .map(|join| join.using.as_slice())
+            .unwrap_or_default();
+
+        // SQLite stores one canonical value before the source columns on both
+        // sides of `USING`. Outer unqualified names find this value first.
+        for using_name in next_using {
+            let column_name = using_name.as_str();
+            let (expr, source_column) =
+                resolve_parenthesized_using_column(source_tables, table_index, column_name);
+            used_columns.push(source_column);
+            result_columns.push(parenthesized_join_result_column(expr, column_name));
+            join_columns.push(ParenthesizedJoinColumn {
+                source: ParenthesizedJoinColumnSource::Using {
+                    column_name: column_name.to_string(),
+                },
+                visibility: ParenthesizedJoinColumnVisibility::Visible,
+            });
+        }
+
+        let hidden_by_using = |column_name: &str| {
+            source_table
+                .join_info
+                .as_ref()
+                .is_some_and(|join| join.merges_column(column_name))
+                || next_using
+                    .iter()
+                    .any(|name| name.as_str().eq_ignore_ascii_case(column_name))
+        };
+
+        if let Table::FromClauseSubquery(source_subquery) = &source_table.table {
+            if let Some(source_join_columns) = &source_subquery.parenthesized_join_columns {
+                assert_eq!(source_table.columns().len(), source_join_columns.len());
+                for (column_index, (column, saved_column)) in source_table
+                    .columns()
+                    .iter()
+                    .zip(source_join_columns)
+                    .enumerate()
+                {
+                    // SQLite does not copy rowid entries through a second join group.
+                    if saved_column.source.is_rowid() {
+                        continue;
+                    }
+                    let Some(column_name) = column.name.as_deref() else {
+                        continue;
+                    };
+                    let mut saved_column = saved_column.clone();
+                    let hidden_by_using = hidden_by_using(column_name);
+                    if hidden_by_using {
+                        saved_column.visibility = ParenthesizedJoinColumnVisibility::QualifiedOnly;
+                    }
+                    result_columns.push(parenthesized_join_result_column(
+                        Expr::Column {
+                            database: None,
+                            table: source_table.internal_id,
+                            column: column_index,
+                            is_rowid_alias: column.is_rowid_alias(),
+                        },
+                        column_name,
+                    ));
+                    join_columns.push(saved_column);
+                    used_columns.push((source_table.internal_id, column_index));
+                }
+                continue;
+            }
+        }
+
+        let database_id = matches!(source_table.table, Table::BTree(_) | Table::Virtual(_))
+            .then_some(source_table.database_id);
+        for (column_index, column) in source_table.columns().iter().enumerate() {
+            if column.hidden() {
+                continue;
+            }
+            let Some(column_name) = column.name.as_deref() else {
+                continue;
+            };
+            let hidden_by_using = hidden_by_using(column_name);
+            result_columns.push(parenthesized_join_result_column(
+                Expr::Column {
+                    database: None,
+                    table: source_table.internal_id,
+                    column: column_index,
+                    is_rowid_alias: column.is_rowid_alias(),
+                },
+                column_name,
+            ));
+            join_columns.push(ParenthesizedJoinColumn {
+                source: ParenthesizedJoinColumnSource::Table {
+                    database_id,
+                    table_name: source_table.identifier.clone(),
+                    column_name: column_name.to_string(),
+                },
+                visibility: if hidden_by_using {
+                    ParenthesizedJoinColumnVisibility::QualifiedOnly
+                } else {
+                    ParenthesizedJoinColumnVisibility::Visible
+                },
+            });
+            used_columns.push((source_table.internal_id, column_index));
+        }
+
+        let Table::BTree(btree) = &source_table.table else {
+            continue;
+        };
+        if !btree.has_rowid {
+            continue;
+        }
+        // SQLite uses the first rowid alias that is not a declared column.
+        let rowid_name = ["_ROWID_", "ROWID", "OID"].into_iter().find(|name| {
+            source_table.columns().iter().all(|column| {
+                column
+                    .name
+                    .as_deref()
+                    .is_none_or(|column_name| !column_name.eq_ignore_ascii_case(name))
+            })
+        });
+        if let Some(rowid_name) = rowid_name {
+            result_columns.push(parenthesized_join_result_column(
+                Expr::RowId {
+                    database: None,
+                    table: source_table.internal_id,
+                },
+                rowid_name,
+            ));
+            join_columns.push(ParenthesizedJoinColumn {
+                source: ParenthesizedJoinColumnSource::RowId {
+                    database_id,
+                    table_name: source_table.identifier.clone(),
+                },
+                visibility: ParenthesizedJoinColumnVisibility::Visible,
+            });
+        }
+    }
+
+    plan.result_columns = result_columns;
+    for (table_id, column_index) in used_columns {
+        plan.table_references
+            .mark_column_used(table_id, column_index);
+    }
+
+    subquery.columns = query_output_columns(&subquery.plan, None)?;
+    assert_eq!(subquery.columns.len(), join_columns.len());
+    for column_index in 0..subquery.columns.len() {
+        let original_name = subquery.columns[column_index]
+            .name
+            .clone()
+            .expect("each generated join column has an alias");
+        let mut column_name = original_name.clone();
+        let mut suffix = 0;
+        let base_name = original_name
+            .rsplit_once(':')
+            .filter(|(_, suffix)| suffix.chars().all(|ch| ch.is_ascii_digit()))
+            .map_or(original_name.as_str(), |(base, _)| base);
+        while let Some(previous_index) =
+            subquery.columns[..column_index].iter().position(|column| {
+                column
+                    .name
+                    .as_deref()
+                    .is_some_and(|name| name.eq_ignore_ascii_case(&column_name))
+            })
+        {
+            // SQLite omits every later collision from `*`. It also hides a
+            // repeated merged value from bare-name lookup. An unrelated source
+            // column stays visible to lookup and makes the bare name ambiguous.
+            if join_columns[previous_index].source.is_using() {
+                let hidden_from_bare_name = join_columns[column_index].source.is_using()
+                    || join_columns[column_index].visibility
+                        == ParenthesizedJoinColumnVisibility::QualifiedOnly;
+                join_columns[column_index].visibility = if hidden_from_bare_name {
+                    ParenthesizedJoinColumnVisibility::QualifiedOnly
+                } else {
+                    ParenthesizedJoinColumnVisibility::HiddenFromStar
+                };
+            }
+            suffix += 1;
+            column_name = format!("{base_name}:{suffix}");
+        }
+        subquery.columns[column_index].name = Some(column_name);
+    }
+    subquery.parenthesized_join_columns = Some(join_columns);
+    Ok(())
+}
+
+/// Build one result column for the generated parenthesized-join query.
+fn parenthesized_join_result_column(expr: Expr, column_name: &str) -> ResultSetColumn {
+    ResultSetColumn {
+        expr,
+        alias: Some(column_name.to_string()),
+        implicit_column_name: None,
+        contains_aggregates: false,
+    }
+}
+
+/// Find the first source column for an INNER or LEFT `USING` join.
+///
+/// These joins preserve the first source. RIGHT and FULL require a merged value.
+fn resolve_parenthesized_using_column(
+    tables: &[JoinedTable],
+    last_table_index: usize,
+    column_name: &str,
+) -> (Expr, (TableInternalId, usize)) {
+    for table in &tables[..=last_table_index] {
+        let Some((column_index, column)) = table.table.get_column_by_name(column_name) else {
+            continue;
+        };
+        return (
+            Expr::Column {
+                database: None,
+                table: table.internal_id,
+                column: column_index,
+                is_rowid_alias: column.is_rowid_alias(),
+            },
+            (table.internal_id, column_index),
+        );
+    }
+    unreachable!("USING already proved that the column exists");
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2257,9 +2501,14 @@ pub fn parse_from(
     Ok(())
 }
 
+/// Replace the alias inside a one-source group with its outer alias.
 fn replace_select_table_alias(table: ast::SelectTable, alias: Option<ast::As>) -> ast::SelectTable {
     match table {
-        ast::SelectTable::Table(name, _, indexed) => ast::SelectTable::Table(name, alias, indexed),
+        ast::SelectTable::Table(name, _, indexed) => {
+            // SQLite removes the inner index choice when the group has an outer alias.
+            let indexed = if alias.is_some() { None } else { indexed };
+            ast::SelectTable::Table(name, alias, indexed)
+        }
         ast::SelectTable::TableCall(name, args, _) => {
             ast::SelectTable::TableCall(name, args, alias)
         }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1,7 +1,8 @@
 use super::emitter::{emit_program, TranslateCtx};
 use super::plan::{
-    select_star, Distinctness, InSeekSource, JoinOrderMember, NamedWindowBound, NamedWindowDef,
-    Operation, OuterQueryReference, QueryDestination, Search, TableReferences, Window,
+    expand_star, expand_table_star, Distinctness, InSeekSource, JoinOrderMember, NamedWindowBound,
+    NamedWindowDef, Operation, OuterQueryReference, QueryDestination, Search, TableReferences,
+    Window,
 };
 use crate::schema::Table;
 use crate::stack::trace_stack;
@@ -346,14 +347,14 @@ fn prepare_one_select_plan(
                         ResultColumn::Star => table_references
                             .joined_tables()
                             .iter()
-                            .map(|t| t.columns().iter().filter(|col| !col.hidden()).count())
+                            .map(|table| table.columns_for_star().count())
                             .sum(),
                         // Guess 5 columns if we can't find the table using the identifier (maybe it's in [brackets] or `tick_quotes`, or miXeDcAse)
                         ResultColumn::TableStar(n) => table_references
                             .joined_tables()
                             .iter()
                             .find(|t| t.identifier == n.as_str())
-                            .map(|t| t.columns().iter().filter(|col| !col.hidden()).count())
+                            .map(|table| table.columns_for_star().count())
                             .unwrap_or(5),
                         // Otherwise allocate space for 1 column
                         ResultColumn::Expr(_, _) => 1,
@@ -496,88 +497,19 @@ fn prepare_one_select_plan(
                 for column in columns.into_iter() {
                     match column {
                         ResultColumn::Star => {
-                            select_star(
-                                plan.table_references.joined_tables(),
+                            expand_star(
+                                &mut plan.table_references,
                                 &mut plan.result_columns,
-                                plan.table_references.right_join_swapped(),
                                 long_names,
                             )?;
-                            for table in plan.table_references.joined_tables_mut() {
-                                for idx in 0..table.columns().len() {
-                                    let column = &table.columns()[idx];
-                                    if column.hidden() {
-                                        continue;
-                                    }
-                                    table.mark_column_used(idx);
-                                }
-                            }
                         }
                         ResultColumn::TableStar(name) => {
-                            let name_normalized = normalize_ident(name.as_str());
-                            // If this table identifier appears more than once in the FROM
-                            // clause, `A.*` is ambiguous (matches SQLite behavior).
-                            let dup_count = plan
-                                .table_references
-                                .joined_tables()
-                                .iter()
-                                .filter(|t| t.identifier == name_normalized)
-                                .count();
-                            if dup_count > 1 {
-                                let first_tbl = plan
-                                    .table_references
-                                    .joined_tables()
-                                    .iter()
-                                    .find(|t| t.identifier == name_normalized)
-                                    .unwrap(); // safe: dup_count > 1 guarantees a match
-                                let col_name = first_tbl
-                                    .columns()
-                                    .iter()
-                                    .find(|c| !c.hidden())
-                                    .and_then(|c| c.name.as_ref())
-                                    .map(|n| n.as_str())
-                                    .unwrap_or("?");
-                                crate::bail_parse_error!(
-                                    "ambiguous column name: {}.{}",
-                                    name.as_str(),
-                                    col_name
-                                );
-                            }
-                            let referenced_table = plan
-                                .table_references
-                                .joined_tables_mut()
-                                .iter_mut()
-                                .find(|t| t.identifier == name_normalized);
-
-                            if referenced_table.is_none() {
-                                crate::bail_parse_error!("no such table: {}", name.as_str());
-                            }
-                            let table = referenced_table.unwrap();
-                            let num_columns = table.columns().len();
-                            for idx in 0..num_columns {
-                                let column = &table.columns()[idx];
-                                if column.hidden() {
-                                    continue;
-                                }
-                                let alias = column.name.as_ref().map(|col_name| {
-                                    if long_names {
-                                        format!("{}.{}", table.identifier, col_name)
-                                    } else {
-                                        col_name.clone()
-                                    }
-                                });
-                                plan.result_columns.push(ResultSetColumn {
-                                    expr: ast::Expr::Column {
-                                        database: None, // TODO: support different databases
-                                        table: table.internal_id,
-                                        column: idx,
-                                        is_rowid_alias: column.is_rowid_alias(),
-                                    },
-                                    alias,
-                                    implicit_column_name: None,
-                                    contains_aggregates: false,
-                                });
-                                table.mark_column_used(idx);
-                            }
+                            expand_table_star(
+                                &mut plan.table_references,
+                                &mut plan.result_columns,
+                                name.as_str(),
+                                long_names,
+                            )?;
                         }
                         ResultColumn::Expr(mut expr, maybe_alias) => {
                             bind_and_rewrite_expr(

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1473,6 +1473,17 @@ pub fn emit_from_clause_subqueries(
             let execution_mode =
                 execution_mode.expect("execution mode was computed above for subquery tables");
             let from_clause_subquery = Arc::make_mut(from_clause_subquery);
+            if from_clause_subquery.parenthesized_join_columns.is_some()
+                && !plan_is_correlated(&from_clause_subquery.plan)
+            {
+                // SQLite replaces unused outputs of an uncorrelated subquery with
+                // NULL. The generated join group has no aggregate, window, compound,
+                // or CTE state that blocks this optimization in SQLite.
+                let Plan::Select(select_plan) = from_clause_subquery.plan.as_mut() else {
+                    unreachable!("a parenthesized join must produce one SELECT plan");
+                };
+                null_unused_result_columns(select_plan, &table_reference.col_used_mask);
+            }
             // Check if this is a CTE that's already materialized
             if let Some(cte_id) = from_clause_subquery.cte_id() {
                 if let Some(cte_info) = program.get_materialized_cte(cte_id).cloned() {
@@ -1574,6 +1585,15 @@ pub fn emit_from_clause_subqueries(
         program.pop_current_parent_explain();
     }
     Ok(())
+}
+
+/// Keep result positions stable but remove work for columns that the parent does not read.
+fn null_unused_result_columns(plan: &mut SelectPlan, used_columns: &ColumnUsedMask) {
+    for (column_index, result_column) in plan.result_columns.iter_mut().enumerate() {
+        if !used_columns.get(column_index) {
+            result_column.expr = ast::Expr::Literal(ast::Literal::Null);
+        }
+    }
 }
 
 /// Emit a FROM clause subquery and return the start register of the result columns.

--- a/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
@@ -1,0 +1,42 @@
+@database :memory:
+
+# SQLite unwraps a group with one source. The alias outside the group replaces
+# the alias inside it.
+@cross-check-integrity
+test one-source-parenthesized-group-uses-outer-alias {
+    CREATE TABLE grouped_one_left(id INTEGER);
+    CREATE TABLE grouped_one_right(id INTEGER);
+    INSERT INTO grouped_one_left VALUES(1),(2);
+    INSERT INTO grouped_one_right VALUES(2),(3);
+
+    SELECT one_left.id, grouped_one_right.id
+      FROM grouped_one_right
+      LEFT JOIN (grouped_one_left AS inner_name) AS one_left
+        ON one_left.id=grouped_one_right.id
+     ORDER BY grouped_one_right.id;
+}
+expect {
+    2|2
+    |3
+}
+
+# SQLite keeps a group with multiple sources together as one join source.
+@cross-check-integrity
+test left-join-keeps-parenthesized-inner-join-together {
+    CREATE TABLE grouped_outer(id INTEGER);
+    CREATE TABLE grouped_first(id INTEGER, first_value TEXT);
+    CREATE TABLE grouped_second(id INTEGER, second_value TEXT);
+    INSERT INTO grouped_outer VALUES(1),(2),(3);
+    INSERT INTO grouped_first VALUES(2,'first-two'),(3,'first-three');
+    INSERT INTO grouped_second VALUES(2,'second-two');
+
+    SELECT id, first_value, second_value
+      FROM grouped_outer
+      LEFT JOIN (grouped_first JOIN grouped_second USING(id)) USING(id)
+     ORDER BY id;
+}
+expect {
+    1||
+    2|first-two|second-two
+    3||
+}

--- a/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
@@ -1624,3 +1624,25 @@ test nested-one-source-alias-keeps-missing-index-error {
 expect error {
     no such index: missing_index
 }
+
+@cross-check-integrity
+test declared-rowids-hide-group-rowids-in-either-order-and-outer-scope {
+    CREATE TABLE implicit_one(x);
+    CREATE TABLE implicit_two(y);
+    INSERT INTO implicit_one VALUES(1);
+    INSERT INTO implicit_two VALUES(2);
+    SELECT rowid, _rowid_, oid, (SELECT rowid), (SELECT (SELECT oid))
+      FROM (implicit_one JOIN implicit_two) AS grouped
+      JOIN (SELECT 'r' AS rowid, 'u' AS _rowid_, 'o' AS oid) AS declared;
+    SELECT rowid, _rowid_, oid, (SELECT rowid), (SELECT (SELECT oid))
+      FROM (SELECT 'r' AS rowid, 'u' AS _rowid_, 'o' AS oid) AS declared
+      JOIN (implicit_one JOIN implicit_two);
+    SELECT rowid FROM implicit_one JOIN (SELECT 'r' AS rowid) AS declared;
+    SELECT rowid FROM (SELECT 'r' AS rowid) AS declared JOIN implicit_one;
+}
+expect {
+    r|u|o|r|o
+    r|u|o|r|o
+    r
+    r
+}

--- a/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
@@ -689,6 +689,23 @@ expect error {
     no such index: missing_index
 }
 
+# After another FROM source, SQLite rebuilds a one-source group and drops its
+# index choice even when there is no outer alias.
+@cross-check-integrity
+@skip-if sqlite "https://sqlite.org/bugs/forumpost/09c09c8e1c207ef5abe7b142b3eaf77446660d8a697563f6fd58f75162add9ed"
+test joined-one-source-group-removes-index-choice-without-outer-alias {
+    CREATE TABLE indexed_group_anchor(marker INTEGER);
+    CREATE TABLE indexed_group_joined(value INTEGER);
+    INSERT INTO indexed_group_anchor VALUES(1);
+    INSERT INTO indexed_group_joined VALUES(7);
+
+    SELECT indexed_group_joined.value
+      FROM indexed_group_anchor
+      JOIN (indexed_group_joined INDEXED BY missing_index);
+}
+expect {
+    7
+}
 
 # An outer alias replaces the index choice inside a one-source group.
 @cross-check-integrity
@@ -1050,6 +1067,33 @@ expect error {
     ambiguous column name:
 }
 
+@setup saved_name_paths
+@cross-check-integrity
+test saved-qualified-column-wins-over-implicit-rowids {
+    CREATE TABLE declared_names(rowid TEXT, _rowid_ TEXT, oid TEXT);
+    CREATE TABLE first_implicit(first_value INTEGER);
+    CREATE TABLE second_implicit(second_value INTEGER);
+    INSERT INTO declared_names VALUES('r','u','o');
+    INSERT INTO first_implicit VALUES(1);
+    INSERT INTO second_implicit VALUES(2);
+
+    SELECT same.rowid, same._rowid_, same.oid
+      FROM path_anchor
+      JOIN (first_implicit AS same JOIN declared_names AS same);
+    SELECT same.rowid, same._rowid_, same.oid, (SELECT same.rowid)
+      FROM path_anchor
+      JOIN (first_implicit AS same JOIN second_implicit AS same
+            JOIN declared_names AS same);
+    SELECT same.rowid, same._rowid_, same.oid, (SELECT same.rowid)
+      FROM path_anchor
+      JOIN (declared_names AS same JOIN first_implicit AS same
+            JOIN second_implicit AS same);
+}
+expect {
+    r|u|o
+    r|u|o|r
+    r|u|o|r
+}
 
 @setup saved_name_paths
 @cross-check-integrity
@@ -1308,6 +1352,14 @@ expect {
     value|value|value
 }
 
+@skip-if sqlite "SQLite 3.50.4 swallows this error, will be fixed in the next version https://sqlite.org/bugs/info/09c09c8e1c207ef5"
+test index-by-missing-column-in-nested-join-group-returns-error {
+    create table t(a);
+    select * from t join (t indexed by something) tt;
+}
+expect error {
+    no such index: something
+}
 
 @cross-check-integrity
 test declared-column-wins-over-two-unqualified-rowids {
@@ -1330,6 +1382,23 @@ expect {
     r|u|o
 }
 
+@cross-check-integrity
+test parenthesized-full-using-keeps-merged-and-source-values {
+    CREATE TABLE full_left(id INTEGER, l TEXT);
+    CREATE TABLE full_right(id INTEGER, r TEXT);
+    INSERT INTO full_left VALUES(1,'l1'),(2,'l2');
+    INSERT INTO full_right VALUES(2,'r2'),(3,'r3');
+
+    SELECT id, full_left.id, full_right.id, *
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN (full_left FULL JOIN full_right USING(id))
+     ORDER BY id;
+}
+expect {
+    1|1||9|1|l1|
+    2|2|2|9|2|l2|r2
+    3||3|9|3||r3
+}
 
 @cross-check-integrity
 test nested-using-keeps-one-visible-merged-value {
@@ -1351,8 +1420,48 @@ expect {
     2|2|2|2|9|2|a2|b2|c2
 }
 
+@cross-check-integrity
+test star-rejects-an-unrelated-using-name-collision {
+    CREATE TABLE collision_first(id INTEGER, a TEXT);
+    CREATE TABLE collision_second(id INTEGER, b TEXT);
+    CREATE TABLE collision_other(id INTEGER, c TEXT);
+    INSERT INTO collision_first VALUES(1,'a');
+    INSERT INTO collision_second VALUES(1,'b');
+    INSERT INTO collision_other VALUES(99,'c');
 
+    SELECT *, collision_other.id
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN (collision_first JOIN collision_second USING(id) JOIN collision_other);
+}
+expect error {
+    ambiguous column name: id
+}
 
+@cross-check-integrity
+test qualified-column-skips-local-saved-table-without-column {
+    SELECT (
+        SELECT same.x
+          FROM (SELECT 0 AS marker) AS anchor
+          JOIN ((SELECT 2 AS y) AS same JOIN (SELECT 3 AS z) AS other)
+    )
+      FROM (SELECT 7 AS x) AS same;
+}
+expect {
+    7
+}
+
+@cross-check-integrity
+test qualified-column-skips-nearer-saved-table-without-column {
+    SELECT (
+        SELECT (SELECT same.x)
+          FROM (SELECT 0 AS marker) AS anchor
+          JOIN ((SELECT 2 AS y) AS same JOIN (SELECT 3 AS z) AS other)
+    )
+      FROM (SELECT 7 AS x) AS same;
+}
+expect {
+    7
+}
 
 @backend cli
 test parenthesized-star-names-with-short-names-disabled {
@@ -1387,4 +1496,61 @@ expect {
     1|2
     marker|a|b
     9|1|2
+}
+
+@cross-check-integrity
+test database-qualified-column-prefers-local-table-to-outer-saved-table {
+    CREATE TABLE db_scope_left(x INTEGER);
+    CREATE TABLE db_scope_right(y INTEGER);
+    INSERT INTO db_scope_left VALUES(1),(2);
+    INSERT INTO db_scope_right VALUES(3);
+    SELECT (SELECT main.db_scope_left.x
+              FROM db_scope_left WHERE db_scope_left.x=2)
+      FROM (SELECT 0 AS marker) AS anchor
+      JOIN (db_scope_left JOIN db_scope_right)
+     WHERE db_scope_left.x=1;
+}
+expect {
+    2
+}
+
+@cross-check-integrity
+test declared-rowid-outside-group-hides-inner-implicit-rowids {
+    CREATE TABLE implicit_first(x INTEGER);
+    CREATE TABLE implicit_second(y INTEGER);
+    INSERT INTO implicit_first VALUES(1);
+    INSERT INTO implicit_second VALUES(2);
+    SELECT rowid, _rowid_, oid
+      FROM (SELECT 'r' AS rowid, 'u' AS _rowid_, 'o' AS oid) AS declared
+      JOIN (implicit_first JOIN implicit_second);
+}
+expect {
+    r|u|o
+}
+
+@cross-check-integrity
+test parenthesized-right-join-star-keeps-original-column-order {
+    CREATE TABLE order_left(id INTEGER, left_value TEXT);
+    CREATE TABLE order_right(id INTEGER, right_value TEXT);
+    INSERT INTO order_left VALUES(1,'left-one'),(2,'left-two');
+    INSERT INTO order_right VALUES(2,'right-two'),(3,'right-three');
+
+    SELECT *
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN (order_left RIGHT JOIN order_right USING(id))
+     ORDER BY id;
+}
+expect {
+    9|2|left-two|right-two
+    9|3||right-three
+}
+
+test qualified-star-keeps-using-merged-direct-and-saved-columns {
+    SELECT same.*
+      FROM (SELECT 1 AS id) AS same
+      JOIN ((SELECT 1 AS id) AS same JOIN (SELECT 2 AS x) AS other) AS grouped
+      USING(id);
+}
+expect {
+    1|1
 }

--- a/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
@@ -1554,3 +1554,44 @@ test qualified-star-keeps-using-merged-direct-and-saved-columns {
 expect {
     1|1
 }
+
+@cross-check-integrity
+test qualified-column-skips-two-saved-scopes-without-column {
+    SELECT (SELECT (SELECT same.x
+                      FROM (SELECT 0 AS marker) AS anchor
+                      JOIN ((SELECT 3 AS z) AS same JOIN (SELECT 4 AS w) AS other))
+              FROM (SELECT 0 AS marker) AS anchor
+              JOIN ((SELECT 2 AS y) AS same JOIN (SELECT 3 AS z) AS other))
+      FROM (SELECT 7 AS x) AS same;
+}
+expect {
+    7
+}
+
+@cross-check-integrity
+test database-qualified-local-column-keeps-database-and-case {
+    CREATE TABLE scope_value(x INTEGER);
+    CREATE TABLE scope_other(y INTEGER);
+    CREATE TEMP TABLE scope_value(x INTEGER);
+    INSERT INTO main.scope_value VALUES(1),(2);
+    INSERT INTO temp.scope_value VALUES(9);
+    INSERT INTO scope_other VALUES(3);
+    SELECT (SELECT MAIN.SCOPE_VALUE.x FROM main.scope_value WHERE x=2),
+           (SELECT temp.scope_value.x FROM temp.scope_value)
+      FROM (SELECT 0 AS marker) AS anchor
+      JOIN (main.scope_value JOIN scope_other)
+     WHERE main.scope_value.x=1;
+}
+expect {
+    2|9
+}
+
+@cross-check-integrity
+test qualified-column-skips-direct-table-without-column {
+    SELECT (SELECT same.x FROM (SELECT 2 AS y) AS same),
+           (SELECT (SELECT same.x) FROM (SELECT 2 AS y) AS same)
+      FROM (SELECT 7 AS x) AS same;
+}
+expect {
+    7|7
+}

--- a/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
@@ -500,6 +500,49 @@ expect {
     2|left-two|right-two|last-two
 }
 
+@cross-check-integrity
+test top-level-group-keeps-join-order-through-repeated-nesting {
+    CREATE TABLE nested_group_first(id INTEGER, first_value TEXT);
+    CREATE TABLE nested_group_second(id INTEGER, second_value TEXT);
+    CREATE TABLE nested_group_third(id INTEGER, third_value TEXT);
+    CREATE TABLE nested_group_last(id INTEGER, last_value TEXT);
+    INSERT INTO nested_group_first VALUES(1,'first-one'),(2,'first-two');
+    INSERT INTO nested_group_second VALUES(2,'second-two');
+    INSERT INTO nested_group_third VALUES(1,'third-one');
+    INSERT INTO nested_group_last VALUES(1,'last-one'),(2,'last-two');
+
+    SELECT *
+      FROM ((nested_group_first LEFT JOIN nested_group_second USING(id))
+            LEFT JOIN nested_group_third USING(id))
+      JOIN nested_group_last USING(id)
+     ORDER BY id;
+}
+expect {
+    1|first-one||third-one|last-one
+    2|first-two|second-two||last-two
+}
+
+@cross-check-integrity
+test top-level-group-exposes-inner-table-to-later-on-condition {
+    CREATE TABLE on_group_first(id INTEGER);
+    CREATE TABLE on_group_second(id INTEGER, last_id INTEGER);
+    CREATE TABLE on_group_last(id INTEGER, value TEXT);
+    INSERT INTO on_group_first VALUES(1),(2),(3);
+    INSERT INTO on_group_second VALUES(1,10),(3,30);
+    INSERT INTO on_group_last VALUES(10,'matched'),(2,'must-not-match');
+
+    SELECT on_group_first.id, on_group_second.last_id, on_group_last.value
+      FROM (on_group_first LEFT JOIN on_group_second
+              ON on_group_first.id=on_group_second.id)
+      LEFT JOIN on_group_last ON on_group_second.last_id=on_group_last.id
+     ORDER BY on_group_first.id;
+}
+expect {
+    1|10|matched
+    2||
+    3|30|
+}
+
 # An alias after a one-source group replaces the alias inside the group.
 # This rule also applies to a SELECT and a table-valued function.
 @cross-check-integrity
@@ -522,9 +565,122 @@ expect {
     2
 }
 
-# Without an outer alias, a one-source group keeps its index choice.
+# These groups follow another source so the leading-FROM unwrapping rule
+# cannot preserve their inner aliases.
 @cross-check-integrity
-test one-source-group-keeps-index-choice-without-outer-alias {
+test one-source-groups-without-outer-alias-keep-source-values {
+    CREATE TABLE no_alias_anchor(marker INTEGER);
+    CREATE TABLE no_alias_base(value INTEGER);
+    INSERT INTO no_alias_anchor VALUES(0);
+    INSERT INTO no_alias_base VALUES(7);
+
+    SELECT no_alias_base.value
+      FROM no_alias_anchor JOIN (no_alias_base AS inner_table);
+    SELECT value
+      FROM no_alias_anchor JOIN ((SELECT 8 AS value) AS inner_query);
+    SELECT generate_series.value
+      FROM no_alias_anchor JOIN (generate_series(2,6,2) AS inner_function)
+     ORDER BY value;
+    SELECT no_alias_base.value
+      FROM no_alias_anchor JOIN ((no_alias_base AS first_name) AS inner_group);
+}
+expect {
+    7
+    8
+    2
+    4
+    6
+    7
+}
+
+@cross-check-integrity
+test one-source-table-without-outer-alias-removes-inner-alias {
+    CREATE TABLE table_alias_anchor(marker INTEGER);
+    CREATE TABLE table_alias_base(value INTEGER);
+
+    SELECT inner_table.*
+      FROM table_alias_anchor JOIN (table_alias_base AS inner_table);
+}
+expect error {
+    no such table: inner_table
+}
+
+@cross-check-integrity
+test one-source-select-without-outer-alias-removes-inner-alias {
+    CREATE TABLE select_alias_anchor(marker INTEGER);
+
+    SELECT inner_query.*
+      FROM select_alias_anchor JOIN ((SELECT 8 AS value) AS inner_query);
+}
+expect error {
+    no such table: inner_query
+}
+
+@cross-check-integrity
+test one-source-function-without-outer-alias-removes-inner-alias {
+    CREATE TABLE function_alias_anchor(marker INTEGER);
+
+    SELECT inner_function.*
+      FROM function_alias_anchor JOIN (generate_series(2,6,2) AS inner_function);
+}
+expect error {
+    no such table: inner_function
+}
+
+@cross-check-integrity
+test one-source-nested-group-without-outer-alias-removes-inner-alias {
+    CREATE TABLE nested_alias_anchor(marker INTEGER);
+    CREATE TABLE nested_alias_base(value INTEGER);
+
+    SELECT inner_group.*
+      FROM nested_alias_anchor
+      JOIN ((nested_alias_base AS first_name) AS inner_group);
+}
+expect error {
+    no such table: inner_group
+}
+
+@cross-check-integrity
+test one-source-table-with-outer-alias-removes-inner-alias {
+    CREATE TABLE replaced_table_alias(value INTEGER);
+
+    SELECT inner_table.* FROM (replaced_table_alias AS inner_table) AS outer_table;
+}
+expect error {
+    no such table: inner_table
+}
+
+@cross-check-integrity
+test one-source-select-with-outer-alias-removes-inner-alias {
+    SELECT inner_query.* FROM ((SELECT 8 AS value) AS inner_query) AS outer_query;
+}
+expect error {
+    no such table: inner_query
+}
+
+@cross-check-integrity
+test one-source-function-with-outer-alias-removes-inner-alias {
+    SELECT inner_function.*
+      FROM (generate_series(2,6,2) AS inner_function) AS outer_function;
+}
+expect error {
+    no such table: inner_function
+}
+
+@cross-check-integrity
+test one-source-nested-group-with-outer-alias-removes-inner-alias {
+    CREATE TABLE replaced_nested_alias(value INTEGER);
+
+    SELECT inner_group.*
+      FROM ((replaced_nested_alias AS first_name) AS inner_group) AS outer_group;
+}
+expect error {
+    no such table: inner_group
+}
+
+# A leading group without an outer alias is reused and keeps its index choice.
+@cross-check-integrity
+test leading-one-source-group-keeps-index-choice-without-outer-alias {
     CREATE TABLE indexed_group_kept(value INTEGER);
 
     SELECT value FROM (indexed_group_kept INDEXED BY missing_index);
@@ -532,6 +688,7 @@ test one-source-group-keeps-index-choice-without-outer-alias {
 expect error {
     no such index: missing_index
 }
+
 
 # An outer alias replaces the index choice inside a one-source group.
 @cross-check-integrity
@@ -858,4 +1015,376 @@ test right-join-keeps-rows-from-a-parenthesized-right-source {
 expect {
     2|left-two|middle-two|right-two
     3||middle-three|
+}
+
+setup saved_name_paths {
+    CREATE TABLE path_anchor(marker INTEGER);
+    CREATE TABLE path_first_id(id INTEGER);
+    CREATE TABLE path_second_id(id INTEGER);
+    CREATE TABLE path_left(id INTEGER, left_value TEXT);
+    CREATE TABLE path_right(id INTEGER, right_value TEXT);
+    INSERT INTO path_anchor VALUES(9);
+    INSERT INTO path_left(rowid,id,left_value) VALUES(11,1,'left');
+    INSERT INTO path_right(rowid,id,right_value) VALUES(22,1,'right');
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-name-rejects-duplicate-qualified-columns {
+    SELECT same.id
+      FROM path_anchor
+      JOIN (path_first_id AS same JOIN path_second_id AS same USING(id));
+}
+expect error {
+    ambiguous column name:
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-name-rejects-duplicate-qualified-rowids {
+    SELECT same.oid
+      FROM path_anchor
+      JOIN (path_first_id AS same JOIN path_second_id AS same USING(id));
+}
+expect error {
+    ambiguous column name:
+}
+
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-name-rejects-missing-qualified-column {
+    SELECT path_left.missing
+      FROM path_anchor
+      JOIN (path_left JOIN path_right USING(id));
+}
+expect error {
+    no such column: path_left.missing
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-name-rejects-missing-database-qualified-column {
+    SELECT main.path_left.missing
+      FROM path_anchor
+      JOIN (path_left JOIN path_right USING(id));
+}
+expect error {
+    no such column: main.path_left.missing
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-name-rejects-ambiguous-database-qualified-column {
+    SELECT main.path_first_id.id
+      FROM path_anchor
+      JOIN (path_first_id JOIN path_first_id USING(id));
+}
+expect error {
+    ambiguous column name:
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test outer-saved-name-rejects-duplicate-qualified-columns {
+    SELECT (SELECT same.id)
+      FROM path_anchor
+      JOIN (path_first_id AS same JOIN path_second_id AS same USING(id));
+}
+expect error {
+    ambiguous column name:
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test outer-saved-name-rejects-duplicate-qualified-rowids {
+    SELECT (SELECT same.rowid)
+      FROM path_anchor
+      JOIN (path_first_id AS same JOIN path_second_id AS same USING(id));
+}
+expect error {
+    ambiguous column name:
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test outer-saved-name-rejects-missing-column {
+    SELECT (SELECT path_left.missing)
+      FROM path_anchor
+      JOIN (path_left JOIN path_right USING(id));
+}
+expect error {
+    no such column: path_left.missing
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test nearest-outer-saved-name-wins {
+    SELECT (SELECT (SELECT same.right_value)
+              FROM path_anchor
+              JOIN (path_right AS same JOIN path_anchor AS other))
+      FROM (SELECT 'outer' AS right_value) AS same;
+}
+expect {
+    right
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test outer-direct-and-saved-name-collision {
+    SELECT (SELECT same.id)
+      FROM path_left AS same
+      JOIN (path_right AS same JOIN path_anchor);
+}
+expect error {
+    ambiguous column name:
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test outer-direct-and-saved-names-with-distinct-columns {
+    SELECT (SELECT same.left_value), (SELECT same.right_value)
+      FROM path_left AS same
+      JOIN (path_right AS same JOIN path_anchor);
+}
+expect {
+    left|right
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-rowid-all-aliases-declared {
+    CREATE TABLE all_rowids(rowid TEXT, _rowid_ TEXT, oid TEXT);
+    INSERT INTO all_rowids VALUES('r','u','o');
+    SELECT all_rowids.*, all_rowids.rowid, all_rowids._rowid_, all_rowids.oid
+      FROM path_anchor
+      JOIN (all_rowids JOIN path_right);
+}
+expect {
+    r|u|o|r|u|o
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-rowid-skips-declared-aliases {
+    CREATE TABLE some_rowids(rowid TEXT, _rowid_ TEXT);
+    INSERT INTO some_rowids(oid,rowid,_rowid_) VALUES(43,'r','u');
+    SELECT some_rowids.rowid, some_rowids._rowid_, some_rowids.oid
+      FROM path_anchor
+      JOIN (some_rowids JOIN path_right);
+}
+expect {
+    r|u|43
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-names-match-case-insensitively {
+    SELECT PaTh_LeFt.ID, MAIN.PATH_RIGHT.RIGHT_VALUE, PATH_LEFT.OID, ID
+      FROM path_anchor
+      JOIN (path_left LEFT JOIN path_right USING(ID));
+}
+expect {
+    1|right|11|1
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-names-from-materialized-cte {
+    WITH grouped AS MATERIALIZED (
+        SELECT path_left.rowid AS rid, path_left.left_value, path_right.right_value
+          FROM path_anchor
+          JOIN (path_left JOIN path_right USING(id))
+    )
+    SELECT a.*, b.*
+      FROM grouped AS a JOIN grouped AS b USING(rid);
+}
+expect {
+    11|left|right|11|left|right
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-numeric-suffix-reuses-base {
+    SELECT g."id:1", g."id:2"
+      FROM path_anchor
+      JOIN ((SELECT 4 AS "id:1") AS x
+            JOIN (SELECT 5 AS "id:1") AS y) AS g;
+}
+expect {
+    4|5
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-rowid-uses-second-alias-when-first-is-declared {
+    CREATE TABLE first_rowid_declared(_rowid_ TEXT);
+    INSERT INTO first_rowid_declared(rowid, _rowid_) VALUES(43, 'declared');
+
+    SELECT first_rowid_declared._rowid_, first_rowid_declared.rowid,
+           first_rowid_declared.oid
+      FROM path_anchor
+      JOIN (first_rowid_declared JOIN path_right);
+}
+expect {
+    declared|43|43
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-names-without-a-database-reject-database-qualification {
+    SELECT main.inner_query.value
+      FROM path_anchor
+      JOIN ((SELECT 7 AS value) AS inner_query JOIN path_right);
+}
+expect error {
+    no such column: main.inner_query.value
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-nonnumeric-suffix-remains-part-of-the-name {
+    SELECT g."value:x", g."value:x:1", g."VALUE:X:2"
+      FROM path_anchor
+      JOIN ((SELECT 4 AS "value:x") AS first
+            JOIN (SELECT 5 AS "value:x") AS second
+            JOIN (SELECT 6 AS "VALUE:X") AS third) AS g;
+}
+expect {
+    4|5|6
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-names-use-nearest-scope-despite-distant-ambiguity {
+    SELECT (SELECT (SELECT same.right_value)
+              FROM path_anchor
+              JOIN (path_right AS same JOIN path_anchor AS other))
+      FROM path_left AS same
+      JOIN (path_right AS same JOIN path_anchor);
+}
+expect {
+    right
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-qualified-name-remains-ambiguous-through-nested-groups {
+    SELECT same.id
+      FROM path_anchor
+      JOIN ((path_left AS same JOIN path_anchor AS first_anchor) AS first_group
+            JOIN (path_right AS same JOIN path_anchor AS second_anchor) AS second_group);
+}
+expect error {
+    ambiguous column name: same.id
+}
+
+@setup saved_name_paths
+@cross-check-integrity
+test saved-rowid-is-null-when-whole-group-is-unmatched {
+    SELECT path_left.rowid, path_right.oid, path_left.left_value
+      FROM path_anchor
+      LEFT JOIN (path_left JOIN path_right USING(id)) ON path_left.id=marker;
+}
+expect {
+    ||
+}
+
+# SQLite stores source names as dot-separated strings and cannot represent
+# these quoted identifiers. Turso preserves their separate parts.
+@setup saved_name_paths
+@skip-if sqlite "SQLite cannot resolve saved source names containing dots"
+@cross-check-integrity
+test saved-names-preserve-quoted-dots {
+    CREATE TABLE "dot.table"("dot.column" TEXT);
+    INSERT INTO "dot.table" VALUES('value');
+
+    SELECT "dot.table"."dot.column", main."dot.table"."dot.column",
+           "dot.table".*
+      FROM path_anchor
+      JOIN ("dot.table" JOIN path_right);
+}
+expect {
+    value|value|value
+}
+
+
+@cross-check-integrity
+test declared-column-wins-over-two-unqualified-rowids {
+    CREATE TABLE declared(rowid TEXT, _rowid_ TEXT, oid TEXT);
+    CREATE TABLE implicit_left(a INTEGER);
+    CREATE TABLE implicit_right(b INTEGER);
+    INSERT INTO declared VALUES('r','u','o');
+    INSERT INTO implicit_left VALUES(11);
+    INSERT INTO implicit_right VALUES(22);
+
+    SELECT rowid, _rowid_, oid
+      FROM (SELECT 1) AS anchor
+      JOIN (implicit_left JOIN implicit_right JOIN declared);
+    SELECT rowid, _rowid_, oid
+      FROM (SELECT 1) AS anchor
+      JOIN (declared JOIN implicit_left JOIN implicit_right);
+}
+expect {
+    r|u|o
+    r|u|o
+}
+
+
+@cross-check-integrity
+test nested-using-keeps-one-visible-merged-value {
+    CREATE TABLE nested_first(id INTEGER, a TEXT);
+    CREATE TABLE nested_second(id INTEGER, b TEXT);
+    CREATE TABLE nested_third(id INTEGER, c TEXT);
+    INSERT INTO nested_first VALUES(1,'a1'),(2,'a2');
+    INSERT INTO nested_second VALUES(2,'b2');
+    INSERT INTO nested_third VALUES(2,'c2');
+
+    SELECT id, nested_first.id, nested_second.id, nested_third.id, *
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN ((nested_first LEFT JOIN nested_second USING(id)) AS inner_group
+            LEFT JOIN nested_third USING(id))
+     ORDER BY id;
+}
+expect {
+    1|1|||9|1|a1||
+    2|2|2|2|9|2|a2|b2|c2
+}
+
+
+
+
+@backend cli
+test parenthesized-star-names-with-short-names-disabled {
+    .headers on
+    CREATE TABLE names_left(a INTEGER);
+    CREATE TABLE names_right(b INTEGER);
+    INSERT INTO names_left VALUES(1);
+    INSERT INTO names_right VALUES(2);
+    PRAGMA short_column_names=OFF;
+    PRAGMA full_column_names=OFF;
+    SELECT names_left.*, names_right.*
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN (names_left JOIN names_right) AS grouped;
+    SELECT *
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN (names_left JOIN names_right) AS grouped;
+    PRAGMA short_column_names=ON;
+    PRAGMA full_column_names=ON;
+    SELECT names_left.*, names_right.*
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN (names_left JOIN names_right) AS grouped;
+    SELECT *
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN (names_left JOIN names_right) AS grouped;
+}
+expect {
+    a|b
+    1|2
+    marker|a|b
+    9|1|2
+    a|b
+    1|2
+    marker|a|b
+    9|1|2
 }

--- a/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
@@ -1662,3 +1662,38 @@ expect {
     9|2|b|left-two|right-two|2|2
     9|3|c||right-three||3
 }
+
+@cross-check-integrity
+test parenthesized-full-using-keeps-null-keys-and-correlated-merged-values {
+    CREATE TABLE full_key_left(id, l);
+    CREATE TABLE full_key_right(id, r);
+    INSERT INTO full_key_left VALUES(NULL,'left-null'),(1,'left-one');
+    INSERT INTO full_key_right VALUES(NULL,'right-null'),(2,'right-two');
+    SELECT id, full_key_left.id, full_key_right.id, (SELECT id), l, r
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN (full_key_left FULL JOIN full_key_right USING(id))
+     ORDER BY id, l, r;
+}
+expect {
+    |||||right-null
+    ||||left-null|
+    1|1||1|left-one|
+    2||2|2||right-two
+}
+
+@cross-check-integrity
+test parenthesized-natural-full-join-merges-each-shared-column {
+    CREATE TABLE natural_full_left(id, shared, l);
+    CREATE TABLE natural_full_right(id, shared, r);
+    INSERT INTO natural_full_left VALUES(1,'a','left-one'),(2,'b','left-two');
+    INSERT INTO natural_full_right VALUES(2,'b','right-two'),(3,'c','right-three');
+    SELECT *
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN (natural_full_left NATURAL FULL JOIN natural_full_right)
+     ORDER BY id;
+}
+expect {
+    9|1|a|left-one|
+    9|2|b|left-two|right-two
+    9|3|c||right-three
+}

--- a/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
@@ -1595,3 +1595,23 @@ test qualified-column-skips-direct-table-without-column {
 expect {
     7|7
 }
+
+@cross-check-integrity
+test parenthesized-star-allows-disjoint-columns-under-one-name {
+    SELECT *
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN ((SELECT 1 AS x) AS same JOIN (SELECT 2 AS y) AS same);
+}
+expect {
+    9|1|2
+}
+
+@cross-check-integrity
+test qualified-star-keeps-using-columns-with-saved-source-first {
+    SELECT same.*
+      FROM ((SELECT 1 AS id) AS same JOIN (SELECT 2 AS x) AS other) AS grouped
+      JOIN (SELECT 1 AS id) AS same USING(id);
+}
+expect {
+    1|1
+}

--- a/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
@@ -1646,3 +1646,19 @@ expect {
     r
     r
 }
+
+@cross-check-integrity
+test parenthesized-natural-right-join-keeps-column-order {
+    CREATE TABLE right_order_left(id, shared, left_value);
+    CREATE TABLE right_order_right(id, shared, right_value);
+    INSERT INTO right_order_left VALUES(1,'a','left-one'),(2,'b','left-two');
+    INSERT INTO right_order_right VALUES(2,'b','right-two'),(3,'c','right-three');
+    SELECT *, right_order_left.id, right_order_right.id
+      FROM (SELECT 9 AS marker) AS anchor
+      JOIN (right_order_left NATURAL RIGHT JOIN right_order_right)
+     ORDER BY id;
+}
+expect {
+    9|2|b|left-two|right-two|2|2
+    9|3|c||right-three||3
+}

--- a/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
@@ -689,11 +689,10 @@ expect error {
     no such index: missing_index
 }
 
-# After another FROM source, SQLite rebuilds a one-source group and drops its
-# index choice even when there is no outer alias.
+# Preserve index hints when unwrapping groups, including after another source.
 @cross-check-integrity
 @skip-if sqlite "https://sqlite.org/bugs/forumpost/09c09c8e1c207ef5abe7b142b3eaf77446660d8a697563f6fd58f75162add9ed"
-test joined-one-source-group-removes-index-choice-without-outer-alias {
+test joined-one-source-group-keeps-index-choice-without-outer-alias {
     CREATE TABLE indexed_group_anchor(marker INTEGER);
     CREATE TABLE indexed_group_joined(value INTEGER);
     INSERT INTO indexed_group_anchor VALUES(1);
@@ -703,21 +702,22 @@ test joined-one-source-group-removes-index-choice-without-outer-alias {
       FROM indexed_group_anchor
       JOIN (indexed_group_joined INDEXED BY missing_index);
 }
-expect {
-    7
+expect error {
+    no such index: missing_index
 }
 
-# An outer alias replaces the index choice inside a one-source group.
+# An outer alias must not discard the index hint inside a one-source group.
 @cross-check-integrity
-test one-source-group-removes-index-choice-with-outer-alias {
+@skip-if sqlite "SQLite 3.50.4 drops the index hint: https://sqlite.org/bugs/info/09c09c8e1c207ef5"
+test one-source-group-keeps-index-choice-with-outer-alias {
     CREATE TABLE indexed_group_replaced(value INTEGER);
     INSERT INTO indexed_group_replaced VALUES(7);
 
     SELECT outer_name.value
       FROM (indexed_group_replaced INDEXED BY missing_index) AS outer_name;
 }
-expect {
-    7
+expect error {
+    no such index: missing_index
 }
 
 # The extra source columns support qualified names. An unqualified star must
@@ -1614,4 +1614,13 @@ test qualified-star-keeps-using-columns-with-saved-source-first {
 }
 expect {
     1|1
+}
+
+@skip-if sqlite "SQLite 3.50.4 drops the index hint: https://sqlite.org/bugs/info/09c09c8e1c207ef5"
+test nested-one-source-alias-keeps-missing-index-error {
+    CREATE TABLE indexed_nested(value);
+    SELECT * FROM (((indexed_nested INDEXED BY missing_index) AS inner_name)) AS outer_name;
+}
+expect error {
+    no such index: missing_index
 }

--- a/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/parenthesized-joins.sqltest
@@ -40,3 +40,822 @@ expect {
     2|first-two|second-two
     3||
 }
+
+# A RIGHT JOIN inside a group keeps its unmatched right rows. The outer query
+# can use the merged USING name and both inner table names.
+@cross-check-integrity
+test parenthesized-right-join-keeps-right-rows-and-source-names {
+    CREATE TABLE right_group_anchor(marker INTEGER);
+    CREATE TABLE right_group_left(id INTEGER, left_value TEXT);
+    CREATE TABLE right_group_right(id INTEGER, right_value TEXT);
+    INSERT INTO right_group_anchor VALUES(1);
+    INSERT INTO right_group_left VALUES(1,'left-one'),(2,'left-two');
+    INSERT INTO right_group_right VALUES(2,'right-two'),(3,'right-three');
+
+    SELECT id, right_group_left.left_value, right_group_right.right_value
+      FROM right_group_anchor
+      JOIN (right_group_left RIGHT JOIN right_group_right USING(id)) ON true
+     ORDER BY id;
+}
+expect {
+    2|left-two|right-two
+    3||right-three
+}
+
+# A FULL JOIN inside a group keeps unmatched rows from both sides. The outer
+# query can still use each inner table name.
+@cross-check-integrity
+test parenthesized-full-join-keeps-both-sides-and-source-names {
+    CREATE TABLE full_group_anchor(marker INTEGER);
+    CREATE TABLE full_group_left(id INTEGER, left_value TEXT);
+    CREATE TABLE full_group_right(id INTEGER, right_value TEXT);
+    INSERT INTO full_group_anchor VALUES(1);
+    INSERT INTO full_group_left VALUES(1,'left-one'),(2,'left-two');
+    INSERT INTO full_group_right VALUES(2,'right-two'),(3,'right-three');
+
+    SELECT full_group_left.id,
+           full_group_right.id,
+           full_group_left.left_value,
+           full_group_right.right_value
+      FROM full_group_anchor
+      JOIN (full_group_left FULL JOIN full_group_right
+              ON full_group_left.id=full_group_right.id) ON true
+     ORDER BY coalesce(full_group_left.id, full_group_right.id);
+}
+expect {
+    1||left-one|
+    2|2|left-two|right-two
+    |3||right-three
+}
+
+# SQLite keeps each inner table name after it turns the join group into one
+# derived table. The outer query can use those names.
+@cross-check-integrity
+test parenthesized-join-keeps-qualified-source-columns {
+    CREATE TABLE named_anchor(marker INTEGER);
+    CREATE TABLE named_left(id INTEGER, left_value TEXT);
+    CREATE TABLE named_right(id INTEGER, right_value TEXT);
+    INSERT INTO named_anchor VALUES(1);
+    INSERT INTO named_left VALUES(1,'left-one'),(2,'left-two');
+    INSERT INTO named_right VALUES(2,'right-two'),(3,'right-three');
+
+    SELECT id, named_left.id, named_right.id,
+           named_left.*, named_right.*
+      FROM named_anchor
+      JOIN (named_left LEFT JOIN named_right USING(id))
+     ORDER BY id;
+}
+expect {
+    1|1||1|left-one||
+    2|2|2|2|left-two|2|right-two
+}
+
+# Long result names use SQLite's generated group name or the outer alias.
+@backend cli
+test parenthesized-join-keeps-long-result-names {
+    .headers on
+    PRAGMA full_column_names=ON;
+    PRAGMA short_column_names=OFF;
+    CREATE TABLE header_anchor(marker INTEGER);
+    CREATE TABLE header_left(id INTEGER, left_value TEXT);
+    CREATE TABLE header_right(id INTEGER, right_value TEXT);
+    INSERT INTO header_anchor VALUES(9);
+    INSERT INTO header_left VALUES(1,'left');
+    INSERT INTO header_right VALUES(1,'right');
+
+    SELECT header_left.*, header_right.*
+      FROM header_anchor
+      JOIN (header_left JOIN header_right USING(id));
+    SELECT *
+      FROM header_anchor
+      JOIN (header_left JOIN header_right USING(id)) AS header_group;
+}
+expect {
+    (join-1).id:1|(join-1).left_value|(join-1).id:2|(join-1).right_value
+    1|left|1|right
+    header_anchor.marker|header_group.id|header_group.left_value|header_group.right_value
+    9|1|left|right
+}
+
+# Saved source names keep their database name in nested scopes.
+@cross-check-integrity
+test parenthesized-join-keeps-database-and-outer-scope-names {
+    CREATE TABLE scope_anchor(marker INTEGER);
+    CREATE TABLE scope_left(id INTEGER, left_value TEXT);
+    CREATE TABLE scope_right(id INTEGER, right_value TEXT);
+    INSERT INTO scope_anchor VALUES(1);
+    INSERT INTO scope_left VALUES(1,'left-one');
+    INSERT INTO scope_right VALUES(1,'right-one');
+
+    SELECT main.scope_left.left_value,
+           (SELECT scope_right.right_value),
+           (SELECT main.scope_left.left_value)
+      FROM scope_anchor
+      JOIN (scope_left JOIN scope_right USING(id));
+}
+expect {
+    left-one|right-one|left-one
+}
+
+# A direct table and a saved inner table can share one alias when each requested
+# column exists in only one of them.
+@cross-check-integrity
+test qualified-name-chooses-between-a-direct-and-saved-source {
+    CREATE TABLE shared_alias_direct(direct_value INTEGER);
+    CREATE TABLE shared_alias_inner(inner_value INTEGER);
+    CREATE TABLE shared_alias_other(other_value INTEGER);
+    INSERT INTO shared_alias_direct VALUES(1);
+    INSERT INTO shared_alias_inner VALUES(2);
+    INSERT INTO shared_alias_other VALUES(3);
+
+    SELECT shared_name.direct_value, shared_name.inner_value
+      FROM shared_alias_direct AS shared_name
+      JOIN (shared_alias_inner AS shared_name JOIN shared_alias_other);
+}
+expect {
+    1|2
+}
+
+# The same alias is ambiguous when the direct and saved tables contain the
+# requested column.
+@cross-check-integrity
+test qualified-name-rejects-a-direct-and-saved-column-collision {
+    CREATE TABLE shared_column_direct(id INTEGER);
+    CREATE TABLE shared_column_inner(id INTEGER);
+    CREATE TABLE shared_column_other(value INTEGER);
+
+    SELECT shared_name.id
+      FROM shared_column_direct AS shared_name
+      JOIN (shared_column_inner AS shared_name JOIN shared_column_other);
+}
+expect error {
+    ambiguous column name: shared_name.id
+}
+
+# When a group alias matches an inner alias, the inner alias wins for its
+# columns. The group alias still finds other generated columns.
+@cross-check-integrity
+test group-alias-falls-back-after-checking-a-matching-inner-alias {
+    CREATE TABLE alias_fallback_anchor(marker INTEGER);
+    CREATE TABLE alias_fallback_inner(id INTEGER, inner_value INTEGER);
+    CREATE TABLE alias_fallback_other(id INTEGER, other_value INTEGER);
+    INSERT INTO alias_fallback_anchor VALUES(0);
+    INSERT INTO alias_fallback_inner VALUES(1,2);
+    INSERT INTO alias_fallback_other VALUES(1,3);
+
+    SELECT shared_name.inner_value, shared_name.other_value
+      FROM alias_fallback_anchor
+      JOIN (alias_fallback_inner AS shared_name
+            JOIN alias_fallback_other USING(id)) AS shared_name;
+}
+expect {
+    2|3
+}
+
+# SQLite lets source table names qualify `*`, but the alias of the generated
+# join group does not qualify `*`.
+@cross-check-integrity
+test parenthesized-join-group-alias-does-not-qualify-star {
+    CREATE TABLE group_star_anchor(marker INTEGER);
+    CREATE TABLE group_star_left(id INTEGER, left_value TEXT);
+    CREATE TABLE group_star_right(id INTEGER, right_value TEXT);
+
+    SELECT grouped_star.*
+      FROM group_star_anchor
+      JOIN (group_star_left JOIN group_star_right USING(id)) AS grouped_star;
+}
+expect error {
+    no such table: grouped_star
+}
+
+# SQLite keeps duplicate derived-table names with numeric suffixes. The group
+# alias can use these names, but an unqualified star omits the extra copies.
+@cross-check-integrity
+test parenthesized-join-keeps-hidden-columns-under-group-alias {
+    CREATE TABLE alias_anchor(marker INTEGER);
+    CREATE TABLE alias_left(id INTEGER, left_value TEXT);
+    CREATE TABLE alias_right(id INTEGER, right_value TEXT);
+    INSERT INTO alias_anchor VALUES(1);
+    INSERT INTO alias_left VALUES(2,'left-two');
+    INSERT INTO alias_right VALUES(2,'right-two');
+
+    SELECT joined.id, joined."id:1", joined."id:2",
+           joined.left_value, joined.right_value
+      FROM alias_anchor
+      JOIN (alias_left JOIN alias_right USING(id)) AS joined;
+}
+expect {
+    2|2|2|left-two|right-two
+}
+
+# The generated parenthesized result keeps the implicit rowids from its source
+# tables. Qualified rowid names can still read them.
+@cross-check-integrity
+test parenthesized-join-keeps-qualified-rowids {
+    CREATE TABLE rowid_anchor(marker INTEGER);
+    CREATE TABLE rowid_left(id INTEGER);
+    CREATE TABLE rowid_right(id INTEGER);
+    INSERT INTO rowid_anchor VALUES(1);
+    INSERT INTO rowid_left VALUES(1),(2);
+    INSERT INTO rowid_right VALUES(2),(3);
+
+    SELECT rowid_left.rowid, rowid_left._rowid_, rowid_right.oid
+      FROM rowid_anchor
+      JOIN (rowid_left LEFT JOIN rowid_right USING(id))
+     ORDER BY id;
+}
+expect {
+    1|1|
+    2|2|1
+}
+
+# An unqualified rowid can use the only rowid inside a join group.
+@cross-check-integrity
+test parenthesized-join-resolves-one-unqualified-rowid {
+    CREATE TABLE unqualified_rowid_left(value TEXT);
+    CREATE VIEW unqualified_rowid_view AS SELECT 1 AS value;
+    INSERT INTO unqualified_rowid_left VALUES('left');
+
+    SELECT rowid
+      FROM (SELECT 1) AS no_rowid
+      JOIN (unqualified_rowid_left JOIN unqualified_rowid_view);
+}
+expect {
+    1
+}
+
+# Two unqualified rowids inside one join group remain ambiguous.
+@cross-check-integrity
+test parenthesized-join-rejects-two-unqualified-rowids {
+    CREATE TABLE ambiguous_rowid_left(value TEXT);
+    CREATE TABLE ambiguous_rowid_right(value TEXT);
+
+    SELECT rowid
+      FROM (SELECT 1) AS no_rowid
+      JOIN (ambiguous_rowid_left JOIN ambiguous_rowid_right);
+}
+expect error {
+    ambiguous column name: rowid
+}
+
+# A declared rowid column wins over implicit rowids in the same join group.
+@cross-check-integrity
+test parenthesized-join-prefers-a-declared-rowid-column {
+    CREATE VIEW declared_rowid_anchor AS SELECT 1 AS marker;
+    CREATE TABLE declared_rowid_table(rowid TEXT);
+    CREATE TABLE implicit_rowid_table(value INTEGER);
+    INSERT INTO declared_rowid_table VALUES('declared');
+    INSERT INTO implicit_rowid_table VALUES(9);
+
+    SELECT rowid
+      FROM declared_rowid_anchor
+      JOIN (declared_rowid_table JOIN implicit_rowid_table);
+}
+expect {
+    declared
+}
+
+# A USING value does not hide an unrelated visible column with the same name.
+@cross-check-integrity
+test parenthesized-join-rejects-an-unrelated-using-name-collision {
+    CREATE VIEW using_collision_anchor AS SELECT 1 AS marker;
+    CREATE TABLE using_collision_left(id INTEGER);
+    CREATE TABLE using_collision_right(id INTEGER);
+    CREATE TABLE using_collision_other(id INTEGER);
+
+    SELECT id
+      FROM using_collision_anchor
+      JOIN (using_collision_left
+            JOIN using_collision_right USING(id)
+            JOIN using_collision_other);
+}
+expect error {
+    ambiguous column name: id
+}
+
+# This is SQLite join7-1.70. A qualified star reaches through the generated
+# parenthesized result without exposing its generated table name.
+@cross-check-integrity
+test table-star-reaches-through-parenthesized-join {
+    CREATE TABLE star_left(a INTEGER, b INTEGER);
+    INSERT INTO star_left VALUES(1,2),(1,3),(1,4);
+    CREATE TABLE star_right(c INTEGER, d INTEGER);
+    INSERT INTO star_right VALUES(3,33),(4,44),(5,55);
+    CREATE VIEW star_dual(dummy) AS VALUES('x');
+
+    SELECT star_left.*, star_right.*
+      FROM star_right
+      LEFT JOIN (star_dual JOIN star_left ON true)
+        ON b=c
+     ORDER BY +b;
+}
+expect {
+    ||5|55
+    1|3|3|33
+    1|4|4|44
+}
+
+# A saved table name can qualify `*` when the only group has distinct names.
+@cross-check-integrity
+test table-star-reaches-through-one-aliased-group {
+    CREATE TABLE single_star_left(left_value INTEGER);
+    CREATE TABLE single_star_right(right_value INTEGER);
+    INSERT INTO single_star_left VALUES(1);
+    INSERT INTO single_star_right VALUES(2);
+
+    SELECT single_star_left.*
+      FROM (single_star_left JOIN single_star_right) AS single_star_group;
+}
+expect {
+    1
+}
+
+# With one FROM source, SQLite binds the generated names from `<table>.*` as
+# bare names. Equal source names are therefore ambiguous.
+@cross-check-integrity
+test table-star-rejects-duplicate-names-in-one-aliased-group {
+    CREATE TABLE single_collision_left(id INTEGER, left_value INTEGER);
+    CREATE TABLE single_collision_right(id INTEGER, right_value INTEGER);
+
+    SELECT single_collision_left.*
+      FROM (single_collision_left JOIN single_collision_right)
+           AS single_collision_group;
+}
+expect error {
+    ambiguous column name: id
+}
+
+# A USING source copy has a numeric output name. SQLite cannot bind that bare
+# generated name when the group is the only FROM source.
+@cross-check-integrity
+test table-star-rejects-a-renamed-using-copy-in-one-aliased-group {
+    CREATE TABLE single_using_left(id INTEGER, left_value INTEGER);
+    CREATE TABLE single_using_right(id INTEGER, right_value INTEGER);
+
+    SELECT single_using_left.*
+      FROM (single_using_left JOIN single_using_right USING(id))
+           AS single_using_group;
+}
+expect error {
+    no such column: id:1
+}
+
+# A group alias does not qualify `*`. A direct table with that name still does.
+@cross-check-integrity
+test table-star-ignores-a-matching-group-alias {
+    CREATE TABLE star_name_direct(id INTEGER);
+    CREATE TABLE star_name_inner(id INTEGER);
+    CREATE TABLE star_name_other(value INTEGER);
+    INSERT INTO star_name_direct VALUES(1);
+    INSERT INTO star_name_inner VALUES(2);
+    INSERT INTO star_name_other VALUES(3);
+
+    SELECT chosen.*
+      FROM star_name_direct AS chosen
+      JOIN (star_name_inner JOIN star_name_other) AS chosen;
+}
+expect {
+    1
+}
+
+# A direct table and a saved inner name both contribute to a qualified star
+# when their column names differ.
+@cross-check-integrity
+test table-star-combines-direct-and-saved-names-with-different-columns {
+    CREATE TABLE star_distinct_direct(direct_value INTEGER);
+    CREATE TABLE star_distinct_inner(inner_value INTEGER);
+    CREATE TABLE star_distinct_other(other_value INTEGER);
+    INSERT INTO star_distinct_direct VALUES(1);
+    INSERT INTO star_distinct_inner VALUES(2);
+    INSERT INTO star_distinct_other VALUES(3);
+
+    SELECT chosen.*
+      FROM star_distinct_direct AS chosen
+      JOIN (star_distinct_inner AS chosen JOIN star_distinct_other);
+}
+expect {
+    1|2
+}
+
+# A direct table and a saved inner name make a qualified star ambiguous when
+# both sources contain the same column name.
+@cross-check-integrity
+test table-star-rejects-a-direct-and-saved-name-collision {
+    CREATE TABLE star_collision_direct(id INTEGER);
+    CREATE TABLE star_collision_inner(id INTEGER);
+    CREATE TABLE star_collision_other(value INTEGER);
+
+    SELECT chosen.*
+      FROM star_collision_direct AS chosen
+      JOIN (star_collision_inner AS chosen JOIN star_collision_other);
+}
+expect error {
+    ambiguous column name:
+}
+
+# Each parenthesized group must pass its source names to the outer group.
+@cross-check-integrity
+test qualified-columns-pass-through-several-parenthesized-joins {
+    CREATE TABLE deep_t1(a INTEGER);
+    CREATE TABLE deep_t2(a INTEGER);
+    CREATE TABLE deep_t3(a INTEGER);
+    CREATE TABLE deep_t4(a INTEGER);
+    CREATE TABLE deep_t5(a INTEGER);
+    INSERT INTO deep_t1 VALUES(1);
+    INSERT INTO deep_t2 VALUES(1);
+    INSERT INTO deep_t3 VALUES(1);
+    INSERT INTO deep_t4 VALUES(1);
+    INSERT INTO deep_t5 VALUES(1);
+
+    SELECT a, deep_t1.a, deep_t2.a, deep_t3.a, deep_t4.a, deep_t5.a
+      FROM deep_t1 INNER JOIN (
+           deep_t2 INNER JOIN (
+           deep_t3 INNER JOIN (
+           deep_t4 INNER JOIN deep_t5 USING(a)
+           ) USING(a)
+           ) USING(a)
+           ) USING(a);
+}
+expect {
+    1|1|1|1|1|1
+}
+
+# Parentheses at the start of FROM do not change the order of the joins.
+@cross-check-integrity
+test top-level-group-keeps-join-order {
+    CREATE TABLE top_group_left(id INTEGER, left_value TEXT);
+    CREATE TABLE top_group_right(id INTEGER, right_value TEXT);
+    CREATE TABLE top_group_last(id INTEGER, last_value TEXT);
+    INSERT INTO top_group_left VALUES(1,'left-one'),(2,'left-two');
+    INSERT INTO top_group_right VALUES(2,'right-two');
+    INSERT INTO top_group_last VALUES(1,'last-one'),(2,'last-two');
+
+    SELECT *
+      FROM (top_group_left LEFT JOIN top_group_right USING(id))
+      JOIN top_group_last USING(id)
+     ORDER BY id;
+}
+expect {
+    1|left-one||last-one
+    2|left-two|right-two|last-two
+}
+
+# An alias after a one-source group replaces the alias inside the group.
+# This rule also applies to a SELECT and a table-valued function.
+@cross-check-integrity
+test one-source-groups-replace-inner-aliases {
+    CREATE TABLE one_source_base(value INTEGER);
+    INSERT INTO one_source_base VALUES(7);
+
+    SELECT final_table.value
+      FROM (((one_source_base AS first_table) AS second_table) AS final_table);
+    SELECT final_query.value
+      FROM ((SELECT 8 AS value) AS first_query) AS final_query;
+    SELECT final_series.value
+      FROM (generate_series(1,2) AS first_series) AS final_series
+     ORDER BY final_series.value;
+}
+expect {
+    7
+    8
+    1
+    2
+}
+
+# Without an outer alias, a one-source group keeps its index choice.
+@cross-check-integrity
+test one-source-group-keeps-index-choice-without-outer-alias {
+    CREATE TABLE indexed_group_kept(value INTEGER);
+
+    SELECT value FROM (indexed_group_kept INDEXED BY missing_index);
+}
+expect error {
+    no such index: missing_index
+}
+
+# An outer alias replaces the index choice inside a one-source group.
+@cross-check-integrity
+test one-source-group-removes-index-choice-with-outer-alias {
+    CREATE TABLE indexed_group_replaced(value INTEGER);
+    INSERT INTO indexed_group_replaced VALUES(7);
+
+    SELECT outer_name.value
+      FROM (indexed_group_replaced INDEXED BY missing_index) AS outer_name;
+}
+expect {
+    7
+}
+
+# The extra source columns support qualified names. An unqualified star must
+# show only the normal join result.
+@cross-check-integrity
+test unqualified-star-hides-extra-source-columns {
+    CREATE TABLE star_group_anchor(marker INTEGER);
+    CREATE TABLE star_group_left(id INTEGER, left_value TEXT);
+    CREATE TABLE star_group_right(id INTEGER, right_value TEXT);
+    INSERT INTO star_group_anchor VALUES(9);
+    INSERT INTO star_group_left VALUES(1,'left-one'),(2,'left-two');
+    INSERT INTO star_group_right VALUES(2,'right-two');
+
+    SELECT *
+      FROM star_group_anchor
+      JOIN (star_group_left LEFT JOIN star_group_right USING(id))
+     ORDER BY id;
+}
+expect {
+    9|1|left-one|
+    9|2|left-two|right-two
+}
+
+# USING provides one unqualified name. Without USING, equal column names stay
+# ambiguous outside the parentheses.
+@cross-check-integrity
+test unqualified-name-stays-ambiguous-without-using {
+    CREATE TABLE ambiguous_group_anchor(marker INTEGER);
+    CREATE TABLE ambiguous_group_left(id INTEGER);
+    CREATE TABLE ambiguous_group_right(id INTEGER);
+
+    SELECT id
+      FROM ambiguous_group_anchor
+      JOIN (ambiguous_group_left JOIN ambiguous_group_right ON true);
+}
+expect error {
+    ambiguous column name: id
+}
+
+# A scalar query can use the one value that USING creates in its outer query.
+@cross-check-integrity
+test outer-scalar-query-finds-parenthesized-using-column {
+    CREATE TABLE scalar_group_anchor(marker INTEGER);
+    CREATE TABLE scalar_group_left(id INTEGER, left_value TEXT);
+    CREATE TABLE scalar_group_right(id INTEGER, right_value TEXT);
+    INSERT INTO scalar_group_anchor VALUES(1);
+    INSERT INTO scalar_group_left VALUES(1,'left-one'),(2,'left-two');
+    INSERT INTO scalar_group_right VALUES(2,'right-two');
+
+    SELECT (SELECT id), (SELECT left_value), (SELECT right_value)
+      FROM scalar_group_anchor
+      JOIN (scalar_group_left LEFT JOIN scalar_group_right USING(id))
+     ORDER BY id;
+}
+expect {
+    1|left-one|
+    2|left-two|right-two
+}
+
+# A scalar query must still report duplicate names in its outer query.
+@cross-check-integrity
+test outer-scalar-query-rejects-ambiguous-parenthesized-column {
+    CREATE TABLE scalar_ambiguous_anchor(marker INTEGER);
+    CREATE TABLE scalar_ambiguous_left(id INTEGER);
+    CREATE TABLE scalar_ambiguous_right(id INTEGER);
+
+    SELECT (SELECT id)
+      FROM scalar_ambiguous_anchor
+      JOIN (scalar_ambiguous_left JOIN scalar_ambiguous_right ON true);
+}
+expect error {
+    ambiguous column name: id
+}
+
+# NATURAL JOIN can merge more than one name. The left value remains available
+# when a row has no match on the right.
+@cross-check-integrity
+test natural-left-join-merges-all-shared-columns {
+    CREATE TABLE natural_group_left(id INTEGER, kind TEXT, left_value TEXT);
+    CREATE TABLE natural_group_right(id INTEGER, kind TEXT, right_value TEXT);
+    CREATE TABLE natural_group_anchor(marker INTEGER);
+    INSERT INTO natural_group_anchor VALUES(1);
+    INSERT INTO natural_group_left VALUES(1,'x','left-one'),(2,'y','left-two');
+    INSERT INTO natural_group_right VALUES(1,'x','right-one'),(2,'z','right-two');
+
+    SELECT *
+      FROM natural_group_anchor
+      JOIN (natural_group_left NATURAL LEFT JOIN natural_group_right)
+     ORDER BY id;
+}
+expect {
+    1|1|x|left-one|right-one
+    1|2|y|left-two|
+}
+
+# Saved source names include the database name. The outer query can use both
+# main and temp names.
+@cross-check-integrity
+test qualified-names-keep-temp-and-main-databases {
+    CREATE TEMP TABLE database_group_temp(id INTEGER, value TEXT);
+    CREATE TABLE database_group_main(id INTEGER, value TEXT);
+    CREATE TABLE database_group_anchor(marker INTEGER);
+    INSERT INTO temp.database_group_temp VALUES(1,'temp-value');
+    INSERT INTO main.database_group_main VALUES(1,'main-value');
+    INSERT INTO database_group_anchor VALUES(1);
+
+    SELECT temp.database_group_temp.value,
+           main.database_group_main.value,
+           temp.database_group_temp.rowid,
+           main.database_group_main.rowid
+      FROM database_group_anchor
+      JOIN (temp.database_group_temp JOIN main.database_group_main USING(id));
+}
+expect {
+    temp-value|main-value|1|1
+}
+
+# A database name must match the database that owns the saved source table.
+@cross-check-integrity
+test qualified-name-rejects-the-wrong-database {
+    CREATE TEMP TABLE wrong_database_temp(id INTEGER, value TEXT);
+    CREATE TABLE wrong_database_main(id INTEGER);
+    CREATE TABLE wrong_database_anchor(marker INTEGER);
+
+    SELECT main.wrong_database_temp.value
+      FROM wrong_database_anchor
+      JOIN (temp.wrong_database_temp JOIN main.wrong_database_main USING(id));
+}
+expect error {
+    no such column: main.wrong_database_temp.value
+}
+
+# A declared rowid name hides only that implicit alias. The next available
+# alias still reads the real rowid.
+@cross-check-integrity
+test declared-rowid-names-hide-implicit-aliases {
+    CREATE TABLE rowid_name_anchor(marker INTEGER);
+    CREATE TABLE rowid_names(rowid TEXT, _rowid_ TEXT, value TEXT);
+    INSERT INTO rowid_name_anchor VALUES(1);
+    INSERT INTO rowid_names(oid,rowid,_rowid_,value)
+         VALUES(43,'declared-rowid','declared-under','stored-value');
+
+    SELECT rowid_names.rowid, rowid_names._rowid_, rowid_names.oid
+      FROM rowid_name_anchor JOIN (rowid_names);
+}
+expect {
+    declared-rowid|declared-under|43
+}
+
+# Views and table-valued functions keep their names when they are inside a
+# parenthesized join.
+@cross-check-integrity
+test view-and-table-function-names-pass-through-group {
+    CREATE TABLE named_view_base(id INTEGER, value TEXT);
+    CREATE TABLE named_view_other(id INTEGER, other_value TEXT);
+    CREATE TABLE named_view_anchor(marker INTEGER);
+    CREATE VIEW named_group_view AS SELECT * FROM named_view_base;
+    INSERT INTO named_view_base VALUES(1,'view-value');
+    INSERT INTO named_view_other VALUES(1,'other-value');
+    INSERT INTO named_view_anchor VALUES(1);
+
+    SELECT named_group_view.id,
+           named_group_view.value,
+           named_view_other.other_value
+      FROM named_view_anchor
+      JOIN (named_group_view JOIN named_view_other USING(id));
+    SELECT first_series.value
+      FROM named_view_anchor
+      JOIN (generate_series(1,2) AS first_series
+            JOIN generate_series(2,3) AS second_series
+              ON first_series.value=second_series.value);
+    SELECT *
+      FROM named_view_anchor
+      JOIN (generate_series(1,2) AS first_series JOIN named_view_other)
+     ORDER BY first_series.value;
+}
+expect {
+    1|view-value|other-value
+    2
+    1|1|1|other-value
+    1|2|1|other-value
+}
+
+# SQLite adds numeric suffixes to duplicate output names. An existing numeric
+# suffix does not cause SQLite to reuse a name.
+@cross-check-integrity
+test duplicate-output-names-skip-existing-numeric-suffixes {
+    CREATE TABLE suffix_group_anchor(marker INTEGER);
+    CREATE TABLE suffix_group_left(id INTEGER, "id:1" INTEGER);
+    CREATE TABLE suffix_group_right(id INTEGER);
+    INSERT INTO suffix_group_anchor VALUES(1);
+    INSERT INTO suffix_group_left VALUES(4,5);
+    INSERT INTO suffix_group_right VALUES(4);
+
+    SELECT suffix_group.id, suffix_group."id:1", suffix_group."id:2"
+      FROM suffix_group_anchor
+      JOIN (suffix_group_left JOIN suffix_group_right
+              ON suffix_group_left.id=suffix_group_right.id) AS suffix_group;
+}
+expect {
+    4|5|4
+}
+
+# A join chain can merge the same name more than once. An unqualified star
+# includes one copy of the merged name.
+@cross-check-integrity
+test using-chain-keeps-one-copy-of-each-merged-name {
+    CREATE TABLE using_chain_anchor(marker INTEGER);
+    CREATE TABLE using_chain_first(id INTEGER, first_value TEXT);
+    CREATE TABLE using_chain_second(id INTEGER, second_value TEXT);
+    CREATE TABLE using_chain_third(id INTEGER, third_value TEXT);
+    INSERT INTO using_chain_anchor VALUES(1);
+    INSERT INTO using_chain_first VALUES(1,'first-one'),(2,'first-two');
+    INSERT INTO using_chain_second VALUES(2,'second-two');
+    INSERT INTO using_chain_third VALUES(2,'third-two');
+
+    SELECT *
+      FROM using_chain_anchor
+      JOIN (using_chain_first
+            LEFT JOIN using_chain_second USING(id)
+            LEFT JOIN using_chain_third USING(id))
+     ORDER BY id;
+}
+expect {
+    1|1|first-one||
+    1|2|first-two|second-two|third-two
+}
+
+# The generated group columns keep the type and collation of their source.
+@cross-check-integrity
+test parenthesized-columns-keep-affinity-and-collation {
+    CREATE TABLE type_group_anchor(marker INTEGER);
+    CREATE TABLE type_group_left(
+        id INTEGER,
+        text_number TEXT,
+        word TEXT COLLATE NOCASE
+    );
+    CREATE TABLE type_group_right(id INTEGER);
+    INSERT INTO type_group_anchor VALUES(1);
+    INSERT INTO type_group_left VALUES(1,'01','AbC');
+    INSERT INTO type_group_right VALUES(1);
+
+    SELECT type_group_left.text_number=1,
+           grouped_type.text_number=1,
+           type_group_left.word='abc',
+           grouped_type.word='abc',
+           typeof(grouped_type.text_number)
+      FROM type_group_anchor
+      JOIN (type_group_left JOIN type_group_right USING(id)) AS grouped_type;
+}
+expect {
+    0|0|1|1|text
+}
+
+# UPDATE FROM uses the same saved source names as SELECT.
+@cross-check-integrity
+test update-from-uses-names-inside-a-parenthesized-join {
+    CREATE TABLE update_group_target(id INTEGER, value TEXT);
+    CREATE TABLE update_group_left(id INTEGER, value TEXT);
+    CREATE TABLE update_group_right(id INTEGER);
+    INSERT INTO update_group_target VALUES(1,'old');
+    INSERT INTO update_group_left VALUES(1,'new');
+    INSERT INTO update_group_right VALUES(1);
+
+    UPDATE update_group_target
+       SET value=update_group_left.value
+      FROM (update_group_left JOIN update_group_right USING(id))
+     WHERE update_group_target.id=update_group_left.id;
+    SELECT * FROM update_group_target;
+}
+expect {
+    1|new
+}
+
+# A second join group keeps named columns from the first group. It does not
+# copy the first group's implicit rowids.
+@cross-check-integrity
+test nested-parenthesized-group-does-not-copy-inner-rowids {
+    CREATE TABLE nested_rowid_anchor(marker INTEGER);
+    CREATE TABLE nested_rowid_left(value INTEGER);
+    CREATE TABLE nested_rowid_middle(value INTEGER);
+    CREATE TABLE nested_rowid_right(value INTEGER);
+
+    SELECT nested_rowid_left.rowid
+      FROM nested_rowid_anchor
+      JOIN ((nested_rowid_left JOIN nested_rowid_middle) AS first_group
+            JOIN nested_rowid_right);
+}
+expect error {
+    no such column: nested_rowid_left.rowid
+}
+
+# A RIGHT JOIN can keep a parenthesized group on its right side.
+@cross-check-integrity
+test right-join-keeps-rows-from-a-parenthesized-right-source {
+    CREATE TABLE right_source_left(id INTEGER, left_value TEXT);
+    CREATE TABLE right_source_middle(id INTEGER, middle_value TEXT);
+    CREATE TABLE right_source_right(id INTEGER, right_value TEXT);
+    INSERT INTO right_source_left VALUES(1,'left-one'),(2,'left-two');
+    INSERT INTO right_source_middle VALUES(2,'middle-two'),(3,'middle-three');
+    INSERT INTO right_source_right VALUES(2,'right-two');
+
+    SELECT id,
+           right_source_left.left_value,
+           right_source_middle.middle_value,
+           right_source_right.right_value
+      FROM right_source_left
+      RIGHT JOIN (right_source_middle
+                  LEFT JOIN right_source_right USING(id)) USING(id)
+     ORDER BY id;
+}
+expect {
+    2|left-two|middle-two|right-two
+    3||middle-three|
+}

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/joins.sqltest
@@ -818,6 +818,18 @@ setup parenthesized_join_snapshot_schema {
     CREATE TABLE nested_prune_right(id INTEGER, value TEXT);
 }
 
+# The generated join group keeps source copies and rowids for qualified names.
+# SQLite writes NULL for each copy that the parent does not read.
+@setup parenthesized_join_snapshot_schema
+snapshot parenthesized-left-join-nulls-unused-source-columns {
+    SELECT id,
+           nested_prune_outer.value,
+           nested_prune_left.value,
+           nested_prune_right.value
+      FROM nested_prune_outer
+      JOIN (nested_prune_left LEFT JOIN nested_prune_right USING(id)) USING(id);
+}
+
 # A top-level group does not need a generated subquery. SQLite keeps the joins
 # in their written order and compiles one join loop.
 @setup parenthesized_join_snapshot_schema
@@ -849,6 +861,7 @@ snapshot correlated-parenthesized-join-keeps-result-expressions {
     )
       FROM nested_prune_outer AS outer_row;
 }
+
 # =============================================================================
 # Hash Join Snapshot Tests
 # =============================================================================

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/joins.sqltest
@@ -812,6 +812,43 @@ snapshot-eqp self-join-prefer-join-dependent-index {
       AND x2.id IS NULL;
 }
 
+setup parenthesized_join_snapshot_schema {
+    CREATE TABLE nested_prune_outer(id INTEGER, value TEXT);
+    CREATE TABLE nested_prune_left(id INTEGER, value TEXT);
+    CREATE TABLE nested_prune_right(id INTEGER, value TEXT);
+}
+
+# A top-level group does not need a generated subquery. SQLite keeps the joins
+# in their written order and compiles one join loop.
+@setup parenthesized_join_snapshot_schema
+snapshot top-level-parenthesized-join-does-not-use-coroutine {
+    SELECT nested_prune_left.value, nested_prune_right.value
+      FROM (nested_prune_left LEFT JOIN nested_prune_right USING(id))
+      JOIN nested_prune_outer USING(id);
+}
+
+# A qualified rowid is part of the generated result only when the outer query
+# reads it.
+@setup parenthesized_join_snapshot_schema
+snapshot parenthesized-join-keeps-used-rowid {
+    SELECT nested_prune_left.rowid
+      FROM nested_prune_outer
+      JOIN (nested_prune_left JOIN nested_prune_right USING(id)) USING(id);
+}
+
+# SQLite does not remove unused result expressions when the generated join
+# reads a value from an outer query.
+@setup parenthesized_join_snapshot_schema
+snapshot correlated-parenthesized-join-keeps-result-expressions {
+    SELECT (
+        SELECT grouped_left.value
+          FROM nested_prune_right AS scalar_anchor
+          JOIN (nested_prune_left AS grouped_left
+                JOIN nested_prune_right AS grouped_right
+                  ON grouped_left.id=outer_row.id)
+    )
+      FROM nested_prune_outer AS outer_row;
+}
 # =============================================================================
 # Hash Join Snapshot Tests
 # =============================================================================

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__correlated-parenthesized-join-keeps-result-expressions.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__correlated-parenthesized-join-keeps-result-expressions.snap
@@ -1,0 +1,82 @@
+---
+source: joins.sqltest
+expression: |-
+  SELECT (
+          SELECT grouped_left.value
+            FROM nested_prune_right AS scalar_anchor
+            JOIN (nested_prune_left AS grouped_left
+                  JOIN nested_prune_right AS grouped_right
+                    ON grouped_left.id=outer_row.id)
+      )
+        FROM nested_prune_outer AS outer_row;
+info:
+  statement_type: SELECT
+  tables:
+  - grouped_left.id
+  - nested_prune_outer
+  - nested_prune_right
+  setup_blocks:
+  - parenthesized_join_snapshot_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN nested_prune_outer AS outer_row
+`--CORRELATED SCALAR SUBQUERY 1
+   |--SCAN (join-1)
+   |  |--SCAN nested_prune_right AS grouped_right
+   |  `--SEARCH grouped_left USING COVERING INDEX ephemeral_nested_prune_left_t4 (id=?)
+   `--SCAN nested_prune_right AS scalar_anchor
+
+BYTECODE
+addr  opcode                p1  p2  p3  p4        p5  comment
+   0    Init                 0  49   0             0  Start at 49
+   1    OpenRead             0   2   0  k(3,B,B)   0  table=nested_prune_outer, root=2, iDb=0
+   2    Rewind               0  48   0             0  Rewind table nested_prune_outer
+   3      BeginSubrtn        3   0   0             0  r[3]=NULL
+   4      Null               0   1   0             0  r[1]=NULL
+   5      InitCoroutine      4  33   6             0
+   6      OpenRead           1   3   0  k(3,B,B)   0  table=nested_prune_left, root=3, iDb=0
+   7      OpenRead           3   4   0  k(3,B,B)   0  table=nested_prune_right, root=4, iDb=0
+   8      Rewind             3  32   0             0  Rewind table nested_prune_right
+   9        Once            18   0   0             0  goto 18
+  10        OpenAutoindex    2   0   0             0  cursor=2
+  11        Rewind           1  12   0             0  Rewind table nested_prune_left
+  12          ColumnRange    1   0  11  2          0  r[11..12]=nested_prune_left.id..value
+  13          RowId          1  13   0             0  r[13]=nested_prune_left.rowid
+  14          MakeRecord    11   3  14             0  r[14]=mkrec(r[11..13]); for ephemeral_nested_prune_left_t4
+  15          FilterAdd      2  11   1             0  bloom_filter_add(r[11..12])
+  16          IdxInsert      2  14  11             0  key=r[14]
+  17        Next             1  12   0             0
+  18        Column           0   0  15             0  r[15]=nested_prune_outer.id
+  19        IsNull          15  31   0             0  if (r[15]==NULL) goto 31
+  20        Affinity        15   1   0             0  r[15..16] = C
+  21        Filter           2  31  15             1  if !bloom_filter(r[15..16]) goto 31
+  22        SeekGE           2  31  15             0  key=[15..15]
+  23          IdxGT          2  31  15             0  key=[15..15]
+  24          DeferredSeek   2   1   0             0
+  25          ColumnRange    2   0   5  2          0  r[5..6]=ephemeral(ephemeral_nested_prune_left_t4).id..value
+  26          IdxRowId       2   7   0             0  r[7]=cursor 2 for index ephemeral(ephemeral_nested_prune_left_t4).rowid
+  27          ColumnRange    3   0   8  2          0  r[8..9]=nested_prune_right.id..value
+  28          RowId          3  10   0             0  r[10]=nested_prune_right.rowid
+  29          Yield          4   0   0             0
+  30        Next             2  23   0             0
+  31      Next               3   9   0             1
+  32      EndCoroutine       4   0   0             0
+  33      Integer            1  17   0             0  r[17]=1; LIMIT counter
+  34      IfNot             17  44   0             0  if !r[17] goto 44
+  35      OpenRead           4   4   0  k(3,B,B)   0  table=nested_prune_right, root=4, iDb=0
+  36      InitCoroutine      4   0   6             0
+  37        Yield            4  44   0             0
+  38        Rewind           4  43   0             0  Rewind table nested_prune_right
+  39          Copy           6  16   0             0  r[16]=r[6]
+  40          Copy          16   1   0             0  r[1]=r[16]
+  41          DecrJumpZero  17  44   0             0  if (--r[17]==0) goto 44
+  42        Next             4  39   0             1
+  43      Goto               0  37   0             0
+  44    Return               3   0   1             0
+  45    Copy                 1   2   0             0  r[2]=r[1]
+  46    ResultRow            2   1   0             0  output=r[2]
+  47  Next                   0   3   0             1
+  48  Halt                   0   0   0             0
+  49  Transaction            0   1   3             0  iDb=0 tx_mode=Read
+  50  Goto                   0   1   0             0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__parenthesized-join-keeps-used-rowid.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__parenthesized-join-keeps-used-rowid.snap
@@ -1,0 +1,81 @@
+---
+source: joins.sqltest
+expression: |-
+  SELECT nested_prune_left.rowid
+        FROM nested_prune_outer
+        JOIN (nested_prune_left JOIN nested_prune_right USING(id)) USING(id);
+info:
+  statement_type: SELECT
+  tables:
+  - nested_prune_outer
+  - nested_prune_right
+  setup_blocks:
+  - parenthesized_join_snapshot_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN (join-1)
+|  |--SCAN nested_prune_left
+|  `--SEARCH nested_prune_right USING COVERING INDEX ephemeral_nested_prune_right_t3 (id=?)
+`--SEARCH nested_prune_outer USING COVERING INDEX ephemeral_nested_prune_outer_t1 (id=?)
+
+BYTECODE
+addr  opcode            p1  p2  p3  p4        p5  comment
+   0  Init               0  56   0             0  Start at 56
+   1  InitCoroutine      1  32   2             0
+   2  OpenRead           0   3   0  k(3,B,B)   0  table=nested_prune_left, root=3, iDb=0
+   3  OpenRead           1   4   0  k(3,B,B)   0  table=nested_prune_right, root=4, iDb=0
+   4  Rewind             0  31   0             0  Rewind table nested_prune_left
+   5    Once            14   0   0             0  goto 14
+   6    OpenAutoindex    2   0   0             0  cursor=2
+   7    Rewind           1   8   0             0  Rewind table nested_prune_right
+   8      ColumnRange    1   0   9  2          0  r[9..10]=nested_prune_right.id..value
+   9      RowId          1  11   0             0  r[11]=nested_prune_right.rowid
+  10      MakeRecord     9   3  12             0  r[12]=mkrec(r[9..11]); for ephemeral_nested_prune_right_t3
+  11      FilterAdd      2   9   1             0  bloom_filter_add(r[9..10])
+  12      IdxInsert      2  12   9             0  key=r[12]
+  13    Next             1   8   0             0
+  14    Column           0   0  13             0  r[13]=nested_prune_left.id
+  15    IsNull          13  30   0             0  if (r[13]==NULL) goto 30
+  16    Affinity        13   1   0             0  r[13..14] = C
+  17    Filter           2  30  13             1  if !bloom_filter(r[13..14]) goto 30
+  18    SeekGE           2  30  13             0  key=[13..13]
+  19      IdxGT          2  30  13             0  key=[13..13]
+  20      DeferredSeek   2   1   0             0
+  21      Column         0   0   2             0  r[2]=nested_prune_left.id
+  22      Null           0   3   0             0  r[3]=NULL
+  23      Null           0   4   0             0  r[4]=NULL
+  24      RowId          0   5   0             0  r[5]=nested_prune_left.rowid
+  25      Null           0   6   0             0  r[6]=NULL
+  26      Null           0   7   0             0  r[7]=NULL
+  27      Null           0   8   0             0  r[8]=NULL
+  28      Yield          1   0   0             0
+  29    Next             2  19   0             0
+  30  Next               0   5   0             1
+  31  EndCoroutine       1   0   0             0
+  32  OpenRead           3   2   0  k(3,B,B)   0  table=nested_prune_outer, root=2, iDb=0
+  33  InitCoroutine      1   0   2             0
+  34    Yield            1  55   0             0
+  35    Once            44   0   0             0  goto 44
+  36    OpenAutoindex    4   0   0             0  cursor=4
+  37    Rewind           3  38   0             0  Rewind table nested_prune_outer
+  38      Column         3   0  15             0  r[15]=nested_prune_outer.id
+  39      RowId          3  16   0             0  r[16]=nested_prune_outer.rowid
+  40      MakeRecord    15   2  17             0  r[17]=mkrec(r[15..16]); for ephemeral_nested_prune_outer_t1
+  41      FilterAdd      4  15   1             0  bloom_filter_add(r[15..16])
+  42      IdxInsert      4  17  15             0  key=r[17]
+  43    Next             3  38   0             0
+  44    Copy             2  18   0             0  r[18]=r[2]
+  45    IsNull          18  54   0             0  if (r[18]==NULL) goto 54
+  46    Affinity        18   1   0             0  r[18..19] = C
+  47    Filter           4  54  18             1  if !bloom_filter(r[18..19]) goto 54
+  48    SeekGE           4  54  18             0  key=[18..18]
+  49      IdxGT          4  54  18             0  key=[18..18]
+  50      DeferredSeek   4   3   0             0
+  51      Copy           5  14   0             0  r[14]=r[5]
+  52      ResultRow     14   1   0             0  output=r[14]
+  53    Next             4  49   0             0
+  54  Goto               0  34   0             0
+  55  Halt               0   0   0             0
+  56  Transaction        0   1   3             0  iDb=0 tx_mode=Read
+  57  Goto               0   1   0             0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__parenthesized-left-join-nulls-unused-source-columns.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__parenthesized-left-join-nulls-unused-source-columns.snap
@@ -1,0 +1,92 @@
+---
+source: joins.sqltest
+expression: |-
+  SELECT id,
+             nested_prune_outer.value,
+             nested_prune_left.value,
+             nested_prune_right.value
+        FROM nested_prune_outer
+        JOIN (nested_prune_left LEFT JOIN nested_prune_right USING(id)) USING(id);
+info:
+  statement_type: SELECT
+  tables:
+  - nested_prune_outer
+  - nested_prune_right
+  setup_blocks:
+  - parenthesized_join_snapshot_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN (join-1)
+|  |--SCAN nested_prune_left
+|  `--SEARCH nested_prune_right USING COVERING INDEX ephemeral_nested_prune_right_t3 (id=?) LEFT-JOIN
+`--SEARCH nested_prune_outer USING COVERING INDEX ephemeral_nested_prune_outer_t1 (id=?)
+
+BYTECODE
+addr  opcode            p1  p2  p3  p4        p5  comment
+   0  Init               0  64   0             0  Start at 64
+   1  InitCoroutine      1  38   2             0
+   2  OpenRead           0   3   0  k(3,B,B)   0  table=nested_prune_left, root=3, iDb=0
+   3  OpenRead           1   4   0  k(3,B,B)   0  table=nested_prune_right, root=4, iDb=0
+   4  Rewind             0  37   0             0  Rewind table nested_prune_left
+   5    Integer          0   9   0             0  r[9]=0
+   6    Once            15   0   0             0  goto 15
+   7    OpenAutoindex    2   0   0             0  cursor=2
+   8    Rewind           1   9   0             0  Rewind table nested_prune_right
+   9      ColumnRange    1   0  10  2          0  r[10..11]=nested_prune_right.id..value
+  10      RowId          1  12   0             0  r[12]=nested_prune_right.rowid
+  11      MakeRecord    10   3  13             0  r[13]=mkrec(r[10..12]); for ephemeral_nested_prune_right_t3
+  12      FilterAdd      2  10   1             0  bloom_filter_add(r[10..11])
+  13      IdxInsert      2  13  10             0  key=r[13]
+  14    Next             1   9   0             0
+  15    Column           0   0  14             0  r[14]=nested_prune_left.id
+  16    IsNull          14  32   0             0  if (r[14]==NULL) goto 32
+  17    Affinity        14   1   0             0  r[14..15] = C
+  18    Filter           2  32  14             1  if !bloom_filter(r[14..15]) goto 32
+  19    SeekGE           2  32  14             0  key=[14..14]
+  20      IdxGT          2  32  14             0  key=[14..14]
+  21      DeferredSeek   2   1   0             0
+  22      Integer        1   9   0             0  r[9]=1
+  23      Column         0   0   2             0  r[2]=nested_prune_left.id
+  24      Null           0   3   0             0  r[3]=NULL
+  25      Column         0   1   4             0  r[4]=nested_prune_left.value
+  26      Null           0   5   0             0  r[5]=NULL
+  27      Null           0   6   0             0  r[6]=NULL
+  28      Column         2   1   7             0  r[7]=ephemeral(ephemeral_nested_prune_right_t3).value
+  29      Null           0   8   0             0  r[8]=NULL
+  30      Yield          1   0   0             0
+  31    Next             2  20   0             0
+  32    IfPos            9  36   0             0  r[9]>0 -> r[9]-=0, goto 36
+  33    NullRow          1   0   0             0  Set cursor 1 to a (pseudo) NULL row
+  34    NullRow          2   0   0             0  Set cursor 2 to a (pseudo) NULL row
+  35    Goto             0  22   0             0
+  36  Next               0   5   0             1
+  37  EndCoroutine       1   0   0             0
+  38  OpenRead           3   2   0  k(3,B,B)   0  table=nested_prune_outer, root=2, iDb=0
+  39  InitCoroutine      1   0   2             0
+  40    Yield            1  63   0             0
+  41    Once            50   0   0             0  goto 50
+  42    OpenAutoindex    4   0   0             0  cursor=4
+  43    Rewind           3  44   0             0  Rewind table nested_prune_outer
+  44      ColumnRange    3   0  19  2          0  r[19..20]=nested_prune_outer.id..value
+  45      RowId          3  21   0             0  r[21]=nested_prune_outer.rowid
+  46      MakeRecord    19   3  22             0  r[22]=mkrec(r[19..21]); for ephemeral_nested_prune_outer_t1
+  47      FilterAdd      4  19   1             0  bloom_filter_add(r[19..20])
+  48      IdxInsert      4  22  19             0  key=r[22]
+  49    Next             3  44   0             0
+  50    Copy             2  23   0             0  r[23]=r[2]
+  51    IsNull          23  62   0             0  if (r[23]==NULL) goto 62
+  52    Affinity        23   1   0             0  r[23..24] = C
+  53    Filter           4  62  23             1  if !bloom_filter(r[23..24]) goto 62
+  54    SeekGE           4  62  23             0  key=[23..23]
+  55      IdxGT          4  62  23             0  key=[23..23]
+  56      DeferredSeek   4   3   0             0
+  57      ColumnRange    4   0  15  2          0  r[15..16]=ephemeral(ephemeral_nested_prune_outer_t1).id..value
+  58      Copy           4  17   0             0  r[17]=r[4]
+  59      Copy           7  18   0             0  r[18]=r[7]
+  60      ResultRow     15   4   0             0  output=r[15..18]
+  61    Next             4  55   0             0
+  62  Goto               0  40   0             0
+  63  Halt               0   0   0             0
+  64  Transaction        0   1   3             0  iDb=0 tx_mode=Read
+  65  Goto               0   1   0             0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__top-level-parenthesized-join-does-not-use-coroutine.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__top-level-parenthesized-join-does-not-use-coroutine.snap
@@ -1,0 +1,74 @@
+---
+source: joins.sqltest
+expression: |-
+  SELECT nested_prune_left.value, nested_prune_right.value
+        FROM (nested_prune_left LEFT JOIN nested_prune_right USING(id))
+        JOIN nested_prune_outer USING(id);
+info:
+  statement_type: SELECT
+  tables:
+  - nested_prune_outer
+  - nested_prune_right
+  setup_blocks:
+  - parenthesized_join_snapshot_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN nested_prune_left
+|--SEARCH nested_prune_right USING COVERING INDEX ephemeral_nested_prune_right_t2 (id=?) LEFT-JOIN
+`--SEARCH nested_prune_outer USING COVERING INDEX ephemeral_nested_prune_outer_t3 (id=?)
+
+BYTECODE
+addr  opcode              p1  p2  p3  p4        p5  comment
+   0  Init                 0  50   0             0  Start at 50
+   1  OpenRead             0   3   0  k(3,B,B)   0  table=nested_prune_left, root=3, iDb=0
+   2  OpenRead             1   4   0  k(3,B,B)   0  table=nested_prune_right, root=4, iDb=0
+   3  OpenRead             3   2   0  k(3,B,B)   0  table=nested_prune_outer, root=2, iDb=0
+   4  Rewind               0  49   0             0  Rewind table nested_prune_left
+   5    Integer            0   3   0             0  r[3]=0
+   6    Once              15   0   0             0  goto 15
+   7    OpenAutoindex      2   0   0             0  cursor=2
+   8    Rewind             1   9   0             0  Rewind table nested_prune_right
+   9      ColumnRange      1   0   4  2          0  r[4..5]=nested_prune_right.id..value
+  10      RowId            1   6   0             0  r[6]=nested_prune_right.rowid
+  11      MakeRecord       4   3   7             0  r[7]=mkrec(r[4..6]); for ephemeral_nested_prune_right_t2
+  12      FilterAdd        2   4   1             0  bloom_filter_add(r[4..5])
+  13      IdxInsert        2   7   4             0  key=r[7]
+  14    Next               1   9   0             0
+  15    Column             0   0   8             0  r[8]=nested_prune_left.id
+  16    IsNull             8  44   0             0  if (r[8]==NULL) goto 44
+  17    Affinity           8   1   0             0  r[8..9] = C
+  18    Filter             2  44   8             1  if !bloom_filter(r[8..9]) goto 44
+  19    SeekGE             2  44   8             0  key=[8..8]
+  20      IdxGT            2  44   8             0  key=[8..8]
+  21      DeferredSeek     2   1   0             0
+  22      Integer          1   3   0             0  r[3]=1
+  23      Once            32   0   0             0  goto 32
+  24      OpenAutoindex    4   0   0             0  cursor=4
+  25      Rewind           3  26   0             0  Rewind table nested_prune_outer
+  26        Column         3   0   9             0  r[9]=nested_prune_outer.id
+  27        RowId          3  10   0             0  r[10]=nested_prune_outer.rowid
+  28        MakeRecord     9   2  11             0  r[11]=mkrec(r[9..10]); for ephemeral_nested_prune_outer_t3
+  29        FilterAdd      4   9   1             0  bloom_filter_add(r[9..10])
+  30        IdxInsert      4  11   9             0  key=r[11]
+  31      Next             3  26   0             0
+  32      Column           0   0  12             0  r[12]=nested_prune_left.id
+  33      IsNull          12  43   0             0  if (r[12]==NULL) goto 43
+  34      Affinity        12   1   0             0  r[12..13] = C
+  35      Filter           4  43  12             1  if !bloom_filter(r[12..13]) goto 43
+  36      SeekGE           4  43  12             0  key=[12..12]
+  37        IdxGT          4  43  12             0  key=[12..12]
+  38        DeferredSeek   4   3   0             0
+  39        Column         0   1   1             0  r[1]=nested_prune_left.value
+  40        Column         2   1   2             0  r[2]=ephemeral(ephemeral_nested_prune_right_t2).value
+  41        ResultRow      1   2   0             0  output=r[1..2]
+  42      Next             4  37   0             0
+  43    Next               2  20   0             0
+  44    IfPos              3  48   0             0  r[3]>0 -> r[3]-=0, goto 48
+  45    NullRow            1   0   0             0  Set cursor 1 to a (pseudo) NULL row
+  46    NullRow            2   0   0             0  Set cursor 2 to a (pseudo) NULL row
+  47    Goto               0  22   0             0
+  48  Next                 0   5   0             1
+  49  Halt                 0   0   0             0
+  50  Transaction          0   1   3             0  iDb=0 tx_mode=Read
+  51  Goto                 0   1   0             0

--- a/sqlite/conformance/upstream/all.test
+++ b/sqlite/conformance/upstream/all.test
@@ -591,7 +591,7 @@ set test_files {
   tkt-6bfb98dfc0       pass
   tkt-752e1646fc       pass
   tkt-78e04e52ea       fail
-  tkt-7a31705a7e6      fail
+  tkt-7a31705a7e6      pass
   tkt-7bbfb7d442       pass
   tkt-80ba201079       fail
   tkt-80e031a00f       fail
@@ -701,7 +701,7 @@ set test_files {
   tkt3841              pass
   tkt3871              fail
   tkt3879              pass
-  tkt3911              fail
+  tkt3911              pass
   tkt3918              fail
   tkt3922              pass
   tkt3929              pass


### PR DESCRIPTION
SQLite accepts joins inside parentheses. For example:

```sql
SELECT t1.a, t2.b, id, t1.rowid
FROM (t1 JOIN t2 USING (id));
```

Code outside the parentheses can still use the table names and `rowid`. The `USING` column appears once and contains the correct value.

SQLite also supports these forms:

```sql
FROM (t1)
FROM (t1 JOIN t2)
FROM (t1 JOIN t2) JOIN t3
```

Turso previously rejected some of these queries. Other queries lost table names, `USING` columns, or access to `rowid`.

This PR makes these forms work like SQLite. Turso also puts `NULL` in result slots that the outer query does not use. This keeps each slot in the correct position and avoids unnecessary reads.

Tests: parenthesized-join SQL tests and `EXPLAIN` bytecode snapshots.