### PR TITLE
core/vdbe: common prefix skipping adaptive sort for the sorter

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -251,6 +251,11 @@ harness = false
 required-features = ["bench"]
 
 [[bench]]
+name = "sorter_benchmark"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
 name = "write_perf_benchmark"
 harness = false
 

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -690,6 +690,90 @@ fn bench_execute_group_by(criterion: &mut Criterion) {
 }
 
 #[turso_macros::codspeed_criterion_benchmark]
+fn bench_execute_order_by(criterion: &mut Criterion) {
+    // https://github.com/tursodatabase/turso/issues/174
+    // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
+    let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
+
+    // ORDER BY over unindexed columns of the 10k-row users table, so every
+    // query goes through the sorter. The three key shapes are a mostly
+    // distinct text key, a multi-column text key with many duplicates, and
+    // an integer key with many duplicates sorted descending. cache_size is
+    // raised so the sort stays in memory instead of merging chunk files.
+    const QUERIES: [(&str, &str); 3] = [
+        ("order_by_email", "SELECT * FROM users ORDER BY email"),
+        (
+            "order_by_state_city",
+            "SELECT id FROM users ORDER BY state, city",
+        ),
+        (
+            "order_by_age_desc_zipcode",
+            "SELECT id FROM users ORDER BY age DESC, zipcode",
+        ),
+    ];
+    const CACHE_SIZE_KIB: i64 = -65536;
+
+    #[allow(clippy::arc_with_non_send_sync)]
+    let io = Arc::new(PlatformIO::new().unwrap());
+    let db =
+        Database::open_file(io, "../testing/system/testing.db", Arc::new(SqliteDialect)).unwrap();
+    let limbo_conn = db.connect().unwrap();
+    limbo_conn
+        .execute(format!("PRAGMA cache_size = {CACHE_SIZE_KIB}"))
+        .unwrap();
+
+    let mut group = criterion.benchmark_group("Execute `SELECT ... FROM users ORDER BY ...`");
+
+    for (name, query) in QUERIES {
+        group.bench_function(format!("limbo_execute_{name}"), |b| {
+            let mut stmt = limbo_conn.prepare(query).unwrap();
+            b.iter(|| {
+                loop {
+                    match stmt.step().unwrap() {
+                        turso_core::StepResult::Row => {
+                            black_box(stmt.row());
+                        }
+                        turso_core::StepResult::IO
+                        | turso_core::StepResult::Yield
+                        | turso_core::StepResult::Sleep { .. } => {
+                            db.io.step().unwrap();
+                        }
+                        turso_core::StepResult::Done => {
+                            break;
+                        }
+                        turso_core::StepResult::Interrupt | turso_core::StepResult::Busy => {
+                            unreachable!();
+                        }
+                    }
+                }
+                stmt.reset().unwrap();
+            });
+        });
+    }
+
+    if enable_rusqlite {
+        let sqlite_conn = rusqlite_open();
+        sqlite_conn
+            .pragma_update(None, "cache_size", CACHE_SIZE_KIB)
+            .unwrap();
+
+        for (name, query) in QUERIES {
+            group.bench_function(format!("sqlite_execute_{name}"), |b| {
+                let mut stmt = sqlite_conn.prepare(query).unwrap();
+                b.iter(|| {
+                    let mut rows = stmt.raw_query();
+                    while let Some(row) = rows.next().unwrap() {
+                        black_box(row);
+                    }
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
 fn bench_insert_rows(criterion: &mut Criterion) {
     // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
     let enable_rusqlite = std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_err();
@@ -1276,14 +1360,14 @@ fn bench_insert_randomblob(criterion: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_execute_group_by, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
+    targets = bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_execute_group_by, bench_execute_order_by, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
 }
 
 #[cfg(feature = "codspeed")]
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_execute_group_by, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
+    targets = bench_open, bench_alter, bench_prepare_query, bench_execute_select_1, bench_execute_select_rows, bench_execute_select_count, bench_execute_group_by, bench_execute_order_by, bench_insert_rows, bench_concurrent_writes, bench_insert_randomblob
 }
 
 criterion_main!(benches);

--- a/core/benches/sorter_benchmark.rs
+++ b/core/benches/sorter_benchmark.rs
@@ -1,0 +1,202 @@
+//! Sorter benchmarks: insert, sort, and drain records through the ORDER BY
+//! sorter with the key shapes that matter for the common prefix skipping
+//! adaptive sort: integers, text with a long shared prefix, few distinct
+//! values, multi-column keys, DESC keys, and presorted input.
+//!
+//! The sort buffer is large enough that nothing spills, so the numbers cover
+//! key conditioning and the in-memory sort, not the external merge.
+//!
+//! Run with:
+//!   cargo bench --bench sorter_benchmark --features bench
+
+#[cfg(not(feature = "codspeed"))]
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+#[cfg(not(feature = "codspeed"))]
+use pprof::criterion::{Output, PProfProfiler};
+
+#[cfg(feature = "codspeed")]
+use codspeed_criterion_compat::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
+};
+
+use rand_chacha::{
+    rand_core::{RngCore, SeedableRng},
+    ChaCha8Rng,
+};
+use std::sync::Arc;
+use turso_core::types::{ImmutableRecord, Value};
+use turso_core::vdbe::sorter::Sorter;
+use turso_core::vdbe::CollationSeq;
+use turso_core::{IOExt, MemoryIO, TempStore};
+use turso_parser::ast::SortOrder;
+
+#[cfg(not(target_family = "wasm"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+const SIZES: [usize; 2] = [10_000, 50_000];
+
+struct Workload {
+    name: &'static str,
+    orders: Vec<SortOrder>,
+    records: Vec<ImmutableRecord>,
+}
+
+fn build(
+    name: &'static str,
+    orders: Vec<SortOrder>,
+    count: usize,
+    mut key: impl FnMut(&mut ChaCha8Rng, usize) -> Vec<Value>,
+) -> Workload {
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+    let records = (0..count)
+        .map(|i| {
+            let mut values = key(&mut rng, i);
+            values.push(Value::from_i64(i as i64));
+            ImmutableRecord::from_values(&values, values.len()).unwrap()
+        })
+        .collect();
+    Workload {
+        name,
+        orders,
+        records,
+    }
+}
+
+fn random_letters(rng: &mut ChaCha8Rng, len: usize) -> String {
+    (0..len)
+        .map(|_| (b'a' + (rng.next_u64() % 26) as u8) as char)
+        .collect()
+}
+
+fn workloads(count: usize) -> Vec<Workload> {
+    const CITIES: [&str; 8] = [
+        "Amsterdam",
+        "Berlin",
+        "Copenhagen",
+        "Dublin",
+        "Edinburgh",
+        "Florence",
+        "Geneva",
+        "Helsinki",
+    ];
+    vec![
+        build("int_random", vec![SortOrder::Asc], count, |rng, _| {
+            vec![Value::from_i64(rng.next_u64() as i64)]
+        }),
+        build("int_presorted", vec![SortOrder::Asc], count, |_, i| {
+            vec![Value::from_i64(i as i64)]
+        }),
+        build("int_few_distinct", vec![SortOrder::Asc], count, |rng, _| {
+            vec![Value::from_i64((rng.next_u64() % 16) as i64)]
+        }),
+        build("float_random", vec![SortOrder::Asc], count, |rng, _| {
+            vec![Value::from_f64(rng.next_u64() as f64 / 1e12)]
+        }),
+        build(
+            "text_shared_prefix",
+            vec![SortOrder::Asc],
+            count,
+            |rng, _| {
+                vec![Value::build_text(format!(
+                    "https://www.example.com/catalog/products/item-{:010}",
+                    rng.next_u64() % 10_000_000_000
+                ))]
+            },
+        ),
+        build(
+            "text_shared_prefix_desc",
+            vec![SortOrder::Desc],
+            count,
+            |rng, _| {
+                vec![Value::build_text(format!(
+                    "https://www.example.com/catalog/products/item-{:010}",
+                    rng.next_u64() % 10_000_000_000
+                ))]
+            },
+        ),
+        build("text_random", vec![SortOrder::Asc], count, |rng, _| {
+            vec![Value::build_text(random_letters(rng, 12))]
+        }),
+        build(
+            "text_few_distinct",
+            vec![SortOrder::Asc],
+            count,
+            |rng, _| {
+                vec![Value::build_text(
+                    CITIES[(rng.next_u64() % CITIES.len() as u64) as usize].to_string(),
+                )]
+            },
+        ),
+        build(
+            "multi_column_country_name",
+            vec![SortOrder::Asc, SortOrder::Asc],
+            count,
+            |rng, _| {
+                vec![
+                    Value::build_text(random_letters(rng, 2).to_uppercase()),
+                    Value::build_text(random_letters(rng, 8)),
+                ]
+            },
+        ),
+    ]
+}
+
+fn sort_workload(io: &Arc<MemoryIO>, workload: &Workload) {
+    let columns = workload.orders.len();
+    let mut sorter = Sorter::new(
+        &workload.orders,
+        turso_core::alloc::vec![CollationSeq::Binary; columns],
+        turso_core::alloc::vec![None; columns],
+        turso_core::alloc::vec![None; columns],
+        1 << 30,
+        64,
+        io.clone(),
+        TempStore::Default,
+    )
+    .unwrap();
+    for record in &workload.records {
+        io.block(|| sorter.insert(record)).unwrap();
+    }
+    io.block(|| sorter.sort()).unwrap();
+    let mut count = 0;
+    while sorter.has_more() {
+        black_box(sorter.record());
+        io.block(|| sorter.next()).unwrap();
+        count += 1;
+    }
+    assert_eq!(count, workload.records.len());
+}
+
+#[turso_macros::codspeed_criterion_benchmark]
+fn bench_sorter(criterion: &mut Criterion) {
+    let io = Arc::new(MemoryIO::new());
+    let mut group = criterion.benchmark_group("Sorter insert, sort, and drain");
+    for count in SIZES {
+        group.throughput(Throughput::Elements(count as u64));
+        for workload in workloads(count) {
+            group.bench_with_input(
+                BenchmarkId::new(workload.name, count),
+                &workload,
+                |b, workload| b.iter(|| sort_workload(&io, workload)),
+            );
+        }
+    }
+    group.finish();
+}
+
+#[cfg(not(feature = "codspeed"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_sorter
+}
+
+#[cfg(feature = "codspeed")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = bench_sorter
+}
+
+criterion_main!(benches);

--- a/core/benches/sorter_benchmark.rs
+++ b/core/benches/sorter_benchmark.rs
@@ -4,7 +4,10 @@
 //! values, multi-column keys, DESC keys, and presorted input.
 //!
 //! The sort buffer is large enough that nothing spills, so the numbers cover
-//! key conditioning and the in-memory sort, not the external merge.
+//! key conditioning and the in-memory sort, not the external merge. Every
+//! workload runs with the sort path the sorter picks itself; the largest
+//! size also runs each workload with each path forced, so both sorts stay
+//! measured whatever the sorter picks.
 //!
 //! Run with:
 //!   cargo bench --bench sorter_benchmark --features bench
@@ -25,7 +28,7 @@ use rand_chacha::{
 };
 use std::sync::Arc;
 use turso_core::types::{ImmutableRecord, Value};
-use turso_core::vdbe::sorter::Sorter;
+use turso_core::vdbe::sorter::{SortPath, Sorter};
 use turso_core::vdbe::CollationSeq;
 use turso_core::{IOExt, MemoryIO, TempStore};
 use turso_parser::ast::SortOrder;
@@ -142,7 +145,7 @@ fn workloads(count: usize) -> Vec<Workload> {
     ]
 }
 
-fn sort_workload(io: &Arc<MemoryIO>, workload: &Workload) {
+fn sort_workload(io: &Arc<MemoryIO>, workload: &Workload, path: Option<SortPath>) {
     let columns = workload.orders.len();
     let mut sorter = Sorter::new(
         &workload.orders,
@@ -155,6 +158,9 @@ fn sort_workload(io: &Arc<MemoryIO>, workload: &Workload) {
         TempStore::Default,
     )
     .unwrap();
+    if let Some(path) = path {
+        sorter.force_sort_path(path);
+    }
     for record in &workload.records {
         io.block(|| sorter.insert(record)).unwrap();
     }
@@ -178,8 +184,20 @@ fn bench_sorter(criterion: &mut Criterion) {
             group.bench_with_input(
                 BenchmarkId::new(workload.name, count),
                 &workload,
-                |b, workload| b.iter(|| sort_workload(&io, workload)),
+                |b, workload| b.iter(|| sort_workload(&io, workload, None)),
             );
+            if count == SIZES[SIZES.len() - 1] {
+                for (label, path) in [
+                    ("comparison", SortPath::Comparison),
+                    ("adaptive", SortPath::Adaptive),
+                ] {
+                    group.bench_with_input(
+                        BenchmarkId::new(format!("{}/{label}", workload.name), count),
+                        &workload,
+                        |b, workload| b.iter(|| sort_workload(&io, workload, Some(path))),
+                    );
+                }
+            }
         }
     }
     group.finish();

--- a/core/vdbe/adaptive_sort.rs
+++ b/core/vdbe/adaptive_sort.rs
@@ -1,0 +1,810 @@
+//! Adaptive quicksort for byte-orderable keys, after US 7,680,791
+//! (Callaghan, Li, Waddington): a common prefix skipping quicksort and a
+//! most significant digit radix sort that call each other, with a two-byte
+//! key substring cache in every item.
+//!
+//! Every partition knows how many leading bytes all of its keys share (its
+//! common prefix), so comparisons start after those bytes. The quicksort
+//! step splits a partition into the keys less than, equal to, and greater
+//! than a pivot, and while doing so records the common prefix of the "less
+//! than" and "greater than" sets. Each of those sets then goes through the
+//! radix step, which buckets the keys on the first byte after their common
+//! prefix, and each bucket with more than one key goes back to the
+//! quicksort step. Both steps keep the input order inside each group, so
+//! equal keys come out in insertion order.
+//!
+//! An item stores the two key bytes that follow the common prefix of its
+//! partition. Comparisons read those bytes from the item array and only
+//! follow the record pointer when the cached bytes tie. The radix step moves
+//! the cache forward when it advances the common prefix by two or more
+//! bytes, and leaves it in place when the prefix grows by one byte, because
+//! the second cached byte is still useful then.
+//!
+//! Two additions to the patent: the recursion runs on an explicit stack of
+//! steps, so a long chain of partitions never touches the thread stack, and
+//! input that is already in order (or in strictly reverse order) is
+//! detected by one pass over the items and returned without partitioning.
+
+use std::cmp::Ordering;
+
+use crate::alloc::*;
+use crate::{turso_assert, Result};
+
+pub(crate) const CACHE_LEN: usize = 2;
+
+pub(crate) trait AdaptiveSortItem: Copy {
+    /// The conditioned key. Follows the record pointer.
+    fn key(&self) -> &[u8];
+    /// The key length, kept in the item so a comparison that runs into the
+    /// end of a key does not follow the record pointer.
+    fn key_len(&self) -> usize;
+    /// The key substring cache: the key bytes at the common prefix of the
+    /// item's partition, zero-filled past the end of the key.
+    fn cache(&self) -> [u8; CACHE_LEN];
+    fn set_cache(&mut self, cache: [u8; CACHE_LEN]);
+}
+
+/// The key substring cache for a key whose partition shares `prefix` bytes.
+pub(crate) fn cache_at(key: &[u8], prefix: usize) -> [u8; CACHE_LEN] {
+    let mut cache = [0u8; CACHE_LEN];
+    let cached = key.get(prefix..).unwrap_or(&[]);
+    for (slot, byte) in cache.iter_mut().zip(cached) {
+        *slot = *byte;
+    }
+    cache
+}
+
+/// Sorts `items` by key, keeping the input order of equal keys. The caches
+/// of the items must hold the first two bytes of their keys.
+pub(crate) fn adaptive_sort<T: AdaptiveSortItem>(items: &mut [T]) -> Result<()> {
+    let len = items.len();
+    if len < 2 {
+        return Ok(());
+    }
+    match input_order(items) {
+        InputOrder::Ascending => return Ok(()),
+        InputOrder::StrictlyDescending => {
+            items.reverse();
+            return Ok(());
+        }
+        InputOrder::Unsorted => {}
+    }
+    turso_assert!(
+        u32::try_from(len).is_ok(),
+        "the adaptive sort keeps item positions in u32"
+    );
+    let mut scratch = items.try_to_vec()?;
+    let mut tags = try_vec![0u32; len]?;
+    let mut steps: Vec<Step> = Vec::try_with_capacity_ext(64)?;
+    steps.try_push(Step::Quick {
+        lo: 0,
+        hi: len as u32,
+        prefix: 0,
+        side: Side::Items,
+    })?;
+    while let Some(step) = steps.pop() {
+        match step {
+            Step::Quick {
+                lo,
+                hi,
+                prefix,
+                side,
+            } => {
+                let (lo, hi) = (lo as usize, hi as usize);
+                let (src, dst) = pick(items, &mut scratch, side);
+                quick_step(
+                    &mut src[lo..hi],
+                    &mut dst[lo..hi],
+                    &mut steps,
+                    lo,
+                    prefix as usize,
+                    side.other(),
+                )?;
+            }
+            Step::Radix {
+                lo,
+                hi,
+                index,
+                prefix,
+                side,
+            } => {
+                let (lo, hi) = (lo as usize, hi as usize);
+                let (src, dst) = pick(items, &mut scratch, side);
+                radix_step(
+                    &mut src[lo..hi],
+                    &mut dst[lo..hi],
+                    &mut tags[lo..hi],
+                    &mut steps,
+                    lo,
+                    index as usize,
+                    prefix as usize,
+                    side.other(),
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
+enum InputOrder {
+    Ascending,
+    StrictlyDescending,
+    Unsorted,
+}
+
+/// One pass over the items that stops at the first pair out of order, so
+/// unsorted input costs a few comparisons. Reverse order only counts when
+/// every key is strictly smaller than the one before it: reversing a run
+/// with equal keys would swap their insertion order.
+fn input_order<T: AdaptiveSortItem>(items: &[T]) -> InputOrder {
+    let mut pairs = items.windows(2);
+    let descending = pairs
+        .next()
+        .is_some_and(|pair| compare_items(&pair[0], &pair[1]) == Ordering::Greater);
+    if descending {
+        if pairs.all(|pair| compare_items(&pair[0], &pair[1]) == Ordering::Greater) {
+            InputOrder::StrictlyDescending
+        } else {
+            InputOrder::Unsorted
+        }
+    } else if pairs.all(|pair| compare_items(&pair[0], &pair[1]) != Ordering::Greater) {
+        InputOrder::Ascending
+    } else {
+        InputOrder::Unsorted
+    }
+}
+
+/// Compares two items whose caches hold the first bytes of their keys,
+/// following the record pointers only when the cached bytes tie.
+fn compare_items<T: AdaptiveSortItem>(a: &T, b: &T) -> Ordering {
+    let (a_len, b_len) = (a.key_len(), b.key_len());
+    let (a_cache, b_cache) = (a.cache(), b.cache());
+    for pos in 0..CACHE_LEN {
+        if pos >= a_len || pos >= b_len {
+            return a_len.cmp(&b_len);
+        }
+        if a_cache[pos] != b_cache[pos] {
+            return a_cache[pos].cmp(&b_cache[pos]);
+        }
+    }
+    compare_from(a, b.key(), 0).0
+}
+
+/// Which of the two buffers holds a partition. Every step reads its
+/// partition from one buffer and writes the partitioned groups to the same
+/// positions of the other one. `Items` is also where the sorted output ends
+/// up, so a group that is finished in the scratch buffer is copied back
+/// right away.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Side {
+    Items,
+    Scratch,
+}
+
+impl Side {
+    fn other(self) -> Self {
+        match self {
+            Side::Items => Side::Scratch,
+            Side::Scratch => Side::Items,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Step {
+    /// Quicksort step on `side[lo..hi]`: the keys share `prefix` bytes and
+    /// the caches hold the bytes at `prefix`.
+    Quick {
+        lo: u32,
+        hi: u32,
+        prefix: u32,
+        side: Side,
+    },
+    /// Radix step on `side[lo..hi]`: bucket on the byte at `index`, while
+    /// the caches still hold the bytes at `prefix`.
+    Radix {
+        lo: u32,
+        hi: u32,
+        index: u32,
+        prefix: u32,
+        side: Side,
+    },
+}
+
+fn pick<'a, T>(items: &'a mut [T], scratch: &'a mut [T], side: Side) -> (&'a mut [T], &'a mut [T]) {
+    match side {
+        Side::Items => (items, scratch),
+        Side::Scratch => (scratch, items),
+    }
+}
+
+/// Partitions `src` around a pivot into `dst` as [less | equal | greater],
+/// each group in input order, and queues the radix steps for the less and
+/// greater groups with the common prefix found for them. The equal group is
+/// finished, its keys are all the same, so it goes straight to the output
+/// buffer. One pass: less keys fill `dst` from the front, greater keys fill
+/// it from the back (reversed, then turned around), and equal keys are
+/// packed into the front of `src`, which has already been read there.
+fn quick_step<T: AdaptiveSortItem>(
+    src: &mut [T],
+    dst: &mut [T],
+    steps: &mut Vec<Step>,
+    lo: usize,
+    prefix: usize,
+    dst_side: Side,
+) -> Result<()> {
+    let len = src.len();
+    let pivot = src[pivot_index(src, prefix)];
+    let pivot_key = pivot.key();
+    let (mut less, mut equal, mut greater) = (0, 0, 0);
+    let mut less_prefix = usize::MAX;
+    let mut greater_prefix = usize::MAX;
+    let mut i = 0;
+    while i < len {
+        let item = src[i];
+        i += 1;
+        let (order, differ_at) = compare_from(&item, pivot_key, prefix);
+        match order {
+            Ordering::Less => {
+                less_prefix = less_prefix.min(differ_at);
+                dst[less] = item;
+                less += 1;
+            }
+            Ordering::Equal => {
+                src[equal] = item;
+                equal += 1;
+            }
+            Ordering::Greater => {
+                greater_prefix = greater_prefix.min(differ_at);
+                greater += 1;
+                dst[len - greater] = item;
+            }
+        }
+    }
+    dst[len - greater..].reverse();
+    match dst_side {
+        Side::Items => dst[less..less + equal].copy_from_slice(&src[..equal]),
+        Side::Scratch => src.copy_within(0..equal, less),
+    }
+    // Steps run last in, first out: the greater group goes first so that the
+    // smaller keys are worked on first, which keeps the working set close.
+    push_group(
+        steps,
+        src,
+        dst,
+        len - greater,
+        len,
+        greater_prefix,
+        prefix,
+        lo,
+        dst_side,
+    )?;
+    push_group(steps, src, dst, 0, less, less_prefix, prefix, lo, dst_side)
+}
+
+/// Queues the radix step for a group produced by a quicksort step. A single
+/// key is finished and only needs to reach the output buffer.
+#[allow(clippy::too_many_arguments)]
+fn push_group<T: AdaptiveSortItem>(
+    steps: &mut Vec<Step>,
+    src: &mut [T],
+    dst: &[T],
+    start: usize,
+    end: usize,
+    index: usize,
+    prefix: usize,
+    lo: usize,
+    dst_side: Side,
+) -> Result<()> {
+    match end - start {
+        0 => Ok(()),
+        1 => {
+            finish(src, dst, start, end, dst_side);
+            Ok(())
+        }
+        _ => Ok(steps.try_push(Step::Radix {
+            lo: (lo + start) as u32,
+            hi: (lo + end) as u32,
+            index: index as u32,
+            prefix: prefix as u32,
+            side: dst_side,
+        })?),
+    }
+}
+
+/// Moves a finished group to the output buffer. `src` has been read in full
+/// by then, so when it is the output buffer the group is copied back over
+/// the positions it came from.
+fn finish<T: AdaptiveSortItem>(src: &mut [T], dst: &[T], start: usize, end: usize, dst_side: Side) {
+    if dst_side == Side::Scratch {
+        src[start..end].copy_from_slice(&dst[start..end]);
+    }
+}
+
+/// The largest sample the pivot is the median of; the patent suggests no
+/// more than 20 keys.
+const MAX_PIVOT_SAMPLE: usize = 19;
+
+fn pivot_index<T: AdaptiveSortItem>(src: &[T], prefix: usize) -> usize {
+    let len = src.len();
+    let sample = (len / 64).clamp(1, MAX_PIVOT_SAMPLE) | 1;
+    if sample == 1 {
+        return len / 2;
+    }
+    let stride = len / sample;
+    let mut chosen = [0usize; MAX_PIVOT_SAMPLE];
+    for (i, slot) in chosen[..sample].iter_mut().enumerate() {
+        *slot = i * stride + stride / 2;
+    }
+    for i in 1..sample {
+        let index = chosen[i];
+        let key = src[index].key();
+        let mut j = i;
+        while j > 0 && compare_from(&src[chosen[j - 1]], key, prefix).0 == Ordering::Greater {
+            chosen[j] = chosen[j - 1];
+            j -= 1;
+        }
+        chosen[j] = index;
+    }
+    chosen[sample / 2]
+}
+
+/// Compares the key of `item` with `other`, both known to share `prefix`
+/// bytes, and returns the order and the index of the first byte where they
+/// differ. The cached bytes are compared first; the key in memory is only
+/// read when they tie.
+#[inline]
+fn compare_from<T: AdaptiveSortItem>(item: &T, other: &[u8], prefix: usize) -> (Ordering, usize) {
+    let len = item.key_len();
+    let other_len = other.len();
+    let cache = item.cache();
+    for (j, cached) in cache.iter().enumerate() {
+        let pos = prefix + j;
+        if pos >= len || pos >= other_len {
+            return (len.cmp(&other_len), pos);
+        }
+        if *cached != other[pos] {
+            return (cached.cmp(&other[pos]), pos);
+        }
+    }
+    let start = prefix + CACHE_LEN;
+    let end = len.min(other_len);
+    let key = item.key();
+    match first_difference(&key[start..end], &other[start..end]) {
+        Some(offset) => {
+            let pos = start + offset;
+            (key[pos].cmp(&other[pos]), pos)
+        }
+        None => (len.cmp(&other_len), end),
+    }
+}
+
+/// Index of the first byte where two equally long slices differ.
+#[inline]
+fn first_difference(a: &[u8], b: &[u8]) -> Option<usize> {
+    let len = a.len();
+    let mut i = 0;
+    while i + 8 <= len {
+        let x = u64::from_ne_bytes(a[i..i + 8].try_into().expect("eight bytes"));
+        let y = u64::from_ne_bytes(b[i..i + 8].try_into().expect("eight bytes"));
+        let diff = x ^ y;
+        if diff != 0 {
+            let byte = if cfg!(target_endian = "little") {
+                diff.trailing_zeros()
+            } else {
+                diff.leading_zeros()
+            } / 8;
+            return Some(i + byte as usize);
+        }
+        i += 8;
+    }
+    while i < len {
+        if a[i] != b[i] {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// A radix tag orders the buckets: keys that end at the partitioning index
+/// come first, then for each byte value the keys that end right after it
+/// (done) before the keys that go on (more). The new cache bytes of a "more"
+/// key ride in the upper half of its tag so the placement pass does not
+/// follow the record pointer again.
+const TAG_ENDED: u32 = 0;
+const TAG_MASK: u32 = 0xFFFF;
+const TAG_COUNT: usize = 1 + 2 * 256;
+/// Partitions up to this size sort their tags by insertion instead of
+/// counting into 513 buckets.
+const SMALL_RADIX_STEP: usize = 32;
+
+fn tag_done(byte: u8) -> u32 {
+    1 + 2 * byte as u32
+}
+
+fn tag_more(byte: u8) -> u32 {
+    2 + 2 * byte as u32
+}
+
+fn tag_is_more(bucket: u32) -> bool {
+    bucket != TAG_ENDED && bucket % 2 == 0
+}
+
+fn packed_cache(cache: [u8; CACHE_LEN]) -> u32 {
+    ((cache[0] as u32) << 16) | ((cache[1] as u32) << 24)
+}
+
+fn unpack_cache(tag: u32) -> [u8; CACHE_LEN] {
+    [(tag >> 16) as u8, (tag >> 24) as u8]
+}
+
+/// Buckets `src` on the byte at `index` into `dst`, each bucket in input
+/// order, and queues a quicksort step for every bucket with more than one
+/// key that goes on past `index`. `prefix` says which bytes the caches hold;
+/// the patent's three cases for the distance between `index` and `prefix`
+/// decide where the bucket byte comes from and whether the caches move:
+/// with the byte in the cache the counting pass needs no tags, and only a
+/// byte beyond the cache is fetched once and remembered in the tags.
+#[allow(clippy::too_many_arguments)]
+fn radix_step<T: AdaptiveSortItem>(
+    src: &mut [T],
+    dst: &mut [T],
+    tags: &mut [u32],
+    steps: &mut Vec<Step>,
+    lo: usize,
+    index: usize,
+    prefix: usize,
+    dst_side: Side,
+) -> Result<()> {
+    turso_assert!(
+        index >= prefix,
+        "the cache never runs ahead of the partition index"
+    );
+    let gap = index - prefix;
+    let new_prefix = if gap == 0 { prefix } else { index + 1 };
+    let len = src.len();
+    if len <= SMALL_RADIX_STEP {
+        let mut small_tags = [0u32; SMALL_RADIX_STEP];
+        let tags = &mut small_tags[..len];
+        for (item, tag) in src.iter().zip(tags.iter_mut()) {
+            *tag = radix_tag(item, index, gap);
+        }
+        place_small(src, dst, tags, gap);
+        let mut end = len;
+        while end > 0 {
+            let bucket = tags[end - 1] & TAG_MASK;
+            let mut start = end;
+            while start > 0 && (tags[start - 1] & TAG_MASK) == bucket {
+                start -= 1;
+            }
+            push_bucket(
+                steps, src, dst, start, end, bucket, new_prefix, lo, dst_side,
+            )?;
+            end = start;
+        }
+        return Ok(());
+    }
+    let mut next = [0u32; TAG_COUNT];
+    if gap >= CACHE_LEN {
+        for (item, tag) in src.iter().zip(tags.iter_mut()) {
+            *tag = radix_tag(item, index, gap);
+            next[(*tag & TAG_MASK) as usize] += 1;
+        }
+        bucket_starts(&mut next);
+        for (item, tag) in src.iter().zip(tags.iter()) {
+            let bucket = *tag & TAG_MASK;
+            let mut placed = *item;
+            if tag_is_more(bucket) {
+                placed.set_cache(unpack_cache(*tag));
+            }
+            let slot = &mut next[bucket as usize];
+            dst[*slot as usize] = placed;
+            *slot += 1;
+        }
+    } else {
+        for item in src.iter() {
+            next[cached_bucket(item, index, gap) as usize] += 1;
+        }
+        bucket_starts(&mut next);
+        for item in src.iter() {
+            let bucket = cached_bucket(item, index, gap);
+            let mut placed = *item;
+            if gap != 0 && tag_is_more(bucket) {
+                placed.set_cache(cache_at(item.key(), index + 1));
+            }
+            let slot = &mut next[bucket as usize];
+            dst[*slot as usize] = placed;
+            *slot += 1;
+        }
+    }
+    for bucket in (0..TAG_COUNT).rev() {
+        let end = next[bucket] as usize;
+        let start = if bucket == 0 {
+            0
+        } else {
+            next[bucket - 1] as usize
+        };
+        if end > start {
+            push_bucket(
+                steps,
+                src,
+                dst,
+                start,
+                end,
+                bucket as u32,
+                new_prefix,
+                lo,
+                dst_side,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// The bucket of a key when the bucket byte sits in the cache (`gap` is 0
+/// or 1).
+fn cached_bucket<T: AdaptiveSortItem>(item: &T, index: usize, gap: usize) -> u32 {
+    let len = item.key_len();
+    if len == index {
+        TAG_ENDED
+    } else {
+        let byte = item.cache()[gap];
+        if len == index + 1 {
+            tag_done(byte)
+        } else {
+            tag_more(byte)
+        }
+    }
+}
+
+/// The bucket of a key, with the next two key bytes packed in when the
+/// cache must move.
+fn radix_tag<T: AdaptiveSortItem>(item: &T, index: usize, gap: usize) -> u32 {
+    let len = item.key_len();
+    if len == index {
+        return TAG_ENDED;
+    }
+    if gap < CACHE_LEN {
+        let bucket = cached_bucket(item, index, gap);
+        if gap != 0 && tag_is_more(bucket) {
+            bucket | packed_cache(cache_at(item.key(), index + 1))
+        } else {
+            bucket
+        }
+    } else {
+        let key = item.key();
+        if len == index + 1 {
+            tag_done(key[index])
+        } else {
+            tag_more(key[index]) | packed_cache(cache_at(key, index + 1))
+        }
+    }
+}
+
+/// Turns bucket counts into the start position of each bucket.
+fn bucket_starts(next: &mut [u32; TAG_COUNT]) {
+    let mut start = 0;
+    for slot in next.iter_mut() {
+        let count = *slot;
+        *slot = start;
+        start += count;
+    }
+}
+
+/// Stable insertion sort of a small partition by bucket, moving the tags
+/// along so the caller can find the bucket runs in `tags`.
+fn place_small<T: AdaptiveSortItem>(src: &[T], dst: &mut [T], tags: &mut [u32], gap: usize) {
+    for (slot, (item, tag)) in dst.iter_mut().zip(src.iter().zip(tags.iter())) {
+        let mut placed = *item;
+        if gap != 0 && tag_is_more(*tag & TAG_MASK) {
+            placed.set_cache(unpack_cache(*tag));
+        }
+        *slot = placed;
+    }
+    for i in 1..dst.len() {
+        let (tag, item) = (tags[i], dst[i]);
+        let bucket = tag & TAG_MASK;
+        let mut j = i;
+        while j > 0 && (tags[j - 1] & TAG_MASK) > bucket {
+            tags[j] = tags[j - 1];
+            dst[j] = dst[j - 1];
+            j -= 1;
+        }
+        tags[j] = tag;
+        dst[j] = item;
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_bucket<T: AdaptiveSortItem>(
+    steps: &mut Vec<Step>,
+    src: &mut [T],
+    dst: &[T],
+    start: usize,
+    end: usize,
+    bucket: u32,
+    prefix: usize,
+    lo: usize,
+    dst_side: Side,
+) -> Result<()> {
+    if tag_is_more(bucket) && end - start > 1 {
+        Ok(steps.try_push(Step::Quick {
+            lo: (lo + start) as u32,
+            hi: (lo + end) as u32,
+            prefix: prefix as u32,
+            side: dst_side,
+        })?)
+    } else {
+        finish(src, dst, start, end, dst_side);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_chacha::{
+        rand_core::{RngCore, SeedableRng},
+        ChaCha8Rng,
+    };
+
+    #[derive(Clone, Copy, Debug)]
+    struct TestItem<'a> {
+        key: &'a [u8],
+        id: usize,
+        cache: [u8; CACHE_LEN],
+    }
+
+    impl AdaptiveSortItem for TestItem<'_> {
+        fn key(&self) -> &[u8] {
+            self.key
+        }
+
+        fn key_len(&self) -> usize {
+            self.key.len()
+        }
+
+        fn cache(&self) -> [u8; CACHE_LEN] {
+            self.cache
+        }
+
+        fn set_cache(&mut self, cache: [u8; CACHE_LEN]) {
+            self.cache = cache;
+        }
+    }
+
+    fn seed() -> u64 {
+        std::env::var("SEED").map_or(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+            |v| v.parse().expect("SEED must be a u64"),
+        )
+    }
+
+    fn check_sorts_like_stable_sort(keys: &[std::vec::Vec<u8>], seed: u64) {
+        let mut items: std::vec::Vec<TestItem> = keys
+            .iter()
+            .enumerate()
+            .map(|(id, key)| TestItem {
+                key,
+                id,
+                cache: cache_at(key, 0),
+            })
+            .collect();
+        let mut expected: std::vec::Vec<usize> = (0..keys.len()).collect();
+        expected.sort_by(|a, b| keys[*a].cmp(&keys[*b]));
+        adaptive_sort(&mut items).unwrap();
+        let got: std::vec::Vec<usize> = items.iter().map(|item| item.id).collect();
+        assert_eq!(
+            got, expected,
+            "seed {seed}: sorted order differs from a stable sort"
+        );
+    }
+
+    fn random_keys(rng: &mut ChaCha8Rng, count: usize) -> std::vec::Vec<std::vec::Vec<u8>> {
+        let alphabet_len = 1 + (rng.next_u64() % 4) as usize;
+        let alphabet = [0x00u8, 0x61, 0xFF, 0x62];
+        let shared_prefix_len = (rng.next_u64() % 70) as usize;
+        let shared_prefix: std::vec::Vec<u8> = (0..shared_prefix_len)
+            .map(|_| rng.next_u64() as u8)
+            .collect();
+        let max_len = 1 + (rng.next_u64() % 40) as usize;
+        (0..count)
+            .map(|_| {
+                let mut key = if rng.next_u64() % 8 == 0 {
+                    std::vec::Vec::new()
+                } else {
+                    shared_prefix.clone()
+                };
+                let len = (rng.next_u64() % max_len as u64) as usize;
+                key.extend((0..len).map(|_| {
+                    if rng.next_u64() % 3 == 0 {
+                        rng.next_u64() as u8
+                    } else {
+                        alphabet[(rng.next_u64() % alphabet_len as u64) as usize]
+                    }
+                }));
+                key
+            })
+            .collect()
+    }
+
+    #[test]
+    fn fuzz_sorts_like_a_stable_sort() {
+        let seed = seed();
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        for round in 0..400 {
+            let count = match round % 4 {
+                0 => (rng.next_u64() % 8) as usize,
+                1 => (rng.next_u64() % 64) as usize,
+                2 => (rng.next_u64() % 600) as usize,
+                _ => (rng.next_u64() % 5000) as usize,
+            };
+            let mut keys = random_keys(&mut rng, count);
+            match round % 5 {
+                0 => keys.sort(),
+                1 => {
+                    keys.sort();
+                    keys.reverse();
+                }
+                _ => {}
+            }
+            check_sorts_like_stable_sort(&keys, seed);
+        }
+    }
+
+    #[test]
+    fn sorts_many_equal_and_prefixed_keys() {
+        let mut keys = std::vec::Vec::new();
+        for i in 0..20_000u32 {
+            let key: std::vec::Vec<u8> = match i % 5 {
+                0 => b"same-key".to_vec(),
+                1 => b"same-key-longer".to_vec(),
+                2 => b"same".to_vec(),
+                3 => std::vec::Vec::new(),
+                _ => format!("same-key-{:04}", i % 300).into_bytes(),
+            };
+            keys.push(key);
+        }
+        check_sorts_like_stable_sort(&keys, 0);
+    }
+
+    #[test]
+    fn sorts_keys_with_long_shared_prefix_and_late_differences() {
+        let prefix: std::vec::Vec<u8> = std::iter::repeat_n(0xABu8, 3000).collect();
+        let keys: std::vec::Vec<std::vec::Vec<u8>> = (0..3000u32)
+            .rev()
+            .map(|i| {
+                let mut key = prefix.clone();
+                key.extend_from_slice(&i.to_be_bytes());
+                key
+            })
+            .collect();
+        check_sorts_like_stable_sort(&keys, 0);
+    }
+
+    #[test]
+    fn sorts_ordered_reversed_and_nearly_ordered_input() {
+        let sorted: std::vec::Vec<std::vec::Vec<u8>> =
+            (0..10_000u64).map(|i| i.to_be_bytes().to_vec()).collect();
+        check_sorts_like_stable_sort(&sorted, 0);
+        let reversed: std::vec::Vec<std::vec::Vec<u8>> = sorted.iter().rev().cloned().collect();
+        check_sorts_like_stable_sort(&reversed, 0);
+        // Reversed with equal keys must not be flipped, or equal keys would
+        // lose their insertion order.
+        let reversed_with_duplicates: std::vec::Vec<std::vec::Vec<u8>> = (0..10_000u64)
+            .rev()
+            .map(|i| (i / 3).to_be_bytes().to_vec())
+            .collect();
+        check_sorts_like_stable_sort(&reversed_with_duplicates, 0);
+        let mut nearly_sorted = sorted.clone();
+        nearly_sorted.swap(9_998, 9_999);
+        check_sorts_like_stable_sort(&nearly_sorted, 0);
+        let mut ordered_with_duplicates = sorted;
+        ordered_with_duplicates[5_000] = ordered_with_duplicates[4_999].clone();
+        check_sorts_like_stable_sort(&ordered_with_duplicates, 0);
+    }
+}

--- a/core/vdbe/adaptive_sort.rs
+++ b/core/vdbe/adaptive_sort.rs
@@ -20,10 +20,8 @@
 //! bytes, and leaves it in place when the prefix grows by one byte, because
 //! the second cached byte is still useful then.
 //!
-//! Two additions to the patent: the recursion runs on an explicit stack of
-//! steps, so a long chain of partitions never touches the thread stack, and
-//! input that is already in order (or in strictly reverse order) is
-//! detected by one pass over the items and returned without partitioning.
+//! One addition to the patent: the recursion runs on an explicit stack of
+//! steps, so a long chain of partitions never touches the thread stack.
 
 use std::cmp::Ordering;
 
@@ -60,14 +58,6 @@ pub(crate) fn adaptive_sort<T: AdaptiveSortItem>(items: &mut [T]) -> Result<()> 
     let len = items.len();
     if len < 2 {
         return Ok(());
-    }
-    match input_order(items) {
-        InputOrder::Ascending => return Ok(()),
-        InputOrder::StrictlyDescending => {
-            items.reverse();
-            return Ok(());
-        }
-        InputOrder::Unsorted => {}
     }
     turso_assert!(
         u32::try_from(len).is_ok(),
@@ -124,50 +114,6 @@ pub(crate) fn adaptive_sort<T: AdaptiveSortItem>(items: &mut [T]) -> Result<()> 
         }
     }
     Ok(())
-}
-
-enum InputOrder {
-    Ascending,
-    StrictlyDescending,
-    Unsorted,
-}
-
-/// One pass over the items that stops at the first pair out of order, so
-/// unsorted input costs a few comparisons. Reverse order only counts when
-/// every key is strictly smaller than the one before it: reversing a run
-/// with equal keys would swap their insertion order.
-fn input_order<T: AdaptiveSortItem>(items: &[T]) -> InputOrder {
-    let mut pairs = items.windows(2);
-    let descending = pairs
-        .next()
-        .is_some_and(|pair| compare_items(&pair[0], &pair[1]) == Ordering::Greater);
-    if descending {
-        if pairs.all(|pair| compare_items(&pair[0], &pair[1]) == Ordering::Greater) {
-            InputOrder::StrictlyDescending
-        } else {
-            InputOrder::Unsorted
-        }
-    } else if pairs.all(|pair| compare_items(&pair[0], &pair[1]) != Ordering::Greater) {
-        InputOrder::Ascending
-    } else {
-        InputOrder::Unsorted
-    }
-}
-
-/// Compares two items whose caches hold the first bytes of their keys,
-/// following the record pointers only when the cached bytes tie.
-fn compare_items<T: AdaptiveSortItem>(a: &T, b: &T) -> Ordering {
-    let (a_len, b_len) = (a.key_len(), b.key_len());
-    let (a_cache, b_cache) = (a.cache(), b.cache());
-    for pos in 0..CACHE_LEN {
-        if pos >= a_len || pos >= b_len {
-            return a_len.cmp(&b_len);
-        }
-        if a_cache[pos] != b_cache[pos] {
-            return a_cache[pos].cmp(&b_cache[pos]);
-        }
-    }
-    compare_from(a, b.key(), 0).0
 }
 
 /// Which of the two buffers holds a partition. Every step reads its

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -22,6 +22,7 @@ use crate::translate::plan::BitSet;
 use crate::types::IOResultOr;
 use crate::types::{Extendable, Text, ValueBlob};
 use crate::{turso_assert, turso_assert_ne, turso_debug_assert, NonNan};
+pub(crate) mod adaptive_sort;
 pub mod affinity;
 pub mod array;
 #[cfg(test)]
@@ -35,6 +36,7 @@ pub mod hash_table;
 pub mod insn;
 pub mod metrics;
 pub mod rowset;
+pub(crate) mod sort_key;
 pub mod sorter;
 #[cfg(test)]
 mod statement_lifecycle_tests;

--- a/core/vdbe/sort_key.rs
+++ b/core/vdbe/sort_key.rs
@@ -1,0 +1,410 @@
+//! Key conditioning for the sorter: turns the sort key of a record into a
+//! byte string whose byte-wise order is the SQL order of the key. The
+//! adaptive sort in [crate::vdbe::adaptive_sort] compares and partitions
+//! keys one byte at a time, so it needs keys in this form.
+//!
+//! Each column becomes a class byte followed by the column value:
+//! - NULL is the class byte alone, ranked below or above the other classes
+//!   as the NULLS FIRST/LAST rule of the column requires.
+//! - Numbers use three classes: floats below the i64 range, values in the
+//!   i64 range, and floats above it. In-range values are the floor as a
+//!   sign-flipped big-endian i64, then a 0 byte for integral values or a 1
+//!   byte plus the order-preserving f64 bits for fractional values, so that
+//!   integers and floats interleave exactly like `Numeric::cmp`.
+//! - Text and blobs are the bytes with 0x00 escaped as 0x00 0xFF and a
+//!   0x00 0x00 terminator, so a shorter key sorts before its extensions and
+//!   the next column starts at a known position. NOCASE folds ASCII letters
+//!   and stops at the first NUL byte, where `CollationSeq::nocase_cmp`
+//!   compares lengths instead. RTRIM removes trailing spaces.
+//!
+//! DESC columns are stored bit-inverted, which reverses their byte order.
+
+use turso_parser::ast::{NullsOrder, SortOrder};
+
+use crate::alloc::*;
+use crate::numeric::Numeric;
+use crate::translate::collate::CollationSeq;
+use crate::types::{KeyInfo, ValueRef};
+use crate::vdbe::sorter::SortComparator;
+use crate::Result;
+
+const CLASS_NULL_LOW: u8 = 0;
+const CLASS_FLOAT_BELOW_I64: u8 = 1;
+const CLASS_NUMERIC: u8 = 2;
+const CLASS_FLOAT_ABOVE_I64: u8 = 3;
+const CLASS_TEXT: u8 = 4;
+const CLASS_BLOB: u8 = 5;
+const CLASS_NULL_HIGH: u8 = 6;
+
+const ESCAPED_ZERO: [u8; 2] = [0x00, 0xFF];
+const TERMINATOR: [u8; 2] = [0x00, 0x00];
+/// Replaces the terminator when a NOCASE string has a NUL byte; the string
+/// length follows it, because that is what the collation compares next.
+const NOCASE_NUL_MARKER: [u8; 2] = [0x00, 0x01];
+
+const I64_RANGE: f64 = 9_223_372_036_854_775_808.0;
+
+/// Conditioned keys reproduce the SQL order only for columns that compare by
+/// bytes. Custom comparators and locale or connection-defined collations
+/// need the value comparison.
+pub(crate) fn keys_are_byte_orderable(
+    key_info: &[KeyInfo],
+    comparators: &[Option<SortComparator>],
+) -> bool {
+    comparators.iter().all(Option::is_none)
+        && key_info.iter().all(|key| {
+            matches!(
+                key.collation,
+                CollationSeq::Unset
+                    | CollationSeq::Binary
+                    | CollationSeq::NoCase
+                    | CollationSeq::Rtrim
+            )
+        })
+}
+
+/// Appends the conditioned key for `values` to `out`.
+pub(crate) fn encode_sort_key(
+    values: &[ValueRef<'_>],
+    key_info: &[KeyInfo],
+    out: &mut Vec<u8>,
+) -> Result<()> {
+    let bound: usize = values.iter().map(encoded_size_bound).sum();
+    // Reserved for the largest possible encoding, so the pushes below cannot grow the vector.
+    out.try_reserve(bound)?;
+    for (value, key) in values.iter().zip(key_info) {
+        let start = out.len();
+        encode_column(value, key, out);
+        if key.sort_order == SortOrder::Desc {
+            for byte in &mut out[start..] {
+                *byte = !*byte;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn encoded_size_bound(value: &ValueRef<'_>) -> usize {
+    match value {
+        ValueRef::Null => 1,
+        ValueRef::Numeric(_) => 1 + 8 + 1 + 8,
+        ValueRef::Text(text) => 1 + 2 * text.value.len() + NOCASE_NUL_MARKER.len() + 8,
+        ValueRef::Blob(blob) => 1 + 2 * blob.len() + TERMINATOR.len(),
+    }
+}
+
+fn encode_column(value: &ValueRef<'_>, key: &KeyInfo, out: &mut Vec<u8>) {
+    match value {
+        ValueRef::Null => {
+            let nulls_high = matches!(
+                (key.nulls_order, key.sort_order),
+                (Some(NullsOrder::Last), SortOrder::Asc)
+                    | (Some(NullsOrder::First), SortOrder::Desc)
+            );
+            out.push(if nulls_high {
+                CLASS_NULL_HIGH
+            } else {
+                CLASS_NULL_LOW
+            });
+        }
+        ValueRef::Numeric(numeric) => encode_numeric(*numeric, out),
+        ValueRef::Text(text) => {
+            out.push(CLASS_TEXT);
+            match key.collation {
+                CollationSeq::Unset | CollationSeq::Binary => {
+                    encode_bytes(text.value.as_bytes(), out)
+                }
+                CollationSeq::NoCase => encode_nocase_text(text.value, out),
+                CollationSeq::Rtrim => {
+                    encode_bytes(text.value.trim_end_matches(' ').as_bytes(), out)
+                }
+                CollationSeq::Locale(_) | CollationSeq::Custom(_) => {
+                    unreachable!(
+                        "keys_are_byte_orderable rejects collations that do not compare by bytes"
+                    )
+                }
+            }
+        }
+        ValueRef::Blob(blob) => {
+            out.push(CLASS_BLOB);
+            encode_bytes(blob, out);
+        }
+    }
+}
+
+fn encode_numeric(numeric: Numeric, out: &mut Vec<u8>) {
+    match numeric {
+        Numeric::Integer(int) => {
+            out.push(CLASS_NUMERIC);
+            out.extend_from_slice(&sign_flipped(int));
+            out.push(0);
+        }
+        Numeric::Float(float) => {
+            let float = f64::from(float);
+            if float < -I64_RANGE {
+                out.push(CLASS_FLOAT_BELOW_I64);
+                out.extend_from_slice(&order_preserving_bits(float));
+            } else if float >= I64_RANGE {
+                out.push(CLASS_FLOAT_ABOVE_I64);
+                out.extend_from_slice(&order_preserving_bits(float));
+            } else {
+                let floor = float.floor();
+                out.push(CLASS_NUMERIC);
+                out.extend_from_slice(&sign_flipped(floor as i64));
+                if float == floor {
+                    out.push(0);
+                } else {
+                    out.push(1);
+                    out.extend_from_slice(&order_preserving_bits(float));
+                }
+            }
+        }
+    }
+}
+
+fn sign_flipped(int: i64) -> [u8; 8] {
+    ((int as u64) ^ (1 << 63)).to_be_bytes()
+}
+
+fn order_preserving_bits(float: f64) -> [u8; 8] {
+    let bits = float.to_bits();
+    let ordered = if bits >> 63 == 1 {
+        !bits
+    } else {
+        bits | (1 << 63)
+    };
+    ordered.to_be_bytes()
+}
+
+fn encode_bytes(mut bytes: &[u8], out: &mut Vec<u8>) {
+    while let Some(zero_at) = bytes.iter().position(|byte| *byte == 0) {
+        out.extend_from_slice(&bytes[..zero_at]);
+        out.extend_from_slice(&ESCAPED_ZERO);
+        bytes = &bytes[zero_at + 1..];
+    }
+    out.extend_from_slice(bytes);
+    out.extend_from_slice(&TERMINATOR);
+}
+
+fn encode_nocase_text(text: &str, out: &mut Vec<u8>) {
+    let bytes = text.as_bytes();
+    let folded_end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    out.extend(bytes[..folded_end].iter().map(u8::to_ascii_lowercase));
+    if folded_end < bytes.len() {
+        out.extend_from_slice(&NOCASE_NUL_MARKER);
+        out.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
+    } else {
+        out.extend_from_slice(&TERMINATOR);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{compare_immutable, AsValueRef, Value};
+    use rand_chacha::{
+        rand_core::{RngCore, SeedableRng},
+        ChaCha8Rng,
+    };
+    use std::cmp::Ordering;
+
+    fn seed() -> u64 {
+        std::env::var("SEED").map_or(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+            |v| v.parse().expect("SEED must be a u64"),
+        )
+    }
+
+    fn random_value(rng: &mut ChaCha8Rng) -> Value {
+        match rng.next_u64() % 12 {
+            0 => Value::Null,
+            1 => Value::from_i64(rng.next_u64() as i64),
+            2 => Value::from_i64((rng.next_u64() % 100) as i64 - 50),
+            3 => {
+                let base = 1i64 << (48 + rng.next_u64() % 15);
+                Value::from_i64(base.wrapping_add((rng.next_u64() % 5) as i64 - 2))
+            }
+            4 => Value::from_i64([i64::MIN, i64::MAX, 0, -1, 1][(rng.next_u64() % 5) as usize]),
+            5 => {
+                let numerator = rng.next_u64() as f64;
+                let denominator = (rng.next_u64() as f64).abs().max(1.0);
+                Value::from_f64(numerator / denominator)
+            }
+            6 => {
+                let int = (rng.next_u64() % 100) as f64 - 50.0;
+                Value::from_f64(int + [0.0, 0.5, -0.5, 0.25][(rng.next_u64() % 4) as usize])
+            }
+            7 => Value::from_f64(
+                [
+                    0.0,
+                    -0.0,
+                    f64::INFINITY,
+                    f64::NEG_INFINITY,
+                    I64_RANGE,
+                    -I64_RANGE,
+                    I64_RANGE * 2.0,
+                    -I64_RANGE * 2.0,
+                    9.007199254740992e15,
+                    9.007199254740994e15,
+                    -9.223372036854775e18,
+                ][(rng.next_u64() % 11) as usize],
+            ),
+            8..=10 => {
+                let alphabet = [b'a', b'b', b'A', b'B', b' ', b'\0', b'z', 0xC3, 0xA9];
+                let len = (rng.next_u64() % 10) as usize;
+                let bytes: std::vec::Vec<u8> = (0..len)
+                    .map(|_| alphabet[(rng.next_u64() % alphabet.len() as u64) as usize])
+                    .collect();
+                Value::build_text(String::from_utf8_lossy(&bytes).into_owned())
+            }
+            _ => {
+                let alphabet = [0x00, 0x01, 0xFF, 0x7F];
+                let len = (rng.next_u64() % 10) as usize;
+                let mut blob = try_vec![0u8; len].unwrap();
+                for byte in blob.iter_mut() {
+                    *byte = if rng.next_u64() % 2 == 0 {
+                        alphabet[(rng.next_u64() % 4) as usize]
+                    } else {
+                        rng.next_u64() as u8
+                    };
+                }
+                Value::Blob(blob)
+            }
+        }
+    }
+
+    fn random_key(rng: &mut ChaCha8Rng) -> KeyInfo {
+        KeyInfo {
+            sort_order: if rng.next_u64() % 2 == 0 {
+                SortOrder::Asc
+            } else {
+                SortOrder::Desc
+            },
+            collation: match rng.next_u64() % 4 {
+                0 => CollationSeq::Unset,
+                1 => CollationSeq::Binary,
+                2 => CollationSeq::NoCase,
+                _ => CollationSeq::Rtrim,
+            },
+            nulls_order: match rng.next_u64() % 3 {
+                0 => None,
+                1 => Some(NullsOrder::First),
+                _ => Some(NullsOrder::Last),
+            },
+        }
+    }
+
+    /// The byte order of two conditioned keys must equal the column-wise
+    /// value comparison, including ties: a tie sends the records into the
+    /// same partition, which is only right when the values are equal.
+    #[test]
+    fn fuzz_conditioned_key_order_matches_value_comparison() {
+        let seed = seed();
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut left_key = try_vec![0u8; 0].unwrap();
+        let mut right_key = try_vec![0u8; 0].unwrap();
+        for _ in 0..300_000 {
+            let ncols = 1 + (rng.next_u64() % 3) as usize;
+            let keys = [
+                random_key(&mut rng),
+                random_key(&mut rng),
+                random_key(&mut rng),
+            ];
+            let left = [
+                random_value(&mut rng),
+                random_value(&mut rng),
+                random_value(&mut rng),
+            ];
+            let right = if rng.next_u64() % 4 == 0 {
+                left.clone()
+            } else {
+                [
+                    random_value(&mut rng),
+                    random_value(&mut rng),
+                    random_value(&mut rng),
+                ]
+            };
+            let left_refs = [
+                left[0].as_value_ref(),
+                left[1].as_value_ref(),
+                left[2].as_value_ref(),
+            ];
+            let right_refs = [
+                right[0].as_value_ref(),
+                right[1].as_value_ref(),
+                right[2].as_value_ref(),
+            ];
+            left_key.clear();
+            right_key.clear();
+            encode_sort_key(&left_refs[..ncols], &keys[..ncols], &mut left_key).unwrap();
+            encode_sort_key(&right_refs[..ncols], &keys[..ncols], &mut right_key).unwrap();
+            let expected = compare_immutable(
+                left_refs[..ncols].iter(),
+                right_refs[..ncols].iter(),
+                &keys[..ncols],
+            );
+            assert_eq!(
+                left_key.as_slice().cmp(right_key.as_slice()),
+                expected,
+                "seed {seed}: {left:?} vs {right:?} with keys {keys:?} encoded as {left_key:?} vs {right_key:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn integers_and_floats_interleave_exactly() {
+        let key = KeyInfo {
+            sort_order: SortOrder::Asc,
+            collation: CollationSeq::Binary,
+            nulls_order: None,
+        };
+        let ordered = [
+            Value::from_f64(f64::NEG_INFINITY),
+            Value::from_f64(-1e300),
+            Value::from_i64(i64::MIN),
+            Value::from_f64(-1.5),
+            Value::from_i64(-1),
+            Value::from_f64(-0.5),
+            Value::from_i64(0),
+            Value::from_f64(0.25),
+            Value::from_i64(1),
+            Value::from_i64(1 << 53),
+            Value::from_i64((1 << 53) + 1),
+            Value::from_f64(9.007199254740994e15),
+            Value::from_i64(i64::MAX),
+            Value::from_f64(I64_RANGE),
+            Value::from_f64(f64::INFINITY),
+        ];
+        let mut previous = try_vec![0u8; 0].unwrap();
+        let mut current = try_vec![0u8; 0].unwrap();
+        for pair in ordered.windows(2) {
+            previous.clear();
+            current.clear();
+            encode_sort_key(&[pair[0].as_value_ref()], &[key], &mut previous).unwrap();
+            encode_sort_key(&[pair[1].as_value_ref()], &[key], &mut current).unwrap();
+            assert_eq!(
+                previous.as_slice().cmp(current.as_slice()),
+                Ordering::Less,
+                "{:?} must sort before {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
+        let mut zero = try_vec![0u8; 0].unwrap();
+        let mut negative_zero = try_vec![0u8; 0].unwrap();
+        encode_sort_key(&[Value::from_i64(0).as_value_ref()], &[key], &mut zero).unwrap();
+        encode_sort_key(
+            &[Value::from_f64(-0.0).as_value_ref()],
+            &[key],
+            &mut negative_zero,
+        )
+        .unwrap();
+        assert_eq!(zero, negative_zero);
+    }
+}

--- a/core/vdbe/sort_key.rs
+++ b/core/vdbe/sort_key.rs
@@ -84,6 +84,20 @@ pub(crate) fn encode_sort_key(
     Ok(())
 }
 
+/// Bytes the conditioned key for `values` will take, counted without
+/// building it. Escaped zero bytes are left out; they are rare.
+pub(crate) fn conditioned_key_estimate(values: &[ValueRef<'_>]) -> usize {
+    values
+        .iter()
+        .map(|value| match value {
+            ValueRef::Null => 1,
+            ValueRef::Numeric(_) => 1 + 8 + 1,
+            ValueRef::Text(text) => 1 + text.value.len() + TERMINATOR.len(),
+            ValueRef::Blob(blob) => 1 + blob.len() + TERMINATOR.len(),
+        })
+        .sum()
+}
+
 fn encoded_size_bound(value: &ValueRef<'_>) -> usize {
     match value {
         ValueRef::Null => 1,

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -14,6 +14,8 @@ use crate::alloc::vec;
 use crate::alloc::*;
 use crate::io::TempFile;
 use crate::types::{cmp_in_column, cmp_with_sort, IOCompletions, ValueIterator};
+use crate::vdbe::adaptive_sort::{adaptive_sort, cache_at, AdaptiveSortItem, CACHE_LEN};
+use crate::vdbe::sort_key::{encode_sort_key, keys_are_byte_orderable};
 use crate::{
     error::LimboError,
     io::{Buffer, Completion, CompletionGroup, File, IO},
@@ -156,10 +158,17 @@ pub struct Sorter {
     /// Arena allocator for records - provides fast bump allocation and bulk deallocation.
     /// All record data (payload bytes, key_values) is stored here for in-memory sorting.
     arena: Bump,
-    /// Pointers to records allocated in the arena. Sorting moves only 8-byte pointers,
-    /// which prevents high memmove costs during sorting.
+    /// Pointers to records allocated in the arena, each with the key length and
+    /// key substring cache of the record next to it. Sorting moves only these
+    /// 16-byte items, which prevents high memmove costs during sorting.
     /// SAFETY: These pointers are valid as long as the arena hasn't been reset.
-    records: Vec<NonNull<ArenaSortableRecord>>,
+    records: Vec<SortItem>,
+    /// True when every key column compares by bytes, so records carry a
+    /// conditioned key and sort with the adaptive sort. Otherwise records
+    /// carry their key values and sort with the value comparison.
+    byte_keys: bool,
+    /// Reused while building the sortable record of each inserted record.
+    scratch: KeyScratch,
     /// The current record.
     current: Option<ImmutableRecord>,
     /// The number of values in the key.
@@ -214,7 +223,7 @@ impl Sorter {
         temp_store: crate::TempStore,
     ) -> Result<Self> {
         turso_assert_eq!(order.len(), collations.len());
-        let index_key_info = order
+        let index_key_info: Vec<KeyInfo> = order
             .iter()
             .zip(collations)
             .zip(nulls_orders)
@@ -224,9 +233,15 @@ impl Sorter {
                 nulls_order: nulls,
             })
             .try_collect()?;
+        let byte_keys = keys_are_byte_orderable(&index_key_info, &comparators);
         let this = Self {
             arena: Bump::new(),
             records: vec![],
+            byte_keys,
+            scratch: KeyScratch {
+                values: TursoAllocExt::new(),
+                bytes: TursoAllocExt::new(),
+            },
             current: None,
             key_len: order.len(),
             index_key_info: Rc::new(index_key_info),
@@ -266,9 +281,7 @@ impl Sorter {
                         // Sort ascending then reverse - we pop from end so this gives ascending output.
                         // NOTE: We can't just sort descending because stable sort preserves insertion
                         // order for equal elements, and descending sort doesn't reverse equal elements.
-                        // SAFETY: All pointers in records are valid (arena hasn't been reset).
-                        self.records
-                            .sort_by(|a, b| unsafe { a.as_ref().cmp(b.as_ref()) });
+                        self.sort_records()?;
                         self.records.reverse();
                         self.sort_state = SortState::Next;
                     } else {
@@ -314,9 +327,9 @@ impl Sorter {
     pub fn next(&mut self) -> IOResultOr<()> {
         if self.chunks.is_empty() {
             match self.records.pop() {
-                Some(ptr) => {
-                    // SAFETY: ptr is valid - arena hasn't been reset yet.
-                    let arena_record = unsafe { ptr.as_ref() };
+                Some(item) => {
+                    // SAFETY: the record pointer is valid - arena hasn't been reset yet.
+                    let arena_record = unsafe { item.record.as_ref() };
                     let payload = arena_record.payload();
 
                     match &mut self.current {
@@ -405,11 +418,23 @@ impl Sorter {
                         self.key_len,
                         &self.index_key_info,
                         &self.comparators,
+                        self.byte_keys,
+                        &mut self.scratch,
                     )?;
+                    let key_len = sortable_record.key().len();
+                    turso_assert!(
+                        u32::try_from(key_len).is_ok(),
+                        "sort keys are shorter than 4 GiB"
+                    );
+                    let cache = cache_at(sortable_record.key(), 0);
                     let record_ref = self.arena.try_alloc(sortable_record)?;
                     // SAFETY: try_alloc returns a valid, aligned, non-null pointer.
-                    self.records.try_push(NonNull::from(record_ref))?;
-                    self.current_buffer_size += payload_size;
+                    self.records.try_push(SortItem {
+                        record: NonNull::from(record_ref),
+                        key_len: key_len as u32,
+                        cache,
+                    })?;
+                    self.current_buffer_size += payload_size + key_len;
                     self.max_payload_size_in_buffer =
                         self.max_payload_size_in_buffer.max(payload_size);
                     self.insert_state = InsertState::Start;
@@ -528,9 +553,7 @@ impl Sorter {
             return Ok(None);
         }
 
-        // SAFETY: All pointers are valid (arena not reset).
-        self.records
-            .sort_by(|a, b| unsafe { a.as_ref().cmp(b.as_ref()) });
+        self.sort_records()?;
 
         let chunk_file = match &self.temp_file {
             Some(temp_file) => temp_file.file.clone(),
@@ -552,8 +575,8 @@ impl Sorter {
         // SAFETY: All pointers are valid because they are allocated in the arena,
         // and the arena hasn't been reset.
         let mut record_size_lengths = Vec::try_with_capacity_ext(self.records.len())?;
-        for ptr in self.records.iter() {
-            let record_size = unsafe { ptr.as_ref().payload().len() };
+        for item in self.records.iter() {
+            let record_size = unsafe { item.record.as_ref().payload().len() };
             let size_len = varint_len(record_size as u64);
             // Enough space was preallocated to `push` instead of `try_push`
             record_size_lengths.push(size_len);
@@ -574,6 +597,59 @@ impl Sorter {
 
         Ok(Some(c))
     }
+
+    /// Orders the in-memory records ascending, keeping insertion order for
+    /// equal keys.
+    fn sort_records(&mut self) -> Result<()> {
+        if self.byte_keys {
+            adaptive_sort(self.records.as_mut_slice())
+        } else {
+            // SAFETY: All pointers are valid (arena not reset).
+            self.records
+                .sort_by(|a, b| unsafe { a.record.as_ref().cmp(b.record.as_ref()) });
+            Ok(())
+        }
+    }
+}
+
+/// One entry of the sorter's item array. The key length and the key
+/// substring cache sit next to the record pointer so the adaptive sort only
+/// follows the pointer when the cached bytes tie.
+#[derive(Clone, Copy)]
+struct SortItem {
+    record: NonNull<ArenaSortableRecord>,
+    key_len: u32,
+    cache: [u8; CACHE_LEN],
+}
+
+impl AdaptiveSortItem for SortItem {
+    #[inline]
+    fn key(&self) -> &[u8] {
+        // SAFETY: the record lives in the arena, which is not reset while items exist.
+        unsafe { self.record.as_ref() }.key()
+    }
+
+    #[inline]
+    fn key_len(&self) -> usize {
+        self.key_len as usize
+    }
+
+    #[inline]
+    fn cache(&self) -> [u8; CACHE_LEN] {
+        self.cache
+    }
+
+    #[inline]
+    fn set_cache(&mut self, cache: [u8; CACHE_LEN]) {
+        self.cache = cache;
+    }
+}
+
+/// Buffers reused for every inserted record: its key values, and the
+/// conditioned key built from them.
+struct KeyScratch {
+    values: Vec<ValueRef<'static>>,
+    bytes: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -823,7 +899,7 @@ impl SortedChunk {
 
     fn write(
         &mut self,
-        records: &[NonNull<ArenaSortableRecord>],
+        records: &[SortItem],
         record_size_lengths: Vec<usize>,
         chunk_size: usize,
     ) -> Result<Completion> {
@@ -835,9 +911,9 @@ impl SortedChunk {
 
         let mut buf_pos = 0;
         let buf = buffer.as_mut_slice();
-        for (ptr, size_len) in records.iter().zip(record_size_lengths) {
+        for (item, size_len) in records.iter().zip(record_size_lengths) {
             // SAFETY: All pointers are valid (arena not reset).
-            let payload = unsafe { ptr.as_ref().payload() };
+            let payload = unsafe { item.record.as_ref().payload() };
             // Write the record size varint.
             write_varint(&mut buf[buf_pos..buf_pos + size_len], payload.len() as u64);
             buf_pos += size_len;
@@ -875,7 +951,11 @@ struct ArenaSortableRecord {
     /// Payload bytes in arena. Using NonNull avoids lifetime issues with
     /// self-referential struct (key_values points into this payload).
     payload: NonNull<[u8]>,
-    /// Pre-computed key values in arena. Points into `payload`.
+    /// Conditioned sort key in arena; see [crate::vdbe::sort_key]. Empty
+    /// when the sorter compares key values instead.
+    key: NonNull<[u8]>,
+    /// Pre-computed key values in arena. Points into `payload`. Empty when
+    /// the sorter compares conditioned keys instead.
     key_values: NonNull<[ValueRef<'static>]>,
     /// Shared KeyInfo owned by Sorter. Avoids Rc refcount overhead that would
     /// leak when arena.reset() skips Drop.
@@ -895,13 +975,15 @@ impl ArenaSortableRecord {
         key_len: usize,
         index_key_info: &[KeyInfo],
         comparators: &[Option<SortComparator>],
+        byte_keys: bool,
+        scratch: &mut KeyScratch,
     ) -> Result<Self> {
         let payload = arena.try_alloc_slice_copy(record.get_payload())?;
 
         let mut payload_iter = ValueIterator::new(payload)?;
 
-        let mut key_values = bumpalo::collections::Vec::new_in(arena);
-        key_values.try_reserve(payload_iter.clone().count())?;
+        scratch.values.clear();
+        scratch.values.try_reserve(key_len)?;
         for _ in 0..key_len {
             let value = match payload_iter.next() {
                 Some(Ok(v)) => v,
@@ -910,20 +992,37 @@ impl ArenaSortableRecord {
             };
             // SAFETY: value borrows from payload which is in the arena and outlives this struct.
             let value: ValueRef<'static> = unsafe { std::mem::transmute(value) };
-            key_values.push(value);
+            // Reserved for key_len values above, so this push cannot grow the vector.
+            scratch.values.push(value);
         }
 
-        let key_values = key_values.into_bump_slice();
-        let (norm_key, norm_decisive) =
-            normalized_first_key(key_values, index_key_info, comparators);
+        let (key, key_values, norm_key, norm_decisive) = if byte_keys {
+            scratch.bytes.clear();
+            encode_sort_key(&scratch.values, index_key_info, &mut scratch.bytes)?;
+            let key: &[u8] = arena.try_alloc_slice_copy(&scratch.bytes)?;
+            (key, &[][..], 0, false)
+        } else {
+            let key_values: &[ValueRef<'static>] = arena.try_alloc_slice_copy(&scratch.values)?;
+            let (norm_key, norm_decisive) =
+                normalized_first_key(key_values, index_key_info, comparators);
+            (&[][..], key_values, norm_key, norm_decisive)
+        };
+        scratch.values.clear();
         Ok(Self {
             payload: NonNull::from(payload),
+            key: NonNull::from(key),
             key_values: NonNull::from(key_values),
             index_key_info: NonNull::from(index_key_info),
             comparators: NonNull::from(comparators),
             norm_key,
             norm_decisive,
         })
+    }
+
+    #[inline]
+    const fn key(&self) -> &[u8] {
+        // SAFETY: valid from construction, arena not reset
+        unsafe { self.key.as_ref() }
     }
 
     #[inline]
@@ -1571,6 +1670,230 @@ mod tests {
                 ValueRef::Null,
                 ValueRef::Null,
             ],
+        );
+    }
+
+    fn random_sort_value(rng: &mut ChaCha8Rng) -> Value {
+        match rng.next_u64() % 9 {
+            0 => Value::Null,
+            1 => Value::from_i64(rng.next_u64() as i64),
+            2 => Value::from_i64((rng.next_u64() % 8) as i64 - 4),
+            3 => Value::from_f64((rng.next_u64() % 16) as f64 / 4.0 - 2.0),
+            4 => Value::from_f64(
+                [0.0, -0.0, f64::INFINITY, f64::NEG_INFINITY, 9.3e18, -9.3e18]
+                    [(rng.next_u64() % 6) as usize],
+            ),
+            5..=7 => {
+                let alphabet = [b'a', b'b', b'A', b'B', b' ', b'\0'];
+                let len = (rng.next_u64() % 8) as usize;
+                let bytes: std::vec::Vec<u8> = (0..len)
+                    .map(|_| alphabet[(rng.next_u64() % alphabet.len() as u64) as usize])
+                    .collect();
+                Value::build_text(String::from_utf8(bytes).unwrap())
+            }
+            _ => {
+                let len = (rng.next_u64() % 8) as usize;
+                let mut blob = try_vec![0u8; len].unwrap();
+                for byte in blob.iter_mut() {
+                    *byte = [0x00, 0x01, 0xFF][(rng.next_u64() % 3) as usize];
+                }
+                Value::Blob(blob)
+            }
+        }
+    }
+
+    /// The sorter must produce exactly the order of a stable sort by the
+    /// value comparison, whether the records stay in memory or spill to
+    /// chunk files, for every collation and NULL placement the conditioned
+    /// keys cover.
+    #[test]
+    fn fuzz_sorter_matches_stable_value_comparison() {
+        use crate::types::{compare_immutable, AsValueRef};
+        use turso_parser::ast::NullsOrder;
+        let seed = get_seed();
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let io = Arc::new(PlatformIO::new().unwrap());
+
+        for round in 0..48 {
+            let ncols = 1 + (rng.next_u64() % 3) as usize;
+            let mut key_info = try_vec![].unwrap();
+            let mut orders = try_vec![].unwrap();
+            let mut collations = try_vec![].unwrap();
+            let mut nulls_orders = try_vec![].unwrap();
+            let mut comparators: Vec<Option<SortComparator>> = try_vec![].unwrap();
+            for _ in 0..ncols {
+                let key = KeyInfo {
+                    sort_order: if rng.next_u64() % 2 == 0 {
+                        SortOrder::Asc
+                    } else {
+                        SortOrder::Desc
+                    },
+                    collation: match rng.next_u64() % 3 {
+                        0 => CollationSeq::Binary,
+                        1 => CollationSeq::NoCase,
+                        _ => CollationSeq::Rtrim,
+                    },
+                    nulls_order: match rng.next_u64() % 3 {
+                        0 => None,
+                        1 => Some(NullsOrder::First),
+                        _ => Some(NullsOrder::Last),
+                    },
+                };
+                key_info.try_push(key).unwrap();
+                orders.try_push(key.sort_order).unwrap();
+                collations.try_push(key.collation).unwrap();
+                nulls_orders.try_push(key.nulls_order).unwrap();
+                comparators.try_push(None).unwrap();
+            }
+            let max_buffer_size = if round % 3 == 0 { 512 } else { 1 << 24 };
+            let mut sorter = Sorter::new(
+                &orders,
+                collations,
+                nulls_orders,
+                comparators,
+                max_buffer_size,
+                64,
+                io.clone(),
+                crate::TempStore::Default,
+            )
+            .unwrap();
+            assert!(sorter.byte_keys);
+
+            let num_records = (rng.next_u64() % 1500) as usize;
+            let mut rows: std::vec::Vec<std::vec::Vec<Value>> = std::vec::Vec::new();
+            for i in 0..num_records {
+                let mut values: std::vec::Vec<Value> =
+                    (0..ncols).map(|_| random_sort_value(&mut rng)).collect();
+                values.push(Value::from_i64(i as i64));
+                let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
+                io.block(|| sorter.insert(&record)).unwrap();
+                rows.push(values);
+            }
+
+            let mut expected: std::vec::Vec<usize> = (0..num_records).collect();
+            expected.sort_by(|a, b| {
+                compare_immutable(
+                    rows[*a][..ncols].iter().map(AsValueRef::as_value_ref),
+                    rows[*b][..ncols].iter().map(AsValueRef::as_value_ref),
+                    &key_info,
+                )
+            });
+
+            io.block(|| sorter.sort()).unwrap();
+            if max_buffer_size == 512 && num_records >= 128 {
+                assert!(
+                    !sorter.chunks.is_empty(),
+                    "128 records do not fit in 512 bytes"
+                );
+            } else if max_buffer_size != 512 {
+                assert!(sorter.chunks.is_empty());
+            }
+            let mut got = std::vec::Vec::new();
+            while sorter.has_more() {
+                let values = sorter.record().unwrap().get_values().unwrap();
+                match values[ncols] {
+                    ValueRef::Numeric(crate::numeric::Numeric::Integer(i)) => got.push(i as usize),
+                    other => panic!("unexpected row id {other:?}"),
+                }
+                io.block(|| sorter.next()).unwrap();
+            }
+            assert_eq!(
+                got, expected,
+                "seed {seed} round {round}: keys {key_info:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn in_memory_sort_applies_nocase_and_rtrim_collations() {
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let mut sorter = Sorter::new(
+            &[SortOrder::Asc, SortOrder::Desc],
+            try_vec![CollationSeq::NoCase, CollationSeq::Rtrim].unwrap(),
+            try_vec![None, None].unwrap(),
+            try_vec![None, None].unwrap(),
+            1 << 20,
+            64,
+            io.clone(),
+            crate::TempStore::Default,
+        )
+        .unwrap();
+        assert!(sorter.byte_keys);
+        let rows = [("b", "x  "), ("A", "y"), ("a", "x"), ("B", "z ")];
+        for (i, (first, second)) in rows.iter().enumerate() {
+            let values = try_vec![
+                Value::build_text(first.to_string()),
+                Value::build_text(second.to_string()),
+                Value::from_i64(i as i64)
+            ]
+            .unwrap();
+            let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
+            io.block(|| sorter.insert(&record)).unwrap();
+        }
+        io.block(|| sorter.sort()).unwrap();
+        let mut got = std::vec::Vec::new();
+        while sorter.has_more() {
+            let values = sorter.record().unwrap().get_values().unwrap();
+            got.push(values[2].to_owned().unwrap());
+            io.block(|| sorter.next()).unwrap();
+        }
+        assert_eq!(
+            got,
+            [
+                Value::from_i64(1),
+                Value::from_i64(2),
+                Value::from_i64(3),
+                Value::from_i64(0)
+            ]
+        );
+    }
+
+    #[test]
+    fn custom_comparator_sorts_by_value_comparison() {
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let by_magnitude: SortComparator = Arc::new(|a: &ValueRef, b: &ValueRef| {
+            let magnitude = |value: &ValueRef| match value {
+                ValueRef::Numeric(crate::numeric::Numeric::Integer(i)) => i.abs(),
+                _ => 0,
+            };
+            Ok(magnitude(a).cmp(&magnitude(b)))
+        });
+        let mut sorter = Sorter::new(
+            &[SortOrder::Asc],
+            try_vec![CollationSeq::Binary].unwrap(),
+            try_vec![None].unwrap(),
+            try_vec![Some(by_magnitude)].unwrap(),
+            1 << 20,
+            64,
+            io.clone(),
+            crate::TempStore::Default,
+        )
+        .unwrap();
+        assert!(!sorter.byte_keys);
+        for value in [-5, 3, -1, 4, -3] {
+            let values = try_vec![Value::from_i64(value)].unwrap();
+            let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
+            io.block(|| sorter.insert(&record)).unwrap();
+        }
+        io.block(|| sorter.sort()).unwrap();
+        let mut got = std::vec::Vec::new();
+        while sorter.has_more() {
+            got.push(
+                sorter.record().unwrap().get_values().unwrap()[0]
+                    .to_owned()
+                    .unwrap(),
+            );
+            io.block(|| sorter.next()).unwrap();
+        }
+        assert_eq!(
+            got,
+            [
+                Value::from_i64(-1),
+                Value::from_i64(3),
+                Value::from_i64(-3),
+                Value::from_i64(4),
+                Value::from_i64(-5)
+            ]
         );
     }
 }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -172,7 +172,8 @@ pub struct Sorter {
     /// Sorted chunks stored on disk.
     chunks: Vec<SortedChunk>,
     /// The heap of records consumed from the chunks and their corresponding chunk index.
-    chunk_heap: BinaryHeap<(Reverse<Box<BoxedSortableRecord>>, usize)>,
+    /// The chunk index breaks ties so equal keys keep their insertion order across chunks.
+    chunk_heap: BinaryHeap<Reverse<(Box<BoxedSortableRecord>, usize)>>,
     /// The maximum size of the in-memory buffer in bytes before the records are flushed to a chunk file.
     max_buffer_size: usize,
     /// The current size of the in-memory buffer in bytes.
@@ -482,11 +483,11 @@ impl Sorter {
         }
 
         // No pending IO - safe to pop from heap
-        if let Some((next_record, chunk_idx)) = self.chunk_heap.pop() {
+        if let Some(Reverse((next_record, chunk_idx))) = self.chunk_heap.pop() {
             if let Some(c) = self.push_to_chunk_heap(chunk_idx, None)? {
                 self.pending_completion = Some((c, chunk_idx));
             }
-            return Ok(IOResult::Done(Some(next_record.0)));
+            return Ok(IOResult::Done(Some(next_record)));
         }
 
         // Heap empty and no pending IO - sorter exhausted
@@ -505,15 +506,15 @@ impl Sorter {
 
         match chunk.next(group)? {
             ChunkNextResult::Done(Some(record)) => {
-                self.chunk_heap.try_push((
-                    Reverse(Box::new(BoxedSortableRecord::new(
+                self.chunk_heap.try_push(Reverse((
+                    Box::new(BoxedSortableRecord::new(
                         record,
                         self.key_len,
                         self.index_key_info.clone(),
                         self.comparators.clone(),
-                    )?)),
+                    )?),
                     chunk_idx,
-                ))?;
+                )))?;
                 Ok(None)
             }
             ChunkNextResult::Done(None) => Ok(None),

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -170,6 +170,10 @@ pub struct Sorter {
     /// Sort path to use for every batch instead of the one chosen from a
     /// sample; only set by tests and benchmarks.
     sort_path_override: Option<SortPath>,
+    /// True while every record of the batch in memory has a decisive
+    /// normalized key (see [normalized_first_key]): the batch then sorts by
+    /// its tags alone and never follows a record pointer.
+    all_decisive: bool,
     /// Reused while building the sortable record of each inserted record and
     /// while conditioning keys.
     scratch: KeyScratch,
@@ -243,6 +247,7 @@ impl Sorter {
             records: vec![],
             byte_orderable,
             sort_path_override: None,
+            all_decisive: true,
             scratch: KeyScratch {
                 values: TursoAllocExt::new(),
                 bytes: TursoAllocExt::new(),
@@ -433,6 +438,10 @@ impl Sorter {
                     } else {
                         0
                     };
+                    if self.records.is_empty() {
+                        self.all_decisive = true;
+                    }
+                    self.all_decisive &= sortable_record.norm_decisive;
                     let record_ref = self.arena.try_alloc(sortable_record)?;
                     // SAFETY: try_alloc returns a valid, aligned, non-null pointer.
                     self.records.try_push(SortItem {
@@ -607,6 +616,10 @@ impl Sorter {
     /// equal keys.
     fn sort_records(&mut self) -> Result<()> {
         match self.choose_sort_path() {
+            SortPath::Comparison if self.all_decisive => {
+                self.records.sort_by_key(|item| item.tag);
+                Ok(())
+            }
             SortPath::Comparison => {
                 self.records.sort_by(compare_items);
                 Ok(())
@@ -627,13 +640,15 @@ impl Sorter {
     /// pairs share a normalized key but differ later: long shared prefixes,
     /// or a first column with few distinct values ahead of more columns.
     /// Equal keys do not count as such ties, because the comparison sort
-    /// settles them as fast as the adaptive sort does.
+    /// settles them as fast as the adaptive sort does. A batch whose
+    /// normalized keys are all decisive is a sort of 64-bit integers, which
+    /// no key conditioning can beat, so it skips the sample.
     fn choose_sort_path(&self) -> SortPath {
         if let Some(path) = self.sort_path_override {
             return path;
         }
         let len = self.records.len();
-        if !self.byte_orderable || len < MIN_ADAPTIVE_RECORDS {
+        if self.all_decisive || !self.byte_orderable || len < MIN_ADAPTIVE_RECORDS {
             return SortPath::Comparison;
         }
         let mut sample: [SortItem; SORT_PATH_SAMPLE] = std::array::from_fn(|i| {
@@ -717,6 +732,7 @@ const SORT_PATH_TIE_DIVISOR: usize = 8;
 
 /// Comparison sort order: the normalized keys in the item array first, the
 /// records only for ties the normalized keys cannot settle.
+#[inline(always)]
 fn compare_items(a: &SortItem, b: &SortItem) -> Ordering {
     match a.tag.cmp(&b.tag) {
         Ordering::Equal => {
@@ -2022,6 +2038,63 @@ mod tests {
             io.block(|| sorter.insert(&record)).unwrap();
         }
         sorter
+    }
+
+    #[test]
+    fn decisive_batches_sort_by_tag_alone() {
+        // Texts of at most seven bytes fit the normalized key whole, so the
+        // batch is decisive and sorts by its tags. One longer text turns that
+        // off and the batch compares records on ties again. Both batches must
+        // come out in key order with insertion order kept for equal keys.
+        let mut rng = ChaCha8Rng::seed_from_u64(11);
+        let cities = ["Berlin", "Oslo", "Paris", "Rome"];
+        let count = 4 * MIN_ADAPTIVE_RECORDS;
+        for long_text_at in [None, Some(count / 2)] {
+            let rows: std::vec::Vec<(String, i64)> = (0..count)
+                .map(|i| {
+                    let city = if long_text_at == Some(i) {
+                        "Copenhagen"
+                    } else {
+                        cities[(rng.next_u64() % 4) as usize]
+                    };
+                    (city.to_string(), i as i64)
+                })
+                .collect();
+            let mut expected = rows.clone();
+            expected.sort_by(|a, b| a.0.cmp(&b.0));
+            let expected: std::vec::Vec<Value> =
+                expected.iter().map(|(_, i)| Value::from_i64(*i)).collect();
+
+            let io = Arc::new(PlatformIO::new().unwrap());
+            let mut sorter = Sorter::new(
+                &[SortOrder::Asc],
+                try_vec![CollationSeq::Binary].unwrap(),
+                try_vec![None].unwrap(),
+                try_vec![None].unwrap(),
+                1 << 24,
+                64,
+                io.clone(),
+                crate::TempStore::Default,
+            )
+            .unwrap();
+            for (city, i) in &rows {
+                let values =
+                    try_vec![Value::build_text(city.clone()), Value::from_i64(*i)].unwrap();
+                let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
+                io.block(|| sorter.insert(&record)).unwrap();
+            }
+            assert_eq!(sorter.all_decisive, long_text_at.is_none());
+            assert_eq!(sorter.choose_sort_path(), SortPath::Comparison);
+
+            io.block(|| sorter.sort()).unwrap();
+            let mut got = std::vec::Vec::new();
+            while sorter.has_more() {
+                let values = sorter.record().unwrap().get_values().unwrap();
+                got.push(values[1].to_owned().unwrap());
+                io.block(|| sorter.next()).unwrap();
+            }
+            assert_eq!(got, expected, "long text at {long_text_at:?}");
+        }
     }
 
     #[test]

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -15,7 +15,7 @@ use crate::alloc::*;
 use crate::io::TempFile;
 use crate::types::{cmp_in_column, cmp_with_sort, IOCompletions, ValueIterator};
 use crate::vdbe::adaptive_sort::{adaptive_sort, cache_at, AdaptiveSortItem, CACHE_LEN};
-use crate::vdbe::sort_key::{encode_sort_key, keys_are_byte_orderable};
+use crate::vdbe::sort_key::{conditioned_key_estimate, encode_sort_key, keys_are_byte_orderable};
 use crate::{
     error::LimboError,
     io::{Buffer, Completion, CompletionGroup, File, IO},
@@ -158,16 +158,20 @@ pub struct Sorter {
     /// Arena allocator for records - provides fast bump allocation and bulk deallocation.
     /// All record data (payload bytes, key_values) is stored here for in-memory sorting.
     arena: Bump,
-    /// Pointers to records allocated in the arena, each with the key length and
-    /// key substring cache of the record next to it. Sorting moves only these
+    /// Pointers to records allocated in the arena, each with the sort tag of
+    /// its record next to it (see [SortItem]). Sorting moves only these
     /// 16-byte items, which prevents high memmove costs during sorting.
     /// SAFETY: These pointers are valid as long as the arena hasn't been reset.
     records: Vec<SortItem>,
-    /// True when every key column compares by bytes, so records carry a
-    /// conditioned key and sort with the adaptive sort. Otherwise records
-    /// carry their key values and sort with the value comparison.
-    byte_keys: bool,
-    /// Reused while building the sortable record of each inserted record.
+    /// True when every key column compares by bytes, so a batch can be sorted
+    /// with conditioned keys and the adaptive sort. Otherwise every batch is
+    /// sorted with the value comparison.
+    byte_orderable: bool,
+    /// Sort path to use for every batch instead of the one chosen from a
+    /// sample; only set by tests and benchmarks.
+    sort_path_override: Option<SortPath>,
+    /// Reused while building the sortable record of each inserted record and
+    /// while conditioning keys.
     scratch: KeyScratch,
     /// The current record.
     current: Option<ImmutableRecord>,
@@ -233,11 +237,12 @@ impl Sorter {
                 nulls_order: nulls,
             })
             .try_collect()?;
-        let byte_keys = keys_are_byte_orderable(&index_key_info, &comparators);
+        let byte_orderable = keys_are_byte_orderable(&index_key_info, &comparators);
         let this = Self {
             arena: Bump::new(),
             records: vec![],
-            byte_keys,
+            byte_orderable,
+            sort_path_override: None,
             scratch: KeyScratch {
                 values: TursoAllocExt::new(),
                 bytes: TursoAllocExt::new(),
@@ -412,29 +417,29 @@ impl Sorter {
                     }
                 }
                 InsertState::Insert => {
-                    let sortable_record = ArenaSortableRecord::new(
+                    let (sortable_record, norm_key) = ArenaSortableRecord::new(
                         &self.arena,
                         record,
                         self.key_len,
                         &self.index_key_info,
                         &self.comparators,
-                        self.byte_keys,
                         &mut self.scratch,
                     )?;
-                    let key_len = sortable_record.key().len();
-                    turso_assert!(
-                        u32::try_from(key_len).is_ok(),
-                        "sort keys are shorter than 4 GiB"
-                    );
-                    let cache = cache_at(sortable_record.key(), 0);
+                    // The conditioned key is only built when the adaptive sort is
+                    // chosen for the batch, but it is counted now so a spill happens
+                    // at the same memory bound either way.
+                    let key_size = if self.byte_orderable {
+                        conditioned_key_estimate(sortable_record.key_values())
+                    } else {
+                        0
+                    };
                     let record_ref = self.arena.try_alloc(sortable_record)?;
                     // SAFETY: try_alloc returns a valid, aligned, non-null pointer.
                     self.records.try_push(SortItem {
                         record: NonNull::from(record_ref),
-                        key_len: key_len as u32,
-                        cache,
+                        tag: norm_key,
                     })?;
-                    self.current_buffer_size += payload_size + key_len;
+                    self.current_buffer_size += payload_size + key_size;
                     self.max_payload_size_in_buffer =
                         self.max_payload_size_in_buffer.max(payload_size);
                     self.insert_state = InsertState::Start;
@@ -601,25 +606,151 @@ impl Sorter {
     /// Orders the in-memory records ascending, keeping insertion order for
     /// equal keys.
     fn sort_records(&mut self) -> Result<()> {
-        if self.byte_keys {
-            adaptive_sort(self.records.as_mut_slice())
-        } else {
-            // SAFETY: All pointers are valid (arena not reset).
-            self.records
-                .sort_by(|a, b| unsafe { a.record.as_ref().cmp(b.record.as_ref()) });
-            Ok(())
+        match self.choose_sort_path() {
+            SortPath::Comparison => {
+                self.records.sort_by(compare_items);
+                Ok(())
+            }
+            SortPath::Adaptive => {
+                self.condition_keys()?;
+                adaptive_sort(self.records.as_mut_slice())
+            }
         }
+    }
+
+    /// Picks the sort for the batch from a sample of its records.
+    ///
+    /// The comparison sort settles most pairs on the normalized keys in the
+    /// item array and finishes ordered input in one pass, so it wins when the
+    /// input is already in order or when the normalized keys rarely tie. The
+    /// adaptive sort pays for key conditioning up front and wins when many
+    /// pairs share a normalized key but differ later: long shared prefixes,
+    /// or a first column with few distinct values ahead of more columns.
+    /// Equal keys do not count as such ties, because the comparison sort
+    /// settles them as fast as the adaptive sort does.
+    fn choose_sort_path(&self) -> SortPath {
+        if let Some(path) = self.sort_path_override {
+            return path;
+        }
+        let len = self.records.len();
+        if !self.byte_orderable || len < MIN_ADAPTIVE_RECORDS {
+            return SortPath::Comparison;
+        }
+        let mut sample: [SortItem; SORT_PATH_SAMPLE] = std::array::from_fn(|i| {
+            self.records[(i as u64 * len as u64 / SORT_PATH_SAMPLE as u64) as usize]
+        });
+        if sample
+            .windows(2)
+            .all(|pair| compare_items(&pair[0], &pair[1]) != Ordering::Greater)
+        {
+            return SortPath::Comparison;
+        }
+        sample.sort_unstable_by_key(|item| item.tag);
+        let ties = sample
+            .windows(2)
+            .filter(|pair| {
+                pair[0].tag == pair[1].tag && compare_items(&pair[0], &pair[1]) != Ordering::Equal
+            })
+            .count();
+        if ties * SORT_PATH_TIE_DIVISOR >= SORT_PATH_SAMPLE {
+            SortPath::Adaptive
+        } else {
+            SortPath::Comparison
+        }
+    }
+
+    /// Builds the conditioned key of every record in the batch and turns the
+    /// items into adaptive sort items.
+    fn condition_keys(&mut self) -> Result<()> {
+        let Self {
+            records,
+            arena,
+            scratch,
+            index_key_info,
+            ..
+        } = self;
+        for item in records.iter_mut() {
+            // SAFETY: the record lives in the arena, and this loop holds the
+            // only reference to it.
+            let record = unsafe { item.record.as_mut() };
+            scratch.bytes.clear();
+            encode_sort_key(
+                record.key_values(),
+                index_key_info.as_slice(),
+                &mut scratch.bytes,
+            )?;
+            let key: &[u8] = arena.try_alloc_slice_copy(&scratch.bytes)?;
+            record.key = NonNull::from(key);
+            item.tag = adaptive_tag(key);
+        }
+        Ok(())
+    }
+
+    #[cfg(any(test, feature = "bench"))]
+    pub fn force_sort_path(&mut self, path: SortPath) {
+        turso_assert!(
+            self.byte_orderable || path == SortPath::Comparison,
+            "keys that need the value comparison cannot take the adaptive sort"
+        );
+        self.sort_path_override = Some(path);
     }
 }
 
-/// One entry of the sorter's item array. The key length and the key
-/// substring cache sit next to the record pointer so the adaptive sort only
-/// follows the pointer when the cached bytes tie.
+/// The in-memory sorts the sorter can run on a batch of records.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SortPath {
+    /// A stable merge sort over the normalized keys, with the value
+    /// comparison for the pairs the normalized keys cannot settle.
+    Comparison,
+    /// Key conditioning followed by [adaptive_sort].
+    Adaptive,
+}
+
+/// Batches smaller than this always take the comparison sort: the adaptive
+/// sort's key conditioning and scratch buffers do not pay off for them.
+const MIN_ADAPTIVE_RECORDS: usize = 256;
+/// Records looked at when picking the sort path.
+const SORT_PATH_SAMPLE: usize = 256;
+/// The adaptive sort is chosen when at least one in this many neighbors of
+/// the sorted sample share a normalized key but differ.
+const SORT_PATH_TIE_DIVISOR: usize = 8;
+
+/// Comparison sort order: the normalized keys in the item array first, the
+/// records only for ties the normalized keys cannot settle.
+fn compare_items(a: &SortItem, b: &SortItem) -> Ordering {
+    match a.tag.cmp(&b.tag) {
+        Ordering::Equal => {
+            // SAFETY: the records live in the arena, which is not reset while items exist.
+            let (a, b) = unsafe { (a.record.as_ref(), b.record.as_ref()) };
+            if a.norm_decisive && b.norm_decisive {
+                Ordering::Equal
+            } else {
+                a.full_cmp(b)
+            }
+        }
+        order => order,
+    }
+}
+
+/// One entry of the sorter's item array: the record pointer and a tag that
+/// keeps the sort from following the pointer. Until a batch is sorted the
+/// tag is the normalized first key (see [normalized_first_key]). When the
+/// adaptive sort is chosen for the batch, [Sorter::condition_keys] turns the
+/// tag into the key length and the key substring cache (see [adaptive_tag]).
 #[derive(Clone, Copy)]
 struct SortItem {
     record: NonNull<ArenaSortableRecord>,
-    key_len: u32,
-    cache: [u8; CACHE_LEN],
+    tag: u64,
+}
+
+/// Packs the key length above the two cached key bytes.
+fn adaptive_tag(key: &[u8]) -> u64 {
+    turso_assert!(
+        (key.len() as u64) < (1u64 << 48),
+        "conditioned sort keys are shorter than 2^48 bytes"
+    );
+    let cache = cache_at(key, 0);
+    ((key.len() as u64) << 16) | ((cache[0] as u64) << 8) | cache[1] as u64
 }
 
 impl AdaptiveSortItem for SortItem {
@@ -631,22 +762,22 @@ impl AdaptiveSortItem for SortItem {
 
     #[inline]
     fn key_len(&self) -> usize {
-        self.key_len as usize
+        (self.tag >> 16) as usize
     }
 
     #[inline]
     fn cache(&self) -> [u8; CACHE_LEN] {
-        self.cache
+        [(self.tag >> 8) as u8, self.tag as u8]
     }
 
     #[inline]
     fn set_cache(&mut self, cache: [u8; CACHE_LEN]) {
-        self.cache = cache;
+        self.tag = (self.tag & !0xFFFF) | ((cache[0] as u64) << 8) | cache[1] as u64;
     }
 }
 
-/// Buffers reused for every inserted record: its key values, and the
-/// conditioned key built from them.
+/// Buffers reused for every inserted record (its key values) and for every
+/// conditioned key.
 struct KeyScratch {
     values: Vec<ValueRef<'static>>,
     bytes: Vec<u8>,
@@ -952,32 +1083,30 @@ struct ArenaSortableRecord {
     /// self-referential struct (key_values points into this payload).
     payload: NonNull<[u8]>,
     /// Conditioned sort key in arena; see [crate::vdbe::sort_key]. Empty
-    /// when the sorter compares key values instead.
+    /// until the batch is sorted with the adaptive sort.
     key: NonNull<[u8]>,
-    /// Pre-computed key values in arena. Points into `payload`. Empty when
-    /// the sorter compares conditioned keys instead.
+    /// Pre-computed key values in arena. Points into `payload`.
     key_values: NonNull<[ValueRef<'static>]>,
     /// Shared KeyInfo owned by Sorter. Avoids Rc refcount overhead that would
     /// leak when arena.reset() skips Drop.
     index_key_info: NonNull<[KeyInfo]>,
     /// Shared comparators owned by Sorter. Same safety model as index_key_info.
     comparators: NonNull<[Option<SortComparator>]>,
-    /// Order-preserving prefix of the first key column; see [normalized_first_key].
-    norm_key: u64,
-    /// True when equal `norm_key`s prove the full keys are equal.
+    /// True when equal normalized keys prove the full keys are equal.
     norm_decisive: bool,
 }
 
 impl ArenaSortableRecord {
+    /// Copies the record into the arena and parses its key values. Returns
+    /// the record and its normalized first key; see [normalized_first_key].
     fn new(
         arena: &Bump,
         record: &ImmutableRecord,
         key_len: usize,
         index_key_info: &[KeyInfo],
         comparators: &[Option<SortComparator>],
-        byte_keys: bool,
         scratch: &mut KeyScratch,
-    ) -> Result<Self> {
+    ) -> Result<(Self, u64)> {
         let payload = arena.try_alloc_slice_copy(record.get_payload())?;
 
         let mut payload_iter = ValueIterator::new(payload)?;
@@ -996,27 +1125,19 @@ impl ArenaSortableRecord {
             scratch.values.push(value);
         }
 
-        let (key, key_values, norm_key, norm_decisive) = if byte_keys {
-            scratch.bytes.clear();
-            encode_sort_key(&scratch.values, index_key_info, &mut scratch.bytes)?;
-            let key: &[u8] = arena.try_alloc_slice_copy(&scratch.bytes)?;
-            (key, &[][..], 0, false)
-        } else {
-            let key_values: &[ValueRef<'static>] = arena.try_alloc_slice_copy(&scratch.values)?;
-            let (norm_key, norm_decisive) =
-                normalized_first_key(key_values, index_key_info, comparators);
-            (&[][..], key_values, norm_key, norm_decisive)
-        };
+        let key_values: &[ValueRef<'static>] = arena.try_alloc_slice_copy(&scratch.values)?;
         scratch.values.clear();
-        Ok(Self {
+        let (norm_key, norm_decisive) =
+            normalized_first_key(key_values, index_key_info, comparators);
+        let record = Self {
             payload: NonNull::from(payload),
-            key: NonNull::from(key),
+            key: NonNull::from(&[] as &[u8]),
             key_values: NonNull::from(key_values),
             index_key_info: NonNull::from(index_key_info),
             comparators: NonNull::from(comparators),
-            norm_key,
             norm_decisive,
-        })
+        };
+        Ok((record, norm_key))
     }
 
     #[inline]
@@ -1076,31 +1197,6 @@ impl ArenaSortableRecord {
         Ordering::Equal
     }
 }
-
-impl Ord for ArenaSortableRecord {
-    #[inline]
-    fn cmp(&self, other: &Self) -> Ordering {
-        match self.norm_key.cmp(&other.norm_key) {
-            Ordering::Equal if self.norm_decisive && other.norm_decisive => Ordering::Equal,
-            Ordering::Equal => self.full_cmp(other),
-            ord => ord,
-        }
-    }
-}
-
-impl PartialOrd for ArenaSortableRecord {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for ArenaSortableRecord {
-    fn eq(&self, other: &Self) -> bool {
-        self.cmp(other) == Ordering::Equal
-    }
-}
-
-impl Eq for ArenaSortableRecord {}
 
 /// Heap-allocated record for external merge sort. Used when records are read
 /// back from chunk files. Normal Drop semantics apply.
@@ -1745,7 +1841,7 @@ mod tests {
                 nulls_orders.try_push(key.nulls_order).unwrap();
                 comparators.try_push(None).unwrap();
             }
-            let max_buffer_size = if round % 3 == 0 { 512 } else { 1 << 24 };
+            let max_buffer_size = if round % 2 == 0 { 512 } else { 1 << 24 };
             let mut sorter = Sorter::new(
                 &orders,
                 collations,
@@ -1757,7 +1853,12 @@ mod tests {
                 crate::TempStore::Default,
             )
             .unwrap();
-            assert!(sorter.byte_keys);
+            assert!(sorter.byte_orderable);
+            match round % 3 {
+                0 => {}
+                1 => sorter.force_sort_path(SortPath::Comparison),
+                _ => sorter.force_sort_path(SortPath::Adaptive),
+            }
 
             let num_records = (rng.next_u64() % 1500) as usize;
             let mut rows: std::vec::Vec<std::vec::Vec<Value>> = std::vec::Vec::new();
@@ -1818,7 +1919,8 @@ mod tests {
             crate::TempStore::Default,
         )
         .unwrap();
-        assert!(sorter.byte_keys);
+        assert!(sorter.byte_orderable);
+        sorter.force_sort_path(SortPath::Adaptive);
         let rows = [("b", "x  "), ("A", "y"), ("a", "x"), ("B", "z ")];
         for (i, (first, second)) in rows.iter().enumerate() {
             let values = try_vec![
@@ -1869,7 +1971,7 @@ mod tests {
             crate::TempStore::Default,
         )
         .unwrap();
-        assert!(!sorter.byte_keys);
+        assert!(!sorter.byte_orderable);
         for value in [-5, 3, -1, 4, -3] {
             let values = try_vec![Value::from_i64(value)].unwrap();
             let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
@@ -1895,5 +1997,106 @@ mod tests {
                 Value::from_i64(-5)
             ]
         );
+    }
+
+    fn sorter_with_records(
+        orders: &[SortOrder],
+        rows: impl Iterator<Item = Vec<Value>>,
+        comparators: Vec<Option<SortComparator>>,
+    ) -> Sorter {
+        let io = Arc::new(PlatformIO::new().unwrap());
+        let columns = orders.len();
+        let mut sorter = Sorter::new(
+            orders,
+            try_vec![CollationSeq::Binary; columns].unwrap(),
+            try_vec![None; columns].unwrap(),
+            comparators,
+            1 << 24,
+            64,
+            io.clone(),
+            crate::TempStore::Default,
+        )
+        .unwrap();
+        for values in rows {
+            let record = ImmutableRecord::from_values(&values, values.len()).unwrap();
+            io.block(|| sorter.insert(&record)).unwrap();
+        }
+        sorter
+    }
+
+    #[test]
+    fn sort_path_follows_the_sample() {
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        let count = 4 * MIN_ADAPTIVE_RECORDS;
+        let no_comparators =
+            |columns: usize| -> Vec<Option<SortComparator>> { try_vec![None; columns].unwrap() };
+        let prefixed = |i: u64| {
+            try_vec![Value::build_text(format!(
+                "https://www.example.com/items/{i:08}"
+            ))]
+            .unwrap()
+        };
+
+        let random_ints = sorter_with_records(
+            &[SortOrder::Asc],
+            (0..count).map(|_| try_vec![Value::from_i64(rng.next_u64() as i64)].unwrap()),
+            no_comparators(1),
+        );
+        assert_eq!(random_ints.choose_sort_path(), SortPath::Comparison);
+
+        let ordered_prefixed = sorter_with_records(
+            &[SortOrder::Asc],
+            (0..count as u64).map(prefixed),
+            no_comparators(1),
+        );
+        assert_eq!(ordered_prefixed.choose_sort_path(), SortPath::Comparison);
+
+        let shuffled_prefixed = sorter_with_records(
+            &[SortOrder::Asc],
+            (0..count).map(|_| prefixed(rng.next_u64() % 100_000)),
+            no_comparators(1),
+        );
+        assert_eq!(shuffled_prefixed.choose_sort_path(), SortPath::Adaptive);
+
+        let few_then_many = sorter_with_records(
+            &[SortOrder::Asc, SortOrder::Asc],
+            (0..count).map(|_| {
+                try_vec![
+                    Value::from_i64((rng.next_u64() % 16) as i64),
+                    Value::from_i64(rng.next_u64() as i64)
+                ]
+                .unwrap()
+            }),
+            no_comparators(2),
+        );
+        assert_eq!(few_then_many.choose_sort_path(), SortPath::Adaptive);
+
+        let small_batch = sorter_with_records(
+            &[SortOrder::Asc],
+            (0..MIN_ADAPTIVE_RECORDS - 1).map(|_| prefixed(rng.next_u64() % 100_000)),
+            no_comparators(1),
+        );
+        assert_eq!(small_batch.choose_sort_path(), SortPath::Comparison);
+
+        let cities = ["Amsterdam", "Berlin", "Copenhagen", "Dublin"];
+        let few_distinct_text = sorter_with_records(
+            &[SortOrder::Asc],
+            (0..count).map(|_| {
+                try_vec![Value::build_text(
+                    cities[(rng.next_u64() % 4) as usize].to_string()
+                )]
+                .unwrap()
+            }),
+            no_comparators(1),
+        );
+        assert_eq!(few_distinct_text.choose_sort_path(), SortPath::Comparison);
+
+        let custom: SortComparator = Arc::new(|a: &ValueRef, b: &ValueRef| Ok(a.cmp(b)));
+        let custom_comparator = sorter_with_records(
+            &[SortOrder::Asc],
+            (0..count).map(|_| prefixed(rng.next_u64() % 100_000)),
+            try_vec![Some(custom)].unwrap(),
+        );
+        assert_eq!(custom_comparator.choose_sort_path(), SortPath::Comparison);
     }
 }


### PR DESCRIPTION
## Description

Implements the sort of US 7,680,791 ("Method for sorting data using common prefix bytes", Callaghan, Li, Waddington; the sort that shipped in Oracle 10gR2, described in Mark Callaghan's post "Common prefix skipping, adaptive sort") for the in-memory part of the ORDER BY / GROUP BY sorter, and makes the sorter pick, per batch, between this sort and the comparison sort it had before.

The patent has three parts, and all three are here:

1. **Common prefix skipping quicksort** (`core/vdbe/adaptive_sort.rs`): a three-way quicksort step compares each key with the pivot starting after the common prefix of the partition, records where each key first differs from the pivot, and keeps the minimum for the "less than" and "greater than" sets. Those minimums are the common prefixes of the next partitions, so later comparisons skip them.
2. **Adaptive quicksort**: the quicksort step and a 256-bucket most significant digit radix step call each other. Each "less than" and "greater than" set goes through the radix step on the first byte after its common prefix (with the "done" and "more" bucket arrays of the patent, keys that end at the byte before keys that go on), and every bucket with more than one key goes back to the quicksort step with the prefix advanced by one.
3. **Key substring caching**: every entry of the sort array holds the record pointer, the key length, and the two key bytes after the common prefix of its partition. Comparisons follow the pointer only when the cached bytes tie. The cache stays in place when the prefix grows by one byte and is refilled when it grows by two or more, following the three cases the patent gives for the radix step.

Sort keys become byte-orderable through key conditioning (`core/vdbe/sort_key.rs`): a class byte per column (NULL placed by the NULLS FIRST/LAST rule), an exact interleaving of integers and floats (floor as sign-flipped i64, then a flag and the f64 bits for fractional values), text and blobs with escaped zeros and a terminator, ASCII folding for NOCASE (including its behavior at an embedded NUL), trailing-space removal for RTRIM, and bit inversion for DESC. Custom comparators and locale or connection-defined collations cannot be conditioned, so those sorters keep the value comparison.

Both steps keep the input order inside each group, so equal keys come out in insertion order as before.

One addition to the patent text, flagged in the module docs: the recursion runs on an explicit stack of steps, so long shared prefixes never risk the thread stack.

The external merge got a small fix on the way: the chunk heap broke ties by the highest chunk index, so equal keys from later chunks came out first once a sort spilled. It now breaks ties by the lowest index, matching the stable in-memory sort and SQLite's merge.

### Choosing the sort for each batch

The two sorts win on different input. The comparison sort (a stable merge sort over the normalized first keys, with the value comparison for pairs the normalized keys cannot settle) finishes ordered input in one pass and is faster when the normalized keys rarely tie: random text, floats, unique integers. The adaptive sort pays for key conditioning up front and is faster when many pairs share a normalized key but differ later: long shared prefixes, or a first column with few distinct values ahead of more columns.

So the sorter decides per batch, right before it sorts (`Sorter::choose_sort_path`), from 256 evenly spaced records of the batch:

- An ordered sample takes the comparison sort.
- Otherwise the sample is sorted by normalized key and the neighbors that share a normalized key but differ are counted. Fewer than one in eight takes the comparison sort; the rest take the adaptive sort. Equal keys do not count, because the comparison sort settles them as fast as the adaptive sort does.
- Batches under 256 records, and sorters whose keys cannot be conditioned (custom comparators, locale or connection-defined collations), always take the comparison sort.

To make this cheap, every sort item carries a 64-bit tag next to the record pointer: the normalized first key until the batch is sorted, and the key length with the key substring cache once the keys are conditioned. Key conditioning therefore runs only for batches that take the adaptive sort, and the comparison sort reads the normalized keys from the item array instead of the records, which speeds it up on large batches as well. The conditioned key size is still counted at insert time, so spills happen at the same memory bound whichever sort a batch takes. A batch is one spill chunk, or the whole input when it fits in the sort buffer; the merge of spilled chunks is unchanged.

A batch whose normalized keys are all decisive (one key column whose values the normalized key holds whole: text or blobs of at most seven bytes, integers of magnitude below 2^49, NULLs) is a sort of 64-bit integers, because equal tags mean equal keys and different tags give the order. Such a batch sorts by its tags alone, never follows a record pointer, and skips the sample. CodSpeed's profile of the GROUP BY benchmark showed the chooser commit spending twice the instructions of `main` in the in-memory sort: its build had stopped inlining the comparison function (now `inline(always)`), and every comparison of two equal normalized keys followed both record pointers, as `main` did too. Callgrind instruction counts for `Sorter::sort` over three runs of the 10k-row benchmark queries:

| query | main | chooser commit | with the tag-only sort |
|---|---|---|---|
| `GROUP BY state` | 4.43M | 6.31M | 4.18M |
| `ORDER BY email` | 13.23M | 16.83M | 14.72M |

The rest of the `ORDER BY email` difference is the 16-byte sort item the tag needs, which the stable sort copies once per level; the cheaper insert path pays it back, so both queries take fewer instructions than on `main` as a whole.

Tests and benchmarks can force either path (`Sorter::force_sort_path`, available under `cfg(test)` and the `bench` feature), so both sorts stay covered: the sorter fuzz test runs each round with the chosen path and with each path forced, and `sorter_benchmark` runs every workload at 50,000 rows with the chosen path and with each path forced.


### Benchmarks

Two benchmarks are added and tracked by CodSpeed:
- `sorter_benchmark` (`cargo bench --bench sorter_benchmark --features bench`): insert, sort, and drain records through the sorter for the key shapes that decide sort cost, with the chosen path and with each path forced.
- `bench_execute_order_by` in `benchmark`: end-to-end `ORDER BY` over the 10k-row `users` table, next to the existing GROUP BY benchmark.

Since the benchmarks are new, CodSpeed has no baseline for them on `main`; the first commit adds only the benchmarks so a baseline exists once it lands. Local numbers (criterion `bench` profile, which is `release`; 4 vCPU VM; median of a 3 s window; all rows measured in one quiet session; `main` measured from a worktree with the same benchmark files):

`sorter_benchmark`, 50,000 rows, insert + sort + drain:

| workload | main | comparison sort (forced) | adaptive sort (forced) | chosen | chosen vs main |
|---|---|---|---|---|---|
| text_shared_prefix (50-byte URL prefix) | 29.1 ms | 23.3 ms | 17.4 ms | 16.6 ms | -43% |
| text_shared_prefix_desc | 29.1 ms | 23.1 ms | 16.3 ms | 17.7 ms | -39% |
| multi_column_country_name | 21.7 ms | 18.3 ms | 11.9 ms | 12.0 ms | -44% |
| int_random | 8.4 ms | 6.4 ms | 7.2 ms | 6.2 ms | -26% |
| float_random | 8.4 ms | 6.9 ms | 8.6 ms | 6.6 ms | -21% |
| text_random (12 letters) | 9.3 ms | 7.3 ms | 10.0 ms | 7.2 ms | -23% |
| int_few_distinct | 4.5 ms | 4.4 ms | 5.2 ms | 4.2 ms | -5% |
| text_few_distinct | 5.9 ms | 5.9 ms | 6.9 ms | 5.8 ms | -3% |
| int_presorted | 2.3 ms | 2.3 ms | 5.2 ms | 2.3 ms | +2% |

The chosen path is the faster of the two in every workload. The comparison sort alone is faster than `main` on random keys because it no longer follows the record pointer for the normalized key; the adaptive sort wins where keys share long prefixes or tie on the first column.

End-to-end (`benchmark`, 10k rows, `PRAGMA cache_size = -65536` so nothing spills):

| query | main | this PR | SQLite |
|---|---|---|---|
| `SELECT state, COUNT(*), MAX(last_name), SUM(age) ... GROUP BY state` | 6.7 ms | 5.9 ms | 4.1 ms |
| `SELECT * FROM users ORDER BY email` | 10.7 ms | 10.4 ms | 5.6 ms |
| `SELECT id FROM users ORDER BY state, city` | 7.0 ms | 6.4 ms | 4.8 ms |
| `SELECT id FROM users ORDER BY age DESC, zipcode` | 6.5 ms | 5.7 ms | 4.5 ms |

The gap to SQLite is the general per-row cost of the VDBE on this VM, not the sorter: the existing benchmarks on `main` show the same ratio without any sort (`SELECT * FROM users LIMIT 100` 34.3 µs vs 19.6 µs, `SELECT count() FROM users` 4.1 µs vs 2.1 µs). Of the 10 ms for `ORDER BY email`, the sorter accounts for about 2 ms.

CodSpeed (simulation mode) flags no regression or improvement among the benchmarks that exist on `main`; its report puts the overall impact at zero.


### Tests

- `sort_key`: fuzz test that the byte order of two conditioned keys equals `compare_immutable` for one to three columns with random ASC/DESC, NULLS FIRST/LAST, and BINARY/NOCASE/RTRIM collations, plus fixed cases for the integer/float boundaries.
- `adaptive_sort`: fuzz test against a stable reference sort (shared prefixes, embedded zeros, empty keys, duplicates, sorted and reversed input), plus long-prefix and duplicate-heavy cases.
- `sorter`: fuzz test that the sorter output (in memory and spilled, with the chosen path and with each path forced) equals a stable sort by the value comparison; NOCASE/RTRIM and custom comparator cases; a test that pins the chosen path for random integers, ordered and shuffled shared-prefix text, a two-column key with a low-cardinality first column, a small batch, text with few distinct values, and a custom comparator; a test for batches whose normalized keys are all decisive, with and without one record that is not, checking the order and the insertion order of equal keys.
- The core unit test suite and the SQL conformance suite (`make -C sqlite/conformance run-rust`, both the SQLite-derived and the Turso `.sqltest` corpora) pass.

## Motivation and context

The patent expired in 2025 and its author, Mark Callaghan, wrote it up in January 2026 ("Common prefix skipping, adaptive sort", smalldatum.blogspot.com). The sorter compared parsed values column by column with a 64-bit normalized prefix as a shortcut, which pays off only while the first seven key bytes differ. Keys with long shared prefixes (URLs, timestamps stored as text, multi-column keys with a low-cardinality leading column) got no help from the shortcut and paid a full value comparison per pair.

Sort keys in SQL databases are byte-orderable after key conditioning, which is exactly the setting the patent targets: comparisons that skip the bytes every key in a partition shares, a radix step on the first byte that differs, and a small cache of key bytes in the sort array so most comparisons never touch the records. Since the comparison sort keeps winning on random keys and on ordered input, the sorter picks between the two from a sample of each batch instead of committing to one.

## Description of AI Usage

This PR was written by Claude Code (Claude Fable 5.1) in a remote session, from the patent PDF and the request to implement it faithfully with benchmarks tracked by CodSpeed, followed by the request to make Turso choose between the two sorts. The blog post itself was not reachable from the sandbox, so the patent text (description, pseudo-code, and claims) is the specification that was followed. Claude wrote the key conditioning, the sort, the sorter integration, the per-batch choice, the tests, and the benchmarks, ran the fuzz tests, clippy, the core unit tests, and the SQL conformance suite, and measured `main` and this branch locally with the same benchmark files. A human has not yet reviewed the output; the PR is a draft for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtiMam3mznpYbJtVKu2Tz5