### PR TITLE
core: cut the cost of index seeks and the per-statement bookkeeping (13/15)

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -3771,24 +3771,34 @@ impl Connection {
     /// (temp + attached).The internal locks are released before `f` runs, which also
     /// makes it safe for `f` to call back into the connection (e.g. `mv_store_for_db`,
     /// which re-reads the attached-database catalog).
+    #[inline(always)]
     pub(crate) fn with_all_attached_pagers_with_index<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&[(usize, Arc<Pager>)]) -> R,
     {
-        if !self.has_non_main_pagers.load(Ordering::Acquire) {
-            return f(&[]);
-        }
-        let mut pagers: SmallVec<[(usize, Arc<Pager>); 8]> = SmallVec::new();
-        if let Some(temp_db) = self.temp.database.read().as_ref() {
-            pagers.push((crate::TEMP_DB_ID, temp_db.pager.clone()));
-        }
+        return if !self.has_non_main_pagers.load(Ordering::Acquire) {
+            f(&[])
+        } else {
+            attach_all_pagers_cold(self, f)
+        };
+
+        #[inline(never)]
+        fn attach_all_pagers_cold<F, R>(conn: &Connection, f: F) -> R
+        where
+            F: FnOnce(&[(usize, Arc<Pager>)]) -> R,
         {
-            let catalog = self.attached_databases.read();
-            for (&idx, entry) in catalog.index_to_data.iter() {
-                pagers.push((idx, entry.pager.clone()));
+            let mut pagers: SmallVec<[(usize, Arc<Pager>); 8]> = SmallVec::new();
+            if let Some(temp_db) = conn.temp.database.read().as_ref() {
+                pagers.push((crate::TEMP_DB_ID, temp_db.pager.clone()));
             }
+            {
+                let catalog = conn.attached_databases.read();
+                for (&idx, entry) in catalog.index_to_data.iter() {
+                    pagers.push((idx, entry.pager.clone()));
+                }
+            }
+            f(&pagers)
         }
-        f(&pagers)
     }
 
     pub(crate) fn database_schemas(&self) -> &RwLock<HashMap<usize, Arc<Schema>>> {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2705,28 +2705,19 @@ impl BTreeCursor {
 
         let mut state = *state;
 
-        loop {
-            let control = self.indexbtree_seek_inner(
-                seek_op,
-                old_top_idx,
-                key_values,
-                record_comparer,
-                &mut state,
-            )?;
-            // Persist state after each iteration since inner function modifies it
-            if matches!(
-                self.seek_state,
-                CursorSeekState::LeafPageBinarySearch { .. }
-            ) {
-                self.seek_state = CursorSeekState::LeafPageBinarySearch { state };
-            }
-            match control {
-                ControlFlow::Continue(_) => {}
-                ControlFlow::Break(res) => {
-                    return Ok(res);
-                }
-            }
-        }
+        let result = self.indexbtree_seek_inner(
+            seek_op,
+            old_top_idx,
+            key_values,
+            record_comparer,
+            &mut state,
+        )?;
+        // The search state goes back to the cursor once per call, not once
+        // per compare, as for the interior pages: only an overflow key read
+        // yields, and it returns before the range changes, so re-entry
+        // retries the same cell.
+        self.seek_state = CursorSeekState::LeafPageBinarySearch { state };
+        Ok(result)
     }
 
     fn indexbtree_seek_inner(
@@ -2736,109 +2727,110 @@ impl BTreeCursor {
         key_values: &[ValueRef<'_>],
         record_comparer: RecordCompare,
         state: &mut LeafPageBinarySearchState,
-    ) -> Result<ControlFlow<IOResult<SeekResult>>> {
+    ) -> IOResultOr<SeekResult> {
         let iter_dir = seek_op.iteration_direction();
-        let min = state.min_cell_idx;
-        let max = state.max_cell_idx;
         let eq_seen = state.eq_seen;
-        if min > max {
-            if let Some(nearest_matching_cell) = state.nearest_matching_cell {
-                self.stack.set_cell_index(nearest_matching_cell as i32);
-                self.set_has_record(true);
+        loop {
+            let min = state.min_cell_idx;
+            let max = state.max_cell_idx;
+            if min > max {
+                if let Some(nearest_matching_cell) = state.nearest_matching_cell {
+                    self.stack.set_cell_index(nearest_matching_cell as i32);
+                    self.set_has_record(true);
 
-                return Ok(ControlFlow::Break(IOResult::Done(SeekResult::Found)));
-            } else {
-                // set cursor to the position where which would hold the op-boundary if it were present
-                let target_cell = state.target_cell_when_not_found;
-                self.stack.set_cell_index(target_cell);
-                let has_record = target_cell >= 0
-                    && target_cell
-                        < self
-                            .stack
-                            .get_page_contents_at_level(old_top_idx)
-                            .unwrap()
-                            .cell_count() as i32;
-                self.has_record = has_record;
+                    return Ok(IOResult::Done(SeekResult::Found));
+                } else {
+                    // set cursor to the position where which would hold the op-boundary if it were present
+                    let target_cell = state.target_cell_when_not_found;
+                    self.stack.set_cell_index(target_cell);
+                    let has_record = target_cell >= 0
+                        && target_cell
+                            < self
+                                .stack
+                                .get_page_contents_at_level(old_top_idx)
+                                .unwrap()
+                                .cell_count() as i32;
+                    self.has_record = has_record;
 
-                // Similar logic as in tablebtree_seek(), but for indexes.
-                // The difference is that since index keys are not necessarily unique, we need to TryAdvance
-                // even when eq_only=true and we have seen an EQ match up in the tree in an interior node.
-                if seek_op.eq_only() && !eq_seen {
-                    return Ok(ControlFlow::Break(IOResult::Done(SeekResult::NotFound)));
-                }
-                return Ok(ControlFlow::Break(IOResult::Done(SeekResult::TryAdvance)));
-            };
-        }
-
-        let cur_cell_idx = (min + max) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
-        self.stack.set_cell_index(cur_cell_idx as i32);
-
-        let (payload, payload_size, first_overflow_page) = self
-            .stack
-            .get_page_contents_at_level(old_top_idx)
-            .unwrap()
-            .cell_read_payload_ptr(cur_cell_idx as usize, self.payload_limits)?;
-
-        if let Some(next_page) = first_overflow_page {
-            let res = self.process_overflow_read(payload, next_page, payload_size)?;
-            if let IOResult::IO(io) = res {
-                return Ok(ControlFlow::Break(IOResult::IO(io)));
+                    // Similar logic as in tablebtree_seek(), but for indexes.
+                    // The difference is that since index keys are not necessarily unique, we need to TryAdvance
+                    // even when eq_only=true and we have seen an EQ match up in the tree in an interior node.
+                    if seek_op.eq_only() && !eq_seen {
+                        return Ok(IOResult::Done(SeekResult::NotFound));
+                    }
+                    return Ok(IOResult::Done(SeekResult::TryAdvance));
+                };
             }
-        } else {
-            self.get_immutable_record_or_create()?
-                .as_mut()
+
+            let cur_cell_idx = (min + max) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
+            self.stack.set_cell_index(cur_cell_idx as i32);
+
+            let (payload, payload_size, first_overflow_page) = self
+                .stack
+                .get_page_contents_at_level(old_top_idx)
                 .unwrap()
-                .invalidate();
-            crate::with_btree_allocation_site!(
-                RecordPayload,
+                .cell_read_payload_ptr(cur_cell_idx as usize, self.payload_limits)?;
+
+            if let Some(next_page) = first_overflow_page {
+                let res = self.process_overflow_read(payload, next_page, payload_size)?;
+                if let IOResult::IO(io) = res {
+                    return Ok(IOResult::IO(io));
+                }
+            } else {
                 self.get_immutable_record_or_create()?
                     .as_mut()
                     .unwrap()
-                    .start_serialization(payload)
-            )?;
-        };
+                    .invalidate();
+                crate::with_btree_allocation_site!(
+                    RecordPayload,
+                    self.get_immutable_record_or_create()?
+                        .as_mut()
+                        .unwrap()
+                        .start_serialization(payload)
+                )?;
+            };
 
-        let (cmp, found) = self.compare_with_current_record(
-            key_values,
-            seek_op,
-            &record_comparer,
-            self.index_info
-                .as_ref()
-                .expect("indexbtree_seek: index_info required"),
-        )?;
-        if found {
-            state.nearest_matching_cell.replace(cur_cell_idx as usize);
-            match iter_dir {
-                IterationDirection::Forwards => {
-                    state.max_cell_idx = cur_cell_idx - 1;
+            let (cmp, found) = self.compare_with_current_record(
+                key_values,
+                seek_op,
+                &record_comparer,
+                self.index_info
+                    .as_ref()
+                    .expect("indexbtree_seek: index_info required"),
+            )?;
+            if found {
+                state.nearest_matching_cell.replace(cur_cell_idx as usize);
+                match iter_dir {
+                    IterationDirection::Forwards => {
+                        state.max_cell_idx = cur_cell_idx - 1;
+                    }
+                    IterationDirection::Backwards => {
+                        state.min_cell_idx = cur_cell_idx + 1;
+                    }
                 }
-                IterationDirection::Backwards => {
-                    state.min_cell_idx = cur_cell_idx + 1;
+            } else if cmp.is_gt() {
+                if matches!(seek_op, SeekOp::GE { eq_only: true }) {
+                    state.target_cell_when_not_found =
+                        state.target_cell_when_not_found.min(cur_cell_idx as i32);
                 }
-            }
-        } else if cmp.is_gt() {
-            if matches!(seek_op, SeekOp::GE { eq_only: true }) {
-                state.target_cell_when_not_found =
-                    state.target_cell_when_not_found.min(cur_cell_idx as i32);
-            }
-            state.max_cell_idx = cur_cell_idx - 1;
-        } else if cmp.is_lt() {
-            if matches!(seek_op, SeekOp::LE { eq_only: true }) {
-                state.target_cell_when_not_found =
-                    state.target_cell_when_not_found.max(cur_cell_idx as i32);
-            }
-            state.min_cell_idx = cur_cell_idx + 1;
-        } else {
-            match iter_dir {
-                IterationDirection::Forwards => {
-                    state.min_cell_idx = cur_cell_idx + 1;
+                state.max_cell_idx = cur_cell_idx - 1;
+            } else if cmp.is_lt() {
+                if matches!(seek_op, SeekOp::LE { eq_only: true }) {
+                    state.target_cell_when_not_found =
+                        state.target_cell_when_not_found.max(cur_cell_idx as i32);
                 }
-                IterationDirection::Backwards => {
-                    state.max_cell_idx = cur_cell_idx - 1;
+                state.min_cell_idx = cur_cell_idx + 1;
+            } else {
+                match iter_dir {
+                    IterationDirection::Forwards => {
+                        state.min_cell_idx = cur_cell_idx + 1;
+                    }
+                    IterationDirection::Backwards => {
+                        state.max_cell_idx = cur_cell_idx - 1;
+                    }
                 }
             }
         }
-        Ok(ControlFlow::Continue(()))
     }
 
     fn compare_with_current_record(

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -1167,7 +1167,16 @@ impl BTreeNodeState {
 }
 
 impl BTreeCursor {
-    pub fn new(pager: Arc<Pager>, root_page: i64, _num_columns: usize) -> Self {
+    pub fn new(pager: Arc<Pager>, root_page: i64, num_columns: usize) -> Self {
+        Self::new_with_index_info(pager, root_page, num_columns, None)
+    }
+
+    fn new_with_index_info(
+        pager: Arc<Pager>,
+        root_page: i64,
+        _num_columns: usize,
+        index_info: Option<Arc<IndexInfo>>,
+    ) -> Self {
         let valid_state = if root_page == 1 && !pager.db_initialized() {
             CursorValidState::Invalid
         } else {
@@ -1192,7 +1201,7 @@ impl BTreeCursor {
             },
             reusable_immutable_record: None,
             noted_payload: NotedPayload::NONE,
-            index_info: None,
+            index_info,
             count: 0,
             context: None,
             valid_state,
@@ -1247,7 +1256,6 @@ impl BTreeCursor {
         table: &BTreeTable,
         num_columns: usize,
     ) -> Self {
-        let mut cursor = Self::new(pager, root_page, num_columns);
         let key_info = table.primary_key_columns.iter().map(|(col_name, order)| {
             let (_, column) = table
                 .get_column(col_name)
@@ -1258,11 +1266,11 @@ impl BTreeCursor {
                 nulls_order: None,
             }
         });
-        cursor.index_info = Some(Arc::new(
+        let index_info = Arc::new(
             IndexInfo::new(key_info, false, table.primary_key_columns.len(), true)
                 .expect(crate::alloc::ALLOC_ERR_MSG),
-        ));
-        cursor
+        );
+        Self::new_with_index_info(pager, root_page, num_columns, Some(index_info))
     }
 
     pub fn new_index(
@@ -1271,9 +1279,23 @@ impl BTreeCursor {
         index: &Index,
         num_columns: usize,
     ) -> Result<Self> {
-        let mut cursor = Self::new(pager, root_page, num_columns);
-        cursor.index_info = Some(Arc::new(IndexInfo::new_from_index(index)?));
-        Ok(cursor)
+        let index_info = Arc::new(IndexInfo::new_from_index(index)?);
+        Ok(Self::new_with_index_info(
+            pager,
+            root_page,
+            num_columns,
+            Some(index_info),
+        ))
+    }
+
+    pub fn new_index_boxed(
+        pager: Arc<Pager>,
+        root_page: i64,
+        index: &Index,
+        num_columns: usize,
+    ) -> Result<Box<Self>> {
+        let index_info = Arc::new(IndexInfo::new_from_index(index)?);
+        Ok(Self::new_with_index_info(pager, root_page, num_columns, Some(index_info)).into_boxed())
     }
 
     /// Resets the cached count state so the next `count()` call re-traverses the

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2385,11 +2385,11 @@ impl BTreeCursor {
                 }
             }
         };
-        let matching_cell = self
+        let left_child_page = self
             .stack
             .get_page_contents_at_level(old_top_idx)
             .unwrap()
-            .cell_get(leftmost_matching_cell, self.usable_space())?;
+            .cell_interior_read_left_child_page(leftmost_matching_cell)?;
         // We don't advance in case of forward iteration and index tree
         // internal nodes because we will visit this node going up.
         // In backwards iteration, we must retreat because otherwise we
@@ -2401,23 +2401,16 @@ impl BTreeCursor {
         //
         // On `IO(spill_c)` we MUST NOT mutate `cell_idx` (set or
         // retreat) — see the Done branch.
-        let BTreeCell::IndexInteriorCell(IndexInteriorCell {
-            left_child_page, ..
-        }) = &matching_cell
-        else {
-            unreachable!("unexpected cell type: {:?}", matching_cell);
-        };
-
         {
             let page = self.stack.get_page_at_level(old_top_idx).unwrap();
             turso_assert!(
-                page.get().id() != *left_child_page as usize,
+                page.get().id() != left_child_page as usize,
                 "corrupt: current page and left child page are the same",
                 { "cell": leftmost_matching_cell, "page_id": page.get().id() }
             );
         }
 
-        match self.read_page(*left_child_page as i64)? {
+        match self.read_page(left_child_page as i64)? {
             IOResult::Done((mem_page, c)) => {
                 self.stack.set_cell_index(leftmost_matching_cell as i32);
                 if iter_dir == IterationDirection::Backwards {

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -10197,9 +10197,9 @@ fn fill_cell_payload(
                 let max_local = payload_overflow_threshold_max(page_type, usable_space);
                 let min_local = payload_overflow_threshold_min(page_type, usable_space);
 
-                let (overflows, local_size_if_overflow) =
-                    payload_overflows(record_buf.len(), max_local, min_local, usable_space);
-                if !overflows {
+                let Some(local_payload_size) =
+                    payload_overflows(record_buf.len(), max_local, min_local, usable_space)
+                else {
                     // enough allowed space to fit inside a btree page
                     crate::with_btree_allocation_site!(
                         CellPayload,
@@ -10207,11 +10207,11 @@ fn fill_cell_payload(
                     )?;
                     cell_payload.extend_from_slice(record_buf);
                     break Ok(IOResult::Done(()));
-                }
+                };
 
                 // so far we've written any of: left child page, rowid, payload size (depending on page type)
                 let cell_non_payload_elems_size = cell_payload.len();
-                let new_total_local_size = cell_non_payload_elems_size + local_size_if_overflow;
+                let new_total_local_size = cell_non_payload_elems_size + local_payload_size;
                 crate::with_btree_allocation_site!(
                     CellPayload,
                     cell_payload.try_reserve(new_total_local_size - cell_payload.len())
@@ -10220,7 +10220,7 @@ fn fill_cell_payload(
 
                 *fill_cell_payload_state = FillCellPayloadState::CopyData {
                     state: CopyDataState::Copy,
-                    space_left_on_cur_page: local_size_if_overflow - overflow_page_pointer_size, // local_size_if_overflow includes the overflow page pointer, but we don't want to write payload data there.
+                    space_left_on_cur_page: local_payload_size - overflow_page_pointer_size,
                     src_data_offset: 0,
                     dst_data_offset: cell_non_payload_elems_size,
                     current_overflow_page: None,

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -3194,7 +3194,7 @@ impl Pager {
     }
 
     #[inline(always)]
-    #[instrument(skip_all, level = Level::DEBUG)]
+    #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     pub fn begin_read_tx(&self) -> Result<()> {
         let Some(wal) = self.wal.as_ref() else {
             return Ok(());
@@ -3435,7 +3435,7 @@ impl Pager {
         }
     }
 
-    #[instrument(skip_all, level = Level::DEBUG)]
+    #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     pub fn end_read_tx(&self) {
         let Some(wal) = self.wal.as_ref() else {
             return;
@@ -3556,7 +3556,7 @@ impl Pager {
     /// `page_idx` arbitrarily many times. Each `Some(page_idx)` mapping in
     /// `pending_reads` corresponds to a single outstanding disk read; the
     /// entry is removed exactly when this method returns `Done`.
-    #[tracing::instrument(skip_all, level = Level::TRACE)]
+    #[cfg_attr(debug_assertions, tracing::instrument(skip_all, level = Level::TRACE))]
     pub fn read_page(&self, page_idx: i64) -> IOResultOr<(PageRef, Option<Completion>)> {
         self.read_page_into(page_idx, None)
     }

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -595,7 +595,7 @@ impl PageInner {
     }
 
     /// Returns a cell's record payload and overflow info without constructing
-    /// a `BTreeCell`.
+    /// a [BTreeCell].
     ///
     /// This bypasses the full `cell_get()` to `read_btree_cell()` path for
     /// record reads and index binary-search hot loops.
@@ -617,12 +617,12 @@ impl PageInner {
     #[inline(always)]
     pub fn cell_read_payload_at(
         &self,
-        idx: usize,
+        cell_idx: usize,
         limits: PayloadLimits,
     ) -> crate::Result<(&'static [u8], usize, u64, Option<u32>)> {
         let buf = self.as_ptr();
         let cell_pointer_array_start = self.header_size();
-        let cell_pointer = cell_pointer_array_start + (idx * CELL_PTR_SIZE_BYTES);
+        let cell_pointer = cell_pointer_array_start + (cell_idx * CELL_PTR_SIZE_BYTES);
         let cell_offset = self.read_u16(cell_pointer) as usize;
 
         let page_type = self.page_type()?;
@@ -650,14 +650,13 @@ impl PageInner {
             }
         };
 
-        let (overflows, local_size) = sqlite3_ondisk::payload_overflows(
-            payload_size as usize,
-            limits.max_local(page_type),
-            limits.min_local,
-            limits.usable_size,
-        );
-
-        let (payload_slice, first_overflow) = if overflows {
+        let (payload_slice, first_overflow) = if let Some(local_size) =
+            sqlite3_ondisk::payload_overflows(
+                payload_size as usize,
+                limits.max_local(page_type),
+                limits.min_local,
+                limits.usable_size,
+            ) {
             let overflow_ptr_offset = payload_start + local_size - 4;
             crate::assert_or_bail_corrupt!(
                 overflow_ptr_offset + 4 <= buf.len(),
@@ -760,14 +759,13 @@ impl PageInner {
             PageType::IndexInterior => {
                 let (len_payload, n_payload) =
                     read_varint(crate::slice_in_bounds_or_corrupt!(buf, start + 4..))?;
-                let (overflows, to_read) = sqlite3_ondisk::payload_overflows(
+                if let Some(local_size) = sqlite3_ondisk::payload_overflows(
                     len_payload as usize,
                     max_local,
                     min_local,
                     usable_size,
-                );
-                if overflows {
-                    4 + to_read + n_payload
+                ) {
+                    4 + local_size + n_payload
                 } else {
                     4 + len_payload as usize + n_payload
                 }
@@ -780,14 +778,13 @@ impl PageInner {
             PageType::IndexLeaf => {
                 let (len_payload, n_payload) =
                     read_varint(crate::slice_in_bounds_or_corrupt!(buf, start..))?;
-                let (overflows, to_read) = sqlite3_ondisk::payload_overflows(
+                if let Some(local_size) = sqlite3_ondisk::payload_overflows(
                     len_payload as usize,
                     max_local,
                     min_local,
                     usable_size,
-                );
-                if overflows {
-                    to_read + n_payload
+                ) {
+                    local_size + n_payload
                 } else {
                     let mut size = len_payload as usize + n_payload;
                     if size < MINIMUM_CELL_SIZE {
@@ -801,14 +798,13 @@ impl PageInner {
                     read_varint(crate::slice_in_bounds_or_corrupt!(buf, start..))?;
                 let (_, n_rowid) =
                     read_varint(crate::slice_in_bounds_or_corrupt!(buf, start + n_payload..))?;
-                let (overflows, to_read) = sqlite3_ondisk::payload_overflows(
+                if let Some(local_size) = sqlite3_ondisk::payload_overflows(
                     len_payload as usize,
                     max_local,
                     min_local,
                     usable_size,
-                );
-                if overflows {
-                    to_read + n_payload + n_rowid
+                ) {
+                    local_size + n_payload + n_rowid
                 } else {
                     let mut size = len_payload as usize + n_payload + n_rowid;
                     if size < MINIMUM_CELL_SIZE {

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -866,9 +866,13 @@ pub fn read_btree_cell(
             let (payload_size, nr) = read_varint(crate::slice_in_bounds_or_corrupt!(page, pos..))?;
             pos += nr;
 
-            let (overflows, to_read) =
-                payload_overflows(payload_size as usize, max_local, min_local, usable_size);
-            let to_read = if overflows { to_read } else { page.len() - pos };
+            let to_read = if let Some(local_size) =
+                payload_overflows(payload_size as usize, max_local, min_local, usable_size)
+            {
+                local_size
+            } else {
+                page.len() - pos
+            };
 
             crate::assert_or_bail_corrupt!(
                 pos + to_read <= page.len(),
@@ -908,9 +912,13 @@ pub fn read_btree_cell(
             let (payload_size, nr) = read_varint(crate::slice_in_bounds_or_corrupt!(page, pos..))?;
             pos += nr;
 
-            let (overflows, to_read) =
-                payload_overflows(payload_size as usize, max_local, min_local, usable_size);
-            let to_read = if overflows { to_read } else { page.len() - pos };
+            let to_read = if let Some(local_size) =
+                payload_overflows(payload_size as usize, max_local, min_local, usable_size)
+            {
+                local_size
+            } else {
+                page.len() - pos
+            };
 
             crate::assert_or_bail_corrupt!(
                 pos + to_read <= page.len(),
@@ -934,9 +942,13 @@ pub fn read_btree_cell(
             let (rowid, nr) = read_varint(crate::slice_in_bounds_or_corrupt!(page, pos..))?;
             pos += nr;
 
-            let (overflows, to_read) =
-                payload_overflows(payload_size as usize, max_local, min_local, usable_size);
-            let to_read = if overflows { to_read } else { page.len() - pos };
+            let to_read = if let Some(local_size) =
+                payload_overflows(payload_size as usize, max_local, min_local, usable_size)
+            {
+                local_size
+            } else {
+                page.len() - pos
+            };
 
             crate::assert_or_bail_corrupt!(
                 pos + to_read <= page.len(),
@@ -2202,27 +2214,27 @@ pub fn begin_write_wal_header<F: File + ?Sized>(
     Ok(c)
 }
 
-/// Checks if payload will overflow a cell based on the maximum allowed size.
-/// It will return the min size that will be stored in that case,
-/// including overflow pointer
-/// see e.g. https://github.com/sqlite/sqlite/blob/9591d3fe93936533c8c3b0dc4d025ac999539e11/src/dbstat.c#L371
+/// If the payload overflows the given limits, returns `Some(local_size)`, where `local_size` is
+/// the size that shall be occupied on the page by the payload plus its overflow page pointer.
+///
+/// Otherwise, returns `None`.
 #[inline]
 pub fn payload_overflows(
     payload_size: usize,
-    payload_overflow_threshold_max: usize,
-    payload_overflow_threshold_min: usize,
+    max_local_bytes: usize,
+    min_local_bytes: usize,
     usable_size: usize,
-) -> (bool, usize) {
-    if payload_size <= payload_overflow_threshold_max {
-        return (false, 0);
+) -> Option<usize> {
+    // See https://github.com/sqlite/sqlite/blob/9591d3fe93936533c8c3b0dc4d025ac999539e11/src/dbstat.c#L371
+    if payload_size <= max_local_bytes {
+        return None;
     }
 
-    let mut space_left = payload_overflow_threshold_min
-        + (payload_size - payload_overflow_threshold_min) % (usable_size - 4);
-    if space_left > payload_overflow_threshold_max {
-        space_left = payload_overflow_threshold_min;
+    let mut space_left = min_local_bytes + (payload_size - min_local_bytes) % (usable_size - 4);
+    if space_left > max_local_bytes {
+        space_left = min_local_bytes;
     }
-    (true, space_left + 4)
+    Some(space_left + 4)
 }
 
 /// The checksum is computed by interpreting the input as an even number of unsigned 32-bit integers: x(0) through x(N).
@@ -2290,15 +2302,54 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
+    #[case(PageType::TableLeaf, 4096, 0, None)]
+    #[case(PageType::TableLeaf, 4096, 4061, None)]
+    #[case(PageType::TableLeaf, 4096, 4062, Some(493))]
+    #[case(PageType::TableLeaf, 4096, 4500, Some(493))]
+    #[case(PageType::TableLeaf, 4096, 4581, Some(493))]
+    #[case(PageType::TableLeaf, 4096, 5000, Some(912))]
+    #[case(PageType::TableLeaf, 4096, 8153, Some(4065))]
+    #[case(PageType::TableLeaf, 4096, 8154, Some(493))]
+    #[case(PageType::IndexLeaf, 4096, 1002, None)]
+    #[case(PageType::IndexLeaf, 4096, 1003, Some(493))]
+    #[case(PageType::IndexLeaf, 4096, 4581, Some(493))]
+    #[case(PageType::IndexLeaf, 4096, 5094, Some(1006))]
+    #[case(PageType::IndexLeaf, 4096, 5095, Some(493))]
+    #[case(PageType::IndexInterior, 4096, 5000, Some(912))]
+    #[case(PageType::TableLeaf, 512, 477, None)]
+    #[case(PageType::TableLeaf, 512, 478, Some(43))]
+    #[case(PageType::IndexLeaf, 512, 102, None)]
+    #[case(PageType::IndexLeaf, 512, 103, Some(43))]
+    #[case(PageType::TableLeaf, 65536, 65501, None)]
+    #[case(PageType::TableLeaf, 65536, 65502, Some(8203))]
+    fn test_payload_overflows(
+        #[case] page_type: PageType,
+        #[case] usable_size: usize,
+        #[case] payload_size: usize,
+        #[case] expected: Option<usize>,
+    ) {
+        let result = payload_overflows(
+            payload_size,
+            payload_overflow_threshold_max(page_type, usable_size),
+            payload_overflow_threshold_min(page_type, usable_size),
+            usable_size,
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
     #[case(&[], SerialType::null(), Value::Null)]
     #[case(&[255], SerialType::i8(), Value::from_i64(-1))]
     #[case(&[0x12, 0x34], SerialType::i16(), Value::from_i64(0x1234))]
     #[case(&[0xFE], SerialType::i8(), Value::from_i64(-2))]
     #[case(&[0x12, 0x34, 0x56], SerialType::i24(), Value::from_i64(0x123456))]
     #[case(&[0x12, 0x34, 0x56, 0x78], SerialType::i32(), Value::from_i64(0x12345678))]
-    #[case(&[0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC], SerialType::i48(), Value::from_i64(0x123456789ABC))]
-    #[case(&[0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xFF], SerialType::i64(), Value::from_i64(0x123456789ABCDEFF))]
-    #[case(&[0x40, 0x09, 0x21, 0xFB, 0x54, 0x44, 0x2D, 0x18], SerialType::f64(), Value::from_f64(std::f64::consts::PI))]
+    #[case(&[0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC], SerialType::i48(), Value::from_i64(0x123456789ABC)
+    )]
+    #[case(&[0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xFF], SerialType::i64(), Value::from_i64(0x123456789ABCDEFF)
+    )]
+    #[case(&[0x40, 0x09, 0x21, 0xFB, 0x54, 0x44, 0x2D, 0x18], SerialType::f64(), Value::from_f64(std::f64::consts::PI)
+    )]
     #[case(&[1, 2], SerialType::const_int0(), Value::from_i64(0))]
     #[case(&[65, 66], SerialType::const_int1(), Value::from_i64(1))]
     #[case(
@@ -2322,8 +2373,10 @@ mod tests {
     #[case(&[0x7f, 0xff], SerialType::i16(), Value::from_i64(32767))]
     #[case(&[0x7f, 0xff, 0xff], SerialType::i24(), Value::from_i64(8388607))]
     #[case(&[0x7f, 0xff, 0xff, 0xff], SerialType::i32(), Value::from_i64(2147483647))]
-    #[case(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff], SerialType::i48(), Value::from_i64(140737488355327))]
-    #[case(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], SerialType::i64(), Value::from_i64(9223372036854775807))]
+    #[case(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff], SerialType::i48(), Value::from_i64(140737488355327)
+    )]
+    #[case(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], SerialType::i64(), Value::from_i64(9223372036854775807)
+    )]
     fn test_read_value(
         #[case] buf: &[u8],
         #[case] serial_type: SerialType,

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -3382,7 +3382,7 @@ impl Wal for WalFile {
 
     /// End a read transaction.
     #[inline(always)]
-    #[instrument(skip_all, level = Level::DEBUG)]
+    #[cfg_attr(debug_assertions, instrument(skip_all, level = Level::DEBUG))]
     fn end_read_tx(&self) {
         let slot = self.max_frame_read_lock_index.load(Ordering::Acquire);
         if slot != NO_LOCK_HELD {

--- a/core/types.rs
+++ b/core/types.rs
@@ -15,7 +15,7 @@ use crate::pseudo::PseudoCursor;
 use crate::schema::Index;
 use crate::storage::btree::{BTreeCursor, CursorTrait};
 use crate::storage::sqlite3_ondisk::{
-    read_integer, read_value, read_varint, varint_len, write_varint,
+    read_integer, read_value, read_value_serial_type, read_varint, varint_len, write_varint,
 };
 use crate::translate::collate::CollationSeq;
 use crate::translate::plan::IterationDirection;
@@ -2111,6 +2111,49 @@ impl<'a> Iterator for ValueIterator<'a> {
         acc
     }
 
+    #[inline(always)]
+    fn last(self) -> Option<Self::Item> {
+        let mut header = self.header_section.get();
+        if unlikely(header.is_empty()) {
+            return None;
+        }
+        let mut data_offset = 0;
+        let last_serial_type = loop {
+            let (serial_type, bytes_read) = match read_varint(header) {
+                Ok(v) => v,
+                Err(e) => {
+                    mark_unlikely();
+                    return Some(Err(e));
+                }
+            };
+            header = &header[bytes_read..];
+            if header.is_empty() {
+                break serial_type;
+            }
+            data_offset += match get_serial_type_size(serial_type) {
+                Ok(size) => size,
+                Err(e) => {
+                    mark_unlikely();
+                    return Some(Err(e));
+                }
+            };
+        };
+
+        let data = self.data_section.get();
+        if unlikely(data_offset > data.len()) {
+            return Some(Err(LimboError::Corrupt(
+                "Data section too small for indicated serial type size".into(),
+            )));
+        }
+        match read_value_serial_type(&data[data_offset..], last_serial_type) {
+            Ok((value, _)) => Some(Ok(value)),
+            Err(e) => {
+                mark_unlikely();
+                Some(Err(e))
+            }
+        }
+    }
+
     /// Returns the nth element of the iterator.
     #[inline(always)]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
@@ -2177,7 +2220,7 @@ impl<'a> Iterator for ValueIterator<'a> {
 
         let data_section = self.data_section.get();
 
-        match crate::storage::sqlite3_ondisk::read_value_serial_type(data_section, serial_type) {
+        match read_value_serial_type(data_section, serial_type) {
             Ok((value, n)) => {
                 self.data_section.set(&data_section[n..]);
                 Some(Ok(value))
@@ -3899,6 +3942,43 @@ mod tests {
         assert_eq!(values[4], ValueRef::Blob(&[1, 2, 3]));
         assert_eq!(values[5], ValueRef::from_i64(0));
         assert_eq!(values[6], ValueRef::from_i64(1));
+    }
+
+    #[test]
+    fn test_value_iterator_last_decodes_only_the_last_value() {
+        let mut buf = std::vec::Vec::new();
+        let record = Record::new(vec![
+            Value::Null,
+            Value::from_i64(100),
+            Value::from_f64(std::f64::consts::PI),
+            Value::Text(Text::new("test")),
+            Value::from_slice(&[1, 2, 3]).expect(crate::alloc::ALLOC_ERR_MSG),
+            Value::from_i64(0),
+            Value::from_i64(1),
+            Value::from_i64(-7_000_000_000),
+        ]);
+        record.serialize(&mut buf);
+
+        let iter = ValueIterator::new(&buf).unwrap();
+        assert_eq!(
+            iter.last().unwrap().unwrap(),
+            ValueRef::from_i64(-7_000_000_000)
+        );
+
+        let mut buf = std::vec::Vec::new();
+        let record = Record::new(vec![Value::Text(Text::new("only"))]);
+        record.serialize(&mut buf);
+        let iter = ValueIterator::new(&buf).unwrap();
+        assert_eq!(
+            iter.last().unwrap().unwrap(),
+            ValueRef::Text(TextRef::new("only", TextSubtype::Text))
+        );
+
+        let mut buf = std::vec::Vec::new();
+        let record = Record::new(vec![]);
+        record.serialize(&mut buf);
+        let iter = ValueIterator::new(&buf).unwrap();
+        assert!(iter.last().is_none());
     }
 
     #[test]

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -3952,69 +3952,74 @@ pub(crate) fn vtab_commit_all(conn: &Connection) -> crate::Result<()> {
 /// Stage pending writes on every index-method cursor before releasing the
 /// statement savepoint. Cursor order is bytecode cursor order, which is stable
 /// across resumptions and avoids attachment-order ambiguity.
+#[inline]
 pub(crate) fn index_method_stage_statement_all(state: &mut ProgramState) -> IOResultOr<()> {
     if state.index_methods_finalized || !has_index_method_work(state) {
         return Ok(IOResult::Done(()));
     }
+    return stage_statement_all_cold(state);
 
-    while state.index_method_finalize_cursor < state.cursors.len() {
-        let cursor_id = state.index_method_finalize_cursor;
-        if matches!(
-            state.cursors[cursor_id].as_ref(),
-            Some(Cursor::IndexMethod(_))
-        ) {
-            let Some(context) = state.index_method_contexts[cursor_id].clone() else {
-                return Err(LimboError::InternalError(format!(
-                    "index-method cursor {cursor_id} has no execution context"
-                ))
-                .into());
-            };
-            crate::mvcc::yield_points::inject_io_yield!(
-                context,
-                crate::index_method::IndexMethodYieldPoint::BeforePrepareStatement
-            );
-            let Some(Cursor::IndexMethod(cursor)) = state.cursors[cursor_id].as_mut() else {
-                unreachable!("cursor kind checked above")
-            };
-            match cursor.stage_statement_commit(&context)? {
-                IOResult::Done(()) => {}
-                IOResult::IO(io) => return Ok(IOResult::IO(io)),
+    #[inline(never)]
+    fn stage_statement_all_cold(state: &mut ProgramState) -> IOResultOr<()> {
+        while state.index_method_finalize_cursor < state.cursors.len() {
+            let cursor_id = state.index_method_finalize_cursor;
+            if matches!(
+                state.cursors[cursor_id].as_ref(),
+                Some(Cursor::IndexMethod(_))
+            ) {
+                let Some(context) = state.index_method_contexts[cursor_id].clone() else {
+                    return Err(LimboError::InternalError(format!(
+                        "index-method cursor {cursor_id} has no execution context"
+                    ))
+                    .into());
+                };
+                crate::mvcc::yield_points::inject_io_yield!(
+                    context,
+                    crate::index_method::IndexMethodYieldPoint::BeforePrepareStatement
+                );
+                let Some(Cursor::IndexMethod(cursor)) = state.cursors[cursor_id].as_mut() else {
+                    unreachable!("cursor kind checked above")
+                };
+                match cursor.stage_statement_commit(&context)? {
+                    IOResult::Done(()) => {}
+                    IOResult::IO(io) => return Ok(IOResult::IO(io)),
+                }
+                state.index_method_finalize_cursor += 1;
+                crate::mvcc::yield_points::inject_io_yield!(
+                    context,
+                    crate::index_method::IndexMethodYieldPoint::AfterPrepareStatement
+                );
+                continue;
             }
             state.index_method_finalize_cursor += 1;
-            crate::mvcc::yield_points::inject_io_yield!(
-                context,
-                crate::index_method::IndexMethodYieldPoint::AfterPrepareStatement
-            );
-            continue;
         }
-        state.index_method_finalize_cursor += 1;
-    }
 
-    let subprogram_keys = state
-        .index_method_finalize_subprogram_keys
-        .get_or_insert_with(|| {
-            let mut keys = state
+        let subprogram_keys = state
+            .index_method_finalize_subprogram_keys
+            .get_or_insert_with(|| {
+                let mut keys = state
+                    .subprogram_stmt_cache
+                    .keys()
+                    .copied()
+                    .collect::<Vec<_>>();
+                keys.sort_unstable();
+                keys
+            });
+        while state.index_method_finalize_subprogram < subprogram_keys.len() {
+            let key = subprogram_keys[state.index_method_finalize_subprogram];
+            let statement = state
                 .subprogram_stmt_cache
-                .keys()
-                .copied()
-                .collect::<Vec<_>>();
-            keys.sort_unstable();
-            keys
-        });
-    while state.index_method_finalize_subprogram < subprogram_keys.len() {
-        let key = subprogram_keys[state.index_method_finalize_subprogram];
-        let statement = state
-            .subprogram_stmt_cache
-            .get_mut(&key)
-            .expect("finalization key must reference a cached subprogram");
-        match statement.prepare_index_methods()? {
-            IOResult::Done(()) => state.index_method_finalize_subprogram += 1,
-            IOResult::IO(io) => return Ok(IOResult::IO(io)),
+                .get_mut(&key)
+                .expect("finalization key must reference a cached subprogram");
+            match statement.prepare_index_methods()? {
+                IOResult::Done(()) => state.index_method_finalize_subprogram += 1,
+                IOResult::IO(io) => return Ok(IOResult::IO(io)),
+            }
         }
-    }
 
-    state.index_methods_finalized = true;
-    Ok(IOResult::Done(()))
+        state.index_methods_finalized = true;
+        Ok(IOResult::Done(()))
+    }
 }
 
 /// Discard statement-owned index-method work before a statement savepoint or
@@ -4095,6 +4100,7 @@ pub(crate) fn index_method_on_transaction_committed_all(
 /// statement into connection-level transaction ownership. Replacing an older
 /// cursor for the same attachment keeps outcome delivery exactly once while
 /// retaining the newest in-transaction view.
+#[inline]
 pub(crate) fn index_method_register_transaction_all(
     state: &mut ProgramState,
     connection: &Connection,
@@ -4102,6 +4108,14 @@ pub(crate) fn index_method_register_transaction_all(
     if !has_index_method_work(state) {
         return Ok(());
     }
+    register_index_method_transactions(state, connection)
+}
+
+#[inline(never)]
+fn register_index_method_transactions(
+    state: &mut ProgramState,
+    connection: &Connection,
+) -> crate::Result<()> {
     let mut registered = 0usize;
     for cursor_id in 0..state.cursors.len() {
         if !matches!(state.cursors[cursor_id], Some(Cursor::IndexMethod(_))) {
@@ -4141,6 +4155,7 @@ pub(crate) fn index_method_register_transaction_all(
 /// Whether this statement has index-method cursors, closed index-method
 /// cursors or cached subprograms that the commit hooks must visit. Almost
 /// every statement has none, and every halt calls the hooks.
+#[inline]
 fn has_index_method_work(state: &ProgramState) -> bool {
     !state.closed_index_method_cursors.is_empty()
         || !state.subprogram_stmt_cache.is_empty()

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -1426,13 +1426,12 @@ pub fn op_open_read(
                 .replace(cursor.into_cursor());
         }
         CursorType::BTreeIndex(index) => {
-            let btree_cursor = BTreeCursor::new_index(
+            let btree_cursor = BTreeCursor::new_index_boxed(
                 pager,
                 maybe_transform_root_page_to_positive(mv_store.as_ref(), *root_page),
                 index.as_ref(),
                 num_columns,
-            )?
-            .into_boxed();
+            )?;
             let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {
                 IndexInfo::new_from_index_in(index, mv_store.allocator())?
             } else {
@@ -13653,12 +13652,12 @@ pub fn op_open_write(
         if let Some(index) = maybe_index {
             let num_columns = index.columns.len();
             let btree_cursor = btree_cursor_with_yield_context(
-                Box::new(BTreeCursor::new_index(
+                BTreeCursor::new_index_boxed(
                     pager,
                     maybe_transform_root_page_to_positive(mv_store.as_ref(), root_page),
                     index.as_ref(),
                     num_columns,
-                )?),
+                )?,
                 &program.connection,
             );
             let index_info = Arc::new(if let Some(mv_store) = mv_store.as_ref() {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -6169,6 +6169,7 @@ fn op_row_id_deferred(state: &mut ProgramState, cursor_id: usize, dest: usize) -
 }
 
 /// Reads the rowid of the cursor's current position into a register.
+#[inline(always)]
 fn op_row_id_read(state: &mut ProgramState, cursor_id: usize, dest: usize) -> InsnResult {
     let cursor = state
         .cursors

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1229,10 +1229,18 @@ impl ProgramState {
         self.auto_txn_cleanup = TxnCleanup::None;
         *self.fk_immediate_violations_during_stmt.get_mut() = 0;
         *self.fk_deferred_violations_when_stmt_started.get_mut() = 0;
-        self.rowsets.clear();
-        self.bloom_filters.clear();
-        self.hash_tables.clear();
-        self.ephemeral_temp_files.clear();
+        if !self.rowsets.is_empty() {
+            self.rowsets.clear();
+        }
+        if !self.bloom_filters.is_empty() {
+            self.bloom_filters.clear();
+        }
+        if !self.hash_tables.is_empty() {
+            self.hash_tables.clear();
+        }
+        if !self.ephemeral_temp_files.is_empty() {
+            self.ephemeral_temp_files.clear();
+        }
         self.uses_subjournal = false;
         self.is_active_write = false;
         self.has_stmt_transaction = false;

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3842,7 +3842,7 @@ impl<'a> ValueIteratorExt for crate::types::ValueIterator<'a> {
     /// The header and data positions live in locals for the whole range and
     /// go back into the iterator once at the end: written back per column,
     /// they cost four stores for every value of every row.
-    #[inline]
+    #[inline(always)]
     fn decode_into_registers_after(
         &mut self,
         skip: usize,


### PR DESCRIPTION
## Description

Part 13 of 15 split out of #8692 (commits 121-130 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### Second session (commits 89 to 149, `98c2b91f` → `cc0dfdf6`)

A second autonomous session continued from `98c2b91f` with the same method: callgrind instruction counts (`Ir`) of the local driver, one measured change per commit, changes that measured worse reverted and listed below. The 100k-row scans run 3 iterations (5 for `SELECT 1 FROM t`); the per-statement numbers are instructions per execution, (Ir at 3000 − Ir at 1000) / 2000. Two more scan workloads join the set: `SELECT name FROM t` (W13, one TEXT column per row) and `SELECT * FROM t ORDER BY name DESC LIMIT 10` (W9, the sorter), plus `SELECT length(name) FROM t` and `SELECT abs(value) FROM t` for the scalar function opcode. The CodSpeed runs of `3c369a50`, `9b2dcf03`, `46436272` and the later heads are in the CodSpeed section of #8692.

| Commit | `SELECT 1 FROM t` | `SELECT * FROM t` | W3 | W4 | W12 (GROUP BY value) | W13 (`SELECT name`) | W9 (ORDER BY) |
|---|---:|---:|---:|---:|---:|---:|---:|
| inline the rowid read into the RowId opcode | 104,827,694 (+0.01%) | 226,632,817 (-2.4%) | 137,748,466 (+0.006%) | 158,206,247 (+0.005%) | 638,258,358 (+0.001%) | 158,077,894 (+0.004%) |  |
| inline the range decoder into the column range fetch | = | 220,934,338 (-2.5%) | = | = | = | = |  |
| build the cursor of an index open once | 104,825,359 (-0.002%, one table open per iteration) | 220,934,326 (-12 instructions) | 137,747,029 (-0.001%, one index open per run) | 158,204,849 (-0.001%) |  |  |  |
| inline the check for attached pagers into its callers | 104,814,074 (-0.01%) |  |  |  |  |  |  |
| clear the per-statement maps only when they hold something | 104,813,979 (-95 instructions) |  |  |  |  |  |  |
| read the left child pointer of an index interior cell directly |  |  | 137,738,311 (-0.006%, the descents of the run) |  |  |  |  |
| decode only the last value in ValueIterator::last |  |  | 137,737,882 (-429 instructions, the three rows returned) | 158,196,134 (-0.005%) |  |  |  |
| search the leaf page of an index seek in one call |  |  | = |  |  |  |  |
| open the tracing spans of page reads and read transactions in debug builds only | 104,784,959 (-0.03%, about 9 per page read) |  |  |  |  |  |  |
| test for index-method work inline at the end of a statement | 104,784,874 (-85 instructions, the five statement ends) |  |  |  |  |  |  |

| Commit | point lookup | `SELECT 1` | index lookup |
|---|---:|---:|---:|
| inline the rowid read into the RowId opcode | 6,951 (-0.2%) | = | 12,633 (-0.1%) |
| inline the range decoder into the column range fetch | 6,935 (-0.2%) | = | = |
| build the cursor of an index open once | 6,931 | = | 12,166 (-3.7%) |
| inline the check for attached pagers into its callers | 6,886 (-0.6%) | 1,575 (-2.9%) | 12,116 (-0.4%) |
| clear the per-statement maps only when they hold something | 6,867 (-0.3%) | 1,556 (-1.2%) | 12,097 (-0.2%) |
| read the left child pointer of an index interior cell directly | = | = | 11,731 (-3.0%) |
| decode only the last value in ValueIterator::last | = | = | 11,588 (-1.2%) |
| search the leaf page of an index seek in one call | = | = | 11,477 (-1.0%) |
| open the tracing spans of page reads and read transactions in debug builds only | 6,752 (-1.7%) | 1,561 (+0.3%, code layout: it opens no read transaction) | 11,356 (-1.1%) |
| test for index-method work inline at the end of a statement | 6,735 (-0.3%) | 1,525 (-2.3%) | 11,339 (-0.1%) |

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_