### PR TITLE
core: Optimize comparisons, cell parsing and record stores

### DIFF
--- a/core/statement.rs
+++ b/core/statement.rs
@@ -304,10 +304,7 @@ pub struct Statement {
     /// - `Some(Some(duration))`: override with a query-specific timeout
     /// - `Some(None)`: disable timeout for this execution
     query_timeout_override: Option<Option<Duration>>,
-    /// True once step() has returned Row for a write statement (INSERT/UPDATE/DELETE
-    /// with RETURNING). With ephemeral-buffered RETURNING, the first Row proves all
-    /// DML completed — only the scan-back remains. Used by reset_internal to decide
-    /// commit vs rollback when a statement is abandoned.
+    /// True once [Self::step] has returned a [Row].
     has_returned_row: bool,
     /// Byte offset in the original SQL string where this statement ends.
     /// Used by sqlite3_prepare_v2 to set the *pzTail output parameter.
@@ -579,14 +576,7 @@ impl Statement {
             .step(&mut self.state, &self.pager, self.query_mode, waker);
         if let Ok(StepResult::Row) = res {
             self.busy = true;
-            // Track when a write statement yields its first Row. With ephemeral-buffered
-            // RETURNING, this proves all DML completed — only the scan-back remains.
-            if self.query_mode == QueryMode::Normal
-                && self.program.change_cnt_on
-                && !self.program.result_columns.is_empty()
-            {
-                self.has_returned_row = true;
-            }
+            self.has_returned_row = true;
             return Ok(StepResult::Row);
         }
         self.finish_step(res, waker)
@@ -731,13 +721,7 @@ impl Statement {
             // else: Handler says stop, res stays as Busy
         }
 
-        // Track when a write statement yields its first Row. With ephemeral-buffered
-        // RETURNING, this proves all DML completed — only the scan-back remains.
-        if matches!(res, Ok(StepResult::Row))
-            && self.query_mode == QueryMode::Normal
-            && self.program.change_cnt_on
-            && !self.program.result_columns.is_empty()
-        {
+        if matches!(res, Ok(StepResult::Row)) {
             self.has_returned_row = true;
         }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6673,7 +6673,7 @@ impl CursorTrait for BTreeCursor {
 
     fn record_payload(&mut self) -> IOResultOr<Option<&[u8]>> {
         if self.needs_restore() {
-            return_if_io!(self.restore_context());
+            return restore_record_payload(self);
         }
         if self.null_flag || !self.has_record() {
             return Ok(IOResult::Done(None));
@@ -6695,27 +6695,33 @@ impl CursorTrait for BTreeCursor {
             .reusable_immutable_record
             .as_ref()
             .is_some_and(|record| !record.is_invalidated());
-        if !cached {
-            let page = self.stack.top_ref();
-            let contents = page.get_contents();
-            let cell_idx = self.stack.current_cell_index();
-            let (payload, payload_start, _payload_size, first_overflow_page) =
-                contents.cell_read_payload_at(cell_idx as usize, self.payload_limits)?;
-            if first_overflow_page.is_none() {
-                // The whole record sits on the pinned page: decode it there
-                // instead of copying it into the reusable record first, and
-                // note where it is for the next column read on this row.
-                // Both fit in 32 bits: the payload lies inside a page of at
-                // most 64 KiB.
-                self.noted_payload = NotedPayload {
-                    start: payload_start as u32,
-                    size: payload.len() as u32,
-                };
-                return Ok(IOResult::Done(Some(payload)));
-            }
+        if cached {
+            return Ok(IOResult::Done(
+                self.reusable_immutable_record
+                    .as_ref()
+                    .map(ImmutableRecord::get_payload),
+            ));
         }
-        let record = return_if_io!(self.record());
-        Ok(IOResult::Done(record.map(ImmutableRecord::get_payload)))
+        let contents = self.stack.top_ref().get_contents();
+        let cell_idx = self.stack.current_cell_index();
+        // Optimistically use a faster decoder that only handles leaf cells without overflow pages.
+        // If this fails, we'll degrade to the slower path.
+        if let Some((payload, start)) =
+            contents.decode_leaf_cell_without_overflow(cell_idx as usize, &self.payload_limits)
+        {
+            self.noted_payload = NotedPayload {
+                start: start as u32,
+                size: payload.len() as u32,
+            };
+            return Ok(IOResult::Done(Some(payload)));
+        }
+        return self.record_payload_general();
+
+        #[inline(never)]
+        fn restore_record_payload(cursor: &mut BTreeCursor) -> IOResultOr<Option<&[u8]>> {
+            return_if_io!(cursor.restore_context());
+            cursor.record_payload()
+        }
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
@@ -7625,6 +7631,24 @@ impl CursorTrait for BTreeCursor {
 }
 
 impl BTreeCursor {
+    #[inline(never)]
+    fn record_payload_general(&mut self) -> IOResultOr<Option<&[u8]>> {
+        let page = self.stack.top_ref();
+        let contents = page.get_contents();
+        let cell_idx = self.stack.current_cell_index();
+        let (payload, payload_start, _payload_size, first_overflow_page) =
+            contents.cell_read_payload_at(cell_idx as usize, self.payload_limits)?;
+        if first_overflow_page.is_none() {
+            self.noted_payload = NotedPayload {
+                start: payload_start as u32,
+                size: payload.len() as u32,
+            };
+            return Ok(IOResult::Done(Some(payload)));
+        }
+        let record = return_if_io!(self.record());
+        Ok(IOResult::Done(record.map(ImmutableRecord::get_payload)))
+    }
+
     /// True when the next cell is on the same leaf page and no resumable
     /// state is pending, so advancing cannot yield and `next()` can skip
     /// its state machine. Every pending flag routes to the full path,
@@ -14291,6 +14315,66 @@ mod tests {
                 Some(6),
                 "next() after peer deletion of our row must land on the next-greater rowid"
             );
+        }
+
+        #[test]
+        fn record_payload_restores_after_peer_insert() {
+            for size in [16, 6000] {
+                let (pager, root_page, _db, _conn) = empty_btree();
+                let mut writer = make_registered_cursor(&pager, root_page, 1);
+                let mut reader = make_registered_cursor(&pager, root_page, 1);
+                let value = Value::Blob(crate::alloc::vec![b'x'; size]);
+                let expected =
+                    ImmutableRecord::from_registers(&[Register::Value(value.clone())], 1).unwrap();
+                insert_record(&mut writer, &pager, 5, value).unwrap();
+                run_until_done(|| reader.rewind(), pager.deref()).unwrap();
+
+                for rowid in [1, 2] {
+                    insert_record(&mut writer, &pager, rowid, Value::from_i64(rowid)).unwrap();
+                    assert!(reader.needs_restore());
+                    // The second read exercises the remembered location or overflow buffer.
+                    for _ in 0..2 {
+                        let payload = run_until_done(
+                            || {
+                                Ok(reader
+                                    .record_payload()?
+                                    .map(|payload| payload.map(<[u8]>::to_vec)))
+                            },
+                            pager.deref(),
+                        )
+                        .unwrap()
+                        .unwrap();
+                        assert_eq!(payload, expected.get_payload());
+                        assert!(!reader.needs_restore());
+                    }
+                }
+
+                insert_record(&mut writer, &pager, 3, Value::from_i64(3)).unwrap();
+                assert!(reader.needs_restore());
+                reader.set_null_flag(true);
+                let restored = run_until_done(
+                    || {
+                        Ok(reader
+                            .record_payload()?
+                            .map(|payload| payload.map(<[u8]>::to_vec)))
+                    },
+                    pager.deref(),
+                )
+                .unwrap()
+                .unwrap();
+                assert_eq!(restored, expected.get_payload());
+                assert!(!reader.needs_restore());
+                assert!(!reader.get_null_flag());
+
+                reader.set_null_flag(true);
+                let missing = run_until_done(
+                    || Ok(reader.record_payload()?.map(|payload| payload.is_none())),
+                    pager.deref(),
+                )
+                .unwrap();
+                assert!(missing);
+                assert!(!reader.needs_restore());
+            }
         }
 
         #[test]

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -495,6 +495,47 @@ impl PageInner {
         Some(unsafe { std::mem::transmute::<&[u8], &'static [u8]>(payload) })
     }
 
+    /// Optimistic decoder: returns the bytes and index of a cell payload if it is entirely on the page.
+    ///
+    /// Returns `None` for interior pages, cells with overflow pages, and corrupt cells.
+    #[inline(always)]
+    pub fn decode_leaf_cell_without_overflow(
+        &self,
+        cell_index: usize,
+        limits: &PayloadLimits,
+    ) -> Option<(&'static [u8], usize)> {
+        let buf = self.as_ptr();
+        let header = self.offset();
+        let page_type = *buf.get(header + BTREE_PAGE_TYPE)?;
+        let is_table = page_type == PageType::TableLeaf as u8;
+        if !is_table && page_type != PageType::IndexLeaf as u8 {
+            return None;
+        }
+        let cell_pointer = header + LEAF_PAGE_HEADER_SIZE_BYTES + cell_index * CELL_PTR_SIZE_BYTES;
+        let cell_offset =
+            u16::from_be_bytes([*buf.get(cell_pointer)?, *buf.get(cell_pointer + 1)?]) as usize;
+        let (size, len) = read_varint(buf.get(cell_offset..)?).ok()?;
+        let mut start = cell_offset + len;
+        if is_table {
+            let (_, rowid_len) = read_varint(buf.get(start..)?).ok()?;
+            start += rowid_len;
+        }
+        let max_local = if is_table {
+            limits.max_local_table
+        } else {
+            limits.max_local_index
+        };
+        if size > max_local as u64 {
+            return None;
+        }
+        let payload = buf.get(start..start + size as usize)?;
+        // SAFETY: valid as long as page is alive
+        Some((
+            unsafe { std::mem::transmute::<&[u8], &'static [u8]>(payload) },
+            start,
+        ))
+    }
+
     /// Reads the two varints that start a table leaf cell: the payload size
     /// and the rowid. The payload starts right after them.
     #[inline(always)]

--- a/core/types.rs
+++ b/core/types.rs
@@ -1335,23 +1335,47 @@ mod immutable_record {
     /// and returns how many it wrote.
     #[inline(always)]
     fn write_value(out: &mut [u8], value: ValueRef<'_>, serial_type: SerialType) -> usize {
+        // Numbers have a size known per serial type, so each arm stores its
+        // bytes with a copy of constant length; a copy of variable length is
+        // a memcpy call for every number of every built record.
         let bytes: &[u8] = match value {
             ValueRef::Null => return 0,
-            ValueRef::Numeric(Numeric::Integer(i)) => match serial_type.kind() {
-                SerialTypeKind::ConstInt0 | SerialTypeKind::ConstInt1 => return 0,
-                SerialTypeKind::I8 => &(i as i8).to_be_bytes(),
-                SerialTypeKind::I16 => &(i as i16).to_be_bytes(),
-                // Without the most significant byte.
-                SerialTypeKind::I24 => &(i as i32).to_be_bytes()[1..],
-                SerialTypeKind::I32 => &(i as i32).to_be_bytes(),
-                // Without the two most significant bytes.
-                SerialTypeKind::I48 => &i.to_be_bytes()[2..],
-                SerialTypeKind::I64 => &i.to_be_bytes(),
-                other => panic!("Serial type is not an integer: {other:?}"),
-            },
+            ValueRef::Numeric(Numeric::Integer(i)) => {
+                return match serial_type.kind() {
+                    SerialTypeKind::ConstInt0 | SerialTypeKind::ConstInt1 => 0,
+                    SerialTypeKind::I8 => {
+                        out[0] = i as u8;
+                        1
+                    }
+                    SerialTypeKind::I16 => {
+                        out[..2].copy_from_slice(&(i as i16).to_be_bytes());
+                        2
+                    }
+                    // Without the most significant byte.
+                    SerialTypeKind::I24 => {
+                        out[..3].copy_from_slice(&(i as i32).to_be_bytes()[1..]);
+                        3
+                    }
+                    SerialTypeKind::I32 => {
+                        out[..4].copy_from_slice(&(i as i32).to_be_bytes());
+                        4
+                    }
+                    // Without the two most significant bytes.
+                    SerialTypeKind::I48 => {
+                        out[..6].copy_from_slice(&i.to_be_bytes()[2..]);
+                        6
+                    }
+                    SerialTypeKind::I64 => {
+                        out[..8].copy_from_slice(&i.to_be_bytes());
+                        8
+                    }
+                    other => panic!("Serial type is not an integer: {other:?}"),
+                };
+            }
             ValueRef::Numeric(Numeric::Float(f)) => {
                 let fval: f64 = f.into();
-                &fval.to_be_bytes()
+                out[..8].copy_from_slice(&fval.to_be_bytes());
+                return 8;
             }
             ValueRef::Text(t) => t.value.as_bytes(),
             ValueRef::Blob(b) => b,

--- a/core/types.rs
+++ b/core/types.rs
@@ -1345,9 +1345,6 @@ mod immutable_record {
     /// and returns how many it wrote.
     #[inline(always)]
     fn write_value(out: &mut [u8], value: ValueRef<'_>, serial_type: SerialType) -> usize {
-        // Numbers have a size known per serial type, so each arm stores its
-        // bytes with a copy of constant length; a copy of variable length is
-        // a memcpy call for every number of every built record.
         let bytes: &[u8] = match value {
             ValueRef::Null => return 0,
             ValueRef::Numeric(Numeric::Integer(i)) => {

--- a/core/types.rs
+++ b/core/types.rs
@@ -1331,6 +1331,16 @@ mod immutable_record {
         }
     }
 
+    /// [`write_varint`] with the one-byte case inline.
+    #[inline(always)]
+    fn write_short_varint(out: &mut [u8], value: u64) -> usize {
+        if value <= 0x7f {
+            out[0] = value as u8;
+            return 1;
+        }
+        write_varint(out, value)
+    }
+
     /// Writes the bytes of `value` for `serial_type` at the start of `out`
     /// and returns how many it wrote.
     #[inline(always)]
@@ -1817,12 +1827,13 @@ mod immutable_record {
 
             // Writing pass: each serial type goes into the header and each
             // value after it, the varints straight into their place.
-            let mut header_pos = write_varint(&mut buf[..header_size], header_size as u64);
+            let mut header_pos = write_short_varint(&mut buf[..header_size], header_size as u64);
             let mut value_pos = header_size;
             for value in values {
                 let value = value.as_value_ref();
                 let serial_type = SerialType::from(value);
-                header_pos += write_varint(&mut buf[header_pos..header_size], serial_type.into());
+                header_pos +=
+                    write_short_varint(&mut buf[header_pos..header_size], serial_type.into());
                 value_pos += write_value(&mut buf[value_pos..], value, serial_type);
             }
             crate::turso_assert!(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1006,95 +1006,62 @@ pub fn op_not_null(
     Ok(InsnFunctionStepResult::Step)
 }
 
-pub fn op_comparison(
-    program: &Program,
-    state: &mut ProgramState,
-    insn: &Insn,
-    _pager: &Arc<Pager>,
-) -> InsnResult {
-    let (lhs, rhs, target_pc, op) = match insn {
-        Insn::Eq {
-            lhs,
-            rhs,
-            target_pc,
-            ..
-        } => (*lhs, *rhs, *target_pc, ComparisonOp::Eq),
-        Insn::Ne {
-            lhs,
-            rhs,
-            target_pc,
-            ..
-        } => (*lhs, *rhs, *target_pc, ComparisonOp::Ne),
-        Insn::Lt {
-            lhs,
-            rhs,
-            target_pc,
-            ..
-        } => (*lhs, *rhs, *target_pc, ComparisonOp::Lt),
-        Insn::Le {
-            lhs,
-            rhs,
-            target_pc,
-            ..
-        } => (*lhs, *rhs, *target_pc, ComparisonOp::Le),
-        Insn::Gt {
-            lhs,
-            rhs,
-            target_pc,
-            ..
-        } => (*lhs, *rhs, *target_pc, ComparisonOp::Gt),
-        Insn::Ge {
-            lhs,
-            rhs,
-            target_pc,
-            ..
-        } => (*lhs, *rhs, *target_pc, ComparisonOp::Ge),
-        _ => unreachable!("unexpected Insn {:?}", insn),
-    };
-    let crate::vdbe::BranchOffset::Offset(target_pc) = target_pc else {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
-    };
+macro_rules! comparison_opcode {
+    ($name:ident, $variant:ident, $op:expr, $jumps:expr) => {
+        pub fn $name(
+            program: &Program,
+            state: &mut ProgramState,
+            insn: &Insn,
+            _pager: &Arc<Pager>,
+        ) -> InsnResult {
+            load_insn!(
+                $variant {
+                    lhs,
+                    rhs,
+                    target_pc,
+                    flags,
+                    collation
+                },
+                insn
+            );
+            let crate::vdbe::BranchOffset::Offset(target_pc) = *target_pc else {
+                crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+            };
 
-    // Two integers compare directly: no NULL handling, affinity or collation.
-    if let (
-        Register::Value(Value::Numeric(Numeric::Integer(l))),
-        Register::Value(Value::Numeric(Numeric::Integer(r))),
-    ) = (&state.registers[lhs], &state.registers[rhs])
-    {
-        let should_jump = match op {
-            ComparisonOp::Eq => l == r,
-            ComparisonOp::Ne => l != r,
-            ComparisonOp::Lt => l < r,
-            ComparisonOp::Le => l <= r,
-            ComparisonOp::Gt => l > r,
-            ComparisonOp::Ge => l >= r,
-        };
-        state.pc = if should_jump { target_pc } else { state.pc + 1 };
-        return Ok(InsnFunctionStepResult::Step);
-    }
-    let (flags, collation) = match insn {
-        Insn::Eq {
-            flags, collation, ..
+            // Two integers compare directly: no NULL handling, affinity or collation.
+            if let (
+                Register::Value(Value::Numeric(Numeric::Integer(l))),
+                Register::Value(Value::Numeric(Numeric::Integer(r))),
+            ) = (&state.registers[*lhs], &state.registers[*rhs])
+            {
+                let jumps = $jumps;
+                state.pc = if jumps(*l, *r) {
+                    target_pc
+                } else {
+                    state.pc + 1
+                };
+                return Ok(InsnFunctionStepResult::Step);
+            }
+            op_comparison_slow(
+                program,
+                state,
+                *lhs,
+                *rhs,
+                target_pc,
+                *flags,
+                collation.unwrap_or_default(),
+                $op,
+            )
         }
-        | Insn::Ne {
-            flags, collation, ..
-        }
-        | Insn::Lt {
-            flags, collation, ..
-        }
-        | Insn::Le {
-            flags, collation, ..
-        }
-        | Insn::Gt {
-            flags, collation, ..
-        }
-        | Insn::Ge {
-            flags, collation, ..
-        } => (*flags, collation.unwrap_or_default()),
-        _ => unreachable!("unexpected Insn {:?}", insn),
     };
-    op_comparison_slow(program, state, lhs, rhs, target_pc, flags, collation, op)
 }
+
+comparison_opcode!(op_eq, Eq, ComparisonOp::Eq, |l: i64, r: i64| l == r);
+comparison_opcode!(op_ne, Ne, ComparisonOp::Ne, |l: i64, r: i64| l != r);
+comparison_opcode!(op_lt, Lt, ComparisonOp::Lt, |l: i64, r: i64| l < r);
+comparison_opcode!(op_le, Le, ComparisonOp::Le, |l: i64, r: i64| l <= r);
+comparison_opcode!(op_gt, Gt, ComparisonOp::Gt, |l: i64, r: i64| l > r);
+comparison_opcode!(op_ge, Ge, ComparisonOp::Ge, |l: i64, r: i64| l >= r);
 
 /// The comparison opcodes for every operand pair that is not two integers:
 /// NULLs, affinity conversions, text collations and array comparison.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1889,7 +1889,14 @@ pub fn op_column(
         },
         insn
     );
-    op_column_impl(
+    if state.active_op_state.is_idle() && state.deferred_seeks[*cursor_id].is_none() {
+        let result = op_column_fetch(program, state, *cursor_id, *column, *dest, default)?;
+        if matches!(result, InsnFunctionStepResult::Step) {
+            state.pc += 1;
+        }
+        return Ok(result);
+    }
+    op_column_deferred(
         program,
         state,
         *cursor_id,
@@ -1920,7 +1927,15 @@ pub fn op_column_range(
         },
         insn
     );
-    op_column_impl(
+    if state.active_op_state.is_idle() && state.deferred_seeks[*cursor_id].is_none() {
+        let result =
+            op_column_range_fetch(program, state, *cursor_id, *start_column, *dest, defaults)?;
+        if matches!(result, InsnFunctionStepResult::Step) {
+            state.pc += 1;
+        }
+        return Ok(result);
+    }
+    op_column_deferred(
         program,
         state,
         *cursor_id,
@@ -1977,27 +1992,6 @@ impl ColumnFetch<'_> {
             } => op_column_range_fetch(program, state, cursor_id, start_column, dest, defaults),
         }
     }
-}
-
-#[inline(always)]
-fn op_column_impl(
-    program: &Program,
-    state: &mut ProgramState,
-    cursor_id: usize,
-    fetch: ColumnFetch<'_>,
-) -> InsnResult {
-    // Fast path: no deferred seek pending and no suspended state machine. The
-    // column fetch either completes or yields IO with nothing persisted, so the
-    // op-state slot (enum write + drop on clear) is bypassed entirely. On IO
-    // resume the slot is still idle and this path re-executes.
-    if state.active_op_state.is_idle() && state.deferred_seeks[cursor_id].is_none() {
-        let result = fetch.fetch(program, state, cursor_id)?;
-        if matches!(result, InsnFunctionStepResult::Step) {
-            state.pc += 1;
-        }
-        return Ok(result);
-    }
-    op_column_deferred(program, state, cursor_id, fetch)
 }
 
 /// Column when a deferred seek is pending or the fetch was suspended for

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3503,16 +3503,7 @@ pub fn op_next(
         let cursor = state.get_cursor(*cursor_id);
         match cursor {
             Cursor::BTree(btree_cursor) => !return_if_io!(btree_cursor.next_row()),
-            Cursor::MaterializedView(mv_cursor) => {
-                let has_more = return_if_io!(mv_cursor.next());
-                !has_more
-            }
-            Cursor::IndexMethod(_) => {
-                let cursor = cursor.as_index_method_mut();
-                let has_more = return_if_io!(cursor.query_next());
-                !has_more
-            }
-            _ => panic!("Next on non-btree/materialized-view cursor"),
+            _ => !return_if_io!(next_row_of_other_cursor(cursor)),
         }
     };
     if !is_empty {
@@ -3534,7 +3525,16 @@ pub fn op_next(
     } else {
         state.pc += 1;
     }
-    Ok(InsnFunctionStepResult::Step)
+    return Ok(InsnFunctionStepResult::Step);
+
+    #[inline(never)]
+    fn next_row_of_other_cursor(cursor: &mut Cursor) -> IOResultOr<bool> {
+        match cursor {
+            Cursor::MaterializedView(mv_cursor) => mv_cursor.next(),
+            Cursor::IndexMethod(_) => cursor.as_index_method_mut().query_next(),
+            _ => panic!("Next on non-btree/materialized-view cursor"),
+        }
+    }
 }
 
 pub fn op_prev(

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6108,49 +6108,37 @@ fn op_row_id_read(state: &mut ProgramState, cursor_id: usize, dest: usize) -> In
         .cursors
         .get_mut(cursor_id)
         .expect("cursor_id should be valid");
-    match cursor {
-        Some(Cursor::NullRow) => {
-            state.registers[dest].set_null();
-        }
-        Some(Cursor::BTree(btree_cursor)) => {
-            // rowid() answers None for a cursor in the null-row state.
-            if let Some(rowid) = return_if_io!(btree_cursor.rowid()) {
-                state.registers[dest].set_int(rowid);
-            } else {
-                state.registers[dest].set_null();
+    let rowid = match cursor {
+        Some(Cursor::BTree(btree_cursor)) => return_if_io!(btree_cursor.rowid()),
+        _ => return_if_io!(row_id_of_other_cursor(cursor)),
+    };
+    match rowid {
+        Some(rowid) => state.registers[dest].set_int(rowid),
+        None => state.registers[dest].set_null(),
+    }
+    return Ok(InsnFunctionStepResult::Step);
+
+    // out of line to keep the stack frame small
+    #[inline(never)]
+    fn row_id_of_other_cursor(cursor: &mut Option<Cursor>) -> IOResultOr<Option<i64>> {
+        match cursor {
+            Some(Cursor::NullRow) => Ok(IOResult::Done(None)),
+            Some(Cursor::Virtual(virtual_cursor)) => {
+                let rowid = virtual_cursor.rowid();
+                Ok(IOResult::Done((rowid != 0).then_some(rowid)))
             }
-        }
-        Some(Cursor::Virtual(virtual_cursor)) => {
-            let rowid = virtual_cursor.rowid();
-            if rowid != 0 {
-                state.registers[dest].set_int(rowid);
-            } else {
-                state.registers[dest].set_null();
+            Some(Cursor::MaterializedView(mv_cursor)) => mv_cursor.rowid(),
+            Some(Cursor::IndexMethod(cursor)) => cursor.query_rowid(),
+            _ => {
+                mark_unlikely();
+                Err(LimboError::InternalError(
+                    "RowId: cursor is not a table, virtual, or materialized view cursor"
+                        .to_string(),
+                )
+                .into())
             }
-        }
-        Some(Cursor::MaterializedView(mv_cursor)) => {
-            if let Some(rowid) = return_if_io!(mv_cursor.rowid()) {
-                state.registers[dest].set_int(rowid);
-            } else {
-                state.registers[dest].set_null();
-            }
-        }
-        Some(Cursor::IndexMethod(cursor)) => {
-            if let Some(rowid) = return_if_io!(cursor.query_rowid()) {
-                state.registers[dest].set_int(rowid);
-            } else {
-                state.registers[dest].set_null();
-            }
-        }
-        _ => {
-            mark_unlikely();
-            return Err(LimboError::InternalError(
-                "RowId: cursor is not a table, virtual, or materialized view cursor".to_string(),
-            )
-            .into());
         }
     }
-    Ok(InsnFunctionStepResult::Step)
 }
 
 pub fn op_idx_row_id(

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -2180,12 +2180,12 @@ impl InsnVariants {
             InsnVariants::Move => execute::op_move,
             InsnVariants::IfPos => execute::op_if_pos,
             InsnVariants::NotNull => execute::op_not_null,
-            InsnVariants::Eq
-            | InsnVariants::Ne
-            | InsnVariants::Lt
-            | InsnVariants::Le
-            | InsnVariants::Gt
-            | InsnVariants::Ge => execute::op_comparison,
+            InsnVariants::Eq => execute::op_eq,
+            InsnVariants::Ne => execute::op_ne,
+            InsnVariants::Lt => execute::op_lt,
+            InsnVariants::Le => execute::op_le,
+            InsnVariants::Gt => execute::op_gt,
+            InsnVariants::Ge => execute::op_ge,
             InsnVariants::If => execute::op_if,
             InsnVariants::IfNot => execute::op_if_not,
             InsnVariants::OpenRead => execute::op_open_read,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2140,6 +2140,7 @@ impl Program {
         state.pre_op_registers = Some(state.registers.clone());
     }
 
+    #[inline(always)]
     fn normal_step(
         &self,
         state: &mut ProgramState,
@@ -2148,85 +2149,99 @@ impl Program {
     ) -> Result<StepResult, Box<LimboError>> {
         let enable_tracing = tracing::enabled!(tracing::Level::TRACE);
         let vdbe_trace = self.connection.get_vdbe_trace();
-        // One flag for the per-instruction test; the two kinds of tracing are
-        // told apart only once it is set.
-        let trace_insns = enable_tracing || vdbe_trace;
-        // Reborrow the instruction list once: reloading it through `self`
-        // every iteration defeats LLVM's hoisting because the opcode call
-        // below is opaque to it.
-        let insns = self.insns.as_slice();
-        // Invalidate the previous result row once per step call: rows are only
-        // handed out between step calls, and ResultRow returns immediately
-        // after setting a fresh one.
-        let _ = state.result_row.take();
-        // The outer loop runs once per step call and is re-entered only when an
-        // instruction completed its IO inline; the inner loop dispatches
-        // instructions without re-inspecting the completion slot every time.
-        'io_check: loop {
-            if state.io_completions.is_some() {
-                if let Some(result) = self.finish_pending_io(state, pager, waker)? {
-                    return Ok(result);
-                }
-            }
-            if state.pending_fail_prepare_error.is_some() {
-                match self.prepare_pending_fail(state, pager, waker)? {
-                    Some(result) => return Ok(result),
-                    None => continue 'io_check,
-                }
-            }
-            loop {
-                if state.metrics.vm_steps & state.check_mask == 0 {
-                    if let Some(result) = self.periodic_checks(state, pager)? {
-                        return Ok(result);
-                    }
-                }
 
-                let (insn, _) = &insns[state.pc as usize];
-                if trace_insns {
-                    self.trace_step(state, insn, enable_tracing, vdbe_trace);
-                }
-
-                // Always increment VM steps for every loop iteration
-                state.metrics.vm_steps = state.metrics.vm_steps.wrapping_add(1);
-
-                let result = insn::dispatch_insn(self, state, insn, pager);
-                if let Ok(InsnFunctionStepResult::Step) = result {
-                    // Instruction completed, moving to next
-                    state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
-                    continue;
-                }
-                if let Ok(InsnFunctionStepResult::Row) = result {
-                    // Instruction completed (ResultRow already incremented PC)
-                    state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
-                    return Ok(StepResult::Row);
-                }
-                // Match less frequent results out of line
-                match dispatch(self, state, pager, waker, result)? {
-                    Some(result) => return Ok(result),
-                    None => continue 'io_check,
-                }
-            }
-        }
+        return if enable_tracing || vdbe_trace {
+            dispatch_loop::<true>(self, state, pager, waker, enable_tracing, vdbe_trace)
+        } else {
+            dispatch_loop::<false>(self, state, pager, waker, false, false)
+        };
 
         #[inline(never)]
-        fn dispatch(
+        fn dispatch_loop<const TRACE: bool>(
             program: &Program,
             state: &mut ProgramState,
             pager: &Arc<Pager>,
             waker: Option<&Waker>,
-            result: execute::InsnResult,
-        ) -> Result<Option<StepResult>, Box<LimboError>> {
-            match result {
-                Ok(InsnFunctionStepResult::Done) => {
-                    // Instruction completed execution
-                    state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
-                    state.auto_txn_cleanup = TxnCleanup::None;
-                    Ok(Some(StepResult::Done))
+            enable_tracing: bool,
+            vdbe_trace: bool,
+        ) -> Result<StepResult, Box<LimboError>> {
+            // Reborrow the instruction list once: reloading it through `self`
+            // every iteration defeats LLVM's hoisting because the opcode call
+            // below is opaque to it.
+            let insns = program.insns.as_slice();
+            // Invalidate the previous result row once per step call: rows are only
+            // handed out between step calls, and ResultRow returns immediately
+            // after setting a fresh one.
+            let _ = state.result_row.take();
+            // The outer loop runs once per step call and is re-entered only when an
+            // instruction completed its IO inline; the inner loop dispatches
+            // instructions without re-inspecting the completion slot every time.
+            'io_check: loop {
+                if state.io_completions.is_some() {
+                    if let Some(result) = program.finish_pending_io(state, pager, waker)? {
+                        return Ok(result);
+                    }
                 }
-                Ok(InsnFunctionStepResult::IO(io)) => Ok(program.park_on_io(state, io, waker)),
-                Err(boxed_err) => program.fail_step(state, pager, *boxed_err),
-                Ok(InsnFunctionStepResult::Step) | Ok(InsnFunctionStepResult::Row) => {
-                    unreachable!("the dispatch loop settles steps and rows itself")
+                if state.pending_fail_prepare_error.is_some() {
+                    match program.prepare_pending_fail(state, pager, waker)? {
+                        Some(result) => return Ok(result),
+                        None => continue 'io_check,
+                    }
+                }
+                loop {
+                    if state.metrics.vm_steps & state.check_mask == 0 {
+                        if let Some(result) = program.periodic_checks(state, pager)? {
+                            return Ok(result);
+                        }
+                    }
+
+                    let (insn, _) = &insns[state.pc as usize];
+                    if TRACE {
+                        program.trace_step(state, insn, enable_tracing, vdbe_trace);
+                    }
+
+                    // Always increment VM steps for every loop iteration
+                    state.metrics.vm_steps = state.metrics.vm_steps.wrapping_add(1);
+
+                    let result = insn::dispatch_insn(program, state, insn, pager);
+                    if let Ok(InsnFunctionStepResult::Step) = result {
+                        // Instruction completed, moving to next
+                        state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
+                        continue;
+                    }
+                    if let Ok(InsnFunctionStepResult::Row) = result {
+                        // Instruction completed (ResultRow already incremented PC)
+                        state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
+                        return Ok(StepResult::Row);
+                    }
+                    // Match less frequent results out of line
+                    match dispatch(program, state, pager, waker, result)? {
+                        Some(result) => return Ok(result),
+                        None => continue 'io_check,
+                    }
+                }
+            }
+
+            #[inline(never)]
+            fn dispatch(
+                program: &Program,
+                state: &mut ProgramState,
+                pager: &Arc<Pager>,
+                waker: Option<&Waker>,
+                result: execute::InsnResult,
+            ) -> Result<Option<StepResult>, Box<LimboError>> {
+                match result {
+                    Ok(InsnFunctionStepResult::Done) => {
+                        // Instruction completed execution
+                        state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
+                        state.auto_txn_cleanup = TxnCleanup::None;
+                        Ok(Some(StepResult::Done))
+                    }
+                    Ok(InsnFunctionStepResult::IO(io)) => Ok(program.park_on_io(state, io, waker)),
+                    Err(boxed_err) => program.fail_step(state, pager, *boxed_err),
+                    Ok(InsnFunctionStepResult::Step) | Ok(InsnFunctionStepResult::Row) => {
+                        unreachable!("the dispatch loop settles steps and rows itself")
+                    }
                 }
             }
         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -108,6 +108,11 @@ use std::{
 };
 use tracing::{instrument, Level};
 
+const MAX_CHECK_MASK: u64 = 255;
+// we use the check interval as bitmask so that we can efficiently calculate if the `vm_steps` counter
+// has reached a check interval (if `n` is a power of 2, `x & (n - 1)` checks for multiples of `n`)
+const _: () = assert!((MAX_CHECK_MASK + 1).is_power_of_two());
+
 type MvccCommitStateMachine = CommitStateMachine<MvccClock, DynAllocator>;
 
 /// State machine for committing view deltas with I/O handling
@@ -985,7 +990,7 @@ impl ProgramState {
         let cursor_seqs = vec![0i64; max_cursors];
         let registers = vec![Register::Value(Value::Null); max_registers].into_boxed_slice();
         Self {
-            check_mask: 63,
+            check_mask: MAX_CHECK_MASK,
             io_completions: None,
             pc: 0,
             cursors,
@@ -2329,24 +2334,15 @@ impl Program {
         }
     }
 
-    /// The checks the dispatch loop runs once every CHECK_INTERVAL
-    /// instructions: a closed connection, an interrupt, the deadline and the
-    /// progress handler. A handler with interval N < 64 narrows the mask at
-    /// the next firing (a one-time lag of at most CHECK_INTERVAL
-    /// instructions; the cadence is approximate by contract).
     #[inline(never)]
     fn periodic_checks(
         &self,
         state: &mut ProgramState,
         pager: &Arc<Pager>,
     ) -> Result<Option<StepResult>, Box<LimboError>> {
-        // The interval must stay a power of two so the gate in the loop is
-        // a mask test, never a division.
-        const CHECK_INTERVAL: u64 = 64;
-        const _: () = assert!(CHECK_INTERVAL.is_power_of_two());
         let progress_ops = self.connection.progress_ops();
-        state.check_mask = if progress_ops == 0 || progress_ops >= CHECK_INTERVAL {
-            CHECK_INTERVAL - 1
+        state.check_mask = if progress_ops == 0 || progress_ops >= MAX_CHECK_MASK {
+            MAX_CHECK_MASK
         } else {
             progress_ops.next_power_of_two() - 1
         };


### PR DESCRIPTION
## Description

Part 9 of 15 split out of #8692 (commits 81-90 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### CodSpeed

Commits 1-117 (`3c369a50`, the second session up to the UTF-8 commit) vs `main`: [run 6a9c77475bd50bcffcfc60bc](https://codspeed.io/tursodatabase/turso/runs/6a9c77475bd50bcffcfc60bc), 103 improvements, 0 regressions, 702 unchanged, 14 new, 1509 skipped (the runners differed in a CPU flag and in the linked libc build, so CodSpeed skipped the benchmarks that ran across the difference; the nightly recovery benchmark is among the skipped). Against the run of `98c2b91f` (end of the first session): 12 improvements, 0 regressions, 807 unchanged, 1523 skipped; `select_one_100k` 12 ms → 9 ms (+33.2%), `select_star_100k` 37.2 ms → 30.8 ms (+20.5%), `count_text_col[1000000]` 219.6 ms → 173.6 ms (+26.5%), the struct/union scans +20% to +30%. Against `main` the scan benchmarks now stand at `select_one_100k` 21.3 ms → 9 ms (×2.4), `select_star_100k` 67.3 ms → 30.8 ms (×2.2), `count_text_col[1000000]` 460.7 ms → 173.6 ms (×2.7), `count_groupby[1000000]` 678.5 ms → 336.2 ms (×2.0), `count_filtered[1000000]` 250.9 ms → 149.9 ms (+67.4%); the per-statement `limbo_execute_select_1` at 12.6 µs → 9.9 µs (+27.4%) and the write benchmarks at +56% to +58% (`Transaction Size Impact::limbo[1000_rows]` 5.9 ms → 3.7 ms, `Key Pattern Impact::limbo[sequential_keys]` 655.6 µs → 414.3 µs, `BEFORE INSERT Trigger::limbo[1000_rows]` 12.6 ms → 8 ms).

Commits 1-121 (`46436272`, the final head) vs `main`: [run 6a9c9281fd41b0f1674a7aca](https://codspeed.io/tursodatabase/turso/runs/6a9c9281fd41b0f1674a7aca), 214 improvements, 1 regression, 1959 unchanged, 28 new, 135 skipped. This is the first run since `98c2b91f` with the nightly benchmark variants (their build had failed on the pool commit, see the second session), so against the run of `9b2dcf03` it shows 112 improvements, 1 regression, 2075 unchanged, 14 new, 135 skipped: the improvements are the nightly variants catching up (`select_one_100k nightly` 21.2 ms → 8.9 ms, `count_text_col[1000000 nightly]` 475.4 ms → 173.6 ms, `limbo_execute_select_1 nightly` 11.8 µs → 9.5 µs against their last values). The one regression is the memory benchmark `mvcc/scan-heavy/80-checkpoint`: peak 1.03 MB → 1.31 MB, with 1,000 fewer allocations and 5,300 fewer frees than the run of `69e2eff2`, where it was unchanged. The only code between the two runs is the one-line build fix, which allocates nothing either way (an empty vec), so the peak moved with the timing of MVCC's background work in the harness; the WAL variant and the other 47 memory benchmarks are unchanged, and the benchmark had measured 1.01-1.03 MB on every run of `main` and of this branch before. The run of `69e2eff2` ([6a9c8e5c8aabe4c55b5d267b](https://codspeed.io/tursodatabase/turso/runs/6a9c8e5c8aabe4c55b5d267b)) holds only the 48 memory benchmarks, all unchanged: its workflow was superseded by the push of the fix before the CPU benchmarks uploaded.

### Measurement history: per-row costs

Callgrind instruction counts (`Ir`) are for 5 iterations of `SELECT 1 FROM t` and 3 iterations of the others. Wall clock is the best of 7 runs of one iteration on a noisy VM, so treat it as a sanity check only.

| Commit | SELECT 1 (Ir) | Δ | SELECT * (Ir) | Δ | W3 (Ir) | Δ | W4 (Ir) | Δ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `095ba6b9` give each comparison opcode its own function | 183,327,244 | 0.00% | 389,295,145 | 0.00% | 250,076,688 | -4.14% | 282,364,730 | -3.68% |
| `4f7b4eaf` keep the non-b-tree arms of Next out of the dispatch loop (one instruction more per step call from the loop's new register assignment, three less per dispatch through the function table) | 183,936,644 | +0.33% | 389,707,706 | +0.11% | 248,903,242 | -0.47% | 280,797,509 | -0.55% |
| `811d1680` parse a local leaf cell for a column read without the general cell reader | 183,935,613 | 0.00% | 387,306,691 | -0.62% | 241,786,896 | -2.86% | 273,681,112 | -2.53% |
| `d4416516` run the periodic checks of the dispatch loop every 256 instructions | 183,507,719 | -0.23% | 386,735,778 | -0.15% | 241,205,252 | -0.24% | 272,954,453 | -0.27% |
| `a8a119ab` read the rowid of a b-tree cursor without the cursor-kind jump table | 183,507,171 | 0.00% | 382,735,195 | -1.03% | 241,204,682 | 0.00% | 272,953,887 | 0.00% |
| `b5246a40` call the column fetch of Column and ColumnRange directly (measured against `c509972f`: 183,507,074 / 382,735,118 / 241,204,692 / 272,953,890) | 183,506,137 | 0.00% | 379,933,669 | -0.73% | 240,004,426 | -0.50% | 271,753,630 | -0.44% |

| Commit | Workload | before | after |
|---|---|---:|---:|
| `4f7b4eaf` keep the non-b-tree arms of Next out of the dispatch loop (measured against `095ba6b9`: 330,465,292 / 912,688,075) | W12 | 330,465,292 | 328,063,295 (-0.7%) |
| | W8 | 912,688,075 | 907,966,086 (-0.5%) |
| `811d1680` parse a local leaf cell for a column read without the general cell reader | W12 | 328,063,295 | 320,922,962 (-2.2%) |
| | `SELECT name FROM t` (W13, table scan with a column read and no rowid read) | 288,957,229 | 280,156,192 (-3.0%) |
| | W8 | 907,966,086 | 900,849,702 (-0.8%) |
| `d4416516` run the periodic checks of the dispatch loop every 256 instructions | W12 | 320,922,962 | 319,885,372 (-0.3%) |
| | W8 | 900,849,702 | 898,958,447 (-0.2%) |
| `c509972f` store the numbers of a record with copies of constant length | W8 | 898,958,065 | 890,757,883 (-0.9%) |
| | W9 | 1,004,246,633 | 989,445,753 (-1.5%) |
| | W11 | 25,524,196 | 25,469,222 (-0.2%) |
| `b5246a40` call the column fetch of Column and ColumnRange directly | W12 | 319,884,871 | 318,680,585 (-0.4%) |
| | W13 | 279,724,178 | 278,922,643 (-0.3%) |
| | W8 | 890,757,883 | 886,354,629 (-0.5%) |
| | W9 | 989,445,753 | 987,844,221 (-0.2%) |
| | W11 | 25,469,222 | 25,436,877 (-0.1%) |
| `98c2b91f` store the one-byte varints of a record header without a call | W8 | 886,354,629 | 876,754,436 (-1.1%) |
| | W9 | 987,844,221 | 967,844,093 (-2.0%) |
| | W11 | 25,436,877 | 25,240,759 (-0.8%) |

### Measurement history: per-statement costs

The second half of the PR works on the fixed cost of executing a prepared statement once: transaction begin and commit, cursor open and close, statement reset, metrics. Measured as callgrind instructions per execution, taken as (Ir at 3000 executions − Ir at 1000 executions) / 2000 so the process start-up is cancelled out. Workloads: a point lookup `SELECT * FROM t WHERE id = 12345` (one `Transaction`, one `OpenRead`, one `SeekRowid`, `Column`, `Halt`), `SELECT 1` (no table, no transaction: the pure statement overhead), and an index lookup `SELECT id FROM t WHERE value = 500 LIMIT 1` (two cursors).

| Commit | point lookup | Δ | `SELECT 1` | Δ | index lookup | Δ |
|---|---:|---:|---:|---:|---:|---:|
| `4f7b4eaf` keep the non-b-tree arms of Next out of the dispatch loop | 7,413 | -0.1% | 1,786 | -0.1% | 13,316 | -0.1% |
| `811d1680` parse a local leaf cell for a column read without the general cell reader | 7,387 | -0.4% | | | 13,297 | -0.1% |
| `d4416516` run the periodic checks of the dispatch loop every 256 instructions | 7,383 | -0.1% | 1,772 | -0.8% | 13,292 | 0.0% |
| `a8a119ab` read the rowid of a b-tree cursor without the cursor-kind jump table | 7,393 | +0.1% | | | 13,311 | +0.1% |
| `b5246a40` call the column fetch of Column and ColumnRange directly | 7,384 | -0.1% | | | 13,309 | 0.0% |

### Second session (commits 89 to 149, `98c2b91f` → `cc0dfdf6`)

A second autonomous session continued from `98c2b91f` with the same method: callgrind instruction counts (`Ir`) of the local driver, one measured change per commit, changes that measured worse reverted and listed below. The 100k-row scans run 3 iterations (5 for `SELECT 1 FROM t`); the per-statement numbers are instructions per execution, (Ir at 3000 − Ir at 1000) / 2000. Two more scan workloads join the set: `SELECT name FROM t` (W13, one TEXT column per row) and `SELECT * FROM t ORDER BY name DESC LIMIT 10` (W9, the sorter), plus `SELECT length(name) FROM t` and `SELECT abs(value) FROM t` for the scalar function opcode. The CodSpeed runs of `3c369a50`, `9b2dcf03`, `46436272` and the later heads are in the CodSpeed section above.

| Commit | `SELECT 1 FROM t` | `SELECT * FROM t` | W3 | W4 | W12 (GROUP BY value) | W13 (`SELECT name`) | W9 (ORDER BY) |
|---|---:|---:|---:|---:|---:|---:|---:|
| `98c2b91f` (end of the first session) | 144,440,710 | 285,011,123 | 181,001,465 | 201,461,312 | 927,217,904 | 205,853,208 | 726,656,887 |
| pick the dispatch loop without a trace test once per step call | 144,453,981 (0.0%) | 284,425,184 (-0.2%) | 180,115,517 (-0.5%) | 200,278,868 (-0.6%) | 921,592,865 (-0.6%) | | |
| record a returned row with one store | 140,453,991 (-2.8%) | 282,025,190 (-0.8%) | = | = | 919,192,871 (-0.3%) | | |

| Commit | point lookup | `SELECT 1` | index lookup |
|---|---:|---:|---:|
| `98c2b91f` | 7,209 | 1,726 | 12,996 |
| pick the dispatch loop without a trace test once per step call | 7,200 | 1,722 | 12,984 |
| record a returned row with one store | 7,194 | 1,716 | 12,978 |

Per row of `SELECT 1 FROM t` (one `step()` call, `ResultRow` + `Next`): about 290 instructions at `98c2b91f`, about 210 now (516 at the baseline of the first session). Per row of `SELECT * FROM t`: about 950 → about 720 (2190 at the first baseline). Per row of `SELECT name FROM t`: about 690 → about 525.

The other workloads of the first session at the final head, against `98c2b91f`: `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5) 376,810,295 → 302,649,942 (-19.7%), `SELECT count(*) FROM t WHERE name LIKE 'name_1%'` (W7) 330,228,368 → 277,245,490 (-16.0%), `SELECT value % 100, count(*) FROM t GROUP BY value % 100` (W8) 673,604,393 → 615,223,378 (-8.7%), the 5000-seek join (W6) 42,807,188 → 40,828,236 (-4.6%).

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_