### PR TITLE
tantivy: stream inverted components through native output

### DIFF
--- a/vendor/tantivy/src/fieldnorm/writer.rs
+++ b/vendor/tantivy/src/fieldnorm/writer.rs
@@ -104,4 +104,16 @@ impl FieldNormsWriter {
         fieldnorms_serializer.close()?;
         Ok(())
     }
+
+    /// Writes resident fieldnorm arrays without capturing a component file.
+    pub async fn serialize_async(&self, write: crate::directory::AsyncWritePtr) -> io::Result<()> {
+        let mut output = crate::directory::AsyncCompositeWrite::wrap(write);
+        for (field_id, bytes) in self.fieldnorms_buffers.iter().enumerate() {
+            if let Some(bytes) = bytes {
+                output.for_field(Field::from_field_id(field_id as u32));
+                output.write_all(bytes).await?;
+            }
+        }
+        output.close().await
+    }
 }

--- a/vendor/tantivy/src/positions/mod.rs
+++ b/vendor/tantivy/src/positions/mod.rs
@@ -34,7 +34,7 @@ mod serializer;
 use bitpacking::{BitPacker, BitPacker4x};
 
 pub use self::reader::PositionReader;
-pub use self::serializer::PositionSerializer;
+pub use self::serializer::{AsyncPositionSerializer, PositionSerializer};
 
 const COMPRESSION_BLOCK_SIZE: usize = BitPacker4x::BLOCK_LEN;
 

--- a/vendor/tantivy/src/positions/serializer.rs
+++ b/vendor/tantivy/src/positions/serializer.rs
@@ -91,3 +91,75 @@ impl<W: io::Write> PositionSerializer<W> {
         self.positions_wrt.flush()
     }
 }
+
+/// One term's positions, with the header and body spooled through injected I/O.
+/// Encoding retains at most one compression block, regardless of term frequency.
+pub struct AsyncPositionSerializer<'a> {
+    directory: &'a dyn crate::directory::Directory,
+    widths: crate::directory::async_spool::AsyncSpool,
+    body: crate::directory::async_spool::AsyncSpool,
+    encoder: BlockEncoder,
+    block: Vec<u32>,
+    usable: bool,
+}
+
+impl<'a> AsyncPositionSerializer<'a> {
+    /// Opens independent header and body scratch streams for one term.
+    pub async fn new(directory: &'a dyn crate::directory::Directory) -> io::Result<Self> {
+        use crate::directory::async_spool::AsyncSpool;
+        Ok(Self {
+            directory,
+            widths: AsyncSpool::open(directory).await?,
+            body: AsyncSpool::open(directory).await?,
+            encoder: BlockEncoder::new(),
+            block: Vec::with_capacity(COMPRESSION_BLOCK_SIZE),
+            usable: true,
+        })
+    }
+
+    /// Encodes deltas a block at a time, awaiting each scratch write.
+    pub async fn write_positions_delta(&mut self, mut deltas: &[u32]) -> io::Result<()> {
+        if !std::mem::replace(&mut self.usable, false) {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Positions output failed or was cancelled",
+            ));
+        }
+        while !deltas.is_empty() {
+            let count = (COMPRESSION_BLOCK_SIZE - self.block.len()).min(deltas.len());
+            self.block.extend_from_slice(&deltas[..count]);
+            deltas = &deltas[count..];
+            if self.block.len() == COMPRESSION_BLOCK_SIZE {
+                let (width, bytes) = self.encoder.compress_block_unsorted(&self.block, false);
+                self.widths.append(&[width]).await?;
+                self.body.append(bytes).await?;
+                self.block.clear();
+            }
+        }
+        self.usable = true;
+        Ok(())
+    }
+
+    /// Emits the header and body in format order, returning bytes appended.
+    pub async fn close_term(
+        mut self,
+        output: &mut dyn crate::directory::AsyncWrite,
+    ) -> io::Result<u64> {
+        if !self.usable {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Positions output failed or was cancelled",
+            ));
+        }
+        if !self.block.is_empty() {
+            let bytes = self.encoder.compress_vint_unsorted(&self.block);
+            self.body.append(bytes).await?;
+        }
+        let mut count = Vec::with_capacity(10);
+        VInt(self.widths.len()).serialize(&mut count)?;
+        output.write_all(&count).await?;
+        let widths = self.widths.copy_to(self.directory, output).await?;
+        let body = self.body.copy_to(self.directory, output).await?;
+        Ok(count.len() as u64 + widths + body)
+    }
+}

