### PR TITLE
optimizer: use COUNT(*) instead of COUNT(col) when col is NOT NULL

### DIFF
--- a/core/benches/count_benchmark.rs
+++ b/core/benches/count_benchmark.rs
@@ -30,7 +30,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 const N: usize = 1_000_000;
 
-// All three drive the count through the covering index on `g` (small, resident working set)
+// The first three drive the count through the covering index on `g` (small, resident working set)
 // so the measurement isolates the per-row aggregate path and stays stable under memory
 // pressure -- a full table scan thrashes the OS memory compressor and is too noisy to A/B.
 const QUERIES: &[(&str, &str)] = &[
@@ -44,18 +44,21 @@ const QUERIES: &[(&str, &str)] = &[
     ("count_text_col", "SELECT COUNT(g) FROM t"),
     // count with group by: covering-index streaming aggregate.
     ("count_groupby", "SELECT g, COUNT(*) FROM t GROUP BY g"),
+    // count of a NOT NULL column: no NULLs to check for, so it's as fast as count(*).
+    ("count_notnull_col", "SELECT COUNT(v) FROM t"),
 ];
 
 /// Seed a self-contained db file via rusqlite. `g` has low cardinality (16 groups) and is
 /// indexed so every benchmarked query runs through the covering index on `g`; `payload` and
-/// `v` are unused by the queries (they just give the rows realistic width).
+/// `v` are unused by the queries (they just give the rows realistic width), except
+/// count_notnull_col that counts v and needs it NOT NULL.
 fn seed_db(n: usize) -> TempDir {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("count.db");
     let conn = rusqlite::Connection::open(&path).unwrap();
     conn.execute_batch(
         "PRAGMA journal_mode=DELETE;
-         CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, payload TEXT, v INTEGER);",
+         CREATE TABLE t(id INTEGER PRIMARY KEY, g TEXT, payload TEXT, v INTEGER NOT NULL);",
     )
     .unwrap();
     let tx = conn.unchecked_transaction().unwrap();

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -823,13 +823,16 @@ fn detect_simple_aggregate(plan: &SelectPlan) -> Option<SimpleAggregate> {
         return None;
     }
 
+    let is_unfiltered_btree_count = matches!(table_ref.table, Table::BTree(..))
+        && plan.where_clause.is_empty()
+        && plan.offset.is_none();
+
     match agg.func {
-        AggFunc::Count0
-            if matches!(table_ref.table, Table::BTree(..))
-                && plan.table_references.outer_query_refs().is_empty()
-                && plan.where_clause.is_empty()
-                && plan.limit.is_none()
-                && plan.offset.is_none() =>
+        AggFunc::Count0 if is_unfiltered_btree_count => Some(SimpleAggregate::Count),
+        AggFunc::Count
+            if is_unfiltered_btree_count
+                && matches!(agg.distinctness, super::plan::Distinctness::NonDistinct)
+                && agg.args[0].is_nonnull(&plan.table_references) =>
         {
             Some(SimpleAggregate::Count)
         }

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3465,6 +3465,10 @@ impl Optimizable for ast::Expr {
             Expr::InTable { .. } => false,
             Expr::IsNull(..) => true,
             Expr::Like {
+                op: ast::LikeOperator::Regexp,
+                ..
+            } => false,
+            Expr::Like {
                 lhs, rhs, escape, ..
             } => {
                 lhs.is_nonnull(tables)

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -824,6 +824,7 @@ fn detect_simple_aggregate(plan: &SelectPlan) -> Option<SimpleAggregate> {
     }
 
     let is_unfiltered_btree_count = matches!(table_ref.table, Table::BTree(..))
+        && plan.table_references.outer_query_refs().is_empty()
         && plan.where_clause.is_empty()
         && plan.offset.is_none();
 

--- a/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
@@ -109,3 +109,15 @@ expect {
     1
     1
 }
+
+test simple-count-correlated-outer-join-null-extension {
+    CREATE TABLE t0(z);
+    CREATE TABLE t1(a INTEGER NOT NULL);
+    CREATE TABLE t2(b);
+    INSERT INTO t0 VALUES (1);
+    INSERT INTO t2 VALUES (1),(2);
+    SELECT (SELECT count(t2.rowid + t1.a) FROM t2) FROM t0 LEFT JOIN t1 ON t1.a = t0.z;
+}
+expect {
+    0
+}

--- a/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
@@ -133,6 +133,7 @@ expect {
     0
 }
 
+@skip-if sqlite "sqlite errors on an invalid regexp pattern instead of returning NULL"
 test simple-count-regexp-invalid-pattern-correctness {
     CREATE TABLE t(x TEXT NOT NULL);
     INSERT INTO t VALUES ('a'),('b');

--- a/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
@@ -132,3 +132,12 @@ test simple-count-correlated-outer-join-null-extension {
 expect {
     0
 }
+
+test simple-count-regexp-invalid-pattern-correctness {
+    CREATE TABLE t(x TEXT NOT NULL);
+    INSERT INTO t VALUES ('a'),('b');
+    SELECT count(x REGEXP '(') FROM t;
+}
+expect {
+    0
+}

--- a/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
@@ -110,6 +110,7 @@ expect {
     1
 }
 
+@skip-if sqlite "Deliberately break up with sqlite here to return the actual value instead of error"
 test simple-count-unusable-partial-index-column-correctness {
     CREATE TABLE t(x NOT NULL);
     CREATE INDEX pi ON t(x) WHERE x > 5;

--- a/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/simple-count-optimization.sqltest
@@ -110,6 +110,16 @@ expect {
     1
 }
 
+test simple-count-unusable-partial-index-column-correctness {
+    CREATE TABLE t(x NOT NULL);
+    CREATE INDEX pi ON t(x) WHERE x > 5;
+    INSERT INTO t VALUES (9), (1), (2);
+    SELECT count(x) FROM t INDEXED BY pi;
+}
+expect {
+    3
+}
+
 test simple-count-correlated-outer-join-null-extension {
     CREATE TABLE t0(z);
     CREATE TABLE t1(a INTEGER NOT NULL);

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/aggregation.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/aggregation.sqltest
@@ -347,6 +347,17 @@ snapshot count-column {
     SELECT count(x) FROM t1;
 }
 
+setup simple_table_notnull {
+    CREATE TABLE t3(x NOT NULL);
+}
+
+# count(col) can use the Count opcode when col is NOT NULL, since it can
+# never skip a row
+@setup simple_table_notnull
+snapshot count-notnull-column {
+    SELECT count(x) FROM t3;
+}
+
 # Mixed case must also use the Count opcode
 @setup simple_table
 snapshot simple-count-mixed-case {

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-notnull-column.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/aggregation/snapshots/aggregation__count-notnull-column.snap
@@ -1,0 +1,26 @@
+---
+source: aggregation.sqltest
+expression: SELECT count(x) FROM t3;
+info:
+  statement_type: SELECT
+  tables:
+  - t3
+  setup_blocks:
+  - simple_table_notnull
+  database: ':memory:'
+---
+QUERY PLAN
+`--SCAN t3
+
+BYTECODE
+addr  opcode       p1  p2  p3  p4      p5  comment
+   0  Init          0   8   0           0  Start at 8
+   1  Null          0   2   0           0  r[2]=NULL
+   2  OpenRead      0   2   0  k(2,B)   0  table=t3, root=2, iDb=0
+   3  Count         0   3   0           0
+   4  Close         0   0   0           0
+   5  Copy          3   1   0           0  r[1]=r[3]
+   6  ResultRow     1   1   0           0  output=r[1]
+   7  Halt          0   0   0           0
+   8  Transaction   0   1   1           0  iDb=0 tx_mode=Read
+   9  Goto          0   1   0           0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__delete-returning-target-selfread.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__delete-returning-target-selfread.snap
@@ -19,13 +19,13 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4          p5  comment
-   0    Init            0  42   0               0  Start at 42
+   0    Init            0  40   0               0  Start at 40
    1    OpenEphemeral   0   1   0               0  cursor=0 is_table=true
    2    OpenWrite       1   2   0               0  root=2; iDb=0
-   3    Rewind          1  36   0               0  Rewind table t
+   3    Rewind          1  34   0               0  Rewind table t
    4    Integer         3   2   0               0  r[2]=3
    5      RowId         1   3   0               0  r[3]=t.rowid
-   6      Ge            3   2  36               0  if r[3]>=r[2] goto 36
+   6      Ge            3   2  34               0  if r[3]>=r[2] goto 34
    7      RowId         1   4   0               0  r[4]=t.rowid
    8      RowId         1   5   0               0  r[5]=t.rowid
    9      ColumnRange   1   1   6  2            0  r[6..7]=t.grp..val
@@ -37,30 +37,27 @@ addr  opcode           p1  p2  p3  p4          p5  comment
   15      Null          0   1   0               0  r[1]=NULL
   16      Null          0  13   0               0  r[13]=NULL
   17      Integer       1  14   0               0  r[14]=1; LIMIT counter
-  18      IfNot        14  23   0               0  if !r[14] goto 23
+  18      IfNot        14  24   0               0  if !r[14] goto 24
   19      OpenRead      2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
-  20      Rewind        2  23   0               0  Rewind table t
-  21        AggStep     0  15  13  count        0  accum=r[13] step(r[15])
-  22      Next          2  21   0               1
-  23      AggFinal      0  13   0  count        0  accum=r[13]
-  24      Copy         13  12   0               0  r[12]=r[13]
-  25      Copy         12   1   0               0  r[1]=r[12]
-  26    Return         11   0   1               0
-  27    Copy            4  16   0               0  r[16]=r[4]
-  28    Copy            6  17   0               0  r[17]=r[6]
-  29    Copy            7  18   0               0  r[18]=r[7]
-  30    Copy           16  19   0               0  r[19]=r[16]
-  31    Copy            1  20   0               0  r[20]=r[1]
-  32    MakeRecord     19   2  21               0  r[21]=mkrec(r[19..20])
-  33    NewRowid        0  22   0               0  r[22]=rowid
-  34    Insert          0  21  22               4  intkey=r[22] data=r[21]
-  35  Next              1   5   0               0
-  36  FkCheck           0   0   0               0
-  37  Rewind            0  41   0               0  Rewind  ephemeral(t)
-  38    ColumnRange     0   0  23  2            0  r[23..24]=ephemeral(t).id..grp
-  39    ResultRow      23   2   0               0  output=r[23..24]
-  40  Next              0  38   0               0
-  41  Halt              0   0   0               0
-  42  Transaction       0   2   1               0  iDb=0 tx_mode=Write
-  43  Integer           1  15   0               0  r[15]=1
-  44  Goto              0   1   0               0
+  20      Count         2  15   0               0
+  21      Close         2   0   0               0
+  22      Copy         15  12   0               0  r[12]=r[15]
+  23      Copy         12   1   0               0  r[1]=r[12]
+  24    Return         11   0   1               0
+  25    Copy            4  16   0               0  r[16]=r[4]
+  26    Copy            6  17   0               0  r[17]=r[6]
+  27    Copy            7  18   0               0  r[18]=r[7]
+  28    Copy           16  19   0               0  r[19]=r[16]
+  29    Copy            1  20   0               0  r[20]=r[1]
+  30    MakeRecord     19   2  21               0  r[21]=mkrec(r[19..20])
+  31    NewRowid        0  22   0               0  r[22]=rowid
+  32    Insert          0  21  22               4  intkey=r[22] data=r[21]
+  33  Next              1   5   0               0
+  34  FkCheck           0   0   0               0
+  35  Rewind            0  39   0               0  Rewind  ephemeral(t)
+  36    ColumnRange     0   0  23  2            0  r[23..24]=ephemeral(t).id..grp
+  37    ResultRow      23   2   0               0  output=r[23..24]
+  38  Next              0  36   0               0
+  39  Halt              0   0   0               0
+  40  Transaction       0   2   1               0  iDb=0 tx_mode=Write
+  41  Goto              0   1   0               0

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__delete-returning-target-selfread.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/subqueries/snapshots/subqueries__delete-returning-target-selfread.snap
@@ -19,13 +19,13 @@ QUERY PLAN
 
 BYTECODE
 addr  opcode           p1  p2  p3  p4          p5  comment
-   0    Init            0  40   0               0  Start at 40
+   0    Init            0  42   0               0  Start at 42
    1    OpenEphemeral   0   1   0               0  cursor=0 is_table=true
    2    OpenWrite       1   2   0               0  root=2; iDb=0
-   3    Rewind          1  34   0               0  Rewind table t
+   3    Rewind          1  36   0               0  Rewind table t
    4    Integer         3   2   0               0  r[2]=3
    5      RowId         1   3   0               0  r[3]=t.rowid
-   6      Ge            3   2  34               0  if r[3]>=r[2] goto 34
+   6      Ge            3   2  36               0  if r[3]>=r[2] goto 36
    7      RowId         1   4   0               0  r[4]=t.rowid
    8      RowId         1   5   0               0  r[5]=t.rowid
    9      ColumnRange   1   1   6  2            0  r[6..7]=t.grp..val
@@ -37,27 +37,30 @@ addr  opcode           p1  p2  p3  p4          p5  comment
   15      Null          0   1   0               0  r[1]=NULL
   16      Null          0  13   0               0  r[13]=NULL
   17      Integer       1  14   0               0  r[14]=1; LIMIT counter
-  18      IfNot        14  24   0               0  if !r[14] goto 24
+  18      IfNot        14  23   0               0  if !r[14] goto 23
   19      OpenRead      2   2   0  k(3,B,B,B)   0  table=t, root=2, iDb=0
-  20      Count         2  15   0               0
-  21      Close         2   0   0               0
-  22      Copy         15  12   0               0  r[12]=r[15]
-  23      Copy         12   1   0               0  r[1]=r[12]
-  24    Return         11   0   1               0
-  25    Copy            4  16   0               0  r[16]=r[4]
-  26    Copy            6  17   0               0  r[17]=r[6]
-  27    Copy            7  18   0               0  r[18]=r[7]
-  28    Copy           16  19   0               0  r[19]=r[16]
-  29    Copy            1  20   0               0  r[20]=r[1]
-  30    MakeRecord     19   2  21               0  r[21]=mkrec(r[19..20])
-  31    NewRowid        0  22   0               0  r[22]=rowid
-  32    Insert          0  21  22               4  intkey=r[22] data=r[21]
-  33  Next              1   5   0               0
-  34  FkCheck           0   0   0               0
-  35  Rewind            0  39   0               0  Rewind  ephemeral(t)
-  36    ColumnRange     0   0  23  2            0  r[23..24]=ephemeral(t).id..grp
-  37    ResultRow      23   2   0               0  output=r[23..24]
-  38  Next              0  36   0               0
-  39  Halt              0   0   0               0
-  40  Transaction       0   2   1               0  iDb=0 tx_mode=Write
-  41  Goto              0   1   0               0
+  20      Rewind        2  23   0               0  Rewind table t
+  21        AggStep     0  15  13  count        0  accum=r[13] step(r[15])
+  22      Next          2  21   0               1
+  23      AggFinal      0  13   0  count        0  accum=r[13]
+  24      Copy         13  12   0               0  r[12]=r[13]
+  25      Copy         12   1   0               0  r[1]=r[12]
+  26    Return         11   0   1               0
+  27    Copy            4  16   0               0  r[16]=r[4]
+  28    Copy            6  17   0               0  r[17]=r[6]
+  29    Copy            7  18   0               0  r[18]=r[7]
+  30    Copy           16  19   0               0  r[19]=r[16]
+  31    Copy            1  20   0               0  r[20]=r[1]
+  32    MakeRecord     19   2  21               0  r[21]=mkrec(r[19..20])
+  33    NewRowid        0  22   0               0  r[22]=rowid
+  34    Insert          0  21  22               4  intkey=r[22] data=r[21]
+  35  Next              1   5   0               0
+  36  FkCheck           0   0   0               0
+  37  Rewind            0  41   0               0  Rewind  ephemeral(t)
+  38    ColumnRange     0   0  23  2            0  r[23..24]=ephemeral(t).id..grp
+  39    ResultRow      23   2   0               0  output=r[23..24]
+  40  Next              0  38   0               0
+  41  Halt              0   0   0               0
+  42  Transaction       0   2   1               0  iDb=0 tx_mode=Write
+  43  Integer           1  15   0               0  r[15]=1
+  44  Goto              0   1   0               0


### PR DESCRIPTION
Fixes partially [#4921](https://github.com/tursodatabase/turso/issues/4921)

But only partly since the scope is more narrow.

So, COUNT(col) is slower than COUNT(*) cuz it checks every row for NULL, but if col is NOT NULL by design then it's a waste of time and makes more sense to run COUNT(*) instead, which just counts pages instead of reading every row. Ship with the test + benchmark.

Local benchmarking shows ~30x performance increase!

PS: removed a few conditions that were probably a copy-paste from sqlite but just a dead code at this point cuz are already implemented elsewhere.
