### PR TITLE
fix(planner): traverse left-hand side of in-select when collecting cte refs (#8655)

### DIFF
--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -478,7 +478,9 @@ fn collect_subquery_table_refs_in_expr(expr: &Expr, out: &mut Vec<String>) {
             }
             Expr::InSelect { rhs, .. } => {
                 collect_from_clause_table_refs(rhs, out);
-                Ok(WalkControl::SkipChildren)
+                // The walker does not descend into the subquery, only the
+                // left-hand side expression.
+                Ok(WalkControl::Continue)
             }
             _ => Ok(WalkControl::Continue),
         }

--- a/sqlite/conformance/sqlite-sqltests/cte_expressions.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/cte_expressions.sqltest
@@ -639,3 +639,30 @@ test cte-schema-qualified-reference-bypasses-inner-shadow {
 expect {
     1
 }
+
+test cte-referenced-in-lhs-of-in-select-loud {
+    CREATE TABLE t_in(x INTEGER);
+    INSERT INTO t_in(x) VALUES (100);
+
+    WITH a AS (SELECT 1 AS v),
+         b AS (SELECT 42 AS w FROM t_in WHERE (SELECT v FROM a) IN (SELECT 1))
+    SELECT * FROM b;
+}
+expect {
+    42
+}
+
+test cte-referenced-in-lhs-of-in-select-shadowed {
+    CREATE TABLE t_shadow(x INTEGER);
+    INSERT INTO t_shadow(x) VALUES (100);
+    CREATE TABLE a_shadow(v INTEGER);
+    INSERT INTO a_shadow(v) VALUES (9);
+
+    WITH a_shadow AS (SELECT 1 AS v),
+         b AS (SELECT 42 AS w FROM t_shadow WHERE (SELECT v FROM a_shadow) IN (SELECT 1))
+    SELECT * FROM b;
+}
+expect {
+    42
+}
+


### PR DESCRIPTION
/claim #8655
Resolves #8655

## Summary of Changes
When a common-table-expression (CTE) name is referenced inside the left-hand side of an `expr IN (SELECT ...)` predicate, `collect_subquery_table_refs_in_expr` previously returned `Ok(WalkControl::SkipChildren)` for `Expr::InSelect { rhs, .. }`. Because `walk_expr` pushes `lhs` onto the walk stack, returning `SkipChildren` prevented the walker from descending into `lhs`, causing CTE dependencies in `lhs` subqueries to be dropped and mistakenly resolved against the outer schema.

### Fix:
1. In `core/translate/planner.rs` (`collect_subquery_table_refs_in_expr`), changed the `Expr::InSelect` arm to return `Ok(WalkControl::Continue)`. This matches the sibling path in `count_expr` (line 318) and allows `walk_expr` to descend into `lhs` while `rhs` is collected via `collect_from_clause_table_refs(rhs, out)`.
2. Added regression test cases in `sqlite/conformance/sqlite-sqltests/cte_expressions.sqltest` covering:
   - Loud form: CTE referenced only in the LHS of `IN (SELECT ...)` without schema shadowing (`test cte-referenced-in-lhs-of-in-select-loud`).
   - Silent form: Base table shadows CTE name (`test cte-referenced-in-lhs-of-in-select-shadowed`).

## Verification
- `cargo check -p turso_core` passes with 0 errors and 0 warnings.
- `sqltest run sqlite/conformance/sqlite-sqltests/cte_expressions.sqltest` passes cleanly (61/61 passed, including new regression tests).
- Parity verified against SQLite oracle.

---
**Bounty Payout Address (USDC on Base):**
`0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