--- a/vendor/tantivy/src/postings/async_serializer.rs
+++ b/vendor/tantivy/src/postings/async_serializer.rs
@@ -1,0 +1,207 @@
+use std::io;
+
+use crate::directory::{AsyncCompositeWrite, ManagedDirectory};
+use crate::fieldnorm::FieldNormReader;
+use crate::index::{Segment, SegmentComponent};
+use crate::positions::AsyncPositionSerializer;
+use crate::schema::{Field, IndexRecordOption, Schema};
+use crate::termdict::AsyncTermDictionaryBuilder;
+use crate::{DocId, Score};
+
+use super::{AsyncPostingsSerializer, TermInfo};
+
+/// Native component output for the FST inverted-index format.
+pub struct AsyncInvertedIndexSerializer {
+    terms: AsyncCompositeWrite,
+    postings: AsyncCompositeWrite,
+    positions: AsyncCompositeWrite,
+    directory: ManagedDirectory,
+    schema: Schema,
+    usable: bool,
+}
+
+impl AsyncInvertedIndexSerializer {
+    /// Opens all inverted-index components through injected output.
+    pub async fn open(segment: &Segment) -> crate::Result<Self> {
+        Ok(Self {
+            terms: AsyncCompositeWrite::wrap(
+                segment.open_write_async(SegmentComponent::Terms).await?,
+            ),
+            postings: AsyncCompositeWrite::wrap(
+                segment.open_write_async(SegmentComponent::Postings).await?,
+            ),
+            positions: AsyncCompositeWrite::wrap(
+                segment
+                    .open_write_async(SegmentComponent::Positions)
+                    .await?,
+            ),
+            directory: segment.index().directory().clone(),
+            schema: segment.schema(),
+            usable: true,
+        })
+    }
+
+    /// Starts a field. Abandoning or failing its serializer poisons the parent.
+    pub async fn new_field(
+        &mut self,
+        field: Field,
+        total_num_tokens: u64,
+        fieldnorms: Option<FieldNormReader>,
+    ) -> io::Result<AsyncFieldSerializer<'_>> {
+        begin(&mut self.usable)?;
+        self.terms.for_field(field);
+        self.postings.for_field(field);
+        self.positions.for_field(field);
+        self.postings
+            .write_all(&total_num_tokens.to_le_bytes())
+            .await?;
+        let postings_start = self.postings.written_bytes();
+        let positions_start = self.positions.written_bytes();
+        let mode = self
+            .schema
+            .get_field_entry(field)
+            .field_type()
+            .index_record_option()
+            .unwrap_or(IndexRecordOption::Basic);
+        let average_fieldnorm = fieldnorms
+            .as_ref()
+            .map(|norms| total_num_tokens as Score / norms.num_docs() as Score)
+            .unwrap_or(0.0);
+        Ok(AsyncFieldSerializer {
+            terms: AsyncTermDictionaryBuilder::new(&self.directory, &mut self.terms).await?,
+            directory: &self.directory,
+            postings: &mut self.postings,
+            positions: &mut self.positions,
+            postings_start,
+            positions_start,
+            mode,
+            average_fieldnorm,
+            fieldnorms,
+            term: None,
+            usable: true,
+            parent_usable: &mut self.usable,
+        })
+    }
+
+    /// Awaits component footers and finalization. Publication belongs to the caller.
+    pub async fn close(mut self) -> io::Result<()> {
+        begin(&mut self.usable)?;
+        self.terms.close().await?;
+        self.postings.close().await?;
+        self.positions.close().await
+    }
+}
+
+/// A field's sorted terms and document lists. No storage callback is synchronous.
+pub struct AsyncFieldSerializer<'a> {
+    directory: &'a ManagedDirectory,
+    terms: AsyncTermDictionaryBuilder<'a>,
+    postings: &'a mut AsyncCompositeWrite,
+    positions: &'a mut AsyncCompositeWrite,
+    postings_start: u64,
+    positions_start: u64,
+    mode: IndexRecordOption,
+    average_fieldnorm: Score,
+    fieldnorms: Option<FieldNormReader>,
+    term: Option<AsyncTerm<'a>>,
+    usable: bool,
+    parent_usable: &'a mut bool,
+}
+
+impl AsyncFieldSerializer<'_> {
+    /// Opens scratch for one term. The preceding term must be closed first.
+    pub async fn new_term(
+        &mut self,
+        key: &[u8],
+        doc_freq: u32,
+        record_freq: bool,
+    ) -> io::Result<()> {
+        begin(&mut self.usable)?;
+        assert!(self.term.is_none(), "previous term was not closed");
+        let postings = AsyncPostingsSerializer::new(
+            self.directory,
+            self.average_fieldnorm,
+            self.mode,
+            self.fieldnorms.clone(),
+            doc_freq,
+            record_freq,
+        )
+        .await?;
+        let positions = if self.mode.has_positions() {
+            Some(AsyncPositionSerializer::new(self.directory).await?)
+        } else {
+            None
+        };
+        let postings_start = (self.postings.written_bytes() - self.postings_start) as usize;
+        let positions_start = (self.positions.written_bytes() - self.positions_start) as usize;
+        self.term = Some(AsyncTerm {
+            key: key.to_vec(),
+            postings,
+            positions,
+            info: TermInfo {
+                doc_freq: 0,
+                postings_range: postings_start..postings_start,
+                positions_range: positions_start..positions_start,
+            },
+        });
+        self.usable = true;
+        Ok(())
+    }
+
+    /// Adds a document, awaiting each completed encoded block's scratch writes.
+    pub async fn write_doc(&mut self, doc: DocId, freq: u32, deltas: &[u32]) -> io::Result<()> {
+        begin(&mut self.usable)?;
+        let term = self.term.as_mut().expect("new_term must precede write_doc");
+        term.postings.write_doc(doc, freq).await?;
+        if let Some(positions) = &mut term.positions {
+            assert_eq!(freq as usize, deltas.len());
+            positions.write_positions_delta(deltas).await?;
+        }
+        term.info.doc_freq += 1;
+        self.usable = true;
+        Ok(())
+    }
+
+    /// Appends one term's scratch streams and commits its dictionary entry.
+    pub async fn close_term(&mut self) -> io::Result<()> {
+        begin(&mut self.usable)?;
+        if let Some(mut term) = self.term.take() {
+            term.postings.close_term(self.postings).await?;
+            term.info.postings_range.end =
+                (self.postings.written_bytes() - self.postings_start) as usize;
+            if let Some(positions) = term.positions {
+                positions.close_term(self.positions).await?;
+                term.info.positions_range.end =
+                    (self.positions.written_bytes() - self.positions_start) as usize;
+            }
+            self.terms.insert(&term.key, &term.info).await?;
+        }
+        self.usable = true;
+        Ok(())
+    }
+
+    /// Finalizes the field dictionary and permits the parent to open another field.
+    pub async fn close(mut self) -> io::Result<()> {
+        self.close_term().await?;
+        self.terms.finish().await?;
+        *self.parent_usable = true;
+        Ok(())
+    }
+}
+
+struct AsyncTerm<'a> {
+    key: Vec<u8>,
+    info: TermInfo,
+    postings: AsyncPostingsSerializer<'a>,
+    positions: Option<AsyncPositionSerializer<'a>>,
+}
+
+fn begin(usable: &mut bool) -> io::Result<()> {
+    if !std::mem::replace(usable, false) {
+        return Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "Inverted-index output incomplete or cancelled",
+        ));
+    }
+    Ok(())
+}

