### PR TITLE
fts: await regex-phrase scorer I/O without a runtime

### DIFF
--- a/core/index_method/fts/tests.rs
+++ b/core/index_method/fts/tests.rs
@@ -595,6 +595,159 @@ fn paged_dictionary_reads_resume_through_completions() {
 }
 
 #[test]
+fn regex_phrase_scorers_suspend_for_payloads_and_preserve_scores() {
+    use std::task::{Context, Poll, Waker};
+    use tantivy::directory::{OwnedBytes, ReadQueue};
+    use tantivy::query::RegexPhraseQuery;
+
+    let attachment = test_attachment();
+    let texts: Vec<_> = (0..600)
+        .map(|i| format!("alpha gap beta alp{i:04} beta"))
+        .collect();
+    let docs: Vec<_> = texts
+        .iter()
+        .enumerate()
+        .map(|(i, text)| (i as i64, text.as_str()))
+        .collect();
+    let (segment, _) = build_and_load_segment(&attachment, &docs);
+    let mut resident = FtsCursor::new(&attachment);
+    resident.segments = vec![segment.clone()];
+    resident.ensure_searcher().unwrap();
+    let expected = resident.searcher.as_ref().unwrap();
+    let queue = ReadQueue::default();
+    let mut source = HashMap::default();
+    let mut handles = HashMap::default();
+    for (name, bytes) in &segment.data.as_ref().unwrap().files {
+        source.insert(name.clone(), bytes.clone());
+        handles.insert(PathBuf::from(name), queue.file(name.clone(), bytes.len()));
+    }
+    let scratch = attachment.shared.scratch_index(&attachment.schema).unwrap();
+    let meta = synthesize_meta_json(&scratch, &attachment.schema, &[segment]).unwrap();
+    let index =
+        Index::open(SnapshotDirectory::new(HashMap::default(), meta).with_async_files(handles))
+            .unwrap();
+    let metas = index.searchable_segment_metas().unwrap();
+    let mut requests = Vec::new();
+    let searcher = drive_queued_future(
+        Searcher::open_async(index, metas, 0),
+        &queue,
+        &source,
+        &mut requests,
+    )
+    .unwrap();
+    let field = attachment.text_fields[0].1;
+    let collector = tantivy::collector::TopDocs::with_limit(1_000).order_by_score();
+    assert_eq!(
+        expected
+            .doc_freq(&tantivy::Term::from_field_text(field, "alpha"))
+            .unwrap(),
+        600
+    );
+    assert_eq!(
+        expected
+            .doc_freq(&tantivy::Term::from_field_text(field, "alp0000"))
+            .unwrap(),
+        1
+    );
+    for (pattern, slop, limit, count) in [
+        ("alp.*", 0, 1000, Some(600)),
+        ("alp.*", 1, 1000, Some(600)),
+        ("missing", 0, 1000, Some(0)),
+        ("alp.*", 0, 600, None),
+        ("[", 0, 1000, None),
+    ] {
+        let mut query = RegexPhraseQuery::new(field, vec![pattern.into(), "beta".into()]);
+        query.set_slop(slop);
+        query.set_max_expansions(limit);
+        let want = expected.search(&query, &collector);
+        match count {
+            Some(count) => assert_eq!(want.as_ref().unwrap().len(), count),
+            None => assert!(want.is_err()),
+        }
+        let got = drive_queued_future(
+            searcher.search_async(&query, &collector),
+            &queue,
+            &source,
+            &mut requests,
+        );
+        match (want, got) {
+            (Ok(want), Ok(got)) => assert_eq!(got, want),
+            (Err(want), Err(got)) => assert_eq!(got.to_string(), want.to_string()),
+            pair => panic!("regex phrase results differ: {pair:?}"),
+        }
+        let want = expected.search(&query, &tantivy::collector::Count);
+        let got = drive_queued_future(
+            searcher.search_async(&query, &tantivy::collector::Count),
+            &queue,
+            &source,
+            &mut requests,
+        );
+        assert_eq!(
+            got.map_err(|e| e.to_string()),
+            want.map_err(|e| e.to_string())
+        );
+    }
+
+    let query = RegexPhraseQuery::new(field, vec!["alp.*".into(), "beta".into()]);
+    let weight = drive_queued_future(
+        query.weight_async(EnableScoring::enabled_from_searcher(&searcher)),
+        &queue,
+        &source,
+        &mut requests,
+    )
+    .unwrap();
+    let reader = searcher.segment_reader(0);
+    for cancel in [false, true] {
+        let mut future = weight.scorer_async(reader, 2.0);
+        let mut cx = Context::from_waker(Waker::noop());
+        let mut position_reads = 0;
+        loop {
+            assert!(future.as_mut().poll(&mut cx).is_pending());
+            let request = queue.pop().unwrap();
+            assert!(future.as_mut().poll(&mut cx).is_pending());
+            assert!(queue.pop().is_none());
+            position_reads += usize::from(request.name().ends_with(".pos"));
+            if position_reads == 2 {
+                if cancel {
+                    drop(future);
+                    assert!(request.is_cancelled());
+                } else {
+                    request.complete(Err(std::io::Error::other("regex payload failure")));
+                    let Poll::Ready(Err(error)) = future.as_mut().poll(&mut cx) else {
+                        panic!("missing read error")
+                    };
+                    assert!(error.to_string().contains("regex payload failure"));
+                }
+                break;
+            }
+            let bytes = OwnedBytes::new(source[request.name()].clone()).slice(request.range());
+            request.complete(Ok(bytes));
+        }
+        let mut got = drive_queued_future(
+            weight.scorer_async(reader, 2.0),
+            &queue,
+            &source,
+            &mut requests,
+        )
+        .unwrap();
+        let expected_weight = query
+            .weight(EnableScoring::enabled_from_searcher(expected))
+            .unwrap();
+        let mut want = expected_weight
+            .scorer(expected.segment_reader(0), 2.0)
+            .unwrap();
+        while want.doc() != tantivy::TERMINATED {
+            assert_eq!(got.doc(), want.doc());
+            assert_eq!(got.score(), want.score());
+            got.advance();
+            want.advance();
+        }
+        assert_eq!(got.doc(), tantivy::TERMINATED);
+        assert!(queue.pop().is_none());
+    }
+}
+
+#[test]
 fn async_snapshot_reads_only_requested_ranges_and_matches_resident_queries() {
     use tantivy::directory::{OwnedBytes, ReadQueue};
     let attachment = test_attachment();

--- a/vendor/tantivy/TURSO_FORK.md
+++ b/vendor/tantivy/TURSO_FORK.md
@@ -112,8 +112,16 @@ Unsupported, never call synchronous storage methods). Statistics providers
 are Send + Sync. CPU-only built-in weight construction remains immediately
 ready; MoreLikeThis has not been converted and fails explicitly on this path.
 
