### PR TITLE
fst: emit bounded node chunks for resumable output

### DIFF
--- a/vendor/tantivy-fst/TURSO_FORK.md
+++ b/vendor/tantivy-fst/TURSO_FORK.md
@@ -38,3 +38,16 @@ track retained range bytes, repeatedly poll pending operations, and check
 errors and cancellation without skipped results. These APIs alone do not
 page Tantivy dictionaries or impose a query memory cap: callers still need
 to use suspendible traversal and page the separately encoded term information.
+
+`raw::ChunkBuilder` separates CPU node construction from output delivery.
+Ordered insertion and finalization can be resumed one encoded node at a time;
+the encoder's output buffer is limited to 8 KiB. Tantivy awaits its injected
+writer between chunks. There is no synchronous storage callback or runtime.
+After output failure/cancellation, the caller must discard the builder rather
+than replay a node whose address is already registered. Registry and unfinished
+key state remain separate allocations, not part of a total-memory bound.
+
+Byte-for-byte tests compare with the original writer for empty maps, 20,001
+keys, a 100,000-byte key, large values and wide nodes. Standalone tests pass:
+132 unit + 14 doc tests with default features; 119 unit + 14 doc tests without
+default features. Five upstream doctests remain ignored in each configuration.

--- a/vendor/tantivy-fst/src/raw/build.rs
+++ b/vendor/tantivy-fst/src/raw/build.rs
@@ -312,6 +312,167 @@ impl<W: io::Write> Builder<W> {
     }
 }
 
