### PR TITLE
fts: await stored-document reads and MoreLikeThis weights

### DIFF
--- a/core/index_method/fts/tests.rs
+++ b/core/index_method/fts/tests.rs
@@ -595,6 +595,122 @@ fn paged_dictionary_reads_resume_through_completions() {
 }
 
 #[test]
+fn more_like_this_reads_stored_documents_through_completions() {
+    use std::path::Path;
+    use std::task::{Context, Poll, Waker};
+    use tantivy::directory::{Directory, ReadQueue};
+    use tantivy::query::MoreLikeThisQuery;
+    use tantivy::schema::{OwnedValue, TantivyDocument, STORED, TEXT};
+
+    let mut schema = tantivy::schema::Schema::builder();
+    let field = schema.add_text_field("text", TEXT | STORED);
+    let directory = BuildDirectory::default();
+    let index = Index::create(directory.clone(), schema.build(), IndexSettings::default()).unwrap();
+    let mut writer = index
+        .writer_with_num_threads::<TantivyDocument>(1, 50_000_000)
+        .unwrap();
+    for text in ["alpha alpha beta", "alpha gamma"] {
+        writer.add_document(tantivy::doc!(field => text)).unwrap();
+    }
+    writer.commit().unwrap();
+    writer
+        .add_document(tantivy::doc!(field => "alpha beta beta"))
+        .unwrap();
+    writer.commit().unwrap();
+    writer.wait_merging_threads().unwrap();
+    let expected = index.reader().unwrap().searcher();
+    let queue = ReadQueue::default();
+    let mut source = HashMap::default();
+    let mut handles = HashMap::default();
+    for (path, bytes) in directory.captured_files() {
+        let name = path.to_str().unwrap().to_owned();
+        handles.insert(path, queue.file(name.clone(), bytes.len()));
+        source.insert(name, bytes);
+    }
+    let meta = directory.atomic_read(Path::new("meta.json")).unwrap();
+    let queued_index =
+        Index::open(SnapshotDirectory::new(HashMap::default(), meta).with_async_files(handles))
+            .unwrap();
+    let metas = queued_index.searchable_segment_metas().unwrap();
+    let mut requests = Vec::new();
+    let searcher = drive_queued_future(
+        Searcher::open_async(queued_index, metas, 0),
+        &queue,
+        &source,
+        &mut requests,
+    )
+    .unwrap();
+    let address = DocAddress::new(0, 0);
+    let builder = MoreLikeThisQuery::builder()
+        .with_min_doc_frequency(1)
+        .with_min_term_frequency(1);
+    let query = builder.clone().with_document(address);
+    for cancel in [false, true] {
+        let mut future = query.weight_async(EnableScoring::enabled_from_searcher(&searcher));
+        let mut cx = Context::from_waker(Waker::noop());
+        assert!(future.as_mut().poll(&mut cx).is_pending());
+        let request = queue.pop().unwrap();
+        assert!(request.name().ends_with(".store"));
+        assert!(future.as_mut().poll(&mut cx).is_pending());
+        assert!(queue.pop().is_none());
+        if cancel {
+            drop(future);
+            assert!(request.is_cancelled());
+        } else {
+            request.complete(Err(std::io::Error::other("stored document failure")));
+            let Poll::Ready(Err(error)) = future.as_mut().poll(&mut cx) else {
+                panic!("missing store error")
+            };
+            assert!(error.to_string().contains("stored document failure"));
+        }
+    }
+    let actual: TantivyDocument =
+        drive_queued_future(searcher.doc_async(address), &queue, &source, &mut requests).unwrap();
+    assert_eq!(actual, expected.doc::<TantivyDocument>(address).unwrap());
+    let collector = tantivy::collector::TopDocs::with_limit(10).order_by_score();
+    for query in [
+        query,
+        builder.clone().with_document_fields(vec![(
+            field,
+            vec![OwnedValue::Str("alpha alpha beta".into())],
+        )]),
+        builder.with_document_fields(Vec::new()),
+    ] {
+        let want = expected.search(&query, &collector);
+        let got = drive_queued_future(
+            searcher.search_async(&query, &collector),
+            &queue,
+            &source,
+            &mut requests,
+        );
+        match (want, got) {
+            (Ok(want), Ok(got)) => {
+                assert!(!want.is_empty());
+                assert_eq!(got.len(), want.len());
+                for ((score, doc), (expected_score, expected_doc)) in got.iter().zip(&want) {
+                    assert_eq!(doc, expected_doc);
+                    assert!((score - expected_score).abs() < 0.00001);
+                }
+            }
+            (Err(want), Err(got)) => assert_eq!(got.to_string(), want.to_string()),
+            results => panic!("more-like-this results differ: {results:?}"),
+        }
+        requests.clear();
+        let error = drive_queued_future(
+            query.weight_async(EnableScoring::disabled_from_searcher(&searcher)),
+            &queue,
+            &source,
+            &mut requests,
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("requires to enable scoring"));
+        assert!(requests.is_empty());
+        assert!(queue.pop().is_none());
+    }
+}
+
+#[test]
 fn regex_phrase_scorers_suspend_for_payloads_and_preserve_scores() {
     use std::task::{Context, Poll, Waker};
     use tantivy::directory::{OwnedBytes, ReadQueue};

--- a/vendor/tantivy/TURSO_FORK.md
+++ b/vendor/tantivy/TURSO_FORK.md
@@ -110,7 +110,21 @@ weight construction; `Searcher::stream` is asynchronous too. Custom queries
 and statistics providers must opt in explicitly (the defaults return
 Unsupported, never call synchronous storage methods). Statistics providers
 are Send + Sync. CPU-only built-in weight construction remains immediately
-ready; MoreLikeThis has not been converted and fails explicitly on this path.
+ready.
+
+MoreLikeThis supports async weight construction from either stored documents
+or supplied field values. Stored-document and term-frequency reads await the
+injected reader; the generated Boolean query also builds its weights async.
+Term selection and filtering share the synchronous algorithm. The decoded
+source document is released after extracting term frequencies.
+
+`Searcher::doc_async`, `StoreReader::get_async` and
+`StoreReader::get_document_bytes_async` are available without Quickwit and need
+no runtime. The StoreReader methods no longer accept an Executor argument;
+this is a fork API change for Quickwit callers. Store-block decompression and
+document deserialization now run on the caller, not a background executor.
+They remain synchronous CPU work, and block/document size and term-frequency
+maps have no enforced byte limit. This is not a CPU-latency or memory bound.
 
 Regex-phrase scorer construction awaits fieldnorms, dictionary stream opening,
 postings and positions. Synchronous and asynchronous entry points share the
@@ -179,7 +193,7 @@ cargo test -p turso_core --features fts index_method::fts --lib
 cargo test -p core_tester --test integration_tests fts_
 ```
 
-The FTS suites cover 26 unit tests and 109 integration tests. The async-only
+The FTS suites cover 27 unit tests and 109 integration tests. The async-only
 unit fixture compares scores and addresses against resident readers, checks
 that opening leaves position payloads unread, and exercises merge, tombstones,
 repeated Pending polls, injected errors and cancellation. The queued-I/O SQL
@@ -195,6 +209,12 @@ multi-segment score parity for term, phrase/slop, Boolean, boost, constant and
 disjunction-max queries. Repeated Pending polls, errors, cancellation, disabled
 scoring and unsupported custom queries are covered. The standalone Tantivy
 query suite passes 229 tests (3 ignored).
+
+The MoreLikeThis fixture exercises stored-document reads through Completions,
+repeated Pending polls, read errors, cancellation and subsequent successful
+reads. Stored and supplied-value queries match resident scores/results; empty
+input errors match and disabled scoring is rejected before I/O. The standalone
+store suite passes 25 tests.
 
 The regex-phrase fixture uses delayed, Completion-driven reads over 600
 documents. It covers common and rare terms, sparse-bucket rollover, exact score

--- a/vendor/tantivy/src/core/searcher.rs
+++ b/vendor/tantivy/src/core/searcher.rs
@@ -201,15 +201,14 @@ impl Searcher {
         cache_stats
     }
 
-    /// Fetches a document in an asynchronous manner.
-    #[cfg(feature = "quickwit")]
+    /// Fetches a document through injected asynchronous reads. Decompression
+    /// and deserialization run on the caller, without a background runtime.
     pub async fn doc_async<D: DocumentDeserialize>(
         &self,
         doc_address: DocAddress,
     ) -> crate::Result<D> {
-        let executor = self.inner.index.search_executor();
         let store_reader = &self.inner.store_readers[doc_address.segment_ord as usize];
-        store_reader.get_async(doc_address.doc_id, executor).await
+        store_reader.get_async(doc_address.doc_id).await
     }
 
     /// Access the schema associated with the index of this searcher.

--- a/vendor/tantivy/src/query/more_like_this/more_like_this.rs
+++ b/vendor/tantivy/src/query/more_like_this/more_like_this.rs
@@ -103,6 +103,35 @@ impl MoreLikeThis {
         Ok(query)
     }
 
+    /// Builds a query while stored-document and term-frequency reads can suspend.
+    pub async fn query_with_document_async(
+        &self,
+        searcher: &Searcher,
+        doc_address: DocAddress,
+    ) -> Result<BooleanQuery> {
+        let frequencies = {
+            let doc = searcher.doc_async::<TantivyDocument>(doc_address).await?;
+            self.term_frequencies_from_doc_fields(searcher, &doc.get_sorted_field_values())?
+        };
+        let scores = self
+            .create_score_term_impl::<true>(searcher, frequencies)
+            .await?;
+        Ok(self.create_query(scores))
+    }
+
+    /// Builds a query from supplied values using injected term-frequency reads.
+    pub async fn query_with_document_fields_async<'a, V: Value<'a>>(
+        &self,
+        searcher: &Searcher,
+        doc_fields: &[(Field, Vec<V>)],
+    ) -> Result<BooleanQuery> {
+        let frequencies = self.term_frequencies_from_doc_fields(searcher, doc_fields)?;
+        let scores = self
+            .create_score_term_impl::<true>(searcher, frequencies)
+            .await?;
+        Ok(self.create_query(scores))
+    }
+
     /// Creates a [`BooleanQuery`] from an ascendingly sorted list of ScoreTerm
     /// This will map the list of ScoreTerm to a list of [`TermQuery`]  and compose a
     /// BooleanQuery using that list as sub queries.
@@ -142,6 +171,17 @@ impl MoreLikeThis {
         searcher: &Searcher,
         field_to_values: &[(Field, Vec<V>)],
     ) -> Result<Vec<ScoreTerm>> {
+        self.create_score_term(
+            searcher,
+            self.term_frequencies_from_doc_fields(searcher, field_to_values)?,
+        )
+    }
+
+    fn term_frequencies_from_doc_fields<'a, V: Value<'a>>(
+        &self,
+        searcher: &Searcher,
+        field_to_values: &[(Field, Vec<V>)],
+    ) -> Result<HashMap<Term, usize>> {
         if field_to_values.is_empty() {
             return Err(TantivyError::InvalidArgument(
                 "Cannot create more like this query on empty field values. The document may not \
@@ -153,7 +193,7 @@ impl MoreLikeThis {
         for (field, values) in field_to_values {
             self.add_term_frequencies(searcher, *field, values, &mut field_to_term_freq_map)?;
         }
-        self.create_score_term(searcher, field_to_term_freq_map)
+        Ok(field_to_term_freq_map)
     }
 
     /// Computes the frequency of values for a field while updating the term frequencies
@@ -301,6 +341,22 @@ impl MoreLikeThis {
         searcher: &Searcher,
         per_field_term_frequencies: HashMap<Term, usize>,
     ) -> Result<Vec<ScoreTerm>> {
+        use std::future::Future;
+        let mut future = std::pin::pin!(
+            self.create_score_term_impl::<false>(searcher, per_field_term_frequencies)
+        );
+        let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
+        match future.as_mut().poll(&mut cx) {
+            std::task::Poll::Ready(result) => result,
+            std::task::Poll::Pending => unreachable!("synchronous term selection cannot suspend"),
+        }
+    }
+
+    async fn create_score_term_impl<const ASYNC: bool>(
+        &self,
+        searcher: &Searcher,
+        per_field_term_frequencies: HashMap<Term, usize>,
+    ) -> Result<Vec<ScoreTerm>> {
         let mut score_terms: BinaryHeap<Reverse<ScoreTerm>> = BinaryHeap::new();
         let num_docs = searcher
             .segment_readers()
@@ -318,7 +374,11 @@ impl MoreLikeThis {
                 continue;
             }
 
-            let doc_freq = searcher.doc_freq(term)?;
+            let doc_freq = if ASYNC {
+                searcher.doc_freq_async(term).await?
+            } else {
+                searcher.doc_freq(term)?
+            };
 
             // ignore terms with less than min_doc_frequency
             if self

--- a/vendor/tantivy/src/query/more_like_this/query.rs
+++ b/vendor/tantivy/src/query/more_like_this/query.rs
@@ -44,6 +44,41 @@ impl MoreLikeThisQuery {
 }
 
 impl Query for MoreLikeThisQuery {
+    fn weight_async<'a>(
+        &'a self,
+        enable_scoring: EnableScoring<'a>,
+    ) -> crate::query::WeightFuture<'a> {
+        Box::pin(async move {
+            let searcher = match enable_scoring {
+                EnableScoring::Enabled { searcher, .. } => searcher,
+                EnableScoring::Disabled { .. } => {
+                    return Err(crate::TantivyError::InvalidArgument(
+                        "MoreLikeThisQuery requires to enable scoring.".to_string(),
+                    ));
+                }
+            };
+            let query = match &self.target {
+                TargetDocument::DocumentAddress(address) => {
+                    self.mlt
+                        .query_with_document_async(searcher, *address)
+                        .await?
+                }
+                TargetDocument::DocumentFields(fields) => {
+                    let values = fields
+                        .iter()
+                        .map(|(field, values)| {
+                            (*field, values.iter().collect::<Vec<&OwnedValue>>())
+                        })
+                        .collect::<Vec<_>>();
+                    self.mlt
+                        .query_with_document_fields_async(searcher, &values)
+                        .await?
+                }
+            };
+            query.weight_async(enable_scoring).await
+        })
+    }
+
     fn weight(&self, enable_scoring: EnableScoring<'_>) -> crate::Result<Box<dyn Weight>> {
         let searcher = match enable_scoring {
             EnableScoring::Enabled { searcher, .. } => searcher,

--- a/vendor/tantivy/src/store/reader.rs
+++ b/vendor/tantivy/src/store/reader.rs
@@ -19,8 +19,6 @@ use crate::schema::document::{BinaryDocumentDeserializer, DocumentDeserialize};
 use crate::space_usage::StoreSpaceUsage;
 use crate::store::index::Checkpoint;
 use crate::DocId;
-#[cfg(feature = "quickwit")]
-use crate::Executor;
 
 pub(crate) const DOCSTORE_CACHE_CAPACITY: usize = 100;
 
@@ -397,18 +395,13 @@ fn block_read_index(block: &[u8], doc_pos: u32) -> crate::Result<Range<usize>> {
     Ok(start_offset..end_offset)
 }
 
-#[cfg(feature = "quickwit")]
 impl StoreReader {
     /// Advanced API.
     ///
     /// In most cases use [`get_async`](Self::get_async)
     ///
-    /// Loads and decompresses a block asynchronously.
-    async fn read_block_async(
-        &self,
-        checkpoint: &Checkpoint,
-        executor: &Executor,
-    ) -> io::Result<Block> {
+    /// Loads a block asynchronously, then decompresses it on the caller.
+    async fn read_block_async(&self, checkpoint: &Checkpoint) -> io::Result<Block> {
         let cache_key = checkpoint.byte_range.start;
         if let Some(block) = self.cache.get_from_cache(checkpoint.byte_range.start) {
             return Ok(block);
@@ -420,12 +413,7 @@ impl StoreReader {
             .read_bytes_async()
             .await?;
 
-        let decompressor = self.decompressor;
-        let maybe_decompressed_block = executor
-            .spawn_blocking(move || decompressor.decompress(compressed_block.as_ref()))
-            .await
-            .expect("decompression panicked");
-        let decompressed_block = OwnedBytes::new(maybe_decompressed_block?);
+        let decompressed_block = OwnedBytes::new(self.decompressor.decompress(&compressed_block)?);
 
         self.cache
             .put_into_cache(cache_key, decompressed_block.clone());
@@ -433,24 +421,17 @@ impl StoreReader {
         Ok(decompressed_block)
     }
 
-    /// Reads raw bytes of a given document asynchronously.
-    pub async fn get_document_bytes_async(
-        &self,
-        doc_id: DocId,
-        executor: &Executor,
-    ) -> crate::Result<OwnedBytes> {
+    /// Reads raw bytes through injected I/O. Decompression is synchronous CPU
+    /// work on one store block; no runtime or background executor is required.
+    pub async fn get_document_bytes_async(&self, doc_id: DocId) -> crate::Result<OwnedBytes> {
         let checkpoint = self.block_checkpoint(doc_id)?;
-        let block = self.read_block_async(&checkpoint, executor).await?;
+        let block = self.read_block_async(&checkpoint).await?;
         Self::get_document_bytes_from_block(block, doc_id, &checkpoint)
     }
 
     /// Fetches a document asynchronously. Async version of [`get`](Self::get).
-    pub async fn get_async<D: DocumentDeserialize>(
-        &self,
-        doc_id: DocId,
-        executor: &Executor,
-    ) -> crate::Result<D> {
-        let mut doc_bytes = self.get_document_bytes_async(doc_id, executor).await?;
+    pub async fn get_async<D: DocumentDeserialize>(&self, doc_id: DocId) -> crate::Result<D> {
+        let mut doc_bytes = self.get_document_bytes_async(doc_id).await?;
 
         let deserializer =
             BinaryDocumentDeserializer::from_reader(&mut doc_bytes, self.doc_store_version)


### PR DESCRIPTION
Stacked on #8816. Adds native async MoreLikeThis weight construction for stored-document and supplied-field targets. Stored blocks and term frequencies use injected reads, and generated Boolean weights also build asynchronously. Synchronous/async term selection shares the same algorithm; decoded source documents are released before term-frequency waits.

Searcher::doc_async and StoreReader async methods are now available without Quickwit. Fork API change: StoreReader::get_async and get_document_bytes_async no longer take an Executor argument. Decompression/deserialization run on the caller instead of an implicit background executor; they remain synchronous CPU work.

Verified: 27 FTS unit tests; 109 FTS integrations; 229 standalone query tests (3 ignored); 25 store tests; quickwit compilation and formatting. Completion-driven tests cover stored read delays, repeated Pending, errors/cancellation, subsequent success, stored/supplied query parity, empty inputs and rejection of disabled scoring before I/O.

Not complete: production paged dictionaries/scorers and async output serialization remain unfinished. No byte limit for documents, store blocks, term-frequency maps or total-query memory, and no CPU latency bound. Vendor CI workflows and lockfiles are untouched by this layer.