### PR TITLE
core: Optimize LIKE, insert path and statement step

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -818,6 +818,8 @@ pub struct BTreeCursor {
     /// 1. an uninitialized database,
     /// 2. an initialized database when the command is immediately followed by VACUUM.
     usable_space_cached: usize,
+    /// The overflow limits for the usable space above
+    payload_limits: PayloadLimits,
     /// Page id of the root page used to go back up fast.
     root_page: i64,
     /// Rowid and record are stored before being consumed.
@@ -1144,6 +1146,7 @@ impl BTreeCursor {
             pager,
             root_page,
             usable_space_cached: usable_space,
+            payload_limits: PayloadLimits::new(usable_space),
             has_record: false,
             null_flag: false,
             going_upwards: false,
@@ -2207,7 +2210,7 @@ impl BTreeCursor {
                 .stack
                 .get_page_contents_at_level(old_top_idx)
                 .unwrap()
-                .cell_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
+                .cell_read_payload_ptr(cur_cell_idx as usize, self.payload_limits)?;
 
             if let Some(next_page) = first_overflow_page {
                 let res = self.process_overflow_read(payload, next_page, payload_size)?;
@@ -2727,7 +2730,7 @@ impl BTreeCursor {
             .stack
             .get_page_contents_at_level(old_top_idx)
             .unwrap()
-            .cell_read_payload_ptr(cur_cell_idx as usize, self.usable_space())?;
+            .cell_read_payload_ptr(cur_cell_idx as usize, self.payload_limits)?;
 
         if let Some(next_page) = first_overflow_page {
             let res = self.process_overflow_read(payload, next_page, payload_size)?;
@@ -6643,7 +6646,7 @@ impl CursorTrait for BTreeCursor {
         let contents = page.get_contents();
         let cell_idx = self.stack.current_cell_index();
         let (payload, payload_size, first_overflow_page) =
-            contents.cell_read_payload_ptr(cell_idx as usize, self.usable_space())?;
+            contents.cell_read_payload_ptr(cell_idx as usize, self.payload_limits)?;
         if let Some(next_page) = first_overflow_page {
             return_if_io!(self.process_overflow_read(payload, next_page, payload_size))
         } else {
@@ -6667,10 +6670,9 @@ impl CursorTrait for BTreeCursor {
         let noted = self.noted_payload;
         if noted.size != 0 {
             let size = noted.size as usize;
-            let usable_space = self.usable_space();
             // A cell that keeps its whole payload on the page: the rowid
             // read already found where it starts.
-            if size <= payload_overflow_threshold_max(PageType::TableLeaf, usable_space) {
+            if size <= self.payload_limits.max_local_table {
                 let start = noted.start as usize;
                 let contents = self.stack.top_ref().get_contents();
                 if let Some(payload) = contents.payload_on_page(start, size) {
@@ -6687,7 +6689,7 @@ impl CursorTrait for BTreeCursor {
             let contents = page.get_contents();
             let cell_idx = self.stack.current_cell_index();
             let (payload, payload_start, _payload_size, first_overflow_page) =
-                contents.cell_read_payload_at(cell_idx as usize, self.usable_space())?;
+                contents.cell_read_payload_at(cell_idx as usize, self.payload_limits)?;
             if first_overflow_page.is_none() {
                 // The whole record sits on the pinned page: decode it there
                 // instead of copying it into the reusable record first, and
@@ -10224,6 +10226,35 @@ fn fill_cell_payload(
     };
     result
 }
+
+/// The payload sizes at which a cell spills to overflow pages
+#[derive(Clone, Copy, Debug)]
+pub struct PayloadLimits {
+    pub usable_size: usize,
+    pub max_local_table: usize,
+    pub max_local_index: usize,
+    pub min_local: usize,
+}
+
+impl PayloadLimits {
+    pub fn new(usable_size: usize) -> Self {
+        Self {
+            usable_size,
+            max_local_table: payload_overflow_threshold_max(PageType::TableLeaf, usable_size),
+            max_local_index: payload_overflow_threshold_max(PageType::IndexLeaf, usable_size),
+            min_local: payload_overflow_threshold_min(PageType::TableLeaf, usable_size),
+        }
+    }
+
+    #[inline(always)]
+    pub fn max_local(&self, page_type: PageType) -> usize {
+        match page_type {
+            PageType::IndexInterior | PageType::IndexLeaf => self.max_local_index,
+            PageType::TableInterior | PageType::TableLeaf => self.max_local_table,
+        }
+    }
+}
+
 /// Returns the maximum payload size (X) that can be stored directly on a b-tree page without spilling to overflow pages.
 ///
 /// For table leaf pages: X = usable_size - 35

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2994,7 +2994,7 @@ impl BTreeCursor {
                         *cell_idx,
                         &record,
                         usable_space,
-                        self.pager.clone(),
+                        &self.pager,
                         fill_cell_payload_state,
                     ));
 
@@ -6047,7 +6047,7 @@ impl BTreeCursor {
                             cell_idx,
                             record,
                             self.usable_space(),
-                            self.pager.clone(),
+                            &self.pager,
                             fill_cell_payload_state,
                         ));
                     }
@@ -10076,7 +10076,7 @@ fn fill_cell_payload(
     cell_idx: usize,
     record: &impl AsRef<[u8]>,
     usable_space: usize,
-    pager: Arc<Pager>,
+    pager: &Pager,
     fill_cell_payload_state: &mut FillCellPayloadState,
 ) -> IOResultOr<()> {
     let overflow_page_pointer_size = 4;
@@ -10116,8 +10116,9 @@ fn fill_cell_payload(
                     // enough allowed space to fit inside a btree page
                     crate::with_btree_allocation_site!(
                         CellPayload,
-                        cell_payload.try_extend(record_buf.iter().copied())
+                        cell_payload.try_reserve(record_buf.len())
                     )?;
+                    cell_payload.extend_from_slice(record_buf);
                     break Ok(IOResult::Done(()));
                 }
 
@@ -10858,7 +10859,7 @@ mod tests {
                     pos,
                     &record,
                     4096,
-                    conn.pager.load().clone(),
+                    &conn.pager.load(),
                     &mut fill_cell_payload_state,
                 )
             },
@@ -13101,7 +13102,7 @@ mod tests {
                                 cell_idx,
                                 &record,
                                 4096,
-                                conn.pager.load().clone(),
+                                &conn.pager.load(),
                                 &mut fill_cell_payload_state,
                             )
                         },
@@ -13184,7 +13185,7 @@ mod tests {
                                     cell_idx,
                                     &record,
                                     4096,
-                                    conn.pager.load().clone(),
+                                    &conn.pager.load(),
                                     &mut fill_cell_payload_state,
                                 )
                             },
@@ -13596,7 +13597,7 @@ mod tests {
                     0,
                     &record,
                     4096,
-                    conn.pager.load().clone(),
+                    &conn.pager.load(),
                     &mut fill_cell_payload_state,
                 )
             },
@@ -13682,7 +13683,7 @@ mod tests {
                     0,
                     &record,
                     4096,
-                    conn.pager.load().clone(),
+                    &conn.pager.load(),
                     &mut fill_cell_payload_state,
                 )
             },
@@ -13933,7 +13934,7 @@ mod tests {
                     cell_idx as usize,
                     &record,
                     pager.usable_space(),
-                    pager.clone(),
+                    &pager,
                     &mut fill_cell_payload_state,
                 )
             },

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1570,10 +1570,10 @@ impl BTreeCursor {
     /// Check if any ancestor pages still have cells to iterate.
     /// If not, traversing back up to parent is of no use because we are at the end of the tree.
     fn ancestor_pages_have_more_children(&self) -> bool {
-        let node_states = self.stack.node_states;
-        (0..self.stack.current())
+        self.stack.node_states[..self.stack.current()]
+            .iter()
             .rev()
-            .any(|idx| !node_states[idx].is_at_end())
+            .any(|node_state| !node_state.is_at_end())
     }
 
     /// Move the cursor to the next record and return it.
@@ -6457,6 +6457,12 @@ impl CursorTrait for BTreeCursor {
             self.invalidate_record();
             return Ok(IOResult::Done(()));
         }
+        if self.is_on_last_cell_of_tree() {
+            self.stack.advance();
+            self.invalidate_record();
+            self.set_has_record(false);
+            return Ok(IOResult::Done(()));
+        }
         if self.valid_state == CursorValidState::Invalid {
             return Ok(IOResult::Done(()));
         }
@@ -7614,19 +7620,40 @@ impl BTreeCursor {
     /// overflow read, and an in-flight spill descent.
     #[inline(always)]
     fn can_advance_within_leaf(&self) -> bool {
-        if !matches!(self.advance_state, AdvanceState::Start)
+        if self.has_pending_advance_state() {
+            return false;
+        }
+        let contents = self.stack.top_ref().get_contents();
+        let cell_idx = self.stack.current_cell_index();
+        cell_idx >= 0 && contents.is_leaf() && cell_idx as usize + 1 < contents.cell_count()
+    }
+
+    /// True when the cursor sits on the last cell of the rightmost leaf and
+    /// nothing is pending: the tree has no next record, so `next()` only has
+    /// to step past the cell. This is what every NewRowid does before an
+    /// append, and what a scan does once at its end.
+    #[inline(always)]
+    fn is_on_last_cell_of_tree(&self) -> bool {
+        if self.has_pending_advance_state() {
+            return false;
+        }
+        let contents = self.stack.top_ref().get_contents();
+        let cell_idx = self.stack.current_cell_index();
+        cell_idx >= 0
+            && contents.is_leaf()
+            && cell_idx as usize + 1 == contents.cell_count()
+            && !self.ancestor_pages_have_more_children()
+    }
+
+    #[inline(always)]
+    fn has_pending_advance_state(&self) -> bool {
+        !matches!(self.advance_state, AdvanceState::Start)
             || !matches!(self.valid_state, CursorValidState::Valid)
             || self.needs_restore()
             || self.skip_advance
             || !self.has_record
             || self.read_overflow_state.is_some()
             || self.iteration_pending_descent.is_some()
-        {
-            return false;
-        }
-        let contents = self.stack.top_ref().get_contents();
-        let cell_idx = self.stack.current_cell_index();
-        cell_idx >= 0 && contents.is_leaf() && cell_idx as usize + 1 < contents.cell_count()
     }
 }
 

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -246,7 +246,7 @@ impl PageInner {
     }
 
     /// Write a u8 to the page content at the given offset, taking account the possible db header on page 1.
-    #[inline]
+    #[inline(always)]
     fn write_u8(&self, pos: usize, value: u8) {
         tracing::trace!("write_u8(pos={}, value={})", pos, value);
         let buf = self.as_ptr();
@@ -254,7 +254,7 @@ impl PageInner {
     }
 
     /// Write a u16 to the page content at the given offset, taking account the possible db header on page 1.
-    #[inline]
+    #[inline(always)]
     fn write_u16(&self, pos: usize, value: u16) {
         tracing::trace!("write_u16(pos={}, value={})", pos, value);
         let buf = self.as_ptr();
@@ -263,7 +263,7 @@ impl PageInner {
     }
 
     /// Write a u32 to the page content at the given offset, taking account the possible db header on page 1.
-    #[inline]
+    #[inline(always)]
     fn write_u32(&self, pos: usize, value: u32) {
         tracing::trace!("write_u32(pos={}, value={})", pos, value);
         let buf = self.as_ptr();
@@ -291,6 +291,7 @@ impl PageInner {
     }
 
     /// Write a u16 at the given absolute offset (no db header offset).
+    #[inline(always)]
     pub fn write_u16_no_offset(&self, pos: usize, value: u16) {
         tracing::trace!("write_u16_no_offset(pos={}, value={})", pos, value);
         let buf = self.as_ptr();
@@ -298,6 +299,7 @@ impl PageInner {
     }
 
     /// Write a u32 at the given absolute offset (no db header offset).
+    #[inline(always)]
     pub fn write_u32_no_offset(&self, pos: usize, value: u32) {
         tracing::trace!("write_u32_no_offset(pos={}, value={})", pos, value);
         let buf = self.as_ptr();
@@ -336,10 +338,12 @@ impl PageInner {
         )
     }
 
+    #[inline(always)]
     pub fn write_cell_count(&self, value: u16) {
         self.write_u16(BTREE_CELL_COUNT, value);
     }
 
+    #[inline(always)]
     pub fn write_cell_content_area(&self, value: usize) {
         turso_debug_assert!(value <= PageSize::MAX as usize);
         let value = value as u16;

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -45,7 +45,7 @@ use super::btree::offset::{
     BTREE_PAGE_TYPE, BTREE_RIGHTMOST_PTR,
 };
 use super::btree::{
-    btree_init_page, payload_overflow_threshold_max, payload_overflow_threshold_min,
+    btree_init_page, payload_overflow_threshold_max, payload_overflow_threshold_min, PayloadLimits,
 };
 use super::page_cache::{CacheError, CacheResizeResult, PageCache, PageCacheKey, SpillResult};
 use super::sqlite3_ondisk::read_varint;
@@ -535,10 +535,9 @@ impl PageInner {
     pub fn cell_read_payload_ptr(
         &self,
         idx: usize,
-        usable_size: usize,
+        limits: PayloadLimits,
     ) -> crate::Result<(&'static [u8], u64, Option<u32>)> {
-        let (payload, _, payload_size, first_overflow) =
-            self.cell_read_payload_at(idx, usable_size)?;
+        let (payload, _, payload_size, first_overflow) = self.cell_read_payload_at(idx, limits)?;
         Ok((payload, payload_size, first_overflow))
     }
 
@@ -548,7 +547,7 @@ impl PageInner {
     pub fn cell_read_payload_at(
         &self,
         idx: usize,
-        usable_size: usize,
+        limits: PayloadLimits,
     ) -> crate::Result<(&'static [u8], usize, u64, Option<u32>)> {
         let buf = self.as_ptr();
         let cell_pointer_array_start = self.header_size();
@@ -580,13 +579,11 @@ impl PageInner {
             }
         };
 
-        let max_local = payload_overflow_threshold_max(page_type, usable_size);
-        let min_local = payload_overflow_threshold_min(page_type, usable_size);
         let (overflows, local_size) = sqlite3_ondisk::payload_overflows(
             payload_size as usize,
-            max_local,
-            min_local,
-            usable_size,
+            limits.max_local(page_type),
+            limits.min_local,
+            limits.usable_size,
         );
 
         let (payload_slice, first_overflow) = if overflows {

--- a/core/types.rs
+++ b/core/types.rs
@@ -479,6 +479,8 @@ impl TryClone for Value {
                 dst.clear();
                 dst.try_extend(src.iter().copied())?;
             }
+            (dst, Self::Null) => *dst = Self::Null,
+            (dst, Self::Numeric(n)) => *dst = Self::Numeric(*n),
             (dst, src) => {
                 *dst = src.try_clone()?;
             }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3278,9 +3278,9 @@ pub fn op_make_record(
             ))
             .into());
         }
-        for (i, affinity_ch) in affinity_str.chars().enumerate().take(count) {
+        for (i, affinity_code) in affinity_str.bytes().enumerate().take(count) {
             let reg_index = start_reg + i;
-            let affinity = Affinity::from_char(affinity_ch);
+            let affinity = Affinity::from_char_code(affinity_code);
             apply_affinity_char(&mut state.registers[reg_index], affinity);
         }
     }
@@ -16207,11 +16207,9 @@ pub fn op_affinity(
         .into());
     }
 
-    for (i, affinity_char) in affinities.chars().enumerate().take(count.get()) {
+    for (i, affinity_code) in affinities.bytes().enumerate().take(count.get()) {
         let reg_index = *start_reg + i;
-
-        let affinity = Affinity::from_char(affinity_char);
-
+        let affinity = Affinity::from_char_code(affinity_code);
         apply_affinity_char(&mut state.registers[reg_index], affinity);
     }
 
@@ -18217,7 +18215,31 @@ pub fn op_hash_grace_advance_partition(
     Ok(InsnFunctionStepResult::Step)
 }
 
+#[inline(always)]
 fn apply_affinity_char(target: &mut Register, affinity: Affinity) -> bool {
+    // handle the common cases that don't require a conversion inline
+    if let Register::Value(value) = target {
+        let settled = match affinity {
+            Affinity::Blob | Affinity::None => true,
+            Affinity::Text => matches!(value, Value::Text(_) | Value::Null | Value::Blob(_)),
+            Affinity::Integer | Affinity::Numeric => matches!(
+                value,
+                Value::Numeric(Numeric::Integer(_)) | Value::Null | Value::Blob(_)
+            ),
+            Affinity::Real => matches!(
+                value,
+                Value::Numeric(Numeric::Float(_)) | Value::Null | Value::Blob(_)
+            ),
+        };
+        if settled {
+            return true;
+        }
+    }
+    apply_affinity_char_slow(target, affinity)
+}
+
+#[inline(never)]
+fn apply_affinity_char_slow(target: &mut Register, affinity: Affinity) -> bool {
     if let Register::Value(value) = target {
         if matches!(value, Value::Blob(_)) {
             return true;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12979,11 +12979,11 @@ fn new_rowid_inner(
 
     const MAX_ROWID: i64 = i64::MAX;
     const MAX_ATTEMPTS: u32 = 100;
-    let mv_store = program.connection.mv_store();
+    let has_mv_store = state.mv_store(&program.connection).is_some();
     loop {
         match *state.active_op_state.new_rowid() {
             OpNewRowidState::Start => {
-                if mv_store.is_some() {
+                if has_mv_store {
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut() as &mut dyn Any;
                     if let Some(mvcc_cursor) = cursor.downcast_mut::<MvCursor>() {
@@ -13056,7 +13056,7 @@ fn new_rowid_inner(
                     return_if_io!(cursor.rowid())
                 };
 
-                if mv_store.is_some() {
+                if has_mv_store {
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut() as &mut dyn Any;
                     if let Some(mvcc_cursor) = cursor.downcast_mut::<MvCursor>() {
@@ -13147,7 +13147,7 @@ fn new_rowid_inner(
                     state.active_op_state.clear();
                     state.pc += 1;
 
-                    if mv_store.is_some() {
+                    if has_mv_store {
                         let cursor = state.get_cursor(*cursor);
                         let cursor = cursor.as_btree_mut() as &mut dyn Any;
                         if let Some(mvcc_cursor) = cursor.downcast_mut::<MvCursor>() {
@@ -13172,7 +13172,7 @@ fn new_rowid_inner(
                 state.active_op_state.clear();
                 state.pc += 1;
 
-                if mv_store.is_some() {
+                if has_mv_store {
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut() as &mut dyn Any;
                     if let Some(mvcc_cursor) = cursor.downcast_mut::<MvCursor>() {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -12134,6 +12134,7 @@ pub fn op_yield(
 
 pub struct OpInsertState {
     pub sub_state: OpInsertSubState,
+    pub has_dependent_views: bool,
     pub old_record: Option<(i64, crate::alloc::Vec<Value>)>,
     /// Set by the NoopCheck sub-state to indicate the row already has the exact
     /// same payload, so the physical write can be skipped.
@@ -12194,6 +12195,7 @@ pub fn op_insert(
                         .get_dependent_materialized_views(table_name)
                         .is_empty()
                 };
+                state.active_op_state.insert().has_dependent_views = has_dependent_views;
                 // If there are no dependent views, we don't need to capture the old record.
                 // We also don't need to do it if the rowid of the UPDATEd row was changed, because
                 // op_delete already captured the deletion for IVM, and this insert only needs to
@@ -12235,12 +12237,7 @@ pub fn op_insert(
                 )? {
                     return Ok(InsnFunctionStepResult::IO(io));
                 }
-                let has_dependent_views = {
-                    let schema = program.connection.schema.read();
-                    !schema
-                        .get_dependent_materialized_views(table_name)
-                        .is_empty()
-                };
+                let has_dependent_views = state.active_op_state.insert().has_dependent_views;
                 let needs_capture =
                     has_dependent_views && !flag.has(InsertFlags::UPDATE_ROWID_CHANGE);
                 if needs_capture {
@@ -12309,19 +12306,14 @@ pub fn op_insert(
                 // The noop check is fundamentally incompatible with the MVCC
                 // Delete+Insert update pattern.
                 state.active_op_state.insert().is_noop_update = false;
-                let is_mvcc = {
-                    let cursor_ref = get_cursor!(state, *cursor_id);
-                    cursor_ref.as_btree_mut().is_mvcc()
-                };
-                let has_rowid = {
-                    let cursor = get_cursor!(state, *cursor_id);
-                    cursor.as_btree_mut().has_rowid()
-                };
-                if !is_mvcc
-                    && has_rowid
-                    && flag.has(InsertFlags::SKIP_LAST_ROWID)
+                let may_be_noop_update = flag.has(InsertFlags::SKIP_LAST_ROWID)
                     && !flag.has(InsertFlags::UPDATE_ROWID_CHANGE)
-                {
+                    && {
+                        let cursor = get_cursor!(state, *cursor_id);
+                        let cursor = cursor.as_btree_mut();
+                        !cursor.is_mvcc() && cursor.has_rowid()
+                    };
+                if may_be_noop_update {
                     let key = match &state.registers[*key_reg].get_value() {
                         Value::Numeric(Numeric::Integer(i)) => *i,
                         _ => unreachable!("expected integer key"),
@@ -12407,21 +12399,18 @@ pub fn op_insert(
                     cursor.has_rowid()
                 };
                 if has_rowid {
-                    let maybe_rowid = {
-                        let cursor = state.get_cursor(*cursor_id);
-                        let cursor = cursor.as_btree_mut();
-                        return_if_io!(cursor.rowid())
-                    };
-                    if let Some(rowid) = maybe_rowid {
-                        if !flag.has(InsertFlags::SKIP_LAST_ROWID) {
-                            program.connection.update_last_rowid(rowid);
-                        }
-                        if !flag.has(InsertFlags::SKIP_ALL_CHANGE_COUNTS) {
-                            if flag.has(InsertFlags::SKIP_STATEMENT_CHANGE_COUNT) {
-                                state.record_total_change();
-                            } else {
-                                state.record_statement_change();
-                            }
+                    if !flag.has(InsertFlags::SKIP_LAST_ROWID) {
+                        let rowid = match &state.registers[*key_reg].get_value() {
+                            Value::Numeric(Numeric::Integer(i)) => *i,
+                            _ => unreachable!("expected integer key"),
+                        };
+                        program.connection.update_last_rowid(rowid);
+                    }
+                    if !flag.has(InsertFlags::SKIP_ALL_CHANGE_COUNTS) {
+                        if flag.has(InsertFlags::SKIP_STATEMENT_CHANGE_COUNT) {
+                            state.record_total_change();
+                        } else {
+                            state.record_statement_change();
                         }
                     }
                 } else if !flag.has(InsertFlags::SKIP_ALL_CHANGE_COUNTS) {
@@ -12431,9 +12420,7 @@ pub fn op_insert(
                         state.record_statement_change();
                     }
                 }
-                let schema = program.connection.schema.read();
-                let dependent_views = schema.get_dependent_materialized_views(table_name);
-                if !dependent_views.is_empty() {
+                if state.active_op_state.insert().has_dependent_views {
                     if !has_rowid {
                         return Err(LimboError::ParseError(
                             "WITHOUT ROWID tables with dependent materialized views are not supported"

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1848,6 +1848,7 @@ impl Program {
     }
 
     #[turso_macros::trace_stack]
+    #[inline(always)]
     pub fn step(
         &self,
         state: &mut ProgramState,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -707,6 +707,7 @@ impl ActiveOpStateSlot {
         OpInsertState,
         OpInsertState {
             sub_state: OpInsertSubState::MaybeCaptureRecord,
+            has_dependent_views: false,
             old_record: None,
             is_noop_update: false,
         }
@@ -3813,6 +3814,7 @@ mod tests {
 
         *state.active_op_state.insert() = OpInsertState {
             sub_state: OpInsertSubState::Seek,
+            has_dependent_views: false,
             old_record: None,
             is_noop_update: false,
         };

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -159,7 +159,14 @@ impl From<SeekOp> for ComparisonOp {
 
 #[inline]
 fn sqlite_text_prefix(s: &str) -> &str {
-    match s.find('\0') {
+    // A short value is scanned byte by byte: the character searcher of
+    // `find` costs more to set up than the scan.
+    let nul = if s.len() <= 32 {
+        s.bytes().position(|b| b == 0)
+    } else {
+        s.find('\0')
+    };
+    match nul {
         Some(idx) => &s[..idx],
         None => s,
     }
@@ -1275,6 +1282,16 @@ impl Value {
         let pattern = sqlite_text_prefix(pattern);
         let text = sqlite_text_prefix(text);
 
+        // ASCII pattern and text without an escape character, the usual
+        // case: match the bytes directly. This comes before the wildcard
+        // scans below, which cost more per row than the match itself.
+        if escape.is_none()
+            && crate::types::is_ascii(pattern.as_bytes())
+            && crate::types::is_ascii(text.as_bytes())
+        {
+            return Ok(like_ascii(pattern.as_bytes(), text.as_bytes()));
+        }
+
         let has_escape = escape.is_some_and(|e| pattern.contains(e));
 
         // 1. Exact match (no wildcards)
@@ -1521,6 +1538,38 @@ const LIKE_INFO: PatternInfo = PatternInfo {
     match_set: None,
     no_case: true,
 };
+
+/// LIKE without an escape character over ASCII bytes: `_` matches one byte,
+/// `%` any run of bytes, letters compare without case. The last `%` seen is
+/// the only backtrack point, as in the classic wildcard match: when the
+/// bytes after it stop matching, the run it covers grows by one and the
+/// match resumes after it. Same answers as `pattern_compare` with
+/// `LIKE_INFO` for every ASCII input (see the tests).
+fn like_ascii(pattern: &[u8], text: &[u8]) -> bool {
+    let (mut p, mut t) = (0, 0);
+    let mut backtrack: Option<(usize, usize)> = None;
+    while t < text.len() {
+        match pattern.get(p) {
+            Some(b'%') => {
+                backtrack = Some((p, t));
+                p += 1;
+            }
+            Some(&c) if c == b'_' || c.eq_ignore_ascii_case(&text[t]) => {
+                p += 1;
+                t += 1;
+            }
+            _ => match backtrack {
+                Some((star_p, star_t)) => {
+                    p = star_p + 1;
+                    t = star_t + 1;
+                    backtrack = Some((star_p, t));
+                }
+                None => return false,
+            },
+        }
+    }
+    pattern[p..].iter().all(|&c| c == b'%')
+}
 
 const GLOB_INFO: PatternInfo = PatternInfo {
     match_all: '*',
@@ -2794,6 +2843,46 @@ mod tests {
     fn test_like_with_escape_or_regexmeta_chars() {
         assert!(Value::exec_like(r#"\%A"#, r#"\A"#, None).unwrap());
         assert!(Value::exec_like("%a%a", "aaaa", None).unwrap());
+    }
+
+    #[test]
+    fn like_ascii_agrees_with_pattern_compare() {
+        fn words(alphabet: &[u8], max_len: usize) -> Vec<Vec<u8>> {
+            let mut all = vec![Vec::new()];
+            let mut last = vec![Vec::new()];
+            for _ in 0..max_len {
+                let mut next = Vec::new();
+                for word in &last {
+                    for &c in alphabet {
+                        let mut longer = word.clone();
+                        longer.push(c);
+                        next.push(longer);
+                    }
+                }
+                all.extend(next.iter().cloned());
+                last = next;
+            }
+            all
+        }
+        for pattern in words(b"ab%_", 4) {
+            for text in words(b"abA", 4) {
+                let pattern_str = std::str::from_utf8(&pattern).unwrap();
+                let text_str = std::str::from_utf8(&text).unwrap();
+                let expected =
+                    super::pattern_compare(pattern_str, text_str, &super::LIKE_INFO, None)
+                        == super::CompareResult::Match;
+                assert_eq!(
+                    super::like_ascii(&pattern, &text),
+                    expected,
+                    "pattern {pattern_str:?}, text {text_str:?}"
+                );
+                assert_eq!(
+                    Value::exec_like(pattern_str, text_str, None).unwrap(),
+                    expected,
+                    "exec_like: pattern {pattern_str:?}, text {text_str:?}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Part 7 of 15 split out of #8692 (commits 61-70 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### CodSpeed

Commits 1-63 (`49fd58b1`) vs `main`: [run 6a9bf85f56074e7b4ca48a21](https://codspeed.io/tursodatabase/turso/runs/6a9bf85f56074e7b4ca48a21), 169 improvements, 0 regressions, 1386 unchanged, 28 new, 754 skipped (environment difference between the runners again). Against the run of `d94d18c2`: 8 improvements, 0 regressions, all of them the LIKE and text benchmarks of `sql_functions/value.rs` (`construct_like_complex` 2,074 ns → 984 ns, `construct_like_contains` 1,769 ns → 890 ns, `construct_like_with_single_wildcard` 1,544 ns → 818 ns, `length_unicode_text` 1,249 ns → 832 ns).

Commits 1-67 (`4558f126`, the first four insert-path commits) vs `main`: [run 6a9bff6f08ed81f2f89cc8dc](https://codspeed.io/tursodatabase/turso/runs/6a9bff6f08ed81f2f89cc8dc), 189 improvements, 0 regressions, 1381 unchanged, 28 new, 739 skipped. Against the run of `49fd58b1`: nothing past the reporting threshold (1598 unchanged, 739 skipped); the insert benchmarks CodSpeed can compare are dominated by syscalls and WAL checksums, so the 2-3% per-row savings of these commits stay below its threshold. The write benchmarks stand at +37% to +44% against `main` (`Transaction Size Impact::limbo[1000_rows]` 5.9 ms → 4.1 ms, `Key Pattern Impact::limbo[sequential_keys]` 655.6 µs → 454.9 µs, `BEFORE INSERT Trigger::limbo[1000_rows]` 12.6 ms → 9.1 ms), most of it from the per-statement commits.

Commits 1-72 (`b17c0692`) vs `main`: [run 6a9c05c428e57d31b0813f52](https://codspeed.io/tursodatabase/turso/runs/6a9c05c428e57d31b0813f52), 183 improvements, 0 regressions, 1372 unchanged, 28 new, 754 skipped. Against the run of `4558f126`: nothing past the reporting threshold (1583 unchanged). Some benchmarks move by several percent between runs in both directions without a change on their path: `count_filtered[1000000]` went 157.7 ms → 170.9 ms here after 169.3 ms → 156.7 ms between the `d94d18c2` and `49fd58b1` runs; CodSpeed classifies both moves as unchanged, and the local callgrind count of the matching workload (W4) for this head went down 1%.

Commits 1-74 (`19fa1c27`) vs `main`: [run 6a9c11d220293c61e16aaf3d](https://codspeed.io/tursodatabase/turso/runs/6a9c11d220293c61e16aaf3d), 191 improvements, 1 regression, 1378 unchanged, 28 new, 739 skipped. The regression is `mvcc-recovery/small-frames[100000 nightly]`, 327.4 ms → 422.8 ms, first seen in the run of `dd86025a` (431.2 ms). The benchmark replays an MVCC log at open and runs no VDBE code; its stable-toolchain variant is unchanged (338.5 ms → 335.7 ms) and the ten-times larger `small-frames[1000000 nightly]` is unchanged at 3.8 s, the same value as in the run of `4558f126`, where the 100000-row nightly variant measured 379 ms. The nightly variants of all the recovery benchmarks run 10-15% slower than the stable ones in every run. Against the run of `b17c0692`: nothing else past the reporting threshold (1597 unchanged).

### Measurement history: per-row costs

Callgrind instruction counts (`Ir`) are for 5 iterations of `SELECT 1 FROM t` and 3 iterations of the others. Wall clock is the best of 7 runs of one iteration on a noisy VM, so treat it as a sanity check only.

| Commit | SELECT 1 (Ir) | Δ | SELECT * (Ir) | Δ | W3 (Ir) | Δ | W4 (Ir) | Δ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `ff93571c` inline `Program::step` into the statement step (measured against `5b91d1ca`: 200,717,660 / 404,537,776 / 272,609,753 / 314,553,421) | 198,917,668 | -0.90% | 403,337,780 | -0.30% | 272,608,557 | 0.00% | 314,552,638 | 0.00% |
| `b17c0692` keep the payload overflow limits on the cursor | 198,917,800 | 0.00% | 402,537,876 | -0.20% | 269,407,332 | -1.17% | 311,355,010 | -1.02% |

| Commit | Workload | before | after |
|---|---|---:|---:|
| `49fd58b1` match ASCII LIKE patterns over bytes | W7 | 627,429,535 | 475,066,207 (-24.3%) |
| | `SELECT count(*) FROM t WHERE name LIKE '%9_9%'` (W7b) | 663,631,067 | 544,133,622 (-18.0%) |
| `05da06c4` step past the last row without the full advance machine | `INSERT INTO t2(name, value) SELECT name, value FROM t LIMIT 1000` (W11, 4000 rows appended) | 33,125,111 | 32,212,495 (-2.8%) |
| `16eeb71c` answer the settled affinity cases without a call | W11 (three affinities per row) | 32,212,495 | 31,640,792 (-1.8%) |
| `18ce6cf2` look the insert's dependent views up once and take the rowid from the key register | W11 | 31,640,792 | 30,817,186 (-2.6%) |
| `4558f126` copy the record into the cell as a slice | W11 | 30,817,186 | 30,587,086 (-0.75%) |
| `5ca55b37` use the statement's cached MvStore handle in NewRowid | W11 | 30,587,086 | 30,334,970 (-0.8%) |
| `5b91d1ca` inline the page header writers | W11 | 30,334,970 | 30,216,719 (-0.4%) |
| `dd86025a` clone NULL and numbers into a register without the generic clone | W11 (one integer Copy per row; 30,212,921 at `b17c0692`) | 30,212,921 | 30,080,957 (-0.4%) |

### Measurement history: per-statement costs

The second half of the PR works on the fixed cost of executing a prepared statement once: transaction begin and commit, cursor open and close, statement reset, metrics. Measured as callgrind instructions per execution, taken as (Ir at 3000 executions − Ir at 1000 executions) / 2000 so the process start-up is cancelled out. Workloads: a point lookup `SELECT * FROM t WHERE id = 12345` (one `Transaction`, one `OpenRead`, one `SeekRowid`, `Column`, `Halt`), `SELECT 1` (no table, no transaction: the pure statement overhead), and an index lookup `SELECT id FROM t WHERE value = 500 LIMIT 1` (two cursors).

| Commit | point lookup | Δ | `SELECT 1` | Δ | index lookup | Δ |
|---|---:|---:|---:|---:|---:|---:|
| `05da06c4` step past the last row without the full advance machine (re-measured; no seek runs this path) | 7,370 | -0.5% | 1,781 | -1.0% | 13,490 | -0.6% |
| `ff93571c` inline `Program::step` into the statement step | 7,368 | 0.0% | 1,779 | -0.1% | 13,488 | 0.0% |
| `b17c0692` keep the payload overflow limits on the cursor (computed once per cursor open, saved per index cell read) | 7,388 | +0.3% | 1,779 | 0.0% | 13,329 | -1.2% |

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_