### PR TITLE
fts: page asynchronous FST dictionary and term-info reads

### DIFF
--- a/core/index_method/fts/tests.rs
+++ b/core/index_method/fts/tests.rs
@@ -306,6 +306,56 @@ fn segment_byte_cache_keeps_newest_and_respects_budget() {
 }
 
 #[test]
+fn paged_dictionary_reads_resume_through_completions() {
+    use tantivy::directory::{FileSlice, ReadQueue};
+    use tantivy::termdict::{PagedTermDictionary, TermDictionaryBuilder};
+
+    let mut builder = TermDictionaryBuilder::create(Vec::new()).unwrap();
+    for i in 0..1_025usize {
+        builder
+            .insert(
+                format!("word-{i:08}"),
+                &tantivy::postings::TermInfo {
+                    doc_freq: i as u32,
+                    postings_range: i * i..(i + 1) * (i + 1),
+                    positions_range: i * i * 2..(i + 1) * (i + 1) * 2,
+                },
+            )
+            .unwrap();
+    }
+    let bytes: Arc<[u8]> = builder.finish().unwrap().into();
+    let queue = ReadQueue::default();
+    let file = FileSlice::new(queue.file("dictionary".into(), bytes.len()));
+    let source = HashMap::from_iter([("dictionary".to_owned(), bytes)]);
+    let mut requests = Vec::new();
+    let dictionary = drive_queued_future(
+        PagedTermDictionary::open(file),
+        &queue,
+        &source,
+        &mut requests,
+    )
+    .unwrap();
+    assert_eq!(
+        requests.iter().map(|(_, range)| range.len()).sum::<usize>(),
+        64
+    );
+    for ordinal in [0, 1, 255, 256, 1_024] {
+        let key = format!("word-{ordinal:08}");
+        let info = drive_queued_future(
+            dictionary.get(key.as_bytes()),
+            &queue,
+            &source,
+            &mut requests,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(info.doc_freq, ordinal);
+    }
+    assert!(requests.iter().all(|(_, range)| range.len() <= 4_619));
+    assert!(queue.pop().is_none());
+}
+
+#[test]
 fn async_snapshot_reads_only_requested_ranges_and_matches_resident_queries() {
     use tantivy::directory::{OwnedBytes, ReadQueue};
     let attachment = test_attachment();

--- a/vendor/tantivy/TURSO_FORK.md
+++ b/vendor/tantivy/TURSO_FORK.md
@@ -95,6 +95,21 @@ its suspended future is Send without unsafe trait assertions.
 
 ## Boundaries and remaining synchronous work
 
+`PagedTermDictionary` provides a separate format-compatible reader over the
+local FST fork's injected async traversal and paged term information. It opens
+with 64 metadata bytes, then reads at most one 4,619-byte FST window or one
+4,604-byte term-info block. It retains no whole dictionary arrays. Its tests
+exercise delayed queued reads, Turso Completion delivery, block boundaries,
+malformed metadata, and cancellation/errors between finding a term and reading
+its information. Key/automaton state and backing reader caches are not included
+in those read-size bounds.
+
+Production query/merge callers have **not yet switched** to this reader. That
+switch also needs suspendible BM25 weight construction, term expansion and
+term merging; using it only in dictionary open would strand synchronous
+callers. The remaining resident dictionaries described below are still on
+the current SQL path.
+
 This removes the requirement to preload every visible index file for a search,
 but is **not a fully paged or bounded-memory Tantivy implementation**:
 
@@ -130,7 +145,7 @@ cargo test -p turso_core --features fts index_method::fts --lib
 cargo test -p core_tester --test integration_tests fts_
 ```
 
-The FTS suites cover 23 unit tests and 109 integration tests. The async-only
+The FTS suites cover 24 unit tests and 109 integration tests. The async-only
 unit fixture compares scores and addresses against resident readers, checks
 that opening leaves position payloads unread, and exercises merge, tombstones,
 repeated Pending polls, injected errors and cancellation. The queued-I/O SQL
@@ -139,6 +154,13 @@ read failures, pending-statement reset, delayed OPTIMIZE, merge-read errors and
 rollback after merge. Native queue tests check invalid/empty ranges, short
 responses and dropped requests. The chunk-cache test checks eviction and the
 eight-row capacity. These suites, cargo check and formatting passed.
+
+The standalone Tantivy dictionary suite has 21 passing tests, including the
+paged reader; the term-offset overflow regression also passes. Command:
+`cargo test --manifest-path vendor/tantivy/Cargo.toml --lib termdict --target-dir /tmp/turso-tantivy-target`.
+On Rust 1.88 the ignored standalone development lockfile selected
+`ordered-float` 5.1.0 (5.5.0 requires Rust 1.90); the Turso lockfile and
+production dependencies were not changed for this test setup.
 
 `cargo clippy -p turso_core --features fts --lib -- --deny=warnings` failed
 on an unfulfilled `clippy::new_without_default` expectation in the unchanged

--- a/vendor/tantivy/src/postings/term_info.rs
+++ b/vendor/tantivy/src/postings/term_info.rs
@@ -48,13 +48,25 @@ impl BinarySerializable for TermInfo {
     }
 
     fn deserialize<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let invalid = || {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Term offset exceeds address space",
+            )
+        };
         let doc_freq = u32::deserialize(reader)?;
-        let postings_start_offset = u64::deserialize(reader)? as usize;
+        let postings_start_offset =
+            usize::try_from(u64::deserialize(reader)?).map_err(|_| invalid())?;
         let postings_num_bytes = u32::deserialize(reader)? as usize;
-        let postings_end_offset = postings_start_offset + postings_num_bytes;
-        let positions_start_offset = u64::deserialize(reader)? as usize;
+        let postings_end_offset = postings_start_offset
+            .checked_add(postings_num_bytes)
+            .ok_or_else(invalid)?;
+        let positions_start_offset =
+            usize::try_from(u64::deserialize(reader)?).map_err(|_| invalid())?;
         let positions_num_bytes = u32::deserialize(reader)? as usize;
-        let positions_end_offset = positions_start_offset + positions_num_bytes;
+        let positions_end_offset = positions_start_offset
+            .checked_add(positions_num_bytes)
+            .ok_or_else(invalid)?;
         Ok(TermInfo {
             doc_freq,
             postings_range: postings_start_offset..postings_end_offset,
@@ -68,8 +80,29 @@ mod tests {
 
     use super::TermInfo;
     use crate::tests::fixed_size_test;
+    use common::BinarySerializable;
 
-    // TODO add serialize/deserialize test for terminfo
+    #[test]
+    fn reject_overflowing_term_info_ranges() {
+        for overflow_postings in [true, false] {
+            let mut bytes = Vec::new();
+            1u32.serialize(&mut bytes).unwrap();
+            (if overflow_postings { u64::MAX } else { 0 })
+                .serialize(&mut bytes)
+                .unwrap();
+            1u32.serialize(&mut bytes).unwrap();
+            (if overflow_postings { 0 } else { u64::MAX })
+                .serialize(&mut bytes)
+                .unwrap();
+            1u32.serialize(&mut bytes).unwrap();
+            assert_eq!(
+                TermInfo::deserialize(&mut bytes.as_slice())
+                    .unwrap_err()
+                    .kind(),
+                std::io::ErrorKind::InvalidData
+            );
+        }
+    }
 
     #[test]
     fn test_fixed_size() {

--- a/vendor/tantivy/src/termdict/fst_termdict/mod.rs
+++ b/vendor/tantivy/src/termdict/fst_termdict/mod.rs
@@ -19,10 +19,12 @@
 //! A second datastructure makes it possible to access a
 //! [`TermInfo`](crate::postings::TermInfo).
 mod merger;
+mod paged;
 mod streamer;
 mod term_info_store;
 mod termdict;
 
 pub use self::merger::TermMerger;
+pub use self::paged::{PagedTermDictionary, PagedTermStreamer};
 pub use self::streamer::{TermStreamer, TermStreamerBuilder};
 pub use self::termdict::{TermDictionary, TermDictionaryBuilder};

--- a/vendor/tantivy/src/termdict/fst_termdict/paged.rs
+++ b/vendor/tantivy/src/termdict/fst_termdict/paged.rs
@@ -1,0 +1,334 @@
+use std::io;
+use std::ops::Range;
+
+use common::{BinarySerializable, HasLen};
+use tantivy_fst::asynchronous::{Fst, RangeReader, Stream};
+use tantivy_fst::Automaton;
+
+use super::term_info_store::PagedTermInfoStore;
+use super::termdict::FST_VERSION;
+use crate::directory::{FileSlice, OwnedBytes};
+use crate::postings::TermInfo;
+use crate::termdict::DictionaryType;
+
+/// A format-compatible FST dictionary read through injected asynchronous I/O.
+/// Neither the FST nor the term-info arrays are retained in memory. Reads are
+/// bounded by one FST node (4,619 bytes) or one 256-term information block.
+#[derive(Clone)]
+pub struct PagedTermDictionary {
+    fst: Fst<FstFile>,
+    infos: PagedTermInfoStore,
+}
+
+impl PagedTermDictionary {
+    /// Opens an FST term dictionary, including its outer type discriminator.
+    pub async fn open(file: FileSlice) -> io::Result<Self> {
+        if file.len() < 16 {
+            return Err(invalid());
+        }
+        let footer_start = file.len() - 16;
+        let mut footer = file.slice(footer_start..).read_bytes_async().await?;
+        let info_len = usize::try_from(u64::deserialize(&mut footer)?).map_err(|_| invalid())?;
+        let version = u32::deserialize(&mut footer)?;
+        let kind = u32::deserialize(&mut footer)?;
+        if version != FST_VERSION || kind != DictionaryType::Fst as u32 || info_len > footer_start {
+            return Err(invalid());
+        }
+        drop(footer);
+        let info_start = footer_start - info_len;
+        let fst = Fst::open(FstFile(file.slice(..info_start))).await?;
+        let infos = PagedTermInfoStore::open(file.slice(info_start..footer_start)).await?;
+        if fst.len() != infos.num_terms() {
+            return Err(invalid());
+        }
+        Ok(Self { fst, infos })
+    }
+
+    /// Number of terms, without I/O.
+    pub fn num_terms(&self) -> usize {
+        self.fst.len()
+    }
+
+    /// Looks up a term without materializing the dictionary.
+    pub async fn get(&self, key: &[u8]) -> io::Result<Option<TermInfo>> {
+        match self.fst.get(key).await? {
+            Some(ordinal) => self.infos.get(ordinal).await.map(Some),
+            None => Ok(None),
+        }
+    }
+
+    /// Looks up the information for a lexicographic term ordinal.
+    pub async fn term_info_from_ord(&self, ordinal: u64) -> io::Result<TermInfo> {
+        self.infos.get(ordinal).await
+    }
+
+    /// Streams matching terms in byte order with suspendible advancement.
+    pub fn search<A: Automaton>(&self, automaton: A) -> PagedTermStreamer<'_, A> {
+        PagedTermStreamer {
+            stream: self.fst.search(automaton),
+            infos: &self.infos,
+            pending: None,
+            key: Vec::new(),
+            value: TermInfo::default(),
+        }
+    }
+}
+
+/// A stream that retains its pending term across term-information read errors
+/// and cancelled `next` futures. Retained keys/automaton state grow with term
+/// length, not with the number of dictionary entries.
+pub struct PagedTermStreamer<'a, A: Automaton> {
+    stream: Stream<'a, FstFile, A>,
+    infos: &'a PagedTermInfoStore,
+    pending: Option<u64>,
+    key: Vec<u8>,
+    value: TermInfo,
+}
+
+impl<A: Automaton> PagedTermStreamer<'_, A> {
+    /// Advances after both the key and its term information are available.
+    pub async fn next(&mut self) -> io::Result<Option<(&[u8], &TermInfo)>> {
+        let ordinal = match self.pending {
+            Some(ordinal) => ordinal,
+            None => {
+                let Some((key, ordinal)) = self.stream.next().await? else {
+                    return Ok(None);
+                };
+                self.key.clear();
+                self.key.extend_from_slice(key);
+                self.pending = Some(ordinal);
+                ordinal
+            }
+        };
+        self.value = self.infos.get(ordinal).await?;
+        self.pending = None;
+        Ok(Some((&self.key, &self.value)))
+    }
+}
+
+#[derive(Clone)]
+struct FstFile(FileSlice);
+
+impl RangeReader for FstFile {
+    type Bytes = OwnedBytes;
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    async fn read(&self, range: Range<usize>) -> io::Result<OwnedBytes> {
+        self.0.slice(range).read_bytes_async().await
+    }
+}
+
+fn invalid() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "Invalid paged FST dictionary")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::future::Future;
+    use std::task::{Context, Poll, Waker};
+
+    use crate::directory::ReadQueue;
+    use crate::termdict::{TermDictionary, TermDictionaryBuilder};
+    use tantivy_fst::automaton::AlwaysMatch;
+
+    #[test]
+    fn paged_dictionary_matches_resident_with_delayed_reads() {
+        let bytes = dictionary_bytes(1_025);
+        let resident = TermDictionary::open(FileSlice::from(bytes.clone())).unwrap();
+        let queue = ReadQueue::default();
+        let file = FileSlice::new(queue.file("dict".into(), bytes.len()));
+        let paged = drive(PagedTermDictionary::open(file), &queue, &bytes).unwrap();
+        assert_eq!(paged.num_terms(), 1_025);
+        for i in 0..1_025u64 {
+            let key = format!("key-{i:08}");
+            let expected = resident.get(&key).unwrap().unwrap();
+            assert_eq!(
+                drive(paged.get(key.as_bytes()), &queue, &bytes).unwrap(),
+                Some(expected.clone())
+            );
+            assert_eq!(
+                drive(paged.term_info_from_ord(i), &queue, &bytes).unwrap(),
+                expected
+            );
+        }
+        assert_eq!(drive(paged.get(b"missing"), &queue, &bytes).unwrap(), None);
+        assert!(drive(paged.term_info_from_ord(1_025), &queue, &bytes).is_err());
+        let mut stream = paged.search(AlwaysMatch);
+        let mut expected = resident.stream().unwrap();
+        while let Some((key, value)) = drive(stream.next(), &queue, &bytes).unwrap() {
+            let (expected_key, expected_value) = expected.next().unwrap();
+            assert_eq!(key, expected_key);
+            assert_eq!(value, expected_value);
+        }
+        assert!(expected.next().is_none());
+    }
+
+    #[test]
+    fn pending_term_info_survives_failure_and_cancellation() {
+        let bytes = dictionary_bytes(2);
+        let footer = bytes.len() - 16;
+        let info_len = u64::from_le_bytes(bytes[footer..footer + 8].try_into().unwrap()) as usize;
+        let metadata_start = bytes.len() - info_len;
+        let queue = ReadQueue::default();
+        let file = FileSlice::new(queue.file("dict".into(), bytes.len()));
+        let paged = drive(PagedTermDictionary::open(file), &queue, &bytes).unwrap();
+        let mut stream = paged.search(AlwaysMatch);
+        let mut cx = Context::from_waker(Waker::noop());
+        // Finish dictionary traversal, then fail the separate term-info read.
+        {
+            let mut next = Box::pin(stream.next());
+            loop {
+                assert!(next.as_mut().poll(&mut cx).is_pending());
+                let request = queue.pop().unwrap();
+                let range = request.range();
+                if range.start == metadata_start {
+                    request.complete(Err(io::Error::other("term info failure")));
+                    let Poll::Ready(Err(error)) = next.as_mut().poll(&mut cx) else {
+                        panic!("missing error")
+                    };
+                    assert_eq!(error.to_string(), "term info failure");
+                    break;
+                }
+                request.complete(Ok(OwnedBytes::new(bytes[range].to_vec())));
+            }
+        }
+        assert_eq!(stream.pending, Some(0));
+        {
+            let mut next = Box::pin(stream.next());
+            assert!(next.as_mut().poll(&mut cx).is_pending());
+        }
+        assert!(queue.pop().is_none());
+        let (key, _) = drive(stream.next(), &queue, &bytes).unwrap().unwrap();
+        assert_eq!(key, b"key-00000000");
+        let (key, _) = drive(stream.next(), &queue, &bytes).unwrap().unwrap();
+        assert_eq!(key, b"key-00000001");
+        assert!(drive(stream.next(), &queue, &bytes).unwrap().is_none());
+    }
+
+    #[test]
+    fn paged_dictionary_empty_and_corrupt_metadata() {
+        let bytes = dictionary_bytes(0);
+        let queue = ReadQueue::default();
+        let file = FileSlice::new(queue.file("dict".into(), bytes.len()));
+        let paged = drive(PagedTermDictionary::open(file), &queue, &bytes).unwrap();
+        assert_eq!(paged.num_terms(), 0);
+        assert!(drive(paged.get(b"x"), &queue, &bytes).unwrap().is_none());
+        for len in 0..16 {
+            assert!(drive(
+                PagedTermDictionary::open(FileSlice::from(vec![0; len])),
+                &queue,
+                &[]
+            )
+            .is_err());
+        }
+        let mut bytes = dictionary_bytes(1);
+        let footer = bytes.len() - 16;
+        bytes[footer..footer + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+        assert!(drive(
+            PagedTermDictionary::open(FileSlice::from(bytes)),
+            &queue,
+            &[]
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn paged_term_info_rejects_bad_widths_and_offsets() {
+        let original = dictionary_bytes(2);
+        let footer = original.len() - 16;
+        let info_len =
+            u64::from_le_bytes(original[footer..footer + 8].try_into().unwrap()) as usize;
+        let metadata_start = original.len() - info_len;
+        let queue = ReadQueue::default();
+        for corruption in 0..3 {
+            let mut bytes = original.clone();
+            match corruption {
+                0 => bytes[metadata_start..metadata_start + 8]
+                    .copy_from_slice(&u64::MAX.to_le_bytes()),
+                1 => bytes[metadata_start + 36] = 255,
+                2 => bytes[metadata_start + 12..metadata_start + 20]
+                    .copy_from_slice(&u64::MAX.to_le_bytes()),
+                _ => unreachable!(),
+            }
+            let paged = drive(
+                PagedTermDictionary::open(FileSlice::from(bytes)),
+                &queue,
+                &[],
+            )
+            .unwrap();
+            assert_eq!(
+                drive(paged.term_info_from_ord(1), &queue, &[])
+                    .unwrap_err()
+                    .kind(),
+                io::ErrorKind::InvalidData
+            );
+        }
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn maximum_width_term_info_block_stays_small() {
+        let mut builder = TermDictionaryBuilder::create(Vec::new()).unwrap();
+        for i in 0..256u64 {
+            let start = (i << 48) as usize;
+            builder
+                .insert(
+                    format!("key-{i:08}"),
+                    &TermInfo {
+                        doc_freq: u32::MAX,
+                        postings_range: start..start + 1,
+                        positions_range: start..start + 1,
+                    },
+                )
+                .unwrap();
+        }
+        let bytes = builder.finish().unwrap();
+        let queue = ReadQueue::default();
+        let file = FileSlice::new(queue.file("dict".into(), bytes.len()));
+        let paged = drive(PagedTermDictionary::open(file), &queue, &bytes).unwrap();
+        for i in [1, 254, 255] {
+            let info = drive(paged.term_info_from_ord(i), &queue, &bytes).unwrap();
+            assert_eq!(info.doc_freq, u32::MAX);
+            assert_eq!(info.postings_range.start, (i << 48) as usize);
+            assert_eq!(info.positions_range.start, (i << 48) as usize);
+        }
+    }
+
+    fn dictionary_bytes(count: u64) -> Vec<u8> {
+        let mut builder = TermDictionaryBuilder::create(Vec::new()).unwrap();
+        for i in 0..count {
+            builder
+                .insert(
+                    format!("key-{i:08}"),
+                    &TermInfo {
+                        doc_freq: i as u32,
+                        postings_range: (i * i) as usize..((i + 1) * (i + 1)) as usize,
+                        positions_range: (i * i * 2) as usize..((i + 1) * (i + 1) * 2) as usize,
+                    },
+                )
+                .unwrap();
+        }
+        builder.finish().unwrap()
+    }
+
+    fn drive<F: Future + Send>(future: F, queue: &ReadQueue, bytes: &[u8]) -> F::Output {
+        let mut future = Box::pin(future);
+        let mut cx = Context::from_waker(Waker::noop());
+        loop {
+            if let Poll::Ready(value) = future.as_mut().poll(&mut cx) {
+                return value;
+            }
+            let request = queue.pop().expect("future must yield a range request");
+            assert!(future.as_mut().poll(&mut cx).is_pending());
+            assert!(future.as_mut().poll(&mut cx).is_pending());
+            assert!(queue.pop().is_none());
+            let range = request.range();
+            assert!(range.len() <= 4_619);
+            request.complete(Ok(OwnedBytes::new(bytes[range].to_vec())));
+        }
+    }
+}

--- a/vendor/tantivy/src/termdict/fst_termdict/term_info_store.rs
+++ b/vendor/tantivy/src/termdict/fst_termdict/term_info_store.rs
@@ -2,7 +2,7 @@ use std::cmp;
 use std::io::{self, Read, Write};
 
 use byteorder::{ByteOrder, LittleEndian};
-use common::{BinarySerializable, FixedSize};
+use common::{BinarySerializable, FixedSize, HasLen};
 use tantivy_bitpacker::{compute_num_bits, BitPacker};
 
 use crate::directory::{FileSlice, OwnedBytes};
@@ -97,6 +97,120 @@ pub struct TermInfoStore {
     num_terms: usize,
     block_meta_bytes: OwnedBytes,
     term_info_bytes: OwnedBytes,
+}
+
+#[derive(Clone)]
+pub(super) struct PagedTermInfoStore {
+    num_terms: usize,
+    block_meta_file: FileSlice,
+    term_info_file: FileSlice,
+}
+
+impl PagedTermInfoStore {
+    pub async fn open(file: FileSlice) -> io::Result<Self> {
+        if file.len() < 16 {
+            return Err(invalid_paged_store());
+        }
+        let mut header = file.slice(..16).read_bytes_async().await?;
+        let meta_len =
+            usize::try_from(u64::deserialize(&mut header)?).map_err(|_| invalid_paged_store())?;
+        let num_terms =
+            usize::try_from(u64::deserialize(&mut header)?).map_err(|_| invalid_paged_store())?;
+        let expected_meta_len = num_terms
+            .div_ceil(BLOCK_LEN)
+            .checked_mul(TermInfoBlockMeta::SIZE_IN_BYTES)
+            .ok_or_else(invalid_paged_store)?;
+        if meta_len != expected_meta_len || meta_len > file.len() - 16 {
+            return Err(invalid_paged_store());
+        }
+        Ok(Self {
+            num_terms,
+            block_meta_file: file.slice(16..16 + meta_len),
+            term_info_file: file.slice(16 + meta_len..),
+        })
+    }
+
+    pub fn num_terms(&self) -> usize {
+        self.num_terms
+    }
+
+    pub async fn get(&self, ordinal: u64) -> io::Result<TermInfo> {
+        let ordinal = usize::try_from(ordinal).map_err(|_| invalid_paged_store())?;
+        if ordinal >= self.num_terms {
+            return Err(invalid_paged_store());
+        }
+        let block = ordinal / BLOCK_LEN;
+        let start = block * TermInfoBlockMeta::SIZE_IN_BYTES;
+        let mut bytes = self
+            .block_meta_file
+            .slice(start..start + TermInfoBlockMeta::SIZE_IN_BYTES)
+            .read_bytes_async()
+            .await?;
+        let meta = TermInfoBlockMeta::deserialize(&mut bytes)?;
+        drop(bytes);
+        if meta.doc_freq_nbits > 32
+            || meta.postings_offset_nbits > 56
+            || meta.positions_offset_nbits > 56
+        {
+            return Err(invalid_paged_store());
+        }
+        let inner = ordinal % BLOCK_LEN;
+        if inner == 0 {
+            return Ok(meta.ref_term_info);
+        }
+        let terms = (self.num_terms - block * BLOCK_LEN).min(BLOCK_LEN);
+        let bits = (terms - 1) * usize::from(meta.num_bits())
+            + usize::from(meta.postings_offset_nbits)
+            + usize::from(meta.positions_offset_nbits);
+        let start = usize::try_from(meta.offset).map_err(|_| invalid_paged_store())?;
+        let end = start
+            .checked_add(bits.div_ceil(8))
+            .ok_or_else(invalid_paged_store)?;
+        if end > self.term_info_file.len() {
+            return Err(invalid_paged_store());
+        }
+        let data = self
+            .term_info_file
+            .slice(start..end)
+            .read_bytes_async()
+            .await?;
+        if data.len() != end - start {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Short term info block",
+            ));
+        }
+        let bit_start = (inner - 1) * usize::from(meta.num_bits());
+        for (base, offset, width) in [
+            (
+                meta.ref_term_info.postings_range.start,
+                bit_start,
+                meta.postings_offset_nbits,
+            ),
+            (
+                meta.ref_term_info.positions_range.start,
+                bit_start + usize::from(meta.postings_offset_nbits),
+                meta.positions_offset_nbits,
+            ),
+        ] {
+            for at in [offset, offset + usize::from(meta.num_bits())] {
+                let delta = usize::try_from(extract_bits(&data, at, width))
+                    .map_err(|_| invalid_paged_store())?;
+                base.checked_add(delta).ok_or_else(invalid_paged_store)?;
+            }
+        }
+        let info = meta.deserialize_term_info(&data, inner - 1);
+        if info.postings_range.start > info.postings_range.end
+            || info.positions_range.start > info.positions_range.end
+        {
+            return Err(invalid_paged_store());
+        }
+        Ok(info)
+    }
+}
+
+fn invalid_paged_store() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "Invalid paged term information")
 }
 
 fn extract_bits(data: &[u8], addr_bits: usize, num_bits: u8) -> u64 {

--- a/vendor/tantivy/src/termdict/fst_termdict/termdict.rs
+++ b/vendor/tantivy/src/termdict/fst_termdict/termdict.rs
@@ -16,7 +16,7 @@ fn convert_fst_error(e: tantivy_fst::Error) -> io::Error {
     io::Error::other(e)
 }
 
-const FST_VERSION: u32 = 1;
+pub(super) const FST_VERSION: u32 = 1;
 
 /// Builder for the new term dictionary.
 ///

--- a/vendor/tantivy/src/termdict/mod.rs
+++ b/vendor/tantivy/src/termdict/mod.rs
@@ -40,6 +40,8 @@ use common::file_slice::FileSlice;
 use common::BinarySerializable;
 use tantivy_fst::Automaton;
 
+#[cfg(not(feature = "quickwit"))]
+pub use self::termdict::{PagedTermDictionary, PagedTermStreamer};
 use self::termdict::{
     TermDictionary as InnerTermDict, TermDictionaryBuilder as InnerTermDictBuilder,
     TermStreamerBuilder,


### PR DESCRIPTION
Adds PagedTermDictionary and PagedTermStreamer over the injected FST reader and FileSlice range I/O. Opens with 64 metadata bytes; reads at most a 4619-byte FST node window or a 4604-byte term-information block. No whole dictionary arrays are retained by this reader. Pending term information survives read errors and cancellation after the FST has found a key. Metadata validation includes checked term-range arithmetic.

Executed verification:
- Standalone Tantivy termdict suite: 21 passed.
- Term-offset overflow regression: 1 passed.
- Turso FTS unit suite: 24 passed, including queued range delivery through Completions.
- Turso FTS integration suite: 109 passed.
- Formatting, diff checks, and FTS cargo check passed.

Standalone tests use an ignored development lockfile with ordered-float 5.1.0 for Rust 1.88; production dependency resolution is unchanged.

Not yet switched: production query and merge dictionary callers. They still need native async BM25 weight construction, term expansion and merging. Postings, columns, fieldnorms and writer buffers also remain unpaged; this is not a total query memory cap.

Stack (bottom to top): #8802 vendor Tantivy → #8803 async fork → #8804 Turso integration → #8806 async Directory → #8807 async index open → #8808 vendor FST → #8809 range nodes → #8810 async traversal → this PR.