### PR TITLE
github: create the target directory before the nightly bench build wr…

### DIFF
--- a/.github/workflows/perf_nightly.yml
+++ b/.github/workflows/perf_nightly.yml
@@ -89,6 +89,8 @@ jobs:
         run: scripts/nightly-bench.sh run prepare_params_benchmark
       - name: Bench record_recycling
         run: scripts/nightly-bench.sh run record_recycling
+      - name: Bench scan_loop_benchmark
+        run: scripts/nightly-bench.sh run scan_loop_benchmark
       - name: Bench select_star_benchmark
         run: scripts/nightly-bench.sh run select_star_benchmark
       - name: Bench sql_functions
@@ -97,6 +99,8 @@ jobs:
         run: scripts/nightly-bench.sh run struct_union_benchmark
       - name: Bench struct_union_profile
         run: scripts/nightly-bench.sh run struct_union_profile
+      - name: Bench text_validate_benchmark
+        run: scripts/nightly-bench.sh run text_validate_benchmark
       - name: Bench triggers
         run: scripts/nightly-bench.sh run triggers
       - name: Bench write_perf_benchmark

--- a/scripts/nightly-bench.sh
+++ b/scripts/nightly-bench.sh
@@ -27,6 +27,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 target_dir=${CARGO_TARGET_DIR:-target}
+# The bench job runs on a fresh checkout with no cargo cache, so the target
+# directory the bookkeeping files below are written to does not exist yet.
+mkdir -p "$target_dir"
 
 # Same target list as `make bench-exclude-tpc-h`.
 bench_targets() {


### PR DESCRIPTION
…ites to it

The nightly bench job runs on a fresh checkout with no cargo cache, so `target/` does not exist when the build step starts. The shell set up the `> target/nightly-bench-build.json` redirect before cargo ran, so the job died in 20 seconds with "No such file or directory" and never compiled a single benchmark. Every nightly run since the per-benchmark steps landed has failed this way.

The step that would have run next, checking that every built benchmark has a workflow step, was also stale: scan_loop_benchmark and text_validate_benchmark had been added with no step to run them.

Tests: faked a cargo artifact JSON and ran `check` against the workflow; it fails on the old workflow with those two names missing and passes now.