### PR TITLE
core/functions: read a BLOB date/time argument as text

### DIFF
--- a/core/functions/datetime.rs
+++ b/core/functions/datetime.rs
@@ -1,6 +1,6 @@
 use crate::numeric::Numeric;
 use crate::types::AsValueRef;
-use crate::types::Value;
+use crate::types::{TextRef, TextSubtype, Value};
 use crate::LimboError::InvalidModifier;
 use crate::{Result, ValueRef};
 // chrono isn't used more due to incompatibility with sqlite
@@ -879,7 +879,7 @@ where
         set_to_current(&mut p);
     } else {
         let first = values.next().unwrap();
-        match first.as_value_ref() {
+        match blob_as_text(first.as_value_ref()) {
             ValueRef::Text(s) => {
                 if parse_date_or_time(s.as_str(), &mut p).is_err() {
                     return Value::Null;
@@ -907,7 +907,7 @@ where
 
     for (i, val) in values.enumerate() {
         has_modifier = true;
-        if let ValueRef::Text(s) = val.as_value_ref() {
+        if let ValueRef::Text(s) = blob_as_text(val.as_value_ref()) {
             if parse_modifier(&mut p, s.as_str(), i).is_err() {
                 return Value::Null;
             }
@@ -1048,7 +1048,7 @@ where
 
     // Parse first argument (d1)
     let val1 = values.next().unwrap();
-    match val1.as_value_ref() {
+    match blob_as_text(val1.as_value_ref()) {
         ValueRef::Text(s) => {
             if parse_date_or_time(s.as_str(), &mut d1).is_err() {
                 return Value::Null;
@@ -1075,7 +1075,7 @@ where
 
     // Parse second argument (d2)
     let val2 = values.next().unwrap();
-    match val2.as_value_ref() {
+    match blob_as_text(val2.as_value_ref()) {
         ValueRef::Text(s) => {
             if parse_date_or_time(s.as_str(), &mut d2).is_err() {
                 return Value::Null;
@@ -1232,7 +1232,7 @@ where
         set_to_current(&mut p);
     } else {
         let init_val = values.next().unwrap();
-        match init_val.as_value_ref() {
+        match blob_as_text(init_val.as_value_ref()) {
             ValueRef::Text(s) => {
                 let s_str = s.as_str();
                 if s_str.eq_ignore_ascii_case("now") {
@@ -1273,7 +1273,7 @@ where
         }
 
         for (i, val) in values.enumerate() {
-            if let ValueRef::Text(s) = val.as_value_ref() {
+            if let ValueRef::Text(s) = blob_as_text(val.as_value_ref()) {
                 if parse_modifier(&mut p, s.as_str(), i).is_err() {
                     return Value::Null;
                 }
@@ -1422,6 +1422,19 @@ where
     Value::from_text(res)
 }
 
+/// SQLite reads date/time arguments with sqlite3_value_text(), which hands back a
+/// BLOB's bytes unchanged, so a blob holding '2024-01-01' parses like that text.
+/// Bytes that are not UTF-8 stay a blob and the caller rejects them.
+fn blob_as_text(value: ValueRef<'_>) -> ValueRef<'_> {
+    let ValueRef::Blob(bytes) = value else {
+        return value;
+    };
+    match std::str::from_utf8(bytes) {
+        Ok(text) => ValueRef::Text(TextRef::new(text, TextSubtype::Text)),
+        Err(_) => value,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1562,7 +1575,7 @@ mod tests {
             Value::from_f64(f64::NAN),                // NaN
             Value::from_f64(f64::INFINITY),           // Infinity
             Value::Null,                              // Null value
-            Value::Blob(crate::alloc::vec![1, 2, 3]), // Blob (unsupported type)
+            Value::Blob(crate::alloc::vec![1, 2, 3]), // Blob whose bytes are not a date
             // Invalid timezone tests
             Value::build_text("2024-07-21T12:00:00+24:00"), // Invalid timezone offset (too large)
             Value::build_text("2024-07-21T12:00:00-24:00"), // Invalid timezone offset (too small)
@@ -1691,7 +1704,7 @@ mod tests {
             Value::from_f64(f64::NAN),                // NaN
             Value::from_f64(f64::INFINITY),           // Infinity
             Value::Null,                              // Null value
-            Value::Blob(crate::alloc::vec![1, 2, 3]), // Blob (unsupported type)
+            Value::Blob(crate::alloc::vec![1, 2, 3]), // Blob whose bytes are not a date
             // Invalid timezone tests
             Value::build_text("2024-07-21T12:00:00+24:00"), // Invalid timezone offset (too large)
             Value::build_text("2024-07-21T12:00:00-24:00"), // Invalid timezone offset (too small)

--- a/sqlite/conformance/sqlite-sqltests/scalar-functions-datetime.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/scalar-functions-datetime.sqltest
@@ -2579,3 +2579,45 @@ test unixepoch-just-past-lower-boundary {
 }
 expect {
 }
+
+test date-blob-time-value {
+    SELECT date(CAST('2024-01-01' AS BLOB));
+}
+expect {
+    2024-01-01
+}
+
+test unixepoch-blob-time-value {
+    SELECT unixepoch(X'323032342D30312D3031');
+}
+expect {
+    1704067200
+}
+
+test date-blob-modifier {
+    SELECT date('2024-06-15', X'2B3120646179');
+}
+expect {
+    2024-06-16
+}
+
+test strftime-blob-time-value {
+    SELECT strftime('%Y-%m-%d', X'323032342D30312D3031');
+}
+expect {
+    2024-01-01
+}
+
+test timediff-blob-time-values {
+    SELECT timediff(X'323032342D30312D3032', X'323032342D30312D3031');
+}
+expect {
+    +0000-00-01 00:00:00.000
+}
+
+test date-blob-that-is-not-utf8 {
+    SELECT typeof(date(X'FF00'));
+}
+expect {
+    null
+}


### PR DESCRIPTION
Passing a BLOB to `date()`, `time()`, `datetime()`, `julianday()`, `unixepoch()`, `strftime()` or `timediff()` returned NULL. SQLite reads those arguments with `sqlite3_value_text()`, so a blob is simply the text its bytes spell, and `date(x'323032342d30312d3031')` gives the same answer as `date('2024-01-01')`.

This is not only about hand-written blob literals. A table with `CHECK(date(x) IS NOT NULL)` refuses a row that SQLite stores, so data that round-trips in SQLite gets rejected here.

The match arms in `exec_datetime_general`, `exec_strftime` and `exec_timediff` accepted only Text and Numeric and fell through to NULL for anything else. They now pass the argument through a small helper that reads a blob as the text it holds. Modifiers get the same treatment, because SQLite reads them the same way. Bytes that are not valid UTF-8 stay a blob and take the existing NULL arm, which is also what SQLite ends up doing with them - it cannot parse them as a date either.

Tests are six cases in `sqlite/conformance/sqlite-sqltests/scalar-functions-datetime.sqltest`. Five of them fail before the change and pass after. The sixth, `date-blob-that-is-not-utf8`, passes both ways on purpose: it pins the fallback so the fix cannot turn arbitrary bytes into a date.

Numbers, CLI backend, debug build. Each test runs against two database variants, so the counts are test runs, not test names:

- that file: 750 passed / 10 failed before, 760 passed / 0 failed after
- whole `sqlite-sqltests` corpus: 10774 passed / 10 failed / 6 skipped before, 10784 passed / 0 failed / 6 skipped after. `big` and `big-mvcc` hit the 600s timeout in both runs; my machine was loaded and neither test touches this code
- `turso-sqltests`: 1994 passed. One FTS test hit the default 90s timeout; re-running that file with `--timeout 600` passes all 65
- `cargo test -p turso_core --lib functions::datetime`: 84 passed

I also re-read the diff for anything that did not need to be there and found nothing to cut. The only other edit is two stale comments in the existing unit tests that called a blob an "unsupported type", which is no longer what happens to it.

Fixes #8541

I am new to open source, and this pull request was made with AI assistance.