--- a/vendor/tantivy/src/postings/json_postings_writer.rs
+++ b/vendor/tantivy/src/postings/json_postings_writer.rs
@@ -101,6 +101,46 @@ impl<Rec: Recorder> PostingsWriter for JsonPostingsWriter<Rec> {
         Ok(())
     }
 
+    #[cfg(not(feature = "quickwit"))]
+    fn serialize_async<'a, 'directory: 'a>(
+        &'a self,
+        ordered_term_addrs: &'a [(Field, OrderedPathId, &[u8], Addr)],
+        ordered_id_to_path: &'a [&str],
+        ctx: &'a IndexingContext,
+        serializer: &'a mut crate::postings::AsyncFieldSerializer<'directory>,
+    ) -> crate::directory::DirectoryFuture<'a, io::Result<()>> {
+        Box::pin(async move {
+            let mut term_buffer = JsonTermSerializer(Vec::with_capacity(48));
+            let mut buffers = BufferLender::default();
+            for (_, path_id, term, addr) in ordered_term_addrs {
+                term_buffer.clear();
+                term_buffer.append_json_path(ordered_id_to_path[path_id.path_id() as usize]);
+                term_buffer.append_bytes(term);
+                let typ = Type::from_code(term[0]).expect("Invalid type code in JSON term");
+                if typ == Type::Str {
+                    SpecializedPostingsWriter::<Rec>::serialize_one_term_async(
+                        term_buffer.as_bytes(),
+                        *addr,
+                        &mut buffers,
+                        ctx,
+                        serializer,
+                    )
+                    .await?;
+                } else {
+                    SpecializedPostingsWriter::<DocIdRecorder>::serialize_one_term_async(
+                        term_buffer.as_bytes(),
+                        *addr,
+                        &mut buffers,
+                        ctx,
+                        serializer,
+                    )
+                    .await?;
+                }
+            }
+            Ok(())
+        })
+    }
+
     fn total_num_tokens(&self) -> u64 {
         self.str_posting_writer.total_num_tokens() + self.non_str_posting_writer.total_num_tokens()
     }

--- a/vendor/tantivy/src/postings/mod.rs
+++ b/vendor/tantivy/src/postings/mod.rs
@@ -1,5 +1,7 @@
 //! Postings module (also called inverted index)
 
+#[cfg(not(feature = "quickwit"))]
+mod async_serializer;
 mod block_search;
 
 pub(crate) use self::block_search::branchless_binary_search;
@@ -22,13 +24,15 @@ mod term_info;
 pub(crate) use loaded_postings::LoadedPostings;
 pub(crate) use stacker::compute_table_memory_size;
 
+#[cfg(not(feature = "quickwit"))]
+pub use self::async_serializer::{AsyncFieldSerializer, AsyncInvertedIndexSerializer};
 pub use self::block_segment_postings::BlockSegmentPostings;
 pub(crate) use self::indexing_context::IndexingContext;
 pub(crate) use self::per_field_postings_writer::PerFieldPostingsWriter;
 pub use self::postings::Postings;
 pub(crate) use self::postings_writer::{serialize_postings, IndexingPosition, PostingsWriter};
 pub use self::segment_postings::SegmentPostings;
-pub use self::serializer::{FieldSerializer, InvertedIndexSerializer};
+pub use self::serializer::{AsyncPostingsSerializer, FieldSerializer, InvertedIndexSerializer};
 pub(crate) use self::skip::{BlockInfo, SkipReader};
 pub use self::term_info::TermInfo;
 

