### PR TITLE
tantivy: add injected resumable segment outputs

### DIFF
--- a/vendor/tantivy/common/src/async_write.rs
+++ b/vendor/tantivy/common/src/async_write.rs
@@ -1,0 +1,338 @@
+//! Runtime-free output. Requests own submitted bytes until the storage driver
+//! acknowledges them; a cancelled producer cannot free an in-flight buffer.
+
+use std::collections::VecDeque;
+use std::future::{Future, poll_fn};
+use std::io;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex, Weak};
+use std::task::{Poll, Waker};
+
+pub type WriteFuture<'a, T> = Pin<Box<dyn Future<Output = io::Result<T>> + Send + 'a>>;
+pub type AsyncWritePtr = Box<dyn AsyncWrite>;
+
+/// An append-only output. `finish` must complete before the file is published.
+/// A failed or cancelled mutation invalidates the writer. Dropping it does not
+/// flush, finalize, or roll back requests already submitted to storage.
+pub trait AsyncWrite: Send {
+    fn write<'a>(&'a mut self, bytes: &'a [u8]) -> WriteFuture<'a, usize>;
+    fn flush(&mut self) -> WriteFuture<'_, ()>;
+    fn finish(self: Box<Self>) -> WriteFuture<'static, ()>;
+
+    fn write_all<'a>(&'a mut self, mut bytes: &'a [u8]) -> WriteFuture<'a, ()> {
+        Box::pin(async move {
+            while !bytes.is_empty() {
+                let written = self.write(bytes).await?;
+                if written == 0 || written > bytes.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "Invalid write progress",
+                    ));
+                }
+                bytes = &bytes[written..];
+            }
+            Ok(())
+        })
+    }
+}
+
+/// One private build's output queue. The bound applies to each submitted write,
+/// not to the encoder's input arrays or the total memory of an index build.
+#[derive(Clone, Debug)]
+pub struct WriteQueue {
+    pending: Arc<Mutex<VecDeque<WriteRequest>>>,
+    request_size: NonZeroUsize,
+}
+
+impl WriteQueue {
+    pub fn new(request_size: NonZeroUsize) -> Self {
+        Self {
+            pending: Arc::default(),
+            request_size,
+        }
+    }
+
+    pub async fn open(&self, name: String) -> io::Result<AsyncWritePtr> {
+        self.submit(name.clone(), WriteOperation::Open).await?;
+        Ok(Box::new(QueuedWriter {
+            queue: self.clone(),
+            name,
+            offset: 0,
+            usable: true,
+        }))
+    }
+
+    pub fn pop(&self) -> Option<WriteRequest> {
+        let mut pending = self.pending.lock().expect("Write queue poisoned");
+        while let Some(request) = pending.pop_front() {
+            if !request.is_cancelled() {
+                return Some(request);
+            }
+        }
+        None
+    }
+
+    async fn submit(&self, name: String, operation: WriteOperation) -> io::Result<usize> {
+        let response = Arc::new(Mutex::new(Response::default()));
+        self.pending
+            .lock()
+            .expect("Write queue poisoned")
+            .push_back(WriteRequest {
+                name,
+                operation,
+                response: Arc::downgrade(&response),
+            });
+        poll_fn(|cx| {
+            let mut response = response.lock().expect("Write response poisoned");
+            if let Some(result) = response.result.take() {
+                Poll::Ready(result)
+            } else {
+                response.waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        })
+        .await
+    }
+}
+
+struct QueuedWriter {
+    queue: WriteQueue,
+    name: String,
+    offset: u64,
+    usable: bool,
+}
+
+impl AsyncWrite for QueuedWriter {
+    fn write<'a>(&'a mut self, bytes: &'a [u8]) -> WriteFuture<'a, usize> {
+        Box::pin(async move {
+            self.begin()?;
+            if bytes.is_empty() {
+                self.usable = true;
+                return Ok(0);
+            }
+            let len = bytes.len().min(self.queue.request_size.get());
+            self.offset
+                .checked_add(len as u64)
+                .ok_or_else(|| io::Error::other("File offset overflow"))?;
+            let written = self
+                .queue
+                .submit(
+                    self.name.clone(),
+                    WriteOperation::Write {
+                        offset: self.offset,
+                        bytes: Arc::from(&bytes[..len]),
+                    },
+                )
+                .await?;
+            self.offset += written as u64;
+            self.usable = true;
+            Ok(written)
+        })
+    }
+
+    fn flush(&mut self) -> WriteFuture<'_, ()> {
+        Box::pin(async move {
+            self.begin()?;
+            self.queue
+                .submit(self.name.clone(), WriteOperation::Flush)
+                .await?;
+            self.usable = true;
+            Ok(())
+        })
+    }
+
+    fn finish(mut self: Box<Self>) -> WriteFuture<'static, ()> {
+        Box::pin(async move {
+            self.begin()?;
+            self.queue
+                .submit(
+                    self.name.clone(),
+                    WriteOperation::Finish { len: self.offset },
+                )
+                .await?;
+            Ok(())
+        })
+    }
+}
+
+impl QueuedWriter {
+    fn begin(&mut self) -> io::Result<()> {
+        if !std::mem::replace(&mut self.usable, false) {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Writer failed or was cancelled",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum WriteOperation {
+    Open,
+    Write { offset: u64, bytes: Arc<[u8]> },
+    Flush,
+    Finish { len: u64 },
+}
+
+#[derive(Debug, Default)]
+struct Response {
+    result: Option<io::Result<usize>>,
+    waker: Option<Waker>,
+}
+
+#[derive(Debug)]
+pub struct WriteRequest {
+    name: String,
+    operation: WriteOperation,
+    response: Weak<Mutex<Response>>,
+}
+
+impl WriteRequest {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn operation(&self) -> &WriteOperation {
+        &self.operation
+    }
+    pub fn is_cancelled(&self) -> bool {
+        self.response.strong_count() == 0
+    }
+
+    /// Writes report bytes accepted; control operations report zero. A zero
+    /// byte write is an error, not a signal to resubmit the same operation.
+    pub fn complete(mut self, result: io::Result<usize>) {
+        let result = result.and_then(|count| match &self.operation {
+            WriteOperation::Write { bytes, .. } if count == 0 || count > bytes.len() => Err(
+                io::Error::new(io::ErrorKind::WriteZero, "Invalid write progress"),
+            ),
+            WriteOperation::Write { .. } => Ok(count),
+            _ if count == 0 => Ok(0),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Control operation returned a byte count",
+            )),
+        });
+        self.respond(result);
+    }
+
+    fn respond(&mut self, result: io::Result<usize>) {
+        if let Some(response) = std::mem::take(&mut self.response).upgrade() {
+            let waker = {
+                let mut response = response.lock().expect("Write response poisoned");
+                response.result = Some(result);
+                response.waker.take()
+            };
+            if let Some(waker) = waker {
+                waker.wake();
+            }
+        }
+    }
+}
+
+impl Drop for WriteRequest {
+    fn drop(&mut self) {
+        self.respond(Err(io::Error::new(
+            io::ErrorKind::Interrupted,
+            "Write request was cancelled",
+        )));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::task::Context;
+
+    #[test]
+    fn partial_writes_preserve_offsets_and_apply_backpressure() {
+        let queue = WriteQueue::new(NonZeroUsize::new(4).unwrap());
+        let mut future = Box::pin(async {
+            let mut writer = queue.open("file".into()).await?;
+            writer.write_all(b"abcdefghij").await?;
+            writer.flush().await?;
+            writer.finish().await
+        });
+        let mut output = Vec::new();
+        let mut finished = false;
+        loop {
+            if let Poll::Ready(result) = poll(future.as_mut()) {
+                result.unwrap();
+                break;
+            }
+            let request = queue.pop().unwrap();
+            for _ in 0..3 {
+                assert!(poll(future.as_mut()).is_pending());
+                assert!(queue.pop().is_none());
+            }
+            let written = match request.operation() {
+                WriteOperation::Open => {
+                    assert!(output.is_empty());
+                    0
+                }
+                WriteOperation::Write { offset, bytes } => {
+                    assert_eq!(*offset as usize, output.len());
+                    assert!(bytes.len() <= 4);
+                    let count = bytes.len().min(2);
+                    output.extend_from_slice(&bytes[..count]);
+                    count
+                }
+                WriteOperation::Flush => {
+                    assert_eq!(output, b"abcdefghij");
+                    0
+                }
+                WriteOperation::Finish { len } => {
+                    assert_eq!(*len, 10);
+                    finished = true;
+                    0
+                }
+            };
+            request.complete(Ok(written));
+        }
+        assert!(finished);
+        assert_eq!(output, b"abcdefghij");
+    }
+
+    #[test]
+    fn cancelled_and_failed_writes_poison_the_writer() {
+        for failure in 0..5 {
+            let queue = WriteQueue::new(NonZeroUsize::new(4).unwrap());
+            let mut opening = Box::pin(queue.open("file".into()));
+            assert!(poll(opening.as_mut()).is_pending());
+            queue.pop().unwrap().complete(Ok(0));
+            let Poll::Ready(Ok(mut writer)) = poll(opening.as_mut()) else {
+                panic!("open did not finish")
+            };
+            let mut write = writer.write_all(b"abcd");
+            assert!(poll(write.as_mut()).is_pending());
+            let request = queue.pop().unwrap();
+            if failure == 0 {
+                drop(write);
+                assert!(request.is_cancelled());
+                assert!(
+                    matches!(request.operation(), WriteOperation::Write { bytes, .. } if bytes.as_ref() == b"abcd")
+                );
+                request.complete(Ok(4));
+            } else {
+                match failure {
+                    1 => request.complete(Ok(0)),
+                    2 => request.complete(Ok(5)),
+                    3 => request.complete(Err(io::Error::other("injected"))),
+                    _ => drop(request),
+                }
+                assert!(matches!(poll(write.as_mut()), Poll::Ready(Err(_))));
+                drop(write);
+            }
+            let mut retry = writer.write(b"x");
+            assert!(
+                matches!(poll(retry.as_mut()), Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::BrokenPipe)
+            );
+            assert!(queue.pop().is_none());
+        }
+    }
+
+    fn poll<F: Future + ?Sized>(future: Pin<&mut F>) -> Poll<F::Output> {
+        future.poll(&mut Context::from_waker(std::task::Waker::noop()))
+    }
+}

--- a/vendor/tantivy/common/src/lib.rs
+++ b/vendor/tantivy/common/src/lib.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 
 pub use byteorder::LittleEndian as Endianness;
 
+pub mod async_write;
 mod bitset;
 pub mod bounds;
 mod byte_count;

--- a/vendor/tantivy/src/directory/async_spool.rs
+++ b/vendor/tantivy/src/directory/async_spool.rs
@@ -1,0 +1,74 @@
+use std::io;
+use std::path::PathBuf;
+
+use common::HasLen;
+
+use super::{AsyncWrite, AsyncWritePtr, Directory};
+
+/// Transaction-private scratch for formats that place an index before its body.
+/// The directory owns cleanup after cancellation; successful copies retire the
+/// name explicitly. No synchronous reads or writes are used.
+pub(crate) struct AsyncSpool {
+    path: PathBuf,
+    write: AsyncWritePtr,
+    len: u64,
+}
+
+impl AsyncSpool {
+    pub async fn open(directory: &dyn Directory) -> io::Result<Self> {
+        let path = PathBuf::from(format!(
+            ".scratch-{}",
+            crate::index::SegmentId::generate_random()
+        ));
+        let write = directory
+            .open_write_async(&path)
+            .await
+            .map_err(io::Error::other)?;
+        Ok(Self {
+            path,
+            write,
+            len: 0,
+        })
+    }
+
+    pub fn len(&self) -> u64 {
+        self.len
+    }
+
+    pub async fn append(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.write.write_all(bytes).await?;
+        self.len += bytes.len() as u64;
+        Ok(())
+    }
+
+    pub async fn copy_to(
+        self,
+        directory: &dyn Directory,
+        output: &mut dyn AsyncWrite,
+    ) -> io::Result<u64> {
+        self.write.finish().await?;
+        let file = directory
+            .open_read_async(&self.path)
+            .await
+            .map_err(io::Error::other)?;
+        if file.len() as u64 != self.len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Scratch length changed",
+            ));
+        }
+        const COPY_BYTES: usize = 64 * 1024;
+        for start in (0..file.len()).step_by(COPY_BYTES) {
+            let bytes = file
+                .slice(start..(start + COPY_BYTES).min(file.len()))
+                .read_bytes_async()
+                .await?;
+            output.write_all(&bytes).await?;
+        }
+        directory
+            .delete_async(&self.path)
+            .await
+            .map_err(io::Error::other)?;
+        Ok(self.len)
+    }
+}

