### PR TITLE
core: Optimize insert path, If, Compare and dispatch loop

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -9906,7 +9906,7 @@ fn insert_into_cell(
 /// Free blocks can be zero, meaning the "real free space" that can be used to allocate is expected
 /// to be between first cell byte and end of cell pointer area.
 #[allow(unused_assignments)]
-#[inline]
+#[inline(always)]
 fn compute_free_space(page: &PageContent, usable_space: usize) -> Result<usize> {
     // TODO(pere): maybe free space is not calculated correctly with offset
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2887,7 +2887,10 @@ impl BTreeCursor {
             .get_record()
             .expect("expected record present on insert");
         if let CursorState::None = &self.state {
-            self.state = CursorState::Write(WriteState::Start);
+            std::mem::forget(std::mem::replace(
+                &mut self.state,
+                CursorState::Write(WriteState::Start),
+            ));
         }
         let usable_space = self.usable_space();
         let ret = loop {
@@ -2976,12 +2979,17 @@ impl BTreeCursor {
                             payload.try_reserve(needed_capacity - payload.capacity())
                         )?;
                     }
-                    *write_state = WriteState::Insert {
-                        page,
-                        cell_idx,
-                        new_payload: payload,
-                        fill_cell_payload_state: FillCellPayloadState::Start,
-                    };
+                    // The current state (`WriteState::Start`) has no allocations, so
+                    // we std::mem::forget it to save on drop glue
+                    std::mem::forget(std::mem::replace(
+                        write_state,
+                        WriteState::Insert {
+                            page,
+                            cell_idx,
+                            new_payload: payload,
+                            fill_cell_payload_state: FillCellPayloadState::Start,
+                        },
+                    ));
                     continue;
                 }
                 WriteState::Insert {
@@ -3093,8 +3101,11 @@ impl BTreeCursor {
             // it's probably not the greatest idea in the world to do this eagerly here,
             // but at least it works.
             return_if_io!(self.restore_context());
+            // WriteState::Finish owns nothing: std::mem::forget it to skip the drop glue
+            std::mem::forget(std::mem::replace(&mut self.state, CursorState::None));
+        } else {
+            self.state = CursorState::None;
         }
-        self.state = CursorState::None;
         ret
     }
 

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -2246,22 +2246,19 @@ pub fn checksum_wal(
     turso_assert_eq!(buf.len() % 8, 0, "buffer must be a multiple of 8");
     let mut s0: u32 = input.0;
     let mut s1: u32 = input.1;
-    let mut i = 0;
     if native_endian {
-        while i < buf.len() {
-            let v0 = u32::from_ne_bytes(buf[i..i + 4].try_into().unwrap());
-            let v1 = u32::from_ne_bytes(buf[i + 4..i + 8].try_into().unwrap());
+        for words in buf.chunks_exact(8) {
+            let v0 = u32::from_ne_bytes([words[0], words[1], words[2], words[3]]);
+            let v1 = u32::from_ne_bytes([words[4], words[5], words[6], words[7]]);
             s0 = s0.wrapping_add(v0.wrapping_add(s1));
             s1 = s1.wrapping_add(v1.wrapping_add(s0));
-            i += 8;
         }
     } else {
-        while i < buf.len() {
-            let v0 = u32::from_ne_bytes(buf[i..i + 4].try_into().unwrap()).swap_bytes();
-            let v1 = u32::from_ne_bytes(buf[i + 4..i + 8].try_into().unwrap()).swap_bytes();
+        for words in buf.chunks_exact(8) {
+            let v0 = u32::from_ne_bytes([words[0], words[1], words[2], words[3]]).swap_bytes();
+            let v1 = u32::from_ne_bytes([words[4], words[5], words[6], words[7]]).swap_bytes();
             s0 = s0.wrapping_add(v0.wrapping_add(s1));
             s1 = s1.wrapping_add(v1.wrapping_add(s0));
-            i += 8;
         }
     }
     (s0, s1)

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3278,10 +3278,9 @@ pub fn op_make_record(
             ))
             .into());
         }
-        for (i, affinity_code) in affinity_str.bytes().enumerate().take(count) {
-            let reg_index = start_reg + i;
-            let affinity = Affinity::from_char_code(affinity_code);
-            apply_affinity_char(&mut state.registers[reg_index], affinity);
+        let registers = &mut state.registers[start_reg..start_reg + count];
+        for (register, &affinity_code) in registers.iter_mut().zip(affinity_str.as_bytes()) {
+            apply_affinity_char(register, Affinity::from_char_code(affinity_code));
         }
     }
 
@@ -16194,10 +16193,9 @@ pub fn op_affinity(
         .into());
     }
 
-    for (i, affinity_code) in affinities.bytes().enumerate().take(count.get()) {
-        let reg_index = *start_reg + i;
-        let affinity = Affinity::from_char_code(affinity_code);
-        apply_affinity_char(&mut state.registers[reg_index], affinity);
+    let registers = &mut state.registers[*start_reg..*start_reg + count.get()];
+    for (register, &affinity_code) in registers.iter_mut().zip(affinities.as_bytes()) {
+        apply_affinity_char(register, Affinity::from_char_code(affinity_code));
     }
 
     state.pc += 1;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -863,17 +863,29 @@ pub fn op_compare(
         }
     }
 
-    // (https://github.com/tursodatabase/turso/issues/2304): reusing logic from compare_immutable().
-    // TODO: There are tons of cases like this where we could reuse this in a similar vein
-    let a_range =
-        (start_reg_a..start_reg_a + count + 1).map(|idx| state.registers[idx].get_value());
-    let b_range =
-        (start_reg_b..start_reg_b + count + 1).map(|idx| state.registers[idx].get_value());
-    let cmp = compare_immutable(a_range, b_range, key_info);
+    return op_compare_slow(state, start_reg_a, start_reg_b, count, key_info);
 
-    state.last_compare = Some(cmp);
-    state.pc += 1;
-    Ok(InsnFunctionStepResult::Step)
+    // keep slow path out of line to keep stack frame small
+    #[inline(never)]
+    fn op_compare_slow(
+        state: &mut ProgramState,
+        start_reg_a: usize,
+        start_reg_b: usize,
+        count: usize,
+        key_info: &[crate::types::KeyInfo],
+    ) -> InsnResult {
+        // (https://github.com/tursodatabase/turso/issues/2304): reusing logic from compare_immutable().
+        // TODO: There are tons of cases like this where we could reuse this in a similar vein
+        let a_range =
+            (start_reg_a..start_reg_a + count + 1).map(|idx| state.registers[idx].get_value());
+        let b_range =
+            (start_reg_b..start_reg_b + count + 1).map(|idx| state.registers[idx].get_value());
+        let cmp = compare_immutable(a_range, b_range, key_info);
+
+        state.last_compare = Some(cmp);
+        state.pc += 1;
+        Ok(InsnFunctionStepResult::Step)
+    }
 }
 
 pub fn op_jump(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -218,6 +218,23 @@ macro_rules! check_arg_count {
 pub type InsnResult = Result<InsnFunctionStepResult, Box<LimboError>>;
 pub type InsnFunction = fn(&Program, &mut ProgramState, &Insn, &Arc<Pager>) -> InsnResult;
 
+/// This is an optimization over `checked_add(n).ok_or(LimboError::Overflow)`. With `ok_or`, the
+/// compiler generates [LimboError] drop glue even though [LimboError::Overflow] owns nothing.
+/// But with [OkOverflow], it's able to skip the drop glue.
+trait OrOverflow<T> {
+    fn or_overflow(self) -> Result<T>;
+}
+
+impl<T> OrOverflow<T> for Option<T> {
+    #[inline(always)]
+    fn or_overflow(self) -> Result<T> {
+        match self {
+            Some(value) => Ok(value),
+            None => Err(LimboError::IntegerOverflow),
+        }
+    }
+}
+
 /// Parse a Value (text, int, float, or blob) into a BigDecimal.
 fn value_to_bigdecimal(val: &Value) -> Result<bigdecimal::BigDecimal> {
     use bigdecimal::BigDecimal;
@@ -7234,7 +7251,7 @@ fn update_agg_payload(
                         "Count: payload is not an integer".to_string(),
                     ));
                 };
-                *i = i.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+                *i = i.checked_add(1).or_overflow()?;
             }
         }
         AggFunc::Count0 => {
@@ -7245,7 +7262,7 @@ fn update_agg_payload(
                     "Count0: payload is not an integer".to_string(),
                 ));
             };
