### PR TITLE
core/vdbe: inline untraced dispatch loop into statement step

### DIFF
--- a/core/statement.rs
+++ b/core/statement.rs
@@ -24,6 +24,7 @@ use crate::{
             EXPLAIN_COLUMNS_TYPE, EXPLAIN_QUERY_PLAN_COLUMNS_TYPE,
             EXPLAIN_QUERY_PLAN_JSON_COLUMNS_TYPE,
         },
+        ProgramStep,
     },
     Connection, EqpFormat, LimboError, MvStore, Pager, QueryMode, Result, TransactionState, Value,
     EXPLAIN_COLUMNS, EXPLAIN_QUERY_PLAN_COLUMNS, EXPLAIN_QUERY_PLAN_JSON_COLUMNS,
@@ -571,14 +572,24 @@ impl Statement {
                 return Ok(result);
             }
         }
-        let res = self
-            .program
-            .step(&mut self.state, &self.pager, self.query_mode, waker);
-        if let Ok(StepResult::Row) = res {
-            self.busy = true;
-            self.has_returned_row = true;
-            return Ok(StepResult::Row);
-        }
+        let res = match self.query_mode {
+            QueryMode::Normal => {
+                match self
+                    .program
+                    .normal_step(&mut self.state, &self.pager, waker)
+                {
+                    ProgramStep::Row => {
+                        self.busy = true;
+                        self.has_returned_row = true;
+                        return Ok(StepResult::Row);
+                    }
+                    step => step.into(),
+                }
+            }
+            _ => self
+                .program
+                .step(&mut self.state, &self.pager, self.query_mode, waker),
+        };
         self.finish_step(res, waker)
     }
 

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -8649,12 +8649,13 @@ impl PageStack {
         page
     }
 
+    /// The page at the top of the stack. Pages on the stack are pinned, and
+    /// every read of the page asserts that its buffer is present, so the
+    /// loaded flag is not tested here again.
     #[inline(always)]
     fn top_ref(&self) -> &PageRef {
         let current = self.current();
-        let page = self.stack[current].as_ref().unwrap();
-        turso_assert!(page.is_loaded_relaxed(), "page should be loaded");
-        page
+        self.stack[current].as_ref().unwrap()
     }
 
     /// Current page pointer being used

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -1015,15 +1015,6 @@ impl Page {
         self.get().flags.load(Ordering::Acquire) & PAGE_LOADED != 0
     }
 
