### PR TITLE
tantivy: open and reload index metadata asynchronously

### DIFF
--- a/core/index_method/fts/directory.rs
+++ b/core/index_method/fts/directory.rs
@@ -89,6 +89,13 @@ impl std::fmt::Debug for SnapshotDirectory {
 }
 
 impl Directory for SnapshotDirectory {
+    fn atomic_read_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> tantivy::directory::DirectoryFuture<'a, std::result::Result<Vec<u8>, OpenReadError>> {
+        Box::pin(async move { self.atomic_read(path) })
+    }
+
     fn get_file_handle_async<'a>(
         &'a self,
         path: &'a Path,
@@ -251,6 +258,13 @@ impl TerminatingWrite for CaptureWriter {
 }
 
 impl Directory for BuildDirectory {
+    fn atomic_read_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> tantivy::directory::DirectoryFuture<'a, std::result::Result<Vec<u8>, OpenReadError>> {
+        Box::pin(async move { self.atomic_read(path) })
+    }
+
     fn get_file_handle_async<'a>(
         &'a self,
         path: &'a Path,

--- a/core/index_method/fts/mod.rs
+++ b/core/index_method/fts/mod.rs
@@ -1887,18 +1887,12 @@ impl FtsCursor {
             let scratch = self.shared.scratch_index(&self.schema)?;
             let meta = synthesize_meta_json(&scratch, &self.schema, &self.segments)?;
             let directory = SnapshotDirectory::new(files, meta).with_async_files(handles);
-            let index = Index::open(directory)
-                .map_err(|error| LimboError::InternalError(error.to_string()))?;
-            self.register_tokenizers(&index);
-            let metas = index
-                .searchable_segment_metas()
-                .map_err(|error| LimboError::InternalError(error.to_string()))?;
-            self.cached_parser = Some(self.build_query_parser(&index));
-            self.index = Some(index.clone());
-            self.opening_searcher = Some(read::SnapshotIo::new(
-                self.read_queue.clone(),
-                Searcher::open_async(index, metas, 0),
-            ));
+            self.opening_searcher =
+                Some(read::SnapshotIo::new(self.read_queue.clone(), async move {
+                    let index = Index::open_async(directory).await?;
+                    let metas = index.load_metas_async().await?;
+                    Searcher::open_async(index, metas.segments, 0).await
+                }));
         }
         let cursor = self
             .fts_dir_cursor
@@ -1910,6 +1904,10 @@ impl FtsCursor {
             .unwrap()
             .resume(cursor.as_mut()));
         self.opening_searcher = None;
+        let index = searcher.index().clone();
+        self.register_tokenizers(&index);
+        self.cached_parser = Some(self.build_query_parser(&index));
+        self.index = Some(index);
         self.searcher = Some(searcher);
         Ok(IOResult::Done(()))
     }

--- a/core/index_method/fts/tests.rs
+++ b/core/index_method/fts/tests.rs
@@ -599,10 +599,20 @@ fn managed_directory_awaits_file_lookup_before_reading_footer() {
         gate: queue.file("lookup".into(), 1),
     };
     let boxed: Box<dyn Directory> = Box::new(directory);
-    let managed: Box<dyn Directory> = Box::new(ManagedDirectory::wrap(boxed).unwrap());
     let mut source = HashMap::default();
     source.insert("lookup".into(), Arc::<[u8]>::from(vec![0]));
     let mut requests = Vec::new();
