### PR TITLE
core: cut the cost of cursor open, column decode and TEXT checks (5/15)

### DIFF
--- a/core/benches/text_validate_benchmark.rs
+++ b/core/benches/text_validate_benchmark.rs
@@ -3,8 +3,8 @@
 //!
 //! Baseline: `simdutf8::basic::from_utf8`, exactly what the TEXT serial-type
 //! arm of `nth_into_register` in `core/vdbe/mod.rs` calls on main today.
-//! Candidate: an ASCII OR-reduction fast path that falls back to the baseline
-//! for non-ASCII input.
+//! Candidates: an ASCII OR-reduction fast path that falls back to the baseline
+//! for non-ASCII input, byte by byte or a word at a time.
 //!
 //! Real TEXT values are decoded from b-tree page cells at arbitrary byte
 //! offsets, and short-input `from_utf8` is alignment-sensitive. Each measured
@@ -44,8 +44,8 @@ fn validate_ascii_or(data: &[u8]) -> Option<&str> {
     simdutf8::basic::from_utf8(data).ok()
 }
 
-/// Verbatim copy of `validate_utf8` in `core/vdbe/mod.rs`: the OR-reduction
-/// only runs where it wins (short strings, where simdutf8's std fallback is
+/// The byte-at-a-time OR-reduction with a cutoff: the OR-reduction only
+/// runs where it wins (short strings, where simdutf8's std fallback is
 /// alignment-sensitive); longer inputs go straight to real SIMD validation.
 #[inline]
 fn validate_ascii_or_cutoff(data: &[u8]) -> Option<&str> {
@@ -61,6 +61,41 @@ fn validate_ascii_or_cutoff(data: &[u8]) -> Option<&str> {
         }
     }
     simdutf8::basic::from_utf8(data).ok()
+}
+
+/// Verbatim copy of `validate_utf8` in `core/vdbe/mod.rs`: the OR-reduction
+/// of the cutoff variant done eight bytes at a time, then four, two and one
+/// for the rest, so a value takes at most `len / 8 + 3` unaligned loads.
+#[inline]
+fn validate_ascii_words(data: &[u8]) -> Option<&str> {
+    const ASCII_SCAN_CUTOFF: usize = 512;
+    if data.len() <= ASCII_SCAN_CUTOFF && is_ascii(data) {
+        // SAFETY: all bytes are ASCII, which is valid UTF-8.
+        return Some(unsafe { core::str::from_utf8_unchecked(data) });
+    }
+    simdutf8::basic::from_utf8(data).ok()
+}
+
+#[inline]
+fn is_ascii(data: &[u8]) -> bool {
+    let mut acc = 0u64;
+    let mut rest = data;
+    while let Some((word, tail)) = rest.split_first_chunk::<8>() {
+        acc |= u64::from_ne_bytes(*word);
+        rest = tail;
+    }
+    if let Some((word, tail)) = rest.split_first_chunk::<4>() {
+        acc |= u64::from(u32::from_ne_bytes(*word));
+        rest = tail;
+    }
+    if let Some((word, tail)) = rest.split_first_chunk::<2>() {
+        acc |= u64::from(u16::from_ne_bytes(*word));
+        rest = tail;
+    }
+    if let Some(&byte) = rest.first() {
+        acc |= u64::from(byte);
+    }
+    acc & 0x8080_8080_8080_8080 == 0
 }
 
 const BUF_LEN: usize = 8192;
@@ -135,6 +170,11 @@ fn assert_functions_agree() {
             validate_ascii_or_cutoff(case),
             "cutoff variant disagrees on {case:?}"
         );
+        assert_eq!(
+            validate_simdutf8(case),
+            validate_ascii_words(case),
+            "word variant disagrees on {case:?}"
+        );
     }
 }
 
@@ -167,6 +207,9 @@ fn bench_text_validate(criterion: &mut Criterion) {
                 )
             });
         });
+        group.bench_function(format!("ascii_words_{size}"), |b| {
+            b.iter(|| run_schedule(&ascii_buf, &schedule, size, rounds, validate_ascii_words));
+        });
     }
 
     let (mb_buf, mb_schedule) = multibyte_fixture();
