### PR TITLE
fts: drive native tantivy futures with turso completions

### DIFF
--- a/core/index_method/fts/directory.rs
+++ b/core/index_method/fts/directory.rs
@@ -24,7 +24,6 @@
 
 use rustc_hash::FxHashMap as HashMap;
 use std::io::{BufWriter, Write};
-use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 use parking_lot::RwLock;
@@ -33,46 +32,11 @@ use tantivy::directory::{
     Directory, DirectoryLock, FileHandle, Lock, OwnedBytes, TerminatingWrite, WatchCallback,
     WatchHandle,
 };
-use tantivy::HasLen;
 
 use crate::sync::Arc;
 
 const TANTIVY_META_FILE: &str = "meta.json";
 const TANTIVY_MANAGED_FILE: &str = ".managed.json";
-
-/// In-memory file handle over resident bytes.
-pub(super) struct InMemoryFileHandle {
-    data: Arc<[u8]>,
-}
-
-impl std::fmt::Debug for InMemoryFileHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("InMemoryFileHandle")
-            .field("len", &self.data.len())
-            .finish()
-    }
-}
-
-impl HasLen for InMemoryFileHandle {
-    fn len(&self) -> usize {
-        self.data.len()
-    }
-}
-
-impl FileHandle for InMemoryFileHandle {
-    fn read_bytes(&self, range: Range<usize>) -> std::io::Result<OwnedBytes> {
-        if range.end > self.data.len() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "range exceeds file length",
-            ));
-        }
-        if range.start >= range.end {
-            return Ok(OwnedBytes::empty());
-        }
-        Ok(OwnedBytes::new(Arc::clone(&self.data)).slice(range))
-    }
-}
 
 /// A no-op directory lock: immediately satisfied, releases nothing.
 struct NoopLockGuard;
