### PR TITLE
core: cut the per-statement cost of statement reset, metrics and seeks (4/15)

### DIFF
--- a/core/statement.rs
+++ b/core/statement.rs
@@ -645,11 +645,9 @@ impl Statement {
 
         // Aggregate metrics when statement completes
         if matches!(res, Ok(StepResult::Done)) {
-            self.program
-                .connection
-                .metrics
-                .write()
-                .record_statement(&self.metrics());
+            let connection = &self.program.connection;
+            self.state
+                .with_metrics(|metrics| connection.metrics.write().record_statement(metrics));
             self.busy = false;
             self.busy_handler_state = None; // Reset busy state on completion
             self.state.query_deadline = None;

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -655,8 +655,7 @@ impl Statement {
             self.state.query_deadline = None;
 
             // After ANALYZE completes, refresh in-memory stats so planners can use them.
-            let sql = self.program.sql.trim_start().as_bytes();
-            if sql.len() >= 7 && sql[..7].eq_ignore_ascii_case(b"ANALYZE") {
+            if self.program.refreshes_analyze_stats {
                 // The stats refresh runs a SELECT on this same connection. At
                 // this point ANALYZE is already Done, so it must not count as a
                 // sibling root statement for that internal SELECT.

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2383,87 +2383,85 @@ impl BTreeCursor {
         state: &mut LeafPageBinarySearchState,
     ) -> Result<ControlFlow<IOResult<SeekResult>>> {
         let iter_dir = seek_op.iteration_direction();
-        let min = state.min_cell_idx;
-        let max = state.max_cell_idx;
-        let target_cell_when_not_found = state.target_cell_when_not_found;
-        if min > max {
-            if let Some(nearest_matching_cell) = state.nearest_matching_cell {
-                self.stack.set_cell_index(nearest_matching_cell as i32);
+        // The compares need no I/O, so narrow the range on this leaf in one
+        // go; the caller persists the state once afterwards.
+        while state.min_cell_idx <= state.max_cell_idx {
+            let cur_cell_idx = (state.min_cell_idx + state.max_cell_idx) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
+            let cell_rowid = contents.cell_table_leaf_read_rowid(cur_cell_idx as usize)?;
+
+            let cmp = cell_rowid.cmp(&rowid);
+
+            let found = match seek_op {
+                SeekOp::GT => cmp.is_gt(),
+                SeekOp::GE { eq_only: true } => cmp.is_eq(),
+                SeekOp::GE { eq_only: false } => cmp.is_ge(),
+                SeekOp::LE { eq_only: true } => cmp.is_eq(),
+                SeekOp::LE { eq_only: false } => cmp.is_le(),
+                SeekOp::LT => cmp.is_lt(),
+            };
+
+            // rowids are unique, so we can return the rowid immediately
+            if found && seek_op.eq_only() {
+                self.stack.set_cell_index(cur_cell_idx as i32);
                 self.set_has_record(true);
                 return Ok(ControlFlow::Break(IOResult::Done(SeekResult::Found)));
+            }
+
+            if found {
+                state.nearest_matching_cell = Some(cur_cell_idx as usize);
+                match iter_dir {
+                    IterationDirection::Forwards => {
+                        state.max_cell_idx = cur_cell_idx - 1;
+                    }
+                    IterationDirection::Backwards => {
+                        state.min_cell_idx = cur_cell_idx + 1;
+                    }
+                }
+            } else if cmp.is_gt() {
+                if matches!(seek_op, SeekOp::GE { eq_only: true }) {
+                    state.target_cell_when_not_found =
+                        state.target_cell_when_not_found.min(cur_cell_idx as i32);
+                }
+                state.max_cell_idx = cur_cell_idx - 1;
+            } else if cmp.is_lt() {
+                if matches!(seek_op, SeekOp::LE { eq_only: true }) {
+                    state.target_cell_when_not_found =
+                        state.target_cell_when_not_found.max(cur_cell_idx as i32);
+                }
+                state.min_cell_idx = cur_cell_idx + 1;
             } else {
-                // if !eq_only - matching entry can exist in neighbour leaf page
-                // this can happen if key in the interiour page was deleted - but divider kept untouched
-                // in such case BTree can navigate to the leaf which no longer has matching key for seek_op
-                // in this case, caller must advance cursor if necessary
-                return Ok(ControlFlow::Break(IOResult::Done(if seek_op.eq_only() {
-                    let has_record = target_cell_when_not_found >= 0
-                        && target_cell_when_not_found < contents.cell_count() as i32;
-                    self.has_record = has_record;
-                    self.stack.set_cell_index(target_cell_when_not_found);
-                    SeekResult::NotFound
-                } else {
-                    // set cursor to the position where which would hold the op-boundary if it were present
-                    self.stack.set_cell_index(target_cell_when_not_found);
-                    SeekResult::TryAdvance
-                })));
-            };
+                match iter_dir {
+                    IterationDirection::Forwards => {
+                        state.min_cell_idx = cur_cell_idx + 1;
+                    }
+                    IterationDirection::Backwards => {
+                        state.max_cell_idx = cur_cell_idx - 1;
+                    }
+                }
+            }
         }
 
-        let cur_cell_idx = (min + max) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
-        let cell_rowid = contents.cell_table_leaf_read_rowid(cur_cell_idx as usize)?;
-
-        let cmp = cell_rowid.cmp(&rowid);
-
-        let found = match seek_op {
-            SeekOp::GT => cmp.is_gt(),
-            SeekOp::GE { eq_only: true } => cmp.is_eq(),
-            SeekOp::GE { eq_only: false } => cmp.is_ge(),
-            SeekOp::LE { eq_only: true } => cmp.is_eq(),
-            SeekOp::LE { eq_only: false } => cmp.is_le(),
-            SeekOp::LT => cmp.is_lt(),
-        };
-
-        // rowids are unique, so we can return the rowid immediately
-        if found && seek_op.eq_only() {
-            self.stack.set_cell_index(cur_cell_idx as i32);
+        let target_cell_when_not_found = state.target_cell_when_not_found;
+        if let Some(nearest_matching_cell) = state.nearest_matching_cell {
+            self.stack.set_cell_index(nearest_matching_cell as i32);
             self.set_has_record(true);
             return Ok(ControlFlow::Break(IOResult::Done(SeekResult::Found)));
         }
-
-        if found {
-            state.nearest_matching_cell = Some(cur_cell_idx as usize);
-            match iter_dir {
-                IterationDirection::Forwards => {
-                    state.max_cell_idx = cur_cell_idx - 1;
-                }
-                IterationDirection::Backwards => {
-                    state.min_cell_idx = cur_cell_idx + 1;
-                }
-            }
-        } else if cmp.is_gt() {
-            if matches!(seek_op, SeekOp::GE { eq_only: true }) {
-                state.target_cell_when_not_found =
-                    target_cell_when_not_found.min(cur_cell_idx as i32);
-            }
-            state.max_cell_idx = cur_cell_idx - 1;
-        } else if cmp.is_lt() {
-            if matches!(seek_op, SeekOp::LE { eq_only: true }) {
-                state.target_cell_when_not_found =
-                    target_cell_when_not_found.max(cur_cell_idx as i32);
-            }
-            state.min_cell_idx = cur_cell_idx + 1;
+        // if !eq_only - matching entry can exist in neighbour leaf page
+        // this can happen if key in the interiour page was deleted - but divider kept untouched
+        // in such case BTree can navigate to the leaf which no longer has matching key for seek_op
+        // in this case, caller must advance cursor if necessary
+        Ok(ControlFlow::Break(IOResult::Done(if seek_op.eq_only() {
+            let has_record = target_cell_when_not_found >= 0
+                && target_cell_when_not_found < contents.cell_count() as i32;
+            self.has_record = has_record;
+            self.stack.set_cell_index(target_cell_when_not_found);
+            SeekResult::NotFound
         } else {
-            match iter_dir {
-                IterationDirection::Forwards => {
-                    state.min_cell_idx = cur_cell_idx + 1;
-                }
-                IterationDirection::Backwards => {
-                    state.max_cell_idx = cur_cell_idx - 1;
-                }
-            }
-        }
-        Ok(ControlFlow::Continue(()))
+            // set cursor to the position where which would hold the op-boundary if it were present
+            self.stack.set_cell_index(target_cell_when_not_found);
+            SeekResult::TryAdvance
+        })))
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2117,189 +2117,188 @@ impl BTreeCursor {
         state: &mut InteriorPageBinarySearchState,
     ) -> Result<ControlFlow<IOResult<()>>> {
         let iter_dir = cmp.iteration_direction();
-        let min = state.min_cell_idx;
-        let max = state.max_cell_idx;
-        if min > max {
-            let Some(leftmost_matching_cell) = state.nearest_matching_cell else {
-                match self
-                    .stack
-                    .get_page_contents_at_level(old_top_idx)
-                    .unwrap()
-                    .rightmost_pointer()?
-                {
-                    Some(right_most_pointer) => {
-                        // On `IO(spill_c)` keep seek_state at the binary
-                        // search so re-entry retries this same step. None
-                        // of the cursor mutations have happened yet.
-                        match self.read_page(right_most_pointer as i64)? {
-                            IOResult::Done((mem_page, c)) => {
-                                self.stack.set_cell_index(cell_count as i32 + 1);
-                                self.stack.push(mem_page);
-                                self.seek_state = CursorSeekState::MovingBetweenPages {
-                                    eq_seen: state.eq_seen,
-                                };
-                                if let Some(c) = c {
-                                    return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(c))));
-                                }
-                                return Ok(ControlFlow::Continue(()));
-                            }
-                            IOResult::IO(IOCompletions(spill_c)) => {
-                                return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(
-                                    spill_c,
-                                ))));
-                            }
-                        }
-                    }
-                    None => {
-                        unreachable!("we shall not go back up! The only way is down the slope");
-                    }
-                }
-            };
-            let matching_cell = self
+        // Compare cells until the range is exhausted: only an overflow key
+        // read can yield here, and it returns before the range changes, so
+        // re-entry retries the same cell. The caller persists the state once
+        // per call instead of once per compare.
+        while state.min_cell_idx <= state.max_cell_idx {
+            let cur_cell_idx = (state.min_cell_idx + state.max_cell_idx) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
+            self.stack.set_cell_index(cur_cell_idx as i32);
+
+            let (payload, payload_size, first_overflow_page) = self
                 .stack
                 .get_page_contents_at_level(old_top_idx)
                 .unwrap()
-                .cell_get(leftmost_matching_cell, self.usable_space())?;
-            // We don't advance in case of forward iteration and index tree
-            // internal nodes because we will visit this node going up.
-            // In backwards iteration, we must retreat because otherwise we
-            // would unnecessarily visit this node again. Example:
-            //   parent:     key 666 (target found in left child)
-            //   left child: key 663, key 664, key 665
-            // we need to move to the previous parent (e.g. key 662) when
-            // iterating backwards so that we don't end up back here again.
-            //
-            // On `IO(spill_c)` we MUST NOT mutate `cell_idx` (set or
-            // retreat) — see the Done branch.
-            let BTreeCell::IndexInteriorCell(IndexInteriorCell {
-                left_child_page, ..
-            }) = &matching_cell
-            else {
-                unreachable!("unexpected cell type: {:?}", matching_cell);
-            };
+                .cell_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
 
-            {
-                let page = self.stack.get_page_at_level(old_top_idx).unwrap();
-                turso_assert!(
-                    page.get().id != *left_child_page as usize,
-                    "corrupt: current page and left child page are the same",
-                    { "cell": leftmost_matching_cell, "page_id": page.get().id }
-                );
-            }
-
-            match self.read_page(*left_child_page as i64)? {
-                IOResult::Done((mem_page, c)) => {
-                    self.stack.set_cell_index(leftmost_matching_cell as i32);
-                    if iter_dir == IterationDirection::Backwards {
-                        self.stack.retreat();
-                    }
-                    self.stack.push(mem_page);
-                    self.seek_state = CursorSeekState::MovingBetweenPages {
-                        eq_seen: state.eq_seen,
-                    };
-                    if let Some(c) = c {
-                        return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(c))));
-                    }
+            if let Some(next_page) = first_overflow_page {
+                let res = self.process_overflow_read(payload, next_page, payload_size)?;
+                if res.is_io() {
+                    return Ok(ControlFlow::Break(res));
                 }
-                IOResult::IO(IOCompletions(spill_c)) => {
-                    return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(spill_c))));
-                }
-            }
-            return Ok(ControlFlow::Continue(()));
-        }
-
-        let cur_cell_idx = (min + max) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
-        self.stack.set_cell_index(cur_cell_idx as i32);
-
-        let (payload, payload_size, first_overflow_page) = self
-            .stack
-            .get_page_contents_at_level(old_top_idx)
-            .unwrap()
-            .cell_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
-
-        if let Some(next_page) = first_overflow_page {
-            let res = self.process_overflow_read(payload, next_page, payload_size)?;
-            if res.is_io() {
-                return Ok(ControlFlow::Break(res));
-            }
-        } else {
-            self.get_immutable_record_or_create()?
-                .as_mut()
-                .unwrap()
-                .invalidate();
-            crate::with_btree_allocation_site!(
-                RecordPayload,
+            } else {
                 self.get_immutable_record_or_create()?
                     .as_mut()
                     .unwrap()
-                    .start_serialization(payload)
-            )?;
-        };
+                    .invalidate();
+                crate::with_btree_allocation_site!(
+                    RecordPayload,
+                    self.get_immutable_record_or_create()?
+                        .as_mut()
+                        .unwrap()
+                        .start_serialization(payload)
+                )?;
+            };
 