--- a/vendor/tantivy/src/directory/composite_file.rs
+++ b/vendor/tantivy/src/directory/composite_file.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 
 use common::{BinarySerializable, CountingWriter, HasLen, VInt};
 
-use crate::directory::{FileSlice, TerminatingWrite, WritePtr};
+use crate::directory::{AsyncWritePtr, FileSlice, TerminatingWrite, WritePtr};
 use crate::schema::{Field, Schema};
 use crate::space_usage::{FieldUsage, PerFieldSpaceUsage};
 
@@ -82,6 +82,82 @@ impl<W: TerminatingWrite + Write> CompositeWrite<W> {
         let footer_len = (self.write.written_bytes() - footer_offset) as u32;
         footer_len.serialize(&mut self.write)?;
         self.write.terminate()
+    }
+}
+
+/// Native output for a composite file. Only field offsets are retained;
+/// component bytes go directly to the injected output.
+pub struct AsyncCompositeWrite {
+    write: AsyncWritePtr,
+    written: u64,
+    offsets: Vec<(FileAddr, u64)>,
+}
+
+impl AsyncCompositeWrite {
+    /// Takes ownership of an injected output, without performing I/O.
+    pub fn wrap(write: AsyncWritePtr) -> Self {
+        Self {
+            write,
+            written: 0,
+            offsets: Vec::new(),
+        }
+    }
+
+    /// Starts a field at the last acknowledged output offset.
+    pub fn for_field(&mut self, field: Field) {
+        let addr = FileAddr::new(field, 0);
+        assert!(!self.offsets.iter().any(|(existing, _)| *existing == addr));
+        self.offsets.push((addr, self.written));
+    }
+
+    /// Number of bytes accepted by the underlying output.
+    pub fn written_bytes(&self) -> u64 {
+        self.written
+    }
+
+    /// Appends bytes to the active field, respecting sink backpressure.
+    pub async fn write_all(&mut self, bytes: &[u8]) -> io::Result<()> {
+        <Self as crate::directory::AsyncWrite>::write_all(self, bytes).await
+    }
+
+    /// Writes field offsets and awaits output finalization.
+    pub async fn close(mut self) -> io::Result<()> {
+        let mut entry = Vec::with_capacity(32);
+        VInt(self.offsets.len() as u64).serialize(&mut entry)?;
+        self.write.write_all(&entry).await?;
+        let mut footer_len = entry.len();
+        let mut previous = 0;
+        for (addr, offset) in self.offsets {
+            entry.clear();
+            VInt(offset - previous).serialize(&mut entry)?;
+            addr.serialize(&mut entry)?;
+            self.write.write_all(&entry).await?;
+            footer_len += entry.len();
+            previous = offset;
+        }
+        let footer_len = u32::try_from(footer_len).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "Composite footer exceeds u32")
+        })?;
+        self.write.write_all(&footer_len.to_le_bytes()).await?;
+        self.write.finish().await
+    }
+}
+
+impl crate::directory::AsyncWrite for AsyncCompositeWrite {
+    fn write<'a>(&'a mut self, bytes: &'a [u8]) -> crate::directory::WriteFuture<'a, usize> {
+        Box::pin(async move {
+            let count = self.write.write(bytes).await?;
+            self.written += count as u64;
+            Ok(count)
+        })
+    }
+
+    fn flush(&mut self) -> crate::directory::WriteFuture<'_, ()> {
+        self.write.flush()
+    }
+
+    fn finish(self: Box<Self>) -> crate::directory::WriteFuture<'static, ()> {
+        Box::pin(async move { self.close().await })
     }
 }
 

