### PR TITLE
core: guard outer-join range seeks against null keys

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -1005,6 +1005,7 @@ pub fn translate_alter_table(
                             cte_id: None,
                             cte_definition_only: false,
                             rowid_referenced: false,
+                            outer_join_can_add_nulls: false,
                             scope_depth: 0,
                         }],
                     );

--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -192,6 +192,7 @@ pub fn emit_program_for_update(
             cte_id: None,
             cte_definition_only: false,
             rowid_referenced: false,
+            outer_join_can_add_nulls: false,
             scope_depth: 0,
         });
         // CTEs are also visible during the write phase, so add them here.

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3422,6 +3422,11 @@ impl Optimizable for ast::Expr {
                 is_rowid_alias,
                 ..
             } => {
+                // SQLite marks columns from the nullable side of an outer join
+                // as nullable, even when the table schema says NOT NULL.
+                if tables.outer_join_may_null_extend(*table) {
+                    return false;
+                }
                 if *is_rowid_alias {
                     return true;
                 }
@@ -3435,7 +3440,9 @@ impl Optimizable for ast::Expr {
                 // Other PRIMARY KEY types (e.g., TEXT PRIMARY KEY) can contain NULL.
                 column.is_rowid_alias() || column.notnull()
             }
-            Expr::RowId { .. } => true,
+            // A rowid is not NULL for a real table row. An outer join can
+            // replace that row with a synthetic row whose rowid is NULL.
+            Expr::RowId { table, .. } => !tables.outer_join_may_null_extend(*table),
             Expr::InList { lhs, rhs, .. } => {
                 lhs.is_nonnull(tables)
                     && (rhs.is_empty() || rhs.iter().all(|v| v.is_nonnull(tables)))

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -1403,6 +1403,9 @@ pub struct OuterQueryReference {
     /// col_used_mask because rowid is not a real column and setting a fake
     /// column index in col_used_mask could mislead covering index decisions.
     pub rowid_referenced: bool,
+    /// Whether an outer join in an outer scope can replace this table's values
+    /// with NULL. The local FROM list does not contain that outer join.
+    pub outer_join_can_add_nulls: bool,
     /// Scope depth for this outer reference. 0 = immediate outer scope,
     /// 1 = grandparent scope, etc. Used to avoid false "ambiguous column"
     /// errors when the same column name exists at different nesting depths.
@@ -1533,7 +1536,11 @@ impl TableReferences {
             .iter()
             .position(|t| t.internal_id == table)
         else {
-            return false;
+            // A correlated subquery does not have the outer FROM list. Its
+            // table reference carries the nullability from that outer scope.
+            return self
+                .find_outer_query_ref_by_internal_id(table)
+                .is_some_and(|outer_ref| outer_ref.outer_join_can_add_nulls);
         };
         if self.joined_tables[pos]
             .join_info

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1229,6 +1229,7 @@ fn plan_cte(
                 // actually adds the table.
                 cte_definition_only: true,
                 rowid_referenced: false,
+                outer_join_can_add_nulls: false,
                 scope_depth: 0,
             });
         }
@@ -1427,6 +1428,7 @@ fn prepare_recursive_cte_plan(
         cte_id: None,
         cte_definition_only: false,
         rowid_referenced: false,
+        outer_join_can_add_nulls: false,
         scope_depth: 0,
     });
 
@@ -1560,6 +1562,7 @@ pub fn plan_ctes_as_outer_refs(
             cte_id: Some(cte_definition.cte_id),
             cte_definition_only: true,
             rowid_referenced: false,
+            outer_join_can_add_nulls: false,
             scope_depth: 0,
         });
     }
@@ -1626,6 +1629,7 @@ fn parse_from_clause_table(
                     cte_id: Some(cte_definition.cte_id),
                     cte_definition_only: false,
                     rowid_referenced: false,
+                    outer_join_can_add_nulls: false,
                     scope_depth: 0,
                 });
             }
@@ -2455,6 +2459,7 @@ pub fn parse_from(
                     // This entry only lets a nested FROM clause find the CTE name.
                     cte_definition_only: true,
                     rowid_referenced: false,
+                    outer_join_can_add_nulls: false,
                     scope_depth: 0,
                 });
             }

