### PR TITLE
core: cut the cost of record builds, arithmetic and register reads (6/15)

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -839,12 +839,12 @@ pub struct BTreeCursor {
     stack: PageStack,
     /// Reusable immutable record, used to allow better allocation strategy.
     reusable_immutable_record: Option<ImmutableRecord>,
-    /// Where the payload of the table leaf cell under the cursor starts and
-    /// how big it is, noted by the rowid read so that a column read on the
-    /// same row does not parse the cell again (SQLite keeps the same in
-    /// BtCursor.info). Cleared wherever the reusable record is invalidated
-    /// and before every write through the cursor, because it holds an
-    /// offset into the page.
+    /// Where the payload of the cell under the cursor starts and how big it
+    /// is, noted by the rowid read and by a column read of a payload without
+    /// overflow, so that the next column read on the same row does not parse
+    /// the cell again (SQLite keeps the same in BtCursor.info). Cleared
+    /// wherever the reusable record is invalidated and before every write
+    /// through the cursor, because it holds an offset into the page.
     noted_payload: NotedPayload,
     /// Information about the index key structure (sort order, collation, etc)
     pub index_info: Option<Arc<IndexInfo>>,
@@ -6657,11 +6657,18 @@ impl CursorTrait for BTreeCursor {
             let page = self.stack.top_ref();
             let contents = page.get_contents();
             let cell_idx = self.stack.current_cell_index();
-            let (payload, _payload_size, first_overflow_page) =
-                contents.cell_read_payload_ptr(cell_idx as usize, self.usable_space())?;
+            let (payload, payload_start, _payload_size, first_overflow_page) =
+                contents.cell_read_payload_at(cell_idx as usize, self.usable_space())?;
             if first_overflow_page.is_none() {
                 // The whole record sits on the pinned page: decode it there
-                // instead of copying it into the reusable record first.
+                // instead of copying it into the reusable record first, and
+                // note where it is for the next column read on this row.
+                // Both fit in 32 bits: the payload lies inside a page of at
+                // most 64 KiB.
+                self.noted_payload = NotedPayload {
+                    start: payload_start as u32,
+                    size: payload.len() as u32,
+                };
                 return Ok(IOResult::Done(Some(payload)));
             }
         }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -533,6 +533,19 @@ impl PageInner {
         idx: usize,
         usable_size: usize,
     ) -> crate::Result<(&'static [u8], u64, Option<u32>)> {
+        let (payload, _, payload_size, first_overflow) =
+            self.cell_read_payload_at(idx, usable_size)?;
+        Ok((payload, payload_size, first_overflow))
+    }
+
+    /// [`Self::cell_read_payload_ptr`] with the offset of the payload on
+    /// the page in second place.
+    #[inline(always)]
+    pub fn cell_read_payload_at(
+        &self,
+        idx: usize,
+        usable_size: usize,
+    ) -> crate::Result<(&'static [u8], usize, u64, Option<u32>)> {
         let buf = self.as_ptr();
         let cell_pointer_array_start = self.header_size();
         let cell_pointer = cell_pointer_array_start + (idx * CELL_PTR_SIZE_BYTES);
@@ -615,7 +628,7 @@ impl PageInner {
             (slice, None)
         };
 
-        Ok((payload_slice, payload_size, first_overflow))
+        Ok((payload_slice, payload_start, payload_size, first_overflow))
     }
 
     #[inline]

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1117,7 +1117,7 @@ pub fn read_value<'a>(buf: &'a [u8], serial_type: SerialType) -> Result<(ValueRe
                     content_size
                 ))
             })?;
-            let val = simdutf8::basic::from_utf8(data).map_err(|_| {
+            let val = crate::types::validate_utf8(data).ok_or_else(|| {
                 mark_unlikely();
                 LimboError::Corrupt("TEXT value contains invalid UTF-8".into())
             })?;
@@ -1247,7 +1247,7 @@ pub fn read_value_serial_type<'a>(
                         content_size
                     ))
                 })?;
