### PR TITLE
Fix RENAME COLUMN with collated table constraints

### DIFF
--- a/core/vdbe/execute.rs
+++ b/core/vdbe/execute.rs
@@ -11701,17 +11701,11 @@ pub fn op_function(
                                                 ..
                                             } => {
                                                 for col in pk_cols {
-                                                    let (ast::Expr::Name(ref name)
-                                                    | ast::Expr::Id(ref name)) = *col.expr
-                                                    else {
-                                                        return Err(LimboError::ParseError("Unexpected expression in PRIMARY KEY constraint".to_string()).into());
-                                                    };
-                                                    if normalize_ident(name.as_str()) == rename_from
-                                                    {
-                                                        *col.expr = ast::Expr::Name(Name::exact(
-                                                            column_def.col_name.as_str().to_owned(),
-                                                        ));
-                                                    }
+                                                    rename_identifiers(
+                                                        col.expr.as_mut(),
+                                                        &rename_from,
+                                                        column_def.col_name.as_str(),
+                                                    );
                                                 }
                                             }
                                             ast::TableConstraint::Unique {
@@ -11719,17 +11713,11 @@ pub fn op_function(
                                                 ..
                                             } => {
                                                 for col in uniq_cols {
-                                                    let (ast::Expr::Name(ref name)
-                                                    | ast::Expr::Id(ref name)) = *col.expr
-                                                    else {
-                                                        return Err(LimboError::ParseError("Unexpected expression in UNIQUE constraint".to_string()).into());
-                                                    };
-                                                    if normalize_ident(name.as_str()) == rename_from
-                                                    {
-                                                        *col.expr = ast::Expr::Name(Name::exact(
-                                                            column_def.col_name.as_str().to_owned(),
-                                                        ));
-                                                    }
+                                                    rename_identifiers(
+                                                        col.expr.as_mut(),
+                                                        &rename_from,
+                                                        column_def.col_name.as_str(),
+                                                    );
                                                 }
                                             }
                                             ast::TableConstraint::ForeignKey {

--- a/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
+++ b/sqlite/conformance/sqlite-sqltests/alter_table.sqltest
@@ -45,6 +45,30 @@ expect {
     CREATE INDEX i ON t (b)
 }
 
+@cross-check-integrity
+test alter-table-rename-column-table-unique-collate {
+    CREATE TABLE t (a TEXT, b TEXT, UNIQUE (a COLLATE NOCASE));
+    INSERT INTO t VALUES ('a', 'x');
+    ALTER TABLE t RENAME COLUMN b TO c;
+    ALTER TABLE t RENAME COLUMN a TO d;
+    SELECT d, c FROM t;
+}
+expect {
+    a|x
+}
+
+@cross-check-integrity
+test alter-table-rename-column-table-primary-key-collate {
+    CREATE TABLE t (a TEXT, b TEXT, PRIMARY KEY (a COLLATE NOCASE));
+    INSERT INTO t VALUES ('a', 'x');
+    ALTER TABLE t RENAME COLUMN b TO c;
+    ALTER TABLE t RENAME COLUMN a TO d;
+    SELECT d, c FROM t;
+}
+expect {
+    a|x
+}
+
 @skip-if mvcc "views not supported in MVCC mode"
 test alter-table-rename-column-view {
     CREATE TABLE t (a, b);


### PR DESCRIPTION
## Description

Fix `ALTER TABLE ... RENAME COLUMN` for table-level `UNIQUE` and `PRIMARY KEY` constraints whose column expression includes `COLLATE`. Constraint expressions are now rewritten recursively, so collated column references are renamed instead of rejected as unexpected expressions.

Adds SQLite conformance coverage for both table-level `UNIQUE` and `PRIMARY KEY` collations.

## Motivation and context

Fixes #8764. SQLite accepts these renames; Turso previously returned `Unexpected expression in UNIQUE/PRIMARY KEY constraint` and left the schema unchanged.

## Description of AI Usage

AI was used to inspect the repository and issue, reproduce the reported SQL behavior, implement the focused Rust and SQL-test changes, and run the validation commands. The patch was reviewed against the existing `rename_identifiers` helper and repository contribution guidance.

## Testing

- `cargo +stable fmt --all -- --check`
- SQL conformance `alter_table.sqltest`: 218 passed
- Focused SQL conformance tests for table-level UNIQUE and PRIMARY KEY with COLLATE: 1 passed each
- `cargo +stable test -p turso_core --lib rename_column`: 3 passed
- Focused .NET aggregate helper test: 1 passed; 20 direct vstest repetitions passed after native SDK setup