### PR TITLE
fix(translate): avoid reading expression index for hash join build tables (#8573)

### DIFF
--- a/core/translate/expr/metadata.rs
+++ b/core/translate/expr/metadata.rs
@@ -270,6 +270,22 @@ pub(super) fn try_emit_expression_index_value(
     let Some((table_id, _)) = single_table_column_usage(expr) else {
         return Ok(false);
     };
+    if program.has_cursor_override(table_id) {
+        return Ok(false);
+    }
+    let is_hash_build_table = referenced_tables.joined_tables().iter().any(|t| {
+        if let Operation::HashJoin(ref hj) = t.op {
+            referenced_tables
+                .joined_tables()
+                .get(hj.build_table_idx)
+                .is_some_and(|bt| bt.internal_id == table_id)
+        } else {
+            false
+        }
+    });
+    if is_hash_build_table {
+        return Ok(false);
+    }
     let Some(table_reference) = referenced_tables.find_joined_table_by_internal_id(table_id) else {
         return Ok(false);
     };

--- a/sqlite/conformance/sqlite-sqltests/expression-index-join.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/expression-index-join.sqltest
@@ -1,0 +1,35 @@
+@database :memory:
+
+setup schema {
+    CREATE TABLE a(x, k);
+    INSERT INTO a VALUES(5, 1);
+    CREATE TABLE b(k);
+    INSERT INTO b VALUES(1);
+    CREATE INDEX ix ON a(abs(x));
+}
+
+@setup schema
+test expression-index-join {
+    SELECT a.x FROM a, b WHERE a.k = b.k AND abs(a.x) = 5;
+}
+expect {
+    5
+}
+
+@setup schema
+test expression-index-join-proj-expr {
+    SELECT abs(a.x), b.k FROM a, b WHERE a.k = b.k AND abs(a.x) = 5;
+}
+expect {
+    5|1
+}
+
+@setup schema
+test expression-index-join-multiple-rows {
+    INSERT INTO a VALUES(-10, 2);
+    INSERT INTO b VALUES(2);
+    SELECT a.x FROM a, b WHERE a.k = b.k AND abs(a.x) = 10;
+}
+expect {
+    -10
+}


### PR DESCRIPTION
Resolves #8573

### Root Cause
When an expression index (e.g. `CREATE INDEX ix ON a(abs(x))`) exists on a table that is selected as the build side of a hash join, `try_emit_expression_index_value` in `core/translate/expr/metadata.rs` attempted to resolve and read from the expression index cursor (`CursorKey::index(table_id, index)`).

However:
1. During the hash build loop (`PreparedHashBuild::emit`), the build table is scanned via a dedicated table scan cursor (`planner.hash_build_cursor_id`), while its index cursor is never opened or rewound. Yet `try_emit_expression_index_value` emitted a `Column` instruction on the unpositioned index cursor, evaluating to NULL and causing build-side WHERE filters (such as `abs(a.x) = 5`) to incorrectly discard every row.
2. During the subsequent probe phase and projection, the build table's columns reside in the hash probe payload registers rather than on any active index cursor.

### Fix
In `core/translate/expr/metadata.rs`:
- Skip expression index emission if the table currently has an active `cursor_override` (such as during hash build table scans).
- Skip expression index emission if the table is a hash join build table (`Operation::HashJoin(hj) if hj.build_table_idx == table_idx`), ensuring expressions are computed natively from the table/payload registers rather than reading unpositioned index cursors.
- Added comprehensive regression tests in `sqlite/conformance/sqlite-sqltests/expression-index-join.sqltest` validating filter evaluation, projection expressions, and multi-row joins.

/claim #8573
Base Sovereign Payout Wallet: `0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
