### PR TITLE
github: cache dist across release workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,19 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+      - name: Restore cached dist
+        id: cache-dist
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/dist
+          key: cargo-dist-${{ runner.os }}-v0.31.0
       - name: Install dist
+        if: steps.cache-dist.outputs.cache-hit != 'true'
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
-      - name: Cache dist
+      - name: Share dist with build jobs
         uses: actions/upload-artifact@v6
         with:
           name: cargo-dist-cache


### PR DESCRIPTION
## Description

Cache the pinned `cargo-dist` binary before the release plan job installs it. Exact cache hits skip the installer, while the existing artifact upload still shares the binary with downstream jobs in the same workflow run.

Validated with actionlint, `git diff --check`, and a static workflow invariant check that fails on the base revision and passes with this change.

## Motivation and context

The release plan job currently downloads `cargo-dist` on every run, so repeated runs for the same ref remain exposed to transient network failures. The exact-version cache reduces those repeated downloads and safely cold-starts when the pinned version changes. GitHub cache scope still keeps unrelated pull requests and tags isolated.

Fixes #6288

## Description of AI Usage

OpenAI Codex assisted with issue triage, the focused workflow change, validation, and an independent adversarial review of cache semantics and security boundaries. The final diff contains only the reviewed release workflow change.