+Regex-phrase scorer construction awaits fieldnorms, dictionary stream opening,
+postings and positions. Synchronous and asynchronous entry points share the
+same bucketing/scoring algorithm. Automaton term collection uses fallible async
+advancement; automaton states must be Send when used as a Weight because they
+survive suspension. FST stream opening remains ready CPU work on resident
+bytes, while SSTable stream opening awaits its existing asynchronous prefetch.
+Term expansion results and scorer payloads are still resident, not bounded.
+
 Production query/merge callers have **not yet switched** to the paged reader.
-Term expansion still requires suspendible traversal; changing only dictionary
+Range and prefix expansion still require suspendible traversal; changing only dictionary
 open would strand those synchronous callers. The FST backend's
 `get_async` currently does a CPU-only lookup in resident bytes. The remaining
 resident dictionaries described below are still on the current SQL path.
@@ -161,7 +169,7 @@ cargo test -p turso_core --features fts index_method::fts --lib
 cargo test -p core_tester --test integration_tests fts_
 ```
 
-The FTS suites cover 25 unit tests and 109 integration tests. The async-only
+The FTS suites cover 26 unit tests and 109 integration tests. The async-only
 unit fixture compares scores and addresses against resident readers, checks
 that opening leaves position payloads unread, and exercises merge, tombstones,
 repeated Pending polls, injected errors and cancellation. The queued-I/O SQL
@@ -177,6 +185,12 @@ multi-segment score parity for term, phrase/slop, Boolean, boost, constant and
 disjunction-max queries. Repeated Pending polls, errors, cancellation, disabled
 scoring and unsupported custom queries are covered. The standalone Tantivy
 query suite passes 229 tests (3 ignored).
+
+The regex-phrase fixture uses delayed, Completion-driven reads over 600
+documents. It covers common and rare terms, sparse-bucket rollover, exact score
+and count parity, slop, boost, missing terms, invalid regexes and expansion
+limits. Errors and cancellation are injected after partial posting construction;
+discarded requests are cancelled and fresh scorers still match resident results.
 
 The async merger test injects an error and a cancellation at every read boundary
 in a mixed paged/resident merge, checking keys, ordinals and term information.

--- a/vendor/tantivy/src/query/automaton_weight.rs
+++ b/vendor/tantivy/src/query/automaton_weight.rs
@@ -9,7 +9,7 @@ use crate::index::SegmentReader;
 use crate::postings::TermInfo;
 use crate::query::{BitSetDocSet, ConstScorer, Explanation, Scorer, Weight};
 use crate::schema::{Field, IndexRecordOption};
-use crate::termdict::{TermDictionary, TermStreamer};
+use crate::termdict::{AsyncTermStreamer, TermDictionary, TermStreamer};
 use crate::{DocId, Score, TantivyError};
 
 /// A weight struct for Fuzzy Term and Regex Queries
@@ -77,12 +77,34 @@ where
         }
         Ok(term_infos)
     }
+
+    /// Collects matching term information without synchronous storage reads.
+    pub async fn get_match_term_infos_async(
+        &self,
+        reader: &SegmentReader,
+    ) -> crate::Result<Vec<TermInfo>> {
+        let inverted_index = reader.inverted_index_async(self.field).await?;
+        let automaton: &A = &self.automaton;
+        let mut builder = inverted_index.terms().search(automaton);
+        if let Some(json_path_bytes) = &self.json_path_bytes {
+            builder = builder.ge(json_path_bytes);
+            if let Some(end) = prefix_end(json_path_bytes) {
+                builder = builder.lt(&end);
+            }
+        }
+        let mut stream = AsyncTermStreamer::Resident(builder.into_stream_async().await?);
+        let mut infos = Vec::new();
+        while stream.advance().await? {
+            infos.push(stream.value().clone());
+        }
+        Ok(infos)
+    }
 }
 
 impl<A> Weight for AutomatonWeight<A>
 where
     A: Automaton + Send + Sync + 'static,
-    A::State: Clone,
+    A::State: Clone + Send,
 {
     fn scorer_async<'a>(
         &'a self,
@@ -92,7 +114,7 @@ where
         Box::pin(async move {
             use crate::DocSet;
             let inverted = reader.inverted_index_async(self.field).await?;
-            let infos = self.get_match_term_infos(reader)?;
+            let infos = self.get_match_term_infos_async(reader).await?;
             let mut docs = BitSet::with_max_value(reader.max_doc());
             for info in infos {
                 let mut postings = inverted

--- a/vendor/tantivy/src/query/phrase_query/regex_phrase_weight.rs
+++ b/vendor/tantivy/src/query/phrase_query/regex_phrase_weight.rs
@@ -59,13 +59,43 @@ impl RegexPhraseWeight {
         reader: &SegmentReader,
         boost: Score,
     ) -> crate::Result<Option<PhraseScorer<UnionType>>> {
+        use std::future::Future;
+        let mut future = std::pin::pin!(self.phrase_scorer_impl::<false>(reader, boost));
+        let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+        match future.as_mut().poll(&mut cx) {
+            std::task::Poll::Ready(result) => result,
+            std::task::Poll::Pending => unreachable!("synchronous phrase scorer cannot suspend"),
+        }
+    }
+
+    async fn phrase_scorer_impl<const ASYNC: bool>(
+        &self,
+        reader: &SegmentReader,
+        boost: Score,
+    ) -> crate::Result<Option<PhraseScorer<UnionType>>> {
         let similarity_weight_opt = self
             .similarity_weight_opt
             .as_ref()
             .map(|similarity_weight| similarity_weight.boost_by(boost));
-        let fieldnorm_reader = self.fieldnorm_reader(reader)?;
+        let fieldnorm_reader = if ASYNC {
+            let norms = if self.similarity_weight_opt.is_some() {
+                reader
+                    .fieldnorms_readers()
+                    .get_field_async(self.field)
+                    .await?
+            } else {
+                None
+            };
+            norms.unwrap_or_else(|| FieldNormReader::constant(reader.max_doc(), 1))
+        } else {
+            self.fieldnorm_reader(reader)?
+        };
         let mut posting_lists = Vec::new();
-        let inverted_index = reader.inverted_index(self.field)?;
+        let inverted_index = if ASYNC {
+            reader.inverted_index_async(self.field).await?
+        } else {
+            reader.inverted_index(self.field)?
+        };
         let mut num_terms = 0;
         for &(offset, ref term) in &self.phrase_terms {
             let regex = Regex::new(term)
@@ -73,7 +103,11 @@ impl RegexPhraseWeight {
 
             let automaton: AutomatonWeight<Regex> =
                 AutomatonWeight::new(self.field, Arc::new(regex));
-            let term_infos = automaton.get_match_term_infos(reader)?;
+            let term_infos = if ASYNC {
+                automaton.get_match_term_infos_async(reader).await?
+            } else {
+                automaton.get_match_term_infos(reader)?
+            };
             // If term_infos is empty, the phrase can not match any documents.
             if term_infos.is_empty() {
                 return Ok(None);
@@ -84,7 +118,9 @@ impl RegexPhraseWeight {
                     "Phrase query exceeded max expansions {num_terms}"
                 )));
             }
-            let union = Self::get_union_from_term_infos(&term_infos, reader, &inverted_index)?;
+            let union =
+                Self::get_union_from_term_infos::<ASYNC>(&term_infos, reader, &inverted_index)
+                    .await?;
 
             posting_lists.push((offset, union));
         }
@@ -98,11 +134,21 @@ impl RegexPhraseWeight {
     }
 
     /// Add all docs of the term to the docset
-    fn add_to_bitset(
+    async fn add_to_bitset<const ASYNC: bool>(
         inverted_index: &InvertedIndexReader,
         term_info: &TermInfo,
         doc_bitset: &mut BitSet,
     ) -> crate::Result<()> {
+        if ASYNC {
+            let mut postings = inverted_index
+                .read_postings_from_terminfo_async(term_info, IndexRecordOption::Basic)
+                .await?;
+            while postings.doc() != crate::TERMINATED {
+                doc_bitset.insert(postings.doc());
+                postings.advance();
+            }
+            return Ok(());
+        }
         let mut block_segment_postings = inverted_index
             .read_block_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
         loop {
@@ -172,7 +218,7 @@ impl RegexPhraseWeight {
     /// docs. For higher cardinality buckets this is irrelevant as they are in most blocks.
     ///
     /// Use Roaring Bitmaps for sparse terms. The full bitvec is main memory consumer currently.
-    pub(crate) fn get_union_from_term_infos(
+    async fn get_union_from_term_infos<const ASYNC: bool>(
         term_infos: &[TermInfo],
         reader: &SegmentReader,
         inverted_index: &InvertedIndexReader,
@@ -195,13 +241,25 @@ impl RegexPhraseWeight {
         const SPARSE_TERM_DOC_THRESHOLD: u32 = 100;
 
         for term_info in term_infos {
-            let mut term_posting = inverted_index
-                .read_postings_from_terminfo(term_info, IndexRecordOption::WithFreqsAndPositions)?;
+            let mut term_posting = if ASYNC {
+                inverted_index
+                    .read_postings_from_terminfo_async(
+                        term_info,
+                        IndexRecordOption::WithFreqsAndPositions,
+                    )
+                    .await?
+            } else {
+                inverted_index.read_postings_from_terminfo(
+                    term_info,
+                    IndexRecordOption::WithFreqsAndPositions,
+                )?
+            };
             let num_docs = term_posting.doc_freq();
 
             if num_docs < SPARSE_TERM_DOC_THRESHOLD {
                 let current_bucket = &mut sparse_buckets[0];
-                Self::add_to_bitset(inverted_index, term_info, &mut current_bucket.0)?;
+                Self::add_to_bitset::<ASYNC>(inverted_index, term_info, &mut current_bucket.0)
+                    .await?;
                 let docset = LoadedPostings::load(&mut term_posting);
                 current_bucket.1.push(docset);
 
@@ -228,7 +286,7 @@ impl RegexPhraseWeight {
                 let bucket = &mut buckets[bucket_index];
 
                 // Add term postings to the appropriate bucket
-                Self::add_to_bitset(inverted_index, term_info, &mut bucket.0)?;
+                Self::add_to_bitset::<ASYNC>(inverted_index, term_info, &mut bucket.0).await?;
                 bucket.1.push(term_posting);
 
                 // Move the bucket to the end if the term limit is reached
@@ -269,6 +327,19 @@ impl RegexPhraseWeight {
 }
 
 impl Weight for RegexPhraseWeight {
+    fn scorer_async<'a>(
+        &'a self,
+        reader: &'a SegmentReader,
+        boost: Score,
+    ) -> crate::query::weight::ScorerFuture<'a> {
+        Box::pin(async move {
+            match self.phrase_scorer_impl::<true>(reader, boost).await? {
+                Some(scorer) => Ok(Box::new(scorer) as Box<dyn Scorer>),
+                None => Ok(Box::new(EmptyScorer) as Box<dyn Scorer>),
+            }
+        })
+    }
+
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
         if let Some(scorer) = self.phrase_scorer(reader, boost)? {
             Ok(Box::new(scorer))

--- a/vendor/tantivy/src/termdict/fst_termdict/streamer.rs
+++ b/vendor/tantivy/src/termdict/fst_termdict/streamer.rs
@@ -70,6 +70,11 @@ where
             current_value: TermInfo::default(),
         })
     }
+
+    /// Opens a stream from this resident FST without storage I/O.
+    pub async fn into_stream_async(self) -> io::Result<TermStreamer<'a, A>> {
+        self.into_stream()
+    }
 }
 
 /// `TermStreamer` acts as a cursor over a range of terms of a segment.

--- a/vendor/tantivy/src/termdict/mod.rs
+++ b/vendor/tantivy/src/termdict/mod.rs
@@ -217,7 +217,9 @@ impl TermDictionary {
     /// Opens a fallible, suspendible stream. The current resident dictionary
     /// backend performs no storage reads during advancement.
     pub async fn stream_async(&self) -> io::Result<AsyncTermStreamer<'_>> {
-        Ok(AsyncTermStreamer::Resident(self.stream()?))
+        Ok(AsyncTermStreamer::Resident(
+            self.range().into_stream_async().await?,
+        ))
     }
 
     /// Returns a search builder, to stream all of the terms


### PR DESCRIPTION
Stacked on #8814. Adds native asynchronous regex-phrase scorer construction and async automaton term collection. Fieldnorm, posting and position reads suspend through the injected reader; synchronous and asynchronous entry points share the scoring and bucketing algorithm. Stream opening now awaits the backend API (ready resident FST opening or existing SSTable async prefetch). Automaton Weight states must be Send across suspension.

Verification: 26 FTS unit tests, 109 FTS integration tests, 229 standalone query tests (3 ignored), quickwit compilation, formatting. A 600-document delayed-I/O fixture covers common/rare terms, sparse bucket rollover, exact score/count parity, slop, boost, missing terms, invalid regexes, expansion limits, errors and cancellation after partial scorer construction. Normal reads are delivered through Turso Completions.

Remaining: production dictionaries, expanded term lists and scorer payloads are resident; this is not a total-memory bound. Range/prefix callers, other unsupported query paths, native paged document traversal and asynchronous output serialization remain unfinished. No range traversal optimization is included.