### PR TITLE
fix(optimizer): do not treat individual composite primary key column as unique (#8664)

### DIFF
--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -381,8 +381,12 @@ fn estimate_selectivity(
 
     match op {
         ConstraintOperator::AstNativeOperator(ast::Operator::Equals) => {
-            let is_pk_or_rowid_alias =
-                is_rowid || column.is_some_and(|c| c.is_rowid_alias() || c.primary_key());
+            let is_composite_pk = schema
+                .get_btree_table(table_name)
+                .is_some_and(|t| t.primary_key_columns.len() > 1);
+            let is_pk_or_rowid_alias = is_rowid
+                || column
+                    .is_some_and(|c| c.is_rowid_alias() || (c.primary_key() && !is_composite_pk));
 
             let selectivity_when_unique = if row_count > 0 {
                 1.0 / row_count as f64

--- a/tests/integration/query_processing/mod.rs
+++ b/tests/integration/query_processing/mod.rs
@@ -21,3 +21,4 @@ mod test_schema_updated;
 mod test_subquery_unnesting;
 mod test_transactions;
 mod test_type_affinity;
+mod test_composite_pk_plan;

--- a/tests/integration/query_processing/test_composite_pk_plan.rs
+++ b/tests/integration/query_processing/test_composite_pk_plan.rs
@@ -1,0 +1,46 @@
+use crate::common::{limbo_exec_rows, TempDatabase};
+use rusqlite::types::Value;
+
+fn query_plan(conn: &std::sync::Arc<turso_core::Connection>, query: &str) -> String {
+    limbo_exec_rows(conn, &format!("EXPLAIN QUERY PLAN {query}"))
+        .iter()
+        .filter_map(|row| match row.get(3) {
+            Some(Value::Text(plan)) => Some(plan.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn test_composite_pk_plan_preferred_over_secondary_index() {
+    let tmp_db = TempDatabase::new_empty();
+    let conn = tmp_db.connect_limbo();
+
+    limbo_exec_rows(&conn, "CREATE TABLE t (a, b, c, PRIMARY KEY (a, b))");
+    limbo_exec_rows(&conn, "CREATE INDEX t_a_c ON t (a, c)");
+    limbo_exec_rows(&conn, "CREATE TABLE u (a, b)");
+    limbo_exec_rows(&conn, "CREATE INDEX u_a ON u (a)");
+
+    // Shape 1: join
+    let plan1 = query_plan(
+        &conn,
+        "SELECT count(*) FROM u JOIN t ON t.a = u.a AND t.b = u.b WHERE u.a = 'x' AND t.c = 'y'",
+    );
+    assert!(
+        plan1.contains("SEARCH t USING INDEX sqlite_autoindex_t_1 (a=? AND b=?)")
+            || plan1.contains("SEARCH t USING COVERING INDEX sqlite_autoindex_t_1 (a=? AND b=?)"),
+        "expected PK autoindex seek for t in join, got:\n{plan1}"
+    );
+
+    // Shape 2: correlated subquery
+    let plan2 = query_plan(
+        &conn,
+        "SELECT count(*) FROM u WHERE u.a = 'x' AND (SELECT count(*) FROM t WHERE t.a = u.a AND t.b = u.b AND t.c = 'y') > 0",
+    );
+    assert!(
+        plan2.contains("SEARCH t USING INDEX sqlite_autoindex_t_1 (a=? AND b=?)")
+            || plan2.contains("SEARCH t USING COVERING INDEX sqlite_autoindex_t_1 (a=? AND b=?)"),
+        "expected PK autoindex seek for t in correlated subquery, got:\n{plan2}"
+    );
+}


### PR DESCRIPTION
### Summary of Changes

/claim #8664
Resolves #8664

#### Problem
In `core/translate/optimizer/constraints.rs:384`, `estimate_selectivity` determined whether an equality constraint targeted a unique column via:
```rust
let is_pk_or_rowid_alias =
    is_rowid || column.is_some_and(|c| c.is_rowid_alias() || c.primary_key());
```
For tables with a composite primary key like `PRIMARY KEY (a, b)`, `Column::primary_key()` is `true` for each individual primary key column (`a` and `b`). Consequently, an equality filter on `a` alone was treated as having unique-key selectivity (`1 / row_count` or `1e-6`).

When a query joined against an inner table with `PRIMARY KEY (a, b)` and a secondary index on `(a, c)`:
```sql
SELECT count(*) FROM u JOIN t ON t.a = u.a AND t.b = u.b WHERE u.a = 'x' AND t.c = 'y'
```
1. Seeking via `sqlite_autoindex_t_1` on `(a, b)` consumed constraints on `a` and `b`, leaving residual `t.c = 'y'` (selectivity `0.1`).
2. Seeking via `t_a_c` on `(a, c)` consumed constraints on `a` and `c`, leaving residual `t.b = u.b`. Because `b` was marked `primary_key`, its residual selectivity was erroneously calculated as `1e-6`.

In `choose_best_btree_candidate()` (`core/translate/optimizer/access_method.rs:443`), residual output selectivity is used to break ties between equal-cost seek candidates. Because `1e-6 < 0.1`, the optimizer erroneously picked the secondary index `t_a_c` over the full composite PK seek, degrading point lookups into full index scans across join rows.

#### Solution
In `core/translate/optimizer/constraints.rs`:
- Check whether the table has a composite primary key (`t.primary_key_columns.len() > 1`).
- Only treat a primary key column as unique if it is not part of a composite primary key:
  ```rust
  let is_composite_pk = schema
      .get_btree_table(table_name)
      .is_some_and(|t| t.primary_key_columns.len() > 1);
  let is_pk_or_rowid_alias = is_rowid
      || column
          .is_some_and(|c| c.is_rowid_alias() || (c.primary_key() && !is_composite_pk));
  ```
  This matches the behavior already present for composite unique indexes (`index.unique && index.columns.len() == 1`).

#### Verification
- Added integration reproduction test: `tests/integration/query_processing/test_composite_pk_plan.rs` verifying that both joins and correlated subqueries with composite primary keys prefer `sqlite_autoindex_t_1 (a=? AND b=?)` over secondary index `t_a_c (a=? AND c=?)`.
- Verified pre-fix failure: EQP previously selected `SEARCH t USING INDEX t_a_c (a=? AND c=?)`.
- Verified post-fix pass: `cargo test --test integration_tests query_processing::test_composite_pk_plan` passed.
- Regression verification:
  - `cargo test --test integration_tests query_processing` (426 passed, 0 failed).
  - `cargo test -p turso_core` (2,374 unit tests passed, 53 doc-tests passed, 0 failed).
  - `cargo clippy --test integration_tests` (0 warnings).

#### Sovereign Escrow Settlement
- Base L2 Payout Address: `0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
