### PR TITLE
core: inline the hot opcodes and the plain b-tree cursor reads (12/15)

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6549,6 +6549,7 @@ impl CursorTrait for BTreeCursor {
         }
     }
 
+    #[inline]
     fn next_row(&mut self) -> CursorStep {
         if self.null_flag {
             self.null_flag = false;
@@ -6611,6 +6612,7 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
+    #[inline]
     fn rowid(&mut self) -> IOResultOr<Option<i64>> {
         if self.needs_restore() {
             return_if_io!(self.restore_context());
@@ -6710,6 +6712,7 @@ impl CursorTrait for BTreeCursor {
         Ok(IOResult::Done(self.reusable_immutable_record.as_ref()))
     }
 
+    #[inline]
     fn record_payload(&mut self) -> IOResultOr<Option<&[u8]>> {
         if self.needs_restore() {
             return restore_record_payload(self);

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6549,7 +6549,7 @@ impl CursorTrait for BTreeCursor {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     fn next_row(&mut self) -> CursorStep {
         if self.null_flag {
             self.null_flag = false;
@@ -6612,15 +6612,15 @@ impl CursorTrait for BTreeCursor {
     }
 
     #[cfg_attr(debug_assertions, instrument(skip(self), level = Level::DEBUG))]
-    #[inline]
+    #[inline(always)]
     fn rowid(&mut self) -> IOResultOr<Option<i64>> {
         if self.needs_restore() {
-            return_if_io!(self.restore_context());
+            return rowid_general(self);
         }
         if self.get_null_flag() {
             return Ok(IOResult::Done(None));
         }
-        if self.has_record() {
+        return if self.has_record() {
             let page = self.stack.top_ref();
             let contents = page.get_contents();
             if contents.is_table() {
@@ -6632,11 +6632,22 @@ impl CursorTrait for BTreeCursor {
                 };
                 Ok(IOResult::Done(Some(cell.rowid)))
             } else {
-                let _ = return_if_io!(self.record());
-                Ok(IOResult::Done(self.get_index_rowid_from_record()))
+                index_rowid(self)
             }
         } else {
             Ok(IOResult::Done(None))
+        };
+
+        #[inline(never)]
+        fn rowid_general(cursor: &mut BTreeCursor) -> IOResultOr<Option<i64>> {
+            return_if_io!(cursor.restore_context());
+            cursor.rowid()
+        }
+
+        #[inline(never)]
+        fn index_rowid(cursor: &mut BTreeCursor) -> IOResultOr<Option<i64>> {
+            let _ = return_if_io!(cursor.record());
+            Ok(IOResult::Done(cursor.get_index_rowid_from_record()))
         }
     }
 
@@ -6712,7 +6723,7 @@ impl CursorTrait for BTreeCursor {
         Ok(IOResult::Done(self.reusable_immutable_record.as_ref()))
     }
 
-    #[inline]
+    #[inline(always)]
     fn record_payload(&mut self) -> IOResultOr<Option<&[u8]>> {
         if self.needs_restore() {
             return restore_record_payload(self);

--- a/core/types.rs
+++ b/core/types.rs
@@ -121,7 +121,7 @@ impl Text {
 ///   4 KB:     ~25% slower without the cutoff; equal with it
 ///   multibyte fallback: pays the wasted OR scan (~15% at 64 B)
 ///   length branch: ~+0.1ns/call, visible only on 1-2 B values
-#[inline]
+#[inline(always)]
 pub(crate) fn validate_utf8(data: &[u8]) -> Option<&str> {
     const ASCII_SCAN_CUTOFF: usize = 512;
     if data.len() <= ASCII_SCAN_CUTOFF && is_ascii(data) {

--- a/core/types.rs
+++ b/core/types.rs
@@ -13,7 +13,7 @@ use crate::numeric::nonnan::NonNan;
 use crate::numeric::Numeric;
 use crate::pseudo::PseudoCursor;
 use crate::schema::Index;
-use crate::storage::btree::CursorTrait;
+use crate::storage::btree::{BTreeCursor, CursorTrait};
 use crate::storage::sqlite3_ondisk::{
     read_integer, read_value, read_varint, varint_len, write_varint,
 };
@@ -3305,7 +3305,11 @@ impl Record {
 }
 
 pub enum Cursor {
-    BTree(Box<dyn CursorTrait>),
+    /// A b-tree cursor
+    BTree(Box<BTreeCursor>),
+    /// A cursor behind a trait object: currently, either the MVCC cursor or test doubles.
+    /// TODO it wouldn't be too hard to get rid of `dyn CursorTrait` everywhere.
+    Dyn(Box<dyn CursorTrait>),
     IndexMethod(Box<dyn IndexMethodCursor>),
     Pseudo(Box<PseudoCursor>),
     Sorter(Box<Sorter>),
@@ -3320,6 +3324,7 @@ impl Debug for Cursor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::BTree(..) => f.debug_tuple("BTree").finish(),
+            Self::Dyn(..) => f.debug_tuple("BTreeDyn").finish(),
             Self::IndexMethod(..) => f.debug_tuple("IndexMethod").finish(),
             Self::Pseudo(..) => f.debug_tuple("Pseudo").finish(),
             Self::Sorter(..) => f.debug_tuple("Sorter").finish(),
@@ -3331,10 +3336,15 @@ impl Debug for Cursor {
 }
 
 impl Cursor {
-    pub fn new_btree(cursor: Box<dyn CursorTrait>) -> Self {
+    pub fn new_btree(cursor: Box<BTreeCursor>) -> Self {
         // Matches sqlite3BtreeCursor adding to BtShared.pCursor (btree.c:4699).
         cursor.register_with_pager();
         Self::BTree(cursor)
+    }
+
+    pub fn new_btree_dyn(cursor: Box<dyn CursorTrait>) -> Self {
+        cursor.register_with_pager();
+        Self::Dyn(cursor)
     }
 
     pub fn new_pseudo(cursor: PseudoCursor) -> Self {
@@ -3354,6 +3364,7 @@ impl Cursor {
     pub fn as_btree_mut(&mut self) -> &mut dyn CursorTrait {
         match self {
             Self::BTree(cursor) => cursor.as_mut(),
+            Self::Dyn(cursor) => cursor.as_mut(),
             _ => {
                 mark_unlikely();
                 panic!("Cursor is not a btree cursor");
@@ -3417,6 +3428,7 @@ impl Cursor {
     pub fn set_null_flag(&mut self, flag: bool) {
         match self {
             Self::BTree(cursor) => cursor.set_null_flag(flag),
+            Self::Dyn(cursor) => cursor.set_null_flag(flag),
             Self::Virtual(cursor) => cursor.set_null_flag(flag),
             // A pseudo cursor always decodes columns from its content
             // register. SQLite's OP_NullRow likewise leaves pseudo-cursor

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -125,6 +125,27 @@ fn btree_cursor_with_yield_context(
     }
 }
 
+enum OpenedBTree {
+    Plain(Box<BTreeCursor>),
+    Mvcc(Box<dyn CursorTrait>),
+}
+
+impl OpenedBTree {
+    fn into_cursor(self) -> Cursor {
+        match self {
+            Self::Plain(cursor) => Cursor::new_btree(cursor),
+            Self::Mvcc(cursor) => Cursor::new_btree_dyn(cursor),
+        }
+    }
+
+    fn into_dyn(self) -> Box<dyn CursorTrait> {
+        match self {
+            Self::Plain(cursor) => cursor,
+            Self::Mvcc(cursor) => cursor,
+        }
+    }
+}
+
 use super::{
     array::{
         array_values_from_blob, compare_arrays, compute_array_length, compute_array_length_at_dim,
@@ -1318,26 +1339,25 @@ pub fn op_open_read(
         _ => unreachable!("This should not have happened"),
     };
 
-    let maybe_promote_to_mvcc_cursor = |btree_cursor: Box<dyn CursorTrait>,
-                                        mv_cursor_type: MvccCursorType|
-     -> Result<Box<dyn CursorTrait>> {
-        // Without an MvStore there is no MVCC transaction to look up.
-        let Some(mv_store) = mv_store.as_ref() else {
-            return Ok(btree_cursor);
+    let maybe_promote_to_mvcc_cursor =
+        |btree_cursor: Box<BTreeCursor>, mv_cursor_type: MvccCursorType| -> Result<OpenedBTree> {
+            // Without an MvStore there is no MVCC transaction to look up.
+            let Some(mv_store) = mv_store.as_ref() else {
+                return Ok(OpenedBTree::Plain(btree_cursor));
+            };
+            if let Some(tx_id) = program.connection.get_mv_tx_id_for_db(*db) {
+                Ok(OpenedBTree::Mvcc(Box::new(MvCursor::new(
+                    mv_store.clone(),
+                    &program.connection,
+                    tx_id,
+                    *root_page,
+                    mv_cursor_type,
+                    btree_cursor,
+                )?)))
+            } else {
+                Ok(OpenedBTree::Plain(btree_cursor))
+            }
         };
-        if let Some(tx_id) = program.connection.get_mv_tx_id_for_db(*db) {
-            Ok(Box::new(MvCursor::new(
-                mv_store.clone(),
-                &program.connection,
-                tx_id,
-                *root_page,
-                mv_cursor_type,
-                btree_cursor,
-            )?))
-        } else {
-            Ok(btree_cursor)
-        }
-    };
 
     match cursor_type {
         CursorType::MaterializedView(_, view_mutex) => {
@@ -1361,7 +1381,7 @@ pub fn op_open_read(
 
             // Create materialized view cursor with this view's transaction state
             let mv_cursor = crate::incremental::cursor::MaterializedViewCursor::new(
-                cursor,
+                cursor.into_dyn(),
                 view_mutex.clone(),
                 pager,
                 tx_state,
@@ -1380,7 +1400,7 @@ pub fn op_open_read(
                 )
                 .into());
             }
-            let btree_cursor: Box<dyn CursorTrait> = if table.has_rowid {
+            let btree_cursor: Box<BTreeCursor> = if table.has_rowid {
                 BTreeCursor::new_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
@@ -1400,7 +1420,7 @@ pub fn op_open_read(
             cursors
                 .get_mut(*cursor_id)
                 .expect("cursor_id should be valid")
-                .replace(Cursor::new_btree(cursor));
+                .replace(cursor.into_cursor());
         }
         CursorType::BTreeIndex(index) => {
             let btree_cursor = BTreeCursor::new_index(
@@ -1420,7 +1440,7 @@ pub fn op_open_read(
             cursors
                 .get_mut(*cursor_id)
                 .expect("cursor_id should be valid")
-                .replace(Cursor::new_btree(cursor));
+                .replace(cursor.into_cursor());
         }
         CursorType::Pseudo(_) => {
             panic!("OpenRead on pseudo cursor");
@@ -1822,7 +1842,8 @@ pub fn op_rewind(
     let is_empty = {
         let cursor = state.get_cursor(*cursor_id);
         match cursor {
-            Cursor::BTree(btree_cursor) => {
+            Cursor::BTree(_) | Cursor::Dyn(_) => {
+                let btree_cursor = cursor.as_btree_mut();
                 return_if_io!(state, btree_cursor.rewind());
                 btree_cursor.is_empty()
             }
@@ -2036,6 +2057,7 @@ fn op_column_deferred(
                     let index_cursor = state.get_cursor(index_cursor_id);
                     match index_cursor {
                         Cursor::BTree(cursor) => return_if_io!(state, cursor.rowid()),
+                        Cursor::Dyn(cursor) => return_if_io!(state, cursor.rowid()),
                         Cursor::IndexMethod(cursor) => return_if_io!(state, cursor.query_rowid()),
                         _ => panic!("unexpected cursor type"),
                     }
@@ -3356,6 +3378,7 @@ fn blob_btree_cursor<'a>(
 ) -> Result<&'a mut dyn crate::storage::btree::CursorTrait> {
     match state.get_cursor(cursor) {
         Cursor::BTree(btree) => Ok(btree.as_mut()),
+        Cursor::Dyn(btree) => Ok(btree.as_mut()),
         _ => Err(LimboError::InternalError(format!(
             "{opcode} requires a b-tree cursor"
         ))),
@@ -3552,6 +3575,12 @@ pub fn op_next(
     #[inline(never)]
     fn next_row_of_other_cursor(cursor: &mut Cursor) -> IOResultOr<bool> {
         match cursor {
+            Cursor::Dyn(btree_cursor) => match btree_cursor.next_row() {
+                CursorStep::Row => Ok(IOResult::Done(true)),
+                CursorStep::Empty => Ok(IOResult::Done(false)),
+                CursorStep::Error(err) => Err(err),
+                CursorStep::IO(io) => Ok(IOResult::IO(io)),
+            },
             Cursor::MaterializedView(mv_cursor) => mv_cursor.next(),
             Cursor::IndexMethod(_) => cursor.as_index_method_mut().query_next(),
             _ => panic!("Next on non-btree/materialized-view cursor"),
@@ -6075,7 +6104,8 @@ fn op_row_id_deferred(state: &mut ProgramState, cursor_id: usize, dest: usize) -
                 let rowid = {
                     let index_cursor = state.get_cursor(index_cursor_id);
                     match index_cursor {
-                        Cursor::BTree(index_cursor) => {
+                        Cursor::BTree(_) | Cursor::Dyn(_) => {
+                            let index_cursor = index_cursor.as_btree_mut();
                             let record = return_if_io!(state, index_cursor.record());
                             let record =
                                 record.as_ref().expect("index cursor should have a record");
@@ -6138,6 +6168,7 @@ fn op_row_id_read(state: &mut ProgramState, cursor_id: usize, dest: usize) -> In
         .expect("cursor_id should be valid");
     let rowid = match cursor {
         Some(Cursor::BTree(btree_cursor)) => return_if_io!(state, btree_cursor.rowid()),
+        Some(Cursor::Dyn(btree_cursor)) => return_if_io!(state, btree_cursor.rowid()),
         _ => return_if_io!(state, row_id_of_other_cursor(cursor)),
     };
     match rowid {
@@ -6185,6 +6216,7 @@ pub fn op_idx_row_id(
 
     let rowid = match cursor {
         Cursor::BTree(cursor) => return_if_io!(state, cursor.rowid()),
+        Cursor::Dyn(cursor) => return_if_io!(state, cursor.rowid()),
         Cursor::IndexMethod(cursor) => return_if_io!(state, cursor.query_rowid()),
         Cursor::NullRow => None,
         _ => panic!("unexpected cursor type"),
@@ -6244,7 +6276,8 @@ pub fn op_seek_rowid(
                     None => (target_pc.as_offset_int(), false),
                 }
             }
-            Cursor::BTree(btree_cursor) => {
+            Cursor::BTree(_) | Cursor::Dyn(_) => {
+                let btree_cursor = cursor.as_btree_mut();
                 let rowid = match state.registers[*src_reg].get_value() {
                     Value::Numeric(Numeric::Integer(rowid)) => Some(*rowid),
                     Value::Null => None,
@@ -13557,38 +13590,36 @@ pub fn op_open_write(
         _ => None,
     };
 
-    // Check if we can reuse the existing cursor
-    let can_reuse_cursor = if let Some(Some(Cursor::BTree(btree_cursor))) = cursors.get(*cursor_id)
-    {
-        // Reuse if the root_page matches (same table/index)
-        btree_cursor.root_page() == root_page
-    } else {
-        false
+    // Reuse the existing cursor if the root_page matches (same table/index)
+    let can_reuse_cursor = match cursors.get(*cursor_id) {
+        Some(Some(Cursor::BTree(btree_cursor))) => btree_cursor.root_page() == root_page,
+        Some(Some(Cursor::Dyn(btree_cursor))) => btree_cursor.root_page() == root_page,
+        _ => false,
     };
 
     if !can_reuse_cursor {
-        let maybe_promote_to_mvcc_cursor = |btree_cursor: Box<dyn CursorTrait>,
+        let maybe_promote_to_mvcc_cursor = |btree_cursor: Box<BTreeCursor>,
                                             mv_cursor_type: MvccCursorType|
-         -> Result<Box<dyn CursorTrait>> {
+         -> Result<OpenedBTree> {
             if let Some(tx_id) = program.connection.get_mv_tx_id_for_db(*db) {
                 let mv_store = mv_store
                     .as_ref()
                     .expect("mv_store should be Some when MVCC transaction is active")
                     .clone();
-                Ok(Box::new(MvCursor::new(
+                Ok(OpenedBTree::Mvcc(Box::new(MvCursor::new(
                     mv_store,
                     &program.connection,
                     tx_id,
                     root_page,
                     mv_cursor_type,
                     btree_cursor,
-                )?))
+                )?)))
             } else if mv_store.is_some() {
                 Err(LimboError::InternalError(
                     "OpenWrite requires an active MVCC transaction".to_string(),
                 ))
             } else {
-                Ok(btree_cursor)
+                Ok(OpenedBTree::Plain(btree_cursor))
             }
         };
         if let Some(index) = maybe_index {
@@ -13612,7 +13643,7 @@ pub fn op_open_write(
             cursors
                 .get_mut(*cursor_id)
                 .expect("cursor_id should be valid")
-                .replace(Cursor::new_btree(cursor));
+                .replace(cursor.into_cursor());
         } else {
             if matches!(cursor_type, CursorType::BTreeTable(table_rc) if !table_rc.has_rowid)
                 && program.connection.get_mv_tx_id_for_db(*db).is_some()
@@ -13630,7 +13661,7 @@ pub fn op_open_write(
                 ),
             };
 
-            let btree_cursor: Box<dyn CursorTrait> = match cursor_type {
+            let btree_cursor: Box<BTreeCursor> = match cursor_type {
                 CursorType::BTreeTable(table_rc) if !table_rc.has_rowid => {
                     btree_cursor_with_yield_context(
                         Box::new(BTreeCursor::new_without_rowid_table(
@@ -13655,7 +13686,7 @@ pub fn op_open_write(
             cursors
                 .get_mut(*cursor_id)
                 .expect("cursor_id should be valid")
-                .replace(Cursor::new_btree(cursor));
+                .replace(cursor.into_cursor());
         }
     }
     state.pc += 1;
@@ -14006,7 +14037,8 @@ fn op_clear_btree_inner(
                 let cleared = cursor.write().clear_btree();
                 return_if_io!(state, cleared);
                 for other_cursor_opt in state.cursors.iter_mut().flatten() {
-                    if let Cursor::BTree(ref mut btree_cursor) = other_cursor_opt {
+                    if let Cursor::BTree(_) | Cursor::Dyn(_) = other_cursor_opt {
+                        let btree_cursor = other_cursor_opt.as_btree_mut();
                         if Arc::ptr_eq(&btree_cursor.get_pager(), pager) {
                             btree_cursor.invalidate_btree_cache();
                         }
@@ -15433,6 +15465,7 @@ pub fn op_populate_materialized_views(
 
             let root_page = match cursor {
                 crate::types::Cursor::BTree(btree_cursor) => btree_cursor.root_page(),
+                crate::types::Cursor::Dyn(btree_cursor) => btree_cursor.root_page(),
                 _ => {
                     return Err(LimboError::InternalError(
                         "Expected BTree cursor for materialized view".into(),
@@ -15467,7 +15500,9 @@ pub fn op_populate_materialized_views(
 
             // Extract the BTreeCursor
             let btree_cursor = match cursor {
-                crate::types::Cursor::BTree(btree_cursor) => btree_cursor,
+                crate::types::Cursor::BTree(_) | crate::types::Cursor::Dyn(_) => {
+                    cursor.as_btree_mut()
+                }
                 _ => {
                     return Err(LimboError::InternalError(
                         "Expected BTree cursor for materialized view population".into(),
@@ -15477,10 +15512,7 @@ pub fn op_populate_materialized_views(
             };
 
             // Now populate it with the cursor for writing
-            return_if_io!(
-                state,
-                view.populate_from_table(&conn, pager, btree_cursor.as_mut())
-            );
+            return_if_io!(state, view.populate_from_table(&conn, pager, btree_cursor));
         }
     }
 
@@ -15862,7 +15894,7 @@ pub enum OpOpenEphemeralState {
     // clippy complains this variant is too big when compared to the rest of the variants
     // so it says we need to box it here
     Rewind {
-        cursor: Box<dyn CursorTrait>,
+        cursor: Box<BTreeCursor>,
         temp_file: Option<TempFile>,
     },
 }
@@ -16103,7 +16135,7 @@ pub fn op_open_dup(
                 )
                 .into());
             }
-            let cursor: Box<dyn CursorTrait> = if table.has_rowid {
+            let cursor: Box<BTreeCursor> = if table.has_rowid {
                 Box::new(BTreeCursor::new_table(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
@@ -16117,31 +16149,31 @@ pub fn op_open_dup(
                     table.columns().len(),
                 ))
             };
-            let cursor: Box<dyn CursorTrait> = if !is_ephemeral {
+            let cursor = if !is_ephemeral {
                 if let Some(tx_id) = program.connection.get_mv_tx_id() {
                     let mv_store = mv_store
                         .as_ref()
                         .expect("mv_store should be Some when MVCC transaction is active")
                         .clone();
-                    Box::new(MvCursor::new(
+                    OpenedBTree::Mvcc(Box::new(MvCursor::new(
                         mv_store,
                         &program.connection,
                         tx_id,
                         root_page,
                         MvccCursorType::Table,
                         cursor,
-                    )?)
+                    )?))
                 } else {
-                    cursor
+                    OpenedBTree::Plain(cursor)
                 }
             } else {
-                cursor
+                OpenedBTree::Plain(cursor)
             };
             let cursors = &mut state.cursors;
             cursors
                 .get_mut(*new_cursor_id)
                 .expect("cursor_id should be valid")
-                .replace(Cursor::new_btree(cursor));
+                .replace(cursor.into_cursor());
         }
         CursorType::BTreeIndex(_) => {
             return Err(LimboError::InternalError(
@@ -17615,7 +17647,8 @@ pub fn op_hash_build(
     if op_state.rowid.is_none() {
         let cursor = state.get_cursor(data.cursor_id);
         let rowid_val = match cursor {
-            Cursor::BTree(btree_cursor) => {
+            Cursor::BTree(_) | Cursor::Dyn(_) => {
+                let btree_cursor = cursor.as_btree_mut();
                 let rowid_opt = match btree_cursor.rowid() {
                     Ok(IOResult::Done(v)) => v,
                     Ok(IOResult::IO(io)) => {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10046,25 +10046,13 @@ pub fn op_function(
                     if is_null_result {
                         state.registers[*dest].set_null();
                     } else {
-                        // 3. Prepare Pattern and Text
-                        let pattern_cow = match pattern_value {
-                            Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
-                            v => match v.exec_cast("TEXT")? {
-                                Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
-                                _ => unreachable!("Cast to TEXT should yield Text"),
-                            },
+                        // 3. and 4. Prepare Pattern and Text, then execute Like.
+                        let matches = match (pattern_value, match_value) {
+                            (Value::Text(pattern), Value::Text(text)) => {
+                                Value::exec_like(pattern.as_str(), text.as_str(), escape_char)?
+                            }
+                            _ => exec_like_converted(pattern_value, match_value, escape_char)?,
                         };
-
-                        let match_cow = match match_value {
-                            Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
-                            v => match v.exec_cast("TEXT")? {
-                                Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
-                                _ => unreachable!("Cast to TEXT should yield Text"),
-                            },
-                        };
-
-                        // 4. Execute Like
-                        let matches = Value::exec_like(&pattern_cow, &match_cow, escape_char)?;
                         state.registers[*dest].set_int(matches as i64);
                     }
                 }
@@ -12101,6 +12089,30 @@ pub fn op_function(
 }
 
 pub(crate) type OpAttachState = crate::connection::AttachDatabaseState;
+
+/// LIKE with an operand that is not TEXT: both are converted to TEXT first.
+#[inline(never)]
+fn exec_like_converted(
+    pattern_value: &Value,
+    match_value: &Value,
+    escape_char: Option<char>,
+) -> Result<bool> {
+    let pattern_cow = match pattern_value {
+        Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+        v => match v.exec_cast("TEXT")? {
+            Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
+            _ => unreachable!("Cast to TEXT should yield Text"),
+        },
+    };
+    let match_cow = match match_value {
+        Value::Text(s) => std::borrow::Cow::Borrowed(s.as_str()),
+        v => match v.exec_cast("TEXT")? {
+            Value::Text(s) => std::borrow::Cow::Owned(s.to_string()),
+            _ => unreachable!("Cast to TEXT should yield Text"),
+        },
+    };
+    Value::exec_like(&pattern_cow, &match_cow, escape_char)
+}
 
 pub fn op_sequence(
     _program: &Program,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -7665,6 +7665,10 @@ fn update_agg_payload(
     Ok(())
 }
 
+/// Max limit of aggregate Vecs we keep around to reuse their allocations. This is a very naive
+/// strategy, but it works well for now.
+const SPARE_AGG_PAYLOADS: usize = 8;
+
 /// Convert the intermediate aggregate state in `payload` into the final result value.
 ///
 /// This finalization logic is shared between both aggregation strategies:
@@ -8925,7 +8929,10 @@ fn op_agg_step_slow(program: &Program, state: &mut ProgramState, data: &AggStepD
             },
             _ => {
                 // Built-in aggregates use flat payload
-                let mut payload = crate::alloc::vec![];
+                let mut payload = state
+                    .spare_agg_payloads
+                    .pop()
+                    .unwrap_or_else(|| crate::alloc::vec![]);
                 init_agg_payload(func, &mut payload)?;
                 Register::Aggregate(AggContext::Builtin(payload))
             }
@@ -9077,6 +9084,18 @@ pub fn op_agg_final(
                     finalize_agg_payload(func, payload)?
                 }
             };
+            if acc_reg == dest_reg {
+                // The result will replace the allocator, so we hold on to the allocated Vec so that
+                // another group can reuse the allocation.
+                let accumulator =
+                    std::mem::replace(&mut state.registers[acc_reg], Register::Value(Value::Null));
+                if let Register::Aggregate(AggContext::Builtin(mut payload)) = accumulator {
+                    if state.spare_agg_payloads.len() < SPARE_AGG_PAYLOADS {
+                        payload.clear();
+                        state.spare_agg_payloads.push(payload);
+                    }
+                }
+            }
             state.registers[dest_reg].set_value(value);
         }
         Register::Value(Value::Null) => {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1042,6 +1042,7 @@ pub fn op_not_null(
 
 macro_rules! comparison_opcode {
     ($name:ident, $variant:ident, $op:expr, $jumps:expr) => {
+        #[inline(always)]
         pub fn $name(
             program: &Program,
             state: &mut ProgramState,
@@ -1202,6 +1203,7 @@ fn op_comparison_slow(
     take_jump_if!(should_jump);
 }
 
+#[inline(always)]
 pub fn op_if(
     _program: &Program,
     state: &mut ProgramState,
@@ -1230,6 +1232,7 @@ pub fn op_if(
     Ok(InsnFunctionStepResult::Step)
 }
 
+#[inline(always)]
 pub fn op_if_not(
     _program: &Program,
     state: &mut ProgramState,
@@ -5629,6 +5632,7 @@ fn check_deferred_fk_on_commit(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+#[inline(always)]
 pub fn op_goto(
     _program: &Program,
     state: &mut ProgramState,
@@ -5643,6 +5647,7 @@ pub fn op_goto(
     Ok(InsnFunctionStepResult::Step)
 }
 
+#[inline(always)]
 pub fn op_gosub(
     _program: &Program,
     state: &mut ProgramState,
@@ -5664,6 +5669,7 @@ pub fn op_gosub(
     Ok(InsnFunctionStepResult::Step)
 }
 
+#[inline(always)]
 pub fn op_return(
     _program: &Program,
     state: &mut ProgramState,
@@ -5678,21 +5684,29 @@ pub fn op_return(
         insn
     );
     if let Value::Numeric(Numeric::Integer(pc)) = state.registers[*return_reg].get_value() {
-        let pc: u32 = (*pc)
-            .try_into()
-            .unwrap_or_else(|_| panic!("Return register is negative: {pc}"));
-        state.pc = pc;
+        state.pc = u32::try_from(*pc).unwrap_or_else(|_| negative_return_address(*pc));
     } else {
         if unlikely(!*can_fallthrough) {
-            return Err(
-                LimboError::InternalError("Return register is not an integer".to_string()).into(),
-            );
+            return Err(return_register_not_an_integer());
         }
         state.pc += 1;
     }
     Ok(InsnFunctionStepResult::Step)
 }
 
+#[cold]
+#[inline(never)]
+fn negative_return_address(pc: i64) -> ! {
+    panic!("Return register is negative: {pc}")
+}
+
+#[cold]
+#[inline(never)]
+fn return_register_not_an_integer() -> Box<LimboError> {
+    LimboError::InternalError("Return register is not an integer".to_string()).into()
+}
+
+#[cfg_attr(not(test), inline(always))]
 pub fn op_integer(
     _program: &Program,
     state: &mut ProgramState,

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3563,12 +3563,9 @@ pub fn op_next(
         state.metrics.search_count = state.metrics.search_count.wrapping_add(1);
         // Only steps codegen marked as part of a full table scan count as
         // fullscan steps, matching SQLITE_STMTSTATUS_FULLSCAN_STEP.
-        if *fullscan {
-            state.metrics.fullscan_steps = state.metrics.fullscan_steps.wrapping_add(1);
-        }
-        if *is_index {
-            state.metrics.index_steps = state.metrics.index_steps.wrapping_add(1);
-        }
+        // Added as 0 or 1 so neither counter costs a branch per row.
+        state.metrics.fullscan_steps = state.metrics.fullscan_steps.wrapping_add(*fullscan as u64);
+        state.metrics.index_steps = state.metrics.index_steps.wrapping_add(*is_index as u64);
         state.pc = pc_if_next.as_offset_int();
     } else {
         state.pc += 1;
@@ -3625,12 +3622,9 @@ pub fn op_prev(
         state.metrics.search_count = state.metrics.search_count.wrapping_add(1);
         // Only steps codegen marked as part of a full table scan count as
         // fullscan steps, matching SQLITE_STMTSTATUS_FULLSCAN_STEP.
-        if *fullscan {
-            state.metrics.fullscan_steps = state.metrics.fullscan_steps.wrapping_add(1);
-        }
-        if *is_index {
-            state.metrics.index_steps = state.metrics.index_steps.wrapping_add(1);
-        }
+        // Added as 0 or 1 so neither counter costs a branch per row.
+        state.metrics.fullscan_steps = state.metrics.fullscan_steps.wrapping_add(*fullscan as u64);
+        state.metrics.index_steps = state.metrics.index_steps.wrapping_add(*is_index as u64);
         state.pc = pc_if_prev.as_offset_int();
     } else {
         state.pc += 1;

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -2447,21 +2447,6 @@ pub enum Cookie {
 
 #[cfg(test)]
 mod tests {
-    use strum::VariantArray;
-
-    #[test]
-    fn test_make_sure_correct_insn_table() {
-        for variant in super::InsnVariants::VARIANTS {
-            let func1 = variant.to_function();
-            let func2 = variant.to_function_fast();
-            assert_eq!(
-                func1 as usize, func2 as usize,
-                "Variant {:?} does not match in fast table at index {}",
-                variant, *variant as usize
-            );
-        }
-    }
-
     #[test]
     fn test_insn_size_does_not_grow() {
         // Interpreter dispatch is sensitive to instruction size. Widening a

--- a/core/vdbe/insn.rs
+++ b/core/vdbe/insn.rs
@@ -379,7 +379,7 @@ pub struct HashDistinctData {
     pub target_pc: BranchOffset,
 }
 
-// There are currently 190 opcodes in sqlite
+// The opcodes the dispatch loop matches directly come first.
 #[repr(u8)]
 #[derive(Description, Debug, Clone, EnumDiscriminants)]
 #[strum_discriminants(vis(pub(crate)))]
@@ -435,6 +435,102 @@ pub enum Insn {
         fullscan: bool,
         /// See [Insn::Next::is_index].
         is_index: bool,
+    },
+    /// Compare two registers and jump to the given PC if they are equal.
+    Eq {
+        lhs: usize,
+        rhs: usize,
+        target_pc: BranchOffset,
+        /// CmpInsFlags are nulleq (null = null) or jump_if_null.
+        ///
+        /// jump_if_null jumps if either of the operands is null. Used for "jump when false" logic.
+        /// Eg. "SELECT * FROM users WHERE id = NULL" becomes:
+        /// <JUMP TO NEXT ROW IF id != NULL>
+        /// Without the jump_if_null flag it would not jump because the logical comparison "id != NULL" is never true.
+        /// This flag indicates that if either is null we should still jump.
+        flags: CmpInsFlags,
+        collation: Option<CollationSeq>,
+    },
+    /// Compare two registers and jump to the given PC if they are not equal.
+    Ne {
+        lhs: usize,
+        rhs: usize,
+        target_pc: BranchOffset,
+        /// CmpInsFlags are nulleq (null = null) or jump_if_null.
+        ///
+        /// jump_if_null jumps if either of the operands is null. Used for "jump when false" logic.
+        flags: CmpInsFlags,
+        collation: Option<CollationSeq>,
+    },
+    /// Compare two registers and jump to the given PC if the left-hand side is less than the right-hand side.
+    Lt {
+        lhs: usize,
+        rhs: usize,
+        target_pc: BranchOffset,
+        /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
+        flags: CmpInsFlags,
+        collation: Option<CollationSeq>,
+    },
+    Le {
+        lhs: usize,
+        rhs: usize,
+        target_pc: BranchOffset,
+        /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
+        flags: CmpInsFlags,
+        collation: Option<CollationSeq>,
+    },
+    /// Compare two registers and jump to the given PC if the left-hand side is greater than the right-hand side.
+    Gt {
+        lhs: usize,
+        rhs: usize,
+        target_pc: BranchOffset,
+        /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
+        flags: CmpInsFlags,
+        collation: Option<CollationSeq>,
+    },
+    /// Compare two registers and jump to the given PC if the left-hand side is greater than or equal to the right-hand side.
+    Ge {
+        lhs: usize,
+        rhs: usize,
+        target_pc: BranchOffset,
+        /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
+        flags: CmpInsFlags,
+        collation: Option<CollationSeq>,
+    },
+    /// Jump to target_pc if r\[reg\] != 0 or (r\[reg\] == NULL && r\[jump_if_null\] != 0)
+    If {
+        reg: usize,              // P1
+        target_pc: BranchOffset, // P2
+        /// P3. If r\[reg\] is null, jump iff r\[jump_if_null\] != 0
+        jump_if_null: bool,
+    },
+    /// Jump to target_pc if r\[reg\] != 0 or (r\[reg\] == NULL && r\[jump_if_null\] != 0)
+    IfNot {
+        reg: usize,              // P1
+        target_pc: BranchOffset, // P2
+        /// P3. If r\[reg\] is null, jump iff r\[jump_if_null\] != 0
+        jump_if_null: bool,
+    },
+    /// Branch to the given PC.
+    Goto {
+        target_pc: BranchOffset,
+    },
+    /// Stores the current program counter into register 'return_reg' then jumps to address target_pc.
+    Gosub {
+        target_pc: BranchOffset,
+        return_reg: usize,
+    },
+    /// Returns to the program counter stored in register 'return_reg'.
+    /// If can_fallthrough is true, fall through to the next instruction
+    /// if return_reg does not contain an integer value. Otherwise raise an error.
+    Return {
+        return_reg: usize,
+        can_fallthrough: bool,
+    },
+    /// Write an integer value into a register.
+    Integer {
+        value: i64,
+        dest: usize,
     },
 
     /// Initialize the program state and jump to the given PC.
@@ -549,21 +645,6 @@ pub enum Insn {
         reg: usize,
         target_pc: BranchOffset,
     },
-    /// Compare two registers and jump to the given PC if they are equal.
-    Eq {
-        lhs: usize,
-        rhs: usize,
-        target_pc: BranchOffset,
-        /// CmpInsFlags are nulleq (null = null) or jump_if_null.
-        ///
-        /// jump_if_null jumps if either of the operands is null. Used for "jump when false" logic.
-        /// Eg. "SELECT * FROM users WHERE id = NULL" becomes:
-        /// <JUMP TO NEXT ROW IF id != NULL>
-        /// Without the jump_if_null flag it would not jump because the logical comparison "id != NULL" is never true.
-        /// This flag indicates that if either is null we should still jump.
-        flags: CmpInsFlags,
-        collation: Option<CollationSeq>,
-    },
     /// Compute a hash on num_keys registers starting with r[key_reg]. Check to see if that hash
     /// is found in the bloom filter associated with the cursor/hash_table. If it is not present
     /// then jump to target_pc. Otherwise fall through.
@@ -587,67 +668,7 @@ pub enum Insn {
         key_reg: usize,
         num_keys: usize,
     },
-    /// Compare two registers and jump to the given PC if they are not equal.
-    Ne {
-        lhs: usize,
-        rhs: usize,
-        target_pc: BranchOffset,
-        /// CmpInsFlags are nulleq (null = null) or jump_if_null.
-        ///
-        /// jump_if_null jumps if either of the operands is null. Used for "jump when false" logic.
-        flags: CmpInsFlags,
-        collation: Option<CollationSeq>,
-    },
-    /// Compare two registers and jump to the given PC if the left-hand side is less than the right-hand side.
-    Lt {
-        lhs: usize,
-        rhs: usize,
-        target_pc: BranchOffset,
-        /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
-        flags: CmpInsFlags,
-        collation: Option<CollationSeq>,
-    },
     // Compare two registers and jump to the given PC if the left-hand side is less than or equal to the right-hand side.
-    Le {
-        lhs: usize,
-        rhs: usize,
-        target_pc: BranchOffset,
-        /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
-        flags: CmpInsFlags,
-        collation: Option<CollationSeq>,
-    },
-    /// Compare two registers and jump to the given PC if the left-hand side is greater than the right-hand side.
-    Gt {
-        lhs: usize,
-        rhs: usize,
-        target_pc: BranchOffset,
-        /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
-        flags: CmpInsFlags,
-        collation: Option<CollationSeq>,
-    },
-    /// Compare two registers and jump to the given PC if the left-hand side is greater than or equal to the right-hand side.
-    Ge {
-        lhs: usize,
-        rhs: usize,
-        target_pc: BranchOffset,
-        /// jump_if_null: Jump if either of the operands is null. Used for "jump when false" logic.
-        flags: CmpInsFlags,
-        collation: Option<CollationSeq>,
-    },
-    /// Jump to target_pc if r\[reg\] != 0 or (r\[reg\] == NULL && r\[jump_if_null\] != 0)
-    If {
-        reg: usize,              // P1
-        target_pc: BranchOffset, // P2
-        /// P3. If r\[reg\] is null, jump iff r\[jump_if_null\] != 0
-        jump_if_null: bool,
-    },
-    /// Jump to target_pc if r\[reg\] != 0 or (r\[reg\] == NULL && r\[jump_if_null\] != 0)
-    IfNot {
-        reg: usize,              // P1
-        target_pc: BranchOffset, // P2
-        /// P3. If r\[reg\] is null, jump iff r\[jump_if_null\] != 0
-        jump_if_null: bool,
-    },
     /// Open a cursor for reading.
     OpenRead {
         cursor_id: CursorID,
@@ -987,25 +1008,6 @@ pub enum Insn {
         name: String,
     },
 
-    /// Branch to the given PC.
-    Goto {
-        target_pc: BranchOffset,
-    },
-
-    /// Stores the current program counter into register 'return_reg' then jumps to address target_pc.
-    Gosub {
-        target_pc: BranchOffset,
-        return_reg: usize,
-    },
-
-    /// Returns to the program counter stored in register 'return_reg'.
-    /// If can_fallthrough is true, fall through to the next instruction
-    /// if return_reg does not contain an integer value. Otherwise raise an error.
-    Return {
-        return_reg: usize,
-        can_fallthrough: bool,
-    },
-
     /// Invoke a trigger or foreign-key action subprogram.
     ///
     /// According to SQLite documentation (https://sqlite.org/opcode.html):
@@ -1033,12 +1035,6 @@ pub enum Insn {
     /// Emitted at the end of INSERT/UPDATE/DELETE programs when PRAGMA count_changes is on,
     /// followed by a ResultRow that returns the count to the caller.
     ChangeCount {
-        dest: usize,
-    },
-
-    /// Write an integer value into a register.
-    Integer {
-        value: i64,
         dest: usize,
     },
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -109,10 +109,7 @@ use std::{
 };
 use tracing::{instrument, Level};
 
-const MAX_CHECK_MASK: u64 = 255;
-// we use the check interval as bitmask so that we can efficiently calculate if the `vm_steps` counter
-// has reached a check interval (if `n` is a power of 2, `x & (n - 1)` checks for multiples of `n`)
-const _: () = assert!((MAX_CHECK_MASK + 1).is_power_of_two());
+const MAX_CHECK_INTERVAL: u64 = 256;
 
 type MvccCommitStateMachine = CommitStateMachine<MvccClock, DynAllocator>;
 
@@ -866,9 +863,12 @@ pub struct SequenceInnerTxState {
 }
 
 pub struct ProgramState {
-    /// Interrupt/progress-check gate mask for normal_step; re-derived from
-    /// the progress handler's interval each time the gate fires.
-    check_mask: u64,
+    /// Instructions left before the next interrupt/progress check of
+    /// normal_step; reloaded with `check_interval` each time it reaches zero.
+    check_countdown: u64,
+    /// The interval the countdown was last reloaded with, re-derived from
+    /// the progress handler's interval each time the check runs.
+    check_interval: u64,
     pub io_completions: Option<IOCompletions>,
     pub pc: InsnReference,
     pub(crate) cursors: Vec<Option<Cursor>>,
@@ -1038,7 +1038,8 @@ impl ProgramState {
         let cursor_seqs = vec![0i64; max_cursors];
         let registers = vec![Register::Value(Value::Null); max_registers].into_boxed_slice();
         Self {
-            check_mask: MAX_CHECK_MASK,
+            check_countdown: 1,
+            check_interval: MAX_CHECK_INTERVAL,
             io_completions: None,
             pc: 0,
             cursors,
@@ -2293,7 +2294,8 @@ impl Program {
                     }
                 }
                 loop {
-                    if state.metrics.vm_steps & state.check_mask == 0 {
+                    state.check_countdown = state.check_countdown.wrapping_sub(1);
+                    if state.check_countdown == 0 {
                         if let Some(result) = program.periodic_checks(state, pager) {
                             return result;
                         }
@@ -2503,11 +2505,12 @@ impl Program {
     #[inline(never)]
     fn periodic_checks(&self, state: &mut ProgramState, pager: &Arc<Pager>) -> Option<ProgramStep> {
         let progress_ops = self.connection.progress_ops();
-        state.check_mask = if progress_ops == 0 || progress_ops >= MAX_CHECK_MASK {
-            MAX_CHECK_MASK
+        state.check_interval = if progress_ops == 0 || progress_ops >= MAX_CHECK_INTERVAL {
+            MAX_CHECK_INTERVAL
         } else {
-            progress_ops.next_power_of_two() - 1
+            progress_ops
         };
+        state.check_countdown = state.check_interval;
         if self.connection.is_closed() {
             return Some(ProgramStep::Error(self.closed_during_step(pager)));
         }
@@ -2530,7 +2533,7 @@ impl Program {
         state: &mut ProgramState,
         pager: &Arc<Pager>,
     ) -> Option<ProgramStep> {
-        let prev_steps = state.metrics.vm_steps.saturating_sub(state.check_mask + 1);
+        let prev_steps = state.metrics.vm_steps.saturating_sub(state.check_interval);
         if self.maybe_request_interrupt(state, pager.io.as_ref(), prev_steps) {
             return self.interrupted_during_step(state, pager);
         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -428,6 +428,9 @@ impl Register {
         #[inline(never)]
         fn set_int_over_other(register: &mut Register, val: i64) {
             match register {
+                Register::Value(null @ Value::Null) => {
+                    std::mem::forget(std::mem::replace(null, Value::from_i64(val)));
+                }
                 Register::Value(other_value_kind) => {
                     *other_value_kind = Value::from_i64(val);
                 }
@@ -495,6 +498,9 @@ impl Register {
     pub fn set_null(&mut self) {
         match self {
             Register::Value(Value::Null) => {}
+            Register::Value(number @ Value::Numeric(_)) => {
+                std::mem::forget(std::mem::replace(number, Value::Null));
+            }
             Register::Value(other_value_kind) => {
                 *other_value_kind = Value::Null;
             }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -976,6 +976,8 @@ pub struct ProgramState {
     pub(crate) subprogram_stmt_cache: HashMap<usize, Box<Statement>>,
     /// RowSet objects stored by register index
     rowsets: HashMap<usize, RowSet>,
+    // Cache of unused allocated Vecs
+    pub(crate) spare_agg_payloads: Vec<crate::alloc::Vec<Value>>,
     /// Bloom filters stored by cursor ID for probabilistic set membership testing
     /// Used to avoid unnecessary seeks on ephemeral indexes and hash tables
     pub(crate) bloom_filters: HashMap<usize, BloomFilter>,
@@ -1068,6 +1070,7 @@ impl ProgramState {
             fk_deferred_violations_when_stmt_started: AtomicIsize::new(0),
             fk_immediate_violations_during_stmt: AtomicIsize::new(0),
             rowsets: HashMap::default(),
+            spare_agg_payloads: Vec::new(),
             bloom_filters: HashMap::default(),
             hash_tables: HashMap::default(),
             ephemeral_temp_files: HashMap::default(),

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1170,8 +1170,10 @@ impl ProgramState {
             {
                 cursor.close(context);
             }
-            if let Some(Cursor::BTree(cursor)) = cursor.take() {
-                cursor.recycle();
+            match cursor.take() {
+                Some(Cursor::BTree(cursor)) => crate::storage::btree::CursorTrait::recycle(cursor),
+                Some(Cursor::Dyn(cursor)) => cursor.recycle(),
+                _ => {}
             }
             *context = None;
         }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -2326,6 +2326,18 @@ impl Program {
                         Insn::ColumnRange { .. } => step_inline!(execute::op_column_range),
                         Insn::RowId { .. } => step_inline!(execute::op_row_id),
                         Insn::Prev { .. } => step_inline!(execute::op_prev),
+                        Insn::Eq { .. } => step_inline!(execute::op_eq),
+                        Insn::Ne { .. } => step_inline!(execute::op_ne),
+                        Insn::Lt { .. } => step_inline!(execute::op_lt),
+                        Insn::Le { .. } => step_inline!(execute::op_le),
+                        Insn::Gt { .. } => step_inline!(execute::op_gt),
+                        Insn::Ge { .. } => step_inline!(execute::op_ge),
+                        Insn::If { .. } => step_inline!(execute::op_if),
+                        Insn::IfNot { .. } => step_inline!(execute::op_if_not),
+                        Insn::Goto { .. } => step_inline!(execute::op_goto),
+                        Insn::Gosub { .. } => step_inline!(execute::op_gosub),
+                        Insn::Return { .. } => step_inline!(execute::op_return),
+                        Insn::Integer { .. } => step_inline!(execute::op_integer),
                         _ => insn.to_function()(program, state, insn, pager),
                     };
                     // The two outcomes of every row are tested here, one compare


### PR DESCRIPTION
## Description

Part 12 of 15 split out of #8692 (commits 111-120 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### CodSpeed

Commits 1-117 (`3c369a50`, the second session up to the UTF-8 commit) vs `main`: [run 6a9c77475bd50bcffcfc60bc](https://codspeed.io/tursodatabase/turso/runs/6a9c77475bd50bcffcfc60bc), 103 improvements, 0 regressions, 702 unchanged, 14 new, 1509 skipped (the runners differed in a CPU flag and in the linked libc build, so CodSpeed skipped the benchmarks that ran across the difference; the nightly recovery benchmark is among the skipped). Against the run of `98c2b91f` (end of the first session): 12 improvements, 0 regressions, 807 unchanged, 1523 skipped; `select_one_100k` 12 ms → 9 ms (+33.2%), `select_star_100k` 37.2 ms → 30.8 ms (+20.5%), `count_text_col[1000000]` 219.6 ms → 173.6 ms (+26.5%), the struct/union scans +20% to +30%. Against `main` the scan benchmarks now stand at `select_one_100k` 21.3 ms → 9 ms (×2.4), `select_star_100k` 67.3 ms → 30.8 ms (×2.2), `count_text_col[1000000]` 460.7 ms → 173.6 ms (×2.7), `count_groupby[1000000]` 678.5 ms → 336.2 ms (×2.0), `count_filtered[1000000]` 250.9 ms → 149.9 ms (+67.4%); the per-statement `limbo_execute_select_1` at 12.6 µs → 9.9 µs (+27.4%) and the write benchmarks at +56% to +58% (`Transaction Size Impact::limbo[1000_rows]` 5.9 ms → 3.7 ms, `Key Pattern Impact::limbo[sequential_keys]` 655.6 µs → 414.3 µs, `BEFORE INSERT Trigger::limbo[1000_rows]` 12.6 ms → 8 ms).

Commits 1-118 (`9b2dcf03`, the LIKE commit) vs `main`: [run 6a9c7ed25bd50bcffcfc6186](https://codspeed.io/tursodatabase/turso/runs/6a9c7ed25bd50bcffcfc6186), 102 improvements, 0 regressions, 1005 unchanged, 14 new, 1207 skipped. Against the run of `3c369a50`: nothing past the reporting threshold (1121 unchanged, 1207 skipped); the LIKE benchmarks of `sql_functions/value.rs` moved under it (`construct_like_complex` 925.6 ns → 896.4 ns, -3.2%). `count_filtered[1000000]` went 149.9 ms → 136.9 ms between the two runs without a change on its path (the local count of W4 is unchanged to the instruction).

Commits 1-121 (`46436272`, the final head) vs `main`: [run 6a9c9281fd41b0f1674a7aca](https://codspeed.io/tursodatabase/turso/runs/6a9c9281fd41b0f1674a7aca), 214 improvements, 1 regression, 1959 unchanged, 28 new, 135 skipped. This is the first run since `98c2b91f` with the nightly benchmark variants (their build had failed on the pool commit, see the second session), so against the run of `9b2dcf03` it shows 112 improvements, 1 regression, 2075 unchanged, 14 new, 135 skipped: the improvements are the nightly variants catching up (`select_one_100k nightly` 21.2 ms → 8.9 ms, `count_text_col[1000000 nightly]` 475.4 ms → 173.6 ms, `limbo_execute_select_1 nightly` 11.8 µs → 9.5 µs against their last values). The one regression is the memory benchmark `mvcc/scan-heavy/80-checkpoint`: peak 1.03 MB → 1.31 MB, with 1,000 fewer allocations and 5,300 fewer frees than the run of `69e2eff2`, where it was unchanged. The only code between the two runs is the one-line build fix, which allocates nothing either way (an empty vec), so the peak moved with the timing of MVCC's background work in the harness; the WAL variant and the other 47 memory benchmarks are unchanged, and the benchmark had measured 1.01-1.03 MB on every run of `main` and of this branch before. The run of `69e2eff2` ([6a9c8e5c8aabe4c55b5d267b](https://codspeed.io/tursodatabase/turso/runs/6a9c8e5c8aabe4c55b5d267b)) holds only the 48 memory benchmarks, all unchanged: its workflow was superseded by the push of the fix before the CPU benchmarks uploaded.

### Second session (commits 89 to 149, `98c2b91f` → `cc0dfdf6`)

A second autonomous session continued from `98c2b91f` with the same method: callgrind instruction counts (`Ir`) of the local driver, one measured change per commit, changes that measured worse reverted and listed below. The 100k-row scans run 3 iterations (5 for `SELECT 1 FROM t`); the per-statement numbers are instructions per execution, (Ir at 3000 − Ir at 1000) / 2000. Two more scan workloads join the set: `SELECT name FROM t` (W13, one TEXT column per row) and `SELECT * FROM t ORDER BY name DESC LIMIT 10` (W9, the sorter), plus `SELECT length(name) FROM t` and `SELECT abs(value) FROM t` for the scalar function opcode. The CodSpeed runs of `3c369a50`, `9b2dcf03`, `46436272` and the later heads are in the CodSpeed section above.

| Commit | `SELECT 1 FROM t` | `SELECT * FROM t` | W3 | W4 | W12 (GROUP BY value) | W13 (`SELECT name`) | W9 (ORDER BY) |
|---|---:|---:|---:|---:|---:|---:|---:|
| inline the small jumps and stores into the dispatch loop | 115,801,638 (-0.4%) | 249,116,903 (-0.1%) | 158,421,359 (+0.4%) | 179,468,465 (+0.3%) | 699,323,354 (-2.2%) | = | = |
| keep the plain b-tree cursor as its own Cursor variant | 114,304,918 (-1.3%) | 248,518,247 (-0.2%) | 157,824,236 (-0.4%) | 178,871,324 (-0.3%) | 700,226,216 (+0.1%) | 177,864,857 (-0.7%) | 693,982,468 (-0.6%) |
| inline the comparison and jump opcodes into the dispatch loop for real | 114,804,928 (+0.4%) | 248,818,259 (+0.1%) | 153,624,242 (-2.7%) | 174,671,333 (-2.4%) | 686,126,120 (-2.0%) | 177,564,869 (-0.2%) | = |
| inline the row reads of the plain b-tree cursor into the opcodes | 106,811,273 (-7.0%) | 233,674,883 (-6.1%) | 139,836,266 (-9.0%) | 160,593,113 (-8.1%) | 669,047,936 (-2.5%) | 162,567,797 (-8.5%) | 667,738,873 (-3.8%) |
| keep the payload vectors of finished groups for the next groups | = | = | = | = | 647,826,182 (-3.2%) | = | = |
| skip the drop glue when a register stores a number over a number or NULL | = | = | 139,536,191 (-0.2%) | 160,292,846 (-0.2%) | 645,426,221 (-0.4%) | 162,267,797 (-0.2%) | 667,138,708 (-0.1%) |
| inline the UTF-8 validation of text column reads (`length(name)` 250,409,585 → 247,409,579, -1.2%) | = | = | = | = | = | 159,267,791 (-1.8%) | 664,739,852 (-0.4%) |
| match LIKE on two TEXT operands without conversion temporaries (`LIKE 'name_1%'` scan 284,174,039 → 278,774,042, -1.9%) | = | = | = | = | 645,126,224 (-0.05%, one instruction per row of code layout; no LIKE runs there) | = | = |
| count down to the periodic checks of the dispatch loop (one decrement and its zero test per instruction instead of a mask test) | 105,815,119 (-0.9%) | 232,479,523 (-0.5%) | 138,340,849 (-0.9%) | 158,798,702 (-0.9%) | 639,150,813 (-0.9%) | 158,371,288 (-0.6%) | |
| count the full-scan and index steps of Next and Prev without a branch | 104,815,129 (-0.9%) | 232,179,526 (-0.1%) | 137,740,855 (-0.4%) | 158,198,708 (-0.4%) | 638,250,819 (-0.1%) | 158,071,291 (-0.2%) | 662,646,601 (-0.3%, the two rows together) |

| Commit | point lookup | `SELECT 1` | index lookup |
|---|---:|---:|---:|
| inline the small jumps and stores into the dispatch loop | 7,119 (-0.5%) | 1,620 (-1.8%) | 12,752 (-0.4%) |
| keep the plain b-tree cursor as its own Cursor variant | 7,018 (-1.4%) | 1,628 (+0.5%) | 12,666 (-0.7%) |
| inline the comparison and jump opcodes into the dispatch loop for real | 7,022 | = | 12,652 (-0.1%) |
| inline the row reads of the plain b-tree cursor into the opcodes | 6,991 (-0.4%) | 1,632 (+0.2%) | 12,672 (+0.2%) |
| skip the drop glue when a register stores a number over a number or NULL | 6,976 (-0.2%) | 1,627 (-0.3%) | 12,657 (-0.1%) |
| match LIKE on two TEXT operands without conversion temporaries | = | = | = |
| count down to the periodic checks of the dispatch loop | 6,966 (-0.1%) | 1,622 (-0.3%) | 12,644 (-0.1%) |
| count the full-scan and index steps of Next and Prev without a branch | = | = | = |

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_