+    let managed: Box<dyn Directory> = Box::new(
+        drive_queued_future(
+            ManagedDirectory::wrap_async(boxed),
+            &queue,
+            &source,
+            &mut requests,
+        )
+        .unwrap(),
+    );
+    assert_eq!(requests.len(), 1);
+    requests.clear();
     let file = drive_queued_future(
         managed.open_read_async(Path::new("segment")),
         &queue,
@@ -630,6 +640,44 @@ fn managed_directory_awaits_file_lookup_before_reading_footer() {
     let request = queue.pop().unwrap();
     drop(cancelled);
     assert!(request.is_cancelled());
+}
+
+#[test]
+fn index_open_and_reload_await_metadata_reads() {
+    use tantivy::directory::ReadQueue;
+    let attachment = test_attachment();
+    let scratch = attachment.shared.scratch_index(&attachment.schema).unwrap();
+    let meta = synthesize_meta_json(&scratch, &attachment.schema, &[]).unwrap();
+    let queue = ReadQueue::default();
+    let directory = DelayedOpenDirectory {
+        inner: SnapshotDirectory::new(HashMap::default(), meta),
+        gate: queue.file("lookup".into(), 1),
+    };
+    let mut source = HashMap::default();
+    source.insert("lookup".into(), Arc::<[u8]>::from(vec![0]));
+    let mut requests = Vec::new();
+    let index = drive_queued_future(
+        Index::open_async(directory.clone()),
+        &queue,
+        &source,
+        &mut requests,
+    )
+    .unwrap();
+    assert_eq!(index.schema(), attachment.schema);
+    assert_eq!(
+        requests.len(),
+        2,
+        "management and index metadata must both await"
+    );
+    let metas =
+        drive_queued_future(index.load_metas_async(), &queue, &source, &mut requests).unwrap();
+    assert!(metas.segments.is_empty());
+    assert_eq!(requests.len(), 3);
+    let mut corrupt = directory;
+    corrupt.inner = SnapshotDirectory::new(HashMap::default(), b"not json".to_vec());
+    assert!(
+        drive_queued_future(Index::open_async(corrupt), &queue, &source, &mut requests).is_err()
+    );
 }
 
 #[derive(Clone, Debug)]
@@ -688,9 +736,23 @@ impl tantivy::Directory for DelayedOpenDirectory {
     }
     fn atomic_read(
         &self,
-        path: &std::path::Path,
+        _: &std::path::Path,
     ) -> std::result::Result<Vec<u8>, tantivy::directory::error::OpenReadError> {
-        self.inner.atomic_read(path)
+        panic!("async metadata reads must not use synchronous storage")
+    }
+    fn atomic_read_async<'a>(
+        &'a self,
+        path: &'a std::path::Path,
+    ) -> tantivy::directory::DirectoryFuture<
+        'a,
+        std::result::Result<Vec<u8>, tantivy::directory::error::OpenReadError>,
+    > {
+        Box::pin(async move {
+            self.gate.read_bytes_async(0..1).await.map_err(|error| {
+                tantivy::directory::error::OpenReadError::wrap_io_error(error, path.to_path_buf())
+            })?;
+            self.inner.atomic_read(path)
+        })
     }
     fn atomic_write(&self, path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
         self.inner.atomic_write(path, data)

--- a/vendor/tantivy/TURSO_FORK.md
+++ b/vendor/tantivy/TURSO_FORK.md
@@ -63,12 +63,17 @@ all/empty, automaton, phrase-prefix, and range query weights support this path.
 Once constructed, scorers decode resident payloads without storage I/O.
 Unsupported external Weight implementations fail explicitly by default.
 
-The `Directory` trait exposes object-safe `get_file_handle_async` and
-`open_read_async` methods. Async managed-file opening awaits directory lookup
+The `Directory` trait exposes object-safe `get_file_handle_async`,
+`open_read_async` and `atomic_read_async` methods. Async managed-file opening awaits directory lookup
 before footer I/O, including through `Box<dyn Directory>`. Implementations
 must opt in; the default returns Unsupported rather than blocking. RamDirectory
 and Turso's resident-registry directories perform ready, memory-only lookups.
-Directory mutation, atomic metadata operations, sync and writer interfaces
+`ManagedDirectory::wrap_async`, `Index::open_async` and `Index::load_metas_async`
+await management/index metadata reads. Turso retains the entire open future
+until the Searcher is ready, then installs its index and parser. The synchronous
+and asynchronous entry points share metadata parsing and corruption handling.
+Metadata still occupies a complete buffer; this is not a metadata memory cap.
+Directory mutation, atomic metadata writes, sync and writer interfaces
 remain synchronous; this is not yet an entirely asynchronous directory API.
 
 `Searcher::stream` returns a native `SearchStream` whose async `next` retains
@@ -124,7 +129,7 @@ cargo test -p turso_core --features fts index_method::fts --lib
 cargo test -p core_tester --test integration_tests fts_
 ```
 
-The FTS suites cover 22 unit tests and 109 integration tests. The async-only
+The FTS suites cover 23 unit tests and 109 integration tests. The async-only
 unit fixture compares scores and addresses against resident readers, checks
 that opening leaves position payloads unread, and exercises merge, tombstones,
 repeated Pending polls, injected errors and cancellation. The queued-I/O SQL

--- a/vendor/tantivy/src/directory/directory.rs
+++ b/vendor/tantivy/src/directory/directory.rs
@@ -203,6 +203,23 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// You should only use this to read files create with [`Directory::atomic_write()`].
     fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError>;
 
+    /// Asynchronously reads a complete atomic metadata file, not a segment
+    /// component. Implementations must not fall back to blocking reads.
+    fn atomic_read_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> DirectoryFuture<'a, Result<Vec<u8>, OpenReadError>> {
+        Box::pin(async move {
+            Err(OpenReadError::wrap_io_error(
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "Directory does not support async metadata reads",
+                ),
+                path.to_path_buf(),
+            ))
+        })
+    }
+
     /// Atomically replace the content of a file with data.
     ///
     /// This calls ensure that reads can never *observe*

--- a/vendor/tantivy/src/directory/managed_directory.rs
+++ b/vendor/tantivy/src/directory/managed_directory.rs
@@ -62,7 +62,21 @@ fn save_managed_paths(
 impl ManagedDirectory {
     /// Wraps a directory as managed directory.
     pub fn wrap(directory: Box<dyn Directory>) -> crate::Result<ManagedDirectory> {
-        match directory.atomic_read(&MANAGED_FILEPATH) {
+        let data = directory.atomic_read(&MANAGED_FILEPATH);
+        Self::from_managed_data(directory, data)
+    }
+
+    /// Opens management metadata without synchronous storage access.
+    pub async fn wrap_async(directory: Box<dyn Directory>) -> crate::Result<ManagedDirectory> {
+        let data = directory.atomic_read_async(&MANAGED_FILEPATH).await;
+        Self::from_managed_data(directory, data)
+    }
+
+    fn from_managed_data(
+        directory: Box<dyn Directory>,
+        data: result::Result<Vec<u8>, OpenReadError>,
+    ) -> crate::Result<ManagedDirectory> {
+        match data {
             Ok(data) => {
                 let managed_files_json = String::from_utf8_lossy(&data);
                 let managed_files: HashSet<PathBuf> = serde_json::from_str(&managed_files_json)
@@ -321,6 +335,13 @@ impl Directory for ManagedDirectory {
 
     fn atomic_read(&self, path: &Path) -> result::Result<Vec<u8>, OpenReadError> {
         self.directory.atomic_read(path)
+    }
+
+    fn atomic_read_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> super::DirectoryFuture<'a, result::Result<Vec<u8>, OpenReadError>> {
+        self.directory.atomic_read_async(path)
     }
 
     fn delete(&self, path: &Path) -> result::Result<(), DeleteError> {

--- a/vendor/tantivy/src/directory/ram_directory.rs
+++ b/vendor/tantivy/src/directory/ram_directory.rs
@@ -167,6 +167,13 @@ impl RamDirectory {
 }
 
 impl Directory for RamDirectory {
+    fn atomic_read_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> super::DirectoryFuture<'a, Result<Vec<u8>, OpenReadError>> {
+        Box::pin(async move { self.atomic_read(path) })
+    }
+
     fn get_file_handle_async<'a>(
         &'a self,
         path: &'a Path,

--- a/vendor/tantivy/src/index/index.rs
+++ b/vendor/tantivy/src/index/index.rs
@@ -31,6 +31,10 @@ fn load_metas(
     inventory: &SegmentMetaInventory,
 ) -> crate::Result<IndexMeta> {
     let meta_data = directory.atomic_read(&META_FILEPATH)?;
+    parse_metas(meta_data, inventory)
+}
+
+fn parse_metas(meta_data: Vec<u8>, inventory: &SegmentMetaInventory) -> crate::Result<IndexMeta> {
     let meta_string = String::from_utf8(meta_data).map_err(|_utf8_err| {
         error!("Meta data is not valid utf8.");
         DataCorruption::new(
@@ -519,6 +523,21 @@ impl Index {
     /// Reads the index meta file from the directory.
     pub fn load_metas(&self) -> crate::Result<IndexMeta> {
         load_metas(self.directory(), &self.inventory)
+    }
+
+    /// Opens management and index metadata through the injected async directory.
+    pub async fn open_async<T: Into<Box<dyn Directory>>>(directory: T) -> crate::Result<Index> {
+        let directory = ManagedDirectory::wrap_async(directory.into()).await?;
+        let inventory = SegmentMetaInventory::default();
+        let data = directory.atomic_read_async(&META_FILEPATH).await?;
+        let metas = parse_metas(data, &inventory)?;
+        Ok(Index::open_from_metas(directory, &metas, inventory))
+    }
+
+    /// Reads one complete metadata version without synchronous storage calls.
+    pub async fn load_metas_async(&self) -> crate::Result<IndexMeta> {
+        let data = self.directory().atomic_read_async(&META_FILEPATH).await?;
+        parse_metas(data, &self.inventory)
     }
 
     /// Open a new index writer with the given options. Attempts to acquire a lockfile.


### PR DESCRIPTION
## Scope
Add object-safe `Directory::atomic_read_async`, `ManagedDirectory::wrap_async`, `Index::open_async`, and `Index::load_metas_async`. No default synchronous storage fallback. Synchronous and async entry points share metadata parsing/corruption handling.

Turso now drives complete index/searcher opening as one persisted future through Completions. It installs the parser and index only once opening succeeds.

## Stack — review bottom to top
`main → #8802 vendor → #8803 native async APIs → #8804 Turso integration → #8806 directory read-open → #8807 metadata/index open`
Managed with `gh stack`, stack #8805. Base: `fts/async-directory`. One focused incremental commit; prior layers remain separate.

## Verification
- `cargo check -p turso_core --features fts`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- `cargo test -p turso_core --features fts index_method::fts --lib`: 23 passed.
- `cargo test -p core_tester --test integration_tests fts_`: 109 passed.
- Test directory panics on synchronous metadata reads, delays both management and index metadata across repeated polls, checks async reload, and rejects malformed metadata.

## Still unfinished
Atomic metadata writes, directory mutations/sync, streaming writers and block paging remain. Metadata is still a complete resident allocation; no total-memory cap is claimed.

## AI usage
Implementation and verification performed with Amp. Draft pending human review.