### PR TITLE
Fix MVCC sync bootstrap and WAL-to-MVCC replica upgrades

### DIFF
--- a/bindings/javascript/sync/packages/wasm/turso-server-setup.ts
+++ b/bindings/javascript/sync/packages/wasm/turso-server-setup.ts
@@ -83,10 +83,6 @@ export default async function setup() {
         startServer(localSyncServer, process.env.VITE_TURSO_DB_URL || 'http://localhost:10001'),
         startServer(localSyncServer, process.env.VITE_TURSO_MVCC_DB_URL || 'http://localhost:10002', mvccDatabase),
     ]);
-    // Keep the server's open MVCC connection, but force its first logical pull
-    // through the same page-base fallback used by a fresh hosted replica.
-    await rm(join(tempDir, 'remote.db-log'));
-
     return async () => {
         for (const child of children) {
             child.kill();

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -16,9 +16,10 @@ use turso_core::{Connection, Value as CoreValue};
 use turso_sync_engine::server_proto::{
     BatchCond, BatchResult, BatchStep, BatchStreamReq, BatchStreamResp, Col, Error,
     ExecuteStreamReq, ExecuteStreamResp, MvccLogicalLogMetadataProto, MvccLogicalLogRangeProto,
-    PageData, PageSetRawEncodingProto, PageUpdatesEncodingReq, PipelineReqBody, PipelineRespBody,
-    PullUpdatesApplyMode, PullUpdatesProtocol, PullUpdatesReqProtoBody, PullUpdatesRespProtoBody,
-    PullUpdatesStreamKind, Row, StmtResult, StreamRequest, StreamResponse, StreamResult, Value,
+    MvccLogicalRevision, PageData, PageSetRawEncodingProto, PageUpdatesEncodingReq,
+    PipelineReqBody, PipelineRespBody, PullUpdatesApplyMode, PullUpdatesProtocol,
+    PullUpdatesReqProtoBody, PullUpdatesRespProtoBody, PullUpdatesStreamKind, Row, StmtResult,
+    StreamRequest, StreamResponse, StreamResult, Value,
 };
 
 const WAL_FRAME_HEADER_SIZE: usize = 24;
@@ -54,6 +55,9 @@ impl TursoSyncServer {
         interrupt_count: Arc<AtomicUsize>,
     ) -> Result<Self> {
         conn.wal_auto_actions_disable();
+        if conn.mvcc_enabled() {
+            conn.prepare_mvcc_for_portable_sync()?;
+        }
 
         Ok(Self {
             address,
@@ -596,7 +600,40 @@ impl TursoSyncServer {
         );
         pages_to_send.reverse();
 
-        let db_size = current_db_size_pages(&conn, wal_state.max_frame)?;
+        let db_size = if conn.mvcc_enabled() {
+            let db_size = current_snapshot_db_size_pages(&conn, wal_state.max_frame)?;
+            pages_to_send.clear();
+            for page_no in 1..=db_size {
+                let page_no_u32 = u32::try_from(page_no)
+                    .map_err(|_| anyhow!("database page number does not fit u32: {page_no}"))?;
+                let page_id = page_no_u32 - 1;
+                if pages_selector
+                    .as_ref()
+                    .is_some_and(|selector| !selector.contains(page_id))
+                {
+                    continue;
+                }
+                let mut page = vec![0; PAGE_SIZE];
+                if !conn.try_wal_watermark_read_page(
+                    page_no_u32,
+                    &mut page,
+                    Some(server_revision),
+                )? {
+                    return Err(anyhow!(
+                        "database page {page_no} is missing from MVCC page snapshot"
+                    ));
+                }
+                pages_to_send.push((page_id, page));
+            }
+            db_size
+        } else {
+            current_db_size_pages(&conn, wal_state.max_frame)?
+        };
+        let logical_resume_revision = if conn.mvcc_enabled() {
+            mvcc_logical_resume_revision(&conn, &self.db_path)?
+        } else {
+            String::new()
+        };
 
         let header = PullUpdatesRespProtoBody {
             server_revision: server_revision.to_string(),
@@ -615,6 +652,7 @@ impl TursoSyncServer {
             } else {
                 PullUpdatesProtocol::Pages as i32
             },
+            logical_resume_revision,
         };
 
         let mut response_body = Vec::new();
@@ -644,14 +682,10 @@ impl TursoSyncServer {
     }
 
     fn handle_logical_pull_updates(&self, req: &PullUpdatesReqProtoBody) -> Result<HttpResponse> {
-        let (db_size, fallback_revision, legacy_current_revision) = {
+        let db_size = {
             let conn = self.conn.lock().unwrap();
             let wal_state = conn.wal_state()?;
-            (
-                current_db_size_pages(&conn, wal_state.max_frame)?,
-                format!("page:{}", wal_state.max_frame),
-                wal_state.max_frame.to_string(),
-            )
+            current_db_size_pages(&conn, wal_state.max_frame)?
         };
         let log_path = match logical_log_path(&self.db_path) {
             Ok(path) => path,
@@ -670,12 +704,7 @@ impl TursoSyncServer {
                     "logical pull requested but no MVCC log exists at {}; returning replace-base fallback",
                     log_path.display()
                 );
-                return self.handle_logical_fallback(
-                    req,
-                    fallback_revision,
-                    &legacy_current_revision,
-                    db_size,
-                );
+                return self.handle_page_pull_updates(req, PullUpdatesApplyMode::ReplaceBase);
             }
             Err(err) => return Err(err.into()),
         };
@@ -685,23 +714,28 @@ impl TursoSyncServer {
                 info!(
                     "logical pull requested but MVCC log is not portable; returning replace-base pages: {err}"
                 );
-                return self.handle_logical_fallback(
-                    req,
-                    fallback_revision,
-                    &legacy_current_revision,
-                    db_size,
-                );
+                return self.handle_page_pull_updates(req, PullUpdatesApplyMode::ReplaceBase);
             }
             Err(err) => return Err(err),
         };
-        let start_offset = parse_mvcc_revision_offset(&req.client_revision, snapshot.end_offset)?;
-        if start_offset > snapshot.end_offset {
-            return Err(anyhow!(
-                "MVCC logical pull revision is from the future: client_offset={} server_offset={}",
-                start_offset,
-                snapshot.end_offset
-            ));
-        }
+        let revision = if req.client_revision.is_empty() {
+            MvccLogicalRevision {
+                generation: snapshot.generation,
+                offset: MVCC_LOG_HEADER_SIZE as u64,
+            }
+        } else {
+            match req.client_revision.parse::<MvccLogicalRevision>() {
+                Ok(revision)
+                    if revision.generation == snapshot.generation
+                        && revision.offset <= snapshot.end_offset
+                        && snapshot.is_frame_boundary(revision.offset) =>
+                {
+                    revision
+                }
+                _ => return self.handle_page_pull_updates(req, PullUpdatesApplyMode::ReplaceBase),
+            }
+        };
+        let start_offset = revision.offset;
         let start = usize::try_from(start_offset)
             .map_err(|_| anyhow!("MVCC logical pull start offset overflows usize"))?;
         let end = usize::try_from(snapshot.end_offset)
@@ -722,7 +756,7 @@ impl TursoSyncServer {
                     format: "lml3".to_string(),
                     checkpoint_transition: false,
                     ranges: vec![MvccLogicalLogRangeProto {
-                        generation: 1,
+                        generation: snapshot.generation,
                         start_offset,
                         end_offset: snapshot.end_offset,
                         starts_with_header: start_offset == 0,
@@ -734,7 +768,11 @@ impl TursoSyncServer {
         };
 
         let header = PullUpdatesRespProtoBody {
-            server_revision: format!("g1:o{}", snapshot.end_offset),
+            server_revision: MvccLogicalRevision {
+                generation: snapshot.generation,
+                offset: snapshot.end_offset,
+            }
+            .to_string(),
             db_size,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,
@@ -742,6 +780,7 @@ impl TursoSyncServer {
             apply_mode: PullUpdatesApplyMode::Incremental as i32,
             mvcc_log,
             protocol: PullUpdatesProtocol::MvccLogical as i32,
+            logical_resume_revision: String::new(),
         };
 
         let header_bytes = header.encode_to_vec();
@@ -762,113 +801,6 @@ impl TursoSyncServer {
             body: response_body,
         })
     }
-
-    fn handle_logical_fallback(
-        &self,
-        req: &PullUpdatesReqProtoBody,
-        server_revision: String,
-        legacy_current_revision: &str,
-        db_size: u64,
-    ) -> Result<HttpResponse> {
-        if req.client_revision == server_revision {
-            return self.handle_empty_logical_pull(server_revision, db_size);
-        }
-        if req.client_revision == legacy_current_revision {
-            return self.handle_empty_logical_pull(req.client_revision.clone(), db_size);
-        }
-
-        self.handle_replace_base_pages(server_revision)
-    }
-
-    fn handle_empty_logical_pull(
-        &self,
-        server_revision: String,
-        db_size: u64,
-    ) -> Result<HttpResponse> {
-        let header = PullUpdatesRespProtoBody {
-            server_revision,
-            db_size,
-            raw_encoding: Some(PageSetRawEncodingProto {}),
-            zstd_encoding: None,
-            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
-            apply_mode: PullUpdatesApplyMode::Incremental as i32,
-            mvcc_log: None,
-            protocol: PullUpdatesProtocol::MvccLogical as i32,
-        };
-
-        let mut response_body = Vec::new();
-        let header_bytes = header.encode_to_vec();
-        encode_length_delimited(&mut response_body, &header_bytes);
-
-        Ok(HttpResponse {
-            status: 200,
-            content_type: "application/protobuf".to_string(),
-            body: response_body,
-        })
-    }
-
-    fn handle_replace_base_pages(&self, server_revision: String) -> Result<HttpResponse> {
-        let (db_size, pages) = self.read_replace_base_pages()?;
-
-        let header = PullUpdatesRespProtoBody {
-            server_revision,
-            db_size,
-            raw_encoding: Some(PageSetRawEncodingProto {}),
-            zstd_encoding: None,
-            stream_kind: PullUpdatesStreamKind::Pages as i32,
-            apply_mode: PullUpdatesApplyMode::ReplaceBase as i32,
-            mvcc_log: None,
-            // Replace-base is only served from the MVCC logical flow here.
-            protocol: PullUpdatesProtocol::MvccLogical as i32,
-        };
-
-        let mut response_body = Vec::new();
-        let header_bytes = header.encode_to_vec();
-        encode_length_delimited(&mut response_body, &header_bytes);
-
-        for (page_id, page) in pages {
-            let page_msg = PageData {
-                page_id,
-                encoded_page: Bytes::from(page),
-            };
-            let page_bytes = page_msg.encode_to_vec();
-            encode_length_delimited(&mut response_body, &page_bytes);
-        }
-
-        Ok(HttpResponse {
-            status: 200,
-            content_type: "application/protobuf".to_string(),
-            body: response_body,
-        })
-    }
-
-    #[allow(clippy::type_complexity)]
-    fn read_replace_base_pages(&self) -> Result<(u64, Vec<(u64, Vec<u8>)>)> {
-        let conn = self.conn.lock().unwrap();
-        let wal_state = conn.wal_state()?;
-        let frame_watermark = Some(wal_state.max_frame);
-        let db_size = current_snapshot_db_size_pages(&conn, wal_state.max_frame)?;
-        let pages_capacity = usize::try_from(db_size)
-            .map_err(|_| anyhow!("database page count does not fit usize: {db_size}"))?;
-        let mut pages = Vec::with_capacity(pages_capacity);
-
-        for page_no in 1..=db_size {
-            let page_no_u32 = u32::try_from(page_no)
-                .map_err(|_| anyhow!("database page number does not fit u32: {page_no}"))?;
-            let mut page = vec![0; PAGE_SIZE];
-            let found =
-                conn.try_wal_watermark_read_page(page_no_u32, &mut page, frame_watermark)?;
-            if !found {
-                return Err(anyhow!(
-                    "database page {} is missing from replace-base snapshot",
-                    page_no
-                ));
-            }
-            pages.push((page_no - 1, page));
-        }
-
-        Ok((db_size, pages))
-    }
 }
 
 struct HttpResponse {
@@ -878,11 +810,24 @@ struct HttpResponse {
 }
 
 struct MvccLogSnapshot {
+    generation: u64,
     end_offset: u64,
     crc_by_offset: Vec<(u64, u32)>,
+    frames: Vec<MvccLogFrameBoundary>,
+}
+
+struct MvccLogFrameBoundary {
+    commit_ts: u64,
+    end_offset: u64,
 }
 
 impl MvccLogSnapshot {
+    fn is_frame_boundary(&self, offset: u64) -> bool {
+        self.crc_by_offset
+            .iter()
+            .any(|(boundary, _)| *boundary == offset)
+    }
+
     fn crc_seed_at(&self, offset: u64) -> Result<u32> {
         self.crc_by_offset
             .iter()
@@ -891,6 +836,45 @@ impl MvccLogSnapshot {
                 anyhow!("MVCC logical pull offset is not a transaction boundary: {offset}")
             })
     }
+
+    fn resume_offset_after(&self, durable_txid_max: u64) -> Result<u64> {
+        let mut resume_offset = MVCC_LOG_HEADER_SIZE as u64;
+        let mut tail_started = false;
+        for frame in &self.frames {
+            if frame.commit_ts <= durable_txid_max {
+                if tail_started {
+                    return Err(anyhow!(
+                        "MVCC logical log timestamps cross the durable boundary out of order"
+                    ));
+                }
+                resume_offset = frame.end_offset;
+            } else {
+                tail_started = true;
+            }
+        }
+        Ok(resume_offset)
+    }
+}
+
+fn mvcc_logical_resume_revision(conn: &Connection, db_path: &str) -> Result<String> {
+    let mv_store = conn
+        .mv_store()
+        .as_ref()
+        .cloned()
+        .ok_or_else(|| anyhow!("MVCC database has no open MVCC store"))?;
+    let log_path = logical_log_path(db_path)?;
+    let log = match std::fs::read(&log_path) {
+        Ok(log) => log,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(err) => return Err(err.into()),
+    };
+    let snapshot = scan_mvcc_log(&log)?;
+    let offset = snapshot.resume_offset_after(mv_store.durable_txid_max())?;
+    Ok(MvccLogicalRevision {
+        generation: snapshot.generation,
+        offset,
+    }
+    .to_string())
 }
 
 fn logical_log_path(db_path: &str) -> Result<PathBuf> {
@@ -915,37 +899,9 @@ fn db_file_path(db_path: &str) -> Result<PathBuf> {
     Ok(PathBuf::from(path))
 }
 
-fn parse_mvcc_revision_offset(revision: &str, legacy_default: u64) -> Result<u64> {
-    if revision.is_empty() {
-        return Ok(0);
-    }
-    if let Some((generation, offset)) = revision.split_once(":o") {
-        let generation = generation
-            .strip_prefix('g')
-            .ok_or_else(|| anyhow!("invalid MVCC pull revision generation: {revision}"))?
-            .parse::<u64>()
-            .map_err(|err| anyhow!("invalid MVCC pull revision generation: {revision}: {err}"))?;
-        if generation != 1 {
-            return Err(anyhow!(
-                "sync_server supports only single-generation MVCC logical pulls: {revision}"
-            ));
-        }
-        return offset
-            .parse::<u64>()
-            .map_err(|err| anyhow!("invalid MVCC pull revision offset: {revision}: {err}"));
-    }
-    // Older page bootstrap responses from this test server used WAL frame
-    // numbers. Treat them as "the page snapshot already includes the current
-    // logical log" so the required follow-up logical pull becomes a no-op.
-    Ok(legacy_default)
-}
-
 fn scan_mvcc_log(log: &[u8]) -> Result<MvccLogSnapshot> {
     if log.is_empty() {
-        return Ok(MvccLogSnapshot {
-            end_offset: 0,
-            crc_by_offset: vec![(0, 0)],
-        });
+        return Err(anyhow!("MVCC logical log is missing its header"));
     }
     if log.len() < MVCC_LOG_HEADER_SIZE {
         return Err(anyhow!(
@@ -955,23 +911,44 @@ fn scan_mvcc_log(log: &[u8]) -> Result<MvccLogSnapshot> {
         ));
     }
     validate_mvcc_log_header(log)?;
+    let generation = u64::from_le_bytes(
+        log[MVCC_LOG_HEADER_SALT_START..MVCC_LOG_HEADER_SALT_END]
+            .try_into()
+            .expect("fixed-size salt slice"),
+    );
     let mut running_crc = initial_mvcc_log_crc(log)?;
     let mut offset = MVCC_LOG_HEADER_SIZE;
     let mut crc_by_offset = vec![(MVCC_LOG_HEADER_SIZE as u64, running_crc)];
+    let mut frames = Vec::new();
 
     while offset < log.len() {
-        let Some((frame_end, frame_crc)) = read_mvcc_frame_boundary(log, offset, running_crc)?
+        let Some((frame_end, frame_crc, commit_ts)) =
+            read_mvcc_frame_boundary(log, offset, running_crc)?
         else {
             break;
         };
+        if frames
+            .last()
+            .is_some_and(|previous: &MvccLogFrameBoundary| previous.commit_ts >= commit_ts)
+        {
+            return Err(anyhow!(
+                "MVCC logical log commit timestamps are not strictly increasing at offset {offset}"
+            ));
+        }
         running_crc = frame_crc;
         offset = frame_end;
         crc_by_offset.push((offset as u64, running_crc));
+        frames.push(MvccLogFrameBoundary {
+            commit_ts,
+            end_offset: offset as u64,
+        });
     }
 
     Ok(MvccLogSnapshot {
+        generation,
         end_offset: offset as u64,
         crc_by_offset,
+        frames,
     })
 }
 
@@ -1028,7 +1005,7 @@ fn read_mvcc_frame_boundary(
     log: &[u8],
     offset: usize,
     running_crc: u32,
-) -> Result<Option<(usize, u32)>> {
+) -> Result<Option<(usize, u32, u64)>> {
     if log.len() - offset < MVCC_TX_HEADER_SIZE + MVCC_TX_TRAILER_SIZE {
         return Ok(None);
     }
@@ -1049,6 +1026,7 @@ fn read_mvcc_frame_boundary(
     }
     let payload_size = usize::try_from(read_u64_le(log, offset + 4)?)
         .map_err(|_| anyhow!("MVCC logical log payload size overflows usize"))?;
+    let commit_ts = read_u64_le(log, offset + 16)?;
     let extension_size = if has_extension_header {
         let extension_size = usize::try_from(read_u64_le(log, offset + 24)?)
             .map_err(|_| anyhow!("MVCC logical log extension size overflows usize"))?;
@@ -1097,7 +1075,7 @@ fn read_mvcc_frame_boundary(
             "invalid MVCC logical log frame end magic at offset {offset}"
         ));
     }
-    Ok(Some((frame_end, stored_crc)))
+    Ok(Some((frame_end, stored_crc, commit_ts)))
 }
 
 fn read_u32_le(buf: &[u8], offset: usize) -> Result<u32> {
@@ -1258,6 +1236,510 @@ fn convert_core_to_value(value: CoreValue) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::NamedTempFile;
+    use turso_core::{Database, PlatformIO, SqliteDialect};
+
+    fn pull_updates_request(stream_kind: PullUpdatesStreamKind) -> PullUpdatesReqProtoBody {
+        PullUpdatesReqProtoBody {
+            encoding: PageUpdatesEncodingReq::Raw as i32,
+            stream_kind: stream_kind as i32,
+            server_revision: String::new(),
+            client_revision: String::new(),
+            long_poll_timeout_ms: 0,
+            server_pages_selector: Bytes::new(),
+            server_query_selector: String::new(),
+            client_pages: Bytes::new(),
+        }
+    }
+
+    fn decode_response_header(response: &HttpResponse) -> (PullUpdatesRespProtoBody, &[u8]) {
+        let mut body = response.body.as_slice();
+        let header = PullUpdatesRespProtoBody::decode_length_delimited(&mut body).unwrap();
+        (header, body)
+    }
+
+    fn open_file_database(db_path: &str) -> (Arc<Database>, Arc<Connection>) {
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file(io, db_path, Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        (db, conn)
+    }
+
+    /// WAL-to-MVCC conversion can leave a complete database beside an empty LML2 log. There are
+    /// no old transactions to translate, so sync startup must begin a portable log generation
+    /// without rejecting or rewriting the already-durable application pages.
+    #[test]
+    fn sync_server_accepts_header_only_lml2_after_wal_to_mvcc_conversion() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_str().unwrap();
+        let (_db, conn) = open_file_database(db_path);
+        conn.execute("CREATE TABLE account_preference(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO account_preference VALUES (1, 'preserved')")
+            .unwrap();
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+
+        let log_path = logical_log_path(db_path).unwrap();
+        let legacy_log = std::fs::read(&log_path).unwrap();
+        assert_eq!(legacy_log.len(), MVCC_LOG_HEADER_SIZE);
+        assert_eq!(legacy_log[4], 2);
+
+        let server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            conn,
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+        let response = server
+            .handle_pull_updates(
+                &pull_updates_request(PullUpdatesStreamKind::Pages).encode_to_vec(),
+            )
+            .unwrap();
+        let (header, body) = decode_response_header(&response);
+
+        assert_eq!(response.status, 200);
+        assert_eq!(
+            PullUpdatesProtocol::try_from(header.protocol).unwrap(),
+            PullUpdatesProtocol::MvccLogical
+        );
+        assert!(header
+            .logical_resume_revision
+            .parse::<MvccLogicalRevision>()
+            .is_ok());
+        assert!(!body.is_empty(), "the complete page base must be returned");
+
+        let portable_log = std::fs::read(log_path).unwrap();
+        assert_eq!(portable_log.len(), MVCC_LOG_HEADER_SIZE);
+        assert_eq!(portable_log[4], MVCC_LOG_VERSION);
+    }
+
+    /// A recovered LML2 tail can contain schema and rows absent from the main database. Startup
+    /// must checkpoint those commits before replacing the old log, otherwise a replacement page
+    /// response would permanently omit committed data.
+    #[test]
+    fn sync_server_checkpoints_nonempty_lml2_before_starting_portable_log() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_str().unwrap();
+        let (db, conn) = open_file_database(db_path);
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        conn.execute("CREATE TABLE account_preference(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO account_preference VALUES (1, 'recovered')")
+            .unwrap();
+
+        let log_path = logical_log_path(db_path).unwrap();
+        let legacy_log = std::fs::read(&log_path).unwrap();
+        assert!(legacy_log.len() > MVCC_LOG_HEADER_SIZE);
+        assert_eq!(legacy_log[4], 2);
+
+        let server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            conn,
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+
+        let portable_log = std::fs::read(log_path).unwrap();
+        assert_eq!(portable_log.len(), MVCC_LOG_HEADER_SIZE);
+        assert_eq!(portable_log[4], MVCC_LOG_VERSION);
+        drop(server);
+        drop(db);
+
+        let (_reopened_db, reopened_conn) = open_file_database(db_path);
+        let mut recovered_value = None;
+        let mut rows = reopened_conn
+            .query("SELECT value FROM account_preference WHERE id = 1")
+            .unwrap()
+            .unwrap();
+        rows.run_with_row_callback(|row| {
+            recovered_value = Some(row.get::<&str>(0)?.to_string());
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(recovered_value.as_deref(), Some("recovered"));
+    }
+
+    /// Numeric revisions belong to the old page protocol. Even when the number happens to equal
+    /// the current WAL frame count, it cannot prove that an MVCC replica contains the current
+    /// schema, so the server must replace its page base and provide a logical resume revision.
+    #[test]
+    fn legacy_numeric_revision_zero_receives_replace_base_pages() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_str().unwrap();
+        let (_db, conn) = open_file_database(db_path);
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        conn.execute("CREATE TABLE account_preference(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+
+        let server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            conn,
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+        let mut request = pull_updates_request(PullUpdatesStreamKind::MvccLogicalLog);
+        request.client_revision = "0".to_string();
+        let response = server
+            .handle_pull_updates(&request.encode_to_vec())
+            .unwrap();
+        let (header, body) = decode_response_header(&response);
+
+        assert_eq!(response.status, 200);
+        assert_eq!(
+            PullUpdatesStreamKind::try_from(header.stream_kind).unwrap(),
+            PullUpdatesStreamKind::Pages
+        );
+        assert_eq!(
+            PullUpdatesApplyMode::try_from(header.apply_mode).unwrap(),
+            PullUpdatesApplyMode::ReplaceBase
+        );
+        assert!(header
+            .logical_resume_revision
+            .parse::<MvccLogicalRevision>()
+            .is_ok());
+        assert!(
+            !body.is_empty(),
+            "replacement pages must accompany the response"
+        );
+    }
+
+    /// Only a revision from the current logical-log generation at a validated frame boundary can
+    /// describe replica contents. Every other revision must replace the page base instead of
+    /// returning an error or claiming that the replica is current.
+    #[test]
+    fn foreign_or_invalid_logical_revisions_receive_replace_base_pages() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_str().unwrap();
+        let (_db, conn) = open_file_database(db_path);
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        let server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            conn.clone(),
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+        conn.execute("CREATE TABLE current_generation(id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let current_response = server
+            .handle_pull_updates(
+                &pull_updates_request(PullUpdatesStreamKind::MvccLogicalLog).encode_to_vec(),
+            )
+            .unwrap();
+        let (current_header, _) = decode_response_header(&current_response);
+        let current = current_header
+            .server_revision
+            .parse::<MvccLogicalRevision>()
+            .unwrap();
+        assert!(current.offset > MVCC_LOG_HEADER_SIZE as u64);
+
+        let invalid_revisions = [
+            "0".to_string(),
+            "page:0".to_string(),
+            format!("g{}:o0", current.generation.saturating_add(1)),
+            MvccLogicalRevision {
+                generation: current.generation,
+                offset: current.offset + 1,
+            }
+            .to_string(),
+            MvccLogicalRevision {
+                generation: current.generation,
+                offset: current.offset - 1,
+            }
+            .to_string(),
+        ];
+
+        for revision in invalid_revisions {
+            let mut request = pull_updates_request(PullUpdatesStreamKind::MvccLogicalLog);
+            request.client_revision = revision.clone();
+            let response = server
+                .handle_pull_updates(&request.encode_to_vec())
+                .unwrap_or_else(|error| panic!("revision {revision} returned an error: {error}"));
+            let (header, body) = decode_response_header(&response);
+
+            assert_eq!(
+                PullUpdatesStreamKind::try_from(header.stream_kind).unwrap(),
+                PullUpdatesStreamKind::Pages,
+                "revision {revision}"
+            );
+            assert_eq!(
+                PullUpdatesApplyMode::try_from(header.apply_mode).unwrap(),
+                PullUpdatesApplyMode::ReplaceBase,
+                "revision {revision}"
+            );
+            assert!(
+                header
+                    .logical_resume_revision
+                    .parse::<MvccLogicalRevision>()
+                    .is_ok(),
+                "revision {revision}"
+            );
+            assert!(!body.is_empty(), "revision {revision}");
+        }
+    }
+
+    /// A revision at the exact end of the current portable log is the one case where an empty
+    /// logical response is valid. Keeping this path narrow prevents replacement loops after a
+    /// replica has genuinely converged.
+    #[test]
+    fn current_logical_revision_receives_empty_incremental_response() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_str().unwrap();
+        let (_db, conn) = open_file_database(db_path);
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        let server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            conn.clone(),
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+        conn.execute("CREATE TABLE current_generation(id INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        let first_response = server
+            .handle_pull_updates(
+                &pull_updates_request(PullUpdatesStreamKind::MvccLogicalLog).encode_to_vec(),
+            )
+            .unwrap();
+        let (first_header, _) = decode_response_header(&first_response);
+        let mut request = pull_updates_request(PullUpdatesStreamKind::MvccLogicalLog);
+        request.client_revision = first_header.server_revision.clone();
+        let response = server
+            .handle_pull_updates(&request.encode_to_vec())
+            .unwrap();
+        let (header, body) = decode_response_header(&response);
+
+        assert_eq!(
+            PullUpdatesStreamKind::try_from(header.stream_kind).unwrap(),
+            PullUpdatesStreamKind::MvccLogicalLog
+        );
+        assert_eq!(
+            PullUpdatesApplyMode::try_from(header.apply_mode).unwrap(),
+            PullUpdatesApplyMode::Incremental
+        );
+        assert_eq!(header.server_revision, request.client_revision);
+        assert!(header.mvcc_log.is_none());
+        assert!(body.is_empty());
+    }
+
+    /// Restarting an already-portable server must preserve its retained logical tail. Treating a
+    /// valid LML3 log as legacy would checkpoint unnecessarily and invalidate active replicas.
+    #[test]
+    fn sync_server_restart_preserves_valid_lml3_tail() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_str().unwrap();
+        let (db, conn) = open_file_database(db_path);
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        let server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            conn.clone(),
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+        conn.execute("CREATE TABLE retained_tail(id INTEGER PRIMARY KEY)")
+            .unwrap();
+        let log_path = logical_log_path(db_path).unwrap();
+        let before_restart = std::fs::read(&log_path).unwrap();
+        assert!(before_restart.len() > MVCC_LOG_HEADER_SIZE);
+        assert_eq!(before_restart[4], MVCC_LOG_VERSION);
+        drop(server);
+        drop(conn);
+        drop(db);
+
+        let (_reopened_db, reopened_conn) = open_file_database(db_path);
+        let _reopened_server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            reopened_conn,
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read(log_path).unwrap(), before_restart);
+    }
+
+    /// Enabling portable writes on a nonempty LML2 log upgrades only the header; it cannot turn
+    /// the older recovery frames into portable changes. Startup must detect that mixed history,
+    /// checkpoint every recovered row, and begin a clean generation.
+    #[test]
+    fn sync_server_checkpoints_lml3_header_with_legacy_frames() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_str().unwrap();
+        let (db, conn) = open_file_database(db_path);
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        conn.execute("CREATE TABLE mixed_history(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO mixed_history VALUES (1, 'legacy')")
+            .unwrap();
+        conn.set_portable_logical_changes_enabled(true);
+        conn.execute("INSERT INTO mixed_history VALUES (2, 'portable')")
+            .unwrap();
+
+        let log_path = logical_log_path(db_path).unwrap();
+        let mixed_log = std::fs::read(&log_path).unwrap();
+        assert!(mixed_log.len() > MVCC_LOG_HEADER_SIZE);
+        assert_eq!(mixed_log[4], MVCC_LOG_VERSION);
+
+        let server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            conn,
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+        let normalized_log = std::fs::read(&log_path).unwrap();
+        assert_eq!(normalized_log.len(), MVCC_LOG_HEADER_SIZE);
+        assert_eq!(normalized_log[4], MVCC_LOG_VERSION);
+        drop(server);
+        drop(db);
+
+        let (_reopened_db, reopened_conn) = open_file_database(db_path);
+        let mut values = Vec::new();
+        let mut rows = reopened_conn
+            .query("SELECT value FROM mixed_history ORDER BY id")
+            .unwrap()
+            .unwrap();
+        rows.run_with_row_callback(|row| {
+            values.push(row.get::<&str>(0)?.to_string());
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(values, ["legacy", "portable"]);
+    }
+
+    /// MVCC compatibility work must not alter the ordinary WAL page protocol. WAL databases keep
+    /// numeric page revisions and never advertise a logical resume token.
+    #[test]
+    fn wal_page_pull_does_not_advertise_logical_revision() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_str().unwrap();
+        let (_db, conn) = open_file_database(db_path);
+        conn.execute("CREATE TABLE wal_only(id INTEGER PRIMARY KEY)")
+            .unwrap();
+        let server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            conn,
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+        let response = server
+            .handle_pull_updates(
+                &pull_updates_request(PullUpdatesStreamKind::Pages).encode_to_vec(),
+            )
+            .unwrap();
+        let (header, _) = decode_response_header(&response);
+
+        assert_eq!(
+            PullUpdatesProtocol::try_from(header.protocol).unwrap(),
+            PullUpdatesProtocol::Pages
+        );
+        assert!(header.server_revision.parse::<u64>().is_ok());
+        assert!(header.logical_resume_revision.is_empty());
+    }
+
+    /// A fresh replica receives the durable page base before switching to logical pulls.
+    /// Commits made after the server starts can exist only in the retained MVCC log, so the
+    /// revision handed across that boundary must cause the first logical pull to return them.
+    #[test]
+    fn fresh_mvcc_page_bootstrap_revision_does_not_skip_logical_tail() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_str().unwrap();
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let db = Database::open_file(io, db_path, Arc::new(SqliteDialect)).unwrap();
+        let conn = db.connect().unwrap();
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+
+        let server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            conn.clone(),
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+
+        conn.execute("CREATE TABLE post_start(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO post_start VALUES (1, 'retained')")
+            .unwrap();
+
+        let log = std::fs::read(logical_log_path(db_path).unwrap()).unwrap();
+        assert!(log.len() > MVCC_LOG_HEADER_SIZE);
+
+        let page_request = pull_updates_request(PullUpdatesStreamKind::Pages);
+        let page_response = server
+            .handle_pull_updates(&page_request.encode_to_vec())
+            .unwrap();
+        let (page_header, _) = decode_response_header(&page_response);
+        assert_eq!(
+            PullUpdatesProtocol::try_from(page_header.protocol).unwrap(),
+            PullUpdatesProtocol::MvccLogical
+        );
+        assert!(page_header.server_revision.parse::<u64>().is_ok());
+        assert!(page_header
+            .logical_resume_revision
+            .parse::<MvccLogicalRevision>()
+            .is_ok());
+
+        let mut logical_request = pull_updates_request(PullUpdatesStreamKind::MvccLogicalLog);
+        logical_request.client_revision = page_header.logical_resume_revision;
+        let logical_response = server
+            .handle_pull_updates(&logical_request.encode_to_vec())
+            .unwrap();
+        let (logical_header, logical_body) = decode_response_header(&logical_response);
+
+        assert!(
+            logical_header.mvcc_log.is_some(),
+            "fresh bootstrap must receive the retained MVCC log tail"
+        );
+        assert!(!logical_body.is_empty());
+    }
+
+    /// Page revisions and logical-log revisions name different histories. Guessing a logical
+    /// offset from a page revision can silently mark missing transactions as synchronized.
+    #[test]
+    fn mvcc_logical_pull_rejects_page_revisions() {
+        assert!("7".parse::<MvccLogicalRevision>().is_err());
+    }
+
+    /// A retained log may contain a prefix already materialized by a passive checkpoint. The
+    /// bootstrap must resume after that prefix while preserving every newer transaction.
+    #[test]
+    fn logical_resume_offset_follows_the_durable_transaction_boundary() {
+        let snapshot = MvccLogSnapshot {
+            generation: 1,
+            end_offset: 350,
+            crc_by_offset: Vec::new(),
+            frames: vec![
+                MvccLogFrameBoundary {
+                    commit_ts: 10,
+                    end_offset: 150,
+                },
+                MvccLogFrameBoundary {
+                    commit_ts: 20,
+                    end_offset: 250,
+                },
+                MvccLogFrameBoundary {
+                    commit_ts: 30,
+                    end_offset: 350,
+                },
+            ],
+        };
+
+        assert_eq!(
+            snapshot.resume_offset_after(0).unwrap(),
+            MVCC_LOG_HEADER_SIZE as u64
+        );
+        assert_eq!(snapshot.resume_offset_after(10).unwrap(), 150);
+        assert_eq!(snapshot.resume_offset_after(25).unwrap(), 250);
+        assert_eq!(snapshot.resume_offset_after(30).unwrap(), 350);
+    }
 
     /// Mirrors the read loop: the terminator must be found whatever the chunk
     /// boundaries, including when it straddles two reads.

--- a/cli/sync_server.rs
+++ b/cli/sync_server.rs
@@ -509,7 +509,13 @@ impl TursoSyncServer {
             return self.handle_logical_pull_updates(&req);
         }
 
-        self.handle_page_pull_updates(&req, PullUpdatesApplyMode::Incremental)
+        let apply_mode =
+            if self.conn.lock().unwrap().mvcc_enabled() && !req.client_revision.is_empty() {
+                PullUpdatesApplyMode::ReplaceBase
+            } else {
+                PullUpdatesApplyMode::Incremental
+            };
+        self.handle_page_pull_updates(&req, apply_mode)
     }
 
     fn handle_page_pull_updates(
@@ -1403,6 +1409,52 @@ mod tests {
         assert!(
             !body.is_empty(),
             "replacement pages must accompany the response"
+        );
+    }
+
+    /// A page revision proves continuity only with a WAL page stream. Once the same remote moves
+    /// to MVCC, applying its page image incrementally would combine incompatible journal states;
+    /// the server must explicitly require one complete replacement instead.
+    #[test]
+    fn existing_page_replica_receives_replace_base_after_remote_moves_to_mvcc() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_str().unwrap();
+        let (_db, conn) = open_file_database(db_path);
+        conn.execute("CREATE TABLE messages(id INTEGER PRIMARY KEY, body TEXT)")
+            .unwrap();
+        conn.execute("INSERT INTO messages VALUES (1, 'preserved')")
+            .unwrap();
+        conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+
+        let server = TursoSyncServer::new(
+            "127.0.0.1:0".to_string(),
+            db_path.to_string(),
+            conn,
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+        let mut request = pull_updates_request(PullUpdatesStreamKind::Pages);
+        request.client_revision = "17".to_string();
+        let response = server
+            .handle_pull_updates(&request.encode_to_vec())
+            .unwrap();
+        let (header, body) = decode_response_header(&response);
+
+        assert_eq!(
+            PullUpdatesProtocol::try_from(header.protocol).unwrap(),
+            PullUpdatesProtocol::MvccLogical
+        );
+        assert_eq!(
+            PullUpdatesApplyMode::try_from(header.apply_mode).unwrap(),
+            PullUpdatesApplyMode::ReplaceBase
+        );
+        assert!(header
+            .logical_resume_revision
+            .parse::<MvccLogicalRevision>()
+            .is_ok());
+        assert!(
+            !body.is_empty(),
+            "the replacement must include the page base"
         );
     }
 

--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2586,6 +2586,48 @@ impl Connection {
         let _ = enabled;
     }
 
+    /// Make the recovered MVCC state safe to expose as a portable page base plus logical tail.
+    /// This must run before a sync server accepts requests or executes writes.
+    #[cfg(feature = "conn_raw_api")]
+    pub fn prepare_mvcc_for_portable_sync(self: &Arc<Self>) -> Result<()> {
+        use crate::mvcc::persistent_storage::PortableSyncLogState;
+
+        let mv_store =
+            self.mv_store().as_ref().cloned().ok_or_else(|| {
+                LimboError::InternalError("portable sync requires MVCC".to_string())
+            })?;
+        let mut state = mv_store.portable_sync_log_state()?;
+        if matches!(state, PortableSyncLogState::NeedsCheckpoint) {
+            self.checkpoint(CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            })?;
+            state = mv_store.portable_sync_log_state()?;
+            if !matches!(state, PortableSyncLogState::NoLog) {
+                return Err(LimboError::InternalError(
+                    "MVCC checkpoint did not clear the non-portable logical log".to_string(),
+                ));
+            }
+        }
+
+        if matches!(state, PortableSyncLogState::NoLog) {
+            crate::types::IOCompletions(mv_store.reset_to_fresh_portable_log()?)
+                .wait(self.db.io.as_ref())?;
+            if self.get_sync_mode() != SyncMode::Off {
+                crate::types::IOCompletions(mv_store.sync_portable_log(self)?)
+                    .wait(self.db.io.as_ref())?;
+            }
+            state = mv_store.portable_sync_log_state()?;
+        }
+
+        let PortableSyncLogState::Portable { .. } = state else {
+            return Err(LimboError::InternalError(
+                "portable logical log preparation did not produce LML3".to_string(),
+            ));
+        };
+        self.set_portable_logical_changes_enabled(true);
+        Ok(())
+    }
+
     pub fn portable_logical_changes_enabled(&self) -> bool {
         #[cfg(feature = "conn_raw_api")]
         {

--- a/core/database.rs
+++ b/core/database.rs
@@ -34,7 +34,7 @@ use crate::{
         page_cache::PageCache,
         page_transform::PageTransform,
         pager::{self, AutoVacuumMode, HeaderRef, HeaderRefMut},
-        sqlite3_ondisk::{PageSize, RawVersion, TextEncoding, Version},
+        sqlite3_ondisk::{DatabaseHeader, PageSize, RawVersion, TextEncoding, Version},
     },
     sync::{
         self,
@@ -2219,6 +2219,7 @@ impl Database {
                     .to_string(),
             ));
         }
+        let restored_version = self.read_restored_database_version()?;
         let flags = self.open_flags;
         #[cfg(host_shared_wal)]
         let shared_authority = self.open_shared_wal_coordination_for_open()?;
@@ -2257,8 +2258,7 @@ impl Database {
         self.shared_wal
             .write()
             .replace_after_external_restore(new_shared_wal.into_inner());
-        if self.mvcc_enabled() || journal_mode::logical_log_exists(std::path::Path::new(&self.path))
-        {
+        if matches!(restored_version, Version::Mvcc) {
             let mv_store = journal_mode::open_mv_store(
                 self.io.clone(),
                 &self.path,
@@ -2282,6 +2282,48 @@ impl Database {
             self.mv_store.store(None);
         }
         Ok(())
+    }
+
+    #[cfg(feature = "conn_raw_api")]
+    fn read_restored_database_version(&self) -> Result<Version> {
+        let header_buf = Arc::new(Buffer::new_temporary(PageSize::MIN as usize));
+        let bytes_read = Arc::new(AtomicUsize::new(0));
+        let completion = self
+            .db_file
+            .read_header(Completion::new_read(header_buf.clone(), {
+                let bytes_read = bytes_read.clone();
+                Box::new(move |result| {
+                    if let Ok((_buffer, count)) = result {
+                        bytes_read.store(count as usize, Ordering::Release);
+                    }
+                    None
+                })
+            }))?;
+        self.io.wait_for_completion(completion)?;
+
+        let bytes_read = bytes_read.load(Ordering::Acquire);
+        if bytes_read < DatabaseHeader::SIZE {
+            return Err(LimboError::Corrupt(format!(
+                "restored database header must be at least {} bytes, got {bytes_read}",
+                DatabaseHeader::SIZE
+            )));
+        }
+        let header =
+            bytemuck::from_bytes::<DatabaseHeader>(&header_buf.as_slice()[..DatabaseHeader::SIZE]);
+        if header.magic != SQLITE_HEADER {
+            return Err(LimboError::NotADB);
+        }
+        if header.read_version != header.write_version {
+            return Err(LimboError::Corrupt(format!(
+                "Read version `{:?}` is not equal to Write version `{:?} in restored database header`",
+                header.read_version, header.write_version
+            )));
+        }
+        header.read_version.to_version().map_err(|version| {
+            LimboError::Corrupt(format!(
+                "Invalid read_version in restored database header: {version}"
+            ))
+        })
     }
 
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/core/mvcc/database/mod.rs
+++ b/core/mvcc/database/mod.rs
@@ -75,6 +75,7 @@ use super::persistent_storage::logical_log::{
     HeaderReadResult, IndexOpKind, ParsedOp, StreamingLogicalLogReader, StreamingResult,
     LOG_HDR_SIZE,
 };
+use super::persistent_storage::PortableSyncLogState;
 #[cfg(feature = "conn_raw_api")]
 use super::portable_logical::{
     is_portable_logical_name, is_portable_schema_row, is_portable_table_schema_row,
@@ -4511,6 +4512,24 @@ impl<Clock: LogicalClock> MvStore<Clock> {
 }
 
 impl<Clock: LogicalClock, A: ConcurrentAllocator> MvStore<Clock, A> {
+    /// Highest MVCC commit timestamp materialized in the pager/WAL snapshot.
+    pub fn durable_txid_max(&self) -> u64 {
+        self.durable_txid_max.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn portable_sync_log_state(&self) -> Result<PortableSyncLogState> {
+        self.storage.portable_sync_log_state()
+    }
+
+    pub(crate) fn reset_to_fresh_portable_log(&self) -> Result<Completion> {
+        self.storage.reset_to_fresh_portable_header()
+    }
+
+    pub(crate) fn sync_portable_log(&self, connection: &Arc<Connection>) -> Result<Completion> {
+        let pager = connection.pager.load();
+        self.storage.sync(pager.get_sync_type())
+    }
+
     pub(crate) fn allocator(&self) -> A {
         self.alloc.clone()
     }

--- a/core/mvcc/database/tests.rs
+++ b/core/mvcc/database/tests.rs
@@ -14,6 +14,8 @@ use crate::mvcc::persistent_storage::logical_log::{
 #[cfg(feature = "conn_raw_api")]
 use crate::mvcc::persistent_storage::logical_log::{ParsedOp, StreamingLogicalLogReader};
 #[cfg(feature = "conn_raw_api")]
+use crate::mvcc::persistent_storage::PortableSyncLogState;
+#[cfg(feature = "conn_raw_api")]
 use crate::mvcc::portable_logical::{PortableLogicalBuilder, PortableObjectMapEntry};
 use crate::mvcc::yield_hooks::YieldPointMarker;
 use crate::mvcc::yield_points::{FailureInjector, YieldInjector, YieldPoint};
@@ -16671,6 +16673,32 @@ fn test_mvcc_portable_changes_metadata_does_not_auto_enable_or_get_consumed() {
     assert_eq!(
         clients,
         vec!["client-a".to_string(), "client-a".to_string()]
+    );
+}
+
+#[cfg(feature = "conn_raw_api")]
+#[test]
+fn test_mvcc_portable_sync_requires_checkpoint_for_mixed_log() {
+    let io = Arc::new(MemoryIO::new());
+    let db = Database::open_file(io, ":memory:", Arc::new(SqliteDialect)).unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+    conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, payload TEXT)")
+        .unwrap();
+
+    conn.set_portable_logical_changes_enabled(true);
+    conn.execute("INSERT INTO items VALUES (1, 'portable')")
+        .unwrap();
+
+    let mv_store = conn
+        .mv_store()
+        .as_ref()
+        .expect("test database must be in MVCC mode")
+        .clone();
+    assert_eq!(
+        mv_store.portable_sync_log_state().unwrap(),
+        PortableSyncLogState::NeedsCheckpoint,
+        "a portable tail cannot make earlier recovery-only frames safe to sync"
     );
 }
 

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -477,6 +477,14 @@ impl LogHeader {
         }
     }
 
+    pub(crate) fn is_portable(&self) -> bool {
+        self.version == LOG_VERSION
+    }
+
+    pub(crate) fn salt(&self) -> u64 {
+        self.salt
+    }
+
     fn encode(&self) -> [u8; LOG_HDR_SIZE] {
         let mut buf = [0u8; LOG_HDR_SIZE];
         buf[0..4].copy_from_slice(&LOG_MAGIC.to_le_bytes());
@@ -660,6 +668,10 @@ impl LogicalLog {
 
     pub(crate) fn encryption_ctx(&self) -> Option<&EncryptionContext> {
         self.encryption_ctx.as_ref()
+    }
+
+    pub(super) fn io(&self) -> Arc<dyn crate::IO> {
+        self.io.clone()
     }
 
     /// Wraps the pre-serialized payload (`tx.buf`) with the log/TX framing
@@ -1074,10 +1086,23 @@ impl LogicalLog {
     /// Either completion order leaves a header-sized file with the fresh header
     /// bytes at offset zero.
     pub fn reset_to_fresh_header(&mut self) -> Result<Completion> {
-        // Regenerate salt so stale frames from before the reset cannot validate
-        // against this new CRC chain.
-        let mut header = self.current_or_new_header()?;
-        header.salt = self.io.generate_random_number() as u64;
+        let version = self
+            .header
+            .as_ref()
+            .map_or(LOG_VERSION_V2, |header| header.version);
+        self.reset_to_fresh_header_with_version(version, 0)
+    }
+
+    pub fn reset_to_fresh_portable_header(&mut self) -> Result<Completion> {
+        self.reset_to_fresh_header_with_version(LOG_VERSION, LOG_HDR_SIZE as u64)
+    }
+
+    fn reset_to_fresh_header_with_version(
+        &mut self,
+        version: u8,
+        writer_offset: u64,
+    ) -> Result<Completion> {
+        let header = LogHeader::new_with_version(&self.io, version);
         self.running_crc = derive_initial_crc(header.salt);
         self.pending_running_crc = None;
         self.header = Some(header.clone());
@@ -1091,7 +1116,8 @@ impl LogicalLog {
         });
         group.add(&c);
         let _truncate_c = self.file.truncate(LOG_HDR_SIZE as u64, c)?;
-        self.offset = 0;
+        self.offset = writer_offset;
+        self.max_appended_commit_ts = 0;
         Ok(group.build())
     }
 }
@@ -3089,19 +3115,16 @@ impl StreamingLogicalLogReader {
             header_bytes[2],
             header_bytes[3],
         ]);
-        let has_extension_header = frame_magic == EXT_FRAME_MAGIC;
-        if frame_magic != FRAME_MAGIC && !has_extension_header {
+        if frame_magic != EXT_FRAME_MAGIC {
             self.last_valid_offset = frame_start;
             return Ok(IOResult::Done(ParseResult::InvalidFrame));
         }
-        if has_extension_header {
-            let Some(extension_header) =
-                return_if_io!(self.try_consume_bytes(TX_EXT_HEADER_SIZE - TX_HEADER_SIZE))
-            else {
-                return Ok(IOResult::Done(ParseResult::Eof));
-            };
-            header_bytes.extend_from_slice(&extension_header);
-        }
+        let Some(extension_header) =
+            return_if_io!(self.try_consume_bytes(TX_EXT_HEADER_SIZE - TX_HEADER_SIZE))
+        else {
+            return Ok(IOResult::Done(ParseResult::Eof));
+        };
+        header_bytes.extend_from_slice(&extension_header);
         let payload_size_u64 = u64::from_le_bytes([
             header_bytes[4],
             header_bytes[5],
@@ -3128,7 +3151,7 @@ impl StreamingLogicalLogReader {
             header_bytes[22],
             header_bytes[23],
         ]);
-        let (extension_size_u64, extension_record_count, frame_flags) = if has_extension_header {
+        let (extension_size_u64, extension_record_count, frame_flags) = {
             let extension_size_u64 = u64::from_le_bytes([
                 header_bytes[24],
                 header_bytes[25],
@@ -3164,8 +3187,6 @@ impl StreamingLogicalLogReader {
                 return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
             (extension_size_u64, extension_record_count, frame_flags)
-        } else {
-            (0, 0, 0)
         };
 
         let payload_size = match usize::try_from(payload_size_u64) {

--- a/core/mvcc/persistent_storage/logical_log.rs
+++ b/core/mvcc/persistent_storage/logical_log.rs
@@ -1513,6 +1513,11 @@ pub struct PortableChangeFrame {
     pub payload: Vec<u8>,
 }
 
+pub(crate) enum PortableSyncFrame {
+    RecoveryOnly,
+    Portable(PortableChangeFrame),
+}
+
 #[derive(Clone, Copy, Debug)]
 enum StreamingState {
     NeedTransactionStart,
@@ -1556,6 +1561,7 @@ struct FrameInProgress {
     extension_size: usize,
     extension_record_count: u32,
     frame_flags: u32,
+    has_extension_header: bool,
     // Accumulators carried across op/unit yields:
     running_crc: u32,
     parsed_ops: Vec<ParsedOp>,
@@ -1575,6 +1581,7 @@ impl FrameInProgress {
             extension_size: 0,
             extension_record_count: 0,
             frame_flags: 0,
+            has_extension_header: false,
             running_crc: 0,
             parsed_ops: Vec::new(),
             portable_changes: Vec::new(),
@@ -1592,6 +1599,7 @@ struct FrameHeader {
     extension_size: usize,
     extension_record_count: u32,
     frame_flags: u32,
+    has_extension_header: bool,
     /// Chained CRC seeded from `self.running_crc` and folded over the header bytes.
     running_crc: u32,
 }
@@ -1935,14 +1943,33 @@ impl StreamingLogicalLogReader {
     /// advance the logical-log offset even though clients have no operation to
     /// apply.
     pub fn next_portable_change_frame(&mut self) -> IOResultOr<Option<PortableChangeFrame>> {
+        loop {
+            match return_if_io!(self.next_portable_sync_frame()) {
+                Some(PortableSyncFrame::RecoveryOnly) => continue,
+                Some(PortableSyncFrame::Portable(frame)) => {
+                    return Ok(IOResult::Done(Some(frame)));
+                }
+                None => return Ok(IOResult::Done(None)),
+            }
+        }
+    }
+
+    pub(crate) fn next_portable_sync_frame(&mut self) -> IOResultOr<Option<PortableSyncFrame>> {
         self.file_size = self.file.size()? as usize;
         match return_if_io!(self.parse_next_portable_changes_frame()) {
-            ParseResult::Frame(frame) => Ok(IOResult::Done(Some(PortableChangeFrame {
-                end_offset: frame.end_offset as u64,
-                commit_ts: frame.commit_ts,
-                extension_record_count: frame.extension_record_count,
-                payload: frame.portable_changes,
-            }))),
+            ParseResult::Frame(frame) => {
+                let frame = if frame.has_extension_header {
+                    PortableSyncFrame::Portable(PortableChangeFrame {
+                        end_offset: frame.end_offset as u64,
+                        commit_ts: frame.commit_ts,
+                        extension_record_count: frame.extension_record_count,
+                        payload: frame.portable_changes,
+                    })
+                } else {
+                    PortableSyncFrame::RecoveryOnly
+                };
+                Ok(IOResult::Done(Some(frame)))
+            }
             ParseResult::Eof | ParseResult::InvalidFrame => Ok(IOResult::Done(None)),
         }
     }
@@ -2685,6 +2712,7 @@ impl StreamingLogicalLogReader {
                         fip.extension_size = header.extension_size;
                         fip.extension_record_count = header.extension_record_count;
                         fip.frame_flags = header.frame_flags;
+                        fip.has_extension_header = header.has_extension_header;
                         fip.running_crc = header.running_crc;
                         fip.phase = next_phase;
                     }
@@ -2906,6 +2934,7 @@ impl StreamingLogicalLogReader {
             extension_size,
             extension_record_count,
             frame_flags,
+            has_extension_header,
             running_crc,
         })))
     }
@@ -3037,6 +3066,7 @@ impl StreamingLogicalLogReader {
         self.frame_anchor = self.buffer_offset;
         Ok(IOResult::Done(ParseResult::Frame(ParsedFrame {
             ops: fip.parsed_ops,
+            has_extension_header: fip.has_extension_header,
             portable_changes: fip.portable_changes,
             extension_record_count: fip.extension_record_count,
             frame_flags: fip.frame_flags,
@@ -3115,16 +3145,19 @@ impl StreamingLogicalLogReader {
             header_bytes[2],
             header_bytes[3],
         ]);
-        if frame_magic != EXT_FRAME_MAGIC {
+        let has_extension_header = frame_magic == EXT_FRAME_MAGIC;
+        if frame_magic != FRAME_MAGIC && !has_extension_header {
             self.last_valid_offset = frame_start;
             return Ok(IOResult::Done(ParseResult::InvalidFrame));
         }
-        let Some(extension_header) =
-            return_if_io!(self.try_consume_bytes(TX_EXT_HEADER_SIZE - TX_HEADER_SIZE))
-        else {
-            return Ok(IOResult::Done(ParseResult::Eof));
-        };
-        header_bytes.extend_from_slice(&extension_header);
+        if has_extension_header {
+            let Some(extension_header) =
+                return_if_io!(self.try_consume_bytes(TX_EXT_HEADER_SIZE - TX_HEADER_SIZE))
+            else {
+                return Ok(IOResult::Done(ParseResult::Eof));
+            };
+            header_bytes.extend_from_slice(&extension_header);
+        }
         let payload_size_u64 = u64::from_le_bytes([
             header_bytes[4],
             header_bytes[5],
@@ -3151,7 +3184,7 @@ impl StreamingLogicalLogReader {
             header_bytes[22],
             header_bytes[23],
         ]);
-        let (extension_size_u64, extension_record_count, frame_flags) = {
+        let (extension_size_u64, extension_record_count, frame_flags) = if has_extension_header {
             let extension_size_u64 = u64::from_le_bytes([
                 header_bytes[24],
                 header_bytes[25],
@@ -3187,6 +3220,8 @@ impl StreamingLogicalLogReader {
                 return Ok(IOResult::Done(ParseResult::InvalidFrame));
             }
             (extension_size_u64, extension_record_count, frame_flags)
+        } else {
+            (0, 0, 0)
         };
 
         let payload_size = match usize::try_from(payload_size_u64) {
@@ -3320,6 +3355,7 @@ impl StreamingLogicalLogReader {
         self.frame_anchor = self.buffer_offset;
         Ok(IOResult::Done(ParseResult::Frame(ParsedFrame {
             ops: Vec::new(),
+            has_extension_header,
             portable_changes,
             extension_record_count,
             frame_flags,
@@ -3734,6 +3770,7 @@ enum ParseResult {
 #[cfg_attr(test, derive(Debug))]
 pub struct ParsedFrame {
     ops: Vec<ParsedOp>,
+    has_extension_header: bool,
     pub portable_changes: Vec<u8>,
     pub extension_record_count: u32,
     pub frame_flags: u32,

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -5,6 +5,7 @@ use crate::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use crate::sync::Arc;
 use crate::sync::RwLock;
 use crate::turso_assert;
+use crate::util::IOExt;
 use std::fmt::Debug;
 
 #[cfg(test)]
@@ -12,7 +13,8 @@ mod discard_pending_tests;
 pub mod logical_log;
 use crate::mvcc::database::{LogRecord, RowVersion};
 use crate::mvcc::persistent_storage::logical_log::{
-    LogSerializer, LogicalLog, OnSerializationComplete, DEFAULT_LOG_CHECKPOINT_THRESHOLD,
+    HeaderReadResult, LogSerializer, LogicalLog, OnSerializationComplete,
+    StreamingLogicalLogReader, DEFAULT_LOG_CHECKPOINT_THRESHOLD,
 };
 use crate::{CheckpointResult, Completion, File, LimboError, Result};
 
@@ -20,6 +22,13 @@ use crate::{CheckpointResult, Completion, File, LimboError, Result};
 pub enum LogicalLogTruncateOutcome {
     Truncated,
     Retained,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortableSyncLogState {
+    NoLog,
+    NeedsCheckpoint,
+    Portable { generation: u64, end_offset: u64 },
 }
 
 pub trait DurableStorage: Send + Sync + Debug {
@@ -91,6 +100,16 @@ pub trait DurableStorage: Send + Sync + Debug {
     /// Used after an external database restore so future MVCC recovery starts
     /// from the restored image instead of replaying stale local log frames.
     fn reset_to_fresh_header(&self) -> Result<Completion>;
+    fn reset_to_fresh_portable_header(&self) -> Result<Completion> {
+        Err(LimboError::InternalError(
+            "durable storage does not support portable logical sync".to_string(),
+        ))
+    }
+    fn portable_sync_log_state(&self) -> Result<PortableSyncLogState> {
+        Err(LimboError::InternalError(
+            "durable storage does not support portable logical sync".to_string(),
+        ))
+    }
     fn get_logical_log_file(&self) -> Arc<dyn File>;
     fn logical_log_offset(&self) -> u64;
     fn should_checkpoint(&self) -> bool;
@@ -237,6 +256,45 @@ impl DurableStorage for Storage {
         let c = self.logical_log.write().reset_to_fresh_header()?;
         self.shadow_offset_store(0);
         Ok(c)
+    }
+
+    fn reset_to_fresh_portable_header(&self) -> Result<Completion> {
+        let c = self.logical_log.write().reset_to_fresh_portable_header()?;
+        self.shadow_offset_store(crate::mvcc::persistent_storage::logical_log::LOG_HDR_SIZE as u64);
+        Ok(c)
+    }
+
+    fn portable_sync_log_state(&self) -> Result<PortableSyncLogState> {
+        let (file, io, encryption_ctx) = {
+            let log = self.logical_log.read();
+            (log.file.clone(), log.io(), log.encryption_ctx().cloned())
+        };
+        let mut reader = StreamingLogicalLogReader::new(file, encryption_ctx);
+        let header = match reader.try_read_header(&io)? {
+            HeaderReadResult::NoLog => return Ok(PortableSyncLogState::NoLog),
+            HeaderReadResult::Invalid => {
+                return Err(LimboError::Corrupt(
+                    "logical log header is invalid during portable sync startup".to_string(),
+                ))
+            }
+            HeaderReadResult::Valid(header) => header,
+        };
+        if !header.is_portable() {
+            return Ok(if reader.is_eof() {
+                PortableSyncLogState::NoLog
+            } else {
+                PortableSyncLogState::NeedsCheckpoint
+            });
+        }
+
+        while io.block(|| reader.next_portable_change_frame())?.is_some() {}
+        if !reader.is_eof() {
+            return Ok(PortableSyncLogState::NeedsCheckpoint);
+        }
+        Ok(PortableSyncLogState::Portable {
+            generation: header.salt(),
+            end_offset: reader.last_valid_offset() as u64,
+        })
     }
 
     fn get_logical_log_file(&self) -> Arc<dyn File> {

--- a/core/mvcc/persistent_storage/mod.rs
+++ b/core/mvcc/persistent_storage/mod.rs
@@ -13,7 +13,7 @@ mod discard_pending_tests;
 pub mod logical_log;
 use crate::mvcc::database::{LogRecord, RowVersion};
 use crate::mvcc::persistent_storage::logical_log::{
-    HeaderReadResult, LogSerializer, LogicalLog, OnSerializationComplete,
+    HeaderReadResult, LogSerializer, LogicalLog, OnSerializationComplete, PortableSyncFrame,
     StreamingLogicalLogReader, DEFAULT_LOG_CHECKPOINT_THRESHOLD,
 };
 use crate::{CheckpointResult, Completion, File, LimboError, Result};
@@ -287,7 +287,15 @@ impl DurableStorage for Storage {
             });
         }
 
-        while io.block(|| reader.next_portable_change_frame())?.is_some() {}
+        loop {
+            match io.block(|| reader.next_portable_sync_frame())? {
+                Some(PortableSyncFrame::RecoveryOnly) => {
+                    return Ok(PortableSyncLogState::NeedsCheckpoint)
+                }
+                Some(PortableSyncFrame::Portable(_)) => {}
+                None => break,
+            }
+        }
         if !reader.is_eof() {
             return Ok(PortableSyncLogState::NeedsCheckpoint);
         }

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -699,8 +699,7 @@ impl<IO: SyncEngineIo> ReplaceBaseApplyGuard<IO> {
                 || file.storage != expected_storage
             {
                 return Err(Error::DatabaseSyncEngineError(format!(
-                    "replace-base recovery marker contains an invalid file entry: {:?}",
-                    file
+                    "replace-base recovery marker contains an invalid file entry: {file:?}"
                 )));
             }
         }
@@ -2135,8 +2134,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             }
         };
 
-        if file.value.size()? == 0
-            && !matches!(stream_kind, DbChangesStreamKind::ReplaceBasePages)
+        if file.value.size()? == 0 && !matches!(stream_kind, DbChangesStreamKind::ReplaceBasePages)
         {
             tracing::info!(
                 "wait_changes(path={}): no changes detected",
@@ -2226,13 +2224,14 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             DbChangesStreamKind::ReplaceBasePages
         );
         let mut replace_base_guard = if replace_base {
+            let synced_revision = self.meta().synced_revision.clone();
             Some(
                 ReplaceBaseApplyGuard::create(
                     coro,
                     self.io.clone(),
                     self.sync_engine_io.clone(),
                     &self.main_db_path,
-                    self.meta().synced_revision.clone(),
+                    synced_revision,
                 )
                 .await?,
             )
@@ -3973,14 +3972,8 @@ mod tests {
                     &main_path,
                     Arc::new(SqliteDialect),
                 )?;
-                let reopened = DatabaseSyncEngine::open_db(
-                    &coro,
-                    io,
-                    sync_stats,
-                    reopened_db,
-                    opts,
-                )
-                .await?;
+                let reopened =
+                    DatabaseSyncEngine::open_db(&coro, io, sync_stats, reopened_db, opts).await?;
                 assert_eq!(reopened.meta().revert_since_wal_watermark, 0);
                 assert!(reopened.meta().revert_since_wal_salt.is_none());
                 let conn = reopened.connect_rw(&coro).await?;

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -2000,9 +2000,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                     "wait_changes(path={}): initial logical MVCC sync returned page base",
                     self.main_db_path,
                 );
-                // Deferred replicas may still be in WAL mode locally; the
-                // MVCC page base must be applied to an MVCC-mode database.
-                self.ensure_local_mvcc_journal_mode(coro).await?;
                 stream_kind = match result {
                     PullUpdatesV1Result::Pages { .. } => DbChangesStreamKind::ReplaceBasePages,
                     PullUpdatesV1Result::Logical { txns, ops } => {
@@ -2138,7 +2135,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             }
         };
 
-        if file.value.size()? == 0 {
+        if file.value.size()? == 0
+            && !matches!(stream_kind, DbChangesStreamKind::ReplaceBasePages)
+        {
             tracing::info!(
                 "wait_changes(path={}): no changes detected",
                 self.main_db_path
@@ -2181,7 +2180,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         remote_changes: DbChangesStatus,
     ) -> Result<()> {
         let mut new_revision = remote_changes.revision.clone();
-        let previous_protocol = self.meta().remote_pull_protocol;
         let next_protocol = match remote_changes.stream_kind {
             DbChangesStreamKind::Logical | DbChangesStreamKind::ReplaceBasePages => {
                 RemotePullProtocol::MvccLogical
@@ -2242,9 +2240,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             None
         };
         let pull_result = async {
-            if next_protocol == RemotePullProtocol::MvccLogical
-                && previous_protocol != RemotePullProtocol::MvccLogical
-            {
+            if next_protocol == RemotePullProtocol::MvccLogical {
                 self.ensure_local_mvcc_journal_mode(coro).await?;
             }
             self.apply_changes_internal(
@@ -2281,6 +2277,9 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         reset_wal_file(coro, revert_wal_file, 0).await?;
 
         self.update_meta(coro, |m| {
+            if next_protocol == RemotePullProtocol::MvccLogical {
+                m.revert_since_wal_salt = None;
+            }
             m.revert_since_wal_watermark = revert_since_wal_watermark;
             m.synced_revision = Some(new_revision);
             m.last_pushed_pull_gen_hint = 0;
@@ -2534,14 +2533,29 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
     ) -> Result<(u64, BTreeMap<u64, String>, Option<DatabasePullRevision>)> {
         tracing::info!("apply_changes(path={})", self.main_db_path);
 
-        let (_, watermark) = self.checkpoint_passive(coro).await?;
-
-        let revert_conn = self.open_revert_db_conn(coro).await?;
-        let main_conn = connect_untracked(&self.main_tape)?;
         let replace_base_pages = matches!(stream_kind, DbChangesStreamKind::ReplaceBasePages);
+        let logical_mvcc_pull_active = remote_protocol == RemotePullProtocol::MvccLogical;
+        let mvcc_replace_base = replace_base_pages && logical_mvcc_pull_active;
+        let watermark = if mvcc_replace_base {
+            0
+        } else {
+            self.checkpoint_passive(coro).await?.1
+        };
 
-        let mut revert_session = WalSession::new(revert_conn.clone());
-        revert_session.begin()?;
+        let revert_conn = if mvcc_replace_base {
+            None
+        } else {
+            Some(self.open_revert_db_conn(coro).await?)
+        };
+        let main_conn = connect_untracked(&self.main_tape)?;
+
+        let mut revert_session = if let Some(revert_conn) = &revert_conn {
+            let mut session = WalSession::new(revert_conn.clone());
+            session.begin()?;
+            Some(session)
+        } else {
+            None
+        };
 
         // start of the pull updates apply process
         // during this process we need to be very careful with the state of the WAL as at some points it can be not safe to read data from it
@@ -2573,8 +2587,6 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         // read current pull generation from local table for the given client
         let (local_pull_gen, local_last_change_id) =
             read_last_change_id(coro, &main_conn, &self.client_unique_id).await?;
-        let logical_mvcc_pull_active = remote_protocol == RemotePullProtocol::MvccLogical;
-        let no_checkpoint_replace_base = replace_base_pages && logical_mvcc_pull_active;
         tracing::info!(
             "apply_changes(path={}): local sync high-water before remote apply: client_id={} pull_gen={} change_id={:?} replace_base={}",
             self.main_db_path,
@@ -2605,7 +2617,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 main_conn.mv_store().as_ref().is_some(),
             );
         let replace_base_precollection_floor = if replace_base_pages {
-            if no_checkpoint_replace_base {
+            if mvcc_replace_base {
                 None
             } else {
                 resolve_local_replay_floor_change_id(
@@ -2675,14 +2687,24 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 watermark,
                 main_conn.wal_state()?.max_frame
             );
-            let local_rollback = main_session
-                .as_mut()
-                .expect("main WAL session must be active")
-                .rollback_changes_after(coro, watermark)
-                .await?;
-            let mut frame = [0u8; WAL_FRAME_SIZE];
-
-            let remote_rollback = revert_conn.wal_state()?.max_frame;
+            let local_rollback = if mvcc_replace_base {
+                0
+            } else {
+                main_session
+                    .as_mut()
+                    .expect("main WAL session must be active")
+                    .rollback_changes_after(coro, watermark)
+                    .await?
+            };
+            let remote_rollback = if mvcc_replace_base {
+                0
+            } else {
+                revert_conn
+                    .as_ref()
+                    .expect("page apply must keep a revert connection")
+                    .wal_state()?
+                    .max_frame
+            };
             tracing::info!(
                 "apply_changes(path={}): rolling back {} frames from revert DB",
                 self.main_db_path,
@@ -2690,14 +2712,23 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             );
             // Phase 1.b: rollback local changes by using frames from revert-db
             // it's important to append pages from revert-db after local revert - because pages from revert-db must overwrite rollback from main DB
-            for frame_no in 1..=remote_rollback {
-                let info = revert_session.read_at(frame_no, &mut frame)?;
-                main_session
-                    .as_mut()
-                    .expect("main WAL session must be active")
-                    .append_page(info.page_no, &frame[WAL_FRAME_HEADER..])?;
+            if !mvcc_replace_base {
+                let mut frame = [0u8; WAL_FRAME_SIZE];
+                for frame_no in 1..=remote_rollback {
+                    let info = revert_session
+                        .as_mut()
+                        .expect("page apply must keep a revert WAL session")
+                        .read_at(frame_no, &mut frame)?;
+                    main_session
+                        .as_mut()
+                        .expect("main WAL session must be active")
+                        .append_page(info.page_no, &frame[WAL_FRAME_HEADER..])?;
+                }
+                revert_session
+                    .take()
+                    .expect("page apply must keep a revert WAL session")
+                    .end(false)?;
             }
-            revert_session.end(false)?;
 
             // Phase 2: after revert DB has no local changes in its latest state - so its safe to apply changes from remote
             let mut logical_replay_conn = None;
@@ -3324,7 +3355,11 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 let logical_table_names_by_stable_id =
                     read_logical_replay_table_map(coro, &logical_conn).await?;
                 return Ok((
-                    logical_conn.wal_state()?.max_frame,
+                    if mvcc_replace_base {
+                        0
+                    } else {
+                        logical_conn.wal_state()?.max_frame
+                    },
                     logical_table_names_by_stable_id,
                     followup_revision,
                 ));
@@ -3454,8 +3489,11 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
             let logical_table_names_by_stable_id =
                 read_logical_replay_table_map(coro, &main_conn).await?;
-            let revert_since_wal_watermark =
-                revert_since_wal_watermark.unwrap_or(main_conn.wal_state()?.max_frame);
+            let revert_since_wal_watermark = if mvcc_replace_base {
+                0
+            } else {
+                revert_since_wal_watermark.unwrap_or(main_conn.wal_state()?.max_frame)
+            };
             Ok((
                 revert_since_wal_watermark,
                 logical_table_names_by_stable_id,
@@ -3686,26 +3724,58 @@ mod tests {
         }
     }
 
-    /// An existing V1 page replica must not lose the response facts that authorize its one-way
-    /// move to logical MVCC. The pending change must retain replacement semantics and the logical
-    /// resume revision instead of entering the incremental WAL apply path.
+    /// A page replica can retain a positive WAL watermark after earlier successful syncs. Moving
+    /// that replica to MVCC retires the WAL, so replacement must preserve pending CDC operations
+    /// without interpreting the old frame number against the new empty WAL.
     #[test]
-    fn existing_page_replica_commits_one_mvcc_transition_then_observes_no_changes() {
+    fn existing_page_replica_with_wal_watermark_transitions_to_mvcc_without_losing_local_changes() {
         let main_file = NamedTempFile::new().unwrap();
+        let legacy_remote_file = NamedTempFile::new().unwrap();
         let remote_file = NamedTempFile::new().unwrap();
+        let legacy_changes_file = NamedTempFile::new().unwrap();
         let main_path = main_file.path().to_str().unwrap().to_string();
+        let legacy_remote_path = legacy_remote_file.path().to_str().unwrap().to_string();
         let remote_path = remote_file.path().to_str().unwrap().to_string();
+        let legacy_changes_path = legacy_changes_file.path().to_str().unwrap().to_string();
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+
+        let legacy_remote_db = turso_core::Database::open_file(
+            io.clone(),
+            &legacy_remote_path,
+            Arc::new(SqliteDialect),
+        )
+        .unwrap();
+        let legacy_remote_conn = legacy_remote_db.connect().unwrap();
+        legacy_remote_conn
+            .execute("CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT)")
+            .unwrap();
+        legacy_remote_conn
+            .execute("INSERT INTO notes VALUES (1, 'base-one'), (2, 'base-two')")
+            .unwrap();
+        legacy_remote_conn
+            .checkpoint(turso_core::CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            })
+            .unwrap();
+        drop(legacy_remote_conn);
+        drop(legacy_remote_db);
 
         let remote_db =
             turso_core::Database::open_file(io.clone(), &remote_path, Arc::new(SqliteDialect))
                 .unwrap();
         let remote_conn = remote_db.connect().unwrap();
+        remote_conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
         remote_conn
             .execute("CREATE TABLE messages(id INTEGER PRIMARY KEY, body TEXT)")
             .unwrap();
         remote_conn
+            .execute("CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT)")
+            .unwrap();
+        remote_conn
             .execute("INSERT INTO messages VALUES (1, 'remote')")
+            .unwrap();
+        remote_conn
+            .execute("INSERT INTO notes VALUES (1, 'base-one'), (2, 'base-two')")
             .unwrap();
         remote_conn
             .checkpoint(turso_core::CheckpointMode::Truncate {
@@ -3788,13 +3858,59 @@ mod tests {
 
         let mut gen = genawaiter::sync::Gen::new({
             let io = io.clone();
+            let legacy_remote_path = legacy_remote_path.clone();
+            let legacy_changes_path = legacy_changes_path.clone();
             move |coro| async move {
                 let coro: Coro<()> = coro.into();
-                let engine =
-                    DatabaseSyncEngine::open_db(&coro, io, sync_stats, main_db, opts).await?;
+                let engine = DatabaseSyncEngine::open_db(
+                    &coro,
+                    io.clone(),
+                    sync_stats.clone(),
+                    main_db,
+                    opts.clone(),
+                )
+                .await?;
+
+                // First apply a real page snapshot through the normal page protocol. This leaves
+                // the watermark coupled to live WAL frames, its salt, and the revert database,
+                // matching a replica that synchronized before its remote moved to MVCC.
+                let legacy_changes = write_replace_base_pages_file(
+                    &coro,
+                    &io,
+                    &legacy_remote_path,
+                    &legacy_changes_path,
+                )
+                .await?;
+                let legacy_slot = Arc::new(Mutex::new(Some(legacy_changes)));
+                let legacy_changes = legacy_slot.lock().unwrap().take().unwrap();
+                let legacy_file_slot = MutexSlot {
+                    value: legacy_changes,
+                    slot: legacy_slot,
+                };
+                engine
+                    .apply_changes_from_remote(
+                        &coro,
+                        DbChangesStatus {
+                            time: turso_core::WallClockInstant { secs: 1, micros: 0 },
+                            revision: DatabasePullRevision::V1 {
+                                revision: "18".to_string(),
+                            },
+                            file_slot: Some(legacy_file_slot),
+                            stream_kind: DbChangesStreamKind::Pages,
+                        },
+                    )
+                    .await?;
+                let legacy_watermark = engine.meta().revert_since_wal_watermark;
+                assert!(legacy_watermark > 0);
+                let legacy_conn = engine.main_tape.connect(&coro).await?;
+                let legacy_wal_state = legacy_conn.wal_state()?;
+                assert!(legacy_wal_state.max_frame >= legacy_watermark);
+                drop(legacy_conn);
+
                 let conn = engine.connect_rw(&coro).await?;
-                conn.execute("CREATE TABLE local_notes(id INTEGER PRIMARY KEY, note TEXT)")?;
-                conn.execute("INSERT INTO local_notes VALUES (1, 'unpushed')")?;
+                conn.execute("UPDATE notes SET body = 'local-update' WHERE id = 1")?;
+                conn.execute("DELETE FROM notes WHERE id = 2")?;
+                conn.execute("INSERT INTO notes VALUES (3, 'local-insert')")?;
                 drop(conn);
 
                 let changes = engine.wait_changes_from_remote(&coro).await?;
@@ -3828,14 +3944,62 @@ mod tests {
                 let row = run_stmt_once(&coro, &mut stmt).await?.unwrap();
                 assert_eq!(row.get_value(0).to_text().unwrap(), "remote");
                 drop(stmt);
-                let mut stmt = conn.prepare("SELECT note FROM local_notes WHERE id = 1")?;
-                let row = run_stmt_once(&coro, &mut stmt).await?.unwrap();
-                assert_eq!(row.get_value(0).to_text().unwrap(), "unpushed");
-                drop(stmt);
+                let mut stmt = conn.prepare("SELECT id, body FROM notes ORDER BY id")?;
+                let mut notes = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await? {
+                    notes.push((
+                        row.get_value(0).as_int().unwrap(),
+                        row.get_value(1).to_text().unwrap().to_string(),
+                    ));
+                }
+                assert_eq!(
+                    notes,
+                    vec![
+                        (1, "local-update".to_string()),
+                        (3, "local-insert".to_string()),
+                    ]
+                );
                 drop(conn);
+
+                assert_eq!(engine.meta().revert_since_wal_watermark, 0);
+                assert!(engine.meta().revert_since_wal_salt.is_none());
 
                 let unchanged = engine.wait_changes_from_remote(&coro).await?;
                 assert!(unchanged.is_empty());
+
+                drop(engine);
+                let reopened_db = turso_core::Database::open_file(
+                    io.clone(),
+                    &main_path,
+                    Arc::new(SqliteDialect),
+                )?;
+                let reopened = DatabaseSyncEngine::open_db(
+                    &coro,
+                    io,
+                    sync_stats,
+                    reopened_db,
+                    opts,
+                )
+                .await?;
+                assert_eq!(reopened.meta().revert_since_wal_watermark, 0);
+                assert!(reopened.meta().revert_since_wal_salt.is_none());
+                let conn = reopened.connect_rw(&coro).await?;
+                assert!(conn.mvcc_enabled());
+                let mut stmt = conn.prepare("SELECT id, body FROM notes ORDER BY id")?;
+                let mut notes = Vec::new();
+                while let Some(row) = run_stmt_once(&coro, &mut stmt).await? {
+                    notes.push((
+                        row.get_value(0).as_int().unwrap(),
+                        row.get_value(1).to_text().unwrap().to_string(),
+                    ));
+                }
+                assert_eq!(
+                    notes,
+                    vec![
+                        (1, "local-update".to_string()),
+                        (3, "local-insert".to_string()),
+                    ]
+                );
                 Result::Ok(())
             }
         });
@@ -3851,7 +4015,7 @@ mod tests {
         let first =
             PullUpdatesReqProtoBody::decode(requests[0].2.as_ref().unwrap().as_slice()).unwrap();
         assert_eq!(first.stream_kind, PullUpdatesStreamKind::Pages as i32);
-        assert_eq!(first.client_revision, "17");
+        assert_eq!(first.client_revision, "18");
         for request in &requests[1..] {
             let request =
                 PullUpdatesReqProtoBody::decode(request.2.as_ref().unwrap().as_slice()).unwrap();
@@ -4637,8 +4801,10 @@ mod tests {
         assert_replace_base_backups_removed(&main_path);
     }
 
+    /// A zero-page MVCC base is still a replacement operation: dropping its empty payload as "no
+    /// changes" would skip the guarded journal conversion and leave an empty replica in WAL mode.
     #[test]
-    fn initial_logical_mvcc_pull_page_bootstrap_uses_replace_base_apply() {
+    fn initial_empty_mvcc_page_base_is_retained_for_replace_base_apply() {
         let temp_file = NamedTempFile::new().unwrap();
         let main_path = temp_file.path().to_str().unwrap().to_string();
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
@@ -4697,7 +4863,8 @@ mod tests {
                 let engine =
                     DatabaseSyncEngine::open_db(&coro, io, sync_stats, main_db, opts).await?;
                 let status = engine.wait_changes_from_remote(&coro).await?;
-                assert!(status.file_slot.is_none());
+                assert!(status.file_slot.is_some());
+                assert!(!status.is_empty());
                 assert!(matches!(
                     status.stream_kind,
                     DbChangesStreamKind::ReplaceBasePages
@@ -4809,7 +4976,7 @@ mod tests {
     /// The page token identifies only the transferred page snapshot, so the next pull must use the
     /// separate logical resume revision supplied with those replacement pages.
     #[test]
-    fn logical_pull_replace_base_persists_logical_resume_revision() {
+    fn logical_pull_replace_base_retains_logical_resume_revision_until_apply() {
         let temp_file = NamedTempFile::new().unwrap();
         let main_path = temp_file.path().to_str().unwrap().to_string();
         let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
@@ -4873,7 +5040,7 @@ mod tests {
                     DatabaseSyncEngine::open_db(&coro, io, sync_stats, main_db, opts).await?;
                 let status = engine.wait_changes_from_remote(&coro).await?;
 
-                assert!(status.file_slot.is_none());
+                assert!(status.file_slot.is_some());
                 assert_eq!(status.stream_kind, DbChangesStreamKind::ReplaceBasePages);
                 assert_eq!(
                     status.revision,
@@ -4881,7 +5048,13 @@ mod tests {
                         revision: logical_resume_revision.to_string(),
                     }
                 );
-                assert_eq!(engine.meta().synced_revision, Some(status.revision));
+                assert_eq!(
+                    engine.meta().synced_revision,
+                    Some(DatabasePullRevision::V1 {
+                        revision: old_revision.to_string(),
+                    }),
+                    "replacement revision must not become durable before guarded apply"
+                );
                 Result::Ok(())
             }
         });
@@ -5583,7 +5756,7 @@ mod tests {
         let mut opts = default_test_opts();
         opts.remote_url = Some("https://example.com".to_string());
         opts.bootstrap_if_empty = false;
-        opts.logical_mvcc_pull = None; // auto-detect
+        opts.logical_mvcc_pull = Some(true);
 
         let mut gen = genawaiter::sync::Gen::new({
             let io = io.clone();
@@ -5603,7 +5776,7 @@ mod tests {
                 })?;
                 assert_eq!(
                     engine.meta().remote_pull_protocol,
-                    RemotePullProtocol::Unknown
+                    RemotePullProtocol::MvccLogical
                 );
 
                 // Local writes before ever contacting the server.
@@ -5627,9 +5800,15 @@ mod tests {
                 assert!(status.file_slot.is_some());
                 assert_eq!(
                     engine.meta().remote_pull_protocol,
-                    RemotePullProtocol::Unknown,
+                    RemotePullProtocol::MvccLogical,
                     "protocol publication must wait until replacement commits"
                 );
+                let conn = engine.connect_rw(&coro).await?;
+                assert!(
+                    !conn.mvcc_enabled(),
+                    "downloading changes must not mutate the local journal mode before the guarded apply begins"
+                );
+                drop(conn);
 
                 engine.apply_changes_from_remote(&coro, status).await?;
                 assert_eq!(

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -138,7 +138,7 @@ fn is_memory(main_db_path: &str) -> bool {
     main_db_path == ":memory:"
 }
 pub fn sync_database_file_paths(main_db_path: &str) -> Vec<String> {
-    vec![
+    let mut paths = vec![
         // Core opens the database and its WAL.
         main_db_path.to_string(),
         create_main_db_wal_path(main_db_path),
@@ -148,7 +148,14 @@ pub fn sync_database_file_paths(main_db_path: &str) -> Vec<String> {
         create_changes_path(main_db_path),
         // MVCC may be selected only after the remote protocol is known.
         create_main_db_log_path(main_db_path),
-    ]
+    ];
+    paths.push(create_replace_base_marker_path(main_db_path));
+    paths.extend(
+        replace_base_file_specs(main_db_path)
+            .into_iter()
+            .map(|(_, name, _)| replace_base_backup_path(main_db_path, name)),
+    );
+    paths
 }
 fn create_main_db_wal_path(main_db_path: &str) -> String {
     format!("{main_db_path}-wal")
@@ -173,6 +180,38 @@ fn create_replace_base_marker_path(main_db_path: &str) -> String {
 }
 fn replace_base_backup_path(main_db_path: &str, name: &str) -> String {
     format!("{main_db_path}-replace-base-apply-{name}.backup")
+}
+
+fn replace_base_file_specs(
+    main_db_path: &str,
+) -> [(String, &'static str, ReplaceBaseFileStorage); 5] {
+    [
+        (
+            main_db_path.to_string(),
+            "main-db",
+            ReplaceBaseFileStorage::Database,
+        ),
+        (
+            create_main_db_wal_path(main_db_path),
+            "main-wal",
+            ReplaceBaseFileStorage::Database,
+        ),
+        (
+            create_main_db_log_path(main_db_path),
+            "main-log",
+            ReplaceBaseFileStorage::Database,
+        ),
+        (
+            create_revert_db_wal_path(main_db_path),
+            "revert-wal",
+            ReplaceBaseFileStorage::Database,
+        ),
+        (
+            create_meta_path(main_db_path),
+            "metadata",
+            ReplaceBaseFileStorage::Metadata,
+        ),
+    ]
 }
 
 #[cfg(test)]
@@ -207,6 +246,20 @@ struct ReplaceBaseBackupFile {
     path: String,
     backup_path: String,
     present: bool,
+    #[serde(default = "legacy_replace_base_file_storage")]
+    storage: ReplaceBaseFileStorage,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ReplaceBaseFileStorage {
+    Database,
+    Metadata,
+}
+
+fn legacy_replace_base_file_storage() -> ReplaceBaseFileStorage {
+    // Version 1 wrote every backup through SyncEngineIo, which maps to browser localStorage.
+    ReplaceBaseFileStorage::Metadata
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -326,11 +379,96 @@ async fn sync_path_if_present<Ctx>(
     Ok(())
 }
 
-fn remove_file_if_present(io: &Arc<dyn turso_core::IO>, path: &str) -> Result<()> {
+async fn remove_or_clear_file<Ctx>(
+    coro: &Coro<Ctx>,
+    io: &Arc<dyn turso_core::IO>,
+    path: &str,
+) -> Result<()> {
     if io.try_open(path)?.is_some() {
         io.remove_file(path)?;
+        // OPFS keeps every registered file handle alive for the database lifetime, so removing a
+        // path is represented by an empty, flushed file. Native IO removes the entry and skips
+        // this branch. `full_read` treats both representations as absent.
+        if let Some(file) = io.try_open(path)? {
+            let truncate = file.truncate(0, Completion::new_trunc(|_| {}))?;
+            drive_core_completion(coro, io, truncate).await?;
+            sync_file(coro, &file).await?;
+        }
     }
     Ok(())
+}
+
+async fn read_database_file<Ctx>(
+    coro: &Coro<Ctx>,
+    io: &Arc<dyn turso_core::IO>,
+    path: &str,
+) -> Result<Option<Vec<u8>>> {
+    let Some(file) = io.try_open(path)? else {
+        return Ok(None);
+    };
+    let size = usize::try_from(file.size()?).map_err(|_| {
+        Error::DatabaseSyncEngineError(format!("replace-base file is too large: {path}"))
+    })?;
+    if size == 0 {
+        return Ok(None);
+    }
+    let buffer = Arc::new(Buffer::new_temporary(size));
+    let bytes_read = Arc::new(Mutex::new(None));
+    let completion = Completion::new_read(buffer.clone(), {
+        let bytes_read = bytes_read.clone();
+        move |result| {
+            *bytes_read.lock().unwrap() = Some(result.map(|(_, size)| size));
+            None
+        }
+    });
+    let completion = file.pread(0, completion)?;
+    drive_core_completion(coro, io, completion).await?;
+    let bytes_read = bytes_read
+        .lock()
+        .unwrap()
+        .expect("completed read must report its result")
+        .map_err(|error| {
+            Error::DatabaseSyncEngineError(format!(
+                "failed to read replace-base source {path}: {error}"
+            ))
+        })?;
+    if bytes_read as usize != size {
+        return Err(Error::DatabaseSyncEngineError(format!(
+            "short read while backing up {path}: expected {size} bytes, read {bytes_read}"
+        )));
+    }
+    Ok(Some(buffer.as_slice().to_vec()))
+}
+
+async fn write_database_file<Ctx>(
+    coro: &Coro<Ctx>,
+    io: &Arc<dyn turso_core::IO>,
+    path: &str,
+    content: Vec<u8>,
+) -> Result<()> {
+    let file = io.open_file(path, OpenFlags::Create, false)?;
+    let truncate = file.truncate(0, Completion::new_trunc(|_| {}))?;
+    drive_core_completion(coro, io, truncate).await?;
+    if !content.is_empty() {
+        let write = file.pwrite(
+            0,
+            Arc::new(Buffer::new(content)),
+            Completion::new_write(|_| {}),
+        )?;
+        drive_core_completion(coro, io, write).await?;
+    }
+    sync_file(coro, &file).await
+}
+
+async fn clear_metadata_file<Ctx, IO: SyncEngineIo>(
+    coro: &Coro<Ctx>,
+    io: &Arc<dyn turso_core::IO>,
+    sync_engine_io: Arc<IO>,
+    path: &str,
+) -> Result<()> {
+    let completion = sync_engine_io.full_write(path, Vec::new())?;
+    wait_all_results(coro, &completion, None).await?;
+    remove_or_clear_file(coro, io, path).await
 }
 
 /// Fsync the directory that contains `path`, making newly created or removed
@@ -369,36 +507,55 @@ fn sync_parent_dir(path: &str) -> Result<()> {
     Ok(())
 }
 
-async fn copy_sync_engine_file<Ctx, IO: SyncEngineIo>(
+async fn copy_replace_base_file<Ctx, IO: SyncEngineIo>(
     coro: &Coro<Ctx>,
     io: Arc<dyn turso_core::IO>,
     sync_engine_io: Arc<IO>,
     source_path: &str,
     target_path: &str,
     is_memory: bool,
+    storage: ReplaceBaseFileStorage,
 ) -> Result<bool> {
-    let Some(content) = full_read(
-        coro,
-        Some(io.clone()),
-        sync_engine_io.clone(),
-        source_path,
-        is_memory,
-    )
-    .await?
-    else {
-        remove_file_if_present(&io, target_path)?;
+    let content = match storage {
+        ReplaceBaseFileStorage::Database => read_database_file(coro, &io, source_path).await?,
+        ReplaceBaseFileStorage::Metadata => {
+            full_read(
+                coro,
+                Some(io.clone()),
+                sync_engine_io.clone(),
+                source_path,
+                is_memory,
+            )
+            .await?
+        }
+    };
+    let Some(content) = content else {
+        match storage {
+            ReplaceBaseFileStorage::Database => {
+                remove_or_clear_file(coro, &io, target_path).await?
+            }
+            ReplaceBaseFileStorage::Metadata => {
+                clear_metadata_file(coro, &io, sync_engine_io, target_path).await?
+            }
+        }
         return Ok(false);
     };
-    full_write(
-        coro,
-        io.clone(),
-        sync_engine_io,
-        target_path,
-        is_memory,
-        content,
-    )
-    .await?;
-    sync_path_if_present(coro, &io, target_path).await?;
+    match storage {
+        ReplaceBaseFileStorage::Database => {
+            write_database_file(coro, &io, target_path, content).await?
+        }
+        ReplaceBaseFileStorage::Metadata => {
+            full_write(
+                coro,
+                io.clone(),
+                sync_engine_io,
+                target_path,
+                is_memory,
+                content,
+            )
+            .await?;
+        }
+    }
     Ok(true)
 }
 
@@ -417,33 +574,29 @@ impl<IO: SyncEngineIo> ReplaceBaseApplyGuard<IO> {
             ));
         }
         let is_memory = is_memory(main_db_path);
-        let file_specs = [
-            (main_db_path.to_string(), "main-db"),
-            (create_main_db_wal_path(main_db_path), "main-wal"),
-            (create_main_db_log_path(main_db_path), "main-log"),
-            (create_revert_db_wal_path(main_db_path), "revert-wal"),
-            (create_meta_path(main_db_path), "metadata"),
-        ];
+        let file_specs = replace_base_file_specs(main_db_path);
         let mut files = Vec::with_capacity(file_specs.len());
-        for (path, name) in file_specs {
+        for (path, name, storage) in file_specs {
             let backup_path = replace_base_backup_path(main_db_path, name);
-            let present = copy_sync_engine_file(
+            let present = copy_replace_base_file(
                 coro,
                 io.clone(),
                 sync_engine_io.io.clone(),
                 &path,
                 &backup_path,
                 is_memory,
+                storage,
             )
             .await?;
             files.push(ReplaceBaseBackupFile {
                 path,
                 backup_path,
                 present,
+                storage,
             });
         }
         let manifest = ReplaceBaseBackupManifest {
-            version: 1,
+            version: 2,
             operation: "replace_base_apply".to_string(),
             main_db_path: main_db_path.to_string(),
             previous_synced_revision,
@@ -499,6 +652,7 @@ impl<IO: SyncEngineIo> ReplaceBaseApplyGuard<IO> {
                     "failed to parse pending replace-base recovery marker {marker_path}: {err}"
                 ))
             })?;
+        Self::validate_manifest(&manifest, main_db_path)?;
         tracing::warn!(
             "recover_pending_replace_base(path={}): restoring local files from pending marker",
             main_db_path
@@ -514,17 +668,57 @@ impl<IO: SyncEngineIo> ReplaceBaseApplyGuard<IO> {
         Ok(true)
     }
 
+    fn validate_manifest(manifest: &ReplaceBaseBackupManifest, main_db_path: &str) -> Result<()> {
+        if !matches!(manifest.version, 1 | 2) {
+            return Err(Error::DatabaseSyncEngineError(format!(
+                "unsupported replace-base recovery marker version: {}",
+                manifest.version
+            )));
+        }
+        if manifest.operation != "replace_base_apply" || manifest.main_db_path != main_db_path {
+            return Err(Error::DatabaseSyncEngineError(
+                "replace-base recovery marker does not belong to this database".to_string(),
+            ));
+        }
+        let expected = replace_base_file_specs(main_db_path);
+        if manifest.files.len() != expected.len() {
+            return Err(Error::DatabaseSyncEngineError(format!(
+                "replace-base recovery marker has {} files, expected {}",
+                manifest.files.len(),
+                expected.len()
+            )));
+        }
+        for (file, (path, name, current_storage)) in manifest.files.iter().zip(expected) {
+            let expected_storage = if manifest.version == 1 {
+                ReplaceBaseFileStorage::Metadata
+            } else {
+                current_storage
+            };
+            if file.path != path
+                || file.backup_path != replace_base_backup_path(main_db_path, name)
+                || file.storage != expected_storage
+            {
+                return Err(Error::DatabaseSyncEngineError(format!(
+                    "replace-base recovery marker contains an invalid file entry: {:?}",
+                    file
+                )));
+            }
+        }
+        Ok(())
+    }
+
     async fn restore<Ctx>(&self, coro: &Coro<Ctx>) -> Result<()> {
         let is_memory = is_memory(&self.main_db_path);
         for file in &self.manifest.files {
             if file.present {
-                let restored = copy_sync_engine_file(
+                let restored = copy_replace_base_file(
                     coro,
                     self.io.clone(),
                     self.sync_engine_io.io.clone(),
                     &file.backup_path,
                     &file.path,
                     is_memory,
+                    file.storage,
                 )
                 .await?;
                 if !restored {
@@ -534,7 +728,20 @@ impl<IO: SyncEngineIo> ReplaceBaseApplyGuard<IO> {
                     )));
                 }
             } else {
-                remove_file_if_present(&self.io, &file.path)?;
+                match file.storage {
+                    ReplaceBaseFileStorage::Database => {
+                        remove_or_clear_file(coro, &self.io, &file.path).await?
+                    }
+                    ReplaceBaseFileStorage::Metadata => {
+                        clear_metadata_file(
+                            coro,
+                            &self.io,
+                            self.sync_engine_io.io.clone(),
+                            &file.path,
+                        )
+                        .await?
+                    }
+                }
             }
         }
         self.cleanup(coro).await
@@ -548,13 +755,29 @@ impl<IO: SyncEngineIo> ReplaceBaseApplyGuard<IO> {
         // pointing at missing backups, which fails `restore` on the next open and
         // bricks the database. Once the marker is durably gone, leftover backups
         // are merely orphaned files (harmless, overwritten by the next apply).
-        remove_file_if_present(
+        clear_metadata_file(
+            coro,
             &self.io,
+            self.sync_engine_io.io.clone(),
             &create_replace_base_marker_path(&self.main_db_path),
-        )?;
+        )
+        .await?;
         sync_parent_dir(&self.main_db_path)?;
         for file in &self.manifest.files {
-            remove_file_if_present(&self.io, &file.backup_path)?;
+            match file.storage {
+                ReplaceBaseFileStorage::Database => {
+                    remove_or_clear_file(coro, &self.io, &file.backup_path).await?
+                }
+                ReplaceBaseFileStorage::Metadata => {
+                    clear_metadata_file(
+                        coro,
+                        &self.io,
+                        self.sync_engine_io.io.clone(),
+                        &file.backup_path,
+                    )
+                    .await?
+                }
+            }
         }
         sync_path_if_present(coro, &self.io, &self.main_db_path).await?;
         Ok(())
@@ -1634,7 +1857,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         // turso_cdc table itself is created eagerly by the capture pragma,
         // so its existence proves nothing.)
         let cdc_high_water = max_local_change_id(coro, &main_conn).await?.unwrap_or(0);
-        if cdc_high_water == 0 {
+        if self.meta().synced_revision.is_none() && cdc_high_water == 0 {
             let user_tables = list_user_tables(coro, &main_conn).await?;
             if !user_tables.is_empty() {
                 return Err(Error::DatabaseSyncEngineError(format!(
@@ -1718,10 +1941,22 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             self.opts.logical_mvcc_pull,
             self.meta().remote_pull_protocol,
         );
+        let response_protocol;
         let next_revision = match (remote_pull_protocol, &revision) {
             (RemotePullProtocol::MvccLogical, Some(DatabasePullRevision::V1 { revision })) => {
                 match pull_updates_v1(ctx, &file.value, revision, long_poll_timeout, true).await? {
-                    (next_revision, result @ PullUpdatesV1Result::Logical { txns, ops }, _) => {
+                    (
+                        next_revision,
+                        result @ PullUpdatesV1Result::Logical { txns, ops },
+                        detected,
+                    ) => {
+                        if detected != RemotePullProtocol::MvccLogical {
+                            return Err(Error::DatabaseSyncEngineError(
+                                "MVCC logical replica cannot downgrade to the page protocol"
+                                    .to_string(),
+                            ));
+                        }
+                        response_protocol = detected;
                         tracing::info!(
                             "wait_changes(path={}): logical pull returned {} transactions / {} ops",
                             self.main_db_path,
@@ -1731,7 +1966,18 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         stream_kind = stream_kind_for_pull_updates_v1_result(&result);
                         next_revision
                     }
-                    (next_revision, result @ PullUpdatesV1Result::Pages { replace_base }, _) => {
+                    (
+                        next_revision,
+                        result @ PullUpdatesV1Result::Pages { replace_base },
+                        detected,
+                    ) => {
+                        if detected != RemotePullProtocol::MvccLogical {
+                            return Err(Error::DatabaseSyncEngineError(
+                                "MVCC logical replica cannot downgrade to the page protocol"
+                                    .to_string(),
+                            ));
+                        }
+                        response_protocol = detected;
                         tracing::info!(
                             "wait_changes(path={}): logical pull returned a page stream fallback; replace_base={replace_base}",
                             self.main_db_path,
@@ -1742,8 +1988,14 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 }
             }
             (RemotePullProtocol::MvccLogical, None) => {
-                let (next_revision, result, _) =
+                let (next_revision, result, detected) =
                     pull_updates_v1(ctx, &file.value, "", long_poll_timeout, false).await?;
+                if detected != RemotePullProtocol::MvccLogical {
+                    return Err(Error::DatabaseSyncEngineError(
+                        "MVCC logical replica cannot downgrade to the page protocol".to_string(),
+                    ));
+                }
+                response_protocol = detected;
                 tracing::info!(
                     "wait_changes(path={}): initial logical MVCC sync returned page base",
                     self.main_db_path,
@@ -1789,19 +2041,13 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         self.opts.partial_sync_opts.is_some(),
                         self.opts.remote_encryption_key.as_deref(),
                     )?;
-                    // Deferred replicas may still be in WAL mode locally; the
-                    // MVCC page base must be applied to an MVCC-mode database.
-                    self.ensure_local_mvcc_journal_mode(coro).await?;
                 }
+                response_protocol = detected;
                 tracing::info!(
                     "wait_changes(path={}): detected remote pull protocol {:?} on first contact",
                     self.main_db_path,
                     detected
                 );
-                self.update_meta(coro, |m| {
-                    m.remote_pull_protocol = detected;
-                })
-                .await?;
                 stream_kind = match (detected, &result) {
                     // Page-protocol remote: mirror the page path exactly,
                     // including its rejection of replace-base streams.
@@ -1829,7 +2075,58 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 };
                 next_revision
             }
+            (
+                RemotePullProtocol::Pages | RemotePullProtocol::Unknown,
+                Some(DatabasePullRevision::V1 { revision }),
+            ) => {
+                let (next_revision, result, detected) =
+                    pull_updates_v1(ctx, &file.value, revision, long_poll_timeout, false).await?;
+                response_protocol = detected;
+                match (detected, result) {
+                    (
+                        RemotePullProtocol::MvccLogical,
+                        result @ PullUpdatesV1Result::Pages { replace_base: true },
+                    ) => {
+                        ensure_logical_mvcc_pull_supported(
+                            self.opts.partial_sync_opts.is_some(),
+                            self.opts.remote_encryption_key.as_deref(),
+                        )?;
+                        stream_kind = stream_kind_for_pull_updates_v1_result(&result);
+                    }
+                    (RemotePullProtocol::MvccLogical, _) => {
+                        return Err(Error::DatabaseSyncEngineError(
+                            "page-to-MVCC protocol transition requires a replace-base page response"
+                                .to_string(),
+                        ));
+                    }
+                    (
+                        RemotePullProtocol::Pages | RemotePullProtocol::Unknown,
+                        result @ PullUpdatesV1Result::Pages {
+                            replace_base: false,
+                        },
+                    ) => {
+                        stream_kind = stream_kind_for_pull_updates_v1_result(&result);
+                    }
+                    (
+                        RemotePullProtocol::Pages | RemotePullProtocol::Unknown,
+                        PullUpdatesV1Result::Pages { replace_base: true },
+                    ) => {
+                        return Err(Error::DatabaseSyncEngineError(
+                            "page protocol response unexpectedly requires replace-base apply"
+                                .to_string(),
+                        ));
+                    }
+                    (_, PullUpdatesV1Result::Logical { .. }) => {
+                        return Err(Error::DatabaseSyncEngineError(
+                            "server returned a logical stream for a page-stream request"
+                                .to_string(),
+                        ));
+                    }
+                }
+                next_revision
+            }
             (RemotePullProtocol::Pages | RemotePullProtocol::Unknown, _) => {
+                response_protocol = RemotePullProtocol::Pages;
                 wal_pull_to_file(
                     ctx,
                     &file.value,
@@ -1849,6 +2146,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             self.update_meta(coro, |m| {
                 m.synced_revision = Some(next_revision.clone());
                 m.last_pull_unix_time = Some(now.secs);
+                m.remote_pull_protocol = response_protocol;
             })
             .await?;
             return Ok(DbChangesStatus {
@@ -1883,10 +2181,20 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         remote_changes: DbChangesStatus,
     ) -> Result<()> {
         let mut new_revision = remote_changes.revision.clone();
+        let previous_protocol = self.meta().remote_pull_protocol;
+        let next_protocol = match remote_changes.stream_kind {
+            DbChangesStreamKind::Logical | DbChangesStreamKind::ReplaceBasePages => {
+                RemotePullProtocol::MvccLogical
+            }
+            DbChangesStreamKind::LegacyPages | DbChangesStreamKind::Pages => {
+                RemotePullProtocol::Pages
+            }
+        };
         if remote_changes.is_empty() {
             self.update_meta(coro, |m| {
                 m.synced_revision = Some(new_revision.clone());
                 m.last_pull_unix_time = Some(remote_changes.time.secs);
+                m.remote_pull_protocol = next_protocol;
             })
             .await?;
             return Ok(());
@@ -1910,22 +2218,56 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 m.last_pushed_replay_floor_change_id_hint = 0;
                 m.last_pull_unix_time = Some(remote_changes.time.secs);
                 m.logical_table_names_by_stable_id = logical_table_names_by_stable_id;
+                m.remote_pull_protocol = next_protocol;
             })
             .await?;
             return Ok(());
         }
-        let pull_result = self
-            .apply_changes_internal(
+        let replace_base = matches!(
+            remote_changes.stream_kind,
+            DbChangesStreamKind::ReplaceBasePages
+        );
+        let mut replace_base_guard = if replace_base {
+            Some(
+                ReplaceBaseApplyGuard::create(
+                    coro,
+                    self.io.clone(),
+                    self.sync_engine_io.clone(),
+                    &self.main_db_path,
+                    self.meta().synced_revision.clone(),
+                )
+                .await?,
+            )
+        } else {
+            None
+        };
+        let pull_result = async {
+            if next_protocol == RemotePullProtocol::MvccLogical
+                && previous_protocol != RemotePullProtocol::MvccLogical
+            {
+                self.ensure_local_mvcc_journal_mode(coro).await?;
+            }
+            self.apply_changes_internal(
                 coro,
                 &changes_file,
                 remote_changes.stream_kind,
                 &remote_changes.revision,
+                next_protocol,
             )
-            .await;
+            .await
+        }
+        .await;
         let Ok((revert_since_wal_watermark, logical_table_names_by_stable_id, followup_revision)) =
             pull_result
         else {
-            return Err(pull_result.err().unwrap());
+            let error = pull_result.err().unwrap();
+            if let Some(guard) = &replace_base_guard {
+                let error = guard.restore_after_error(coro, error).await;
+                let conn = connect_untracked(&self.main_tape)?;
+                reload_connection_after_external_restore(&conn, "replace-base error recovery")?;
+                return Err(error);
+            }
+            return Err(error);
         };
         if let Some(revision) = followup_revision {
             new_revision = revision;
@@ -1946,8 +2288,12 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             m.last_pushed_replay_floor_change_id_hint = 0;
             m.last_pull_unix_time = Some(remote_changes.time.secs);
             m.logical_table_names_by_stable_id = logical_table_names_by_stable_id;
+            m.remote_pull_protocol = next_protocol;
         })
         .await?;
+        if let Some(guard) = &mut replace_base_guard {
+            guard.mark_complete(coro).await?;
+        }
         Ok(())
     }
 
@@ -2184,6 +2530,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         changes_file: &Arc<dyn turso_core::File>,
         stream_kind: DbChangesStreamKind,
         remote_revision: &DatabasePullRevision,
+        remote_protocol: RemotePullProtocol,
     ) -> Result<(u64, BTreeMap<u64, String>, Option<DatabasePullRevision>)> {
         tracing::info!("apply_changes(path={})", self.main_db_path);
 
@@ -2226,8 +2573,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         // read current pull generation from local table for the given client
         let (local_pull_gen, local_last_change_id) =
             read_last_change_id(coro, &main_conn, &self.client_unique_id).await?;
-        let no_checkpoint_replace_base =
-            replace_base_pages && self.meta().logical_mvcc_pull_active();
+        let logical_mvcc_pull_active = remote_protocol == RemotePullProtocol::MvccLogical;
+        let no_checkpoint_replace_base = replace_base_pages && logical_mvcc_pull_active;
         tracing::info!(
             "apply_changes(path={}): local sync high-water before remote apply: client_id={} pull_gen={} change_id={:?} replace_base={}",
             self.main_db_path,
@@ -2252,7 +2599,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
             || matches!(stream_kind, DbChangesStreamKind::Logical)
             || should_replay_raw_pages_on_sql_conn(
                 self.opts.protocol_version_hint,
-                self.meta().logical_mvcc_pull_active(),
+                logical_mvcc_pull_active,
                 false,
                 stream_kind,
                 main_conn.mv_store().as_ref().is_some(),
@@ -2309,23 +2656,8 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                 self.main_db_path,
             );
         }
-        let previous_synced_revision = self.meta().synced_revision.clone();
         let mut logical_table_names_by_stable_id =
             self.meta().logical_table_names_by_stable_id.clone();
-        let mut replace_base_guard = if replace_base_pages {
-            Some(
-                ReplaceBaseApplyGuard::create(
-                    coro,
-                    self.io.clone(),
-                    self.sync_engine_io.clone(),
-                    &self.main_db_path,
-                    previous_synced_revision,
-                )
-                .await?,
-            )
-        } else {
-            None
-        };
 
         let apply_result: Result<(
             u64,
@@ -2512,7 +2844,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
                         })?;
                         logical_replay_conn = Some(conn);
 
-                        if self.meta().logical_mvcc_pull_active() {
+                        if logical_mvcc_pull_active {
                             let DatabasePullRevision::V1 { revision } = remote_revision else {
                                 return Err(Error::DatabaseSyncEngineError(format!(
                                     "replace-base follow-up logical pull requires a V1 revision, got {remote_revision:?}"
@@ -2618,7 +2950,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
 
             let raw_page_replay_on_sql_conn = should_replay_raw_pages_on_sql_conn(
                 self.opts.protocol_version_hint,
-                self.meta().logical_mvcc_pull_active(),
+                logical_mvcc_pull_active,
                 logical_replay_conn.is_some(),
                 stream_kind,
                 main_conn.mv_store().as_ref().is_some(),
@@ -3132,30 +3464,7 @@ impl<IO: SyncEngineIo> DatabaseSyncEngine<IO> {
         }
         .await;
 
-        match apply_result {
-            Ok(frame) => {
-                if let Some(guard) = &mut replace_base_guard {
-                    guard.mark_complete(coro).await?;
-                }
-                Ok(frame)
-            }
-            Err(error) => {
-                if let Some(guard) = &replace_base_guard {
-                    let error = guard.restore_after_error(coro, error).await;
-                    match reload_connection_after_external_restore(
-                        &main_conn,
-                        "replace-base error recovery",
-                    ) {
-                        Ok(()) => Err(error),
-                        Err(reload_error) => Err(Error::DatabaseSyncEngineError(format!(
-                            "{error}; additionally failed to reload restored database state: {reload_error}",
-                        ))),
-                    }
-                } else {
-                    Err(error)
-                }
-            }
-        }
+        apply_result
     }
 
     /// Sync local changes to remote DB
@@ -3244,12 +3553,13 @@ mod tests {
         create_main_db_log_path, create_main_db_wal_path, create_meta_path,
         create_replace_base_marker_path, create_revert_db_wal_path,
         ensure_logical_mvcc_pull_supported, ensure_stream_kind_can_use_legacy_page_apply,
-        replace_base_backup_path, resolve_local_replay_floor_change_id,
-        resolve_remote_pull_protocol, should_replay_raw_pages_on_sql_conn,
-        should_request_logical_pull, stream_kind_applies_remote_pages,
-        stream_kind_for_pull_updates_v1_result, sync_database_file_paths,
-        synced_change_id_after_remote_apply, use_pushed_change_hint_for_local_replay,
-        DatabaseSyncEngine, DatabaseSyncEngineOpts, ReplaceBaseApplyGuard,
+        full_write, remove_or_clear_file, replace_base_backup_path, replace_base_file_specs,
+        resolve_local_replay_floor_change_id, resolve_remote_pull_protocol,
+        should_replay_raw_pages_on_sql_conn, should_request_logical_pull,
+        stream_kind_applies_remote_pages, stream_kind_for_pull_updates_v1_result,
+        sync_database_file_paths, synced_change_id_after_remote_apply,
+        use_pushed_change_hint_for_local_replay, DatabaseSyncEngine, DatabaseSyncEngineOpts,
+        ReplaceBaseApplyGuard, ReplaceBaseBackupManifest, ReplaceBaseFileStorage,
         REPLACE_BASE_LOCAL_REPLAY_FAILURE_AFTER,
     };
     use crate::{
@@ -3284,6 +3594,40 @@ mod tests {
     use tempfile::NamedTempFile;
     use turso_core::SqliteDialect;
 
+    struct RegisteredFileIo {
+        inner: Arc<turso_core::MemoryIO>,
+    }
+
+    impl turso_core::Clock for RegisteredFileIo {
+        fn current_time_monotonic(&self) -> turso_core::MonotonicInstant {
+            self.inner.current_time_monotonic()
+        }
+
+        fn current_time_wall_clock(&self) -> turso_core::WallClockInstant {
+            self.inner.current_time_wall_clock()
+        }
+    }
+
+    impl turso_core::IO for RegisteredFileIo {
+        fn open_file(
+            &self,
+            path: &str,
+            flags: turso_core::OpenFlags,
+            direct: bool,
+        ) -> turso_core::Result<Arc<dyn turso_core::File>> {
+            self.inner.open_file(path, flags, direct)
+        }
+
+        fn remove_file(&self, _path: &str) -> turso_core::Result<()> {
+            // OPFS cannot remove a file while its pre-registered sync handle is open.
+            Ok(())
+        }
+
+        fn file_id(&self, path: &str) -> turso_core::Result<turso_core::io::FileId> {
+            self.inner.file_id(path)
+        }
+    }
+
     #[test]
     fn sync_database_paths_include_core_sync_and_mvcc_files() {
         assert_eq!(
@@ -3295,8 +3639,228 @@ mod tests {
                 "replica.sqlite-info",
                 "replica.sqlite-changes",
                 "replica.db-log",
+                "replica.sqlite-replace-base-apply",
+                "replica.sqlite-replace-base-apply-main-db.backup",
+                "replica.sqlite-replace-base-apply-main-wal.backup",
+                "replica.sqlite-replace-base-apply-main-log.backup",
+                "replica.sqlite-replace-base-apply-revert-wal.backup",
+                "replica.sqlite-replace-base-apply-metadata.backup",
             ]
         );
+    }
+
+    /// Browser files remain registered until close, so OPFS reports successful removal while the
+    /// handle and directory entry remain. Cleanup must still erase and flush the marker contents;
+    /// otherwise the next open would mistake a completed replacement for an interrupted one.
+    #[test]
+    fn replace_base_cleanup_clears_a_registered_file_when_removal_keeps_it_open() {
+        let io: Arc<dyn turso_core::IO> = Arc::new(RegisteredFileIo {
+            inner: Arc::new(turso_core::MemoryIO::new()),
+        });
+        let sync_stats = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
+        let path = "registered-replace-base-marker";
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                full_write(
+                    &coro,
+                    io.clone(),
+                    sync_stats.io.clone(),
+                    path,
+                    true,
+                    b"pending".to_vec(),
+                )
+                .await?;
+                remove_or_clear_file(&coro, &io, path).await?;
+                let file = io.try_open(path)?.expect("registered handle must remain");
+                assert_eq!(file.size()?, 0);
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+    }
+
+    /// An existing V1 page replica must not lose the response facts that authorize its one-way
+    /// move to logical MVCC. The pending change must retain replacement semantics and the logical
+    /// resume revision instead of entering the incremental WAL apply path.
+    #[test]
+    fn existing_page_replica_commits_one_mvcc_transition_then_observes_no_changes() {
+        let main_file = NamedTempFile::new().unwrap();
+        let remote_file = NamedTempFile::new().unwrap();
+        let main_path = main_file.path().to_str().unwrap().to_string();
+        let remote_path = remote_file.path().to_str().unwrap().to_string();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+
+        let remote_db =
+            turso_core::Database::open_file(io.clone(), &remote_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let remote_conn = remote_db.connect().unwrap();
+        remote_conn
+            .execute("CREATE TABLE messages(id INTEGER PRIMARY KEY, body TEXT)")
+            .unwrap();
+        remote_conn
+            .execute("INSERT INTO messages VALUES (1, 'remote')")
+            .unwrap();
+        remote_conn
+            .checkpoint(turso_core::CheckpointMode::Truncate {
+                upper_bound_inclusive: None,
+            })
+            .unwrap();
+        drop(remote_conn);
+        drop(remote_db);
+        let remote_bytes = std::fs::read(&remote_path).unwrap();
+        let logical_revision = "g8:o56";
+        let mut response = encoded_page_stream_response(
+            &remote_bytes,
+            "0",
+            logical_revision,
+            PullUpdatesProtocol::MvccLogical,
+        );
+        let mut response_body = response.as_slice();
+        let mut header =
+            PullUpdatesRespProtoBody::decode_length_delimited(&mut response_body).unwrap();
+        header.apply_mode = PullUpdatesApplyMode::ReplaceBase as i32;
+        let page_messages = response_body.to_vec();
+        response = header.encode_length_delimited_to_vec();
+        response.extend_from_slice(&page_messages);
+        let empty_logical_response = PullUpdatesRespProtoBody {
+            server_revision: logical_revision.to_string(),
+            db_size: (remote_bytes.len() / super::PAGE_SIZE) as u64,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
+            logical_resume_revision: String::new(),
+        }
+        .encode_length_delimited_to_vec();
+
+        let sync_io = Arc::new(QueuedSyncEngineIo {
+            responses: Mutex::new(
+                vec![
+                    response,
+                    empty_logical_response.clone(),
+                    empty_logical_response,
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            requests: Mutex::new(Vec::new()),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io.clone());
+        let main_db =
+            turso_core::Database::open_file(io.clone(), &main_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let metadata = DatabaseMetadata {
+            version: DATABASE_METADATA_VERSION.to_string(),
+            client_unique_id: "existing-page-client".to_string(),
+            synced_revision: Some(DatabasePullRevision::V1 {
+                revision: "17".to_string(),
+            }),
+            revert_since_wal_salt: None,
+            revert_since_wal_watermark: 0,
+            last_pull_unix_time: None,
+            last_push_unix_time: None,
+            last_pushed_pull_gen_hint: 0,
+            last_pushed_change_id_hint: 0,
+            last_pushed_replay_floor_change_id_hint: 0,
+            partial_bootstrap_server_revision: None,
+            fresh_bootstrap_pending_cdc_ack: false,
+            remote_pull_protocol: RemotePullProtocol::Pages,
+            logical_table_names_by_stable_id: Default::default(),
+            saved_configuration: Some(DatabaseSavedConfiguration {
+                remote_url: Some("https://same.example/database".to_string()),
+                partial_sync_prefetch: None,
+                partial_sync_segment_size: None,
+            }),
+        };
+        std::fs::write(create_meta_path(&main_path), metadata.dump().unwrap()).unwrap();
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://same.example/database".to_string());
+        opts.logical_mvcc_pull = None;
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine =
+                    DatabaseSyncEngine::open_db(&coro, io, sync_stats, main_db, opts).await?;
+                let conn = engine.connect_rw(&coro).await?;
+                conn.execute("CREATE TABLE local_notes(id INTEGER PRIMARY KEY, note TEXT)")?;
+                conn.execute("INSERT INTO local_notes VALUES (1, 'unpushed')")?;
+                drop(conn);
+
+                let changes = engine.wait_changes_from_remote(&coro).await?;
+                assert_eq!(changes.stream_kind, DbChangesStreamKind::ReplaceBasePages);
+                assert_eq!(
+                    changes.revision,
+                    DatabasePullRevision::V1 {
+                        revision: logical_revision.to_string(),
+                    }
+                );
+                assert!(!changes.is_empty());
+                assert_eq!(
+                    engine.meta().remote_pull_protocol,
+                    RemotePullProtocol::Pages,
+                    "protocol publication must wait until replacement commits"
+                );
+                engine.apply_changes_from_remote(&coro, changes).await?;
+                assert_eq!(
+                    engine.meta().remote_pull_protocol,
+                    RemotePullProtocol::MvccLogical
+                );
+                assert_eq!(
+                    engine.meta().synced_revision,
+                    Some(DatabasePullRevision::V1 {
+                        revision: logical_revision.to_string(),
+                    })
+                );
+                let conn = engine.connect_rw(&coro).await?;
+                assert!(conn.mvcc_enabled());
+                let mut stmt = conn.prepare("SELECT body FROM messages WHERE id = 1")?;
+                let row = run_stmt_once(&coro, &mut stmt).await?.unwrap();
+                assert_eq!(row.get_value(0).to_text().unwrap(), "remote");
+                drop(stmt);
+                let mut stmt = conn.prepare("SELECT note FROM local_notes WHERE id = 1")?;
+                let row = run_stmt_once(&coro, &mut stmt).await?.unwrap();
+                assert_eq!(row.get_value(0).to_text().unwrap(), "unpushed");
+                drop(stmt);
+                drop(conn);
+
+                let unchanged = engine.wait_changes_from_remote(&coro).await?;
+                assert!(unchanged.is_empty());
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        let requests = sync_io.requests.lock().unwrap();
+        assert_eq!(requests.len(), 3);
+        let first =
+            PullUpdatesReqProtoBody::decode(requests[0].2.as_ref().unwrap().as_slice()).unwrap();
+        assert_eq!(first.stream_kind, PullUpdatesStreamKind::Pages as i32);
+        assert_eq!(first.client_revision, "17");
+        for request in &requests[1..] {
+            let request =
+                PullUpdatesReqProtoBody::decode(request.2.as_ref().unwrap().as_slice()).unwrap();
+            assert_eq!(
+                request.stream_kind,
+                PullUpdatesStreamKind::MvccLogicalLog as i32
+            );
+            assert_eq!(request.client_revision, logical_revision);
+        }
     }
 
     #[test]
@@ -3995,6 +4559,43 @@ mod tests {
         assert_replace_base_backups_removed(&main_path);
     }
 
+    /// Version 1 stored every backup through SyncEngineIo. Browser recovery must continue reading
+    /// those files from localStorage, while rejecting marker paths that could escape this database.
+    #[test]
+    fn legacy_replace_base_manifest_keeps_its_storage_and_path_boundaries() {
+        let main_path = "legacy.db";
+        let files = replace_base_file_specs(main_path)
+            .into_iter()
+            .map(|(path, name, _)| {
+                serde_json::json!({
+                    "path": path,
+                    "backup_path": replace_base_backup_path(main_path, name),
+                    "present": true
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut manifest: ReplaceBaseBackupManifest = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "operation": "replace_base_apply",
+            "main_db_path": main_path,
+            "previous_synced_revision": null,
+            "files": files
+        }))
+        .unwrap();
+
+        ReplaceBaseApplyGuard::<NoopSyncEngineIo>::validate_manifest(&manifest, main_path).unwrap();
+        assert!(manifest
+            .files
+            .iter()
+            .all(|file| file.storage == ReplaceBaseFileStorage::Metadata));
+
+        manifest.files[0].path = "other.db".to_string();
+        assert!(
+            ReplaceBaseApplyGuard::<NoopSyncEngineIo>::validate_manifest(&manifest, main_path)
+                .is_err()
+        );
+    }
+
     #[test]
     fn replace_base_guard_mark_complete_removes_marker_without_restoring() {
         let temp_dir = tempfile::TempDir::new().unwrap();
@@ -4069,7 +4670,7 @@ mod tests {
         std::fs::write(create_meta_path(&main_path), meta.dump().unwrap()).unwrap();
 
         let header = PullUpdatesRespProtoBody {
-            protocol: 0,
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
             server_revision: "g1:o10".to_string(),
             db_size: 0,
             raw_encoding: None,
@@ -4077,7 +4678,7 @@ mod tests {
             stream_kind: PullUpdatesStreamKind::Pages as i32,
             apply_mode: PullUpdatesApplyMode::Incremental as i32,
             mvcc_log: None,
-            logical_resume_revision: String::new(),
+            logical_resume_revision: "g1:o10".to_string(),
         };
         let sync_io = Arc::new(CapturingSyncEngineIo {
             response: Mutex::new(Some(header.encode_length_delimited_to_vec())),
@@ -4117,6 +4718,91 @@ mod tests {
         assert_eq!(request.stream_kind, PullUpdatesStreamKind::Pages as i32);
         assert_eq!(request.client_revision, "");
         assert_eq!(request.server_revision, "");
+    }
+
+    /// Once a replica has applied logical changes, accepting a page-protocol response would run
+    /// those pages through incompatible WAL bookkeeping. Reject the downgrade before returning a
+    /// change file, and leave the durable protocol and revision untouched for a safe retry.
+    #[test]
+    fn logical_mvcc_replica_rejects_page_protocol_downgrade() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let main_path = temp_file.path().to_str().unwrap().to_string();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let main_db =
+            turso_core::Database::open_file(io.clone(), &main_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let revision = DatabasePullRevision::V1 {
+            revision: "g4:o8".to_string(),
+        };
+        let meta = DatabaseMetadata {
+            version: DATABASE_METADATA_VERSION.to_string(),
+            client_unique_id: "logical-client".to_string(),
+            synced_revision: Some(revision.clone()),
+            revert_since_wal_salt: None,
+            revert_since_wal_watermark: 0,
+            last_pull_unix_time: None,
+            last_push_unix_time: None,
+            last_pushed_pull_gen_hint: 0,
+            last_pushed_change_id_hint: 0,
+            last_pushed_replay_floor_change_id_hint: 0,
+            partial_bootstrap_server_revision: None,
+            fresh_bootstrap_pending_cdc_ack: false,
+            remote_pull_protocol: RemotePullProtocol::MvccLogical,
+            logical_table_names_by_stable_id: Default::default(),
+            saved_configuration: Some(DatabaseSavedConfiguration {
+                remote_url: Some("https://example.com".to_string()),
+                partial_sync_prefetch: None,
+                partial_sync_segment_size: None,
+            }),
+        };
+        std::fs::write(create_meta_path(&main_path), meta.dump().unwrap()).unwrap();
+
+        let header = PullUpdatesRespProtoBody {
+            protocol: PullUpdatesProtocol::Pages as i32,
+            server_revision: "9".to_string(),
+            db_size: 0,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            logical_resume_revision: String::new(),
+        };
+        let sync_io = Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(Some(header.encode_length_delimited_to_vec())),
+            request: Mutex::new(None),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io);
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_db = main_db.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine =
+                    DatabaseSyncEngine::open_db(&coro, io, sync_stats, main_db, opts).await?;
+                let error = engine.wait_changes_from_remote(&coro).await.unwrap_err();
+                assert!(
+                    format!("{error:#}")
+                        .contains("MVCC logical replica cannot downgrade to the page protocol"),
+                    "{error:#}"
+                );
+                assert_eq!(engine.meta().synced_revision, Some(revision));
+                assert_eq!(
+                    engine.meta().remote_pull_protocol,
+                    RemotePullProtocol::MvccLogical
+                );
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
     }
 
     /// A server can replace an existing MVCC replica when its saved logical generation is stale.
@@ -4623,7 +5309,25 @@ mod tests {
             })
             .unwrap();
 
-        let sync_engine_io = SyncEngineIoStats::new(Arc::new(NoopSyncEngineIo));
+        // A replacement is only a stable MVCC base after one logical pull closes the
+        // page-snapshot race. Keep that protocol step in this failure test so rollback
+        // is exercised from the same state as a real page-to-MVCC transition.
+        let followup_logical_response = PullUpdatesRespProtoBody {
+            server_revision: "new-revision".to_string(),
+            db_size: std::fs::metadata(&remote_path).unwrap().len() / super::PAGE_SIZE as u64,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
+            logical_resume_revision: String::new(),
+        }
+        .encode_length_delimited_to_vec();
+        let sync_engine_io = SyncEngineIoStats::new(Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(Some(followup_logical_response)),
+            request: Mutex::new(None),
+        }));
         let old_revision = DatabasePullRevision::V1 {
             revision: "old-revision".to_string(),
         };
@@ -4703,8 +5407,12 @@ mod tests {
                     "{err:#}"
                 );
                 assert_eq!(engine.meta().synced_revision, Some(old_revision.clone()));
+                assert_eq!(
+                    engine.meta().remote_pull_protocol,
+                    RemotePullProtocol::Pages
+                );
 
-                let on_disk_meta = DatabaseSyncEngine::<NoopSyncEngineIo>::read_db_meta(
+                let on_disk_meta = DatabaseSyncEngine::<CapturingSyncEngineIo>::read_db_meta(
                     &coro,
                     Some(io.clone()),
                     sync_engine_io.clone(),
@@ -4716,6 +5424,7 @@ mod tests {
                 })?
                 .unwrap();
                 assert_eq!(on_disk_meta.synced_revision, Some(old_revision));
+                assert_eq!(on_disk_meta.remote_pull_protocol, RemotePullProtocol::Pages);
                 assert!(io
                     .try_open(&create_replace_base_marker_path(&main_path))?
                     .is_none());
@@ -4733,6 +5442,7 @@ mod tests {
                 let verify_conn = verify_db.connect().map_err(|error| {
                     Error::DatabaseSyncEngineError(format!("test verify connect failed: {error}"))
                 })?;
+                assert!(!verify_conn.mvcc_enabled());
                 let mut value_stmt = verify_conn
                     .prepare("SELECT value FROM items WHERE id = 1")
                     .unwrap();
@@ -4917,11 +5627,16 @@ mod tests {
                 assert!(status.file_slot.is_some());
                 assert_eq!(
                     engine.meta().remote_pull_protocol,
+                    RemotePullProtocol::Unknown,
+                    "protocol publication must wait until replacement commits"
+                );
+
+                engine.apply_changes_from_remote(&coro, status).await?;
+                assert_eq!(
+                    engine.meta().remote_pull_protocol,
                     RemotePullProtocol::MvccLogical
                 );
                 assert!(engine.meta().logical_mvcc_pull_active());
-
-                engine.apply_changes_from_remote(&coro, status).await?;
                 assert_eq!(
                     engine.meta().synced_revision,
                     Some(DatabasePullRevision::V1 {

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -4077,6 +4077,7 @@ mod tests {
             stream_kind: PullUpdatesStreamKind::Pages as i32,
             apply_mode: PullUpdatesApplyMode::Incremental as i32,
             mvcc_log: None,
+            logical_resume_revision: String::new(),
         };
         let sync_io = Arc::new(CapturingSyncEngineIo {
             response: Mutex::new(Some(header.encode_length_delimited_to_vec())),
@@ -4116,6 +4117,103 @@ mod tests {
         assert_eq!(request.stream_kind, PullUpdatesStreamKind::Pages as i32);
         assert_eq!(request.client_revision, "");
         assert_eq!(request.server_revision, "");
+    }
+
+    /// A server can replace an existing MVCC replica when its saved logical generation is stale.
+    /// The page token identifies only the transferred page snapshot, so the next pull must use the
+    /// separate logical resume revision supplied with those replacement pages.
+    #[test]
+    fn logical_pull_replace_base_persists_logical_resume_revision() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let main_path = temp_file.path().to_str().unwrap().to_string();
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let main_db =
+            turso_core::Database::open_file(io.clone(), &main_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let old_revision = "g7:o80";
+        let logical_resume_revision = "g8:o56";
+
+        let meta = DatabaseMetadata {
+            version: DATABASE_METADATA_VERSION.to_string(),
+            client_unique_id: "stale-generation-client".to_string(),
+            synced_revision: Some(DatabasePullRevision::V1 {
+                revision: old_revision.to_string(),
+            }),
+            revert_since_wal_salt: None,
+            revert_since_wal_watermark: 0,
+            last_pull_unix_time: None,
+            last_push_unix_time: None,
+            last_pushed_pull_gen_hint: 0,
+            last_pushed_change_id_hint: 0,
+            last_pushed_replay_floor_change_id_hint: 0,
+            partial_bootstrap_server_revision: None,
+            fresh_bootstrap_pending_cdc_ack: false,
+            remote_pull_protocol: RemotePullProtocol::MvccLogical,
+            logical_table_names_by_stable_id: Default::default(),
+            saved_configuration: Some(DatabaseSavedConfiguration {
+                remote_url: Some("https://example.com".to_string()),
+                partial_sync_prefetch: None,
+                partial_sync_segment_size: None,
+            }),
+        };
+        std::fs::write(create_meta_path(&main_path), meta.dump().unwrap()).unwrap();
+
+        let header = PullUpdatesRespProtoBody {
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
+            server_revision: "41".to_string(),
+            db_size: 0,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::Pages as i32,
+            apply_mode: PullUpdatesApplyMode::ReplaceBase as i32,
+            mvcc_log: None,
+            logical_resume_revision: logical_resume_revision.to_string(),
+        };
+        let sync_io = Arc::new(CapturingSyncEngineIo {
+            response: Mutex::new(Some(header.encode_length_delimited_to_vec())),
+            request: Mutex::new(None),
+        });
+        let sync_stats = SyncEngineIoStats::new(sync_io.clone());
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.logical_mvcc_pull = Some(true);
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_db = main_db.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine =
+                    DatabaseSyncEngine::open_db(&coro, io, sync_stats, main_db, opts).await?;
+                let status = engine.wait_changes_from_remote(&coro).await?;
+
+                assert!(status.file_slot.is_none());
+                assert_eq!(status.stream_kind, DbChangesStreamKind::ReplaceBasePages);
+                assert_eq!(
+                    status.revision,
+                    DatabasePullRevision::V1 {
+                        revision: logical_resume_revision.to_string(),
+                    }
+                );
+                assert_eq!(engine.meta().synced_revision, Some(status.revision));
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        let (_method, path, body) = sync_io.request.lock().unwrap().clone().unwrap();
+        assert_eq!(path, "/pull-updates");
+        let request = PullUpdatesReqProtoBody::decode(body.unwrap().as_slice()).unwrap();
+        assert_eq!(
+            request.stream_kind,
+            PullUpdatesStreamKind::MvccLogicalLog as i32
+        );
+        assert_eq!(request.client_revision, old_revision);
     }
 
     #[test]
@@ -4678,6 +4776,7 @@ mod tests {
     fn encoded_page_stream_response(
         db_bytes: &[u8],
         server_revision: &str,
+        logical_resume_revision: &str,
         protocol: PullUpdatesProtocol,
     ) -> Vec<u8> {
         assert_eq!(db_bytes.len() % super::PAGE_SIZE, 0);
@@ -4690,6 +4789,7 @@ mod tests {
             apply_mode: PullUpdatesApplyMode::Incremental as i32,
             mvcc_log: None,
             protocol: protocol as i32,
+            logical_resume_revision: logical_resume_revision.to_string(),
         };
         let mut bytes = header.encode_length_delimited_to_vec();
         for (page_idx, page) in db_bytes.chunks_exact(super::PAGE_SIZE).enumerate() {
@@ -4738,16 +4838,18 @@ mod tests {
         let remote_bytes = std::fs::read(&remote_path).unwrap();
         assert!(!remote_bytes.is_empty());
 
-        let server_revision = "g1:o0";
+        let page_revision = "17";
+        let logical_revision = "g1:o0";
         let first_contact_response = encoded_page_stream_response(
             &remote_bytes,
-            server_revision,
+            page_revision,
+            logical_revision,
             PullUpdatesProtocol::MvccLogical,
         );
         // The replace-base apply issues one follow-up logical pull from the
         // new revision; serve it an empty logical stream.
         let followup_logical_response = PullUpdatesRespProtoBody {
-            server_revision: server_revision.to_string(),
+            server_revision: logical_revision.to_string(),
             db_size: (remote_bytes.len() / super::PAGE_SIZE) as u64,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,
@@ -4755,6 +4857,7 @@ mod tests {
             apply_mode: PullUpdatesApplyMode::Incremental as i32,
             mvcc_log: None,
             protocol: PullUpdatesProtocol::MvccLogical as i32,
+            logical_resume_revision: String::new(),
         }
         .encode_length_delimited_to_vec();
         let sync_io = Arc::new(QueuedSyncEngineIo {
@@ -4822,7 +4925,7 @@ mod tests {
                 assert_eq!(
                     engine.meta().synced_revision,
                     Some(DatabasePullRevision::V1 {
-                        revision: server_revision.to_string(),
+                        revision: logical_revision.to_string(),
                     })
                 );
 
@@ -4910,15 +5013,17 @@ mod tests {
         drop(remote_db);
         let remote_bytes = std::fs::read(&remote_path).unwrap();
 
-        let server_revision = "g1:o64";
+        let page_revision = "23";
+        let logical_revision = "g1:o64";
         let bootstrap_response = encoded_page_stream_response(
             &remote_bytes,
-            server_revision,
+            page_revision,
+            logical_revision,
             PullUpdatesProtocol::MvccLogical,
         );
         // The catch-up pull gets an empty logical stream: already current.
         let catch_up_response = PullUpdatesRespProtoBody {
-            server_revision: server_revision.to_string(),
+            server_revision: logical_revision.to_string(),
             db_size: (remote_bytes.len() / super::PAGE_SIZE) as u64,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,
@@ -4926,6 +5031,7 @@ mod tests {
             apply_mode: PullUpdatesApplyMode::Incremental as i32,
             mvcc_log: None,
             protocol: PullUpdatesProtocol::MvccLogical as i32,
+            logical_resume_revision: String::new(),
         }
         .encode_length_delimited_to_vec();
         let sync_io = Arc::new(QueuedSyncEngineIo {
@@ -4966,7 +5072,7 @@ mod tests {
                 assert_eq!(
                     engine.meta().synced_revision,
                     Some(DatabasePullRevision::V1 {
-                        revision: server_revision.to_string(),
+                        revision: logical_revision.to_string(),
                     })
                 );
                 Result::Ok(())
@@ -4991,7 +5097,7 @@ mod tests {
             catch_up.stream_kind,
             PullUpdatesStreamKind::MvccLogicalLog as i32
         );
-        assert_eq!(catch_up.client_revision, server_revision);
+        assert_eq!(catch_up.client_revision, logical_revision);
         assert_eq!(catch_up.long_poll_timeout_ms, 0);
     }
 

--- a/sync/engine/src/database_sync_engine.rs
+++ b/sync/engine/src/database_sync_engine.rs
@@ -5988,6 +5988,113 @@ mod tests {
         assert_eq!(catch_up.long_poll_timeout_ms, 0);
     }
 
+    /// Currently deployed Turso Cloud sends an opaque `server_revision` on a fresh MVCC page
+    /// bootstrap and omits the fork's separate logical resume field. Fresh replicas must preserve
+    /// that token exactly for the mandatory logical catch-up request.
+    #[test]
+    fn fresh_mvcc_bootstrap_forwards_opaque_upstream_revision() {
+        let main_file = NamedTempFile::new().unwrap();
+        let remote_file = NamedTempFile::new().unwrap();
+        let main_path = main_file.path().to_str().unwrap().to_string();
+        let remote_path = remote_file.path().to_str().unwrap().to_string();
+
+        let io: Arc<dyn turso_core::IO> = Arc::new(turso_core::PlatformIO::new().unwrap());
+        let remote_db =
+            turso_core::Database::open_file(io.clone(), &remote_path, Arc::new(SqliteDialect))
+                .unwrap();
+        let remote_conn = remote_db.connect().unwrap();
+        remote_conn.execute("PRAGMA journal_mode = 'mvcc'").unwrap();
+        remote_conn
+            .execute("CREATE TABLE seeded_items(id INTEGER PRIMARY KEY, value TEXT)")
+            .unwrap();
+        remote_conn
+            .execute("INSERT INTO seeded_items VALUES (1, 'from-page-base')")
+            .unwrap();
+        let remote_wal_state = remote_conn.wal_state().unwrap();
+        remote_conn
+            .checkpoint(turso_core::CheckpointMode::Truncate {
+                upper_bound_inclusive: Some(remote_wal_state.max_frame),
+            })
+            .unwrap();
+        drop(remote_conn);
+        drop(remote_db);
+        let remote_bytes = std::fs::read(&remote_path).unwrap();
+
+        let opaque_revision = r#"{"generation":4,"log_offset":128}"#;
+        let bootstrap_response = encoded_page_stream_response(
+            &remote_bytes,
+            opaque_revision,
+            "",
+            PullUpdatesProtocol::MvccLogical,
+        );
+        let catch_up_response = PullUpdatesRespProtoBody {
+            server_revision: opaque_revision.to_string(),
+            db_size: (remote_bytes.len() / super::PAGE_SIZE) as u64,
+            raw_encoding: Some(PageSetRawEncodingProto {}),
+            zstd_encoding: None,
+            stream_kind: PullUpdatesStreamKind::MvccLogicalLog as i32,
+            apply_mode: PullUpdatesApplyMode::Incremental as i32,
+            mvcc_log: None,
+            protocol: PullUpdatesProtocol::MvccLogical as i32,
+            logical_resume_revision: String::new(),
+        }
+        .encode_length_delimited_to_vec();
+        let sync_io = Arc::new(QueuedSyncEngineIo {
+            responses: Mutex::new(
+                vec![bootstrap_response, catch_up_response]
+                    .into_iter()
+                    .collect(),
+            ),
+            requests: Mutex::new(Vec::new()),
+        });
+        let sync_engine_io = SyncEngineIoStats::new(sync_io.clone());
+
+        let mut opts = default_test_opts();
+        opts.remote_url = Some("https://example.com".to_string());
+        opts.bootstrap_if_empty = true;
+        opts.logical_mvcc_pull = None;
+
+        let mut gen = genawaiter::sync::Gen::new({
+            let io = io.clone();
+            let main_path = main_path.clone();
+            move |coro| async move {
+                let coro: Coro<()> = coro.into();
+                let engine =
+                    DatabaseSyncEngine::create_db(&coro, io, sync_engine_io, &main_path, opts)
+                        .await?;
+                assert_eq!(
+                    engine.meta().synced_revision,
+                    Some(DatabasePullRevision::V1 {
+                        revision: opaque_revision.to_string(),
+                    })
+                );
+                let conn = engine.connect_rw(&coro).await?;
+                let mut statement = conn.prepare("SELECT value FROM seeded_items WHERE id = 1")?;
+                let row = run_stmt_once(&coro, &mut statement).await?.unwrap();
+                assert_eq!(row.get_value(0).to_text(), Some("from-page-base"));
+                Result::Ok(())
+            }
+        });
+        loop {
+            match gen.resume_with(Ok(())) {
+                genawaiter::GeneratorState::Yielded(..) => io.step().unwrap(),
+                genawaiter::GeneratorState::Complete(result) => break result.unwrap(),
+            }
+        }
+
+        assert!(sync_io.responses.lock().unwrap().is_empty());
+        let requests = sync_io.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        let catch_up =
+            PullUpdatesReqProtoBody::decode(requests[1].2.as_ref().unwrap().as_slice()).unwrap();
+        assert_eq!(
+            catch_up.stream_kind,
+            PullUpdatesStreamKind::MvccLogicalLog as i32
+        );
+        assert_eq!(catch_up.client_revision, opaque_revision);
+        assert_eq!(catch_up.long_poll_timeout_ms, 0);
+    }
+
     /// Forcing `logical_mvcc_pull: Some(true)` on a replica whose revision
     /// came from the legacy wire protocol is a misconfiguration: the server
     /// cannot resume an MVCC logical stream from a legacy revision.

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -29,8 +29,8 @@ use crate::{
     errors::Error,
     io_operations::IoOperations,
     server_proto::{
-        self, Batch, BatchCond, BatchStep, BatchStreamReq, PageData, PageUpdatesEncodingReq,
-        PullUpdatesApplyMode, PullUpdatesProtocol, PullUpdatesReqProtoBody,
+        self, Batch, BatchCond, BatchStep, BatchStreamReq, MvccLogicalRevision, PageData,
+        PageUpdatesEncodingReq, PullUpdatesApplyMode, PullUpdatesProtocol, PullUpdatesReqProtoBody,
         PullUpdatesRespProtoBody, PullUpdatesStreamKind, Stmt, StmtResult, StreamRequest,
     },
     types::{
@@ -1930,13 +1930,17 @@ pub async fn pull_updates_v1<IO: SyncEngineIo, Ctx>(
         header.mvcc_log
     );
 
-    let next_revision = DatabasePullRevision::V1 {
-        revision: header.server_revision.clone(),
-    };
     let remote_protocol = detect_remote_pull_protocol(&header);
     let apply_mode = pull_updates_apply_mode(&header)?;
     match pull_updates_stream_kind(&header)? {
         PullUpdatesStreamKind::Pages => {
+            let revision = if remote_protocol == RemotePullProtocol::MvccLogical {
+                validate_logical_resume_revision(&header.logical_resume_revision)?;
+                header.logical_resume_revision.clone()
+            } else {
+                header.server_revision.clone()
+            };
+            let next_revision = DatabasePullRevision::V1 { revision };
             let replace_base = matches!(apply_mode, PullUpdatesApplyMode::ReplaceBase);
             truncate_file(ctx.coro, frames_file).await?;
 
@@ -2005,6 +2009,9 @@ pub async fn pull_updates_v1<IO: SyncEngineIo, Ctx>(
             ))
         }
         PullUpdatesStreamKind::MvccLogicalLog => {
+            let next_revision = DatabasePullRevision::V1 {
+                revision: header.server_revision.clone(),
+            };
             if matches!(apply_mode, PullUpdatesApplyMode::ReplaceBase) {
                 return Err(Error::DatabaseSyncEngineError(
                     "server returned replace_base apply mode with raw MVCC logical-log stream"
@@ -3500,7 +3507,7 @@ pub async fn bootstrap_db_file_v1<IO: SyncEngineIo, Ctx>(
         while start < last_page_id {
             let end = std::cmp::min(start + n as u64, last_page_id);
             let selector = page_range_bitmap(start as u32, end as u32)?;
-            pull_chunk_into_file(
+            let chunk_header = pull_chunk_into_file(
                 ctx,
                 &file,
                 &header.server_revision,
@@ -3509,6 +3516,16 @@ pub async fn bootstrap_db_file_v1<IO: SyncEngineIo, Ctx>(
                 false,
             )
             .await?;
+            if chunk_header.server_revision != header.server_revision {
+                return Err(Error::DatabaseSyncEngineError(
+                    "page bootstrap revision changed between chunks".to_string(),
+                ));
+            }
+            if chunk_header.logical_resume_revision != header.logical_resume_revision {
+                return Err(Error::DatabaseSyncEngineError(
+                    "logical resume revision changed between page bootstrap chunks".to_string(),
+                ));
+            }
             start = end;
         }
     }
@@ -3519,12 +3536,22 @@ pub async fn bootstrap_db_file_v1<IO: SyncEngineIo, Ctx>(
     sync_file(ctx.coro, &file).await?;
 
     let remote_protocol = detect_remote_pull_protocol(&header);
-    Ok((
-        DatabasePullRevision::V1 {
-            revision: header.server_revision,
-        },
-        remote_protocol,
-    ))
+    let revision = if remote_protocol == RemotePullProtocol::MvccLogical {
+        validate_logical_resume_revision(&header.logical_resume_revision)?;
+        header.logical_resume_revision
+    } else {
+        header.server_revision
+    };
+    Ok((DatabasePullRevision::V1 { revision }, remote_protocol))
+}
+
+fn validate_logical_resume_revision(revision: &str) -> Result<()> {
+    revision.parse::<MvccLogicalRevision>().map_err(|error| {
+        Error::DatabaseSyncEngineError(format!(
+            "MVCC page bootstrap response has an invalid logical resume revision: {error}"
+        ))
+    })?;
+    Ok(())
 }
 
 fn decode_page(header: &PullUpdatesRespProtoBody, page_data: PageData) -> Result<Vec<u8>> {
@@ -4555,6 +4582,7 @@ mod tests {
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: format!("g1:o{end_offset}"),
+            logical_resume_revision: String::new(),
             db_size: 0,
             raw_encoding: None,
             zstd_encoding: None,
@@ -4644,6 +4672,7 @@ mod tests {
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: format!("g1:o{end_offset}"),
+            logical_resume_revision: String::new(),
             db_size: 0,
             raw_encoding: None,
             zstd_encoding: None,
@@ -4729,6 +4758,7 @@ mod tests {
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: format!("g1:o{range_end}"),
+            logical_resume_revision: String::new(),
             db_size: 0,
             raw_encoding: None,
             zstd_encoding: None,
@@ -4813,6 +4843,7 @@ mod tests {
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: "g1:o45".to_string(),
+            logical_resume_revision: String::new(),
             db_size: 1,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,
@@ -4899,6 +4930,7 @@ mod tests {
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: "g1:o80".to_string(),
+            logical_resume_revision: String::new(),
             db_size: 1,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,
@@ -4973,6 +5005,7 @@ mod tests {
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: "g1:o80".to_string(),
+            logical_resume_revision: String::new(),
             db_size: 1,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,
@@ -5039,6 +5072,7 @@ mod tests {
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: "g1:o80".to_string(),
+            logical_resume_revision: String::new(),
             db_size: 3,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,
@@ -5168,6 +5202,7 @@ mod tests {
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: format!("g1:o{range_end}"),
+            logical_resume_revision: String::new(),
             db_size: 0,
             raw_encoding: None,
             zstd_encoding: None,
@@ -5212,6 +5247,7 @@ mod tests {
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: format!("g1:o{end_offset}"),
+            logical_resume_revision: String::new(),
             db_size: 0,
             raw_encoding: None,
             zstd_encoding: None,
@@ -5247,6 +5283,7 @@ mod tests {
         let header = PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: format!("g1:o{end_offset}"),
+            logical_resume_revision: String::new(),
             db_size: 0,
             raw_encoding: None,
             zstd_encoding: None,
@@ -5636,6 +5673,7 @@ mod tests {
         PullUpdatesRespProtoBody {
             protocol: 0,
             server_revision: "rev".to_string(),
+            logical_resume_revision: String::new(),
             db_size: 1,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,
@@ -5744,6 +5782,7 @@ mod tests {
 
         let header = |protocol: i32| PullUpdatesRespProtoBody {
             server_revision: "g1:o0".to_string(),
+            logical_resume_revision: String::new(),
             db_size: 0,
             raw_encoding: Some(PageSetRawEncodingProto {}),
             zstd_encoding: None,

--- a/sync/engine/src/database_sync_operations.rs
+++ b/sync/engine/src/database_sync_operations.rs
@@ -1934,12 +1934,7 @@ pub async fn pull_updates_v1<IO: SyncEngineIo, Ctx>(
     let apply_mode = pull_updates_apply_mode(&header)?;
     match pull_updates_stream_kind(&header)? {
         PullUpdatesStreamKind::Pages => {
-            let revision = if remote_protocol == RemotePullProtocol::MvccLogical {
-                validate_logical_resume_revision(&header.logical_resume_revision)?;
-                header.logical_resume_revision.clone()
-            } else {
-                header.server_revision.clone()
-            };
+            let revision = page_stream_resume_revision(&header, remote_protocol, false)?;
             let next_revision = DatabasePullRevision::V1 { revision };
             let replace_base = matches!(apply_mode, PullUpdatesApplyMode::ReplaceBase);
             truncate_file(ctx.coro, frames_file).await?;
@@ -3536,13 +3531,36 @@ pub async fn bootstrap_db_file_v1<IO: SyncEngineIo, Ctx>(
     sync_file(ctx.coro, &file).await?;
 
     let remote_protocol = detect_remote_pull_protocol(&header);
-    let revision = if remote_protocol == RemotePullProtocol::MvccLogical {
-        validate_logical_resume_revision(&header.logical_resume_revision)?;
-        header.logical_resume_revision
-    } else {
-        header.server_revision
-    };
+    let revision = page_stream_resume_revision(&header, remote_protocol, true)?;
     Ok((DatabasePullRevision::V1 { revision }, remote_protocol))
+}
+
+fn page_stream_resume_revision(
+    header: &PullUpdatesRespProtoBody,
+    remote_protocol: RemotePullProtocol,
+    allow_legacy_mvcc_bootstrap: bool,
+) -> Result<String> {
+    if remote_protocol != RemotePullProtocol::MvccLogical {
+        Ok(header.server_revision.clone())
+    } else if !header.logical_resume_revision.is_empty() {
+        validate_logical_resume_revision(&header.logical_resume_revision)?;
+        Ok(header.logical_resume_revision.clone())
+    } else if allow_legacy_mvcc_bootstrap
+        && matches!(
+            pull_updates_apply_mode(header)?,
+            PullUpdatesApplyMode::Incremental
+        )
+        && !header.server_revision.is_empty()
+    {
+        tracing::warn!(
+            "fresh MVCC page bootstrap omitted logical_resume_revision; using the opaque server_revision compatibility cursor"
+        );
+        Ok(header.server_revision.clone())
+    } else {
+        Err(Error::DatabaseSyncEngineError(
+            "MVCC page response is missing a logical resume revision".to_string(),
+        ))
+    }
 }
 
 fn validate_logical_resume_revision(revision: &str) -> Result<()> {
@@ -3971,20 +3989,21 @@ mod tests {
         database_sync_operations::{
             apply_logical_transactions_file_without_commit_excluding_client_txns_with_table_map_and_stats,
             detect_remote_pull_protocol, ensure_incremental_page_stream, ensure_page_stream,
-            is_logically_replayable_table, logical_txn_to_tape_operations, pull_pages_v1,
-            pull_updates_v1, should_push_change, should_replay_local_change, wait_proto_message,
-            wal_pull_to_file_v1, PullUpdatesV1Result, SyncEngineIoStats, SyncOperationCtx,
+            is_logically_replayable_table, logical_txn_to_tape_operations,
+            page_stream_resume_revision, pull_pages_v1, pull_updates_v1, should_push_change,
+            should_replay_local_change, wait_proto_message, wal_pull_to_file_v1,
+            PullUpdatesV1Result, SyncEngineIoStats, SyncOperationCtx,
         },
         database_tape::{run_stmt_once, DatabaseReplaySessionOpts, DatabaseTape},
         server_proto,
         server_proto::{
-            PageData, PageSetRawEncodingProto, PullUpdatesApplyMode, PullUpdatesReqProtoBody,
-            PullUpdatesRespProtoBody, PullUpdatesStreamKind,
+            PageData, PageSetRawEncodingProto, PullUpdatesApplyMode, PullUpdatesProtocol,
+            PullUpdatesReqProtoBody, PullUpdatesRespProtoBody, PullUpdatesStreamKind,
         },
         types::{
             parse_bin_record, Coro, DatabasePullRevision, DatabaseRowMutation,
             DatabaseRowTransformResult, DatabaseSchemaReplay, DatabaseTapeOperation,
-            DatabaseTapeRowChange, DatabaseTapeRowChangeType,
+            DatabaseTapeRowChange, DatabaseTapeRowChangeType, RemotePullProtocol,
         },
         Result,
     };
@@ -5746,6 +5765,63 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("unknown pull-updates apply mode"));
+    }
+
+    #[test]
+    fn fresh_mvcc_bootstrap_accepts_opaque_upstream_revision() {
+        let opaque_revision =
+            "opaque-cloud-bootstrap-revision-token-with-no-logical-shape-1234567890";
+        let mut header = page_header(
+            PullUpdatesStreamKind::Pages as i32,
+            PullUpdatesApplyMode::Incremental as i32,
+        );
+        header.protocol = PullUpdatesProtocol::MvccLogical as i32;
+        header.server_revision = opaque_revision.to_string();
+
+        assert_eq!(
+            page_stream_resume_revision(&header, RemotePullProtocol::MvccLogical, true).unwrap(),
+            opaque_revision
+        );
+    }
+
+    #[test]
+    fn mvcc_page_fallback_is_rejected_outside_fresh_bootstrap() {
+        let mut header = page_header(
+            PullUpdatesStreamKind::Pages as i32,
+            PullUpdatesApplyMode::Incremental as i32,
+        );
+        header.protocol = PullUpdatesProtocol::MvccLogical as i32;
+        header.server_revision = "opaque-cloud-bootstrap-revision".to_string();
+
+        let error = page_stream_resume_revision(&header, RemotePullProtocol::MvccLogical, false)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("missing a logical resume revision"));
+
+        header.apply_mode = PullUpdatesApplyMode::ReplaceBase as i32;
+        let error = page_stream_resume_revision(&header, RemotePullProtocol::MvccLogical, true)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("missing a logical resume revision"));
+    }
+
+    #[test]
+    fn malformed_explicit_logical_resume_revision_never_uses_fallback() {
+        let mut header = page_header(
+            PullUpdatesStreamKind::Pages as i32,
+            PullUpdatesApplyMode::Incremental as i32,
+        );
+        header.protocol = PullUpdatesProtocol::MvccLogical as i32;
+        header.server_revision = "opaque-cloud-bootstrap-revision".to_string();
+        header.logical_resume_revision = "malformed".to_string();
+
+        let error = page_stream_resume_revision(&header, RemotePullProtocol::MvccLogical, true)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("invalid logical resume revision"));
     }
 
     /// Pushed DDL is replayed verbatim on the remote, where the same object may

--- a/sync/engine/src/server_proto.rs
+++ b/sync/engine/src/server_proto.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, fmt, str::FromStr};
 
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
@@ -86,6 +86,37 @@ pub enum PullUpdatesProtocol {
     MvccLogical = 2,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MvccLogicalRevision {
+    pub generation: u64,
+    pub offset: u64,
+}
+
+impl fmt::Display for MvccLogicalRevision {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "g{}:o{}", self.generation, self.offset)
+    }
+}
+
+impl FromStr for MvccLogicalRevision {
+    type Err = String;
+
+    fn from_str(revision: &str) -> Result<Self, Self::Err> {
+        let (generation, offset) = revision
+            .split_once(":o")
+            .ok_or_else(|| format!("invalid MVCC logical revision: {revision}"))?;
+        let generation = generation
+            .strip_prefix('g')
+            .ok_or_else(|| format!("invalid MVCC logical revision: {revision}"))?
+            .parse::<u64>()
+            .map_err(|error| format!("invalid MVCC logical revision {revision}: {error}"))?;
+        let offset = offset
+            .parse::<u64>()
+            .map_err(|error| format!("invalid MVCC logical revision {revision}: {error}"))?;
+        Ok(Self { generation, offset })
+    }
+}
+
 #[derive(prost::Message)]
 pub struct PageSetRawEncodingProto {}
 
@@ -140,6 +171,12 @@ pub struct PullUpdatesRespProtoBody {
     pub mvcc_log: Option<MvccLogicalLogMetadataProto>,
     #[prost(enumeration = "PullUpdatesProtocol", tag = "8")]
     pub protocol: i32,
+    /// Logical-log revision represented by a page bootstrap.
+    ///
+    /// `server_revision` continues to pin page chunks to one physical snapshot. MVCC clients
+    /// persist this separate revision before requesting the logical tail after those pages.
+    #[prost(string, tag = "9")]
+    pub logical_resume_revision: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -547,9 +584,9 @@ pub(crate) mod bytes_as_base64_pad {
 #[cfg(test)]
 mod pull_updates_tests {
     use super::{
-        MvccLogicalLogMetadataProto, MvccLogicalLogRangeProto, PageSetRawEncodingProto,
-        PageUpdatesEncodingReq, PullUpdatesApplyMode, PullUpdatesProtocol, PullUpdatesReqProtoBody,
-        PullUpdatesRespProtoBody, PullUpdatesStreamKind,
+        MvccLogicalLogMetadataProto, MvccLogicalLogRangeProto, MvccLogicalRevision,
+        PageSetRawEncodingProto, PageUpdatesEncodingReq, PullUpdatesApplyMode, PullUpdatesProtocol,
+        PullUpdatesReqProtoBody, PullUpdatesRespProtoBody, PullUpdatesStreamKind,
     };
     use prost::Message;
 
@@ -574,9 +611,22 @@ mod pull_updates_tests {
     }
 
     #[test]
+    fn mvcc_logical_revision_round_trips_and_rejects_foreign_shapes() {
+        let revision = "g7:o42".parse::<MvccLogicalRevision>().unwrap();
+        assert_eq!(revision.generation, 7);
+        assert_eq!(revision.offset, 42);
+        assert_eq!(revision.to_string(), "g7:o42");
+
+        for invalid in ["", "7", "g7:", "g7:o", "g7:o42:extra"] {
+            assert!(invalid.parse::<MvccLogicalRevision>().is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
     fn pull_updates_mvcc_log_header_round_trips_metadata() {
         let header = PullUpdatesRespProtoBody {
             server_revision: "rev-42".to_string(),
+            logical_resume_revision: "g7:o11".to_string(),
             protocol: PullUpdatesProtocol::MvccLogical as i32,
             db_size: 3,
             raw_encoding: Some(PageSetRawEncodingProto {}),
@@ -608,6 +658,7 @@ mod pull_updates_tests {
             PullUpdatesApplyMode::try_from(decoded.apply_mode).unwrap(),
             PullUpdatesApplyMode::Incremental
         );
+        assert_eq!(decoded.logical_resume_revision, "g7:o11");
         let mvcc_log = decoded.mvcc_log.unwrap();
         assert_eq!(mvcc_log.format, "lml3");
         assert!(mvcc_log.checkpoint_transition);


### PR DESCRIPTION
## Description

This PR fixes a connected set of MVCC sync compatibility failures affecting fresh file-backed replicas and existing replicas created under WAL/page sync:

- A fresh MVCC page bootstrap could omit committed schema and rows that existed only in the retained logical-log tail.
- Existing LML2 databases could fail at startup or appear current even when their page base did not include recovered commits.
- Existing page replicas could keep using page continuation after their remote switched to MVCC, causing repeated replacement downloads, high CPU, or a later `WAL has committed frames but logical log header is missing` error.
- Browser replicas could fail replace-base recovery because OPFS files used by the recovery marker and backups were not registered before the worker opened them.
- A page replica with a valid positive WAL sync watermark could repeatedly fail its first MVCC replacement with `wal_max_frame=0` below the saved watermark because journal conversion had already retired the WAL.

The server now treats the page snapshot revision and logical resume revision as separate durability boundaries. Before serving MVCC sync, it normalizes historical logical-log state: nonempty LML2 history is checkpointed into the page base, a header-only LML2 log is replaced with a fresh portable LML3 generation, and existing valid LML3 history is retained. Only revisions from the current logical generation at validated transaction boundaries can continue incrementally. Page revisions, stale generations, malformed offsets, and foreign generations receive a complete replace-base response with an explicit logical resume revision.

The client preserves the response protocol and replacement mode through dispatch. A Pages replica can move to `MvccLogical` only through a guarded replace-base operation, while an MVCC replica cannot silently downgrade to Pages. The guarded operation backs up the database, WAL, logical log, revert WAL, and metadata before mutation; installs the page base; catches up the logical tail; replays pending local CDC changes; refreshes storage and schema state; and publishes the protocol and revision only after the new state is durable.

MVCC replace-base is also treated as a storage-protocol boundary. Pending local work comes from CDC, so the engine does not interpret retired WAL or revert-WAL frame history after journal conversion. On success it clears the legacy watermark, salt, and revert state together. The original watermark validation and rollback path remain unchanged for normal page synchronization.

Empty MVCC databases still pass through guarded replace-base instead of being collapsed into a no-change response. Browser setup registers the complete deterministic database and recovery file family before OPFS opens it, and recovery clears files that cannot be unlinked while registered handles remain open.

Closes #8725

## Motivation and context

An MVCC replica is assembled from two related pieces: a durable page snapshot and the logical transactions committed after that snapshot. Correct synchronization requires the server and client to agree on the boundary between them. A numeric page revision cannot establish a position in a logical-log generation, and changing a log version byte cannot turn recovery-only LML2 frames into portable LML3 changes.

The missing boundary appeared in several forms, but the root causes were concrete:

- Fresh bootstrap reused a page-oriented revision as if it were a logical-log offset, allowing the client to skip transactions absent from its page base.
- Server startup enabled portable logical writes without first proving that historical recovery records had been materialized into the main database and replaced by a clean portable generation.
- The client persisted only part of a protocol transition. Response protocol and apply mode could be discarded before apply, while journal mode, revision metadata, and recovery sidecars could describe different states after failure or reopen.
- The final transition path converted the local journal before calling the ordinary page checkpoint path, so a valid legacy watermark was compared with the new empty WAL.

The implementation follows existing ownership boundaries rather than adding a parallel sync system:

- Core owns MVCC recovery, checkpointing, logical-log initialization, and reload after external restoration.
- The sync server owns revision validation and selection of incremental versus replace-base responses.
- The sync engine owns local protocol state, CDC preservation and replay, durable metadata publication, and replacement rollback.
- Core IO owns database-family files, including OPFS-backed files; `SyncEngineIo` continues to own metadata and marker storage.

The recovery marker is versioned and validates the exact expected paths before restoring anything. The new manifest records each file's storage backend, while version 1 remains readable using its original storage behavior. This avoids a public `DbChangesStatus` change and keeps compatibility logic local to the transition that needs it.

The external surface remains narrow. No user-facing driver method, sync option, or configuration shape changes. The pull response adds explicit protocol, apply-mode, and logical-resume fields so old page tokens are never overloaded with logical meaning. New `DurableStorage` operations have default implementations, avoiding mandatory changes to unrelated storage implementations, and the raw connection preparation entry point centralizes behavior already owned by core.

Regression coverage exercises the storage lifecycles rather than only checking response headers:

- fresh MVCC bootstrap with a logical tail not present in the page base;
- header-only and nonempty LML2 recovery logs, mixed legacy frames, and valid LML3 restart;
- current, stale, foreign, numeric, malformed, and non-boundary logical revisions;
- existing Pages-to-MVCC replacement, one-way protocol state, logical catch-up, and no-change follow-up pulls;
- pending local insert, update, and delete replay across replacement;
- a positive WAL watermark created by a real page apply, followed by MVCC transition and disk reopen;
- failure rollback without revision advancement, recovery-marker compatibility and path validation;
- zero-page MVCC replacement;
- registered-file cleanup and Chromium OPFS reopen behavior;
- unchanged WAL/page synchronization paths.

The full sync-engine and CLI test suites pass, as does the Chromium sync-wasm suite. The same build was also tested against a preserved application replica that had exhibited the repeated protocol-transition and positive-watermark failures. It transitioned without deleting its local database or browser storage, reopened successfully, and resumed synchronization. This application-level result complements the deterministic regression tests without replacing them.

## Description of AI Usage

The work was a collaboration between the human contributor and AI coding agents. The human contributor identified the application-visible failures, preserved affected replica states, supplied runtime evidence and constraints, reviewed the proposed designs, built and installed the artifacts, and repeatedly verified the fixes against a real application lifecycle.

AI agents helped trace those symptoms through the sync server, sync engine, MVCC recovery, WAL bookkeeping, CDC replay, and browser OPFS paths. They assisted with source inspection, root-cause hypotheses, test-first regression fixtures, implementation, code review, and commit and PR documentation. Proposed changes were checked against the repository's transaction-correctness, MVCC, asynchronous IO, testing, code-quality, and PR workflow guidance.

The fixes were developed iteratively: tests first reproduced each failure, implementation followed human approval of the design, and both automated suites and the preserved real-world replica were used to find gaps in earlier revisions.