### PR TITLE
core: return instruction results and cursor advances in registers

### DIFF
--- a/core/incremental/cursor.rs
+++ b/core/incremental/cursor.rs
@@ -1714,7 +1714,7 @@ mod tests {
     mod io_resumption_tests {
         use super::*;
         use crate::io::Completion;
-        use crate::storage::btree::{BTreeKey, CursorTrait};
+        use crate::storage::btree::{BTreeKey, CursorStep, CursorTrait};
         use crate::types::{IOCompletions, ImmutableRecord, IndexInfo};
         use crate::Register;
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1734,6 +1734,80 @@ mod tests {
             record: ImmutableRecord,
             /// Index info
             index_info: Arc<IndexInfo>,
+            advance_completion: Completion,
+            advance_error: Option<Box<crate::LimboError>>,
+            null_flag: bool,
+        }
+
+        #[test]
+        fn cursor_step_owns_io_after_cursor_is_dropped() {
+            for forward in [true, false] {
+                let mut cursor = MockBTreeCursor::new();
+                cursor.advance_completion = Completion::new_sync(|_| {});
+                let completion = cursor.advance_completion.clone();
+                let mut cursor: Box<dyn CursorTrait> = Box::new(cursor);
+                let step = if forward {
+                    cursor.next_row()
+                } else {
+                    cursor.prev_row()
+                };
+                let CursorStep::IO(io) = step else {
+                    panic!("expected IO, got {step:?}");
+                };
+                let resumed = if forward {
+                    cursor.next_row()
+                } else {
+                    cursor.prev_row()
+                };
+                assert!(matches!(resumed, CursorStep::Row));
+                drop(cursor);
+                assert!(!io.finished());
+                completion.complete(0);
+                assert!(io.finished());
+            }
+        }
+
+        #[test]
+        fn cursor_step_preserves_advance_errors() {
+            for forward in [true, false] {
+                let mut cursor = MockBTreeCursor::new();
+                let error = Box::new(crate::LimboError::InternalError("advance failed".into()));
+                let original = std::ptr::from_ref(error.as_ref());
+                cursor.advance_error = Some(error);
+                let cursor: &mut dyn CursorTrait = &mut cursor;
+                let step = if forward {
+                    cursor.next_row()
+                } else {
+                    cursor.prev_row()
+                };
+                let CursorStep::Error(error) = step else {
+                    panic!("expected error, got {step:?}");
+                };
+                assert_eq!(std::ptr::from_ref(error.as_ref()), original);
+            }
+        }
+
+        #[test]
+        fn cursor_step_handles_null_and_empty_rows() {
+            for forward in [true, false] {
+                let mut cursor = MockBTreeCursor::new();
+                cursor.set_null_flag(true);
+                let advance = |cursor: &mut dyn CursorTrait| {
+                    if forward {
+                        cursor.next_row()
+                    } else {
+                        cursor.prev_row()
+                    }
+                };
+                assert!(matches!(advance(&mut cursor), CursorStep::Empty));
+                assert!(!cursor.get_null_flag());
+                assert_eq!(cursor.next_count.load(Ordering::SeqCst), 0);
+                assert_eq!(cursor.get_prev_count(), 0);
+                assert!(matches!(advance(&mut cursor), CursorStep::IO(_)));
+                assert!(matches!(advance(&mut cursor), CursorStep::Row));
+                cursor.current_rowid = None;
+                assert!(matches!(advance(&mut cursor), CursorStep::Empty));
+            }
         }
 
         impl MockBTreeCursor {
@@ -1747,6 +1821,9 @@ mod tests {
                     current_rowid: Some(1),
                     record,
                     index_info: Arc::new(IndexInfo::default()),
+                    advance_completion: Completion::new_yield(),
+                    advance_error: None,
+                    null_flag: false,
                 }
             }
 
@@ -1802,11 +1879,13 @@ mod tests {
             }
 
             fn next(&mut self) -> IOResultOr<()> {
+                if let Some(err) = self.advance_error.take() {
+                    return Err(err);
+                }
                 let count = self.next_count.fetch_add(1, Ordering::SeqCst);
                 if count == 0 {
                     // First call returns IO (pending)
-                    let completion = Completion::new_yield();
-                    Ok(IOResult::IO(IOCompletions(completion)))
+                    Ok(IOResult::IO(IOCompletions(self.advance_completion.clone())))
                 } else {
                     // Subsequent calls return Done
                     Ok(IOResult::Done(()))
@@ -1814,11 +1893,13 @@ mod tests {
             }
 
             fn prev(&mut self) -> IOResultOr<()> {
+                if let Some(err) = self.advance_error.take() {
+                    return Err(err);
+                }
                 let count = self.prev_count.fetch_add(1, Ordering::SeqCst);
                 if count == 0 {
                     // First call returns IO (pending)
-                    let completion = Completion::new_yield();
-                    Ok(IOResult::IO(IOCompletions(completion)))
+                    Ok(IOResult::IO(IOCompletions(self.advance_completion.clone())))
                 } else {
                     // Subsequent calls return Done
                     Ok(IOResult::Done(()))
@@ -1845,10 +1926,12 @@ mod tests {
                 Ok(IOResult::Done(()))
             }
 
-            fn set_null_flag(&mut self, _flag: bool) {}
+            fn set_null_flag(&mut self, flag: bool) {
+                self.null_flag = flag;
+            }
 
             fn get_null_flag(&self) -> bool {
-                false
+                self.null_flag
             }
 
             fn exists(&mut self, _key: &Value) -> IOResultOr<bool> {
@@ -1868,7 +1951,7 @@ mod tests {
             }
 
             fn is_empty(&self) -> bool {
-                false
+                self.current_rowid.is_none()
             }
 
             fn root_page(&self) -> i64 {

--- a/core/incremental/expr_compiler.rs
+++ b/core/incremental/expr_compiler.rs
@@ -402,7 +402,7 @@ impl CompiledExpression {
 
                     // Execute the instruction
                     match insn_fn(program, &mut state, insn, &pager)? {
-                        crate::vdbe::execute::InsnFunctionStepResult::IO(_) => {
+                        crate::vdbe::execute::InsnFunctionStepResult::IO => {
                             return Err(crate::LimboError::InternalError(
                                 "Expression evaluation encountered unexpected I/O".to_string(),
                             ));

--- a/core/statement.rs
+++ b/core/statement.rs
@@ -1540,7 +1540,11 @@ impl Statement {
                             halt_completed = true;
                             break;
                         }
-                        Ok(vdbe::execute::InsnFunctionStepResult::IO(_)) => {
+                        Ok(vdbe::execute::InsnFunctionStepResult::IO) => {
+                            // halt() is re-entered until it finishes; the
+                            // IO loop runs once per attempt, as before the
+                            // completion was parked in the state.
+                            drop(self.state.take_suspended_io());
                             if let Err(e) = self.pager.io.step() {
                                 capture_reset_error(
                                     &mut reset_error,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -661,6 +661,32 @@ pub enum SavePositionResult {
     MustInvalidate,
 }
 
+/// The result value of advancing a cursor.
+///
+/// This is an optimization for [CursorTrait::next_row] and [CursorTrait::prev_row]. Combining the
+/// return type into the [Result] lets the compiler use a direct return (through registers) instead
+/// of a structure return (LLVM `sret`).
+#[repr(u64)]
+#[derive(Debug)]
+#[must_use]
+pub enum CursorStep {
+    Row,
+    Empty,
+    IO(IOCompletions),
+    Error(Box<LimboError>),
+}
+
+impl CursorStep {
+    #[inline]
+    fn at_row(has_row: bool) -> Self {
+        if has_row {
+            CursorStep::Row
+        } else {
+            CursorStep::Empty
+        }
+    }
+}
+
 pub trait CursorTrait: Any + Send + Sync {
     /// Move cursor to last entry.
     fn last(&mut self) -> IOResultOr<()>;
@@ -672,24 +698,30 @@ pub trait CursorTrait: Any + Send + Sync {
     /// unless it was set, moves to the next entry. Returns whether the cursor
     /// points at a row afterwards. A NullRow cursor does not advance, like
     /// SQLite's OP_Next when btreeNext() sees CURSOR_INVALID.
-    fn next_row(&mut self) -> IOResultOr<bool> {
+    fn next_row(&mut self) -> CursorStep {
         let was_null_row = self.get_null_flag();
         self.set_null_flag(false);
         if was_null_row {
-            return Ok(IOResult::Done(false));
+            return CursorStep::Empty;
         }
-        return_if_io!(self.next());
-        Ok(IOResult::Done(!self.is_empty()))
+        match self.next() {
+            Ok(IOResult::IO(io)) => CursorStep::IO(io),
+            Err(err) => CursorStep::Error(err),
+            Ok(IOResult::Done(())) => CursorStep::at_row(!self.is_empty()),
+        }
     }
     /// The `Prev` opcode counterpart of [`CursorTrait::next_row`].
-    fn prev_row(&mut self) -> IOResultOr<bool> {
+    fn prev_row(&mut self) -> CursorStep {
         let was_null_row = self.get_null_flag();
         self.set_null_flag(false);
         if was_null_row {
-            return Ok(IOResult::Done(false));
+            return CursorStep::Empty;
         }
-        return_if_io!(self.prev());
-        Ok(IOResult::Done(!self.is_empty()))
+        match self.prev() {
+            Ok(IOResult::IO(io)) => CursorStep::IO(io),
+            Err(err) => CursorStep::Error(err),
+            Ok(IOResult::Done(())) => CursorStep::at_row(!self.is_empty()),
+        }
     }
     /// Get the rowid of the entry the cursor is poiting to if any
     fn rowid(&mut self) -> IOResultOr<Option<i64>>;
@@ -6516,27 +6548,33 @@ impl CursorTrait for BTreeCursor {
         }
     }
 
-    fn next_row(&mut self) -> IOResultOr<bool> {
+    fn next_row(&mut self) -> CursorStep {
         if self.null_flag {
             self.null_flag = false;
-            return Ok(IOResult::Done(false));
+            return CursorStep::Empty;
         }
         if self.can_advance_within_leaf() {
             self.stack.advance();
             self.invalidate_record();
-            return Ok(IOResult::Done(true));
+            return CursorStep::Row;
         }
-        return_if_io!(self.next());
-        Ok(IOResult::Done(self.has_record))
+        match self.next() {
+            Ok(IOResult::IO(io)) => CursorStep::IO(io),
+            Err(err) => CursorStep::Error(err),
+            Ok(IOResult::Done(())) => CursorStep::at_row(self.has_record),
+        }
     }
 
-    fn prev_row(&mut self) -> IOResultOr<bool> {
+    fn prev_row(&mut self) -> CursorStep {
         if self.null_flag {
             self.null_flag = false;
-            return Ok(IOResult::Done(false));
+            return CursorStep::Empty;
         }
-        return_if_io!(self.prev());
-        Ok(IOResult::Done(self.has_record))
+        match self.prev() {
+            Ok(IOResult::IO(io)) => CursorStep::IO(io),
+            Err(err) => CursorStep::Error(err),
+            Ok(IOResult::Done(())) => CursorStep::at_row(self.has_record),
+        }
     }
 
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1652,7 +1652,7 @@ impl BTreeCursor {
                 let mem_page = mem_page.clone();
                 let contents = mem_page.get_contents();
                 tracing::debug!(
-                    id = mem_page.get().id,
+                    id = mem_page.get().id(),
                     cell = self.stack.current_cell_index(),
                     cell_count,
                     "current_before_advance",
@@ -1667,7 +1667,7 @@ impl BTreeCursor {
                 if should_skip_advance {
                     tracing::debug!(
                         going_upwards = self.going_upwards,
-                        page = mem_page.get().id,
+                        page = mem_page.get().id(),
                         cell_idx = self.stack.current_cell_index(),
                         "skipping advance",
                     );
@@ -1678,7 +1678,7 @@ impl BTreeCursor {
                 // Important to advance only after loading the page in order to not advance > 1 times
                 self.stack.advance();
                 let cell_idx = self.stack.current_cell_index() as usize;
-                tracing::debug!(id = mem_page.get().id, cell = cell_idx, "current");
+                tracing::debug!(id = mem_page.get().id(), cell = cell_idx, "current");
 
                 if cell_idx >= cell_count {
                     let rightmost_already_traversed = cell_idx > cell_count;
@@ -1724,7 +1724,7 @@ impl BTreeCursor {
                 turso_assert!(
                     cell_idx < cell_count,
                     "cell index out of bounds",
-                    { "cell_idx": cell_idx, "cell_count": cell_count, "page_type": contents.page_type().ok(), "page_id": mem_page.get().id }
+                    { "cell_idx": cell_idx, "cell_count": cell_count, "page_type": contents.page_type().ok(), "page_id": mem_page.get().id() }
                 );
 
                 if is_leaf {
@@ -1857,7 +1857,7 @@ impl BTreeCursor {
                         // balancing, or a peer cursor's write (e.g. a trigger subprogram's, via
                         // the saveAllCursors pass) — invalidates it.
                         let current_page = self.stack.top_ref();
-                        if current_page.get().id == *rightmost_page_id {
+                        if current_page.get().id() == *rightmost_page_id {
                             let contents = current_page.get_contents();
                             let cell_count = contents.cell_count();
                             self.stack.set_cell_index(cell_count as i32 - 1);
@@ -1873,7 +1873,7 @@ impl BTreeCursor {
                 }
                 MoveToRightState::ProcessPage => {
                     let mem_page = self.stack.top_ref();
-                    let page_idx = mem_page.get().id;
+                    let page_idx = mem_page.get().id();
                     let contents = mem_page.get_contents();
                     if contents.is_leaf() {
                         self.move_to_right_state = (MoveToRightState::Start, Some(page_idx));
@@ -2389,9 +2389,9 @@ impl BTreeCursor {
         {
             let page = self.stack.get_page_at_level(old_top_idx).unwrap();
             turso_assert!(
-                page.get().id != *left_child_page as usize,
+                page.get().id() != *left_child_page as usize,
                 "corrupt: current page and left child page are the same",
-                { "cell": leftmost_matching_cell, "page_id": page.get().id }
+                { "cell": leftmost_matching_cell, "page_id": page.get().id() }
             );
         }
 
@@ -3078,7 +3078,7 @@ impl BTreeCursor {
                     cell_idx,
                     ref mut state,
                 } => {
-                    turso_assert!(page.is_loaded(), "page is not loaded", { "page_id": page.get().id });
+                    turso_assert!(page.is_loaded(), "page is not loaded", { "page_id": page.get().id() });
                     let page = page.clone();
 
                     // Currently it's necessary to .take() here to prevent double-borrow of `self` in `overwrite_cell`.
@@ -3232,10 +3232,11 @@ impl BTreeCursor {
                                     mark_unlikely();
                                     LimboError::Corrupt(format!(
                                         "parent page {} is a leaf page, expected interior page",
-                                        parent.get().id
+                                        parent.get().id()
                                     ))
                                 })?;
-                            if parent.get().id != 1 && parent_rightmost == cur_page.get().id as u32
+                            if parent.get().id() != 1
+                                && parent_rightmost == cur_page.get().id() as u32
                             {
                                 // If all of the following are true, we can use the balance_quick() fast path:
                                 // - The page is a table leaf page
@@ -3308,7 +3309,7 @@ impl BTreeCursor {
             .rightmost_pointer()?
             .expect("parent should have a rightmost pointer");
         turso_assert!(
-            rightmost_pointer == old_rightmost_leaf.get().id as u32,
+            rightmost_pointer == old_rightmost_leaf.get().id() as u32,
             "leaf should be the rightmost page in the subtree"
         );
 
@@ -3331,7 +3332,7 @@ impl BTreeCursor {
 
         // Create a new divider cell in the parent - it contains the page number of the old rightmost leaf, plus the largest rowid on that page.
         let mut new_divider: [u8; 13] = [0; 13]; // 4 bytes for page number, max 9 bytes for rowid (varint)
-        new_divider[0..4].copy_from_slice(&(old_rightmost_leaf.get().id as u32).to_be_bytes());
+        new_divider[0..4].copy_from_slice(&(old_rightmost_leaf.get().id() as u32).to_be_bytes());
         let largest_rowid = old_rightmost_leaf_contents
             .cell_table_leaf_read_rowid(old_rightmost_leaf_contents.cell_count() - 1)?;
         let n = write_varint(&mut new_divider[4..], largest_rowid as u64);
@@ -3344,7 +3345,7 @@ impl BTreeCursor {
             parent_contents.cell_count(),
             usable_space,
         )?;
-        parent_contents.write_rightmost_ptr(new_rightmost_leaf.get().id as u32);
+        parent_contents.write_rightmost_ptr(new_rightmost_leaf.get().id() as u32);
         // Continue balance from the parent page (inserting the new divider cell may have overflowed the parent)
         self.stack.pop();
 
@@ -3421,7 +3422,7 @@ impl BTreeCursor {
                         turso_assert!(
                             overflow_cell.index == parent_page_cell_idx,
                             "overflow cell index must be the result of InteriorNodeReplacement that leaves both child and parent unbalanced, and hence parent page's position must equal overflow_cell.index",
-                            { "parent_page_id": parent_page.get().id, "parent_page_cell_idx": parent_page_cell_idx, "overflow_cell_index": overflow_cell.index }
+                            { "parent_page_id": parent_page.get().id(), "parent_page_cell_idx": parent_page_cell_idx, "overflow_cell_index": overflow_cell.index }
                         );
                     }
                     self.pager.add_dirty(parent_page)?;
@@ -3430,7 +3431,7 @@ impl BTreeCursor {
 
                     tracing::debug!(
                         "balance_non_root(parent_id={} page_to_balance_idx={})",
-                        parent_page.get().id,
+                        parent_page.get().id(),
                         page_to_balance_idx
                     );
                     // Part 1: Find the sibling pages to balance
@@ -4251,7 +4252,7 @@ impl BTreeCursor {
                             .take(sibling_count_new)
                             .enumerate()
                         {
-                            page_numbers[i] = page.as_ref().unwrap().get().id;
+                            page_numbers[i] = page.as_ref().unwrap().get().id();
                         }
                         page_numbers.sort_unstable();
                         for (page, new_id) in pages_to_balance_new
@@ -4261,8 +4262,8 @@ impl BTreeCursor {
                             .zip(page_numbers.iter().rev().take(sibling_count_new))
                         {
                             let page = page.as_ref().unwrap();
-                            if *new_id != page.get().id {
-                                page.get().id = *new_id;
+                            if *new_id != page.get().id() {
+                                page.get().set_id(*new_id);
                                 self.pager
                                     .upsert_page_in_cache(*new_id, page.0.clone(), true)?;
                             }
@@ -4272,12 +4273,12 @@ impl BTreeCursor {
                         {
                             tracing::debug!(
                                 "balance_non_root(parent page_id={})",
-                                parent_page.get().id
+                                parent_page.get().id()
                             );
                             for page in pages_to_balance_new.iter().take(sibling_count_new) {
                                 tracing::debug!(
                                     "balance_non_root(new_sibling page_id={})",
-                                    page.as_ref().unwrap().get().id
+                                    page.as_ref().unwrap().get().id()
                                 );
                             }
                         }
@@ -4295,7 +4296,7 @@ impl BTreeCursor {
                         .as_ref()
                         .unwrap()
                         .get()
-                        .id as u32;
+                        .id() as u32;
                     let rightmost_pointer = balance_info.rightmost_pointer;
                     let rightmost_pointer =
                         unsafe { std::slice::from_raw_parts_mut(rightmost_pointer, 4) };
@@ -4356,7 +4357,7 @@ impl BTreeCursor {
                             // divider cell now points to this page
                             balance_info
                                 .reusable_divider_cell
-                                .extend_from_slice(&(page.get().id as u32).to_be_bytes());
+                                .extend_from_slice(&(page.get().id() as u32).to_be_bytes());
                             // now copy the rest of the divider cell:
                             // Table Interior page:
                             //   * varint rowid
@@ -4379,7 +4380,7 @@ impl BTreeCursor {
                             let (rowid, _) = read_varint(&divider_cell[n_bytes_payload..])?;
                             balance_info
                                 .reusable_divider_cell
-                                .extend_from_slice(&(page.get().id as u32).to_be_bytes());
+                                .extend_from_slice(&(page.get().id() as u32).to_be_bytes());
                             write_varint_to_vec(rowid, &mut balance_info.reusable_divider_cell)?;
                         } else {
                             // Leaf index
@@ -4400,7 +4401,7 @@ impl BTreeCursor {
                             };
                             balance_info
                                 .reusable_divider_cell
-                                .extend_from_slice(&(page.get().id as u32).to_be_bytes());
+                                .extend_from_slice(&(page.get().id() as u32).to_be_bytes());
                             balance_info
                                 .reusable_divider_cell
                                 .extend_from_slice(divider_cell);
@@ -4411,7 +4412,7 @@ impl BTreeCursor {
                             0,
                         );
                         turso_assert!(
-                            left_pointer != parent_page.get().id as u32,
+                            left_pointer != parent_page.get().id() as u32,
                             "left pointer is the same as parent page id"
                         );
                         #[cfg(debug_assertions)]
@@ -4425,7 +4426,7 @@ impl BTreeCursor {
                             );
                         }
                         turso_assert!(
-                            left_pointer == page.get().id as u32,
+                            left_pointer == page.get().id() as u32,
                             "left pointer is not the same as page id"
                         );
                         // FIXME: remove this lock
@@ -4476,9 +4477,9 @@ impl BTreeCursor {
                         for page in pages_to_balance_new.iter().take(sibling_count_new) {
                             let page = page.as_ref().unwrap();
                             turso_assert!(
-                                pages_pointed_to.contains(&(page.get().id as u32)),
+                                pages_pointed_to.contains(&(page.get().id() as u32)),
                                 "page not pointed to by divider cell or rightmost pointer",
-                                { "page_id": page.get().id }
+                                { "page_id": page.get().id() }
                             );
                         }
                     }
@@ -4553,7 +4554,7 @@ impl BTreeCursor {
                                 )
                             };
                             let page = pages_to_balance_new[page_idx].as_ref().unwrap();
-                            tracing::debug!("pre_edit_page(page={})", page.get().id);
+                            tracing::debug!("pre_edit_page(page={})", page.get().id());
                             let page_contents = page.get_contents();
                             edit_page(
                                 page_contents,
@@ -4566,7 +4567,7 @@ impl BTreeCursor {
                             debug_validate_cells!(page_contents, usable_space);
                             tracing::trace!(
                                 "edit_page page={} cells={}",
-                                page.get().id,
+                                page.get().id(),
                                 page_contents.cell_count()
                             );
                             page_contents.overflow_cells.clear();
@@ -4591,7 +4592,7 @@ impl BTreeCursor {
                         // b-tree structure by one. This is described as the "balance-shallower"
                         // sub-algorithm in some documentation.
                         turso_assert_eq!(sibling_count_new, 1);
-                        let parent_offset = if parent_page.get().id == 1 {
+                        let parent_offset = if parent_page.get().id() == 1 {
                             DatabaseHeader::SIZE
                         } else {
                             0
@@ -4679,7 +4680,7 @@ impl BTreeCursor {
                     } else {
                         let balance_info = balance_info.as_ref().expect("must be balancing");
                         let page = balance_info.pages_to_balance[*curr_page].as_ref().unwrap();
-                        return_if_io!(self.pager.free_page(Some(page.0.clone()), page.get().id));
+                        return_if_io!(self.pager.free_page(Some(page.0.clone()), page.get().id()));
                         *sub_state = BalanceSubState::FreePages {
                             curr_page: *curr_page + 1,
                             sibling_count_new: *sibling_count_new,
@@ -4734,9 +4735,9 @@ impl BTreeCursor {
         // Verify the left pointer points to the correct page
         turso_assert_eq!(
             left_pointer,
-            child_page.get().id as u32,
+            child_page.get().id() as u32,
             "inserted cell doesn't point to correct page",
-            { "left_pointer": left_pointer, "child_page_id": child_page.get().id }
+            { "left_pointer": left_pointer, "child_page_id": child_page.get().id() }
         );
     }
 
@@ -4761,9 +4762,9 @@ impl BTreeCursor {
             match cell {
                 BTreeCell::TableInteriorCell(table_interior_cell) => {
                     let left_child_page = table_interior_cell.left_child_page;
-                    if left_child_page == parent_page.get().id as u32 {
+                    if left_child_page == parent_page.get().id() as u32 {
                         tracing::error!("balance_non_root(parent_divider_points_to_same_page, page_id={}, cell_left_child_page={})",
-                                parent_page.get().id,
+                                parent_page.get().id(),
                                 left_child_page,
                             );
                         valid = false;
@@ -4771,9 +4772,9 @@ impl BTreeCursor {
                 }
                 BTreeCell::IndexInteriorCell(index_interior_cell) => {
                     let left_child_page = index_interior_cell.left_child_page;
-                    if left_child_page == parent_page.get().id as u32 {
+                    if left_child_page == parent_page.get().id() as u32 {
                         tracing::error!("balance_non_root(parent_divider_points_to_same_page, page_id={}, cell_left_child_page={})",
-                                parent_page.get().id,
+                                parent_page.get().id(),
                                 left_child_page,
                             );
                         valid = false;
@@ -4801,7 +4802,7 @@ impl BTreeCursor {
                 let cell_buf_in_array = &cells_debug[current_index_cell];
                 if cell_buf != cell_buf_in_array {
                     tracing::error!("balance_non_root(cell_not_found_debug, page_id={}, cell_in_cell_array_idx={})",
-                        page.get().id,
+                        page.get().id(),
                         current_index_cell,
                     );
                     valid = false;
@@ -4817,17 +4818,17 @@ impl BTreeCursor {
                 match &cell {
                     BTreeCell::TableInteriorCell(table_interior_cell) => {
                         let left_child_page = table_interior_cell.left_child_page;
-                        if left_child_page == page.get().id as u32 {
+                        if left_child_page == page.get().id() as u32 {
                             tracing::error!("balance_non_root(child_page_points_same_page, page_id={}, cell_left_child_page={}, page_idx={})",
-                                page.get().id,
+                                page.get().id(),
                                 left_child_page,
                                 page_idx
                             );
                             valid = false;
                         }
-                        if left_child_page == parent_page.get().id as u32 {
+                        if left_child_page == parent_page.get().id() as u32 {
                             tracing::error!("balance_non_root(child_page_points_parent_of_child, page_id={}, cell_left_child_page={}, page_idx={})",
-                                page.get().id,
+                                page.get().id(),
                                 left_child_page,
                                 page_idx
                             );
@@ -4836,17 +4837,17 @@ impl BTreeCursor {
                     }
                     BTreeCell::IndexInteriorCell(index_interior_cell) => {
                         let left_child_page = index_interior_cell.left_child_page;
-                        if left_child_page == page.get().id as u32 {
+                        if left_child_page == page.get().id() as u32 {
                             tracing::error!("balance_non_root(child_page_points_same_page, page_id={}, cell_left_child_page={}, page_idx={})",
-                                page.get().id,
+                                page.get().id(),
                                 left_child_page,
                                 page_idx
                             );
                             valid = false;
                         }
-                        if left_child_page == parent_page.get().id as u32 {
+                        if left_child_page == parent_page.get().id() as u32 {
                             tracing::error!("balance_non_root(child_page_points_parent_of_child, page_id={}, cell_left_child_page={}, page_idx={})",
-                                page.get().id,
+                                page.get().id(),
                                 left_child_page,
                                 page_idx
                             );
@@ -4901,12 +4902,12 @@ impl BTreeCursor {
                     valid = false;
                 }
 
-                if right_page_id == page.get().id as u32
-                    || right_page_id == parent_page.get().id as u32
+                if right_page_id == page.get().id() as u32
+                    || right_page_id == parent_page.get().id() as u32
                 {
                     tracing::error!("balance_non_root(balance_shallower_rightmost_pointer, page_id={}, parent_page_id={}, rightmost={})",
-                        page.get().id,
-                        parent_page.get().id,
+                        page.get().id(),
+                        parent_page.get().id(),
                         right_page_id,
                     );
                     valid = false;
@@ -4959,7 +4960,7 @@ impl BTreeCursor {
 
                     if cell_buf != cell_buf_in_array || cell_buf != parent_cell_buf {
                         tracing::error!("balance_non_root(balance_shallower_cell_not_found_debug, page_id={}, cell_in_cell_array_idx={})",
-                            page.get().id,
+                            page.get().id(),
                             parent_cell_idx,
                         );
                         valid = false;
@@ -4970,10 +4971,10 @@ impl BTreeCursor {
                 // insert cell could've defragmented the page and invalidated the pointer.
                 // right pointer, we just check right pointer points to this page.
                 if cell_divider_idx == parent_contents.cell_count()
-                    && right_page_id != page.get().id as u32
+                    && right_page_id != page.get().id() as u32
                 {
                     tracing::error!("balance_non_root(cell_divider_right_pointer, should point to {}, but points to {})",
-                        page.get().id,
+                        page.get().id(),
                         right_page_id
                     );
                     valid = false;
@@ -4984,9 +4985,9 @@ impl BTreeCursor {
                 for overflow_cell in &parent_contents.overflow_cells {
                     if overflow_cell.index == cell_divider_idx {
                         let left_pointer = read_u32(&overflow_cell.payload, 0);
-                        if left_pointer != page.get().id as u32 {
+                        if left_pointer != page.get().id() as u32 {
                             tracing::error!("balance_non_root(cell_divider_left_pointer_overflow, should point to page_id={}, but points to {}, divider_cell={}, overflow_cells_parent={})",
-                        page.get().id,
+                        page.get().id(),
                         left_pointer,
                         page_idx,
                         parent_contents.overflow_cells.len()
@@ -5010,9 +5011,9 @@ impl BTreeCursor {
                     .cell_get_raw_region(cell_divider_idx, usable_space)
                     .unwrap();
                 let cell_left_pointer = read_u32(&parent_buf[cell_start..cell_start + cell_len], 0);
-                if cell_left_pointer != page.get().id as u32 {
+                if cell_left_pointer != page.get().id() as u32 {
                     tracing::error!("balance_non_root(cell_divider_left_pointer, should point to page_id={}, but points to {}, divider_cell={}, overflow_cells_parent={})",
-                        page.get().id,
+                        page.get().id(),
                         cell_left_pointer,
                         page_idx,
                         parent_contents.overflow_cells.len()
@@ -5051,7 +5052,7 @@ impl BTreeCursor {
                     };
                     if rowid_parent != rowid {
                         tracing::error!("balance_non_root(cell_divider_rowid, page_id={}, cell_divider_idx={}, rowid_parent={}, rowid={})",
-                            page.get().id,
+                            page.get().id(),
                             cell_divider_idx,
                             rowid_parent,
                             rowid
@@ -5064,9 +5065,9 @@ impl BTreeCursor {
                     for overflow_cell in &parent_contents.overflow_cells {
                         if overflow_cell.index == cell_divider_idx {
                             let left_pointer = read_u32(&overflow_cell.payload, 0);
-                            if left_pointer != page.get().id as u32 {
+                            if left_pointer != page.get().id() as u32 {
                                 tracing::error!("balance_non_root(cell_divider_divider_cell_overflow should point to page_id={}, but points to {}, divider_cell={}, overflow_cells_parent={})",
-                                    page.get().id,
+                                    page.get().id(),
                                     left_pointer,
                                     page_idx,
                                     parent_contents.overflow_cells.len()
@@ -5092,9 +5093,9 @@ impl BTreeCursor {
                         &parent_buf[parent_cell_start..parent_cell_start + parent_cell_len],
                         0,
                     );
-                    if left_pointer != page.get().id as u32 {
+                    if left_pointer != page.get().id() as u32 {
                         tracing::error!("balance_non_root(divider_cell_left_pointer_interior should point to page_id={}, but points to {}, divider_cell={}, overflow_cells_parent={})",
-                                    page.get().id,
+                                    page.get().id(),
                                     left_pointer,
                                     page_idx,
                                     parent_contents.overflow_cells.len()
@@ -5107,7 +5108,7 @@ impl BTreeCursor {
                                 &parent_buf[parent_cell_start..parent_cell_start + parent_cell_len];
                             if parent_cell_buf[4..] != cell_buf_in_array[4..] {
                                 tracing::error!("balance_non_root(cell_divider_cell, page_id={}, cell_divider_idx={})",
-                                    page.get().id,
+                                    page.get().id(),
                                     cell_divider_idx,
                                 );
                                 valid = false;
@@ -5126,7 +5127,7 @@ impl BTreeCursor {
                                 && (cell_buf_in_array.len() == parent_payload.len() || padded);
                             if !matches {
                                 tracing::error!("balance_non_root(cell_divider_cell_index_leaf, page_id={}, cell_divider_idx={})",
-                                    page.get().id,
+                                    page.get().id(),
                                     cell_divider_idx,
                                 );
                                 valid = false;
@@ -5176,15 +5177,15 @@ impl BTreeCursor {
             BtreePageAllocMode::Any
         ));
 
-        let is_page_1 = root.get().id == 1;
+        let is_page_1 = root.get().id() == 1;
         let offset = if is_page_1 { DatabaseHeader::SIZE } else { 0 };
         #[cfg(debug_assertions)]
         turso_assert_eq!(offset, root_contents.offset());
 
         tracing::debug!(
             "balance_root(root={}, rightmost={}, page_type={:?})",
-            root.get().id,
-            child.get().id,
+            root.get().id(),
+            child.get().id(),
             root_contents.page_type().ok()
         );
 
@@ -5227,14 +5228,14 @@ impl BTreeCursor {
         } as u8;
         // set new page type
         root_contents.write_page_type(new_root_page_type);
-        root_contents.write_rightmost_ptr(child.get().id as u32);
+        root_contents.write_rightmost_ptr(child.get().id() as u32);
         root_contents.write_cell_content_area(self.usable_space());
         root_contents.write_cell_count(0);
         root_contents.write_first_freeblock(0);
 
         root_contents.write_fragmented_bytes_count(0);
         root_contents.overflow_cells.clear();
-        self.root_page = root.get().id as i64;
+        self.root_page = root.get().id() as i64;
         self.stack.clear();
         self.stack.push(root);
         self.stack.set_cell_index(0); // leave parent pointing at the rightmost pointer (in this case 0, as there are no cells), since we will be balancing the rightmost child page.
@@ -5295,7 +5296,7 @@ impl BTreeCursor {
 
                     let contents = page.get_contents();
                     let next = contents.read_u32_no_offset(0);
-                    let next_page_id = page.get().id;
+                    let next_page_id = page.get().id();
 
                     return_if_io!(self.pager.free_page(Some(page), next_page_id));
 
@@ -5587,7 +5588,7 @@ impl BTreeCursor {
                 }
                 DestroyState::FreePage => {
                     let page = self.stack.top();
-                    let page_id = page.get().id;
+                    let page_id = page.get().id();
 
                     if self.stack.has_parent() {
                         return_if_io!(self.pager.free_page(Some(page), page_id));
@@ -5678,7 +5679,7 @@ impl BTreeCursor {
             return Err(LimboError::BlobHandleExpired.into());
         }
         let cell_idx = cell_idx as usize;
-        let leaf_id = self.stack.top_ref().get().id;
+        let leaf_id = self.stack.top_ref().get().id();
         if self.blob_cache.valid
             && self.blob_cache.leaf_id == leaf_id
             && self.blob_cache.cell_idx == cell_idx
@@ -6059,7 +6060,7 @@ impl BTreeCursor {
         state: &mut OverwriteCellState,
     ) -> IOResultOr<()> {
         loop {
-            turso_assert!(page.is_loaded(), "page is not loaded", { "page_id": page.get().id });
+            turso_assert!(page.is_loaded(), "page is not loaded", { "page_id": page.get().id() });
             match state {
                 OverwriteCellState::AllocatePayload => {
                     let serial_types_len = record.column_count();
@@ -6873,7 +6874,7 @@ impl CursorTrait for BTreeCursor {
 
                     tracing::debug!(
                         "DeleteState::FindCell: page_id: {}, cell_idx: {}",
-                        page.get().id,
+                        page.get().id(),
                         cell_idx
                     );
 
@@ -7017,7 +7018,7 @@ impl CursorTrait for BTreeCursor {
                     // Step 2: Replace the cell in the parent (interior) page.
                     {
                         let parent_contents = page.get_contents();
-                        let parent_page_id = page.get().id;
+                        let parent_page_id = page.get().id();
                         let left_child_page = u32::from_be_bytes(
                             cell_payload[..4].try_into().expect("invalid cell payload"),
                         );
@@ -8026,14 +8027,14 @@ pub fn integrity_check(
                 if next_freelist_trunk_page as usize > state.db_size {
                     tracing::error!(
                         "integrity_check: freelist trunk page {} has invalid next pointer {}. header_bytes={:02x?}",
-                        page.get().id,
+                        page.get().id(),
                         next_freelist_trunk_page,
                         &contents.as_ptr()[0..16]
                     );
                     push_integrity_error(
                         errors,
                         IntegrityCheckError::FreelistPointerOutOfRange {
-                            page_id: page.get().id as i64,
+                            page_id: page.get().id() as i64,
                             pointer: next_freelist_trunk_page as i64,
                         },
                     )?;
@@ -8048,7 +8049,7 @@ pub fn integrity_check(
                         overflow_pages_expected: None,
                         overflow_pages_seen: 0,
                     },
-                    page.get().id as i64,
+                    page.get().id() as i64,
                     errors,
                 )?;
             }
@@ -8059,7 +8060,7 @@ pub fn integrity_check(
             if unlikely(page_pointers as usize > max_pointers) {
                 tracing::error!(
                     "integrity_check: freelist trunk page {} has invalid leaf count {} (max {}). header_bytes={:02x?}",
-                    page.get().id,
+                    page.get().id(),
                     page_pointers,
                     max_pointers,
                     &contents.as_ptr()[0..16]
@@ -8067,7 +8068,7 @@ pub fn integrity_check(
                 push_integrity_error(
                     errors,
                     IntegrityCheckError::FreelistTrunkCorrupt {
-                        page_id: page.get().id as i64,
+                        page_id: page.get().id() as i64,
                         page_pointers,
                         max_pointers,
                     },
@@ -8080,14 +8081,14 @@ pub fn integrity_check(
                 if unlikely(offset + FREELIST_LEAF_PTR_SIZE > page_size) {
                     tracing::error!(
                         "integrity_check: freelist trunk page {} has invalid leaf offset {}. header_bytes={:02x?}",
-                        page.get().id,
+                        page.get().id(),
                         offset,
                         &contents.as_ptr()[0..16]
                     );
                     push_integrity_error(
                         errors,
                         IntegrityCheckError::FreelistTrunkCorrupt {
-                            page_id: page.get().id as i64,
+                            page_id: page.get().id() as i64,
                             page_pointers,
                             max_pointers,
                         },
@@ -8098,14 +8099,14 @@ pub fn integrity_check(
                 if page_pointer as usize > state.db_size {
                     tracing::error!(
                         "integrity_check: freelist trunk page {} has invalid leaf pointer {}. header_bytes={:02x?}",
-                        page.get().id,
+                        page.get().id(),
                         page_pointer,
                         &contents.as_ptr()[0..16]
                     );
                     push_integrity_error(
                         errors,
                         IntegrityCheckError::FreelistPointerOutOfRange {
-                            page_id: page.get().id as i64,
+                            page_id: page.get().id() as i64,
                             pointer: page_pointer as i64,
                         },
                     )?;
@@ -8120,7 +8121,7 @@ pub fn integrity_check(
                         overflow_pages_expected: None,
                         overflow_pages_seen: 0,
                     },
-                    page.get().id as i64,
+                    page.get().id() as i64,
                     errors,
                 )?;
             }
@@ -8143,7 +8144,7 @@ pub fn integrity_check(
                         overflow_pages_expected,
                         overflow_pages_seen,
                     },
-                    page.get().id as i64,
+                    page.get().id() as i64,
                     errors,
                 )?;
             } else if let Some(expected) = overflow_pages_expected {
@@ -8161,7 +8162,7 @@ pub fn integrity_check(
         }
 
         let usable_space = pager.usable_space();
-        let mut coverage_checker = CoverageChecker::new(page.get().id as i64);
+        let mut coverage_checker = CoverageChecker::new(page.get().id() as i64);
 
         // Now we check every cell for few things:
         // 1. Check cell is in correct range. Not exceeds page and not starts before we have marked
@@ -8181,7 +8182,7 @@ pub fn integrity_check(
                     errors,
                     IntegrityCheckError::CellOutOfRange {
                         cell_idx,
-                        page_id: page.get().id as i64,
+                        page_id: page.get().id() as i64,
                         cell_start,
                         cell_end: cell_start + cell_length,
                         content_area: contents.cell_content_area() as usize,
@@ -8194,7 +8195,7 @@ pub fn integrity_check(
                     errors,
                     IntegrityCheckError::CellOverflowsPage {
                         cell_idx,
-                        page_id: page.get().id as i64,
+                        page_id: page.get().id() as i64,
                         cell_start,
                         cell_end: cell_start + cell_length,
                         content_area: contents.cell_content_area() as usize,
@@ -8215,7 +8216,7 @@ pub fn integrity_check(
                             overflow_pages_expected: None,
                             overflow_pages_seen: 0,
                         },
-                        page.get().id as i64,
+                        page.get().id() as i64,
                         errors,
                     )?;
                     let rowid = table_interior_cell.rowid;
@@ -8223,7 +8224,7 @@ pub fn integrity_check(
                         push_integrity_error(
                             errors,
                             IntegrityCheckError::CellRowidOutOfRange {
-                                page_id: page.get().id as i64,
+                                page_id: page.get().id() as i64,
                                 page_category,
                                 cell_idx,
                                 rowid,
@@ -8241,7 +8242,7 @@ pub fn integrity_check(
                             push_integrity_error(
                                 errors,
                                 IntegrityCheckError::LeafDepthMismatch {
-                                    page_id: page.get().id as i64,
+                                    page_id: page.get().id() as i64,
                                     this_page_depth: level,
                                     other_page_depth: expected_leaf_level,
                                 },
@@ -8255,7 +8256,7 @@ pub fn integrity_check(
                         push_integrity_error(
                             errors,
                             IntegrityCheckError::CellRowidOutOfRange {
-                                page_id: page.get().id as i64,
+                                page_id: page.get().id() as i64,
                                 page_category,
                                 cell_idx,
                                 rowid,
@@ -8280,7 +8281,7 @@ pub fn integrity_check(
                                 overflow_pages_expected: Some(expected_pages),
                                 overflow_pages_seen: 0,
                             },
-                            page.get().id as i64,
+                            page.get().id() as i64,
                             errors,
                         )?;
                     }
@@ -8295,7 +8296,7 @@ pub fn integrity_check(
                             overflow_pages_expected: None,
                             overflow_pages_seen: 0,
                         },
-                        page.get().id as i64,
+                        page.get().id() as i64,
                         errors,
                     )?;
                     if let Some(first_overflow_page) = index_interior_cell.first_overflow_page {
@@ -8313,7 +8314,7 @@ pub fn integrity_check(
                                 overflow_pages_expected: Some(expected_pages),
                                 overflow_pages_seen: 0,
                             },
-                            page.get().id as i64,
+                            page.get().id() as i64,
                             errors,
                         )?;
                     }
@@ -8325,7 +8326,7 @@ pub fn integrity_check(
                             push_integrity_error(
                                 errors,
                                 IntegrityCheckError::LeafDepthMismatch {
-                                    page_id: page.get().id as i64,
+                                    page_id: page.get().id() as i64,
                                     this_page_depth: level,
                                     other_page_depth: expected_leaf_level,
                                 },
@@ -8349,7 +8350,7 @@ pub fn integrity_check(
                                 overflow_pages_expected: Some(expected_pages),
                                 overflow_pages_seen: 0,
                             },
-                            page.get().id as i64,
+                            page.get().id() as i64,
                             errors,
                         )?;
                     }
@@ -8367,7 +8368,7 @@ pub fn integrity_check(
                     overflow_pages_expected: None,
                     overflow_pages_seen: 0,
                 },
-                page.get().id as i64,
+                page.get().id() as i64,
                 errors,
             )?;
         }
@@ -8384,7 +8385,7 @@ pub fn integrity_check(
                     push_integrity_error(
                         errors,
                         IntegrityCheckError::FreeBlockOutOfRange {
-                            page_id: page.get().id as i64,
+                            page_id: page.get().id() as i64,
                             start: pc,
                             end: pc + size,
                         },
@@ -8548,7 +8549,7 @@ impl PageStack {
     /// This effectively means traversing to a child page.
     #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG, name = "pagestack::push"))]
     fn _push(&mut self, page: PageRef, starting_cell_idx: i32) {
-        tracing::trace!(current = self.current_page, new_page_id = page.get().id,);
+        tracing::trace!(current = self.current_page, new_page_id = page.get().id(),);
         'validate: {
             let current = self.current_page;
             if current == -1 {
@@ -8557,9 +8558,9 @@ impl PageStack {
             let current_top = self.stack[current as usize].as_ref();
             if let Some(current_top) = current_top {
                 turso_assert!(
-                    current_top.get().id != page.get().id,
+                    current_top.get().id() != page.get().id(),
                     "about to push page twice",
-                    { "page_id": page.get().id }
+                    { "page_id": page.get().id() }
                 );
             }
         }
@@ -8599,12 +8600,12 @@ impl PageStack {
         turso_assert!(
             page.is_pinned(),
             "parent page is not pinned",
-            { "page_id": page.get().id }
+            { "page_id": page.get().id() }
         );
         turso_assert!(
             page.is_loaded(),
             "parent page is not loaded",
-            { "page_id": page.get().id }
+            { "page_id": page.get().id() }
         );
         let contents = page.get_contents();
         let cell_count = contents.cell_count() as i32;
@@ -8756,7 +8757,7 @@ impl PageStack {
         self.current_page >= 0
             && self.stack[0]
                 .as_ref()
-                .is_some_and(|page| page.get().id as i64 == root_page && page.is_loaded())
+                .is_some_and(|page| page.get().id() as i64 == root_page && page.is_loaded())
     }
 
     /// Drop every page below the root and leave the stack on the root as a
@@ -8920,7 +8921,7 @@ pub fn btree_init_page(page: &PageRef, page_type: PageType, offset: usize, usabl
     contents.overflow_cells.clear();
     tracing::debug!(
         "btree_init_page(id={}, offset={}, usable_space={})",
-        page.get().id,
+        page.get().id(),
         offset,
         usable_space
     );
@@ -9877,7 +9878,7 @@ fn _insert_into_cell(
         #[cfg(debug_assertions)]
         {
             if let Some(overflow_cell) = page.overflow_cells.last() {
-                turso_assert!(overflow_cell.index + 1 == cell_idx, "multiple overflow cells can only occur when a parent overflows during balancing as divider cells are inserted into it. those cells should always be in-order and sequential", { "page_id": page.id, "last_overflow_index": overflow_cell.index, "cell_idx": cell_idx, "cell_count": page.cell_count(), "overflow_count": page.overflow_cells.len() });
+                turso_assert!(overflow_cell.index + 1 == cell_idx, "multiple overflow cells can only occur when a parent overflows during balancing as divider cells are inserted into it. those cells should always be in-order and sequential", { "page_id": page.id(), "last_overflow_index": overflow_cell.index, "cell_idx": cell_idx, "cell_count": page.cell_count(), "overflow_count": page.overflow_cells.len() });
             }
         }
         let mut payload = crate::with_btree_allocation_site!(OverflowCell, payload.try_to_vec())?;
@@ -10257,7 +10258,7 @@ fn fill_cell_payload(
                             new_overflow_page.is_loaded(),
                             "new overflow page is not loaded"
                         );
-                        let new_overflow_page_id = new_overflow_page.get().id as u32;
+                        let new_overflow_page_id = new_overflow_page.get().id() as u32;
 
                         if let Some(prev_page) = current_overflow_page {
                             // Update the previous overflow page's "next overflow page" pointer to point to the new overflow page.
@@ -11082,7 +11083,7 @@ mod tests {
                         pager.io.step().unwrap();
                     }
                     child_pages.push(child_page);
-                    if left_child_page == page.get().id as u32 {
+                    if left_child_page == page.get().id() as u32 {
                         valid = false;
                         tracing::error!(
                             "left child page is the same as parent {}",
@@ -11136,7 +11137,7 @@ mod tests {
             if !p.is_loaded() {
                 let (new_page, _c) = pager
                     .io
-                    .block(|| pager.read_page(p.get().id as i64))
+                    .block(|| pager.read_page(p.get().id() as i64))
                     .unwrap();
                 *p = new_page;
             }
@@ -11150,7 +11151,7 @@ mod tests {
                 if !page.is_loaded() {
                     let (new_page, _c) = pager
                         .io
-                        .block(|| pager.read_page(page.get().id as i64))
+                        .block(|| pager.read_page(page.get().id() as i64))
                         .unwrap();
                     *page = new_page;
                 }
@@ -11252,7 +11253,7 @@ mod tests {
 
         let page2 = run_until_done(|| pager.allocate_page(), &pager).unwrap();
         btree_init_page(&page2, PageType::TableLeaf, 0, pager.usable_space());
-        (pager, page2.get().id as i64, db, conn)
+        (pager, page2.get().id() as i64, db, conn)
     }
 
     #[test]
@@ -12736,15 +12737,15 @@ mod tests {
             let contents = root_page.get_contents();
 
             // Set rightmost pointer to page4
-            contents.write_rightmost_ptr(page4.get().id as u32);
+            contents.write_rightmost_ptr(page4.get().id() as u32);
 
             // Create a cell with pointer to page3
             let cell_content = vec![
                 // First 4 bytes: left child pointer (page3)
-                (page3.get().id >> 24) as u8,
-                (page3.get().id >> 16) as u8,
-                (page3.get().id >> 8) as u8,
-                page3.get().id as u8,
+                (page3.get().id() >> 24) as u8,
+                (page3.get().id() >> 16) as u8,
+                (page3.get().id() >> 8) as u8,
+                page3.get().id() as u8,
                 // Next byte: rowid as varint (simple value 100)
                 100,
             ];
@@ -12759,8 +12760,8 @@ mod tests {
 
             // Simple record with just a rowid and payload
             let record_bytes = vec![
-                5,                   // Payload length (varint)
-                page.get().id as u8, // Rowid (varint)
+                5,                     // Payload length (varint)
+                page.get().id() as u8, // Rowid (varint)
                 b'h',
                 b'e',
                 b'l',
@@ -14182,7 +14183,7 @@ mod tests {
             let (pager, root_a, _db, _conn) = empty_btree();
             let page_b = run_until_done(|| pager.allocate_page(), &pager).unwrap();
             btree_init_page(&page_b, PageType::TableLeaf, 0, pager.usable_space());
-            let root_b = page_b.get().id as i64;
+            let root_b = page_b.get().id() as i64;
 
             let cursor_a = make_registered_cursor(&pager, root_a, 1);
             let cursor_b = make_registered_cursor(&pager, root_b, 1);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6729,17 +6729,6 @@ impl CursorTrait for BTreeCursor {
                 }
             }
         }
-        let cached = self
-            .reusable_immutable_record
-            .as_ref()
-            .is_some_and(|record| !record.is_invalidated());
-        if cached {
-            return Ok(IOResult::Done(
-                self.reusable_immutable_record
-                    .as_ref()
-                    .map(ImmutableRecord::get_payload),
-            ));
-        }
         let contents = self.stack.top_ref().get_contents();
         let cell_idx = self.stack.current_cell_index();
         // Optimistically use a faster decoder that only handles leaf cells without overflow pages.

--- a/core/storage/page_cache.rs
+++ b/core/storage/page_cache.rs
@@ -339,17 +339,17 @@ impl PageCache {
 
         if page.is_locked() {
             return Err(CacheError::Locked {
-                pgno: page.get().id,
+                pgno: page.get().id(),
             });
         }
         if page.is_dirty() {
             return Err(CacheError::Dirty {
-                pgno: page.get().id,
+                pgno: page.get().id(),
             });
         }
         if page.is_pinned() {
             return Err(CacheError::Pinned {
-                pgno: page.get().id,
+                pgno: page.get().id(),
             });
         }
 
@@ -521,7 +521,7 @@ impl PageCache {
             && !page.is_locked()
             && !page.is_pinned()
             && Arc::strong_count(page) == 1
-            && page.get().id.ne(&DatabaseHeader::PAGE_ID)
+            && page.get().id().ne(&DatabaseHeader::PAGE_ID)
             && page.get().overflow_cells.is_empty()
     }
 
@@ -531,7 +531,7 @@ impl PageCache {
     /// since those are typically short-lived. We track based on dirty/spilled state.
     fn counted_as_evictable(page: &PageRef) -> bool {
         // Page 1 is never evictable
-        if page.get().id == DatabaseHeader::PAGE_ID {
+        if page.get().id() == DatabaseHeader::PAGE_ID {
             return false;
         }
         // A page is evictable if it's clean OR spilled
@@ -547,7 +547,7 @@ impl PageCache {
             let page = &entry.page;
             // Page was evictable (clean or spilled) before becoming dirty,
             // now it's dirty && !spilled, so not evictable
-            if page.get().id != DatabaseHeader::PAGE_ID {
+            if page.get().id() != DatabaseHeader::PAGE_ID {
                 // Only decrement if we were counting it as evictable
                 // (it was clean or spilled before this call)
                 self.evictable_count = self.evictable_count.saturating_sub(1);
@@ -563,7 +563,7 @@ impl PageCache {
             let entry = unsafe { &*entry_ptr };
             let page = &entry.page;
             // Page was dirty && !spilled (not evictable), now it's spilled (evictable)
-            if page.get().id != DatabaseHeader::PAGE_ID {
+            if page.get().id() != DatabaseHeader::PAGE_ID {
                 self.evictable_count += 1;
             }
         }
@@ -594,7 +594,7 @@ impl PageCache {
                 break;
             }
         }
-        spillable.sort_by_key(|pg| pg.get().id);
+        spillable.sort_by_key(|pg| pg.get().id());
         spillable
     }
 
@@ -654,7 +654,7 @@ impl PageCache {
         (!page.is_dirty() || page.is_spilled())
             && !page.is_locked()
             && !page.is_pinned()
-            && page.get().id.ne(&DatabaseHeader::PAGE_ID)
+            && page.get().id().ne(&DatabaseHeader::PAGE_ID)
             && Arc::strong_count(page) == 1
     }
 
@@ -733,7 +733,7 @@ impl PageCache {
             let entry = unsafe { &*entry_ptr };
             if entry.page.is_dirty() && !clear_dirty {
                 return Err(CacheError::Dirty {
-                    pgno: entry.page.get().id,
+                    pgno: entry.page.get().id(),
                 });
             }
         }
@@ -1066,14 +1066,14 @@ mod tests {
         let key3 = insert_page(&mut cache, 3);
 
         // With capacity=1, inserting key3 should evict key2
-        assert_eq!(cache.get(&key3).unwrap().unwrap().get().id, 3);
+        assert_eq!(cache.get(&key3).unwrap().unwrap().get().id(), 3);
         assert!(
             cache.get(&key2).unwrap().is_none(),
             "key2 should be evicted"
         );
 
         // key3 should still be accessible
-        assert_eq!(cache.get(&key3).unwrap().unwrap().get().id, 3);
+        assert_eq!(cache.get(&key3).unwrap().unwrap().get().id(), 3);
         assert!(
             cache.get(&key2).unwrap().is_none(),
             "capacity=1 should have evicted the older page"
@@ -1268,8 +1268,8 @@ mod tests {
         let key1 = insert_page(&mut cache, 1);
         let key2 = insert_page(&mut cache, 2);
 
-        assert_eq!(cache.get(&key1).unwrap().unwrap().get().id, 1);
-        assert_eq!(cache.get(&key2).unwrap().unwrap().get().id, 2);
+        assert_eq!(cache.get(&key1).unwrap().unwrap().get().id(), 1);
+        assert_eq!(cache.get(&key2).unwrap().unwrap().get().id(), 2);
         cache.verify_cache_integrity();
     }
 
@@ -1524,8 +1524,8 @@ mod tests {
             // Verify all pages in reference_map are in cache
             for (key, page) in &reference_map {
                 let cached_page = cache.peek(key, false).expect("Page should be in cache");
-                assert_eq!(cached_page.get().id, key.0);
-                assert_eq!(page.get().id, key.0);
+                assert_eq!(cached_page.get().id(), key.0);
+                assert_eq!(page.get().id(), key.0);
             }
         }
     }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -512,8 +512,11 @@ impl PageInner {
             return None;
         }
         let cell_pointer = header + LEAF_PAGE_HEADER_SIZE_BYTES + cell_index * CELL_PTR_SIZE_BYTES;
-        let cell_offset =
-            u16::from_be_bytes([*buf.get(cell_pointer)?, *buf.get(cell_pointer + 1)?]) as usize;
+        let cell_offset = u16::from_be_bytes(
+            buf.get(cell_pointer..cell_pointer + CELL_PTR_SIZE_BYTES)?
+                .try_into()
+                .ok()?,
+        ) as usize;
         let (size, len) = read_varint(buf.get(cell_offset..)?).ok()?;
         let mut start = cell_offset + len;
         if is_table {

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -119,110 +119,137 @@ pub struct TableLeafCellHeader {
     pub payload_size: u64,
 }
 
-pub struct PageInner {
-    pub flags: AtomicUsize,
-    pub id: usize,
-    /// If >0, the page is pinned and not eligible for eviction from the page cache.
-    /// The reason this is a counter is that multiple nested code paths may signal that
-    /// a page must not be evicted from the page cache, so even if an inner code path
-    /// requests unpinning via [Page::unpin], the pin count will still be >0 if the outer
-    /// code path has not yet requested to unpin the page as well.
-    ///
-    /// Note that [PageCache::clear] evicts the pages even if pinned, so as long as
-    /// we clear the page cache on errors, pins will not 'leak'.
-    pub pin_count: AtomicUsize,
-    /// The WAL frame number this page was loaded from (0 if loaded from main DB file)
-    /// This tracks which version of the page we have in memory
-    pub wal_tag: AtomicU64,
-    /// The actual page data buffer. None if not loaded.
-    buffer: Option<Arc<Buffer>>,
-    /// Start and length of the bytes of `buffer`, kept next to it so a page
-    /// read does not go through the `Option`, the `Arc` and the `Buffer`
-    /// variant on every access. Null and 0 while `buffer` is `None`.
-    data_ptr: *mut u8,
-    data_len: usize,
-    /// Overflow cells during btree operations
-    pub overflow_cells: crate::alloc::Vec<OverflowCell>,
+pub use page_inner::PageInner;
+
+mod page_inner {
+    use super::*;
+
+    pub struct PageInner {
+        pub flags: AtomicUsize,
+        id: usize,
+        /// Where the b-tree page header starts: after the database header on
+        /// page 1, at the start of every other page. Kept next to the id so a
+        /// header read does not test the id every time.
+        header_offset: u8,
+        /// If >0, the page is pinned and not eligible for eviction from the page cache.
+        /// The reason this is a counter is that multiple nested code paths may signal that
+        /// a page must not be evicted from the page cache, so even if an inner code path
+        /// requests unpinning via [Page::unpin], the pin count will still be >0 if the outer
+        /// code path has not yet requested to unpin the page as well.
+        ///
+        /// Note that [PageCache::clear] evicts the pages even if pinned, so as long as
+        /// we clear the page cache on errors, pins will not 'leak'.
+        pub pin_count: AtomicUsize,
+        /// The WAL frame number this page was loaded from (0 if loaded from main DB file)
+        /// This tracks which version of the page we have in memory
+        pub wal_tag: AtomicU64,
+        /// The actual page data buffer. None if not loaded.
+        buffer: Option<Arc<Buffer>>,
+        /// Start and length of the bytes of `buffer`, kept next to it so a page
+        /// read does not go through the `Option`, the `Arc` and the `Buffer`
+        /// variant on every access. Null and 0 while `buffer` is `None`.
+        data_ptr: *mut u8,
+        data_len: usize,
+        /// Overflow cells during btree operations
+        pub overflow_cells: crate::alloc::Vec<OverflowCell>,
+    }
+
+    // SAFETY: data_ptr and data_len only cache the address and length of the
+    // bytes owned by `buffer`, an `Arc<Buffer>` that is itself Send and Sync, so
+    // PageInner can cross threads exactly as it could before the cache existed.
+    unsafe impl Send for PageInner {}
+    unsafe impl Sync for PageInner {}
+
+    // Methods moved from PageContent - these provide btree page access
+    impl PageInner {
+        /// Creates a new PageInner from an Arc<Buffer>.
+        pub fn new(buffer: Arc<Buffer>) -> Self {
+            let mut inner = Self::unloaded(0);
+            inner.set_buffer(buffer);
+            inner
+        }
+
+        /// Creates a new PageInner with an owned buffer.
+        pub fn from_buffer(buffer: Buffer) -> Self {
+            Self::new(Arc::new(buffer))
+        }
+
+        /// Creates a PageInner with no buffer loaded.
+        pub fn unloaded(id: usize) -> Self {
+            Self {
+                flags: AtomicUsize::new(0),
+                id,
+                header_offset: Self::header_offset_of(id),
+                pin_count: AtomicUsize::new(0),
+                wal_tag: AtomicU64::new(TAG_UNSET),
+                buffer: None,
+                data_ptr: std::ptr::null_mut(),
+                data_len: 0,
+                overflow_cells: crate::alloc::vec![],
+            }
+        }
+
+        /// The page data buffer, if loaded.
+        #[inline]
+        pub fn buffer(&self) -> Option<&Arc<Buffer>> {
+            self.buffer.as_ref()
+        }
+
+        /// Installs the page data buffer.
+        pub fn set_buffer(&mut self, buffer: Arc<Buffer>) {
+            self.data_ptr = buffer.as_mut_ptr();
+            self.data_len = buffer.len();
+            self.buffer = Some(buffer);
+        }
+
+        /// Removes the page data buffer, leaving the page unloaded.
+        pub fn take_buffer(&mut self) -> Option<Arc<Buffer>> {
+            self.data_ptr = std::ptr::null_mut();
+            self.data_len = 0;
+            self.buffer.take()
+        }
+
+        /// Get the page buffer as a mutable slice. Panics if buffer not loaded.
+        #[inline(always)]
+        #[allow(clippy::mut_from_ref)]
+        pub fn as_ptr(&self) -> &mut [u8] {
+            turso_assert!(!self.data_ptr.is_null(), "buffer not loaded");
+            // SAFETY: `data_ptr`/`data_len` describe the bytes of the `Arc<Buffer>`
+            // held in `self.buffer`, which stays alive and does not move while it is
+            // installed. Handing out `&mut [u8]` from `&self` mirrors
+            // `Buffer::as_mut_slice`; the page byte range is mutated only under the
+            // pager's own exclusion rules, as before.
+            unsafe { std::slice::from_raw_parts_mut(self.data_ptr, self.data_len) }
+        }
+
+        /// The position where page content starts. It's 100 for page 1 (database file header is 100 bytes),
+        /// 0 for all other pages.
+        #[inline(always)]
+        pub fn offset(&self) -> usize {
+            self.header_offset as usize
+        }
+
+        #[inline]
+        pub fn id(&self) -> usize {
+            self.id
+        }
+
+        pub fn set_id(&mut self, id: usize) {
+            self.id = id;
+            self.header_offset = Self::header_offset_of(id);
+        }
+
+        const fn header_offset_of(id: usize) -> u8 {
+            if id == 1 {
+                DatabaseHeader::SIZE as u8
+            } else {
+                0
+            }
+        }
+    }
 }
 
-// SAFETY: data_ptr and data_len only cache the address and length of the
-// bytes owned by `buffer`, an `Arc<Buffer>` that is itself Send and Sync, so
-// PageInner can cross threads exactly as it could before the cache existed.
-unsafe impl Send for PageInner {}
-unsafe impl Sync for PageInner {}
-
-// Methods moved from PageContent - these provide btree page access
 impl PageInner {
-    /// Creates a new PageInner from an Arc<Buffer>.
-    pub fn new(buffer: Arc<Buffer>) -> Self {
-        let mut inner = Self::unloaded(0);
-        inner.set_buffer(buffer);
-        inner
-    }
-
-    /// Creates a new PageInner with an owned buffer.
-    pub fn from_buffer(buffer: Buffer) -> Self {
-        Self::new(Arc::new(buffer))
-    }
-
-    /// Creates a PageInner with no buffer loaded.
-    pub fn unloaded(id: usize) -> Self {
-        Self {
-            flags: AtomicUsize::new(0),
-            id,
-            pin_count: AtomicUsize::new(0),
-            wal_tag: AtomicU64::new(TAG_UNSET),
-            buffer: None,
-            data_ptr: std::ptr::null_mut(),
-            data_len: 0,
-            overflow_cells: crate::alloc::vec![],
-        }
-    }
-
-    /// The page data buffer, if loaded.
-    #[inline]
-    pub fn buffer(&self) -> Option<&Arc<Buffer>> {
-        self.buffer.as_ref()
-    }
-
-    /// Installs the page data buffer.
-    pub fn set_buffer(&mut self, buffer: Arc<Buffer>) {
-        self.data_ptr = buffer.as_mut_ptr();
-        self.data_len = buffer.len();
-        self.buffer = Some(buffer);
-    }
-
-    /// Removes the page data buffer, leaving the page unloaded.
-    pub fn take_buffer(&mut self) -> Option<Arc<Buffer>> {
-        self.data_ptr = std::ptr::null_mut();
-        self.data_len = 0;
-        self.buffer.take()
-    }
-
-    /// Get the page buffer as a mutable slice. Panics if buffer not loaded.
-    #[inline(always)]
-    #[allow(clippy::mut_from_ref)]
-    pub fn as_ptr(&self) -> &mut [u8] {
-        turso_assert!(!self.data_ptr.is_null(), "buffer not loaded");
-        // SAFETY: `data_ptr`/`data_len` describe the bytes of the `Arc<Buffer>`
-        // held in `self.buffer`, which stays alive and does not move while it is
-        // installed. Handing out `&mut [u8]` from `&self` mirrors
-        // `Buffer::as_mut_slice`; the page byte range is mutated only under the
-        // pager's own exclusion rules, as before.
-        unsafe { std::slice::from_raw_parts_mut(self.data_ptr, self.data_len) }
-    }
-
-    /// The position where page content starts. It's 100 for page 1 (database file header is 100 bytes),
-    /// 0 for all other pages.
-    #[inline(always)]
-    pub fn offset(&self) -> usize {
-        if self.id == 1 {
-            DatabaseHeader::SIZE
-        } else {
-            0
-        }
-    }
-
     /// Read a u8 from the page content at the given offset, taking account the possible db header on page 1.
     #[inline(always)]
     fn read_u8(&self, pos: usize) -> u8 {
@@ -913,7 +940,7 @@ impl Page {
         turso_debug_assert!(
             inner.buffer().is_some(),
             "page buffer not loaded",
-            { "page_id": inner.id }
+            { "page_id": inner.id() }
         );
         inner
     }
@@ -941,7 +968,7 @@ impl Page {
     #[inline]
     /// almost never should be called explicitly - instead [Pager::add_dirty] method must be used
     pub fn set_dirty(&self) {
-        tracing::debug!("set_dirty(page={})", self.get().id);
+        tracing::debug!("set_dirty(page={})", self.get().id());
         self.clear_wal_tag();
         // Clear spilled flag since page is being modified again
         self.get().flags.fetch_and(!PAGE_SPILLED, Ordering::Release);
@@ -951,7 +978,7 @@ impl Page {
     #[inline]
     /// caller must ensure that [Pager::dirty_pages] will be updated accordingly
     pub fn clear_dirty(&self) {
-        tracing::debug!("clear_dirty(page={})", self.get().id);
+        tracing::debug!("clear_dirty(page={})", self.get().id());
         self.get().flags.fetch_and(!PAGE_DIRTY, Ordering::Release);
         self.clear_wal_tag();
     }
@@ -960,7 +987,7 @@ impl Page {
     /// Used when a WAL frame has been durably written and the tag already encodes it.
     #[inline]
     pub fn clear_dirty_keep_wal_tag(&self) {
-        tracing::debug!("clear_dirty_keep_wal_tag(page={})", self.get().id);
+        tracing::debug!("clear_dirty_keep_wal_tag(page={})", self.get().id());
         self.get().flags.fetch_and(!PAGE_DIRTY, Ordering::Release);
     }
 
@@ -973,7 +1000,7 @@ impl Page {
     /// Mark the page as spilled to WAL. Spilled pages remain dirty but may be evicted from cache.
     #[inline]
     pub fn set_spilled(&self) {
-        tracing::debug!("set_spilled(page={})", self.get().id);
+        tracing::debug!("set_spilled(page={})", self.get().id());
         self.get().flags.fetch_or(PAGE_SPILLED, Ordering::Release);
     }
 
@@ -1004,7 +1031,7 @@ impl Page {
 
     #[inline]
     pub fn clear_loaded(&self) {
-        tracing::debug!("clear loaded {}", self.get().id);
+        tracing::debug!("clear loaded {}", self.get().id());
         self.get().flags.fetch_and(!PAGE_LOADED, Ordering::Release);
     }
 
@@ -1031,7 +1058,7 @@ impl Page {
         turso_assert!(
             was_pinned,
             "Attempted to unpin page that was not pinned",
-            { "page_id": self.get().id }
+            { "page_id": self.get().id() }
         );
     }
 
@@ -1088,7 +1115,7 @@ impl Page {
         let result = tag != TAG_UNSET && tag != TAG_WRITE_PENDING;
         tracing::debug!(
             "has_wal_tag(page={}) = {} (tag={:x})",
-            self.get().id,
+            self.get().id(),
             result,
             tag
         );
@@ -1100,7 +1127,7 @@ impl Page {
     /// This is set before starting a spill/cacheflush so we can detect
     /// if the page was modified during the write.
     pub fn set_write_pending(&self) {
-        tracing::debug!("set_write_pending(page={})", self.get().id);
+        tracing::debug!("set_write_pending(page={})", self.get().id());
         self.get()
             .wal_tag
             .store(TAG_WRITE_PENDING, Ordering::Release);
@@ -1111,7 +1138,7 @@ impl Page {
     /// Returns true if the tag was set, false if the page was modified (wal_tag became TAG_UNSET).
     pub fn try_set_wal_tag(&self, frame: u64, epoch: u32) -> bool {
         let new_tag = pack_tag_pair(frame, epoch);
-        let page_id = self.get().id;
+        let page_id = self.get().id();
         let current = self.get().wal_tag.load(Ordering::Acquire);
         // Only set if current tag is not TAG_UNSET (meaning page wasn't modified during write)
         // TAG_WRITE_PENDING is fine, it means the write was in progress and page wasn't modified
@@ -2060,7 +2087,7 @@ impl Pager {
                     }
                     turso_assert!(page.is_loaded(), "page should be loaded");
                     turso_assert!(
-                        page.get().id == DatabaseHeader::PAGE_ID,
+                        page.get().id() == DatabaseHeader::PAGE_ID,
                         "incorrect header page id"
                     );
                     *self.header_ref_state.write() = HeaderRefState::Start;
@@ -2116,7 +2143,7 @@ impl Pager {
             // New pages (allocated during this statement) can be "rolled back" by simply
             // truncating back to the original db_size. This matches SQLite's subjRequiresPage()
             // which checks: p->nOrig >= pgno.
-            let page_id_u32 = page.get().id as u32;
+            let page_id_u32 = page.get().id() as u32;
             if page_id_u32 > cur_savepoint.db_size.load(Ordering::Acquire) {
                 return Ok(());
             }
@@ -2125,10 +2152,10 @@ impl Pager {
             }
             cur_savepoint.write_offset.load(Ordering::SeqCst)
         };
-        let page_id = page.get().id;
+        let page_id = page.get().id();
         let page_size = self.page_size.load(Ordering::SeqCst) as usize;
         let buffer = {
-            let page_id = page.get().id as u32;
+            let page_id = page.get().id() as u32;
             let contents = page.get_contents();
             let buffer = self.buffer_pool.allocate(page_size + 4);
             let contents_buffer = contents.as_ptr();
@@ -2663,7 +2690,7 @@ impl Pager {
                 } => {
                     turso_assert!(ptrmap_page.is_loaded(), "ptrmap_page should be loaded");
                     let page_content = ptrmap_page.get_contents();
-                    let ptrmap_pg_no = page_content.id;
+                    let ptrmap_pg_no = page_content.id();
 
                     let full_buffer_slice: &[u8] = page_content.as_ptr();
 
@@ -2767,7 +2794,7 @@ impl Pager {
                     turso_assert!(ptrmap_page.is_loaded(), "page should be loaded");
                     self.add_dirty(&ptrmap_page)?;
                     let page_content = ptrmap_page.get_contents();
-                    let ptrmap_pg_no = page_content.id;
+                    let ptrmap_pg_no = page_content.id();
 
                     let full_buffer_slice = page_content.as_ptr();
 
@@ -2791,7 +2818,7 @@ impl Pager {
                     )?;
 
                     turso_assert!(
-                        ptrmap_page.get().id == ptrmap_pg_no,
+                        ptrmap_page.get().id() == ptrmap_pg_no,
                         "ptrmap page has unexpected number"
                     );
                     self.vacuum_state.write().ptrmap_put_state = PtrMapPutState::Start;
@@ -2813,7 +2840,7 @@ impl Pager {
         #[cfg(not(feature = "autovacuum"))]
         {
             let page = return_if_io!(self.do_allocate_page(page_type, 0, BtreePageAllocMode::Any));
-            Ok(IOResult::Done(page.get().id as u32))
+            Ok(IOResult::Done(page.get().id() as u32))
         }
 
         //  If autovacuum is enabled, we need to allocate a new page number that is greater than the largest root page number
@@ -2825,7 +2852,7 @@ impl Pager {
                 AutoVacuumMode::None => {
                     let page =
                         return_if_io!(self.do_allocate_page(page_type, 0, BtreePageAllocMode::Any));
-                    Ok(IOResult::Done(page.get().id as u32))
+                    Ok(IOResult::Done(page.get().id() as u32))
                 }
                 AutoVacuumMode::Full => {
                     loop {
@@ -2869,7 +2896,7 @@ impl Pager {
                                     0,
                                     BtreePageAllocMode::Exact(root_page_num),
                                 ));
-                                let allocated_page_id = page.get().id as u32;
+                                let allocated_page_id = page.get().id() as u32;
 
                                 return_if_io!(self.with_header_mut(|header| {
                                     if allocated_page_id
@@ -2922,7 +2949,7 @@ impl Pager {
     // FIXME: handle no room in page cache
     pub fn allocate_overflow_page(&self) -> IOResultOr<PageRef> {
         let page = return_if_io!(self.allocate_page());
-        tracing::debug!("Pager::allocate_overflow_page(id={})", page.get().id);
+        tracing::debug!("Pager::allocate_overflow_page(id={})", page.get().id());
 
         // setup overflow page
         let contents = page.get_contents();
@@ -2951,7 +2978,7 @@ impl Pager {
         btree_init_page(&page, page_type, offset, self.usable_space());
         tracing::debug!(
             "do_allocate_page(id={}, page_type={:?})",
-            page.get().id,
+            page.get().id(),
             page.get_contents().page_type().ok()
         );
         Ok(IOResult::Done(page))
@@ -3573,9 +3600,9 @@ impl Pager {
                 let page_key = PageCacheKey::new(page_idx as usize);
                 if let Some(page) = page_cache.get(&page_key)? {
                     turso_assert!(
-                        page_idx as usize == page.get().id,
+                        page_idx as usize == page.get().id(),
                         "attempted to read page but got different page",
-                        { "expected_page": page_idx, "actual_page": page.get().id }
+                        { "expected_page": page_idx, "actual_page": page.get().id() }
                     );
                     if !page.is_loaded() {
                         // The page is cache-resident but its read is still in
@@ -3784,11 +3811,11 @@ impl Pager {
         turso_assert!(
             page.is_loaded(),
             "page must be loaded in add_dirty() so its contents can be subjournaled",
-            { "page_id": page.get().id }
+            { "page_id": page.get().id() }
         );
         self.subjournal_page_if_required(page)?;
         let mut dirty_pages = self.dirty_pages.write();
-        dirty_pages.insert(page.get().id as u32);
+        dirty_pages.insert(page.get().id() as u32);
         // Notify cache before marking dirty (page was evictable, now it won't be)
         // Only notify if page wasn't already dirty, or if it was spilled
         // State before set_dirty():
@@ -3796,7 +3823,7 @@ impl Pager {
         // - dirty + spilled page: evictable -> set_dirty() clears spilled and makes it unevictable
         // - dirty + not spilled page: already unevictable -> no cache accounting change
         if !page.is_dirty() || page.is_spilled() {
-            let key = PageCacheKey::new(page.get().id);
+            let key = PageCacheKey::new(page.get().id());
             self.page_cache.write().notify_page_dirty(key);
         }
         page.set_dirty();
@@ -4200,7 +4227,7 @@ impl Pager {
                         let mut cache = self.page_cache.write();
                         for page in &pages {
                             if page.has_wal_tag() {
-                                let key = PageCacheKey::new(page.get().id);
+                                let key = PageCacheKey::new(page.get().id());
                                 cache.notify_page_spilled(key);
                                 page.set_spilled();
                                 spilled_count += 1;
@@ -4208,7 +4235,7 @@ impl Pager {
                                 // Page was modified during write, it will need to be re-spilled
                                 tracing::debug!(
                                 "try_spill_dirty_pages: page {} modified during write, not marking as spilled",
-                                page.get().id
+                                page.get().id()
                             );
                             }
                         }
@@ -4278,7 +4305,7 @@ impl Pager {
                 let mut cache = self.page_cache.write();
                 for page in &pages {
                     if page.has_wal_tag() {
-                        let key = PageCacheKey::new(page.get().id);
+                        let key = PageCacheKey::new(page.get().id());
                         cache.notify_page_spilled(key);
                         page.set_spilled();
                     }
@@ -4547,14 +4574,14 @@ impl Pager {
                         if !page.is_loaded() {
                             return Err(LimboError::InternalError(format!(
                                 "dirty page {} has no buffer loaded at commit time",
-                                page.get().id
+                                page.get().id()
                             ))
                             .into());
                         }
                         turso_assert!(
                             page.get().overflow_cells.is_empty(),
                             "dirty page still has overflow cells at commit time",
-                            { "page_id": page.get().id }
+                            { "page_id": page.get().id() }
                         );
                         commit_info.page_source_cursor += 1;
                         commit_info.collected_pages.push(page);
@@ -4768,7 +4795,7 @@ impl Pager {
             let content = page.get_contents();
             content.as_ptr().copy_from_slice(raw_page);
             turso_assert!(
-                page.get().id == header.page_number as usize,
+                page.get().id() == header.page_number as usize,
                 "page has unexpected id"
             );
         }
@@ -5453,10 +5480,10 @@ impl Pager {
                     let (page, c) = match page.take() {
                         Some(page) => {
                             turso_assert_eq!(
-                                page.get().id,
+                                page.get().id(),
                                 page_id,
                                 "free_page page id mismatch",
-                                { "expected": page_id, "actual": page.get().id }
+                                { "expected": page_id, "actual": page.get().id() }
                             );
                             (page, None)
                         }
@@ -5506,7 +5533,7 @@ impl Pager {
 
                     if number_of_leaf_pages < max_free_list_entries as u32 {
                         turso_assert!(
-                            trunk_page.get().id == trunk_page_id as usize,
+                            trunk_page.get().id() == trunk_page_id as usize,
                             "trunk page has unexpected id"
                         );
                         self.add_dirty(&trunk_page)?;
@@ -5531,7 +5558,7 @@ impl Pager {
                 FreePageState::NewTrunk { page } => {
                     turso_assert!(page.is_loaded(), "page should be loaded");
                     // If we get here, need to make this page a new trunk
-                    turso_assert!(page.get().id == page_id, "page has unexpected id");
+                    turso_assert!(page.get().id() == page_id, "page has unexpected id");
                     self.add_dirty(page)?;
 
                     let trunk_page_id = header.freelist_trunk_page.get();
@@ -5649,7 +5676,7 @@ impl Pager {
     /// WAL-backed databases, fsync'd) to the main database file; publish it
     /// in the page cache and mark the database initialized.
     fn finish_allocate_page1(&self, page: PageRef) -> IOResultOr<PageRef> {
-        let page_key = PageCacheKey::new(page.get().id);
+        let page_key = PageCacheKey::new(page.get().id());
         let mut cache = self.page_cache.write();
         cache.insert(page_key, page.clone()).map_err(|e| {
             LimboError::InternalError(format!("Failed to insert page 1 into cache: {e:?}"))
@@ -5750,7 +5777,7 @@ impl Pager {
                     turso_assert!(
                         trunk_page.is_loaded(),
                         "Freelist trunk page is not loaded",
-                        { "page_id": trunk_page.get().id }
+                        { "page_id": trunk_page.get().id() }
                     );
                     let page_contents = trunk_page.get_contents();
                     let next_trunk_page_id =
@@ -5771,7 +5798,7 @@ impl Pager {
                         turso_assert!(
                             number_of_freelist_leaves > 0,
                             "Freelist trunk page has no leaves",
-                            { "page_id": trunk_page.get().id }
+                            { "page_id": trunk_page.get().id() }
                         );
 
                         // Pin leaf_page to prevent eviction while stored in state machine
@@ -5799,16 +5826,16 @@ impl Pager {
                     turso_assert!(
                         trunk_page.get_contents().overflow_cells.is_empty(),
                         "Freelist trunk page has overflow cells",
-                        { "page_id": trunk_page.get().id }
+                        { "page_id": trunk_page.get().id() }
                     );
                     trunk_page.get_contents().as_ptr().fill(0);
-                    let page_key = PageCacheKey::new(trunk_page.get().id);
+                    let page_key = PageCacheKey::new(trunk_page.get().id());
                     {
                         let page_cache = self.page_cache.read();
                         turso_assert!(
                             page_cache.contains_key(&page_key),
                             "page is not in cache",
-                            { "page_id": trunk_page.get().id }
+                            { "page_id": trunk_page.get().id() }
                         );
                     }
                     // Unpin trunk_page before returning - caller takes ownership
@@ -5825,7 +5852,7 @@ impl Pager {
                     turso_assert!(
                         leaf_page.is_loaded(),
                         "Leaf page is not loaded",
-                        { "page_id": leaf_page.get().id }
+                        { "page_id": leaf_page.get().id() }
                     );
                     let page_contents = trunk_page.get_contents();
                     self.add_dirty(leaf_page)?;
@@ -5833,16 +5860,16 @@ impl Pager {
                     turso_assert!(
                         leaf_page.get_contents().overflow_cells.is_empty(),
                         "Freelist leaf page has overflow cells",
-                        { "page_id": leaf_page.get().id }
+                        { "page_id": leaf_page.get().id() }
                     );
                     leaf_page.get_contents().as_ptr().fill(0);
-                    let page_key = PageCacheKey::new(leaf_page.get().id);
+                    let page_key = PageCacheKey::new(leaf_page.get().id());
                     {
                         let page_cache = self.page_cache.read();
                         turso_assert!(
                             page_cache.contains_key(&page_key),
                             "page is not in cache",
-                            { "page_id": leaf_page.get().id }
+                            { "page_id": leaf_page.get().id() }
                         );
                     }
 
@@ -5885,7 +5912,7 @@ impl Pager {
                         let richard_hipp_special_page =
                             allocate_new_page(new_db_size as i64, &self.buffer_pool);
                         self.add_dirty(&richard_hipp_special_page)?;
-                        let page_key = PageCacheKey::new(richard_hipp_special_page.get().id);
+                        let page_key = PageCacheKey::new(richard_hipp_special_page.get().id());
                         self.page_cache
                             .write()
                             .force_insert_page(page_key, richard_hipp_special_page)?;
@@ -5908,7 +5935,7 @@ impl Pager {
                         // setup page and add to cache
                         self.add_dirty(&page)?;
 
-                        let page_key = PageCacheKey::new(page.get().id as usize);
+                        let page_key = PageCacheKey::new(page.get().id() as usize);
                         self.page_cache
                             .write()
                             .force_insert_page(page_key, page.clone())?;
@@ -6420,6 +6447,25 @@ mod tests {
     use super::{default_page1, CacheFlushState, CollectingState, Page, PageRef, Pager};
     use crate::{Buffer, Completion, CompletionError, LimboError};
 
+    #[test]
+    fn page_id_changes_keep_header_access_at_the_correct_offset() {
+        let mut page = super::PageInner::from_buffer(Buffer::new_temporary(4096));
+        for id in [1, 2, 1, 0, usize::MAX] {
+            page.set_id(id);
+            assert_eq!(page.id(), id);
+            let offset = if id == 1 { 100 } else { 0 };
+            assert_eq!(page.offset(), offset);
+            page.as_ptr().fill(0);
+            page.write_page_type(super::PageType::TableLeaf as u8);
+            assert_eq!(page.as_ptr()[offset], super::PageType::TableLeaf as u8);
+            assert_eq!(page.page_type().unwrap(), super::PageType::TableLeaf);
+
+            let unloaded = super::PageInner::unloaded(id);
+            assert_eq!(unloaded.id(), id);
+            assert_eq!(unloaded.offset(), offset);
+        }
+    }
+
     fn pager_with_cache_capacity(cache_capacity: usize, database_pages: u32) -> Arc<Pager> {
         let io: Arc<dyn IO> = Arc::new(MemoryIO::new());
         let buffer_pool = BufferPool::begin_init(&io, 4096 * 128);
@@ -6490,7 +6536,7 @@ mod tests {
         while page.is_locked() {
             pager.io.step().unwrap();
         }
-        assert_eq!(page.get().id as i64, missing);
+        assert_eq!(page.get().id() as i64, missing);
         assert!(
             pager.page_cache.read().len() > CAP,
             "page must have been admitted over capacity"
@@ -6522,7 +6568,7 @@ mod tests {
         assert_eq!(held.len(), CAP, "cache should be at capacity");
 
         let page = pager.io.block(|| pager.allocate_page()).unwrap();
-        assert_eq!(page.get().id, 6);
+        assert_eq!(page.get().id(), 6);
         assert!(
             pager.page_cache.read().len() > CAP,
             "page must have been admitted over capacity"
@@ -6577,7 +6623,7 @@ mod tests {
         let mut cache = cache.write();
         let page_key = PageCacheKey::new(1);
         let page = cache.get(&page_key).unwrap();
-        assert_eq!(page.unwrap().get().id, 1);
+        assert_eq!(page.unwrap().get().id(), 1);
     }
 }
 
@@ -6848,7 +6894,7 @@ mod ptrmap_tests {
         let res = pager.read_page(1).unwrap();
         match res {
             IOResult::Done((page, c)) => {
-                assert_eq!(page.get().id, 1);
+                assert_eq!(page.get().id(), 1);
                 assert!(
                     c.is_none(),
                     "cache hit must not return a disk-read completion"

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -1335,6 +1335,13 @@ pub fn read_integer(buf: &[u8], serial_type: u8) -> Result<i64> {
 /// This function is similar to `sqlite3GetVarint32`
 #[inline(always)]
 pub fn read_varint(buf: &[u8]) -> Result<(u64, usize)> {
+    match buf {
+        [b0, ..] if *b0 < 0x80 => return Ok((*b0 as u64, 1)),
+        [b0, b1, ..] if *b1 < 0x80 => {
+            return Ok(((((*b0 & 0x7f) as u64) << 7) | *b1 as u64, 2));
+        }
+        _ => {}
+    }
     let mut v: u64 = 0;
     for i in 0..8 {
         match buf.get(i) {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -636,11 +636,11 @@ pub fn begin_write_btree_page(
     page: &PageRef,
     group: Option<&mut CompletionGroup>,
 ) -> Result<Completion> {
-    tracing::trace!("begin_write_btree_page(page={})", page.get().id);
+    tracing::trace!("begin_write_btree_page(page={})", page.get().id());
     let page_source = &pager.db_file;
     let page_finish = page.clone();
 
-    let page_id = page.get().id;
+    let page_id = page.get().id();
     tracing::trace!("begin_write_btree_page(page_id={})", page_id);
 
     let buffer = page.get().buffer().cloned().expect("buffer not loaded");

--- a/core/storage/subjournal.rs
+++ b/core/storage/subjournal.rs
@@ -105,7 +105,7 @@ impl Subjournal {
                 let Ok((buf, bytes_read)) = res else {
                     return None;
                 };
-                let page_idx = page.get().id;
+                let page_idx = page.get().id();
                 if bytes_read != page_size as i32 {
                     tracing::error!(
                         "subjournal short read on page {page_idx}: expected {page_size} bytes, got {bytes_read}"

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -3593,13 +3593,13 @@ impl Wal for WalFile {
     ) -> Result<Completion> {
         tracing::debug!(
             "read_frame(page_idx = {}, frame_id = {})",
-            page.get().id,
+            page.get().id(),
             frame_id
         );
         let offset = self.frame_offset(frame_id);
         page.set_locked();
         let frame = page.clone();
-        let page_idx = page.get().id;
+        let page_idx = page.get().id();
         let epoch_at_issue = self.coordination.checkpoint_epoch();
         let complete = Box::new(move |res: Result<(Arc<Buffer>, i32), CompletionError>| {
             let Ok((buf, bytes_read)) = res else {
@@ -3622,7 +3622,7 @@ impl Wal for WalFile {
                 });
             }
             let cloned = frame.clone();
-            finish_read_page(page.get().id, buf, cloned);
+            finish_read_page(page.get().id(), buf, cloned);
             frame.set_wal_tag(frame_id, epoch_at_issue);
             None
         });
@@ -3675,16 +3675,16 @@ impl Wal for WalFile {
             {
                 turso_assert!(
                     !page.is_locked(), "read_frames_batch target page must not already be locked",
-                    { "page_id": page.get().id }
+                    { "page_id": page.get().id() }
                 );
                 turso_assert!(
                     !page.is_loaded(), "read_frames_batch target page must be an unloaded scratch page",
-                    { "page_id": page.get().id }
+                    { "page_id": page.get().id() }
                 );
                 turso_assert!(
                     page.get().buffer().is_none(),
                     "read_frames_batch target page must not already retain a buffer",
-                    { "page_id": page.get().id }
+                    { "page_id": page.get().id() }
                 );
             }
             page.set_locked();
@@ -3724,7 +3724,7 @@ impl Wal for WalFile {
                 let frame_start = i * frame_size;
                 let frame = &raw[frame_start..frame_start + frame_size];
                 let (header, page_body) = sqlite3_ondisk::parse_wal_frame_header(frame);
-                let expected_page_id = page.get().id;
+                let expected_page_id = page.get().id();
                 if header.page_number as usize != expected_page_id {
                     mark_unlikely();
                     tracing::error!(
@@ -3783,7 +3783,7 @@ impl Wal for WalFile {
             }
 
             for (i, (page, page_buf)) in slots.iter().enumerate() {
-                let page_id = page.get().id;
+                let page_id = page.get().id();
                 finish_read_page(page_id, page_buf.clone(), page.clone());
                 page.set_wal_tag(start_frame + i as u64, epoch);
             }
@@ -4461,7 +4461,7 @@ impl Wal for WalFile {
         let page_transform = self.io_ctx.read().page_transform().clone();
 
         for (idx, page) in pages.iter().enumerate() {
-            let page_id = page.get().id;
+            let page_id = page.get().id();
             let plain = page.get_contents().as_ptr();
 
             // if DB size is included for commit frame, it will need to be included only in the last frame of the batch.
@@ -4503,7 +4503,7 @@ impl Wal for WalFile {
         for batch in batches {
             for (page, frame_id, checksum) in &batch.metadata {
                 // Update WAL index mapping page -> frame
-                self.complete_append_frame(page.get().id as u64, *frame_id, *checksum);
+                self.complete_append_frame(page.get().id() as u64, *frame_id, *checksum);
             }
             // Update rolling checksum
             self.set_last_checksum(batch.final_checksum);
@@ -4568,8 +4568,8 @@ impl Wal for WalFile {
         };
         // Build every frame in order, updating the rolling checksum
         for page in pages.iter() {
-            tracing::debug!("append_frames_vectored: page_id={}", page.get().id);
-            let page_id = page.get().id;
+            tracing::debug!("append_frames_vectored: page_id={}", page.get().id());
+            let page_id = page.get().id();
             let plain = page.get_contents().as_ptr();
 
             let frame_db_size = 0; // this method is not used for the commit path
@@ -4619,7 +4619,7 @@ impl Wal for WalFile {
 
             for (page, fid, _csum) in &page_frame_for_cb {
                 page.set_wal_tag(*fid, epoch);
-                coordination.cache_frame(page.get().id as u64, *fid);
+                coordination.cache_frame(page.get().id() as u64, *fid);
             }
         };
 
@@ -6677,8 +6677,12 @@ pub mod test {
         io.wait_for_completion(c).unwrap();
 
         for (idx, page) in target_pages.iter().enumerate() {
-            assert!(page.is_loaded(), "page {} should be loaded", page.get().id);
-            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert!(
+                page.is_loaded(),
+                "page {} should be loaded",
+                page.get().id()
+            );
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id());
             assert_eq!(page.wal_tag_pair(), ((idx + 1) as u64, 0));
             assert_eq!(page.get_contents().as_ptr(), expected[idx].as_slice());
         }
@@ -7016,8 +7020,12 @@ pub mod test {
         io.wait_for_completion(c).unwrap();
 
         for (idx, page) in target_pages.iter().enumerate() {
-            assert!(page.is_loaded(), "page {} should be loaded", page.get().id);
-            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert!(
+                page.is_loaded(),
+                "page {} should be loaded",
+                page.get().id()
+            );
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id());
             assert_eq!(page.wal_tag_pair(), ((idx + 2) as u64, 0));
             assert_eq!(page.get_contents().as_ptr(), expected[idx + 1].as_slice());
         }
@@ -7051,7 +7059,7 @@ pub mod test {
                 page.get_contents().as_ptr(),
                 expected[idx].as_slice(),
                 "frame-order read should preserve page {} contents",
-                page.get().id
+                page.get().id()
             );
             assert_eq!(page.wal_tag_pair(), ((idx + 1) as u64, 0));
         }
@@ -7082,16 +7090,16 @@ pub mod test {
             "unexpected error: {err:?}"
         );
         for page in &target_pages {
-            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id());
             assert!(
                 !page.is_loaded(),
                 "page {} should not be loaded",
-                page.get().id
+                page.get().id()
             );
             assert!(
                 !page.has_wal_tag(),
                 "page {} should not be tagged",
-                page.get().id
+                page.get().id()
             );
         }
     }
@@ -7127,21 +7135,21 @@ pub mod test {
             "unexpected error: {err:?}"
         );
         for page in &target_pages {
-            assert!(!page.is_locked(), "page {} lock leaked", page.get().id);
+            assert!(!page.is_locked(), "page {} lock leaked", page.get().id());
             assert!(
                 !page.is_loaded(),
                 "page {} should not be loaded",
-                page.get().id
+                page.get().id()
             );
             assert!(
                 !page.has_wal_tag(),
                 "page {} should not be tagged",
-                page.get().id
+                page.get().id()
             );
             assert!(
                 page.get().buffer().is_none(),
                 "page {} should not retain a buffer",
-                page.get().id
+                page.get().id()
             );
         }
     }

--- a/core/translate/alter.rs
+++ b/core/translate/alter.rs
@@ -708,6 +708,7 @@ fn emit_add_virtual_column_validation(
         cursor_id,
         pc_if_next: loop_start,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(skip_label);

--- a/core/translate/analyze.rs
+++ b/core/translate/analyze.rs
@@ -319,6 +319,7 @@ pub fn translate_analyze(
                 cursor_id: stat_cursor,
                 pc_if_next: loop_start,
                 fullscan: false,
+                is_index: false,
             });
         } else {
             let rowid_reg = program.alloc_register();
@@ -335,6 +336,7 @@ pub fn translate_analyze(
                 cursor_id: stat_cursor,
                 pc_if_next: loop_start,
                 fullscan: false,
+                is_index: false,
             });
         }
 
@@ -343,6 +345,7 @@ pub fn translate_analyze(
             cursor_id: stat_cursor,
             pc_if_next: loop_start,
             fullscan: false,
+            is_index: false,
         });
         program.preassign_label_to_next_insn(rewind_done);
 
@@ -582,6 +585,7 @@ fn emit_index_stats(
         cursor_id: idx_cursor,
         pc_if_next: lbl_loop,
         fullscan: false,
+        is_index: false,
     });
 
     // stat_get(accum) to get the final stat string

--- a/core/translate/compound_select.rs
+++ b/core/translate/compound_select.rs
@@ -667,6 +667,7 @@ fn read_deduplicated_union_or_except_rows(
         cursor_id: dedupe_cursor_id,
         pc_if_next: label_dedupe_loop_start,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(label_close);
     program.emit_insn(Insn::Close {
@@ -741,6 +742,7 @@ fn read_intersect_rows(
         cursor_id: left_cursor_id,
         pc_if_next: label_loop_start,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(label_close);
@@ -1000,6 +1002,7 @@ fn emit_compound_order_by(
         cursor_id: collection_cursor_id,
         pc_if_next: label_sorter_loop,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(label_sorter_done);
     program.emit_insn(Insn::Close {

--- a/core/translate/expr/emission.rs
+++ b/core/translate/expr/emission.rs
@@ -254,6 +254,7 @@ pub(crate) fn emit_returning_scan_back(program: &mut ProgramBuilder, buf: &Retur
         cursor_id: buf.cursor_id,
         pc_if_next: scan_start,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(end_label);
 }

--- a/core/translate/expr/functions.rs
+++ b/core/translate/expr/functions.rs
@@ -321,6 +321,7 @@ pub(super) fn translate_sequence_function(
             cursor_id,
             pc_if_next: loop_label,
             fullscan: false,
+            is_index: false,
         });
         program.preassign_label_to_next_insn(empty_label);
 

--- a/core/translate/expr/translator.rs
+++ b/core/translate/expr/translator.rs
@@ -322,6 +322,7 @@ pub fn translate_expr(
                         cursor_id: *cursor_id,
                         pc_if_next: label_null_checks_loop_start,
                         fullscan: false,
+                        is_index: false,
                     });
                     // Loop exhausted without finding all-NULL row
                     program.emit_insn(Insn::Goto {

--- a/core/translate/fkeys.rs
+++ b/core/translate/fkeys.rs
@@ -424,6 +424,7 @@ where
         cursor_id: icur,
         pc_if_next: loop_top,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(done);
@@ -533,6 +534,7 @@ where
         cursor_id: ccur,
         pc_if_next: loop_top,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(done);
@@ -2445,6 +2447,7 @@ pub fn emit_fk_drop_table_check(
         cursor_id: parent_cur,
         pc_if_next: collect_loop,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(collect_done);
@@ -2592,6 +2595,7 @@ pub fn emit_fk_drop_table_check(
             cursor_id: child_cur,
             pc_if_next: child_loop,
             fullscan: false,
+            is_index: false,
         });
 
         program.preassign_label_to_next_insn(child_done);

--- a/core/translate/index.rs
+++ b/core/translate/index.rs
@@ -448,6 +448,7 @@ pub(crate) fn emit_refill_index(
             cursor_id: table_cursor_id,
             pc_if_next: loop_start_label,
             fullscan: false,
+            is_index: false,
         });
         program.preassign_label_to_next_insn(loop_end_label);
     } else {
@@ -544,6 +545,7 @@ pub(crate) fn emit_refill_index(
             cursor_id: table_cursor_id,
             pc_if_next: loop_start_label,
             fullscan: false,
+            is_index: false,
         });
         program.preassign_label_to_next_insn(loop_end_label);
 
@@ -1361,6 +1363,7 @@ pub fn translate_drop_index(
         cursor_id: sqlite_schema_cursor_id,
         pc_if_next: loop_start_label,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(loop_end_label);

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -1255,6 +1255,7 @@ fn emit_epilogue(
                 cursor_id: temp_table_ctx.cursor_id,
                 pc_if_next: temp_table_ctx.loop_start_label,
                 fullscan: false,
+                is_index: false,
             });
             program.preassign_label_to_next_insn(temp_table_ctx.loop_end_label);
 
@@ -1759,6 +1760,7 @@ fn reload_autoincrement_state(program: &mut ProgramBuilder, meta: AutoincMeta) {
         cursor_id: seq_cursor_id,
         pc_if_next: loop_start_label,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(loop_end_label);
 }
@@ -3420,6 +3422,7 @@ fn ensure_sequence_initialized(
         cursor_id: seq_cursor_id,
         pc_if_next: loop_start_label,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(insert_new_label);
@@ -4332,6 +4335,7 @@ pub fn emit_parent_side_fk_decrement_on_insert(
                 cursor_id: ccur,
                 pc_if_next: loop_top,
                 fullscan: false,
+                is_index: false,
             });
             program.preassign_label_to_next_insn(done);
             program.emit_insn(Insn::Close { cursor_id: ccur });

--- a/core/translate/integrity_check.rs
+++ b/core/translate/integrity_check.rs
@@ -617,6 +617,7 @@ fn translate_integrity_check_for_schema(
                         cursor_id: bound_index.cursor_id,
                         pc_if_next: next_exists,
                         fullscan: false,
+                        is_index: false,
                     });
                     program.emit_insn(Insn::Goto {
                         target_pc: unique_ok,
@@ -649,6 +650,7 @@ fn translate_integrity_check_for_schema(
             cursor_id: table_cursor_id,
             pc_if_next: loop_start_label,
             fullscan: false,
+            is_index: false,
         });
         program.preassign_label_to_next_insn(table_empty_label);
 

--- a/core/translate/main_loop/close.rs
+++ b/core/translate/main_loop/close.rs
@@ -95,12 +95,14 @@ impl CloseLoop {
                                     cursor_id: iteration_cursor_id,
                                     pc_if_prev: loop_labels.loop_start,
                                     fullscan,
+                                    is_index: false,
                                 });
                             } else {
                                 program.emit_insn(Insn::Next {
                                     cursor_id: iteration_cursor_id,
                                     pc_if_next: loop_labels.loop_start,
                                     fullscan,
+                                    is_index: false,
                                 });
                             }
                         }
@@ -123,12 +125,14 @@ impl CloseLoop {
                                             cursor_id: *cursor_id,
                                             pc_if_prev: loop_labels.loop_start,
                                             fullscan: false,
+                                            is_index: false,
                                         });
                                     } else {
                                         program.emit_insn(Insn::Next {
                                             cursor_id: *cursor_id,
                                             pc_if_next: loop_labels.loop_start,
                                             fullscan: false,
+                                            is_index: false,
                                         });
                                     }
                                 } else {
@@ -196,12 +200,14 @@ impl CloseLoop {
                                     cursor_id: iteration_cursor_id,
                                     pc_if_prev: loop_labels.loop_start,
                                     fullscan: false,
+                                    is_index: false,
                                 });
                             } else {
                                 program.emit_insn(Insn::Next {
                                     cursor_id: iteration_cursor_id,
                                     pc_if_next: loop_labels.loop_start,
                                     fullscan: false,
+                                    is_index: false,
                                 });
                             }
                         }
@@ -223,6 +229,7 @@ impl CloseLoop {
                                     cursor_id: iteration_cursor_id,
                                     pc_if_next: loop_labels.loop_start,
                                     fullscan: false,
+                                    is_index: false,
                                 });
                             }
 
@@ -233,6 +240,7 @@ impl CloseLoop {
                                 cursor_id: ephemeral_cursor_id,
                                 pc_if_next: outer_loop_start,
                                 fullscan: false,
+                                is_index: false,
                             });
                         }
                     }
@@ -244,6 +252,7 @@ impl CloseLoop {
                         cursor_id: index_cursor_id.unwrap(),
                         pc_if_next: loop_labels.loop_start,
                         fullscan: false,
+                        is_index: false,
                     });
                     program.preassign_label_to_next_insn(loop_labels.loop_end);
                 }
@@ -273,6 +282,7 @@ impl CloseLoop {
                         cursor_id: probe_cursor_id,
                         pc_if_next: loop_labels.loop_start,
                         fullscan: false,
+                        is_index: false,
                     });
                     program.preassign_label_to_next_insn(loop_labels.loop_end);
 
@@ -605,6 +615,7 @@ pub(super) fn emit_autoindex(
         cursor_id: table_cursor_id,
         pc_if_next: label_ephemeral_build_loop_start,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(label_ephemeral_build_end);
     Ok(AutoIndexResult { use_bloom_filter })

--- a/core/translate/main_loop/hash.rs
+++ b/core/translate/main_loop/hash.rs
@@ -509,6 +509,7 @@ impl<'a, 'plan> PreparedHashBuild<'a, 'plan> {
             cursor_id: build_iter_cursor_id,
             pc_if_next: build_loop_start,
             fullscan: false,
+            is_index: false,
         });
 
         planner.program.preassign_label_to_next_insn(build_loop_end);

--- a/core/translate/main_loop/multi_index.rs
+++ b/core/translate/main_loop/multi_index.rs
@@ -193,11 +193,13 @@ fn emit_seek_multi_index_branch(
             cursor_id: branch_cursor_id,
             pc_if_next: branch_loop_start,
             fullscan: false,
+            is_index: false,
         }),
         IterationDirection::Backwards => program.emit_insn(Insn::Prev {
             cursor_id: branch_cursor_id,
             pc_if_prev: branch_loop_start,
             fullscan: false,
+            is_index: false,
         }),
     }
     program.preassign_label_to_next_insn(branch_loop_end);
@@ -325,6 +327,7 @@ fn emit_in_seek_multi_index_branch(
             cursor_id: branch_cursor_id,
             pc_if_next: branch_loop_start,
             fullscan: false,
+            is_index: false,
         });
     } else {
         program.emit_insn(Insn::SeekRowid {
@@ -366,6 +369,7 @@ fn emit_in_seek_multi_index_branch(
         cursor_id: ephemeral_cursor_id,
         pc_if_next: outer_loop_start,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(branch_loop_end);
 

--- a/core/translate/order_by.rs
+++ b/core/translate/order_by.rs
@@ -477,6 +477,7 @@ impl EmitOrderBy {
                 cursor_id: sort_cursor,
                 pc_if_next: sort_loop_start_label,
                 fullscan: false,
+                is_index: false,
             });
         }
         program.preassign_label_to_next_insn(sort_loop_end_label);

--- a/core/translate/schema.rs
+++ b/core/translate/schema.rs
@@ -1983,6 +1983,7 @@ pub fn translate_drop_table(
         cursor_id: sqlite_schema_cursor_id_0,
         pc_if_next: metadata_loop,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(end_metadata_label);
     // end of loop on schema table
@@ -2093,6 +2094,7 @@ pub fn translate_drop_table(
                     cursor_id: temp_cursor,
                     pc_if_next: temp_loop_label,
                     fullscan: false,
+                    is_index: false,
                 });
                 program.preassign_label_to_next_insn(temp_end_label);
             }
@@ -2247,6 +2249,7 @@ pub fn translate_drop_table(
             cursor_id: sqlite_schema_cursor_id_1,
             pc_if_next: copy_schema_to_temp_table_loop,
             fullscan: false,
+            is_index: false,
         });
         program.preassign_label_to_next_insn(copy_schema_to_temp_table_loop_end_label);
         // End loop to copy over row id's from the schema table for rows that have the same root page as the one that was moved
@@ -2314,6 +2317,7 @@ pub fn translate_drop_table(
             cursor_id: ephemeral_cursor_id,
             pc_if_next: copy_temp_table_to_schema_loop,
             fullscan: false,
+            is_index: false,
         });
         program.preassign_label_to_next_insn(copy_temp_table_to_schema_loop_end_label);
         // End loop to copy over row id's from the ephemeral table and then re-insert into the schema table with the correct root page
@@ -2376,6 +2380,7 @@ pub fn translate_drop_table(
             cursor_id: seq_cursor_id,
             pc_if_next: loop_start_label,
             fullscan: false,
+            is_index: false,
         });
 
         program.preassign_label_to_next_insn(end_loop_label);
@@ -2477,6 +2482,7 @@ pub fn translate_drop_table(
             cursor_id: ver_cursor_id,
             pc_if_next: ver_loop_start_label,
             fullscan: false,
+            is_index: false,
         });
 
         program.preassign_label_to_next_insn(end_ver_loop_label);
@@ -3025,6 +3031,7 @@ pub fn translate_drop_type(
         cursor_id: types_cursor_id,
         pc_if_next: loop_start_label,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(end_loop_label);

--- a/core/translate/sequence.rs
+++ b/core/translate/sequence.rs
@@ -633,6 +633,7 @@ pub(crate) fn emit_backing_table_compaction(
         cursor_id,
         pc_if_next: loop_top_label,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(skip_label);
 }
@@ -708,6 +709,7 @@ pub(crate) fn emit_sqlite_sequence_sync(
         cursor_id: sseq_cursor,
         pc_if_next: loop_top_label,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(insert_label);
 
@@ -987,6 +989,7 @@ pub(crate) fn emit_drop_sequence_cleanup(
         cursor_id: sqlite_schema_cursor_id,
         pc_if_next: loop_start_label,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(end_loop_label);
 

--- a/core/translate/trigger.rs
+++ b/core/translate/trigger.rs
@@ -586,6 +586,7 @@ pub fn translate_drop_trigger(
         cursor_id: sqlite_schema_cursor_id,
         pc_if_next: search_loop_label,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(done_label);

--- a/core/translate/view.rs
+++ b/core/translate/view.rs
@@ -161,6 +161,7 @@ pub fn translate_create_materialized_view(
         cursor_id: view_cursor_id,
         pc_if_next: clear_loop_label,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(clear_done_label);
@@ -608,6 +609,7 @@ pub fn translate_drop_view(
         cursor_id: sqlite_schema_cursor_id,
         pc_if_next: loop_start_label,
         fullscan: false,
+        is_index: false,
     });
 
     program.preassign_label_to_next_insn(end_loop_label);
@@ -724,6 +726,7 @@ pub fn translate_drop_view(
             cursor_id: sqlite_schema_cursor_id,
             pc_if_next: dbsp_loop_start_label,
             fullscan: false,
+            is_index: false,
         });
 
         program.preassign_label_to_next_insn(dbsp_end_loop_label);

--- a/core/translate/window.rs
+++ b/core/translate/window.rs
@@ -2439,6 +2439,7 @@ fn emit_window_full_scan(
         cursor_id: scan_cursor,
         pc_if_next: label_loop,
         fullscan: false,
+        is_index: false,
     });
     program.preassign_label_to_next_insn(label_break);
     emit_window_agg_final(program, window, &registers, &minmax, true);
@@ -2934,6 +2935,7 @@ fn emit_window_op(
         cursor_id: cursor_for_op,
         pc_if_next: label_after_next,
         fullscan: false,
+        is_index: false,
     });
     if let Some(break_target) = break_on_eof {
         program.emit_insn(Insn::Goto {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -2107,6 +2107,7 @@ impl ProgramBuilder {
             cursor_id,
             pc_if_next: loop_start,
             fullscan: false,
+            is_index: false,
         });
         self.preassign_label_to_next_insn(loop_end);
     }
@@ -2252,6 +2253,26 @@ impl ProgramBuilder {
         sql: &str,
     ) -> crate::Result<PreparedProgram> {
         self.resolve_labels()?;
+
+        // Fill in the is_index field on Next and Prev, now that we know all cursor types
+        for (insn, _) in self.insns.iter_mut() {
+            if let Insn::Next {
+                cursor_id,
+                is_index,
+                ..
+            }
+            | Insn::Prev {
+                cursor_id,
+                is_index,
+                ..
+            } = insn
+            {
+                *is_index = self
+                    .cursor_ref
+                    .get(*cursor_id)
+                    .is_some_and(|(_, cursor_type)| cursor_type.is_index());
+            }
+        }
 
         self.parameters.list.dedup();
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -219,6 +219,12 @@ macro_rules! check_arg_count {
 pub type InsnResult = Result<InsnFunctionStepResult, Box<LimboError>>;
 pub type InsnFunction = fn(&Program, &mut ProgramState, &Insn, &Arc<Pager>) -> InsnResult;
 
+#[cold]
+#[inline(never)]
+fn unresolved_branch_target(target_pc: crate::vdbe::BranchOffset) -> Box<LimboError> {
+    LimboError::Corrupt(format!("Unresolved label: {target_pc:?}")).into()
+}
+
 /// This is an optimization over `checked_add(n).ok_or(LimboError::Overflow)`. With `ok_or`, the
 /// compiler generates [LimboError] drop glue even though [LimboError::Overflow] owns nothing.
 /// But with [OkOverflow], it's able to skip the drop glue.
@@ -438,7 +444,7 @@ pub fn op_init(
 ) -> InsnResult {
     load_insn!(Init { target_pc }, insn);
     if unlikely(!target_pc.is_offset()) {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
     state.pc = target_pc.as_offset_int();
     Ok(InsnFunctionStepResult::Step)
@@ -959,7 +965,7 @@ pub fn op_if_pos(
         insn
     );
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
     let reg = *reg;
     let target_pc = *target_pc;
@@ -990,7 +996,7 @@ pub fn op_not_null(
 ) -> InsnResult {
     load_insn!(NotNull { reg, target_pc }, insn);
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
     let reg = *reg;
     let target_pc = *target_pc;
@@ -1182,7 +1188,7 @@ pub fn op_if(
         insn
     );
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
     if state.registers[*reg]
         .get_value()
@@ -1210,7 +1216,7 @@ pub fn op_if_not(
         insn
     );
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
     if state.registers[*reg]
         .get_value()
@@ -2484,7 +2490,7 @@ pub fn op_column_has_field(
         insn
     );
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
 
     let (_, cursor_type) = program
@@ -5594,7 +5600,7 @@ pub fn op_goto(
 ) -> InsnResult {
     load_insn!(Goto { target_pc }, insn);
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
     state.pc = target_pc.as_offset_int();
     Ok(InsnFunctionStepResult::Step)
@@ -5614,7 +5620,7 @@ pub fn op_gosub(
         insn
     );
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
     state.registers[*return_reg].set_int((state.pc + 1) as i64);
     state.pc = target_pc.as_offset_int();
@@ -6198,7 +6204,7 @@ pub fn op_seek_rowid(
         insn
     );
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
     invalidate_deferred_seeks_for_cursor(state, *cursor_id);
     let (pc, did_seek) = {
@@ -6825,7 +6831,7 @@ pub fn op_idx_ge(
         insn
     );
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
 
     let pc = {
@@ -6895,7 +6901,7 @@ pub fn op_idx_le(
         insn
     );
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
 
     let pc = {
@@ -6942,7 +6948,7 @@ pub fn op_idx_gt(
         insn
     );
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
 
     let pc = {
@@ -6989,7 +6995,7 @@ pub fn op_idx_lt(
         insn
     );
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
 
     let pc = {
@@ -7028,7 +7034,7 @@ pub fn op_decr_jump_zero(
 ) -> InsnResult {
     load_insn!(DecrJumpZero { reg, target_pc }, insn);
     if !target_pc.is_offset() {
-        crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+        return Err(unresolved_branch_target(*target_pc));
     }
     match &mut state.registers[*reg] {
         Register::Value(Value::Numeric(Numeric::Integer(n))) => {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -18,7 +18,8 @@ use crate::schema::{
 };
 use crate::state_machine::StateMachine;
 use crate::storage::btree::{
-    integrity_check, CursorTrait, IntegrityCheckError, IntegrityCheckState, PageCategory,
+    integrity_check, CursorStep, CursorTrait, IntegrityCheckError, IntegrityCheckState,
+    PageCategory,
 };
 use crate::storage::database::DatabaseFile;
 use crate::storage::journal_mode;
@@ -3504,7 +3505,14 @@ pub fn op_next(
     let is_empty = {
         let cursor = state.get_cursor(*cursor_id);
         match cursor {
-            Cursor::BTree(btree_cursor) => !return_if_io!(state, btree_cursor.next_row()),
+            Cursor::BTree(btree_cursor) => match btree_cursor.next_row() {
+                CursorStep::Row => false,
+                CursorStep::Empty => true,
+                CursorStep::Error(err) => return Err(err),
+                CursorStep::IO(io) => {
+                    return Ok(state.suspend_on_io(io));
+                }
+            },
             _ => !return_if_io!(state, next_row_of_other_cursor(cursor)),
         }
     };
@@ -3554,7 +3562,15 @@ pub fn op_prev(
     );
     let is_empty = {
         let cursor = must_be_btree_cursor!(*cursor_id, program.cursor_ref, state, "Prev");
-        !return_if_io!(state, cursor.as_btree_mut().prev_row())
+        let cursor = cursor.as_btree_mut();
+        match cursor.prev_row() {
+            CursorStep::Row => false,
+            CursorStep::Empty => true,
+            CursorStep::Error(err) => return Err(err),
+            CursorStep::IO(io) => {
+                return Ok(state.suspend_on_io(io));
+            }
+        }
     };
     if !is_empty {
         // Increment metrics for row read

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3480,7 +3480,7 @@ pub fn op_result_row(
 // pointer-identity check.
 #[cfg_attr(not(test), inline(always))]
 pub fn op_next(
-    program: &Program,
+    _program: &Program,
     state: &mut ProgramState,
     insn: &Insn,
     _pager: &Arc<Pager>,
@@ -3490,6 +3490,7 @@ pub fn op_next(
             cursor_id,
             pc_if_next,
             fullscan,
+            is_index,
         },
         insn
     );
@@ -3510,10 +3511,8 @@ pub fn op_next(
         if *fullscan {
             state.metrics.fullscan_steps = state.metrics.fullscan_steps.wrapping_add(1);
         }
-        if let Some((_, cursor_type)) = program.cursor_ref.get(*cursor_id) {
-            if cursor_type.is_index() {
-                state.metrics.index_steps = state.metrics.index_steps.wrapping_add(1);
-            }
+        if *is_index {
+            state.metrics.index_steps = state.metrics.index_steps.wrapping_add(1);
         }
         state.pc = pc_if_next.as_offset_int();
     } else {
@@ -3542,6 +3541,7 @@ pub fn op_prev(
             cursor_id,
             pc_if_prev,
             fullscan,
+            is_index,
         },
         insn
     );
@@ -3559,10 +3559,8 @@ pub fn op_prev(
         if *fullscan {
             state.metrics.fullscan_steps = state.metrics.fullscan_steps.wrapping_add(1);
         }
-        if let Some((_, cursor_type)) = program.cursor_ref.get(*cursor_id) {
-            if cursor_type.is_index() {
-                state.metrics.index_steps = state.metrics.index_steps.wrapping_add(1);
-            }
+        if *is_index {
+            state.metrics.index_steps = state.metrics.index_steps.wrapping_add(1);
         }
         state.pc = pc_if_prev.as_offset_int();
     } else {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -13653,13 +13653,32 @@ pub fn op_copy(
         if src == dst {
             continue;
         }
-        // try_clone_from reuses the destination register's allocation.
         let [src, dst] = state
             .registers
             .get_disjoint_mut([src, dst])
             .expect("Copy source and destination registers are distinct");
-        dst.try_clone_from(src)?;
+        if !try_copy_heapless_value(dst, src) {
+            dst.try_clone_from(src)?;
+        }
     }
+
+    #[inline]
+    fn try_copy_heapless_value(dst: &mut Register, src: &Register) -> bool {
+        match (dst, src) {
+            (
+                Register::Value(dst @ (Value::Null | Value::Numeric(_))),
+                Register::Value(src @ (Value::Null | Value::Numeric(_))),
+            ) => {
+                *dst = match src {
+                    Value::Numeric(n) => Value::Numeric(*n),
+                    _ => Value::Null,
+                };
+                true
+            }
+            _ => false,
+        }
+    }
+
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
 }

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -187,10 +187,10 @@ macro_rules! load_insn {
 }
 
 macro_rules! return_if_io {
-    ($expr:expr) => {
+    ($state:expr, $expr:expr) => {
         match $expr {
             Ok(IOResult::Done(v)) => v,
-            Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
+            Ok(IOResult::IO(io)) => return Ok($state.suspend_on_io(io)),
             Err(err) => {
                 mark_unlikely();
                 return Err(err.into());
@@ -415,20 +415,18 @@ fn comparison_matches_order(op: ComparisonOp, order: std::cmp::Ordering) -> bool
     }
 }
 
+/// The outcome of one instruction. An instruction that waits for IO leaves
+/// its completion in `ProgramState::io_completions` (see
+/// `ProgramState::suspend_on_io`) and answers `IO` without a payload: with
+/// a pointer payload in this variant and a byte in the others, `InsnResult`
+/// went through memory on every call of an opcode function. Fieldless with
+/// a word-sized discriminant, the `Result` is returned in two registers.
+#[repr(u64)]
 pub enum InsnFunctionStepResult {
     Done,
-    IO(IOCompletions),
+    IO,
     Row,
     Step,
-}
-
-impl<T> From<IOResult<T>> for InsnFunctionStepResult {
-    fn from(value: IOResult<T>) -> Self {
-        match value {
-            IOResult::Done(_) => InsnFunctionStepResult::Done,
-            IOResult::IO(io) => InsnFunctionStepResult::IO(io),
-        }
-    }
 }
 
 pub fn op_init(
@@ -751,7 +749,7 @@ pub fn op_checkpoint(
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
-        Ok(IOResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
+        Ok(IOResult::IO(io)) => Ok(state.suspend_on_io(io)),
         Err(err) => {
             tracing::debug!("PRAGMA wal_checkpoint failed: {err:?}");
             pager.clear_checkpoint_state();
@@ -1282,7 +1280,7 @@ pub fn op_open_read(
             .as_mut()
             .expect("cursor should exist after initialization");
         let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.open_read(&context));
+        return_if_io!(state, cursor.open_read(&context));
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
@@ -1810,11 +1808,11 @@ pub fn op_rewind(
         let cursor = state.get_cursor(*cursor_id);
         match cursor {
             Cursor::BTree(btree_cursor) => {
-                return_if_io!(btree_cursor.rewind());
+                return_if_io!(state, btree_cursor.rewind());
                 btree_cursor.is_empty()
             }
             Cursor::MaterializedView(mv_cursor) => {
-                return_if_io!(mv_cursor.rewind());
+                return_if_io!(state, mv_cursor.rewind());
                 !mv_cursor.is_valid()?
             }
             _ => panic!("Rewind on non-btree/materialized-view cursor"),
@@ -1847,7 +1845,7 @@ pub fn op_last(
     let is_empty = {
         let cursor = must_be_btree_cursor!(*cursor_id, program.cursor_ref, state, "Last");
         let cursor = cursor.as_btree_mut();
-        return_if_io!(cursor.last());
+        return_if_io!(state, cursor.last());
         cursor.is_empty()
     };
     if is_empty {
@@ -2022,8 +2020,8 @@ fn op_column_deferred(
                 let Some(rowid) = ({
                     let index_cursor = state.get_cursor(index_cursor_id);
                     match index_cursor {
-                        Cursor::BTree(cursor) => return_if_io!(cursor.rowid()),
-                        Cursor::IndexMethod(cursor) => return_if_io!(cursor.query_rowid()),
+                        Cursor::BTree(cursor) => return_if_io!(state, cursor.rowid()),
+                        Cursor::IndexMethod(cursor) => return_if_io!(state, cursor.query_rowid()),
                         _ => panic!("unexpected cursor type"),
                     }
                 }) else {
@@ -2046,14 +2044,20 @@ fn op_column_deferred(
                     match table_cursor {
                         Cursor::MaterializedView(mv_cursor) => {
                             // Seek to the rowid in the materialized view
-                            return_if_io!(mv_cursor
-                                .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true }));
+                            return_if_io!(
+                                state,
+                                mv_cursor
+                                    .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true })
+                            );
                         }
                         _ => {
                             // Regular btree cursor
                             let table_cursor = table_cursor.as_btree_mut();
-                            return_if_io!(table_cursor
-                                .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true }));
+                            return_if_io!(
+                                state,
+                                table_cursor
+                                    .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true })
+                            );
                         }
                     }
                 }
@@ -2102,7 +2106,7 @@ fn op_column_fetch(
         }
         _ => return op_column_fetch_other(program, state, cursor_id, column, dest, default),
     };
-    let Some(payload) = return_if_io!(cursor.record_payload()) else {
+    let Some(payload) = return_if_io!(state, cursor.record_payload()) else {
         // A null-row cursor, or one that is not positioned on a valid row
         // (e.g., empty table). Return NULL, not the column's default value.
         state.registers[dest].set_null();
@@ -2177,7 +2181,7 @@ fn op_column_fetch_other(
         let cursor = state.get_cursor(cursor_id);
         if let Cursor::MaterializedView(mv_cursor) = cursor {
             // Handle materialized view column access
-            let value = return_if_io!(mv_cursor.column(column));
+            let value = return_if_io!(state, mv_cursor.column(column));
             state.registers[dest].set_value(value);
             return Ok(InsnFunctionStepResult::Step);
         }
@@ -2208,7 +2212,7 @@ fn op_column_fetch_other(
                     return Ok(InsnFunctionStepResult::Step);
                 }
 
-                let record_result = return_if_io!(cursor.record());
+                let record_result = return_if_io!(state, cursor.record());
                 let Some(record) = record_result else {
                     // Cursor is not positioned on a valid row (e.g., empty table).
                     // Return NULL, not the column's default value.
@@ -2264,7 +2268,7 @@ fn op_column_fetch_other(
                 .as_mut()
                 .expect("cursor should exist");
             let cursor = cursor.as_index_method_mut();
-            let value = return_if_io!(cursor.query_column(column));
+            let value = return_if_io!(state, cursor.query_column(column));
             state.registers[dest].set_value(value);
         }
         CursorType::VirtualTable(_) => {
@@ -2316,7 +2320,7 @@ fn op_column_range_fetch(
             defaults,
         );
     };
-    let Some(payload) = return_if_io!(cursor.record_payload()) else {
+    let Some(payload) = return_if_io!(state, cursor.record_payload()) else {
         for reg in &mut state.registers[dest..dest + count] {
             reg.set_null();
         }
@@ -2385,7 +2389,7 @@ fn op_column_range_fetch_other(
                     return Ok(InsnFunctionStepResult::Step);
                 }
 
-                let record_result = return_if_io!(cursor.record());
+                let record_result = return_if_io!(state, cursor.record());
                 let Some(record) = record_result else {
                     for reg in &mut state.registers[dest..dest + count] {
                         reg.set_null();
@@ -2500,7 +2504,7 @@ pub fn op_column_has_field(
                 if cursor.get_null_flag() {
                     false
                 } else {
-                    match return_if_io!(cursor.record()) {
+                    match return_if_io!(state, cursor.record()) {
                         Some(record) => record.column_count() > *column,
                         None => false,
                     }
@@ -3378,7 +3382,7 @@ pub fn op_blob_read(
         .blob_read_column(*column, off, amt, &mut out)
     {
         Ok(IOResult::Done(())) => {}
-        Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
+        Ok(IOResult::IO(io)) => return Ok(state.suspend_on_io(io)),
         Err(err) if matches!(*err, LimboError::BlobHandleExpired) => {
             return Ok(blob_expired_ack(state, *dest))
         }
@@ -3406,7 +3410,10 @@ pub fn op_blob_len(
         },
         insn
     );
-    let len = return_if_io!(blob_btree_cursor(state, *cursor, "BlobLen")?.blob_column_len(*column));
+    let len = return_if_io!(
+        state,
+        blob_btree_cursor(state, *cursor, "BlobLen")?.blob_column_len(*column)
+    );
     let len = i64::try_from(len)
         .map_err(|_| LimboError::Corrupt("column byte length does not fit in i64".to_string()))?;
     state.registers[*dest].set_value(Value::Numeric(Numeric::Integer(len)));
@@ -3444,7 +3451,7 @@ pub fn op_blob_write(
     };
     match blob_btree_cursor(state, *cursor, "BlobWrite")?.blob_write_column(*column, off, &data) {
         Ok(IOResult::Done(())) => {}
-        Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
+        Ok(IOResult::IO(io)) => return Ok(state.suspend_on_io(io)),
         Err(err) if matches!(*err, LimboError::BlobHandleExpired) => {
             return Ok(blob_expired_ack(state, *dest))
         }
@@ -3497,8 +3504,8 @@ pub fn op_next(
     let is_empty = {
         let cursor = state.get_cursor(*cursor_id);
         match cursor {
-            Cursor::BTree(btree_cursor) => !return_if_io!(btree_cursor.next_row()),
-            _ => !return_if_io!(next_row_of_other_cursor(cursor)),
+            Cursor::BTree(btree_cursor) => !return_if_io!(state, btree_cursor.next_row()),
+            _ => !return_if_io!(state, next_row_of_other_cursor(cursor)),
         }
     };
     if !is_empty {
@@ -3547,7 +3554,7 @@ pub fn op_prev(
     );
     let is_empty = {
         let cursor = must_be_btree_cursor!(*cursor_id, program.cursor_ref, state, "Prev");
-        !return_if_io!(cursor.as_btree_mut().prev_row())
+        !return_if_io!(state, cursor.as_btree_mut().prev_row())
     };
     if !is_empty {
         // Increment metrics for row read
@@ -3595,7 +3602,7 @@ pub fn halt(
             }
             IOResult::IO(io) => {
                 state.pending_fail_error = Some(pending_error); // put it back and wait
-                return Ok(InsnFunctionStepResult::IO(io));
+                return Ok(state.suspend_on_io(io));
             }
         }
     }
@@ -3613,7 +3620,7 @@ pub fn halt(
             // writes now, exactly like the normal trigger-subprogram halt
             // below, so the kept base rows keep their index entries too.
             if program.is_trigger_subprogram() {
-                return_if_io!(index_method_stage_statement_all(state));
+                return_if_io!(state, index_method_stage_statement_all(state));
             }
             return Err(LimboError::RaiseIgnore.into());
         }
@@ -3690,7 +3697,7 @@ pub fn halt(
             // interrupt, deadline, and progress-handler requests from
             // replacing the outcome while the staged work is in flight.
             vtab_commit_all(&program.connection)?;
-            return_if_io!(index_method_stage_statement_all(state));
+            return_if_io!(state, index_method_stage_statement_all(state));
             state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
 
             // Commit the transaction with partial changes
@@ -3702,7 +3709,7 @@ pub fn halt(
                 IOResult::IO(io) => {
                     // store the error for reentrancy
                     state.pending_fail_error = Some(error);
-                    return Ok(InsnFunctionStepResult::IO(io));
+                    return Ok(state.suspend_on_io(io));
                 }
             }
         }
@@ -3747,7 +3754,7 @@ pub fn halt(
         // Stage their index-method writes now so reset cannot drop pending
         // work from an earlier row in the parent statement. The parent still
         // owns the statement savepoint and the final transaction outcome.
-        return_if_io!(index_method_stage_statement_all(state));
+        return_if_io!(state, index_method_stage_statement_all(state));
         return Ok(InsnFunctionStepResult::Done);
     }
 
@@ -3778,7 +3785,7 @@ pub fn halt(
         }
         if can_autocommit_now {
             vtab_commit_all(&program.connection)?;
-            return_if_io!(index_method_stage_statement_all(state));
+            return_if_io!(state, index_method_stage_statement_all(state));
             state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
             // Sequence backing-table compaction and sqlite_sequence sync
             // are emitted as straight-line bytecode inside the
@@ -3789,9 +3796,8 @@ pub fn halt(
             // `sqlite_sequence` is already in sync, so the commit does
             // not invoke a sequence flush — keeping op_halt within the
             // vdbe async contract.
-            let result = program
-                .commit_txn(pager.clone(), state, mv_store.as_ref(), false)
-                .map(Into::into);
+            let result = program.commit_txn(pager.clone(), state, mv_store.as_ref(), false);
+            let result = state.done_or_suspend(result);
             // Apply deferred CDC state and reset CDC txn ID after successful commit
             if matches!(result, Ok(InsnFunctionStepResult::Done)) {
                 index_method_on_transaction_committed_all(state, &program.connection);
@@ -3809,7 +3815,7 @@ pub fn halt(
             // savepoint is released, and its cursors handed to the connection
             // so the sibling that eventually commits (or rolls back) the
             // shared transaction delivers their outcome.
-            return_if_io!(index_method_stage_statement_all(state));
+            return_if_io!(state, index_method_stage_statement_all(state));
             state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
             index_method_register_transaction_all(state, &program.connection)?;
             //
@@ -3852,7 +3858,7 @@ pub fn halt(
         // Otherwise the cursor's Drop fallback performs these writes after
         // statement success, where an I/O error can no longer be returned to
         // the caller or rolled back at statement scope.
-        return_if_io!(index_method_stage_statement_all(state));
+        return_if_io!(state, index_method_stage_statement_all(state));
         state.end_statement(&program.connection, pager, EndStatement::ReleaseSavepoint)?;
         index_method_register_transaction_all(state, &program.connection)?;
         // Apply deferred CDC state after successful statement completion
@@ -4528,7 +4534,7 @@ pub fn op_transaction_inner(
                             TransactionYieldPoint::BeforeStart,
                         )
                     {
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        return Ok(state.suspend_on_io(io));
                     }
                 }
 
@@ -4620,7 +4626,7 @@ pub fn op_transaction_inner(
                                         TransactionYieldPoint::BeforeMvccBegin,
                                     )
                                 {
-                                    return Ok(InsnFunctionStepResult::IO(io));
+                                    return Ok(state.suspend_on_io(io));
                                 }
                             }
                             match begin_fresh_mvcc_tx(
@@ -4726,7 +4732,7 @@ pub fn op_transaction_inner(
                                         TransactionYieldPoint::BeforeMvccBegin,
                                     )
                                 {
-                                    return Ok(InsnFunctionStepResult::IO(io));
+                                    return Ok(state.suspend_on_io(io));
                                 }
                             }
                             match begin_fresh_mvcc_tx(
@@ -4883,7 +4889,7 @@ pub fn op_transaction_inner(
                             conn.set_tx_state(TransactionState::PendingUpgrade {
                                 has_read_txn: matches!(current_state, TransactionState::Read),
                             });
-                            return Ok(InsnFunctionStepResult::IO(io));
+                            return Ok(state.suspend_on_io(io));
                         }
                     }
                 }
@@ -4908,7 +4914,7 @@ pub fn op_transaction_inner(
                 let conn = program.connection.clone();
                 let res = pager.begin_write_tx(conn.wal_auto_actions())?;
                 if let IOResult::IO(io) = res {
-                    return Ok(InsnFunctionStepResult::IO(io));
+                    return Ok(state.suspend_on_io(io));
                 }
                 *state.active_op_state.transaction() = OpTransactionState::CheckSchemaCookie;
                 continue;
@@ -4929,7 +4935,7 @@ pub fn op_transaction_inner(
                         }
                         continue;
                     }
-                    IOResult::IO(io) => return Ok(InsnFunctionStepResult::IO(io)),
+                    IOResult::IO(io) => return Ok(state.suspend_on_io(io)),
                 }
             }
             // 4. Check whether schema has changed if we are actually going to access the database.
@@ -4948,7 +4954,7 @@ pub fn op_transaction_inner(
                             return Err(LimboError::SchemaUpdated.into());
                         }
                     }
-                    Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
+                    Ok(IOResult::IO(io)) => return Ok(state.suspend_on_io(io)),
                     // This means we are starting a read_tx and we do not have a page 1 yet, so we just continue execution
                     Err(err) if matches!(*err, LimboError::Page1NotAlloc) => {}
                     Err(err) => {
@@ -4970,7 +4976,7 @@ pub fn op_transaction_inner(
                             statement_writes_db,
                         )?;
                         if let IOResult::IO(io) = res {
-                            return Ok(InsnFunctionStepResult::IO(io));
+                            return Ok(state.suspend_on_io(io));
                         }
                     } else if statement_writes_db && in_explicit_txn {
                         if !state.has_stmt_transaction {
@@ -4994,6 +5000,7 @@ pub fn op_transaction_inner(
                         } else {
                             // Attached WAL DB: open a pager savepoint for statement rollback.
                             let db_size = return_if_io!(
+                                state,
                                 pager.with_header(|header| header.database_size.get())
                             );
                             pager.open_subjournal()?;
@@ -5103,9 +5110,8 @@ pub fn op_auto_commit(
     // (CommittingAttached), MVCC commits (CommittingMvcc), and attached
     // MVCC commits (CommittingAttachedMvcc) that yielded on IO and need re-entry.
     if !matches!(state.commit_state, CommitState::Ready) {
-        let res = program
-            .commit_txn(pager.clone(), state, mv_store.as_ref(), *rollback)
-            .map(Into::into);
+        let res = program.commit_txn(pager.clone(), state, mv_store.as_ref(), *rollback);
+        let res = state.done_or_suspend(res);
         // Only clear after a final, successful non-rollback COMMIT.
         if fk_on
             && !*rollback
@@ -5248,12 +5254,9 @@ pub fn op_auto_commit(
     // an IO yield would then fail `valid_transition` with a torn-down
     // transaction.
 
-    let res = match program
-        .commit_txn(pager.clone(), state, mv_store.as_ref(), *rollback)
-        .map(Into::<InsnFunctionStepResult>::into)?
-    {
-        res @ (InsnFunctionStepResult::Done | InsnFunctionStepResult::Step) => res,
-        res @ (InsnFunctionStepResult::IO(_) | InsnFunctionStepResult::Row) => return Ok(res),
+    let res = match program.commit_txn(pager.clone(), state, mv_store.as_ref(), *rollback)? {
+        IOResult::Done(_) => InsnFunctionStepResult::Done,
+        IOResult::IO(io) => return Ok(state.suspend_on_io(io)),
     };
 
     if mv_store.is_none() {
@@ -5323,7 +5326,7 @@ pub fn op_savepoint(
             // cannot yield halfway through. Load every active WAL header
             // before opening the first savepoint so an I/O yield is restartable.
             if let IOResult::IO(io) = load_active_non_main_wal_headers_for_named_savepoint(&conn)? {
-                return Ok(InsnFunctionStepResult::IO(io));
+                return Ok(state.suspend_on_io(io));
             }
             #[cfg(any(test, injected_yields))]
             {
@@ -5336,7 +5339,7 @@ pub fn op_savepoint(
                             TransactionYieldPoint::BeforeMvccBegin,
                         )
                     {
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        return Ok(state.suspend_on_io(io));
                     }
                 }
             }
@@ -5384,8 +5387,10 @@ pub fn op_savepoint(
                             conn.set_tx_state(TransactionState::Read);
                         }
                         pager.open_subjournal()?;
-                        let db_size =
-                            return_if_io!(pager.with_header(|header| header.database_size.get()));
+                        let db_size = return_if_io!(
+                            state,
+                            pager.with_header(|header| header.database_size.get())
+                        );
                         pager.open_named_savepoint(
                             name.clone(),
                             db_size,
@@ -5819,7 +5824,7 @@ pub fn op_program(
                                     saved_last_insert_rowid,
                                     saved_changes_value: saved_last_changes_value,
                                 };
-                                return Ok(InsnFunctionStepResult::IO(io));
+                                return Ok(state.suspend_on_io(io));
                             }
                             StepResult::Row => continue,
                             StepResult::Interrupt | StepResult::Busy => {
@@ -5965,7 +5970,7 @@ pub fn op_row_data(
     let record = {
         let cursor_ref = must_be_btree_cursor!(*cursor_id, program.cursor_ref, state, "RowData");
         let cursor = cursor_ref.as_btree_mut();
-        let record_option = return_if_io!(cursor.record());
+        let record_option = return_if_io!(state, cursor.record());
 
         let record = record_option.ok_or_else(|| {
             mark_unlikely();
@@ -6041,7 +6046,7 @@ fn op_row_id_deferred(state: &mut ProgramState, cursor_id: usize, dest: usize) -
                     let index_cursor = state.get_cursor(index_cursor_id);
                     match index_cursor {
                         Cursor::BTree(index_cursor) => {
-                            let record = return_if_io!(index_cursor.record());
+                            let record = return_if_io!(state, index_cursor.record());
                             let record =
                                 record.as_ref().expect("index cursor should have a record");
                             let rowid = record
@@ -6053,7 +6058,7 @@ fn op_row_id_deferred(state: &mut ProgramState, cursor_id: usize, dest: usize) -
                             }
                         }
                         Cursor::IndexMethod(index_cursor) => {
-                            return_if_io!(index_cursor.query_rowid())
+                            return_if_io!(state, index_cursor.query_rowid())
                                 .expect("index cursor should have a rowid")
                         }
                         _ => panic!("unexpected cursor type"),
@@ -6072,6 +6077,7 @@ fn op_row_id_deferred(state: &mut ProgramState, cursor_id: usize, dest: usize) -
                     let table_cursor = state.get_cursor(table_cursor_id);
                     let table_cursor = table_cursor.as_btree_mut();
                     return_if_io!(
+                        state,
                         table_cursor.seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true })
                     );
                 }
@@ -6101,8 +6107,8 @@ fn op_row_id_read(state: &mut ProgramState, cursor_id: usize, dest: usize) -> In
         .get_mut(cursor_id)
         .expect("cursor_id should be valid");
     let rowid = match cursor {
-        Some(Cursor::BTree(btree_cursor)) => return_if_io!(btree_cursor.rowid()),
-        _ => return_if_io!(row_id_of_other_cursor(cursor)),
+        Some(Cursor::BTree(btree_cursor)) => return_if_io!(state, btree_cursor.rowid()),
+        _ => return_if_io!(state, row_id_of_other_cursor(cursor)),
     };
     match rowid {
         Some(rowid) => state.registers[dest].set_int(rowid),
@@ -6148,8 +6154,8 @@ pub fn op_idx_row_id(
         .expect("cursor should exist");
 
     let rowid = match cursor {
-        Cursor::BTree(cursor) => return_if_io!(cursor.rowid()),
-        Cursor::IndexMethod(cursor) => return_if_io!(cursor.query_rowid()),
+        Cursor::BTree(cursor) => return_if_io!(state, cursor.rowid()),
+        Cursor::IndexMethod(cursor) => return_if_io!(state, cursor.query_rowid()),
         Cursor::NullRow => None,
         _ => panic!("unexpected cursor type"),
     };
@@ -6193,8 +6199,11 @@ pub fn op_seek_rowid(
 
                 match rowid {
                     Some(rowid) => {
-                        let seek_result = return_if_io!(mv_cursor
-                            .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true }));
+                        let seek_result = return_if_io!(
+                            state,
+                            mv_cursor
+                                .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true })
+                        );
                         let pc = if !matches!(seek_result, SeekResult::Found) {
                             target_pc.as_offset_int()
                         } else {
@@ -6227,8 +6236,11 @@ pub fn op_seek_rowid(
 
                 match rowid {
                     Some(rowid) => {
-                        let seek_result = return_if_io!(btree_cursor
-                            .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true }));
+                        let seek_result = return_if_io!(
+                            state,
+                            btree_cursor
+                                .seek(SeekKey::TableRowId(rowid), SeekOp::GE { eq_only: true })
+                        );
                         let pc = if !matches!(seek_result, SeekResult::Found) {
                             target_pc.as_offset_int()
                         } else {
@@ -6402,7 +6414,7 @@ pub fn op_seek(
             state.pc = target_pc.as_offset_int();
             Ok(InsnFunctionStepResult::Step)
         }
-        Ok(SeekInternalResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
+        Ok(SeekInternalResult::IO(io)) => Ok(state.suspend_on_io(io)),
         Err(e) => Err(e.into()),
     }
 }
@@ -6805,7 +6817,7 @@ pub fn op_idx_ge(
         let cursor = cursor.as_btree_mut();
         let index_info = cursor.get_index_info().clone();
 
-        let pc = if let Some(idx_record) = return_if_io!(cursor.record()) {
+        let pc = if let Some(idx_record) = return_if_io!(state, cursor.record()) {
             // Create the comparison record from registers
             let values =
                 registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
@@ -6844,7 +6856,7 @@ pub fn op_seek_end(
     {
         let cursor = state.get_cursor(cursor_id);
         let cursor = cursor.as_btree_mut();
-        return_if_io!(cursor.seek_end());
+        return_if_io!(state, cursor.seek_end());
     }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -6875,7 +6887,7 @@ pub fn op_idx_le(
         let cursor = cursor.as_btree_mut();
         let index_info = cursor.get_index_info().clone();
 
-        let pc = if let Some(idx_record) = return_if_io!(cursor.record()) {
+        let pc = if let Some(idx_record) = return_if_io!(state, cursor.record()) {
             let values =
                 registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
             let tie_breaker = get_tie_breaker_from_idx_comp_op(insn);
@@ -6922,7 +6934,7 @@ pub fn op_idx_gt(
         let cursor = cursor.as_btree_mut();
         let index_info = cursor.get_index_info().clone();
 
-        let pc = if let Some(idx_record) = return_if_io!(cursor.record()) {
+        let pc = if let Some(idx_record) = return_if_io!(state, cursor.record()) {
             let values =
                 registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
             let tie_breaker = get_tie_breaker_from_idx_comp_op(insn);
@@ -6969,7 +6981,7 @@ pub fn op_idx_lt(
         let cursor = cursor.as_btree_mut();
         let index_info = cursor.get_index_info().clone();
 
-        let pc = if let Some(idx_record) = return_if_io!(cursor.record()) {
+        let pc = if let Some(idx_record) = return_if_io!(state, cursor.record()) {
             let values =
                 registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
 
@@ -9064,7 +9076,7 @@ pub fn op_sorter_open(
     let page_size = match pager.with_header(|header| header.page_size) {
         Ok(IOResult::Done(page_size)) => page_size,
         Err(_) => PageSize::default(),
-        Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
+        Ok(IOResult::IO(io)) => return Ok(state.suspend_on_io(io)),
     };
     let page_size = page_size.get() as usize;
 
@@ -9189,7 +9201,7 @@ pub fn op_sorter_insert(
             Register::Record(record) => record,
             _ => unreachable!("SorterInsert on non-record register"),
         };
-        return_if_io!(cursor.insert(record));
+        return_if_io!(state, cursor.insert(record));
     }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -9213,7 +9225,7 @@ pub fn op_sorter_sort(
         let cursor = cursor.as_sorter_mut();
         let is_empty = cursor.is_empty();
         if !is_empty {
-            return_if_io!(cursor.sort());
+            return_if_io!(state, cursor.sort());
         }
         (is_empty, !is_empty)
     };
@@ -9247,7 +9259,7 @@ pub fn op_sorter_next(
     let has_more = {
         let cursor = state.get_cursor(*cursor_id);
         let cursor = cursor.as_sorter_mut();
-        return_if_io!(cursor.next());
+        return_if_io!(state, cursor.next());
         cursor.has_more()
     };
     if has_more {
@@ -10257,8 +10269,8 @@ pub fn op_function(
                     state.registers[*dest].set_text(Text::new(info::build::PKG_VERSION))?;
                 } else {
                     let version_integer =
-                        return_if_io!(pager.with_header(|header| header.version_number)).get()
-                            as i64;
+                        return_if_io!(state, pager.with_header(|header| header.version_number))
+                            .get() as i64;
                     let version = execute_turso_version(version_integer);
                     state.registers[*dest].set_text(Text::new(version))?;
                 }
@@ -10460,11 +10472,14 @@ pub fn op_function(
                     .into());
                 };
 
-                return_if_io!(program.connection.attach_database(
-                    filename_str.as_str(),
-                    dbname_str.as_str(),
-                    state.active_op_state.attach(),
-                ));
+                return_if_io!(
+                    state,
+                    program.connection.attach_database(
+                        filename_str.as_str(),
+                        dbname_str.as_str(),
+                        state.active_op_state.attach(),
+                    )
+                );
                 // Sequence descriptors for the attached database are
                 // loaded lazily by `maybe_reparse_schema` on the next
                 // statement (ATTACH bumps the schema cookie, so the
@@ -12232,7 +12247,7 @@ pub fn op_insert(
                     is_without_rowid,
                     SeekOp::GE { eq_only: true },
                 )? {
-                    return Ok(InsnFunctionStepResult::IO(io));
+                    return Ok(state.suspend_on_io(io));
                 }
                 let has_dependent_views = state.active_op_state.insert().has_dependent_views;
                 let needs_capture =
@@ -12261,10 +12276,10 @@ pub fn op_insert(
 
                 let cursor = state.get_cursor(*cursor_id);
                 let cursor = cursor.as_btree_mut();
-                let maybe_key = return_if_io!(cursor.rowid());
+                let maybe_key = return_if_io!(state, cursor.rowid());
                 let old_record = if let Some(key) = maybe_key {
                     if key == insert_key {
-                        let maybe_record = return_if_io!(cursor.record());
+                        let maybe_record = return_if_io!(state, cursor.record());
                         if let Some(record) = maybe_record {
                             let mut values = record.get_values_owned()?;
                             let schema = program.connection.schema.read();
@@ -12317,7 +12332,7 @@ pub fn op_insert(
                     };
                     let cursor = get_cursor!(state, *cursor_id);
                     let cursor = cursor.as_btree_mut();
-                    let existing_key = return_if_io!(cursor.rowid());
+                    let existing_key = return_if_io!(state, cursor.rowid());
                     if existing_key == Some(key) {
                         let record = match &state.registers[*record_reg] {
                             Register::Record(r) => std::borrow::Cow::Borrowed(r),
@@ -12330,7 +12345,7 @@ pub fn op_insert(
                                 unreachable!("Cannot insert an aggregate value.")
                             }
                         };
-                        let existing_record = return_if_io!(cursor.record());
+                        let existing_record = return_if_io!(state, cursor.record());
                         if existing_record.is_some_and(|r| r == record.as_ref()) {
                             state.active_op_state.insert().is_noop_update = true;
                         }
@@ -12359,9 +12374,13 @@ pub fn op_insert(
                             Value::Numeric(Numeric::Integer(i)) => *i,
                             _ => unreachable!("expected integer key"),
                         };
-                        return_if_io!(cursor.insert(&BTreeKey::new_table_rowid(key, Some(&record))));
+                        return_if_io!(
+                            state,
+                            cursor.insert(&BTreeKey::new_table_rowid(key, Some(&record)))
+                        );
                     } else {
                         return_if_io!(
+                            state,
                             cursor.insert(&BTreeKey::new_index_key(record.as_record_ref()))
                         );
                     }
@@ -12560,12 +12579,12 @@ pub fn op_delete(
                     let cursor = state.get_cursor(*cursor_id);
                     let cursor = cursor.as_btree_mut();
                     // Get the current key
-                    let maybe_key = return_if_io!(cursor.rowid());
+                    let maybe_key = return_if_io!(state, cursor.rowid());
                     let key = maybe_key.ok_or_else(|| {
                         LimboError::InternalError("Cannot delete: no current row".to_string())
                     })?;
                     // Get the current record before deletion and extract values
-                    let maybe_record = return_if_io!(cursor.record());
+                    let maybe_record = return_if_io!(state, cursor.record());
                     if let Some(record) = maybe_record {
                         let mut values = record.get_values_owned()?;
 
@@ -12590,7 +12609,7 @@ pub fn op_delete(
                 {
                     let cursor = state.get_cursor(*cursor_id);
                     let cursor = cursor.as_btree_mut();
-                    return_if_io!(cursor.delete());
+                    return_if_io!(state, cursor.delete());
                 }
                 // Increment metrics for row write (DELETE is a write operation)
                 state.record_rows_written(1);
@@ -12654,7 +12673,10 @@ pub fn op_idx_delete(
     );
 
     if let Some(Cursor::IndexMethod(cursor)) = &mut state.cursors[*cursor_id] {
-        return_if_io!(cursor.delete(&state.registers[*start_reg..*start_reg + *num_regs]));
+        return_if_io!(
+            state,
+            cursor.delete(&state.registers[*start_reg..*start_reg + *num_regs])
+        );
         state.record_rows_written(1);
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
@@ -12686,7 +12708,7 @@ pub fn op_idx_delete(
                 ) {
                     Ok(SeekInternalResult::Found) => true,
                     Ok(SeekInternalResult::NotFound) => false,
-                    Ok(SeekInternalResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
+                    Ok(SeekInternalResult::IO(io)) => return Ok(state.suspend_on_io(io)),
                     Err(e) => return Err(e.into()),
                 };
 
@@ -12717,7 +12739,7 @@ pub fn op_idx_delete(
                 let rowid = {
                     let cursor = state.get_cursor(*cursor_id);
                     let cursor = cursor.as_btree_mut();
-                    return_if_io!(cursor.rowid())
+                    return_if_io!(state, cursor.rowid())
                 };
 
                 if rowid.is_none() && *raise_error_if_no_matching_entry {
@@ -12734,7 +12756,7 @@ pub fn op_idx_delete(
                 {
                     let cursor = state.get_cursor(*cursor_id);
                     let cursor = cursor.as_btree_mut();
-                    return_if_io!(cursor.delete());
+                    return_if_io!(state, cursor.delete());
                 }
                 // Increment metrics for index write (delete is a write operation)
                 state.record_rows_written(1);
@@ -12787,7 +12809,10 @@ pub fn op_idx_insert(
             )
             .into());
         };
-        return_if_io!(cursor.insert(&state.registers[start..start + count as usize]));
+        return_if_io!(
+            state,
+            cursor.insert(&state.registers[start..start + count as usize])
+        );
         state.record_rows_written(1);
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
@@ -12843,7 +12868,7 @@ pub fn op_idx_insert(
                     *state.active_op_state.idx_insert() = OpIdxInsertState::Insert;
                     Ok(InsnFunctionStepResult::Step)
                 }
-                SeekInternalResult::IO(io) => Ok(InsnFunctionStepResult::IO(io)),
+                SeekInternalResult::IO(io) => Ok(state.suspend_on_io(io)),
             }
         }
         OpIdxInsertState::UniqueConstraintCheck => {
@@ -12852,7 +12877,7 @@ pub fn op_idx_insert(
                 let cursor = cursor.as_btree_mut();
                 let has_rowid = cursor.has_rowid();
                 let index_info = cursor.get_index_info().clone();
-                let record_opt = return_if_io!(cursor.record());
+                let record_opt = return_if_io!(state, cursor.record());
                 let Some(record) = record_opt.as_ref() else {
                     // Cursor not pointing at a record — table is empty or past last
                     break 'i false;
@@ -12899,6 +12924,7 @@ pub fn op_idx_insert(
                 let cursor = get_cursor!(state, cursor_id);
                 let cursor = cursor.as_btree_mut();
                 return_if_io!(
+                    state,
                     cursor.insert(&BTreeKey::new_index_key(record_to_insert.as_record_ref()))
                 );
             }
@@ -12984,7 +13010,7 @@ fn new_rowid_inner(
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut() as &mut dyn Any;
                     if let Some(mvcc_cursor) = cursor.downcast_mut::<MvCursor>() {
-                        match return_if_io!(mvcc_cursor.start_new_rowid()) {
+                        match return_if_io!(state, mvcc_cursor.start_new_rowid()) {
                             NextRowidResult::Uninitialized => {
                                 *state.active_op_state.new_rowid() =
                                     OpNewRowidState::SeekingToLast {
@@ -13037,7 +13063,7 @@ fn new_rowid_inner(
                 {
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut();
-                    return_if_io!(cursor.seek_to_last());
+                    return_if_io!(state, cursor.seek_to_last());
                 }
                 if mvcc_already_initialized {
                     *state.active_op_state.new_rowid() = OpNewRowidState::GoNext;
@@ -13050,7 +13076,7 @@ fn new_rowid_inner(
                 let current_max = {
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut();
-                    return_if_io!(cursor.rowid())
+                    return_if_io!(state, cursor.rowid())
                 };
 
                 if has_mv_store {
@@ -13132,9 +13158,10 @@ fn new_rowid_inner(
                 let exists = {
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut();
-                    let seek_result =
-                        return_if_io!(cursor
-                            .seek(SeekKey::TableRowId(candidate), SeekOp::GE { eq_only: true }));
+                    let seek_result = return_if_io!(
+                        state,
+                        cursor.seek(SeekKey::TableRowId(candidate), SeekOp::GE { eq_only: true })
+                    );
                     matches!(seek_result, SeekResult::Found)
                 };
 
@@ -13164,7 +13191,7 @@ fn new_rowid_inner(
                 {
                     let cursor = state.get_cursor(*cursor);
                     let cursor = cursor.as_btree_mut();
-                    return_if_io!(cursor.next());
+                    return_if_io!(state, cursor.next());
                 }
                 state.active_op_state.clear();
                 state.pc += 1;
@@ -13321,7 +13348,7 @@ pub fn op_no_conflict(
                         state.active_op_state.clear();
                         Ok(InsnFunctionStepResult::Step)
                     }
-                    SeekInternalResult::IO(io) => Ok(InsnFunctionStepResult::IO(io)),
+                    SeekInternalResult::IO(io) => Ok(state.suspend_on_io(io)),
                 };
             }
         }
@@ -13344,7 +13371,10 @@ pub fn op_not_exists(
     );
     let cursor = must_be_btree_cursor!(*cursor, program.cursor_ref, state, "NotExists");
     let cursor = cursor.as_btree_mut();
-    let exists = return_if_io!(cursor.exists(state.registers[*rowid_reg].get_value()));
+    let exists = return_if_io!(
+        state,
+        cursor.exists(state.registers[*rowid_reg].get_value())
+    );
 
     if exists {
         state.pc += 1;
@@ -13437,7 +13467,7 @@ pub fn op_open_write(
             .as_mut()
             .expect("cursor should exist");
         let cursor = cursor.as_index_method_mut();
-        return_if_io!(cursor.open_write(&context));
+        return_if_io!(state, cursor.open_write(&context));
         state.pc += 1;
         return Ok(InsnFunctionStepResult::Step);
     }
@@ -13655,7 +13685,7 @@ pub fn op_create_btree(
     }
     let pager = program.get_pager_from_database_index(db)?;
     // FIXME: handle page cache is full
-    let root_page = return_if_io!(pager.btree_create(flags));
+    let root_page = return_if_io!(state, pager.btree_create(flags));
     state.registers[*root].set_int(root_page as i64);
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13689,7 +13719,7 @@ pub fn op_index_method_create(
         .as_mut()
         .expect("cursor should exist")
         .as_index_method_mut();
-    return_if_io!(cursor.create(&context));
+    return_if_io!(state, cursor.create(&context));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13721,7 +13751,7 @@ pub fn op_index_method_destroy(
         .as_mut()
         .expect("cursor should exist")
         .as_index_method_mut();
-    return_if_io!(cursor.destroy(&context));
+    return_if_io!(state, cursor.destroy(&context));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13753,7 +13783,7 @@ pub fn op_index_method_optimize(
         .as_mut()
         .expect("cursor should exist")
         .as_index_method_mut();
-    return_if_io!(cursor.optimize(&context));
+    return_if_io!(state, cursor.optimize(&context));
 
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)
@@ -13779,8 +13809,10 @@ pub fn op_index_method_query(
         .as_mut()
         .expect("cursor should exist");
     let cursor = cursor.as_index_method_mut();
-    let has_rows =
-        return_if_io!(cursor.query_start(&state.registers[*start_reg..*start_reg + *count_reg]));
+    let has_rows = return_if_io!(
+        state,
+        cursor.query_start(&state.registers[*start_reg..*start_reg + *count_reg])
+    );
     if !has_rows {
         state.pc = pc_if_empty.as_offset_int();
     } else {
@@ -13841,7 +13873,8 @@ pub fn op_destroy(
                     OpDestroyState::DestroyBtree(Arc::new(RwLock::new(cursor)));
             }
             OpDestroyState::DestroyBtree(ref mut cursor) => {
-                let maybe_former_root_page = return_if_io!(cursor.write().btree_destroy());
+                let destroyed = cursor.write().btree_destroy();
+                let maybe_former_root_page = return_if_io!(state, destroyed);
                 state.registers[*former_root_reg]
                     .set_int(maybe_former_root_page.unwrap_or(0) as i64);
                 state.active_op_state.clear();
@@ -13907,7 +13940,8 @@ fn op_clear_btree_inner(
                 };
             }
             OpClearBtreeState::ClearBtree { pager, cursor } => {
-                return_if_io!(cursor.write().clear_btree());
+                let cleared = cursor.write().clear_btree();
+                return_if_io!(state, cleared);
                 for other_cursor_opt in state.cursors.iter_mut().flatten() {
                     if let Cursor::BTree(ref mut btree_cursor) = other_cursor_opt {
                         if Arc::ptr_eq(&btree_cursor.get_pager(), pager) {
@@ -13940,7 +13974,7 @@ pub fn op_reset_sorter(
     match cursor_type {
         CursorType::BTreeTable(_) | CursorType::BTreeIndex(_) => {
             let cursor = cursor.as_btree_mut();
-            return_if_io!(cursor.clear_btree());
+            return_if_io!(state, cursor.clear_btree());
         }
         CursorType::Sorter => {
             return Err(LimboError::InternalError(
@@ -14570,7 +14604,7 @@ pub fn op_sequence_begin_inner_tx(
 /// Commit the autonomous inner tx started by a paired
 /// `SequenceBeginInnerTx`. Multi-step. Drives the inner's
 /// `CommitStateMachine` one step per opcode call, yielding
-/// `InsnFunctionStepResult::IO(io)` to the VDBE driver when commit
+/// `InsnFunctionStepResult::IO` to the VDBE driver when commit
 /// state machine wants IO. Mirrors `op_auto_commit`'s drive of the
 /// outer commit's state machine.
 ///
@@ -14652,7 +14686,7 @@ pub fn op_sequence_commit_inner_tx(
     let commit_sm = state.sequence_inner_commit.as_mut().expect("just set");
 
     match commit_sm.step(&mv_store) {
-        Ok(IOResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
+        Ok(IOResult::IO(io)) => Ok(state.suspend_on_io(io)),
         Ok(IOResult::Done(())) => {
             state.sequence_inner_commit = None;
             state.sequence_inner_tx_pending = None;
@@ -14753,7 +14787,7 @@ pub fn op_close(
                 ))
             })?
             .clone();
-        return_if_io!(cursor.stage_statement_commit(&context));
+        return_if_io!(state, cursor.stage_statement_commit(&context));
         let Some(Cursor::IndexMethod(cursor)) = state.cursors[*cursor_id].take() else {
             unreachable!("cursor variant checked above");
         };
@@ -14804,7 +14838,7 @@ pub fn op_page_count(
     }) {
         Err(_) => 0.into(),
         Ok(IOResult::Done(v)) => v.into(),
-        Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
+        Ok(IOResult::IO(io)) => return Ok(state.suspend_on_io(io)),
     };
     state.registers[*dest].set_int(count);
     state.pc += 1;
@@ -14957,7 +14991,7 @@ fn op_parse_schema_step(state: &mut ProgramState, conn: &Arc<Connection>) -> Ins
                     .stmt
                     .take_io_completions()
                     .unwrap_or_else(|| IOCompletions(Completion::new_yield()));
-                return Ok(InsnFunctionStepResult::IO(io));
+                return Ok(state.suspend_on_io(io));
             }
             StepResult::Row => {
                 let inner = state
@@ -15223,7 +15257,7 @@ fn drive_init_cdc_version(
                     .stmt
                     .take_io_completions()
                     .unwrap_or_else(|| IOCompletions(Completion::new_yield()));
-                return Ok(InsnFunctionStepResult::IO(io));
+                return Ok(state.suspend_on_io(io));
             }
             StepResult::Row => match &inner.phase {
                 OpInitCdcVersionPhase::CheckTable => {
@@ -15380,7 +15414,10 @@ pub fn op_populate_materialized_views(
             };
 
             // Now populate it with the cursor for writing
-            return_if_io!(view.populate_from_table(&conn, pager, btree_cursor.as_mut()));
+            return_if_io!(
+                state,
+                view.populate_from_table(&conn, pager, btree_cursor.as_mut())
+            );
         }
     }
 
@@ -15424,7 +15461,7 @@ pub fn op_read_cookie(
         ) {
             Err(_) => 0.into(),
             Ok(IOResult::Done(v)) => v,
-            Ok(IOResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
+            Ok(IOResult::IO(io)) => return Ok(state.suspend_on_io(io)),
         };
 
     state.registers[*dest].set_int(cookie_value);
@@ -15525,7 +15562,7 @@ pub fn op_set_cookie(
         Ok(())
     })? {
         IOResult::Done(result) => result?,
-        IOResult::IO(io) => return Ok(InsnFunctionStepResult::IO(io)),
+        IOResult::IO(io) => return Ok(state.suspend_on_io(io)),
     }
 
     state.pc += 1;
@@ -15797,13 +15834,12 @@ pub fn op_open_ephemeral(
             }
             // Ephemeral tables always use the main DB's page size (db index 0)
             // regardless of which database triggered the ephemeral allocation.
-            let page_size = return_if_io!(with_header(
-                pager,
-                mv_store.as_ref(),
-                program,
-                0,
-                |header| { header.page_size }
-            ));
+            let page_size = return_if_io!(
+                state,
+                with_header(pager, mv_store.as_ref(), program, 0, |header| {
+                    header.page_size
+                })
+            );
             let conn = program.connection.clone();
             let io = conn.pager.load().io.clone();
             let temp_store = conn.get_temp_store();
@@ -15842,7 +15878,7 @@ pub fn op_open_ephemeral(
                 .expect("cursor should exist in ClearExisting state");
             let btree_cursor = cursor.as_btree_mut();
             btree_cursor.set_null_flag(false);
-            return_if_io!(btree_cursor.clear_btree());
+            return_if_io!(state, btree_cursor.clear_btree());
             invalidate_deferred_seeks_for_cursor(state, cursor_id);
             *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::RewindExisting;
         }
@@ -15852,7 +15888,7 @@ pub fn op_open_ephemeral(
                 .as_mut()
                 .expect("cursor should exist in RewindExisting state");
             let btree_cursor = cursor.as_btree_mut();
-            return_if_io!(btree_cursor.rewind());
+            return_if_io!(state, btree_cursor.rewind());
             state.pc += 1;
             state.active_op_state.clear();
         }
@@ -15861,7 +15897,7 @@ pub fn op_open_ephemeral(
             pager
                 .begin_read_tx() // we have to begin a read tx before beginning a write
                 .expect("Failed to start read transaction");
-            return_if_io!(pager.begin_write_tx(WalAutoActions::all_enabled()));
+            return_if_io!(state, pager.begin_write_tx(WalAutoActions::all_enabled()));
             *state.active_op_state.open_ephemeral() = OpOpenEphemeralState::CreateBtree {
                 pager: pager.clone(),
                 temp_file: temp_file.take(),
@@ -15875,7 +15911,7 @@ pub fn op_open_ephemeral(
             } else {
                 &CreateBTreeFlags::new_index()
             };
-            let root_page = return_if_io!(pager.btree_create(flag)) as i64;
+            let root_page = return_if_io!(state, pager.btree_create(flag)) as i64;
 
             let (_, cursor_type) = program
                 .cursor_ref
@@ -15906,7 +15942,7 @@ pub fn op_open_ephemeral(
             cursor,
             temp_file: _,
         } => {
-            return_if_io!(cursor.rewind());
+            return_if_io!(state, cursor.rewind());
 
             let cursors = &mut state.cursors;
 
@@ -16154,7 +16190,7 @@ pub fn op_found(
     ) {
         Ok(SeekInternalResult::Found) => SeekResult::Found,
         Ok(SeekInternalResult::NotFound) => SeekResult::NotFound,
-        Ok(SeekInternalResult::IO(io)) => return Ok(InsnFunctionStepResult::IO(io)),
+        Ok(SeekInternalResult::IO(io)) => return Ok(state.suspend_on_io(io)),
         Err(e) => return Err(e.into()),
     };
 
@@ -16218,7 +16254,7 @@ pub fn op_count(
     let count = {
         let cursor = must_be_btree_cursor!(*cursor_id, program.cursor_ref, state, "Count");
         let cursor = cursor.as_btree_mut();
-        return_if_io!(cursor.count())
+        return_if_io!(state, cursor.count())
     };
 
     state.registers[*target_reg].set_int(count as i64);
@@ -16299,25 +16335,31 @@ pub fn op_integrity_check(
         .filter(|mv_store| !mv_store.uses_passive_checkpoint());
     match state.active_op_state.integrity_check() {
         OpIntegrityCheckState::Start => {
-            let (freelist_trunk_page, db_size) = return_if_io!(with_header(
-                &target_pager,
-                physical_header_store,
-                program,
-                *db,
-                |header| (header.freelist_trunk_page.get(), header.database_size.get())
-            ));
+            let (freelist_trunk_page, db_size) = return_if_io!(
+                state,
+                with_header(
+                    &target_pager,
+                    physical_header_store,
+                    program,
+                    *db,
+                    |header| (header.freelist_trunk_page.get(), header.database_size.get())
+                )
+            );
             let mut errors: crate::alloc::Vec<_> = crate::alloc::vec![];
             let mut integrity_check_state = IntegrityCheckState::new(db_size as usize);
             let mut current_root_idx = 0;
 
             if freelist_trunk_page > 0 {
-                let expected_freelist_count = return_if_io!(with_header(
-                    &target_pager,
-                    physical_header_store,
-                    program,
-                    *db,
-                    |header| { header.freelist_pages.get() }
-                ));
+                let expected_freelist_count = return_if_io!(
+                    state,
+                    with_header(
+                        &target_pager,
+                        physical_header_store,
+                        program,
+                        *db,
+                        |header| { header.freelist_pages.get() }
+                    )
+                );
                 integrity_check_state.set_expected_freelist_count(expected_freelist_count as usize);
                 integrity_check_state.start(
                     freelist_trunk_page as i64,
@@ -16343,12 +16385,15 @@ pub fn op_integrity_check(
             current_dropped_idx,
             state: integrity_check_state,
         } => {
-            return_if_io!(integrity_check(
-                integrity_check_state,
-                errors,
-                &target_pager,
-                mv_store.as_ref()
-            ));
+            return_if_io!(
+                state,
+                integrity_check(
+                    integrity_check_state,
+                    errors,
+                    &target_pager,
+                    mv_store.as_ref()
+                )
+            );
 
             if errors.len() >= *max_errors {
                 errors.truncate(*max_errors);
@@ -17512,7 +17557,7 @@ pub fn op_hash_build(
                     Ok(IOResult::Done(v)) => v,
                     Ok(IOResult::IO(io)) => {
                         *state.active_op_state.hash_build() = Some(op_state);
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        return Ok(state.suspend_on_io(io));
                     }
                     Err(e) => {
                         *state.active_op_state.hash_build() = Some(op_state);
@@ -17547,7 +17592,7 @@ pub fn op_hash_build(
                 op_state.key_values = pending.key_values;
                 op_state.payload_values = pending.payload_values;
                 *state.active_op_state.hash_build() = Some(op_state);
-                return Ok(InsnFunctionStepResult::IO(io));
+                return Ok(state.suspend_on_io(io));
             }
         }
     }
@@ -17615,7 +17660,10 @@ pub fn op_hash_distinct(
 
     let mut key_refs: SmallVec<[ValueRef; 2]> = SmallVec::with_capacity(data.num_keys);
     key_refs.extend(key_values.iter().map(|v| v.as_ref()));
-    match hash_table.insert_distinct(key_values, &key_refs, Some(&mut state.metrics.hash_join))? {
+    let inserted =
+        hash_table.insert_distinct(key_values, &key_refs, Some(&mut state.metrics.hash_join))?;
+    drop(key_refs);
+    match inserted {
         IOResult::Done(inserted) => {
             state.pc = if inserted {
                 state.pc + 1
@@ -17624,7 +17672,7 @@ pub fn op_hash_distinct(
             };
             Ok(InsnFunctionStepResult::Step)
         }
-        IOResult::IO(io) => Ok(InsnFunctionStepResult::IO(io)),
+        IOResult::IO(io) => Ok(state.suspend_on_io(io)),
     }
 }
 
@@ -17640,7 +17688,7 @@ pub fn op_hash_build_finalize(
         match ht.finalize_build(Some(&mut state.metrics.hash_join))? {
             crate::types::IOResult::Done(()) => {}
             crate::types::IOResult::IO(io) => {
-                return Ok(InsnFunctionStepResult::IO(io));
+                return Ok(state.suspend_on_io(io));
             }
         }
     }
@@ -17761,7 +17809,7 @@ pub fn op_hash_probe(
                             partition_idx,
                             probe_buffered: true,
                         });
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        return Ok(state.suspend_on_io(io));
                     }
                 }
                 // Jump to target_pc: this row is deferred to grace processing.
@@ -17957,6 +18005,7 @@ pub fn op_hash_scan_unmatched(
         *payload_dest_reg,
         *num_payload,
         &mut state.metrics.hash_join,
+        &mut state.io_completions,
     )
 }
 
@@ -17990,6 +18039,7 @@ pub fn op_hash_next_unmatched(
         *payload_dest_reg,
         *num_payload,
         &mut state.metrics.hash_join,
+        &mut state.io_completions,
     )
 }
 
@@ -18005,6 +18055,7 @@ fn advance_unmatched_scan(
     payload_dest_reg: Option<usize>,
     num_payload: usize,
     metrics: &mut HashJoinMetrics,
+    io_slot: &mut Option<IOCompletions>,
 ) -> InsnResult {
     if hash_table.has_spilled() {
         if let Some(partition_idx) = hash_table.unmatched_scan_current_partition() {
@@ -18012,7 +18063,8 @@ fn advance_unmatched_scan(
                 match hash_table.load_spilled_partition(partition_idx, Some(metrics))? {
                     crate::types::IOResult::Done(()) => {}
                     crate::types::IOResult::IO(io) => {
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        *io_slot = Some(io);
+                        return Ok(InsnFunctionStepResult::IO);
                     }
                 }
             }
@@ -18034,7 +18086,8 @@ fn advance_unmatched_scan(
                             match hash_table.load_spilled_partition(partition_idx, Some(metrics))? {
                                 crate::types::IOResult::Done(()) => continue,
                                 crate::types::IOResult::IO(io) => {
-                                    return Ok(InsnFunctionStepResult::IO(io));
+                                    *io_slot = Some(io);
+                                    return Ok(InsnFunctionStepResult::IO);
                                 }
                             }
                         }
@@ -18077,7 +18130,7 @@ pub fn op_hash_grace_init(
     match hash_table.finalize_probe_spill(Some(&mut state.metrics.hash_join))? {
         IOResult::Done(()) => {}
         IOResult::IO(io) => {
-            return Ok(InsnFunctionStepResult::IO(io));
+            return Ok(state.suspend_on_io(io));
         }
     }
 
@@ -18119,7 +18172,7 @@ pub fn op_hash_grace_load_partition(
             state.pc = target_pc.as_offset_int();
             Ok(InsnFunctionStepResult::Step)
         }
-        IOResult::IO(io) => Ok(InsnFunctionStepResult::IO(io)),
+        IOResult::IO(io) => Ok(state.suspend_on_io(io)),
     }
 }
 
@@ -18166,7 +18219,7 @@ pub fn op_hash_grace_next_probe(
             state.pc = target_pc.as_offset_int();
             Ok(InsnFunctionStepResult::Step)
         }
-        IOResult::IO(io) => Ok(InsnFunctionStepResult::IO(io)),
+        IOResult::IO(io) => Ok(state.suspend_on_io(io)),
     }
 }
 
@@ -18421,7 +18474,7 @@ pub fn op_max_pgcnt(
         pager.get_max_page_count()
     } else {
         // Set new maximum page count (will be clamped to current database size)
-        return_if_io!(pager.set_max_page_count(*new_max as u32))
+        return_if_io!(state, pager.set_max_page_count(*new_max as u32))
     };
 
     state.registers[*dest].set_int(result_value.into());
@@ -18534,7 +18587,7 @@ pub fn op_journal_mode(
 ) -> InsnResult {
     match op_journal_mode_inner(program, state, insn, pager) {
         Ok(result) => {
-            if !matches!(result, InsnFunctionStepResult::IO(_)) {
+            if !matches!(result, InsnFunctionStepResult::IO) {
                 // Reset state if we are done with this instruction
                 state.active_op_state.clear();
             }
@@ -18569,7 +18622,7 @@ fn op_journal_mode_inner(
                     header.read_version
                 });
 
-                let prev_mode_raw = return_if_io!(header_result);
+                let prev_mode_raw = return_if_io!(state, header_result);
 
                 let prev_mode_version = prev_mode_raw
                     .to_version()
@@ -18692,7 +18745,7 @@ fn op_journal_mode_inner(
                         .checkpoint_sm
                         .as_mut()
                         .unwrap();
-                    return_if_io!(ckpt_sm.step(&()));
+                    return_if_io!(state, ckpt_sm.step(&()));
                     state.active_op_state.journal_mode().checkpoint_sm = None;
                     state.active_op_state.journal_mode().sub_state =
                         OpJournalModeSubState::UpdateHeader;
@@ -18705,7 +18758,7 @@ fn op_journal_mode_inner(
                         program.connection.get_sync_mode(),
                         false, // Don't clear cache yet, we'll do it in Finalize
                     );
-                    return_if_io!(checkpoint_result);
+                    return_if_io!(state, checkpoint_result);
                     state.active_op_state.journal_mode().sub_state =
                         OpJournalModeSubState::UpdateHeader;
                 }
@@ -18724,8 +18777,10 @@ fn op_journal_mode_inner(
 
                 // Get the header page reference (handles both initialized and uninitialized databases)
                 // This uses the pager's cache and won't fail for empty database files
-                let header_ref =
-                    return_if_io!(crate::storage::pager::HeaderRefMut::from_pager(pager));
+                let header_ref = return_if_io!(
+                    state,
+                    crate::storage::pager::HeaderRefMut::from_pager(pager)
+                );
 
                 // Update the header version
                 {
@@ -18750,7 +18805,7 @@ fn op_journal_mode_inner(
                     .expect("page_ref should be set");
                 let completion = begin_write_btree_page(pager, page, None)?;
                 state.active_op_state.journal_mode().sub_state = OpJournalModeSubState::Finalize;
-                return Ok(InsnFunctionStepResult::IO(IOCompletions(completion)));
+                return Ok(state.suspend_on_io(IOCompletions(completion)));
             }
 
             OpJournalModeSubState::Finalize => {
@@ -18813,10 +18868,13 @@ fn op_journal_mode_inner(
                     )
                     .into());
                 };
-                return_if_io!(mv_store.bootstrap_nonblock(
-                    &program.connection,
-                    &mut state.active_op_state.journal_mode().bootstrap_state
-                ));
+                return_if_io!(
+                    state,
+                    mv_store.bootstrap_nonblock(
+                        &program.connection,
+                        &mut state.active_op_state.journal_mode().bootstrap_state
+                    )
+                );
 
                 // Bootstrap finished: disarm the abandonment guard so it does
                 // not roll back the now-published MVCC store on drop.
@@ -18996,9 +19054,9 @@ pub fn op_vacuum_into(
             state.op_vacuum_state = VacuumOpState::None;
             Ok(InsnFunctionStepResult::Step)
         }
-        Ok(InsnFunctionStepResult::IO(io)) => {
+        Ok(InsnFunctionStepResult::IO) => {
             // Waiting for I/O, keep state for resumption
-            Ok(InsnFunctionStepResult::IO(io))
+            Ok(InsnFunctionStepResult::IO)
         }
         Ok(InsnFunctionStepResult::Done | InsnFunctionStepResult::Row) => {
             unreachable!("op_vacuum_into_inner only returns Step or IO")
@@ -19251,7 +19309,7 @@ fn op_vacuum_into_inner(program: &Program, state: &mut ProgramState, insn: &Insn
                     }
                     crate::IOResult::IO(io) => {
                         vacuum_state.phase = VacuumIntoOpPhase::Build;
-                        return Ok(InsnFunctionStepResult::IO(io));
+                        return Ok(state.suspend_on_io(io));
                     }
                 }
             }
@@ -19305,7 +19363,7 @@ pub fn op_vacuum(
             state.pc += 1;
             Ok(InsnFunctionStepResult::Step)
         }
-        Ok(IOResult::IO(io)) => Ok(InsnFunctionStepResult::IO(io)),
+        Ok(IOResult::IO(io)) => Ok(state.suspend_on_io(io)),
         Err(err) => {
             let VacuumOpState::InPlace(vacuum_state) = std::mem::take(&mut state.op_vacuum_state)
             else {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -770,18 +770,18 @@ pub fn op_null(
 ) -> InsnResult {
     match insn {
         Insn::Null { dest, dest_end } | Insn::BeginSubrtn { dest, dest_end } => {
-            if let Some(dest_end) = dest_end {
-                for i in *dest..=*dest_end {
-                    state.registers[i].set_null();
-                    // Clear any associated RowSet so it can be reused in a fresh
-                    // state.  In SQLite the RowSet lives inside the register and
-                    // is destroyed by OP_Null; we keep RowSets in a side map, so
-                    // we must remove them explicitly.
+            let dest_end = dest_end.unwrap_or(*dest);
+            for i in *dest..=dest_end {
+                state.registers[i].set_null();
+            }
+            // Clear any associated RowSet so it can be reused in a fresh
+            // state. In SQLite the RowSet lives inside the register and is
+            // destroyed by OP_Null; we keep RowSets in a side map, so we must
+            // remove them explicitly.
+            if !state.rowsets.is_empty() {
+                for i in *dest..=dest_end {
                     state.rowsets.remove(&i);
                 }
-            } else {
-                state.registers[*dest].set_null();
-                state.rowsets.remove(dest);
             }
         }
         _ => {

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -973,6 +973,7 @@ pub fn insn_to_row(
                 cursor_id,
                 pc_if_next,
                 fullscan,
+                ..
             } => (
                 "Next",
                 *cursor_id as i64,
@@ -2047,6 +2048,7 @@ pub fn insn_to_row(
                 cursor_id,
                 pc_if_prev,
                 fullscan,
+                ..
             } => (
                 "Prev",
                 *cursor_id as i64,

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -932,6 +932,7 @@ pub enum Insn {
         /// count toward SQLITE_STMTSTATUS_FULLSCAN_STEP, matching SQLite,
         /// which tags the opcode with P5 at codegen time.
         fullscan: bool,
+        is_index: bool,
     },
 
     Prev {
@@ -939,6 +940,8 @@ pub enum Insn {
         pc_if_prev: BranchOffset,
         /// See [Insn::Next::fullscan].
         fullscan: bool,
+        /// See [Insn::Next::is_index].
+        is_index: bool,
     },
 
     /// Halt the program.

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -2130,28 +2130,6 @@ const fn get_insn_virtual_table() -> [InsnFunction; InsnVariants::COUNT] {
 
 const INSN_VTABLE: [InsnFunction; InsnVariants::COUNT] = get_insn_virtual_table();
 
-/// Dispatches one instruction.
-///
-/// The opcodes that are most likely to run in a loop are matched directly so LLVM can inline them
-/// into the dispatch loop.
-#[inline(always)]
-pub(crate) fn dispatch_insn(
-    program: &super::Program,
-    state: &mut super::ProgramState,
-    insn: &Insn,
-    pager: &std::sync::Arc<crate::Pager>,
-) -> execute::InsnResult {
-    match insn {
-        Insn::Next { .. } => execute::op_next(program, state, insn, pager),
-        Insn::ResultRow { .. } => execute::op_result_row(program, state, insn, pager),
-        Insn::Column { .. } => execute::op_column(program, state, insn, pager),
-        Insn::ColumnRange { .. } => execute::op_column_range(program, state, insn, pager),
-        Insn::RowId { .. } => execute::op_row_id(program, state, insn, pager),
-        Insn::Prev { .. } => execute::op_prev(program, state, insn, pager),
-        _ => insn.to_function()(program, state, insn, pager),
-    }
-}
-
 impl InsnVariants {
     // This function is used for testing
     #[allow(dead_code)]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1317,6 +1317,37 @@ impl ProgramState {
         self.metrics.rows_written = self.metrics.rows_written.wrapping_add(count);
     }
 
+    /// Parks the completion an instruction waits for and answers the result
+    /// the instruction returns for it. The dispatch loop takes the
+    /// completion back with [`Self::take_suspended_io`] before it decides
+    /// whether the statement yields to the caller.
+    #[inline]
+    pub(crate) fn suspend_on_io(&mut self, io: IOCompletions) -> InsnFunctionStepResult {
+        turso_debug_assert!(
+            self.io_completions.is_none(),
+            "an instruction reported IO while a completion was already parked"
+        );
+        self.io_completions = Some(io);
+        InsnFunctionStepResult::IO
+    }
+
+    /// The instruction result of a state machine step: `Done` when it
+    /// finished, `IO` with the completion parked when it waits.
+    pub(crate) fn done_or_suspend<T>(&mut self, result: IOResultOr<T>) -> execute::InsnResult {
+        match result {
+            Ok(IOResult::Done(_)) => Ok(InsnFunctionStepResult::Done),
+            Ok(IOResult::IO(io)) => Ok(self.suspend_on_io(io)),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// The completion the instruction that just returned `IO` parked.
+    pub(crate) fn take_suspended_io(&mut self) -> IOCompletions {
+        self.io_completions
+            .take()
+            .expect("an instruction that reports IO leaves its completion in the state")
+    }
+
     /// Runs `f` on the metrics of this statement including its active and
     /// cached subprograms, without copying them when there is no subprogram.
     pub(crate) fn with_metrics<R>(&self, f: impl FnOnce(&StatementMetrics) -> R) -> R {
@@ -2200,10 +2231,41 @@ impl Program {
                         program.trace_step(state, insn, enable_tracing, vdbe_trace);
                     }
 
-                    // Always increment VM steps for every loop iteration
                     state.metrics.vm_steps = state.metrics.vm_steps.wrapping_add(1);
-
-                    let result = insn::dispatch_insn(program, state, insn, pager);
+                    // The opcodes that run once per row of a scan are matched here
+                    // so LLVM inlines them into the loop, and each one tests its
+                    // own result right after its body, where the result is a
+                    // constant: tested after a shared merge point, the constant
+                    // reaches the compare through a phi and stays a runtime test.
+                    // Every other opcode goes through the function table.
+                    macro_rules! step_inline {
+                        ($op:path) => {
+                            match $op(program, state, insn, pager) {
+                                Ok(InsnFunctionStepResult::Step) => {
+                                    state.metrics.insn_executed =
+                                        state.metrics.insn_executed.wrapping_add(1);
+                                    continue;
+                                }
+                                Ok(InsnFunctionStepResult::Row) => {
+                                    state.metrics.insn_executed =
+                                        state.metrics.insn_executed.wrapping_add(1);
+                                    return Ok(StepResult::Row);
+                                }
+                                other => other,
+                            }
+                        };
+                    }
+                    let result = match insn {
+                        Insn::Next { .. } => step_inline!(execute::op_next),
+                        Insn::ResultRow { .. } => step_inline!(execute::op_result_row),
+                        Insn::Column { .. } => step_inline!(execute::op_column),
+                        Insn::ColumnRange { .. } => step_inline!(execute::op_column_range),
+                        Insn::RowId { .. } => step_inline!(execute::op_row_id),
+                        Insn::Prev { .. } => step_inline!(execute::op_prev),
+                        _ => insn.to_function()(program, state, insn, pager),
+                    };
+                    // The two outcomes of every row are tested here, one compare
+                    // each; the rest settles out of line.
                     if let Ok(InsnFunctionStepResult::Step) = result {
                         // Instruction completed, moving to next
                         state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
@@ -2214,7 +2276,6 @@ impl Program {
                         state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
                         return Ok(StepResult::Row);
                     }
-                    // Match less frequent results out of line
                     match dispatch(program, state, pager, waker, result)? {
                         Some(result) => return Ok(result),
                         None => continue 'io_check,
@@ -2237,7 +2298,10 @@ impl Program {
                         state.auto_txn_cleanup = TxnCleanup::None;
                         Ok(Some(StepResult::Done))
                     }
-                    Ok(InsnFunctionStepResult::IO(io)) => Ok(program.park_on_io(state, io, waker)),
+                    Ok(InsnFunctionStepResult::IO) => {
+                        let io = state.take_suspended_io();
+                        Ok(program.park_on_io(state, io, waker))
+                    }
                     Err(boxed_err) => program.fail_step(state, pager, *boxed_err),
                     Ok(InsnFunctionStepResult::Step) | Ok(InsnFunctionStepResult::Row) => {
                         unreachable!("the dispatch loop settles steps and rows itself")

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -150,10 +150,19 @@ impl BranchOffset {
 
     /// Returns the offset value. Panics if the branch offset is a label or placeholder.
     pub fn as_offset_int(&self) -> InsnReference {
-        match self {
-            BranchOffset::Label(v) => unreachable!("Unresolved label: {}", v),
+        return match self {
             BranchOffset::Offset(v) => *v,
-            BranchOffset::Placeholder => unreachable!("Unresolved placeholder"),
+            _ => unresolved(self),
+        };
+
+        #[cold]
+        #[inline(never)]
+        fn unresolved(offset: &BranchOffset) -> ! {
+            match offset {
+                BranchOffset::Label(v) => unreachable!("Unresolved label: {}", v),
+                BranchOffset::Offset(_) => unreachable!("offset is resolved"),
+                BranchOffset::Placeholder => unreachable!("Unresolved placeholder"),
+            }
         }
     }
 

--- a/core/vdbe/vacuum.rs
+++ b/core/vdbe/vacuum.rs
@@ -2057,12 +2057,12 @@ fn vacuum_in_place_step(
                     turso_assert!(
                         page.is_loaded(),
                         "VACUUM read batch page must be loaded before WAL prepare",
-                        { "page_id": page.get().id }
+                        { "page_id": page.get().id() }
                     );
                     turso_assert!(
                         !page.is_locked(),
                         "VACUUM read batch page lock leaked before WAL prepare",
-                        { "page_id": page.get().id }
+                        { "page_id": page.get().id() }
                     );
                 }
                 let all_read = *next_page > *total_pages;
@@ -2593,7 +2593,7 @@ mod tests {
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].0, 42);
         assert_eq!(runs[0].1.len(), 1);
-        assert_eq!(runs[0].1[0].get().id, 1);
+        assert_eq!(runs[0].1[0].get().id(), 1);
     }
 
     #[test]
@@ -2612,12 +2612,12 @@ mod tests {
         assert_eq!(runs[0].0, 10);
         assert_eq!(runs[0].1.len(), 3);
         assert_eq!(
-            runs[0].1.iter().map(|p| p.get().id).collect::<Vec<_>>(),
+            runs[0].1.iter().map(|p| p.get().id()).collect::<Vec<_>>(),
             vec![1, 2, 3]
         );
         assert_eq!(runs[1].0, 14);
         assert_eq!(runs[1].1.len(), 1);
-        assert_eq!(runs[1].1[0].get().id, 4);
+        assert_eq!(runs[1].1[0].get().id(), 4);
     }
 
     #[test]
@@ -2673,7 +2673,7 @@ mod tests {
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].0, 10);
         assert_eq!(
-            runs[0].1.iter().map(|p| p.get().id).collect::<Vec<_>>(),
+            runs[0].1.iter().map(|p| p.get().id()).collect::<Vec<_>>(),
             vec![2, 3, 1, 4]
         );
     }


### PR DESCRIPTION
## Description

Part 10 of 15 split out of #8692 (commits 91-100 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### Second session (commits 89 to 149, `98c2b91f` → `cc0dfdf6`)

A second autonomous session continued from `98c2b91f` with the same method: callgrind instruction counts (`Ir`) of the local driver, one measured change per commit, changes that measured worse reverted and listed below. The 100k-row scans run 3 iterations (5 for `SELECT 1 FROM t`); the per-statement numbers are instructions per execution, (Ir at 3000 − Ir at 1000) / 2000. Two more scan workloads join the set: `SELECT name FROM t` (W13, one TEXT column per row) and `SELECT * FROM t ORDER BY name DESC LIMIT 10` (W9, the sorter), plus `SELECT length(name) FROM t` and `SELECT abs(value) FROM t` for the scalar function opcode. The CodSpeed runs of `3c369a50`, `9b2dcf03`, `46436272` and the later heads are in the CodSpeed section of #8692.

| Commit | `SELECT 1 FROM t` | `SELECT * FROM t` | W3 | W4 | W12 (GROUP BY value) | W13 (`SELECT name`) | W9 (ORDER BY) |
|---|---:|---:|---:|---:|---:|---:|---:|
| keep the index flag of Next and Prev in the instruction, first half (a per-cursor table) | 140,470,539 (0.0%) | 281,434,819 (-0.2%) | 179,228,704 (-0.5%) | 199,093,217 (-0.6%) | 913,524,801 (-0.6%) | | |
| return the instruction result in registers | 141,970,499 (+1.1%) | 280,533,251 (-0.3%) | 174,725,544 (-2.5%) | 194,288,438 (-2.4%) | 891,902,404 (-2.4%) | | |
| answer a cursor advance in registers | 138,473,849 (-2.5%) | 278,434,976 (-0.8%) | 172,327,557 (-1.4%) | 191,890,451 (-1.2%) | 889,804,414 (-0.2%) | | |
| skip the RowSet lookups of Null while no RowSet exists | = | = | = | = | 777,002,242 (-12.7%) | | = |
| copy NULL and numbers between registers in place | = | = | = | = | 750,602,242 (-3.4%) | | = |
| keep the unresolved-branch paths out of the jump opcodes | 137,473,739 (-0.7%) | 277,834,910 (-0.2%) | 171,727,491 (-0.3%) | 191,289,743 (-0.3%) | 749,102,179 (-0.2%) | | 716,733,520 (-0.5%) |
| keep the index flag of Next and Prev in the instruction, second half (the flag itself; the two halves are one commit) | 134,459,444 (-2.2%) | 276,029,954 (-0.7%) | 170,518,908 (-0.7%) | 190,081,154 (-0.6%) | 746,693,584 (-0.3%) | 195,667,732 | 718,577,944 |
| read the payload of a local leaf cell without testing the record cache | = | = | 168,130,908 (-1.4%) | 188,881,154 (-0.6%) | 745,493,584 (-0.2%) | = | 717,377,944 (-0.2%) |
| read the cell pointer of a leaf cell with one bounds check | = | = | 166,635,633 (-0.9%) | 187,385,879 (-0.8%) | 743,998,309 (-0.2%) | 194,167,732 (-0.8%) | 715,877,944 (-0.2%) |
| keep the header offset of a page next to its id | 131,881,819 (-1.9%) | 274,167,098 (-0.7%) | 164,786,211 (-1.1%) | 185,536,469 (-1.0%) | 742,148,899 (-0.2%) | 192,304,876 (-1.0%) | 713,714,101 (-0.3%) |
| decode one- and two-byte varints before the loop | 131,891,364 (0.0%) | 271,065,365 (-1.1%) | 163,893,840 (-0.5%) | 184,644,068 (-0.5%) | 739,456,510 (-0.4%) | 190,206,547 (-1.1%) | 706,062,986 (-1.1%) |

| Commit | point lookup | `SELECT 1` | index lookup |
|---|---:|---:|---:|
| return the instruction result in registers | 7,180 | 1,696 | 12,941 |
| answer a cursor advance in registers | 7,203 | 1,710 | 12,978 |
| keep the unresolved-branch paths out of the jump opcodes | 7,178 | 1,694 | 12,949 |
| keep the header offset of a page next to its id | 7,158 | = | 12,881 |
| decode one- and two-byte varints before the loop | 7,170 | = | 12,859 |

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_