### PR TITLE
core/io: keep waiting when io_uring_enter is interrupted by a signal

### DIFF
--- a/core/io/io_uring.rs
+++ b/core/io/io_uring.rs
@@ -537,9 +537,14 @@ impl IO for UringIO {
 
             let wants = std::cmp::min(pending, MAX_WAIT);
             tracing::trace!("submit_and_wait for {wants} pending operations to complete");
-            self.ring
-                .submit_and_wait(wants)
-                .map_err(|e| io_error(e, "io_uring_submit_and_wait"))?;
+            match self.ring.submit_and_wait(wants) {
+                Ok(_) => {}
+                // A signal (a profiler, a debugger attaching, a timer) cuts
+                // the wait short without completing anything. That is not
+                // an I/O error: go round again and keep waiting.
+                Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(e) => return Err(io_error(e, "io_uring_submit_and_wait")),
+            }
 
             // Drain while still holding `_wait_guard`.
             self.drain_cq()?;


### PR DESCRIPTION
## Description
`submit_and_wait` returns EINTR when a signal lands while the leader is waiting in the kernel: a profiler, a debugger attaching, a timer. The wait was cut short without completing anything, so nothing is wrong with the I/O, but the error was passed up and the statement failed with "I/O error (io_uring_submit_and_wait): operation interrupted". Go round the loop again instead, matching the EINTR retries already in `core/io/unix.rs`.

The retry is safe: EINTR only returns when the completion queue is empty (partial completions return success and reach `drain_cq`), the next `submit_and_wait` recomputes the submission length so nothing is double-submitted, and completions sit in the mmap ring until drained.
## Motivation and context
Attaching a stack sampler to a benchmark made its COMMIT fail; any signal-generating tool pointed at a running process could fail in-flight statements.
