### PR TITLE
fts: await term expansion and consume postings incrementally

### DIFF
--- a/core/index_method/fts/tests.rs
+++ b/core/index_method/fts/tests.rs
@@ -849,6 +849,87 @@ fn async_snapshot_reads_only_requested_ranges_and_matches_resident_queries() {
             );
         }
     }
+    {
+        use std::ops::Bound::{Excluded, Included, Unbounded};
+        use tantivy::query::{InvertedIndexRangeWeight, PhrasePrefixQuery, Weight};
+        let field = attachment.text_fields[0].1;
+        let term = |text| tantivy::Term::from_field_text(field, text);
+        for (lower, upper) in [
+            (Unbounded, Unbounded),
+            (Included(term("alpha")), Included(term("gamma"))),
+            (Excluded(term("alpha")), Excluded(term("gamma"))),
+            (Included(term("absent")), Excluded(term("alpha"))),
+        ] {
+            for limit in [None, Some(0), Some(1), Some(2)] {
+                let weight = InvertedIndexRangeWeight::new(field, &lower, &upper, limit);
+                requests.clear();
+                let mut actual = drive_queued_future(
+                    weight.scorer_async(searcher.segment_reader(0), 2.0),
+                    &queue,
+                    &source,
+                    &mut requests,
+                )
+                .unwrap();
+                let mut expected = weight
+                    .scorer(expected_searcher.segment_reader(0), 2.0)
+                    .unwrap();
+                while expected.doc() != tantivy::TERMINATED {
+                    assert_eq!(actual.doc(), expected.doc());
+                    assert_eq!(actual.score(), expected.score());
+                    actual.advance();
+                    expected.advance();
+                }
+                assert_eq!(actual.doc(), tantivy::TERMINATED);
+                if let Some(limit) = limit {
+                    assert!(
+                        requests
+                            .iter()
+                            .filter(|(name, _)| name.ends_with(".idx"))
+                            .count() as u64
+                            <= limit,
+                        "range read postings beyond its expansion limit"
+                    );
+                }
+            }
+        }
+        for prefix in ["", "b", "missing"] {
+            for limit in [0, 1, 2, 10] {
+                let mut query = PhrasePrefixQuery::new(vec![term("alpha"), term(prefix)]);
+                query.set_max_expansions(limit);
+                let collector = tantivy::collector::TopDocs::with_limit(10).order_by_score();
+                let expected = expected_searcher.search(&query, &collector).unwrap();
+                let actual = drive_queued_future(
+                    searcher.search_async(&query, &collector),
+                    &queue,
+                    &source,
+                    &mut requests,
+                )
+                .unwrap();
+                assert_eq!(actual, expected, "prefix={prefix:?}, limit={limit}");
+                let count = drive_queued_future(
+                    searcher.search_async(&query, &tantivy::collector::Count),
+                    &queue,
+                    &source,
+                    &mut requests,
+                )
+                .unwrap();
+                assert_eq!(count, expected.len());
+            }
+        }
+        for pattern in ["a.*", ".*", "missing"] {
+            let query = tantivy::query::RegexQuery::from_pattern(pattern, field).unwrap();
+            let collector = tantivy::collector::TopDocs::with_limit(10).order_by_score();
+            let expected = expected_searcher.search(&query, &collector).unwrap();
+            let actual = drive_queued_future(
+                searcher.search_async(&query, &collector),
+                &queue,
+                &source,
+                &mut requests,
+            )
+            .unwrap();
+            assert_eq!(actual, expected, "pattern={pattern:?}");
+        }
+    }
     let column = drive_queued_future(
         searcher
             .segment_reader(1)

--- a/vendor/tantivy/TURSO_FORK.md
+++ b/vendor/tantivy/TURSO_FORK.md
@@ -118,11 +118,21 @@ same bucketing/scoring algorithm. Automaton term collection uses fallible async
 advancement; automaton states must be Send when used as a Weight because they
 survive suspension. FST stream opening remains ready CPU work on resident
 bytes, while SSTable stream opening awaits its existing asynchronous prefetch.
-Term expansion results and scorer payloads are still resident, not bounded.
+Regex-phrase expansion results and scorer payloads are still resident, not bounded.
+
+Range, phrase-prefix and automaton scorers await stream opening and fallible
+advancement, and process each term's postings before advancing to the next term.
+They no longer build an intermediate Vec<TermInfo> for the entire expansion.
+Range/automaton result bitsets and phrase-prefix suffix postings are still
+retained. Bounds and expansion limits are unchanged; no FST range-traversal
+optimization is included. The delayed-I/O fixture checks inclusive/exclusive
+bounds, missing terms, zero/small expansion limits, score/count parity and
+postings-read counts against the range limit, with tombstones in the snapshot.
 
 Production query/merge callers have **not yet switched** to the paged reader.
-Range and prefix expansion still require suspendible traversal; changing only dictionary
-open would strand those synchronous callers. The FST backend's
+The converted expansion callers still select resident streams. Dictionary
+opening and stream builders must select the paged backend before these awaits
+can suspend on FST traversal itself. The FST backend's
 `get_async` currently does a CPU-only lookup in resident bytes. The remaining
 resident dictionaries described below are still on the current SQL path.
 

--- a/vendor/tantivy/src/query/automaton_weight.rs
+++ b/vendor/tantivy/src/query/automaton_weight.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::sync::Arc;
 
 use common::BitSet;
@@ -9,7 +8,7 @@ use crate::index::SegmentReader;
 use crate::postings::TermInfo;
 use crate::query::{BitSetDocSet, ConstScorer, Explanation, Scorer, Weight};
 use crate::schema::{Field, IndexRecordOption};
-use crate::termdict::{AsyncTermStreamer, TermDictionary, TermStreamer};
+use crate::termdict::{AsyncTermStreamer, TermDictionary, TermStreamerBuilder};
 use crate::{DocId, Score, TantivyError};
 
 /// A weight struct for Fuzzy Term and Regex Queries
@@ -49,10 +48,10 @@ where
         }
     }
 