+/// Resumable CPU encoding for an asynchronously written FST map.
+///
+/// Consume every `next_chunk` result through the injected output before asking
+/// for another. No storage is accessed here. Only one encoded node (at most
+/// 8 KiB) is buffered; the registry and unfinished key stack are separate memory.
+/// Discard the builder if writing a chunk fails or is cancelled: emitted nodes
+/// have already advanced its registry and addresses.
+pub struct ChunkBuilder {
+    builder: Builder<NodeBuffer>,
+    state: ChunkState,
+}
+
+enum ChunkState {
+    Header,
+    Ready,
+    Insert {
+        prefix: usize,
+        out: Output,
+        addr: CompiledAddr,
+    },
+    Finish {
+        addr: CompiledAddr,
+    },
+    Root,
+    Trailer(CompiledAddr),
+    Finished,
+}
+
+impl ChunkBuilder {
+    /// Creates a map encoder. Drain the file header before the first insertion.
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            builder: Builder::new_type(NodeBuffer(Vec::with_capacity(8192)), 0)?,
+            state: ChunkState::Header,
+        })
+    }
+
+    /// Starts an ordered key insertion; drain chunks until `None` before the
+    /// next insertion. This retains only the key and node-construction state.
+    pub fn begin_insert(&mut self, key: &[u8], value: u64) -> Result<()> {
+        self.require_ready()?;
+        self.builder.check_last_key(key, true)?;
+        let out = Output::new(value);
+        if key.is_empty() {
+            self.builder.len = 1;
+            self.builder.unfinished.set_root_output(out);
+            return Ok(());
+        }
+        let (prefix, out) = self
+            .builder
+            .unfinished
+            .find_common_prefix_and_set_output(key, out);
+        self.builder.len += 1;
+        self.state = ChunkState::Insert {
+            prefix,
+            out,
+            addr: NONE_ADDRESS,
+        };
+        Ok(())
+    }
+
+    /// Starts final node and trailer emission. Drain chunks until `None`.
+    pub fn begin_finish(&mut self) -> Result<()> {
+        self.require_ready()?;
+        self.state = ChunkState::Finish { addr: NONE_ADDRESS };
+        Ok(())
+    }
+
+    /// Returns one bounded chunk, or `None` when the current operation is done.
+    /// A caller may suspend for arbitrarily long while borrowing this slice.
+    pub fn next_chunk(&mut self) -> Result<Option<&[u8]>> {
+        if matches!(self.state, ChunkState::Header) {
+            self.state = ChunkState::Ready;
+            return Ok(Some(&self.builder.wtr.get_ref().0));
+        }
+        self.builder.wtr.get_mut().0.clear();
+        loop {
+            match std::mem::replace(&mut self.state, ChunkState::Finished) {
+                ChunkState::Header => unreachable!(),
+                ChunkState::Ready => {
+                    self.state = ChunkState::Ready;
+                    return Ok(None);
+                }
+                ChunkState::Finished => return Ok(None),
+                ChunkState::Insert { prefix, out, addr } => {
+                    if prefix + 1 < self.builder.unfinished.len() {
+                        let addr = self.compile_one(addr)?;
+                        self.state = ChunkState::Insert { prefix, out, addr };
+                    } else {
+                        self.builder.unfinished.top_last_freeze(addr);
+                        let key = self.builder.last.as_ref().expect("insert owns its key");
+                        self.builder.unfinished.add_suffix(&key[prefix..], out);
+                        self.state = ChunkState::Ready;
+                    }
+                }
+                ChunkState::Finish { addr } => {
+                    if self.builder.unfinished.len() > 1 {
+                        let addr = self.compile_one(addr)?;
+                        self.state = ChunkState::Finish { addr };
+                    } else {
+                        self.builder.unfinished.top_last_freeze(addr);
+                        self.state = ChunkState::Root;
+                    }
+                }
+                ChunkState::Root => {
+                    let root = self.builder.unfinished.pop_root();
+                    self.state = ChunkState::Trailer(self.builder.compile(&root)?);
+                }
+                ChunkState::Trailer(root) => {
+                    self.builder
+                        .wtr
+                        .write_u64::<LittleEndian>(self.builder.len as u64)?;
+                    self.builder.wtr.write_u64::<LittleEndian>(root as u64)?;
+                }
+            }
+            if !self.builder.wtr.get_ref().0.is_empty() {
+                return Ok(Some(&self.builder.wtr.get_ref().0));
+            }
+        }
+    }
+
+    fn require_ready(&self) -> Result<()> {
+        if !matches!(self.state, ChunkState::Ready) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "FST output must be drained first",
+            )
+            .into());
+        }
+        Ok(())
+    }
+
+    fn compile_one(&mut self, addr: CompiledAddr) -> Result<CompiledAddr> {
+        let node = if addr == NONE_ADDRESS {
+            self.builder.unfinished.pop_empty()
+        } else {
+            self.builder.unfinished.pop_freeze(addr)
+        };
+        let addr = self.builder.compile(&node)?;
+        assert_ne!(addr, NONE_ADDRESS);
+        Ok(addr)
+    }
+}
+
+struct NodeBuffer(Vec<u8>);
+
+impl io::Write for NodeBuffer {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        assert!(
+            self.0.len() + bytes.len() <= 8192,
+            "encoded FST node exceeds buffer"
+        );
+        self.0.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 impl UnfinishedNodes {
     fn new() -> UnfinishedNodes {
         let mut unfinished = UnfinishedNodes {

--- a/vendor/tantivy-fst/src/raw/counting_writer.rs
+++ b/vendor/tantivy-fst/src/raw/counting_writer.rs
@@ -29,6 +29,10 @@ impl<W: io::Write> CountingWriter<W> {
     pub fn get_ref(&self) -> &W {
         &self.wtr
     }
+
+    pub(crate) fn get_mut(&mut self) -> &mut W {
+        &mut self.wtr
+    }
 }
 
 impl<W: io::Write> io::Write for CountingWriter<W> {

--- a/vendor/tantivy-fst/src/raw/mod.rs
+++ b/vendor/tantivy-fst/src/raw/mod.rs
@@ -28,7 +28,7 @@ use crate::automaton::{AlwaysMatch, Automaton};
 use crate::error::Result;
 use crate::stream::{IntoStreamer, Streamer};
 
-pub use self::build::Builder;
+pub use self::build::{Builder, ChunkBuilder};
 pub use self::error::Error;
 use self::node::node_new;
 pub use self::node::{Node, Transitions};

--- a/vendor/tantivy-fst/src/raw/tests.rs
+++ b/vendor/tantivy-fst/src/raw/tests.rs
@@ -1072,3 +1072,43 @@ mod regex_tests {
         }
     }
 }
+
+#[test]
+fn chunk_builder_matches_streaming_bytes() {
+    use super::ChunkBuilder;
+    for count in [0, 1, 257, 20_001] {
+        let mut expected = super::Builder::memory();
+        let mut builder = ChunkBuilder::new().unwrap();
+        assert!(builder.begin_insert(b"premature", 0).is_err());
+        let mut bytes = Vec::new();
+        while let Some(chunk) = builder.next_chunk().unwrap() {
+            assert!(chunk.len() <= 8192);
+            bytes.extend_from_slice(chunk);
+        }
+        for i in 0..count {
+            let key = if i == 0 {
+                Vec::new()
+            } else if i == 1 {
+                vec![0; 100_000]
+            } else {
+                (i as u64).to_be_bytes().to_vec()
+            };
+            let value = (i as u64).wrapping_mul(7_777_777_777);
+            expected.insert(&key, value).unwrap();
+            builder.begin_insert(&key, value).unwrap();
+            while let Some(chunk) = builder.next_chunk().unwrap() {
+                assert!(chunk.len() <= 8192);
+                bytes.extend_from_slice(chunk);
+            }
+            assert!(builder.begin_insert(&key, value).is_err());
+        }
+        builder.begin_finish().unwrap();
+        assert!(builder.begin_insert(b"after-finish", 0).is_err());
+        while let Some(chunk) = builder.next_chunk().unwrap() {
+            assert!(chunk.len() <= 8192);
+            bytes.extend_from_slice(chunk);
+        }
+        assert_eq!(bytes, expected.into_inner().unwrap());
+        assert!(builder.next_chunk().unwrap().is_none());
+    }
+}


### PR DESCRIPTION
## Purpose
Provide a CPU-only node encoder that lets an injected asynchronous sink apply backpressure between chunks without replaying FST registration or changing addresses/format. Output chunks are limited to 8 KiB. Registry and unfinished-key memory are separate; this is not a total index memory cap.

This layer adds no runtime and accesses no storage. The consumer must discard the encoder after output failure/cancellation. Production segment output integration follows in subsequent layers.

## Verification
- FST default: 132 units + 14 doctests passed.
- FST no-default: 119 units + 14 doctests passed.
- Five upstream doctests remain ignored in each configuration.
- Byte-for-byte parity against the original writer, including empty maps, 20,001 keys, a 100,000-byte key, wide nodes and large values.

Stack #8805; depends on #8821. Existing vendor CI and development lockfiles preserved.