### PR TITLE
core: skip the shared schema lock in maybe_update_schema inside a transaction

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -2020,16 +2020,22 @@ impl Connection {
         if self.schema_reparse_in_progress() {
             return;
         }
+        // Inside a transaction the schema cannot change under the
+        // connection, so there is nothing to adopt. This runs on every step
+        // of every statement in MVCC mode, and the check below takes the
+        // database's shared schema lock, which every connection contends
+        // for: decide without it whenever possible.
+        if !self.has_no_open_transaction_state() {
+            return;
+        }
         let current_schema = self.schema.read().clone();
         let schema = self.db.schema.lock();
         // MVCC checkpoint can publish physical btree roots into the shared
         // schema without changing SQLite's schema cookie. If this connection
         // still has the older schema snapshot, prepared statements must be
         // invalidated and recompiled with the published roots.
-        if self.has_no_open_transaction_state()
-            && (current_schema.schema_version != schema.schema_version
-                || self
-                    .has_mvcc_schema_snapshot_changed_with_same_version(&current_schema, &schema))
+        if current_schema.schema_version != schema.schema_version
+            || self.has_mvcc_schema_snapshot_changed_with_same_version(&current_schema, &schema)
         {
             let mut adopted = schema.clone();
             // Resolve placeholder (negative) roots to the real pages a checkpoint has


### PR DESCRIPTION
## Description
`maybe_update_schema` runs on every step of every statement in MVCC mode. It cloned the connection's schema and took the database's shared schema mutex before checking whether the connection has an open transaction, in which case it never adopts anything: inside a transaction the schema cannot change under the connection. Check that first, so a statement in a transaction never touches the mutex every connection contends for.
The paths that do need schema changes are unaffected: a connection's own DDL writes through `op_parse_schema`, the deferred-BEGIN window still has no open transaction state, and cross-process cookie bumps reprepare through `CheckSchemaCookie`, all outside this function.
## Motivation and context
The shared schema mutex is global across connections; removing it from the per-step hot path of in-transaction statements removes contention that grows with connection count.