-    /// `is_loaded` for a check that needs no ordering: the caller already
-    /// synchronized with the load of the page, so a relaxed read cannot
-    /// see the flag unset. Unlike the acquire read, it lets the compiler
-    /// keep values it read before the check in registers across it.
-    #[inline]
-    pub fn is_loaded_relaxed(&self) -> bool {
-        self.get().flags.load(Ordering::Relaxed) & PAGE_LOADED != 0
-    }
-
     #[inline]
     pub fn set_loaded(&self) {
         self.get().flags.fetch_or(PAGE_LOADED, Ordering::Release);

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7148,9 +7148,14 @@ fn kbn_init_from_int(acc: &mut Value, i: i64, state: &mut SumAggState) {
 /// - JsonGroupObject/JsonbGroupObject: [Blob([])]
 /// - JsonGroupArray/JsonbGroupArray: [Blob([])]
 fn init_agg_payload(func: &AggFunc, payload: &mut crate::alloc::Vec<Value>) -> Result<()> {
+    // This initializes `payload` at exactly the right size.
     match func {
-        AggFunc::Count | AggFunc::Count0 => payload.push(Value::from_i64(0)),
+        AggFunc::Count | AggFunc::Count0 => {
+            payload.try_reserve_exact(1)?;
+            payload.push(Value::from_i64(0));
+        }
         AggFunc::Sum | AggFunc::Total => {
+            payload.try_reserve_exact(5)?;
             let acc = if matches!(func, AggFunc::Total) {
                 Value::from_f64(0.0)
             } else {
@@ -7163,12 +7168,17 @@ fn init_agg_payload(func: &AggFunc, payload: &mut crate::alloc::Vec<Value>) -> R
             payload.push(Value::from_i64(0));
         }
         AggFunc::Avg => {
+            payload.try_reserve_exact(3)?;
             payload.push(Value::from_f64(0.0));
             payload.push(Value::from_f64(0.0));
             payload.push(Value::from_i64(0));
         }
-        AggFunc::Min | AggFunc::Max => payload.push(Value::Null),
+        AggFunc::Min | AggFunc::Max => {
+            payload.try_reserve_exact(1)?;
+            payload.push(Value::Null);
+        }
         AggFunc::GroupConcat | AggFunc::StringAgg => {
+            payload.try_reserve_exact(4)?;
             // Use Null as sentinel to distinguish "no values yet" from an
             // accumulated empty string. SQLite normally remembers one
             // separator length and only materializes the per-separator queue
@@ -7178,38 +7188,42 @@ fn init_agg_payload(func: &AggFunc, payload: &mut crate::alloc::Vec<Value>) -> R
             payload.push(Value::from_i64(0));
             payload.push(Value::Blob(crate::alloc::vec![]));
         }
-        AggFunc::External(_) => {
-            mark_unlikely();
-            // External aggregates use ExternalAggState, not flat payload
-            return Err(LimboError::InternalError(
-                "External aggregate not supported in init_agg_payload".to_string(),
-            ));
-        }
         AggFunc::ArrayAgg => {
+            payload.try_reserve_exact(1)?;
             // payload[0] = element count (Integer), remaining slots = accumulated values.
             // We serialize to a record blob only in finalize, avoiding O(n²) re-serialization.
             payload.push(Value::from_i64(0));
         }
         AggFunc::Mode => {
+            payload.try_reserve_exact(2)?;
             // [0] = collation bits, [1] = count, [2..] = buffered values.
-            payload.push(Value::from_i64(0)); // collation (recorded at step time)
-            payload.push(Value::from_i64(0)); // count
+            payload.push(Value::from_i64(0));
+            payload.push(Value::from_i64(0));
         }
         AggFunc::PercentileCont | AggFunc::PercentileDisc => {
+            payload.try_reserve_exact(3)?;
             // [0] = collation bits, [1] = count, [2] = fraction, [3..] = buffered values.
-            payload.push(Value::from_i64(0)); // collation (recorded at step time)
-            payload.push(Value::from_i64(0)); // count
-            payload.push(Value::Null); // fraction (set on first step)
+            payload.push(Value::from_i64(0));
+            payload.push(Value::from_i64(0));
+            payload.push(Value::Null);
         }
         #[cfg(feature = "json")]
         AggFunc::JsonGroupObject | AggFunc::JsonbGroupObject => {
+            payload.try_reserve_exact(1)?;
             payload.push(Value::Blob(crate::alloc::vec![]));
         }
         #[cfg(feature = "json")]
         AggFunc::JsonGroupArray | AggFunc::JsonbGroupArray => {
+            payload.try_reserve_exact(1)?;
             payload.push(Value::Blob(crate::alloc::vec![]));
         }
-    };
+        AggFunc::External(_) => {
+            mark_unlikely();
+            return Err(LimboError::InternalError(
+                "External aggregate not supported in init_agg_payload".to_string(),
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -20085,6 +20099,38 @@ mod tests {
                     panic!("'{input}' should remain text, got {other:?}");
                 }
             }
+        }
+    }
+
+    #[test]
+    fn test_init_agg_payload_reserves_exact_capacity() {
+        let funcs = [
+            AggFunc::Count,
+            AggFunc::Count0,
+            AggFunc::Sum,
+            AggFunc::Total,
+            AggFunc::Avg,
+            AggFunc::Min,
+            AggFunc::Max,
+            AggFunc::GroupConcat,
+            AggFunc::StringAgg,
+            AggFunc::ArrayAgg,
+            AggFunc::Mode,
+            AggFunc::PercentileCont,
+            AggFunc::PercentileDisc,
+            #[cfg(feature = "json")]
+            AggFunc::JsonGroupObject,
+            #[cfg(feature = "json")]
+            AggFunc::JsonbGroupObject,
+            #[cfg(feature = "json")]
+            AggFunc::JsonGroupArray,
+            #[cfg(feature = "json")]
+            AggFunc::JsonbGroupArray,
+        ];
+        for func in funcs {
+            let mut payload = crate::alloc::vec![];
+            init_agg_payload(&func, &mut payload).unwrap();
+            assert_eq!(payload.capacity(), payload.len(), "{func:?}");
         }
     }
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -970,7 +970,9 @@ pub fn op_if_pos(
     match state.registers[reg].get_value() {
         Value::Numeric(Numeric::Integer(n)) if *n > 0 => {
             state.pc = target_pc.as_offset_int();
-            state.registers[reg].set_int(*n - *decrement_by as i64);
+            if *decrement_by != 0 {
+                state.registers[reg].set_int(*n - *decrement_by as i64);
+            }
         }
         Value::Numeric(Numeric::Integer(_)) => {
             state.pc += 1;

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -200,16 +200,24 @@ macro_rules! return_if_io {
     };
 }
 
-macro_rules! check_arg_count {
-    ($actual:expr, $expected:expr) => {
-        if unlikely($actual != $expected) {
-            return Err(LimboError::InternalError(format!(
-                "expected {} argument(s), got {}",
-                $expected, $actual
-            ))
-            .into());
-        }
-    };
+use arg_count::check_arg_count;
+mod arg_count {
+    use crate::LimboError;
+
+    macro_rules! check_arg_count {
+        ($actual:expr, $expected:expr) => {
+            if unlikely($actual != $expected) {
+                return Err(arg_count::wrong_arg_count($expected, $actual));
+            }
+        };
+    }
+    pub(super) use check_arg_count;
+
+    #[cold]
+    #[inline(never)]
+    pub(super) fn wrong_arg_count(expected: usize, actual: usize) -> Box<LimboError> {
+        LimboError::InternalError(format!("expected {expected} argument(s), got {actual}")).into()
+    }
 }
 
 /// Errors are boxed so an op's whole return value stays small: a LimboError

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1038,7 +1038,7 @@ macro_rules! comparison_opcode {
                 insn
             );
             let crate::vdbe::BranchOffset::Offset(target_pc) = *target_pc else {
-                crate::bail_corrupt_error!("Unresolved label: {target_pc:?}");
+                return Err(unresolved_branch_target(*target_pc));
             };
 
             // Two integers compare directly: no NULL handling, affinity or collation.

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -941,10 +941,8 @@ pub fn op_move(
     let dest_reg = *dest_reg;
     let count = *count;
     for i in 0..count {
-        state.registers[dest_reg + i] = std::mem::replace(
-            &mut state.registers[source_reg + i],
-            Register::Value(Value::Null),
-        );
+        state.registers.swap(source_reg + i, dest_reg + i);
+        state.registers[source_reg + i].set_null();
     }
     state.pc += 1;
     Ok(InsnFunctionStepResult::Step)

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -386,6 +386,57 @@ pub struct HashDistinctData {
 #[strum_discriminants(derive(VariantArray, EnumCount, FromRepr))]
 #[strum_discriminants(name(InsnVariants))]
 pub enum Insn {
+    /// Advance the cursor to the next row.
+    Next {
+        cursor_id: CursorID,
+        pc_if_next: BranchOffset,
+        /// True when this step is part of a full table scan (a loop over the
+        /// whole table with no index or rowid constraint). Only these steps
+        /// count toward SQLITE_STMTSTATUS_FULLSCAN_STEP, matching SQLite,
+        /// which tags the opcode with P5 at codegen time.
+        fullscan: bool,
+        is_index: bool,
+    },
+
+    /// Emit a row of results.
+    ResultRow {
+        start_reg: usize, // P1
+        count: usize,     // P2
+    },
+
+    /// Read a column from the current row of the cursor.
+    Column {
+        cursor_id: CursorID,
+        column: usize,
+        dest: usize,
+        default: Option<Value>,
+    },
+
+    /// Read `defaults.len()` consecutive columns starting at `start_column` from the current row
+    /// of the cursor into consecutive registers starting at `dest`.
+    ColumnRange {
+        cursor_id: CursorID,
+        start_column: usize,
+        dest: usize,
+        // this can't be a SmallVec because it would make the enum too large.
+        defaults: Vec<Option<Value>>,
+    },
+
+    /// Read the rowid of the current row.
+    RowId {
+        cursor_id: CursorID,
+        dest: usize,
+    },
+
+    Prev {
+        cursor_id: CursorID,
+        pc_if_prev: BranchOffset,
+        /// See [Insn::Next::fullscan].
+        fullscan: bool,
+        /// See [Insn::Next::is_index].
+        is_index: bool,
+    },
+
     /// Initialize the program state and jump to the given PC.
     Init {
         target_pc: BranchOffset,
@@ -684,24 +735,6 @@ pub enum Insn {
         pc_if_empty: BranchOffset,
     },
 
-    /// Read a column from the current row of the cursor.
-    Column {
-        cursor_id: CursorID,
-        column: usize,
-        dest: usize,
-        default: Option<Value>,
-    },
-
-    /// Read `defaults.len()` consecutive columns starting at `start_column` from the current row
-    /// of the cursor into consecutive registers starting at `dest`.
-    ColumnRange {
-        cursor_id: CursorID,
-        start_column: usize,
-        dest: usize,
-        // this can't be a SmallVec because it would make the enum too large.
-        defaults: Vec<Option<Value>>,
-    },
-
     /// Jump to `target_pc` if the cursor's current record contains a field at
     /// the given column index.  Falls through when the record has fewer fields
     /// (a "short record" from before ALTER TABLE ADD COLUMN).
@@ -917,33 +950,6 @@ pub enum Insn {
         affinity_str: Option<String>,
     },
 
-    /// Emit a row of results.
-    ResultRow {
-        start_reg: usize, // P1
-        count: usize,     // P2
-    },
-
-    /// Advance the cursor to the next row.
-    Next {
-        cursor_id: CursorID,
-        pc_if_next: BranchOffset,
-        /// True when this step is part of a full table scan (a loop over the
-        /// whole table with no index or rowid constraint). Only these steps
-        /// count toward SQLITE_STMTSTATUS_FULLSCAN_STEP, matching SQLite,
-        /// which tags the opcode with P5 at codegen time.
-        fullscan: bool,
-        is_index: bool,
-    },
-
-    Prev {
-        cursor_id: CursorID,
-        pc_if_prev: BranchOffset,
-        /// See [Insn::Next::fullscan].
-        fullscan: bool,
-        /// See [Insn::Next::is_index].
-        is_index: bool,
-    },
-
     /// Halt the program.
     Halt {
         err_code: usize,
@@ -1065,11 +1071,6 @@ pub enum Insn {
         dest: usize,
     },
 
-    /// Read the rowid of the current row.
-    RowId {
-        cursor_id: CursorID,
-        dest: usize,
-    },
     /// Read the rowid of the current row from an index cursor.
     IdxRowId {
         cursor_id: CursorID,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -90,6 +90,7 @@ use execute::{
 use turso_parser::ast::{EqpFormat, ResolveType};
 
 use crate::io::TempFile;
+use crate::storage::sqlite3_ondisk::read_varint;
 use crate::vdbe::bloom_filter::BloomFilter;
 use crate::vdbe::rowset::RowSet;
 use explain::{
@@ -3791,232 +3792,240 @@ pub trait ValueIteratorExt {
 impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
     #[inline(always)]
     fn nth_into_register(&mut self, n: usize, dest: &mut Register) -> Option<Result<()>> {
-        use crate::storage::sqlite3_ondisk::read_varint;
-        use crate::types::{get_serial_type_size, Extendable, Text};
-
         let mut header = self.header_section_ref();
         let mut data = self.data_section_ref();
 
-        // Skip n elements
-        let mut data_sum = 0;
-        for _ in 0..n {
-            if header.is_empty() {
-                return None;
-            }
-
-            let (serial_type, bytes_read) = match read_varint(header) {
-                Ok(v) => v,
-                Err(e) => return Some(Err(e)),
-            };
-            header = &header[bytes_read..];
-
-            data_sum += match get_serial_type_size(serial_type) {
-                Ok(size) => size,
-                Err(e) => return Some(Err(e)),
-            };
+        if let Err(e) = skip_serial_types(&mut header, &mut data, n) {
+            return Some(Err(e));
         }
-
-        if data_sum > data.len() {
-            return Some(Err(LimboError::Corrupt(
-                "Data section too small for indicated serial type size".into(),
-            )));
-        }
-        data = &data[data_sum..];
-
-        // Read the serial type for the target element
         if header.is_empty() {
             return None;
         }
 
-        let (serial_type, bytes_read) = match read_varint(header) {
+        let serial_type = match read_serial_type(&mut header) {
             Ok(v) => v,
             Err(e) => return Some(Err(e)),
         };
-
         // Update iterator state
-        self.set_header_section(&header[bytes_read..]);
-
-        // Decode directly into register based on serial type
-        match serial_type {
-            // NULL
-            0 => {
-                self.set_data_section(data);
-                dest.set_null();
-            }
-            // I8
-            1 => {
-                if unlikely(data.is_empty()) {
-                    return Some(Err(LimboError::Corrupt("Invalid 1-byte int".into())));
-                }
-                self.set_data_section(&data[1..]);
-                dest.set_int(data[0] as i8 as i64);
-            }
-            // I16
-            2 => {
-                if unlikely(data.len() < 2) {
-                    return Some(Err(LimboError::Corrupt("Invalid 2-byte int".into())));
-                }
-                self.set_data_section(&data[2..]);
-                dest.set_int(i16::from_be_bytes([data[0], data[1]]) as i64);
-            }
-            // I24
-            3 => {
-                if unlikely(data.len() < 3) {
-                    return Some(Err(LimboError::Corrupt("Invalid 3-byte int".into())));
-                }
-                self.set_data_section(&data[3..]);
-                let sign_extension = if data[0] <= 0x7F { 0 } else { 0xFF };
-                dest.set_int(
-                    i32::from_be_bytes([sign_extension, data[0], data[1], data[2]]) as i64,
-                );
-            }
-            // I32
-            4 => {
-                if unlikely(data.len() < 4) {
-                    return Some(Err(LimboError::Corrupt("Invalid 4-byte int".into())));
-                }
-                self.set_data_section(&data[4..]);
-                dest.set_int(i32::from_be_bytes([data[0], data[1], data[2], data[3]]) as i64);
-            }
-            // I48
-            5 => {
-                if unlikely(data.len() < 6) {
-                    return Some(Err(LimboError::Corrupt("Invalid 6-byte int".into())));
-                }
-                self.set_data_section(&data[6..]);
-                let sign_extension = if data[0] <= 0x7F { 0 } else { 0xFF };
-                dest.set_int(i64::from_be_bytes([
-                    sign_extension,
-                    sign_extension,
-                    data[0],
-                    data[1],
-                    data[2],
-                    data[3],
-                    data[4],
-                    data[5],
-                ]));
-            }
-            // I64
-            6 => {
-                if unlikely(data.len() < 8) {
-                    return Some(Err(LimboError::Corrupt("Invalid 8-byte int".into())));
-                }
-                self.set_data_section(&data[8..]);
-                dest.set_int(i64::from_be_bytes([
-                    data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
-                ]));
-            }
-            // F64
-            7 => {
-                if unlikely(data.len() < 8) {
-                    return Some(Err(LimboError::Corrupt("Invalid 8-byte float".into())));
-                }
-                self.set_data_section(&data[8..]);
-                let val = f64::from_be_bytes([
-                    data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
-                ]);
-                if let Some(nn) = NonNan::new(val) {
-                    dest.set_float(nn);
-                } else {
-                    dest.set_null();
-                }
-            }
-            // CONST_INT0
-            8 => {
-                self.set_data_section(data);
-                dest.set_int(0);
-            }
-            // CONST_INT1
-            9 => {
-                self.set_data_section(data);
-                dest.set_int(1);
-            }
-            // Reserved
-            10 | 11 => {
-                mark_unlikely();
-                return Some(Err(LimboError::Corrupt(format!(
-                    "Reserved serial type: {serial_type}"
-                ))));
-            }
-            // BLOB (n >= 12 && n & 1 == 0)
-            n if n >= 12 && n & 1 == 0 => crate::with_value_blob_allocation_site!(RecordDecode, {
-                let content_size = ((n - 12) / 2) as usize;
-                if unlikely(data.len() < content_size) {
-                    return Some(Err(LimboError::Corrupt("Invalid Blob value".into())));
-                }
-                self.set_data_section(&data[content_size..]);
-                let blob_data = &data[..content_size];
-                match dest {
-                    Register::Value(Value::Blob(existing_blob)) => {
-                        if let Err(err) = existing_blob.do_extend(&blob_data) {
-                            return Some(Err(err));
-                        }
-                    }
-                    _ => {
-                        let blob = match crate::types::value_blob_from_slice(blob_data) {
-                            Ok(blob) => blob,
-                            Err(err) => return Some(Err(err.into())),
-                        };
-                        if let Err(err) = dest.set_blob(blob) {
-                            return Some(Err(err));
-                        }
-                    }
-                }
-            }),
-            // TEXT (n >= 13 && n & 1 == 1)
-            n if n >= 13 && n & 1 == 1 => {
-                let content_size = ((n - 13) / 2) as usize;
-                if unlikely(data.len() < content_size) {
-                    return Some(Err(LimboError::Corrupt("Invalid Text value".into())));
-                }
-                self.set_data_section(&data[content_size..]);
-                let text_data = &data[..content_size];
-                let Some(text_str) = crate::types::validate_utf8(text_data) else {
-                    mark_unlikely();
-                    return Some(Err(LimboError::Corrupt(
-                        "TEXT value contains invalid UTF-8".into(),
-                    )));
-                };
-                match dest {
-                    Register::Value(Value::Text(existing_text)) => {
-                        if let Err(err) = existing_text.do_extend(&text_str) {
-                            return Some(Err(err));
-                        }
-                    }
-                    _ => {
-                        if let Err(err) = dest.set_text(Text::new(text_str.to_string())) {
-                            return Some(Err(err));
-                        }
-                    }
-                }
-            }
-            _ => {
-                mark_unlikely();
-                return Some(Err(LimboError::Corrupt(format!(
-                    "Invalid serial type: {serial_type}"
-                ))));
-            }
-        }
-
-        Some(Ok(()))
+        self.set_header_section(header);
+        let result = decode_serial_type_into_register(serial_type, &mut data, dest);
+        self.set_data_section(data);
+        Some(result)
     }
 
+    /// The header and data positions live in locals for the whole range and
+    /// go back into the iterator once at the end: written back per column,
+    /// they cost four stores for every value of every row.
     #[inline]
     fn decode_into_registers_after(
         &mut self,
         skip: usize,
         dests: &mut [Register],
     ) -> Result<usize> {
-        for (i, dest) in dests.iter_mut().enumerate() {
-            let n = if i == 0 { skip } else { 0 };
-            match self.nth_into_register(n, dest) {
-                Some(Ok(())) => {}
-                Some(Err(e)) => return Err(e),
-                None => return Ok(i),
+        let mut header = self.header_section_ref();
+        let mut data = self.data_section_ref();
+        skip_serial_types(&mut header, &mut data, skip)?;
+        let mut decoded = 0;
+        for dest in dests.iter_mut() {
+            if header.is_empty() {
+                break;
             }
+            let serial_type = read_serial_type(&mut header)?;
+            decode_serial_type_into_register(serial_type, &mut data, dest)?;
+            decoded += 1;
         }
-        Ok(dests.len())
+        self.set_header_section(header);
+        self.set_data_section(data);
+        Ok(decoded)
     }
+}
+
+/// Advance `header` and `data` past `n` serial types, stopping early if the header is shorter than
+/// expected.
+///
+/// If the header is short, returns `Ok(())` with an empty `header`.
+#[inline(always)]
+fn skip_serial_types(header: &mut &[u8], data: &mut &[u8], n: usize) -> Result<()> {
+    use crate::types::get_serial_type_size;
+    let mut data_sum = 0;
+    for _ in 0..n {
+        if header.is_empty() {
+            break;
+        }
+        let serial_type = read_serial_type(header)?;
+        data_sum += get_serial_type_size(serial_type)?;
+    }
+    if data_sum > data.len() {
+        return Err(LimboError::Corrupt(
+            "Data section too small for indicated serial type size".into(),
+        ));
+    }
+    *data = &data[data_sum..];
+    Ok(())
+}
+
+/// Reads the serial type at the front of `header` and moves past it.
+#[inline(always)]
+fn read_serial_type(header: &mut &[u8]) -> Result<u64> {
+    let (serial_type, bytes_read) = read_varint(header)?;
+    *header = &header[bytes_read..];
+    Ok(serial_type)
+}
+
+/// Decodes the value of `serial_type` at the front of `data` into `dest`
+/// and moves `data` past it.
+#[inline(always)]
+fn decode_serial_type_into_register(
+    serial_type: u64,
+    data: &mut &[u8],
+    dest: &mut Register,
+) -> Result<()> {
+    use crate::types::{Extendable, Text};
+    match serial_type {
+        // NULL
+        0 => {
+            dest.set_null();
+        }
+        // I8
+        1 => {
+            if unlikely(data.is_empty()) {
+                return Err(LimboError::Corrupt("Invalid 1-byte int".into()));
+            }
+            dest.set_int(data[0] as i8 as i64);
+            *data = &data[1..];
+        }
+        // I16
+        2 => {
+            if unlikely(data.len() < 2) {
+                return Err(LimboError::Corrupt("Invalid 2-byte int".into()));
+            }
+            dest.set_int(i16::from_be_bytes([data[0], data[1]]) as i64);
+            *data = &data[2..];
+        }
+        // I24
+        3 => {
+            if unlikely(data.len() < 3) {
+                return Err(LimboError::Corrupt("Invalid 3-byte int".into()));
+            }
+            let sign_extension = if data[0] <= 0x7F { 0 } else { 0xFF };
+            dest.set_int(i32::from_be_bytes([sign_extension, data[0], data[1], data[2]]) as i64);
+            *data = &data[3..];
+        }
+        // I32
+        4 => {
+            if unlikely(data.len() < 4) {
+                return Err(LimboError::Corrupt("Invalid 4-byte int".into()));
+            }
+            dest.set_int(i32::from_be_bytes([data[0], data[1], data[2], data[3]]) as i64);
+            *data = &data[4..];
+        }
+        // I48
+        5 => {
+            if unlikely(data.len() < 6) {
+                return Err(LimboError::Corrupt("Invalid 6-byte int".into()));
+            }
+            let sign_extension = if data[0] <= 0x7F { 0 } else { 0xFF };
+            dest.set_int(i64::from_be_bytes([
+                sign_extension,
+                sign_extension,
+                data[0],
+                data[1],
+                data[2],
+                data[3],
+                data[4],
+                data[5],
+            ]));
+            *data = &data[6..];
+        }
+        // I64
+        6 => {
+            if unlikely(data.len() < 8) {
+                return Err(LimboError::Corrupt("Invalid 8-byte int".into()));
+            }
+            dest.set_int(i64::from_be_bytes([
+                data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+            ]));
+            *data = &data[8..];
+        }
+        // F64
+        7 => {
+            if unlikely(data.len() < 8) {
+                return Err(LimboError::Corrupt("Invalid 8-byte float".into()));
+            }
+            let val = f64::from_be_bytes([
+                data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+            ]);
+            if let Some(nn) = NonNan::new(val) {
+                dest.set_float(nn);
+            } else {
+                dest.set_null();
+            }
+            *data = &data[8..];
+        }
+        // CONST_INT0
+        8 => {
+            dest.set_int(0);
+        }
+        // CONST_INT1
+        9 => {
+            dest.set_int(1);
+        }
+        // Reserved
+        10 | 11 => {
+            mark_unlikely();
+            return Err(LimboError::Corrupt(format!(
+                "Reserved serial type: {serial_type}"
+            )));
+        }
+        // BLOB (n >= 12 && n & 1 == 0)
+        n if n >= 12 && n & 1 == 0 => crate::with_value_blob_allocation_site!(RecordDecode, {
+            let content_size = ((n - 12) / 2) as usize;
+            if unlikely(data.len() < content_size) {
+                return Err(LimboError::Corrupt("Invalid Blob value".into()));
+            }
+            let blob_data = &data[..content_size];
+            match dest {
+                Register::Value(Value::Blob(existing_blob)) => {
+                    existing_blob.do_extend(&blob_data)?;
+                }
+                _ => {
+                    let blob = crate::types::value_blob_from_slice(blob_data)?;
+                    dest.set_blob(blob)?;
+                }
+            }
+            *data = &data[content_size..];
+        }),
+        // TEXT (n >= 13 && n & 1 == 1)
+        n if n >= 13 && n & 1 == 1 => {
+            let content_size = ((n - 13) / 2) as usize;
+            if unlikely(data.len() < content_size) {
+                return Err(LimboError::Corrupt("Invalid Text value".into()));
+            }
+            let text_data = &data[..content_size];
+            let Some(text_str) = crate::types::validate_utf8(text_data) else {
+                mark_unlikely();
+                return Err(LimboError::Corrupt(
+                    "TEXT value contains invalid UTF-8".into(),
+                ));
+            };
+            match dest {
+                Register::Value(Value::Text(existing_text)) => {
+                    existing_text.do_extend(&text_str)?;
+                }
+                _ => {
+                    dest.set_text(Text::new(text_str.to_string()))?;
+                }
+            }
+            *data = &data[content_size..];
+        }
+        _ => {
+            mark_unlikely();
+            return Err(LimboError::Corrupt(format!(
+                "Invalid serial type: {serial_type}"
+            )));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -205,6 +205,36 @@ pub enum StepResult {
     },
 }
 
+/// This is an optimization over `Result<StepResult, Box<LimboError>>`.
+///
+/// See [crate::storage::btree::CursorStep] for the rationale behind this.
+#[repr(u8)]
+#[derive(Debug)]
+#[must_use]
+pub(crate) enum ProgramStep {
+    Done,
+    IO,
+    Row,
+    Interrupt,
+    Busy,
+    Yield,
+    Error(Box<LimboError>),
+}
+
+impl From<ProgramStep> for Result<StepResult, Box<LimboError>> {
+    fn from(step: ProgramStep) -> Self {
+        match step {
+            ProgramStep::Done => Ok(StepResult::Done),
+            ProgramStep::IO => Ok(StepResult::IO),
+            ProgramStep::Row => Ok(StepResult::Row),
+            ProgramStep::Interrupt => Ok(StepResult::Interrupt),
+            ProgramStep::Busy => Ok(StepResult::Busy),
+            ProgramStep::Yield => Ok(StepResult::Yield),
+            ProgramStep::Error(err) => Err(err),
+        }
+    }
+}
+
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 /// The commit state of the program.
@@ -1910,16 +1940,11 @@ impl Program {
         query_mode: QueryMode,
         waker: Option<&Waker>,
     ) -> Result<StepResult, Box<LimboError>> {
-        state.execution_state = ProgramExecutionState::Running;
-        let result = if let QueryMode::Normal = query_mode {
-            self.normal_step(state, pager, waker)
-        } else {
-            self.explain_step_for_mode(state, pager, query_mode)
-        };
-        // Rows are the common result and leave the execution state untouched.
-        if let Ok(StepResult::Row) = &result {
-            return result;
+        if let QueryMode::Normal = query_mode {
+            return self.normal_step(state, pager, waker).into();
         }
+        state.execution_state = ProgramExecutionState::Running;
+        let result = self.explain_step_for_mode(state, pager, query_mode);
         match &result {
             Ok(StepResult::Done) => {
                 state.execution_state = ProgramExecutionState::Done;
@@ -2180,23 +2205,50 @@ impl Program {
         state.pre_op_registers = Some(state.registers.clone());
     }
 
+    /// Step in [QueryMode::Normal]
     #[inline(always)]
-    fn normal_step(
+    pub(crate) fn normal_step(
         &self,
         state: &mut ProgramState,
         pager: &Arc<Pager>,
         waker: Option<&Waker>,
-    ) -> Result<StepResult, Box<LimboError>> {
+    ) -> ProgramStep {
+        state.execution_state = ProgramExecutionState::Running;
         let enable_tracing = tracing::enabled!(tracing::Level::TRACE);
         let vdbe_trace = self.connection.get_vdbe_trace();
-
-        return if enable_tracing || vdbe_trace {
-            dispatch_loop::<true>(self, state, pager, waker, enable_tracing, vdbe_trace)
+        let result = if enable_tracing || vdbe_trace {
+            dispatch_loop_traced(self, state, pager, waker, enable_tracing, vdbe_trace)
         } else {
             dispatch_loop::<false>(self, state, pager, waker, false, false)
         };
+        match &result {
+            ProgramStep::Row => {}
+            ProgramStep::Done => {
+                state.execution_state = ProgramExecutionState::Done;
+            }
+            ProgramStep::Interrupt => {
+                state.execution_state = ProgramExecutionState::Interrupted;
+            }
+            ProgramStep::Error(_) => {
+                state.execution_state = ProgramExecutionState::Failed;
+            }
+            _ => {}
+        }
+        return result;
 
         #[inline(never)]
+        fn dispatch_loop_traced(
+            program: &Program,
+            state: &mut ProgramState,
+            pager: &Arc<Pager>,
+            waker: Option<&Waker>,
+            enable_tracing: bool,
+            vdbe_trace: bool,
+        ) -> ProgramStep {
+            dispatch_loop::<true>(program, state, pager, waker, enable_tracing, vdbe_trace)
+        }
+
+        #[inline(always)]
         fn dispatch_loop<const TRACE: bool>(
             program: &Program,
             state: &mut ProgramState,
@@ -2204,8 +2256,8 @@ impl Program {
             waker: Option<&Waker>,
             enable_tracing: bool,
             vdbe_trace: bool,
-        ) -> Result<StepResult, Box<LimboError>> {
-            // Reborrow the instruction list once: reloading it through `self`
+        ) -> ProgramStep {
+            // Reborrow the instruction list once: reloading it through `program`
             // every iteration defeats LLVM's hoisting because the opcode call
             // below is opaque to it.
             let insns = program.insns.as_slice();
@@ -2218,20 +2270,20 @@ impl Program {
             // instructions without re-inspecting the completion slot every time.
             'io_check: loop {
                 if state.io_completions.is_some() {
-                    if let Some(result) = program.finish_pending_io(state, pager, waker)? {
-                        return Ok(result);
+                    if let Some(result) = program.finish_pending_io(state, pager, waker) {
+                        return result;
                     }
                 }
                 if state.pending_fail_prepare_error.is_some() {
-                    match program.prepare_pending_fail(state, pager, waker)? {
-                        Some(result) => return Ok(result),
+                    match program.prepare_pending_fail(state, pager, waker) {
+                        Some(result) => return result,
                         None => continue 'io_check,
                     }
                 }
                 loop {
                     if state.metrics.vm_steps & state.check_mask == 0 {
-                        if let Some(result) = program.periodic_checks(state, pager)? {
-                            return Ok(result);
+                        if let Some(result) = program.periodic_checks(state, pager) {
+                            return result;
                         }
                     }
 
@@ -2240,7 +2292,9 @@ impl Program {
                         program.trace_step(state, insn, enable_tracing, vdbe_trace);
                     }
 
+                    // Always increment VM steps for every loop iteration
                     state.metrics.vm_steps = state.metrics.vm_steps.wrapping_add(1);
+
                     // The opcodes that run once per row of a scan are matched here
                     // so LLVM inlines them into the loop, and each one tests its
                     // own result right after its body, where the result is a
@@ -2258,7 +2312,7 @@ impl Program {
                                 Ok(InsnFunctionStepResult::Row) => {
                                     state.metrics.insn_executed =
                                         state.metrics.insn_executed.wrapping_add(1);
-                                    return Ok(StepResult::Row);
+                                    return ProgramStep::Row;
                                 }
                                 other => other,
                             }
@@ -2283,33 +2337,33 @@ impl Program {
                     if let Ok(InsnFunctionStepResult::Row) = result {
                         // Instruction completed (ResultRow already incremented PC)
                         state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
-                        return Ok(StepResult::Row);
+                        return ProgramStep::Row;
                     }
-                    match dispatch(program, state, pager, waker, result)? {
-                        Some(result) => return Ok(result),
+                    match dispatch_cold(program, state, pager, waker, result) {
+                        Some(result) => return result,
                         None => continue 'io_check,
                     }
                 }
             }
 
             #[inline(never)]
-            fn dispatch(
+            fn dispatch_cold(
                 program: &Program,
                 state: &mut ProgramState,
                 pager: &Arc<Pager>,
                 waker: Option<&Waker>,
                 result: execute::InsnResult,
-            ) -> Result<Option<StepResult>, Box<LimboError>> {
+            ) -> Option<ProgramStep> {
                 match result {
                     Ok(InsnFunctionStepResult::Done) => {
                         // Instruction completed execution
                         state.metrics.insn_executed = state.metrics.insn_executed.wrapping_add(1);
                         state.auto_txn_cleanup = TxnCleanup::None;
-                        Ok(Some(StepResult::Done))
+                        Some(ProgramStep::Done)
                     }
                     Ok(InsnFunctionStepResult::IO) => {
                         let io = state.take_suspended_io();
-                        Ok(program.park_on_io(state, io, waker))
+                        program.park_on_io(state, io, waker)
                     }
                     Err(boxed_err) => program.fail_step(state, pager, *boxed_err),
                     Ok(InsnFunctionStepResult::Step) | Ok(InsnFunctionStepResult::Row) => {
@@ -2329,14 +2383,14 @@ impl Program {
         state: &mut ProgramState,
         pager: &Arc<Pager>,
         waker: Option<&Waker>,
-    ) -> Result<Option<StepResult>, Box<LimboError>> {
+    ) -> Option<ProgramStep> {
         let io = state
             .io_completions
             .as_ref()
             .expect("the caller checked the completion slot");
         if !io.finished() {
             io.set_waker(waker);
-            return Ok(Some(StepResult::IO));
+            return Some(ProgramStep::IO);
         }
         if let Some(err) = io.get_error() {
             if pager.is_checkpointing() {
@@ -2353,16 +2407,16 @@ impl Program {
                     );
                 }
                 pager.cleanup_after_checkpoint_failure();
-                return Err(checkpoint_err.into());
+                return Some(ProgramStep::Error(checkpoint_err.into()));
             }
             let err = err.into();
             if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
                 tracing::error!("Abort failed during error handling: {abort_err}");
             }
-            return Err(err.into());
+            return Some(ProgramStep::Error(err.into()));
         }
         state.io_completions = None;
-        Ok(None)
+        None
     }
 
     /// A trigger returned FAIL before the parent program reached Halt. FAIL
@@ -2377,7 +2431,7 @@ impl Program {
         state: &mut ProgramState,
         pager: &Arc<Pager>,
         waker: Option<&Waker>,
-    ) -> Result<Option<StepResult>, Box<LimboError>> {
+    ) -> Option<ProgramStep> {
         let fail_error = state
             .pending_fail_prepare_error
             .take()
@@ -2387,20 +2441,20 @@ impl Program {
                 if let Err(abort_err) = self.abort(pager, Some(&fail_error), state, true) {
                     tracing::error!("Abort failed after preparing FAIL index methods: {abort_err}");
                 }
-                Err(fail_error.into())
+                Some(ProgramStep::Error(fail_error.into()))
             }
             Ok(IOResult::IO(io)) => {
                 state.pending_fail_prepare_error = Some(fail_error);
                 io.set_waker(waker);
                 if io.is_explicit_yield() {
-                    return Ok(Some(StepResult::Yield));
+                    return Some(ProgramStep::Yield);
                 }
                 let finished = io.finished();
                 state.io_completions = Some(io);
                 if !finished {
-                    return Ok(Some(StepResult::IO));
+                    return Some(ProgramStep::IO);
                 }
-                Ok(None)
+                None
             }
             Err(prepare_error) => {
                 // FAIL may keep earlier base-table rows only when every
@@ -2417,17 +2471,13 @@ impl Program {
                          {abort_err}"
                     );
                 }
-                Err(prepare_error)
+                Some(ProgramStep::Error(prepare_error))
             }
         }
     }
 
     #[inline(never)]
-    fn periodic_checks(
-        &self,
-        state: &mut ProgramState,
-        pager: &Arc<Pager>,
-    ) -> Result<Option<StepResult>, Box<LimboError>> {
+    fn periodic_checks(&self, state: &mut ProgramState, pager: &Arc<Pager>) -> Option<ProgramStep> {
         let progress_ops = self.connection.progress_ops();
         state.check_mask = if progress_ops == 0 || progress_ops >= MAX_CHECK_MASK {
             MAX_CHECK_MASK
@@ -2435,7 +2485,7 @@ impl Program {
             progress_ops.next_power_of_two() - 1
         };
         if self.connection.is_closed() {
-            return Err(self.closed_during_step(pager));
+            return Some(ProgramStep::Error(self.closed_during_step(pager)));
         }
         // With no interrupt requested, no deadline and no progress handler
         // there is nothing to look at; the full test stays out of this
@@ -2445,7 +2495,7 @@ impl Program {
             && state.query_deadline.is_none()
             && progress_ops == 0;
         if quiet {
-            return Ok(None);
+            return None;
         }
         self.periodic_interrupt_checks(state, pager)
     }
@@ -2455,12 +2505,12 @@ impl Program {
         &self,
         state: &mut ProgramState,
         pager: &Arc<Pager>,
-    ) -> Result<Option<StepResult>, Box<LimboError>> {
+    ) -> Option<ProgramStep> {
         let prev_steps = state.metrics.vm_steps.saturating_sub(state.check_mask + 1);
         if self.maybe_request_interrupt(state, pager.io.as_ref(), prev_steps) {
             return self.interrupted_during_step(state, pager);
         }
-        Ok(None)
+        None
     }
 
     #[cold]
@@ -2479,9 +2529,11 @@ impl Program {
         &self,
         state: &mut ProgramState,
         pager: &Arc<Pager>,
-    ) -> Result<Option<StepResult>, Box<LimboError>> {
-        self.abort(pager, None, state, true)?;
-        Ok(Some(StepResult::Interrupt))
+    ) -> Option<ProgramStep> {
+        Some(match self.abort(pager, None, state, true) {
+            Ok(()) => ProgramStep::Interrupt,
+            Err(err) => ProgramStep::Error(err.into()),
+        })
     }
 
     #[inline(never)]
@@ -2509,7 +2561,7 @@ impl Program {
         state: &mut ProgramState,
         io: IOCompletions,
         waker: Option<&Waker>,
-    ) -> Option<StepResult> {
+    ) -> Option<ProgramStep> {
         io.set_waker(waker);
         if io.is_explicit_yield() {
             // Yield: return control to the cooperative scheduler so
@@ -2517,12 +2569,12 @@ impl Program {
             // contended lock). Don't store in io_completions —
             // yields aren't pending I/O, so the instruction will
             // simply re-execute on the next step.
-            return Some(StepResult::Yield);
+            return Some(ProgramStep::Yield);
         }
         let finished = io.finished();
         state.io_completions = Some(io);
         if !finished {
-            return Some(StepResult::IO);
+            return Some(ProgramStep::IO);
         }
         None
     }
@@ -2537,9 +2589,9 @@ impl Program {
         state: &mut ProgramState,
         pager: &Arc<Pager>,
         err: LimboError,
-    ) -> Result<Option<StepResult>, Box<LimboError>> {
+    ) -> Option<ProgramStep> {
         match err {
-            LimboError::Busy => Ok(Some(StepResult::Busy)),
+            LimboError::Busy => Some(ProgramStep::Busy),
             LimboError::BusySnapshot
                 if self.connection.transaction_state.get() == TransactionState::None =>
             {
@@ -2547,20 +2599,20 @@ impl Program {
                 // because the snapshot will continue to be stale no matter how many times we retry.
                 // However, for auto-commits or BEGIN IMMEDIATE, failing to promote to write transaction means it was rolled
                 // back, so auto-retrying can be useful.
-                Ok(Some(StepResult::Busy))
+                Some(ProgramStep::Busy)
             }
             err if (matches!(err, LimboError::Constraint(_))
                 && self.resolve_type == ResolveType::Fail)
                 || matches!(err, LimboError::Raise(ResolveType::Fail, _)) =>
             {
                 state.pending_fail_prepare_error = Some(err);
-                Ok(None)
+                None
             }
             err => {
                 if let Err(abort_err) = self.abort(pager, Some(&err), state, true) {
                     tracing::error!("Abort failed during error handling: {abort_err}");
                 }
-                Err(err.into())
+                Some(ProgramStep::Error(err.into()))
             }
         }
     }
@@ -3971,6 +4023,43 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
 mod tests {
     use super::*;
     use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    #[test]
+    fn program_step_conversion_preserves_error_allocation() {
+        let err = Box::new(LimboError::InternalError("test error".into()));
+        let original = std::ptr::from_ref(err.as_ref());
+        let result: Result<StepResult, Box<LimboError>> = ProgramStep::Error(err).into();
+        let returned = result.unwrap_err();
+        assert_eq!(std::ptr::from_ref(returned.as_ref()), original);
+        assert!(matches!(*returned, LimboError::InternalError(ref msg) if msg == "test error"));
+    }
+
+    #[test]
+    fn normal_step_preserves_execution_state_with_and_without_tracing() {
+        for trace in [false, true] {
+            let io = Arc::new(crate::MemoryIO::new());
+            let db =
+                crate::Database::open_file(io, ":memory:", Arc::new(crate::SqliteDialect)).unwrap();
+            let conn = db.connect().unwrap();
+            conn.set_vdbe_trace(trace);
+            let mut stmt = conn.prepare("SELECT 1 UNION ALL SELECT 2").unwrap();
+            assert_eq!(stmt.execution_state(), ProgramExecutionState::Init);
+            assert!(matches!(stmt.step().unwrap(), StepResult::Row));
+            assert_eq!(stmt.execution_state(), ProgramExecutionState::Running);
+            assert!(matches!(stmt.step().unwrap(), StepResult::Row));
+            assert!(matches!(stmt.step().unwrap(), StepResult::Done));
+            assert_eq!(stmt.execution_state(), ProgramExecutionState::Done);
+
+            let mut stmt = conn.prepare("SELECT abs(-9223372036854775808)").unwrap();
+            assert!(matches!(stmt.step(), Err(LimboError::IntegerOverflow)));
+            assert_eq!(stmt.execution_state(), ProgramExecutionState::Failed);
+
+            conn.set_progress_handler(1, Some(Box::new(|| true)));
+            let mut stmt = conn.prepare("WITH RECURSIVE t(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM t WHERE x<1000) SELECT sum(x) FROM t").unwrap();
+            assert!(matches!(stmt.step().unwrap(), StepResult::Interrupt));
+            assert_eq!(stmt.execution_state(), ProgramExecutionState::Interrupted);
+        }
+    }
 
     #[test]
     fn active_opcode_helpers_initialize_defaults() {


### PR DESCRIPTION
## Description

Part 11 of 15 split out of #8692 (commits 101-110 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### Second session (commits 89 to 149, `98c2b91f` → `cc0dfdf6`)

A second autonomous session continued from `98c2b91f` with the same method: callgrind instruction counts (`Ir`) of the local driver, one measured change per commit, changes that measured worse reverted and listed below. The 100k-row scans run 3 iterations (5 for `SELECT 1 FROM t`); the per-statement numbers are instructions per execution, (Ir at 3000 − Ir at 1000) / 2000. Two more scan workloads join the set: `SELECT name FROM t` (W13, one TEXT column per row) and `SELECT * FROM t ORDER BY name DESC LIMIT 10` (W9, the sorter), plus `SELECT length(name) FROM t` and `SELECT abs(value) FROM t` for the scalar function opcode. The CodSpeed runs of `3c369a50`, `9b2dcf03`, `46436272` and the later heads are in the CodSpeed section of #8692.

| Commit | `SELECT 1 FROM t` | `SELECT * FROM t` | W3 | W4 | W12 (GROUP BY value) | W13 (`SELECT name`) | W9 (ORDER BY) |
|---|---:|---:|---:|---:|---:|---:|---:|
| move registers with a swap and an in-place clear | = | = | = | = | 736,756,486 (-0.4%) | = | = |
| keep the top page and its cell index of the page stack in their own fields | 128,353,964 (-2.7%) | 265,658,945 (-2.0%) | 160,862,862 (-1.9%) | 181,613,123 (-1.6%) | 732,225,541 (-0.6%) | 187,200,127 (-1.6%) | 699,756,520 (-0.9%) |
| drop the loaded test from top_ref | 128,804,251 (-1.2%) | 264,720,092 (-1.0%) | 160,223,199 (-1.1%) | 181,269,974 (-1.0%) | 736,326,148 (-0.4%) | 186,864,793 (-1.0%) | 697,910,963 (-0.5%) |
| give the inlined opcodes the first discriminants | 128,301,788 (-0.4%) | 263,816,909 (-0.3%) | 159,321,527 (-0.6%) | 180,068,687 (-0.7%) | 723,124,787 (-1.8%) | 186,263,564 (-0.3%) | 695,210,626 (-0.4%) |
| skip the store of IfPos when it decrements by nothing | = | = | = | = | 721,624,790 (-0.2%) | = | = |
| inline the untraced dispatch loop into the statement step (with the register answer above: one commit) | 116,301,823 (-9.4%) | 257,216,903 (-2.5%) | 158,421,425 (-0.6%) | 179,468,615 (-0.3%) | = | 179,063,558 (-3.9%) | 694,610,326 (-0.1%) |
| keep the wrong-argument-count error out of the function opcode (`abs(value)` 210,926,702 → 210,326,684, -0.3%; `length(name)` -0.1%) | = | = | = | = | 719,524,754 (-0.3%) | = | 697,659,757 (+0.4%, the sort's comparator inlining) |
| keep the record decoder positions in locals across a column range | = | 249,416,987 (-3.0%) | 158,121,464 (-0.2%) | 179,168,633 (-0.2%) | 718,924,811 (-0.1%) | = | = |
| reserve the aggregate payload once | = | = | = | = | 715,223,615 (-0.5%) | = | = |
| keep the unresolved-branch error out of the comparison opcodes | = | = | 157,821,464 (-0.2%) | 178,868,600 (-0.2%) | = | = | = |

| Commit | point lookup | `SELECT 1` | index lookup |
|---|---:|---:|---:|
| keep the top page and its cell index of the page stack in their own fields (a descent pays for the two fields it maintains) | 7,232 (+0.9%) | = | 12,852 |
| drop the loaded test from top_ref | 7,210 (-0.3%) | = | 12,821 (-0.2%) |
| give the inlined opcodes the first discriminants | 7,184 (-0.4%) | 1,667 (-1.0%) | 12,788 (-0.3%) |
| inline the untraced dispatch loop into the statement step | 7,161 (-0.3%) | 1,642 (-1.5%) | 12,797 (+0.1%) |
| keep the wrong-argument-count error out of the function opcode | 7,155 | 1,639 (-0.2%) | 12,790 |
| keep the record decoder positions in locals across a column range | 7,157 | 1,650 (+0.7%) | 12,813 (+0.2%) |

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_