### PR TITLE
fix(alter): rewrite column references in trigger exists subqueries (#8654)

### DIFF
--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -3222,7 +3222,7 @@ fn apply_expr_column_ref_with_context(
 fn apply_expr_for_column_rename(
     mode: ColumnRenameMode<'_>,
     expr: &mut ast::Expr,
-    traversal: ColumnRenameExprTraversal,
+    _traversal: ColumnRenameExprTraversal,
     trigger_table: &BTreeTable,
     trigger_table_name: &str,
     target_table_name: &str,
@@ -3250,23 +3250,7 @@ fn apply_expr_for_column_rename(
 
     walk_expr_mut(expr, &mut |e: &mut ast::Expr| -> Result<WalkControl> {
         match e {
-            ast::Expr::Exists(select) => {
-                if matches!(traversal, ColumnRenameExprTraversal::RewriteResultExpr) {
-                    return Ok(WalkControl::SkipChildren);
-                }
-                apply_select_for_column_rename(
-                    mode,
-                    select,
-                    trigger_table,
-                    trigger_table_name,
-                    target_table_name,
-                    old_col_norm,
-                    from_target_qualifiers,
-                    database_id,
-                    resolver,
-                )?;
-            }
-            ast::Expr::Subquery(select) => {
+            ast::Expr::Exists(select) | ast::Expr::Subquery(select) => {
                 apply_select_for_column_rename(
                     mode,
                     select,

--- a/core/util.rs
+++ b/core/util.rs
@@ -3994,8 +3994,7 @@ fn rename_result_identifiers_scoped(
         expr,
         &mut |e: &mut ast::Expr| -> crate::Result<WalkControl> {
             match e {
-                ast::Expr::Exists(_) => return Ok(WalkControl::SkipChildren),
-                ast::Expr::Subquery(select) => {
+                ast::Expr::Exists(select) | ast::Expr::Subquery(select) => {
                     let mut quals = target_qualifiers.unwrap_or(&[]).to_vec();
                     rewrite_select_column_refs_scoped(
                         select,

--- a/sqlite/conformance/sqlite-sqltests/alter-rename-column-trigger-exists.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter-rename-column-trigger-exists.sqltest
@@ -1,0 +1,39 @@
+@database :memory:
+
+# Regression test for https://github.com/tursodatabase/turso/issues/8654
+#
+# ALTER TABLE RENAME COLUMN is refused when the column is referenced from
+# a result-position EXISTS in a trigger body.
+
+@cross-check-integrity
+test rename-column-trigger-result-exists {
+    CREATE TABLE t1(a, b);
+    CREATE TABLE t2(x);
+    CREATE TABLE log(hit);
+    INSERT INTO t1(a, b) VALUES (5, 0);
+    CREATE TRIGGER trg AFTER INSERT ON t2 BEGIN
+        INSERT INTO log(hit) SELECT EXISTS(SELECT 1 FROM t1 WHERE t1.a = 5);
+    END;
+    ALTER TABLE t1 RENAME COLUMN a TO c;
+    SELECT sql FROM sqlite_schema WHERE name = 'trg';
+}
+expect {
+    CREATE TRIGGER trg AFTER INSERT ON t2 BEGIN INSERT INTO log (hit) SELECT EXISTS (SELECT 1 FROM t1 WHERE t1.c = 5); END
+}
+
+@cross-check-integrity
+test rename-column-trigger-result-exists-fires-correctly {
+    CREATE TABLE t1(a, b);
+    CREATE TABLE t2(x);
+    CREATE TABLE log(hit);
+    INSERT INTO t1(a, b) VALUES (5, 0);
+    CREATE TRIGGER trg AFTER INSERT ON t2 BEGIN
+        INSERT INTO log(hit) SELECT EXISTS(SELECT 1 FROM t1 WHERE t1.a = 5);
+    END;
+    ALTER TABLE t1 RENAME COLUMN a TO c;
+    INSERT INTO t2(x) VALUES (42);
+    SELECT * FROM log;
+}
+expect {
+    1
+}

--- a/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
@@ -2016,7 +2016,7 @@ expect {
     0
 }
 
-test alter-table-rename-column-temp-trigger-exists-result-expr-error {
+test alter-table-rename-column-temp-trigger-exists-result-expr {
     CREATE TEMP TABLE temp_exists_driver (n);
     CREATE TABLE src_temp_exists (c1, c2, b);
     CREATE TRIGGER trig_temp_exists AFTER INSERT ON temp.temp_exists_driver BEGIN
@@ -2030,9 +2030,10 @@ test alter-table-rename-column-temp-trigger-exists-result-expr-error {
         );
     END;
     ALTER TABLE src_temp_exists RENAME COLUMN b TO bb;
+    SELECT sql FROM sqlite_temp_schema WHERE name = 'trig_temp_exists';
 }
-expect error {
-    error in trigger trig_temp_exists after rename: no such column: b
+expect {
+    CREATE TRIGGER trig_temp_exists AFTER INSERT ON "temp".temp_exists_driver BEGIN SELECT 1 NOT IN (NOT EXISTS (SELECT * FROM src_temp_exists WHERE c1 ORDER BY bb ASC, CASE WHEN bb THEN 'x' WHEN bb THEN 1 END)); END
 }
 
 test alter-table-rename-column-temp-trigger-result-scalar-subquery {


### PR DESCRIPTION
### Summary
Resolves #8654

When `ALTER TABLE RENAME COLUMN` rewrites triggers referencing the renamed column, column references in `ast::Expr::Exists(select)` expressions were skipped because `apply_expr_for_column_rename` and `rename_result_identifiers_scoped` specifically returned `WalkControl::SkipChildren` for `Expr::Exists`.

As a consequence, the trigger SQL retained the old column name in `EXISTS` subqueries, causing subsequent schema re-validation / compilation to fail with `no such column: <table>.<column>`.

### Fix
- Unified `ast::Expr::Exists(select) | ast::Expr::Subquery(select)` in `apply_expr_for_column_rename` (`core/translate/alter.rs`) and `rename_result_identifiers_scoped` (`core/util.rs`) so that `Exists` subquery contents are traversed and renamed consistently during trigger rewrite.
- Updated snapshot regression test `alter-table-rename-column-temp-trigger-exists-result-expr` in `sqlite/conformance/sqlite-sqltests/alter_table.sqltest` to expect the successfully rewritten trigger schema.
- Added dedicated regression test in `sqlite/conformance/sqlite-sqltests/alter-rename-column-trigger-exists.sqltest` verifying that `ALTER TABLE ... RENAME COLUMN` rewrites the column in `EXISTS` trigger subqueries and that the trigger subsequently fires and executes correctly.

### Sovereign Payout Details
- Claim: /claim #8654
- Base L2 Payout Address: `0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