-                let val = simdutf8::basic::from_utf8(data).map_err(|_| {
+                let val = crate::types::validate_utf8(data).ok_or_else(|| {
                     mark_unlikely();
                     LimboError::Corrupt("TEXT value contains invalid UTF-8".into())
                 })?;

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1409,6 +1409,7 @@ pub fn varint_len(value: u64) -> usize {
     }
 }
 
+#[inline]
 pub fn write_varint(buf: &mut [u8], value: u64) -> usize {
     if value <= 0x7f {
         buf[0] = (value & 0x7f) as u8;

--- a/core/types.rs
+++ b/core/types.rs
@@ -1329,36 +1329,33 @@ mod immutable_record {
         }
     }
 
-    struct AppendWriter<'a> {
-        buf: &'a mut ValueBlob,
-        pos: usize,
-        buf_capacity_start: usize,
-        buf_ptr_start: *const u8,
-    }
-
-    impl<'a> AppendWriter<'a> {
-        fn new(buf: &'a mut ValueBlob, pos: usize) -> Self {
-            let buf_ptr_start = buf.as_ptr();
-            let buf_capacity_start = buf.capacity();
-            Self {
-                buf,
-                pos,
-                buf_capacity_start,
-                buf_ptr_start,
+    /// Writes the bytes of `value` for `serial_type` at the start of `out`
+    /// and returns how many it wrote.
+    #[inline(always)]
+    fn write_value(out: &mut [u8], value: ValueRef<'_>, serial_type: SerialType) -> usize {
+        let bytes: &[u8] = match value {
+            ValueRef::Null => return 0,
+            ValueRef::Numeric(Numeric::Integer(i)) => match serial_type.kind() {
+                SerialTypeKind::ConstInt0 | SerialTypeKind::ConstInt1 => return 0,
+                SerialTypeKind::I8 => &(i as i8).to_be_bytes(),
+                SerialTypeKind::I16 => &(i as i16).to_be_bytes(),
+                // Without the most significant byte.
+                SerialTypeKind::I24 => &(i as i32).to_be_bytes()[1..],
+                SerialTypeKind::I32 => &(i as i32).to_be_bytes(),
+                // Without the two most significant bytes.
+                SerialTypeKind::I48 => &i.to_be_bytes()[2..],
+                SerialTypeKind::I64 => &i.to_be_bytes(),
+                other => panic!("Serial type is not an integer: {other:?}"),
+            },
+            ValueRef::Numeric(Numeric::Float(f)) => {
+                let fval: f64 = f.into();
+                &fval.to_be_bytes()
             }
-        }
-
-        #[inline]
-        fn extend_from_slice(&mut self, slice: &[u8]) {
-            self.buf[self.pos..self.pos + slice.len()].copy_from_slice(slice);
-            self.pos += slice.len();
-        }
-
-        fn assert_finish_capacity(&self) {
-            // let's make sure we didn't reallocate anywhere else
-            assert_eq!(self.buf_capacity_start, self.buf.capacity());
-            assert_eq!(self.buf_ptr_start, self.buf.as_ptr());
-        }
+            ValueRef::Text(t) => t.value.as_bytes(),
+            ValueRef::Blob(b) => b,
+        };
+        out[..bytes.len()].copy_from_slice(bytes);
+        bytes.len()
     }
 
     #[inline(always)]
@@ -1750,6 +1747,7 @@ mod immutable_record {
         }
 
         /// Like [Self::from_registers], but serializes into `buf`; see [Self::build].
+        #[inline]
         pub fn build_from_registers<'a, I: Iterator<Item = &'a Register> + Clone>(
             registers: impl IntoIterator<Item = &'a Register, IntoIter = I>,
             buf: RecordBuf,
@@ -1769,6 +1767,7 @@ mod immutable_record {
         /// register's previous record buffer, making steady-state record
         /// construction allocation-free.
         #[turso_macros::allocation_site(crate::alloc::ValueBlobAllocationSite::RecordBuild)]
+        #[inline]
         pub fn build<'a>(
             values: impl IntoIterator<Item = impl AsValueRef + 'a> + Clone,
             buf: RecordBuf,
@@ -1777,9 +1776,8 @@ mod immutable_record {
             let mut size_header = 0;
             let mut size_values = 0;
 
-            let mut serial_type_buf = [0; 9];
-            // Sizing pass: the cloneable iterator is re-walked below to write
-            // the serial types, so no scratch buffer is needed.
+            // Sizing pass: the cloneable iterator is walked again below to
+            // write the serial types and the values.
             for value in values.clone() {
                 let serial_type = SerialType::from(value.as_value_ref());
                 size_header += varint_len(serial_type.into());
@@ -1787,63 +1785,24 @@ mod immutable_record {
             }
 
             let header_size = Record::calc_header_size(size_header);
-
-            // 1. write header size
             let total_size = header_size + size_values;
             buf.try_reserve_exact(total_size)?;
-            let n = write_varint(&mut serial_type_buf, header_size as u64);
-
             buf.resize(total_size, 0);
-            let mut writer = AppendWriter::new(&mut buf, 0);
-            writer.extend_from_slice(&serial_type_buf[..n]);
 
-            // 2. Write serial types
-            for value in values.clone() {
-                let serial_type = SerialType::from(value.as_value_ref());
-                let n = write_varint(&mut serial_type_buf[0..], serial_type.into());
-                writer.extend_from_slice(&serial_type_buf[..n]);
-            }
-
-            // write content
+            // Writing pass: each serial type goes into the header and each
+            // value after it, the varints straight into their place.
+            let mut header_pos = write_varint(&mut buf[..header_size], header_size as u64);
+            let mut value_pos = header_size;
             for value in values {
                 let value = value.as_value_ref();
-                match value {
-                    ValueRef::Null => {}
-                    ValueRef::Numeric(Numeric::Integer(i)) => {
-                        let serial_type = SerialType::from(value);
-                        match serial_type.kind() {
-                            SerialTypeKind::ConstInt0 | SerialTypeKind::ConstInt1 => {}
-                            SerialTypeKind::I8 => {
-                                writer.extend_from_slice(&(i as i8).to_be_bytes())
-                            }
-                            SerialTypeKind::I16 => {
-                                writer.extend_from_slice(&(i as i16).to_be_bytes())
-                            }
-                            SerialTypeKind::I24 => {
-                                writer.extend_from_slice(&(i as i32).to_be_bytes()[1..])
-                            } // remove most significant byte
-                            SerialTypeKind::I32 => {
-                                writer.extend_from_slice(&(i as i32).to_be_bytes())
-                            }
-                            SerialTypeKind::I48 => writer.extend_from_slice(&i.to_be_bytes()[2..]), // remove 2 most significant bytes
-                            SerialTypeKind::I64 => writer.extend_from_slice(&i.to_be_bytes()),
-                            other => panic!("Serial type is not an integer: {other:?}"),
-                        }
-                    }
-                    ValueRef::Numeric(Numeric::Float(f)) => {
-                        let fval: f64 = f.into();
-                        writer.extend_from_slice(&fval.to_be_bytes());
-                    }
-                    ValueRef::Text(t) => {
-                        writer.extend_from_slice(t.value.as_bytes());
-                    }
-                    ValueRef::Blob(b) => {
-                        writer.extend_from_slice(b);
-                    }
-                };
+                let serial_type = SerialType::from(value);
+                header_pos += write_varint(&mut buf[header_pos..header_size], serial_type.into());
+                value_pos += write_value(&mut buf[value_pos..], value, serial_type);
             }
-
-            writer.assert_finish_capacity();
+            crate::turso_assert!(
+                header_pos == header_size && value_pos == total_size,
+                "record sizing pass and writing pass disagree"
+            );
             Ok(Self {
                 payload: Value::Blob(buf),
             })

--- a/core/types.rs
+++ b/core/types.rs
@@ -102,6 +102,61 @@ impl Text {
     }
 }
 
+/// UTF-8 validation tuned for record decoding. TEXT values are usually short
+/// ASCII read at arbitrary offsets inside a b-tree page: simdutf8 only uses
+/// SIMD from 64 bytes up, and core's `from_utf8` word-at-a-time path is
+/// alignment-sensitive, so both are slow here. OR-ing every byte together is
+/// alignment-independent and branch-light; if no byte had the high bit set
+/// the value is pure ASCII and needs no further validation. Non-ASCII and
+/// values longer than the cutoff fall back to full simdutf8 validation —
+/// above the cutoff the scalar OR loop loses to real SIMD.
+///
+/// Measured by `core/benches/text_validate_benchmark.rs` (varying slice
+/// alignment, ASCII content) on an Apple M2, macOS 15.7, vs
+/// `simdutf8::basic::from_utf8` alone:
+///
+///   1-128 B:  1.4-4x faster (peak 4.1x at 16 B)
+///   256-512 B: 1.1-1.2x faster
+///   1-2 KB:   parity
+///   4 KB:     ~25% slower without the cutoff; equal with it
+///   multibyte fallback: pays the wasted OR scan (~15% at 64 B)
+///   length branch: ~+0.1ns/call, visible only on 1-2 B values
+#[inline]
+pub(crate) fn validate_utf8(data: &[u8]) -> Option<&str> {
+    const ASCII_SCAN_CUTOFF: usize = 512;
+    if data.len() <= ASCII_SCAN_CUTOFF && is_ascii(data) {
+        // SAFETY: all bytes are ASCII, which is valid UTF-8.
+        return Some(unsafe { core::str::from_utf8_unchecked(data) });
+    }
+    simdutf8::basic::from_utf8(data).ok()
+}
+
+/// ORs the bytes together a word at a time: eight, then four, two and one
+/// for the rest, so a value of any length takes at most `len / 8 + 3`
+/// loads. The loads are unaligned, so the slice's position on the page
+/// does not matter.
+#[inline]
+pub(crate) fn is_ascii(data: &[u8]) -> bool {
+    let mut acc = 0u64;
+    let mut rest = data;
+    while let Some((word, tail)) = rest.split_first_chunk::<8>() {
+        acc |= u64::from_ne_bytes(*word);
+        rest = tail;
+    }
+    if let Some((word, tail)) = rest.split_first_chunk::<4>() {
+        acc |= u64::from(u32::from_ne_bytes(*word));
+        rest = tail;
+    }
+    if let Some((word, tail)) = rest.split_first_chunk::<2>() {
+        acc |= u64::from(u16::from_ne_bytes(*word));
+        rest = tail;
+    }
+    if let Some(&byte) = rest.first() {
+        acc |= u64::from(byte);
+    }
+    acc & 0x8080_8080_8080_8080 == 0
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct TextRef<'a> {
     pub value: &'a str,
@@ -3660,6 +3715,25 @@ mod tests {
     use super::*;
     use crate::alloc::vec;
     use crate::translate::collate::CollationSeq;
+
+    #[test]
+    fn is_ascii_checks_every_byte_of_every_length() {
+        for len in 0..40 {
+            let mut ascii: Vec<u8> = vec![];
+            ascii.extend((0..len).map(|i| b'a' + (i % 26) as u8));
+            assert!(is_ascii(&ascii), "length {len}");
+            assert_eq!(validate_utf8(&ascii), std::str::from_utf8(&ascii).ok());
+            for position in 0..len {
+                let mut bytes = ascii.clone();
+                bytes[position] = 0xc3;
+                assert!(!is_ascii(&bytes), "length {len}, byte {position}");
+                assert_eq!(validate_utf8(&bytes), std::str::from_utf8(&bytes).ok());
+            }
+        }
+        let text = "héllo wörld, ünïcödé";
+        assert!(!is_ascii(text.as_bytes()));
+        assert_eq!(validate_utf8(text.as_bytes()), Some(text));
+    }
 
     fn assert_integer_conversions<T>(in_range: &[(i64, T)], out_of_range: &[i64])
     where

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -2083,12 +2083,17 @@ fn op_column_fetch(
     dest: usize,
     default: &Option<Value>,
 ) -> InsnResult {
-    let Some(Cursor::BTree(cursor)) = state
+    let cursor = match state
         .cursors
         .get_mut(cursor_id)
         .unwrap_or_else(|| panic!("cursor id {cursor_id} out of bounds"))
-    else {
-        return op_column_fetch_other(program, state, cursor_id, column, dest, default);
+    {
+        Some(Cursor::BTree(cursor)) => cursor,
+        Some(Cursor::Pseudo(pseudo)) => {
+            let content_reg = pseudo.content_reg();
+            return op_column_fetch_pseudo(state, content_reg, column, dest);
+        }
+        _ => return op_column_fetch_other(program, state, cursor_id, column, dest, default),
     };
     let Some(payload) = return_if_io!(cursor.record_payload()) else {
         // A null-row cursor, or one that is not positioned on a valid row
@@ -2103,6 +2108,48 @@ fn op_column_fetch(
             // The record has fewer columns than expected.
             apply_column_default(default, &mut state.registers[dest])?;
         }
+    }
+    Ok(InsnFunctionStepResult::Step)
+}
+
+/// Column for a pseudo cursor: decodes the record in its content register.
+fn op_column_fetch_pseudo(
+    state: &mut ProgramState,
+    content_reg: usize,
+    column: usize,
+    dest: usize,
+) -> InsnResult {
+    // The record is read while decoding into the destination register,
+    // so the two registers must be distinct.
+    let [content, dest_reg] = state
+        .registers
+        .get_disjoint_mut([content_reg, dest])
+        .map_err(|_| {
+            LimboError::InternalError(format!(
+                "Column: pseudo-cursor content register {content_reg} and destination register {dest} must be distinct"
+            ))
+        })?;
+    match content {
+        Register::Record(record) => {
+            // Decode straight into the register; going through an owned
+            // Value would allocate for every TEXT/BLOB column on every row.
+            let mut payload_iterator = record.iter()?;
+            match payload_iterator.nth_into_register(column, dest_reg) {
+                Some(result) => result?,
+                // A pseudo cursor is opened with num_fields matching the
+                // record built for it, so every emitted Column index is in
+                // range. NULL on a missing column matches the b-tree arm.
+                None => {
+                    turso_debug_assert!(
+                        false,
+                        "pseudo-cursor column out of range for record",
+                        { "column": column }
+                    );
+                    dest_reg.set_null();
+                }
+            }
+        }
+        _ => dest_reg.set_null(),
     }
     Ok(InsnFunctionStepResult::Step)
 }
@@ -2203,38 +2250,7 @@ fn op_column_fetch_other(
             let content_reg = crate::get_cursor!(state, cursor_id)
                 .as_pseudo_mut()
                 .content_reg();
-            // The record is read while decoding into the destination register,
-            // so the two registers must be distinct.
-            let [content, dest_reg] = state
-                .registers
-                .get_disjoint_mut([content_reg, dest])
-                .map_err(|_| {
-                    LimboError::InternalError(format!(
-                        "Column: pseudo-cursor content register {content_reg} and destination register {dest} must be distinct"
-                    ))
-                })?;
-            match content {
-                Register::Record(record) => {
-                    // Decode straight into the register; going through an owned
-                    // Value would allocate for every TEXT/BLOB column on every row.
-                    let mut payload_iterator = record.iter()?;
-                    match payload_iterator.nth_into_register(column, dest_reg) {
-                        Some(result) => result?,
-                        // A pseudo cursor is opened with num_fields matching the
-                        // record built for it, so every emitted Column index is in
-                        // range. NULL on a missing column matches the b-tree arm.
-                        None => {
-                            turso_debug_assert!(
-                                false,
-                                "pseudo-cursor column out of range for record",
-                                { "column": column }
-                            );
-                            dest_reg.set_null();
-                        }
-                    }
-                }
-                _ => dest_reg.set_null(),
-            }
+            return op_column_fetch_pseudo(state, content_reg, column, dest);
         }
         CursorType::IndexMethod(..) => {
             let cursor = state.cursors[cursor_id]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -832,6 +832,20 @@ pub fn op_compare(
         return Err(LimboError::InternalError("Compare registers overlap".to_string()).into());
     }
 
+    // One integer against another needs no collation and no NULL order:
+    // the case of every GROUP BY on an integer key.
+    if key_info.len() == 1 {
+        if let Some((a, b)) = integer_operands(state, start_reg_a, start_reg_b) {
+            let cmp = a.cmp(&b);
+            state.last_compare = Some(match key_info[0].sort_order {
+                turso_parser::ast::SortOrder::Asc => cmp,
+                turso_parser::ast::SortOrder::Desc => cmp.reverse(),
+            });
+            state.pc += 1;
+            return Ok(InsnFunctionStepResult::Step);
+        }
+    }
+
     // (https://github.com/tursodatabase/turso/issues/2304): reusing logic from compare_immutable().
     // TODO: There are tons of cases like this where we could reuse this in a similar vein
     let a_range =

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -549,13 +549,14 @@ pub fn op_remainder(
     _pager: &Arc<Pager>,
 ) -> InsnResult {
     load_insn!(Remainder { lhs, rhs, dest }, insn);
-    state.registers[*dest].set_value(
-        state.registers[*lhs]
-            .get_value()
-            .exec_remainder(state.registers[*rhs].get_value()),
-    );
-    state.pc += 1;
-    Ok(InsnFunctionStepResult::Step)
+    // A zero divisor gives NULL and i64::MIN % -1 overflows: both stay on
+    // the slow path, which handles them like every other operand mix.
+    if let Some(result) = integer_operands(state, *lhs, *rhs).and_then(|(l, r)| l.checked_rem(r)) {
+        state.registers[*dest].set_int(result);
+        state.pc += 1;
+        return Ok(InsnFunctionStepResult::Step);
+    }
+    op_arithmetic_slow(state, *lhs, *rhs, *dest, Value::exec_remainder)
 }
 
 pub fn op_bit_and(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -511,13 +511,14 @@ pub fn op_divide(
     _pager: &Arc<Pager>,
 ) -> InsnResult {
     load_insn!(Divide { lhs, rhs, dest }, insn);
-    state.registers[*dest].set_value(
-        state.registers[*lhs]
-            .get_value()
-            .exec_divide(state.registers[*rhs].get_value()),
-    );
-    state.pc += 1;
-    Ok(InsnFunctionStepResult::Step)
+    // A zero divisor (NULL) and i64::MIN / -1 (a float quotient) stay on
+    // the slow path, which handles them like every other operand mix.
+    if let Some(result) = integer_operands(state, *lhs, *rhs).and_then(|(l, r)| l.checked_div(r)) {
+        state.registers[*dest].set_int(result);
+        state.pc += 1;
+        return Ok(InsnFunctionStepResult::Step);
+    }
+    op_arithmetic_slow(state, *lhs, *rhs, *dest, Value::exec_divide)
 }
 
 pub fn op_drop_index(
@@ -566,13 +567,12 @@ pub fn op_bit_and(
     _pager: &Arc<Pager>,
 ) -> InsnResult {
     load_insn!(BitAnd { lhs, rhs, dest }, insn);
-    state.registers[*dest].set_value(
-        state.registers[*lhs]
-            .get_value()
-            .exec_bit_and(state.registers[*rhs].get_value()),
-    );
-    state.pc += 1;
-    Ok(InsnFunctionStepResult::Step)
+    if let Some((l, r)) = integer_operands(state, *lhs, *rhs) {
+        state.registers[*dest].set_int(l & r);
+        state.pc += 1;
+        return Ok(InsnFunctionStepResult::Step);
+    }
+    op_arithmetic_slow(state, *lhs, *rhs, *dest, Value::exec_bit_and)
 }
 
 pub fn op_bit_or(
@@ -582,13 +582,12 @@ pub fn op_bit_or(
     _pager: &Arc<Pager>,
 ) -> InsnResult {
     load_insn!(BitOr { lhs, rhs, dest }, insn);
-    state.registers[*dest].set_value(
-        state.registers[*lhs]
-            .get_value()
-            .exec_bit_or(state.registers[*rhs].get_value()),
-    );
-    state.pc += 1;
-    Ok(InsnFunctionStepResult::Step)
+    if let Some((l, r)) = integer_operands(state, *lhs, *rhs) {
+        state.registers[*dest].set_int(l | r);
+        state.pc += 1;
+        return Ok(InsnFunctionStepResult::Step);
+    }
+    op_arithmetic_slow(state, *lhs, *rhs, *dest, Value::exec_bit_or)
 }
 
 pub fn op_bit_not(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3268,7 +3268,7 @@ pub fn op_make_record(
     let buf = state.registers[dest_reg].take_buf();
     let regs = &state.registers[start_reg..start_reg + count];
     let record = ImmutableRecord::build_from_registers(regs, buf)?;
-    state.registers[dest_reg] = Register::Record(record);
+    state.registers[dest_reg].put_record_into_null_register(record);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -5954,10 +5954,7 @@ pub fn op_row_data(
 
         ImmutableRecord::copy_payload(record.get_payload(), buf)?
     };
-
-    let reg = &mut state.registers[*dest];
-    *reg = Register::Record(record);
-
+    state.registers[*dest].put_record_into_null_register(record);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }
@@ -9159,7 +9156,7 @@ pub fn op_sorter_data(
             .take_current(buf)
             .expect("sorter record checked above")
     };
-    state.registers[*dest_reg] = Register::Record(record);
+    state.registers[*dest_reg].put_record_into_null_register(record);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3681,7 +3681,7 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
                 }
                 self.set_data_section(&data[content_size..]);
                 let text_data = &data[..content_size];
-                let Some(text_str) = validate_utf8(text_data) else {
+                let Some(text_str) = crate::types::validate_utf8(text_data) else {
                     mark_unlikely();
                     return Some(Err(LimboError::Corrupt(
                         "TEXT value contains invalid UTF-8".into(),
@@ -3729,61 +3729,6 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
     }
 }
 
-/// UTF-8 validation tuned for record decoding. TEXT values are usually short
-/// ASCII read at arbitrary offsets inside a b-tree page: simdutf8 only uses
-/// SIMD from 64 bytes up, and core's `from_utf8` word-at-a-time path is
-/// alignment-sensitive, so both are slow here. OR-ing every byte together is
-/// alignment-independent and branch-light; if no byte had the high bit set
-/// the value is pure ASCII and needs no further validation. Non-ASCII and
-/// values longer than the cutoff fall back to full simdutf8 validation —
-/// above the cutoff the scalar OR loop loses to real SIMD.
-///
-/// Measured by `core/benches/text_validate_benchmark.rs` (varying slice
-/// alignment, ASCII content) on an Apple M2, macOS 15.7, vs
-/// `simdutf8::basic::from_utf8` alone:
-///
-///   1-128 B:  1.4-4x faster (peak 4.1x at 16 B)
-///   256-512 B: 1.1-1.2x faster
-///   1-2 KB:   parity
-///   4 KB:     ~25% slower without the cutoff; equal with it
-///   multibyte fallback: pays the wasted OR scan (~15% at 64 B)
-///   length branch: ~+0.1ns/call, visible only on 1-2 B values
-#[inline]
-fn validate_utf8(data: &[u8]) -> Option<&str> {
-    const ASCII_SCAN_CUTOFF: usize = 512;
-    if data.len() <= ASCII_SCAN_CUTOFF && is_ascii(data) {
-        // SAFETY: all bytes are ASCII, which is valid UTF-8.
-        return Some(unsafe { core::str::from_utf8_unchecked(data) });
-    }
-    simdutf8::basic::from_utf8(data).ok()
-}
-
-/// ORs the bytes together a word at a time: eight, then four, two and one
-/// for the rest, so a value of any length takes at most `len / 8 + 3`
-/// loads. The loads are unaligned, so the slice's position on the page
-/// does not matter.
-#[inline]
-fn is_ascii(data: &[u8]) -> bool {
-    let mut acc = 0u64;
-    let mut rest = data;
-    while let Some((word, tail)) = rest.split_first_chunk::<8>() {
-        acc |= u64::from_ne_bytes(*word);
-        rest = tail;
-    }
-    if let Some((word, tail)) = rest.split_first_chunk::<4>() {
-        acc |= u64::from(u32::from_ne_bytes(*word));
-        rest = tail;
-    }
-    if let Some((word, tail)) = rest.split_first_chunk::<2>() {
-        acc |= u64::from(u16::from_ne_bytes(*word));
-        rest = tail;
-    }
-    if let Some(&byte) = rest.first() {
-        acc |= u64::from(byte);
-    }
-    acc & 0x8080_8080_8080_8080 == 0
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3800,24 +3745,6 @@ mod tests {
         ));
         state.active_op_state.clear();
         assert!(state.active_op_state.parse_schema().is_none());
-    }
-
-    #[test]
-    fn is_ascii_checks_every_byte_of_every_length() {
-        for len in 0..40 {
-            let ascii: Vec<u8> = (0..len).map(|i| b'a' + (i % 26) as u8).collect();
-            assert!(is_ascii(&ascii), "length {len}");
-            assert_eq!(validate_utf8(&ascii), std::str::from_utf8(&ascii).ok());
-            for position in 0..len {
-                let mut bytes = ascii.clone();
-                bytes[position] = 0xc3;
-                assert!(!is_ascii(&bytes), "length {len}, byte {position}");
-                assert_eq!(validate_utf8(&bytes), std::str::from_utf8(&bytes).ok());
-            }
-        }
-        let text = "héllo wörld, ünïcödé";
-        assert!(!is_ascii(text.as_bytes()));
-        assert_eq!(validate_utf8(text.as_bytes()), Some(text));
     }
 
     #[test]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1617,9 +1617,21 @@ pub enum EndStatement {
 }
 
 impl Register {
+    #[inline]
     pub fn get_value(&self) -> &Value {
         match self {
             Register::Value(v) => v,
+            _ => self.get_value_of_other(),
+        }
+    }
+
+    /// The value of a register that holds no plain value: a record reads as
+    /// its blob, anything else is a bug. Kept out of line so that
+    /// `get_value` inlines as a tag check.
+    #[cold]
+    #[inline(never)]
+    fn get_value_of_other(&self) -> &Value {
+        match self {
             Register::Record(r) => {
                 turso_assert!(!r.is_invalidated());
                 r.as_blob_value()

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -327,6 +327,23 @@ impl Register {
         }
     }
 
+    /// Puts `record` into a register and leaks the register's previous value. We do this, because
+    /// the drop glue could not be inlined and was too costly.
+    ///
+    /// Precondition: The register must contain [Value::Null]. It would also be safe to use on any
+    /// [Value] that doesn't own heap memory, but enforcing [Value::Null] is simpler for now.
+    #[aristo::intent(
+        "The function is only called on a register that contains Value::Null.",
+        verify = "full",
+        id = "register_previously_contained_null"
+    )]
+    #[inline]
+    pub fn put_record_into_null_register(&mut self, record: ImmutableRecord) {
+        let emptied = std::mem::replace(self, Register::Record(record));
+        turso_debug_assert!(matches!(emptied, Register::Value(Value::Null)));
+        std::mem::forget(emptied);
+    }
+
     /// Fallibly sets the register to a copy of `val`, reusing the register's
     /// existing allocation when possible; see [Value::try_clone_from].
     #[inline]

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -900,7 +900,7 @@ impl ArenaSortableRecord {
         let mut payload_iter = ValueIterator::new(payload)?;
 
         let mut key_values = bumpalo::collections::Vec::new_in(arena);
-        key_values.try_reserve(payload_iter.clone().count())?;
+        key_values.try_reserve(key_len)?;
         for _ in 0..key_len {
             let value = match payload_iter.next() {
                 Some(Ok(v)) => v,


### PR DESCRIPTION
## Description

Part 6 of 15 split out of #8692 (commits 51-60 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### CodSpeed

Commits 1-53 (`e26a6fd7`) vs `main`: [run 6a9be90353fe8399e6f4ab02](https://codspeed.io/tursodatabase/turso/runs/6a9be90353fe8399e6f4ab02), 156 improvements, 0 regressions, 1372 unchanged, 14 new. CodSpeed skipped 781 comparisons because the two runs did not share an identical environment (the report lists different libc builds and CPU flags on the runners); the skipped ones are mostly the syscall-dominated write and FTS benchmarks.

Commits 1-59 (`d94d18c2`) vs `main`: [run 6a9bf03a94e35f3469fc65f4](https://codspeed.io/tursodatabase/turso/runs/6a9bf03a94e35f3469fc65f4), 156 improvements, 0 regressions, 2018 unchanged, 28 new, 135 skipped. Against the run of `e26a6fd7`: no benchmark moved past CodSpeed's reporting threshold in either direction (2188 unchanged); the record-build, arithmetic and sorter commits in between show only in the local measurements below. The tracked benchmarks are within noise of the `e26a6fd7` run (`select_one_100k` 13.3 ms, `select_star_100k` 40.1 ms, `count_text_col` 247.6 ms, `limbo_execute_select_1` 9.9 µs).

Commits 1-63 (`49fd58b1`) vs `main`: [run 6a9bf85f56074e7b4ca48a21](https://codspeed.io/tursodatabase/turso/runs/6a9bf85f56074e7b4ca48a21), 169 improvements, 0 regressions, 1386 unchanged, 28 new, 754 skipped (environment difference between the runners again). Against the run of `d94d18c2`: 8 improvements, 0 regressions, all of them the LIKE and text benchmarks of `sql_functions/value.rs` (`construct_like_complex` 2,074 ns → 984 ns, `construct_like_contains` 1,769 ns → 890 ns, `construct_like_with_single_wildcard` 1,544 ns → 818 ns, `length_unicode_text` 1,249 ns → 832 ns).

Commits 1-72 (`b17c0692`) vs `main`: [run 6a9c05c428e57d31b0813f52](https://codspeed.io/tursodatabase/turso/runs/6a9c05c428e57d31b0813f52), 183 improvements, 0 regressions, 1372 unchanged, 28 new, 754 skipped. Against the run of `4558f126`: nothing past the reporting threshold (1583 unchanged). Some benchmarks move by several percent between runs in both directions without a change on their path: `count_filtered[1000000]` went 157.7 ms → 170.9 ms here after 169.3 ms → 156.7 ms between the `d94d18c2` and `49fd58b1` runs; CodSpeed classifies both moves as unchanged, and the local callgrind count of the matching workload (W4) for this head went down 1%.

### Measurement history: per-row costs

Callgrind instruction counts (`Ir`) are for 5 iterations of `SELECT 1 FROM t` and 3 iterations of the others. Wall clock is the best of 7 runs of one iteration on a noisy VM, so treat it as a sanity check only.

| Commit | Workload | before | after |
|---|---|---:|---:|
| `e26a6fd7` validate TEXT values of records with the ASCII fast path | `SELECT * FROM t ORDER BY name DESC LIMIT 10` (W9) | 1,132,011,165 | 1,088,596,960 (-3.8%) |
| | `SELECT value % 100, count(*) FROM t GROUP BY value % 100` (W8) | 1,142,233,009 | 1,137,269,595 (-0.4%) |
| `938bb71f` build records in two passes with the varints written in place | W8 | 1,137,269,595 | 1,119,553,617 (-1.6%) |
| | W9 | 1,088,596,960 | 1,061,427,316 (-2.5%) |
| `2f1f8517` put a built record into its register without the drop glue | W8 | 1,119,553,617 | 1,102,115,272 (-1.6%) |
| | W9 | 1,061,427,316 | 1,052,700,201 (-0.8%) |
| `880cbe6c` integer fast path for Remainder | W8 | 1,102,115,272 | 1,041,539,554 (-5.5%) |
| `ee55fc72` integer fast paths for Divide, BitAnd and BitOr | `SELECT sum(value / 7), sum(value & 255), sum(value \| 1) FROM t` (W10) | 765,890,643 | 687,890,938 (-10.2%) |
| `78e413c3` note the payload position on a column read as well | W10 (three Column per row) | 687,890,938 | 640,412,350 (-6.9%) |
| | W3 and W4 (one Column per row): the two stores of the note | 272,220,828 / 314,165,269 | 274,276,090 (+0.8%) / 316,628,656 (+0.8%) |
| `d94d18c2` read pseudo-cursor columns without the cursor-type detour | W8 | 1,047,306,717 | 1,035,649,564 (-1.1%) |
| `9d073ea7` compare one integer key without the generic column comparison | W8 | 1,035,649,564 | 978,852,246 (-5.5%) |
| `3b0320f5` size the sorter's key vector by the key length | W8 | 978,852,246 | 970,052,541 (-0.9%) |
| | W9 | 1,052,244,518 | 1,035,450,781 (-1.6%) |
| `9649d2fd` inline the register value accessor, its rare cases out of line | W7 | 637,536,173 | 627,429,535 (-1.6%) |
| | W8 | 970,052,541 | 960,621,200 (-1.0%) |

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_