### PR TITLE
fts: fix stack lint failures without changing behavior

### DIFF
--- a/core/index_method/fts/mod.rs
+++ b/core/index_method/fts/mod.rs
@@ -2591,7 +2591,8 @@ async fn run_async_query(
         let mut rowids = HashMap::default();
         let mut hits = Vec::with_capacity(top.len());
         for (score, address) in top {
-            if !rowids.contains_key(&address.segment_ord) {
+            if let std::collections::hash_map::Entry::Vacant(e) = rowids.entry(address.segment_ord)
+            {
                 let column = searcher
                     .segment_reader(address.segment_ord)
                     .fast_fields()
@@ -2600,7 +2601,7 @@ async fn run_async_query(
                     .ok_or_else(|| {
                         tantivy::TantivyError::InvalidArgument("FTS rowid column missing".into())
                     })?;
-                rowids.insert(address.segment_ord, column);
+                e.insert(column);
             }
             let rowid = rowids[&address.segment_ord]
                 .first(address.doc_id)


### PR DESCRIPTION
Follow-up to #8818 in stack #8805.

Fix the two lint failures observed on the published stack: use HashMap entry when awaiting rowid columns; split the vendored stopword generator license literal without changing its Python AST. No generated data, manifests, lockfiles or vendor workflows change.

Verified locally: all-feature core Clippy with warnings denied; 28 FTS unit tests; repository Ruff 0.5.4; exact Python AST equality; cargo fmt and diff checks. GitHub Actions results pending for this head.

Segment-output conversion continues separately; this PR does not claim production async output is finished.