@@ -179,6 +222,9 @@ fn bench_text_validate(criterion: &mut Criterion) {
     });
     group.bench_function("ascii_or_cutoff_multibyte_64", |b| {
         b.iter(|| run_schedule(&mb_buf, &mb_schedule, 64, rounds, validate_ascii_or_cutoff));
+    });
+    group.bench_function("ascii_words_multibyte_64", |b| {
+        b.iter(|| run_schedule(&mb_buf, &mb_schedule, 64, rounds, validate_ascii_words));
     });
 
     group.finish();

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -734,8 +734,12 @@ pub trait CursorTrait: Any + Send + Sync {
     /// The serialized record of the entry the cursor points to, if any, for
     /// decoding in place. A b-tree cursor hands out the bytes of the pinned
     /// page when the cell has no overflow, so the caller must not move the
-    /// cursor while it holds the slice. Default: the bytes of `record`.
+    /// cursor while it holds the slice. None for a cursor in the null-row
+    /// state, like the rowid. Default: the bytes of `record`.
     fn record_payload(&mut self) -> IOResultOr<Option<&[u8]>> {
+        if self.get_null_flag() {
+            return Ok(IOResult::Done(None));
+        }
         Ok(match self.record()? {
             IOResult::Done(record) => IOResult::Done(record.map(ImmutableRecord::get_payload)),
             IOResult::IO(io) => IOResult::IO(io),
@@ -6628,7 +6632,7 @@ impl CursorTrait for BTreeCursor {
         if self.needs_restore() {
             return_if_io!(self.restore_context());
         }
-        if !self.has_record() {
+        if self.null_flag || !self.has_record() {
             return Ok(IOResult::Done(None));
         }
         let noted = self.noted_payload;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -8531,7 +8531,7 @@ impl PageStack {
     fn top_ref(&self) -> &PageRef {
         let current = self.current();
         let page = self.stack[current].as_ref().unwrap();
-        turso_assert!(page.is_loaded(), "page should be loaded");
+        turso_assert!(page.is_loaded_relaxed(), "page should be loaded");
         page
     }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1761,6 +1761,14 @@ impl BTreeCursor {
         self.seek_state = CursorSeekState::Start;
         self.going_upwards = false;
         tracing::trace!(root_page = self.root_page);
+        // The stack still holds the pinned root page from the last descent
+        // unless the cursor was invalidated, which clears the stack. Keep it
+        // and drop the pages below it, like SQLite's moveToRoot, instead of
+        // going through the page cache again.
+        if self.stack.holds_root(self.root_page) {
+            self.stack.pop_to_root();
+            return Ok(IOResult::Done(None));
+        }
         let (mem_page, c) = return_if_io!(self.read_page(self.root_page));
         self.stack.clear();
         self.stack.push(mem_page);
@@ -8536,6 +8544,33 @@ impl PageStack {
     fn clear(&mut self) {
         self.unpin_all_and_clear_slots();
         self.current_page = -1;
+    }
+
+    /// Whether slot 0 holds the loaded root page of the btree.
+    fn holds_root(&self, root_page: i64) -> bool {
+        self.current_page >= 0
+            && self.stack[0]
+                .as_ref()
+                .is_some_and(|page| page.get().id as i64 == root_page && page.is_loaded())
+    }
+
+    /// Drop every page below the root and leave the stack on the root as a
+    /// fresh push of it would.
+    fn pop_to_root(&mut self) {
+        let used = (self.current_page + 1) as usize;
+        for slot in self.stack[1..used].iter_mut() {
+            if let Some(page) = slot.take() {
+                let _ = page.try_unpin();
+            }
+        }
+        for state in self.node_states[1..used].iter_mut() {
+            *state = BTreeNodeState::default();
+        }
+        self.node_states[0] = BTreeNodeState {
+            cell_idx: -1,
+            cell_count: None,
+        };
+        self.current_page = 0;
     }
 }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -779,6 +779,10 @@ pub trait CursorTrait: Any + Send + Sync {
     /// Opt into the pager's cursor_registry. Default no-op so non-BTreeCursor
     /// impls (MvccLazyCursor) stay out. Opt-in impls must unregister in Drop.
     fn register_with_pager(&self) {}
+    /// Drops the cursor at statement reset. BTreeCursor keeps its heap
+    /// allocation in the pager's pool for the next cursor; the default is a
+    /// plain drop.
+    fn recycle(self: Box<Self>) {}
     /// Mirror of SQLite's BTCF_Multiple flag; toggled by Pager when a bucket
     /// crosses the 1↔2 threshold.
     fn set_has_peers_for_external_writes(&self, _has_peers: bool) {}
@@ -1157,6 +1161,15 @@ impl BTreeCursor {
 
     pub fn new_table(pager: Arc<Pager>, root_page: i64, num_columns: usize) -> Self {
         Self::new(pager, root_page, num_columns)
+    }
+
+    /// Moves the cursor to the heap, into an allocation retired by an earlier
+    /// cursor on the same pager when the pool has one.
+    pub fn into_boxed(self) -> Box<Self> {
+        match self.pager.take_cursor_allocation() {
+            Some(allocation) => Box::write(allocation, self),
+            None => Box::new(self),
+        }
     }
 
     pub fn new_without_rowid_table(
@@ -7280,6 +7293,20 @@ impl CursorTrait for BTreeCursor {
         self.did_register
             .store(true, crate::sync::atomic::Ordering::Relaxed);
         self.pager.register_cursor(self);
+    }
+
+    fn recycle(self: Box<Self>) {
+        let pager = self.pager.clone();
+        let raw = Box::into_raw(self);
+        // SAFETY: `raw` came from a Box of a live cursor. Its contents are
+        // dropped exactly once here (Drop unregisters the cursor and retires
+        // its record buffer), and the allocation goes on as uninitialized
+        // memory of the same layout.
+        let allocation = unsafe {
+            std::ptr::drop_in_place(raw);
+            Box::from_raw(raw.cast::<std::mem::MaybeUninit<BTreeCursor>>())
+        };
+        pager.recycle_cursor_allocation(allocation);
     }
 
     fn set_has_peers_for_external_writes(&self, has_peers: bool) {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -731,6 +731,16 @@ pub trait CursorTrait: Any + Send + Sync {
     fn note_external_row_write(&mut self, _rowid: Option<i64>) {}
     /// Get the record of the entry the cursor is poiting to if any
     fn record(&mut self) -> IOResultOr<Option<&ImmutableRecord>>;
+    /// The serialized record of the entry the cursor points to, if any, for
+    /// decoding in place. A b-tree cursor hands out the bytes of the pinned
+    /// page when the cell has no overflow, so the caller must not move the
+    /// cursor while it holds the slice. Default: the bytes of `record`.
+    fn record_payload(&mut self) -> IOResultOr<Option<&[u8]>> {
+        Ok(match self.record()? {
+            IOResult::Done(record) => IOResult::Done(record.map(ImmutableRecord::get_payload)),
+            IOResult::IO(io) => IOResult::IO(io),
+        })
+    }
     /// Move the cursor based on the key and the type of operation (op).
     fn seek(&mut self, key: SeekKey<'_>, op: SeekOp) -> IOResultOr<SeekResult>;
     /// Seek using registers directly without serializing them into an ImmutableRecord first.
@@ -6587,6 +6597,33 @@ impl CursorTrait for BTreeCursor {
         };
 
         Ok(IOResult::Done(self.reusable_immutable_record.as_ref()))
+    }
+
+    fn record_payload(&mut self) -> IOResultOr<Option<&[u8]>> {
+        if self.needs_restore() {
+            return_if_io!(self.restore_context());
+        }
+        if !self.has_record() {
+            return Ok(IOResult::Done(None));
+        }
+        let cached = self
+            .reusable_immutable_record
+            .as_ref()
+            .is_some_and(|record| !record.is_invalidated());
+        if !cached {
+            let page = self.stack.top_ref();
+            let contents = page.get_contents();
+            let cell_idx = self.stack.current_cell_index();
+            let (payload, _payload_size, first_overflow_page) =
+                contents.cell_read_payload_ptr(cell_idx as usize, self.usable_space())?;
+            if first_overflow_page.is_none() {
+                // The whole record sits on the pinned page: decode it there
+                // instead of copying it into the reusable record first.
+                return Ok(IOResult::Done(Some(payload)));
+            }
+        }
+        let record = return_if_io!(self.record());
+        Ok(IOResult::Done(record.map(ImmutableRecord::get_payload)))
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -835,6 +835,13 @@ pub struct BTreeCursor {
     stack: PageStack,
     /// Reusable immutable record, used to allow better allocation strategy.
     reusable_immutable_record: Option<ImmutableRecord>,
+    /// Where the payload of the table leaf cell under the cursor starts and
+    /// how big it is, noted by the rowid read so that a column read on the
+    /// same row does not parse the cell again (SQLite keeps the same in
+    /// BtCursor.info). Cleared wherever the reusable record is invalidated
+    /// and before every write through the cursor, because it holds an
+    /// offset into the page.
+    noted_payload: NotedPayload,
     /// Information about the index key structure (sort order, collation, etc)
     pub index_info: Option<Arc<IndexInfo>>,
     /// Maintain count of the number of records in the btree. Used for the `Count` opcode
@@ -916,6 +923,18 @@ pub struct BTreeCursor {
     yield_injector: Option<Arc<dyn crate::mvcc::yield_points::YieldInjector>>,
     #[cfg(any(test, injected_yields))]
     yield_instance_id: u64,
+}
+
+/// See [`BTreeCursor::noted_payload`]. A payload is never empty (its header
+/// takes at least one byte), so a size of 0 means nothing is noted.
+#[derive(Clone, Copy)]
+struct NotedPayload {
+    start: u32,
+    size: u32,
+}
+
+impl NotedPayload {
+    const NONE: Self = Self { start: 0, size: 0 };
 }
 
 /// Records the in-flight descent for `iteration_pending_descent`. The direction
@@ -1133,6 +1152,7 @@ impl BTreeCursor {
                 stack: [const { None }; BTCURSOR_MAX_DEPTH + 1],
             },
             reusable_immutable_record: None,
+            noted_payload: NotedPayload::NONE,
             index_info: None,
             count: 0,
             context: None,
@@ -6194,6 +6214,7 @@ impl BTreeCursor {
     pub fn save_context(&mut self, cursor_context: CursorContext) {
         self.valid_state = CursorValidState::RequireSeek;
         self.context = Some(cursor_context);
+        self.noted_payload = NotedPayload::NONE;
         // The tree is about to change under this cursor (that is the only reason a
         // position ever gets saved), so cached payload offsets and overflow page
         // numbers must not survive: blob I/O through them would touch relocated or
@@ -6516,8 +6537,12 @@ impl CursorTrait for BTreeCursor {
             let contents = page.get_contents();
             if contents.is_table() {
                 let cell_idx = self.stack.current_cell_index();
-                let rowid = contents.cell_table_leaf_read_rowid(cell_idx as usize)?;
-                Ok(IOResult::Done(Some(rowid)))
+                let cell = contents.cell_table_leaf_read_header(cell_idx as usize)?;
+                self.noted_payload = NotedPayload {
+                    start: cell.payload_start as u32,
+                    size: u32::try_from(cell.payload_size).unwrap_or(0),
+                };
+                Ok(IOResult::Done(Some(cell.rowid)))
             } else {
                 let _ = return_if_io!(self.record());
                 Ok(IOResult::Done(self.get_index_rowid_from_record()))
@@ -6606,6 +6631,20 @@ impl CursorTrait for BTreeCursor {
         if !self.has_record() {
             return Ok(IOResult::Done(None));
         }
+        let noted = self.noted_payload;
+        if noted.size != 0 {
+            let size = noted.size as usize;
+            let usable_space = self.usable_space();
+            // A cell that keeps its whole payload on the page: the rowid
+            // read already found where it starts.
+            if size <= payload_overflow_threshold_max(PageType::TableLeaf, usable_space) {
+                let start = noted.start as usize;
+                let contents = self.stack.top_ref().get_contents();
+                if let Some(payload) = contents.payload_on_page(start, size) {
+                    return Ok(IOResult::Done(Some(payload)));
+                }
+            }
+        }
         let cached = self
             .reusable_immutable_record
             .as_ref()
@@ -6629,6 +6668,7 @@ impl CursorTrait for BTreeCursor {
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     fn insert(&mut self, key: &BTreeKey) -> IOResultOr<()> {
         tracing::debug!(valid_state = ?self.valid_state, cursor_state = ?self.state, is_write_in_progress = self.is_write_in_progress());
+        self.noted_payload = NotedPayload::NONE;
         // saveAllCursors at the head of sqlite3BtreeInsert (btree.c:9348).
         return_if_io!(self.drive_pending_peer_save(key.maybe_rowid()));
         return_if_io!(self.insert_into_page(key));
@@ -6653,6 +6693,7 @@ impl CursorTrait for BTreeCursor {
     /// 9. SeekAfterBalancing -> adjust the cursor to a node that is closer to the deleted value. go to Finish
     /// 10. Finish -> Delete operation is done. Return CursorResult(Ok())
     fn delete(&mut self) -> IOResultOr<()> {
+        self.noted_payload = NotedPayload::NONE;
         if let CursorState::None = &self.state {
             // saveAllCursors at the head of sqlite3BtreeDelete (btree.c:9841). The
             // cursor is positioned on the row being deleted, so its rowid tells peer
@@ -7292,6 +7333,7 @@ impl CursorTrait for BTreeCursor {
 
     #[inline]
     fn invalidate_record(&mut self) {
+        self.noted_payload = NotedPayload::NONE;
         if let Some(record) = self.reusable_immutable_record.as_mut() {
             record.invalidate();
         }
@@ -7316,6 +7358,7 @@ impl CursorTrait for BTreeCursor {
     fn invalidate_btree_cache(&mut self) {
         self.stack.clear();
         self.has_record = false;
+        self.noted_payload = NotedPayload::NONE;
         self.move_to_right_state.1 = None;
         self.invalidate_count_cache();
         self.blob_cache.reset();

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -109,6 +109,16 @@ impl HeaderRefMut {
     }
 }
 
+/// The header of a table leaf cell: its rowid and where its payload starts.
+#[derive(Clone, Copy, Debug)]
+pub struct TableLeafCellHeader {
+    pub rowid: i64,
+    /// Offset of the first payload byte on the page.
+    pub payload_start: usize,
+    /// Size of the whole payload, overflow pages included.
+    pub payload_size: u64,
+}
+
 pub struct PageInner {
     pub flags: AtomicUsize,
     pub id: usize,
@@ -469,6 +479,22 @@ impl PageInner {
 
     #[inline(always)]
     pub fn cell_table_leaf_read_rowid(&self, idx: usize) -> crate::Result<i64> {
+        Ok(self.cell_table_leaf_read_header(idx)?.rowid)
+    }
+
+    /// The bytes at `start..start + size` of this page, None when the range
+    /// is not inside it. The slice is valid as long as the page is alive.
+    #[inline(always)]
+    pub fn payload_on_page(&self, start: usize, size: usize) -> Option<&'static [u8]> {
+        let payload = self.as_ptr().get(start..start + size)?;
+        // SAFETY: valid as long as page is alive
+        Some(unsafe { std::mem::transmute::<&[u8], &'static [u8]>(payload) })
+    }
+
+    /// Reads the two varints that start a table leaf cell: the payload size
+    /// and the rowid. The payload starts right after them.
+    #[inline(always)]
+    pub fn cell_table_leaf_read_header(&self, idx: usize) -> crate::Result<TableLeafCellHeader> {
         turso_debug_assert!(matches!(self.page_type(), Ok(PageType::TableLeaf)));
         let buf = self.as_ptr();
         let cell_pointer_array_start = self.header_size();
@@ -482,10 +508,15 @@ impl PageInner {
         );
         let cell_pointer = self.read_u16(cell_pointer) as usize;
         let mut pos = cell_pointer;
-        let (_, nr) = read_varint(crate::slice_in_bounds_or_corrupt!(buf, pos..))?;
+        let (payload_size, nr) = read_varint(crate::slice_in_bounds_or_corrupt!(buf, pos..))?;
         pos += nr;
-        let (rowid, _) = read_varint(crate::slice_in_bounds_or_corrupt!(buf, pos..))?;
-        Ok(rowid as i64)
+        let (rowid, nr) = read_varint(crate::slice_in_bounds_or_corrupt!(buf, pos..))?;
+        pos += nr;
+        Ok(TableLeafCellHeader {
+            rowid: rowid as i64,
+            payload_start: pos,
+            payload_size,
+        })
     }
 
     /// Returns a cell's record payload and overflow info without constructing

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -930,6 +930,15 @@ impl Page {
         self.get().flags.load(Ordering::Acquire) & PAGE_LOADED != 0
     }
 
+    /// `is_loaded` for a check that needs no ordering: the caller already
+    /// synchronized with the load of the page, so a relaxed read cannot
+    /// see the flag unset. Unlike the acquire read, it lets the compiler
+    /// keep values it read before the check in registers across it.
+    #[inline]
+    pub fn is_loaded_relaxed(&self) -> bool {
+        self.get().flags.load(Ordering::Relaxed) & PAGE_LOADED != 0
+    }
+
     #[inline]
     pub fn set_loaded(&self) {
         self.get().flags.fetch_or(PAGE_LOADED, Ordering::Release);

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1471,10 +1471,18 @@ pub struct Pager {
     /// each statement execution does not allocate and free a page-sized
     /// buffer per cursor.
     record_pool: Mutex<Vec<crate::types::RecordBuf>>,
+    /// Heap allocations of closed b-tree cursors, kept for the next cursor so
+    /// each statement execution does not allocate and free one per cursor.
+    /// The boxes are the point: each one is a cursor-sized allocation.
+    #[allow(clippy::vec_box)]
+    cursor_allocations: Mutex<Vec<Box<std::mem::MaybeUninit<crate::storage::btree::BTreeCursor>>>>,
 }
 
 /// Retired record buffers kept per pager. Each holds a page-sized allocation.
 const RECORD_POOL_SIZE: usize = 8;
+
+/// Retired cursor allocations kept per pager.
+const CURSOR_POOL_SIZE: usize = 8;
 
 /// Raw fat pointer to a registered cursor.
 ///
@@ -1764,7 +1772,27 @@ impl Pager {
             sync_type: AtomicFileSyncType::new(FileSyncType::Fsync),
             cursor_registry: Mutex::new(rustc_hash::FxHashMap::default()),
             record_pool: Mutex::new(Vec::new()),
+            cursor_allocations: Mutex::new(Vec::new()),
         })
+    }
+
+    /// An allocation retired by an earlier b-tree cursor on this pager, if any.
+    pub(crate) fn take_cursor_allocation(
+        &self,
+    ) -> Option<Box<std::mem::MaybeUninit<crate::storage::btree::BTreeCursor>>> {
+        self.cursor_allocations.lock().pop()
+    }
+
+    /// Keep the allocation of a closed b-tree cursor for the next cursor on
+    /// this pager. Extra allocations beyond the pool size are freed.
+    pub(crate) fn recycle_cursor_allocation(
+        &self,
+        allocation: Box<std::mem::MaybeUninit<crate::storage::btree::BTreeCursor>>,
+    ) {
+        let mut pool = self.cursor_allocations.lock();
+        if pool.len() < CURSOR_POOL_SIZE {
+            pool.push(allocation);
+        }
     }
 
     /// A record buffer retired by an earlier cursor on this pager, if any.

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -2709,8 +2709,10 @@ pub struct WalFile {
     max_frame: AtomicU64,
     /// Start of range to look for frames range=(minframe..max_frame)
     min_frame: AtomicU64,
-    /// Check of last frame in WAL, this is a cumulative checksum over all frames in the WAL
-    last_checksum: RwLock<(u32, u32)>,
+    /// Check of last frame in WAL, this is a cumulative checksum over all frames in the WAL.
+    /// Both halves packed into one word, high half first, so the connection
+    /// reads and writes it without a lock.
+    last_checksum: AtomicU64,
     checkpoint_seq: AtomicU32,
     transaction_count: AtomicU64,
 
@@ -3086,6 +3088,10 @@ enum TryBeginReadResult {
     Busy,
 }
 
+fn pack_checksum(checksum: (u32, u32)) -> u64 {
+    ((checksum.0 as u64) << 32) | checksum.1 as u64
+}
+
 impl WalFile {
     fn prepare_transformed_frame(
         buffer_pool: &Arc<BufferPool>,
@@ -3152,13 +3158,23 @@ impl WalFile {
         self.coordination.load_snapshot()
     }
 
+    fn last_checksum(&self) -> (u32, u32) {
+        let packed = self.last_checksum.load(Ordering::Acquire);
+        ((packed >> 32) as u32, packed as u32)
+    }
+
+    fn set_last_checksum(&self, checksum: (u32, u32)) {
+        self.last_checksum
+            .store(pack_checksum(checksum), Ordering::Release);
+    }
+
     /// Reconstruct the connection-local WAL state stored on this `WalFile`.
     fn connection_state(&self) -> WalConnectionState {
         WalConnectionState::new(
             WalSnapshot {
                 max_frame: self.max_frame.load(Ordering::Acquire),
                 nbackfills: self.min_frame.load(Ordering::Acquire).saturating_sub(1),
-                last_checksum: *self.last_checksum.read(),
+                last_checksum: self.last_checksum(),
                 checkpoint_seq: self.checkpoint_seq.load(Ordering::Acquire),
                 transaction_count: self.transaction_count.load(Ordering::Acquire),
             },
@@ -3172,7 +3188,7 @@ impl WalFile {
             .store(state.snapshot.max_frame, Ordering::Release);
         self.min_frame
             .store(state.snapshot.min_frame(), Ordering::Release);
-        *self.last_checksum.write() = state.snapshot.last_checksum;
+        self.set_last_checksum(state.snapshot.last_checksum);
         self.checkpoint_seq
             .store(state.snapshot.checkpoint_seq, Ordering::Release);
         self.transaction_count
@@ -3540,7 +3556,7 @@ impl Wal for WalFile {
             WalSnapshot {
                 max_frame,
                 nbackfills: self.min_frame.load(Ordering::Acquire).saturating_sub(1),
-                last_checksum: *self.last_checksum.read(),
+                last_checksum: self.last_checksum(),
                 checkpoint_seq: self.coordination.wal_header().checkpoint_seq,
                 transaction_count: self.transaction_count.load(Ordering::Acquire),
             },
@@ -3948,7 +3964,7 @@ impl Wal for WalFile {
         let offset = self.frame_offset(frame_id);
         let header = self.coordination.wal_header();
         let file = self.coordination.wal_file()?;
-        let previous_checksums = *self.last_checksum.read();
+        let previous_checksums = self.last_checksum();
         let page_number = u32::try_from(page_id).map_err(|_| LimboError::IntegerOverflow)?;
         let db_size = u32::try_from(db_size).map_err(|_| LimboError::IntegerOverflow)?;
         let page_transform = self.io_ctx.read().page_transform().clone();
@@ -4102,7 +4118,7 @@ impl Wal for WalFile {
     }
 
     fn get_last_checksum(&self) -> (u32, u32) {
-        *self.last_checksum.read()
+        self.last_checksum()
     }
     #[instrument(skip_all, level = Level::DEBUG)]
 
@@ -4149,7 +4165,7 @@ impl Wal for WalFile {
             .map(|r| r.checksum)
             .unwrap_or(snapshot.last_checksum);
         self.coordination.rollback_cache(max_frame);
-        *self.last_checksum.write() = last_checksum;
+        self.set_last_checksum(last_checksum);
         self.max_frame.store(max_frame, Ordering::Release);
         if !is_savepoint {
             self.reset_internal_states();
@@ -4245,7 +4261,7 @@ impl Wal for WalFile {
     #[instrument(skip_all, level = Level::DEBUG)]
     fn finish_append_frames_commit(&self) -> Result<()> {
         let max_frame = self.max_frame.load(Ordering::Acquire);
-        let last_checksum = *self.last_checksum.read();
+        let last_checksum = self.last_checksum();
         tracing::trace!(max_frame, ?last_checksum);
         let transaction_count = self.transaction_count.fetch_add(1, Ordering::AcqRel) + 1;
         self.coordination.publish_commit(WalCommitState {
@@ -4289,7 +4305,7 @@ impl Wal for WalFile {
         else {
             return Ok(None);
         };
-        *self.last_checksum.write() = (header.checksum_1, header.checksum_2);
+        self.set_last_checksum((header.checksum_1, header.checksum_2));
 
         self.max_frame.store(0, Ordering::Release);
         let file = self.coordination.wal_file()?;
@@ -4490,7 +4506,7 @@ impl Wal for WalFile {
                 self.complete_append_frame(page.get().id as u64, *frame_id, *checksum);
             }
             // Update rolling checksum
-            *self.last_checksum.write() = batch.final_checksum;
+            self.set_last_checksum(batch.final_checksum);
             // Advance max_frame and make frames visible to readers
             self.max_frame
                 .store(batch.final_max_frame, Ordering::Release);
@@ -4548,7 +4564,7 @@ impl Wal for WalFile {
         let mut rolling_checksum = if next_frame_id == 1 {
             (header.checksum_1, header.checksum_2)
         } else {
-            *self.last_checksum.read()
+            self.last_checksum()
         };
         // Build every frame in order, updating the rolling checksum
         for page in pages.iter() {
@@ -4633,7 +4649,7 @@ impl Wal for WalFile {
         // deadlock a caller that drives I/O from a single-threaded event loop.
         if let Some((_, last_frame_id, last_checksum)) = page_frame_and_checksum.last() {
             self.dirty.store(true, Ordering::Release);
-            *self.last_checksum.write() = *last_checksum;
+            self.set_last_checksum(*last_checksum);
             self.max_frame.store(*last_frame_id, Ordering::Release);
         }
 
@@ -4727,7 +4743,7 @@ impl WalFile {
             min_frame: AtomicU64::new(0),
             transaction_count: AtomicU64::new(0),
             max_frame_read_lock_index: AtomicUsize::new(NO_LOCK_HELD),
-            last_checksum: RwLock::new(last_checksum),
+            last_checksum: AtomicU64::new(pack_checksum(last_checksum)),
             checkpoint_guard: RwLock::new(None),
             io_ctx: RwLock::new(IOContext::default()),
             dirty: Arc::new(AtomicBool::new(false)),
@@ -4775,7 +4791,7 @@ impl WalFile {
 
     fn complete_append_frame(&self, page_id: u64, frame_id: u64, checksums: (u32, u32)) {
         self.dirty.store(true, Ordering::Release);
-        *self.last_checksum.write() = checksums;
+        self.set_last_checksum(checksums);
         self.max_frame.store(frame_id, Ordering::Release);
         self.coordination.cache_frame(page_id, frame_id);
     }
@@ -5251,7 +5267,7 @@ impl WalFile {
     }
 
     fn apply_restart_snapshot(&self, snapshot: WalSnapshot) {
-        *self.last_checksum.write() = snapshot.last_checksum;
+        self.set_last_checksum(snapshot.last_checksum);
         self.max_frame.store(snapshot.max_frame, Ordering::Release);
         self.min_frame.store(0, Ordering::Release);
         self.checkpoint_seq
@@ -7619,7 +7635,7 @@ pub mod test {
         assert_eq!(coordination.find_frame(9, 0, 30, None), Some(26));
         assert_eq!(coordination.find_frame(11, 0, 30, None), None);
         assert_eq!(wal.get_max_frame(), 27);
-        assert_eq!(*wal.last_checksum.read(), (13, 21));
+        assert_eq!(wal.last_checksum(), (13, 21));
 
         // Rolling back to the committed high-water mark discards every
         // spill.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2090,14 +2090,9 @@ fn op_column_fetch(
     else {
         return op_column_fetch_other(program, state, cursor_id, column, dest, default);
     };
-    if cursor.get_null_flag() {
-        tracing::trace!("op_column(null_flag)");
-        state.registers[dest].set_null();
-        return Ok(InsnFunctionStepResult::Step);
-    }
     let Some(payload) = return_if_io!(cursor.record_payload()) else {
-        // Cursor is not positioned on a valid row (e.g., empty table).
-        // Return NULL, not the column's default value.
+        // A null-row cursor, or one that is not positioned on a valid row
+        // (e.g., empty table). Return NULL, not the column's default value.
         state.registers[dest].set_null();
         return Ok(InsnFunctionStepResult::Step);
     };
@@ -2298,13 +2293,6 @@ fn op_column_range_fetch(
             defaults,
         );
     };
-    if cursor.get_null_flag() {
-        tracing::trace!("op_column_range(null_flag)");
-        for reg in &mut state.registers[dest..dest + count] {
-            reg.set_null();
-        }
-        return Ok(InsnFunctionStepResult::Step);
-    }
     let Some(payload) = return_if_io!(cursor.record_payload()) else {
         for reg in &mut state.registers[dest..dest + count] {
             reg.set_null();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -4125,7 +4125,7 @@ pub fn op_halt_if_null(
         },
         insn
     );
-    if state.registers[*target_reg].get_value() == &Value::Null {
+    if matches!(state.registers[*target_reg].get_value(), Value::Null) {
         halt(program, state, pager, *err_code, description, None)
     } else {
         state.pc += 1;
@@ -9837,7 +9837,7 @@ pub fn op_function(
                 let pattern_value = pattern_reg.get_value();
                 let match_value = match_reg.get_value();
 
-                if pattern_value == &Value::Null || match_value == &Value::Null {
+                if matches!(pattern_value, Value::Null) || matches!(match_value, Value::Null) {
                     state.registers[*dest].set_null();
                 } else {
                     let pattern_cow = match pattern_value {
@@ -9881,7 +9881,7 @@ pub fn op_function(
                 let match_value = match_reg.get_value();
 
                 // 1. Check for NULL inputs
-                if pattern_value == &Value::Null || match_value == &Value::Null {
+                if matches!(pattern_value, Value::Null) || matches!(match_value, Value::Null) {
                     state.registers[*dest].set_null();
                 } else {
                     // 2. Resolve Escape Character (if 3rd arg exists)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2095,16 +2095,13 @@ fn op_column_fetch(
         state.registers[dest].set_null();
         return Ok(InsnFunctionStepResult::Step);
     }
-    let Some(record) = return_if_io!(cursor.record()) else {
+    let Some(payload) = return_if_io!(cursor.record_payload()) else {
         // Cursor is not positioned on a valid row (e.g., empty table).
         // Return NULL, not the column's default value.
         state.registers[dest].set_null();
         return Ok(InsnFunctionStepResult::Step);
     };
-    match record
-        .iter()?
-        .nth_into_register(column, &mut state.registers[dest])
-    {
+    match ValueIterator::new(payload)?.nth_into_register(column, &mut state.registers[dest]) {
         Some(result) => result?,
         None => {
             branches::mark_unlikely();
@@ -2308,14 +2305,13 @@ fn op_column_range_fetch(
         }
         return Ok(InsnFunctionStepResult::Step);
     }
-    let Some(record) = return_if_io!(cursor.record()) else {
+    let Some(payload) = return_if_io!(cursor.record_payload()) else {
         for reg in &mut state.registers[dest..dest + count] {
             reg.set_null();
         }
         return Ok(InsnFunctionStepResult::Step);
     };
-    let filled = record
-        .iter()?
+    let filled = ValueIterator::new(payload)?
         .decode_into_registers_after(start_column, &mut state.registers[dest..dest + count])?;
     if filled < count {
         branches::mark_unlikely();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1321,11 +1321,12 @@ pub fn op_open_read(
             // This is a materialized view with storage
             // Create btree cursor for reading the persistent data
 
-            let btree_cursor = Box::new(BTreeCursor::new_table(
+            let btree_cursor = BTreeCursor::new_table(
                 pager.clone(),
                 maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                 num_columns,
-            ));
+            )
+            .into_boxed();
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
 
             // Get the view name and look up or create its transaction state
@@ -1357,18 +1358,20 @@ pub fn op_open_read(
                 .into());
             }
             let btree_cursor: Box<dyn CursorTrait> = if table.has_rowid {
-                Box::new(BTreeCursor::new_table(
+                BTreeCursor::new_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                     num_columns,
-                ))
+                )
+                .into_boxed()
             } else {
-                Box::new(BTreeCursor::new_without_rowid_table(
+                BTreeCursor::new_without_rowid_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                     table.as_ref(),
                     num_columns,
-                ))
+                )
+                .into_boxed()
             };
             let cursor = maybe_promote_to_mvcc_cursor(btree_cursor, MvccCursorType::Table)?;
             cursors
@@ -1377,12 +1380,13 @@ pub fn op_open_read(
                 .replace(Cursor::new_btree(cursor));
         }
         CursorType::BTreeIndex(index) => {
-            let btree_cursor = Box::new(BTreeCursor::new_index(
+            let btree_cursor = BTreeCursor::new_index(
                 pager,
                 maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                 index.as_ref(),
                 num_columns,
-            )?);
+            )?
+            .into_boxed();
             let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {
                 IndexInfo::new_from_index_in(index, mv_store.allocator())?
             } else {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3751,17 +3751,37 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
 #[inline]
 fn validate_utf8(data: &[u8]) -> Option<&str> {
     const ASCII_SCAN_CUTOFF: usize = 512;
-    if data.len() <= ASCII_SCAN_CUTOFF {
-        let mut acc = 0u8;
-        for &byte in data {
-            acc |= byte;
-        }
-        if acc.is_ascii() {
-            // SAFETY: all bytes are ASCII, which is valid UTF-8.
-            return Some(unsafe { core::str::from_utf8_unchecked(data) });
-        }
+    if data.len() <= ASCII_SCAN_CUTOFF && is_ascii(data) {
+        // SAFETY: all bytes are ASCII, which is valid UTF-8.
+        return Some(unsafe { core::str::from_utf8_unchecked(data) });
     }
     simdutf8::basic::from_utf8(data).ok()
+}
+
+/// ORs the bytes together a word at a time: eight, then four, two and one
+/// for the rest, so a value of any length takes at most `len / 8 + 3`
+/// loads. The loads are unaligned, so the slice's position on the page
+/// does not matter.
+#[inline]
+fn is_ascii(data: &[u8]) -> bool {
+    let mut acc = 0u64;
+    let mut rest = data;
+    while let Some((word, tail)) = rest.split_first_chunk::<8>() {
+        acc |= u64::from_ne_bytes(*word);
+        rest = tail;
+    }
+    if let Some((word, tail)) = rest.split_first_chunk::<4>() {
+        acc |= u64::from(u32::from_ne_bytes(*word));
+        rest = tail;
+    }
+    if let Some((word, tail)) = rest.split_first_chunk::<2>() {
+        acc |= u64::from(u16::from_ne_bytes(*word));
+        rest = tail;
+    }
+    if let Some(&byte) = rest.first() {
+        acc |= u64::from(byte);
+    }
+    acc & 0x8080_8080_8080_8080 == 0
 }
 
 #[cfg(test)]
@@ -3780,6 +3800,24 @@ mod tests {
         ));
         state.active_op_state.clear();
         assert!(state.active_op_state.parse_schema().is_none());
+    }
+
+    #[test]
+    fn is_ascii_checks_every_byte_of_every_length() {
+        for len in 0..40 {
+            let ascii: Vec<u8> = (0..len).map(|i| b'a' + (i % 26) as u8).collect();
+            assert!(is_ascii(&ascii), "length {len}");
+            assert_eq!(validate_utf8(&ascii), std::str::from_utf8(&ascii).ok());
+            for position in 0..len {
+                let mut bytes = ascii.clone();
+                bytes[position] = 0xc3;
+                assert!(!is_ascii(&bytes), "length {len}, byte {position}");
+                assert_eq!(validate_utf8(&bytes), std::str::from_utf8(&bytes).ok());
+            }
+        }
+        let text = "héllo wörld, ünïcödé";
+        assert!(!is_ascii(text.as_bytes()));
+        assert_eq!(validate_utf8(text.as_bytes()), Some(text));
     }
 
     #[test]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1098,7 +1098,9 @@ impl ProgramState {
             {
                 cursor.close(context);
             }
-            let _ = cursor.take();
+            if let Some(Cursor::BTree(cursor)) = cursor.take() {
+                cursor.recycle();
+            }
             *context = None;
         }
         for (mut cursor, context) in self.closed_index_method_cursors.drain(..) {

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -565,7 +565,7 @@ impl Value {
     }
 
     pub fn exec_instr(&self, pattern: &Value) -> Value {
-        if self == &Value::Null || pattern == &Value::Null {
+        if matches!(self, Value::Null) || matches!(pattern, Value::Null) {
             return Value::Null;
         }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -763,11 +763,14 @@ fn emit_condition_assert(
     let details = details_json(&input.details);
 
     let fmt_args = details_format_args(&msg, &input.details);
+    // Without the antithesis cfg, a debug assertion must not evaluate its
+    // condition in release builds: `debug_assert!` keeps the expression
+    // inside the `if cfg!(debug_assertions)` block, so the compiler can drop
+    // it together with the check. Binding it to `__turso_cond` first would
+    // keep every condition with a fallible or non-trivial callee alive.
     let assert_call = match kind {
-        ConditionAssertKind::Assert => quote! { assert!(__turso_cond, #fmt_args); },
-        ConditionAssertKind::DebugAssert => {
-            quote! { debug_assert!(__turso_cond, #fmt_args); }
-        }
+        ConditionAssertKind::Assert => quote! { assert!(#cond, #fmt_args); },
+        ConditionAssertKind::DebugAssert => quote! { debug_assert!(#cond, #fmt_args); },
     };
     let exit_msg = quote! {
         eprint!("[antithesis] assertion failed: ");
@@ -778,9 +781,9 @@ fn emit_condition_assert(
     let env_check = antithesis_env_check();
     quote! {
         {
-            let __turso_cond = #cond;
             #[cfg(antithesis)]
             {
+                let __turso_cond = #cond;
                 #env_check
                 antithesis_sdk::assert_always_or_unreachable!(__turso_cond, #prefixed, #details);
                 if !__turso_cond {


### PR DESCRIPTION
## Description

Part 5 of 15 split out of #8692 (commits 41-50 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits. The base branch of this PR carries commits 1-40; part 4 is open against `main` on its own.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### CodSpeed

Commits 1-42 (`191e0aab`, end of the per-statement work) vs `main`: [run 6a9bcec882847971dd44b6ee](https://codspeed.io/tursodatabase/turso/runs/6a9bcec882847971dd44b6ee), 144 improvements, 0 regressions, 2030 unchanged. Against the run of `e710ae7a`: 13 improvements, 0 regressions; the per-statement commits show as `limbo_execute_select_1` 12.3 µs → 9.6 µs (+28.2%) and the FTS query benchmarks, which run many short statements, +20% to +24%.

Later commits will be linked as their runs complete. The branch was force-pushed once at `2dfe2cb8`: that commit now carries the update of its own unit test, which the first push had left in the working tree.

### Measurement history: per-row costs

Callgrind instruction counts (`Ir`) are for 5 iterations of `SELECT 1 FROM t` and 3 iterations of the others. Wall clock is the best of 7 runs of one iteration on a noisy VM, so treat it as a sanity check only.

| Commit | SELECT 1 (Ir) | Δ | SELECT * (Ir) | Δ | W3 (Ir) | Δ | W4 (Ir) | Δ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `5c554dca` decode Column and ColumnRange from the page bytes without copying the record | 204,344,009 | +0.28% | 452,683,309 | -4.52% | 275,029,355 | -7.87% | 316,969,450 | -6.92% |
| `70a6a36c` evaluate turso_debug_assert conditions only in debug builds (the rowid read loses 8 per row; the rest is the inlining of `Program::step`, see below) | 207,366,183 | +1.48% | 451,116,424 | -0.35% | 277,470,462 | +0.89% | 319,821,829 | +0.90% |
| `4a115fee` let a column read reuse the cell position the rowid read found (`SELECT id FROM t`, rowid only: 230,631,086 → 232,927,598, +1.0%) | 204,328,736 | -1.46% | 421,331,222 | -6.60% | 279,018,856 | +0.56% | 320,960,498 | +0.36% |
| `eaab0a0e` answer Column from record_payload without a separate null-row call (`SELECT 1 FROM t` runs no Column: its delta is the inlining of `Program::step`) | 207,965,169 | +1.78% | 418,580,132 | -0.65% | 278,322,983 | -0.25% | 320,674,349 | -0.09% |
| `bcf4a534` check TEXT values for ASCII a word at a time (only `SELECT *` decodes TEXT) | 207,968,817 | 0.00% | 413,023,069 | -1.33% | 278,326,676 | 0.00% | 320,678,105 | 0.00% |
| `8fbebd79` check that the top page is loaded with a relaxed read (all of it inside the cursor functions) | 204,294,350 | -1.77% | 407,764,036 | -1.27% | 273,474,336 | -1.74% | 315,828,535 | -1.51% |

| Commit | Workload | before | after |
|---|---|---:|---:|
| `d172cfd6` test for NULL without comparing whole values | `SELECT count(*) FROM t WHERE name LIKE 'name_1%'` (W7) | 681,533,605 | 636,336,175 (-6.6%) |

### Measurement history: per-statement costs

The second half of the PR works on the fixed cost of executing a prepared statement once: transaction begin and commit, cursor open and close, statement reset, metrics. Measured as callgrind instructions per execution, taken as (Ir at 3000 executions − Ir at 1000 executions) / 2000 so the process start-up is cancelled out. Workloads: a point lookup `SELECT * FROM t WHERE id = 12345` (one `Transaction`, one `OpenRead`, one `SeekRowid`, `Column`, `Halt`), `SELECT 1` (no table, no transaction: the pure statement overhead), and an index lookup `SELECT id FROM t WHERE value = 500 LIMIT 1` (two cursors).

| Commit | point lookup | Δ | `SELECT 1` | Δ | index lookup | Δ |
|---|---:|---:|---:|---:|---:|---:|
| `972105fa` recycle the heap allocation of b-tree cursors through the pager | 8,055 | -2.2% | 1,801 | +0.4% | 13,560 | -1.9% |
| `191e0aab` keep the pinned root page across seeks of one cursor | 8,056 | 0.0% | | | 13,561 | 0.0% |
| `2dfe2cb8` keep the connection's WAL checksum in an atomic word | 8,016 | -0.5% | | | 13,518 | -0.3% |
| `5c554dca` decode Column and ColumnRange from the page bytes without copying the record | 7,878 | -1.7% | | | 13,527 | +0.1% |
| `70a6a36c` evaluate turso_debug_assert conditions only in debug builds | 7,532 | -4.4% | 1,813 | +0.7% | 13,605 | +0.6% |
| `4a115fee` let a column read reuse the cell position the rowid read found | 7,452 | -1.1% | 1,799 | -0.8% | 13,584 | -0.2% |
| `eaab0a0e` answer Column from record_payload without a separate null-row call | 7,457 | +0.1% | | | 13,606 | +0.2% |
| `bcf4a534` check TEXT values for ASCII a word at a time | 7,436 | -0.3% | | | | |
| `8fbebd79` check that the top page is loaded with a relaxed read | 7,409 | -0.4% | | | 13,574 | -0.2% |

The seek changes also show up per seek inside a statement. Over 3 x 5000 rowid seeks of `SELECT count(*) FROM t AS a JOIN t AS b ON b.id = a.id WHERE a.id <= 5000` (W6): 101,860,737 Ir at `4c0522c4` → 87,447,949 after `5213b9d1` (-14.1%) → 84,216,225 after `ae8316e9` (-3.7%) → 83,189,013 at `972105fa` → 78,811,525 after `191e0aab` (-5.3%); -22.6% in total.

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_