--- a/vendor/tantivy/src/directory/directory.rs
+++ b/vendor/tantivy/src/directory/directory.rs
@@ -208,6 +208,23 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// The file may not previously exist.
     fn open_write(&self, path: &Path) -> Result<WritePtr, OpenWriteError>;
 
+    /// Opens an injected append-only output. Callers must await `finish` before
+    /// publishing a file. No synchronous writer is used as a fallback.
+    fn open_write_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> DirectoryFuture<'a, Result<super::AsyncWritePtr, OpenWriteError>> {
+        Box::pin(async move {
+            Err(OpenWriteError::wrap_io_error(
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "Directory does not support async output",
+                ),
+                path.to_path_buf(),
+            ))
+        })
+    }
+
     /// Reads the full content file that has been written using
     /// [`Directory::atomic_write()`].
     ///

--- a/vendor/tantivy/src/directory/footer.rs
+++ b/vendor/tantivy/src/directory/footer.rs
@@ -187,6 +187,44 @@ impl<W: TerminatingWrite> TerminatingWrite for FooterProxy<W> {
     }
 }
 
+pub(crate) struct AsyncFooterProxy {
+    hasher: Hasher,
+    writer: super::AsyncWritePtr,
+}
+
+impl AsyncFooterProxy {
+    pub(crate) fn new(writer: super::AsyncWritePtr) -> Self {
+        Self {
+            hasher: Hasher::new(),
+            writer,
+        }
+    }
+}
+
+impl super::AsyncWrite for AsyncFooterProxy {
+    fn write<'a>(&'a mut self, bytes: &'a [u8]) -> super::WriteFuture<'a, usize> {
+        Box::pin(async move {
+            let written = self.writer.write(bytes).await?;
+            self.hasher.update(&bytes[..written]);
+            Ok(written)
+        })
+    }
+
+    fn flush(&mut self) -> super::WriteFuture<'_, ()> {
+        self.writer.flush()
+    }
+
+    fn finish(self: Box<Self>) -> super::WriteFuture<'static, ()> {
+        Box::pin(async move {
+            let Self { hasher, mut writer } = *self;
+            let mut footer = Vec::new();
+            Footer::new(hasher.finalize()).append_footer(&mut footer)?;
+            writer.write_all(&footer).await?;
+            writer.finish().await
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/vendor/tantivy/src/directory/managed_directory.rs
+++ b/vendor/tantivy/src/directory/managed_directory.rs
@@ -8,7 +8,7 @@ use crc32fast::Hasher;
 
 use crate::core::MANAGED_FILEPATH;
 use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
-use crate::directory::footer::{Footer, FooterProxy};
+use crate::directory::footer::{AsyncFooterProxy, Footer, FooterProxy};
 use crate::directory::{
     DirectoryLock, FileHandle, FileSlice, GarbageCollectionResult, Lock, WatchCallback,
     WatchHandle, WritePtr, META_LOCK,
@@ -367,6 +367,22 @@ impl Directory for ManagedDirectory {
         self.directory.atomic_write(path, data)
     }
 
+    fn open_write_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> super::DirectoryFuture<'a, result::Result<super::AsyncWritePtr, OpenWriteError>> {
+        Box::pin(async move {
+            let _writer = self.metadata_writer.lock().await;
+            let paths = self
+                .begin_managed_write(path)
+                .await
+                .map_err(|error| OpenWriteError::wrap_io_error(error, path.to_path_buf()))?;
+            let writer = self.directory.open_write_async(path).await?;
+            self.complete_managed_write(paths);
+            Ok(Box::new(AsyncFooterProxy::new(writer)) as super::AsyncWritePtr)
+        })
+    }
+
     fn atomic_write_async<'a>(
         &'a self,
         path: &'a Path,
@@ -374,32 +390,9 @@ impl Directory for ManagedDirectory {
     ) -> super::DirectoryFuture<'a, io::Result<()>> {
         Box::pin(async move {
             let _writer = self.metadata_writer.lock().await;
-            self.check_metadata_writer()?;
-            let mut paths = {
-                let mut meta = self
-                    .meta_informations
-                    .write()
-                    .expect("Managed file lock poisoned");
-                meta.async_write_incomplete = true;
-                meta.managed_paths.clone()
-            };
-            if is_managed(path) && paths.insert(path.to_path_buf()) {
-                let mut bytes = serde_json::to_vec(&paths)?;
-                writeln!(&mut bytes)?;
-                self.directory
-                    .atomic_write_async(&MANAGED_FILEPATH, &bytes)
-                    .await?;
-                if paths.len() == 1 {
-                    self.directory.sync_directory_async().await?;
-                }
-            }
+            let paths = self.begin_managed_write(path).await?;
             self.directory.atomic_write_async(path, data).await?;
-            let mut meta = self
-                .meta_informations
-                .write()
-                .expect("Managed file lock poisoned");
-            meta.managed_paths = paths;
-            meta.async_write_incomplete = false;
+            self.complete_managed_write(paths);
             Ok(())
         })
     }
@@ -445,6 +438,42 @@ impl Directory for ManagedDirectory {
 
     fn sync_directory_async(&self) -> super::DirectoryFuture<'_, io::Result<()>> {
         self.directory.sync_directory_async()
+    }
+}
+
+impl ManagedDirectory {
+    // The caller holds metadata_writer across registration and the actual
+    // creation, so cancellation poisons both operations as one mutation.
+    async fn begin_managed_write(&self, path: &Path) -> io::Result<HashSet<PathBuf>> {
+        self.check_metadata_writer()?;
+        let mut paths = {
+            let mut meta = self
+                .meta_informations
+                .write()
+                .expect("Managed file lock poisoned");
+            meta.async_write_incomplete = true;
+            meta.managed_paths.clone()
+        };
+        if is_managed(path) && paths.insert(path.to_path_buf()) {
+            let mut bytes = serde_json::to_vec(&paths)?;
+            writeln!(&mut bytes)?;
+            self.directory
+                .atomic_write_async(&MANAGED_FILEPATH, &bytes)
+                .await?;
+            if paths.len() == 1 {
+                self.directory.sync_directory_async().await?;
+            }
+        }
+        Ok(paths)
+    }
+
+    fn complete_managed_write(&self, paths: HashSet<PathBuf>) {
+        let mut meta = self
+            .meta_informations
+            .write()
+            .expect("Managed file lock poisoned");
+        meta.managed_paths = paths;
+        meta.async_write_incomplete = false;
     }
 }
 

