### PR TITLE
fts: make term merging suspendible across injected I/O

### DIFF
--- a/core/index_method/fts/tests.rs
+++ b/core/index_method/fts/tests.rs
@@ -528,7 +528,9 @@ impl Query for SyncOnlyQuery {
 #[test]
 fn paged_dictionary_reads_resume_through_completions() {
     use tantivy::directory::{FileSlice, ReadQueue};
-    use tantivy::termdict::{PagedTermDictionary, TermDictionaryBuilder};
+    use tantivy::termdict::{
+        AsyncTermMerger, AsyncTermStreamer, PagedTermDictionary, TermDictionaryBuilder,
+    };
 
     let mut builder = TermDictionaryBuilder::create(Vec::new()).unwrap();
     for i in 0..1_025usize {
@@ -571,6 +573,23 @@ fn paged_dictionary_reads_resume_through_completions() {
         .unwrap();
         assert_eq!(info.doc_freq, ordinal);
     }
+    let mut merger = AsyncTermMerger::new(vec![
+        AsyncTermStreamer::Paged(dictionary.stream()),
+        AsyncTermStreamer::Paged(dictionary.stream()),
+    ]);
+    let mut ordinal = 0;
+    while drive_queued_future(merger.advance(), &queue, &source, &mut requests).unwrap() {
+        assert_eq!(merger.key(), format!("word-{ordinal:08}").as_bytes());
+        assert_eq!(
+            merger.matching_segments().collect::<Vec<_>>(),
+            [(0, ordinal), (1, ordinal)]
+        );
+        for (_, info) in merger.current_segment_ords_and_term_infos() {
+            assert_eq!(u64::from(info.doc_freq), ordinal);
+        }
+        ordinal += 1;
+    }
+    assert_eq!(ordinal, 1_025);
     assert!(requests.iter().all(|(_, range)| range.len() <= 4_619));
     assert!(queue.pop().is_none());
 }

--- a/vendor/tantivy/TURSO_FORK.md
+++ b/vendor/tantivy/TURSO_FORK.md
@@ -113,10 +113,18 @@ are Send + Sync. CPU-only built-in weight construction remains immediately
 ready; MoreLikeThis has not been converted and fails explicitly on this path.
 
 Production query/merge callers have **not yet switched** to the paged reader.
-Term expansion and term merging still require suspendible traversal; changing
-only dictionary open would strand those synchronous callers. The FST backend's
+Term expansion still requires suspendible traversal; changing only dictionary
+open would strand those synchronous callers. The FST backend's
 `get_async` currently does a CPU-only lookup in resident bytes. The remaining
 resident dictionaries described below are still on the current SQL path.
+
+`AsyncTermStreamer` supports resident and paged input cursors. `AsyncTermMerger`
+retains initialization, the pending input index and partial matches across
+errors/cancellation. Its current term information is captured before input
+advancement rather than reread synchronously by ordinal. The index merge loop
+awaits field opening, stream opening and merger advancement. Production streams
+are still resident; the delayed-I/O tests exercise the paged variant directly.
+No range-traversal changes are included in this layer.
 
 This removes the requirement to preload every visible index file for a search,
 but is **not a fully paged or bounded-memory Tantivy implementation**:
@@ -170,7 +178,11 @@ disjunction-max queries. Repeated Pending polls, errors, cancellation, disabled
 scoring and unsupported custom queries are covered. The standalone Tantivy
 query suite passes 229 tests (3 ignored).
 
-The standalone Tantivy dictionary suite has 21 passing tests, including the
+The async merger test injects an error and a cancellation at every read boundary
+in a mixed paged/resident merge, checking keys, ordinals and term information.
+The Turso dictionary fixture also merges 1,025 terms through Completions.
+
+The standalone Tantivy dictionary suite has 22 passing tests, including the
 paged reader; the term-offset overflow regression also passes. Command:
 `cargo test --manifest-path vendor/tantivy/Cargo.toml --lib termdict --target-dir /tmp/turso-tantivy-target`.
 On Rust 1.88 the ignored standalone development lockfile selected

--- a/vendor/tantivy/src/indexer/merger.rs
+++ b/vendor/tantivy/src/indexer/merger.rs
@@ -18,7 +18,7 @@ use crate::indexer::SegmentSerializer;
 use crate::postings::{InvertedIndexSerializer, Postings, SegmentPostings};
 use crate::schema::{value_type_to_column_type, Field, FieldType, Schema};
 use crate::store::StoreWriter;
-use crate::termdict::{TermMerger, TermOrdinal};
+use crate::termdict::{AsyncTermMerger, AsyncTermStreamer, TermOrdinal};
 use crate::{DocAddress, DocId, InvertedIndexReader};
 
 /// Segment's max doc must be `< MAX_DOC_LIMIT`.
@@ -324,20 +324,27 @@ impl IndexMerger {
 
         let mut max_term_ords: Vec<TermOrdinal> = Vec::new();
 
-        let field_readers: Vec<Arc<InvertedIndexReader>> = self
-            .readers
-            .iter()
-            .map(|reader| reader.inverted_index(indexed_field))
-            .collect::<crate::Result<Vec<_>>>()?;
+        let mut field_readers: Vec<Arc<InvertedIndexReader>> = Vec::new();
+        for reader in &self.readers {
+            field_readers.push(if ASYNC {
+                reader.inverted_index_async(indexed_field).await?
+            } else {
+                reader.inverted_index(indexed_field)?
+            });
+        }
 
         let mut field_term_streams = Vec::new();
         for field_reader in &field_readers {
             let terms = field_reader.terms();
-            field_term_streams.push(terms.stream()?);
+            field_term_streams.push(if ASYNC {
+                terms.stream_async().await?
+            } else {
+                AsyncTermStreamer::Resident(terms.stream()?)
+            });
             max_term_ords.push(terms.num_terms() as u64);
         }
 
-        let mut merged_terms = TermMerger::new(field_term_streams);
+        let mut merged_terms = AsyncTermMerger::new(field_term_streams);
 
         // map from segment doc ids to the resulting merged segment doc id.
 
@@ -384,7 +391,7 @@ impl IndexMerger {
 
         let mut segment_postings_containing_the_term: Vec<(usize, SegmentPostings)> = vec![];
 
-        while merged_terms.advance() {
+        while merged_terms.advance().await? {
             segment_postings_containing_the_term.clear();
             let term_bytes: &[u8] = merged_terms.key();
 

--- a/vendor/tantivy/src/termdict/async_merger.rs
+++ b/vendor/tantivy/src/termdict/async_merger.rs
@@ -1,0 +1,114 @@
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::io;
+
+use super::{AsyncTermStreamer, TermOrdinal};
+use crate::postings::TermInfo;
+
+/// Suspendible union of sorted dictionary streams. Each input retains only its
+/// current key and traversal state, not a materialized list of terms.
+pub struct AsyncTermMerger<'a> {
+    streams: Vec<AsyncTermStreamer<'a>>,
+    heap: BinaryHeap<Reverse<(Vec<u8>, usize)>>,
+    state: State,
+    key: Vec<u8>,
+    matches: Vec<(usize, TermOrdinal, TermInfo)>,
+}
+
+enum State {
+    Initialize(usize),
+    StartTerm,
+    Collect,
+    Advance(usize),
+}
+
+impl<'a> AsyncTermMerger<'a> {
+    /// Creates a merger without reading any input. Initialization suspends in
+    /// `advance`, whose progress survives cancellation and I/O failures.
+    pub fn new(streams: Vec<AsyncTermStreamer<'a>>) -> Self {
+        Self {
+            streams,
+            heap: BinaryHeap::new(),
+            state: State::Initialize(0),
+            key: Vec::new(),
+            matches: Vec::new(),
+        }
+    }
+
+    /// Advances to the next unique term, sorted by byte order. Read errors and
+    /// dropped futures leave this operation resumable without losing matches.
+    pub async fn advance(&mut self) -> io::Result<bool> {
+        loop {
+            match self.state {
+                State::Initialize(index) if index == self.streams.len() => {
+                    self.state = State::StartTerm;
+                }
+                State::Initialize(index) => {
+                    self.advance_stream(index).await?;
+                    self.state = State::Initialize(index + 1);
+                }
+                State::StartTerm => {
+                    let Some(Reverse((key, _))) = self.heap.peek() else {
+                        return Ok(false);
+                    };
+                    self.key.clone_from(key);
+                    self.matches.clear();
+                    self.state = State::Collect;
+                }
+                State::Collect => {
+                    if self
+                        .heap
+                        .peek()
+                        .is_some_and(|Reverse((key, _))| key == &self.key)
+                    {
+                        let Reverse((_, index)) = self.heap.pop().unwrap();
+                        let stream = &self.streams[index];
+                        self.matches
+                            .push((index, stream.term_ord(), stream.value().clone()));
+                        // The heap entry is already consumed. Remember which
+                        // stream to advance before any read can suspend.
+                        self.state = State::Advance(index);
+                    } else {
+                        self.matches.sort_unstable_by_key(|entry| entry.0);
+                        self.state = State::StartTerm;
+                        return Ok(true);
+                    }
+                }
+                State::Advance(index) => {
+                    self.advance_stream(index).await?;
+                    self.state = State::Collect;
+                }
+            }
+        }
+    }
+
+    async fn advance_stream(&mut self, index: usize) -> io::Result<()> {
+        let stream = &mut self.streams[index];
+        if stream.advance().await? {
+            self.heap.push(Reverse((stream.key().to_vec(), index)));
+        }
+        Ok(())
+    }
+
+    /// Current key, valid after `advance` returned true.
+    pub fn key(&self) -> &[u8] {
+        &self.key
+    }
+
+    /// Input segment and term ordinals, sorted by segment ordinal.
+    pub fn matching_segments(&self) -> impl Iterator<Item = (usize, TermOrdinal)> + '_ {
+        self.matches
+            .iter()
+            .map(|&(index, ordinal, _)| (index, ordinal))
+    }
+
+    /// Input term information, captured before advancing each input stream.
+    /// Calling this never rereads a dictionary by ordinal.
+    pub fn current_segment_ords_and_term_infos(
+        &self,
+    ) -> impl Iterator<Item = (usize, TermInfo)> + '_ {
+        self.matches
+            .iter()
+            .map(|(index, _, info)| (*index, info.clone()))
+    }
+}

--- a/vendor/tantivy/src/termdict/fst_termdict/paged.rs
+++ b/vendor/tantivy/src/termdict/fst_termdict/paged.rs
@@ -62,6 +62,11 @@ impl PagedTermDictionary {
         self.infos.get(ordinal).await
     }
 
+    /// Streams all terms without reading dictionary bytes at construction.
+    pub fn stream(&self) -> PagedTermStreamer<'_> {
+        self.search(tantivy_fst::automaton::AlwaysMatch)
+    }
+
     /// Streams matching terms in byte order with suspendible advancement.
     pub fn search<A: Automaton>(&self, automaton: A) -> PagedTermStreamer<'_, A> {
         PagedTermStreamer {
@@ -70,6 +75,7 @@ impl PagedTermDictionary {
             pending: None,
             key: Vec::new(),
             value: TermInfo::default(),
+            ordinal: 0,
         }
     }
 }
@@ -77,22 +83,47 @@ impl PagedTermDictionary {
 /// A stream that retains its pending term across term-information read errors
 /// and cancelled `next` futures. Retained keys/automaton state grow with term
 /// length, not with the number of dictionary entries.
-pub struct PagedTermStreamer<'a, A: Automaton> {
+pub struct PagedTermStreamer<'a, A: Automaton = tantivy_fst::automaton::AlwaysMatch> {
     stream: Stream<'a, FstFile, A>,
     infos: &'a PagedTermInfoStore,
     pending: Option<u64>,
     key: Vec<u8>,
     value: TermInfo,
+    ordinal: u64,
 }
 
 impl<A: Automaton> PagedTermStreamer<'_, A> {
     /// Advances after both the key and its term information are available.
     pub async fn next(&mut self) -> io::Result<Option<(&[u8], &TermInfo)>> {
+        if self.advance().await? {
+            Ok(Some((self.key(), self.value())))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Current key, available without I/O after successful advancement.
+    pub fn key(&self) -> &[u8] {
+        &self.key
+    }
+
+    /// Current term information, available without I/O.
+    pub fn value(&self) -> &TermInfo {
+        &self.value
+    }
+
+    /// Current lexicographic ordinal, available without I/O.
+    pub fn term_ord(&self) -> u64 {
+        self.ordinal
+    }
+
+    /// Advances without losing a pending term on cancellation or read failure.
+    pub async fn advance(&mut self) -> io::Result<bool> {
         let ordinal = match self.pending {
             Some(ordinal) => ordinal,
             None => {
                 let Some((key, ordinal)) = self.stream.next().await? else {
-                    return Ok(None);
+                    return Ok(false);
                 };
                 self.key.clear();
                 self.key.extend_from_slice(key);
@@ -101,8 +132,9 @@ impl<A: Automaton> PagedTermStreamer<'_, A> {
             }
         };
         self.value = self.infos.get(ordinal).await?;
+        self.ordinal = ordinal;
         self.pending = None;
-        Ok(Some((&self.key, &self.value)))
+        Ok(true)
     }
 }
 
@@ -132,7 +164,9 @@ mod tests {
     use std::task::{Context, Poll, Waker};
 
     use crate::directory::ReadQueue;
-    use crate::termdict::{TermDictionary, TermDictionaryBuilder};
+    use crate::termdict::{
+        AsyncTermMerger, AsyncTermStreamer, TermDictionary, TermDictionaryBuilder,
+    };
     use tantivy_fst::automaton::AlwaysMatch;
 
     #[test]
@@ -166,6 +200,125 @@ mod tests {
         }
         assert!(expected.next().is_none());
     }
+
+    #[test]
+    fn async_merger_resumes_at_every_read_boundary() {
+        let bytes = dictionary_bytes(7);
+        let resident = TermDictionary::open(FileSlice::from(bytes.clone())).unwrap();
+        let empty = TermDictionary::empty();
+        let queue = ReadQueue::default();
+        let file = FileSlice::new(queue.file("dict".into(), bytes.len()));
+        let paged = drive(PagedTermDictionary::open(file), &queue, &bytes).unwrap();
+        let make_merger = || {
+            AsyncTermMerger::new(vec![
+                AsyncTermStreamer::Paged(paged.search(AlwaysMatch)),
+                AsyncTermStreamer::Resident(
+                    resident.range().ge(b"key-00000003").into_stream().unwrap(),
+                ),
+                AsyncTermStreamer::Resident(empty.stream().unwrap()),
+                AsyncTermStreamer::Paged(paged.search(AlwaysMatch)),
+            ])
+        };
+        let reads = check_merger(make_merger(), &queue, &bytes, &resident, None);
+        assert!(reads > 20);
+        for read in 0..reads {
+            for cancel in [false, true] {
+                check_merger(
+                    make_merger(),
+                    &queue,
+                    &bytes,
+                    &resident,
+                    Some((read, cancel)),
+                );
+            }
+        }
+        let mut no_inputs = AsyncTermMerger::new(Vec::new());
+        assert!(!drive(no_inputs.advance(), &queue, &bytes).unwrap());
+        assert!(!drive(no_inputs.advance(), &queue, &bytes).unwrap());
+    }
+
+    fn check_merger(
+        mut merger: AsyncTermMerger<'_>,
+        queue: &ReadQueue,
+        bytes: &[u8],
+        resident: &TermDictionary,
+        mut fault: Option<(usize, bool)>,
+    ) -> usize {
+        let mut reads = 0;
+        let mut ordinal = 0;
+        let mut cx = Context::from_waker(Waker::noop());
+        loop {
+            let result = {
+                let mut next = Box::pin(merger.advance());
+                assert_send(&next);
+                loop {
+                    if let Poll::Ready(value) = next.as_mut().poll(&mut cx) {
+                        break Some(value.unwrap());
+                    }
+                    let request = queue.pop().unwrap();
+                    assert!(next.as_mut().poll(&mut cx).is_pending());
+                    assert!(next.as_mut().poll(&mut cx).is_pending());
+                    assert!(queue.pop().is_none());
+                    reads += 1;
+                    if fault.is_some_and(|(target, _)| target == reads - 1) {
+                        let (_, cancel) = fault.take().unwrap();
+                        if cancel {
+                            drop(next);
+                            assert!(request.is_cancelled());
+                        } else {
+                            request.complete(Err(io::Error::other("merge read failure")));
+                            let Poll::Ready(Err(error)) = next.as_mut().poll(&mut cx) else {
+                                panic!("merge read failure not propagated")
+                            };
+                            assert_eq!(error.to_string(), "merge read failure");
+                        }
+                        break None;
+                    }
+                    let range = request.range();
+                    assert!(range.len() <= 4_619);
+                    request.complete(Ok(OwnedBytes::new(bytes[range].to_vec())));
+                }
+            };
+            match result {
+                None => continue,
+                Some(false) => break,
+                Some(true) => {
+                    let key = format!("key-{ordinal:08}");
+                    assert_eq!(merger.key(), key.as_bytes());
+                    let segments = if ordinal < 3 {
+                        vec![0, 3]
+                    } else {
+                        vec![0, 1, 3]
+                    };
+                    assert_eq!(
+                        merger.matching_segments().collect::<Vec<_>>(),
+                        segments
+                            .iter()
+                            .map(|index| (*index, ordinal))
+                            .collect::<Vec<_>>()
+                    );
+                    let info = resident.get(&key).unwrap().unwrap();
+                    assert_eq!(
+                        merger
+                            .current_segment_ords_and_term_infos()
+                            .collect::<Vec<_>>(),
+                        segments
+                            .into_iter()
+                            .map(|index| (index, info.clone()))
+                            .collect::<Vec<_>>()
+                    );
+                    ordinal += 1;
+                }
+            }
+        }
+        assert_eq!(ordinal, 7);
+        assert!(fault.is_none());
+        assert!(queue.pop().is_none());
+        assert!(!drive(merger.advance(), queue, bytes).unwrap());
+        reads
+    }
+
+    fn assert_send<T: Send>(_: &T) {}
 
     #[test]
     fn pending_term_info_survives_failure_and_cancellation() {

--- a/vendor/tantivy/src/termdict/mod.rs
+++ b/vendor/tantivy/src/termdict/mod.rs
@@ -18,6 +18,9 @@
 //!
 //! A second datastructure makes it possible to access a [`TermInfo`].
 
+mod async_merger;
+pub use async_merger::AsyncTermMerger;
+
 #[cfg(not(feature = "quickwit"))]
 mod fst_termdict;
 #[cfg(not(feature = "quickwit"))]
@@ -48,6 +51,60 @@ use self::termdict::{
 };
 pub use self::termdict::{TermMerger, TermStreamer};
 use crate::postings::TermInfo;
+
+/// A fallible asynchronous cursor over resident or injected-I/O dictionary
+/// storage. Resident advancement only performs CPU work.
+pub enum AsyncTermStreamer<'a, A: Automaton = tantivy_fst::automaton::AlwaysMatch>
+where
+    A::State: Clone,
+{
+    /// A previously opened resident dictionary stream.
+    Resident(TermStreamer<'a, A>),
+    /// A dictionary whose traversal can suspend for storage reads.
+    #[cfg(not(feature = "quickwit"))]
+    Paged(PagedTermStreamer<'a, A>),
+}
+
+impl<A: Automaton> AsyncTermStreamer<'_, A>
+where
+    A::State: Clone,
+{
+    /// Advances the input, retaining pending progress across cancellation.
+    pub async fn advance(&mut self) -> io::Result<bool> {
+        match self {
+            Self::Resident(stream) => Ok(stream.advance()),
+            #[cfg(not(feature = "quickwit"))]
+            Self::Paged(stream) => stream.advance().await,
+        }
+    }
+
+    /// Current key, valid after successful advancement.
+    pub fn key(&self) -> &[u8] {
+        match self {
+            Self::Resident(stream) => stream.key(),
+            #[cfg(not(feature = "quickwit"))]
+            Self::Paged(stream) => stream.key(),
+        }
+    }
+
+    /// Current term information, available without I/O.
+    pub fn value(&self) -> &TermInfo {
+        match self {
+            Self::Resident(stream) => stream.value(),
+            #[cfg(not(feature = "quickwit"))]
+            Self::Paged(stream) => stream.value(),
+        }
+    }
+
+    /// Current lexicographic ordinal, available without I/O.
+    pub fn term_ord(&self) -> TermOrdinal {
+        match self {
+            Self::Resident(stream) => stream.term_ord(),
+            #[cfg(not(feature = "quickwit"))]
+            Self::Paged(stream) => stream.term_ord(),
+        }
+    }
+}
 
 #[derive(Debug, Eq, PartialEq)]
 #[repr(u32)]
@@ -155,6 +212,12 @@ impl TermDictionary {
     /// A stream of all the sorted terms.
     pub fn stream(&self) -> io::Result<TermStreamer<'_>> {
         self.0.stream()
+    }
+
+    /// Opens a fallible, suspendible stream. The current resident dictionary
+    /// backend performs no storage reads during advancement.
+    pub async fn stream_async(&self) -> io::Result<AsyncTermStreamer<'_>> {
+        Ok(AsyncTermStreamer::Resident(self.stream()?))
     }
 
     /// Returns a search builder, to stream all of the terms


### PR DESCRIPTION
Stacked on #8813. Prioritizes asynchronous control flow; no range traversal changes.

Adds AsyncTermStreamer and a resumable AsyncTermMerger. Initialization, pending input index, and partial matches survive cancellation and read errors. The merge loop now awaits index/stream opening and term advancement. Current term information is captured before advancing inputs rather than synchronously reread by ordinal.

Verification: 25 FTS unit tests; 109 FTS integration tests; 22 standalone dictionary tests; 120 standalone indexer tests; quickwit compilation and formatting. Native tests inject errors and cancellation at every read boundary. The Turso fixture merges 1,025 terms through Completions.

Limitations: production dictionaries still select resident streams. Paged streams are tested directly; query expansion must be converted before changing production dictionary opening. Postings/columns, serialization and total-query memory remain unfinished. This is not a fully async or bounded-memory implementation.