--- a/vendor/tantivy/src/postings/postings_writer.rs
+++ b/vendor/tantivy/src/postings/postings_writer.rs
@@ -52,6 +52,58 @@ pub(crate) fn serialize_postings(
     fieldnorm_readers: FieldNormReaders,
     serializer: &mut InvertedIndexSerializer,
 ) -> crate::Result<()> {
+    let term_offsets = sorted_term_offsets(&ctx, &schema);
+    let ordered_id_to_path = ctx.path_to_unordered_id.ordered_id_to_path();
+    let field_offsets = make_field_partition(&term_offsets);
+    for (field, byte_offsets) in field_offsets {
+        let postings_writer = per_field_postings_writers.get_for_field(field);
+        let fieldnorm_reader = fieldnorm_readers.get_field(field)?;
+        let mut field_serializer =
+            serializer.new_field(field, postings_writer.total_num_tokens(), fieldnorm_reader)?;
+        postings_writer.serialize(
+            &term_offsets[byte_offsets],
+            &ordered_id_to_path,
+            &ctx,
+            &mut field_serializer,
+        )?;
+        field_serializer.close()?;
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "quickwit"))]
+pub(crate) async fn serialize_postings_async(
+    ctx: IndexingContext,
+    schema: Schema,
+    per_field_postings_writers: &PerFieldPostingsWriter,
+    fieldnorm_readers: FieldNormReaders,
+    serializer: &mut crate::postings::AsyncInvertedIndexSerializer,
+) -> crate::Result<()> {
+    let term_offsets = sorted_term_offsets(&ctx, &schema);
+    let ordered_id_to_path = ctx.path_to_unordered_id.ordered_id_to_path();
+    for (field, byte_offsets) in make_field_partition(&term_offsets) {
+        let postings_writer = per_field_postings_writers.get_for_field(field);
+        let fieldnorm_reader = fieldnorm_readers.get_field_async(field).await?;
+        let mut field_serializer = serializer
+            .new_field(field, postings_writer.total_num_tokens(), fieldnorm_reader)
+            .await?;
+        postings_writer
+            .serialize_async(
+                &term_offsets[byte_offsets],
+                &ordered_id_to_path,
+                &ctx,
+                &mut field_serializer,
+            )
+            .await?;
+        field_serializer.close().await?;
+    }
+    Ok(())
+}
+
+fn sorted_term_offsets<'a>(
+    ctx: &'a IndexingContext,
+    schema: &Schema,
+) -> Vec<(Field, OrderedPathId, &'a [u8], Addr)> {
     // Replace unordered ids by ordered ids to be able to sort
     let unordered_id_to_ordered_id: Vec<OrderedPathId> =
         ctx.path_to_unordered_id.unordered_id_to_ordered_id();
@@ -75,23 +127,7 @@ pub(crate) fn serialize_postings(
             (field1, path_id1, bytes1).cmp(&(field2, path_id2, bytes2))
         },
     );
-    let ordered_id_to_path = ctx.path_to_unordered_id.ordered_id_to_path();
-    let field_offsets = make_field_partition(&term_offsets);
-    for (field, byte_offsets) in field_offsets {
-        let postings_writer = per_field_postings_writers.get_for_field(field);
-        let fieldnorm_reader = fieldnorm_readers.get_field(field)?;
-        let mut field_serializer =
-            serializer.new_field(field, postings_writer.total_num_tokens(), fieldnorm_reader)?;
-        postings_writer.serialize(
-            &term_offsets[byte_offsets],
-            &ordered_id_to_path,
-            &ctx,
-            &mut field_serializer,
-        )?;
-        field_serializer.close()?;
-    }
-
-    Ok(())
+    term_offsets
 }
 
 #[derive(Default, Debug)]
@@ -123,6 +159,15 @@ pub(crate) trait PostingsWriter: Send + Sync {
         ctx: &IndexingContext,
         serializer: &mut FieldSerializer,
     ) -> io::Result<()>;