-            *i = i.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+            *i = i.checked_add(1).or_overflow()?;
         }
         AggFunc::Avg => {
             if matches!(arg, Value::Null) {
@@ -7278,7 +7295,7 @@ fn update_agg_payload(
                 NumericArg::Null => unreachable!("NULL early-returned above"),
             }
             *r_err_val = Value::from_f64(sum_state.r_err);
-            *count = count.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+            *count = count.checked_add(1).or_overflow()?;
         }
         AggFunc::Sum | AggFunc::Total => {
             // invariant as per init_agg_payload: payload[0] is acc (Null/Integer/Float),
@@ -7315,7 +7332,7 @@ fn update_agg_payload(
                 ovrfl: *ovrfl_i != 0,
             };
             if !matches!(arg, Value::Null) {
-                *count = count.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+                *count = count.checked_add(1).or_overflow()?;
             }
             if matches!(*acc, Value::Null) && sum_state.approx {
                 return Ok(());
@@ -7471,7 +7488,7 @@ fn update_agg_payload(
                         separator_lengths.try_reserve(
                             count
                                 .checked_mul(std::mem::size_of::<i64>())
-                                .ok_or(LimboError::IntegerOverflow)?,
+                                .or_overflow()?,
                         )?;
                         let bytes = first_separator_len.to_be_bytes();
                         for _ in 0..prior_separator_count {
@@ -7484,7 +7501,7 @@ fn update_agg_payload(
                 }
             }
             acc.exec_group_concat(arg)?;
-            *count = count.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+            *count = count.checked_add(1).or_overflow()?;
         }
         AggFunc::External(_) => {
             mark_unlikely();
@@ -7995,7 +8012,7 @@ fn op_window_step(
             let Value::Numeric(Numeric::Integer(step)) = &payload[1] else {
                 unreachable!("nth_value step count must be Integer");
             };
-            let step = step.checked_add(1).ok_or(LimboError::IntegerOverflow)?;
+            let step = step.checked_add(1).or_overflow()?;
             payload[1] = Value::from_i64(step);
             if step == n {
                 payload[0].try_clone_from(arg_slot.get_value())?;
@@ -8620,7 +8637,7 @@ fn inverse_agg_payload(func: &AggFunc, arg: Value, payload: &mut [Value]) -> Res
             let expected_separator_bytes = old_count
                 .saturating_sub(1)
                 .checked_mul(std::mem::size_of::<i64>())
-                .ok_or(LimboError::IntegerOverflow)?;
+                .or_overflow()?;
             if !separator_lengths.is_empty() && separator_lengths.len() != expected_separator_bytes
             {
                 return Err(LimboError::InternalError(format!(
@@ -8652,9 +8669,7 @@ fn inverse_agg_payload(func: &AggFunc, arg: Value, payload: &mut [Value]) -> Res
             } else {
                 0
             };
-            let remove_len = value_len
-                .checked_add(separator_len)
-                .ok_or(LimboError::IntegerOverflow)?;
+            let remove_len = value_len.checked_add(separator_len).or_overflow()?;
             let Value::Text(text) = acc else {
                 unreachable!("GroupConcat accumulator is Text after a non-NULL xStep");
             };
@@ -8708,7 +8723,7 @@ fn inverse_agg_payload(func: &AggFunc, arg: Value, payload: &mut [Value]) -> Res
             for _ in 0..element_count {
                 end = end
                     .checked_add(raw_jsonb_element_len(data, end)?)
-                    .ok_or(LimboError::IntegerOverflow)?;
+                    .or_overflow()?;
             }
             data.drain(1..end);
         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -376,14 +376,23 @@ impl Register {
             Register::Value(Value::Numeric(float)) => {
                 *float = Numeric::Integer(val);
             }
-            Register::Value(other_value_kind) => {
-                *other_value_kind = Value::from_i64(val);
-            }
-            _ => {
-                *self = Register::Value(Value::from_i64(val));
+            _ => set_int_over_other(self, val),
+        };
+
+        // less frequent cases kept out of line to keep stack frames small
+        #[inline(never)]
+        fn set_int_over_other(register: &mut Register, val: i64) {
+            match register {
+                Register::Value(other_value_kind) => {
+                    *other_value_kind = Value::from_i64(val);
+                }
+                _ => {
+                    *register = Register::Value(Value::from_i64(val));
+                }
             }
         }
     }
+
     /// Set the value of the register to a floating point,
     /// reusing Register::Value(Value::Numeric(Numeric::Float(_))) if possible.
     #[inline(always)]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2158,211 +2158,325 @@ impl Program {
         // instruction completed its IO inline; the inner loop dispatches
         // instructions without re-inspecting the completion slot every time.
         'io_check: loop {
-            if let Some(io) = &state.io_completions {
-                if !io.finished() {
-                    io.set_waker(waker);
-                    return Ok(StepResult::IO);
+            if state.io_completions.is_some() {
+                if let Some(result) = self.finish_pending_io(state, pager, waker)? {
+                    return Ok(result);
                 }
-                if let Some(err) = io.get_error() {
-                    if pager.is_checkpointing() {
-                        // Wrap IO errors that occurred during checkpointing in CheckpointFailed error,
-                        // so that abort() knows not to try to rollback the transaction, because the transaction
-                        // is already durable in the WAL and hence committed.
-                        // This also lets the simulator know that it should shadow the results of the query because
-                        // the write itself succeeded.
-                        let checkpoint_err = LimboError::CheckpointFailed(err.to_string());
-                        tracing::error!("Checkpoint failed: {checkpoint_err}");
-                        if let Err(abort_err) =
-                            self.abort(pager, Some(&checkpoint_err), state, true)
-                        {
-                            tracing::error!(
-                                "Abort also failed during checkpoint error handling: {abort_err}"
-                            );
-                        }
-                        pager.cleanup_after_checkpoint_failure();
-                        return Err(checkpoint_err.into());
-                    }
-                    let err = err.into();
-                    if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
-                        tracing::error!("Abort failed during error handling: {abort_err}");
-                    }
-                    return Err(err.into());
-                }
-                state.io_completions = None;
             }
-            // A trigger can return FAIL before the parent program reaches
-            // Halt. FAIL keeps changes made by earlier rows, so their
-            // index-method writes must finish before abort() releases the
-            // statement savepoint and commits those partial changes. The
-            // error is stored by the dispatch loop below, which then comes
-            // back here, and by the IO arm of this block on resume.
             if state.pending_fail_prepare_error.is_some() {
-                let fail_error = state
-                    .pending_fail_prepare_error
-                    .take()
-                    .expect("checked is_some above");
-                match execute::index_method_stage_statement_all(state) {
-                    Ok(IOResult::Done(())) => {
-                        if let Err(abort_err) = self.abort(pager, Some(&fail_error), state, true) {
-                            tracing::error!(
-                                "Abort failed after preparing FAIL index methods: {abort_err}"
-                            );
-                        }
-                        return Err(fail_error.into());
-                    }
-                    Ok(IOResult::IO(io)) => {
-                        state.pending_fail_prepare_error = Some(fail_error);
-                        io.set_waker(waker);
-                        if io.is_explicit_yield() {
-                            return Ok(StepResult::Yield);
-                        }
-                        let finished = io.finished();
-                        state.io_completions = Some(io);
-                        if !finished {
-                            return Ok(StepResult::IO);
-                        }
-                        continue 'io_check;
-                    }
-                    Err(prepare_error) => {
-                        // FAIL may keep earlier base-table rows only when every
-                        // matching index-method write was staged successfully.
-                        // Once preparation fails, committing those rows would
-                        // leave the table and index out of sync, so roll back the
-                        // whole transaction while returning the real preparation
-                        // error to the caller.
-                        let rollback_error =
-                            LimboError::Raise(ResolveType::Rollback, prepare_error.to_string());
-                        if let Err(abort_err) =
-                            self.abort(pager, Some(&rollback_error), state, true)
-                        {
-                            tracing::error!(
-                                "Abort also failed after FAIL index-method preparation: \
-                                 {abort_err}"
-                            );
-                        }
-                        return Err(prepare_error);
-                    }
+                match self.prepare_pending_fail(state, pager, waker)? {
+                    Some(result) => return Ok(result),
+                    None => continue 'io_check,
                 }
             }
             loop {
-                // Closed/interrupt/deadline/progress checks run once every
-                // CHECK_INTERVAL instructions instead of on each one (SQLite
-                // similarly only checks at jump opcodes). vm_steps persists
-                // across step calls, so the cadence spans the whole statement;
-                // callers regain control at every returned row regardless.
-                // The interval must stay a power of two so this gate is a
-                // mask test, never a division, in the interpreter hot loop.
-                // The gate mask lives in ProgramState and is re-derived from the
-                // progress handler's interval only when the gate fires, so the
-                // steady-state cost is one mask test with no atomics. A handler
-                // with interval N < 64 narrows the mask at the next firing (a
-                // one-time lag of at most CHECK_INTERVAL instructions; the
-                // cadence is approximate by contract).
-                const CHECK_INTERVAL: u64 = 64;
-                const _: () = assert!(CHECK_INTERVAL.is_power_of_two());
                 if state.metrics.vm_steps & state.check_mask == 0 {
-                    let progress_ops = self.connection.progress_ops();
-                    state.check_mask = if progress_ops == 0 || progress_ops >= CHECK_INTERVAL {
-                        CHECK_INTERVAL - 1
-                    } else {
-                        progress_ops.next_power_of_two() - 1
-                    };
-                    if self.connection.is_closed() {
-                        // Connection is closed for whatever reason, rollback the transaction.
-                        let state = self.connection.get_tx_state();
-                        if let TransactionState::Write { .. } = state {
-                            pager.rollback_tx(&self.connection);
-                        }
-                        return Err(
-                            LimboError::InternalError("Connection closed".to_string()).into()
-                        );
-                    }
-                    let prev_steps = state.metrics.vm_steps.saturating_sub(state.check_mask + 1);
-                    if self.maybe_request_interrupt(state, pager.io.as_ref(), prev_steps) {
-                        self.abort(pager, None, state, true)?;
-                        return Ok(StepResult::Interrupt);
+                    if let Some(result) = self.periodic_checks(state, pager)? {
+                        return Ok(result);
                     }
                 }
 
                 let (insn, _) = &insns[state.pc as usize];
                 if trace_insns {
-                    if enable_tracing {
-                        trace_insn(self, state.pc as InsnReference, insn);
-                        crate::stack::trace_remaining("program_step:opcode");
-                    }
-                    self.trace_registers(state, insn, vdbe_trace);
+                    self.trace_step(state, insn, enable_tracing, vdbe_trace);
                 }
 
                 // Always increment VM steps for every loop iteration
                 state.metrics.vm_steps = state.metrics.vm_steps.wrapping_add(1);
 
-                match insn::dispatch_insn(self, state, insn, pager) {
-                    Ok(InsnFunctionStepResult::Step) => {
-                        // Instruction completed, moving to next
-                        state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
-                    }
-                    Ok(InsnFunctionStepResult::Done) => {
-                        // Instruction completed execution
-                        state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
-                        state.auto_txn_cleanup = TxnCleanup::None;
-                        return Ok(StepResult::Done);
-                    }
-                    Ok(InsnFunctionStepResult::IO(io)) => {
-                        // Instruction not complete - waiting for I/O, will resume at same PC
-                        io.set_waker(waker);
-                        let is_yield = io.is_explicit_yield();
-                        if is_yield {
-                            // Yield: return control to the cooperative scheduler so
-                            // other connections can make progress (e.g. release a
-                            // contended lock). Don't store in io_completions —
-                            // yields aren't pending I/O, so the instruction will
-                            // simply re-execute on the next step.
-                            return Ok(StepResult::Yield);
-                        }
-                        let finished = io.finished();
-                        state.io_completions = Some(io);
-                        if !finished {
-                            return Ok(StepResult::IO);
-                        }
-                        // IO already finished: loop back to the completion check so
-                        // errors are observed, then continue execution immediately.
-                        continue 'io_check;
-                    }
-                    Ok(InsnFunctionStepResult::Row) => {
-                        // Instruction completed (ResultRow already incremented PC)
-                        state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
-                        return Ok(StepResult::Row);
-                    }
-                    Err(boxed_err) => match *boxed_err {
-                        LimboError::Busy => {
-                            // Instruction blocked - will retry at same PC
-                            return Ok(StepResult::Busy);
-                        }
-                        LimboError::BusySnapshot
-                            if self.connection.transaction_state.get()
-                                == TransactionState::None =>
-                        {
-                            // For interactive transactions that are already in a read transaction, retrying BusySnapshot is pointless
-                            // because the snapshot will continue to be stale no matter how many times we retry.
-                            // However, for auto-commits or BEGIN IMMEDIATE, failing to promote to write transaction means it was rolled
-                            // back, so auto-retrying can be useful.
-                            return Ok(StepResult::Busy);
-                        }
-                        err if (matches!(err, LimboError::Constraint(_))
-                            && self.resolve_type == ResolveType::Fail)
-                            || matches!(err, LimboError::Raise(ResolveType::Fail, _)) =>
-                        {
-                            state.pending_fail_prepare_error = Some(err);
-                            continue 'io_check;
-                        }
-                        err => {
-                            if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
-                                tracing::error!("Abort failed during error handling: {abort_err}");
-                            }
-                            return Err(err.into());
-                        }
-                    },
+                let result = insn::dispatch_insn(self, state, insn, pager);
+                if let Ok(InsnFunctionStepResult::Step) = result {
+                    // Instruction completed, moving to next
+                    state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
+                    continue;
                 }
+                if let Ok(InsnFunctionStepResult::Row) = result {
+                    // Instruction completed (ResultRow already incremented PC)
+                    state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
+                    return Ok(StepResult::Row);
+                }
+                // Match less frequent results out of line
+                match dispatch(self, state, pager, waker, result)? {
+                    Some(result) => return Ok(result),
+                    None => continue 'io_check,
+                }
+            }
+        }
+
+        #[inline(never)]
+        fn dispatch(
+            program: &Program,
+            state: &mut ProgramState,
+            pager: &Arc<Pager>,
+            waker: Option<&Waker>,
+            result: execute::InsnResult,
+        ) -> Result<Option<StepResult>, Box<LimboError>> {
+            match result {
+                Ok(InsnFunctionStepResult::Done) => {
+                    // Instruction completed execution
+                    state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
+                    state.auto_txn_cleanup = TxnCleanup::None;
+                    Ok(Some(StepResult::Done))
+                }
+                Ok(InsnFunctionStepResult::IO(io)) => Ok(program.park_on_io(state, io, waker)),
+                Err(boxed_err) => program.fail_step(state, pager, *boxed_err),
+                Ok(InsnFunctionStepResult::Step) | Ok(InsnFunctionStepResult::Row) => {
+                    unreachable!("the dispatch loop settles steps and rows itself")
+                }
+            }
+        }
+    }
+
+    /// The IO an instruction waited for, seen at the top of the dispatch
+    /// loop: still pending, failed, or finished. None means the loop goes
+    /// on with the instruction that waited.
+    #[inline(never)]
+    fn finish_pending_io(
+        &self,
+        state: &mut ProgramState,
+        pager: &Arc<Pager>,
+        waker: Option<&Waker>,
+    ) -> Result<Option<StepResult>, Box<LimboError>> {
+        let io = state
+            .io_completions
+            .as_ref()
+            .expect("the caller checked the completion slot");
+        if !io.finished() {
+            io.set_waker(waker);
+            return Ok(Some(StepResult::IO));
+        }
+        if let Some(err) = io.get_error() {
+            if pager.is_checkpointing() {
+                // Wrap IO errors that occurred during checkpointing in CheckpointFailed error,
+                // so that abort() knows not to try to rollback the transaction, because the transaction
+                // is already durable in the WAL and hence committed.
+                // This also lets the simulator know that it should shadow the results of the query because
+                // the write itself succeeded.
+                let checkpoint_err = LimboError::CheckpointFailed(err.to_string());
+                tracing::error!("Checkpoint failed: {checkpoint_err}");
+                if let Err(abort_err) = self.abort(pager, Some(&checkpoint_err), state, true) {
+                    tracing::error!(
+                        "Abort also failed during checkpoint error handling: {abort_err}"
+                    );
+                }
+                pager.cleanup_after_checkpoint_failure();
+                return Err(checkpoint_err.into());
+            }
+            let err = err.into();
+            if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
+                tracing::error!("Abort failed during error handling: {abort_err}");
+            }
+            return Err(err.into());
+        }
+        state.io_completions = None;
+        Ok(None)
+    }
+
+    /// A trigger returned FAIL before the parent program reached Halt. FAIL
+    /// keeps changes made by earlier rows, so their index-method writes must
+    /// finish before abort() releases the statement savepoint and commits
+    /// those partial changes. None means the staging finished its IO inline
+    /// and the loop starts over.
+    #[cold]
+    #[inline(never)]
+    fn prepare_pending_fail(
+        &self,
+        state: &mut ProgramState,
+        pager: &Arc<Pager>,
+        waker: Option<&Waker>,
+    ) -> Result<Option<StepResult>, Box<LimboError>> {
+        let fail_error = state
+            .pending_fail_prepare_error
+            .take()
+            .expect("the caller checked the pending error");
+        match execute::index_method_stage_statement_all(state) {
+            Ok(IOResult::Done(())) => {
+                if let Err(abort_err) = self.abort(pager, Some(&fail_error), state, true) {
+                    tracing::error!("Abort failed after preparing FAIL index methods: {abort_err}");
+                }
+                Err(fail_error.into())
+            }
+            Ok(IOResult::IO(io)) => {
+                state.pending_fail_prepare_error = Some(fail_error);
+                io.set_waker(waker);
+                if io.is_explicit_yield() {
+                    return Ok(Some(StepResult::Yield));
+                }
+                let finished = io.finished();
+                state.io_completions = Some(io);
+                if !finished {
+                    return Ok(Some(StepResult::IO));
+                }
+                Ok(None)
+            }
+            Err(prepare_error) => {
+                // FAIL may keep earlier base-table rows only when every
+                // matching index-method write was staged successfully.
+                // Once preparation fails, committing those rows would
+                // leave the table and index out of sync, so roll back the
+                // whole transaction while returning the real preparation
+                // error to the caller.
+                let rollback_error =
+                    LimboError::Raise(ResolveType::Rollback, prepare_error.to_string());
+                if let Err(abort_err) = self.abort(pager, Some(&rollback_error), state, true) {
+                    tracing::error!(
+                        "Abort also failed after FAIL index-method preparation: \
+                         {abort_err}"
+                    );
+                }
+                Err(prepare_error)
+            }
+        }
+    }
+
+    /// The checks the dispatch loop runs once every CHECK_INTERVAL
+    /// instructions: a closed connection, an interrupt, the deadline and the
+    /// progress handler. A handler with interval N < 64 narrows the mask at
+    /// the next firing (a one-time lag of at most CHECK_INTERVAL
+    /// instructions; the cadence is approximate by contract).
+    #[inline(never)]
+    fn periodic_checks(
+        &self,
+        state: &mut ProgramState,
+        pager: &Arc<Pager>,
+    ) -> Result<Option<StepResult>, Box<LimboError>> {
+        // The interval must stay a power of two so the gate in the loop is
+        // a mask test, never a division.
+        const CHECK_INTERVAL: u64 = 64;
+        const _: () = assert!(CHECK_INTERVAL.is_power_of_two());
+        let progress_ops = self.connection.progress_ops();
+        state.check_mask = if progress_ops == 0 || progress_ops >= CHECK_INTERVAL {
+            CHECK_INTERVAL - 1
+        } else {
+            progress_ops.next_power_of_two() - 1
+        };
+        if self.connection.is_closed() {
+            return Err(self.closed_during_step(pager));
+        }
+        // With no interrupt requested, no deadline and no progress handler
+        // there is nothing to look at; the full test stays out of this
+        // function so it is a leaf.
+        let quiet = !state.is_interrupted()
+            && !self.connection.is_interrupted()
+            && state.query_deadline.is_none()
+            && progress_ops == 0;
+        if quiet {
+            return Ok(None);
+        }
+        self.periodic_interrupt_checks(state, pager)
+    }
+
+    #[inline(never)]
+    fn periodic_interrupt_checks(
+        &self,
+        state: &mut ProgramState,
+        pager: &Arc<Pager>,
+    ) -> Result<Option<StepResult>, Box<LimboError>> {
+        let prev_steps = state.metrics.vm_steps.saturating_sub(state.check_mask + 1);
+        if self.maybe_request_interrupt(state, pager.io.as_ref(), prev_steps) {
+            return self.interrupted_during_step(state, pager);
+        }
+        Ok(None)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn closed_during_step(&self, pager: &Arc<Pager>) -> Box<LimboError> {
+        // Connection is closed for whatever reason, rollback the transaction.
+        if let TransactionState::Write { .. } = self.connection.get_tx_state() {
+            pager.rollback_tx(&self.connection);
+        }
+        LimboError::InternalError("Connection closed".to_string()).into()
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn interrupted_during_step(
+        &self,
+        state: &mut ProgramState,
+        pager: &Arc<Pager>,
+    ) -> Result<Option<StepResult>, Box<LimboError>> {
+        self.abort(pager, None, state, true)?;
+        Ok(Some(StepResult::Interrupt))
+    }
+
+    #[inline(never)]
+    fn trace_step(
+        &self,
+        state: &mut ProgramState,
+        insn: &Insn,
+        enable_tracing: bool,
+        vdbe_trace: bool,
+    ) {
+        if enable_tracing {
+            trace_insn(self, state.pc as InsnReference, insn);
+            crate::stack::trace_remaining("program_step:opcode");
+        }
+        self.trace_registers(state, insn, vdbe_trace);
+    }
+
+    /// An instruction that waits for IO: the statement parks on it and
+    /// resumes at the same PC, unless the IO is an explicit yield. None
+    /// means the IO already finished and the loop starts over to observe
+    /// its outcome.
+    #[inline(never)]
+    fn park_on_io(
+        &self,
+        state: &mut ProgramState,
+        io: IOCompletions,
+        waker: Option<&Waker>,
+    ) -> Option<StepResult> {
+        io.set_waker(waker);
+        if io.is_explicit_yield() {
+            // Yield: return control to the cooperative scheduler so
+            // other connections can make progress (e.g. release a
+            // contended lock). Don't store in io_completions —
+            // yields aren't pending I/O, so the instruction will
+            // simply re-execute on the next step.
+            return Some(StepResult::Yield);
+        }
+        let finished = io.finished();
+        state.io_completions = Some(io);
+        if !finished {
+            return Some(StepResult::IO);
+        }
+        None
+    }
+
+    /// An instruction that failed: a busy error retries at the same PC, a
+    /// trigger's FAIL is staged for the loop to prepare (None), and every
+    /// other error aborts the statement.
+    #[cold]
+    #[inline(never)]
+    fn fail_step(
+        &self,
+        state: &mut ProgramState,
+        pager: &Arc<Pager>,
+        err: LimboError,
+    ) -> Result<Option<StepResult>, Box<LimboError>> {
+        match err {
+            LimboError::Busy => Ok(Some(StepResult::Busy)),
+            LimboError::BusySnapshot
+                if self.connection.transaction_state.get() == TransactionState::None =>
+            {
+                // For interactive transactions that are already in a read transaction, retrying BusySnapshot is pointless
+                // because the snapshot will continue to be stale no matter how many times we retry.
+                // However, for auto-commits or BEGIN IMMEDIATE, failing to promote to write transaction means it was rolled
+                // back, so auto-retrying can be useful.
+                Ok(Some(StepResult::Busy))
+            }
+            err if (matches!(err, LimboError::Constraint(_))
+                && self.resolve_type == ResolveType::Fail)
+                || matches!(err, LimboError::Raise(ResolveType::Fail, _)) =>
+            {
+                state.pending_fail_prepare_error = Some(err);
+                Ok(None)
+            }
+            err => {
+                if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
+                    tracing::error!("Abort failed during error handling: {abort_err}");
+                }
+                Err(err.into())
             }
         }
     }

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -941,10 +941,19 @@ impl Value {
 
     // exec_if returns whether you should jump
     pub fn exec_if(&self, jump_if_null: bool, not: bool) -> bool {
-        Numeric::from_value(self)
-            .map(|v| v.to_bool())
-            .map(|jump| if not { !jump } else { jump })
-            .unwrap_or(jump_if_null)
+        // An integer, the usual operand, needs no numeric conversion.
+        let jump = match self {
+            Value::Numeric(Numeric::Integer(i)) => *i != 0,
+            other => match Numeric::from_value(other) {
+                Some(v) => v.to_bool(),
+                None => return jump_if_null,
+            },
+        };
+        if not {
+            !jump
+        } else {
+            jump
+        }
     }
 
     pub fn exec_cast(

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -940,19 +940,21 @@ impl Value {
     }
 
     // exec_if returns whether you should jump
+    #[inline(always)]
     pub fn exec_if(&self, jump_if_null: bool, not: bool) -> bool {
-        // An integer, the usual operand, needs no numeric conversion.
-        let jump = match self {
-            Value::Numeric(Numeric::Integer(i)) => *i != 0,
-            other => match Numeric::from_value(other) {
-                Some(v) => v.to_bool(),
-                None => return jump_if_null,
-            },
-        };
-        if not {
-            !jump
+        return if let Value::Numeric(Numeric::Integer(i)) = self {
+            (*i != 0) != not
         } else {
-            jump
+            exec_if_converted(self, jump_if_null, not)
+        };
+
+        // Less common cases kept out of line to keep stack frames small
+        #[inline(never)]
+        fn exec_if_converted(value: &Value, jump_if_null: bool, not: bool) -> bool {
+            match Numeric::from_value(value) {
+                Some(v) => v.to_bool() != not,
+                None => jump_if_null,
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Part 8 of 15 split out of #8692 (commits 71-80 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### CodSpeed

Commits 1-74 (`19fa1c27`) vs `main`: [run 6a9c11d220293c61e16aaf3d](https://codspeed.io/tursodatabase/turso/runs/6a9c11d220293c61e16aaf3d), 191 improvements, 1 regression, 1378 unchanged, 28 new, 739 skipped. The regression is `mvcc-recovery/small-frames[100000 nightly]`, 327.4 ms → 422.8 ms, first seen in the run of `dd86025a` (431.2 ms). The benchmark replays an MVCC log at open and runs no VDBE code; its stable-toolchain variant is unchanged (338.5 ms → 335.7 ms) and the ten-times larger `small-frames[1000000 nightly]` is unchanged at 3.8 s, the same value as in the run of `4558f126`, where the 100000-row nightly variant measured 379 ms. The nightly variants of all the recovery benchmarks run 10-15% slower than the stable ones in every run. Against the run of `b17c0692`: nothing else past the reporting threshold (1597 unchanged).

Commits 1-77 (`4f58aedc`) vs `main`: [run 6a9c17ee0b3b743db286b342](https://codspeed.io/tursodatabase/turso/runs/6a9c17ee0b3b743db286b342), 192 improvements, 1 regression (the same `mvcc-recovery/small-frames[100000 nightly]`, at 424.9 ms), 1679 unchanged, 28 new, 437 skipped. Against the run of `19fa1c27`: nothing past the reporting threshold (1900 unchanged, 437 skipped).

Commits 1-85 (`c8ba9a93`) vs `main`: [run 6a9c1f9920293c61e16ab091](https://codspeed.io/tursodatabase/turso/runs/6a9c1f9920293c61e16ab091), 188 improvements, 1 regression (the same nightly recovery benchmark, at 422.7 ms), 1985 unchanged, 28 new, 135 skipped. Against the run of `4f58aedc`: nothing past the reporting threshold (2202 unchanged, 135 skipped); the commits in between save 1-3% per row on the GROUP BY and count scans in the local measurements below, under CodSpeed's threshold.

### Measurement history: per-row costs

Callgrind instruction counts (`Ir`) are for 5 iterations of `SELECT 1 FROM t` and 3 iterations of the others. Wall clock is the best of 7 runs of one iteration on a noisy VM, so treat it as a sanity check only.

| Commit | SELECT 1 (Ir) | Δ | SELECT * (Ir) | Δ | W3 (Ir) | Δ | W4 (Ir) | Δ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `6a99121e` keep the cold paths of the dispatch loop out of line | 183,327,516 | -6.23% | 389,295,445 | -2.37% | 260,877,014 | -0.86% | 293,165,031 | -0.92% |

| Commit | Workload | before | after |
|---|---|---:|---:|
| `19fa1c27` apply the affinity string to the registers as two slices | W11 | 30,080,957 | 29,925,851 (-0.5%) |
| `eaa46e94` skip the drop glue of the empty write states of an insert | W11 | 29,925,851 | 29,725,944 (-0.7%) |
| `4f58aedc` inline the free-space computation of a page | W11 | 29,725,944 | 29,511,250 (-0.7%) |
| `b96cf172` checksum WAL frames over fixed-size chunks (WAL recovery at open of the 3.4 MB WAL and the 4 commits; not a per-row cost) | W11 | 29,511,250 | 25,784,398 (-12.6%) |
| | `SELECT 1 FROM t`, all of it the recovery at open | 198,918,821 | 195,509,941 (-1.7%) |
| `5c2517fd` build the overflow error of a counter only when it overflows | W4 (`count(*)` per row) | 307,946,969 | 298,746,951 (-3.0%) |
| | `SELECT value, count(*) FROM t GROUP BY value` (W12, index-streamed GROUP BY) | 365,514,812 | 356,322,816 (-2.5%) |
| | W8 | 953,233,677 | 944,034,479 (-1.0%) |
| `b5456cc2` test an integer register in If without the numeric conversion | W12 | 356,322,816 | 345,922,819 (-2.9%) |
| | W8 | 944,034,479 | 933,634,479 (-1.1%) |
| `1e9a4db5` keep the general comparison of Compare out of line | W12 | 345,922,819 | 338,722,933 (-2.1%) |
| | W8 | 933,634,479 | 926,434,602 (-0.8%) |
| `ac4dce4d` store an integer over a non-numeric register out of line | W12 | 338,722,933 | 335,464,145 (-1.0%) |
| | W8 | 926,434,602 | 920,379,294 (-0.7%) |
| | W4 | 298,746,951 | 295,892,561 (-1.0%) |
| `c8ba9a93` keep the converting path of If out of line | W12 | 335,464,145 | 334,264,063 (-0.4%) |
| `6a99121e` keep the cold paths of the dispatch loop out of line | W12 | 334,264,063 | 330,465,616 (-1.1%) |
| | W8 | 919,179,205 | 912,688,415 (-0.7%) |

### Measurement history: per-statement costs

The second half of the PR works on the fixed cost of executing a prepared statement once: transaction begin and commit, cursor open and close, statement reset, metrics. Measured as callgrind instructions per execution, taken as (Ir at 3000 executions − Ir at 1000 executions) / 2000 so the process start-up is cancelled out. Workloads: a point lookup `SELECT * FROM t WHERE id = 12345` (one `Transaction`, one `OpenRead`, one `SeekRowid`, `Column`, `Halt`), `SELECT 1` (no table, no transaction: the pure statement overhead), and an index lookup `SELECT id FROM t WHERE value = 500 LIMIT 1` (two cursors).

| Commit | point lookup | Δ | `SELECT 1` | Δ | index lookup | Δ |
|---|---:|---:|---:|---:|---:|---:|
| `6a99121e` keep the cold paths of the dispatch loop out of line | 7,417 | -0.3% | 1,787 | -0.7% | 13,324 | -0.2% |

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_