### PR TITLE
core/wal: register fully-backfilled fast-path readers with the shared WAL authority

### DIFF
--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -6719,8 +6719,7 @@ impl CursorTrait for BTreeCursor {
     /// 2. DeterminePostBalancingSeekKey -> determine the key to seek to after balancing.
     /// 3. LoadPage -> load the page.
     /// 4. FindCell -> find the cell to be deleted in the page.
-    /// 5. ClearOverflowPages -> Clear the overflow pages if there are any before dropping the cell, then if we are in a leaf page we just drop the cell in place.
-    /// if we are in interior page, we need to rotate keys in order to replace current cell (InteriorNodeReplacement).
+    /// 5. ClearOverflowPages -> Clear the overflow pages if there are any before dropping the cell, then if we are in a leaf page we just drop the cell in place. If we are in an interior page, we need to rotate keys in order to replace the current cell (InteriorNodeReplacement).
     /// 6. InteriorNodeReplacement -> we copy the left subtree leaf node into the deleted interior node's place.
     /// 7. Balancing -> perform balancing
     /// 8. PostInteriorNodeReplacement -> if an interior node was replaced, we need to advance the cursor once.

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -10889,7 +10889,7 @@ pub mod test {
             &open_test_db_file_for_wal(&io, &wal_path),
         )
         .unwrap();
-        let coordination = ShmWalCoordination::new(shared.clone(), authority.clone());
+        let coordination = ShmWalCoordination::new(shared, authority.clone());
 
         // Reach the fully-backfilled state the DbFile fast path requires.
         coordination.publish_backfill(header.max_frame);

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -2055,6 +2055,29 @@ impl WalCoordination for ShmWalCoordination {
                 read_locks[0].unlock();
                 return None;
             }
+            // The local mark-0 read lock only blocks checkpoints in THIS
+            // process. Readers in other processes are protected exclusively
+            // through the shared authority's registered reader marks, which
+            // gate `min_active_reader_frame()` and therefore the backfill
+            // boundary of every cross-process checkpoint. A reader on the
+            // fully-backfilled fast path must register too: the DB file is
+            // only stable as of its snapshot while no checkpoint may publish
+            // newer frames into it. Skipping the registration let a
+            // concurrent PASSIVE checkpoint in another process overwrite DB
+            // pages under this transaction, mixing pre- and post-checkpoint
+            // page images within one read transaction (seen as FTS vs
+            // base-table divergence in the multiprocess whopper).
+            let reader = self
+                .authority
+                .register_reader_for_snapshot(self.owner, snapshot.max_frame)?;
+            if self.load_snapshot() != snapshot {
+                self.authority.unregister_reader_for_snapshot(reader);
+                read_locks[0].unlock();
+                return None;
+            }
+            let mut active_reader = self.active_reader.lock();
+            turso_assert!(active_reader.is_none(), "shared reader registration leaked");
+            *active_reader = Some(reader);
             return Some(ReadGuardKind::DbFile);
         }
 

--- a/core/storage/wal.rs
+++ b/core/storage/wal.rs
@@ -10858,4 +10858,79 @@ pub mod test {
             "checkpoint must succeed after rollback, not return Busy"
         );
     }
+
+    /// Regression: a read transaction on the fully-backfilled fast path
+    /// (`max_frame == nbackfills`, guard kind [`ReadGuardKind::DbFile`]) must
+    /// register its snapshot with the shared authority.
+    ///
+    /// The fast path used to skip authority registration entirely. The local
+    /// mark-0 read lock only blocks checkpoints in the same process, so a
+    /// PASSIVE checkpoint in ANOTHER process could backfill newer frames into
+    /// the DB file while the fast-path reader was still open. That reader then
+    /// mixed pre-checkpoint page images (from its page cache) with
+    /// post-checkpoint images (from the rewritten DB file) within one
+    /// transaction — observed as FTS vs base-table scan divergence in the
+    /// multiprocess whopper (seed 7399741717491843615, whopper CI
+    /// `Concurrent simulator (stable, multiprocess-kill)`).
+    #[test]
+    fn dbfile_guard_reader_pins_cross_process_checkpoint_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let wal_path = dir.path().join("test-dbfile-guard-pin.db-wal");
+        let shm_path = dir.path().join("test-dbfile-guard-pin.db-tshm");
+        let io = shared_wal_test_io();
+        let header = write_test_wal_with_single_commit_frame(&io, &wal_path);
+        let authority =
+            Arc::new(MappedSharedWalCoordination::create_or_open(&io, &shm_path, 64).unwrap());
+        let shared = WalFileShared::open_shared_from_authority_if_exists(
+            &io,
+            wal_path.to_str().unwrap(),
+            crate::OpenFlags::Create,
+            &authority,
+            &open_test_db_file_for_wal(&io, &wal_path),
+        )
+        .unwrap();
+        let coordination = ShmWalCoordination::new(shared.clone(), authority.clone());
+
+        // Reach the fully-backfilled state the DbFile fast path requires.
+        coordination.publish_backfill(header.max_frame);
+        let snapshot = coordination.load_snapshot();
+        assert_eq!(
+            snapshot.max_frame, snapshot.nbackfills,
+            "setup must reach the fully-backfilled state"
+        );
+
+        let guard = coordination.try_begin_read_tx(snapshot);
+        assert!(
+            matches!(guard, Some(ReadGuardKind::DbFile)),
+            "setup must take the fully-backfilled (DbFile) read fast path"
+        );
+
+        // The contract: the fast-path reader is visible to the shared
+        // authority, so a checkpoint in ANY process caps its backfill at the
+        // reader's snapshot for as long as the read transaction is open.
+        assert_eq!(
+            authority.min_active_reader_frame(),
+            Some(snapshot.max_frame),
+            "a DbFile-guard reader must register with the shared authority"
+        );
+        coordination.publish_commit(WalCommitState {
+            max_frame: 2,
+            last_checksum: snapshot.last_checksum,
+            transaction_count: snapshot.transaction_count + 1,
+        });
+        assert_eq!(
+            coordination.determine_max_safe_checkpoint_frame(2),
+            snapshot.max_frame,
+            "an open fast-path reader must pin the checkpoint backfill boundary"
+        );
+
+        // Ending the read releases the pin and unblocks checkpoint progress.
+        coordination.end_read_tx(guard.unwrap());
+        assert_eq!(authority.min_active_reader_frame(), None);
+        assert_eq!(
+            coordination.determine_max_safe_checkpoint_frame(2),
+            2,
+            "after the reader ends, the boundary must advance again"
+        );
+    }
 }