-        let (target_leaf_page_is_in_left_subtree, is_eq) = {
-            let record = self.get_immutable_record();
-            let record = record.as_ref().unwrap();
+            let (target_leaf_page_is_in_left_subtree, is_eq) = {
+                let record = self.get_immutable_record();
+                let record = record.as_ref().unwrap();
 
-            let interior_cell_vs_index_key = record_comparer.compare(
-                record,
-                key_values,
-                self.index_info
-                    .as_ref()
-                    .expect("indexbtree_move_to: index_info required"),
-                0,
-                tie_breaker,
-            )?;
+                let interior_cell_vs_index_key = record_comparer.compare(
+                    record,
+                    key_values,
+                    self.index_info
+                        .as_ref()
+                        .expect("indexbtree_move_to: index_info required"),
+                    0,
+                    tie_breaker,
+                )?;
 
-            // in sqlite btrees left child pages have <= keys.
-            // in general, in forwards iteration we want to find the first key that matches the seek condition.
-            // in backwards iteration we want to find the last key that matches the seek condition.
-            //
-            // Logic table for determining if target leaf page is in left subtree.
-            // For index b-trees this is a bit more complicated since the interior cells contain payloads (the key is the payload).
-            // and for non-unique indexes there might be several cells with the same key.
-            //
-            // Forwards iteration (looking for first match in tree):
-            // OP  | Current Cell vs Seek Key  | Action?  | Explanation
-            // GT  | >                         | go left  | First > key could be exactly this one, or in left subtree
-            // GT  | = or <                    | go right | First > key must be in right subtree
-            // GE  | >                         | go left  | First >= key could be exactly this one, or in left subtree
-            // GE  | =                         | go left  | First >= key could be exactly this one, or in left subtree
-            // GE  | <                         | go right | First >= key must be in right subtree
-            //
-            // Backwards iteration (looking for last match in tree):
-            // OP  | Current Cell vs Seek Key  | Action?  | Explanation
-            // LE  | >                         | go left  | Last <= key must be in left subtree
-            // LE  | =                         | go right | Last <= key is either this one, or somewhere to the right of this one. So we need to go right to make sure
-            // LE  | <                         | go right | Last <= key must be in right subtree
-            // LT  | >                         | go left  | Last < key must be in left subtree
-            // LT  | =                         | go left  | Last < key must be in left subtree since we want strictly less than
-            // LT  | <                         | go right | Last < key could be exactly this one, or in right subtree
-            //
-            // No iteration (point query):
-            // EQ  | >                         | go left  | First = key must be in left subtree
-            // EQ  | =                         | go left  | First = key could be exactly this one, or in left subtree
-            // EQ  | <                         | go right | First = key must be in right subtree
+                // in sqlite btrees left child pages have <= keys.
+                // in general, in forwards iteration we want to find the first key that matches the seek condition.
+                // in backwards iteration we want to find the last key that matches the seek condition.
+                //
+                // Logic table for determining if target leaf page is in left subtree.
+                // For index b-trees this is a bit more complicated since the interior cells contain payloads (the key is the payload).
+                // and for non-unique indexes there might be several cells with the same key.
+                //
+                // Forwards iteration (looking for first match in tree):
+                // OP  | Current Cell vs Seek Key  | Action?  | Explanation
+                // GT  | >                         | go left  | First > key could be exactly this one, or in left subtree
+                // GT  | = or <                    | go right | First > key must be in right subtree
+                // GE  | >                         | go left  | First >= key could be exactly this one, or in left subtree
+                // GE  | =                         | go left  | First >= key could be exactly this one, or in left subtree
+                // GE  | <                         | go right | First >= key must be in right subtree
+                //
+                // Backwards iteration (looking for last match in tree):
+                // OP  | Current Cell vs Seek Key  | Action?  | Explanation
+                // LE  | >                         | go left  | Last <= key must be in left subtree
+                // LE  | =                         | go right | Last <= key is either this one, or somewhere to the right of this one. So we need to go right to make sure
+                // LE  | <                         | go right | Last <= key must be in right subtree
+                // LT  | >                         | go left  | Last < key must be in left subtree
+                // LT  | =                         | go left  | Last < key must be in left subtree since we want strictly less than
+                // LT  | <                         | go right | Last < key could be exactly this one, or in right subtree
+                //
+                // No iteration (point query):
+                // EQ  | >                         | go left  | First = key must be in left subtree
+                // EQ  | =                         | go left  | First = key could be exactly this one, or in left subtree
+                // EQ  | <                         | go right | First = key must be in right subtree
 
-            (
-                match cmp {
-                    SeekOp::GT => interior_cell_vs_index_key.is_gt(),
-                    SeekOp::GE { .. } => interior_cell_vs_index_key.is_ge(),
-                    SeekOp::LE { .. } => interior_cell_vs_index_key.is_gt(),
-                    SeekOp::LT => interior_cell_vs_index_key.is_ge(),
-                },
-                interior_cell_vs_index_key.is_eq(),
-            )
-        };
+                (
+                    match cmp {
+                        SeekOp::GT => interior_cell_vs_index_key.is_gt(),
+                        SeekOp::GE { .. } => interior_cell_vs_index_key.is_ge(),
+                        SeekOp::LE { .. } => interior_cell_vs_index_key.is_gt(),
+                        SeekOp::LT => interior_cell_vs_index_key.is_ge(),
+                    },
+                    interior_cell_vs_index_key.is_eq(),
+                )
+            };
 
