### PR TITLE
tantivy: await directory lookup when opening managed files

### DIFF
--- a/core/index_method/fts/directory.rs
+++ b/core/index_method/fts/directory.rs
@@ -1,16 +1,15 @@
 //! Tantivy `Directory` implementations for segment-registry storage.
 //!
-//! Tantivy's `Directory` trait is synchronous while Turso storage is
-//! asynchronous, so every byte a directory serves must already be resident:
-//! the cursor loads segment contents through its resumable state machine
-//! before any Tantivy object is constructed, and captures every byte Tantivy
-//! writes so the cursor can persist it afterwards. Directory callbacks never
-//! open a B-tree cursor or drive the pager.
+//! Directory lookup uses the snapshot's resident registry, while logical
+//! file handles submit asynchronous range requests. The transaction-bound
+//! cursor services those requests through Completions. Writes still capture
+//! output bytes for subsequent resumable publication; directory callbacks
+//! never drive the pager themselves.
 //!
 //! Two directories cover the two directions:
 //!
-//! * [`SnapshotDirectory`] — an immutable per-snapshot read view: resident
-//!   segment files, synthesized `meta.json` and `.del` files. Nothing can be
+//! * [`SnapshotDirectory`] — an immutable per-snapshot read view: logical
+//!   segment files and resident synthesized metadata/deletes. Nothing can be
 //!   written through it.
 //! * [`BuildDirectory`] — a private write buffer for building one immutable
 //!   segment (or one merged segment). Files are captured on terminate;
