### PR TITLE
tests: scope ephemeral temp file cleanup check to its own temp dir

### DIFF
--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -28,6 +28,8 @@ fn delete_temp_dirs() {
 pub struct TempDatabase {
     pub path: PathBuf,
     pub io: Arc<dyn IO + Send>,
+    /// Directories of the `TempFile`s this database opened, see [`TestIo`].
+    pub temp_file_dirs: Arc<Mutex<Vec<PathBuf>>>,
     pub db: Arc<Database>,
     pub db_opts: turso_core::DatabaseOpts,
     #[allow(dead_code)]
@@ -53,6 +55,12 @@ pub struct TempDatabaseBuilder {
 
 struct TestIo {
     io: Arc<dyn IO>,
+    /// Directories of the `tursodb_temp_file`s opened through this IO, i.e. the
+    /// ephemeral tables and sorter/hash join spill files this database created.
+    /// `TempFile` puts those directories in `std::env::temp_dir()`, which every
+    /// test on the machine shares, so a test that wants to check they were
+    /// cleaned up has to know which ones are its own.
+    temp_file_dirs: Arc<Mutex<Vec<PathBuf>>>,
 }
 
 impl Clock for TestIo {
@@ -75,6 +83,15 @@ impl IO for TestIo {
         flags: turso_core::OpenFlags,
         direct: bool,
     ) -> turso_core::Result<Arc<dyn turso_core::File>> {
+        let path_buf = Path::new(path);
+        if path_buf
+            .file_name()
+            .is_some_and(|n| n == "tursodb_temp_file")
+        {
+            if let Some(dir) = path_buf.parent() {
+                self.temp_file_dirs.lock().unwrap().push(dir.to_path_buf());
+            }
+        }
         self.io.open_file(path, flags, direct)
     }
 
@@ -217,9 +234,11 @@ impl TempDatabaseBuilder {
             connection.execute(init_sql, ()).unwrap();
         }
 
+        let temp_file_dirs = Arc::new(Mutex::new(Vec::new()));
         let io = if !self.io_uring {
             Arc::new(TestIo {
                 io: Arc::new(turso_core::PlatformIO::new().unwrap()),
+                temp_file_dirs: temp_file_dirs.clone(),
             })
         } else {
             #[cfg(not(all(target_os = "linux", feature = "io_uring")))]
@@ -230,6 +249,7 @@ impl TempDatabaseBuilder {
             {
                 Arc::new(TestIo {
                     io: Arc::new(turso_core::UringIO::new().unwrap()),
+                    temp_file_dirs: temp_file_dirs.clone(),
                 })
             }
         };
@@ -253,6 +273,7 @@ impl TempDatabaseBuilder {
         TempDatabase {
             path: db_path,
             io,
+            temp_file_dirs,
             db,
             db_opts: opts,
             db_flags: flags,

--- a/tests/integration/query_processing/test_ephemeral_cleanup.rs
+++ b/tests/integration/query_processing/test_ephemeral_cleanup.rs
@@ -1,23 +1,6 @@
 use crate::common::{limbo_exec_rows, ExecRows, TempDatabase};
 use rusqlite::types::Value;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-
-const EPHEMERAL_CLEANUP_CHILD_TEST: &str =
-    "query_processing::test_ephemeral_cleanup::ephemeral_temp_files_cleaned_up_child_process";
-
-/// Directory the child process scans, also handed to it as its system temp dir.
-const EPHEMERAL_CLEANUP_TEMP_DIR: &str = "TURSO_EPHEMERAL_CLEANUP_TEMP_DIR";
-
-/// Find directories that contain a `tursodb_temp_file` — these are leaked TempFiles.
-fn find_leaked_temp_files(temp_dir: &Path) -> Vec<PathBuf> {
-    std::fs::read_dir(temp_dir)
-        .expect("failed to read temp dir")
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| p.is_dir() && p.join("tursodb_temp_file").exists())
-        .collect()
-}
+use std::path::PathBuf;
 
 fn value_as_text(value: &Value) -> Option<&str> {
     match value {
@@ -27,42 +10,13 @@ fn value_as_text(value: &Value) -> Option<&str> {
 }
 
 /// `TempFile` puts its directory in `std::env::temp_dir()`, which every test on
-/// the machine shares, so scanning that directory here would report the live
-/// ephemeral files of tests running alongside this one as leaks. Do the scan in
-/// a child process that has its temp dir to itself instead.
+/// the machine shares, so scanning that directory would report the live
+/// ephemeral files of tests running alongside this one as leaks. Ask this
+/// database's own IO which temp files it opened instead.
 #[test]
 fn test_ephemeral_temp_files_cleaned_up() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let current_exe = std::env::current_exe().unwrap();
-    let child_output = Command::new(&current_exe)
-        .arg(EPHEMERAL_CLEANUP_CHILD_TEST)
-        .arg("--exact")
-        .arg("--nocapture")
-        .env(EPHEMERAL_CLEANUP_TEMP_DIR, temp_dir.path())
-        // `std::env::temp_dir()` reads TMPDIR on unix, TMP and TEMP on windows.
-        .env("TMPDIR", temp_dir.path())
-        .env("TMP", temp_dir.path())
-        .env("TEMP", temp_dir.path())
-        .output()
-        .unwrap();
-
-    // A filter that matches nothing still exits 0, so check the test really ran.
-    let stdout = String::from_utf8_lossy(&child_output.stdout);
-    assert!(
-        child_output.status.success() && stdout.contains("1 passed"),
-        "ephemeral cleanup child process failed: stdout={stdout}; stderr={}",
-        String::from_utf8_lossy(&child_output.stderr)
-    );
-}
-
-#[test]
-fn ephemeral_temp_files_cleaned_up_child_process() {
-    let Some(temp_dir) = std::env::var_os(EPHEMERAL_CLEANUP_TEMP_DIR) else {
-        return;
-    };
-    let temp_dir = PathBuf::from(temp_dir);
-
     let db = TempDatabase::new_empty();
+    let temp_file_dirs = db.temp_file_dirs.clone();
     let conn = db.connect_limbo();
 
     conn.execute("CREATE TABLE t_eph(x INTEGER)").unwrap();
@@ -93,6 +47,11 @@ fn ephemeral_temp_files_cleaned_up_child_process() {
     drop(conn);
     drop(db);
 
-    let leaked = find_leaked_temp_files(&temp_dir);
+    let temp_file_dirs = temp_file_dirs.lock().unwrap();
+    assert!(
+        !temp_file_dirs.is_empty(),
+        "expected the ephemeral table to open a temp file"
+    );
+    let leaked: Vec<&PathBuf> = temp_file_dirs.iter().filter(|dir| dir.exists()).collect();
     assert!(leaked.is_empty(), "Ephemeral temp files leaked: {leaked:?}");
 }

--- a/tests/integration/query_processing/test_ephemeral_cleanup.rs
+++ b/tests/integration/query_processing/test_ephemeral_cleanup.rs
@@ -1,24 +1,21 @@
 use crate::common::{limbo_exec_rows, ExecRows, TempDatabase};
 use rusqlite::types::Value;
-use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
-/// Snapshot all directory entries in the system temp dir.
-fn snapshot_temp_dir() -> HashSet<PathBuf> {
-    let temp_dir = std::env::temp_dir();
-    std::fs::read_dir(&temp_dir)
-        .expect("failed to read system temp dir")
+const EPHEMERAL_CLEANUP_CHILD_TEST: &str =
+    "query_processing::test_ephemeral_cleanup::ephemeral_temp_files_cleaned_up_child_process";
+
+/// Directory the child process scans, also handed to it as its system temp dir.
+const EPHEMERAL_CLEANUP_TEMP_DIR: &str = "TURSO_EPHEMERAL_CLEANUP_TEMP_DIR";
+
+/// Find directories that contain a `tursodb_temp_file` — these are leaked TempFiles.
+fn find_leaked_temp_files(temp_dir: &Path) -> Vec<PathBuf> {
+    std::fs::read_dir(temp_dir)
+        .expect("failed to read temp dir")
         .filter_map(|e| e.ok())
         .map(|e| e.path())
-        .collect()
-}
-
-/// Find new directories that contain a `tursodb_temp_file` — these are leaked TempFiles.
-fn find_leaked_temp_files(before: &HashSet<PathBuf>, after: &HashSet<PathBuf>) -> Vec<PathBuf> {
-    after
-        .difference(before)
         .filter(|p| p.is_dir() && p.join("tursodb_temp_file").exists())
-        .cloned()
         .collect()
 }
 
@@ -29,9 +26,41 @@ fn value_as_text(value: &Value) -> Option<&str> {
     }
 }
 
+/// `TempFile` puts its directory in `std::env::temp_dir()`, which every test on
+/// the machine shares, so scanning that directory here would report the live
+/// ephemeral files of tests running alongside this one as leaks. Do the scan in
+/// a child process that has its temp dir to itself instead.
 #[test]
 fn test_ephemeral_temp_files_cleaned_up() {
-    let before = snapshot_temp_dir();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let current_exe = std::env::current_exe().unwrap();
+    let child_output = Command::new(&current_exe)
+        .arg(EPHEMERAL_CLEANUP_CHILD_TEST)
+        .arg("--exact")
+        .arg("--nocapture")
+        .env(EPHEMERAL_CLEANUP_TEMP_DIR, temp_dir.path())
+        // `std::env::temp_dir()` reads TMPDIR on unix, TMP and TEMP on windows.
+        .env("TMPDIR", temp_dir.path())
+        .env("TMP", temp_dir.path())
+        .env("TEMP", temp_dir.path())
+        .output()
+        .unwrap();
+
+    // A filter that matches nothing still exits 0, so check the test really ran.
+    let stdout = String::from_utf8_lossy(&child_output.stdout);
+    assert!(
+        child_output.status.success() && stdout.contains("1 passed"),
+        "ephemeral cleanup child process failed: stdout={stdout}; stderr={}",
+        String::from_utf8_lossy(&child_output.stderr)
+    );
+}
+
+#[test]
+fn ephemeral_temp_files_cleaned_up_child_process() {
+    let Some(temp_dir) = std::env::var_os(EPHEMERAL_CLEANUP_TEMP_DIR) else {
+        return;
+    };
+    let temp_dir = PathBuf::from(temp_dir);
 
     let db = TempDatabase::new_empty();
     let conn = db.connect_limbo();
@@ -64,7 +93,6 @@ fn test_ephemeral_temp_files_cleaned_up() {
     drop(conn);
     drop(db);
 
-    let after = snapshot_temp_dir();
-    let leaked = find_leaked_temp_files(&before, &after);
+    let leaked = find_leaked_temp_files(&temp_dir);
     assert!(leaked.is_empty(), "Ephemeral temp files leaked: {leaked:?}");
 }


### PR DESCRIPTION
## Description

`test_ephemeral_temp_files_cleaned_up` snapshotted `std::env::temp_dir()` before and after its query and failed for every new directory holding a `tursodb_temp_file`. That directory is shared with every other test on the machine, and `TempFile::with_temp_store` is reached from sorting, hash joins and `OpenEphemeral`, so any test running alongside this one drops a live ephemeral file into the window and trips the assertion.

The test now records the temp files instead of scanning for them. Every `TempDatabase` already routes its IO through `TestIo`, and `TempFile` opens its chunk file through that IO, so `TestIo` notes the directory of each `tursodb_temp_file` it is asked to open. The assertion then looks only at the directories this database created, and no longer depends on what else is running, in this process or another one.

It also gets stricter: it asserts the ephemeral table really did open a temp file. The directory scan could not tell "nothing leaked" apart from "nothing was created", so a plan change that stopped using a temp file would have kept the test green.

## Motivation and context

Fixes #8781

Reproduced on `main` (macOS, debug):

* In-process, `integration_tests query_processing` (libtest threads): failed 3/3, e.g. `Ephemeral temp files leaked: ["/var/folders/.../T/.tmpjZpppf"]` — a sibling test's live directory, gone moments later.
* Cross-process, the test alone while other `query_processing` binaries ran hash-join tests in a loop: failed 5/12. This is the shape CI hits, since `rust.yml` runs nextest.

With the change both go to 0 failures (425/425 three times in a row in-process, 12/12 cross-process).

To confirm the test still catches a real leak, I patched `TempFile::new` locally to `std::mem::forget` its `TempDir` and set `temp_dir: None`; the test fails as it should:

```
Ephemeral temp files leaked: ["/var/folders/.../T/.tmpMLSrMb"]
```

That patch was reverted; the diff is test-only.

`cargo fmt --check` and `cargo clippy -p core_tester --all-features --all-targets -- --deny=warnings` are clean, and `cargo nextest run -p core_tester -E 'binary(integration_tests)'` passes 1137/1137.

I did not take the `TMPDIR`-for-the-process suggestion from the issue: setting it process-wide still leaves the sibling threads of a plain `cargo test` run writing into the same directory, and `set_var` races with other threads reading the environment. Recording at the IO boundary needs no global state at all.

## Description of AI Usage

Written with Claude Code (Opus 5). I directed the work: it read `core/io/mod.rs` to confirm `TempFile` opens its chunk file through the connection's IO, traced the callers that create ephemeral files, ran the reproductions above, and drafted the change. The first version used a child process; after @LeMikaelF's review I had it look for a way to identify the test's own temp files instead, which is what landed. I asked for the "a temp file was actually opened" guard and the injected-leak check before accepting the diff, and reviewed the final code and the reproduction output myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