+
+    #[cfg(not(feature = "quickwit"))]
+    fn serialize_async<'a, 'directory: 'a>(
+        &'a self,
+        term_addrs: &'a [(Field, OrderedPathId, &[u8], Addr)],
+        ordered_id_to_path: &'a [&str],
+        ctx: &'a IndexingContext,
+        serializer: &'a mut crate::postings::AsyncFieldSerializer<'directory>,
+    ) -> crate::directory::DirectoryFuture<'a, io::Result<()>>;
 
     /// Tokenize a text and subscribe all of its token.
     fn index_text(
@@ -198,6 +243,29 @@ impl<Rec: Recorder> SpecializedPostingsWriter<Rec> {
         serializer.close_term()?;
         Ok(())
     }
+
+    #[cfg(not(feature = "quickwit"))]
+    pub(crate) async fn serialize_one_term_async(
+        term: &[u8],
+        addr: Addr,
+        buffer_lender: &mut BufferLender,
+        ctx: &IndexingContext,
+        serializer: &mut crate::postings::AsyncFieldSerializer<'_>,
+    ) -> io::Result<()> {
+        let recorder: Rec = ctx.term_index.read(addr);
+        serializer
+            .new_term(
+                term,
+                recorder.term_doc_freq().unwrap_or(0),
+                recorder.has_term_freq(),
+            )
+            .await?;
+        let mut docs = recorder.recorded_docs(&ctx.arena, buffer_lender);
+        while let Some((doc, freq, positions)) = docs.next_doc() {
+            serializer.write_doc(doc, freq, positions).await?;
+        }
+        serializer.close_term().await
+    }
 }
 
 impl<Rec: Recorder> PostingsWriter for SpecializedPostingsWriter<Rec> {
@@ -244,7 +312,127 @@ impl<Rec: Recorder> PostingsWriter for SpecializedPostingsWriter<Rec> {
         Ok(())
     }
 
+    #[cfg(not(feature = "quickwit"))]
+    fn serialize_async<'a, 'directory: 'a>(
+        &'a self,
+        term_addrs: &'a [(Field, OrderedPathId, &[u8], Addr)],
+        _ordered_id_to_path: &'a [&str],
+        ctx: &'a IndexingContext,
+        serializer: &'a mut crate::postings::AsyncFieldSerializer<'directory>,
+    ) -> crate::directory::DirectoryFuture<'a, io::Result<()>> {
+        Box::pin(async move {
+            let mut buffers = BufferLender::default();
+            for (_, _, term, addr) in term_addrs {
+                Self::serialize_one_term_async(term, *addr, &mut buffers, ctx, serializer).await?;
+            }
+            Ok(())
+        })
+    }
+
     fn total_num_tokens(&self) -> u64 {
         self.total_num_tokens
+    }
+}
+
+#[cfg(all(test, not(feature = "quickwit")))]
+mod async_tests {
+    use super::*;
+    use crate::directory::tests::AsyncOutputDirectory;
+    use crate::index::SegmentComponent;
+    use crate::indexer::operation::AddOperation;
+    use crate::indexer::SegmentWriter;
+    use crate::postings::AsyncInvertedIndexSerializer;
+    use crate::schema::{IndexRecordOption, TextFieldIndexing, TextOptions, INDEXED, TEXT};
+    use crate::{Index, TantivyDocument};
+
+    #[test]
+    fn async_recorded_postings_match_sync_with_delayed_short_writes() -> crate::Result<()> {
+        let mut builder = Schema::builder();
+        for (name, option) in [
+            ("basic", IndexRecordOption::Basic),
+            ("freq", IndexRecordOption::WithFreqs),
+            ("positions", IndexRecordOption::WithFreqsAndPositions),
+        ] {
+            builder.add_text_field(
+                name,
+                TextOptions::default()
+                    .set_indexing_options(TextFieldIndexing::default().set_index_option(option)),
+            );
+        }
+        builder.add_i64_field("number", INDEXED);
+        builder.add_json_field("json", TEXT);
+        let schema = builder.build();
+        let expected_index = Index::create_in_ram(schema.clone());
+        let mut expected_segment = expected_index.new_segment();
+        let (ctx, writers, norms) = recorded(&schema)?;
+        let mut expected = InvertedIndexSerializer::open(&mut expected_segment)?;
+        serialize_postings(ctx, schema.clone(), &writers, norms, &mut expected)?;
+        expected.close()?;
+
+        let directory = AsyncOutputDirectory::default();
+        let index = directory.run(Index::create_async(
+            directory.clone(),
+            schema.clone(),
+            Default::default(),
+        ))?;
+        let segment = index.new_segment();
+        let (ctx, writers, norms) = recorded(&schema)?;
+        directory.run(async {
+            let mut output = AsyncInvertedIndexSerializer::open(&segment).await?;
+            serialize_postings_async(ctx, schema, &writers, norms, &mut output).await?;
+            output.close().await?;
+            crate::Result::Ok(())
+        })?;
+        for component in [
+            SegmentComponent::Terms,
+            SegmentComponent::Postings,
+            SegmentComponent::Positions,
+        ] {
+            let expected = expected_segment.open_read(component)?.read_bytes()?;
+            let actual = directory.run(async {
+                segment
+                    .open_read_async(component)
+                    .await?
+                    .read_bytes_async()
+                    .await
+                    .map_err(crate::TantivyError::from)
+            })?;
+            assert_eq!(actual.as_slice(), expected.as_slice());
+        }
+        Ok(())
+    }
+
+    fn recorded(
+        schema: &Schema,
+    ) -> crate::Result<(IndexingContext, PerFieldPostingsWriter, FieldNormReaders)> {
+        let index = Index::create_in_ram(schema.clone());
+        let segment = index.new_segment();
+        let mut writer = SegmentWriter::for_segment(8_000_000, segment.clone())?;
+        for id in 0..513 {
+            let text = format!("common common term{id}");
+            let document = TantivyDocument::parse_json(
+                schema,
+                &serde_json::json!({
+                    "basic": text, "freq": text, "positions": text, "number": id - 256,
+                    "json": {"text": text, "number": id, "nested": {"text": "nested common"}}
+                })
+                .to_string(),
+            )
+            .unwrap();
+            writer.add_document(AddOperation {
+                document,
+                opstamp: id as u64,
+            })?;
+        }
+        writer.fieldnorms_writer.fill_up_to_max_doc(writer.max_doc);
+        writer.fieldnorms_writer.serialize(
+            writer
+                .segment_serializer
+                .extract_fieldnorms_serializer()
+                .unwrap(),
+        )?;
+        let norms = FieldNormReaders::open(segment.open_read(SegmentComponent::FieldNorms)?)?;
+        writer.segment_serializer.close()?;
+        Ok((writer.ctx, writer.per_field_postings_writers, norms))
     }
 }