-    fn automaton_stream<'a>(
+    fn automaton_stream_builder<'a>(
         &'a self,
         term_dict: &'a TermDictionary,
-    ) -> io::Result<TermStreamer<'a, &'a A>> {
+    ) -> TermStreamerBuilder<'a, &'a A> {
         let automaton: &A = &self.automaton;
         let mut term_stream_builder = term_dict.search(automaton);
 
@@ -63,14 +62,14 @@ where
             }
         }
 
-        term_stream_builder.into_stream()
+        term_stream_builder
     }
 
     /// Returns the term infos that match the automaton
     pub fn get_match_term_infos(&self, reader: &SegmentReader) -> crate::Result<Vec<TermInfo>> {
         let inverted_index = reader.inverted_index(self.field)?;
         let term_dict = inverted_index.terms();
-        let mut term_stream = self.automaton_stream(term_dict)?;
+        let mut term_stream = self.automaton_stream_builder(term_dict).into_stream()?;
         let mut term_infos = Vec::new();
         while term_stream.advance() {
             term_infos.push(term_stream.value().clone());
@@ -84,15 +83,11 @@ where
         reader: &SegmentReader,
     ) -> crate::Result<Vec<TermInfo>> {
         let inverted_index = reader.inverted_index_async(self.field).await?;
-        let automaton: &A = &self.automaton;
-        let mut builder = inverted_index.terms().search(automaton);
-        if let Some(json_path_bytes) = &self.json_path_bytes {
-            builder = builder.ge(json_path_bytes);
-            if let Some(end) = prefix_end(json_path_bytes) {
-                builder = builder.lt(&end);
-            }
-        }
-        let mut stream = AsyncTermStreamer::Resident(builder.into_stream_async().await?);
+        let mut stream = AsyncTermStreamer::Resident(
+            self.automaton_stream_builder(inverted_index.terms())
+                .into_stream_async()
+                .await?,
+        );
         let mut infos = Vec::new();
         while stream.advance().await? {
             infos.push(stream.value().clone());
@@ -114,11 +109,15 @@ where
         Box::pin(async move {
             use crate::DocSet;
             let inverted = reader.inverted_index_async(self.field).await?;
-            let infos = self.get_match_term_infos_async(reader).await?;
+            let mut stream = AsyncTermStreamer::Resident(
+                self.automaton_stream_builder(inverted.terms())
+                    .into_stream_async()
+                    .await?,
+            );
             let mut docs = BitSet::with_max_value(reader.max_doc());
-            for info in infos {
+            while stream.advance().await? {
                 let mut postings = inverted
-                    .read_postings_from_terminfo_async(&info, IndexRecordOption::Basic)
+                    .read_postings_from_terminfo_async(stream.value(), IndexRecordOption::Basic)
                     .await?;
                 while postings.doc() != crate::TERMINATED {
                     docs.insert(postings.doc());
@@ -134,7 +133,7 @@ where
         let mut doc_bitset = BitSet::with_max_value(max_doc);
         let inverted_index = reader.inverted_index(self.field)?;
         let term_dict = inverted_index.terms();
-        let mut term_stream = self.automaton_stream(term_dict)?;
+        let mut term_stream = self.automaton_stream_builder(term_dict).into_stream()?;
         while term_stream.advance() {
             let term_info = term_stream.value();
             let mut block_segment_postings = inverted_index

--- a/vendor/tantivy/src/query/phrase_prefix_query/phrase_prefix_weight.rs
+++ b/vendor/tantivy/src/query/phrase_prefix_query/phrase_prefix_weight.rs
@@ -6,6 +6,7 @@ use crate::query::bm25::Bm25Weight;
 use crate::query::explanation::does_not_match;
 use crate::query::{EmptyScorer, Explanation, Scorer, Weight};
 use crate::schema::{IndexRecordOption, Term};
+use crate::termdict::AsyncTermStreamer;
 use crate::{DocId, DocSet, Score};
 
 pub struct PhrasePrefixWeight {
@@ -138,27 +139,24 @@ impl Weight for PhrasePrefixWeight {
                 };
                 postings.push((*offset, list));
             }
-            let infos = {
-                let mut range = inverted
-                    .terms()
-                    .range()
-                    .ge(self.prefix.1.serialized_value_bytes());
-                if let Some(end) = prefix_end(self.prefix.1.serialized_value_bytes()) {
-                    range = range.lt(&end);
-                }
-                let mut stream = range.into_stream()?;
-                let mut infos = Vec::new();
-                while infos.len() < self.max_expansions as usize && stream.advance() {
-                    infos.push(stream.value().clone());
-                }
-                infos
-            };
+            let mut range = inverted
+                .terms()
+                .range()
+                .ge(self.prefix.1.serialized_value_bytes());
+            if let Some(end) = prefix_end(self.prefix.1.serialized_value_bytes()) {
+                range = range.lt(&end);
+            }
+            #[cfg(feature = "quickwit")]
+            {
+                range = range.limit(self.max_expansions as u64);
+            }
+            let mut stream = AsyncTermStreamer::Resident(range.into_stream_async().await?);
             let mut suffixes = Vec::new();
-            for info in infos {
+            while suffixes.len() < self.max_expansions as usize && stream.advance().await? {
                 suffixes.push(
                     inverted
                         .read_postings_from_terminfo_async(
-                            &info,
+                            stream.value(),
                             IndexRecordOption::WithFreqsAndPositions,
                         )
                         .await?,

--- a/vendor/tantivy/src/query/range_query/range_query.rs
+++ b/vendor/tantivy/src/query/range_query/range_query.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::ops::Bound;
 
 use common::bounds::{map_bound, BoundsRange};
@@ -10,7 +9,7 @@ use crate::query::explanation::does_not_match;
 use crate::query::range_query::is_type_valid_for_fastfield_range_query;
 use crate::query::{BitSetDocSet, ConstScorer, EnableScoring, Explanation, Query, Scorer, Weight};
 use crate::schema::{Field, IndexRecordOption, Term, Type};
-use crate::termdict::{TermDictionary, TermStreamer};
+use crate::termdict::{AsyncTermStreamer, TermDictionary, TermStreamerBuilder};
 use crate::{DocId, Score};
 
 /// `RangeQuery` matches all documents that have at least one term within a defined range.
@@ -198,7 +197,7 @@ impl InvertedIndexRangeWeight {
         }
     }
 
-    fn term_range<'a>(&self, term_dict: &'a TermDictionary) -> io::Result<TermStreamer<'a>> {
+    fn term_range_builder<'a>(&self, term_dict: &'a TermDictionary) -> TermStreamerBuilder<'a> {
         use std::ops::Bound::*;
         let mut term_stream_builder = term_dict.range();
         term_stream_builder = match self.lower_bound {
@@ -215,7 +214,7 @@ impl InvertedIndexRangeWeight {
         if let Some(limit) = self.limit {
             term_stream_builder = term_stream_builder.limit(limit);
         }
-        term_stream_builder.into_stream()
+        term_stream_builder
     }
 }
 
@@ -228,25 +227,24 @@ impl Weight for InvertedIndexRangeWeight {
         Box::pin(async move {
             use crate::DocSet;
             let inverted = reader.inverted_index_async(self.field).await?;
-            let infos = {
-                let mut stream = self.term_range(inverted.terms())?;
-                let mut infos = Vec::new();
-                while !self.limit.is_some_and(|limit| infos.len() as u64 >= limit)
-                    && stream.advance()
-                {
-                    infos.push(stream.value().clone());
-                }
-                infos
-            };
+            let mut stream = AsyncTermStreamer::Resident(
+                self.term_range_builder(inverted.terms())
+                    .into_stream_async()
+                    .await?,
+            );
             let mut docs = BitSet::with_max_value(reader.max_doc());
-            for info in infos {
+            let mut processed_count = 0;
+            while !self.limit.is_some_and(|limit| processed_count >= limit)
+                && stream.advance().await?
+            {
                 let mut postings = inverted
-                    .read_postings_from_terminfo_async(&info, IndexRecordOption::Basic)
+                    .read_postings_from_terminfo_async(stream.value(), IndexRecordOption::Basic)
                     .await?;
                 while postings.doc() != crate::TERMINATED {
                     docs.insert(postings.doc());
                     postings.advance();
                 }
+                processed_count += 1;
             }
             Ok(Box::new(ConstScorer::new(BitSetDocSet::from(docs), boost)) as Box<dyn Scorer>)
         })
@@ -258,7 +256,7 @@ impl Weight for InvertedIndexRangeWeight {
 
         let inverted_index = reader.inverted_index(self.field)?;
         let term_dict = inverted_index.terms();
-        let mut term_range = self.term_range(term_dict)?;
+        let mut term_range = self.term_range_builder(term_dict).into_stream()?;
         let mut processed_count = 0;
         while term_range.advance() {
             if let Some(limit) = self.limit {

--- a/vendor/tantivy/src/termdict/mod.rs
+++ b/vendor/tantivy/src/termdict/mod.rs
@@ -43,11 +43,11 @@ use common::file_slice::FileSlice;
 use common::BinarySerializable;
 use tantivy_fst::Automaton;
 
+pub(crate) use self::termdict::TermStreamerBuilder;
 #[cfg(not(feature = "quickwit"))]
 pub use self::termdict::{PagedTermDictionary, PagedTermStreamer};
 use self::termdict::{
     TermDictionary as InnerTermDict, TermDictionaryBuilder as InnerTermDictBuilder,
-    TermStreamerBuilder,
 };
 pub use self::termdict::{TermMerger, TermStreamer};
 use crate::postings::TermInfo;


### PR DESCRIPTION
Stacked on #8815. Converts range and phrase-prefix scorer callers to asynchronous stream opening and fallible advancement. Range, phrase-prefix and automaton scorers consume each term before advancing rather than collecting an intermediate Vec<TermInfo>. Synchronous/async paths share range/automaton bound construction, and phrase-prefix async SSTable opening honors the expansion prefetch limit.

Verified: 26 FTS unit tests; 109 integration tests; 229 standalone query tests (3 ignored); quickwit compilation; formatting. Completion-driven tests cover inclusive/exclusive bounds, missing terms, zero/small limits, exact score/count parity, postings-read counts within the range limit and snapshot tombstones.

No FST range-traversal optimization is included. Production streams are still resident: dictionary/stream builders must adopt the paged backend before traversal itself can yield reads. Result bitsets, suffix postings, regex-phrase expansions and other scorer payloads remain allocated. This is not a fully asynchronous or bounded-memory implementation; output serialization and unsupported query paths remain unfinished.