### PR TITLE
optimizer: correct join cardinality and connectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,6 +1194,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rusqlite",
+ "serde_json",
  "serial_test",
  "similar-asserts",
  "sql_generation",

--- a/core/translate/optimizer/OPTIMIZER.md
+++ b/core/translate/optimizer/OPTIMIZER.md
@@ -1,175 +1,97 @@
-# Overview of the current state of the query optimizer in Limbo
+# Join optimizer
 
-Query optimization is obviously an important part of any SQL-based database engine. This document is an overview of what we currently do.
+The join optimizer chooses a table order and an access method for each table.
+Its main goal is to reduce query execution work.
 
-## Structure of the optimizer directory
+Planning time is not a target for current join work.
+Execution usually costs much more than planning.
 
-1. `mod.rs`
-   - Provides the high-level optimization interface through `optimize_plan()`
+## Main flow
 
-2. `access_method.rs`
-   - Determines what is the best index to use when joining a table to a set of preceding tables
+The optimizer processes a query in this order:
 
-3. `constraints.rs` - Manages query constraints:
-   - Extracts constraints from the WHERE clause
-   - Determines which constraints are usable with indexes
+1. It plans supported correlated subqueries in their written and unnested forms.
+2. It keeps the form with the lower estimated cost.
+3. It removes constant conditions and rewrites supported expressions.
+4. It changes a left join to an inner join when a later filter rejects null rows.
+5. It builds equality classes for compatible inner-join columns.
+6. It extracts index constraints from `WHERE` and `ON` terms.
+7. It searches for a table order and access methods.
+8. It includes sort work when an order can remove a later sort.
+9. It writes the selected order, methods, costs, and row estimates into the plan.
 
-4. `cost.rs`
-   - Calculates the cost of doing a seek vs a scan, for example
+## Equality classes
 
-5. `join.rs`
-   - Implements the System R style dynamic programming join ordering algorithm
+An equality class links columns that must have equal values.
+For example, `a.x = b.x AND b.x = c.x` also gives `a.x = c.x`.
 
-6. `order.rs`
-   - Determines if sort operations can be eliminated based on the chosen access methods and join order
+The optimizer selects one column as the class representative.
+It adds missing links from that column to other class members.
+This star shape avoids a quadratic set of links.
 
-7. `unnest.rs`
-   - Changes a correlated subquery into a join when both forms give the same rows
-   - Leaves all other forms as subqueries
+The optimizer only infers links for plain column equalities in inner joins.
+The columns must have the same affinity and supported collation.
+The original terms still verify each result during execution.
 
-## Join reordering and optimal index selection
+## Join search
 
-**The goals of query optimization are at least the following:**
+Queries with at most 12 tables use dynamic programming.
+The memo keeps the best plan for each table set and final table.
+This retains useful alternatives for later joins and hash joins.
 
-1. Do as little page I/O as possible
-2. Do as little CPU work as possible
-3. Retain query correctness.
+Each prefix finishes an available connected component before it starts a cross join.
+This rule prevents repeated scans of unrelated small tables.
+The rule still permits a cross join after the current component is complete.
 
-**The most important ways to achieve no. 1 and no. 2 are:**
+Larger queries use a greedy search.
+The greedy search uses the same connected-component rule.
 
-1. Choose the optimal access method for each table (e.g. an index or a rowid-based seek, or a full table scan if all else fails).
-2. Choose the best or near-best way to reorder the tables in the query so that those optimal access methods can be used.
-3. Also factor in whether the chosen join order and indexes allow removal of any sort operations that are necessary for query correctness.
+Outer joins, semi-joins, anti-joins, and `CROSS JOIN` can restrict table movement.
+The search applies these restrictions before it compares plans.
 
-## Limbo's optimizer
+## Cost and row estimates
 
-Limbo's optimizer is an implementation of an extremely traditional [IBM System R](https://www.cs.cmu.edu/~15721-f24/slides/02-Selinger-SystemR-opt.pdf) style optimizer,
-i.e. straight from the 70s! The DP algorithm is explained below.
+Each table access has these estimates:
 
-### Current high level flow of the optimizer
+- Input rows from the current join prefix.
+- Output rows for each input row.
+- Output rows after the access and ready filters.
+- Cost of the table access.
+- Total cost through the table access.
 
-1. **Choose how to run correlated subqueries**
-   - Keep the query as written as one choice.
-   - Make a second choice by changing supported `EXISTS`, `IN`, and subqueries that return one aggregate value into joins.
-   - Plan both choices and keep the one with the lower cost.
-   - On equal cost, keep the join because it avoids one subquery call per outer row.
-2. **SQL rewriting**
-  - Rewrite certain SQL expressions to another form (not a lot currently; e.g. rewrite BETWEEN as two comparisons)
-  - Eliminate constant conditions: e.g. `WHERE 1` is removed, `WHERE 0` short-circuits the whole query because it is trivially false.
-3. **Check whether there is an "interesting order"** that we should consider when evaluating indexes and join orders
-    - Is there a GROUP BY? an ORDER BY? Both?
-4. **Convert WHERE clause conjucts to Constraints**
-    - E.g. in `WHERE t.x = 5`, the expression `5` _constrains_  table `t` to values of `x` that are exactly `5`.
-    - E.g. in `Where t.x = u.x`, the expression `u.x` constrains `t`, AND `t.x` constrains `u`.
-    - Per table, each constraint has an estimated _selectivity_ (how much it filters the result set); this affects join order calculations, see the paragraph on _Estimation_  below.
-    - Per table, constraints are also analyzed for whether one or multiple of them can be used as an index seek key to avoid a full scan.
-5. **Compute the best join order using a dynamic programming algorithm:**
-  - `n` = number of tables considered
-  - `n=1`: find the lowest _cost_ way to access each single table, given the constraints of the query. Memoize the result.
-  - `n=2`: for each table found in the `n=1` step, find the best way to join that table with each other table. Memoize the result.
-  - `n=3`: for each 2-table subset found, find the best way to join that result to each other table. Memoize the result.
-  - `n=m`: for each `m-1` table subset found, find the best way to join that result to the `m'th` table
-  - **Use pruning to reduce search space:**
-    - Compute the literal query order first, and store its _cost_ as an upper threshold.
-      In some cases it is not possible to compute this upper threshold from the literal order—for example, when 
-      table-valued functions are involved and their arguments reference tables that appear to the right in the join order. 
-      In such situations, the literal order cannot be executed directly, so no meaningful _cost_ can be assigned. 
-      In these cases, the threshold is set to infinity, ensuring that valid plans are still considered.
-    - If at any point a considered join order exceeds the upper threshold, discard that search path since it cannot be better than the current best.
-      - For example, we have `SELECT * FROM a JOIN b JOIN c JOIN d`. Compute `JOIN(a,b,c,d)` first. If `JOIN (b,a)` is already worse than `JOIN(a,b,c,d)`, we don't have to even try `JOIN(b,a,c)`.
-    - Also keep track of the best plan per _subset_:
-      - If we find that `JOIN(b,a,c)` is better than any other permutation of the same tables, e.g. `JOIN(a,b,c)`, then we can discard _ALL_ of the other permutations for that subset. For example, we don't need to consider `JOIN(a,b,c,d)` because we know it's worse than `JOIN(b,a,c,d)`.
-      - This is possible due to the associativity and commutativity of INNER JOINs.
-  - Also keep track of the best _ordered plan_ , i.e. one that provides the "interesting order" mentioned above.
-  - At the end, apply a cost penalty to the best overall plan
-    - If it is now worse than the best sorted plan, then choose the sorted plan as the best plan for the query.
-      - This allows us to eliminate a sorting operation.
-    - If the best overall plan is still best even with the sorting penalty, then keep it. A sorting operation is later applied to sort the rows according to the desired order.
-6. **Mutate the plan's `join_order` and `Operation`s to match the computed best plan.**
+The model includes page reads, seeks, row work, filter work, hash work, and sort work.
+It uses `sqlite_stat1` data after `ANALYZE`.
 