--- a/vendor/tantivy/src/postings/serializer.rs
+++ b/vendor/tantivy/src/postings/serializer.rs
@@ -446,6 +446,20 @@ impl PostingsSerializer {
         doc_freq: u32,
         output_write: &mut impl std::io::Write,
     ) -> io::Result<()> {
+        self.encode_remainder()?;
+        if doc_freq >= COMPRESSION_BLOCK_SIZE as u32 {
+            let skip_data = self.skip_write.data();
+            VInt(skip_data.len() as u64).serialize(output_write)?;
+            output_write.write_all(skip_data)?;
+        }
+        output_write.write_all(&self.postings_write[..])?;
+        self.skip_write.clear();
+        self.postings_write.clear();
+        self.bm25_weight = None;
+        Ok(())
+    }
+
+    fn encode_remainder(&mut self) -> io::Result<()> {
         if !self.block.is_empty() {
             // we have doc ids waiting to be written
             // this happens when the number of doc ids is
@@ -468,20 +482,97 @@ impl PostingsSerializer {
             }
             self.block.clear();
         }
-        if doc_freq >= COMPRESSION_BLOCK_SIZE as u32 {
-            let skip_data = self.skip_write.data();
-            VInt(skip_data.len() as u64).serialize(output_write)?;
-            output_write.write_all(skip_data)?;
-        }
-        output_write.write_all(&self.postings_write[..])?;
-        self.skip_write.clear();
-        self.postings_write.clear();
-        self.bm25_weight = None;
         Ok(())
     }
 
     fn clear(&mut self) {
         self.block.clear();
         self.last_doc_id_encoded = 0;
+    }
+}
+
+/// One term's posting blocks. Skip metadata precedes the encoded body in the
+/// component format, so both streams use transaction-private async scratch.
+pub struct AsyncPostingsSerializer<'a> {
+    directory: &'a dyn crate::directory::Directory,
+    encoder: PostingsSerializer,
+    skips: crate::directory::async_spool::AsyncSpool,
+    body: crate::directory::async_spool::AsyncSpool,
+    doc_freq: u32,
+    usable: bool,
+}
+
+impl<'a> AsyncPostingsSerializer<'a> {
+    /// Opens scratch output and initializes the same block-WAND statistics as
+    /// the resident serializer. Fieldnorms are already decoded resident data.
+    pub async fn new(
+        directory: &'a dyn crate::directory::Directory,
+        average_fieldnorm: Score,
+        mode: IndexRecordOption,
+        fieldnorm_reader: Option<FieldNormReader>,
+        term_doc_freq: u32,
+        record_term_freq: bool,
+    ) -> io::Result<Self> {
+        use crate::directory::async_spool::AsyncSpool;
+        let mut encoder = PostingsSerializer::new(average_fieldnorm, mode, fieldnorm_reader);
+        encoder.new_term(term_doc_freq, record_term_freq);
+        Ok(Self {
+            directory,
+            encoder,
+            skips: AsyncSpool::open(directory).await?,
+            body: AsyncSpool::open(directory).await?,
+            doc_freq: 0,
+            usable: true,
+        })
+    }
+
+    /// Adds a document and awaits scratch output whenever a block fills.
+    pub async fn write_doc(&mut self, doc: DocId, term_freq: u32) -> io::Result<()> {
+        if !std::mem::replace(&mut self.usable, false) {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Postings output failed or was cancelled",
+            ));
+        }
+        self.encoder.write_doc(doc, term_freq);
+        self.doc_freq += 1;
+        self.drain_block().await?;
+        self.usable = true;
+        Ok(())
+    }
+
+    /// Copies finalized skip metadata and posting blocks in format order.
+    pub async fn close_term(
+        mut self,
+        output: &mut dyn crate::directory::AsyncWrite,
+    ) -> io::Result<u64> {
+        if !self.usable {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Postings output failed or was cancelled",
+            ));
+        }
+        self.encoder.encode_remainder()?;
+        self.drain_block().await?;
+        let mut count = Vec::with_capacity(10);
+        if self.doc_freq >= COMPRESSION_BLOCK_SIZE as u32 {
+            VInt(self.skips.len()).serialize(&mut count)?;
+            output.write_all(&count).await?;
+        }
+        let skips = self.skips.copy_to(self.directory, output).await?;
+        let body = self.body.copy_to(self.directory, output).await?;
+        Ok(count.len() as u64 + skips + body)
+    }
+
+    async fn drain_block(&mut self) -> io::Result<()> {
+        if !self.encoder.skip_write.data().is_empty() {
+            self.skips.append(self.encoder.skip_write.data()).await?;
+            self.encoder.skip_write.clear();
+        }
+        if !self.encoder.postings_write.is_empty() {
+            self.body.append(&self.encoder.postings_write).await?;
+            self.encoder.postings_write.clear();
+        }
+        Ok(())
     }
 }