--- a/vendor/tantivy/src/directory/mod.rs
+++ b/vendor/tantivy/src/directory/mod.rs
@@ -13,17 +13,21 @@ mod watch_event_router;
 /// Errors specific to the directory module.
 pub mod error;
 
+pub(crate) mod async_spool;
 mod composite_file;
 
 use std::io::BufWriter;
 use std::path::PathBuf;
 
+pub use common::async_write::{
+    AsyncWrite, AsyncWritePtr, WriteFuture, WriteOperation, WriteQueue, WriteRequest,
+};
 pub use common::cooperative_io;
 pub use common::file_slice::{FileHandle, FileSlice};
 pub use common::read_queue::{ReadQueue, ReadRequest};
 pub use common::{AntiCallToken, OwnedBytes, TerminatingWrite};
 
-pub use self::composite_file::{CompositeFile, CompositeWrite};
+pub use self::composite_file::{AsyncCompositeWrite, CompositeFile, CompositeWrite};
 pub use self::directory::{Directory, DirectoryClone, DirectoryFuture, DirectoryLock};
 pub use self::directory_lock::{Lock, INDEX_WRITER_LOCK, META_LOCK};
 pub use self::ram_directory::RamDirectory;
@@ -57,4 +61,4 @@ pub use self::mmap_directory::MmapDirectory;
 pub type WritePtr = BufWriter<Box<dyn TerminatingWrite + Send + Sync>>;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/vendor/tantivy/src/directory/tests.rs
