### PR TITLE
serverless/rust: support browser wasm response streams

### DIFF
--- a/serverless/rust/session.rs
+++ b/serverless/rust/session.rs
@@ -65,8 +65,14 @@ pub struct Session {
 
 /// Reads newline-separated JSON values from a cursor response body
 /// (section 7.2).
+#[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+type ResponseStream = Pin<Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>>;
+
+#[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+type ResponseStream = Pin<Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>>>>;
+
 struct LineReader {
-    stream: Pin<Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>>,
+    stream: ResponseStream,
     buf: Vec<u8>,
     eof: bool,
 }

--- a/serverless/rust/session.rs
+++ b/serverless/rust/session.rs
@@ -63,14 +63,15 @@ pub struct Session {
     pub shared: Arc<SharedState>,
 }
 
-/// Reads newline-separated JSON values from a cursor response body
-/// (section 7.2).
-#[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+#[cfg(not(target_arch = "wasm32"))]
 type ResponseStream = Pin<Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>> + Send>>;
 
-#[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+/// On wasm32 the response body is a JavaScript `ReadableStream`, which is not `Send`.
+#[cfg(target_arch = "wasm32")]
 type ResponseStream = Pin<Box<dyn futures::Stream<Item = reqwest::Result<bytes::Bytes>>>>;
 
+/// Reads newline-separated JSON values from a cursor response body
+/// (section 7.2).
 struct LineReader {
     stream: ResponseStream,
     buf: Vec<u8>,


### PR DESCRIPTION
Reqwest uses a non-Send JavaScript ReadableStream on browser-style wasm32 targets. Keep the cursor response stream Send on native targets, but omit that bound for wasm32-unknown-unknown so the serverless driver compiles for browser WASM.\n\nTests:\n- cargo fmt --check\n- cargo test -p turso_serverless --lib\n- cargo check -p turso_serverless --target wasm32-unknown-unknown