### PR TITLE
core: Optimize index seek opcodes and count aggregate

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -423,7 +423,9 @@ impl Display for FtsFunc {
 #[derive(Debug, Clone, strum::EnumIter)]
 pub enum AggFunc {
     Avg,
+    /// COUNT(expr)
     Count,
+    /// COUNT(*) or COUNT()
     Count0,
     GroupConcat,
     Max,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2257,6 +2257,7 @@ impl BTreeCursor {
         // read can yield here, and it returns before the range changes, so
         // re-entry retries the same cell. The caller persists the state once
         // per call instead of once per compare.
+        let payload_limits = self.payload_limits;
         while state.min_cell_idx <= state.max_cell_idx {
             let cur_cell_idx = (state.min_cell_idx + state.max_cell_idx) >> 1; // rustc generates extra insns for (min+max)/2 due to them being isize. we know min&max are >=0 here.
             self.stack.set_cell_index(cur_cell_idx as i32);
@@ -2265,7 +2266,7 @@ impl BTreeCursor {
                 .stack
                 .get_page_contents_at_level(old_top_idx)
                 .unwrap()
-                .cell_read_payload_ptr(cur_cell_idx as usize, self.payload_limits)?;
+                .cell_read_payload_ptr(cur_cell_idx as usize, payload_limits)?;
 
             let cell_payload: &[u8] = if let Some(next_page) = first_overflow_page {
                 let res = self.process_overflow_read(payload, next_page, payload_size)?;
@@ -2788,6 +2789,7 @@ impl BTreeCursor {
         };
         let iter_dir = seek_op.iteration_direction();
         let eq_seen = state.eq_seen;
+        let payload_limits = self.payload_limits;
         loop {
             let min = state.min_cell_idx;
             let max = state.max_cell_idx;
@@ -2827,7 +2829,7 @@ impl BTreeCursor {
                 .stack
                 .get_page_contents_at_level(old_top_idx)
                 .unwrap()
-                .cell_read_payload_ptr(cur_cell_idx as usize, self.payload_limits)?;
+                .cell_read_payload_ptr(cur_cell_idx as usize, payload_limits)?;
 
             let cell_payload: &[u8] = if let Some(next_page) = first_overflow_page {
                 let res = self.process_overflow_read(payload, next_page, payload_size)?;

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -2287,7 +2287,6 @@ impl BTreeCursor {
                     self.index_info
                         .as_ref()
                         .expect("indexbtree_move_to: index_info required"),
-                    0,
                     tie_breaker,
                 )?;
 
@@ -2896,7 +2895,7 @@ impl BTreeCursor {
         ) -> Result<(Ordering, bool)> {
             let tie_breaker = get_tie_breaker_from_seek_op(seek_op);
             let cmp =
-                record_comparer.compare_payload(payload, key_values, index_info, 0, tie_breaker)?;
+                record_comparer.compare_payload(payload, key_values, index_info, tie_breaker)?;
 
             let found = match seek_op {
                 SeekOp::GT => cmp.is_gt(),

--- a/core/types.rs
+++ b/core/types.rs
@@ -2648,7 +2648,10 @@ pub fn cmp_with_sort(cmp: Ordering, a: &ValueRef, b: &ValueRef, key: &KeyInfo) -
 
 #[derive(Debug, Clone, Copy)]
 pub enum RecordCompare {
-    Int,
+    /// Optimization: the first rhs value is this integer.
+    Int {
+        rhs_first_value: i64,
+    },
     String,
     Generic,
 }
@@ -2686,9 +2689,9 @@ impl RecordCompare {
     {
         let right_values = right_values.into_iter();
         match self {
-            RecordCompare::Int => {
-                compare_payload_int(left_payload, right_values, index_info, tie_breaker)
-            }
+            RecordCompare::Int {
+                rhs_first_value: key,
+            } => compare_payload_int(left_payload, right_values, index_info, tie_breaker, *key),
             RecordCompare::String => {
                 compare_payload_string(left_payload, right_values, index_info, tie_breaker)
             }
@@ -2707,7 +2710,9 @@ where
     if right_values.len() != 0 && index_info.num_cols <= 13 {
         let val = right_values.peek().unwrap();
         match val.as_value_ref() {
-            ValueRef::Numeric(Numeric::Integer(_)) => RecordCompare::Int,
+            ValueRef::Numeric(Numeric::Integer(key)) => RecordCompare::Int {
+                rhs_first_value: key,
+            },
             ValueRef::Text(_) if index_info.key_info[0].collation == CollationSeq::Binary => {
                 RecordCompare::String
             }
@@ -2778,6 +2783,7 @@ fn compare_payload_int<V, I>(
     right_unpacked: I,
     index_info: &IndexInfo,
     tie_breaker: std::cmp::Ordering,
+    rhs_int: i64,
 ) -> Result<std::cmp::Ordering>
 where
     V: AsValueRef,
@@ -2808,13 +2814,6 @@ where
     let data_start = header_size;
 
     let lhs_int = read_integer(&left_packed[data_start..], first_serial_type as u8)?;
-    let mut right_unpacked = right_unpacked.peekable();
-    // Do not consume iterator here
-    let ValueRef::Numeric(Numeric::Integer(rhs_int)) =
-        right_unpacked.peek().unwrap().as_value_ref()
-    else {
-        return compare_payload_generic(left_packed, right_unpacked, index_info, 0, tie_breaker);
-    };
     let comparison = match index_info.key_info[0].sort_order {
         SortOrder::Asc => lhs_int.cmp(&rhs_int),
         SortOrder::Desc => lhs_int.cmp(&rhs_int).reverse(),
@@ -4631,7 +4630,9 @@ mod tests {
         ];
         assert!(matches!(
             find_compare(int_values.iter().peekable(), &index_info_small),
-            RecordCompare::Int
+            RecordCompare::Int {
+                rhs_first_value: 42
+            }
         ));
 
         let string_values = [

--- a/core/types.rs
+++ b/core/types.rs
@@ -2653,40 +2653,30 @@ pub enum RecordCompare {
     Generic,
 }
 
-impl RecordCompare {
-    #[inline(always)]
-    pub fn compare<V, E, I>(
-        &self,
-        serialized: &ImmutableRecord,
-        unpacked: I,
-        index_info: &IndexInfo,
-        skip: usize,
-        tie_breaker: std::cmp::Ordering,
-    ) -> Result<std::cmp::Ordering>
-    where
-        V: AsValueRef,
-        E: ExactSizeIterator<Item = V>,
-        I: IntoIterator<IntoIter = E, Item = E::Item>,
-    {
-        self.compare_payload(
-            serialized.get_payload(),
-            unpacked,
-            index_info,
-            skip,
-            tie_breaker,
-        )
-    }
+pub fn compare_record<V, I>(
+    left_payload: &[u8],
+    right_values: I,
+    index_info: &IndexInfo,
+    tie_breaker: std::cmp::Ordering,
+) -> Result<std::cmp::Ordering>
+where
+    V: AsValueRef,
+    I: ExactSizeIterator<Item = V> + Clone,
+{
+    let comparer = find_compare(right_values.clone().peekable(), index_info);
+    comparer.compare_payload(left_payload, right_values, index_info, tie_breaker)
+}
 
+impl RecordCompare {
     /// The comparison on the serialized bytes of a record. The seek loops
     /// compare the cells of a page where they lie, without a copy into the
     /// cursor's record buffer.
     #[inline(always)]
     pub fn compare_payload<V, E, I>(
         &self,
-        payload: &[u8],
-        unpacked: I,
+        left_payload: &[u8],
+        right_values: I,
         index_info: &IndexInfo,
-        skip: usize,
         tie_breaker: std::cmp::Ordering,
     ) -> Result<std::cmp::Ordering>
     where
@@ -2694,28 +2684,28 @@ impl RecordCompare {
         E: ExactSizeIterator<Item = V>,
         I: IntoIterator<IntoIter = E, Item = E::Item>,
     {
-        let unpacked = unpacked.into_iter();
+        let right_values = right_values.into_iter();
         match self {
-            RecordCompare::Int => compare_payload_int(payload, unpacked, index_info, tie_breaker),
+            RecordCompare::Int => {
+                compare_payload_int(left_payload, right_values, index_info, tie_breaker)
+            }
             RecordCompare::String => {
-                compare_payload_string(payload, unpacked, index_info, tie_breaker)
+                compare_payload_string(left_payload, right_values, index_info, tie_breaker)
             }
             RecordCompare::Generic => {
-                compare_payload_generic(payload, unpacked, index_info, skip, tie_breaker)
+                compare_payload_generic(left_payload, right_values, index_info, 0, tie_breaker)
             }
         }
     }
 }
 
-pub fn find_compare<I, E, V>(unpacked: I, index_info: &IndexInfo) -> RecordCompare
+pub fn find_compare<V, I>(mut right_values: Peekable<I>, index_info: &IndexInfo) -> RecordCompare
 where
     V: AsValueRef,
-    E: ExactSizeIterator<Item = V>,
-    I: IntoIterator<IntoIter = Peekable<E>, Item = V>,
+    I: ExactSizeIterator<Item = V>,
 {
-    let mut unpacked = unpacked.into_iter();
-    if unpacked.len() != 0 && index_info.num_cols <= 13 {
-        let val = unpacked.peek().unwrap();
+    if right_values.len() != 0 && index_info.num_cols <= 13 {
+        let val = right_values.peek().unwrap();
         match val.as_value_ref() {
             ValueRef::Numeric(Numeric::Integer(_)) => RecordCompare::Int,
             ValueRef::Text(_) if index_info.key_info[0].collation == CollationSeq::Binary => {
@@ -2745,7 +2735,7 @@ pub fn get_tie_breaker_from_seek_op(seek_op: SeekOp) -> std::cmp::Ordering {
 
 /// Optimized integer-first record comparison function.
 ///
-/// This function is an optimized version of `compare_records_generic()` for the
+/// This function is an optimized version of `compare_payload_generic()` for the
 /// common case where:
 /// - (a) The first field of the unpacked record is an integer
 /// - (b) The serialized record's first field is also an integer
@@ -2762,7 +2752,7 @@ pub fn get_tie_breaker_from_seek_op(seek_op: SeekOp) -> std::cmp::Ordering {
 /// - First serial type indicates integer (`1-6`, `8`, or `9`)
 /// - First unpacked field is a `ValueRef::Numeric(Numeric::Integer)`
 ///
-/// If any condition fails, it falls back to `compare_records_generic()`.
+/// If any condition fails, it falls back to `compare_payload_generic()`.
 ///
 /// # Arguments
 ///
@@ -2781,7 +2771,7 @@ pub fn get_tie_breaker_from_seek_op(seek_op: SeekOp) -> std::cmp::Ordering {
 /// 3. **Native comparison**: Uses Rust's built-in `i64::cmp()` for speed
 /// 4. **Sort order**: Applies ascending/descending order to comparison result
 /// 5. **Remaining fields**: If first field is equal and more fields exist,
-///    delegates to `compare_records_generic()` with `skip=1`
+///    delegates to `compare_payload_generic()` with `skip=1`
 #[inline(always)]
 fn compare_payload_int<V, I>(
     left_packed: &[u8],
@@ -2847,7 +2837,7 @@ where
     }
 }
 
-/// This function is an optimized version of `compare_records_generic()` for the
+/// This function is an optimized version of `compare_payload_generic()` for the
 /// common case where:
 /// - (a) The first field of the unpacked record is a string
 /// - (b) The serialized record's first field is also a string
@@ -2865,7 +2855,7 @@ where
 /// - First serial type indicates string (`>= 13` and odd number)
 /// - First unpacked field is a `RefValue::Text`
 ///
-/// If any condition fails, it falls back to `compare_records_generic()`.
+/// If any condition fails, it falls back to `compare_payload_generic()`.
 ///
 /// # Arguments
 ///
@@ -2884,7 +2874,7 @@ where
 /// 3. **Sort order**: Applies ascending/descending order to comparison result
 /// 4. **Length comparison**: If strings are equal, compares lengths
 /// 5. **Remaining fields**: If first field is equal and more fields exist,
-///    delegates to `compare_records_generic()` with `skip=1`
+///    delegates to `compare_payload_generic()` with `skip=1`
 fn compare_payload_string<V, I>(
     left_packed: &[u8],
     right_unpacked: I,
@@ -3000,28 +2990,7 @@ where
 /// The serialized and unpacked records do not have to contain the same number
 /// of fields. If all fields that appear in both records are equal, then
 /// `tie_breaker` is returned.
-pub fn compare_records_generic<V, I>(
-    left_packed: &ImmutableRecord,
-    right_unpacked: I,
-    index_info: &IndexInfo,
-    skip: usize,
-    tie_breaker: std::cmp::Ordering,
-) -> Result<std::cmp::Ordering>
-where
-    V: AsValueRef,
-    I: ExactSizeIterator<Item = V>,
-{
-    compare_payload_generic(
-        left_packed.get_payload(),
-        right_unpacked,
-        index_info,
-        skip,
-        tie_breaker,
-    )
-}
-
-/// [compare_records_generic] on the serialized bytes of the record.
-pub fn compare_payload_generic<V, I>(
+fn compare_payload_generic<V, I>(
     left_packed: &[u8],
     right_unpacked: I,
     index_info: &IndexInfo,
@@ -4170,7 +4139,12 @@ mod tests {
 
         let comparer = find_compare(unpacked_values.iter().peekable(), index_info);
         let optimized_result = comparer
-            .compare(&serialized, &unpacked_values, index_info, 0, tie_breaker)
+            .compare_payload(
+                serialized.get_payload(),
+                &unpacked_values,
+                index_info,
+                tie_breaker,
+            )
             .unwrap();
 
         assert_eq!(
@@ -4178,8 +4152,17 @@ mod tests {
             "Test '{test_name}' failed: Full Comparison: {gold_result:?}, Optimized: {optimized_result:?}, Strategy: {comparer:?}"
         );
 
-        let generic_result = compare_records_generic(
-            &serialized,
+        let selected_result = compare_record(
+            serialized.get_payload(),
+            unpacked_values.iter(),
+            index_info,
+            tie_breaker,
+        )
+        .unwrap();
+        assert_eq!(gold_result, selected_result, "Test '{test_name}' failed");
+
+        let generic_result = compare_payload_generic(
+            serialized.get_payload(),
             unpacked_values.iter(),
             index_info,
             0,
@@ -4568,6 +4551,28 @@ mod tests {
     }
 
     #[test]
+    fn compare_record_preserves_prefix_tie_breakers() {
+        let index_info =
+            create_index_info(2, vec![SortOrder::Asc; 2], vec![CollationSeq::Binary; 2]);
+        for first in [Value::from_i64(42), Value::build_text("key"), Value::Null] {
+            let serialized = create_record(vec![first.clone(), Value::from_i64(99)]);
+            for tie_breaker in [Ordering::Less, Ordering::Equal, Ordering::Greater] {
+                let right_values = [first.as_ref()];
+                assert_eq!(
+                    compare_record(
+                        serialized.get_payload(),
+                        right_values.into_iter(),
+                        &index_info,
+                        tie_breaker,
+                    )
+                    .unwrap(),
+                    tie_breaker,
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_skip_parameter() {
         let index_info = create_index_info(
             3,
@@ -4587,12 +4592,22 @@ mod tests {
         ];
 
         let tie_breaker = std::cmp::Ordering::Equal;
-        let result_skip_0 =
-            compare_records_generic(&serialized, unpacked.iter(), &index_info, 0, tie_breaker)
-                .unwrap();
-        let result_skip_1 =
-            compare_records_generic(&serialized, unpacked.iter(), &index_info, 1, tie_breaker)
-                .unwrap();
+        let result_skip_0 = compare_payload_generic(
+            serialized.get_payload(),
+            unpacked.iter(),
+            &index_info,
+            0,
+            tie_breaker,
+        )
+        .unwrap();
+        let result_skip_1 = compare_payload_generic(
+            serialized.get_payload(),
+            unpacked.iter(),
+            &index_info,
+            1,
+            tie_breaker,
+        )
+        .unwrap();
 
         assert_eq!(result_skip_0, std::cmp::Ordering::Less);
 

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -8918,6 +8918,28 @@ fn op_agg_step_slow(program: &Program, state: &mut ProgramState, data: &AggStepD
 
     // Initialize aggregate state if not already done
     if let Register::Value(Value::Null) = state.registers[*acc_reg] {
+        // Fast path for the first row of a COUNT group
+        if let AggFunc::Count | AggFunc::Count0 = func {
+            let counts = match (func, &state.registers[*col]) {
+                (AggFunc::Count0, _) => Some(true),
+                (_, Register::Value(Value::Null)) => Some(false),
+                (_, Register::Value(_) | Register::Record(_)) => Some(true),
+                (_, Register::Aggregate(_)) => None,
+            };
+            if let Some(counts) = counts {
+                let mut payload = state
+                    .spare_agg_payloads
+                    .pop()
+                    .unwrap_or_else(|| crate::alloc::vec![]);
+                init_agg_payload(func, &mut payload)?;
+                if counts {
+                    payload[0] = Value::from_i64(1);
+                }
+                state.registers[*acc_reg] = Register::Aggregate(AggContext::Builtin(payload));
+                state.pc += 1;
+                return Ok(InsnFunctionStepResult::Step);
+            }
+        }
         state.registers[*acc_reg] = match func {
             AggFunc::External(ext_func) => match ext_func.as_ref() {
                 ExtFunc::Aggregate {

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -29,7 +29,7 @@ use crate::storage::sqlite3_ondisk::{DatabaseHeader, PageSize, RawVersion};
 use crate::translate::collate::CollationSeq;
 use crate::types::IOResultOr;
 use crate::types::{
-    compare_immutable, compare_immutable_single, compare_records_generic, AsValueRef, Extendable,
+    compare_immutable, compare_immutable_single, compare_record, AsValueRef, Extendable,
     IOCompletions, IOResult, ImmutableRecord, IndexInfo, SeekResult, Text, ValueIterator,
 };
 use crate::util::{
@@ -6904,15 +6904,11 @@ pub fn op_idx_ge(
         let index_info = cursor.get_index_info().clone();
 
         let pc = if let Some(idx_record) = return_if_io!(state, cursor.record()) {
-            // Create the comparison record from registers
-            let values =
-                registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
             let tie_breaker = get_tie_breaker_from_idx_comp_op(insn);
-            let ord = compare_records_generic(
-                idx_record,  // The serialized record from the index
-                values,      // The record built from registers
-                &index_info, // Sort order flags
-                0,
+            let ord = compare_record(
+                idx_record.get_payload(),
+                registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]),
+                &index_info,
                 tie_breaker,
             )?;
 
@@ -6974,10 +6970,13 @@ pub fn op_idx_le(
         let index_info = cursor.get_index_info().clone();
 
         let pc = if let Some(idx_record) = return_if_io!(state, cursor.record()) {
-            let values =
-                registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
             let tie_breaker = get_tie_breaker_from_idx_comp_op(insn);
-            let ord = compare_records_generic(idx_record, values, &index_info, 0, tie_breaker)?;
+            let ord = compare_record(
+                idx_record.get_payload(),
+                registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]),
+                &index_info,
+                tie_breaker,
+            )?;
 
             if ord.is_le() {
                 target_pc.as_offset_int()
@@ -7021,10 +7020,13 @@ pub fn op_idx_gt(
         let index_info = cursor.get_index_info().clone();
 
         let pc = if let Some(idx_record) = return_if_io!(state, cursor.record()) {
-            let values =
-                registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
             let tie_breaker = get_tie_breaker_from_idx_comp_op(insn);
-            let ord = compare_records_generic(idx_record, values, &index_info, 0, tie_breaker)?;
+            let ord = compare_record(
+                idx_record.get_payload(),
+                registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]),
+                &index_info,
+                tie_breaker,
+            )?;
 
             if ord.is_gt() {
                 target_pc.as_offset_int()
@@ -7068,11 +7070,13 @@ pub fn op_idx_lt(
         let index_info = cursor.get_index_info().clone();
 
         let pc = if let Some(idx_record) = return_if_io!(state, cursor.record()) {
-            let values =
-                registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]);
-
             let tie_breaker = get_tie_breaker_from_idx_comp_op(insn);
-            let ord = compare_records_generic(idx_record, values, &index_info, 0, tie_breaker)?;
+            let ord = compare_record(
+                idx_record.get_payload(),
+                registers_to_ref_values(&state.registers[*start_reg..*start_reg + *num_regs]),
+                &index_info,
+                tie_breaker,
+            )?;
 
             if ord.is_lt() {
                 target_pc.as_offset_int()

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -10226,7 +10226,13 @@ pub fn op_function(
                     ScalarFunc::Soundex => Some(reg_value.exec_soundex()),
                     _ => unreachable!(),
                 };
-                state.registers[*dest].set_value(result.unwrap_or(Value::Null));
+                // this is a `match` instead of `unwrap_or_else` because on the current pinned
+                // toolchain, it compiles to fewer instructions
+                let value = match result {
+                    Some(value) => value,
+                    None => Value::Null,
+                };
+                state.registers[*dest].set_value(value);
             }
             ScalarFunc::Hex => {
                 let reg_value = state.registers[*start_reg].borrow_mut();

--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -9114,24 +9114,28 @@ pub fn op_agg_final(
                     // External aggregates use FFI finalization
                     agg.compute_external()?
                 }
-                AggContext::Builtin(payload) => {
-                    // Built-in aggregates use shared finalization
-                    finalize_agg_payload(func, payload)?
-                }
+                AggContext::Builtin(payload) => match func {
+                    AggFunc::Count | AggFunc::Count0 => {
+                        let [Value::Numeric(Numeric::Integer(count))] = payload.as_slice() else {
+                            unreachable!("COUNT payload must contain one integer");
+                        };
+                        Value::from_i64(*count)
+                    }
+                    _ => finalize_agg_payload(func, payload)?,
+                },
             };
             if acc_reg == dest_reg {
-                // The result will replace the allocator, so we hold on to the allocated Vec so that
-                // another group can reuse the allocation.
                 let accumulator =
-                    std::mem::replace(&mut state.registers[acc_reg], Register::Value(Value::Null));
+                    std::mem::replace(&mut state.registers[acc_reg], Register::Value(value));
                 if let Register::Aggregate(AggContext::Builtin(mut payload)) = accumulator {
                     if state.spare_agg_payloads.len() < SPARE_AGG_PAYLOADS {
                         payload.clear();
                         state.spare_agg_payloads.push(payload);
                     }
                 }
+            } else {
+                state.registers[dest_reg].set_value(value);
             }
-            state.registers[dest_reg].set_value(value);
         }
         Register::Value(Value::Null) => {
             // No row was stepped: write the empty-set default explicitly.

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -3709,7 +3709,7 @@ pub(crate) fn split_registers(
 
 pub fn registers_to_ref_values<'a>(
     registers: &'a [Register],
-) -> impl ExactSizeIterator<Item = ValueRef<'a>> {
+) -> impl ExactSizeIterator<Item = ValueRef<'a>> + Clone {
     registers.iter().map(|reg| reg.get_value().as_ref())
 }
 

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1271,7 +1271,7 @@ impl ProgramState {
 
     /// Whether this statement may finish the implicit autocommit transaction
     /// now, including re-entry while its commit is in progress.
-    #[inline]
+    #[inline(always)]
     /// `self_counted` is true while this statement is still included in
     /// `Connection::n_active_root_statements`. It is false when a statement
     /// that already finished (released on Done or on its step error) is being

--- a/core/vdbe/value.rs
+++ b/core/vdbe/value.rs
@@ -286,11 +286,15 @@ impl Value {
         Value::build_text(result)
     }
 
+    #[expect(
+        clippy::unnecessary_lazy_evaluations,
+        reason = "ok_or skips the drop glue that otherwise bloats the happy path"
+    )]
     pub fn exec_abs(&self) -> Result<Self> {
         Ok(match self {
             Value::Null => Value::Null,
             Value::Numeric(Numeric::Integer(v)) => {
-                Value::from_i64(v.checked_abs().ok_or(LimboError::IntegerOverflow)?)
+                Value::from_i64(v.checked_abs().ok_or_else(|| LimboError::IntegerOverflow)?)
             }
             Value::Numeric(Numeric::Float(non_nan)) => Value::from_f64(f64::from(*non_nan).abs()),
             _ => {

--- a/sqlite/conformance/sqlite-sqltests/agg-functions/memory.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/agg-functions/memory.sqltest
@@ -1,5 +1,56 @@
 @database :memory:
 
+test finalize-mixed-aggregates-across-groups {
+    CREATE TABLE t(g INTEGER, v INTEGER, s TEXT);
+    INSERT INTO t VALUES (1, 2, 'a'), (1, 4, 'a'),
+                         (2, NULL, NULL), (2, NULL, NULL),
+                         (3, 7, 'c'), (4, 9, 'd');
+    SELECT g, count(*), count(v), count(DISTINCT v),
+           coalesce(sum(v), -1), total(v), coalesce(avg(v), -1),
+           coalesce(min(s), '-'), coalesce(max(s), '-'),
+           coalesce(group_concat(s), '-'), count(*) FILTER (WHERE 0)
+    FROM t GROUP BY g ORDER BY g;
+}
+expect {
+    1|2|2|2|6|6.0|3.0|a|a|a,a|0
+    2|2|0|0|-1|0.0|-1|-|-|-|0
+    3|1|1|1|7|7.0|7.0|c|c|c|0
+    4|1|1|1|9|9.0|9.0|d|d|d|0
+}
+expect @js {
+    1|2|2|2|6|6|3|a|a|a,a|0
+    2|2|0|0|-1|0|-1|-|-|-|0
+    3|1|1|1|7|7|7|c|c|c|0
+    4|1|1|1|9|9|9|d|d|d|0
+}
+
+test aggregate-values-preserve-state-across-window-rows {
+    CREATE TABLE t(id INTEGER, g INTEGER, v INTEGER);
+    INSERT INTO t VALUES (1, 1, 2), (2, 1, NULL), (3, 1, 4),
+                         (4, 2, NULL), (5, 2, 7);
+    SELECT id, count(*) OVER w, count(v) OVER w,
+           coalesce(sum(v) OVER w, -1), total(v) OVER w,
+           count(*) FILTER (WHERE 0) OVER w
+    FROM t
+    WINDOW w AS (PARTITION BY g ORDER BY id
+                 ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+    ORDER BY id;
+}
+expect {
+    1|1|1|2|2.0|0
+    2|2|1|2|2.0|0
+    3|2|1|4|4.0|0
+    4|1|0|-1|0.0|0
+    5|2|1|7|7.0|0
+}
+expect @js {
+    1|1|1|2|2|0
+    2|2|1|2|2|0
+    3|2|1|4|4|0
+    4|1|0|-1|0|0
+    5|2|1|7|7|0
+}
+
 @cross-check-integrity
 test min-null-regression-test {
     CREATE TABLE t (a);

--- a/sqlite/conformance/sqlite-sqltests/scalar-functions.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/scalar-functions.sqltest
@@ -1,6 +1,20 @@
 @database :default:
 @database :default-no-rowidalias:
 
+test abs-integer-boundaries {
+    SELECT abs(-9223372036854775807), abs(9223372036854775807), abs(0), abs(NULL) IS NULL;
+}
+expect {
+    9223372036854775807|9223372036854775807|0|1
+}
+
+test abs-integer-overflow {
+    SELECT abs(-9223372036854775808);
+}
+expect error {
+    integer overflow
+}
+
 test concat-chars {
     select concat('l', 'i');
 }

--- a/sqlite/conformance/sqlite-sqltests/scalar-functions.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/scalar-functions.sqltest
@@ -15,6 +15,17 @@ expect error {
     integer overflow
 }
 
+test scalar-result-followed-by-null {
+    WITH t(id, v) AS (VALUES (1, 'ABC'), (2, NULL), (3, 'DEF'))
+    SELECT id, coalesce(lower(v), '-'), coalesce(sign(v), 9),
+           coalesce(length(v), -1) FROM t ORDER BY id;
+}
+expect {
+    1|abc|9|3
+    2|-|9|-1
+    3|def|9|3
+}
+
 test concat-chars {
     select concat('l', 'i');
 }


### PR DESCRIPTION
## Description

Part 15 of 15 split out of #8692 (commits 141-148 of that branch), which stays open as the reference. The text below is the part of its description that covers these commits.

A sequence of small, separately measured changes that reduce the fixed cost of executing VDBE instructions. Each commit rests on one measurement: the instruction count of a 100k-row scan under callgrind (the same instrumentation model CodSpeed's simulation mode uses), plus per-instruction listings of the hot functions and wall-clock timings. Prepare time and the optimizer are out of scope.

Workloads (local driver, 100k-row table `t(id INTEGER PRIMARY KEY, name TEXT, value INTEGER)` with an index on `value`, page cache warm):

- `SELECT 1 FROM t`: two opcodes per row (`ResultRow`, `Next`) and one `step()` call per row. Isolates the dispatch loop, the statement step wrapper and the cursor advance.
- `SELECT * FROM t`: adds `RowId` and `ColumnRange` (record decode) per row.
- `SELECT id FROM t WHERE value + 0 = 999` (W3): index scan with `Column`, `Add`, `Ne`, `Next` per row.
- `SELECT count(*) FROM t WHERE value + 0 >= 0` (W4): index scan with `Column`, `Add`, `Lt`, `AggStep`, `Next` per row and no row returned to the caller.
- `SELECT sum(value), max(value) FROM t WHERE value + 0 >= 0` (W5): like W4 with two aggregate steps per row.

### Second session (commits 89 to 149, `98c2b91f` → `cc0dfdf6`)

A second autonomous session continued from `98c2b91f` with the same method: callgrind instruction counts (`Ir`) of the local driver, one measured change per commit, changes that measured worse reverted and listed below. The 100k-row scans run 3 iterations (5 for `SELECT 1 FROM t`); the per-statement numbers are instructions per execution, (Ir at 3000 − Ir at 1000) / 2000. Two more scan workloads join the set: `SELECT name FROM t` (W13, one TEXT column per row) and `SELECT * FROM t ORDER BY name DESC LIMIT 10` (W9, the sorter), plus `SELECT length(name) FROM t` and `SELECT abs(value) FROM t` for the scalar function opcode. The CodSpeed runs of `3c369a50`, `9b2dcf03`, `46436272` and the later heads are in the CodSpeed section of #8692.

| Commit | `SELECT 1 FROM t` | `SELECT * FROM t` | W3 | W4 | W12 (GROUP BY value) | W13 (`SELECT name`) | W9 (ORDER BY) |
|---|---:|---:|---:|---:|---:|---:|---:|
| copy the payload limits into a local before the index seek loops |  |  |  |  |  |  |  |
| compare with the fast paths of the seek in the IdxGE/LE/GT/LT opcodes |  |  |  |  |  |  |  |
| always inline can_autocommit_now into its callers |  |  |  |  |  |  |  |
| carry the integer key in the record comparer |  |  |  |  |  |  |  |
| start a count group in AggStep without the generic step (W4, W5 and W8 unchanged per row) |  |  |  |  | 625,329,222 (-2.2%) |  |  |
| write the count of a group from its payload in AggFinal (W8 615,213,250 → 612,205,207, -0.5%) |  |  |  |  | 608,837,835 (-2.6%) |  |  |
| build the overflow error of abs only when the value overflows (`abs(value)` 191,734,357 → 186,342,973, -2.8%; `length(name)` unchanged) |  |  |  |  | = |  |  |

| Commit | point lookup | `SELECT 1` | index lookup |
|---|---:|---:|---:|
| copy the payload limits into a local before the index seek loops | = | = | 9,748 (-0.4%) |
| compare with the fast paths of the seek in the IdxGE/LE/GT/LT opcodes | 6,339 (-0.5%, code layout: it runs none of these opcodes) | = | 9,640 (-1.1%) |
| always inline can_autocommit_now into its callers | 6,305 (-0.5%) | 1,412 (-2.4%) | 9,606 (-0.4%) |
| carry the integer key in the record comparer | 6,294 (-0.2%, code layout: it runs no record compare) | = | 9,550 (-0.6%) |
| start a count group in AggStep without the generic step | = | = | 9,548 (-2 instructions) |
| write the count of a group from its payload in AggFinal | 6,319 (+0.4%, code layout: halt and abort compiled differently, none of the three runs AggFinal) | 1,428 (+1.1%, the same) | 9,570 (+0.2%, the same) |
| build the overflow error of abs only when the value overflows | 6,320 (+1 instruction) | 1,430 (+1 instruction) |  |

## Motivation and context

The per-row base cost of a scan (step wrapper, dispatch loop, cursor advance, page header reads, metrics, comparisons) is a large share of every query's execution time. This PR works down that cost with concrete measurements, one change at a time.

## Description of AI Usage

The analysis and the changes were done by Claude Code in two autonomous sessions, using callgrind/cachegrind per-instruction profiles and CodSpeed flame graphs of `main` as the evidence for each change. Every change was measured before and after; changes that did not measure as improvements were reverted and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUjoDU7LjcZUUrvaqA2boi)_