--- a/testing/concurrent-simulator/operations.rs
+++ b/testing/concurrent-simulator/operations.rs
@@ -331,7 +331,8 @@ impl Operation {
                        (SELECT group_concat(id) FROM (\
                           SELECT id FROM {table} WHERE (' '||body||' ') LIKE '% {token} %' \
                           EXCEPT \
-                          SELECT id FROM {table} WHERE fts_match(body, '{token}')))"
+                          SELECT id FROM {table} WHERE fts_match(body, '{token}'))), \
+                       (SELECT group_concat(id||'='||body) FROM {table} WHERE (' '||body||' ') LIKE '% {token} %')"
                 )
             }
         }

--- a/testing/concurrent-simulator/properties.rs
+++ b/testing/concurrent-simulator/properties.rs
@@ -351,12 +351,15 @@ impl Property for FtsSelfDifferentialProperty {
             );
         }
         if symmetric_difference != Some(0) {
+            // Column 4 carries every scan-matching `id=body` pair, so the
+            // failure log records exactly which ghost body the scan observed.
             bail!(
                 "step {step} fiber {fiber_id}: fts_match and the base-table scan disagree \
                  for token {token:?}: symmetric difference {symmetric_difference:?} \
-                 (fts-only ids: {:?}, scan-only ids: {:?})",
+                 (fts-only ids: {:?}, scan-only ids: {:?}, scan rows: {:?})",
                 row.get(2),
-                row.get(3)
+                row.get(3),
+                row.get(4)
             );
         }
         Ok(())

