### PR TITLE
fts: await metadata creation and merge publication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6343,6 +6343,7 @@ dependencies = [
  "fastdivide",
  "fnv",
  "fs4",
+ "futures-util",
  "htmlescape",
  "itertools 0.14.0",
  "levenshtein_automata",

--- a/core/index_method/fts/directory.rs
+++ b/core/index_method/fts/directory.rs
@@ -258,6 +258,25 @@ impl TerminatingWrite for CaptureWriter {
 }
 
 impl Directory for BuildDirectory {
+    fn atomic_write_async<'a>(
+        &'a self,
+        path: &'a Path,
+        data: &'a [u8],
+    ) -> tantivy::directory::DirectoryFuture<'a, std::io::Result<()>> {
+        Box::pin(async move { self.atomic_write(path, data) })
+    }
+
+    fn delete_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> tantivy::directory::DirectoryFuture<'a, std::result::Result<(), DeleteError>> {
+        Box::pin(async move { self.delete(path) })
+    }
+
+    fn sync_directory_async(&self) -> tantivy::directory::DirectoryFuture<'_, std::io::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
     fn atomic_read_async<'a>(
         &'a self,
         path: &'a Path,

--- a/core/index_method/fts/tests.rs
+++ b/core/index_method/fts/tests.rs
@@ -1234,7 +1234,7 @@ fn managed_directory_awaits_file_lookup_before_reading_footer() {
         Arc::from(with_tantivy_footer(vec![1, 2, 3]).unwrap()),
     );
     let directory = DelayedOpenDirectory {
-        inner: SnapshotDirectory::new(files, Vec::new()),
+        inner: Box::new(SnapshotDirectory::new(files, Vec::new())),
         gate: queue.file("lookup".into(), 1),
     };
     let boxed: Box<dyn Directory> = Box::new(directory);
@@ -1289,7 +1289,7 @@ fn index_open_and_reload_await_metadata_reads() {
     let meta = synthesize_meta_json(&scratch, &attachment.schema, &[]).unwrap();
     let queue = ReadQueue::default();
     let directory = DelayedOpenDirectory {
-        inner: SnapshotDirectory::new(HashMap::default(), meta),
+        inner: Box::new(SnapshotDirectory::new(HashMap::default(), meta)),
         gate: queue.file("lookup".into(), 1),
     };
     let mut source = HashMap::default();
@@ -1313,15 +1313,43 @@ fn index_open_and_reload_await_metadata_reads() {
     assert!(metas.segments.is_empty());
     assert_eq!(requests.len(), 3);
     let mut corrupt = directory;
-    corrupt.inner = SnapshotDirectory::new(HashMap::default(), b"not json".to_vec());
+    corrupt.inner = Box::new(SnapshotDirectory::new(
+        HashMap::default(),
+        b"not json".to_vec(),
+    ));
     assert!(
         drive_queued_future(Index::open_async(corrupt), &queue, &source, &mut requests).is_err()
     );
 }
 
+#[test]
+fn index_creation_delivers_metadata_writes_through_completions() {
+    let queue = tantivy::directory::ReadQueue::default();
+    let directory = DelayedOpenDirectory {
+        inner: Box::new(BuildDirectory::default()),
+        gate: queue.file("metadata".into(), 1),
+    };
+    let source = HashMap::from_iter([("metadata".into(), Arc::<[u8]>::from(vec![0]))]);
+    let mut requests = Vec::new();
+    let schema = test_attachment().schema;
+    let index = drive_queued_future(
+        Index::create_async(directory, schema.clone(), IndexSettings::default()),
+        &queue,
+        &source,
+        &mut requests,
+    )
+    .unwrap();
+    assert_eq!(index.schema(), schema);
+    assert_eq!(
+        requests.len(),
+        6,
+        "management read, three syncs and two atomic writes"
+    );
+}
+
 #[derive(Clone, Debug)]
 struct DelayedOpenDirectory {
-    inner: SnapshotDirectory,
+    inner: Box<dyn tantivy::Directory>,
     gate: Arc<dyn tantivy::directory::FileHandle>,
 }
 
@@ -1393,11 +1421,27 @@ impl tantivy::Directory for DelayedOpenDirectory {
             self.inner.atomic_read(path)
         })
     }