-        if is_eq {
-            state.eq_seen = true;
+            if is_eq {
+                state.eq_seen = true;
+            }
+
+            if target_leaf_page_is_in_left_subtree {
+                state.nearest_matching_cell = Some(cur_cell_idx as usize);
+                state.max_cell_idx = cur_cell_idx - 1;
+            } else {
+                state.min_cell_idx = cur_cell_idx + 1;
+            }
         }
 
-        if target_leaf_page_is_in_left_subtree {
-            state.nearest_matching_cell = Some(cur_cell_idx as usize);
-            state.max_cell_idx = cur_cell_idx - 1;
-        } else {
-            state.min_cell_idx = cur_cell_idx + 1;
+        let Some(leftmost_matching_cell) = state.nearest_matching_cell else {
+            match self
+                .stack
+                .get_page_contents_at_level(old_top_idx)
+                .unwrap()
+                .rightmost_pointer()?
+            {
+                Some(right_most_pointer) => {
+                    // On `IO(spill_c)` keep seek_state at the binary
+                    // search so re-entry retries this same step. None
+                    // of the cursor mutations have happened yet.
+                    match self.read_page(right_most_pointer as i64)? {
+                        IOResult::Done((mem_page, c)) => {
+                            self.stack.set_cell_index(cell_count as i32 + 1);
+                            self.stack.push(mem_page);
+                            self.seek_state = CursorSeekState::MovingBetweenPages {
+                                eq_seen: state.eq_seen,
+                            };
+                            if let Some(c) = c {
+                                return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(c))));
+                            }
+                            return Ok(ControlFlow::Continue(()));
+                        }
+                        IOResult::IO(IOCompletions(spill_c)) => {
+                            return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(spill_c))));
+                        }
+                    }
+                }
+                None => {
+                    unreachable!("we shall not go back up! The only way is down the slope");
+                }
+            }
+        };
+        let matching_cell = self
+            .stack
+            .get_page_contents_at_level(old_top_idx)
+            .unwrap()
+            .cell_get(leftmost_matching_cell, self.usable_space())?;
+        // We don't advance in case of forward iteration and index tree
+        // internal nodes because we will visit this node going up.
+        // In backwards iteration, we must retreat because otherwise we
+        // would unnecessarily visit this node again. Example:
+        //   parent:     key 666 (target found in left child)
+        //   left child: key 663, key 664, key 665
+        // we need to move to the previous parent (e.g. key 662) when
+        // iterating backwards so that we don't end up back here again.
+        //
+        // On `IO(spill_c)` we MUST NOT mutate `cell_idx` (set or
+        // retreat) — see the Done branch.
+        let BTreeCell::IndexInteriorCell(IndexInteriorCell {
+            left_child_page, ..
+        }) = &matching_cell
+        else {
+            unreachable!("unexpected cell type: {:?}", matching_cell);
+        };
+
+        {
+            let page = self.stack.get_page_at_level(old_top_idx).unwrap();
+            turso_assert!(
+                page.get().id != *left_child_page as usize,
+                "corrupt: current page and left child page are the same",
+                { "cell": leftmost_matching_cell, "page_id": page.get().id }
+            );
+        }
+
+        match self.read_page(*left_child_page as i64)? {
+            IOResult::Done((mem_page, c)) => {
+                self.stack.set_cell_index(leftmost_matching_cell as i32);
+                if iter_dir == IterationDirection::Backwards {
+                    self.stack.retreat();
+                }
+                self.stack.push(mem_page);
+                self.seek_state = CursorSeekState::MovingBetweenPages {
+                    eq_seen: state.eq_seen,
+                };
+                if let Some(c) = c {
+                    return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(c))));
+                }
+            }
+            IOResult::IO(IOCompletions(spill_c)) => {
+                return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(spill_c))));
+            }
         }
         Ok(ControlFlow::Continue(()))
     }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1867,105 +1867,105 @@ impl BTreeCursor {
         cell_count: usize,
         state: &mut InteriorPageBinarySearchState,
     ) -> Result<ControlFlow<IOResult<()>>> {
-        let min = state.min_cell_idx;
-        let max = state.max_cell_idx;
-        if min > max {
-            if let Some(nearest_matching_cell) = state.nearest_matching_cell {
-                let left_child_page = self
-                    .stack
-                    .get_page_contents_at_level(old_top_idx)
-                    .unwrap()
-                    .cell_interior_read_left_child_page(nearest_matching_cell)?;
-                // On `IO(spill_c)` we keep `seek_state` at
-                // `InteriorPageBinarySearch` (the caller persists `state` to
-                // it after we return), so re-entry retries this same step
-                // with no double-push and no cell-index drift.
-                match self.read_page(left_child_page as i64)? {
-                    IOResult::Done((mem_page, c)) => {
-                        self.stack.set_cell_index(nearest_matching_cell as i32);
-                        self.stack.push(mem_page);
-                        self.seek_state = CursorSeekState::MovingBetweenPages {
-                            eq_seen: state.eq_seen,
-                        };
-                        if let Some(c) = c {
-                            return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(c))));
-                        }
-                        return Ok(ControlFlow::Continue(()));
-                    }
-                    IOResult::IO(IOCompletions(spill_c)) => {
-                        return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(spill_c))));
-                    }
+        // The compares need no I/O, so narrow the range on this page in one
+        // go. The caller persists the state once afterwards, before the child
+        // page read below, which is the only step here that can yield.
+        {
+            let contents = self.stack.get_page_contents_at_level(old_top_idx).unwrap();
+            while state.min_cell_idx <= state.max_cell_idx {
+                let cur_cell_idx = (state.min_cell_idx + state.max_cell_idx) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
+                let cell_rowid = contents.cell_table_interior_read_rowid(cur_cell_idx as usize)?;
+                // in sqlite btrees left child pages have <= keys.
+                // table btrees can have a duplicate rowid in the interior cell, so for example if we are looking for rowid=10,
+                // and we find an interior cell with rowid=10, we need to move to the left page since (due to the <= rule of sqlite btrees)
+                // the left page may have a rowid=10.
+                // Logic table for determining if target leaf page is in left subtree
+                //
+                // Forwards iteration (looking for first match in tree):
+                // OP  | Current Cell vs Seek Key   | Action?  | Explanation
+                // GT  | >                          | go left  | First > key is in left subtree
+                // GT  | = or <                     | go right | First > key is in right subtree
+                // GE  | > or =                     | go left  | First >= key is in left subtree
+                // GE  | <                          | go right | First >= key is in right subtree
+                //
+                // Backwards iteration (looking for last match in tree):
+                // OP  | Current Cell vs Seek Key   | Action?  | Explanation
+                // LE  | > or =                     | go left  | Last <= key is in left subtree
+                // LE  | <                          | go right | Last <= key is in right subtree
+                // LT  | > or =                     | go left  | Last < key is in left subtree
+                // LT  | <                          | go right?| Last < key is in right subtree, except if cell rowid is exactly 1 less
+                //
+                // No iteration (point query):
+                // EQ  | > or =                     | go left  | Last = key is in left subtree
+                // EQ  | <                          | go right | Last = key is in right subtree
+                let is_on_left = match seek_op {
+                    SeekOp::GT => cell_rowid > rowid,
+                    SeekOp::GE { .. } => cell_rowid >= rowid,
+                    SeekOp::LE { .. } => cell_rowid >= rowid,
+                    SeekOp::LT => cell_rowid + 1 >= rowid,
+                };
+                if is_on_left {
+                    state.nearest_matching_cell.replace(cur_cell_idx as usize);
+                    state.max_cell_idx = cur_cell_idx - 1;
+                } else {
+                    state.min_cell_idx = cur_cell_idx + 1;
                 }
             }
-            match self
+        }
+
+        if let Some(nearest_matching_cell) = state.nearest_matching_cell {
+            let left_child_page = self
                 .stack
                 .get_page_contents_at_level(old_top_idx)
                 .unwrap()
-                .rightmost_pointer()?
-            {
-                Some(right_most_pointer) => match self.read_page(right_most_pointer as i64)? {
-                    IOResult::Done((mem_page, c)) => {
-                        self.stack.set_cell_index(cell_count as i32 + 1);
-                        self.stack.push(mem_page);
-                        self.seek_state = CursorSeekState::MovingBetweenPages {
-                            eq_seen: state.eq_seen,
-                        };
-                        if let Some(c) = c {
-                            return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(c))));
-                        }
-                        return Ok(ControlFlow::Continue(()));
+                .cell_interior_read_left_child_page(nearest_matching_cell)?;
+            // On `IO(spill_c)` we keep `seek_state` at
+            // `InteriorPageBinarySearch` (the caller persists `state` to
+            // it after we return), so re-entry retries this same step
+            // with no double-push and no cell-index drift.
+            match self.read_page(left_child_page as i64)? {
+                IOResult::Done((mem_page, c)) => {
+                    self.stack.set_cell_index(nearest_matching_cell as i32);
+                    self.stack.push(mem_page);
+                    self.seek_state = CursorSeekState::MovingBetweenPages {
+                        eq_seen: state.eq_seen,
+                    };
+                    if let Some(c) = c {
+                        return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(c))));
                     }
