### PR TITLE
Add aristo intent on partial writes

### DIFF
--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -3014,6 +3014,11 @@ impl<Clock: LogicalClock, A: ConcurrentAllocator> StateTransition for CommitStat
     type Context = Arc<MvStore<Clock, A>>;
     type SMResult = ();
 
+    #[aristo::intent(
+        "An abandoned partial write never reaches disk.",
+        verify = "full",
+        id = "abandoned_partial_write_never_reaches_disk"
+    )]
     #[tracing::instrument(fields(state = ?self.state), skip(self, mvcc_store), level = Level::DEBUG)]
     fn step(&mut self, mvcc_store: &Self::Context) -> Result<TransitionResult<Self::SMResult>> {
         tracing::trace!("step(state={:?})", self.state);


### PR DESCRIPTION
This adds an aristo intent that matches the assumption we have in the codebase: https://github.com/tursodatabase/turso/blob/0999bc1c3f342a0b95844a8d475c63f1f19ef385/tests/integration/abandoned_statement_pager.rs#L6

It's not very precise, but mostly I just want to see what Aristo can do with something as minimal as this.

This is my first time adding Aristo intents. I think this is the correct way to do it, but I would appreciate some expert eyes.