-    fn atomic_write(&self, path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
-        self.inner.atomic_write(path, data)
+    fn atomic_write(&self, _: &std::path::Path, _: &[u8]) -> std::io::Result<()> {
+        panic!("async metadata writes must not use synchronous storage")
+    }
+    fn atomic_write_async<'a>(
+        &'a self,
+        path: &'a std::path::Path,
+        data: &'a [u8],
+    ) -> tantivy::directory::DirectoryFuture<'a, std::io::Result<()>> {
+        Box::pin(async move {
+            self.gate.read_bytes_async(0..1).await?;
+            self.inner.atomic_write_async(path, data).await
+        })
     }
     fn sync_directory(&self) -> std::io::Result<()> {
-        self.inner.sync_directory()
+        panic!("async durability must not use synchronous storage")
+    }
+    fn sync_directory_async(&self) -> tantivy::directory::DirectoryFuture<'_, std::io::Result<()>> {
+        Box::pin(async move {
+            self.gate.read_bytes_async(0..1).await?;
+            self.inner.sync_directory_async().await
+        })
     }
     fn watch(
         &self,

--- a/vendor/tantivy/Cargo.toml
+++ b/vendor/tantivy/Cargo.toml
@@ -66,7 +66,7 @@ common = { version = "0.11", path = "./common/", package = "tantivy-common" }
 tokenizer-api = { version = "0.7", path = "./tokenizer-api", package = "tantivy-tokenizer-api" }
 sketches-ddsketch = { version = "0.4", features = ["use_serde"] }
 datasketches = "0.2.0"
-futures-util = { version = "0.3.28", optional = true }
+futures-util = { version = "0.3.28" }
 futures-channel = { version = "0.3.28", optional = true }
 fnv = "1.0.7"
 typetag = "0.2.21"
@@ -127,7 +127,7 @@ columnar-zstd-compression = ["columnar/zstd-compression"]
 failpoints = ["fail", "fail/failpoints"]
 unstable = []                            # useful for benches.
 
-quickwit = ["sstable", "futures-util", "futures-channel"]
+quickwit = ["sstable", "futures-channel"]
 
 # Compares only the hash of a string when indexing data.
 # Increases indexing speed, but may lead to extremely rare missing terms, when there's a hash collision.

--- a/vendor/tantivy/TURSO_FORK.md
+++ b/vendor/tantivy/TURSO_FORK.md
@@ -74,8 +74,20 @@ await management/index metadata reads. Turso retains the entire open future
 until the Searcher is ready, then installs its index and parser. The synchronous
 and asynchronous entry points share metadata parsing and corruption handling.
 Metadata still occupies a complete buffer; this is not a metadata memory cap.
-Directory mutation, atomic metadata writes, sync and writer interfaces
+Directory mutation has opt-in `atomic_write_async`, `delete_async` and
+`sync_directory_async` methods; their defaults return Unsupported. Index
+creation and final merge metadata publication await these methods, preserving the
+sync-before-publish ordering. RamDirectory and Turso's private BuildDirectory
+implement these as ready, memory-only operations. Segment writer interfaces
 remain synchronous; this is not yet an entirely asynchronous directory API.
+
+Managed metadata writes serialize across clones with a runtime-free async
+mutex. No lock guard over the managed-path set survives an await. A failed or
+cancelled mutation prevents further metadata writes on that managed instance
+and its clones: the owner must drain submitted storage before reopening.
+Cancellation is not rollback and must not race a new write against an older
+one still running in the driver. Mixing synchronous mutation/GC with an
+in-flight asynchronous metadata mutation is not supported.
 
 `Searcher::stream` returns a native `SearchStream` whose async `next` retains
 one segment scorer at a time and uses global snapshot statistics. Turso's
@@ -193,7 +205,7 @@ cargo test -p turso_core --features fts index_method::fts --lib
 cargo test -p core_tester --test integration_tests fts_
 ```
 
-The FTS suites cover 27 unit tests and 109 integration tests. The async-only
+The FTS suites cover 28 unit tests and 109 integration tests. The async-only
 unit fixture compares scores and addresses against resident readers, checks
 that opening leaves position payloads unread, and exercises merge, tombstones,
 repeated Pending polls, injected errors and cancellation. The queued-I/O SQL
@@ -202,6 +214,12 @@ read failures, pending-statement reset, delayed OPTIMIZE, merge-read errors and
 rollback after merge. Native queue tests check invalid/empty ranges, short
 responses and dropped requests. The chunk-cache test checks eviction and the
 eight-row capacity. These suites, cargo check and formatting passed.
+
+Metadata creation is also driven through Turso Completions. The standalone
+directory tests inject delayed writes/syncs and an error at each creation
+boundary, check repeated Pending polls and concurrent registrations, and
+cancel writes while the driver retains their bytes. Synchronous storage
+methods panic in that fixture. The directory suite passes 37 tests.
 
 The weight-construction test uses a paged statistics provider whose synchronous
 methods panic, delivers its reads through Completions, and checks exact

--- a/vendor/tantivy/src/directory/directory.rs
+++ b/vendor/tantivy/src/directory/directory.rs
@@ -164,6 +164,19 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// [`DeleteError::FileDoesNotExist`].
     fn delete(&self, path: &Path) -> Result<(), DeleteError>;
 
+    /// Removes a file without blocking. Cancellation does not undo a submitted deletion.
+    fn delete_async<'a>(&'a self, path: &'a Path) -> DirectoryFuture<'a, Result<(), DeleteError>> {
+        Box::pin(async move {
+            Err(DeleteError::IoError {
+                io_error: Arc::new(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "Directory does not support async deletion",
+                )),
+                filepath: path.to_path_buf(),
+            })
+        })
+    }
+
     /// Returns true if and only if the file exists
     fn exists(&self, path: &Path) -> Result<bool, OpenReadError>;
 
@@ -228,11 +241,37 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// The file may or may not previously exist.
     fn atomic_write(&self, path: &Path, data: &[u8]) -> io::Result<()>;
 
+    /// Atomically replaces metadata without blocking. The driver must retain any
+    /// submitted buffers if the future is dropped. Cancellation does not imply
+    /// rollback: callers must reconcile the directory before publishing again.
+    fn atomic_write_async<'a>(
+        &'a self,
+        _path: &'a Path,
+        _data: &'a [u8],
+    ) -> DirectoryFuture<'a, io::Result<()>> {
+        Box::pin(async {
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Directory does not support async metadata writes",
+            ))
+        })
+    }
+
     /// Sync the directory.
     ///
     /// This call is required to ensure that newly created files are
     /// effectively stored durably.
     fn sync_directory(&self) -> io::Result<()>;
+
+    /// Awaits directory durability without invoking synchronous storage methods.
+    fn sync_directory_async(&self) -> DirectoryFuture<'_, io::Result<()>> {
+        Box::pin(async {
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Directory does not support async directory sync",
+            ))
+        })
+    }
 
     /// Acquire a lock in the directory given in the [`Lock`].
     ///

--- a/vendor/tantivy/src/directory/managed_directory.rs
+++ b/vendor/tantivy/src/directory/managed_directory.rs
@@ -40,11 +40,14 @@ fn is_managed(path: &Path) -> bool {
 pub struct ManagedDirectory {
     directory: Box<dyn Directory>,
     meta_informations: Arc<RwLock<MetaInformation>>,
+    metadata_writer: Arc<futures_util::lock::Mutex<()>>,
 }
 
 #[derive(Debug, Default)]
 struct MetaInformation {
     managed_paths: HashSet<PathBuf>,
+    // Dropping a future need not cancel storage already submitted to a driver.
+    async_write_incomplete: bool,
 }
 
 /// Saves the file containing the list of existing files
@@ -90,12 +93,15 @@ impl ManagedDirectory {
                     directory,
                     meta_informations: Arc::new(RwLock::new(MetaInformation {
                         managed_paths: managed_files,
+                        async_write_incomplete: false,
                     })),
+                    metadata_writer: Arc::default(),
                 })
             }
             Err(OpenReadError::FileDoesNotExist(_)) => Ok(ManagedDirectory {
                 directory,
                 meta_informations: Arc::default(),
+                metadata_writer: Arc::default(),
             }),
             io_err @ Err(OpenReadError::IoError { .. }) => Err(io_err.err().unwrap().into()),
             Err(OpenReadError::IncompatibleIndex(incompatibility)) => {
@@ -124,6 +130,13 @@ impl ManagedDirectory {
         &mut self,
         get_living_files: L,
     ) -> crate::Result<GarbageCollectionResult> {
+        let _writer = self.metadata_writer.try_lock().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "Asynchronous metadata write in progress",
+            )
+        })?;
+        self.check_metadata_writer()?;
         info!("Garbage collect");
         let mut files_to_delete = vec![];
 
@@ -225,14 +238,20 @@ impl ManagedDirectory {
     /// They are not managed and cannot be subjected
     /// to garbage collection.
     fn register_file_as_managed(&self, filepath: &Path) -> io::Result<()> {
-        // Files starting by "." (e.g. lock files) are not managed.
-        if !is_managed(filepath) {
-            return Ok(());
-        }
         let mut meta_wlock = self
             .meta_informations
             .write()
             .expect("Managed file lock poisoned");
+        if meta_wlock.async_write_incomplete {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Asynchronous metadata write incomplete",
+            ));
+        }
+        // Files starting by "." (e.g. lock files) are not managed.
+        if !is_managed(filepath) {
+            return Ok(());
+        }
         let has_changed = meta_wlock.managed_paths.insert(filepath.to_owned());
         if !has_changed {
             return Ok(());
@@ -250,6 +269,21 @@ impl ManagedDirectory {
             return Ok(());
         }
         self.directory.sync_directory()?;
+        Ok(())
+    }
+
+    fn check_metadata_writer(&self) -> io::Result<()> {
+        if self
+            .meta_informations
+            .read()
+            .expect("Managed file lock poisoned")
+            .async_write_incomplete
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Metadata write failed or was cancelled; drain storage and reopen the directory",
+            ));
+        }
         Ok(())
     }
 
@@ -333,6 +367,43 @@ impl Directory for ManagedDirectory {
         self.directory.atomic_write(path, data)
     }
 
+    fn atomic_write_async<'a>(
+        &'a self,
+        path: &'a Path,
+        data: &'a [u8],
+    ) -> super::DirectoryFuture<'a, io::Result<()>> {
+        Box::pin(async move {
+            let _writer = self.metadata_writer.lock().await;
+            self.check_metadata_writer()?;
+            let mut paths = {
+                let mut meta = self
+                    .meta_informations
+                    .write()
+                    .expect("Managed file lock poisoned");
+                meta.async_write_incomplete = true;
+                meta.managed_paths.clone()
+            };
+            if is_managed(path) && paths.insert(path.to_path_buf()) {
+                let mut bytes = serde_json::to_vec(&paths)?;
+                writeln!(&mut bytes)?;
+                self.directory
+                    .atomic_write_async(&MANAGED_FILEPATH, &bytes)
+                    .await?;
+                if paths.len() == 1 {
+                    self.directory.sync_directory_async().await?;
+                }
+            }
+            self.directory.atomic_write_async(path, data).await?;
+            let mut meta = self
+                .meta_informations
+                .write()
+                .expect("Managed file lock poisoned");
+            meta.managed_paths = paths;
+            meta.async_write_incomplete = false;
+            Ok(())
+        })
+    }
+
     fn atomic_read(&self, path: &Path) -> result::Result<Vec<u8>, OpenReadError> {
         self.directory.atomic_read(path)
     }
@@ -346,6 +417,13 @@ impl Directory for ManagedDirectory {
 
     fn delete(&self, path: &Path) -> result::Result<(), DeleteError> {
         self.directory.delete(path)
+    }
+
+    fn delete_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> super::DirectoryFuture<'a, result::Result<(), DeleteError>> {
+        self.directory.delete_async(path)
     }
 
     fn exists(&self, path: &Path) -> Result<bool, OpenReadError> {
@@ -364,6 +442,10 @@ impl Directory for ManagedDirectory {
         self.directory.sync_directory()?;
         Ok(())
     }
+
+    fn sync_directory_async(&self) -> super::DirectoryFuture<'_, io::Result<()>> {
+        self.directory.sync_directory_async()
+    }
 }
 
 impl Clone for ManagedDirectory {
@@ -371,6 +453,7 @@ impl Clone for ManagedDirectory {
         ManagedDirectory {
             directory: self.directory.box_clone(),
             meta_informations: Arc::clone(&self.meta_informations),
+            metadata_writer: Arc::clone(&self.metadata_writer),
         }
     }
 }

--- a/vendor/tantivy/src/directory/ram_directory.rs
+++ b/vendor/tantivy/src/directory/ram_directory.rs
@@ -251,6 +251,25 @@ impl Directory for RamDirectory {
     fn sync_directory(&self) -> io::Result<()> {
         Ok(())
     }
+
+    fn atomic_write_async<'a>(
+        &'a self,
+        path: &'a Path,
+        data: &'a [u8],
+    ) -> super::DirectoryFuture<'a, io::Result<()>> {
+        Box::pin(async move { self.atomic_write(path, data) })
+    }
+
+    fn delete_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> super::DirectoryFuture<'a, result::Result<(), DeleteError>> {
+        Box::pin(async move { self.delete(path) })
+    }
+
+    fn sync_directory_async(&self) -> super::DirectoryFuture<'_, io::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
 }
 
 #[cfg(test)]

--- a/vendor/tantivy/src/directory/tests.rs
+++ b/vendor/tantivy/src/directory/tests.rs
@@ -274,3 +274,258 @@ fn test_lock_blocking(directory: &dyn Directory) {
     assert!(sender.send(()).is_ok());
     assert!(join_handle.join().is_ok());
 }
+
+mod async_mutations {
+    use std::collections::VecDeque;
+    use std::future::Future;
+    use std::io;
+    use std::pin::Pin;
+    use std::sync::Mutex;
+    use std::task::{Context, Poll};
+
+    use futures::channel::oneshot;
+    use futures::FutureExt;
+
+    use super::*;
+    use crate::directory::error::{DeleteError, OpenReadError, OpenWriteError};
+    use crate::{Index, IndexSettings};
+
+    #[test]
+    fn ram_metadata_mutations_work_through_a_boxed_directory() {
+        let directory: Box<dyn Directory> = Box::new(RamDirectory::default());
+        async {
+            directory
+                .atomic_write_async(Path::new("meta"), b"old")
+                .await
+                .unwrap();
+            directory
+                .atomic_write_async(Path::new("meta"), b"new")
+                .await
+                .unwrap();
+            directory.sync_directory_async().await.unwrap();
+            assert_eq!(
+                directory
+                    .atomic_read_async(Path::new("meta"))
+                    .await
+                    .unwrap(),
+                b"new"
+            );
+            directory.delete_async(Path::new("meta")).await.unwrap();
+            assert!(matches!(
+                directory.delete_async(Path::new("meta")).await,
+                Err(DeleteError::FileDoesNotExist(_))
+            ));
+        }
+        .now_or_never()
+        .unwrap();
+        let unsupported = DelayedDirectory::default();
+        assert!(
+            matches!(unsupported.delete_async(Path::new("meta")).now_or_never().unwrap(), Err(DeleteError::IoError { io_error, .. }) if io_error.kind() == io::ErrorKind::Unsupported)
+        );
+    }
+
+    #[test]
+    fn index_creation_awaits_each_metadata_operation() {
+        for fail_at in 0..=5 {
+            let directory = DelayedDirectory::default();
+            let schema = crate::schema::Schema::builder().build();
+            let mut create = Box::pin(Index::create_async(
+                directory.clone(),
+                schema.clone(),
+                IndexSettings::default(),
+            ));
+            for (step, expected) in ["sync", ".managed.json", "sync", "meta.json", "sync"]
+                .iter()
+                .enumerate()
+            {
+                for _ in 0..3 {
+                    assert!(poll(create.as_mut()).is_pending());
+                    assert_eq!(directory.pending.lock().unwrap().len(), 1);
+                }
+                assert_eq!(directory.complete(step == fail_at), *expected);
+                if step == fail_at {
+                    assert!(matches!(poll(create.as_mut()), Poll::Ready(Err(_))));
+                    assert!(directory.pending.lock().unwrap().is_empty());
+                    break;
+                }
+            }
+            if fail_at == 5 {
+                let Poll::Ready(Ok(index)) = poll(create.as_mut()) else {
+                    panic!("creation did not complete")
+                };
+                assert_eq!(index.schema(), schema);
+                let opened = Index::open_async(directory.clone())
+                    .now_or_never()
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(opened.schema(), schema);
+            }
+        }
+    }
+
+    #[test]
+    fn cancelled_metadata_writes_cannot_race_a_new_write() {
+        for cancel_at in 0..3 {
+            let directory = DelayedDirectory::default();
+            let managed = ManagedDirectory::wrap_async(Box::new(directory.clone()))
+                .now_or_never()
+                .unwrap()
+                .unwrap();
+            let mut write = managed.atomic_write_async(Path::new("first"), b"one");
+            for _ in 0..cancel_at {
+                assert!(poll(write.as_mut()).is_pending());
+                directory.complete(false);
+            }
+            assert!(poll(write.as_mut()).is_pending());
+            drop(write);
+            let clone = managed.clone();
+            let error = clone
+                .atomic_write_async(Path::new("second"), b"two")
+                .now_or_never()
+                .unwrap()
+                .unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+            assert_eq!(
+                clone
+                    .atomic_write(Path::new(".managed.json"), b"[]")
+                    .unwrap_err()
+                    .kind(),
+                io::ErrorKind::BrokenPipe
+            );
+            // The driver still owns the cancelled write and its bytes.
+            assert_eq!(directory.pending.lock().unwrap().len(), 1);
+            directory.complete(false);
+            assert!(!directory.ram.exists(Path::new("second")).unwrap());
+        }
+    }
+
+    #[test]
+    fn concurrent_metadata_registration_waits_without_losing_paths() {
+        let directory = DelayedDirectory::default();
+        let managed = ManagedDirectory::wrap_async(Box::new(directory.clone()))
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        let clone = managed.clone();
+        let mut first = managed.atomic_write_async(Path::new("first"), b"one");
+        let mut second = clone.atomic_write_async(Path::new("second"), b"two");
+        for _ in 0..3 {
+            assert!(poll(first.as_mut()).is_pending());
+            assert!(poll(second.as_mut()).is_pending());
+            assert_eq!(directory.pending.lock().unwrap().len(), 1);
+            directory.complete(false);
+        }
+        assert!(matches!(poll(first.as_mut()), Poll::Ready(Ok(()))));
+        for _ in 0..2 {
+            assert!(poll(second.as_mut()).is_pending());
+            directory.complete(false);
+        }
+        assert!(matches!(poll(second.as_mut()), Poll::Ready(Ok(()))));
+        let bytes = directory
+            .ram
+            .atomic_read(Path::new(".managed.json"))
+            .unwrap();
+        let paths: std::collections::HashSet<String> = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(paths, ["first".to_owned(), "second".to_owned()].into());
+    }
+
+    fn poll<F: Future + ?Sized>(future: Pin<&mut F>) -> Poll<F::Output> {
+        future.poll(&mut Context::from_waker(futures::task::noop_waker_ref()))
+    }
+
+    #[derive(Debug)]
+    struct Mutation {
+        path: Option<PathBuf>,
+        bytes: Vec<u8>,
+        response: oneshot::Sender<io::Result<()>>,
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct DelayedDirectory {
+        ram: RamDirectory,
+        pending: Arc<Mutex<VecDeque<Mutation>>>,
+    }
+
+    impl DelayedDirectory {
+        fn complete(&self, fail: bool) -> String {
+            let mutation = self.pending.lock().unwrap().pop_front().unwrap();
+            let name = mutation
+                .path
+                .as_ref()
+                .map(|p| p.to_str().unwrap())
+                .unwrap_or("sync")
+                .to_owned();
+            let result = if fail {
+                Err(io::Error::other("injected metadata error"))
+            } else if let Some(path) = mutation.path {
+                self.ram.atomic_write(&path, &mutation.bytes)
+            } else {
+                Ok(())
+            };
+            let _ = mutation.response.send(result);
+            name
+        }
+
+        fn submit(
+            &self,
+            path: Option<PathBuf>,
+            bytes: Vec<u8>,
+        ) -> DirectoryFuture<'_, io::Result<()>> {
+            Box::pin(async move {
+                let (response, receiver) = oneshot::channel();
+                self.pending.lock().unwrap().push_back(Mutation {
+                    path,
+                    bytes,
+                    response,
+                });
+                receiver
+                    .await
+                    .map_err(|_| io::Error::other("driver dropped request"))?
+            })
+        }
+    }
+
+    impl Directory for DelayedDirectory {
+        fn get_file_handle(&self, _: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError> {
+            panic!("sync lookup")
+        }
+        fn delete(&self, _: &Path) -> Result<(), DeleteError> {
+            panic!("sync delete")
+        }
+        fn exists(&self, _: &Path) -> Result<bool, OpenReadError> {
+            panic!("sync exists")
+        }
+        fn open_write(&self, _: &Path) -> Result<WritePtr, OpenWriteError> {
+            panic!("sync open write")
+        }
+        fn atomic_read(&self, _: &Path) -> Result<Vec<u8>, OpenReadError> {
+            panic!("sync metadata read")
+        }
+        fn atomic_write(&self, _: &Path, _: &[u8]) -> io::Result<()> {
+            panic!("sync metadata write")
+        }
+        fn sync_directory(&self) -> io::Result<()> {
+            panic!("sync durability")
+        }
+        fn watch(&self, _: WatchCallback) -> crate::Result<WatchHandle> {
+            Ok(WatchHandle::empty())
+        }
+
+        fn atomic_read_async<'a>(
+            &'a self,
+            path: &'a Path,
+        ) -> DirectoryFuture<'a, Result<Vec<u8>, OpenReadError>> {
+            self.ram.atomic_read_async(path)
+        }
+        fn atomic_write_async<'a>(
+            &'a self,
+            path: &'a Path,
+            bytes: &'a [u8],
+        ) -> DirectoryFuture<'a, io::Result<()>> {
+            self.submit(Some(path.to_owned()), bytes.to_vec())
+        }
+        fn sync_directory_async(&self) -> DirectoryFuture<'_, io::Result<()>> {
+            self.submit(None, Vec::new())
+        }
+    }
+}

--- a/vendor/tantivy/src/index/index.rs
+++ b/vendor/tantivy/src/index/index.rs
@@ -18,7 +18,7 @@ use crate::index::{IndexMeta, SegmentId, SegmentMeta, SegmentMetaInventory};
 use crate::indexer::index_writer::{
     IndexWriterOptions, MAX_NUM_THREAD, MEMORY_BUDGET_NUM_BYTES_MIN,
 };
-use crate::indexer::segment_updater::save_metas;
+use crate::indexer::segment_updater::{save_metas, save_metas_async};
 use crate::indexer::{IndexWriter, SingleSegmentIndexWriter};
 use crate::reader::{IndexReader, IndexReaderBuilder};
 use crate::schema::document::Document;
@@ -378,6 +378,26 @@ impl Index {
         let mut builder = IndexBuilder::new().schema(schema);
         builder = builder.settings(settings);
         builder.create(dir)
+    }
+
+    /// Creates metadata using injected asynchronous writes and durability operations.
+    /// Segment serializers still require their own asynchronous output contract.
+    pub async fn create_async<T: Into<Box<dyn Directory>>>(
+        dir: T,
+        schema: Schema,
+        settings: IndexSettings,
+    ) -> crate::Result<Index> {
+        let builder = IndexBuilder::new().schema(schema).settings(settings);
+        builder.validate()?;
+        let directory = ManagedDirectory::wrap_async(dir.into()).await?;
+        let mut metas = IndexMeta::with_schema(builder.get_expect_schema()?);
+        metas.index_settings = builder.index_settings;
+        save_metas_async(&metas, &directory).await?;
+        directory.sync_directory_async().await?;
+        let mut index = Index::open_from_metas(directory, &metas, SegmentMetaInventory::default());
+        index.set_tokenizers(builder.tokenizer_manager);
+        index.set_fast_field_tokenizers(builder.fast_field_tokenizer_manager);
+        Ok(index)
     }
 
     /// Creates a new index given a directory and an [`IndexMeta`].

--- a/vendor/tantivy/src/indexer/segment_updater.rs
+++ b/vendor/tantivy/src/indexer/segment_updater.rs
@@ -36,6 +36,26 @@ const PANIC_CAUGHT: &str = "Panic caught in merge thread";
 ///
 /// This method is not part of tantivy's public API
 pub(crate) fn save_metas(metas: &IndexMeta, directory: &dyn Directory) -> crate::Result<()> {
+    let buffer = serialize_metas(metas)?;
+    directory.sync_directory()?;
+    directory.atomic_write(&META_FILEPATH, &buffer)?;
+    debug!("Saved metas {:?}", serde_json::to_string_pretty(&metas));
+    Ok(())
+}
+
+pub(crate) async fn save_metas_async(
+    metas: &IndexMeta,
+    directory: &dyn Directory,
+) -> crate::Result<()> {
+    let buffer = serialize_metas(metas)?;
+    directory.sync_directory_async().await?;
+    directory
+        .atomic_write_async(&META_FILEPATH, &buffer)
+        .await?;
+    Ok(())
+}
+
+fn serialize_metas(metas: &IndexMeta) -> crate::Result<Vec<u8>> {
     info!("save metas");
     let mut buffer = serde_json::to_vec_pretty(metas)?;
     // Just adding a new line at the end of the buffer.
@@ -46,10 +66,7 @@ pub(crate) fn save_metas(metas: &IndexMeta, directory: &dyn Directory) -> crate:
             msg.unwrap_or_else(|| "Undefined".to_string())
         )
     )));
-    directory.sync_directory()?;
-    directory.atomic_write(&META_FILEPATH, &buffer[..])?;
-    debug!("Saved metas {:?}", serde_json::to_string_pretty(&metas));
-    Ok(())
+    Ok(buffer)
 }
 
 // The segment update runner is in charge of processing all
@@ -248,11 +265,20 @@ async fn merge_filtered_segments_impl<const ASYNC: bool, T: Into<Box<dyn Directo
         ));
     }
 
-    let mut merged_index = Index::create(
-        output_directory,
-        target_schema.clone(),
-        target_settings.clone(),
-    )?;
+    let mut merged_index = if ASYNC {
+        Index::create_async(
+            output_directory,
+            target_schema.clone(),
+            target_settings.clone(),
+        )
+        .await?
+    } else {
+        Index::create(
+            output_directory,
+            target_schema.clone(),
+            target_settings.clone(),
+        )?
+    };
     let merged_segment = merged_index.new_segment();
     let merged_segment_id = merged_segment.id();
     let merger = if ASYNC {
@@ -289,7 +315,11 @@ async fn merge_filtered_segments_impl<const ASYNC: bool, T: Into<Box<dyn Directo
     };
 
     // save the meta.json
-    save_metas(&index_meta, merged_index.directory_mut())?;
+    if ASYNC {
+        save_metas_async(&index_meta, merged_index.directory_mut()).await?;
+    } else {
+        save_metas(&index_meta, merged_index.directory_mut())?;
+    }
 
     Ok(merged_index)
 }


### PR DESCRIPTION
## Scope
- Add opt-in async atomic-write, delete and directory-sync methods; defaults reject unsupported operations rather than blocking.
- Await index creation and final merge metadata publication with sync-before-publish ordering.
- Serialize async managed-file registration across clones. Failed or cancelled writes prevent further metadata mutation on that managed instance; drain submitted storage before reopening.
- Use ready, memory-only implementations in RamDirectory and Turso BuildDirectory.

## Verification
- 37 standalone directory tests, including delayed writes/syncs, repeated Pending, injected failures at each creation boundary, cancellation and concurrent registrations.
- 28 FTS unit tests, including metadata writes driven through Turso Completions.
- 109 FTS integration tests, including queued-I/O OPTIMIZE and rollback.
- Quickwit compilation, root/vendor formatting and diff checks pass.

## Remaining work
This is one async-conversion layer, not completion of the full conversion. Segment open/write, serialization and finalization still use synchronous buffered output. Memory is not globally bounded. Synchronous mutation/GC must not run concurrently with an async metadata mutation on the same managed directory.

Stacked on #8817.