--- a/core/translate/subquery.rs
+++ b/core/translate/subquery.rs
@@ -612,6 +612,8 @@ fn plan_subqueries_with_outer_query_access<'a>(
                     cte_id,
                     cte_definition_only: false,
                     rowid_referenced: false,
+                    outer_join_can_add_nulls: referenced_tables
+                        .outer_join_may_null_extend(t.internal_id),
                     scope_depth: 0,
                 };
                 Ok::<_, crate::LimboError>(outer_ref)
@@ -628,6 +630,7 @@ fn plan_subqueries_with_outer_query_access<'a>(
                     cte_id: t.cte_id, // Preserve CTE ID from outer query refs
                     cte_definition_only: t.cte_definition_only,
                     rowid_referenced: false,
+                    outer_join_can_add_nulls: t.outer_join_can_add_nulls,
                     scope_depth: t.scope_depth + 1,
                 })
             }))

--- a/sqlite/conformance/sqlite-sqltests/joins/left_join_null_index_bug.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/joins/left_join_null_index_bug.sqltest
@@ -25,6 +25,28 @@ expect {
 2||
 }
 
+# The first LEFT JOIN can replace a declared NOT NULL value with NULL. The
+# second join must not start an index range with that synthetic NULL value.
+@cross-check-integrity
+test left-join-range-seek-stops-on-null-extended-key {
+    CREATE TABLE range_left(seed INTEGER);
+    INSERT INTO range_left VALUES(1);
+    CREATE TABLE range_middle(key INTEGER NOT NULL);
+    CREATE TABLE range_right(value INTEGER);
+    CREATE INDEX range_right_value ON range_right(value);
+    INSERT INTO range_right VALUES(1);
+
+    SELECT quote(range_left.seed), quote(range_middle.key),
+           quote(range_right.value)
+      FROM range_left
+      LEFT JOIN range_middle ON true
+      LEFT JOIN range_right INDEXED BY range_right_value
+        ON range_middle.key<=range_right.value;
+}
+expect {
+    1|NULL|NULL
+}
+
 setup left-join-null-index-bug-composite-index-schema {
     CREATE TABLE a(id INTEGER PRIMARY KEY);
     CREATE TABLE b(id INTEGER PRIMARY KEY, a_id INTEGER);

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/joins.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/joins.sqltest
@@ -881,6 +881,25 @@ snapshot left-join-group-by-keeps-expression-index-value {
      GROUP BY grouped_expr_right.a;
 }
 
+setup left_join_null_range_schema {
+    CREATE TABLE null_range_left(seed INTEGER);
+    CREATE TABLE null_range_middle(key INTEGER NOT NULL);
+    CREATE TABLE null_range_right(value INTEGER);
+    CREATE INDEX null_range_right_value ON null_range_right(value);
+}
+
+# The first LEFT JOIN can make the declared NOT NULL key NULL. IsNull must stop
+# the later range seek before SeekGE reads that key.
+@setup left_join_null_range_schema
+snapshot left-join-range-seek-checks-null-extended-key {
+    SELECT null_range_left.seed, null_range_middle.key,
+           null_range_right.value
+      FROM null_range_left
+      LEFT JOIN null_range_middle ON true
+      LEFT JOIN null_range_right INDEXED BY null_range_right_value
+        ON null_range_middle.key<=null_range_right.value;
+}
+
 # =============================================================================
 # Hash Join Snapshot Tests
 # =============================================================================

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-join-range-seek-checks-null-extended-key.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-join-range-seek-checks-null-extended-key.snap
@@ -1,0 +1,59 @@
+---
+source: joins.sqltest
+expression: |-
+  SELECT null_range_left.seed, null_range_middle.key,
+             null_range_right.value
+        FROM null_range_left
+        LEFT JOIN null_range_middle ON true
+        LEFT JOIN null_range_right INDEXED BY null_range_right_value
+          ON null_range_middle.key<=null_range_right.value;
+info:
+  statement_type: SELECT
+  tables:
+  - null_range_left
+  - null_range_middle
+  - null_range_middle.key
+  - null_range_right
+  setup_blocks:
+  - left_join_null_range_schema
+  database: ':memory:'
+---
+QUERY PLAN
+|--SCAN null_range_left
+|--SCAN null_range_middle LEFT-JOIN
+`--SEARCH null_range_right USING COVERING INDEX null_range_right_value (value>=?) LEFT-JOIN
+
+BYTECODE
+addr  opcode           p1  p2  p3  p4      p5  comment
+   0  Init              0  29   0           0  Start at 29
+   1  OpenRead          0   2   0  k(2,B)   0  table=null_range_left, root=2, iDb=0
+   2  OpenRead          1   3   0  k(2,B)   0  table=null_range_middle, root=3, iDb=0
+   3  OpenRead          2   5   0  k(2,B)   0  index=null_range_right_value, root=5, iDb=0
+   4  Rewind            0  28   0           0  Rewind table null_range_left
+   5    Integer         0   4   0           0  r[4]=0
+   6    Rewind          1  24   0           0  Rewind table null_range_middle
+   7      IfNot         6  23   1           0  if !r[6] goto 23
+   8      Integer       1   4   0           0  r[4]=1
+   9      Integer       0   5   0           0  r[5]=0
+  10      Column        1   0   7           0  r[7]=null_range_middle.key
+  11      IsNull        7  20   0           0  if (r[7]==NULL) goto 20
+  12      Affinity      7   1   0           0  r[7..8] = C
+  13      SeekGE        2  20   7           0  key=[7..7]
+  14        Integer     1   5   0           0  r[5]=1
+  15        Column      0   0   1           0  r[1]=null_range_left.seed
+  16        Column      1   0   2           0  r[2]=null_range_middle.key
+  17        Column      2   0   3           0  r[3]=null_range_right_value.value
+  18        ResultRow   1   3   0           0  output=r[1..3]
+  19      Next          2  14   0           0
+  20      IfPos         5  23   0           0  r[5]>0 -> r[5]-=0, goto 23
+  21      NullRow       2   0   0           0  Set cursor 2 to a (pseudo) NULL row
+  22      Goto          0  14   0           0
+  23    Next            1   7   0           1
+  24    IfPos           4  27   0           0  r[4]>0 -> r[4]-=0, goto 27
+  25    NullRow         1   0   0           0  Set cursor 1 to a (pseudo) NULL row
+  26    Goto            0   8   0           0
+  27  Next              0   5   0           1
+  28  Halt              0   0   0           0
+  29  Transaction       0   1   4           0  iDb=0 tx_mode=Read
+  30  Integer           1   6   0           0  r[6]=1
+  31  Goto              0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-chained.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/joins/snapshots/joins__left-outer-join-chained.snap
@@ -33,46 +33,47 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode              p1  p2  p3  p4              p5  comment
-   0  Init                 0  41   0                   0  Start at 41
+   0  Init                 0  42   0                   0  Start at 42
    1  OpenRead             0   2   0  k(5,B,B,B,B,B)   0  table=customers, root=2, iDb=0
    2  OpenRead             1   8   0  k(2,B)           0  index=idx_orders_customer_id, root=8, iDb=0
    3  OpenRead             2   5   0  k(5,B,B,B,B,B)   0  table=order_items, root=5, iDb=0
    4  OpenRead             3   9   0  k(2,B)           0  index=idx_order_items_order_id, root=9, iDb=0
    5  OpenRead             4   3   0  k(5,B,B,B,B,B)   0  table=products, root=3, iDb=0
-   6  Rewind               0  40   0                   0  Rewind table customers
+   6  Rewind               0  41   0                   0  Rewind table customers
    7    Integer            0   5   0                   0  r[5]=0
    8    RowId              0   8   0                   0  r[8]=customers.rowid
-   9    SeekGE             1  36   8                   0  key=[8..8]
-  10      IdxGT            1  36   8                   0  key=[8..8]
+   9    SeekGE             1  37   8                   0  key=[8..8]
+  10      IdxGT            1  37   8                   0  key=[8..8]
   11      Integer          1   5   0                   0  r[5]=1
   12      Integer          0   6   0                   0  r[6]=0
   13      IdxRowId         1   9   0                   0  r[9]=cursor 1 for index idx_orders_customer_id.rowid
-  14      SeekGE           3  31   9                   0  key=[9..9]
-  15        IdxGT          3  31   9                   0  key=[9..9]
-  16        DeferredSeek   3   2   0                   0
-  17        Integer        1   6   0                   0  r[6]=1
-  18        Integer        0   7   0                   0  r[7]=0
-  19        Column         2   2  10                   0  r[10]=order_items.product_id
-  20        SeekRowid      4  10  27                   0  if (r[10]!=cursor 4 for table products.rowid) goto 27
-  21        Integer        1   7   0                   0  r[7]=1
-  22        Column         0   1   1                   0  r[1]=customers.name
-  23        IdxRowId       1   2   0                   0  r[2]=cursor 1 for index idx_orders_customer_id.rowid
-  24        IdxRowId       3   3   0                   0  r[3]=cursor 3 for index idx_order_items_order_id.rowid
-  25        Column         4   1   4                   0  r[4]=products.name
-  26        ResultRow      1   4   0                   0  output=r[1..4]
-  27        IfPos          7  30   0                   0  r[7]>0 -> r[7]-=0, goto 30
-  28        NullRow        4   0   0                   0  Set cursor 4 to a (pseudo) NULL row
-  29        Goto           0  21   0                   0
-  30      Next             3  15   0                   0
-  31      IfPos            6  35   0                   0  r[6]>0 -> r[6]-=0, goto 35
-  32      NullRow          2   0   0                   0  Set cursor 2 to a (pseudo) NULL row
-  33      NullRow          3   0   0                   0  Set cursor 3 to a (pseudo) NULL row
-  34      Goto             0  17   0                   0
-  35    Next               1  10   0                   0
-  36    IfPos              5  39   0                   0  r[5]>0 -> r[5]-=0, goto 39
-  37    NullRow            1   0   0                   0  Set cursor 1 to a (pseudo) NULL row
-  38    Goto               0  11   0                   0
-  39  Next                 0   7   0                   1
-  40  Halt                 0   0   0                   0
-  41  Transaction          0   1  10                   0  iDb=0 tx_mode=Read
-  42  Goto                 0   1   0                   0
+  14      IsNull           9  32   0                   0  if (r[9]==NULL) goto 32
+  15      SeekGE           3  32   9                   0  key=[9..9]
+  16        IdxGT          3  32   9                   0  key=[9..9]
+  17        DeferredSeek   3   2   0                   0
+  18        Integer        1   6   0                   0  r[6]=1
+  19        Integer        0   7   0                   0  r[7]=0
+  20        Column         2   2  10                   0  r[10]=order_items.product_id
+  21        SeekRowid      4  10  28                   0  if (r[10]!=cursor 4 for table products.rowid) goto 28
+  22        Integer        1   7   0                   0  r[7]=1
+  23        Column         0   1   1                   0  r[1]=customers.name
+  24        IdxRowId       1   2   0                   0  r[2]=cursor 1 for index idx_orders_customer_id.rowid
+  25        IdxRowId       3   3   0                   0  r[3]=cursor 3 for index idx_order_items_order_id.rowid
+  26        Column         4   1   4                   0  r[4]=products.name
+  27        ResultRow      1   4   0                   0  output=r[1..4]
+  28        IfPos          7  31   0                   0  r[7]>0 -> r[7]-=0, goto 31
+  29        NullRow        4   0   0                   0  Set cursor 4 to a (pseudo) NULL row
+  30        Goto           0  22   0                   0
+  31      Next             3  16   0                   0
+  32      IfPos            6  36   0                   0  r[6]>0 -> r[6]-=0, goto 36
+  33      NullRow          2   0   0                   0  Set cursor 2 to a (pseudo) NULL row
+  34      NullRow          3   0   0                   0  Set cursor 3 to a (pseudo) NULL row
+  35      Goto             0  18   0                   0
+  36    Next               1  10   0                   0
+  37    IfPos              5  40   0                   0  r[5]>0 -> r[5]-=0, goto 40
+  38    NullRow            1   0   0                   0  Set cursor 1 to a (pseudo) NULL row
+  39    Goto               0  11   0                   0
+  40  Next                 0   7   0                   1
+  41  Halt                 0   0   0                   0
+  42  Transaction          0   1  10                   0  iDb=0 tx_mode=Read
+  43  Goto                 0   1   0                   0


### PR DESCRIPTION
An earlier outer join can replace a NOT NULL column, rowid alias, or implicit rowid with NULL. The range planner previously trusted schema nullability and could seek with that null-extended key.\n\nThis preserves the possible NULL state in correlated outer references and emits SQLite's IsNull guard before the seek.\n\nTests: LEFT JOIN regression tests and a focused bytecode snapshot