### PR TITLE
core: cut the per-statement cost of transaction start and cursor open (3/15)

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -434,6 +434,10 @@ pub struct Connection {
     pub(crate) temp: TempDbContext,
     /// Attached databases
     pub(super) attached_databases: RwLock<DatabaseCatalog>,
+    /// Set before the first temp or attached database is installed and
+    /// never cleared, so the statement paths that visit the non-main pagers
+    /// can skip the catalog locks while no such pager can exist.
+    pub(super) has_non_main_pagers: AtomicBool,
     pub(super) query_only: AtomicBool,
     pub(super) vdbe_trace: AtomicBool,
     /// If enabled, the UPDATE/DELETE statements must have a WHERE clause
@@ -780,6 +784,7 @@ impl Connection {
         let temp_db = self.create_temp_database()?;
         let mut guard = self.temp.database.write();
         if guard.is_none() {
+            self.has_non_main_pagers.store(true, Ordering::Release);
             *guard = Some(temp_db);
         }
         Ok(())
@@ -3654,6 +3659,7 @@ impl Connection {
                     };
                 }
                 AttachDatabaseState::Publish { alias, db, pager } => {
+                    self.has_non_main_pagers.store(true, Ordering::Release);
                     self.attached_databases.write().insert(
                         alias.as_str(),
                         db.clone(),
@@ -3759,6 +3765,9 @@ impl Connection {
     where
         F: FnOnce(&[(usize, Arc<Pager>)]) -> R,
     {
+        if !self.has_non_main_pagers.load(Ordering::Acquire) {
+            return f(&[]);
+        }
         let mut pagers: SmallVec<[(usize, Arc<Pager>); 8]> = SmallVec::new();
         if let Some(temp_db) = self.temp.database.read().as_ref() {
             pagers.push((crate::TEMP_DB_ID, temp_db.pager.clone()));

--- a/core/database.rs
+++ b/core/database.rs
@@ -2419,6 +2419,7 @@ impl Database {
             closed: AtomicBool::new(false),
             temp: crate::connection::TempDbContext::new(),
             attached_databases: RwLock::new(DatabaseCatalog::new()),
+            has_non_main_pagers: AtomicBool::new(false),
             query_only: AtomicBool::new(false),
             vdbe_trace: AtomicBool::new(false),
             dml_require_where: AtomicBool::new(false),

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -611,7 +611,7 @@ impl Statement {
         if matches!(self.state.execution_state, ProgramExecutionState::Init)
             && self.origin != StatementOrigin::InternalHelper
         {
-            if self.program.connection.mvcc_enabled() {
+            if self.state.db_mv_store(&self.program.connection).is_some() {
                 // MVCC checkpoints can publish internal schema roots without changing
                 // SQLite's schema cookie, so refresh before deciding whether to reprepare.
                 self.program.connection.maybe_update_schema();

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6057,11 +6057,16 @@ impl BTreeCursor {
     #[cold]
     #[inline(never)]
     fn allocate_reusable_record(&mut self) -> Result<()> {
-        let page_size = self.pager.get_page_size_unchecked().get();
-        let record = crate::with_btree_allocation_site!(
-            RecordPayload,
-            ImmutableRecord::new(page_size as usize)
-        )?;
+        let record = match self.pager.take_record_buf() {
+            Some(buf) => ImmutableRecord::from_buf(buf),
+            None => {
+                let page_size = self.pager.get_page_size_unchecked().get();
+                crate::with_btree_allocation_site!(
+                    RecordPayload,
+                    ImmutableRecord::new(page_size as usize)
+                )?
+            }
+        };
         self.reusable_immutable_record.replace(record);
         Ok(())
     }
@@ -6362,6 +6367,9 @@ impl BTreeCursor {
 impl Drop for BTreeCursor {
     fn drop(&mut self) {
         self.clear_transient_overflow_cells();
+        if let Some(record) = self.reusable_immutable_record.take() {
+            self.pager.recycle_record_buf(record.retire());
+        }
         if !self
             .did_register
             .load(crate::sync::atomic::Ordering::Relaxed)

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -8507,12 +8507,19 @@ impl PageStack {
     /// unpinned again on the next reset, decrementing the pin count of a
     /// page another cursor's stack still relies on.
     fn unpin_all_and_clear_slots(&mut self) {
-        for slot in self.stack.iter_mut() {
+        // Only the slots up to the current page hold pages and states: push
+        // fills the slot above the top and pop clears the top slot.
+        let used = (self.current_page + 1).max(0) as usize;
+        debug_assert!(
+            self.stack[used..].iter().all(|slot| slot.is_none()),
+            "page stack holds a page above its top"
+        );
+        for slot in self.stack[..used].iter_mut() {
             if let Some(page) = slot.take() {
                 let _ = page.try_unpin();
             }
         }
-        for state in self.node_states.iter_mut() {
+        for state in self.node_states[..used].iter_mut() {
             *state = BTreeNodeState::default();
         }
     }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1462,7 +1462,14 @@ pub struct Pager {
     /// Counterpart of SQLite's BtShared.pCursor list; bucketing per root
     /// supplies the BTCF_Multiple fast path (btree.c:9348).
     pub(crate) cursor_registry: Mutex<rustc_hash::FxHashMap<i64, Vec<RegisteredCursor>>>,
+    /// Record buffers retired by closed cursors, kept for the next cursor so
+    /// each statement execution does not allocate and free a page-sized
+    /// buffer per cursor.
+    record_pool: Mutex<Vec<crate::types::RecordBuf>>,
 }
+
+/// Retired record buffers kept per pager. Each holds a page-sized allocation.
+const RECORD_POOL_SIZE: usize = 8;
 
 /// Raw fat pointer to a registered cursor.
 ///
@@ -1750,7 +1757,22 @@ impl Pager {
             #[cfg(target_vendor = "apple")]
             sync_type: AtomicFileSyncType::new(FileSyncType::Fsync),
             cursor_registry: Mutex::new(rustc_hash::FxHashMap::default()),
+            record_pool: Mutex::new(Vec::new()),
         })
+    }
+
+    /// A record buffer retired by an earlier cursor on this pager, if any.
+    pub(crate) fn take_record_buf(&self) -> Option<crate::types::RecordBuf> {
+        self.record_pool.lock().pop()
+    }
+
+    /// Keep a retired record buffer for the next cursor on this pager. Extra
+    /// buffers beyond the pool size are freed.
+    pub(crate) fn recycle_record_buf(&self, buf: crate::types::RecordBuf) {
+        let mut pool = self.record_pool.lock();
+        if pool.len() < RECORD_POOL_SIZE {
+            pool.push(buf);
+        }
     }
 
     /// Add a cursor to the registry. Called from Cursor::new_btree once the

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1784,9 +1784,10 @@ impl Pager {
                 // SAFETY: see RegisteredCursor's invariant.
                 unsafe { surviving.as_mut().set_has_peers_for_external_writes(false) };
             }
-            if bucket.is_empty() {
-                registry.remove(&root);
-            }
+            // An empty bucket stays in the map with its capacity: the next
+            // cursor on this root reuses it instead of inserting a new map
+            // entry and growing a new Vec. Roots are few and bounded by the
+            // schema of the pager, so the map does not grow without limit.
         }
     }
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -861,6 +861,7 @@ impl InProcessWalCoordination {
         Self { shared }
     }
 
+    #[cfg(test)]
     fn try_read_mark_shared(&self, slot: usize) -> bool {
         self.shared.read().runtime.read_locks[slot].read()
     }
@@ -875,6 +876,17 @@ impl InProcessWalCoordination {
 
     fn read_mark_value(&self, slot: usize) -> u32 {
         self.shared.read().runtime.read_locks[slot].get_value()
+    }
+
+    fn snapshot_of(shared: &WalFileShared) -> WalSnapshot {
+        let checkpoint_seq = shared.metadata.wal_header.lock().checkpoint_seq;
+        WalSnapshot {
+            max_frame: shared.metadata.max_frame.load(Ordering::Acquire),
+            nbackfills: shared.metadata.nbackfills.load(Ordering::Acquire),
+            last_checksum: shared.metadata.last_checksum,
+            checkpoint_seq,
+            transaction_count: shared.metadata.transaction_count.load(Ordering::Acquire),
+        }
     }
 
     /// Lowest read-mark frame across slots currently held by a reader (1..5; slot 0 is the
@@ -924,15 +936,7 @@ impl InProcessWalCoordination {
 
 impl WalCoordination for InProcessWalCoordination {
     fn load_snapshot(&self) -> WalSnapshot {
-        let shared = self.shared.read();
-        let checkpoint_seq = shared.metadata.wal_header.lock().checkpoint_seq;
-        WalSnapshot {
-            max_frame: shared.metadata.max_frame.load(Ordering::Acquire),
-            nbackfills: shared.metadata.nbackfills.load(Ordering::Acquire),
-            last_checksum: shared.metadata.last_checksum,
-            checkpoint_seq,
-            transaction_count: shared.metadata.transaction_count.load(Ordering::Acquire),
-        }
+        Self::snapshot_of(&self.shared.read())
     }
 
     fn publish_commit(&self, commit: WalCommitState) {
@@ -1020,12 +1024,18 @@ impl WalCoordination for InProcessWalCoordination {
             snapshot.max_frame <= u32::MAX as u64,
             "max_frame exceeds u32 read mark range"
         );
+        // One read lock on the shared state for the whole slot selection.
+        // The read marks are atomics inside it, so taking the lock once
+        // instead of once per access changes nothing about their ordering,
+        // and it saves about eight lock round trips per read transaction.
+        let shared = self.shared.read();
+        let read_locks = &shared.runtime.read_locks;
         if snapshot.max_frame == snapshot.nbackfills {
-            if !self.try_read_mark_shared(0) {
+            if !read_locks[0].read() {
                 return None;
             }
-            if self.load_snapshot() != snapshot {
-                self.unlock_read_mark(0);
+            if Self::snapshot_of(&shared) != snapshot {
+                read_locks[0].unlock();
                 return None;
             }
             return Some(ReadGuardKind::DbFile);
@@ -1033,8 +1043,8 @@ impl WalCoordination for InProcessWalCoordination {
 
         let mut best_idx: i64 = -1;
         let mut best_mark: u32 = 0;
-        for idx in 1..5 {
-            let mark = self.read_mark_value(idx);
+        for (idx, read_lock) in read_locks.iter().enumerate().skip(1) {
+            let mark = read_lock.get_value();
             if mark != READMARK_NOT_USED && mark <= snapshot.max_frame as u32 && mark > best_mark {
                 best_mark = mark;
                 best_idx = idx as i64;
@@ -1042,26 +1052,26 @@ impl WalCoordination for InProcessWalCoordination {
         }
 
         if best_idx == -1 || (best_mark as u64) < snapshot.max_frame {
-            for idx in 1..5 {
-                if !self.try_read_mark_exclusive(idx) {
+            for (idx, read_lock) in read_locks.iter().enumerate().skip(1) {
+                if !read_lock.write() {
                     continue;
                 }
-                self.set_read_mark_value_exclusive(idx, snapshot.max_frame as u32);
+                read_lock.set_value_exclusive(snapshot.max_frame as u32);
                 best_idx = idx as i64;
                 best_mark = snapshot.max_frame as u32;
-                self.unlock_read_mark(idx);
+                read_lock.unlock();
                 break;
             }
         }
 
-        if best_idx == -1 || !self.try_read_mark_shared(best_idx as usize) {
+        if best_idx == -1 || !read_locks[best_idx as usize].read() {
             return None;
         }
 
-        let snapshot_after_lock = self.load_snapshot();
-        let current_slot_mark = self.read_mark_value(best_idx as usize);
+        let snapshot_after_lock = Self::snapshot_of(&shared);
+        let current_slot_mark = read_locks[best_idx as usize].get_value();
         if current_slot_mark != best_mark || snapshot_after_lock != snapshot {
-            self.unlock_read_mark(best_idx as usize);
+            read_locks[best_idx as usize].unlock();
             return None;
         }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1254,7 +1254,7 @@ pub fn op_open_read(
     invalidate_deferred_seeks_for_cursor(state, *cursor_id);
 
     let pager = program.get_pager_from_database_index(db)?;
-    let mv_store = program.connection.mv_store_for_db(*db);
+    let mv_store = mv_store_for_db(program, state, *db);
 
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
         if mv_store.is_some() {
@@ -3570,7 +3570,7 @@ pub fn halt(
     on_error: Option<ResolveType>,
 ) -> InsnResult {
     state.halt_in_progress = true;
-    let mv_store = program.connection.mv_store();
+    let mv_store = state.mv_store(&program.connection).cloned();
     let auto_commit = program.connection.auto_commit.load(Ordering::SeqCst);
     // halt() runs while the statement is still stepping, so it is always
     // counted in n_active_root_statements here.
@@ -4436,7 +4436,7 @@ pub fn op_transaction_inner(
     }
     let pager = program.get_pager_from_database_index(db)?;
     // Get the MvStore for the specific database (main or attached).
-    let mv_store = program.connection.mv_store_for_db(*db);
+    let mv_store = mv_store_for_db(program, state, *db);
     let is_main_db = *db == crate::MAIN_DB_ID;
     let is_secondary_db = !is_main_db;
     let write = matches!(
@@ -5020,6 +5020,17 @@ pub fn op_transaction_inner(
                 return Ok(InsnFunctionStepResult::Step);
             }
         }
+    }
+}
+
+/// The MvStore of database `db` for this statement, like
+/// `Connection::mv_store_for_db`, through the statement's cached handle for
+/// the main database.
+fn mv_store_for_db(program: &Program, state: &mut ProgramState, db: usize) -> Option<Arc<MvStore>> {
+    if db == crate::MAIN_DB_ID {
+        state.mv_store(&program.connection).cloned()
+    } else {
+        program.connection.mv_store_for_db(db)
     }
 }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1240,7 +1240,7 @@ pub fn op_open_read(
     program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
-    _pager: &Arc<Pager>,
+    pager: &Arc<Pager>,
 ) -> InsnResult {
     load_insn!(
         OpenRead {
@@ -1253,7 +1253,7 @@ pub fn op_open_read(
 
     invalidate_deferred_seeks_for_cursor(state, *cursor_id);
 
-    let pager = program.get_pager_from_database_index(db)?;
+    let pager = pager_for_db(program, pager, *db)?;
     let mv_store = mv_store_for_db(program, state, *db);
 
     if let (_, CursorType::IndexMethod(module)) = &program.cursor_ref[*cursor_id] {
@@ -4435,7 +4435,7 @@ pub fn op_transaction_inner(
     program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
-    _pager: &Arc<Pager>,
+    pager: &Arc<Pager>,
 ) -> InsnResult {
     load_insn!(
         Transaction {
@@ -4453,7 +4453,7 @@ pub fn op_transaction_inner(
     if *db == crate::TEMP_DB_ID {
         program.connection.ensure_temp_database()?;
     }
-    let pager = program.get_pager_from_database_index(db)?;
+    let pager = pager_for_db(program, pager, *db)?;
     // Get the MvStore for the specific database (main or attached).
     let mv_store = mv_store_for_db(program, state, *db);
     let is_main_db = *db == crate::MAIN_DB_ID;
@@ -5050,6 +5050,21 @@ fn mv_store_for_db(program: &Program, state: &mut ProgramState, db: usize) -> Op
         state.mv_store(&program.connection).cloned()
     } else {
         program.connection.mv_store_for_db(db)
+    }
+}
+
+/// The pager of database `db`. Every opcode receives the main pager of the
+/// connection, so only the temp and attached databases go through the
+/// catalog and its locks.
+fn pager_for_db(program: &Program, main_pager: &Arc<Pager>, db: usize) -> Result<Arc<Pager>> {
+    if db == crate::MAIN_DB_ID {
+        debug_assert!(
+            Arc::ptr_eq(main_pager, &program.connection.pager.load()),
+            "opcode pager is not the main pager of the connection"
+        );
+        Ok(main_pager.clone())
+    } else {
+        program.get_pager_from_database_index(&db)
     }
 }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3884,7 +3884,7 @@ pub(crate) fn vtab_commit_all(conn: &Connection) -> crate::Result<()> {
 /// statement savepoint. Cursor order is bytecode cursor order, which is stable
 /// across resumptions and avoids attachment-order ambiguity.
 pub(crate) fn index_method_stage_statement_all(state: &mut ProgramState) -> IOResultOr<()> {
-    if state.index_methods_finalized {
+    if state.index_methods_finalized || !has_index_method_work(state) {
         return Ok(IOResult::Done(()));
     }
 
@@ -3994,6 +3994,10 @@ pub(crate) fn index_method_on_transaction_committed_all(
         subprograms = state.subprogram_stmt_cache.len(),
         "publishing committed index-method state"
     );
+    if !has_index_method_work(state) {
+        connection.index_methods_on_transaction_committed();
+        return;
+    }
     for (cursor_id, cursor_opt) in state.cursors.iter_mut().enumerate() {
         let Some(Cursor::IndexMethod(cursor)) = cursor_opt else {
             continue;
@@ -4026,6 +4030,9 @@ pub(crate) fn index_method_register_transaction_all(
     state: &mut ProgramState,
     connection: &Connection,
 ) -> crate::Result<()> {
+    if !has_index_method_work(state) {
+        return Ok(());
+    }
     let mut registered = 0usize;
     for cursor_id in 0..state.cursors.len() {
         if !matches!(state.cursors[cursor_id], Some(Cursor::IndexMethod(_))) {
@@ -4060,6 +4067,18 @@ pub(crate) fn index_method_register_transaction_all(
         "retained statement index-method cursors for transaction outcome"
     );
     Ok(())
+}
+
+/// Whether this statement has index-method cursors, closed index-method
+/// cursors or cached subprograms that the commit hooks must visit. Almost
+/// every statement has none, and every halt calls the hooks.
+fn has_index_method_work(state: &ProgramState) -> bool {
+    !state.closed_index_method_cursors.is_empty()
+        || !state.subprogram_stmt_cache.is_empty()
+        || state
+            .cursors
+            .iter()
+            .any(|cursor| matches!(cursor, Some(Cursor::IndexMethod(_))))
 }
 
 /// Rollback all virtual tables that are part of the current transaction.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8664,6 +8664,67 @@ pub fn op_agg_step(
     _pager: &Arc<Pager>,
 ) -> InsnResult {
     load_insn!(AggStep { data }, insn);
+    // Fast paths for the common integer cases of sum and min/max over
+    // an initialized accumulator. The slow path keeps every other function
+    // and value type, the first-row initialization and the error cases.
+    if let AccumulatorFunc::Agg(agg) = &data.func {
+        match agg {
+            AggFunc::Sum | AggFunc::Total => {
+                if let Register::Value(Value::Numeric(Numeric::Integer(arg))) =
+                    state.registers[data.col]
+                {
+                    if let Register::Aggregate(AggContext::Builtin(payload)) =
+                        &mut state.registers[data.acc_reg]
+                    {
+                        // Integer total so far, no float seen (payload[2] is the
+                        // approx flag), and neither the total nor the row count
+                        // overflows: the same result as the generic step.
+                        if let [Value::Numeric(Numeric::Integer(acc)), _, Value::Numeric(Numeric::Integer(0)), _, Value::Numeric(Numeric::Integer(count)), ..] =
+                            payload.as_mut_slice()
+                        {
+                            if let (Some(sum), Some(rows)) =
+                                (acc.checked_add(arg), count.checked_add(1))
+                            {
+                                *acc = sum;
+                                *count = rows;
+                                state.pc += 1;
+                                return Ok(InsnFunctionStepResult::Step);
+                            }
+                        }
+                    }
+                }
+            }
+            AggFunc::Min | AggFunc::Max
+                if data.comparator.is_none() && data.collation.is_none_or(|c| !c.is_custom()) =>
+            {
+                if let Register::Value(Value::Numeric(Numeric::Integer(arg))) =
+                    state.registers[data.col]
+                {
+                    if let Register::Aggregate(AggContext::Builtin(payload)) =
+                        &mut state.registers[data.acc_reg]
+                    {
+                        if let Some(Value::Numeric(Numeric::Integer(best))) = payload.first_mut() {
+                            let better = match agg {
+                                AggFunc::Max => arg > *best,
+                                _ => arg < *best,
+                            };
+                            if better {
+                                *best = arg;
+                            }
+                            state.pc += 1;
+                            return Ok(InsnFunctionStepResult::Step);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    op_agg_step_slow(program, state, data)
+}
+
+#[inline(never)]
+fn op_agg_step_slow(program: &Program, state: &mut ProgramState, data: &AggStepData) -> InsnResult {
     let AggStepData {
         acc_reg,
         col,
@@ -8671,7 +8732,7 @@ pub fn op_agg_step(
         func,
         comparator,
         collation,
-    } = data.as_ref();
+    } = data;
 
     if let AccumulatorFunc::Window(win_func) = func {
         return op_window_step(state, *acc_reg, *col, win_func);

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1245,6 +1245,7 @@ impl ProgramState {
     /// `Connection::mv_store`, but a full ArcSwap load (thread-local debt
     /// slot, ~50 instructions) only when the slot changed since the last
     /// call. The MVCC bootstrap connection never uses the store.
+    #[inline(always)]
     pub(crate) fn mv_store(&mut self, connection: &Connection) -> Option<&Arc<MvStore>> {
         if connection.is_mvcc_bootstrap_connection() {
             return None;
@@ -1254,6 +1255,7 @@ impl ProgramState {
 
     /// The MvStore of the database, whether or not this connection is the
     /// MVCC bootstrap connection: the same answer as `Database::get_mv_store`.
+    #[inline(always)]
     pub(crate) fn db_mv_store(&mut self, connection: &Connection) -> &Option<Arc<MvStore>> {
         let cache = self
             .mv_store_cache

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -914,6 +914,20 @@ pub struct ProgramState {
     has_stmt_transaction: bool,
     pub n_change: AtomicI64,
     pub n_total_change: AtomicI64,
+    /// The connection's MvStore handle, revalidated with one pointer compare
+    /// per use instead of a full ArcSwap load (see `ProgramState::mv_store`).
+    mv_store_cache: Option<arc_swap::Cache<MvStoreHandle, Option<Arc<MvStore>>>>,
+}
+
+/// Lets an `arc_swap::Cache` follow the MvStore slot of a database.
+pub(crate) struct MvStoreHandle(Arc<crate::Database>);
+
+impl std::ops::Deref for MvStoreHandle {
+    type Target = arc_swap::ArcSwapOption<MvStore>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.mv_store
+    }
 }
 
 impl std::fmt::Debug for Program {
@@ -990,6 +1004,7 @@ impl ProgramState {
             halt_in_progress: false,
             pending_cdc_info: None,
             subprogram_stmt_cache: HashMap::default(),
+            mv_store_cache: None,
         }
     }
 
@@ -1161,7 +1176,11 @@ impl ProgramState {
     /// treating the count as "just me" would make teardown finish or roll
     /// back a transaction a suspended sibling is still using (e.g. a COMMIT
     /// parked inside its post-commit auto-checkpoint).
-    pub(crate) fn can_autocommit_now(&self, connection: &Connection, self_counted: bool) -> bool {
+    pub(crate) fn can_autocommit_now(
+        &mut self,
+        connection: &Connection,
+        self_counted: bool,
+    ) -> bool {
         let is_already_committing = !matches!(self.commit_state, CommitState::Ready);
         if is_already_committing {
             return true;
@@ -1177,7 +1196,7 @@ impl ProgramState {
                 "active writer state without an active writer count"
             );
         }
-        if connection.mv_store().is_some() {
+        if self.mv_store(connection).is_some() {
             // MVCC keeps one tx id on the connection. A writer waits for
             // sibling readers, and a reader waits for sibling readers/writers.
             return self.auto_txn_cleanup == TxnCleanup::RollbackTxn
@@ -1220,6 +1239,30 @@ impl ProgramState {
         }
         self.auto_txn_cleanup == TxnCleanup::RollbackTxn
             || (connection.get_auto_commit() && attached_txn_open())
+    }
+
+    /// The MvStore this statement runs against: the same answer as
+    /// `Connection::mv_store`, but a full ArcSwap load (thread-local debt
+    /// slot, ~50 instructions) only when the slot changed since the last
+    /// call. The MVCC bootstrap connection never uses the store.
+    pub(crate) fn mv_store(&mut self, connection: &Connection) -> Option<&Arc<MvStore>> {
+        if connection.is_mvcc_bootstrap_connection() {
+            return None;
+        }
+        self.db_mv_store(connection).as_ref()
+    }
+
+    /// The MvStore of the database, whether or not this connection is the
+    /// MVCC bootstrap connection: the same answer as `Database::get_mv_store`.
+    pub(crate) fn db_mv_store(&mut self, connection: &Connection) -> &Option<Arc<MvStore>> {
+        let cache = self
+            .mv_store_cache
+            .get_or_insert_with(|| arc_swap::Cache::new(MvStoreHandle(connection.db.clone())));
+        debug_assert!(
+            std::ptr::eq(cache.arc_swap(), &connection.db.mv_store),
+            "statement state used with a connection on another database"
+        );
+        cache.load()
     }
 
     #[inline]
@@ -2989,7 +3032,7 @@ impl Program {
             }
 
             let can_autocommit_now = state.can_autocommit_now(&self.connection, self_counted);
-            let is_mvcc = self.connection.mv_store().is_some();
+            let is_mvcc = state.mv_store(&self.connection).is_some();
             let changed_shared_mvcc_auto_txn = !can_autocommit_now
                 && state.auto_txn_cleanup == TxnCleanup::RollbackTxn
                 && state.n_change.load(Ordering::SeqCst) > 0;


### PR DESCRIPTION
## Description

Part 3 of 15 split out of #8692 (commits 21-30 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### CodSpeed

Commits 1-21 (`e710ae7a`) vs `main`: [run 6a9baefa55c77f65a5b3147f](https://codspeed.io/tursodatabase/turso/runs/6a9baefa55c77f65a5b3147f), 55 improvements, 0 regressions, 2119 unchanged.

Commits 1-42 (`191e0aab`, end of the per-statement work) vs `main`: [run 6a9bcec882847971dd44b6ee](https://codspeed.io/tursodatabase/turso/runs/6a9bcec882847971dd44b6ee), 144 improvements, 0 regressions, 2030 unchanged. Against the run of `e710ae7a`: 13 improvements, 0 regressions; the per-statement commits show as `limbo_execute_select_1` 12.3 µs → 9.6 µs (+28.2%) and the FTS query benchmarks, which run many short statements, +20% to +24%.

### Measurement history: per-row costs

Callgrind instruction counts (`Ir`) are for 5 iterations of `SELECT 1 FROM t` and 3 iterations of the others. Wall clock is the best of 7 runs of one iteration on a noisy VM, so treat it as a sanity check only.

| Commit | SELECT 1 (Ir) | Δ | SELECT * (Ir) | Δ | W3 (Ir) | Δ | W4 (Ir) | Δ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `e710ae7a` sum and min/max integers without the generic aggregate step (W5: 700,726,242 → 568,021,021, -18.9%) | | | | | | | 340,924,909 | +0.47% |

Wall clock (best of 7): `SELECT 1 FROM t` 2.81 ms → 2.19 ms; `SELECT * FROM t` 9.84 ms → 6.45 ms; W3 4.40 ms and W4 5.34 ms at `e710ae7a`.

### Measurement history: per-statement costs

The second half of the PR works on the fixed cost of executing a prepared statement once: transaction begin and commit, cursor open and close, statement reset, metrics. Measured as callgrind instructions per execution, taken as (Ir at 3000 executions − Ir at 1000 executions) / 2000 so the process start-up is cancelled out. Workloads: a point lookup `SELECT * FROM t WHERE id = 12345` (one `Transaction`, one `OpenRead`, one `SeekRowid`, `Column`, `Halt`), `SELECT 1` (no table, no transaction: the pure statement overhead), and an index lookup `SELECT id FROM t WHERE value = 500 LIMIT 1` (two cursors).

| Commit | point lookup | Δ | `SELECT 1` | Δ | index lookup | Δ |
|---|---:|---:|---:|---:|---:|---:|
| `e710ae7a` (end of the per-row work) | 11,153 | | 2,502 | | 16,648 | |
| `64c08e57` cache the connection's MvStore handle in the statement state | 10,755 | -3.6% | 2,216 | -11.4% | 16,184 | -2.8% |
| `e3d96195` keep the MvStore cache accessors inline | 10,741 | -0.1% | 2,207 | -0.4% | 16,229 | +0.3% |
| `51a28f95` keep empty cursor-registry buckets | 10,533 | -1.9% | 2,219 | +0.5% | 16,025 | -1.3% |
| `4d8ef887` clear only the used slots of the page stack | 10,246 | -2.7% | 2,232 | +0.6% | 15,741 | -1.8% |
| `da5f6537` skip the attached-pager walk while no attached pager exists | 10,081 | -1.6% | 2,126 | -4.7% | 15,573 | -1.1% |
| `1538a9b1` skip the index-method commit hooks without index methods | 10,011 | -0.7% | 2,017 | -5.1% | 15,503 | -0.4% |
| `a4dad585` use the main pager every opcode receives in Transaction and OpenRead | 9,928 | -0.8% | 2,017 | 0.0% | 15,304 | -1.3% |
| `e47798b0` take the shared WAL lock once per read-mark selection | 9,821 | -1.1% | 2,017 | 0.0% | 15,197 | -0.7% |
| `5d215c0f` recycle the record buffer of closed cursors through the pager | 9,516 | -3.1% | 2,018 | 0.0% | 14,899 | -2.0% |

Wall clock per execution (best of 5 runs of 20,000 executions, noisy VM): point lookup 1.31 µs at `64c08e57` → 0.90 µs now; index lookup 1.71 µs → 1.39 µs; `SELECT 1` 270 ns → 149 ns.

Per-statement measurements carry a noise of about ±50 instructions from inlining decisions that thin LTO makes differently for each build (seen directly: one build stopped inlining a four-instruction accessor, which is what `e3d96195` pins).

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_