-### Estimation of cost and cardinalities + a note on table statistics
+Without statistics, the model uses fixed fallback values.
+The main fallback assumes one million rows per table.
+Fixed selectivity values estimate equality, range, and other filters.
 
-Currently, in the absence of `ANALYZE`, `sqlite_stat1` etc. we assume the following:
+A compound lookup can contain a join key and a constant filter.
+The row estimate includes the constant filter even when the index consumes it.
 
-1. Each table has `1,000,000` rows.
-2. Each equality (`=`) filter will filter out some percentage of the result set.
-3. Each nonequality (e.g. `>`) will filter out some smaller percentage of the result set.
-4. Each `4096` byte database page holds `50` rows, i.e. roughly `80` bytes per row 
-5. Sort operations have some CPU cost dependent on the number of input rows to the sort operation.
+For an outer join, the model estimates both matched and unmatched rows.
+It uses a Poisson model when only the average match count is known.
+This estimate handles common `LEFT JOIN ... WHERE right.key IS NULL` anti-joins.
 
-From the above, we derive the following formula for estimating the cost of joining `t1` with `t2`
+## Observability
 
-```
-JOIN_COST = PAGE_IO(t1.rows) + t1.rows * PAGE_IO(t2.rows)
-```
+Use `EXPLAIN QUERY PLAN FORMAT=JSON` to inspect the selected plan.
+Each table access can contain an `estimate` object.
+See [`docs/eqp-json.md`](../../../docs/eqp-json.md) for the field definitions.
 
-For example, let's take the query `SELECT * FROM t1 JOIN t2 USING(foo) WHERE t2.foo > 10`. Let's assume the following:
+Use statement metrics to measure actual execution work.
+Important counters include rows read, VM steps, seeks, scans, sorts, and hash-table work.
 
-- `t1` has `6400` rows and `t2` has `8000` rows
-- there are no indexes at all
-- let's ignore the CPU cost from the equation for simplicity.
+Use [`perf/join-benchmark`](../../../perf/join-benchmark) to collect plans and execution metrics.
+The runner consumes result rows instead of printing them.
+This keeps large query output out of benchmark logs.
 
-The best access method for both is a full table scan. The output cardinality of `t1` is the full table, because nothing is filtering it. Hence, the cost of `t1 JOIN t2` becomes:
+## Source files
 
