### PR TITLE
core: recompute expression-index values for outer null rows

### DIFF
--- a/core/translate/aggregation.rs
+++ b/core/translate/aggregation.rs
@@ -258,7 +258,7 @@ pub fn handle_distinct(
 ///   (used for GROUP BY without a sorter, where the main loop is already sorted).
 /// * `Expression`: arguments are evaluated on-the-fly from the original AST
 ///   (used for ungrouped aggregates, window functions, and for the GROUP BY sorter
-///   path where leaf columns are cached in `expr_to_reg_cache` before evaluation).
+///   path where saved sorter values are cached before evaluation).
 pub enum AggArgumentSource<'a> {
     Register {
         src_reg_start: usize,

--- a/core/translate/emitter/mod.rs
+++ b/core/translate/emitter/mod.rs
@@ -1053,11 +1053,11 @@ pub struct TranslateCtx<'a> {
     /// - First: all `GROUP BY` expressions, in the order they appear in the `GROUP BY` clause.
     /// - Then: remaining non-aggregate expressions that are not part of `GROUP BY`.
     pub non_aggregate_expressions: Vec<(&'a Expr, bool)>,
-    /// Unique leaf column expressions extracted from aggregate function arguments.
-    /// Only populated when GROUP BY uses a sorter, enabling deferred expression
-    /// evaluation: the sorter stores raw columns instead of pre-computed expressions,
-    /// and full expressions are re-evaluated from the pseudo cursor during aggregation.
-    pub agg_leaf_columns: Vec<Expr>,
+    /// Values that aggregate expressions read from the GROUP BY sorter.
+    ///
+    /// This list contains complete expression-index values and the remaining
+    /// leaf values. The source cursors are not valid when GROUP BY reads them.
+    pub agg_sorter_values: Vec<Expr>,
     /// Cursor id for cdc table (if capture_data_changes PRAGMA is set and query can modify the data)
     pub cdc_cursor_id: Option<usize>,
     pub meta_window: Option<WindowMetadata<'a>>,
@@ -1098,7 +1098,7 @@ impl<'a> TranslateCtx<'a> {
             materialized_build_inputs: HashMap::default(),
             resolver,
             non_aggregate_expressions: Vec::new(),
-            agg_leaf_columns: Vec::new(),
+            agg_sorter_values: Vec::new(),
             cdc_cursor_id: None,
             meta_window: None,
             meta_in_seeks: (0..table_count).map(|_| None).collect(),

--- a/core/translate/expr/metadata.rs
+++ b/core/translate/expr/metadata.rs
@@ -245,47 +245,67 @@ macro_rules! translate_fixed_insn {
 }
 
 #[inline]
-/// For expression indexes, try to emit code that directly reads the value from the index
-/// under the following conditions:
-/// - The expression only references columns from a single table
-/// - The referenced table has an index whose expression matches the given expression
+/// Try to read a complete expression from the selected index.
 ///
-/// If an expression index exactly matches the requested expression, we can
-/// fetch the precomputed value from the index key instead of re-evaluating
-/// the expression. That matters for:
-/// - SELECT a/b FROM t with INDEX ON t(a/b) (avoid computing a/b for every row)
-/// - ORDER BY a+b when the index already stores a+b (preserves ordering)
-///
-/// We mut do this check early in translate_expr so downstream translation does
-/// not build redundant bytecode.
+/// If an outer join nulls the index row, SQLite computes the original
+/// expression. A NULL input does not always produce a NULL result.
 pub(super) fn try_emit_expression_index_value(
     program: &mut ProgramBuilder,
     referenced_tables: Option<&TableReferences>,
     expr: &ast::Expr,
     target_register: usize,
+    resolver: &Resolver,
 ) -> Result<bool> {
     let Some(referenced_tables) = referenced_tables else {
         return Ok(false);
     };
-    let Some((table_id, _)) = single_table_column_usage(expr) else {
-        return Ok(false);
-    };
-    let Some(table_reference) = referenced_tables.find_joined_table_by_internal_id(table_id) else {
-        return Ok(false);
-    };
-    let Some(index) = table_reference.op.index() else {
-        return Ok(false);
-    };
-    let normalized = normalize_expr_for_index_matching(expr, table_reference, referenced_tables);
-    let Some(expr_pos) = index.expression_to_index_pos(&normalized) else {
-        return Ok(false);
-    };
-    let Some(cursor_id) =
-        program.resolve_cursor_id_safe(&CursorKey::index(table_id, index.clone()))
+    let Some((table, index, expression_position)) =
+        selected_expression_index(expr, referenced_tables)
     else {
         return Ok(false);
     };
-    program.emit_column_or_rowid(cursor_id, expr_pos, target_register);
+    let Some(index_cursor) =
+        program.resolve_cursor_id_safe(&CursorKey::index(table.internal_id, index.clone()))
+    else {
+        return Ok(false);
+    };
+    // SQLite cannot use the stored index value after an outer join replaces
+    // the source row with NULL. It computes the original expression instead.
+    let needs_null_row_fallback = referenced_tables.outer_join_may_null_extend(table.internal_id);
+    if !needs_null_row_fallback {
+        program.emit_column_or_rowid(index_cursor, expression_position, target_register);
+        return Ok(true);
+    }
+
+    let compute_expression = program.allocate_label();
+    let expression_done = program.allocate_label();
+    program.emit_insn(Insn::IfNullRow {
+        cursor_id: index_cursor,
+        target_pc: compute_expression,
+        dest: target_register,
+    });
+    program.emit_column_or_rowid(index_cursor, expression_position, target_register);
+    program.emit_insn(Insn::Goto {
+        target_pc: expression_done,
+    });
+
+    program.preassign_label_to_next_insn(compute_expression);
+    // Disable index substitution while the fallback computes the original
+    // expression. SQLite clears pIdxEpr for the same interval.
+    let skipped_index_values = program.flags.skip_expression_index_values();
+    program.flags.set_skip_expression_index_values(true);
+    let result = translate_expr(
+        program,
+        Some(referenced_tables),
+        expr,
+        target_register,
+        resolver,
+    );
+    program
+        .flags
+        .set_skip_expression_index_values(skipped_index_values);
+    result?;
+    program.preassign_label_to_next_insn(expression_done);
     Ok(true)
 }
 

--- a/core/translate/expr/mod.rs
+++ b/core/translate/expr/mod.rs
@@ -19,9 +19,7 @@ use crate::schema::{
     Table, Type, TypeDef,
 };
 use crate::sync::Arc;
-use crate::translate::expression_index::{
-    normalize_expr_for_index_matching, single_table_column_usage,
-};
+use crate::translate::expression_index::selected_expression_index;
 use crate::translate::plan::{ColumnMask, Operation, ResultSetColumn, Search};
 use crate::translate::planner::parse_row_id;
 use crate::util::{exprs_are_equivalent, normalize_ident, parse_numeric_literal};

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -163,15 +163,23 @@ pub fn translate_expr(
         return Ok(target_register);
     }
 
-    // At the very start we try to satisfy the expression from an expression index
-    let has_expression_indexes = referenced_tables.is_some_and(|tables| {
-        tables
-            .joined_tables()
-            .iter()
-            .any(|t| !t.expression_index_usages.is_empty())
-    });
+    // SQLite clears pIdxEpr while an IfNullRow fallback computes the original
+    // expression. The flag below prevents the same index match from recurring.
+    let has_expression_indexes = !program.flags.skip_expression_index_values()
+        && referenced_tables.is_some_and(|tables| {
+            tables
+                .joined_tables()
+                .iter()
+                .any(|t| !t.expression_index_usages.is_empty())
+        });
     if has_expression_indexes
-        && try_emit_expression_index_value(program, referenced_tables, expr, target_register)?
+        && try_emit_expression_index_value(
+            program,
+            referenced_tables,
+            expr,
+            target_register,
+            resolver,
+        )?
     {
         if let Some(span) = constant_span {
             program.constant_span_end(span);

--- a/core/translate/expression_index.rs
+++ b/core/translate/expression_index.rs
@@ -4,9 +4,24 @@ use crate::translate::expr::{
 };
 use crate::translate::plan::{ColumnUsedMask, JoinedTable, TableReferences};
 use crate::translate::planner::ROWID_STRS;
-use crate::Result;
+use crate::{schema::Index, sync::Arc, Result};
 use turso_parser::ast;
 use turso_parser::ast::TableInternalId;
+
+/// Find the selected index key that stores this complete expression.
+///
+/// GROUP BY and expression translation must use the same match rules.
+pub fn selected_expression_index<'a>(
+    expr: &ast::Expr,
+    table_references: &'a TableReferences,
+) -> Option<(&'a JoinedTable, &'a Arc<Index>, usize)> {
+    let (table_id, _) = single_table_column_usage(expr)?;
+    let table = table_references.find_joined_table_by_internal_id(table_id)?;
+    let index = table.op.index()?;
+    let normalized = normalize_expr_for_index_matching(expr, table, table_references);
+    let expression_position = index.expression_to_index_pos(&normalized)?;
+    Some((table, index, expression_position))
+}
 
 /// Normalize a query expression so it can be compared with an
 /// expression stored on an index definition.

--- a/core/translate/group_by.rs
+++ b/core/translate/group_by.rs
@@ -10,6 +10,7 @@ use super::{
 use crate::function::AccumulatorFunc;
 use crate::translate::{
     aggregation::{translate_aggregation_step, AggArgumentSource},
+    expression_index::selected_expression_index,
     order_by::{custom_type_comparator, EmitOrderBy},
     plan::{Aggregate, NonFromClauseSubquery},
     subquery::emit_non_from_clause_subqueries_for_phase,
@@ -140,10 +141,8 @@ impl EmitGroupBy {
 
         let reg_sorter_key = program.alloc_register();
         let column_count = if !group_by.sort_elided {
-            // Sorter path: store only unique leaf columns from aggregate args
-            // instead of pre-computed expression results.
-            t_ctx.agg_leaf_columns = collect_agg_leaf_columns(&plan.aggregates, plan)?;
-            t_ctx.non_aggregate_expressions.len() + t_ctx.agg_leaf_columns.len()
+            t_ctx.agg_sorter_values = collect_agg_sorter_values(&plan.aggregates, plan)?;
+            t_ctx.non_aggregate_expressions.len() + t_ctx.agg_sorter_values.len()
         } else {
             plan.agg_args_count() + t_ctx.non_aggregate_expressions.len()
         };
@@ -347,28 +346,38 @@ pub fn compute_group_by_sort_order(
     (sort_order, nulls_order)
 }
 
-/// Extracts unique leaf column references from all aggregate function arguments.
-/// These are the base table columns that aggregate expressions depend on.
-/// By storing only these in the GROUP BY sorter (instead of pre-computed expression
-/// results), we reduce sorter record size and avoid redundant B-tree column reads.
+/// Collect each value that aggregate expressions must read from the GROUP BY sorter.
 ///
-/// Correlated subquery results (`SubqueryResult`) inside aggregate arguments are
-/// also collected as leaf expressions.  Their value is computed per-row during the
-/// scan loop, stored in the sorter, and read back during the sorter loop so that
-/// each sorted row sees the correct subquery result instead of a stale register
-/// value left over from the last scanned row.
-fn collect_agg_leaf_columns(aggregates: &[Aggregate], plan: &SelectPlan) -> Result<Vec<ast::Expr>> {
-    let mut leaf_columns: Vec<ast::Expr> = Vec::new();
+/// Save a complete expression when the selected index stores it. SQLite reads
+/// that value before it inserts the sorter row. For other expressions, save
+/// only the unique column, rowid, and correlated-subquery values they need.
+/// This keeps sorter rows small and preserves each subquery result for its row.
+fn collect_agg_sorter_values(
+    aggregates: &[Aggregate],
+    plan: &SelectPlan,
+) -> Result<Vec<ast::Expr>> {
+    let mut sorter_values: Vec<ast::Expr> = Vec::new();
     let mut collect = |expr: &ast::Expr| -> Result<WalkControl> {
+        if selected_expression_index(expr, &plan.table_references).is_some() {
+            if !sorter_values
+                .iter()
+                .any(|value| exprs_are_equivalent(value, expr))
+            {
+                sorter_values.push(expr.clone());
+            }
+            return Ok(WalkControl::SkipChildren);
+        }
         match expr {
             ast::Expr::Column { table, .. } | ast::Expr::RowId { table, .. } => {
                 if plan
                     .table_references
                     .find_joined_table_by_internal_id(*table)
                     .is_some()
-                    && !leaf_columns.iter().any(|e| exprs_are_equivalent(e, expr))
+                    && !sorter_values
+                        .iter()
+                        .any(|value| exprs_are_equivalent(value, expr))
                 {
-                    leaf_columns.push(expr.clone());
+                    sorter_values.push(expr.clone());
                 }
                 Ok(WalkControl::SkipChildren)
             }
@@ -379,8 +388,11 @@ fn collect_agg_leaf_columns(aggregates: &[Aggregate], plan: &SelectPlan) -> Resu
                     .find(|s| s.internal_id == *subquery_id)
                     .is_some_and(|s| s.correlated);
                 if is_correlated {
-                    if !leaf_columns.iter().any(|e| exprs_are_equivalent(e, expr)) {
-                        leaf_columns.push(expr.clone());
+                    if !sorter_values
+                        .iter()
+                        .any(|value| exprs_are_equivalent(value, expr))
+                    {
+                        sorter_values.push(expr.clone());
                     }
                     Ok(WalkControl::SkipChildren)
                 } else {
@@ -402,7 +414,7 @@ fn collect_agg_leaf_columns(aggregates: &[Aggregate], plan: &SelectPlan) -> Resu
             walk_expr(filter_expr, &mut collect)?;
         }
     }
-    Ok(leaf_columns)
+    Ok(sorter_values)
 }
 
 fn collect_non_aggregate_expressions<'a>(
@@ -743,20 +755,19 @@ pub fn group_by_process_single_group(
 
     match &row_source {
         GroupByRowSource::Sorter { pseudo_cursor, .. } => {
-            // Read leaf columns from the pseudo cursor and cache them so that
-            // translate_expr can resolve column references during expression evaluation.
-            let leaf_start_idx = t_ctx.non_aggregate_expressions.len();
-            let leaf_regs = program.alloc_registers(t_ctx.agg_leaf_columns.len());
-            for i in 0..t_ctx.agg_leaf_columns.len() {
-                program.emit_column_or_rowid(*pseudo_cursor, leaf_start_idx + i, leaf_regs + i);
+            // Cache each saved value before aggregate expressions read it.
+            let value_start_idx = t_ctx.non_aggregate_expressions.len();
+            let value_regs = program.alloc_registers(t_ctx.agg_sorter_values.len());
+            for i in 0..t_ctx.agg_sorter_values.len() {
+                program.emit_column_or_rowid(*pseudo_cursor, value_start_idx + i, value_regs + i);
             }
 
             let cache_len = t_ctx.resolver.expr_to_reg_cache.len();
             let cache_was_enabled = t_ctx.resolver.expr_to_reg_cache_enabled;
-            for (i, leaf_expr) in t_ctx.agg_leaf_columns.drain(..).enumerate() {
+            for (i, sorter_value) in t_ctx.agg_sorter_values.drain(..).enumerate() {
                 t_ctx.resolver.cache_expr_reg(
-                    std::borrow::Cow::Owned(leaf_expr),
-                    leaf_regs + i,
+                    std::borrow::Cow::Owned(sorter_value),
+                    value_regs + i,
                     false,
                     None,
                 );

--- a/core/translate/main_loop/body.rs
+++ b/core/translate/main_loop/body.rs
@@ -172,15 +172,16 @@ fn emit_loop_source<'a>(
                     reg_sorter_key,
                     ..
                 } => {
-                    // Sorter path: store only unique leaf columns from aggregate args.
-                    // Full expressions are re-evaluated from the pseudo cursor during aggregation.
-                    for leaf_expr in t_ctx.agg_leaf_columns.iter() {
+                    // Store the smallest set of values needed to rebuild aggregate
+                    // arguments. Save complete expression-index values before an
+                    // outer join can set their source cursors to null rows.
+                    for sorter_value in t_ctx.agg_sorter_values.iter() {
                         let reg = cur_reg;
                         cur_reg += 1;
                         translate_expr(
                             program,
                             Some(&plan.table_references),
-                            leaf_expr,
+                            sorter_value,
                             reg,
                             &t_ctx.resolver,
                         )?;

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -1670,7 +1670,7 @@ pub fn emit_from_clause_subquery(
                     reg_limit_offset_sum: None,
                     resolver: t_ctx.resolver.fork(),
                     non_aggregate_expressions: Vec::new(),
-                    agg_leaf_columns: Vec::new(),
+                    agg_sorter_values: Vec::new(),
                     cdc_cursor_id: None,
                     meta_window: None,
                     meta_in_seeks: (0..select_plan.joined_tables().len())
@@ -1767,7 +1767,7 @@ fn emit_indexed_materialized_subquery(
                 reg_limit_offset_sum: None,
                 resolver: t_ctx.resolver.fork(),
                 non_aggregate_expressions: Vec::new(),
-                agg_leaf_columns: Vec::new(),
+                agg_sorter_values: Vec::new(),
                 cdc_cursor_id: None,
                 meta_window: None,
                 meta_in_seeks: (0..select_plan.joined_tables().len())
@@ -1880,7 +1880,7 @@ fn emit_materialized_subquery_table(
                 reg_limit_offset_sum: None,
                 resolver: t_ctx.resolver.fork(),
                 non_aggregate_expressions: Vec::new(),
-                agg_leaf_columns: Vec::new(),
+                agg_sorter_values: Vec::new(),
                 cdc_cursor_id: None,
                 meta_window: None,
                 meta_in_seeks: (0..select_plan.joined_tables().len())

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -333,17 +333,18 @@ pub struct ProgramBuilder {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct ProgramBuilderFlags(u8);
+pub struct ProgramBuilderFlags(u16);
 
 impl ProgramBuilderFlags {
-    const ROLLBACK: u8 = 1 << 0;
-    const IS_MULTI_WRITE: u8 = 1 << 1;
-    const MAY_ABORT: u8 = 1 << 2;
-    const READONLY: u8 = 1 << 3;
-    const IS_SUBPROGRAM: u8 = 1 << 4;
-    const HAS_STATEMENT_CONFLICT: u8 = 1 << 5;
-    const SUPPRESS_CUSTOM_TYPE_DECODE: u8 = 1 << 6;
-    const SUPPRESS_COLUMN_DEFAULT: u8 = 1 << 7;
+    const ROLLBACK: u16 = 1 << 0;
+    const IS_MULTI_WRITE: u16 = 1 << 1;
+    const MAY_ABORT: u16 = 1 << 2;
+    const READONLY: u16 = 1 << 3;
+    const IS_SUBPROGRAM: u16 = 1 << 4;
+    const HAS_STATEMENT_CONFLICT: u16 = 1 << 5;
+    const SUPPRESS_CUSTOM_TYPE_DECODE: u16 = 1 << 6;
+    const SUPPRESS_COLUMN_DEFAULT: u16 = 1 << 7;
+    const SKIP_EXPRESSION_INDEX_VALUES: u16 = 1 << 8;
 
     const fn new(is_subprogram: bool) -> Self {
         let mut new = Self(0);
@@ -357,12 +358,12 @@ impl ProgramBuilderFlags {
     }
 
     #[inline]
-    const fn get(self, bit: u8) -> bool {
+    const fn get(self, bit: u16) -> bool {
         (self.0 & bit) != 0
     }
 
     #[inline]
-    const fn set(&mut self, bit: u8, value: bool) {
+    const fn set(&mut self, bit: u16, value: bool) {
         if value {
             self.0 |= bit;
         } else {
@@ -460,6 +461,17 @@ impl ProgramBuilderFlags {
     #[inline]
     pub const fn set_suppress_column_default(&mut self, v: bool) {
         self.set(Self::SUPPRESS_COLUMN_DEFAULT, v)
+    }
+
+    /// Whether expression translation must ignore selected expression indexes.
+    pub const fn skip_expression_index_values(self) -> bool {
+        self.get(Self::SKIP_EXPRESSION_INDEX_VALUES)
+    }
+
+    /// Set this while an `IfNullRow` fallback computes the original expression.
+    /// This prevents the same index match from emitting another fallback.
+    pub const fn set_skip_expression_index_values(&mut self, value: bool) {
+        self.set(Self::SKIP_EXPRESSION_INDEX_VALUES, value)
     }
 }
 

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -1674,6 +1674,9 @@ impl ProgramBuilder {
                 } => {
                     resolve(target_pc, "NotNull")?;
                 }
+                Insn::IfNullRow { target_pc, .. } => {
+                    resolve(target_pc, "IfNullRow")?;
+                }
                 Insn::ColumnHasField { target_pc, .. } => {
                     resolve(target_pc, "ColumnHasField")?;
                 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -809,6 +809,50 @@ pub fn op_null_row(
     Ok(InsnFunctionStepResult::Step)
 }
 
+/// Implement SQLite's `OP_IfNullRow` branch.
+///
+/// This branch lets expression code use an index value for a real row and
+/// compute the original expression for an outer-join null row.
+pub fn op_if_null_row(
+    _program: &Program,
+    state: &mut ProgramState,
+    insn: &Insn,
+    _pager: &Arc<Pager>,
+) -> InsnResult {
+    load_insn!(
+        IfNullRow {
+            cursor_id,
+            target_pc,
+            dest
+        },
+        insn
+    );
+    if !target_pc.is_offset() {
+        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+    }
+    let cursor_is_null = state
+        .cursors
+        .get(*cursor_id)
+        .expect("cursor_id should be valid")
+        .as_ref()
+        .is_some_and(|cursor| match cursor {
+            Cursor::BTree(cursor) => cursor.get_null_flag(),
+            Cursor::Virtual(cursor) => cursor.is_null_row(),
+            Cursor::NullRow => true,
+            Cursor::IndexMethod(_)
+            | Cursor::Pseudo(_)
+            | Cursor::Sorter(_)
+            | Cursor::MaterializedView(_) => false,
+        });
+    if cursor_is_null {
+        state.registers[*dest].set_null();
+        state.pc = target_pc.as_offset_int();
+    } else {
+        state.pc += 1;
+    }
+    Ok(InsnFunctionStepResult::Step)
+}
+
 pub fn op_compare(
     _program: &Program,
     state: &mut ProgramState,
@@ -19883,6 +19927,45 @@ mod tests {
         let version_integer = 3046001;
         let expected = "3.46.1";
         assert_eq!(execute_turso_version(version_integer), expected);
+    }
+
+    #[test]
+    fn if_null_row_does_nothing_for_unopened_cursor() {
+        let stmt = prepare_test_statement();
+        let mut state = ProgramState::new(1, 1);
+        state.set_register(0, Register::Value(Value::from_i64(7)));
+        let insn = Insn::IfNullRow {
+            cursor_id: 0,
+            target_pc: BranchOffset::Offset(9),
+            dest: 0,
+        };
+
+        let step = op_if_null_row(stmt.get_program(), &mut state, &insn, stmt.get_pager())
+            .expect("IfNullRow must accept an unopened cursor");
+
+        assert!(matches!(step, InsnFunctionStepResult::Step));
+        assert_eq!(state.pc, 1);
+        assert_eq!(state.get_register(0).get_value(), &Value::from_i64(7));
+    }
+
+    #[test]
+    fn if_null_row_clears_destination_and_jumps() {
+        let stmt = prepare_test_statement();
+        let mut state = ProgramState::new(1, 1);
+        state.cursors[0] = Some(Cursor::NullRow);
+        state.set_register(0, Register::Value(Value::from_i64(7)));
+        let insn = Insn::IfNullRow {
+            cursor_id: 0,
+            target_pc: BranchOffset::Offset(9),
+            dest: 0,
+        };
+
+        let step = op_if_null_row(stmt.get_program(), &mut state, &insn, stmt.get_pager())
+            .expect("IfNullRow must accept a null-row cursor");
+
+        assert!(matches!(step, InsnFunctionStepResult::Step));
+        assert_eq!(state.pc, 9);
+        assert_eq!(state.get_register(0).get_value(), &Value::Null);
     }
 
     #[test]

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -202,6 +202,22 @@ pub fn insn_to_row(
                 0,
                 format!("Set cursor {cursor_id} to a (pseudo) NULL row"),
             ),
+            Insn::IfNullRow {
+                cursor_id,
+                target_pc,
+                dest,
+            } => (
+                "IfNullRow",
+                *cursor_id as i64,
+                target_pc.as_debug_int() as i64,
+                *dest as i64,
+                Value::build_text(""),
+                0,
+                format!(
+                    "if {cursor_id}.nullRow then r[{dest}]=NULL, goto {}",
+                    target_pc.as_debug_int()
+                ),
+            ),
             Insn::NotNull { reg, target_pc } => (
                 "NotNull",
                 *reg as i64,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -405,6 +405,13 @@ pub enum Insn {
     NullRow {
         cursor_id: CursorID,
     },
+    /// If the cursor is on a null row, write NULL to `dest` and jump.
+    /// This instruction does nothing for an unopened cursor.
+    IfNullRow {
+        cursor_id: CursorID,
+        target_pc: BranchOffset,
+        dest: usize,
+    },
     /// Add two registers and store the result in a third register.
     Add {
         lhs: usize,
@@ -2165,6 +2172,7 @@ impl InsnVariants {
             InsnVariants::Null => execute::op_null,
             InsnVariants::BeginSubrtn => execute::op_null,
             InsnVariants::NullRow => execute::op_null_row,
+            InsnVariants::IfNullRow => execute::op_if_null_row,
             InsnVariants::Add => execute::op_add,
             InsnVariants::Subtract => execute::op_subtract,
             InsnVariants::Multiply => execute::op_multiply,

--- a/core/vtab.rs
+++ b/core/vtab.rs
@@ -275,6 +275,11 @@ impl VirtualTableCursor {
         self.null_flag = flag;
     }
 
+    /// Whether an outer join set this cursor to its synthetic null row.
+    pub(crate) fn is_null_row(&self) -> bool {
+        self.null_flag
+    }
+
     pub(crate) fn next(&mut self) -> crate::Result<bool> {
         self.null_flag = false;
         match &mut self.inner {

--- a/sqlite/conformance/sqlite-sqltests/group-by-expression-index.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/group-by-expression-index.sqltest
@@ -54,3 +54,48 @@ expect {
     alice|2
     bob|2
 }
+
+# An expression index stores the value for a real row. A LEFT JOIN can replace
+# that row with NULL, so SQLite computes the expression again.
+@cross-check-integrity
+test left-join-recomputes-expression-index-value-for-null-row {
+    CREATE TABLE expr_left(x INTEGER);
+    INSERT INTO expr_left VALUES(1),(99);
+    CREATE TABLE expr_right(a INTEGER, b INTEGER);
+    CREATE INDEX expr_right_idx ON expr_right(a,coalesce(b,7));
+    INSERT INTO expr_right VALUES(1,2);
+
+    SELECT expr_left.x, quote(coalesce(expr_right.b,7))
+      FROM expr_left
+      LEFT JOIN expr_right INDEXED BY expr_right_idx
+        ON expr_right.a=expr_left.x
+     ORDER BY expr_left.x;
+}
+expect {
+    1|2
+    99|7
+}
+
+# GROUP BY reads aggregate inputs after it sorts the rows. The sorter must
+# save each expression-index value before the source cursor can become NULL.
+@cross-check-integrity
+test left-join-group-by-keeps-expression-index-value {
+    CREATE TABLE grouped_expr_left(x INTEGER);
+    INSERT INTO grouped_expr_left VALUES(1),(99);
+    CREATE TABLE grouped_expr_right(a INTEGER, b INTEGER);
+    CREATE INDEX grouped_expr_right_idx
+        ON grouped_expr_right(a,coalesce(b,7));
+    INSERT INTO grouped_expr_right VALUES(1,2);
+
+    SELECT quote(grouped_expr_right.a),
+           quote(sum(coalesce(grouped_expr_right.b,7)))
+      FROM grouped_expr_left
+      LEFT JOIN grouped_expr_right INDEXED BY grouped_expr_right_idx
+        ON grouped_expr_right.a=grouped_expr_left.x
+     GROUP BY grouped_expr_right.a
+     ORDER BY grouped_expr_right.a;
+}
+expect {
+    NULL|7
+    1|2
+}

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/joins.sqltest
@@ -862,6 +862,25 @@ snapshot correlated-parenthesized-join-keeps-result-expressions {
       FROM nested_prune_outer AS outer_row;
 }
 
+setup left_join_grouped_expression_index_schema {
+    CREATE TABLE grouped_expr_left(x INTEGER);
+    CREATE TABLE grouped_expr_right(a INTEGER, b INTEGER);
+    CREATE INDEX grouped_expr_right_idx
+        ON grouped_expr_right(a,coalesce(b,7));
+}
+
+# The sorter saves the selected expression-index value. IfNullRow computes the
+# expression again for the synthetic row from the LEFT JOIN.
+@setup left_join_grouped_expression_index_schema
+snapshot left-join-group-by-keeps-expression-index-value {
+    SELECT grouped_expr_right.a,
+           sum(coalesce(grouped_expr_right.b,7))
+      FROM grouped_expr_left
+      LEFT JOIN grouped_expr_right INDEXED BY grouped_expr_right_idx
+        ON grouped_expr_right.a=grouped_expr_left.x
+     GROUP BY grouped_expr_right.a;
+}
+
 # =============================================================================
 # Hash Join Snapshot Tests
 # =============================================================================

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-join-group-by-keeps-expression-index-value.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-join-group-by-keeps-expression-index-value.snap
@@ -1,0 +1,92 @@
+---
+source: joins.sqltest
+expression: |-
+  SELECT grouped_expr_right.a,
+             sum(coalesce(grouped_expr_right.b,7))
+        FROM grouped_expr_left
+        LEFT JOIN grouped_expr_right INDEXED BY grouped_expr_right_idx
+          ON grouped_expr_right.a=grouped_expr_left.x
+       GROUP BY grouped_expr_right.a;
+info:
+  statement_type: SELECT
+  tables:
+  - grouped_expr_left
+  - grouped_expr_right
+  - grouped_expr_right.a
+  setup_blocks:
+  - left_join_grouped_expression_index_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN grouped_expr_left
+|--SEARCH grouped_expr_right USING INDEX grouped_expr_right_idx (a=?) LEFT-JOIN
+`--USE SORTER FOR GROUP BY
+
+BYTECODE
+addr  opcode                    p1  p2  p3  p4            p5  comment
+   0          Init               0  64   0                 0  Start at 64
+   1          Null               0   8   0                 0  r[8]=NULL
+   2          SorterOpen         0   2   0  k(1,B)         0  cursor=0
+   3          Integer            0   5   0                 0  r[5]=0; clear group by abort flag
+   4          Null               0   6   0                 0  r[6]=NULL; initialize group by comparison registers to NULL
+   5          Gosub             12  60   0                 0  ; go to clear accumulator subroutine
+   6          OpenRead           2   2   0  k(2,B)         0  table=grouped_expr_left, root=2, iDb=0
+   7          OpenRead           3   3   0  k(3,B,B)       0  table=grouped_expr_right, root=3, iDb=0
+   8          OpenRead           4   4   0  k(3,B,B)       0  index=grouped_expr_right_idx, root=4, iDb=0
+   9          Rewind             2  33   0                 0  Rewind table grouped_expr_left
+  10            Integer          0  13   0                 0  r[13]=0
+  11            Column           2   0  14                 0  r[14]=grouped_expr_left.x
+  12            IsNull          14  28   0                 0  if (r[14]==NULL) goto 28
+  13            Affinity        14   1   0                 0  r[14..15] = C
+  14            SeekGE           4  28  14                 0  key=[14..14]
+  15              IdxGT          4  28  14                 0  key=[14..14]
+  16              DeferredSeek   4   3   0                 0
+  17              Integer        1  13   0                 0  r[13]=1
+  18              Column         4   0  10                 0  r[10]=grouped_expr_right_idx.a
+  19              IfNullRow      4  22  11                 0  if 4.nullRow then r[11]=NULL, goto 22
+  20              Column         4   1  11                 0  r[11]=grouped_expr_right_idx.coalesce (b, 7)
+  21              Goto           0  25   0                 0
+  22              Column         3   1  11                 0  r[11]=grouped_expr_right.b
+  23              NotNull       11  25   0                 0  r[11]!=NULL -> goto 25
+  24              Integer        7  11   0                 0  r[11]=7
+  25              MakeRecord    10   2   9                 0  r[9]=mkrec(r[10..11])
+  26              SorterInsert   0   9   0  0              0  key=r[9]
+  27            Next             4  15   0                 0
+  28            IfPos           13  32   0                 0  r[13]>0 -> r[13]-=0, goto 32
+  29            NullRow          3   0   0                 0  Set cursor 3 to a (pseudo) NULL row
+  30            NullRow          4   0   0                 0  Set cursor 4 to a (pseudo) NULL row
+  31            Goto             0  17   0                 0
+  32          Next               2  10   0                 1
+  33          OpenPseudo         1   9   2                 0  2 columns in r[9]
+  34          SorterSort         0  49   0                 0
+  35            SorterData       0   9   1                 0  r[9]=data
+  36            Column           1   0  15                 0  r[15]=pseudo.column 0
+  37            Compare          6  15   1  k(1, Binary)   0  r[6..6]==r[15..15]
+  38            Jump            39  43  39                 0  ; start new group if comparison is not equal
+  39            Gosub            3  53   0                 0  ; check if ended group had data, and output if so
+  40            Move            15   6   1                 0  r[6..6]=r[15..15]
+  41            IfPos            5  63   0                 0  r[5]>0 -> r[5]-=0, goto 63; check abort flag
+  42            Gosub           12  60   0                 0  ; goto clear accumulator subroutine
+  43            Column           1   1  16                 0  r[16]=pseudo.column 1
+  44            AggStep          0  16   8  sum            0  accum=r[8] step(r[16])
+  45            If               4  47   0                 0  if r[4] goto 47; don't emit group columns if continuing existing group
+  46            Column           1   0   7                 0  r[7]=pseudo.column 0
+  47            Integer          1   4   0                 0  r[4]=1; indicate data in accumulator
+  48          SorterNext         0  35   0                 0
+  49          Gosub              3  53   0                 0  ; emit row for final group
+  50          Goto               0  63   0                 0  ; group by finished
+  51          Integer            1   5   0                 0  r[5]=1
+  52        Return               3   0   0                 0
+  53        IfPos                4  55   0                 0  r[4]>0 -> r[4]-=0, goto 55; output group by row subroutine start
+  54      Return                 3   0   0                 0
+  55      AggFinal               0   8   0  sum            0  accum=r[8]
+  56      Copy                   7   1   0                 0  r[1]=r[7]
+  57      Copy                   8   2   0                 0  r[2]=r[8]
+  58      ResultRow              1   2   0                 0  output=r[1..2]
+  59    Return                   3   0   0                 0
+  60    Null                     0   7   8                 0  r[7..8]=NULL; clear accumulator subroutine start
+  61    Integer                  0   4   0                 0  r[4]=0
+  62  Return                    12   0   0                 0
+  63  Halt                       0   0   0                 0
+  64  Transaction                0   1   3                 0  iDb=0 tx_mode=Read
+  65  Goto                       0   1   0                 0


### PR DESCRIPTION
An outer join can move an index cursor to its NULL row. The stored expression-index value then belongs to a real table row and can differ from evaluating the expression over NULL columns.\n\nThis adds SQLite's IfNullRow instruction and uses it to recompute the expression when needed. GROUP BY sorter rows also keep complete indexed expressions when the source cursor will no longer be valid.\n\nTests: VDBE unit tests, expression-index SQL tests, and a focused bytecode snapshot