### PR TITLE
fix(optimizer): mark arrow operators and like with null escape as nullable (#8690)

### DIFF
--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -3388,7 +3388,14 @@ impl Optimizable for ast::Expr {
             Expr::Between {
                 lhs, start, end, ..
             } => lhs.is_nonnull(tables) && start.is_nonnull(tables) && end.is_nonnull(tables),
-            Expr::Binary(_, ast::Operator::Modulus | ast::Operator::Divide, _) => false, // 1 % 0, 1 / 0
+            Expr::Binary(
+                _,
+                ast::Operator::Modulus
+                | ast::Operator::Divide
+                | ast::Operator::ArrowRight
+                | ast::Operator::ArrowRightShift,
+                _,
+            ) => false, // 1 % 0, 1 / 0, '{"k":1}' -> '$.missing' -> NULL
             Expr::Binary(expr, _, expr1) => expr.is_nonnull(tables) && expr1.is_nonnull(tables),
             Expr::Case {
                 when_then_pairs,
@@ -3443,7 +3450,18 @@ impl Optimizable for ast::Expr {
             Expr::InSelect { .. } => false,
             Expr::InTable { .. } => false,
             Expr::IsNull(..) => true,
-            Expr::Like { lhs, rhs, .. } => lhs.is_nonnull(tables) && rhs.is_nonnull(tables),
+            Expr::Like {
+                lhs,
+                rhs,
+                escape,
+                ..
+            } => {
+                lhs.is_nonnull(tables)
+                    && rhs.is_nonnull(tables)
+                    && escape
+                        .as_ref()
+                        .is_none_or(|escape| escape.is_nonnull(tables))
+            }
             Expr::Literal(literal) => match literal {
                 ast::Literal::Numeric(_) => true,
                 ast::Literal::String(_) => true,

--- a/tests/integration/query_processing/test_is_seek.rs
+++ b/tests/integration/query_processing/test_is_seek.rs
@@ -393,3 +393,30 @@ fn is_operator_seek_matches_null_in_65th_key_column() {
         vec![vec![Value::Integer(1)]]
     );
 }
+
+#[test]
+fn test_index_seek_null_key_operators() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE t3(c)");
+    limbo_exec_rows(&conn, "CREATE INDEX i3 ON t3(c)");
+    limbo_exec_rows(&conn, "INSERT INTO t3 VALUES (1),(2),(3)");
+
+    // JSON arrow shift extract returning NULL
+    let res = limbo_exec_rows(&conn, "SELECT count(*) FROM t3 WHERE c > ('{\"k\":1}' ->> '$.missing')");
+    assert_eq!(res, vec![vec![Value::Integer(0)]]);
+
+    // JSON arrow extract returning NULL
+    let res = limbo_exec_rows(&conn, "SELECT count(*) FROM t3 WHERE c > ('{\"k\":1}' -> '$.missing')");
+    assert_eq!(res, vec![vec![Value::Integer(0)]]);
+
+    // LIKE ESCAPE NULL
+    let res = limbo_exec_rows(&conn, "SELECT count(*) FROM t3 WHERE c > ('a' LIKE 'a' ESCAPE NULL)");
+    assert_eq!(res, vec![vec![Value::Integer(0)]]);
+
+    // DELETE with NULL key does not delete any rows
+    limbo_exec_rows(&conn, "DELETE FROM t3 WHERE c > ('{\"k\":1}' ->> '$.missing')");
+    let res = limbo_exec_rows(&conn, "SELECT count(*) FROM t3");
+    assert_eq!(res, vec![vec![Value::Integer(3)]]);
+}


### PR DESCRIPTION
### Summary of Changes

/claim #8690
Resolves #8690

#### Problem
`Expr::is_nonnull()` in `core/translate/optimizer/mod.rs` previously returned `true` for:
1. `->` (`Operator::ArrowRight`) and `->>` (`Operator::ArrowRightShift`) binary operators when both arguments were non-null, even though JSON field extraction yields `NULL` when the specified key/path does not exist in the JSON document.
2. `LIKE ... ESCAPE <expr>` without inspecting the `escape` expression, even when `escape` evaluates to `NULL` (which causes `LIKE` to return `NULL`).

In `core/translate/main_loop/seek.rs:185` and `:358`, an index seek skips emitting the `Insn::IsNull` guard if `expr.is_nonnull()` returns `true`. When one of these operators returned `NULL` at runtime, the seek proceeded without checking for `NULL`, starting at a `NULL` key and scanning the entire index, causing `SELECT` to return extra rows and `DELETE` to erase all rows.

#### Solution
1. In `core/translate/optimizer/mod.rs` (`impl Optimizable for ast::Expr::is_nonnull`):
   - Added `ast::Operator::ArrowRight` and `ast::Operator::ArrowRightShift` to the binary operator branch that returns `false`.
   - Updated `Expr::Like` pattern match to inspect `escape` nullability:
     ```rust
     Expr::Like { lhs, rhs, escape, .. } => {
         lhs.is_nonnull(tables)
             && rhs.is_nonnull(tables)
             && escape
                 .as_ref()
                 .is_none_or(|escape| escape.is_nonnull(tables))
     }
     ```
2. In `tests/integration/query_processing/test_is_seek.rs`:
   - Added regression test `test_index_seek_null_key_operators` verifying that:
     - `SELECT count(*) FROM t3 WHERE c > ('{"k":1}' ->> '$.missing')` returns `0` (not `3`).
     - `SELECT count(*) FROM t3 WHERE c > ('{"k":1}' -> '$.missing')` returns `0` (not `3`).
     - `SELECT count(*) FROM t3 WHERE c > ('a' LIKE 'a' ESCAPE NULL)` returns `0` (not `3`).
     - `DELETE FROM t3 WHERE c > ('{"k":1}' ->> '$.missing')` preserves all rows (deletes `0` rows).

#### Verification
- Native integration tests: `cargo test --test integration_tests query_processing::test_is_seek` (11 passed, 0 failed).
- Core unit test suite: `cargo test -p turso_core` (2,374 passed, 0 failed, 53 doc-tests passed).

#### Sovereign Escrow Settlement
- Base L2 Payout Address: `0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