@@ -47,10 +46,10 @@ fn noop_lock() -> DirectoryLock {
 
 /// Immutable read view of one snapshot's visible segment set.
 ///
-/// `files` holds every byte Tantivy may ask for: each visible segment's
-/// files under their real names, plus one synthesized `.del` file per
-/// segment with tombstones. `meta_json` is the `meta.json` synthesized
-/// from the visible registry rows; no stored file ever carries that name.
+/// `async_files` maps visible segment names to logical range-read handles.
+/// `files` contains resident tombstone bitsets (and resident test fixtures).
+/// Metadata is synthesized from the visible registry, not read from a shared
+/// on-disk manifest.
 #[derive(Clone)]
 pub(super) struct SnapshotDirectory {
     files: Arc<HashMap<PathBuf, Arc<[u8]>>>,
@@ -90,6 +89,16 @@ impl std::fmt::Debug for SnapshotDirectory {
 }
 
 impl Directory for SnapshotDirectory {
+    fn get_file_handle_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> tantivy::directory::DirectoryFuture<
+        'a,
+        std::result::Result<Arc<dyn FileHandle>, OpenReadError>,
+    > {
+        Box::pin(async move { self.get_file_handle(path) })
+    }
+
     fn get_file_handle(
         &self,
         path: &Path,
@@ -242,6 +251,16 @@ impl TerminatingWrite for CaptureWriter {
 }
 
 impl Directory for BuildDirectory {
+    fn get_file_handle_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> tantivy::directory::DirectoryFuture<
+        'a,
+        std::result::Result<Arc<dyn FileHandle>, OpenReadError>,
+    > {
+        Box::pin(async move { self.get_file_handle(path) })
+    }
+
     fn get_file_handle(
         &self,
         path: &Path,

--- a/core/index_method/fts/tests.rs
+++ b/core/index_method/fts/tests.rs
@@ -584,6 +584,128 @@ fn queued_file_validates_ranges_short_reads_and_dropped_requests() {
     );
 }
 
+#[test]
+fn managed_directory_awaits_file_lookup_before_reading_footer() {
+    use std::path::Path;
+    use tantivy::directory::{Directory, ManagedDirectory, ReadQueue};
+    let queue = ReadQueue::default();
+    let mut files = HashMap::default();
+    files.insert(
+        PathBuf::from("segment"),
+        Arc::from(with_tantivy_footer(vec![1, 2, 3]).unwrap()),
+    );
+    let directory = DelayedOpenDirectory {
+        inner: SnapshotDirectory::new(files, Vec::new()),
+        gate: queue.file("lookup".into(), 1),
+    };
+    let boxed: Box<dyn Directory> = Box::new(directory);
+    let managed: Box<dyn Directory> = Box::new(ManagedDirectory::wrap(boxed).unwrap());
+    let mut source = HashMap::default();
+    source.insert("lookup".into(), Arc::<[u8]>::from(vec![0]));
+    let mut requests = Vec::new();
+    let file = drive_queued_future(
+        managed.open_read_async(Path::new("segment")),
+        &queue,
+        &source,
+        &mut requests,
+    )
+    .unwrap();
+    assert_eq!(requests, [("lookup".into(), 0..1)]);
+    assert_eq!(&*file.read_bytes().unwrap(), &[1, 2, 3]);
+
+    let mut opening = managed.open_read_async(Path::new("segment"));
+    let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+    assert!(opening.as_mut().poll(&mut cx).is_pending());
+    queue
+        .pop()
+        .unwrap()
+        .complete(Err(std::io::Error::other("lookup failure")));
+    assert!(
+        matches!(opening.as_mut().poll(&mut cx), std::task::Poll::Ready(Err(error))
+        if error.to_string().contains("lookup failure"))
+    );
+
+    let mut cancelled = managed.open_read_async(Path::new("segment"));
+    assert!(cancelled.as_mut().poll(&mut cx).is_pending());
+    let request = queue.pop().unwrap();
+    drop(cancelled);
+    assert!(request.is_cancelled());
+}
+
+#[derive(Clone, Debug)]
+struct DelayedOpenDirectory {
+    inner: SnapshotDirectory,
+    gate: Arc<dyn tantivy::directory::FileHandle>,
+}
+
+impl tantivy::Directory for DelayedOpenDirectory {
+    fn get_file_handle(
+        &self,
+        _: &std::path::Path,
+    ) -> std::result::Result<
+        Arc<dyn tantivy::directory::FileHandle>,
+        tantivy::directory::error::OpenReadError,
+    > {
+        panic!("async open must not call synchronous lookup")
+    }
+
+    fn get_file_handle_async<'a>(
+        &'a self,
+        path: &'a std::path::Path,
+    ) -> tantivy::directory::DirectoryFuture<
+        'a,
+        std::result::Result<
+            Arc<dyn tantivy::directory::FileHandle>,
+            tantivy::directory::error::OpenReadError,
+        >,
+    > {
+        Box::pin(async move {
+            self.gate.read_bytes_async(0..1).await.map_err(|error| {
+                tantivy::directory::error::OpenReadError::wrap_io_error(error, path.to_path_buf())
+            })?;
+            self.inner.get_file_handle(path)
+        })
+    }
+
+    fn delete(
+        &self,
+        path: &std::path::Path,
+    ) -> std::result::Result<(), tantivy::directory::error::DeleteError> {
+        self.inner.delete(path)
+    }
+    fn exists(
+        &self,
+        path: &std::path::Path,
+    ) -> std::result::Result<bool, tantivy::directory::error::OpenReadError> {
+        self.inner.exists(path)
+    }
+    fn open_write(
+        &self,
+        path: &std::path::Path,
+    ) -> std::result::Result<tantivy::directory::WritePtr, tantivy::directory::error::OpenWriteError>
+    {
+        self.inner.open_write(path)
+    }
+    fn atomic_read(
+        &self,
+        path: &std::path::Path,
+    ) -> std::result::Result<Vec<u8>, tantivy::directory::error::OpenReadError> {
+        self.inner.atomic_read(path)
+    }
+    fn atomic_write(&self, path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
+        self.inner.atomic_write(path, data)
+    }
+    fn sync_directory(&self) -> std::io::Result<()> {
+        self.inner.sync_directory()
+    }
+    fn watch(
+        &self,
+        callback: tantivy::directory::WatchCallback,
+    ) -> tantivy::Result<tantivy::directory::WatchHandle> {
+        self.inner.watch(callback)
+    }
+}
+
 fn drive_queued_future<T>(
     future: impl std::future::Future<Output = T>,
     queue: &tantivy::directory::ReadQueue,

--- a/vendor/tantivy/TURSO_FORK.md
+++ b/vendor/tantivy/TURSO_FORK.md
@@ -63,6 +63,14 @@ all/empty, automaton, phrase-prefix, and range query weights support this path.
 Once constructed, scorers decode resident payloads without storage I/O.
 Unsupported external Weight implementations fail explicitly by default.
 
+The `Directory` trait exposes object-safe `get_file_handle_async` and
+`open_read_async` methods. Async managed-file opening awaits directory lookup
+before footer I/O, including through `Box<dyn Directory>`. Implementations
+must opt in; the default returns Unsupported rather than blocking. RamDirectory
+and Turso's resident-registry directories perform ready, memory-only lookups.
+Directory mutation, atomic metadata operations, sync and writer interfaces
+remain synchronous; this is not yet an entirely asynchronous directory API.
+
 `Searcher::stream` returns a native `SearchStream` whose async `next` retains
 one segment scorer at a time and uses global snapshot statistics. Turso's
 unordered MATCH paths use it and retain only the current rowid column; crossing
@@ -116,7 +124,7 @@ cargo test -p turso_core --features fts index_method::fts --lib
 cargo test -p core_tester --test integration_tests fts_
 ```
 
-The FTS suites cover 21 unit tests and 109 integration tests. The async-only
+The FTS suites cover 22 unit tests and 109 integration tests. The async-only
 unit fixture compares scores and addresses against resident readers, checks
 that opening leaves position payloads unread, and exercises merge, tombstones,
 repeated Pending polls, injected errors and cancellation. The queued-I/O SQL

--- a/vendor/tantivy/src/directory/directory.rs
+++ b/vendor/tantivy/src/directory/directory.rs
@@ -8,6 +8,10 @@ use crate::directory::directory_lock::Lock;
 use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
 use crate::directory::{FileHandle, FileSlice, WatchCallback, WatchHandle, WritePtr};
 
+/// Runtime-independent suspension of a directory operation.
+pub type DirectoryFuture<'a, T> =
+    std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
 /// Retry the logic of acquiring locks is pretty simple.
 /// We just retry `n` times after a given `duratio`, both
 /// depending on the type of lock.
@@ -110,6 +114,34 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// Users of `Directory` should typically call `Directory::open_read(...)`,
     /// while `Directory` implementer should implement `get_file_handle()`.
     fn get_file_handle(&self, path: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError>;
+
+    /// Opens an immutable file without blocking the caller's storage driver.
+    /// Implementations must opt in; the default never calls synchronous I/O.
+    fn get_file_handle_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> DirectoryFuture<'a, Result<Arc<dyn FileHandle>, OpenReadError>> {
+        Box::pin(async move {
+            Err(OpenReadError::wrap_io_error(
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "Directory does not support async open",
+                ),
+                path.to_path_buf(),
+            ))
+        })
+    }
+
+    /// Opens a logical slice after the directory's asynchronous file lookup.
+    fn open_read_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> DirectoryFuture<'a, Result<FileSlice, OpenReadError>> {
+        Box::pin(async move {
+            let handle = self.get_file_handle_async(path).await?;
+            Ok(FileSlice::new(handle))
+        })
+    }
 
     /// Once a virtual file is open, its data may not
     /// change.

--- a/vendor/tantivy/src/directory/managed_directory.rs
+++ b/vendor/tantivy/src/directory/managed_directory.rs
@@ -241,7 +241,7 @@ impl ManagedDirectory {
 
     /// Opens a managed file with resumable footer reads.
     pub async fn open_read_async(&self, path: &Path) -> result::Result<FileSlice, OpenReadError> {
-        let file = self.directory.open_read(path)?;
+        let file = self.directory.open_read_async(path).await?;
         let (footer, body) = Footer::extract_footer_async(file)
             .await
             .map_err(|error| OpenReadError::wrap_io_error(error, path.to_path_buf()))?;
@@ -279,6 +279,16 @@ impl ManagedDirectory {
 }
 
 impl Directory for ManagedDirectory {
+    fn get_file_handle_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> super::DirectoryFuture<'a, Result<Arc<dyn FileHandle>, OpenReadError>> {
+        Box::pin(async move {
+            let file = ManagedDirectory::open_read_async(self, path).await?;
+            Ok(Arc::new(file) as Arc<dyn FileHandle>)
+        })
+    }
+
     fn get_file_handle(&self, path: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError> {
         let file_slice = self.open_read(path)?;
         Ok(Arc::new(file_slice))

--- a/vendor/tantivy/src/directory/mod.rs
+++ b/vendor/tantivy/src/directory/mod.rs
@@ -24,7 +24,7 @@ pub use common::read_queue::{ReadQueue, ReadRequest};
 pub use common::{AntiCallToken, OwnedBytes, TerminatingWrite};
 
 pub use self::composite_file::{CompositeFile, CompositeWrite};
-pub use self::directory::{Directory, DirectoryClone, DirectoryLock};
+pub use self::directory::{Directory, DirectoryClone, DirectoryFuture, DirectoryLock};
 pub use self::directory_lock::{Lock, INDEX_WRITER_LOCK, META_LOCK};
 pub use self::ram_directory::RamDirectory;
 pub use self::watch_event_router::{WatchCallback, WatchCallbackList, WatchHandle};

--- a/vendor/tantivy/src/directory/ram_directory.rs
+++ b/vendor/tantivy/src/directory/ram_directory.rs
@@ -167,6 +167,13 @@ impl RamDirectory {
 }
 
 impl Directory for RamDirectory {
+    fn get_file_handle_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> super::DirectoryFuture<'a, Result<Arc<dyn FileHandle>, OpenReadError>> {
+        Box::pin(async move { self.get_file_handle(path) })
+    }
+
     fn get_file_handle(&self, path: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError> {
         let file_slice = self.open_read(path)?;
         Ok(Arc::new(file_slice))


### PR DESCRIPTION
## Scope
Add object-safe `Directory::get_file_handle_async` and `Directory::open_read_async`. The default rejects unsupported async lookup rather than falling back to synchronous I/O. ManagedDirectory now awaits lookup before footer reads, including through `Box<dyn Directory>`. RamDirectory and Turso snapshot/build directories opt into ready memory-only lookup.

## Stack — review bottom to top
`main → #8802 vendor → #8803 native async APIs → #8804 Turso integration → #8806 async directory read-open → #8807 async index open`
Managed by `gh stack`, stack #8805. This PR targets `fts/turso-async-integration` and has one focused commit.

## Verification
- `cargo check -p turso_core --features fts`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- `cargo test -p turso_core --features fts index_method::fts --lib`: 22 passed.
- `cargo test -p core_tester --test integration_tests fts_`: 109 passed.
- New trait-object regression makes synchronous lookup panic, delays async lookup across repeated polls, and checks error propagation and cancellation.

## Remaining scope
This converts read-open, not the entire directory API. Directory mutation, atomic metadata operations, sync, writer interfaces, streaming serialization and full memory bounds remain unfinished. No new total-memory guarantee is claimed.

## AI usage
Implementation and verification performed with Amp. Draft pending human review.