-```
-JOIN_COST = PAGE_IO(t1.input_rows) + t1.output_rows * PAGE_IO(t2.input_rows)
-
-// plugging in the values:
-
-JOIN_COST = PAGE_IO(6400) + 6400 * PAGE_IO(8000)
-JOIN_COST = 80 + 6400 * 100 = 640080
-```
-
-Now let's consider `t2 JOIN t1`. The best access method for both is still a full scan, but since we can filter on `t2.foo > 10`, its output cardinality decreases. Let's assume only 1/4 of the rows of `t2` match the condition `t2.foo > 10`. Hence, the cost of `t2 join t1` becomes:
-
-```
-JOIN_COST = PAGE_IO(t2.input_rows) + t2.output_rows * PAGE_IO(t1.input_rows)
-
-// plugging in the values:
-
-JOIN_COST = PAGE_IO(8000) + 1/4 * 8000 * PAGE_IO(6400)
-JOIN_COST = 100 + 2000 * 80 = 160100
-```
-
-Even though `t2` is a larger table, because we were able to reduce the input set to the join operation, it's dramatically cheaper.
-
-#### Statistics
-
-Since we don't support `ANALYZE`, nor can we assume that users will call `ANALYZE` anyway, we use simple magic constants to estimate the selectivity of join predicates, row count of tables, and so on. When we have support for `ANALYZE`, we should plug the statistics from `sqlite_stat1` and friends into the optimizer to make more informed decisions.
-
-### Estimating the output cardinality of a join
-
-The output cardinality (output row count) of an operation is as follows:
-
-```
-OUTPUT_CARDINALITY_JOIN = INPUT_CARDINALITY_RHS * OUTPUT_CARDINALITY_RHS
-
-where
-
-INPUT_CARDINALITY_RHS = OUTPUT_CARDINALITY_LHS
-```
-
-example:
-
-```
-SELECT * FROM products p JOIN order_lines o ON p.id = o.product_id
-```
-Assuming there are 100 products, i.e. just selecting all products would yield 100 rows:
-
-```
-OUTPUT_CARDINALITY_LHS = 100
-INPUT_CARDINALITY_RHS = 100
-```
-
-Assuming p.id = o.product_id will return three orders per each product:
-
-```
-OUTPUT_CARDINALITY_RHS = 3
-
-OUTPUT_CARDINALITY_JOIN = 100 * 3 = 300
-```
-i.e. the join is estimated to return 300 rows, 3 for each product.
-
-Again, in the absence of statistics, we use magic constants to estimate these cardinalities.
-
-Estimating them is important because in multi-way joins the output cardinality of the previous join becomes the input cardinality of the next one.
+- `mod.rs` runs the main optimizer flow and writes the selected plan.
+- `constraints.rs` builds equality classes and index constraints.
+- `access_method.rs` compares scans, seeks, custom indexes, and hash joins.
+- `cost.rs` estimates rows and execution work.
+- `join.rs` searches table orders and estimates join prefixes.
+- `order.rs` finds plans that can remove sorting.
+- `unnest.rs` changes supported subqueries into joins.

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -1302,7 +1302,7 @@ pub fn usable_constraints_for_lhs_mask(
         if other_side_refers_to_self {
             // Self-referential constraints cannot seed a lookup, but if they are
             // on a later index column they also terminate the usable prefix.
-            if cref.index_col_pos != current_required_column_pos {
+            if cref.index_col_pos > current_required_column_pos {
                 break;
             }
             continue;
@@ -1311,7 +1311,7 @@ pub fn usable_constraints_for_lhs_mask(
             // Join-dependent constraints are only usable when every referenced
             // outer table is already on the left side of the join order. As
             // above, a missing earlier prefix column terminates the prefix.
-            if cref.index_col_pos != current_required_column_pos {
+            if cref.index_col_pos > current_required_column_pos {
                 break;
             }
             continue;

--- a/core/translate/optimizer/constraints.rs
+++ b/core/translate/optimizer/constraints.rs
@@ -518,6 +518,168 @@ fn expression_matches_table(
     }
 }
 
+pub(super) fn add_implied_column_equalities(
+    where_clause: &mut Vec<WhereTerm>,
+    table_references: &TableReferences,
+) -> Result<()> {
+    let mut columns = Vec::new();
+    let mut parents = Vec::new();
+    let mut direct_pairs = Vec::new();
+
+    for term in where_clause
+        .iter()
+        .filter(|term| term.from_outer_join.is_none())
+    {
+        let Some((left, operator, right)) = as_binary_components(&term.expr)? else {
+            continue;
+        };
+        if operator.as_ast_operator() != Some(ast::Operator::Equals) {
+            continue;
+        }
+        let (Some((left_table, left_column)), Some((right_table, right_column))) =
+            (plain_column(left), plain_column(right))
+        else {
+            continue;
+        };
+        if left_table == right_table {
+            continue;
+        }
+
+        let left_affinity = get_expr_affinity(left, Some(table_references), None);
+        let right_affinity = get_expr_affinity(right, Some(table_references), None);
+        let left_collation = get_collseq_from_expr(left, table_references)?.unwrap_or_default();
+        let right_collation = get_collseq_from_expr(right, table_references)?.unwrap_or_default();
+        if left_affinity != right_affinity
+            || left_collation != right_collation
+            || !matches!(
+                left_collation,
+                CollationSeq::Binary | CollationSeq::NoCase | CollationSeq::Rtrim
+            )
+        {
+            continue;
+        }
+
+        let left_index = find_or_add_equal_column(
+            &mut columns,
+            &mut parents,
+            left_table,
+            left_column,
+            left.clone(),
+        );
+        let right_index = find_or_add_equal_column(
+            &mut columns,
+            &mut parents,
+            right_table,
+            right_column,
+            right.clone(),
+        );
+        direct_pairs.push(ordered_pair(left_index, right_index));
+        union_equal_columns(&mut parents, left_index, right_index);
+    }
+
+    let mut inferred = Vec::new();
+    for member in 0..columns.len() {
+        let representative = equal_column_root(&mut parents, member);
+        if representative == member
+            || columns[representative].table == columns[member].table
+            || direct_pairs.contains(&ordered_pair(representative, member))
+            || both_columns_are_rowid_aliases(&columns[representative].expr, &columns[member].expr)
+        {
+            continue;
+        }
+        inferred.push(WhereTerm {
+            expr: ast::Expr::Binary(
+                Box::new(columns[representative].expr.clone()),
+                ast::Operator::Equals,
+                Box::new(columns[member].expr.clone()),
+            ),
+            from_outer_join: None,
+            // The inferred term can select an access path. The original
+            // equalities still verify the result during execution.
+            consumed: true,
+        });
+    }
+
+    where_clause.extend(inferred);
+    Ok(())
+}
+
+fn both_columns_are_rowid_aliases(left: &ast::Expr, right: &ast::Expr) -> bool {
+    matches!(
+        left,
+        ast::Expr::Column {
+            is_rowid_alias: true,
+            ..
+        }
+    ) && matches!(
+        right,
+        ast::Expr::Column {
+            is_rowid_alias: true,
+            ..
+        }
+    )
+}
+
+struct EqualColumn {
+    table: TableInternalId,
+    column: usize,
+    expr: ast::Expr,
+}
+
+fn plain_column(expr: &ast::Expr) -> Option<(TableInternalId, usize)> {
+    let ast::Expr::Column { table, column, .. } = expr else {
+        return None;
+    };
+    Some((*table, *column))
+}
+
+fn find_or_add_equal_column(
+    columns: &mut Vec<EqualColumn>,
+    parents: &mut Vec<usize>,
+    table: TableInternalId,
+    column: usize,
+    expr: ast::Expr,
+) -> usize {
+    if let Some(index) = columns
+        .iter()
+        .position(|item| item.table == table && item.column == column)
+    {
+        return index;
+    }
+    let index = columns.len();
+    columns.push(EqualColumn {
+        table,
+        column,
+        expr,
+    });
+    parents.push(index);
+    index
+}
+
+fn ordered_pair(left: usize, right: usize) -> (usize, usize) {
+    (left.min(right), left.max(right))
+}
+
+fn union_equal_columns(parents: &mut [usize], left: usize, right: usize) {
+    let left_root = equal_column_root(parents, left);
+    let right_root = equal_column_root(parents, right);
+    if left_root != right_root {
+        let representative = left_root.min(right_root);
+        parents[left_root] = representative;
+        parents[right_root] = representative;
+    }
+}
+
+fn equal_column_root(parents: &mut [usize], column: usize) -> usize {
+    let parent = parents[column];
+    if parent == column {
+        return column;
+    }
+    let root = equal_column_root(parents, parent);
+    parents[column] = root;
+    root
+}
+
 /// Precompute all potentially usable [Constraints] from a WHERE clause.
 /// The resulting list of [TableConstraints] is then used to evaluate the best access methods for various join orders.
 ///

--- a/core/translate/optimizer/cost.rs
+++ b/core/translate/optimizer/cost.rs
@@ -289,8 +289,10 @@ pub(crate) fn estimate_rows_per_seek(
     base_row_count: RowCountEstimate,
     analyze_ctx: Option<&AnalyzeCtx>,
 ) -> f64 {
+    let join_probe_constant_selectivity =
+        join_probe_constant_selectivity(constraints, usable_constraint_refs);
     if is_unique_point_lookup(index_info, usable_constraint_refs) {
-        return 1.0;
+        return join_probe_constant_selectivity;
     }
 
     if let Some(ctx) = analyze_ctx {
@@ -318,7 +320,8 @@ pub(crate) fn estimate_rows_per_seek(
                         sel
                     })
                     .product();
-                return (eq_prefix_rows * range_selectivity).max(1.0);
+                return (eq_prefix_rows * range_selectivity).max(1.0)
+                    * join_probe_constant_selectivity;
             }
         }
     }
@@ -340,7 +343,27 @@ pub(crate) fn estimate_rows_per_seek(
         })
         .product();
 
-    (selectivity_multiplier * *base_row_count).max(1.0)
+    (selectivity_multiplier * *base_row_count).max(1.0) * join_probe_constant_selectivity
+}
+
+fn join_probe_constant_selectivity(
+    constraints: &[Constraint],
+    usable_constraint_refs: &[RangeConstraintRef],
+) -> f64 {
+    let equality_constraints = usable_constraint_refs
+        .iter()
+        .take_while(|constraint| constraint.eq.is_some())
+        .map(|constraint| &constraints[constraint.eq.as_ref().unwrap().constraint_pos]);
+    if !equality_constraints
+        .clone()
+        .any(|constraint| !constraint.lhs_mask.is_empty())
+    {
+        return 1.0;
+    }
+    equality_constraints
+        .filter(|constraint| constraint.lhs_mask.is_empty())
+        .map(|constraint| constraint.selectivity)
+        .product()
 }
 
 /// Estimate rows per seek using ANALYZE stats (sqlite_stat1 histogram data).

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -74,7 +74,31 @@ fn constraint_output_multipliers(
     rhs_self_mask: TableMask,
     consumed_where_terms: &BitSet<usize>,
     skipped_where_terms: &BitSet<usize>,
+    where_clause: &[WhereTerm],
     params: &CostModelParams,
+) -> f64 {
+    constraint_output_multipliers_for(
+        rhs_constraints,
+        lhs_mask,
+        rhs_self_mask,
+        consumed_where_terms,
+        skipped_where_terms,
+        where_clause,
+        params,
+        |_| true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn constraint_output_multipliers_for(
+    rhs_constraints: &TableConstraints,
+    lhs_mask: &TableMask,
+    rhs_self_mask: TableMask,
+    consumed_where_terms: &BitSet<usize>,
+    skipped_where_terms: &BitSet<usize>,
+    where_clause: &[WhereTerm],
+    params: &CostModelParams,
+    include: impl Fn(&super::constraints::Constraint) -> bool,
 ) -> f64 {
     let mut multiplier = 1.0;
     let mut bounds: SmallVec<[(Option<usize>, bool, bool); 4]> = SmallVec::new();
@@ -100,6 +124,8 @@ fn constraint_output_multipliers(
             || constraint.lhs_mask.is_empty())
             && !consumed_where_terms.get(constraint.where_clause_pos.0)
             && !skipped_where_terms.get(constraint.where_clause_pos.0)
+            && !where_clause[constraint.where_clause_pos.0].consumed
+            && include(constraint)
     }) {
         multiplier *= constraint.selectivity;
 
@@ -125,6 +151,7 @@ fn constraint_output_multipliers(
 }
 
 /// Return the row count after one table and its ready filters.
+#[allow(clippy::too_many_arguments)]
 fn rows_after_join(
     input_cardinality: f64,
     method: &AccessMethod,
@@ -132,6 +159,7 @@ fn rows_after_join(
     lhs_mask: &TableMask,
     rhs_mask: TableMask,
     rhs_table: &JoinedTable,
+    where_clause: &[WhereTerm],
     params: &CostModelParams,
 ) -> f64 {
     if rhs_table
@@ -141,15 +169,82 @@ fn rows_after_join(
     {
         return input_cardinality;
     }
-    let remaining_filter_selectivity = constraint_output_multipliers(
+    let is_outer_join = rhs_table
+        .join_info
+        .as_ref()
+        .is_some_and(|join_info| join_info.is_outer());
+    if !is_outer_join {
+        let remaining_filter_selectivity = constraint_output_multipliers(
+            rhs_constraints,
+            lhs_mask,
+            rhs_mask,
+            &method.consumed_where_terms,
+            &Default::default(),
+            where_clause,
+            params,
+        );
+        return input_cardinality
+            * method.estimated_rows_per_outer_row
+            * remaining_filter_selectivity;
+    }
+
+    let is_on_term = |constraint: &super::constraints::Constraint| {
+        where_clause[constraint.where_clause_pos.0].from_outer_join == Some(rhs_table.internal_id)
+    };
+    let on_selectivity = constraint_output_multipliers_for(
+        rhs_constraints,
+        lhs_mask,
+        rhs_mask.clone(),
+        &method.consumed_where_terms,
+        &Default::default(),
+        where_clause,
+        params,
+        is_on_term,
+    );
+    let matching_rows_per_input = method.estimated_rows_per_outer_row * on_selectivity;
+    // Statistics give an average match count, but not its distribution.
+    // A Poisson model estimates the chance that an input row has no match.
+    let unmatched_probability = (-matching_rows_per_input).exp();
+    let outer_join_rows_per_input = matching_rows_per_input + unmatched_probability;
+
+    let selects_unmatched_rows = |constraint: &super::constraints::Constraint| {
+        if is_on_term(constraint)
+            || !matches!(constraint.operator.as_ast_operator(), Some(Operator::Is))
+        {
+            return false;
+        }
+        matches!(
+            constraint.get_constraining_expr_ref(where_clause),
+            turso_parser::ast::Expr::Literal(turso_parser::ast::Literal::Null)
+        ) && constraint.table_col_pos.is_some_and(|column_pos| {
+            rhs_table
+                .table
+                .get_column_at(column_pos)
+                .is_some_and(|column| column.is_rowid_alias() || column.notnull())
+        })
+    };
+    let selects_only_unmatched_rows = rhs_constraints.constraints.iter().any(|constraint| {
+        !method
+            .consumed_where_terms
+            .get(constraint.where_clause_pos.0)
+            && selects_unmatched_rows(constraint)
+    });
+    let where_selectivity = constraint_output_multipliers_for(
         rhs_constraints,
         lhs_mask,
         rhs_mask,
         &method.consumed_where_terms,
         &Default::default(),
+        where_clause,
         params,
+        |constraint| !is_on_term(constraint) && !selects_unmatched_rows(constraint),
     );
-    input_cardinality * method.estimated_rows_per_outer_row * remaining_filter_selectivity
+    let rows_per_input = if selects_only_unmatched_rows {
+        unmatched_probability
+    } else {
+        outer_join_rows_per_input
+    };
+    input_cardinality * rows_per_input * where_selectivity
 }
 
 /// Count calls to each subquery when all of its outer tables have been read.
@@ -212,6 +307,7 @@ fn count_subquery_calls_after_join(
             new_table_mask.clone(),
             &method.consumed_where_terms,
             &skipped_where_terms,
+            where_clause,
             params,
         );
         let rows = rows_before_filters * multiplier;
@@ -264,6 +360,7 @@ pub(super) fn count_subquery_calls_for_plan(
             &prior_tables,
             table_mask,
             &joined_tables[*table_number],
+            where_clause,
             params,
         );
         prior_tables.set(*table_number)?;
@@ -922,6 +1019,7 @@ fn join_lhs_and_rhs<'a>(
         &lhs_mask,
         rhs_self_mask,
         &joined_tables[rhs_table_number],
+        where_clause,
         params,
     );
 

--- a/core/translate/optimizer/join.rs
+++ b/core/translate/optimizer/join.rs
@@ -1467,6 +1467,17 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
                     continue;
                 }
 
+                if has_connected_legal_candidate(
+                    &lhs_mask,
+                    num_tables,
+                    &where_terms,
+                    required_lhs_by_table.as_deref(),
+                    left_join_illegal_map.as_ref(),
+                ) && !tables_are_connected(&lhs_mask, rhs_idx, &where_terms)
+                {
+                    continue;
+                }
+
                 // If this join ordering would violate LEFT JOIN ordering restrictions, skip.
                 if let Some(illegal_lhs) = left_join_illegal_map
                     .as_ref()
@@ -1671,6 +1682,50 @@ pub(crate) fn compute_best_join_order_with_context<'a>(
     }
 }
 
+fn has_connected_legal_candidate(
+    prefix: &TableMask,
+    num_tables: usize,
+    where_terms: &[WhereTermInfo],
+    required_lhs_by_table: Option<&[TableMask]>,
+    left_join_illegal_map: Option<&HashMap<usize, TableMask>>,
+) -> bool {
+    (0..num_tables).any(|candidate| {
+        !prefix.get(candidate)
+            && can_add_table_to_prefix(
+                prefix,
+                candidate,
+                required_lhs_by_table,
+                left_join_illegal_map,
+            )
+            && tables_are_connected(prefix, candidate, where_terms)
+    })
+}
+
+fn can_add_table_to_prefix(
+    prefix: &TableMask,
+    candidate: usize,
+    required_lhs_by_table: Option<&[TableMask]>,
+    left_join_illegal_map: Option<&HashMap<usize, TableMask>>,
+) -> bool {
+    let has_required_tables = required_lhs_by_table
+        .and_then(|required| required.get(candidate))
+        .is_none_or(|required| prefix.contains_all_set_bits_of(required));
+    let keeps_outer_join_order = left_join_illegal_map
+        .and_then(|illegal| illegal.get(&candidate))
+        .is_none_or(|illegal| !prefix.intersects(illegal));
+    has_required_tables && keeps_outer_join_order
+}
+
+fn tables_are_connected(
+    prefix: &TableMask,
+    candidate: usize,
+    where_terms: &[WhereTermInfo],
+) -> bool {
+    where_terms
+        .iter()
+        .any(|term| term.table_mask.get(candidate) && term.table_mask.intersects(prefix))
+}
+
 /// Above this threshold, use greedy O(n²) ordering instead of exhaustive O(2^n) DP.
 pub const GREEDY_JOIN_THRESHOLD: usize = 12;
 
@@ -1781,37 +1836,21 @@ fn compute_greedy_join_order<'a>(
 
         let mut best: Option<(usize, JoinN)> = None;
 
-        let mut has_connected_candidate = false;
-        for idx in &remaining {
-            // Outer join RHS requires all preceding tables joined first
-            if let Some(required) = left_join_deps.get(&idx) {
-                if !current_mask.contains_all_set_bits_of(required) {
-                    continue;
-                }
-            }
-            let connected = where_terms
-                .iter()
-                .any(|term| term.table_mask.get(idx) && term.table_mask.intersects(&current_mask));
-            if connected {
-                has_connected_candidate = true;
-                break;
-            }
-        }
+        let candidate_is_legal = |candidate| {
+            left_join_deps
+                .get(&candidate)
+                .is_none_or(|required| current_mask.contains_all_set_bits_of(required))
+        };
+        let must_stay_connected = remaining.iter().any(|candidate| {
+            candidate_is_legal(candidate)
+                && tables_are_connected(&current_mask, candidate, where_terms)
+        });
 
         for idx in &remaining {
-            // Outer join RHS requires all preceding tables joined first
-            if let Some(required) = left_join_deps.get(&idx) {
-                if !current_mask.contains_all_set_bits_of(required) {
-                    continue;
-                }
-            }
-            if has_connected_candidate {
-                let connected = where_terms.iter().any(|term| {
-                    term.table_mask.get(idx) && term.table_mask.intersects(&current_mask)
-                });
-                if !connected {
-                    continue;
-                }
+            if !candidate_is_legal(idx)
+                || (must_stay_connected && !tables_are_connected(&current_mask, idx, where_terms))
+            {
+                continue;
             }
 
             let table = &joined_tables[idx];
@@ -2529,6 +2568,193 @@ mod tests {
         let ready = ready_where_work(&outer_join_where, &where_terms, &joined_mask, 1, second_id);
         assert_eq!(ready.as_slice(), &[(0, where_terms[0].extra_steps)]);
         Ok(())
+    }
+
+    #[test]
+    fn connected_component_finishes_before_a_cross_join() -> Result<()> {
+        let mut table_id_counter = TableRefIdCounter::new();
+        let joined_tables = (0..4)
+            .map(|index| {
+                _create_table_reference(
+                    _create_btree_table(
+                        &format!("table_{index}"),
+                        _create_column_list(&["key"], Type::Integer),
+                    ),
+                    None,
+                    table_id_counter.next(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut where_clause = vec![
+            _create_binary_expr(
+                _create_column_expr(joined_tables[0].internal_id, 0, false),
+                Operator::Equals,
+                _create_column_expr(joined_tables[1].internal_id, 0, false),
+            ),
+            _create_binary_expr(
+                _create_column_expr(joined_tables[2].internal_id, 0, false),
+                Operator::Equals,
+                _create_column_expr(joined_tables[3].internal_id, 0, false),
+            ),
+        ];
+        let table_references = TableReferences::new(joined_tables, vec![]);
+        let available_indexes = AvailableIndexes::default();
+        let constraints = constraints_from_where_clause(
+            &where_clause,
+            &table_references,
+            &available_indexes,
+            &[],
+            &empty_schema(),
+            &DEFAULT_PARAMS,
+        )?;
+        let base_table_rows =
+            [1.0, 1_000_000.0, 10.0, 10.0].map(RowCountEstimate::HardcodedFallback);
+        let mut access_methods = Vec::new();
+        let schema = empty_schema();
+        let plan = compute_best_join_order(
+            table_references.joined_tables(),
+            1.0,
+            None,
+            &constraints,
+            &base_table_rows,
+            &mut access_methods,
+            &mut where_clause,
+            &[],
+            &[],
+            &DEFAULT_PARAMS,
+            &AnalyzeStats::default(),
+            &available_indexes,
+            &table_references,
+            &schema,
+        )?
+        .unwrap()
+        .best_plan;
+        let order = plan.table_numbers().collect::<Vec<_>>();
+        let component = |table| table / 2;
+
+        assert_eq!(component(order[0]), component(order[1]), "order: {order:?}");
+        assert_eq!(component(order[2]), component(order[3]), "order: {order:?}");
+        assert_ne!(component(order[1]), component(order[2]), "order: {order:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn equality_class_connects_columns_through_a_third_table() -> Result<()> {
+        let (table_references, table_ids) =
+            equality_test_tables([Type::Integer, Type::Integer, Type::Integer]);
+        let mut where_clause = vec![
+            _create_binary_expr(
+                _create_column_expr(table_ids[0], 0, false),
+                Operator::Equals,
+                _create_column_expr(table_ids[1], 0, false),
+            ),
+            _create_binary_expr(
+                _create_column_expr(table_ids[1], 0, false),
+                Operator::Equals,
+                _create_column_expr(table_ids[2], 0, false),
+            ),
+        ];
+
+        super::super::constraints::add_implied_column_equalities(
+            &mut where_clause,
+            &table_references,
+        )?;
+
+        assert_eq!(where_clause.len(), 3);
+        assert!(where_clause[2].consumed);
+        assert_eq!(
+            table_mask_from_expr(&where_clause[2].expr, &table_references, &[])?,
+            TableMask::try_from(0b101_u128)?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn equality_class_does_not_cross_column_affinities() -> Result<()> {
+        let (table_references, table_ids) =
+            equality_test_tables([Type::Integer, Type::Integer, Type::Text]);
+        let mut where_clause = vec![
+            _create_binary_expr(
+                _create_column_expr(table_ids[0], 0, false),
+                Operator::Equals,
+                _create_column_expr(table_ids[1], 0, false),
+            ),
+            _create_binary_expr(
+                _create_column_expr(table_ids[1], 0, false),
+                Operator::Equals,
+                _create_column_expr(table_ids[2], 0, false),
+            ),
+        ];
+
+        super::super::constraints::add_implied_column_equalities(
+            &mut where_clause,
+            &table_references,
+        )?;
+
+        assert_eq!(where_clause.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn equality_class_does_not_link_rowid_aliases() -> Result<()> {
+        let mut table_id_counter = TableRefIdCounter::new();
+        let joined_tables = (0..3)
+            .map(|index| {
+                _create_table_reference(
+                    _create_btree_table(
+                        &format!("table_{index}"),
+                        vec![_create_column_rowid_alias("id")],
+                    ),
+                    None,
+                    table_id_counter.next(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let table_references = TableReferences::new(joined_tables, vec![]);
+        let table_ids: [TableInternalId; 3] =
+            std::array::from_fn(|index| table_references.joined_tables()[index].internal_id);
+        let mut where_clause = vec![
+            _create_binary_expr(
+                _create_column_expr(table_ids[0], 0, true),
+                Operator::Equals,
+                _create_column_expr(table_ids[1], 0, true),
+            ),
+            _create_binary_expr(
+                _create_column_expr(table_ids[1], 0, true),
+                Operator::Equals,
+                _create_column_expr(table_ids[2], 0, true),
+            ),
+        ];
+
+        super::super::constraints::add_implied_column_equalities(
+            &mut where_clause,
+            &table_references,
+        )?;
+
+        assert_eq!(where_clause.len(), 2);
+        Ok(())
+    }
+
+    fn equality_test_tables(column_types: [Type; 3]) -> (TableReferences, [TableInternalId; 3]) {
+        let mut table_id_counter = TableRefIdCounter::new();
+        let joined_tables = column_types
+            .into_iter()
+            .enumerate()
+            .map(|(index, column_type)| {
+                _create_table_reference(
+                    _create_btree_table(
+                        &format!("table_{index}"),
+                        _create_column_list(&["key"], column_type),
+                    ),
+                    None,
+                    table_id_counter.next(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let table_references = TableReferences::new(joined_tables, vec![]);
+        let table_ids =
+            std::array::from_fn(|index| table_references.joined_tables()[index].internal_id);
+        (table_references, table_ids)
     }
 
     #[test]

--- a/core/translate/optimizer/mod.rs
+++ b/core/translate/optimizer/mod.rs
@@ -55,8 +55,8 @@ use crate::{
 };
 use crate::{turso_assert, turso_assert_eq, turso_debug_assert, turso_soft_unreachable};
 use constraints::{
-    can_use_partial_index, constraints_from_where_clause, partial_index,
-    partial_index_predicate_terms, Constraint,
+    add_implied_column_equalities, can_use_partial_index, constraints_from_where_clause,
+    partial_index, partial_index_predicate_terms, Constraint,
 };
 use cost::Cost;
 use join::{
@@ -2285,7 +2285,7 @@ fn optimize_table_access(
     result_columns: &mut [ResultSetColumn],
     table_references: &mut TableReferences,
     available_indexes: &AvailableIndexes,
-    where_clause: &mut [WhereTerm],
+    where_clause: &mut Vec<WhereTerm>,
     order_by: &mut Vec<(
         Box<ast::Expr>,
         SortOrder,
@@ -2334,7 +2334,7 @@ fn find_table_access_plan(
     result_columns: &mut [ResultSetColumn],
     table_references: &mut TableReferences,
     available_indexes: &AvailableIndexes,
-    where_clause: &mut [WhereTerm],
+    where_clause: &mut Vec<WhereTerm>,
     order_by: &mut Vec<(
         Box<ast::Expr>,
         SortOrder,
@@ -2409,7 +2409,7 @@ fn find_table_access_plan(
 
     // For multi-table queries, collect index method candidates to pass to the DP algorithm.
     // This allows the optimizer to consider index methods at any position in the join order.
-    let base_table_rows_for_candidates = table_references
+    let base_table_rows = table_references
         .joined_tables()
         .iter()
         .map(|t| base_row_estimate(schema, t, params))
@@ -2424,7 +2424,7 @@ fn find_table_access_plan(
             group_by,
             limit,
             offset,
-            &base_table_rows_for_candidates,
+            &base_table_rows,
             params,
         )?
     } else {
@@ -2433,21 +2433,6 @@ fn find_table_access_plan(
     let maybe_order_target = simple_aggregate
         .and_then(|sa| simple_aggregate_order_target(sa, table_references))
         .or_else(|| compute_order_target(order_by, group_by.as_mut(), table_references));
-    let mut constraints_per_table = constraints_from_where_clause(
-        where_clause,
-        table_references,
-        available_indexes,
-        subqueries,
-        schema,
-        params,
-    )?;
-
-    let base_table_rows = table_references
-        .joined_tables()
-        .iter()
-        .map(|t| base_row_estimate(schema, t, params))
-        .collect::<Vec<_>>();
-
     // Currently the expressions we evaluate as constraints are binary comparisons that (except for IS/IS NOT)
     // will never be true for a NULL operand.
     // If there are any constraints on the right hand side table of an outer join that are not part of the outer join condition,
@@ -2457,9 +2442,7 @@ fn find_table_access_plan(
     // there can never be a situation where null columns are emitted for t2 because t2.id = 5 will never be true in that case.
     // hence: we can convert the outer join into an inner join.
     //
-    // Converting a LEFT JOIN into an INNER JOIN is an optimization opportunity:
-    // it can enable join reordering and let more predicates participate in key selection.
-    // -> recompute constraints if we rewrote a LEFT JOIN into an INNER JOIN.
+    // Converting a LEFT JOIN into an INNER JOIN can enable join reordering.
     loop {
         let mut outer_join_rewritten = false;
         for t in table_references.joined_tables_mut().iter_mut().filter(|t| {
@@ -2493,15 +2476,17 @@ fn find_table_access_plan(
         if !outer_join_rewritten {
             break;
         }
-        constraints_per_table = constraints_from_where_clause(
-            where_clause,
-            table_references,
-            available_indexes,
-            subqueries,
-            schema,
-            params,
-        )?;
     }
+
+    add_implied_column_equalities(where_clause, table_references)?;
+    let mut constraints_per_table = constraints_from_where_clause(
+        where_clause,
+        table_references,
+        available_indexes,
+        subqueries,
+        schema,
+        params,
+    )?;
 
     // Enforce INDEXED BY / NOT INDEXED after outer-join rewrites settle, because
     // a null-rejecting WHERE term can turn a LEFT JOIN into an INNER JOIN and

--- a/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q5-local-supplier-volume.snap
+++ b/sqlite/conformance/sqlite-sqltests/snapshot_tests/tpch/snapshots/tpch__q5-local-supplier-volume.snap
@@ -35,10 +35,10 @@ info:
 ---
 QUERY PLAN
 |--SCAN orders
-|--SEARCH lineitem USING INDEX sqlite_autoindex_lineitem_1 (l_orderkey=?)
-|--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH customer USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH nation USING INTEGER PRIMARY KEY (rowid=?)
 |--SEARCH region USING INTEGER PRIMARY KEY (rowid=?)
+|--SEARCH lineitem USING INDEX sqlite_autoindex_lineitem_1 (l_orderkey=?)
+|--SEARCH supplier USING INTEGER PRIMARY KEY (rowid=?)
 |--USE SORTER FOR GROUP BY
 `--USE SORTER FOR ORDER BY

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -36,6 +36,7 @@ log = "0.4.22"
 assert_cmd = "^2"
 rand_chacha = { workspace = true }
 rand = { workspace = true }
+serde_json = { workspace = true }
 zerocopy = "0.8.26"
 ctor = "0.5.0"
 twox-hash = "2.1.1"

--- a/tests/integration/query_processing/test_eqp_json.rs
+++ b/tests/integration/query_processing/test_eqp_json.rs
@@ -1,11 +1,14 @@
 use crate::common::{limbo_exec_rows, TempDatabase};
+use rusqlite::types::Value;
+use std::sync::Arc;
+use turso_core::Connection;
 
 const SCHEMA: [&str; 2] = [
     "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)",
     "CREATE INDEX idx_users_age ON users(age)",
 ];
 
-fn connect_with_schema(tmp_db: &TempDatabase) -> std::sync::Arc<turso_core::Connection> {
+fn connect_with_schema(tmp_db: &TempDatabase) -> Arc<Connection> {
     let conn = tmp_db.connect_limbo();
     for ddl in SCHEMA {
         limbo_exec_rows(&conn, ddl);
@@ -21,4 +24,201 @@ fn format_json_statement_reports_one_text_column(tmp_db: TempDatabase) -> anyhow
     assert_eq!(stmt.get_column_name(0), "plan_json");
     assert_eq!(stmt.get_column_decltype(0).as_deref(), Some("TEXT"));
     Ok(())
+}
+
+#[turso_macros::test]
+fn join_access_nodes_report_cost_and_row_estimates(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = connect_with_schema(&tmp_db);
+    limbo_exec_rows(
+        &conn,
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, total INTEGER)",
+    );
+    limbo_exec_rows(&conn, "CREATE INDEX idx_orders_user ON orders(user_id)");
+
+    let plan = explain_query_plan(
+        &conn,
+        "SELECT users.name, orders.total
+         FROM users JOIN orders ON orders.user_id = users.id
+         WHERE users.id = 1",
+    )?;
+    let access_nodes: Vec<_> = plan["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|node| matches!(node["op"]["type"].as_str(), Some("scan" | "search")))
+        .collect();
+
+    assert_eq!(access_nodes.len(), 2);
+    assert_eq!(access_nodes[0]["op"]["estimate"]["input_rows"], 1.0);
+    for node in access_nodes {
+        let estimate = &node["op"]["estimate"];
+        assert!(estimate["rows_per_input"].as_f64().unwrap() > 0.0);
+        assert!(estimate["output_rows"].as_f64().unwrap() > 0.0);
+        assert!(estimate["access_cost"].as_f64().unwrap() > 0.0);
+        assert!(estimate["total_cost"].as_f64().unwrap() > 0.0);
+    }
+    Ok(())
+}
+
+#[turso_macros::test]
+fn outer_join_null_test_estimates_unmatched_rows(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    create_parent_child_data(&conn, "CREATE INDEX child_parent ON child(parent_id)");
+
+    let query = "SELECT parent.id
+                 FROM parent
+                 LEFT JOIN child ON child.parent_id = parent.id AND child.kind = 1
+                 WHERE child.id IS NULL";
+    assert_eq!(limbo_exec_rows(&conn, query).len(), 90);
+
+    let plan = explain_query_plan(&conn, query)?;
+    let estimated_rows = final_output_rows(&plan);
+    assert!(
+        (80.0..99.0).contains(&estimated_rows),
+        "expected 80 to 99 rows, got {estimated_rows}"
+    );
+    Ok(())
+}
+
+#[turso_macros::test]
+fn nullable_primary_key_null_test_keeps_matched_rows(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    limbo_exec_rows(&conn, "CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+    limbo_exec_rows(
+        &conn,
+        "CREATE TABLE child (
+            key TEXT PRIMARY KEY,
+            nullable_value TEXT,
+            parent_id INTEGER
+        )",
+    );
+    limbo_exec_rows(&conn, "CREATE INDEX child_parent ON child(parent_id)");
+    limbo_exec_rows(&conn, "INSERT INTO parent VALUES (1), (2)");
+    limbo_exec_rows(
+        &conn,
+        "INSERT INTO child VALUES (NULL, NULL, 1), ('two', 'two', 2)",
+    );
+    limbo_exec_rows(&conn, "ANALYZE");
+
+    let primary_key_plan = explain_query_plan(
+        &conn,
+        "SELECT parent.id
+         FROM parent LEFT JOIN child ON child.parent_id = parent.id
+         WHERE child.key IS NULL",
+    )?;
+    let nullable_column_plan = explain_query_plan(
+        &conn,
+        "SELECT parent.id
+         FROM parent LEFT JOIN child ON child.parent_id = parent.id
+         WHERE child.nullable_value IS NULL",
+    )?;
+
+    assert_eq!(
+        final_output_rows(&primary_key_plan),
+        final_output_rows(&nullable_column_plan)
+    );
+    Ok(())
+}
+
+#[turso_macros::test]
+fn compound_join_lookup_estimates_its_constant_filter(tmp_db: TempDatabase) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    create_parent_child_data(
+        &conn,
+        "CREATE INDEX child_parent_kind ON child(parent_id, kind)",
+    );
+
+    let query = "SELECT parent.id
+                 FROM parent CROSS JOIN child
+                 WHERE child.parent_id = parent.id AND child.kind = 1";
+    assert_eq!(limbo_exec_rows(&conn, query).len(), 10);
+
+    let plan = explain_query_plan(&conn, query)?;
+    let child_estimate = plan["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|node| node["op"]["table"] == "child")
+        .map(|node| &node["op"]["estimate"])
+        .unwrap();
+    assert_eq!(child_estimate["input_rows"], 100.0);
+    let output_rows = child_estimate["output_rows"].as_f64().unwrap();
+    assert!(
+        (5.0..=20.0).contains(&output_rows),
+        "expected 5 to 20 rows, got {output_rows}"
+    );
+    Ok(())
+}
+
+#[turso_macros::test]
+fn unavailable_duplicate_does_not_stop_a_compound_lookup(
+    tmp_db: TempDatabase,
+) -> anyhow::Result<()> {
+    let conn = tmp_db.connect_limbo();
+    limbo_exec_rows(&conn, "CREATE TABLE first (a INTEGER, b INTEGER)");
+    limbo_exec_rows(&conn, "CREATE TABLE middle (x INTEGER, y INTEGER)");
+    limbo_exec_rows(&conn, "CREATE INDEX middle_xy ON middle(x, y)");
+    limbo_exec_rows(&conn, "CREATE TABLE last (z INTEGER)");
+
+    let plan = explain_query_plan(
+        &conn,
+        "SELECT *
+         FROM first CROSS JOIN middle CROSS JOIN last
+         WHERE middle.x = first.a
+           AND middle.x = last.z
+           AND middle.y = first.b",
+    )?;
+    let middle_constraints = plan["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|node| node["op"]["table"] == "middle")
+        .map(|node| node["op"]["constraints"].as_array().unwrap())
+        .unwrap();
+    assert_eq!(middle_constraints.len(), 2);
+    assert_eq!(middle_constraints[0], "x=?");
+    assert_eq!(middle_constraints[1], "y=?");
+    Ok(())
+}
+
+fn explain_query_plan(conn: &Arc<Connection>, query: &str) -> anyhow::Result<serde_json::Value> {
+    let rows = limbo_exec_rows(conn, &format!("EXPLAIN QUERY PLAN FORMAT=JSON {query}"));
+    let Value::Text(plan) = &rows[0][0] else {
+        panic!("query plan must be text");
+    };
+    Ok(serde_json::from_str(plan.as_str())?)
+}
+
+fn final_output_rows(plan: &serde_json::Value) -> f64 {
+    plan["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|node| node["op"]["estimate"]["output_rows"].as_f64())
+        .next_back()
+        .unwrap()
+}
+
+fn create_parent_child_data(conn: &Arc<Connection>, index_sql: &str) {
+    limbo_exec_rows(conn, "CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+    limbo_exec_rows(
+        conn,
+        "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER, kind INTEGER)",
+    );
+    limbo_exec_rows(conn, index_sql);
+
+    let parent_values = (1..=100)
+        .map(|value| format!("({value})"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let child_values = (1..=100)
+        .map(|value| {
+            let kind = if value <= 10 { 1 } else { 2 };
+            format!("({value},{value},{kind})")
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    limbo_exec_rows(conn, &format!("INSERT INTO parent VALUES {parent_values}"));
+    limbo_exec_rows(conn, &format!("INSERT INTO child VALUES {child_values}"));
+    limbo_exec_rows(conn, "ANALYZE");
 }


### PR DESCRIPTION
## What changed and why

This PR corrects join row estimates and keeps each join prefix connected. It also finds implied equality links between compatible inner-join columns.

Access methods now report the full row estimate for each probe. Join costs and output estimates use the same value.

The optimizer builds table constraints once after join rewrites and equality inference. Equality inference skips extra rowid links because direct rowid links are unique.

Bad row estimates distort later cost choices. A disconnected prefix can also cause an avoidable cross join.

## Example

TPC-H 5 has `customer.nation = supplier.nation` and `supplier.nation = nation.id`. The optimizer can now infer `customer.nation = nation.id`.

For separate join components, the optimizer finishes an available connected component before it adds a cross join.

## Result

TPC-H 5 VM steps fell by 35.9%, from 19.4 million to 12.4 million. Rows read fell by 46.6%, from 3.56 million to 1.90 million.

This PR is layer 3 of 7. It depends on #8832. The next PR is #8834.

## Tests

- `CI=1 make -C sqlite/conformance run-rust` (1,589 passed)
- JSON query-plan integration tests
- Join optimizer unit tests
- `join_chain` release benchmark

## Description of AI usage

Codex helped inspect plans, implement the estimate changes, run tests, and organize the commit stack.