@@ -90,6 +54,7 @@ fn noop_lock() -> DirectoryLock {
 #[derive(Clone)]
 pub(super) struct SnapshotDirectory {
     files: Arc<HashMap<PathBuf, Arc<[u8]>>>,
+    async_files: Arc<HashMap<PathBuf, Arc<dyn FileHandle>>>,
     meta_json: Arc<[u8]>,
 }
 
@@ -97,8 +62,14 @@ impl SnapshotDirectory {
     pub fn new(files: HashMap<PathBuf, Arc<[u8]>>, meta_json: Vec<u8>) -> Self {
         Self {
             files: Arc::new(files),
+            async_files: Arc::new(HashMap::default()),
             meta_json: Arc::from(meta_json),
         }
+    }
+
+    pub fn with_async_files(mut self, files: HashMap<PathBuf, Arc<dyn FileHandle>>) -> Self {
+        self.async_files = Arc::new(files);
+        self
     }
 
     fn lookup(&self, path: &Path) -> Option<Arc<[u8]>> {
@@ -123,14 +94,17 @@ impl Directory for SnapshotDirectory {
         &self,
         path: &Path,
     ) -> std::result::Result<Arc<dyn FileHandle>, OpenReadError> {
+        if let Some(handle) = self.async_files.get(path) {
+            return Ok(Arc::clone(handle));
+        }
         match self.lookup(path) {
-            Some(data) => Ok(Arc::new(InMemoryFileHandle { data })),
+            Some(data) => Ok(Arc::new(OwnedBytes::new(data))),
             None => Err(OpenReadError::FileDoesNotExist(path.to_path_buf())),
         }
     }
 
     fn exists(&self, path: &Path) -> std::result::Result<bool, OpenReadError> {
-        Ok(self.lookup(path).is_some())
+        Ok(self.async_files.contains_key(path) || self.lookup(path).is_some())
     }
 
     fn atomic_read(&self, path: &Path) -> std::result::Result<Vec<u8>, OpenReadError> {
@@ -273,9 +247,7 @@ impl Directory for BuildDirectory {
         path: &Path,
     ) -> std::result::Result<Arc<dyn FileHandle>, OpenReadError> {
         match self.inner.read().files.get(path) {
-            Some(data) => Ok(Arc::new(InMemoryFileHandle {
-                data: Arc::clone(data),
-            })),
+            Some(data) => Ok(Arc::new(OwnedBytes::new(Arc::clone(data)))),
             None => Err(OpenReadError::FileDoesNotExist(path.to_path_buf())),
         }
     }

--- a/core/index_method/fts/format.rs
+++ b/core/index_method/fts/format.rs
@@ -274,7 +274,7 @@ impl SegmentData {
 #[derive(Debug, Clone)]
 pub(super) struct LoadedSegment {
     pub descriptor: SegmentDescriptor,
-    pub data: Arc<SegmentData>,
+    pub data: Option<Arc<SegmentData>>,
     /// Doc ids whose postings are dead at this snapshot. Ordered so cache
     /// identity comparisons and bitset builds are deterministic.
     pub deleted: BTreeSet<u32>,
@@ -288,7 +288,7 @@ impl LoadedSegment {
     ) -> Self {
         Self {
             descriptor,
-            data,
+            data: Some(data),
             deleted,
         }
     }

--- a/core/index_method/fts/mod.rs
+++ b/core/index_method/fts/mod.rs
@@ -43,7 +43,7 @@ use tantivy::{
     fastfield::Column,
     index::SegmentId,
     indexer::{AddOperation, SegmentWriter},
-    query::{EnableScoring, Query, Scorer},
+    query::{EnableScoring, Query},
     schema::{Field, IndexRecordOption, Schema},
     tokenizer::{
         NgramTokenizer, RawTokenizer, SimpleTokenizer, TextAnalyzer, TokenStream,
@@ -57,6 +57,7 @@ use uncased::UncasedStr;
 
 mod directory;
 mod format;
+mod read;
 mod rows;
 
 use directory::{BuildDirectory, SnapshotDirectory};
@@ -934,10 +935,7 @@ enum FtsState {
     LoadChunks {
         queue: Vec<usize>,
         pos: usize,
-        /// file_ord -> (chunk_no -> bytes) for the segment at `queue[pos]`.
-        chunks: HashMap<u32, HashMap<i64, Vec<u8>>>,
-        seeked: bool,
-        advance_pending: bool,
+        read: read::SegmentRead,
     },
     /// Assembling the Tantivy view over the loaded segment set.
     BuildIndex,
@@ -945,53 +943,58 @@ enum FtsState {
     Ready,
 }
 
-/// Streaming query support: one segment's scorer plus its rowid column.
-struct FtsStreamingSegment {
-    scorer: Box<dyn Scorer>,
-    rowids: Column<i64>,
-    alive: Option<tantivy::fastfield::AliveBitSet>,
-}
-
 struct FtsHitStream {
-    segments: Vec<FtsStreamingSegment>,
-    segment_pos: usize,
+    searcher: Searcher,
+    hits: Option<tantivy::SearchStream>,
+    rowids: Option<(u32, Column<i64>)>,
     remaining: usize,
-    scores_enabled: bool,
     current: Option<(f32, i64)>,
 }
 
+enum FtsQueryResult {
+    Streaming(FtsHitStream),
+    Ranked(Vec<(f32, DocAddress, i64)>),
+}
+
 impl FtsHitStream {
-    fn advance(&mut self) -> Result<bool> {
+    async fn advance(&mut self) -> tantivy::Result<()> {
         self.current = None;
         if self.remaining == 0 {
-            return Ok(false);
+            self.hits = None;
+            self.rowids = None;
+            return Ok(());
         }
-
-        while let Some(segment) = self.segments.get_mut(self.segment_pos) {
-            let doc_id = segment.scorer.doc();
-            if doc_id == TERMINATED {
-                self.segment_pos += 1;
-                continue;
-            }
-            let score = self.scores_enabled.then(|| segment.scorer.score());
-            segment.scorer.advance();
-
-            if segment
-                .alive
-                .as_ref()
-                .is_some_and(|alive| alive.is_deleted(doc_id))
-            {
-                continue;
-            }
-            let rowid = segment.rowids.first(doc_id).ok_or_else(|| {
-                LimboError::InternalError("FTS: rowid fast field missing value".into())
-            })?;
-            self.current = Some((score.unwrap_or(0.0), rowid));
-            self.remaining -= 1;
-            return Ok(true);
+        let Some(hits) = self.hits.as_mut() else {
+            return Ok(());
+        };
+        let Some((score, address)) = hits.next().await? else {
+            self.hits = None;
+            self.rowids = None;
+            return Ok(());
+        };
+        if self.rowids.as_ref().map(|(ord, _)| *ord) != Some(address.segment_ord) {
+            self.rowids = None;
+            let rowids = self
+                .searcher
+                .segment_reader(address.segment_ord)
+                .fast_fields()
+                .column_opt_async::<i64>(ROWID_FIELD)
+                .await?
+                .ok_or_else(|| {
+                    tantivy::TantivyError::InvalidArgument("FTS rowid column missing".into())
+                })?;
+            self.rowids = Some((address.segment_ord, rowids));
         }
-
-        Ok(false)
+        let rowid = self
+            .rowids
+            .as_ref()
+            .unwrap()
+            .1
+            .first(address.doc_id)
+            .ok_or_else(|| tantivy::TantivyError::InvalidArgument("FTS rowid missing".into()))?;
+        self.current = Some((score, rowid));
+        self.remaining -= 1;
+        Ok(())
     }
 }
 
@@ -1048,6 +1051,12 @@ pub struct FtsCursor {
     reader: Option<IndexReader>,
     searcher: Option<Searcher>,
     cached_parser: Option<Arc<tantivy::query::QueryParser>>,
+    async_reads: bool,
+    read_queue: tantivy::directory::ReadQueue,
+    opening_searcher: Option<read::SnapshotIo<Searcher>>,
+    running_query: Option<read::SnapshotIo<FtsQueryResult>>,
+    rowid_lookup: Option<read::SnapshotIo<Vec<(SegmentId, u32)>>>,
+    merging: Option<read::SnapshotIo<(Index, BuildDirectory)>>,
 
     // Write buffers.
     doc_buffer: Vec<BufferedDoc>,
@@ -1128,6 +1137,12 @@ impl FtsCursor {
             reader: None,
             searcher: None,
             cached_parser: None,
+            async_reads: true,
+            read_queue: Default::default(),
+            opening_searcher: None,
+            running_query: None,
+            rowid_lookup: None,
+            merging: None,
             doc_buffer: Vec::new(),
             pending_tombstone_rows: Vec::new(),
             publish: None,
@@ -1381,7 +1396,11 @@ impl FtsCursor {
 
         let mut files: HashMap<PathBuf, Arc<[u8]>> = HashMap::default();
         for segment in &self.segments {
-            for (name, data) in &segment.data.files {
+            let data = segment
+                .data
+                .as_ref()
+                .expect("synchronous view requires resident segment data");
+            for (name, data) in &data.files {
                 files.insert(PathBuf::from(name), Arc::clone(data));
             }
             if !segment.deleted.is_empty() {
@@ -1738,84 +1757,28 @@ impl FtsCursor {
                         .insert(doc_id);
                     *advance_pending = true;
                 }
-                FtsState::LoadChunks {
-                    queue,
-                    pos,
-                    chunks,
-                    seeked,
-                    advance_pending,
-                } => {
+                FtsState::LoadChunks { queue, pos, read } => {
                     let Some(descriptor_idx) = queue.get(*pos).copied() else {
                         self.state = FtsState::BuildIndex;
                         continue;
                     };
-                    let segment_id = self.scan_descriptors[descriptor_idx].segment_id;
-                    let prefix = segment_chunk_prefix(&segment_id);
                     let cursor = self.fts_dir_cursor.as_mut().ok_or_else(|| {
                         LimboError::InternalError("cursor not initialized".into())
                     })?;
-                    if !*seeked {
-                        let seek_key = seek_key_for_path(&prefix)?;
-                        let seek_result = return_if_io!(cursor.seek(
-                            SeekKey::IndexKey(seek_key.as_record_ref()),
-                            SeekOp::GE { eq_only: false },
-                        ));
-                        *seeked = true;
-                        if matches!(seek_result, SeekResult::TryAdvance) {
-                            *advance_pending = true;
-                        }
-                    }
-                    if *advance_pending {
-                        return_if_io!(cursor.next());
-                        *advance_pending = false;
-                    }
-                    let mut segment_done = !cursor.has_record();
-                    if !segment_done {
-                        let record = return_if_io!(cursor.record()).ok_or_else(|| {
-                            LimboError::Corrupt("FTS cursor has no record payload".into())
-                        })?;
-                        let (path, chunk_no, bytes) = row_fields(record)?;
-                        match path.strip_prefix(prefix.as_str()) {
-                            Some(file_ord) => {
-                                let file_ord: u32 = file_ord.parse().map_err(|_| {
-                                    LimboError::Corrupt(format!(
-                                        "FTS chunk row has malformed file ordinal: {path}"
-                                    ))
-                                })?;
-                                if chunks
-                                    .entry(file_ord)
-                                    .or_default()
-                                    .insert(chunk_no, bytes)
-                                    .is_some()
-                                {
-                                    return Err(LimboError::Corrupt(format!(
-                                        "duplicate FTS chunk {path}:{chunk_no}"
-                                    ))
-                                    .into());
-                                }
-                                *advance_pending = true;
-                            }
-                            None => segment_done = true,
-                        }
-                    }
-                    if segment_done {
-                        let descriptor = &self.scan_descriptors[descriptor_idx];
-                        let data = assemble_segment_data(descriptor, std::mem::take(chunks))?;
-                        let data = Arc::new(data);
-                        self.shared
-                            .stats
-                            .segment_loads
-                            .fetch_add(1, Ordering::Relaxed);
-                        self.shared.segment_bytes.lock().put(
-                            descriptor.segment_id,
-                            Arc::clone(&data),
-                            fts_max_retained_cache_bytes(),
-                        );
-                        self.scan_data.insert(descriptor.segment_id, data);
-                        *pos += 1;
-                        *seeked = false;
-                        *advance_pending = false;
-                    }
+                    let descriptor = &self.scan_descriptors[descriptor_idx];
+                    let data = Arc::new(return_if_io!(read.resume(cursor.as_mut(), descriptor)));
+                    self.shared
+                        .stats
+                        .segment_loads
+                        .fetch_add(1, Ordering::Relaxed);
+                    self.shared.segment_bytes.lock().put(
+                        descriptor.segment_id,
+                        Arc::clone(&data),
+                        fts_max_retained_cache_bytes(),
+                    );
+                    self.scan_data.insert(descriptor.segment_id, data);
+                    *pos += 1;
+                    *read = read::SegmentRead::default();
                 }
                 FtsState::BuildIndex => {
                     if !self.snapshot_loaded {
@@ -1827,12 +1790,13 @@ impl FtsCursor {
                             .into_iter()
                             .map(|descriptor| {
                                 let id = descriptor.segment_id;
-                                let data = data_by_id.remove(&id).ok_or_else(|| {
-                                    LimboError::Corrupt(format!(
+                                let data = data_by_id.remove(&id);
+                                if data.is_none() && !self.async_reads {
+                                    return Err(LimboError::Corrupt(format!(
                                         "FTS segment {} has a registry row but no loaded data",
                                         id.uuid_string()
-                                    ))
-                                })?;
+                                    )));
+                                }
                                 let deleted = tombs.remove(&id).unwrap_or_default();
                                 // Tantivy asserts (panics) on delete counts
                                 // and doc ids beyond `max_doc`; a corrupt
@@ -1844,7 +1808,11 @@ impl FtsCursor {
                                         descriptor.max_doc
                                     )));
                                 }
-                                Ok(LoadedSegment::new(descriptor, data, deleted))
+                                Ok(LoadedSegment {
+                                    descriptor,
+                                    data,
+                                    deleted,
+                                })
                             })
                             .collect::<Result<Vec<_>>>()?;
                         if !tombs.is_empty() {
@@ -1867,7 +1835,11 @@ impl FtsCursor {
                             .visible_segment_estimate
                             .store(self.segments.len(), Ordering::Relaxed);
                     }
-                    self.ensure_searcher()?;
+                    if self.async_reads {
+                        return_if_io!(self.open_async_searcher());
+                    } else {
+                        self.ensure_searcher()?;
+                    }
                     self.state = FtsState::Ready;
                     return Ok(IOResult::Done(()));
                 }
@@ -1878,9 +1850,96 @@ impl FtsCursor {
         }
     }
 
+    fn open_async_searcher(&mut self) -> IOResultOr<()> {
+        if self.searcher.is_some() {
+            return Ok(IOResult::Done(()));
+        }
+        if self.opening_searcher.is_none() {
+            let mut files = HashMap::default();
+            let mut handles = HashMap::default();
+            for segment in &self.segments {
+                for (ord, entry) in segment.descriptor.files.iter().enumerate() {
+                    let len = usize::try_from(entry.size).map_err(|_| {
+                        LimboError::Corrupt("FTS file length overflows usize".into())
+                    })?;
+                    if len.div_ceil(DEFAULT_CHUNK_SIZE).max(1) != entry.num_chunks as usize {
+                        return Err(LimboError::Corrupt(
+                            "FTS file chunk count disagrees with size".into(),
+                        )
+                        .into());
+                    }
+                    handles.insert(
+                        PathBuf::from(&entry.name),
+                        self.read_queue
+                            .file(segment_chunk_path(&segment.id(), ord as u32), len),
+                    );
+                }
+                if !segment.deleted.is_empty() {
+                    files.insert(
+                        PathBuf::from(tombstone_del_file_name(&segment.id())),
+                        Arc::from(with_tantivy_footer(alive_bitset_bytes(
+                            segment.descriptor.max_doc,
+                            &segment.deleted,
+                        ))?),
+                    );
+                }
+            }
+            let scratch = self.shared.scratch_index(&self.schema)?;
+            let meta = synthesize_meta_json(&scratch, &self.schema, &self.segments)?;
+            let directory = SnapshotDirectory::new(files, meta).with_async_files(handles);
+            let index = Index::open(directory)
+                .map_err(|error| LimboError::InternalError(error.to_string()))?;
+            self.register_tokenizers(&index);
+            let metas = index
+                .searchable_segment_metas()
+                .map_err(|error| LimboError::InternalError(error.to_string()))?;
+            self.cached_parser = Some(self.build_query_parser(&index));
+            self.index = Some(index.clone());
+            self.opening_searcher = Some(read::SnapshotIo::new(
+                self.read_queue.clone(),
+                Searcher::open_async(index, metas, 0),
+            ));
+        }
+        let cursor = self
+            .fts_dir_cursor
+            .as_mut()
+            .expect("snapshot cursor initialized");
+        let searcher = return_if_io!(self
+            .opening_searcher
+            .as_mut()
+            .unwrap()
+            .resume(cursor.as_mut()));
+        self.opening_searcher = None;
+        self.searcher = Some(searcher);
+        Ok(IOResult::Done(()))
+    }
+
+    fn resume_async_query(&mut self) -> IOResultOr<bool> {
+        let cursor = self
+            .fts_dir_cursor
+            .as_mut()
+            .expect("snapshot cursor initialized");
+        let output = return_if_io!(self.running_query.as_mut().unwrap().resume(cursor.as_mut()));
+        self.running_query = None;
+        match output {
+            FtsQueryResult::Streaming(stream) => {
+                let ready = stream.current.is_some();
+                self.streaming_hits = Some(stream);
+                Ok(IOResult::Done(ready))
+            }
+            FtsQueryResult::Ranked(hits) => {
+                self.current_hits = hits;
+                Ok(IOResult::Done(!self.current_hits.is_empty()))
+            }
+        }
+    }
+
     /// The state that loads chunk rows for scanned descriptors the byte
     /// cache does not already hold. Cache hits are collected here.
     fn chunk_load_state(&mut self) -> FtsState {
+        if self.async_reads {
+            return FtsState::BuildIndex;
+        }
         let mut queue = Vec::new();
         let mut cache = self.shared.segment_bytes.lock();
         for (idx, descriptor) in self.scan_descriptors.iter().enumerate() {
@@ -1894,9 +1953,7 @@ impl FtsCursor {
         FtsState::LoadChunks {
             queue,
             pos: 0,
-            chunks: HashMap::default(),
-            seeked: false,
-            advance_pending: false,
+            read: read::SegmentRead::default(),
         }
     }
 
@@ -2027,14 +2084,9 @@ impl FtsCursor {
         let mut new_segment = None;
         if !self.doc_buffer.is_empty() {
             let (segment, rows) = self.build_segment()?;
-            if let Some(segment) = segment {
+            if let Some(mut segment) = segment {
                 inserts.extend(rows);
-                self.own_published.push(segment.id());
-                self.shared.segment_bytes.lock().put(
-                    segment.id(),
-                    Arc::clone(&segment.data),
-                    fts_max_retained_cache_bytes(),
-                );
+                segment.data = None;
                 new_segment = Some(segment);
             }
         }
@@ -2156,8 +2208,8 @@ impl FtsCursor {
     /// the writer slot and the maintenance lease, and drive the staged
     /// publication afterwards. OPTIMIZE passes every visible segment; the
     /// write-path auto-merge passes its tiered candidates.
-    fn stage_merge_of_segments(&mut self, candidate_ids: &HashSet<SegmentId>) -> Result<()> {
-        self.ensure_searcher()?;
+    fn stage_merge_of_segments(&mut self, candidate_ids: &HashSet<SegmentId>) -> IOResultOr<()> {
+        return_if_io!(self.open_async_searcher());
         let index = self
             .index
             .as_ref()
@@ -2175,7 +2227,6 @@ impl FtsCursor {
             .filter(|meta| candidate_ids.contains(&meta.id()))
             .map(|meta| index.segment(meta.clone()))
             .collect();
-        let build_dir = BuildDirectory::default();
         let live_total: u64 = self
             .segments
             .iter()
@@ -2183,13 +2234,26 @@ impl FtsCursor {
             .map(LoadedSegment::live_docs)
             .sum();
         let merged = if live_total > 0 {
-            let merged_index = tantivy::indexer::merge_filtered_segments(
-                &input_segments,
-                IndexSettings::default(),
-                vec![None; input_segments.len()],
-                build_dir.clone(),
-            )
-            .map_err(|e| LimboError::InternalError(format!("FTS merge failed: {e}")))?;
+            if self.merging.is_none() {
+                self.merging = Some(read::SnapshotIo::new(self.read_queue.clone(), async move {
+                    let directory = BuildDirectory::default();
+                    let index = tantivy::indexer::merge_filtered_segments_async(
+                        &input_segments,
+                        IndexSettings::default(),
+                        vec![None; input_segments.len()],
+                        directory.clone(),
+                    )
+                    .await?;
+                    Ok((index, directory))
+                }));
+            }
+            let cursor = self
+                .fts_dir_cursor
+                .as_mut()
+                .expect("snapshot cursor initialized");
+            let (merged_index, build_dir) =
+                return_if_io!(self.merging.as_mut().unwrap().resume(cursor.as_mut()));
+            self.merging = None;
             let merged_metas = merged_index
                 .searchable_segment_metas()
                 .map_err(|e| LimboError::InternalError(format!("FTS merged metas: {e}")))?;
@@ -2233,7 +2297,7 @@ impl FtsCursor {
             }
         }
         let mut inserts = Vec::new();
-        if let Some((segment, rows)) = merged {
+        if let Some((mut segment, rows)) = merged {
             tracing::debug!(
                 inputs = candidate_ids.len(),
                 survivors = new_segments.len(),
@@ -2241,12 +2305,7 @@ impl FtsCursor {
                 "FTS merge: merged candidate segments"
             );
             inserts = rows;
-            self.own_published.push(segment.id());
-            self.shared.segment_bytes.lock().put(
-                segment.id(),
-                Arc::clone(&segment.data),
-                fts_max_retained_cache_bytes(),
-            );
+            segment.data = None;
             new_segments.push(segment);
         }
         self.publish = Some(PendingPublish {
@@ -2254,7 +2313,7 @@ impl FtsCursor {
             deleter: Some(RowDeleter::new(deletes)),
             apply: PublishApply::ReplaceSegments(new_segments),
         });
-        Ok(())
+        Ok(IOResult::Done(()))
     }
 
     /// Which visible segments the write-path merge should rewrite (B2):
@@ -2309,61 +2368,60 @@ impl FtsCursor {
     /// `WriteWriteConflict`) skips the merge silently: a writer must never
     /// fail because maintenance was contended.
     fn try_auto_merge(&mut self) -> Result<IOResult<()>> {
-        // Re-entry after an IO yield inside the merge publication: the
-        // pending flag was already cleared when the merge was staged, so
-        // this only handles yields from the snapshot scan below.
-        let Some(conn) = self.connection.as_ref().and_then(Weak::upgrade) else {
-            self.auto_merge_pending = false;
-            return Ok(IOResult::Done(()));
-        };
-        let threshold = conn.get_fts_merge_threshold();
-        if threshold <= 0 {
-            self.auto_merge_pending = false;
-            return Ok(IOResult::Done(()));
-        }
-        // Cheap pre-check: below the threshold, a flushed statement must pay
-        // nothing beyond this load — the estimate keeps the insert fast path
-        // scan-free. Over-estimates cost one wasted scan; under-estimates
-        // delay the merge until the next reconciling scan.
-        if self
-            .shared
-            .visible_segment_estimate
-            .load(Ordering::Relaxed)
-            .max(self.segments.len())
-            <= threshold as usize
-        {
-            self.auto_merge_pending = false;
-            return Ok(IOResult::Done(()));
-        }
-        // The insert fast path stops after format detection; counting the
-        // visible set needs the full registry scan (resumable on IO).
-        return_if_io!(self.ensure_snapshot_loaded());
-        if self.segments.len() <= threshold as usize {
-            self.auto_merge_pending = false;
-            return Ok(IOResult::Done(()));
-        }
-        match self.acquire_mvcc_maintenance_lease() {
-            Ok(()) => {}
-            Err(LimboError::Busy | LimboError::WriteWriteConflict) => {
-                tracing::debug!("FTS auto-merge: lease contended, skipping");
+        if self.merging.is_none() {
+            let Some(conn) = self.connection.as_ref().and_then(Weak::upgrade) else {
+                self.auto_merge_pending = false;
+                return Ok(IOResult::Done(()));
+            };
+            let threshold = conn.get_fts_merge_threshold();
+            if threshold <= 0 {
                 self.auto_merge_pending = false;
                 return Ok(IOResult::Done(()));
             }
-            Err(err) => return Err(err),
-        }
-        if let Some((mv_store, tx_id, index_id)) = self.mvcc_index_id(
-            &conn,
-            self.database_id
-                .ok_or_else(|| LimboError::InternalError("FTS database id not set".into()))?,
-        )? {
-            match mv_store.check_index_method_merge_admissible(tx_id, index_id) {
+            // Cheap pre-check: below the threshold, a flushed statement must pay
+            // nothing beyond this load — the estimate keeps the insert fast path
+            // scan-free. Over-estimates cost one wasted scan; under-estimates
+            // delay the merge until the next reconciling scan.
+            if self
+                .shared
+                .visible_segment_estimate
+                .load(Ordering::Relaxed)
+                .max(self.segments.len())
+                <= threshold as usize
+            {
+                self.auto_merge_pending = false;
+                return Ok(IOResult::Done(()));
+            }
+            // The insert fast path stops after format detection; counting the
+            // visible set needs the full registry scan (resumable on IO).
+            return_if_io!(self.ensure_snapshot_loaded());
+            if self.segments.len() <= threshold as usize {
+                self.auto_merge_pending = false;
+                return Ok(IOResult::Done(()));
+            }
+            match self.acquire_mvcc_maintenance_lease() {
                 Ok(()) => {}
                 Err(LimboError::Busy | LimboError::WriteWriteConflict) => {
-                    tracing::debug!("FTS auto-merge: deleter overlap, skipping");
+                    tracing::debug!("FTS auto-merge: lease contended, skipping");
                     self.auto_merge_pending = false;
                     return Ok(IOResult::Done(()));
                 }
                 Err(err) => return Err(err),
+            }
+            if let Some((mv_store, tx_id, index_id)) = self.mvcc_index_id(
+                &conn,
+                self.database_id
+                    .ok_or_else(|| LimboError::InternalError("FTS database id not set".into()))?,
+            )? {
+                match mv_store.check_index_method_merge_admissible(tx_id, index_id) {
+                    Ok(()) => {}
+                    Err(LimboError::Busy | LimboError::WriteWriteConflict) => {
+                        tracing::debug!("FTS auto-merge: deleter overlap, skipping");
+                        self.auto_merge_pending = false;
+                        return Ok(IOResult::Done(()));
+                    }
+                    Err(err) => return Err(err),
+                }
             }
         }
         // Tiered candidacy: rewrite the small tier and tombstone-heavy
@@ -2374,7 +2432,7 @@ impl FtsCursor {
             self.auto_merge_pending = false;
             return Ok(IOResult::Done(()));
         }
-        self.stage_merge_of_segments(&candidates)?;
+        return_if_io!(self.stage_merge_of_segments(&candidates));
         // Clear before driving: a yield inside the publication resumes
         // through `stage_statement_commit`'s is_publishing branch, which
         // must not evaluate the trigger again.
@@ -2404,49 +2462,47 @@ impl FtsCursor {
     /// set. One rowid-term lookup per segment, checked against the
     /// transaction's own tombstone state (the searcher's alive bitsets may
     /// lag behind tombstones applied since the view was built).
-    fn live_postings_for_rowid(&mut self, rowid: i64) -> Result<Vec<(SegmentId, u32)>> {
+    fn live_postings_for_rowid(&mut self, rowid: i64) -> IOResultOr<Vec<(SegmentId, u32)>> {
         if self.segments.is_empty() {
-            return Ok(Vec::new());
+            return Ok(IOResult::Done(Vec::new()));
         }
-        self.ensure_searcher()?;
-        let searcher = self
-            .searcher
-            .as_ref()
-            .expect("searcher built by ensure_searcher");
-        let term = Term::from_field_i64(self.rowid_field, rowid);
-        let mut hits = Vec::new();
-        for segment_reader in searcher.segment_readers() {
-            let segment_id = segment_reader.segment_id();
-            let Some(segment) = self
+        return_if_io!(self.open_async_searcher());
+        if self.rowid_lookup.is_none() {
+            let searcher = self.searcher.as_ref().unwrap().clone();
+            let term = Term::from_field_i64(self.rowid_field, rowid);
+            let deleted: HashMap<_, _> = self
                 .segments
                 .iter()
-                .find(|segment| segment.id() == segment_id)
-            else {
-                continue;
-            };
-            let inverted = segment_reader
-                .inverted_index(self.rowid_field)
-                .map_err(|e| LimboError::InternalError(format!("FTS rowid lookup: {e}")))?;
-            let Some(mut postings) = inverted
-                .read_postings(&term, IndexRecordOption::Basic)
-                .map_err(|e| LimboError::InternalError(format!("FTS rowid postings: {e}")))?
-            else {
-                continue;
-            };
-            loop {
-                let doc_id = postings.doc();
-                if doc_id == TERMINATED {
-                    break;
+                .map(|segment| (segment.id(), segment.deleted.clone()))
+                .collect();
+            self.rowid_lookup = Some(read::SnapshotIo::new(self.read_queue.clone(), async move {
+                let mut hits = Vec::new();
+                for reader in searcher.segment_readers() {
+                    let id = reader.segment_id();
+                    let inverted = reader.inverted_index_async(term.field()).await?;
+                    if let Some(mut postings) = inverted
+                        .read_postings_async(&term, IndexRecordOption::Basic)
+                        .await?
+                    {
+                        while postings.doc() != TERMINATED {
+                            let doc = postings.doc();
+                            if !deleted[&id].contains(&doc) {
+                                hits.push((id, doc));
+                            }
+                            postings.advance();
+                        }
+                    }
                 }
-                // Raw postings are not alive-filtered; consult the
-                // transaction's own tombstone state.
-                if !segment.deleted.contains(&doc_id) {
-                    hits.push((segment_id, doc_id));
-                }
-                postings.advance();
-            }
+                Ok(hits)
+            }));
         }
-        Ok(hits)
+        let cursor = self
+            .fts_dir_cursor
+            .as_mut()
+            .expect("snapshot cursor initialized");
+        let hits = return_if_io!(self.rowid_lookup.as_mut().unwrap().resume(cursor.as_mut()));
+        self.rowid_lookup = None;
+        Ok(IOResult::Done(hits))
     }
 
     fn constant_integer_expression(expr: &turso_parser::ast::Expr) -> Option<i64> {
@@ -2498,6 +2554,12 @@ impl FtsCursor {
         self.scan_data.clear();
         self.control = None;
         self.invalidate_snapshot_view();
+        self.opening_searcher = None;
+        self.running_query = None;
+        self.rowid_lookup = None;
+        self.merging = None;
+        self.read_queue = Default::default();
+        self.async_reads = true;
         self.fts_dir_cursor = None;
         self.current_hits.clear();
         self.streaming_hits = None;
@@ -2509,102 +2571,86 @@ impl FtsCursor {
     }
 }
 
-/// Assemble one segment's files from its scanned chunk rows, validating
-/// them against the descriptor.
-fn assemble_segment_data(
-    descriptor: &SegmentDescriptor,
-    mut chunks: HashMap<u32, HashMap<i64, Vec<u8>>>,
-) -> Result<SegmentData> {
-    let mut files: HashMap<String, Arc<[u8]>> = HashMap::default();
-    for (file_ord, entry) in descriptor.files.iter().enumerate() {
-        let file_ord = file_ord as u32;
-        let chunk_map = chunks.remove(&file_ord).ok_or_else(|| {
-            LimboError::Corrupt(format!(
-                "FTS segment {} is missing chunks for file {}",
-                descriptor.segment_id.uuid_string(),
-                entry.name
-            ))
-        })?;
-        if chunk_map.len() != entry.num_chunks as usize {
-            return Err(LimboError::Corrupt(format!(
-                "FTS segment file {} has {} chunks but the descriptor records {}",
-                entry.name,
-                chunk_map.len(),
-                entry.num_chunks
-            )));
+async fn run_async_query(
+    searcher: Searcher,
+    query: Box<dyn Query>,
+    limit: usize,
+    streaming_scores: Option<bool>,
+) -> tantivy::Result<FtsQueryResult> {
+    let scores_enabled = streaming_scores.unwrap_or(true);
+    let scoring = if scores_enabled {
+        EnableScoring::enabled_from_searcher(&searcher)
+    } else {
+        EnableScoring::disabled_from_searcher(&searcher)
+    };
+    if streaming_scores.is_none() && limit < searcher.num_docs() as usize {
+        let top = searcher
+            .search_async(
+                query.as_ref(),
+                &tantivy::collector::TopDocs::with_limit(limit).order_by_score(),
+            )
+            .await?;
+        let mut rowids = HashMap::default();
+        let mut hits = Vec::with_capacity(top.len());
+        for (score, address) in top {
+            if !rowids.contains_key(&address.segment_ord) {
+                let column = searcher
+                    .segment_reader(address.segment_ord)
+                    .fast_fields()
+                    .column_opt_async::<i64>(ROWID_FIELD)
+                    .await?
+                    .ok_or_else(|| {
+                        tantivy::TantivyError::InvalidArgument("FTS rowid column missing".into())
+                    })?;
+                rowids.insert(address.segment_ord, column);
+            }
+            let rowid = rowids[&address.segment_ord]
+                .first(address.doc_id)
+                .ok_or_else(|| {
+                    tantivy::TantivyError::InvalidArgument("FTS rowid missing".into())
+                })?;
+            hits.push((score, address, rowid));
         }
-        let assembled = assemble_chunks(std::path::Path::new(&entry.name), chunk_map)?;
-        if assembled.len() as u64 != entry.size {
-            return Err(LimboError::Corrupt(format!(
-                "FTS segment file {} has {} bytes but the descriptor records {}",
-                entry.name,
-                assembled.len(),
-                entry.size
-            )));
+        return Ok(FtsQueryResult::Ranked(hits));
+    }
+    if streaming_scores.is_some() {
+        let mut stream = FtsHitStream {
+            hits: Some(searcher.stream(query.as_ref(), scores_enabled)?),
+            searcher,
+            rowids: None,
+            remaining: limit,
+            current: None,
+        };
+        stream.advance().await?;
+        return Ok(FtsQueryResult::Streaming(stream));
+    }
+    let weight = query.weight(scoring)?;
+    let mut hits = Vec::new();
+    for (ord, reader) in searcher.segment_readers().iter().enumerate() {
+        let mut scorer = weight.scorer_async(reader, 1.0).await?;
+        let rowids = reader
+            .fast_fields()
+            .column_opt_async::<i64>(ROWID_FIELD)
+            .await?
+            .ok_or_else(|| {
+                tantivy::TantivyError::InvalidArgument("FTS rowid column missing".into())
+            })?;
+        while scorer.doc() != TERMINATED {
+            let doc = scorer.doc();
+            if !reader
+                .alive_bitset()
+                .is_some_and(|alive| alive.is_deleted(doc))
+            {
+                let rowid = rowids.first(doc).ok_or_else(|| {
+                    tantivy::TantivyError::InvalidArgument("FTS rowid missing".into())
+                })?;
+                hits.push((scorer.score(), DocAddress::new(ord as u32, doc), rowid));
+            }
+            scorer.advance();
         }
-        files.insert(entry.name.clone(), assembled);
     }
-    if !chunks.is_empty() {
-        return Err(LimboError::Corrupt(format!(
-            "FTS segment {} stores chunks for files absent from its descriptor",
-            descriptor.segment_id.uuid_string()
-        )));
-    }
-    Ok(SegmentData::new(files))
-}
-
-/// Concatenate one file's chunk rows (`chunk_no` → bytes) into whole bytes.
-///
-/// The chunks are written straight into the shared allocation: building a
-/// `Vec` first and converting it with `Arc::from` would copy every byte a
-/// second time and hold both copies at once. Each chunk is dropped as soon
-/// as it has been copied, so peak memory is the file plus one chunk.
-fn assemble_chunks(path: &std::path::Path, mut chunks: HashMap<i64, Vec<u8>>) -> Result<Arc<[u8]>> {
-    let max_chunk =
-        chunks.keys().max().copied().ok_or_else(|| {
-            LimboError::Corrupt(format!("FTS file {} has no chunks", path.display()))
-        })?;
-    if max_chunk < 0 {
-        return Err(LimboError::Corrupt(format!(
-            "FTS file {} has a negative chunk number",
-            path.display()
-        )));
-    }
-    let total: usize = chunks.values().map(Vec::len).sum();
-    let mut assembled = Arc::<[u8]>::new_uninit_slice(total);
-    let buffer = Arc::get_mut(&mut assembled).expect("a freshly allocated Arc is unique");
-    let mut offset = 0;
-    for chunk_no in 0..=max_chunk {
-        let data = chunks.remove(&chunk_no).ok_or_else(|| {
-            LimboError::Corrupt(format!(
-                "FTS file {} is missing chunk {}",
-                path.display(),
-                chunk_no
-            ))
-        })?;
-        for (slot, byte) in buffer[offset..offset + data.len()].iter_mut().zip(&data) {
-            slot.write(*byte);
-        }
-        offset += data.len();
-    }
-    if !chunks.is_empty() {
-        // Keys outside `0..=max_chunk` (a negative chunk number next to
-        // valid ones) were counted into `total` but never written.
-        return Err(LimboError::Corrupt(format!(
-            "FTS file {} has chunk numbers outside 0..={}",
-            path.display(),
-            max_chunk
-        )));
-    }
-    turso_assert!(
-        offset == total,
-        "FTS chunk assembly must write exactly the bytes it counted"
-    );
-    // SAFETY: `total` is the sum of every chunk's length and every chunk was
-    // consumed by the loop above exactly once, writing `total` bytes
-    // contiguously from offset 0 (asserted), so every byte of the slice is
-    // initialized.
-    Ok(unsafe { assembled.assume_init() })
+    hits.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    Ok(FtsQueryResult::Ranked(hits))
 }
 
 /// Turn a built segment's captured files into a `LoadedSegment` plus its
@@ -2900,6 +2946,9 @@ impl IndexMethodCursor for FtsCursor {
         let database_id = context.database().id;
         self.database_id = Some(database_id);
         self.connection = Some(Arc::downgrade(&conn));
+        if matches!(self.state, FtsState::Init) {
+            self.async_reads = true;
+        }
         if matches!(self.state, FtsState::Ready) {
             return self.ensure_snapshot_loaded();
         }
@@ -2998,13 +3047,11 @@ impl IndexMethodCursor for FtsCursor {
             }
         };
 
-        // The transaction's own unflushed documents are simply un-buffered.
-        self.doc_buffer.retain(|buffered| buffered.rowid != rowid);
-
         // Postings in visible segments get tombstone rows, applied to the
         // in-memory set immediately (own-write visibility) and queued as
         // rows for the next flush.
-        let postings = self.live_postings_for_rowid(rowid)?;
+        let postings = return_if_io!(self.live_postings_for_rowid(rowid));
+        self.doc_buffer.retain(|buffered| buffered.rowid != rowid);
         for (segment_id, doc_id) in postings {
             if let Some(segment) = self
                 .segments
@@ -3023,7 +3070,10 @@ impl IndexMethodCursor for FtsCursor {
     /// Starts an FTS query. Parses the query string and executes the search.
     /// Returns true if there are results, false otherwise.
     fn query_start(&mut self, values: &[Register]) -> IOResultOr<bool> {
-        self.ensure_searcher()?;
+        if self.running_query.is_some() {
+            return self.resume_async_query();
+        }
+        return_if_io!(self.open_async_searcher());
         let searcher = self
             .searcher
             .as_ref()
@@ -3145,137 +3195,32 @@ impl IndexMethodCursor for FtsCursor {
             return Ok(IOResult::Done(false));
         }
 
-        // Unordered patterns can walk Tantivy's per-segment scorers directly.
-        // This keeps memory constant for the common MATCH path. Global score
-        // ordering still uses TopDocs because it inherently needs a top-k heap.
+        // Unordered patterns do not retain a result set. The scorer inputs
+        // (term payloads and rowid columns) still require resident bytes.
         let streaming_scores = match pattern_idx {
             FTS_PATTERN_MATCH | FTS_PATTERN_MATCH_LIMIT => Some(false),
             FTS_PATTERN_COMBINED | FTS_PATTERN_COMBINED_LIMIT => Some(true),
             _ => None,
         };
-        if let Some(scores_enabled) = streaming_scores {
-            let scoring = if scores_enabled {
-                EnableScoring::enabled_from_searcher(searcher)
-            } else {
-                EnableScoring::disabled_from_searcher(searcher)
-            };
-            let weight = query
-                .weight(scoring)
-                .map_err(|e| LimboError::InternalError(format!("FTS query weight error: {e}")))?;
-            let mut segments = Vec::with_capacity(searcher.segment_readers().len());
-            for segment_reader in searcher.segment_readers() {
-                let scorer = weight
-                    .scorer(segment_reader, 1.0)
-                    .map_err(|e| LimboError::InternalError(format!("FTS scorer error: {e}")))?;
-                let rowids = segment_reader
-                    .fast_fields()
-                    .i64(ROWID_FIELD)
-                    .map_err(|e| LimboError::InternalError(format!("FTS fast field error: {e}")))?;
-                segments.push(FtsStreamingSegment {
-                    scorer,
-                    rowids,
-                    alive: segment_reader.alive_bitset().cloned(),
-                });
-            }
-            let mut stream = FtsHitStream {
-                segments,
-                segment_pos: 0,
-                remaining: limit,
-                scores_enabled,
-                current: None,
-            };
-            let has_result = stream.advance()?;
-            self.streaming_hits = Some(stream);
-            return Ok(IOResult::Done(has_result));
-        }
-
-        // A global score ordering with no effective LIMIT: TopDocs would
-        // eagerly allocate per-segment heaps sized to the whole corpus before
-        // scoring a single document. Walk the scorers and sort what actually
-        // matched instead, so memory is proportional to the matches.
-        if limit >= searcher.num_docs() as usize {
-            let weight = query
-                .weight(EnableScoring::enabled_from_searcher(searcher))
-                .map_err(|e| LimboError::InternalError(format!("FTS query weight error: {e}")))?;
-            for (segment_ord, segment_reader) in searcher.segment_readers().iter().enumerate() {
-                let mut scorer = weight
-                    .scorer(segment_reader, 1.0)
-                    .map_err(|e| LimboError::InternalError(format!("FTS scorer error: {e}")))?;
-                let rowids = segment_reader
-                    .fast_fields()
-                    .i64(ROWID_FIELD)
-                    .map_err(|e| LimboError::InternalError(format!("FTS fast field error: {e}")))?;
-                let alive = segment_reader.alive_bitset();
-                loop {
-                    let doc_id = scorer.doc();
-                    if doc_id == TERMINATED {
-                        break;
-                    }
-                    let score = scorer.score();
-                    scorer.advance();
-                    if alive.is_some_and(|alive| alive.is_deleted(doc_id)) {
-                        continue;
-                    }
-                    let rowid = rowids.first(doc_id).ok_or_else(|| {
-                        LimboError::InternalError("FTS: rowid fast field missing value".into())
-                    })?;
-                    self.current_hits.push((
-                        score,
-                        DocAddress::new(segment_ord as u32, doc_id),
-                        rowid,
-                    ));
-                }
-            }
-            self.current_hits
-                .sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-            return Ok(IOResult::Done(!self.current_hits.is_empty()));
-        }
-
-        let top_docs = searcher
-            .search(
-                &query,
-                &tantivy::collector::TopDocs::with_limit(limit).order_by_score(),
-            )
-            .map_err(|e| LimboError::InternalError(format!("FTS search error: {e}")))?;
-
-        // Group results by segment for efficient fast field access.
-        // This avoids creating a new fast field reader for each document.
-        let mut by_segment: HashMap<u32, Vec<(f32, tantivy::DocAddress)>> = HashMap::default();
-        for (score, doc_addr) in top_docs {
-            by_segment
-                .entry(doc_addr.segment_ord)
-                .or_default()
-                .push((score, doc_addr));
-        }
-
-        // Process each segment's results with a single fast field reader.
-        // Fast fields provide columnar O(1) access to rowids without loading full documents.
-        for (segment_ord, hits) in by_segment {
-            let segment_reader = searcher.segment_reader(segment_ord);
-            let rowid_reader = segment_reader
-                .fast_fields()
-                .i64(ROWID_FIELD)
-                .map_err(|e| LimboError::InternalError(format!("FTS fast field error: {e}")))?;
-
-            for (score, doc_addr) in hits {
-                let rowid = rowid_reader.first(doc_addr.doc_id).ok_or_else(|| {
-                    LimboError::InternalError("FTS: rowid fast field missing value".into())
-                })?;
-                self.current_hits.push((score, doc_addr, rowid));
-            }
-        }
-
-        // Re-sort by score since we grouped by segment (preserves original ranking order)
-        self.current_hits
-            .sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-
-        Ok(IOResult::Done(!self.current_hits.is_empty()))
+        let searcher = searcher.clone();
+        self.running_query = Some(read::SnapshotIo::new(
+            self.read_queue.clone(),
+            run_async_query(searcher, query, limit, streaming_scores),
+        ));
+        self.resume_async_query()
     }
 
     /// Advances to the next query result. Returns true if more results exist.
     fn query_next(&mut self) -> IOResultOr<bool> {
-        if let Some(stream) = &mut self.streaming_hits {
-            return Ok(IOResult::Done(stream.advance()?));
+        if self.running_query.is_some() {
+            return self.resume_async_query();
+        }
+        if let Some(mut stream) = self.streaming_hits.take() {
+            self.running_query = Some(read::SnapshotIo::new(self.read_queue.clone(), async move {
+                stream.advance().await?;
+                Ok(FtsQueryResult::Streaming(stream))
+            }));
+            return self.resume_async_query();
         }
         if self.hit_pos >= self.current_hits.len() {
             return Ok(IOResult::Done(false));
@@ -3484,7 +3429,7 @@ impl IndexMethodCursor for FtsCursor {
         // OPTIMIZE is the explicit "compact now" command: it merges every
         // visible segment, with no tier exemptions.
         let all_visible: HashSet<SegmentId> = self.segments.iter().map(LoadedSegment::id).collect();
-        self.stage_merge_of_segments(&all_visible)?;
+        return_if_io!(self.stage_merge_of_segments(&all_visible));
         return_if_io!(self.drive_publish());
         Ok(IOResult::Done(()))
     }

--- a/core/index_method/fts/read.rs
+++ b/core/index_method/fts/read.rs
@@ -1,0 +1,558 @@
+//! Snapshot-bound range reads. The backing cursor, not a callback on a
+//! shared Tantivy Directory, owns the transaction and outstanding page I/O.
+
+use std::ops::Range;
+
+use rustc_hash::FxHashMap as HashMap;
+use tantivy::directory::cooperative_io::{RangeReader, ReadBytes, ReadError, ReadStatus};
+
+use super::format::{segment_chunk_path, segment_chunk_prefix, SegmentData, SegmentDescriptor};
+use super::rows::{row_fields, seek_key_for_path};
+use super::DEFAULT_CHUNK_SIZE;
+use crate::storage::btree::CursorTrait;
+use crate::sync::Arc;
+use crate::types::{IOCompletions, IOResult, IOResultOr, SeekKey, SeekOp, SeekResult};
+use crate::{return_if_io, Completion, LimboError};
+
+/// The future owns Tantivy's partial progress; this driver alone owns the
+/// transaction cursor. No snapshot handle can access or outlive that cursor.
+pub(super) struct SnapshotIo<T> {
+    future: Option<std::pin::Pin<Box<dyn std::future::Future<Output = tantivy::Result<T>> + Send>>>,
+    queue: tantivy::directory::ReadQueue,
+    pending: Option<RangeRead>,
+    chunks: ChunkCache,
+}
+
+impl<T> SnapshotIo<T> {
+    pub fn new(
+        queue: tantivy::directory::ReadQueue,
+        future: impl std::future::Future<Output = tantivy::Result<T>> + Send + 'static,
+    ) -> Self {
+        Self {
+            future: Some(Box::pin(future)),
+            queue,
+            pending: None,
+            chunks: ChunkCache::default(),
+        }
+    }
+
+    pub fn resume(&mut self, cursor: &mut dyn CursorTrait) -> IOResultOr<T> {
+        let result = self.drive(cursor);
+        if result.is_err() {
+            self.future = None;
+            self.pending = None;
+        }
+        result
+    }
+
+    fn drive(&mut self, cursor: &mut dyn CursorTrait) -> IOResultOr<T> {
+        loop {
+            if let Some(read) = &mut self.pending {
+                let bytes = return_if_io!(read.resume(cursor, &mut self.chunks));
+                let read = self.pending.take().unwrap();
+                read.request
+                    .complete(Ok(tantivy::directory::OwnedBytes::new(bytes)));
+            }
+            let future = self.future.as_mut().ok_or_else(|| {
+                LimboError::InternalError("FTS operation resumed after completion".into())
+            })?;
+            // All suspension comes from this queue, which the owner drains
+            // before polling again. Storage readiness is a Turso Completion.
+            let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+            if let std::task::Poll::Ready(result) = future.as_mut().poll(&mut context) {
+                self.future = None;
+                return Ok(IOResult::Done(result.map_err(|error| {
+                    LimboError::InternalError(format!("FTS asynchronous operation: {error}"))
+                })?));
+            }
+            let request = self.queue.pop().ok_or_else(|| {
+                LimboError::InternalError("FTS suspended without a storage request".into())
+            })?;
+            self.pending = Some(RangeRead::new(request));
+        }
+    }
+}
+
+struct RangeRead {
+    request: tantivy::directory::ReadRequest,
+    next: usize,
+    bytes: Vec<u8>,
+    key: Option<crate::types::ImmutableRecord>,
+    scan: ChunkScan,
+}
+
+impl RangeRead {
+    fn new(request: tantivy::directory::ReadRequest) -> Self {
+        Self {
+            next: request.range().start,
+            request,
+            bytes: Vec::new(),
+            key: None,
+            scan: ChunkScan::default(),
+        }
+    }
+
+    fn resume(
+        &mut self,
+        cursor: &mut dyn CursorTrait,
+        chunks: &mut ChunkCache,
+    ) -> IOResultOr<Vec<u8>> {
+        if let Some(wait) = &self.scan.wait {
+            if !wait.finished() {
+                return Ok(IOResult::IO(IOCompletions(wait.clone())));
+            }
+            if let Some(error) = wait.get_error() {
+                return Err(LimboError::CompletionError(error).into());
+            }
+            self.scan.wait = None;
+        }
+        let result = self.drive(cursor, chunks);
+        if let Ok(IOResult::IO(wait)) = &result {
+            self.scan.wait = Some(wait.0.clone());
+        }
+        result
+    }
+
+    fn drive(
+        &mut self,
+        cursor: &mut dyn CursorTrait,
+        chunks: &mut ChunkCache,
+    ) -> IOResultOr<Vec<u8>> {
+        use crate::types::{ImmutableRecord, TextRef, TextSubtype, ValueRef};
+        while self.next < self.request.range().end {
+            let chunk = self.next / DEFAULT_CHUNK_SIZE;
+            if let Some(bytes) = chunks.get(self.request.name(), chunk) {
+                self.append_chunk(bytes);
+                continue;
+            }
+            if self.key.is_none() {
+                self.key = Some(ImmutableRecord::from_values(
+                    [
+                        ValueRef::Text(TextRef::new(self.request.name(), TextSubtype::Text)),
+                        ValueRef::Numeric(crate::Numeric::Integer(chunk as i64)),
+                        ValueRef::Blob(&[]),
+                    ],
+                    3,
+                )?);
+            }
+            if !self.scan.seeked {
+                let found = return_if_io!(cursor.seek(
+                    SeekKey::IndexKey(self.key.as_ref().unwrap().as_record_ref()),
+                    SeekOp::GE { eq_only: false },
+                ));
+                self.scan.seeked = true;
+                self.scan.advance = matches!(found, SeekResult::TryAdvance);
+            }
+            return_if_io!(self.scan.advance(cursor));
+            if !cursor.has_record() {
+                return Err(LimboError::Corrupt("FTS missing range chunk".into()).into());
+            }
+            let record = return_if_io!(cursor.record())
+                .ok_or_else(|| LimboError::Corrupt("FTS missing record".into()))?;
+            let bytes = chunk_bytes(record, self.request.name(), chunk as i64)?;
+            let chunk_start = chunk * DEFAULT_CHUNK_SIZE;
+            let expected = (self.request.file_len() - chunk_start).min(DEFAULT_CHUNK_SIZE);
+            if bytes.len() != expected {
+                return Err(LimboError::Corrupt("FTS range chunk has wrong size".into()).into());
+            }
+            self.append_chunk(&bytes);
+            chunks.put(self.request.name().into(), chunk, bytes);
+            self.key = None;
+            self.scan.seeked = false;
+        }
+        Ok(IOResult::Done(std::mem::take(&mut self.bytes)))
+    }
+
+    fn append_chunk(&mut self, bytes: &[u8]) {
+        let chunk_start = self.next / DEFAULT_CHUNK_SIZE * DEFAULT_CHUNK_SIZE;
+        let start = self.next - chunk_start;
+        let end = (self.request.range().end - chunk_start).min(bytes.len());
+        self.bytes.extend_from_slice(&bytes[start..end]);
+        self.next = chunk_start + end;
+    }
+}
+
+/// Avoid rereading a 512 KiB row for every small term payload in a merge.
+/// This bounds only this operation's chunk cache, not Tantivy's live memory.
+#[derive(Default)]
+struct ChunkCache(std::collections::VecDeque<(String, usize, Vec<u8>)>);
+
+impl ChunkCache {
+    fn get(&mut self, path: &str, chunk: usize) -> Option<&[u8]> {
+        let pos = self
+            .0
+            .iter()
+            .position(|(name, index, _)| name == path && *index == chunk)?;
+        let entry = self.0.remove(pos).unwrap();
+        self.0.push_back(entry);
+        Some(&self.0.back().unwrap().2)
+    }
+
+    fn put(&mut self, path: String, chunk: usize, bytes: Vec<u8>) {
+        assert!(bytes.len() <= DEFAULT_CHUNK_SIZE);
+        if self.0.len() == 8 {
+            self.0.pop_front();
+        }
+        self.0.push_back((path, chunk, bytes));
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct SegmentRead {
+    file: usize,
+    read: Option<ReadBytes>,
+    files: HashMap<String, Arc<[u8]>>,
+    scan: ChunkScan,
+}
+
+impl SegmentRead {
+    pub fn resume(
+        &mut self,
+        cursor: &mut dyn CursorTrait,
+        descriptor: &SegmentDescriptor,
+    ) -> IOResultOr<SegmentData> {
+        if let Some(wait) = &self.scan.wait {
+            if !wait.finished() {
+                return Ok(IOResult::IO(IOCompletions(wait.clone())));
+            }
+            if let Some(error) = wait.get_error() {
+                return Err(LimboError::CompletionError(error).into());
+            }
+            self.scan.wait = None;
+        }
+        let result = self.drive(cursor, descriptor);
+        if let Ok(IOResult::IO(wait)) = &result {
+            self.scan.wait = Some(wait.0.clone());
+        }
+        result
+    }
+
+    fn drive(
+        &mut self,
+        cursor: &mut dyn CursorTrait,
+        descriptor: &SegmentDescriptor,
+    ) -> IOResultOr<SegmentData> {
+        if !self.scan.seeked {
+            let key = seek_key_for_path(&segment_chunk_prefix(&descriptor.segment_id))?;
+            let found = return_if_io!(cursor.seek(
+                SeekKey::IndexKey(key.as_record_ref()),
+                SeekOp::GE { eq_only: false },
+            ));
+            self.scan.seeked = true;
+            self.scan.advance = matches!(found, SeekResult::TryAdvance);
+        }
+        while let Some(entry) = descriptor.files.get(self.file) {
+            let size = usize::try_from(entry.size)
+                .map_err(|_| LimboError::Corrupt("FTS file length overflows usize".into()))?;
+            if size.div_ceil(DEFAULT_CHUNK_SIZE).max(1) != entry.num_chunks as usize {
+                return Err(
+                    LimboError::Corrupt("FTS file chunk count disagrees with size".into()).into(),
+                );
+            }
+            if self.read.is_none() {
+                self.read = Some(
+                    ReadBytes::new(size, 0..size, DEFAULT_CHUNK_SIZE)
+                        .map_err(|e| LimboError::Corrupt(format!("FTS read range: {e:?}")))?,
+                );
+            }
+            let mut reader = ChunkReader {
+                cursor,
+                scan: &mut self.scan,
+                path: segment_chunk_path(&descriptor.segment_id, self.file as u32),
+            };
+            // The on-disk format represents an empty file with one empty row.
+            if size == 0 {
+                match reader.read_range(0..0)? {
+                    ReadStatus::Pending(wait) => return Ok(IOResult::IO(wait)),
+                    ReadStatus::Done(bytes) if bytes.is_empty() => {}
+                    ReadStatus::Done(_) => {
+                        return Err(LimboError::Corrupt("FTS empty file has data".into()).into())
+                    }
+                }
+            }
+            let bytes = match self.read.as_mut().unwrap().resume(&mut reader) {
+                Ok(ReadStatus::Pending(wait)) => return Ok(IOResult::IO(wait)),
+                Ok(ReadStatus::Done(bytes)) => bytes,
+                Err(ReadError::Storage(error)) => return Err(error),
+                Err(error) => {
+                    return Err(LimboError::Corrupt(format!("FTS file read: {error:?}")).into())
+                }
+            };
+            self.files.insert(entry.name.clone(), bytes);
+            self.file += 1;
+            self.read = None;
+        }
+        return_if_io!(self.scan.advance(cursor));
+        if cursor.has_record() {
+            let record = return_if_io!(cursor.record())
+                .ok_or_else(|| LimboError::Corrupt("FTS missing record".into()))?;
+            let (path, _, _) = row_fields(record)?;
+            if path.starts_with(&segment_chunk_prefix(&descriptor.segment_id)) {
+                return Err(LimboError::Corrupt("FTS segment has extra chunks".into()).into());
+            }
+        }
+        Ok(IOResult::Done(SegmentData::new(std::mem::take(
+            &mut self.files,
+        ))))
+    }
+}
+
+#[derive(Debug, Default)]
+struct ChunkScan {
+    seeked: bool,
+    advance: bool,
+    wait: Option<Completion>,
+}
+
+impl ChunkScan {
+    fn advance(&mut self, cursor: &mut dyn CursorTrait) -> IOResultOr<()> {
+        if self.advance {
+            return_if_io!(cursor.next());
+            self.advance = false;
+        }
+        Ok(IOResult::Done(()))
+    }
+}
+
+struct ChunkReader<'a> {
+    cursor: &'a mut dyn CursorTrait,
+    scan: &'a mut ChunkScan,
+    path: String,
+}
+
+impl RangeReader for ChunkReader<'_> {
+    type Completion = IOCompletions;
+    type Error = Box<LimboError>;
+
+    fn read_range(
+        &mut self,
+        range: Range<usize>,
+    ) -> std::result::Result<ReadStatus<Vec<u8>, IOCompletions>, Self::Error> {
+        let result = self.read_chunk(range)?;
+        Ok(match result {
+            IOResult::Done(bytes) => ReadStatus::Done(bytes),
+            IOResult::IO(wait) => ReadStatus::Pending(wait),
+        })
+    }
+}
+
+impl ChunkReader<'_> {
+    fn read_chunk(&mut self, range: Range<usize>) -> IOResultOr<Vec<u8>> {
+        return_if_io!(self.scan.advance(self.cursor));
+        if !self.cursor.has_record() {
+            return Err(LimboError::Corrupt("FTS segment is missing chunks".into()).into());
+        }
+        let record = return_if_io!(self.cursor.record())
+            .ok_or_else(|| LimboError::Corrupt("FTS missing record".into()))?;
+        let bytes = chunk_bytes(
+            record,
+            &self.path,
+            (range.start / DEFAULT_CHUNK_SIZE) as i64,
+        )?;
+        self.scan.advance = true;
+        Ok(IOResult::Done(bytes))
+    }
+}
+
+fn chunk_bytes(
+    record: &crate::types::ImmutableRecord,
+    expected_path: &str,
+    expected_chunk: i64,
+) -> crate::Result<Vec<u8>> {
+    let (path, chunk, bytes) = row_fields(record)?;
+    if path != expected_path || chunk != expected_chunk {
+        return Err(LimboError::Corrupt(format!(
+            "FTS unexpected chunk {path}:{chunk}"
+        )));
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn range_cache_evicts_least_recently_used_row() {
+        let mut cache = ChunkCache::default();
+        for chunk in 0..8 {
+            cache.put("file".into(), chunk, vec![chunk as u8; DEFAULT_CHUNK_SIZE]);
+        }
+        assert_eq!(cache.get("file", 0).unwrap()[0], 0);
+        cache.put("file".into(), 8, vec![8; DEFAULT_CHUNK_SIZE]);
+        assert!(cache.get("file", 1).is_none());
+        assert!(cache.get("file", 0).is_some());
+        assert!(cache.get("other-file", 8).is_none());
+        assert_eq!(cache.0.len(), 8);
+        assert_eq!(
+            cache
+                .0
+                .iter()
+                .map(|(_, _, bytes)| bytes.len())
+                .sum::<usize>(),
+            8 * DEFAULT_CHUNK_SIZE
+        );
+    }
+
+    #[test]
+    fn chunk_read_rejects_missing_duplicate_and_stray_chunk_numbers() {
+        use crate::types::{ImmutableRecord, TextRef, TextSubtype, ValueRef};
+        for chunk in [-1, 0, 1, 2] {
+            let record = ImmutableRecord::from_values(
+                [
+                    ValueRef::Text(TextRef::new("file", TextSubtype::Text)),
+                    ValueRef::Numeric(crate::Numeric::Integer(chunk)),
+                    ValueRef::Blob(&[1, 2, 3]),
+                ],
+                3,
+            )
+            .unwrap();
+            if chunk == 1 {
+                assert_eq!(chunk_bytes(&record, "file", 1).unwrap(), vec![1, 2, 3]);
+            } else {
+                assert!(matches!(
+                    chunk_bytes(&record, "file", 1),
+                    Err(LimboError::Corrupt(_))
+                ));
+            }
+            assert!(matches!(
+                chunk_bytes(&record, "other-file", chunk),
+                Err(LimboError::Corrupt(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn cooperative_read_resumes_without_resubmitting_ranges() {
+        let mut reader = DelayedReader::default();
+        let mut read = ReadBytes::new(20, 3..14, 4).unwrap();
+        for expected in [3..7, 7..11, 11..14] {
+            let ReadStatus::Pending(wait) = read.resume(&mut reader).unwrap() else {
+                panic!()
+            };
+            assert!(!wait.finished());
+            assert_eq!(reader.requests.last(), Some(&expected));
+            for _ in 0..3 {
+                assert!(matches!(
+                    read.resume(&mut reader).unwrap(),
+                    ReadStatus::Pending(_)
+                ));
+            }
+            wait.complete(0);
+        }
+        let ReadStatus::Done(bytes) = read.resume(&mut reader).unwrap() else {
+            panic!()
+        };
+        assert_eq!(&*bytes, &(3..14).collect::<Vec<u8>>());
+        assert_eq!(reader.requests, vec![3..7, 7..11, 11..14]);
+        assert!(matches!(read.resume(&mut reader), Err(ReadError::Finished)));
+    }
+
+    #[test]
+    fn cooperative_read_propagates_completion_error_and_stops() {
+        let mut reader = DelayedReader::default();
+        let mut read = ReadBytes::new(8, 0..8, 4).unwrap();
+        let ReadStatus::Pending(wait) = read.resume(&mut reader).unwrap() else {
+            panic!()
+        };
+        wait.abort();
+        assert!(matches!(
+            read.resume(&mut reader),
+            Err(ReadError::Storage(_))
+        ));
+        assert!(matches!(read.resume(&mut reader), Err(ReadError::Finished)));
+        assert_eq!(reader.requests, vec![0..4]);
+    }
+
+    #[test]
+    fn cooperative_read_accepts_inline_completion_and_rejects_short_read() {
+        let mut reader = DelayedReader {
+            inline: true,
+            ..Default::default()
+        };
+        let mut read = ReadBytes::new(8, 1..8, 4).unwrap();
+        let ReadStatus::Done(bytes) = read.resume(&mut reader).unwrap() else {
+            panic!()
+        };
+        assert_eq!(&*bytes, &[1, 2, 3, 4, 5, 6, 7]);
+        reader.short = true;
+        let mut read = ReadBytes::new(8, 0..8, 4).unwrap();
+        assert!(matches!(
+            read.resume(&mut reader),
+            Err(ReadError::WrongLength {
+                expected: 4,
+                actual: 3
+            })
+        ));
+        assert!(matches!(read.resume(&mut reader), Err(ReadError::Finished)));
+    }
+
+    #[test]
+    fn cooperative_read_drop_does_not_destroy_pending_storage() {
+        let mut reader = DelayedReader::default();
+        let mut read = ReadBytes::new(8, 0..8, 4).unwrap();
+        let ReadStatus::Pending(wait) = read.resume(&mut reader).unwrap() else {
+            panic!()
+        };
+        drop(read);
+        assert!(!wait.finished());
+        wait.complete(0);
+        assert!(wait.succeeded());
+        assert_eq!(reader.requests, vec![0..4]);
+    }
+
+    #[test]
+    fn cooperative_read_validates_ranges_and_empty_reads_do_no_io() {
+        assert!(ReadBytes::new(4, 3..5, 1).is_err());
+        assert!(ReadBytes::new(4, Range { start: 3, end: 2 }, 1).is_err());
+        assert!(ReadBytes::new(4, 0..4, 0).is_err());
+        let mut reader = DelayedReader::default();
+        let mut read = ReadBytes::new(4, 2..2, 1).unwrap();
+        let ReadStatus::Done(bytes) = read.resume(&mut reader).unwrap() else {
+            panic!()
+        };
+        assert!(bytes.is_empty());
+        assert!(reader.requests.is_empty());
+    }
+
+    #[derive(Default)]
+    struct DelayedReader {
+        requests: Vec<Range<usize>>,
+        pending: Option<(Range<usize>, Completion)>,
+        inline: bool,
+        short: bool,
+    }
+
+    impl RangeReader for DelayedReader {
+        type Completion = Completion;
+        type Error = crate::CompletionError;
+
+        fn read_range(
+            &mut self,
+            range: Range<usize>,
+        ) -> std::result::Result<ReadStatus<Vec<u8>, Completion>, Self::Error> {
+            if self.pending.is_none() {
+                self.requests.push(range.clone());
+                let wait = Completion::new_sync(|_| {});
+                if self.inline {
+                    wait.complete(0);
+                }
+                self.pending = Some((range.clone(), wait));
+            }
+            let (submitted, wait) = self.pending.as_ref().unwrap();
+            assert_eq!(&range, submitted);
+            if !wait.finished() {
+                return Ok(ReadStatus::Pending(wait.clone()));
+            }
+            if let Some(error) = wait.get_error() {
+                return Err(error);
+            }
+            self.pending = None;
+            let mut bytes = range.map(|n| n as u8).collect::<Vec<_>>();
+            if self.short {
+                bytes.pop();
+            }
+            Ok(ReadStatus::Done(bytes))
+        }
+    }
+}

--- a/core/index_method/fts/tests.rs
+++ b/core/index_method/fts/tests.rs
@@ -96,35 +96,6 @@ fn fts_cost_estimate_applies_literal_limit_to_output_rows() {
 }
 
 #[test]
-fn chunk_assembly_rejects_stray_chunk_numbers_without_panicking() {
-    let path = std::path::Path::new("x.term");
-    let mut chunks: HashMap<i64, Vec<u8>> = HashMap::default();
-    chunks.insert(0, vec![1, 2, 3]);
-    chunks.insert(1, vec![4, 5]);
-    assert_eq!(
-        &*assemble_chunks(path, chunks.clone()).unwrap(),
-        &[1, 2, 3, 4, 5]
-    );
-
-    // A negative chunk number next to valid ones: it is counted but never
-    // written, so assembly must error rather than hand out uninitialized
-    // bytes or trip an assert.
-    chunks.insert(-1, vec![9]);
-    assert!(matches!(
-        assemble_chunks(path, chunks.clone()),
-        Err(LimboError::Corrupt(_))
-    ));
-
-    // A hole is reported as the missing chunk.
-    chunks.remove(&-1);
-    chunks.remove(&0);
-    assert!(matches!(
-        assemble_chunks(path, chunks),
-        Err(LimboError::Corrupt(_))
-    ));
-}
-
-#[test]
 fn query_limit_is_exact_and_bounded_by_live_documents() {
     assert_eq!(bounded_query_limit(None, 1_500_000), 1_500_000);
     assert_eq!(bounded_query_limit(Some(-1), 1_500_000), 1_500_000);
@@ -199,6 +170,8 @@ fn merged_segment_files_can_be_rekeyed_to_a_minted_id() {
 
     let files: HashMap<PathBuf, Arc<[u8]>> = segment
         .data
+        .as_ref()
+        .unwrap()
         .files
         .iter()
         .map(|(name, bytes)| (PathBuf::from(name), Arc::clone(bytes)))
@@ -251,10 +224,22 @@ fn tombstoned_docs_are_invisible_at_the_reader_level() {
     let mut cursor = FtsCursor::new(&attachment);
     cursor.segments = vec![segment.clone()];
     cursor.snapshot_loaded = true;
-    let postings = cursor.live_postings_for_rowid(2).unwrap();
+    cursor.ensure_searcher().unwrap();
+    let term = tantivy::query::TermQuery::new(
+        Term::from_field_i64(cursor.rowid_field, 2),
+        IndexRecordOption::Basic,
+    );
+    let postings = cursor
+        .searcher
+        .as_ref()
+        .unwrap()
+        .search(
+            &term,
+            &tantivy::collector::TopDocs::with_limit(1).order_by_score(),
+        )
+        .unwrap();
     assert_eq!(postings.len(), 1);
-    let (segment_id, doc_id) = postings[0];
-    assert_eq!(segment_id, segment.id());
+    let doc_id = postings[0].1.doc_id;
 
     // Tombstone rowid 2 and rebuild the view: the posting must disappear
     // from every query path, including counts.
@@ -269,7 +254,10 @@ fn tombstoned_docs_are_invisible_at_the_reader_level() {
     let (query, _) = parser.parse_query_lenient("hello");
     let hits = searcher.search(&query, &tantivy::collector::Count).unwrap();
     assert_eq!(hits, 1, "the tombstoned posting must not match");
-    assert!(cursor.live_postings_for_rowid(2).unwrap().is_empty());
+    assert_eq!(
+        searcher.search(&term, &tantivy::collector::Count).unwrap(),
+        0
+    );
 }
 
 #[test]
@@ -315,4 +303,314 @@ fn segment_byte_cache_keeps_newest_and_respects_budget() {
     assert!(cache.get(&a).is_some());
     assert!(cache.get(&b).is_none());
     assert!(cache.get(&c).is_none());
+}
+
+#[test]
+fn async_snapshot_reads_only_requested_ranges_and_matches_resident_queries() {
+    use tantivy::directory::{OwnedBytes, ReadQueue};
+    let attachment = test_attachment();
+    let long = "alpha beta ".repeat(6000);
+    let (first, _) = build_and_load_segment(&attachment, &[(1, &long), (2, "alpha gamma beta")]);
+    let (mut second, _) =
+        build_and_load_segment(&attachment, &[(3, "alpha beta"), (4, "alpha beta deleted")]);
+    second.deleted.insert(1);
+    let segments = vec![first, second];
+    let mut resident = FtsCursor::new(&attachment);
+    resident.segments = segments.clone();
+    resident.ensure_searcher().unwrap();
+    let expected_searcher = resident.searcher.as_ref().unwrap();
+    let queue = ReadQueue::default();
+    let mut source = HashMap::default();
+    let mut handles = HashMap::default();
+    let mut files = HashMap::default();
+    for segment in &segments {
+        for (name, bytes) in &segment.data.as_ref().unwrap().files {
+            source.insert(name.clone(), Arc::clone(bytes));
+            handles.insert(PathBuf::from(name), queue.file(name.clone(), bytes.len()));
+        }
+        if !segment.deleted.is_empty() {
+            files.insert(
+                PathBuf::from(tombstone_del_file_name(&segment.id())),
+                Arc::from(
+                    with_tantivy_footer(alive_bitset_bytes(
+                        segment.descriptor.max_doc,
+                        &segment.deleted,
+                    ))
+                    .unwrap(),
+                ),
+            );
+        }
+    }
+    let scratch = attachment.shared.scratch_index(&attachment.schema).unwrap();
+    let meta = synthesize_meta_json(&scratch, &attachment.schema, &segments).unwrap();
+    let index = Index::open(SnapshotDirectory::new(files, meta).with_async_files(handles)).unwrap();
+    resident.register_tokenizers(&index);
+    let metas = index.searchable_segment_metas().unwrap();
+    let mut requests = Vec::new();
+    let searcher = drive_queued_future(
+        Searcher::open_async(index, metas, 0),
+        &queue,
+        &source,
+        &mut requests,
+    )
+    .unwrap();
+    let position_bytes: usize = source
+        .iter()
+        .filter(|(name, _)| name.ends_with(".pos"))
+        .map(|(_, bytes)| bytes.len())
+        .sum();
+    let positions_read: usize = requests
+        .iter()
+        .filter(|(name, _)| name.ends_with(".pos"))
+        .map(|(_, range)| range.len())
+        .sum();
+    assert!(
+        positions_read * 4 < position_bytes,
+        "opening read position payloads: {positions_read}/{position_bytes}"
+    );
+
+    for text in [
+        "alpha",
+        "\"alpha beta\"",
+        "alpha -gamma",
+        "alpha OR gamma",
+        "alpha^2",
+        "\"alpha be\"*",
+        "title:[alpha TO gamma]",
+        "title: IN [alpha gamma]",
+        "rowid:[1 TO 3]",
+        "*",
+    ] {
+        let query = resident
+            .cached_parser
+            .as_ref()
+            .unwrap()
+            .parse_query(text)
+            .unwrap();
+        let collector = tantivy::collector::TopDocs::with_limit(10).order_by_score();
+        let expected = expected_searcher
+            .search(query.as_ref(), &collector)
+            .unwrap();
+        let actual = drive_queued_future(
+            searcher.search_async(query.as_ref(), &collector),
+            &queue,
+            &source,
+            &mut requests,
+        )
+        .unwrap();
+        assert_eq!(actual.len(), expected.len(), "{text}");
+        for ((score, address), (expected_score, expected_address)) in actual.iter().zip(&expected) {
+            assert_eq!(address, expected_address, "{text}");
+            assert!(
+                (score - expected_score).abs() < 0.00001,
+                "{text}: {score} != {expected_score}"
+            );
+        }
+    }
+    let column = drive_queued_future(
+        searcher
+            .segment_reader(1)
+            .fast_fields()
+            .column_opt_async::<i64>(ROWID_FIELD),
+        &queue,
+        &source,
+        &mut requests,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(column.first(0), Some(3));
+
+    for limit in [1, usize::MAX] {
+        requests.clear();
+        let query = resident
+            .cached_parser
+            .as_ref()
+            .unwrap()
+            .parse_query("alpha")
+            .unwrap();
+        let expected_scores = expected_searcher
+            .search(
+                query.as_ref(),
+                &tantivy::collector::TopDocs::with_limit(10).order_by_score(),
+            )
+            .unwrap();
+        let result = drive_queued_future(
+            run_async_query(searcher.clone(), query, limit, Some(true)),
+            &queue,
+            &source,
+            &mut requests,
+        )
+        .unwrap();
+        let FtsQueryResult::Streaming(mut stream) = result else {
+            panic!("expected stream")
+        };
+        assert_eq!(stream.rowids.as_ref().unwrap().0, 0);
+        assert!(
+            requests
+                .iter()
+                .all(|(name, _)| !name.starts_with(&segments[1].id().uuid_string())),
+            "first hit must not load the next segment's scorer or rowids"
+        );
+        let mut rowids = Vec::new();
+        while let Some((score, rowid)) = stream.current {
+            let address = match rowid {
+                1 => DocAddress::new(0, 0),
+                2 => DocAddress::new(0, 1),
+                3 => DocAddress::new(1, 0),
+                _ => panic!("unexpected rowid {rowid}"),
+            };
+            let expected = expected_scores
+                .iter()
+                .find(|(_, doc)| *doc == address)
+                .unwrap()
+                .0;
+            assert!(
+                (score - expected).abs() < 0.00001,
+                "global BM25 changed at {rowid}"
+            );
+            rowids.push(rowid);
+            drive_queued_future(stream.advance(), &queue, &source, &mut requests).unwrap();
+        }
+        assert!(
+            stream.hits.is_none() && stream.rowids.is_none(),
+            "exhausted stream must release payloads"
+        );
+        if limit == 1 {
+            assert_eq!(rowids, [1]);
+            assert!(requests
+                .iter()
+                .all(|(name, _)| !name.starts_with(&segments[1].id().uuid_string())));
+        } else {
+            assert_eq!(rowids, [1, 2, 3]);
+        }
+    }
+
+    let inputs: Vec<_> = searcher
+        .index()
+        .searchable_segment_metas()
+        .unwrap()
+        .into_iter()
+        .map(|meta| searcher.index().segment(meta))
+        .collect();
+    let directory = BuildDirectory::default();
+    let merged = drive_queued_future(
+        tantivy::indexer::merge_filtered_segments_async(
+            &inputs,
+            IndexSettings::default(),
+            vec![None; inputs.len()],
+            directory,
+        ),
+        &queue,
+        &source,
+        &mut requests,
+    )
+    .unwrap();
+    let merged_reader: IndexReader = merged.reader().unwrap();
+    let merged_searcher = merged_reader.searcher();
+    assert_eq!(merged_searcher.num_docs(), 3);
+    for text in ["alpha", "\"alpha beta\"", "alpha -gamma", "rowid:[1 TO 3]"] {
+        let query = resident
+            .cached_parser
+            .as_ref()
+            .unwrap()
+            .parse_query(text)
+            .unwrap();
+        assert_eq!(
+            merged_searcher
+                .search(query.as_ref(), &tantivy::collector::Count)
+                .unwrap(),
+            expected_searcher
+                .search(query.as_ref(), &tantivy::collector::Count)
+                .unwrap(),
+            "merged: {text}",
+        );
+    }
+
+    let handle = queue.file("error".into(), 4);
+    let mut future = handle.read_bytes_async(0..4);
+    let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+    assert!(future.as_mut().poll(&mut cx).is_pending());
+    let request = queue.pop().unwrap();
+    request.complete(Err(std::io::Error::other("injected failure")));
+    assert!(
+        matches!(future.as_mut().poll(&mut cx), std::task::Poll::Ready(Err(error)) if error.to_string() == "injected failure")
+    );
+    let mut abandoned = handle.read_bytes_async(0..4);
+    assert!(abandoned.as_mut().poll(&mut cx).is_pending());
+    let request = queue.pop().unwrap();
+    drop(abandoned);
+    assert!(request.is_cancelled());
+    request.complete(Ok(OwnedBytes::new(vec![0; 4])));
+}
+
+#[test]
+fn queued_file_validates_ranges_short_reads_and_dropped_requests() {
+    use std::task::{Context, Poll, Waker};
+    use tantivy::directory::{OwnedBytes, ReadQueue};
+    let queue = ReadQueue::default();
+    let file = queue.file("file".into(), 4);
+    let mut cx = Context::from_waker(Waker::noop());
+    assert_eq!(
+        file.read_bytes(0..1).unwrap_err().kind(),
+        std::io::ErrorKind::Unsupported
+    );
+    for range in [0..5, std::ops::Range { start: 3, end: 2 }] {
+        let mut read = file.read_bytes_async(range);
+        assert!(
+            matches!(read.as_mut().poll(&mut cx), Poll::Ready(Err(error))
+            if error.kind() == std::io::ErrorKind::InvalidInput)
+        );
+        assert!(queue.pop().is_none());
+    }
+    let mut empty = file.read_bytes_async(4..4);
+    assert!(matches!(empty.as_mut().poll(&mut cx), Poll::Ready(Ok(bytes)) if bytes.is_empty()));
+    assert!(queue.pop().is_none());
+    let mut short = file.read_bytes_async(0..4);
+    assert!(short.as_mut().poll(&mut cx).is_pending());
+    queue
+        .pop()
+        .unwrap()
+        .complete(Ok(OwnedBytes::new(vec![0; 3])));
+    assert!(
+        matches!(short.as_mut().poll(&mut cx), Poll::Ready(Err(error))
+        if error.kind() == std::io::ErrorKind::UnexpectedEof)
+    );
+    let mut cancelled = file.read_bytes_async(0..4);
+    assert!(cancelled.as_mut().poll(&mut cx).is_pending());
+    drop(queue.pop().unwrap());
+    assert!(
+        matches!(cancelled.as_mut().poll(&mut cx), Poll::Ready(Err(error))
+        if error.kind() == std::io::ErrorKind::Interrupted)
+    );
+}
+
+fn drive_queued_future<T>(
+    future: impl std::future::Future<Output = T>,
+    queue: &tantivy::directory::ReadQueue,
+    source: &HashMap<String, Arc<[u8]>>,
+    requests: &mut Vec<(String, std::ops::Range<usize>)>,
+) -> T {
+    use tantivy::directory::OwnedBytes;
+    let mut future = std::pin::pin!(future);
+    let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+    loop {
+        if let std::task::Poll::Ready(value) = future.as_mut().poll(&mut cx) {
+            return value;
+        }
+        let request = queue.pop().expect("future must wait on injected I/O");
+        for _ in 0..3 {
+            assert!(future.as_mut().poll(&mut cx).is_pending());
+            assert!(queue.pop().is_none(), "pending read was submitted twice");
+        }
+        requests.push((request.name().into(), request.range()));
+        let bytes = OwnedBytes::new(Arc::clone(&source[request.name()])).slice(request.range());
+        let response = Mutex::new(Some((request, bytes)));
+        let completion = crate::Completion::new_write(move |_| {
+            let (request, bytes) = response.lock().take().expect("completion called once");
+            request.complete(Ok(bytes));
+        });
+        assert!(!completion.finished());
+        completion.complete(0);
+        assert!(completion.succeeded());
+    }
 }

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -3997,7 +3997,7 @@ fn fts_mvcc_statements_in_one_transaction_publish_independent_segments() {
 
 #[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
 #[test]
-fn fts_mvcc_repeated_reads_reuse_the_cached_searcher() {
+fn fts_mvcc_repeated_reads_do_not_share_snapshot_handles() {
     let tmp_db = TempDatabase::builder()
         .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
         .with_mvcc(true)
@@ -4019,8 +4019,7 @@ fn fts_mvcc_repeated_reads_reuse_the_cached_searcher() {
     let after_first = fts_attachment_test_stats(&tmp_db, &conn, "docs", "docs_fts");
     conn.execute("COMMIT").unwrap();
 
-    // A new read transaction over the unchanged registry sees the same
-    // segment set, so it shares the cached searcher instead of rebuilding.
+    // A new read transaction must bind its own range requests to its snapshot.
     conn.execute("BEGIN").unwrap();
     assert_eq!(
         limbo_exec_rows(&conn, "SELECT id FROM docs WHERE fts_match(body, 'first')"),
@@ -4033,12 +4032,8 @@ fn fts_mvcc_repeated_reads_reuse_the_cached_searcher() {
         after_second.full_snapshot_loads, after_first.full_snapshot_loads,
         "an unchanged segment set must not be reloaded from storage"
     );
-    // The SELECT under test and the stats probe both hit; require two so the
-    // assertion fails if the SELECT is deleted.
-    assert!(
-        after_second.read_cache_hits.unwrap() >= after_first.read_cache_hits.unwrap() + 2,
-        "repeated reads over one segment set must share the cached searcher"
-    );
+    assert_eq!(after_first.cached_connection_count, Some(0));
+    assert_eq!(after_second.cached_connection_count, Some(0));
 }
 
 #[cfg(all(feature = "fts", not(target_family = "wasm")))]
@@ -4310,7 +4305,7 @@ fn fts_segment_registry_is_transactional() {
 
 #[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
 #[test]
-fn fts_mvcc_reuses_snapshot_within_one_read_transaction() {
+fn fts_mvcc_reads_within_one_transaction_do_not_load_complete_segments() {
     let tmp_db = TempDatabase::builder()
         .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
         .with_mvcc(true)
@@ -4346,20 +4341,15 @@ fn fts_mvcc_reuses_snapshot_within_one_read_transaction() {
 
     assert_eq!(
         after_second.full_snapshot_loads, after_first.full_snapshot_loads,
-        "the second read in one MVCC transaction must not rescan the directory"
+        "the second read must not load complete segment files"
     );
-    // The stats probe itself opens a read cursor and scores one cache hit, so
-    // require two: the probe's and the SELECT under test's. A plain `>` would
-    // pass even with the SELECT deleted.
-    assert!(
-        after_second.read_cache_hits.unwrap() >= after_first.read_cache_hits.unwrap() + 2,
-        "the second read must use the transaction-bound snapshot cache"
-    );
+    assert_eq!(after_first.cached_connection_count, Some(0));
+    assert_eq!(after_second.cached_connection_count, Some(0));
 }
 
 #[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
 #[test]
-fn fts_wal_reuses_segments_after_unrelated_commit() {
+fn fts_wal_reads_ranges_after_unrelated_commit() {
     let tmp_db = TempDatabase::builder()
         .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
         .build();
@@ -4390,15 +4380,13 @@ fn fts_wal_reuses_segments_after_unrelated_commit() {
         after.full_snapshot_loads, before.full_snapshot_loads,
         "an unrelated commit must not reload the FTS segment files"
     );
-    assert!(
-        after.read_cache_hits > before.read_cache_hits,
-        "the unchanged segment set must share the cached searcher across the commit"
-    );
+    assert_eq!(before.cached_connection_count, Some(0));
+    assert_eq!(after.cached_connection_count, Some(0));
 }
 
 #[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
 #[test]
-fn fts_mvcc_reuses_segments_across_read_transactions() {
+fn fts_mvcc_reads_ranges_across_read_transactions() {
     let tmp_db = TempDatabase::builder()
         .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
         .with_mvcc(true)
@@ -4437,15 +4425,13 @@ fn fts_mvcc_reuses_segments_across_read_transactions() {
         after.full_snapshot_loads, before.full_snapshot_loads,
         "a new MVCC read transaction must not reload an unchanged segment set"
     );
-    assert!(
-        after.read_cache_hits > before.read_cache_hits,
-        "the new MVCC snapshot must share the cached searcher for the same segment set"
-    );
+    assert_eq!(before.cached_connection_count, Some(0));
+    assert_eq!(after.cached_connection_count, Some(0));
 }
 
 #[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
 #[test]
-fn fts_new_segment_set_invalidates_stale_searcher_once() {
+fn fts_new_segment_set_opens_fresh_snapshot_handles() {
     let tmp_db = TempDatabase::builder()
         .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
         .build();
@@ -4482,18 +4468,8 @@ fn fts_new_segment_set_invalidates_stale_searcher_once() {
         "the observer must reject its stale snapshot after the writer commits"
     );
     let after_write = fts_attachment_test_stats(&tmp_db, &reader, "docs", "docs_fts");
-    assert!(
-        after_write.read_cache_misses > before_write.read_cache_misses,
-        "a changed segment set must miss the searcher cache"
-    );
-    // Pins that the SELECT — not the stats probe — performed the reload: the
-    // probe after a successful reload scores a cache hit, while a probe that
-    // had to do the reload itself would not. Without this, deleting the
-    // SELECT above still satisfies the two counter assertions.
-    assert!(
-        after_write.read_cache_hits > before_write.read_cache_hits,
-        "the stats probe after the reload must hit the refreshed cache"
-    );
+    assert_eq!(before_write.cached_connection_count, Some(0));
+    assert_eq!(after_write.cached_connection_count, Some(0));
 
     assert_eq!(
         limbo_exec_rows(
@@ -4595,13 +4571,11 @@ fn fts_uncommitted_changes_are_connection_isolated() {
     );
 }
 
-/// The searcher cache is keyed by the visible segment set, so any number of
-/// connections reading the same committed index share one entry — the
-/// per-connection cache ceiling of the v1 design is gone — and the byte
-/// cache stays within its aggregate budget.
+/// Read-only cursors must neither publish transaction-bound handles into a
+/// shared cache nor populate the full-segment byte cache.
 #[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
 #[test]
-fn fts_read_cache_is_shared_across_connections_and_bounded() {
+fn fts_readers_do_not_populate_shared_searcher_or_segment_caches() {
     let tmp_db = TempDatabase::builder()
         .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
         .build();
@@ -4626,7 +4600,6 @@ fn fts_read_cache_is_shared_across_connections_and_bounded() {
         .unwrap();
     let readers = (0..5).map(|_| tmp_db.connect_limbo()).collect::<Vec<_>>();
 
-    let mut hits_before = 0;
     for (round, reader) in readers.iter().enumerate() {
         let mut cursor = attachment.init().unwrap();
         run(&tmp_db, || {
@@ -4636,24 +4609,15 @@ fn fts_read_cache_is_shared_across_connections_and_bounded() {
         let stats = cursor.test_stats().unwrap().unwrap();
         assert_eq!(
             stats.cached_connection_count,
-            Some(1),
-            "every reader of one segment set must share one cached searcher (round {round})"
+            Some(0),
+            "snapshot handles must remain private (round {round})"
         );
-        // The probe attachment is fresh (its own byte cache), so the first
-        // reader loads the one segment; every later reader is served from
-        // the shared cache.
         assert_eq!(
             stats.full_snapshot_loads,
-            Some(1),
-            "only the first reader may load segment bytes (round {round})"
+            Some(0),
+            "readers must not load complete segments (round {round})"
         );
-        if round > 0 {
-            assert!(
-                stats.read_cache_hits.unwrap() > hits_before,
-                "later readers must hit the shared searcher cache (round {round})"
-            );
-        }
-        hits_before = stats.read_cache_hits.unwrap();
+        assert_eq!(stats.read_cache_hits, Some(0));
         assert!(
             stats.cached_bytes.unwrap() <= 192 * 1024 * 1024,
             "retained segment bytes exceeded the aggregate cache budget"
@@ -6382,7 +6346,7 @@ fn fts_auto_merge_skips_when_lease_contended() {
 /// with wide vocabulary, then return the connection. The follow-up OPTIMIZE
 /// compacts the batch flushes into a single segment.
 #[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
-fn fts_build_large_segment(conn: &Arc<turso_core::Connection>, rows: usize) {
+fn fts_build_large_segment(db: &TempDatabase, conn: &Arc<turso_core::Connection>, rows: usize) {
     conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
         .unwrap();
     conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
@@ -6402,6 +6366,20 @@ fn fts_build_large_segment(conn: &Arc<turso_core::Connection>, rows: usize) {
     }
     conn.execute(sql).unwrap();
     conn.execute("OPTIMIZE INDEX docs_fts").unwrap();
+    let mut dumper =
+        turso_core::index_method::fts::FtsBackingRowDumper::new(conn, MAIN_DB_ID, "docs_fts")
+            .unwrap();
+    run(db, || dumper.step()).unwrap();
+    let segment_bytes: usize = dumper
+        .rows
+        .iter()
+        .filter(|(path, _, _, _)| path.starts_with("fts2/chunk/"))
+        .map(|(_, _, len, _)| len)
+        .sum();
+    assert!(
+        segment_bytes > 100 * 1024,
+        "the merged segment must exceed the smallest merge layer, got {segment_bytes} bytes"
+    );
 }
 
 /// B2 tiered candidacy: the write-path merge must only rewrite the small
@@ -6415,15 +6393,9 @@ fn fts_auto_merge_spares_large_segments() {
         .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
         .build();
     let conn = tmp_db.connect_limbo();
-    fts_build_large_segment(&conn, 3000);
+    fts_build_large_segment(&tmp_db, &conn, 3000);
     let stats = fts_stats_in_txn(&tmp_db, &conn, "docs", "docs_fts");
     assert_eq!(stats.segment_count, Some(1));
-    assert!(
-        stats.cached_bytes.unwrap() > 100 * 1024,
-        "premise: the merged segment must exceed the smallest merge layer \
-         (100KB), got {} bytes",
-        stats.cached_bytes.unwrap()
-    );
 
     conn.execute("PRAGMA fts_merge_threshold = 2").unwrap();
     for id in 10_000..10_006 {
@@ -6462,12 +6434,7 @@ fn fts_auto_merge_rewrites_tombstone_heavy_segments() {
         .with_opts(turso_core::DatabaseOpts::new().with_index_method(true))
         .build();
     let conn = tmp_db.connect_limbo();
-    fts_build_large_segment(&conn, 3000);
-    let stats = fts_stats_in_txn(&tmp_db, &conn, "docs", "docs_fts");
-    assert!(
-        stats.cached_bytes.unwrap() > 100 * 1024,
-        "premise: large segment"
-    );
+    fts_build_large_segment(&tmp_db, &conn, 3000);
 
     // Tombstone 60% of the large segment, then trigger the write-path merge
     // exactly once (the second small insert pushes the count past the
@@ -6607,4 +6574,177 @@ fn fts_optimize_succeeds_under_concurrent_update_churn() {
         ),
         vec![vec![rusqlite::types::Value::Integer(40)]]
     );
+}
+
+#[cfg(all(feature = "fts", feature = "test_helper", not(target_family = "wasm")))]
+#[test]
+fn fts_cooperative_cold_reads_match_hot_queries_and_recover_from_io_errors() -> anyhow::Result<()> {
+    use crate::queued_io::{QueuedIo, QueuedIoOpKind};
+    use turso_core::{Database, DatabaseOpts, OpenFlags, SqliteDialect, StepResult};
+
+    let io = Arc::new(QueuedIo::new());
+    let path = "queued-fts-reads.db";
+    let open = || {
+        Database::open_file_with_flags(
+            io.clone(),
+            path,
+            OpenFlags::default(),
+            DatabaseOpts::new().with_index_method(true),
+            None,
+            Arc::new(SqliteDialect),
+        )
+    };
+    let queries = [
+        "SELECT id FROM docs WHERE fts_match(body, 'alpha') ORDER BY id",
+        "SELECT id FROM docs WHERE fts_match(body, '\"alpha beta\"') ORDER BY id",
+        "SELECT id, fts_score(body, 'alpha') AS score FROM docs WHERE fts_match(body, 'alpha') ORDER BY score DESC LIMIT 3",
+        "SELECT id FROM docs WHERE fts_match(body, 'token079999')",
+    ];
+    let expected = {
+        let db = open()?;
+        let conn = db.connect()?;
+        conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")?;
+        conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")?;
+        conn.execute("INSERT INTO docs VALUES (1, 'alpha beta'), (2, 'alpha gamma beta'), (3, 'alpha alpha beta')")?;
+        let large = (0..300_000)
+            .map(|n| format!("token{n:06} "))
+            .collect::<String>();
+        conn.execute(format!("INSERT INTO docs VALUES (4, '{large}')"))?;
+        conn.execute("BEGIN")?;
+        conn.execute("DELETE FROM docs WHERE id = 2")?;
+        conn.execute("INSERT INTO docs VALUES (5, 'alpha beta rollback')")?;
+        {
+            let mut dumper = turso_core::index_method::fts::FtsBackingRowDumper::new(
+                &conn, MAIN_DB_ID, "docs_fts",
+            )?;
+            loop {
+                match dumper.step()? {
+                    IOResult::Done(()) => break,
+                    IOResult::IO(wait) => wait.wait(io.as_ref())?,
+                }
+            }
+            assert!(
+                dumper
+                    .rows
+                    .iter()
+                    .any(|(path, chunk, _, _)| { path.starts_with("fts2/chunk/") && *chunk > 0 }),
+                "fixture must include a file spanning multiple 512 KiB chunks"
+            );
+        }
+        conn.execute("ROLLBACK")?;
+        let expected = queries.map(|sql| limbo_exec_rows(&conn, sql));
+        assert_eq!(
+            expected[0],
+            vec![vec![1.into()], vec![2.into()], vec![3.into()]]
+        );
+        assert_eq!(expected[1], vec![vec![1.into()], vec![3.into()]]);
+        assert_eq!(expected[3], vec![vec![4.into()]]);
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")?;
+        expected
+    };
+
+    for (sql, expected) in queries.iter().zip(&expected) {
+        let db = open()?;
+        let conn = db.connect()?;
+        let mut stmt = conn.prepare(sql)?;
+        let mut rows = Vec::new();
+        let mut reads = 0;
+        loop {
+            match stmt.step()? {
+                StepResult::Row => {
+                    let row = stmt.row().unwrap();
+                    rows.push(
+                        row.get_values()
+                            .map(|v| match v {
+                                Value::Numeric(Numeric::Integer(n)) => {
+                                    rusqlite::types::Value::Integer(*n)
+                                }
+                                Value::Numeric(Numeric::Float(n)) => {
+                                    rusqlite::types::Value::Real(f64::from(*n))
+                                }
+                                other => panic!("unexpected result {other:?}"),
+                            })
+                            .collect::<Vec<_>>(),
+                    );
+                }
+                StepResult::Done => break,
+                StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
+                    if let Some(event) = io.step_one()? {
+                        reads += usize::from(event.kind == QueuedIoOpKind::Pread);
+                    }
+                }
+                result => anyhow::bail!("unexpected step: {result:?}"),
+            }
+        }
+        assert_eq!(&rows, expected, "cold query: {sql}");
+        assert!(
+            reads > 20,
+            "cold snapshot must exercise delayed page reads, got {reads}"
+        );
+        eprintln!("{sql}: {reads} delayed page reads");
+    }
+
+    {
+        let db = open()?;
+        let conn = db.connect()?;
+        io.fault_after(path, QueuedIoOpKind::Pread, 20);
+        let result = conn.prepare(queries[0])?.run_with_row_callback(|_| Ok(()));
+        let error = result.expect_err("cold read must propagate injected failure");
+        assert!(error.to_string().contains("queued_io"), "{error}");
+        io.clear_fault();
+    }
+    {
+        let db = open()?;
+        let conn = db.connect()?;
+        let mut stmt = conn.prepare(queries[0])?;
+        loop {
+            match stmt.step()? {
+                StepResult::IO => break,
+                StepResult::Yield | StepResult::Sleep { .. } => {
+                    io.step_one()?;
+                }
+                result => anyhow::bail!("expected pending read before reset, got {result:?}"),
+            }
+        }
+        stmt.reset()?;
+    }
+    {
+        let db = open()?;
+        let conn = db.connect()?;
+        conn.execute("BEGIN")?;
+        let mut stmt = conn.prepare("OPTIMIZE INDEX docs_fts")?;
+        let mut reads = 0;
+        loop {
+            match stmt.step()? {
+                StepResult::Done => break,
+                StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
+                    if let Some(event) = io.step_one()? {
+                        reads += usize::from(event.kind == QueuedIoOpKind::Pread);
+                    }
+                }
+                result => anyhow::bail!("unexpected optimize step: {result:?}"),
+            }
+        }
+        assert!(reads > 20, "merge must exercise delayed input reads");
+        for (sql, expected) in queries.iter().zip(&expected) {
+            assert_eq!(&limbo_exec_rows(&conn, sql), expected);
+        }
+        conn.execute("ROLLBACK")?;
+    }
+    {
+        let db = open()?;
+        let conn = db.connect()?;
+        io.fault_after(path, QueuedIoOpKind::Pread, 20);
+        let error = conn
+            .execute("OPTIMIZE INDEX docs_fts")
+            .expect_err("merge must propagate delayed input failure");
+        assert!(error.to_string().contains("queued_io"), "{error}");
+        io.clear_fault();
+    }
+    let db = open()?;
+    let conn = db.connect()?;
+    for (sql, expected) in queries.iter().zip(expected) {
+        assert_eq!(limbo_exec_rows(&conn, sql), expected);
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Scope
Integrate Tantivy native futures with snapshot-bound Turso B-tree reads and real Completions. Avoid preloading every visible file. MATCH, ranked/phrase queries, rowid deletion and merge inputs use the native read path. Unordered iteration retains one scorer and one rowid column and can suspend between segments.

## Incremental commit
[Turso integration and regression coverage](https://github.com/tursodatabase/turso/commit/b9b68e9ca)

## Stack — review bottom to top
`main → #8802 (vendor) → #8803 (native async APIs) → #8804 (Turso integration) → #8806 (async directory read-open) → #8807 (async index open)`
Managed with `gh stack`; GitHub stack #8805. Base: `fts/async-tantivy`.

## Verification
- `cargo check -p turso_core --features fts`: passed.
- `cargo fmt --all -- --check`: passed.
- `cargo test -p turso_core --features fts index_method::fts --lib`: 21 passed.
- `cargo test -p core_tester --test integration_tests fts_`: 109 passed.
- Delayed QueuedIo, early reentry, range validation, cancellation, cold ranked/phrase/rowid queries, OPTIMIZE errors and rollback, LIMIT laziness and global BM25 parity covered.

## Remaining work — do not treat as complete
Block-paged readers, bounded ranked-result storage, streaming serialization/publication with backpressure, and removal of dormant resident-open/cache machinery remain. No total-memory cap is enforced. The prior clippy run failed on an unchanged lint expectation in core/json/cache.rs; no lint was suppressed. Full upstream/workspace suites and memory benchmarks were not run.

## AI usage
Implementation and verification performed with Amp. This draft records the tested progress toward the broader async and bounded-memory goal, not completion of that goal.