--- a/vendor/tantivy/src/termdict/fst_termdict/mod.rs
+++ b/vendor/tantivy/src/termdict/fst_termdict/mod.rs
@@ -27,4 +27,5 @@ mod termdict;
 pub use self::merger::TermMerger;
 pub use self::paged::{PagedTermDictionary, PagedTermStreamer};
 pub use self::streamer::{TermStreamer, TermStreamerBuilder};
+pub(super) use self::termdict::AsyncTermDictionaryBuilder;
 pub use self::termdict::{TermDictionary, TermDictionaryBuilder};

--- a/vendor/tantivy/src/termdict/fst_termdict/term_info_store.rs
+++ b/vendor/tantivy/src/termdict/fst_termdict/term_info_store.rs
@@ -276,6 +276,7 @@ pub struct TermInfoStoreWriter {
     buffer_term_infos: Vec<u8>,
     term_infos: Vec<TermInfo>,
     num_terms: u64,
+    spooled_bytes: u64,
 }
 
 fn bitpack_serialize<W: Write>(
@@ -309,6 +310,7 @@ impl TermInfoStoreWriter {
             buffer_term_infos: Vec::new(),
             term_infos: Vec::with_capacity(BLOCK_LEN),
             num_terms: 0u64,
+            spooled_bytes: 0,
         }
     }
 
@@ -341,7 +343,7 @@ impl TermInfoStoreWriter {
         let max_positions_offset_nbits = compute_num_bits(positions_end_offset as u64);
 
         let term_info_block_meta = TermInfoBlockMeta {
-            offset: self.buffer_term_infos.len() as u64,
+            offset: self.spooled_bytes + self.buffer_term_infos.len() as u64,
             ref_term_info,
             doc_freq_nbits: max_doc_freq_nbits,
             postings_offset_nbits: max_postings_offset_nbits,
@@ -395,6 +397,51 @@ impl TermInfoStoreWriter {
         self.num_terms.serialize(write)?;
         write.write_all(&self.buffer_block_metas)?;
         write.write_all(&self.buffer_term_infos)?;
+        Ok(())
+    }
+
+    pub(super) async fn write_term_info_async(
+        &mut self,
+        term_info: &TermInfo,
+        metas: &mut crate::directory::async_spool::AsyncSpool,
+        body: &mut crate::directory::async_spool::AsyncSpool,
+    ) -> io::Result<()> {
+        self.write_term_info(term_info)?;
+        self.drain_block(metas, body).await
+    }
+
+    pub(super) async fn serialize_async(
+        mut self,
+        directory: &dyn crate::directory::Directory,
+        output: &mut dyn crate::directory::AsyncWrite,
+        mut metas: crate::directory::async_spool::AsyncSpool,
+        mut body: crate::directory::async_spool::AsyncSpool,
+    ) -> io::Result<u64> {
+        if !self.term_infos.is_empty() {
+            self.flush_block()?;
+        }
+        self.drain_block(&mut metas, &mut body).await?;
+        output.write_all(&metas.len().to_le_bytes()).await?;
+        output.write_all(&self.num_terms.to_le_bytes()).await?;
+        let meta_len = metas.copy_to(directory, output).await?;
+        let body_len = body.copy_to(directory, output).await?;
+        Ok(16 + meta_len + body_len)
+    }
+
+    async fn drain_block(
+        &mut self,
+        metas: &mut crate::directory::async_spool::AsyncSpool,
+        body: &mut crate::directory::async_spool::AsyncSpool,
+    ) -> io::Result<()> {
+        if !self.buffer_block_metas.is_empty() {
+            metas.append(&self.buffer_block_metas).await?;
+            self.buffer_block_metas.clear();
+        }
+        if !self.buffer_term_infos.is_empty() {
+            body.append(&self.buffer_term_infos).await?;
+            self.spooled_bytes += self.buffer_term_infos.len() as u64;
+            self.buffer_term_infos.clear();
+        }
         Ok(())
     }
 }

--- a/vendor/tantivy/src/termdict/fst_termdict/termdict.rs
+++ b/vendor/tantivy/src/termdict/fst_termdict/termdict.rs
@@ -90,6 +90,88 @@ where
     }
 }
 
