### PR TITLE
fix(cdc): place synthetic insert row image in after on rowid update (#8656)

### DIFF
--- a/core/translate/emitter/update.rs
+++ b/core/translate/emitter/update.rs
@@ -2512,8 +2512,8 @@ fn emit_update_insns<'a>(
                         OperationMode::INSERT,
                         cdc_cursor_id,
                         cdc_rowid_after_reg,
-                        cdc_after_reg,
                         None,
+                        cdc_after_reg,
                         None,
                         table_name,
                     )?;

--- a/tests/integration/functions/test_cdc.rs
+++ b/tests/integration/functions/test_cdc.rs
@@ -1958,3 +1958,88 @@ fn test_journal_mode_mvcc_switch_allowed_without_cdc(db: TempDatabase) {
     let rows = limbo_exec_rows(&conn, "SELECT COUNT(*) FROM t");
     assert_eq!(rows, vec![vec![Value::Integer(1)]]);
 }
+
+/// Issue #8656: A rowid-changing UPDATE's synthetic INSERT record carries the row image in `after` (not `before`).
+#[turso_macros::test]
+fn test_cdc_rowid_update_carries_image_in_after_not_before(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE t (k INTEGER PRIMARY KEY, v)").unwrap();
+    conn.execute("PRAGMA capture_data_changes_conn('full')").unwrap();
+
+    conn.execute("INSERT INTO t VALUES (1, 'x')").unwrap();
+    conn.execute("UPDATE t SET k = 44 WHERE k = 1").unwrap();
+
+    let rows = normalize_cdc_v2_rows(limbo_exec_rows(&conn, "SELECT * FROM turso_cdc"));
+    assert_eq!(
+        rows,
+        vec![
+            // INSERT INTO t VALUES (1, 'x')
+            v2_row(
+                1,
+                "t",
+                1,
+                None,
+                Some(record([Value::Integer(1), Value::Text("x".to_string())])),
+                None,
+            ),
+            v2_commit(),
+            // UPDATE t SET k = 44 WHERE k = 1: rowid move decomposes into DELETE(1) + INSERT(44)
+            v2_row(
+                -1,
+                "t",
+                1,
+                Some(record([Value::Integer(1), Value::Text("x".to_string())])),
+                None,
+                None,
+            ),
+            v2_row(
+                1,
+                "t",
+                44,
+                None,
+                Some(record([Value::Integer(44), Value::Text("x".to_string())])),
+                None,
+            ),
+            v2_commit(),
+        ]
+    );
+}
+
+/// Also verify rowid-changing UPDATE in 'after' capture mode.
+#[turso_macros::test]
+fn test_cdc_rowid_update_after_mode(db: TempDatabase) {
+    let conn = db.connect_limbo();
+    conn.execute("CREATE TABLE t (k INTEGER PRIMARY KEY, v)").unwrap();
+    conn.execute("PRAGMA capture_data_changes_conn('after')").unwrap();
+
+    conn.execute("INSERT INTO t VALUES (1, 'x')").unwrap();
+    conn.execute("UPDATE t SET k = 44 WHERE k = 1").unwrap();
+
+    let rows = normalize_cdc_v2_rows(limbo_exec_rows(&conn, "SELECT * FROM turso_cdc"));
+    assert_eq!(
+        rows,
+        vec![
+            // INSERT INTO t VALUES (1, 'x')
+            v2_row(
+                1,
+                "t",
+                1,
+                None,
+                Some(record([Value::Integer(1), Value::Text("x".to_string())])),
+                None,
+            ),
+            v2_commit(),
+            // UPDATE t SET k = 44 WHERE k = 1: DELETE has no image in 'after' mode, INSERT has after image
+            v2_row(-1, "t", 1, None, None, None),
+            v2_row(
+                1,
+                "t",
+                44,
+                None,
+                Some(record([Value::Integer(44), Value::Text("x".to_string())])),
+                None,
+            ),
+            v2_commit(),
+        ]
+    );
+}


### PR DESCRIPTION
### Summary of Changes

/claim #8656
Resolves #8656

This PR resolves the issue where a rowid-changing `UPDATE` under Change Data Capture (CDC) emits an inverted synthetic `INSERT` record carrying the new row image in `before` and `NULL` in `after`:

1. **Fix Parameter Transposition in Emitter (`core/translate/emitter/update.rs`)**:
   - In `emit_update_insns`, on the `updates_rowid` branch where `OperationMode::INSERT` is emitted to write to the CDC table, `cdc_after_reg` was erroneously passed to the 6th parameter (`before_record_reg`), and `None` to the 7th parameter (`after_record_reg`).
   - Reordered arguments to pass `None` to `before_record_reg` and `cdc_after_reg` to `after_record_reg`, matching the canonical `INSERT` record format where `after` holds the post-image and `before` is absent.

2. **Integration Tests (`tests/integration/functions/test_cdc.rs`)**:
   - Added `test_cdc_rowid_update_carries_image_in_after_not_before` verifying that in `full` mode, `UPDATE t SET k = 44 WHERE k = 1` yields a synthetic `DELETE(1)` with `before = [1, 'x'], after = NULL` and a synthetic `INSERT(44)` with `before = NULL, after = [44, 'x']`.
   - Added `test_cdc_rowid_update_after_mode` verifying that post-images are properly recorded in `after` capture mode.

---

### Verification
- Ran native test suite:
  ```bash
  cargo test --test integration_tests test_cdc_rowid_update
  ```
  Result: 2 passed, 0 failed, 0 ignored.

### Sovereign Escrow Payout
- Sovereign Settlement Destination (Base L2): `0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
