### PR TITLE
fix(core): ensure attached DB transactions roll back on connection close and drop

### DIFF
--- a/core/connection.rs
+++ b/core/connection.rs
@@ -592,6 +592,7 @@ impl Drop for Connection {
                 }
             }
             self.rollback_attached_mvcc_txs(false);
+            self.rollback_attached_wal_txns();
 
             // Release any WAL locks the connection might be holding.
             // This prevents deadlocks if a connection is dropped (e.g., due to a panic)
@@ -2443,14 +2444,14 @@ impl Connection {
                 } else {
                     pager.rollback_tx(self);
                 }
-                // Roll back all attached DB transactions regardless of main
-                // DB mode — a :memory: attached DB may use WAL even when the
-                // main DB uses MVCC.
-                self.rollback_attached_mvcc_txs(false);
-                self.rollback_attached_wal_txns();
                 self.set_tx_state(TransactionState::None);
             }
         }
+        // Roll back all attached DB transactions regardless of main DB mode
+        // or whether main DB had an active transaction. An attached DB
+        // can have an active transaction even when the main DB is idle.
+        self.rollback_attached_mvcc_txs(false);
+        self.rollback_attached_wal_txns();
         self.index_methods_on_transaction_rolled_back();
         self.clear_mvcc_log_meta();
 


### PR DESCRIPTION
## Description

Fixes #8780.

### Root Cause
In simulator runs (e.g. `write_heavy` profile, seed `13758530722023520577`), the simulator reported:
```text
Assertion 'table aux0.gleaming_winstanley_120 should have the expected content' failed:
expected 31 rows but got 41 for table aux0.gleaming_winstanley_120
```
This failure followed `FAULT 'REOPEN_DATABASE'` and `FAULT 'DISCONNECT'`.

Investigation of `core/connection.rs` revealed two rollback leakage paths for attached databases:
1. In `Connection::close()` (`core/connection.rs:2431`):
   `self.rollback_attached_wal_txns()` and `self.rollback_attached_mvcc_txs(false)` were positioned inside `match self.get_tx_state() { TransactionState::None => {}, _ => ... }`. When a transaction only wrote to an attached database (like `aux0`), `self.get_tx_state()` remained `TransactionState::None`. Calling `close()` consequently skipped rolling back attached database transactions.
2. In `impl Drop for Connection` (`core/connection.rs:571`):
   `Drop::drop` called `self.rollback_attached_mvcc_txns(false)` and then iterated over attached pagers to call `wal.end_write_tx()` directly without calling `rollback_attached()` or `self.rollback_attached_wal_txns()`. Releasing the WAL write lock without clearing dirty page caches and rolling back WAL frames left uncommitted writes in the attached database WAL.

When the database was reopened or inspected by subsequent connections, the uncommitted WAL frames were replayed as valid data, causing the 10 uncommitted rows to persist in `aux0` (41 rows instead of 31).

### Solution
1. In `Connection::close()`, move `self.rollback_attached_mvcc_txs(false)` and `self.rollback_attached_wal_txns()` outside the `match self.get_tx_state()` block so they execute unconditionally whenever a connection is closed.
2. In `impl Drop for Connection`, invoke `self.rollback_attached_wal_txns()` alongside `self.rollback_attached_mvcc_txns(false)` before releasing remaining locks, ensuring any in-flight WAL transactions on attached databases are cleanly rolled back upon connection drop/disconnect.