+++ b/vendor/tantivy/src/directory/tests.rs
@@ -8,6 +8,168 @@ use std::time::Duration;
 
 use super::*;
 
+#[test]
+fn async_segment_output_preserves_footer_with_short_writes() -> crate::Result<()> {
+    let directory = AsyncOutputDirectory::default();
+    let index = directory.run(crate::Index::create_async(
+        directory.clone(),
+        crate::schema::Schema::builder().build(),
+        Default::default(),
+    ))?;
+    let segment = index.new_segment();
+    let bytes = vec![19; 1025];
+    directory.run(async {
+        let mut writer = segment
+            .open_write_async(crate::index::SegmentComponent::Store)
+            .await?;
+        writer.write_all(&bytes).await?;
+        writer.flush().await?;
+        writer.finish().await?;
+        let file = segment
+            .open_read_async(crate::index::SegmentComponent::Store)
+            .await?;
+        assert_eq!(file.read_bytes_async().await?.as_slice(), bytes);
+        let raw = directory
+            .ram
+            .open_read(&segment.relative_path(crate::index::SegmentComponent::Store))?;
+        let (footer, _) = footer::Footer::extract_footer(raw)?;
+        assert_eq!(footer.crc, crc32fast::hash(&bytes));
+        crate::Result::Ok(())
+    })
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AsyncOutputDirectory {
+    pub ram: RamDirectory,
+    writes: WriteQueue,
+}
+
+impl Default for AsyncOutputDirectory {
+    fn default() -> Self {
+        Self {
+            ram: RamDirectory::default(),
+            writes: WriteQueue::new(31.try_into().unwrap()),
+        }
+    }
+}
+
+impl AsyncOutputDirectory {
+    pub fn run<F: std::future::Future>(&self, future: F) -> F::Output {
+        use std::task::{Context, Poll};
+        let mut future = std::pin::pin!(future);
+        let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+        let mut files = std::collections::HashMap::<String, Vec<u8>>::new();
+        loop {
+            if let Poll::Ready(result) = future.as_mut().poll(&mut cx) {
+                assert!(files.is_empty());
+                return result;
+            }
+            let request = self
+                .writes
+                .pop()
+                .expect("pending without an output request");
+            for _ in 0..3 {
+                assert!(future.as_mut().poll(&mut cx).is_pending());
+                assert!(
+                    self.writes.pop().is_none(),
+                    "resubmitted an in-flight operation"
+                );
+            }
+            let count = match request.operation() {
+                WriteOperation::Open => {
+                    assert!(files
+                        .insert(request.name().to_owned(), Vec::new())
+                        .is_none());
+                    0
+                }
+                WriteOperation::Write { offset, bytes } => {
+                    let file = files.get_mut(request.name()).unwrap();
+                    assert_eq!(*offset, file.len() as u64);
+                    let count = bytes.len().min(7);
+                    file.extend_from_slice(&bytes[..count]);
+                    count
+                }
+                WriteOperation::Flush => 0,
+                WriteOperation::Finish { len } => {
+                    let file = files.remove(request.name()).unwrap();
+                    assert_eq!(*len, file.len() as u64);
+                    self.ram
+                        .atomic_write(Path::new(request.name()), &file)
+                        .unwrap();
+                    0
+                }
+            };
+            request.complete(Ok(count));
+        }
+    }
+}
+
+impl Directory for AsyncOutputDirectory {
+    fn get_file_handle(&self, _: &Path) -> Result<Arc<dyn FileHandle>, error::OpenReadError> {
+        panic!("synchronous file lookup")
+    }
+    fn delete(&self, _: &Path) -> Result<(), error::DeleteError> {
+        panic!("synchronous delete")
+    }
+    fn exists(&self, _: &Path) -> Result<bool, error::OpenReadError> {
+        panic!("synchronous exists")
+    }
+    fn open_write(&self, _: &Path) -> Result<WritePtr, error::OpenWriteError> {
+        panic!("synchronous output")
+    }
+    fn atomic_read(&self, _: &Path) -> Result<Vec<u8>, error::OpenReadError> {
+        panic!("synchronous metadata read")
+    }
+    fn atomic_write(&self, _: &Path, _: &[u8]) -> std::io::Result<()> {
+        panic!("synchronous metadata write")
+    }
+    fn sync_directory(&self) -> std::io::Result<()> {
+        panic!("synchronous sync")
+    }
+    fn watch(&self, _: WatchCallback) -> crate::Result<WatchHandle> {
+        Ok(WatchHandle::empty())
+    }
+    fn get_file_handle_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> DirectoryFuture<'a, Result<Arc<dyn FileHandle>, error::OpenReadError>> {
+        self.ram.get_file_handle_async(path)
+    }
+    fn delete_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> DirectoryFuture<'a, Result<(), error::DeleteError>> {
+        self.ram.delete_async(path)
+    }
+    fn open_write_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> DirectoryFuture<'a, Result<AsyncWritePtr, error::OpenWriteError>> {
+        Box::pin(async move {
+            self.writes
+                .open(path.to_str().unwrap().to_owned())
+                .await
+                .map_err(|error| error::OpenWriteError::wrap_io_error(error, path.to_owned()))
+        })
+    }
+    fn atomic_read_async<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> DirectoryFuture<'a, Result<Vec<u8>, error::OpenReadError>> {
+        self.ram.atomic_read_async(path)
+    }
+    fn atomic_write_async<'a>(
+        &'a self,
+        path: &'a Path,
+        bytes: &'a [u8],
+    ) -> DirectoryFuture<'a, std::io::Result<()>> {
+        self.ram.atomic_write_async(path, bytes)
+    }
+    fn sync_directory_async(&self) -> DirectoryFuture<'_, std::io::Result<()>> {
+        self.ram.sync_directory_async()
+    }
+}
+
 #[cfg(feature = "mmap")]
 mod mmap_directory_tests {
     use crate::directory::MmapDirectory;

--- a/vendor/tantivy/src/index/segment.rs
+++ b/vendor/tantivy/src/index/segment.rs
@@ -96,4 +96,15 @@ impl Segment {
         let write = self.index.directory_mut().open_write(&path)?;
         Ok(write)
     }
+
+    /// Opens a component whose writes and footer finalization can suspend.
+    pub async fn open_write_async(
+        &self,
+        component: SegmentComponent,
+    ) -> Result<crate::directory::AsyncWritePtr, OpenWriteError> {
+        self.index
+            .directory()
+            .open_write_async(&self.relative_path(component))
+            .await
+    }
 }


### PR DESCRIPTION
## Purpose
Native runtime-free `AsyncWrite` and `WriteQueue` for directory output opening, partial writes, flush and consuming finish. The driver owns submitted bytes until acknowledgment; cancellation/errors poison the writer rather than replay mutations. Managed output preserves registration and checksum footers.

Adds composite output and transaction-private scratch copying without whole-component capture. These are native I/O contracts for subsequent serializers, not a claim that production SQL segment output has been converted. Existing synchronous APIs remain compatibility paths; native methods never fall back to them.

## Verification
- Isolated layer: standalone workspace library suite passed (see local evidence in thread).
- 38 directory tests, including seven-byte writes, repeated Pending, complete body and footer CRC validation with synchronous directory methods that panic.
- Queue tests cover short acknowledgments, invalid progress, request errors/drop, cancellation and poisoned reuse.
- Full working-tree vendor matrix passed before the added footer test: default 1490, no-default libraries 1393, Quickwit libraries/tests 1423, Quickwit docs 55; zero failures. This matrix includes later serializer work, not yet in this PR.

Stack #8805; depends on #8822. No Tokio, worker-thread bridge, manifests/locks/workflow changes or total-memory-bound claim.