+/// Native dictionary output. FST nodes are emitted individually; term metadata
+/// is spooled one block at a time until the FST has been finalized.
+pub struct AsyncTermDictionaryBuilder<'a> {
+    directory: &'a dyn crate::directory::Directory,
+    output: &'a mut dyn crate::directory::AsyncWrite,
+    fst: tantivy_fst::raw::ChunkBuilder,
+    values: TermInfoStoreWriter,
+    metas: crate::directory::async_spool::AsyncSpool,
+    body: crate::directory::async_spool::AsyncSpool,
+    ordinal: u64,
+    usable: bool,
+}
+
+impl<'a> AsyncTermDictionaryBuilder<'a> {
+    /// Opens private scratch and emits the FST header through injected output.
+    pub async fn new(
+        directory: &'a dyn crate::directory::Directory,
+        output: &'a mut dyn crate::directory::AsyncWrite,
+    ) -> io::Result<Self> {
+        use crate::directory::async_spool::AsyncSpool;
+        let mut builder = Self {
+            directory,
+            output,
+            fst: tantivy_fst::raw::ChunkBuilder::new().map_err(convert_fst_error)?,
+            values: TermInfoStoreWriter::new(),
+            metas: AsyncSpool::open(directory).await?,
+            body: AsyncSpool::open(directory).await?,
+            ordinal: 0,
+            usable: true,
+        };
+        builder.drain_nodes().await?;
+        Ok(builder)
+    }
+
+    /// Inserts an ordered key and its term information. Failed or cancelled
+    /// insertions poison the builder; they must not be restarted.
+    pub async fn insert(&mut self, key: &[u8], info: &TermInfo) -> io::Result<()> {
+        if !std::mem::replace(&mut self.usable, false) {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Dictionary output failed or was cancelled",
+            ));
+        }
+        self.fst
+            .begin_insert(key, self.ordinal)
+            .map_err(convert_fst_error)?;
+        self.drain_nodes().await?;
+        self.values
+            .write_term_info_async(info, &mut self.metas, &mut self.body)
+            .await?;
+        self.ordinal += 1;
+        self.usable = true;
+        Ok(())
+    }
+
+    /// Finalizes dictionary bytes without closing the containing component.
+    pub async fn finish(mut self) -> io::Result<&'a mut dyn crate::directory::AsyncWrite> {
+        if !self.usable {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Dictionary output failed or was cancelled",
+            ));
+        }
+        self.fst.begin_finish().map_err(convert_fst_error)?;
+        self.drain_nodes().await?;
+        let size = self
+            .values
+            .serialize_async(self.directory, self.output, self.metas, self.body)
+            .await?;
+        self.output.write_all(&size.to_le_bytes()).await?;
+        self.output.write_all(&FST_VERSION.to_le_bytes()).await?;
+        Ok(self.output)
+    }
+
+    async fn drain_nodes(&mut self) -> io::Result<()> {
+        while let Some(bytes) = self.fst.next_chunk().map_err(convert_fst_error)? {
+            self.output.write_all(bytes).await?;
+        }
+        Ok(())
+    }
+}
+
 fn open_fst_index(fst_file: FileSlice) -> io::Result<tantivy_fst::Map<OwnedBytes>> {
     let bytes = fst_file.read_bytes()?;
     let fst = Fst::new(bytes).map_err(|err| {

--- a/vendor/tantivy/src/termdict/mod.rs
+++ b/vendor/tantivy/src/termdict/mod.rs
@@ -303,3 +303,32 @@ impl<W: io::Write> TermDictionaryBuilder<W> {
         Ok(writer)
     }
 }
+
+/// Native output for the FST dictionary format. Encoded nodes and term-info
+/// blocks are written incrementally, without retaining the dictionary file.
+#[cfg(not(feature = "quickwit"))]
+pub struct AsyncTermDictionaryBuilder<'a>(fst_termdict::AsyncTermDictionaryBuilder<'a>);
+
+#[cfg(not(feature = "quickwit"))]
+impl<'a> AsyncTermDictionaryBuilder<'a> {
+    /// Opens scratch storage and emits the dictionary header.
+    pub async fn new(
+        directory: &'a dyn crate::directory::Directory,
+        output: &'a mut dyn crate::directory::AsyncWrite,
+    ) -> io::Result<Self> {
+        fst_termdict::AsyncTermDictionaryBuilder::new(directory, output)
+            .await
+            .map(Self)
+    }
+
+    /// Inserts one sorted key/value pair, respecting output backpressure.
+    pub async fn insert(&mut self, key: &[u8], info: &TermInfo) -> io::Result<()> {
+        self.0.insert(key, info).await
+    }
+
+    /// Finalizes dictionary bytes, leaving the containing output open.
+    pub async fn finish(self) -> io::Result<()> {
+        let output = self.0.finish().await?;
+        output.write_all(&(CURRENT_TYPE as u32).to_le_bytes()).await
+    }
+}


### PR DESCRIPTION
## Purpose
Native fieldnorm, FST dictionary, postings and positions output over the injected writer. Encode FST nodes individually, spool 256-term metadata blocks and 128-value posting/position blocks, and await scratch reads/writes in format order. Preserve file format, record modes and BM25 block statistics. Recorded document dispatch covers text, numeric and nested JSON. Failed/cancelled fields poison the parent instead of replaying partial mutations.

This layer provides component serializers. Production SegmentWriter/OPTIMIZE output callers and columnar output remain under conversion; this PR does not claim complete asynchronous SQL output or a total memory cap. Quickwit keeps its synchronous-format compatibility writer; native inverted output targets FST.

## Verification
- Isolated layer: 45 postings tests passed, including byte parity with repeated Pending and seven-byte writes.
- Local Completion-driven B-tree component tests pass, including 65,537-term dictionary parity, partial chunks, scratch lifetime and rollback (Turso driver placement follows in a later layer).
- Full working-tree standalone matrix: default 1490, no-default libraries 1393, Quickwit libraries/tests 1423, Quickwit docs 55; zero failures. Matrix also contains later store work and preceded the added directory footer-CRC test.

Stack #8805; depends on #8823. Vendor CI and development locks preserved.