-                    IOResult::IO(IOCompletions(spill_c)) => {
-                        return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(spill_c))));
-                    }
-                },
-                None => {
-                    unreachable!("we shall not go back up! The only way is down the slope");
+                    return Ok(ControlFlow::Continue(()));
+                }
+                IOResult::IO(IOCompletions(spill_c)) => {
+                    return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(spill_c))));
                 }
             }
         }
-        let cur_cell_idx = (min + max) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
-        let cell_rowid = self
+        match self
             .stack
             .get_page_contents_at_level(old_top_idx)
             .unwrap()
-            .cell_table_interior_read_rowid(cur_cell_idx as usize)?;
-        // in sqlite btrees left child pages have <= keys.
-        // table btrees can have a duplicate rowid in the interior cell, so for example if we are looking for rowid=10,
-        // and we find an interior cell with rowid=10, we need to move to the left page since (due to the <= rule of sqlite btrees)
-        // the left page may have a rowid=10.
-        // Logic table for determining if target leaf page is in left subtree
-        //
-        // Forwards iteration (looking for first match in tree):
-        // OP  | Current Cell vs Seek Key   | Action?  | Explanation
-        // GT  | >                          | go left  | First > key is in left subtree
-        // GT  | = or <                     | go right | First > key is in right subtree
-        // GE  | > or =                     | go left  | First >= key is in left subtree
-        // GE  | <                          | go right | First >= key is in right subtree
-        //
-        // Backwards iteration (looking for last match in tree):
-        // OP  | Current Cell vs Seek Key   | Action?  | Explanation
-        // LE  | > or =                     | go left  | Last <= key is in left subtree
-        // LE  | <                          | go right | Last <= key is in right subtree
-        // LT  | > or =                     | go left  | Last < key is in left subtree
-        // LT  | <                          | go right?| Last < key is in right subtree, except if cell rowid is exactly 1 less
-        //
-        // No iteration (point query):
-        // EQ  | > or =                     | go left  | Last = key is in left subtree
-        // EQ  | <                          | go right | Last = key is in right subtree
-        let is_on_left = match seek_op {
-            SeekOp::GT => cell_rowid > rowid,
-            SeekOp::GE { .. } => cell_rowid >= rowid,
-            SeekOp::LE { .. } => cell_rowid >= rowid,
-            SeekOp::LT => cell_rowid + 1 >= rowid,
-        };
-        if is_on_left {
-            state.nearest_matching_cell.replace(cur_cell_idx as usize);
-            state.max_cell_idx = cur_cell_idx - 1;
-        } else {
-            state.min_cell_idx = cur_cell_idx + 1;
+            .rightmost_pointer()?
+        {
+            Some(right_most_pointer) => match self.read_page(right_most_pointer as i64)? {
+                IOResult::Done((mem_page, c)) => {
+                    self.stack.set_cell_index(cell_count as i32 + 1);
+                    self.stack.push(mem_page);
+                    self.seek_state = CursorSeekState::MovingBetweenPages {
+                        eq_seen: state.eq_seen,
+                    };
+                    if let Some(c) = c {
+                        return Ok(ControlFlow::Break(IOResult::IO(IOCompletions(c))));
+                    }
+                    Ok(ControlFlow::Continue(()))
+                }
+                IOResult::IO(IOCompletions(spill_c)) => {
+                    Ok(ControlFlow::Break(IOResult::IO(IOCompletions(spill_c))))
+                }
+            },
+            None => {
+                unreachable!("we shall not go back up! The only way is down the slope");
+            }
         }
-        Ok(ControlFlow::Continue(()))
     }
 
     /// Specialized version of move_to() for index btrees.

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1374,6 +1374,11 @@ pub struct Pager {
     /// `read_page_nonblock(idx)` reuses the stored `(page, disk_read)` pair
     /// instead of issuing a duplicate disk read.
     pending_reads: RwLock<HashMap<i64, PendingRead>>,
+    /// True while `pending_reads` may hold an entry. Set before an entry is
+    /// added and cleared after the last one is removed, both under the write
+    /// lock, so a reader that sees false can skip the lock: every page read
+    /// checks for a pending entry first.
+    has_pending_reads: AtomicBool,
     #[cfg(test)]
     spill_yield: SpillYieldHook,
     /// Dirty pages as a bitmap, naturally sorted by page number.
@@ -1669,6 +1674,7 @@ impl Pager {
             page_cache: Arc::new(RwLock::new(page_cache)),
             io,
             pending_reads: RwLock::new(HashMap::new()),
+            has_pending_reads: AtomicBool::new(false),
             #[cfg(test)]
             spill_yield: SpillYieldHook::new(),
             dirty_pages: Arc::new(RwLock::new(RoaringBitmap::new())),
@@ -3362,7 +3368,11 @@ impl Pager {
         if self.spill_yield.should_yield_for(page_idx) {
             io_yield_one!(crate::Completion::new_yield());
         }
-        let pending = self.pending_reads.read().get(&page_idx).cloned();
+        let pending = if self.has_pending_reads.load(Ordering::Acquire) {
+            self.pending_reads.read().get(&page_idx).cloned()
+        } else {
+            None
+        };
         let (page, c_disk) = if let Some(pending) = pending {
             // Re-entry: previous call yielded on spill before completing
             // `cache_insert`. Reuse the same PageRef and in-flight disk read
@@ -3400,7 +3410,7 @@ impl Pager {
 
             tracing::debug!("read_page(page_idx = {page_idx}) = reading page from disk");
             let (page, c) = self.read_page_no_cache(page_idx, None, false, group)?;
-            self.pending_reads.write().insert(
+            self.insert_pending_read(
                 page_idx,
                 PendingRead {
                     page: page.clone(),
@@ -3412,7 +3422,7 @@ impl Pager {
 
         match self.cache_insert(page_idx as usize, page.clone())? {
             IOResult::Done(()) => {
-                self.pending_reads.write().remove(&page_idx);
+                self.remove_pending_read(page_idx);
                 Ok(IOResult::Done((page, c_disk)))
             }
             IOResult::IO(IOCompletions(spill_c)) => {
@@ -3421,6 +3431,21 @@ impl Pager {
                 // `cache_insert` without re-issuing the disk read.
                 io_yield_one!(spill_c);
             }
+        }
+    }
+
+    /// Records a page read that is still in flight so a re-entry finds it.
+    fn insert_pending_read(&self, page_idx: i64, pending: PendingRead) {
+        let mut pending_reads = self.pending_reads.write();
+        self.has_pending_reads.store(true, Ordering::Release);
+        pending_reads.insert(page_idx, pending);
+    }
+
+    fn remove_pending_read(&self, page_idx: i64) {
+        let mut pending_reads = self.pending_reads.write();
+        pending_reads.remove(&page_idx);
+        if pending_reads.is_empty() {
+            self.has_pending_reads.store(false, Ordering::Release);
         }
     }
 
@@ -6643,7 +6668,7 @@ mod ptrmap_tests {
         // contents don't matter for this test.
         synthetic_page.set_loaded();
         let stub_disk_read = Completion::new_yield();
-        pager.pending_reads.write().insert(
+        pager.insert_pending_read(
             target_idx,
             PendingRead {
                 page: synthetic_page.clone(),

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -2275,6 +2275,11 @@ impl ProgramBuilder {
             result_columns: self.result_columns,
             table_references: self.table_references,
             sql: sql.to_string(),
+            refreshes_analyze_stats: sql
+                .trim_start()
+                .as_bytes()
+                .get(..7)
+                .is_some_and(|head| head.eq_ignore_ascii_case(b"ANALYZE")),
             needs_stmt_subtransactions: crate::Arc::new(crate::AtomicBool::new(
                 needs_stmt_subtransactions,
             )),

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1261,7 +1261,7 @@ pub fn op_open_read(
         .cursor_ref
         .get(*cursor_id)
         .expect("cursor_id should exist in cursor_ref");
-    if program.connection.get_mv_tx_id_for_db(*db).is_none() {
+    if mv_store.is_none() || program.connection.get_mv_tx_id_for_db(*db).is_none() {
         assert!(
             *root_page >= 0,
             "root page should be non negative when we are not in a MVCC transaction"
@@ -1278,13 +1278,13 @@ pub fn op_open_read(
     let maybe_promote_to_mvcc_cursor = |btree_cursor: Box<dyn CursorTrait>,
                                         mv_cursor_type: MvccCursorType|
      -> Result<Box<dyn CursorTrait>> {
+        // Without an MvStore there is no MVCC transaction to look up.
+        let Some(mv_store) = mv_store.as_ref() else {
+            return Ok(btree_cursor);
+        };
         if let Some(tx_id) = program.connection.get_mv_tx_id_for_db(*db) {
-            let mv_store = mv_store
-                .as_ref()
-                .expect("mv_store should be Some when MVCC transaction is active")
-                .clone();
             Ok(Box::new(MvCursor::new(
-                mv_store,
+                mv_store.clone(),
                 &program.connection,
                 tx_id,
                 *root_page,

--- a/core/vdbe/metrics.rs
+++ b/core/vdbe/metrics.rs
@@ -28,32 +28,32 @@ impl HashJoinMetrics {
     pub fn merge(&mut self, other: &HashJoinMetrics) {
         self.spill_bytes_written = self
             .spill_bytes_written
-            .saturating_add(other.spill_bytes_written);
-        self.spill_chunks = self.spill_chunks.saturating_add(other.spill_chunks);
+            .wrapping_add(other.spill_bytes_written);
+        self.spill_chunks = self.spill_chunks.wrapping_add(other.spill_chunks);
         self.spill_max_chunks_per_partition = self
             .spill_max_chunks_per_partition
             .max(other.spill_max_chunks_per_partition);
         self.spill_max_partition_bytes = self
             .spill_max_partition_bytes
             .max(other.spill_max_partition_bytes);
-        self.load_bytes_read = self.load_bytes_read.saturating_add(other.load_bytes_read);
-        self.probe_calls = self.probe_calls.saturating_add(other.probe_calls);
+        self.load_bytes_read = self.load_bytes_read.wrapping_add(other.load_bytes_read);
+        self.probe_calls = self.probe_calls.wrapping_add(other.probe_calls);
         self.probe_spill_bytes_written = self
             .probe_spill_bytes_written
-            .saturating_add(other.probe_spill_bytes_written);
+            .wrapping_add(other.probe_spill_bytes_written);
         self.probe_spill_chunks = self
             .probe_spill_chunks
-            .saturating_add(other.probe_spill_chunks);
+            .wrapping_add(other.probe_spill_chunks);
         self.grace_partitions_processed = self
             .grace_partitions_processed
-            .saturating_add(other.grace_partitions_processed);
+            .wrapping_add(other.grace_partitions_processed);
         self.grace_probe_rows_streamed = self
             .grace_probe_rows_streamed
-            .saturating_add(other.grace_probe_rows_streamed);
+            .wrapping_add(other.grace_probe_rows_streamed);
         self.grace_probe_rows_buffered = self
             .grace_probe_rows_buffered
-            .saturating_add(other.grace_probe_rows_buffered);
-        self.grace_matches = self.grace_matches.saturating_add(other.grace_matches);
+            .wrapping_add(other.grace_probe_rows_buffered);
+        self.grace_matches = self.grace_matches.wrapping_add(other.grace_matches);
     }
 
     pub fn reset(&mut self) {
@@ -110,21 +110,19 @@ impl StatementMetrics {
 
     /// Merge another metrics instance into this one (for aggregation)
     pub fn merge(&mut self, other: &StatementMetrics) {
-        self.rows_read = self.rows_read.saturating_add(other.rows_read);
-        self.rows_written = self.rows_written.saturating_add(other.rows_written);
-        self.vm_steps = self.vm_steps.saturating_add(other.vm_steps);
-        self.insn_executed = self.insn_executed.saturating_add(other.insn_executed);
-        self.reprepares = self.reprepares.saturating_add(other.reprepares);
-        self.fullscan_steps = self.fullscan_steps.saturating_add(other.fullscan_steps);
-        self.index_steps = self.index_steps.saturating_add(other.index_steps);
-        self.sort_operations = self.sort_operations.saturating_add(other.sort_operations);
-        self.filter_operations = self
-            .filter_operations
-            .saturating_add(other.filter_operations);
-        self.btree_seeks = self.btree_seeks.saturating_add(other.btree_seeks);
-        self.btree_next = self.btree_next.saturating_add(other.btree_next);
-        self.btree_prev = self.btree_prev.saturating_add(other.btree_prev);
-        self.search_count = self.search_count.saturating_add(other.search_count);
+        self.rows_read = self.rows_read.wrapping_add(other.rows_read);
+        self.rows_written = self.rows_written.wrapping_add(other.rows_written);
+        self.vm_steps = self.vm_steps.wrapping_add(other.vm_steps);
+        self.insn_executed = self.insn_executed.wrapping_add(other.insn_executed);
+        self.reprepares = self.reprepares.wrapping_add(other.reprepares);
+        self.fullscan_steps = self.fullscan_steps.wrapping_add(other.fullscan_steps);
+        self.index_steps = self.index_steps.wrapping_add(other.index_steps);
+        self.sort_operations = self.sort_operations.wrapping_add(other.sort_operations);
+        self.filter_operations = self.filter_operations.wrapping_add(other.filter_operations);
+        self.btree_seeks = self.btree_seeks.wrapping_add(other.btree_seeks);
+        self.btree_next = self.btree_next.wrapping_add(other.btree_next);
+        self.btree_prev = self.btree_prev.wrapping_add(other.btree_prev);
+        self.search_count = self.search_count.wrapping_add(other.search_count);
         self.hash_join.merge(&other.hash_join);
     }
 
@@ -228,7 +226,7 @@ impl ConnectionMetrics {
 
     /// Record a completed statement's metrics (borrows, no clone).
     pub fn record_statement(&mut self, metrics: &StatementMetrics) {
-        self.total_statements = self.total_statements.saturating_add(1);
+        self.total_statements = self.total_statements.wrapping_add(1);
 
         // Update high-water marks
         self.max_vm_steps_per_statement = self.max_vm_steps_per_statement.max(metrics.vm_steps);

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1115,10 +1115,8 @@ impl ProgramState {
         self.op_vacuum_state = VacuumOpState::None;
         self.view_delta_state = ViewDeltaCommitState::NotStarted;
         self.auto_txn_cleanup = TxnCleanup::None;
-        self.fk_immediate_violations_during_stmt
-            .store(0, Ordering::SeqCst);
-        self.fk_deferred_violations_when_stmt_started
-            .store(0, Ordering::SeqCst);
+        *self.fk_immediate_violations_during_stmt.get_mut() = 0;
+        *self.fk_deferred_violations_when_stmt_started.get_mut() = 0;
         self.rowsets.clear();
         self.bloom_filters.clear();
         self.hash_tables.clear();
@@ -1128,9 +1126,10 @@ impl ProgramState {
         self.has_stmt_transaction = false;
         self.distinct_key_values.clear();
         self.attached_savepoint_pagers.clear();
-        self.n_change.store(0, Ordering::SeqCst);
-        self.n_total_change.store(0, Ordering::SeqCst);
-        *self.explain_state.write() = ExplainState::default();
+        *self.n_change.get_mut() = 0;
+        *self.n_total_change.get_mut() = 0;
+        // reset has exclusive access, so no lock or atomic store is needed.
+        *self.explain_state.get_mut() = ExplainState::default();
         self.pending_fail_error = None;
         self.pending_fail_prepare_error = None;
         self.halt_in_progress = false;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1613,6 +1613,10 @@ pub struct PreparedProgram {
     pub result_columns: Vec<ResultSetColumn>,
     pub table_references: TableReferences,
     pub sql: String,
+    /// The statement is ANALYZE, so its completion refreshes the in-memory
+    /// planner statistics. Decided once here instead of by scanning the SQL
+    /// text on every completion.
+    pub refreshes_analyze_stats: bool,
     /// Whether the statement needs to be wrapped in a statement subtransaction
     /// when run as part of an interactive (non-autocommit) transaction.
     /// See [crate::vdbe::builder::ProgramBuilder::is_multi_write] and [crate::vdbe::builder::ProgramBuilder::may_abort] for more details.

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1227,6 +1227,20 @@ impl ProgramState {
         self.metrics.rows_written = self.metrics.rows_written.saturating_add(count);
     }
 
+    /// Runs `f` on the metrics of this statement including its active and
+    /// cached subprograms, without copying them when there is no subprogram.
+    pub(crate) fn with_metrics<R>(&self, f: impl FnOnce(&StatementMetrics) -> R) -> R {
+        let has_subprograms = matches!(
+            self.active_op_state.program_ref(),
+            Some(OpProgramState::Step { .. })
+        ) || !self.subprogram_stmt_cache.is_empty();
+        if has_subprograms {
+            f(&self.metrics())
+        } else {
+            f(&self.metrics)
+        }
+    }
+
     pub(crate) fn metrics(&self) -> StatementMetrics {
         let mut metrics = self.metrics.clone();
         if let Some(OpProgramState::Step { statement, .. }) = self.active_op_state.program_ref() {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -588,7 +588,12 @@ macro_rules! active_state_accessor {
     ($name:ident, $variant:ident, $ty:ty, $init:expr) => {
         fn $name(&mut self) -> &mut $ty {
             if matches!(self.state, ActiveOpState::None) {
-                self.state = ActiveOpState::$variant($init);
+                // None owns nothing, so skip the drop glue of the enum that
+                // a plain assignment would run on the old value.
+                std::mem::forget(std::mem::replace(
+                    &mut self.state,
+                    ActiveOpState::$variant($init),
+                ));
             }
             match &mut self.state {
                 ActiveOpState::$variant(state) => state,
@@ -610,7 +615,9 @@ impl Default for ActiveOpState {
 
 impl ActiveOpStateSlot {
     fn clear(&mut self) {
-        self.state = ActiveOpState::None;
+        if !matches!(self.state, ActiveOpState::None) {
+            self.state = ActiveOpState::None;
+        }
     }
 
     /// True when no multi-step opcode is suspended. Hot opcodes use this to


### PR DESCRIPTION
## Description

Part 4 of 15 split out of #8692 (commits 31-40 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits. These ten commits apply to `main` and build there on their own, so this PR targets `main` and not the branch of part 3.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### Measurement history: per-statement costs

The second half of the PR works on the fixed cost of executing a prepared statement once: transaction begin and commit, cursor open and close, statement reset, metrics. Measured as callgrind instructions per execution, taken as (Ir at 3000 executions − Ir at 1000 executions) / 2000 so the process start-up is cancelled out. Workloads: a point lookup `SELECT * FROM t WHERE id = 12345` (one `Transaction`, one `OpenRead`, one `SeekRowid`, `Column`, `Halt`), `SELECT 1` (no table, no transaction: the pure statement overhead), and an index lookup `SELECT id FROM t WHERE value = 500 LIMIT 1` (two cursors).

| Commit | point lookup | Δ | `SELECT 1` | Δ | index lookup | Δ |
|---|---:|---:|---:|---:|---:|---:|
| `3e5e0c6b` decide at prepare time whether a statement refreshes ANALYZE stats | 9,498 | -0.2% | 1,976 | -2.1% | 14,808 | -0.6% |
| `3bdd5989` reset the statement state through exclusive access | 9,476 | -0.2% | 1,957 | -1.0% | 14,789 | -0.1% |
| `f267c9f7` record completion metrics without copying them | 9,396 | -0.8% | 1,874 | -4.2% | 14,706 | -0.6% |
| `4c0522c4` merge metrics with wrapping adds | 9,340 | -0.6% | 1,818 | -3.0% | 14,650 | -0.4% |
| `5213b9d1` run the interior binary search of a table seek without persisting each step | 8,609 | -7.8% | | | 14,650 | 0.0% |
| `ae8316e9` run the leaf binary search of a table seek without persisting each step | 8,443 | -1.9% | | | | |
| `2e08a1cd` run the interior binary search of an index seek without persisting each step | 8,443 | 0.0% | | | 14,024 | -4.3% |
| `1420bb89` look the MVCC transaction up in OpenRead only when the database has an MvStore | 8,325 | -1.4% | | | 13,910 | -0.8% |
| `671ac195` skip the drop glue of the opcode state slot when it holds nothing | 8,284 | -0.5% | 1,794 | -1.2% | 13,869 | -0.3% |
| `236fed48` skip the pending-read lookup while no page read is in flight | 8,233 | -0.6% | | | 13,818 | -0.4% |

The seek changes also show up per seek inside a statement. Over 3 x 5000 rowid seeks of `SELECT count(*) FROM t AS a JOIN t AS b ON b.id = a.id WHERE a.id <= 5000` (W6): 101,860,737 Ir at `4c0522c4` → 87,447,949 after `5213b9d1` (-14.1%) → 84,216,225 after `ae8316e9` (-3.7%) → 83,189,013 at `972105fa` → 78,811,525 after `191e0aab` (-5.3%); -22.6% in total.

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_