### PR TITLE
fix(optimizer): is_nonnull must return false for JSON arrow operators and LIKE with nullable ESCAPE

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3389,6 +3389,7 @@ impl Optimizable for ast::Expr {
                 lhs, start, end, ..
             } => lhs.is_nonnull(tables) && start.is_nonnull(tables) && end.is_nonnull(tables),
             Expr::Binary(_, ast::Operator::Modulus | ast::Operator::Divide, _) => false, // 1 % 0, 1 / 0
+            Expr::Binary(_, ast::Operator::ArrowRight | ast::Operator::ArrowRightShift, _) => false, // JSON path may be absent, yielding NULL
             Expr::Binary(expr, _, expr1) => expr.is_nonnull(tables) && expr1.is_nonnull(tables),
             Expr::Case {
                 when_then_pairs,
@@ -3443,7 +3444,11 @@ impl Optimizable for ast::Expr {
             Expr::InSelect { .. } => false,
             Expr::InTable { .. } => false,
             Expr::IsNull(..) => true,
-            Expr::Like { lhs, rhs, .. } => lhs.is_nonnull(tables) && rhs.is_nonnull(tables),
+            Expr::Like { lhs, rhs, escape, .. } => {
+                lhs.is_nonnull(tables)
+                    && rhs.is_nonnull(tables)
+                    && escape.as_ref().is_none_or(|escape| escape.is_nonnull(tables))
+            }
             Expr::Literal(literal) => match literal {
                 ast::Literal::Numeric(_) => true,
                 ast::Literal::String(_) => true,

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3444,10 +3444,14 @@ impl Optimizable for ast::Expr {
             Expr::InSelect { .. } => false,
             Expr::InTable { .. } => false,
             Expr::IsNull(..) => true,
-            Expr::Like { lhs, rhs, escape, .. } => {
+            Expr::Like {
+                lhs, rhs, escape, ..
+            } => {
                 lhs.is_nonnull(tables)
                     && rhs.is_nonnull(tables)
-                    && escape.as_ref().is_none_or(|escape| escape.is_nonnull(tables))
+                    && escape
+                        .as_ref()
+                        .is_none_or(|escape| escape.is_nonnull(tables))
             }
             Expr::Literal(literal) => match literal {
                 ast::Literal::Numeric(_) => true,

--- a/sqlite/conformance/sqlite-sqltests/index-seek-null-key.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/index-seek-null-key.sqltest
@@ -1,0 +1,56 @@
+@database :temp:
+
+# Regression tests for NULL-key index seek (issue #8690).
+# Expr::is_nonnull() must return false for JSON arrow operators (-> / ->>)
+# and for LIKE with a nullable ESCAPE clause, because these expressions can
+# evaluate to NULL even when their operands are non-NULL. If the optimizer
+# believes the seek key is non-NULL, the IsNull guard is skipped and the
+# seek starts at a NULL key, reading the full index: SELECT returns extra
+# rows and DELETE erases all rows.
+
+setup schema {
+    CREATE TABLE t3(c);
+    CREATE INDEX i3 ON t3(c);
+    INSERT INTO t3 VALUES (1),(2),(3);
+}
+
+@setup schema
+test json-arrow-shift-missing-path-select {
+    SELECT count(*) FROM t3 WHERE c > ('{"k":1}' ->> '$.missing');
+}
+expect {
+    0
+}
+
+@setup schema
+test json-arrow-shift-missing-path-delete {
+    DELETE FROM t3 WHERE c > ('{"k":1}' ->> '$.missing');
+    SELECT count(*) FROM t3;
+}
+expect {
+    3
+}
+
+@setup schema
+test json-arrow-missing-path-select {
+    SELECT count(*) FROM t3 WHERE c > ('{"k":1}' -> '$.missing');
+}
+expect {
+    0
+}
+
+@setup schema
+test like-escape-null-select {
+    SELECT count(*) FROM t3 WHERE c > ('a' LIKE 'a' ESCAPE NULL);
+}
+expect {
+    0
+}
+
+@setup schema
+test json-arrow-existing-path-still-uses-index {
+    SELECT count(*) FROM t3 WHERE c > ('{"k":2}' ->> '$.k');
+}
+expect {
+    1
+}


### PR DESCRIPTION
Fixes #8690

## Problem

`Expr::is_nonnull()` (`core/translate/optimizer/mod.rs`) returned `true` for:

1. **`->` / `->>`** binary operators — the generic `Expr::Binary` arm treated them like any binary op whose NULL-ness depends only on operand NULL-ness. But JSON path extraction yields NULL when the path is absent: `'{"k":1}' ->> '$.missing'` is NULL despite both operands being non-NULL.
2. **`LIKE ... ESCAPE <nullable>`** — the `Like` arm checked `lhs` and `rhs` but ignored the `escape` clause. `'a' LIKE 'a' ESCAPE NULL` evaluates to NULL.

Because `is_nonnull()` gates emission of the `IsNull` guard in `core/translate/main_loop/seek.rs` (:185 and :358), an index seek was started with a NULL key and read the full index.

## Impact

- `SELECT count(*) FROM t3 WHERE c > ('{"k":1}' ->> '$.missing')` returned **3** instead of 0 (with index on `c`)
- The same predicate in a `DELETE` **erased all rows** — data loss
- `c > ('a' LIKE 'a' ESCAPE NULL)` returned 3 instead of 0

All reproductions from the issue, verified against `sqlite3` semantics.

## Fix

- `Expr::Binary` with `ArrowRight | ArrowRightShift` now returns `false` (same treatment as `Modulus | Divide`, for the same reason: the operator itself can introduce NULL)
- `Expr::Like` now also requires the `escape` expression to be non-NULL when present

## Verification

Built `turso_cli` on Windows and ran all three repro cases from the issue plus sanity queries (plain index seeks, `->` with an existing path, `IS NULL`, equality):

```
SELECT count(*) FROM t3 WHERE c > ('{"k":1}' ->> '$.missing');
-- before: 3   after: 0   (sqlite3: 0)

DELETE FROM t3 WHERE c > ('{"k":1}' ->> '$.missing');
SELECT count(*) FROM t3;
-- before: 0   after: 3   (sqlite3: 3 rows stay)

SELECT count(*) FROM t3 WHERE c > ('a' LIKE 'a' ESCAPE NULL);
-- before: 3   after: 0   (sqlite3: 0)
```

No regressions observed in manual sanity runs. CI should confirm the full conformance suite.