--- a/tests/integration/index_method/fts_durability_contract.rs
+++ b/tests/integration/index_method/fts_durability_contract.rs
@@ -1,0 +1,107 @@
+//! FTS durability contract across a crash-shaped reopen.
+//!
+//! locks in the post-mortem finding of the multiprocess FTS hunt (seed
+//! 7399741717491843615): the on-disk segment registry survives kill/respawn
+//! churn, so every generation — checkpointed, WAL-only, and rewritten — must
+//! stay visible through `fts_match` after recovery, in exact agreement with
+//! the base table. The hazards covered here are the ones that make FTS and
+//! the base table diverge:
+//!
+//! * a row REPLACEd to a body without the token must stop matching (retired
+//!   posting: no ghost hits),
+//! * a row DELETEd must stop matching (tombstones honored after reload),
+//! * an INSERTed row must start matching (published segment reloaded),
+//! * the v2 control row must survive so later writes can still append (a
+//!   registry scan refuses stores without it).
+
+use crate::common::{limbo_exec_rows, TempDatabase};
+
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+#[test]
+fn fts_base_table_agreement_after_crash_shaped_reopen() {
+    let builder =
+        TempDatabase::builder().with_opts(turso_core::DatabaseOpts::new().with_index_method(true));
+    let tmp_db = builder.build();
+    let conn = tmp_db.connect_limbo();
+    conn.execute("CREATE TABLE docs(id INTEGER PRIMARY KEY, body TEXT)")
+        .unwrap();
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts(body)")
+        .unwrap();
+
+    // Generation 1: checkpointed into the main file.
+    for (id, body) in [
+        (1, "charlie alpha"),
+        (2, "bravo echo"),
+        (3, "charlie foxtrot delta"),
+    ] {
+        conn.execute(format!("INSERT INTO docs VALUES ({id}, '{body}')"))
+            .unwrap();
+    }
+    conn.execute("PRAGMA wal_checkpoint(FULL)").unwrap();
+
+    // Generation 2: WAL-only (crash-shaped: the handle is dropped without a
+    // final checkpoint, so recovery must reload this generation from the WAL).
+    for (id, body) in [(4, "delta echo charlie"), (5, "hotel golf")] {
+        conn.execute(format!("INSERT INTO docs VALUES ({id}, '{body}')"))
+            .unwrap();
+    }
+    // REPLACE a token row to a body without the token: the retired posting
+    // must be tombstoned, not left behind as a ghost hit.
+    conn.execute("INSERT OR REPLACE INTO docs VALUES (1, 'alpha golf golf')")
+        .unwrap();
+    // DELETE a token row: the tombstone must survive the reopen.
+    conn.execute("DELETE FROM docs WHERE id = 3").unwrap();
+
+    let path = tmp_db.path.clone();
+    let opts = tmp_db.db_opts;
+    let flags = tmp_db.db_flags;
+    drop(conn);
+    drop(tmp_db);
+
+    let reopened = TempDatabase::builder()
+        .with_db_path(&path)
+        .with_opts(opts)
+        .with_flags(flags)
+        .build();
+    let conn = reopened.connect_limbo();
+
+    let ids_of = |query: String| limbo_exec_rows(&conn, &query).remove(0).remove(0);
+    let scan = |token: &str| {
+        ids_of(format!(
+            "SELECT group_concat(id) FROM (SELECT id FROM docs WHERE \
+             (' '||body||' ') LIKE '% {token} %' ORDER BY id)"
+        ))
+    };
+    let fts = |token: &str| {
+        ids_of(format!(
+            "SELECT group_concat(id) FROM (SELECT id FROM docs WHERE \
+             fts_match(body, '{token}') ORDER BY id)"
+        ))
+    };
+    let text = |v: rusqlite::types::Value| match v {
+        rusqlite::types::Value::Text(s) => s,
+        other => panic!("expected text, got {other:?}"),
+    };
+
+    for token in ["charlie", "alpha", "golf", "delta", "hotel"] {
+        assert_eq!(
+            text(fts(token)),
+            text(scan(token)),
+            "fts_match and the base-table scan disagree for {token:?} after a crash-shaped reopen"
+        );
+    }
+    // Exact contents for the hunted token: only id 4 still carries it
+    // (1 was replaced away, 3 was deleted; 2 never had the token).
+    assert_eq!(text(fts("charlie")), "4");
+
+    // The recovered registry must accept further writes (control row
+    // present), and the agreement contract must keep holding afterwards.
+    conn.execute("INSERT INTO docs VALUES (6, 'charlie bravo india')")
+        .unwrap();
+    assert_eq!(
+        text(fts("charlie")),
+        text(scan("charlie")),
+        "post-reopen insert broke FTS/base agreement"
+    );
+    assert_eq!(text(fts("charlie")), "4,6");
+}

--- a/tests/integration/index_method/mod.rs
+++ b/tests/integration/index_method/mod.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+#[cfg(all(feature = "fts", not(target_family = "wasm")))]
+mod fts_durability_contract;
 use core_tester::common::rng_from_time_or_env;
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;


### PR DESCRIPTION
## Description

Fixes a read-snapshot consistency defect in the multiprocess shared-WAL path: a read transaction on the fully-backfilled fast path (`max_frame == nbackfills`) held only the local mark-0 read lock, which blocks checkpoints **in this process** but not in others. A concurrent PASSIVE checkpoint in another process could backfill newer frames into the DB file while the reader was open — mixing pre- and post-checkpoint page images within one read transaction (violating read-your-committed-writes across processes).

The fix registers the reader's snapshot with the shared authority (`register_reader_for_snapshot`), so `min_active_reader_frame()` gates every cross-process checkpoint's backfill boundary; the reader unregisters on guard release.

## Motivation and context

Found via the [data-corruption challenge](https://algora.io/challenges/turso): the concurrent simulator (whopper) surfaced an FTS-vs-base-table disagreement (`fts_match` and the scan diverging on one id, seed `7399741717491843615`, `--mode fast --multiprocess --connections-per-process 4 --processes 4 --kill-probability 0.01` — fails identically at step 41933 in 5/5 runs pre-fix). FTS was only the detector: its view materializes many pages, so it exposes the mixed page images that any multi-page read can hit.

Forensics (WAL checksum-chain verification on a SIGKILL-frozen scene — tooling and verdict in the branch history) ruled out lost commits, registry wipes and torn publishes: the durable state at the failure instant is fully consistent. The defect is purely the read path above.

Evidence:
- Pre-fix: 5/5 deterministic runs fail at step 41933.
- Post-fix: 2×300 s pinned runs with the exact same command: clean.
- New durability-contract test `index_method::fts_durability_contract` (registry completeness, ghost-posting retirement, tombstone survival, control-row liveness after a crash-shaped reopen) + a regression test pinning the fast-path reader registration.

Sibling PR: #8812 (autovacuum ptrmap fixes, different defect, same hunt).

## Description of AI Usage

Produced by an autonomous coding agent (pi coding-agent harness, GLM model) running a supervised bug-hunting experiment: deterministic repro, WAL forensics, root-cause isolation, fix and tests. A human supervised the run, re-verified the repro pre/post-fix, and opened this PR. The committer is fully responsible for the content.
